### PR TITLE
fix(nextly): say which of seven things stops a preview link resolving

### DIFF
--- a/.changeset/preview-refusal-says-which.md
+++ b/.changeset/preview-refusal-says-which.md
@@ -1,5 +1,29 @@
 ---
 "nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 Asking for a preview link that cannot be built now says which of five things is

--- a/.changeset/preview-refusal-says-which.md
+++ b/.changeset/preview-refusal-says-which.md
@@ -26,29 +26,39 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Asking for a preview link that cannot be built now says which of five things is
+Asking for a preview link that cannot be built now says which of six things is
 wrong, instead of telling every editor to fill in a slug.
 
-The resolver behind preview links refuses for five distinct reasons: the
-document is gone, the collection declares no preview at all, the declaration
-yields no address for this document yet, the address it yields is on a different
-site, or it does not parse. All five arrived as one message — "this entry has no
-preview address yet, so filling in the fields its preview URL is built from —
-usually the slug — makes it shareable." For three of them that is wrong and
-unactionable. An editor whose slug was already correct was sent to look at the
-one field that was not the problem, and a preview URL pointing at another origin
-is something no field on the entry can change.
+The resolver behind preview links refuses for six distinct reasons: the document
+is confirmed gone, the document could not be READ at all, the collection declares
+no preview, the declaration yields no address for this document yet, the address
+it yields is on a different site, or it does not parse. All of them arrived as
+one message — "this entry has no preview address yet, so filling in the fields
+its preview URL is built from — usually the slug — makes it shareable." For most
+of them that is wrong and unactionable. An editor whose slug was already correct
+was sent to look at the one field that was not the problem, and a preview URL
+pointing at another origin is something no field on the entry can change.
 
 Each refusal now names its own remedy and the person who can apply it — a
 missing declaration is a developer's job, an empty slug is the editor's, and a
 foreign origin belongs to whoever owns the preview URL or the site URL setting.
 
-**The public preview route is deliberately unchanged and still answers all five
+**A failed read is no longer reported as a deletion**, and that pair is worth
+calling out because the two diagnoses are opposites. A transient database error,
+a rate limit, or a throwing read hook establishes nothing about whether the
+document exists — so the read reports absence only on a 404, and anything else
+now says "could not be read just now, please try again in a moment" rather than
+telling an author their work may have been deleted while it sits there intact.
+Reads that report failure by throwing rather than by returning an envelope, which
+is how the Direct API answers for Singles, are translated the same way.
+
+**The public preview route is deliberately unchanged and still answers all six
 with the same 404.** That is not an oversight: distinguishing them there would
 let a stranger holding a forged token tell a deleted entry from an unpublished
 one from a collection that has no preview, which is an oracle for what exists in
 draft. The reasons are surfaced only on the authenticated path, where the caller
-already holds edit access on the document and learns nothing by being told. The
-route's answer is now DERIVED from the detailed one in a single place rather than
-computed alongside it, so the two cannot drift into disagreeing about when to
-refuse.
+already holds edit access on the document and learns nothing by being told —
+enforced by a capability the anonymous path cannot construct, rather than by a
+comment asking callers not to. The route's answer is DERIVED from the detailed
+one in a single place rather than computed alongside it, so the two cannot drift
+into disagreeing about when to refuse.

--- a/.changeset/preview-refusal-says-which.md
+++ b/.changeset/preview-refusal-says-which.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+---
+
+Asking for a preview link that cannot be built now says which of five things is
+wrong, instead of telling every editor to fill in a slug.
+
+The resolver behind preview links refuses for five distinct reasons: the
+document is gone, the collection declares no preview at all, the declaration
+yields no address for this document yet, the address it yields is on a different
+site, or it does not parse. All five arrived as one message — "this entry has no
+preview address yet, so filling in the fields its preview URL is built from —
+usually the slug — makes it shareable." For three of them that is wrong and
+unactionable. An editor whose slug was already correct was sent to look at the
+one field that was not the problem, and a preview URL pointing at another origin
+is something no field on the entry can change.
+
+Each refusal now names its own remedy and the person who can apply it — a
+missing declaration is a developer's job, an empty slug is the editor's, and a
+foreign origin belongs to whoever owns the preview URL or the site URL setting.
+
+**The public preview route is deliberately unchanged and still answers all five
+with the same 404.** That is not an oversight: distinguishing them there would
+let a stranger holding a forged token tell a deleted entry from an unpublished
+one from a collection that has no preview, which is an oracle for what exists in
+draft. The reasons are surfaced only on the authenticated path, where the caller
+already holds edit access on the document and learns nothing by being told. The
+route's answer is now DERIVED from the detailed one in a single place rather than
+computed alongside it, so the two cannot drift into disagreeing about when to
+refuse.

--- a/packages/nextly/src/api/__tests__/preview-access-route-authorized.integration.test.ts
+++ b/packages/nextly/src/api/__tests__/preview-access-route-authorized.integration.test.ts
@@ -59,9 +59,20 @@ describe("assertEntryPreviewable and the gate that may or may not have run", () 
   it("does not re-ask that gate for a caller the route already authorized", async () => {
     const id = await seed();
 
-    await expect(
-      assertEntryPreviewable("pages", id, DENIED, { routeAuthorized: true })
-    ).resolves.toBeUndefined();
+    /*
+     * RESOLVING is the property. `DENIED` cannot pass the coarse gate, so a
+     * gate that re-asked it would throw — and the assertion used to be
+     * `toBeUndefined`, which pinned the return TYPE rather than that. It broke
+     * the moment the gate began returning the preview grant it had just
+     * established, even though the behaviour it names was unchanged.
+     */
+    const grant = await assertEntryPreviewable("pages", id, DENIED, {
+      routeAuthorized: true,
+    });
+
+    // And the grant is what the gate now produces, so a caller cannot assemble
+    // one without having passed exactly these checks for this document.
+    expect(grant).toBeDefined();
   });
 
   // The control that makes the pair mean something: the SAME rule, reached

--- a/packages/nextly/src/api/preview-access.ts
+++ b/packages/nextly/src/api/preview-access.ts
@@ -25,6 +25,10 @@
 
 import { getService } from "../di";
 import {
+  previewCallerAuthorized,
+  type AuthorizedPreviewCaller,
+} from "../domains/collections/services/preview-redirect-resolver";
+import {
   singleDocumentEditable,
   singleDocumentReadable,
 } from "../domains/singles/services/single-document-access";
@@ -95,7 +99,7 @@ export async function assertEntryPreviewable(
      */
     routeAuthorized: boolean;
   }
-): Promise<void> {
+): Promise<AuthorizedPreviewCaller> {
   const collections = getService("collectionsHandler");
 
   // Enforced and as the caller, which is the same evaluation the bearer's read
@@ -164,6 +168,14 @@ export async function assertEntryPreviewable(
       },
     });
   }
+
+  /*
+   * The grant is PRODUCED by the check, and that is the point of returning one.
+   * A caller assembling its own would be asserting the very thing this function
+   * exists to establish; minted here it cannot exist unless every refusal above
+   * was passed for THIS document.
+   */
+  return previewCallerAuthorized(user, { collection, entryId });
 }
 
 /**
@@ -199,7 +211,7 @@ export async function assertSinglePreviewable(
      */
     routeAuthorized: boolean;
   }
-): Promise<void> {
+): Promise<AuthorizedPreviewCaller> {
   const identity = {
     user,
     // No `actor`. It carried an API KEY's own stamped grants, and both mints
@@ -243,4 +255,7 @@ export async function assertSinglePreviewable(
       logContext: { reason: "preview-link-single-not-editable", single },
     });
   }
+
+  // See {@link assertEntryPreviewable}: the check produces the grant.
+  return previewCallerAuthorized(user, { single });
 }

--- a/packages/nextly/src/api/preview-access.ts
+++ b/packages/nextly/src/api/preview-access.ts
@@ -257,5 +257,10 @@ export async function assertSinglePreviewable(
   }
 
   // See {@link assertEntryPreviewable}: the check produces the grant.
-  return previewCallerAuthorized(user, { single });
+  return previewCallerAuthorized(user, {
+    single,
+    // The locale this check was run FOR. Omitting it would grant every
+    // translation on the strength of one having been checked.
+    ...(locale === undefined ? {} : { locale }),
+  });
 }

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -587,6 +587,111 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
 
     expect(response.status).toBe(200);
   });
+
+  /*
+   * The three refusals an editor cannot act on, asserted THROUGH the endpoint.
+   *
+   * The resolver's own suite stops at the cause value, which says nothing about
+   * what anyone reads: the mapping from cause to message could be swapped back
+   * to the slug advice and every resolver test would stay green, while the
+   * user-facing behaviour this change exists for would be gone. So each case
+   * asserts the remedy it names AND that it does not name the slug.
+   */
+  const slugAdvice = /slug/i;
+
+  /** The message an endpoint refusal put in front of the editor. */
+  const messageOf = (b: { error?: unknown }): string =>
+    String((b.error as { message?: string } | undefined)?.message ?? "");
+
+  async function refusalMessage(): Promise<string> {
+    return messageOf(
+      await json(
+        await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+      )
+    );
+  }
+
+  it("says the document could not be read, rather than blaming the slug", async () => {
+    // The entry vanished between the authorization read and the resolver's own.
+    getEntry.mockResolvedValue({ success: true, statusCode: 200, data: null });
+
+    const message = await refusalMessage();
+
+    expect(message).toMatch(/could not be read|deleted/i);
+    expect(message).not.toMatch(slugAdvice);
+  });
+
+  it("says the preview URL names another site, rather than blaming the slug", async () => {
+    // No field on this entry can move the declaration to another origin, so
+    // sending the editor to fill one in is advice they cannot act on.
+    previewDeclaration.mockResolvedValue({
+      url: () => "https://elsewhere.test/about",
+    });
+
+    const message = await refusalMessage();
+
+    expect(message).toMatch(/different site/i);
+    expect(message).not.toMatch(slugAdvice);
+  });
+
+  it("says the preview URL does not resolve, rather than blaming the slug", async () => {
+    getSettings.mockResolvedValue({ siteUrl: "not a url" });
+    previewDeclaration.mockResolvedValue({
+      url: () => "https://site.example/about",
+    });
+
+    const message = await refusalMessage();
+
+    expect(message).toMatch(/could not be turned into an address/i);
+    expect(message).not.toMatch(slugAdvice);
+  });
+
+  it("gives all five refusals five different messages", async () => {
+    /*
+     * Stronger than each matching its own pattern: two causes could both match
+     * their phrases while sharing a message, and the whole point is that an
+     * editor can tell which of the five happened. The set having five members
+     * is the property; five individual assertions do not state it.
+     */
+    previewDeclaration.mockResolvedValue(undefined);
+    const notConfigured = await refusalMessage();
+
+    previewDeclaration.mockResolvedValue({ url: () => null });
+    const unavailable = await refusalMessage();
+
+    previewDeclaration.mockResolvedValue({ urlTemplate: "/{slug}" });
+    getEntry.mockResolvedValue({ success: true, statusCode: 200, data: null });
+    const documentGone = await refusalMessage();
+
+    getEntry.mockResolvedValue({
+      success: true,
+      statusCode: 200,
+      data: { id: "7", slug: "seven" },
+    });
+    previewDeclaration.mockResolvedValue({
+      url: () => "https://elsewhere.test/about",
+    });
+    const foreignOrigin = await refusalMessage();
+
+    getSettings.mockResolvedValue({ siteUrl: "not a url" });
+    previewDeclaration.mockResolvedValue({
+      url: () => "https://site.example/about",
+    });
+    const unresolvable = await refusalMessage();
+
+    const all = [
+      notConfigured,
+      unavailable,
+      documentGone,
+      foreignOrigin,
+      unresolvable,
+    ];
+    // Non-empty first, so five identical empty strings cannot satisfy the size
+    // check by collapsing to one — and so a refusal that stopped carrying a
+    // message at all fails here rather than passing quietly.
+    expect(all.every(m => m.length > 0)).toBe(true);
+    expect(new Set(all).size).toBe(5);
+  });
 });
 
 describe("mintPreviewLink: the link it hands back", () => {

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -621,6 +621,55 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
     expect(message).not.toMatch(slugAdvice);
   });
 
+  /**
+   * A read that succeeds for AUTHORIZATION and then fails for the resolver.
+   *
+   * Both of the cases below are only reachable through this window, and
+   * discovering that was worth the fixture: the mint authorizes by reading the
+   * entry, so a read failing on the FIRST call is refused as a permission
+   * problem and never reaches the resolver at all. What the resolver can see is
+   * the race — the entry readable when the caller was authorized and not
+   * readable a moment later — which is exactly the situation being diagnosed.
+   */
+  function readableThenFailing(second: Record<string, unknown>): void {
+    getEntry.mockReset();
+    getEntry.mockResolvedValueOnce({
+      success: true,
+      statusCode: 200,
+      data: { id: "7", slug: "seven" },
+    });
+    getEntry.mockResolvedValue(second);
+  }
+
+  it("does not call a FAILED read a deletion", async () => {
+    /*
+     * A transient database error, a rate limit or a throwing read hook all
+     * arrive as `success: false` with a non-404 status. None of them shows the
+     * entry is absent, so "it may have been deleted" is a claim the read never
+     * established — and it is the most alarming possible wrong answer to give
+     * an editor about their own work.
+     */
+    readableThenFailing({ success: false, statusCode: 500 });
+
+    const message = await refusalMessage();
+
+    expect(message).toMatch(/could not be read just now|try again/i);
+    expect(message).not.toMatch(/deleted/i);
+    expect(message).not.toMatch(slugAdvice);
+  });
+
+  it("still calls a 404 a deletion, so the pair discriminates", async () => {
+    // The control for the case above: a read that DID establish absence keeps
+    // the permanent diagnosis, so the split is on the failure KIND rather than
+    // this endpoint having stopped saying "deleted" at all.
+    readableThenFailing({ success: false, statusCode: 404 });
+
+    const message = await refusalMessage();
+
+    expect(message).toMatch(/deleted/i);
+    expect(message).not.toMatch(/try again/i);
+  });
+
   it("says the preview URL names another site, rather than blaming the slug", async () => {
     // No field on this entry can move the declaration to another origin, so
     // sending the editor to fill one in is advice they cannot act on.
@@ -646,12 +695,12 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
     expect(message).not.toMatch(slugAdvice);
   });
 
-  it("gives all five refusals five different messages", async () => {
+  it("gives all six refusals six different messages", async () => {
     /*
      * Stronger than each matching its own pattern: two causes could both match
      * their phrases while sharing a message, and the whole point is that an
-     * editor can tell which of the five happened. The set having five members
-     * is the property; five individual assertions do not state it.
+     * editor can tell which of the six happened. The set having six members is
+     * the property; six individual assertions do not state it.
      */
     previewDeclaration.mockResolvedValue(undefined);
     const notConfigured = await refusalMessage();
@@ -662,6 +711,9 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
     previewDeclaration.mockResolvedValue({ urlTemplate: "/{slug}" });
     getEntry.mockResolvedValue({ success: true, statusCode: 200, data: null });
     const documentGone = await refusalMessage();
+
+    readableThenFailing({ success: false, statusCode: 500 });
+    const documentUnreadable = await refusalMessage();
 
     getEntry.mockResolvedValue({
       success: true,
@@ -683,14 +735,15 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
       notConfigured,
       unavailable,
       documentGone,
+      documentUnreadable,
       foreignOrigin,
       unresolvable,
     ];
-    // Non-empty first, so five identical empty strings cannot satisfy the size
+    // Non-empty first, so six identical empty strings cannot satisfy the size
     // check by collapsing to one — and so a refusal that stopped carrying a
     // message at all fails here rather than passing quietly.
     expect(all.every(m => m.length > 0)).toBe(true);
-    expect(new Set(all).size).toBe(5);
+    expect(new Set(all).size).toBe(6);
   });
 });
 

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -464,6 +464,52 @@ describe("mintPreviewLink for a Single", () => {
     expect(response.status).toBe(409);
   });
 
+  /*
+   * A Single's read reports failure by THROWING, not by returning null.
+   * `findSingle` raises a typed error for every unsuccessful service result, so
+   * a loader that only checked for null let the throw travel past it and the
+   * endpoint answered with the raw error instead of a refusal. A fixture that
+   * resolves null cannot reproduce that, which is why these reject instead.
+   */
+  it("refuses, rather than erroring, when the Single's read throws not-found", async () => {
+    findSingle.mockRejectedValue(
+      new NextlyError({
+        code: "NOT_FOUND",
+        statusCode: 404,
+        publicMessage: "No such single",
+      })
+    );
+
+    const response = await mintPreviewLink(post({ single: "homepage" }));
+    const message = String(
+      ((await json(response)).error as { message?: string } | undefined)
+        ?.message ?? ""
+    );
+
+    expect(response.status).toBe(409);
+    expect(message).toMatch(/deleted|removed/i);
+  });
+
+  it("says a FAILED Single read could not be read, not that it was deleted", async () => {
+    findSingle.mockRejectedValue(
+      new NextlyError({
+        code: "INTERNAL_ERROR",
+        statusCode: 500,
+        publicMessage: "Database unavailable",
+      })
+    );
+
+    const response = await mintPreviewLink(post({ single: "homepage" }));
+    const message = String(
+      ((await json(response)).error as { message?: string } | undefined)
+        ?.message ?? ""
+    );
+
+    expect(response.status).toBe(409);
+    expect(message).toMatch(/could not be read just now|try again/i);
+    expect(message).not.toMatch(/deleted/i);
+  });
+
   // Naming both is not a narrower request, it is two different documents — and
   // silently honouring one would mint a credential for a document the caller
   // may not have meant.
@@ -656,6 +702,11 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
     expect(message).toMatch(/could not be read just now|try again/i);
     expect(message).not.toMatch(/deleted/i);
     expect(message).not.toMatch(slugAdvice);
+    // The ENTRY, not the collection. What failed is the trusted read of one
+    // document; the collection and its declaration were both read fine a
+    // moment earlier, so naming the collection points at the wrong scope.
+    expect(message).toMatch(/this entry/i);
+    expect(message).not.toMatch(/this collection/i);
   });
 
   it("still calls a 404 a deletion, so the pair discriminates", async () => {

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -293,9 +293,22 @@ const REFUSALS: Record<
       "it shareable.",
     reason: "has-no-preview-target",
     remedy:
-      "The preview declaration returned no address for this document. A " +
-      "`url` function answering null, or a `urlTemplate` whose placeholder " +
-      "field is empty, both mean 'not previewable yet'.",
+      "The preview declaration DECLINED to name an address for this document. " +
+      "A `url` function answering null, or a `urlTemplate` whose placeholder " +
+      "field is empty, both mean 'not previewable yet'. A declaration that " +
+      "threw or produced an unusable address is `declarationFailed` instead.",
+  },
+  declarationFailed: {
+    message: (_subject, noun) =>
+      `This ${noun}'s preview URL could not be built, so a shared link would ` +
+      "have nowhere to open. Nothing on the document can fix it — a developer " +
+      "needs to correct the preview declaration.",
+    reason: "preview-declaration-failed",
+    remedy:
+      "The declaration threw while running, or returned pieces that do not " +
+      "compose into a URL under the site. Both are faults in " +
+      "`admin.preview.url` / `admin.preview.urlTemplate` rather than in this " +
+      "document, so they reproduce for every document in the collection.",
   },
   foreignOrigin: {
     message: (_subject, noun) =>

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -34,6 +34,7 @@ import {
   explainPreviewRedirect,
   explainSinglePreviewRedirect,
   previewCallerAuthorized,
+  readFromEnvelope,
   readOrReport,
   type PreviewPathOutcome,
   type PreviewRefusalCause,
@@ -674,9 +675,10 @@ async function mintForSingle(
             readOrReport(() => loadSingleForPreview(slug, singleLocale)),
           ...sharedRedirectDeps(declaration),
         },
-        // The gate above already required `update` on this Single, which is
-        // what makes naming a cause safe here.
-        previewCallerAuthorized(auth)
+        // The gate above already required `update` on THIS Single, and the
+        // witness carries which one — so the grant proves the thing the
+        // explainer relies on rather than merely that somebody signed in.
+        previewCallerAuthorized(auth, { single })
       )
     : { kind: "refused", cause: "notConfigured" };
 
@@ -808,33 +810,25 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
               includeWorkingDraft: true,
             });
             /*
-             * A FAILED read is not an absent entry. Folding both into `null`
-             * made a transient database error, a rate limit or a throwing read
-             * hook arrive as "this may have been deleted" — telling an editor
-             * their work is gone while it sits there intact. Only a 404 is
-             * evidence of absence; every other failure means the question was
-             * not answered.
+             * A FAILED read is not an absent entry: a transient database error,
+             * a rate limit or a throwing read hook would otherwise arrive as
+             * "this may have been deleted", telling an editor their work is
+             * gone while it sits there intact. Which envelope means absence is
+             * decided in ONE place, so this loader and the anonymous route's
+             * cannot come to disagree about the same entry.
              */
-            if (!read.success) {
-              return read.statusCode === 404
-                ? { kind: "absent" }
-                : { kind: "unreadable" };
-            }
-            return read.data === null
-              ? { kind: "absent" }
-              : {
-                  kind: "document",
-                  document: read.data as Record<string, unknown>,
-                };
+            return readFromEnvelope(read);
           },
           // Already resolved above, so this hands back the value rather than
           // fetching it again — the resolver takes a loader and this call site
           // happens to have the answer.
           ...sharedRedirectDeps(declaration),
         },
-        // The route gate above already required `update` on this entry, so its
-        // holder learns nothing from a cause they could not read anyway.
-        previewCallerAuthorized(auth)
+        // The route gate above already required `update` on THIS entry, so its
+        // holder learns nothing from a cause they could not read anyway — and
+        // the witness names the entry, so that claim is checked rather than
+        // assumed.
+        previewCallerAuthorized(auth, { collection, entryId })
       )
     : // Stated rather than resolved, so an undeclared collection costs no entry
       // read to learn what the absent declaration already says.

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -31,8 +31,10 @@ import {
   type AuditLogWriter,
 } from "../domains/audit/audit-log-writer";
 import {
-  resolvePreviewRedirect,
-  resolveSinglePreviewRedirect,
+  explainPreviewRedirect,
+  explainSinglePreviewRedirect,
+  type PreviewPathOutcome,
+  type PreviewRefusalCause,
 } from "../domains/collections/services/preview-redirect-resolver";
 import {
   hasPreviewConfigured,
@@ -195,7 +197,7 @@ function sharedRedirectDeps(declaration: PreviewDeclaration | undefined): {
 }
 
 /**
- * The one refusal both mint paths make, and the two causes it distinguishes.
+ * The one refusal both mint paths make, and the causes it distinguishes.
  *
  * Written once because the DECISION is one decision — "there is nowhere for
  * this link to open" — while only the noun and the remedy differ. Two copies
@@ -203,41 +205,98 @@ function sharedRedirectDeps(declaration: PreviewDeclaration | undefined): {
  * the message an editor reads instead of finding out from a reviewer that the
  * link 404s.
  *
- * The two causes are kept apart because they name different people. An
- * unconfigured collection or Single is a developer's job; a document whose
- * address cannot be built yet is usually one empty field the editor can fill.
- * Telling an editor to "ask a developer" about their own unfilled slug sends
- * them to the wrong person.
+ * The causes are kept apart because they name DIFFERENT PEOPLE. An unconfigured
+ * collection or Single is a developer's job; a document whose address cannot be
+ * built yet is usually one empty field the editor can fill; a declaration
+ * pointing at another origin is neither, and no field on the entry will ever
+ * change it. Telling an editor to fill in a slug that is already correct sends
+ * them to look at the one thing that is not the problem.
+ *
+ * A `Record` rather than a chain of ternaries, so a new
+ * {@link PreviewRefusalCause} is a type error here rather than silently taking
+ * whichever branch happened to be last.
  */
+const REFUSALS: Record<
+  PreviewRefusalCause,
+  {
+    message: (subject: "collection" | "single", noun: string) => string;
+    reason: string;
+    remedy: string;
+  }
+> = {
+  documentGone: {
+    message: subject =>
+      `This ${subject === "single" ? "single" : "entry"} could not be read, so ` +
+      "a shared link would have nowhere to open. It may have been deleted.",
+    reason: "has-no-readable-document",
+    remedy:
+      "The token names a document the resolver could not load. For an entry " +
+      "that usually means it was deleted; for a Single, that it was removed " +
+      "from the configuration.",
+  },
+  notConfigured: {
+    message: (_subject, noun) =>
+      `This ${noun} has no preview URL configured, so a shared link would ` +
+      "have nowhere to open. A developer can add one before links can be " +
+      "shared.",
+    reason: "has-no-preview-url",
+    remedy:
+      "Add `admin.preview.url` (code-first) or `admin.preview.urlTemplate` " +
+      "(UI-created). It answers where the document is served on the site, " +
+      "which nothing outside the application can know.",
+  },
+  unavailable: {
+    message: subject =>
+      `This ${subject === "single" ? "single" : "entry"} has no preview ` +
+      "address yet, so a shared link would have nowhere to open. Filling in " +
+      "the fields its preview URL is built from — usually the slug — makes " +
+      "it shareable.",
+    reason: "has-no-preview-target",
+    remedy:
+      "The preview declaration returned no address for this document. A " +
+      "`url` function answering null, or a `urlTemplate` whose placeholder " +
+      "field is empty, both mean 'not previewable yet'.",
+  },
+  foreignOrigin: {
+    message: (_subject, noun) =>
+      `This ${noun}'s preview URL points at a different site than this one, ` +
+      "so a shared link would leave the preview behind. A developer can " +
+      "align the preview URL with the configured site URL.",
+    reason: "preview-url-names-another-origin",
+    remedy:
+      "The declaration resolved to an absolute URL whose origin differs from " +
+      "the configured site URL (or, with none set, from the origin serving " +
+      "the request). Filling in fields on the document cannot change this — " +
+      "either the declaration or the site URL setting has to move.",
+  },
+  unresolvable: {
+    message: (_subject, noun) =>
+      `This ${noun}'s preview URL could not be turned into an address on ` +
+      "this site, so a shared link would have nowhere to open. A developer " +
+      "can check the preview URL and the site URL setting.",
+    reason: "preview-url-does-not-resolve",
+    remedy:
+      "Either the preview URL or the configured site URL did not parse, or " +
+      "the declaration produced a path that leaves this origin. Note that " +
+      "`//host` and `/\\host` are absolute despite the leading slash.",
+  },
+};
+
 function refuseUnservableLink(args: {
   subject: "collection" | "single";
   name: string;
-  declared: boolean;
+  cause: PreviewRefusalCause;
 }): never {
-  const { subject, name, declared } = args;
+  const { subject, name, cause } = args;
   const noun = subject === "single" ? "single" : "collection";
+  const refusal = REFUSALS[cause];
 
   throw NextlyError.conflict({
     reason: "state",
-    message: declared
-      ? `This ${subject === "single" ? "single" : "entry"} has no preview ` +
-        "address yet, so a shared link would have nowhere to open. Filling in " +
-        "the fields its preview URL is built from — usually the slug — makes " +
-        "it shareable."
-      : `This ${noun} has no preview URL configured, so a shared link would ` +
-        "have nowhere to open. A developer can add one before links can be " +
-        "shared.",
+    message: refusal.message(subject, noun),
     logContext: {
-      reason: declared
-        ? `preview-link-${subject}-has-no-preview-target`
-        : `preview-link-${subject}-has-no-preview-url`,
-      remedy: declared
-        ? "The preview declaration returned no address for this document. A " +
-          "`url` function answering null, or a `urlTemplate` whose placeholder " +
-          "field is empty, both mean 'not previewable yet'."
-        : "Add `admin.preview.url` (code-first) or `admin.preview.urlTemplate` " +
-          "(UI-created). It answers where the document is served on the site, " +
-          "which nothing outside the application can know.",
+      reason: `preview-link-${subject}-${refusal.reason}`,
+      remedy: refusal.remedy,
       [noun]: name,
     },
   });
@@ -568,21 +627,24 @@ async function mintForSingle(
   // same reason the entry path does it: a `url` answering null means "not
   // previewable yet", and minting on the strength of a declaration alone hands
   // out a link that 404s at the redirect.
-  const target = hasPreviewConfigured(declaration)
-    ? await resolveSinglePreviewRedirect(
+  // The undeclared case is stated HERE rather than resolved, because the guard
+  // exists to skip the document read: asking the resolver would load a Single
+  // only to be told what the missing declaration already says.
+  const outcome: PreviewPathOutcome = hasPreviewConfigured(declaration)
+    ? await explainSinglePreviewRedirect(
         { single, ...(locale === undefined ? {} : { locale }) },
         {
           loadSingle: loadSingleForPreview,
           ...sharedRedirectDeps(declaration),
         }
       )
-    : null;
+    : { kind: "refused", cause: "notConfigured" };
 
-  if (target === null) {
+  if (outcome.kind === "refused") {
     refuseUnservableLink({
       subject: "single",
       name: single,
-      declared: hasPreviewConfigured(declaration),
+      cause: outcome.cause,
     });
   }
 
@@ -691,8 +753,8 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   // Resolved through the SAME function the preview route will call, so the
   // answer here and the answer the reviewer gets cannot disagree. The entry is
   // already authorized at this point, which is why a trusted read is correct.
-  const target = hasPreviewConfigured(declaration)
-    ? await resolvePreviewRedirect(
+  const outcome: PreviewPathOutcome = hasPreviewConfigured(declaration)
+    ? await explainPreviewRedirect(
         { collection, entryId, ...(locale === undefined ? {} : { locale }) },
         {
           loadEntry: async (name, id, entryLocale) => {
@@ -715,13 +777,15 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
           ...sharedRedirectDeps(declaration),
         }
       )
-    : null;
+    : // Stated rather than resolved, so an undeclared collection costs no entry
+      // read to learn what the absent declaration already says.
+      { kind: "refused", cause: "notConfigured" };
 
-  if (target === null) {
+  if (outcome.kind === "refused") {
     refuseUnservableLink({
       subject: "collection",
       name: collection,
-      declared: hasPreviewConfigured(declaration),
+      cause: outcome.cause,
     });
   }
 

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -244,10 +244,18 @@ const REFUSALS: Record<
      * for a deletion that never happened is worse off than one told the read
      * failed.
      */
+    /*
+     * Deliberately NOT "a non-404 failure". A 404 CARRYING A CODE lands here
+     * too, because a thrown not-found — an `afterRead` hook refusing a
+     * dependent lookup — cannot be told apart from the document itself being
+     * absent. Describing this as necessarily non-404 sends an operator looking
+     * anywhere but the hook path that produced it.
+     */
     remedy:
-      "The trusted read returned a non-404 failure, so whether the document " +
-      "exists is unknown. Look at the read path — a transient database error, " +
-      "a rate limit, or a throwing read hook all arrive this way.",
+      "The trusted read failed without establishing that the previewed " +
+      "document is absent. Look at the read path — a transient database " +
+      "error, a rate limit, or a read hook raising not-found for something " +
+      "the document merely references all arrive this way.",
   },
   documentGone: {
     message: subject =>

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -34,6 +34,7 @@ import {
   explainPreviewRedirect,
   explainSinglePreviewRedirect,
   previewCallerAuthorized,
+  readOrReport,
   type PreviewPathOutcome,
   type PreviewRefusalCause,
 } from "../domains/collections/services/preview-redirect-resolver";
@@ -226,10 +227,16 @@ const REFUSALS: Record<
   }
 > = {
   documentUnreadable: {
-    message: (_subject, noun) =>
-      `This ${noun} could not be read just now, so a shared link would have ` +
-      "nowhere to open. Nothing is known to be wrong with it — please try " +
-      "again in a moment.",
+    /*
+     * The DOCUMENT, not the collection. What failed is the trusted read of one
+     * entry; the collection and its declaration were both read successfully a
+     * moment earlier. Naming the collection sends the editor to look at the
+     * wrong scope, which is the same misdirection this cause was added to stop.
+     */
+    message: subject =>
+      `This ${subject === "single" ? "single" : "entry"} could not be read ` +
+      "just now, so a shared link would have nowhere to open. Nothing is " +
+      "known to be wrong with it — please try again in a moment.",
     reason: "document-read-failed",
     /*
      * Deliberately NOT the deletion remedy. The read failed, which establishes
@@ -659,17 +666,12 @@ async function mintForSingle(
     ? await explainSinglePreviewRedirect(
         { single, ...(locale === undefined ? {} : { locale }) },
         {
-          // `findSingle` has no failure envelope — it either hands back the
-          // document or it does not — so this path can only ever report
-          // `absent`, never `unreadable`. Stated rather than inferred, because
-          // a reader comparing it with the entry loader beside it will notice
-          // the asymmetry and should know it is the API's, not an omission.
-          loadSingle: async (slug, singleLocale) => {
-            const document = await loadSingleForPreview(slug, singleLocale);
-            return document === null
-              ? { kind: "absent" }
-              : { kind: "document", document };
-          },
+          // `findSingle` reports failure by THROWING rather than by returning
+          // an envelope, so checking for `null` here saw neither absence nor a
+          // failed read — the throw simply travelled past, and the endpoint
+          // answered with a raw internal error instead of this refusal.
+          loadSingle: (slug, singleLocale) =>
+            readOrReport(() => loadSingleForPreview(slug, singleLocale)),
           ...sharedRedirectDeps(declaration),
         },
         // The gate above already required `update` on this Single, which is

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -33,7 +33,6 @@ import {
 import {
   explainPreviewRedirect,
   explainSinglePreviewRedirect,
-  previewCallerAuthorized,
   readFromEnvelope,
   readOrReport,
   type PreviewPathOutcome,
@@ -647,7 +646,7 @@ async function mintForSingle(
   // read below, so a refused caller reaches neither.
   refuseApiKeyMint(auth);
   const { user } = await callerFor(auth);
-  await assertSinglePreviewable(single, locale, user, {
+  const singleGrant = await assertSinglePreviewable(single, locale, user, {
     // The route above ran the coarse gate for `update` on this Single, so
     // repeating it here would ask a question already answered. The preview
     // RENDER passes `false`: it has no route gate at all.
@@ -675,10 +674,11 @@ async function mintForSingle(
             readOrReport(() => loadSingleForPreview(slug, singleLocale)),
           ...sharedRedirectDeps(declaration),
         },
-        // The gate above already required `update` on THIS Single, and the
-        // witness carries which one — so the grant proves the thing the
-        // explainer relies on rather than merely that somebody signed in.
-        previewCallerAuthorized(auth, { single })
+        // The grant the gate above RETURNED, rather than one assembled here:
+        // a witness built at the call site would assert the very thing the gate
+        // exists to establish, and would be accepted by a comparison against
+        // that same self-asserted value.
+        singleGrant
       )
     : { kind: "refused", cause: "notConfigured" };
 
@@ -761,7 +761,7 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
   // visible at all INCLUDING one never published, and whether this caller may
   // edit it — which is what the draft overlay requires before surfacing the
   // working draft the token hands out.
-  await assertEntryPreviewable(collection, entryId, user, {
+  const entryGrant = await assertEntryPreviewable(collection, entryId, user, {
     // The route above ran the coarse gate for `update` on this collection, so
     // repeating it here would ask a question already answered. The preview
     // RENDER passes `false`: it has no route gate at all.
@@ -824,11 +824,9 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
           // happens to have the answer.
           ...sharedRedirectDeps(declaration),
         },
-        // The route gate above already required `update` on THIS entry, so its
-        // holder learns nothing from a cause they could not read anyway — and
-        // the witness names the entry, so that claim is checked rather than
-        // assumed.
-        previewCallerAuthorized(auth, { collection, entryId })
+        // The grant `assertEntryPreviewable` returned. See the Single path:
+        // it cannot exist unless that gate passed for this exact document.
+        entryGrant
       )
     : // Stated rather than resolved, so an undeclared collection costs no entry
       // read to learn what the absent declaration already says.

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -229,10 +229,17 @@ const REFUSALS: Record<
       `This ${subject === "single" ? "single" : "entry"} could not be read, so ` +
       "a shared link would have nowhere to open. It may have been deleted.",
     reason: "has-no-readable-document",
+    /*
+     * The REQUEST, never "the token" — nothing has been signed at this point.
+     * This refusal is thrown before `respondWithPreviewLink`, so a log line
+     * saying a token names something would record a credential that was never
+     * issued, and an incident reader would go looking for it.
+     */
     remedy:
-      "The token names a document the resolver could not load. For an entry " +
-      "that usually means it was deleted; for a Single, that it was removed " +
-      "from the configuration.",
+      "The mint request named a document the resolver could not load. For an " +
+      "entry that usually means it was deleted between the authorization read " +
+      "and the resolver's own; for a Single, that it was removed from the " +
+      "configuration.",
   },
   notConfigured: {
     message: (_subject, noun) =>

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -33,6 +33,7 @@ import {
 import {
   explainPreviewRedirect,
   explainSinglePreviewRedirect,
+  previewCallerAuthorized,
   type PreviewPathOutcome,
   type PreviewRefusalCause,
 } from "../domains/collections/services/preview-redirect-resolver";
@@ -224,6 +225,23 @@ const REFUSALS: Record<
     remedy: string;
   }
 > = {
+  documentUnreadable: {
+    message: (_subject, noun) =>
+      `This ${noun} could not be read just now, so a shared link would have ` +
+      "nowhere to open. Nothing is known to be wrong with it — please try " +
+      "again in a moment.",
+    reason: "document-read-failed",
+    /*
+     * Deliberately NOT the deletion remedy. The read failed, which establishes
+     * nothing about whether the document exists, and an operator sent looking
+     * for a deletion that never happened is worse off than one told the read
+     * failed.
+     */
+    remedy:
+      "The trusted read returned a non-404 failure, so whether the document " +
+      "exists is unknown. Look at the read path — a transient database error, " +
+      "a rate limit, or a throwing read hook all arrive this way.",
+  },
   documentGone: {
     message: subject =>
       `This ${subject === "single" ? "single" : "entry"} could not be read, so ` +
@@ -641,9 +659,22 @@ async function mintForSingle(
     ? await explainSinglePreviewRedirect(
         { single, ...(locale === undefined ? {} : { locale }) },
         {
-          loadSingle: loadSingleForPreview,
+          // `findSingle` has no failure envelope — it either hands back the
+          // document or it does not — so this path can only ever report
+          // `absent`, never `unreadable`. Stated rather than inferred, because
+          // a reader comparing it with the entry loader beside it will notice
+          // the asymmetry and should know it is the API's, not an omission.
+          loadSingle: async (slug, singleLocale) => {
+            const document = await loadSingleForPreview(slug, singleLocale);
+            return document === null
+              ? { kind: "absent" }
+              : { kind: "document", document };
+          },
           ...sharedRedirectDeps(declaration),
-        }
+        },
+        // The gate above already required `update` on this Single, which is
+        // what makes naming a cause safe here.
+        previewCallerAuthorized(auth)
       )
     : { kind: "refused", cause: "notConfigured" };
 
@@ -774,15 +805,34 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
               ...(entryLocale === undefined ? {} : { locale: entryLocale }),
               includeWorkingDraft: true,
             });
-            return read.success && read.data !== null
-              ? (read.data as Record<string, unknown>)
-              : null;
+            /*
+             * A FAILED read is not an absent entry. Folding both into `null`
+             * made a transient database error, a rate limit or a throwing read
+             * hook arrive as "this may have been deleted" — telling an editor
+             * their work is gone while it sits there intact. Only a 404 is
+             * evidence of absence; every other failure means the question was
+             * not answered.
+             */
+            if (!read.success) {
+              return read.statusCode === 404
+                ? { kind: "absent" }
+                : { kind: "unreadable" };
+            }
+            return read.data === null
+              ? { kind: "absent" }
+              : {
+                  kind: "document",
+                  document: read.data as Record<string, unknown>,
+                };
           },
           // Already resolved above, so this hands back the value rather than
           // fetching it again — the resolver takes a loader and this call site
           // happens to have the answer.
           ...sharedRedirectDeps(declaration),
-        }
+        },
+        // The route gate above already required `update` on this entry, so its
+        // holder learns nothing from a cause they could not read anyway.
+        previewCallerAuthorized(auth)
       )
     : // Stated rather than resolved, so an undeclared collection costs no entry
       // read to learn what the absent declaration already says.

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -6,7 +6,9 @@
  * entry that was deleted, for a collection that declares no preview, and — the
  * one with teeth — for a host that is not the site's.
  */
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -47,12 +49,7 @@ const unreadable = () => vi.fn().mockResolvedValue({ kind: "unreadable" });
  * symbol behind the type is not exported, so no anonymous handler can conjure
  * one and reach a refusal cause.
  */
-const PRINCIPAL = {
-  userId: "u1",
-  permissions: [],
-  roles: [],
-  authMethod: "session" as const,
-};
+const PRINCIPAL = { id: "u1" };
 
 /** A grant for the entry `SCOPE` names, which is what most cases ask about. */
 const CALLER = previewCallerAuthorized(PRINCIPAL, SCOPE);
@@ -618,6 +615,31 @@ describe("readFromEnvelope, the one place a service result becomes an outcome", 
     });
   });
 
+  it("reads a 404 carrying a CODE as unreadable, not as absence", () => {
+    /*
+     * The pair the `code` check exists for. A thrown `NextlyError` reaches this
+     * envelope through `errorEnvelopeFields`, which always sets `code` — so an
+     * `afterRead` hook raising not-found for a DEPENDENT lookup arrives as a
+     * 404 while the previewed row loaded perfectly well. Calling that absence
+     * tells an author their entry may have been deleted because something it
+     * references was.
+     */
+    expect(
+      readFromEnvelope({
+        success: false,
+        statusCode: 404,
+        code: "NOT_FOUND",
+      })
+    ).toEqual({ kind: "unreadable" });
+
+    // The control, asserted beside it: a BARE 404 is the service's own
+    // not-found branch and still establishes absence, so the split is on
+    // provenance rather than the endpoint having stopped reporting deletions.
+    expect(readFromEnvelope({ success: false, statusCode: 404 })).toEqual({
+      kind: "absent",
+    });
+  });
+
   it("reads any other failure as unreadable", () => {
     expect(readFromEnvelope({ success: false, statusCode: 500 })).toEqual({
       kind: "unreadable",
@@ -787,26 +809,43 @@ describe("the authenticated boundary on the explaining form", () => {
     expect(singleWitnessIsExact).toBe(true);
   });
 
-  it("mints proof only from a full authenticated context, not a bare id", () => {
+  it("is minted from exactly ONE module, the authorization gate", () => {
     /*
-     * The anonymous preview route holds a plausible user id — a verified token
-     * records its minter — so a constructor asking only for `{ userId }` could
-     * be called there with a REAL value and would read as reasonable. Pinning
-     * the whole authenticated shape is what makes that call an obvious
-     * fabrication instead, and pinning it EXACTLY is what stops the requirement
-     * being quietly narrowed back to an id.
+     * THE control, and the reason the parameter shape no longer is one.
+     *
+     * An earlier version demanded the whole route-auth shape on the theory that
+     * an anonymous handler could not produce it — a proxy for "you
+     * authenticated", and a weak one, because any handler can assemble an
+     * object literal and the anonymous preview route holds a real user id to
+     * put in it. What establishes the claim is provenance: the grant is
+     * returned by `assertEntryPreviewable` / `assertSinglePreviewable` after
+     * their refusals have all been passed FOR THIS DOCUMENT, so one cannot
+     * exist unless the gate ran and allowed it.
+     *
+     * A second importer would quietly restore the self-asserted grant, so this
+     * asserts the whole importer set rather than that some particular module is
+     * absent — a test naming one module passes for every module it does not
+     * name.
      */
-    const demandsAuthenticatedContext: Exactly<
-      Parameters<typeof previewCallerAuthorized>[0],
-      {
-        userId: string;
-        permissions: string[];
-        roles: string[];
-        authMethod: "session" | "api-key";
-      }
-    > = true;
+    const root = new URL("../../../../", import.meta.url);
+    const importers = execFileSync(
+      "grep",
+      ["-rl", "--include=*.ts", "previewCallerAuthorized", fileURLToPath(root)],
+      { encoding: "utf8" }
+    )
+      .split("\n")
+      .filter(Boolean)
+      .map(p => p.slice(fileURLToPath(root).length))
+      .filter(p => !p.includes("__tests__") && !p.endsWith(".test.ts"))
+      .sort();
 
-    expect(demandsAuthenticatedContext).toBe(true);
+    // Control: the search found something, so an empty list cannot pass by
+    // having looked in the wrong place.
+    expect(importers.length).toBeGreaterThan(0);
+    expect(importers).toEqual([
+      "api/preview-access.ts",
+      "domains/collections/services/preview-redirect-resolver.ts",
+    ]);
   });
 
   it("refuses to mint proof without an authenticated identity", () => {
@@ -814,15 +853,7 @@ describe("the authenticated boundary on the explaining form", () => {
     // no principal cannot satisfy it with a placeholder.
     let thrown: unknown;
     try {
-      previewCallerAuthorized(
-        {
-          userId: "",
-          permissions: [],
-          roles: [],
-          authMethod: "session",
-        },
-        SCOPE
-      );
+      previewCallerAuthorized({ id: "" }, SCOPE);
     } catch (error) {
       thrown = error;
     }

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -9,6 +9,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import {
+  explainPreviewRedirect,
+  explainSinglePreviewRedirect,
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
   type PreviewRedirectDeps,
@@ -271,5 +273,180 @@ describe("resolveSinglePreviewRedirect", () => {
     expect(await resolveSinglePreviewRedirect({ single: "homepage" }, d)).toBe(
       "/about"
     );
+  });
+});
+
+/**
+ * Every refusal, as the deps that produce it.
+ *
+ * A table because the pair of assertions below has to run over the SAME set:
+ * one says each cause is named, the other says none of them is visible from
+ * the route. Two hand-written lists would agree on the day they were written,
+ * and the one that fell behind would be the one facing the public.
+ */
+const CAUSES: ReadonlyArray<{
+  cause: string;
+  why: string;
+  deps: () => PreviewRedirectDeps;
+}> = [
+  {
+    cause: "documentGone",
+    why: "the entry was deleted between minting and clicking",
+    deps: () => deps({ loadEntry: vi.fn().mockResolvedValue(null) }),
+  },
+  {
+    cause: "notConfigured",
+    why: "the collection declares no preview at all",
+    deps: () => deps({ loadDeclaration: vi.fn().mockResolvedValue(undefined) }),
+  },
+  {
+    cause: "unavailable",
+    why: "declared, but this document has no slug yet",
+    deps: () =>
+      deps({ loadEntry: vi.fn().mockResolvedValue({ id: "entry-1" }) }),
+  },
+  {
+    cause: "foreignOrigin",
+    why: "the declaration named another site",
+    deps: () =>
+      deps({
+        loadDeclaration: vi
+          .fn()
+          .mockResolvedValue({ url: () => "https://elsewhere.test/about" }),
+      }),
+  },
+  {
+    cause: "unresolvable",
+    why: "a protocol-relative path escapes this origin",
+    deps: () =>
+      deps({
+        loadSiteUrl: vi.fn().mockResolvedValue(null),
+        loadDeclaration: vi
+          .fn()
+          .mockResolvedValue({ url: () => "//evil.test" }),
+      }),
+  },
+  {
+    cause: "unresolvable",
+    why: "an absolute url arrives with no origin to compare it against",
+    /*
+     * The branch reached only when BOTH origins are missing: no site URL is
+     * configured AND the caller passed no request origin, while the declaration
+     * returned something absolute. There is then nothing to judge the target
+     * against, which is not the same as judging it and finding it foreign —
+     * conflating the two would tell a developer their preview URL points at
+     * another site when in fact nothing was configured to compare it to.
+     */
+    deps: () =>
+      deps({
+        loadSiteUrl: vi.fn().mockResolvedValue(null),
+        loadDeclaration: vi
+          .fn()
+          .mockResolvedValue({ url: () => "https://anywhere.test/about" }),
+      }),
+  },
+];
+
+describe("explainPreviewRedirect", () => {
+  it.each(CAUSES)("names $cause when $why", async ({ cause, deps: build }) => {
+    expect(await explainPreviewRedirect(SCOPE, build())).toEqual({
+      kind: "refused",
+      cause,
+    });
+  });
+
+  it("answers a path when there is one", async () => {
+    // The control for the table above: these are refusals rather than a
+    // function that refuses everything put to it.
+    expect(await explainPreviewRedirect(SCOPE, deps())).toEqual({
+      kind: "path",
+      path: "/about",
+    });
+  });
+});
+
+describe("the route sees ONE refusal, whatever the cause", () => {
+  /*
+   * The security property, and the reason `resolvePreviewRedirect` was kept
+   * rather than replaced. The preview route answers `null` with the same 404 an
+   * invalid token gets, so a stranger must not be able to tell a deleted entry
+   * from an unconfigured collection from one whose slug is merely empty. The
+   * moment any cause reaches that caller, the endpoint is an oracle for which
+   * documents exist in draft.
+   */
+  it.each(CAUSES)(
+    "collapses $cause to a bare null",
+    async ({ deps: build }) => {
+      expect(await resolvePreviewRedirect(SCOPE, build())).toBeNull();
+    }
+  );
+
+  it("returns the path when there is one, so null MEANS refused", async () => {
+    // Without this the assertions above are satisfied by a function that
+    // returns null unconditionally — which would pass while telling a visitor
+    // nothing and a valid preview nothing either.
+    expect(await resolvePreviewRedirect(SCOPE, deps())).toBe("/about");
+  });
+
+  it("gives every cause a byte-identical answer", async () => {
+    // Stronger than each being null on its own: it is the INDISTINGUISHABILITY
+    // that matters, so the set of distinct answers must have exactly one member.
+    const answers = await Promise.all(
+      CAUSES.map(c => resolvePreviewRedirect(SCOPE, c.deps()))
+    );
+    expect(new Set(answers).size).toBe(1);
+    expect(answers).toHaveLength(CAUSES.length);
+  });
+});
+
+describe("explainSinglePreviewRedirect", () => {
+  function singleDeps(
+    overrides: Partial<SinglePreviewRedirectDeps> = {}
+  ): SinglePreviewRedirectDeps {
+    return {
+      loadSingle: vi.fn().mockResolvedValue({ path: "welcome" }),
+      loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
+      loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
+      ...overrides,
+    };
+  }
+
+  it("names documentGone when the Single was removed from the config", async () => {
+    expect(
+      await explainSinglePreviewRedirect(
+        { single: "homepage" },
+        singleDeps({ loadSingle: vi.fn().mockResolvedValue(null) })
+      )
+    ).toEqual({ kind: "refused", cause: "documentGone" });
+  });
+
+  it("names foreignOrigin rather than blaming the document", async () => {
+    // The case the editor can do nothing about, and the one they were
+    // previously told to fix by filling in a slug.
+    expect(
+      await explainSinglePreviewRedirect(
+        { single: "homepage" },
+        singleDeps({
+          loadDeclaration: vi
+            .fn()
+            .mockResolvedValue({ url: () => "https://elsewhere.test/" }),
+        })
+      )
+    ).toEqual({ kind: "refused", cause: "foreignOrigin" });
+  });
+
+  it("answers a path when there is one", async () => {
+    expect(
+      await explainSinglePreviewRedirect({ single: "homepage" }, singleDeps())
+    ).toEqual({ kind: "path", path: "/" });
+  });
+
+  it("still collapses to null for the route", async () => {
+    expect(
+      await resolveSinglePreviewRedirect(
+        { single: "homepage" },
+        singleDeps({ loadSingle: vi.fn().mockResolvedValue(null) })
+      )
+    ).toBeNull();
   });
 });

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -17,6 +17,7 @@ import {
   explainPreviewRedirect,
   explainSinglePreviewRedirect,
   previewCallerAuthorized,
+  readFromEnvelope,
   readOrReport,
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
@@ -46,11 +47,19 @@ const unreadable = () => vi.fn().mockResolvedValue({ kind: "unreadable" });
  * symbol behind the type is not exported, so no anonymous handler can conjure
  * one and reach a refusal cause.
  */
-const CALLER = previewCallerAuthorized({
+const PRINCIPAL = {
   userId: "u1",
   permissions: [],
   roles: [],
-  authMethod: "session",
+  authMethod: "session" as const,
+};
+
+/** A grant for the entry `SCOPE` names, which is what most cases ask about. */
+const CALLER = previewCallerAuthorized(PRINCIPAL, SCOPE);
+
+/** A grant for the Single the Single cases ask about. */
+const SINGLE_CALLER = previewCallerAuthorized(PRINCIPAL, {
+  single: "homepage",
 });
 
 /**
@@ -472,6 +481,7 @@ describe("what this module lets anyone reach", () => {
       "explainPreviewRedirect",
       "explainSinglePreviewRedirect",
       "previewCallerAuthorized",
+      "readFromEnvelope",
       "readOrReport",
       "resolvePreviewRedirect",
       "resolveSinglePreviewRedirect",
@@ -507,6 +517,132 @@ describe("what the ANONYMOUS preview path is wired to", () => {
       expect(source).not.toMatch(/\bexplainSinglePreviewRedirect\b/);
       expect(source).not.toMatch(/\bpreviewCallerAuthorized\b/);
     }
+  });
+});
+
+describe("who decides which envelope means absent", () => {
+  it("is decided here, and not re-decided by either loader", () => {
+    /*
+     * The mint and the anonymous route both read entries through a service
+     * envelope, and each used to map it itself. Two copies of one decision
+     * agree until one is edited — and these two would then disagree about the
+     * SAME entry, minting a link the route refuses. A source-level assertion
+     * rather than a behavioural one because the defect IS the second copy: both
+     * behaved identically the day it was written.
+     */
+    const loaders = [
+      "../../../../api/preview-links.ts",
+      "../../../../runtime/preview/preview-route-defaults.ts",
+    ];
+
+    for (const relative of loaders) {
+      const source = readFileSync(new URL(relative, import.meta.url), "utf8");
+      // Control: a mistyped path reads as "" and would let this pass having
+      // examined nothing.
+      expect(source.length).toBeGreaterThan(0);
+      expect(source).toMatch(/\breadFromEnvelope\b/);
+      expect(source).not.toMatch(/statusCode === 404/);
+    }
+  });
+});
+
+describe("a grant covers ONE document, not the holder", () => {
+  /*
+   * `requireRouteAuthentication` returns a full `AuthContext` without consulting
+   * any permission — it exists for handlers doing their own per-resource
+   * filtering — so a witness that demanded only that shape would be obtainable
+   * by any signed-in account, including one with no access to the document it
+   * then asked about. The grant names its document, and the façade compares.
+   */
+  it("refuses a question about a DIFFERENT entry", async () => {
+    const forAnotherEntry = previewCallerAuthorized(PRINCIPAL, {
+      collection: "pages",
+      entryId: "entry-2",
+    });
+
+    await expect(
+      explainPreviewRedirect(SCOPE, deps(), forAnotherEntry)
+    ).rejects.toThrow();
+  });
+
+  it("refuses a question about a different COLLECTION", async () => {
+    // Same entry id, different collection: ids are not unique across them, so
+    // comparing only the id would let a grant travel between collections.
+    const forAnotherCollection = previewCallerAuthorized(PRINCIPAL, {
+      collection: "posts",
+      entryId: "entry-1",
+    });
+
+    await expect(
+      explainPreviewRedirect(SCOPE, deps(), forAnotherCollection)
+    ).rejects.toThrow();
+  });
+
+  it("refuses a Single's grant on a collection question, and the reverse", async () => {
+    await expect(
+      explainPreviewRedirect(SCOPE, deps(), SINGLE_CALLER)
+    ).rejects.toThrow();
+
+    await expect(
+      explainSinglePreviewRedirect(
+        { single: "homepage" },
+        {
+          loadSingle: reads({ path: "welcome" }),
+          loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
+          loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
+        },
+        CALLER
+      )
+    ).rejects.toThrow();
+  });
+
+  it("ALLOWS the document the grant names", async () => {
+    // The control for all four refusals above: a matching grant works, so the
+    // comparison discriminates rather than rejecting everything.
+    expect(await explainPreviewRedirect(SCOPE, deps(), CALLER)).toEqual({
+      kind: "path",
+      path: "/about",
+    });
+  });
+});
+
+describe("readFromEnvelope, the one place a service result becomes an outcome", () => {
+  /*
+   * One translator because this is a single decision. Two copies would agree
+   * until one was edited, and the mint and the anonymous route would then
+   * disagree about the SAME entry — minting a link the route refuses.
+   */
+  it("reads a 404 envelope as absence", () => {
+    expect(readFromEnvelope({ success: false, statusCode: 404 })).toEqual({
+      kind: "absent",
+    });
+  });
+
+  it("reads any other failure as unreadable", () => {
+    expect(readFromEnvelope({ success: false, statusCode: 500 })).toEqual({
+      kind: "unreadable",
+    });
+  });
+
+  it("reads a failure with NO status as unreadable rather than absent", () => {
+    // Absence has to be established. An envelope that reports failure without
+    // saying how is not evidence the document is gone.
+    expect(readFromEnvelope({ success: false })).toEqual({
+      kind: "unreadable",
+    });
+  });
+
+  it("reads a success carrying no document as absence", () => {
+    expect(readFromEnvelope({ success: true, data: null })).toEqual({
+      kind: "absent",
+    });
+    expect(readFromEnvelope({ success: true })).toEqual({ kind: "absent" });
+  });
+
+  it("hands back the document when there is one", () => {
+    expect(
+      readFromEnvelope({ success: true, data: { id: "7", slug: "seven" } })
+    ).toEqual({ kind: "document", document: { id: "7", slug: "seven" } });
   });
 });
 
@@ -678,12 +814,15 @@ describe("the authenticated boundary on the explaining form", () => {
     // no principal cannot satisfy it with a placeholder.
     let thrown: unknown;
     try {
-      previewCallerAuthorized({
-        userId: "",
-        permissions: [],
-        roles: [],
-        authMethod: "session",
-      });
+      previewCallerAuthorized(
+        {
+          userId: "",
+          permissions: [],
+          roles: [],
+          authMethod: "session",
+        },
+        SCOPE
+      );
     } catch (error) {
       thrown = error;
     }
@@ -756,7 +895,7 @@ describe("explainSinglePreviewRedirect", () => {
       await explainSinglePreviewRedirect(
         { single: "homepage" },
         singleDeps({ loadSingle: absent() }),
-        CALLER
+        SINGLE_CALLER
       )
     ).toEqual({ kind: "refused", cause: "documentGone" });
   });
@@ -772,7 +911,7 @@ describe("explainSinglePreviewRedirect", () => {
             .fn()
             .mockResolvedValue({ url: () => "https://elsewhere.test/" }),
         }),
-        CALLER
+        SINGLE_CALLER
       )
     ).toEqual({ kind: "refused", cause: "foreignOrigin" });
   });
@@ -782,7 +921,7 @@ describe("explainSinglePreviewRedirect", () => {
       await explainSinglePreviewRedirect(
         { single: "homepage" },
         singleDeps(),
-        CALLER
+        SINGLE_CALLER
       )
     ).toEqual({ kind: "path", path: "/" });
   });

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -902,6 +902,67 @@ describe("the authenticated boundary on the explaining form", () => {
     ]);
   });
 
+  it("is not reachable from any of the package's PUBLIC entry points", () => {
+    /*
+     * The importer scan above is a syntax search over this package's own
+     * sources, and on its own it would miss the escape that matters: a barrel
+     * adding `export * from "…/preview-redirect-resolver"` puts the constructor
+     * on the public API, after which an application outside the scanned tree
+     * can self-mint a grant for any scope — and every assertion above stays
+     * green, because nothing inside `src` gained a reference.
+     *
+     * So the entry points are checked directly, DERIVED from `package.json`
+     * rather than listed here: a new export map entry is covered the day it is
+     * added, which a hand-written list would not be.
+     *
+     * What this reaches is a direct re-export from an entry point, which is the
+     * shape a barrel takes. It does not walk the full resolved graph — a chain
+     * through an intermediate barrel would evade it — and that limit is stated
+     * rather than left for someone to discover.
+     */
+    const pkgRoot = new URL("../../../../../", import.meta.url);
+    const pkg = JSON.parse(
+      readFileSync(new URL("package.json", pkgRoot), "utf8")
+    ) as { exports?: Record<string, { import?: string }> };
+
+    /*
+     * From `import`, not `types`. They do not always name the same module —
+     * `./field-catalog` declares `dist/field-catalog.d.ts` beside
+     * `dist/collections/fields/catalog.mjs` — and the runtime entry is the one
+     * that decides what an application can actually import.
+     */
+    const entrySources = Object.values(pkg.exports ?? {})
+      .map(e => e.import)
+      .filter((i): i is string => typeof i === "string")
+      .map(i => i.replace(/^\.\/dist\//, "src/").replace(/\.mjs$/, ".ts"));
+
+    // Control: the export map was read and produced entries, so an empty list
+    // cannot certify a package whose manifest this failed to parse.
+    expect(entrySources.length).toBeGreaterThan(0);
+
+    const reachable = entrySources.filter(rel => {
+      let source: string;
+      try {
+        source = readFileSync(new URL(rel, pkgRoot), "utf8");
+      } catch {
+        try {
+          // A bundled entry may be a directory index rather than a file.
+          source = readFileSync(
+            new URL(rel.replace(/\.ts$/, "/index.ts"), pkgRoot),
+            "utf8"
+          );
+        } catch {
+          // An entry whose source is nowhere the map implies is not evidence of
+          // safety; surface it by name rather than skipping it.
+          return true;
+        }
+      }
+      return /preview-redirect-resolver|previewCallerAuthorized/.test(source);
+    });
+
+    expect(reachable).toEqual([]);
+  });
+
   it("refuses to mint proof without an authenticated identity", () => {
     // The witness CARRIES the id rather than discarding it, so a handler with
     // no principal cannot satisfy it with a placeholder.

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -8,10 +8,14 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { NextlyError } from "../../../../errors/nextly-error";
+
+import * as resolverModule from "../preview-redirect-resolver";
 import {
   explainPreviewRedirect,
   explainSinglePreviewRedirect,
   previewCallerAuthorized,
+  readOrReport,
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
   type PreviewRedirectDeps,
@@ -429,39 +433,127 @@ describe("explainPreviewRedirect", () => {
   });
 });
 
-describe("the authenticated boundary on the explaining form", () => {
-  /*
-   * A COMPILE-TIME assertion, which is the only kind that can state this.
-   *
-   * The property is "an anonymous handler cannot reach a refusal cause", and
-   * nothing at runtime enforces it — the docblock that used to be the whole
-   * control is exactly what AGENTS.md means by a documented rule with nothing
-   * behind it. `@ts-expect-error` fails the build when the line it guards
-   * COMPILES, so this test goes red the moment the witness stops being
-   * required. That is the control, and the assertions below are incidental.
-   */
-  it("will not compile without proof the caller was authorized", async () => {
-    // @ts-expect-error - omitting the witness must not typecheck.
-    const withoutProof = explainPreviewRedirect(SCOPE, deps());
-    // @ts-expect-error - and the same for the Single façade beside it.
-    const singleWithoutProof = explainSinglePreviewRedirect(
-      { single: "homepage" },
-      {
-        loadSingle: reads({ path: "welcome" }),
-        loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
-        loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
-      }
-    );
+describe("what this module lets anyone reach", () => {
+  it("exports exactly these, and nothing else that hands out a cause", () => {
+    /*
+     * A MANIFEST rather than a check that one function is private, because the
+     * property is about every path to a refusal cause and not about the one
+     * that was found. `reduceToSitePath` became a bypass the moment its return
+     * type changed from `string | null` to the detailed outcome — it was still
+     * exported, and nothing noticed. This fails when the surface changes at
+     * all, so a new export has to be considered rather than merely added.
+     *
+     * The two `explain*` façades are on the list because they demand a witness;
+     * `readOrReport` and `previewCallerAuthorized` carry no cause at all.
+     */
+    expect(Object.keys(resolverModule).sort()).toEqual([
+      "explainPreviewRedirect",
+      "explainSinglePreviewRedirect",
+      "previewCallerAuthorized",
+      "readOrReport",
+      "resolvePreviewRedirect",
+      "resolveSinglePreviewRedirect",
+    ]);
+  });
+});
 
-    // Awaited so neither becomes an unhandled rejection; the values are not the
-    // point, the two lines above failing to compile is.
-    await expect(withoutProof).resolves.toBeDefined();
-    await expect(singleWithoutProof).resolves.toBeDefined();
+describe("readOrReport, for loaders that throw instead of returning", () => {
+  /*
+   * The Direct API has no failure envelope: `findSingle` throws for every
+   * unsuccessful result. A loader that only checked for `null` produced neither
+   * `absent` nor `unreadable` — the throw travelled straight past it, and the
+   * endpoint answered with a raw internal error instead of the refusal it had
+   * prepared. These cases exist because a mock returning `null` cannot
+   * reproduce that contract, so the suite agreed with an implementation
+   * production never runs.
+   */
+  it("reads a 404 as absence, because that status DOES establish it", async () => {
+    const notFound = new NextlyError({
+      code: "NOT_FOUND",
+      statusCode: 404,
+      publicMessage: "No such single",
+    });
+
+    expect(await readOrReport(() => Promise.reject(notFound))).toEqual({
+      kind: "absent",
+    });
   });
 
-  it("compiles and answers WITH the witness, so the refusal above is about the proof", async () => {
-    // The control: the same call is fine once authorized, so `@ts-expect-error`
-    // above is catching the missing witness rather than some unrelated error.
+  it("reads any other failure as unreadable, never as absence", async () => {
+    const boom = new NextlyError({
+      code: "INTERNAL_ERROR",
+      statusCode: 500,
+      publicMessage: "Database unavailable",
+    });
+
+    expect(await readOrReport(() => Promise.reject(boom))).toEqual({
+      kind: "unreadable",
+    });
+  });
+
+  it("reads a non-Nextly throw as unreadable rather than assuming anything", async () => {
+    // A driver error or a bug in a read hook arrives as a plain Error with no
+    // status at all. Guessing absence from it would be the same wrong
+    // diagnosis reached by a different route.
+    expect(
+      await readOrReport(() => Promise.reject(new Error("socket hang up")))
+    ).toEqual({ kind: "unreadable" });
+  });
+
+  it("still reads a returned null as absence", async () => {
+    expect(await readOrReport(() => Promise.resolve(null))).toEqual({
+      kind: "absent",
+    });
+  });
+
+  it("hands back the document when there is one", async () => {
+    // The control: it is a translator, not a function that reports failure
+    // whatever it is given.
+    expect(
+      await readOrReport(() => Promise.resolve({ path: "welcome" }))
+    ).toEqual({ kind: "document", document: { path: "welcome" } });
+  });
+});
+
+describe("the authenticated boundary on the explaining form", () => {
+  /*
+   * The parameter SHAPE, asserted two ways, and neither is a suppressed error.
+   *
+   * A blanket directive would accept ANY diagnostic on the line beneath it, so
+   * an unrelated signature or fixture mistake keeps the purported contract
+   * green while proving nothing about the witness. Both assertions below name
+   * exactly what is expected instead.
+   */
+  it("takes the witness as a positional parameter of its own", () => {
+    /*
+     * Four: scope, deps, caller, requestOrigin. A TypeScript `?` compiles to an
+     * ordinary parameter with no default, so `Function.length` counts it —
+     * which means this is 4 while the witness is present and 3 the moment it is
+     * removed. Evaluated at run time, and unlike a blanket directive it cannot
+     * be satisfied by an unrelated error somewhere else in the file.
+     */
+    expect(explainPreviewRedirect).toHaveLength(4);
+    expect(explainSinglePreviewRedirect).toHaveLength(4);
+  });
+
+  it("types that parameter as the proof only previewCallerAuthorized mints", () => {
+    /*
+     * A compile-time assertion that names its type. If the third parameter
+     * stopped being `AuthorizedPreviewCaller` — widened to `unknown`, reordered,
+     * or dropped — these assignments stop typechecking, and `check-types` fails
+     * on THIS line rather than somewhere a directive happened to be pointing.
+     */
+    const witness: Parameters<typeof explainPreviewRedirect>[2] = CALLER;
+    const singleWitness: Parameters<typeof explainSinglePreviewRedirect>[2] =
+      CALLER;
+
+    expect(witness).toBe(CALLER);
+    expect(singleWitness).toBe(CALLER);
+  });
+
+  it("answers normally once the witness is supplied", async () => {
+    // The control: the boundary refuses the missing proof rather than the
+    // function being unusable.
     expect(await explainPreviewRedirect(SCOPE, deps(), CALLER)).toEqual({
       kind: "path",
       path: "/about",

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -593,6 +593,60 @@ describe("a grant covers ONE document, not the holder", () => {
     ).rejects.toThrow();
   });
 
+  it("refuses a grant for a DIFFERENT translation of the same Single", async () => {
+    /*
+     * `assertSinglePreviewable` runs a locale-specific readable check, so a
+     * grant naming only the Single would claim more than was verified — an `en`
+     * grant answering for `fr`, whose custom read rule may deny it. The locale
+     * travels in the grant and the comparison asks for it.
+     */
+    const forEnglish = previewCallerAuthorized(PRINCIPAL, {
+      single: "homepage",
+      locale: "en",
+    });
+
+    await expect(
+      explainSinglePreviewRedirect(
+        { single: "homepage", locale: "fr" },
+        {
+          loadSingle: reads({ path: "accueil" }),
+          loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
+          loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
+        },
+        forEnglish
+      )
+    ).rejects.toThrow();
+  });
+
+  it("ALLOWS the translation the grant names", async () => {
+    // The control: the refusal above is about the locale rather than the
+    // comparison having stopped accepting anything.
+    const forFrench = previewCallerAuthorized(PRINCIPAL, {
+      single: "homepage",
+      locale: "fr",
+    });
+
+    expect(
+      await explainSinglePreviewRedirect(
+        { single: "homepage", locale: "fr" },
+        {
+          loadSingle: reads({ path: "accueil" }),
+          loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
+          loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
+        },
+        forFrench
+      )
+    ).toEqual({ kind: "path", path: "/" });
+  });
+
+  it("still covers an UNLOCALIZED Single, where neither side names a locale", () => {
+    // Both undefined must match, or every unlocalized Single would be refused
+    // for a precondition nothing establishes.
+    expect(() =>
+      previewCallerAuthorized(PRINCIPAL, { single: "homepage" })
+    ).not.toThrow();
+  });
+
   it("ALLOWS the document the grant names", async () => {
     // The control for all four refusals above: a matching grant works, so the
     // comparison discriminates rather than rejecting everything.

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -7,8 +7,16 @@
  * one with teeth — for a host that is not the site's.
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { describe, expect, it, vi } from "vitest";
 
@@ -902,6 +910,95 @@ describe("the authenticated boundary on the explaining form", () => {
     ]);
   });
 
+  /**
+   * Every module reachable from `entries` by `export *` that EXPORTS the
+   * constructor, relative to `root`.
+   *
+   * Only `export *` recurses, because only it propagates names the author did
+   * not write down: a named re-export exposes exactly the identifiers in its
+   * clause, which the export test below reads in place. A module that merely
+   * IMPORTS the constructor to call it exposes nothing, so it is not followed —
+   * otherwise every consumer would be reported and the boundary assertion would
+   * fail on correct code.
+   *
+   * A module the map names and the tree does not have is reported rather than
+   * skipped: an entry whose source cannot be found is not evidence of safety.
+   */
+  function modulesExportingTheConstructor(
+    root: URL,
+    entries: string[]
+  ): string[] {
+    const declaresIt =
+      /export\s+(?:async\s+)?(?:function|const|let|var|class|type|interface)\s+previewCallerAuthorized\b/;
+    const listsIt = /export\s*\{[^}]*\bpreviewCallerAuthorized\b[^}]*\}/;
+
+    /*
+     * Returns WHERE the module was found as well as its text. A bundled entry
+     * may be a directory index rather than a file, and a relative specifier
+     * inside it resolves against that directory — so resolving children against
+     * the name that was asked for sends the walk one level too high and every
+     * module it names comes back missing.
+     */
+    const readModule = (rel: string): { at: string; source: string } | null => {
+      for (const at of [rel, rel.replace(/\.ts$/, "/index.ts")]) {
+        try {
+          return { at, source: readFileSync(new URL(at, root), "utf8") };
+        } catch {
+          continue;
+        }
+      }
+      return null;
+    };
+
+    const seen = new Set<string>();
+    const found: string[] = [];
+
+    const walk = (rel: string): void => {
+      if (seen.has(rel)) return;
+      seen.add(rel);
+
+      const module = readModule(rel);
+      if (module === null) {
+        found.push(rel);
+        return;
+      }
+
+      /*
+       * Comments are removed before anything is matched. This package's own
+       * `src/index.ts` documents its barrel chain by quoting the statements
+       * verbatim, so a scan over raw text follows a specifier that no module
+       * actually re-exports — and reports the file it fails to find as a
+       * reachable one.
+       */
+      const source = module.source
+        .replace(/\/\*[\s\S]*?\*\//g, "")
+        .replace(/\/\/[^\n]*/g, "");
+      const { at } = module;
+      if (declaresIt.test(source) || listsIt.test(source)) {
+        found.push(at);
+        return;
+      }
+
+      const stars = source.matchAll(
+        /export\s+\*(?:\s+as\s+\w+)?\s+from\s*["']([^"']+)["']/g
+      );
+      for (const [, spec] of stars) {
+        if (spec === undefined || !spec.startsWith(".")) continue;
+        const href = new URL(spec, new URL(at, root)).href.slice(
+          root.href.length
+        );
+        walk(
+          /\.[cm]?[jt]s$/.test(href)
+            ? href.replace(/\.[cm]?js$/, ".ts")
+            : `${href}.ts`
+        );
+      }
+    };
+
+    for (const entry of entries) walk(entry);
+    return found.sort();
+  }
+
   it("is not reachable from any of the package's PUBLIC entry points", () => {
     /*
      * The importer scan above is a syntax search over this package's own
@@ -915,10 +1012,9 @@ describe("the authenticated boundary on the explaining form", () => {
      * rather than listed here: a new export map entry is covered the day it is
      * added, which a hand-written list would not be.
      *
-     * What this reaches is a direct re-export from an entry point, which is the
-     * shape a barrel takes. It does not walk the full resolved graph — a chain
-     * through an intermediate barrel would evade it — and that limit is stated
-     * rather than left for someone to discover.
+     * The walk is TRANSITIVE, so an intermediate barrel is followed rather than
+     * ending the search: an entry re-exporting a barrel that re-exports the
+     * module reaches the same verdict a direct re-export does.
      */
     const pkgRoot = new URL("../../../../../", import.meta.url);
     const pkg = JSON.parse(
@@ -940,27 +1036,61 @@ describe("the authenticated boundary on the explaining form", () => {
     // cannot certify a package whose manifest this failed to parse.
     expect(entrySources.length).toBeGreaterThan(0);
 
-    const reachable = entrySources.filter(rel => {
-      let source: string;
-      try {
-        source = readFileSync(new URL(rel, pkgRoot), "utf8");
-      } catch {
-        try {
-          // A bundled entry may be a directory index rather than a file.
-          source = readFileSync(
-            new URL(rel.replace(/\.ts$/, "/index.ts"), pkgRoot),
-            "utf8"
-          );
-        } catch {
-          // An entry whose source is nowhere the map implies is not evidence of
-          // safety; surface it by name rather than skipping it.
-          return true;
-        }
-      }
-      return /preview-redirect-resolver|previewCallerAuthorized/.test(source);
-    });
+    expect(modulesExportingTheConstructor(pkgRoot, entrySources)).toEqual([]);
+  });
 
-    expect(reachable).toEqual([]);
+  it("follows a chain of barrels rather than stopping at the first", () => {
+    /*
+     * The instrument's own control. The assertion above passes when the walk
+     * reports nothing, and a walk that reports nothing under any circumstances
+     * satisfies it perfectly — so the walker is run against a tree whose answer
+     * is known and required to NAME the module it should find.
+     *
+     * The fixture carries both halves of the discrimination:
+     *   entry -> barrel -> leaf     re-exported, must be reported
+     *   entry -> uses               imports and calls it, must NOT be reported
+     *   entry's COMMENTS            quote both forms, must NOT be followed
+     *
+     * The second separates re-export from ordinary use. Every module consuming
+     * the constructor mentions its name, so a walker matching on the name alone
+     * would report the whole call graph and the real assertion above would fail
+     * on correct code.
+     *
+     * The third names a module that does not exist, so following it produces a
+     * report of an unreadable file — the shape a missing entry takes, arriving
+     * from a module nobody re-exports.
+     */
+    const dir = mkdtempSync(join(tmpdir(), "preview-export-walk-"));
+    try {
+      const root = pathToFileURL(`${dir}/`);
+      mkdirSync(join(dir, "barrel"));
+      writeFileSync(
+        join(dir, "entry.ts"),
+        'export * from "./barrel/index.js";\n' +
+          'export * from "./uses.js";\n' +
+          '// export * from "./ghost.js";\n' +
+          '/* export { previewCallerAuthorized } from "./ghost.js"; */\n'
+      );
+      writeFileSync(
+        join(dir, "barrel", "index.ts"),
+        'export * from "../leaf.js";\n'
+      );
+      writeFileSync(
+        join(dir, "leaf.ts"),
+        "export function previewCallerAuthorized() {}\n"
+      );
+      writeFileSync(
+        join(dir, "uses.ts"),
+        'import { previewCallerAuthorized } from "./leaf.js";\n' +
+          "export const call = () => previewCallerAuthorized();\n"
+      );
+
+      expect(modulesExportingTheConstructor(root, ["entry.ts"])).toEqual([
+        "leaf.ts",
+      ]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it("refuses to mint proof without an authenticated identity", () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   explainPreviewRedirect,
   explainSinglePreviewRedirect,
+  previewCallerAuthorized,
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
   type PreviewRedirectDeps,
@@ -19,11 +20,32 @@ import {
 
 const SCOPE = { collection: "pages", entryId: "entry-1" };
 
+/**
+ * Loaders on the discriminated read shape.
+ *
+ * Named rather than spelled out at each site because the three cases are the
+ * point: a loader that folds a FAILED read into "no such document" is what made
+ * a database hiccup arrive as "this may have been deleted".
+ */
+const reads = (document: Record<string, unknown>) =>
+  vi.fn().mockResolvedValue({ kind: "document", document });
+const absent = () => vi.fn().mockResolvedValue({ kind: "absent" });
+const unreadable = () => vi.fn().mockResolvedValue({ kind: "unreadable" });
+
+/**
+ * Proof of authorization, which the explaining façades demand.
+ *
+ * Obtainable only from `previewCallerAuthorized`, which is the control: the
+ * symbol behind the type is not exported, so no anonymous handler can conjure
+ * one and reach a refusal cause.
+ */
+const CALLER = previewCallerAuthorized({ userId: "u1" });
+
 function deps(
   overrides: Partial<PreviewRedirectDeps> = {}
 ): PreviewRedirectDeps {
   return {
-    loadEntry: vi.fn().mockResolvedValue({ id: "entry-1", slug: "about" }),
+    loadEntry: reads({ id: "entry-1", slug: "about" }),
     loadDeclaration: vi.fn().mockResolvedValue({ urlTemplate: "/{slug}" }),
     loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
     ...overrides,
@@ -36,9 +58,7 @@ describe("resolvePreviewRedirect", () => {
   // link redirects to a different translation — and the draft gate, which does
   // carry the locale, then refuses the very draft the link was minted for.
   it("reads the entry in the locale the token names", async () => {
-    const loadEntry = vi
-      .fn()
-      .mockResolvedValue({ id: "entry-1", slug: "a-propos" });
+    const loadEntry = reads({ id: "entry-1", slug: "a-propos" });
     const d = deps({ loadEntry });
 
     await resolvePreviewRedirect({ ...SCOPE, locale: "fr" }, d);
@@ -47,9 +67,7 @@ describe("resolvePreviewRedirect", () => {
   });
 
   it("passes no locale when the token names none", async () => {
-    const loadEntry = vi
-      .fn()
-      .mockResolvedValue({ id: "entry-1", slug: "about" });
+    const loadEntry = reads({ id: "entry-1", slug: "about" });
     const d = deps({ loadEntry });
 
     await resolvePreviewRedirect(SCOPE, d);
@@ -89,7 +107,7 @@ describe("resolvePreviewRedirect", () => {
   // A link outlives what it points at: the entry can be deleted between minting
   // and clicking, which is a refusal rather than a fault.
   it("returns null when the entry no longer exists", async () => {
-    const d = deps({ loadEntry: vi.fn().mockResolvedValue(null) });
+    const d = deps({ loadEntry: absent() });
 
     expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
   });
@@ -101,7 +119,7 @@ describe("resolvePreviewRedirect", () => {
   });
 
   it("returns null when a template placeholder has no value yet", async () => {
-    const d = deps({ loadEntry: vi.fn().mockResolvedValue({ id: "entry-1" }) });
+    const d = deps({ loadEntry: reads({ id: "entry-1" }) });
 
     expect(await resolvePreviewRedirect(SCOPE, d)).toBeNull();
   });
@@ -194,7 +212,7 @@ describe("resolveSinglePreviewRedirect", () => {
     overrides: Partial<SinglePreviewRedirectDeps> = {}
   ): SinglePreviewRedirectDeps {
     return {
-      loadSingle: vi.fn().mockResolvedValue({ path: "welcome" }),
+      loadSingle: reads({ path: "welcome" }),
       loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
       loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
       ...overrides,
@@ -208,7 +226,7 @@ describe("resolveSinglePreviewRedirect", () => {
   });
 
   it("reads the Single in the locale the token names", async () => {
-    const loadSingle = vi.fn().mockResolvedValue({ path: "accueil" });
+    const loadSingle = reads({ path: "accueil" });
 
     await resolveSinglePreviewRedirect(
       { single: "homepage", locale: "fr" },
@@ -243,7 +261,7 @@ describe("resolveSinglePreviewRedirect", () => {
   // A Single is not deleted the way an entry is, but it can be dropped from the
   // configuration — and a link minted before that points at nothing.
   it("returns null when the Single can no longer be read", async () => {
-    const d = singleDeps({ loadSingle: vi.fn().mockResolvedValue(null) });
+    const d = singleDeps({ loadSingle: absent() });
 
     expect(
       await resolveSinglePreviewRedirect({ single: "homepage" }, d)
@@ -292,7 +310,12 @@ const CAUSES: ReadonlyArray<{
   {
     cause: "documentGone",
     why: "the entry was deleted between minting and clicking",
-    deps: () => deps({ loadEntry: vi.fn().mockResolvedValue(null) }),
+    deps: () => deps({ loadEntry: absent() }),
+  },
+  {
+    cause: "documentUnreadable",
+    why: "the read itself failed, so absence was never established",
+    deps: () => deps({ loadEntry: unreadable() }),
   },
   {
     cause: "notConfigured",
@@ -302,8 +325,7 @@ const CAUSES: ReadonlyArray<{
   {
     cause: "unavailable",
     why: "declared, but this document has no slug yet",
-    deps: () =>
-      deps({ loadEntry: vi.fn().mockResolvedValue({ id: "entry-1" }) }),
+    deps: () => deps({ loadEntry: reads({ id: "entry-1" }) }),
   },
   {
     cause: "foreignOrigin",
@@ -367,7 +389,7 @@ const CAUSES: ReadonlyArray<{
 
 describe("explainPreviewRedirect", () => {
   it.each(CAUSES)("names $cause when $why", async ({ cause, deps: build }) => {
-    expect(await explainPreviewRedirect(SCOPE, build())).toEqual({
+    expect(await explainPreviewRedirect(SCOPE, build(), CALLER)).toEqual({
       kind: "refused",
       cause,
     });
@@ -376,7 +398,71 @@ describe("explainPreviewRedirect", () => {
   it("answers a path when there is one", async () => {
     // The control for the table above: these are refusals rather than a
     // function that refuses everything put to it.
-    expect(await explainPreviewRedirect(SCOPE, deps())).toEqual({
+    expect(await explainPreviewRedirect(SCOPE, deps(), CALLER)).toEqual({
+      kind: "path",
+      path: "/about",
+    });
+  });
+
+  it("does not report a failed read as a deletion", async () => {
+    /*
+     * The two are a pair, so they are asserted as a pair: each alone would pass
+     * against an implementation that returned the same cause for both. A read
+     * that failed establishes nothing about whether the document exists, and
+     * telling an editor their entry may have been deleted because the database
+     * hiccuped is the wrong-diagnosis failure this type exists to end.
+     */
+    const gone = await explainPreviewRedirect(
+      SCOPE,
+      deps({ loadEntry: absent() }),
+      CALLER
+    );
+    const failed = await explainPreviewRedirect(
+      SCOPE,
+      deps({ loadEntry: unreadable() }),
+      CALLER
+    );
+
+    expect(gone).toEqual({ kind: "refused", cause: "documentGone" });
+    expect(failed).toEqual({ kind: "refused", cause: "documentUnreadable" });
+    expect(gone).not.toEqual(failed);
+  });
+});
+
+describe("the authenticated boundary on the explaining form", () => {
+  /*
+   * A COMPILE-TIME assertion, which is the only kind that can state this.
+   *
+   * The property is "an anonymous handler cannot reach a refusal cause", and
+   * nothing at runtime enforces it — the docblock that used to be the whole
+   * control is exactly what AGENTS.md means by a documented rule with nothing
+   * behind it. `@ts-expect-error` fails the build when the line it guards
+   * COMPILES, so this test goes red the moment the witness stops being
+   * required. That is the control, and the assertions below are incidental.
+   */
+  it("will not compile without proof the caller was authorized", async () => {
+    // @ts-expect-error - omitting the witness must not typecheck.
+    const withoutProof = explainPreviewRedirect(SCOPE, deps());
+    // @ts-expect-error - and the same for the Single façade beside it.
+    const singleWithoutProof = explainSinglePreviewRedirect(
+      { single: "homepage" },
+      {
+        loadSingle: reads({ path: "welcome" }),
+        loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
+        loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
+      }
+    );
+
+    // Awaited so neither becomes an unhandled rejection; the values are not the
+    // point, the two lines above failing to compile is.
+    await expect(withoutProof).resolves.toBeDefined();
+    await expect(singleWithoutProof).resolves.toBeDefined();
+  });
+
+  it("compiles and answers WITH the witness, so the refusal above is about the proof", async () => {
+    // The control: the same call is fine once authorized, so `@ts-expect-error`
+    // above is catching the missing witness rather than some unrelated error.
+    expect(await explainPreviewRedirect(SCOPE, deps(), CALLER)).toEqual({
       kind: "path",
       path: "/about",
     });
@@ -422,7 +508,7 @@ describe("explainSinglePreviewRedirect", () => {
     overrides: Partial<SinglePreviewRedirectDeps> = {}
   ): SinglePreviewRedirectDeps {
     return {
-      loadSingle: vi.fn().mockResolvedValue({ path: "welcome" }),
+      loadSingle: reads({ path: "welcome" }),
       loadDeclaration: vi.fn().mockResolvedValue({ url: () => "/" }),
       loadSiteUrl: vi.fn().mockResolvedValue("https://site.example"),
       ...overrides,
@@ -433,7 +519,8 @@ describe("explainSinglePreviewRedirect", () => {
     expect(
       await explainSinglePreviewRedirect(
         { single: "homepage" },
-        singleDeps({ loadSingle: vi.fn().mockResolvedValue(null) })
+        singleDeps({ loadSingle: absent() }),
+        CALLER
       )
     ).toEqual({ kind: "refused", cause: "documentGone" });
   });
@@ -448,14 +535,19 @@ describe("explainSinglePreviewRedirect", () => {
           loadDeclaration: vi
             .fn()
             .mockResolvedValue({ url: () => "https://elsewhere.test/" }),
-        })
+        }),
+        CALLER
       )
     ).toEqual({ kind: "refused", cause: "foreignOrigin" });
   });
 
   it("answers a path when there is one", async () => {
     expect(
-      await explainSinglePreviewRedirect({ single: "homepage" }, singleDeps())
+      await explainSinglePreviewRedirect(
+        { single: "homepage" },
+        singleDeps(),
+        CALLER
+      )
     ).toEqual({ kind: "path", path: "/" });
   });
 
@@ -463,7 +555,7 @@ describe("explainSinglePreviewRedirect", () => {
     expect(
       await resolveSinglePreviewRedirect(
         { single: "homepage" },
-        singleDeps({ loadSingle: vi.fn().mockResolvedValue(null) })
+        singleDeps({ loadSingle: absent() })
       )
     ).toBeNull();
   });

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -328,6 +328,24 @@ const CAUSES: ReadonlyArray<{
   },
   {
     cause: "unresolvable",
+    why: "the configured site URL does not parse",
+    /*
+     * The `catch` branch, which the other two `unresolvable` cases do not
+     * reach: one is rejected by `siteRelativePath` and the other returns before
+     * any parsing happens. An absolute declaration URL skips the `noSiteUrl`
+     * path entirely, so the first thing to throw is `new URL(comparisonOrigin)`
+     * on the unparseable setting.
+     */
+    deps: () =>
+      deps({
+        loadSiteUrl: vi.fn().mockResolvedValue("not a url"),
+        loadDeclaration: vi
+          .fn()
+          .mockResolvedValue({ url: () => "https://site.example/about" }),
+      }),
+  },
+  {
+    cause: "unresolvable",
     why: "an absolute url arrives with no origin to compare it against",
     /*
      * The branch reached only when BOTH origins are missing: no site URL is

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-redirect-resolver.test.ts
@@ -6,6 +6,8 @@
  * entry that was deleted, for a collection that declares no preview, and — the
  * one with teeth — for a host that is not the site's.
  */
+import { readFileSync } from "node:fs";
+
 import { describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../../../../errors/nextly-error";
@@ -18,6 +20,7 @@ import {
   readOrReport,
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
+  type AuthorizedPreviewCaller,
   type PreviewRedirectDeps,
   type SinglePreviewRedirectDeps,
 } from "../preview-redirect-resolver";
@@ -43,7 +46,26 @@ const unreadable = () => vi.fn().mockResolvedValue({ kind: "unreadable" });
  * symbol behind the type is not exported, so no anonymous handler can conjure
  * one and reach a refusal cause.
  */
-const CALLER = previewCallerAuthorized({ userId: "u1" });
+const CALLER = previewCallerAuthorized({
+  userId: "u1",
+  permissions: [],
+  roles: [],
+  authMethod: "session",
+});
+
+/**
+ * Are these two types EXACTLY the same, in both directions?
+ *
+ * Assignability alone is one-directional: `CALLER` assigns happily to
+ * `unknown` and to `AuthorizedPreviewCaller | undefined`, so an assignment test
+ * stays green through precisely the widening it exists to catch. The
+ * conditional-on-a-generic-signature trick is the standard way to ask for
+ * identity rather than compatibility.
+ */
+type Exactly<X, Y> =
+  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2
+    ? true
+    : false;
 
 function deps(
   overrides: Partial<PreviewRedirectDeps> = {}
@@ -457,6 +479,37 @@ describe("what this module lets anyone reach", () => {
   });
 });
 
+describe("what the ANONYMOUS preview path is wired to", () => {
+  it("never reaches an explaining façade", () => {
+    /*
+     * The witness makes the wrong call awkward; this makes it visible. Within
+     * one package no value is unforgeable against code that means to forge one,
+     * so the boundary needs a second control that reads the anonymous side
+     * directly rather than trusting it to ask nicely.
+     *
+     * These modules serve requests carrying no session — the preview route and
+     * the loaders it is built from — and a refusal cause reaching any of them
+     * is the draft-existence oracle the flattening wrapper exists to prevent.
+     */
+    const anonymous = [
+      "../../../../runtime/preview/preview-route-defaults.ts",
+      "../../../../runtime/preview/preview-route.ts",
+      "../../../../runtime/preview/preview-draft-gate.ts",
+      "../../../../runtime/preview/preview-single-draft-gate.ts",
+    ];
+
+    for (const relative of anonymous) {
+      const source = readFileSync(new URL(relative, import.meta.url), "utf8");
+      // A control first: reading the wrong path returns "" and would let every
+      // assertion below pass by having examined nothing.
+      expect(source.length).toBeGreaterThan(0);
+      expect(source).not.toMatch(/\bexplainPreviewRedirect\b/);
+      expect(source).not.toMatch(/\bexplainSinglePreviewRedirect\b/);
+      expect(source).not.toMatch(/\bpreviewCallerAuthorized\b/);
+    }
+  });
+});
+
 describe("readOrReport, for loaders that throw instead of returning", () => {
   /*
    * The Direct API has no failure envelope: `findSingle` throws for every
@@ -498,6 +551,28 @@ describe("readOrReport, for loaders that throw instead of returning", () => {
     expect(
       await readOrReport(() => Promise.reject(new Error("socket hang up")))
     ).toEqual({ kind: "unreadable" });
+  });
+
+  it("recognises a not-found thrown by ANOTHER copy of this package", async () => {
+    /*
+     * Next.js and Turbopack duplicate ESM modules — `getCachedNextly` keeps the
+     * instance on `globalThis` for exactly that reason — so an error raised by
+     * one copy is not `instanceof` the class as this copy sees it. Under
+     * `instanceof` a removed Single would be reported as a transient read
+     * failure, telling an author to retry something that can never succeed.
+     *
+     * This object carries the registry-shared brand and the code, which is what
+     * the structural guard reads, and is deliberately NOT a NextlyError.
+     */
+    const fromAnotherCopy = Object.assign(new Error("No such single"), {
+      [Symbol.for("nextly/NextlyError")]: true,
+      code: "NOT_FOUND",
+    });
+    expect(fromAnotherCopy).not.toBeInstanceOf(NextlyError);
+
+    expect(await readOrReport(() => Promise.reject(fromAnotherCopy))).toEqual({
+      kind: "absent",
+    });
   });
 
   it("still reads a returned null as absence", async () => {
@@ -549,6 +624,75 @@ describe("the authenticated boundary on the explaining form", () => {
 
     expect(witness).toBe(CALLER);
     expect(singleWitness).toBe(CALLER);
+  });
+
+  it("types that parameter as EXACTLY the branded proof, not merely something it fits", () => {
+    /*
+     * Bidirectional, because assignability is not the property. Widen that
+     * parameter to `unknown` or to `AuthorizedPreviewCaller | undefined` and
+     * `CALLER` still assigns, the runtime identity still holds and the arity is
+     * unchanged — so the one-way assignment above returns green from both the
+     * correct implementation and the widening it was written to catch. It stays
+     * as a readable statement of intent; THIS is the assertion with teeth.
+     *
+     * Both constants are typed `true`, so any widening resolves `Exactly<…>` to
+     * `false` and `check-types` fails on this line.
+     */
+    const entryWitnessIsExact: Exactly<
+      Parameters<typeof explainPreviewRedirect>[2],
+      AuthorizedPreviewCaller
+    > = true;
+    const singleWitnessIsExact: Exactly<
+      Parameters<typeof explainSinglePreviewRedirect>[2],
+      AuthorizedPreviewCaller
+    > = true;
+
+    expect(entryWitnessIsExact).toBe(true);
+    expect(singleWitnessIsExact).toBe(true);
+  });
+
+  it("mints proof only from a full authenticated context, not a bare id", () => {
+    /*
+     * The anonymous preview route holds a plausible user id — a verified token
+     * records its minter — so a constructor asking only for `{ userId }` could
+     * be called there with a REAL value and would read as reasonable. Pinning
+     * the whole authenticated shape is what makes that call an obvious
+     * fabrication instead, and pinning it EXACTLY is what stops the requirement
+     * being quietly narrowed back to an id.
+     */
+    const demandsAuthenticatedContext: Exactly<
+      Parameters<typeof previewCallerAuthorized>[0],
+      {
+        userId: string;
+        permissions: string[];
+        roles: string[];
+        authMethod: "session" | "api-key";
+      }
+    > = true;
+
+    expect(demandsAuthenticatedContext).toBe(true);
+  });
+
+  it("refuses to mint proof without an authenticated identity", () => {
+    // The witness CARRIES the id rather than discarding it, so a handler with
+    // no principal cannot satisfy it with a placeholder.
+    let thrown: unknown;
+    try {
+      previewCallerAuthorized({
+        userId: "",
+        permissions: [],
+        roles: [],
+        authMethod: "session",
+      });
+    } catch (error) {
+      thrown = error;
+    }
+
+    // Asserted on the LOG message and the code rather than on what a caller
+    // would see: the public text is deliberately generic, because tripping this
+    // is a handler's mistake and not something the requester can act on.
+    expect(NextlyError.isCode(thrown, "INTERNAL_ERROR")).toBe(true);
+    expect((thrown as NextlyError).logMessage).toMatch(/authenticated caller/i);
   });
 
   it("answers normally once the witness is supplied", async () => {

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-url-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-url-resolver.test.ts
@@ -98,9 +98,12 @@ describe("resolvePreviewUrl", () => {
     ).toEqual({ status: "unavailable" });
   });
 
-  it("reports unavailable when the authored function throws", () => {
+  it("separates a THROWN declaration from one that declines", () => {
     // User code runs inside a request here. A throw is the collection failing to
-    // produce a URL, not the server failing, so it must not escape as a 500.
+    // produce a URL, not the server failing, so it must not escape as a 500 —
+    // and not as `unavailable` either, which tells the editor to fill in the
+    // field the URL is built from. A declaration that throws does so for every
+    // document, so no field on this one is the remedy.
     expect(
       resolvePreviewUrl({
         preview: {
@@ -111,8 +114,30 @@ describe("resolvePreviewUrl", () => {
         entry: {},
         siteUrl: SITE,
       })
+    ).toEqual({ status: "declarationFailed" });
+
+    // The control: the same declaration DECLINING is still `unavailable`, so
+    // the assertion above is about the throw rather than about this shape of
+    // call answering `declarationFailed` whatever it does.
+    expect(
+      resolvePreviewUrl({
+        preview: { url: () => null },
+        entry: {},
+        siteUrl: SITE,
+      })
     ).toEqual({ status: "unavailable" });
   });
+
+  /*
+   * The resolver's other `declarationFailed` producer — a candidate that fails
+   * to parse — has NO test, and that is stated rather than left as a gap for
+   * someone to read as coverage. The candidate is built by prefixing the site's
+   * own origin and path, so it always begins with a URL the parser already
+   * accepted, and no authored path reaches the failure: `/../../elsewhere`
+   * normalises to the site's root instead. The guard stays because reachability
+   * is a property of that composition rather than of the function, and it costs
+   * nothing to hold.
+   */
 
   it("reports unavailable when a template placeholder has no value yet", () => {
     for (const slug of [undefined, null, ""]) {

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -193,7 +193,15 @@ export type PreviewRefusalCause =
   /** The declaration named a different origin than the site is served from. */
   | "foreignOrigin"
   /** A URL that would not parse, or a path that escapes this origin. */
-  | "unresolvable";
+  | "unresolvable"
+  /**
+   * The declaration threw, or produced pieces that do not compose into a URL.
+   *
+   * Kept apart from `unavailable` for the reason that type exists: one is an
+   * empty field on this document and the other is broken code, and only the
+   * first is something the editor holding the document can act on.
+   */
+  | "declarationFailed";
 
 /** A site-relative path, or the reason there is not one. */
 export type PreviewPathOutcome =

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -46,6 +46,36 @@ export type PreviewDocumentRead =
   | { kind: "unreadable" };
 
 /**
+ * A service ENVELOPE reduced to one of the three outcomes.
+ *
+ * One translator, called by every loader that reads through a service result,
+ * because this is a single decision — which envelope means the document is
+ * absent — and two copies of it agree only until one is edited. They would
+ * then disagree about the SAME entry: the mint would hand out a link the route
+ * refuses, or the two would diagnose one read differently. That the rule is
+ * currently `statusCode === 404` is exactly why it belongs in one place; the
+ * day it becomes the envelope's canonical code instead, it moves once.
+ *
+ * `undefined` data counts as absent alongside `null`: a success envelope that
+ * carries no document is not a document, and a loader reading `data` off a
+ * partially-populated result must not present that as one.
+ */
+export function readFromEnvelope(read: {
+  success: boolean;
+  statusCode?: number;
+  data?: unknown;
+}): PreviewDocumentRead {
+  if (!read.success) {
+    return read.statusCode === 404
+      ? { kind: "absent" }
+      : { kind: "unreadable" };
+  }
+  return read.data === null || read.data === undefined
+    ? { kind: "absent" }
+    : { kind: "document", document: read.data as Record<string, unknown> };
+}
+
+/**
  * A read whose failures arrive as THROWN errors, as one of the three outcomes.
  *
  * The Direct API does not hand back a failure envelope: `findSingle` throws for
@@ -56,8 +86,8 @@ export type PreviewDocumentRead =
  *
  * Written ONCE and shared by every caller with a throwing loader, because two
  * copies of "which status counts as absent" agree until one is edited. Only a
- * 404 is evidence of absence; anything else means the question went unanswered,
- * which is the same rule the entry loader applies to its envelope.
+ * not-found is evidence of absence; anything else means the question went
+ * unanswered, which is the same rule {@link readFromEnvelope} applies.
  */
 export async function readOrReport(
   load: () => Promise<Record<string, unknown> | null>
@@ -201,9 +231,35 @@ function pathOrNull(outcome: PreviewPathOutcome): string | null {
  */
 const AUTHORIZED_PREVIEW_CALLER = Symbol("nextly.preview.authorizedCaller");
 
-/** Proof that the caller was authorized before a refusal reason was handed over. */
+/**
+ * The one document a witness was granted for.
+ *
+ * A grant is per-DOCUMENT because that is what the mint checks: `update` on
+ * this entry, or on this Single. A witness that named only its holder would
+ * claim something broader than anything was ever verified.
+ */
+export type AuthorizedPreviewScope =
+  | { collection: string; entryId: string }
+  | { single: string };
+
+/**
+ * Proof that the caller was authorized FOR THIS DOCUMENT before a refusal
+ * reason was handed over.
+ *
+ * The scope travels inside the proof because authentication is not the property
+ * being relied on. `requireRouteAuthentication` returns a full `AuthContext`
+ * without consulting a single permission — it exists for handlers that do their
+ * own per-resource filtering — so a witness demanding only that shape would be
+ * obtainable by any signed-in account, including one with no access to the
+ * document it then asked about. The explainer's whole premise is that its
+ * caller could already read this draft; the witness now carries the fact that
+ * makes that true.
+ */
 export interface AuthorizedPreviewCaller {
-  readonly [AUTHORIZED_PREVIEW_CALLER]: string;
+  readonly [AUTHORIZED_PREVIEW_CALLER]: {
+    userId: string;
+    scope: AuthorizedPreviewScope;
+  };
 }
 
 /**
@@ -226,12 +282,15 @@ export interface AuthorizedPreviewCaller {
  * path cannot be reached by accident — which, with the export manifest beside
  * it, is the enforcement this boundary can actually have.
  */
-export function previewCallerAuthorized(auth: {
-  userId: string;
-  permissions: string[];
-  roles: string[];
-  authMethod: "session" | "api-key";
-}): AuthorizedPreviewCaller {
+export function previewCallerAuthorized(
+  auth: {
+    userId: string;
+    permissions: string[];
+    roles: string[];
+    authMethod: "session" | "api-key";
+  },
+  authorizedFor: AuthorizedPreviewScope
+): AuthorizedPreviewCaller {
   if (auth.userId === "") {
     /*
      * The public message stays generic and the detail goes to the log: reaching
@@ -246,7 +305,43 @@ export function previewCallerAuthorized(auth: {
         "previewCallerAuthorized requires the authenticated caller's id",
     });
   }
-  return { [AUTHORIZED_PREVIEW_CALLER]: auth.userId };
+  return {
+    [AUTHORIZED_PREVIEW_CALLER]: { userId: auth.userId, scope: authorizedFor },
+  };
+}
+
+/**
+ * Refuse a witness granted for some OTHER document.
+ *
+ * Checked rather than trusted, because the grant and the question are supplied
+ * by the same caller and nothing else compares them. Without this the witness
+ * would still only prove "was authorized for something", and a handler holding
+ * a grant for a document it may read could ask about one it may not.
+ *
+ * A throw rather than a refusal outcome: this is a handler passing mismatched
+ * arguments, not a document that cannot be previewed, and answering it with a
+ * refusal cause would hide a bug behind a legitimate-looking response.
+ */
+function assertGrantCovers(
+  caller: AuthorizedPreviewCaller,
+  asked: AuthorizedPreviewScope
+): void {
+  const granted = caller[AUTHORIZED_PREVIEW_CALLER].scope;
+  const covers =
+    "single" in asked
+      ? "single" in granted && granted.single === asked.single
+      : "collection" in granted &&
+        granted.collection === asked.collection &&
+        granted.entryId === asked.entryId;
+
+  if (!covers) {
+    throw new NextlyError({
+      code: "INTERNAL_ERROR",
+      publicMessage: "An unexpected error occurred.",
+      logMessage:
+        "a preview refusal was asked for a document the caller's grant does not cover",
+    });
+  }
 }
 
 /**
@@ -263,8 +358,13 @@ export async function explainPreviewRedirect(
   caller: AuthorizedPreviewCaller,
   requestOrigin?: string
 ): Promise<PreviewPathOutcome> {
-  // The parameter IS the control; nothing is read from it.
-  void caller;
+  // READ, not merely required. A witness nobody inspects proves only that the
+  // caller could construct one, which is a weaker claim than the explainer
+  // relies on.
+  assertGrantCovers(caller, {
+    collection: scope.collection,
+    entryId: scope.entryId,
+  });
   return computePreviewRedirect(scope, deps, requestOrigin);
 }
 
@@ -479,8 +579,9 @@ export async function explainSinglePreviewRedirect(
   caller: AuthorizedPreviewCaller,
   requestOrigin?: string
 ): Promise<PreviewPathOutcome> {
-  // The parameter IS the control; nothing is read from it.
-  void caller;
+  // See {@link explainPreviewRedirect}: the grant is compared against the
+  // document actually being asked about, not merely presented.
+  assertGrantCovers(caller, { single: scope.single });
   return computeSinglePreviewRedirect(scope, deps, requestOrigin);
 }
 

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -68,7 +68,15 @@ export async function readOrReport(
       ? { kind: "absent" }
       : { kind: "document", document };
   } catch (error) {
-    return error instanceof NextlyError && error.statusCode === 404
+    /*
+     * The STRUCTURAL guard, not `instanceof`. The cached instance lives on
+     * `globalThis` precisely because Next.js and Turbopack duplicate ESM
+     * modules, so an error thrown by one copy of this package fails an
+     * `instanceof` check performed in another — and a removed Single would then
+     * be reported as a transient read failure, telling an author to retry
+     * something that will never succeed.
+     */
+    return NextlyError.isNotFound(error)
       ? { kind: "absent" }
       : { kind: "unreadable" };
   }
@@ -195,20 +203,50 @@ const AUTHORIZED_PREVIEW_CALLER = Symbol("nextly.preview.authorizedCaller");
 
 /** Proof that the caller was authorized before a refusal reason was handed over. */
 export interface AuthorizedPreviewCaller {
-  readonly [AUTHORIZED_PREVIEW_CALLER]: true;
+  readonly [AUTHORIZED_PREVIEW_CALLER]: string;
 }
 
 /**
- * Mint that proof. Call ONLY after the caller's own grant has been checked.
+ * Mint that proof, from an AUTHENTICATED context and nothing less.
  *
- * Takes the principal rather than nothing at all, so the witness cannot be
- * conjured by a handler that never authorized anybody.
+ * The parameter is the whole shape `requireRoutePermission` and
+ * `requireRouteCollectionAccess` return, not just an id. That matters because
+ * the anonymous preview route DOES hold a plausible id — a verified token
+ * carries its minter — so a witness asking only for `{ userId }` could be built
+ * there from a real value and would look entirely reasonable in review. Nothing
+ * on that path has permissions, roles or an auth method, so demanding them
+ * turns a natural-looking call into an obvious fabrication.
+ *
+ * The identity is CARRIED rather than discarded, and an empty one is refused:
+ * a witness that reads nothing from its argument is a witness that would accept
+ * anything shaped vaguely right.
+ *
+ * Within one package no value is unforgeable against code that means to forge
+ * it. What this buys is that the honest path is the easy one and the dishonest
+ * path cannot be reached by accident — which, with the export manifest beside
+ * it, is the enforcement this boundary can actually have.
  */
 export function previewCallerAuthorized(auth: {
   userId: string;
+  permissions: string[];
+  roles: string[];
+  authMethod: "session" | "api-key";
 }): AuthorizedPreviewCaller {
-  void auth;
-  return { [AUTHORIZED_PREVIEW_CALLER]: true };
+  if (auth.userId === "") {
+    /*
+     * The public message stays generic and the detail goes to the log: reaching
+     * this is a programming mistake in a handler, not something the person
+     * making the request can act on, and naming the boundary in a response
+     * would describe an internal control to whoever tripped it.
+     */
+    throw new NextlyError({
+      code: "INTERNAL_ERROR",
+      publicMessage: "An unexpected error occurred.",
+      logMessage:
+        "previewCallerAuthorized requires the authenticated caller's id",
+    });
+  }
+  return { [AUTHORIZED_PREVIEW_CALLER]: auth.userId };
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -59,19 +59,74 @@ export interface PreviewRedirectScope {
 }
 
 /**
+ * Why a document has no preview path, when it has none.
+ *
+ * Every member names a DIFFERENT person and a different next action, which is
+ * the whole reason they are separate values. A missing declaration is a
+ * developer's job; a document that cannot be addressed yet is usually one empty
+ * field the editor can fill; a foreign origin is a settings or declaration
+ * problem that no field on the entry will ever fix. Collapsing them meant the
+ * editor was told to fill in a slug that was already correct.
+ */
+export type PreviewRefusalCause =
+  /** The document the token names is gone, or was never readable. */
+  | "documentGone"
+  /** No `preview.url` or `urlTemplate` on this collection or Single at all. */
+  | "notConfigured"
+  /** Declared, but it yields no address for THIS document yet — usually an empty slug. */
+  | "unavailable"
+  /** The declaration named a different origin than the site is served from. */
+  | "foreignOrigin"
+  /** A URL that would not parse, or a path that escapes this origin. */
+  | "unresolvable";
+
+/** A site-relative path, or the reason there is not one. */
+export type PreviewPathOutcome =
+  | { kind: "path"; path: string }
+  | { kind: "refused"; cause: PreviewRefusalCause };
+
+/**
  * The site-relative path a preview token should land on, or `null` to refuse.
  *
- * `null` is not an error channel. The preview route answers it with exactly the
- * 404 an invalid token gets, which is what keeps the endpoint from becoming an
- * oracle for which entries exist in draft: a stranger must not be able to tell
- * a deleted entry from one that was never previewable from one whose token was
- * forged.
+ * `null` is not an error channel, and this function exists to keep it that way.
+ * The preview route answers `null` with exactly the 404 an invalid token gets,
+ * which is what stops the endpoint becoming an oracle for which entries exist
+ * in draft: a stranger must not be able to tell a deleted entry from one that
+ * was never previewable from one whose token was forged.
+ *
+ * So the flattening lives HERE, in one place, DERIVED from
+ * {@link explainPreviewRedirect} rather than computed beside it. The route goes
+ * on calling this and cannot leak a cause even by accident, while the
+ * authenticated mint path — where the caller already holds `update` on the
+ * document and learns nothing by being told why — calls the explaining form.
+ * Two functions each deciding when to refuse would agree until one was edited,
+ * and the one that drifted would be the one facing the public.
  */
 export async function resolvePreviewRedirect(
   scope: PreviewRedirectScope,
   deps: PreviewRedirectDeps,
   requestOrigin?: string
 ): Promise<string | null> {
+  return pathOrNull(await explainPreviewRedirect(scope, deps, requestOrigin));
+}
+
+/** The one place an outcome becomes the route's deliberately uninformative `null`. */
+function pathOrNull(outcome: PreviewPathOutcome): string | null {
+  return outcome.kind === "path" ? outcome.path : null;
+}
+
+/**
+ * The same answer as {@link resolvePreviewRedirect}, saying why when it refuses.
+ *
+ * For AUTHENTICATED callers only. The cause distinguishes documents a stranger
+ * must not be able to tell apart, so handing it to an anonymous request would
+ * rebuild the oracle the `null` above exists to prevent.
+ */
+export async function explainPreviewRedirect(
+  scope: PreviewRedirectScope,
+  deps: PreviewRedirectDeps,
+  requestOrigin?: string
+): Promise<PreviewPathOutcome> {
   const [entry, preview, siteUrl] = await Promise.all([
     // The locale the token names, not the site's default. A localized entry's
     // slug lives in its companion row, so reading without one resolves the
@@ -85,7 +140,7 @@ export async function resolvePreviewRedirect(
 
   // A link outlives what it points at: an entry can be deleted between minting
   // and clicking, and that is a refusal rather than a fault.
-  if (entry === null) return null;
+  if (entry === null) return { kind: "refused", cause: "documentGone" };
 
   return reduceToSitePath({ preview, document: entry, siteUrl, requestOrigin });
 }
@@ -109,7 +164,7 @@ export function reduceToSitePath({
   document: Record<string, unknown>;
   siteUrl: string | null;
   requestOrigin?: string;
-}): string | null {
+}): PreviewPathOutcome {
   const resolution = resolvePreviewUrl({ preview, entry: document, siteUrl });
 
   // `noSiteUrl` is ACCEPTED here, and it is the case that matters most: having
@@ -123,10 +178,20 @@ export function reduceToSitePath({
   // the origin it is standing on. Refusing here would make preview depend on a
   // settings field it never reads.
   if (resolution.status === "noSiteUrl") {
-    return siteRelativePath(resolution.path);
+    const path = siteRelativePath(resolution.path);
+    return path === null
+      ? { kind: "refused", cause: "unresolvable" }
+      : { kind: "path", path };
   }
 
-  if (resolution.status !== "resolved") return null;
+  // The two remaining non-resolved statuses are kept APART rather than folded
+  // into one refusal, because they are the pair this whole return type exists
+  // for: `notConfigured` is a collection nobody has declared a preview for, and
+  // `unavailable` is a declared collection whose document has no address YET.
+  // The first is a developer's job and the second is usually one empty field.
+  if (resolution.status !== "resolved") {
+    return { kind: "refused", cause: resolution.status };
+  }
 
   // The origin is COMPARED, never stripped from the URL.
   //
@@ -142,16 +207,26 @@ export function reduceToSitePath({
   // installation whose declaration returns an absolute same-origin URL still
   // gets a 404.
   const comparisonOrigin = siteUrl ?? requestOrigin;
-  if (comparisonOrigin === undefined) return null;
+  if (comparisonOrigin === undefined) {
+    return { kind: "refused", cause: "unresolvable" };
+  }
   try {
     const target = new URL(resolution.url);
     const site = new URL(comparisonOrigin);
-    if (target.origin !== site.origin) return null;
-    return `${target.pathname}${target.search}${target.hash}`;
+    // Named rather than folded into `unresolvable`: this is the one refusal an
+    // editor can neither cause nor cure, so telling them to fill in a field
+    // sends them to look at a slug that was correct all along.
+    if (target.origin !== site.origin) {
+      return { kind: "refused", cause: "foreignOrigin" };
+    }
+    return {
+      kind: "path",
+      path: `${target.pathname}${target.search}${target.hash}`,
+    };
   } catch {
     // An unparseable site URL or target. Both are configuration a visitor
     // cannot act on, and both refuse the same way everything else here does.
-    return null;
+    return { kind: "refused", cause: "unresolvable" };
   }
 }
 
@@ -221,6 +296,23 @@ export async function resolveSinglePreviewRedirect(
   deps: SinglePreviewRedirectDeps,
   requestOrigin?: string
 ): Promise<string | null> {
+  return pathOrNull(
+    await explainSinglePreviewRedirect(scope, deps, requestOrigin)
+  );
+}
+
+/**
+ * The same answer as {@link resolveSinglePreviewRedirect}, saying why it refused.
+ *
+ * Authenticated callers only, on the same grounds as
+ * {@link explainPreviewRedirect}: the cause separates cases a stranger must not
+ * be able to tell apart.
+ */
+export async function explainSinglePreviewRedirect(
+  scope: SinglePreviewRedirectScope,
+  deps: SinglePreviewRedirectDeps,
+  requestOrigin?: string
+): Promise<PreviewPathOutcome> {
   const [document, preview, siteUrl] = await Promise.all([
     deps.loadSingle(scope.single, scope.locale),
     deps.loadDeclaration(scope.single),
@@ -229,7 +321,7 @@ export async function resolveSinglePreviewRedirect(
 
   // A Single is never deleted the way an entry is, but it can be removed from
   // the configuration, and a link minted before that is a link to nothing.
-  if (document === null) return null;
+  if (document === null) return { kind: "refused", cause: "documentGone" };
 
   return reduceToSitePath({ preview, document, siteUrl, requestOrigin });
 }

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -63,10 +63,26 @@ export type PreviewDocumentRead =
 export function readFromEnvelope(read: {
   success: boolean;
   statusCode?: number;
+  /** Present only when a typed error was flattened into this envelope. */
+  code?: string;
   data?: unknown;
 }): PreviewDocumentRead {
   if (!read.success) {
-    return read.statusCode === 404
+    /*
+     * A 404 alone does NOT establish absence, and `code` is what separates the
+     * two. The service's own not-found branch returns a bare
+     * `{ success: false, statusCode: 404, message: "Entry not found" }`, while
+     * a THROWN NextlyError reaches this envelope through `errorEnvelopeFields`,
+     * which always sets `code` — and an `afterRead` hook raising not-found for
+     * a DEPENDENT lookup lands there with a 404 while the previewed row loaded
+     * perfectly well. Reading that as absence tells an author their entry may
+     * have been deleted because something it references was.
+     *
+     * Erring toward `unreadable` is the safe direction and STAYS safe if that
+     * branch ever gains a code: absence becomes unreachable and every failure
+     * reads as "could not be read", which is unhelpful rather than alarming.
+     */
+    return read.statusCode === 404 && read.code === undefined
       ? { kind: "absent" }
       : { kind: "unreadable" };
   }
@@ -263,40 +279,34 @@ export interface AuthorizedPreviewCaller {
 }
 
 /**
- * Mint that proof, from an AUTHENTICATED context and nothing less.
+ * Mint that proof. Called from ONE place: the per-document authorization gate.
  *
- * The parameter is the whole shape `requireRoutePermission` and
- * `requireRouteCollectionAccess` return, not just an id. That matters because
- * the anonymous preview route DOES hold a plausible id — a verified token
- * carries its minter — so a witness asking only for `{ userId }` could be built
- * there from a real value and would look entirely reasonable in review. Nothing
- * on that path has permissions, roles or an auth method, so demanding them
- * turns a natural-looking call into an obvious fabrication.
+ * The parameter SHAPE is not the control and must not be mistaken for it. An
+ * earlier version demanded the whole route-auth shape on the theory that an
+ * anonymous handler could not produce one — a proxy for "you authenticated",
+ * and a weak one, since any handler can assemble an object literal. What
+ * actually establishes the claim is WHERE this is called from:
+ * `assertEntryPreviewable` and `assertSinglePreviewable` return it only after
+ * every one of their refusals has been passed FOR THIS DOCUMENT, so a grant
+ * cannot exist unless the gate ran and allowed it.
  *
- * The identity is CARRIED rather than discarded, and an empty one is refused:
- * a witness that reads nothing from its argument is a witness that would accept
- * anything shaped vaguely right.
+ * That provenance is enforced by a test asserting exactly one non-test module
+ * imports this, rather than by a comment asking nicely — a second importer is
+ * a failing build, which is the difference between a control and a convention.
  *
- * Within one package no value is unforgeable against code that means to forge
- * it. What this buys is that the honest path is the easy one and the dishonest
- * path cannot be reached by accident — which, with the export manifest beside
- * it, is the enforcement this boundary can actually have.
+ * The identity is carried rather than discarded, and an empty one refused: a
+ * gate that authorized nobody has not authorized this document either.
  */
 export function previewCallerAuthorized(
-  auth: {
-    userId: string;
-    permissions: string[];
-    roles: string[];
-    authMethod: "session" | "api-key";
-  },
+  principal: { id: string },
   authorizedFor: AuthorizedPreviewScope
 ): AuthorizedPreviewCaller {
-  if (auth.userId === "") {
+  if (principal.id === "") {
     /*
      * The public message stays generic and the detail goes to the log: reaching
-     * this is a programming mistake in a handler, not something the person
-     * making the request can act on, and naming the boundary in a response
-     * would describe an internal control to whoever tripped it.
+     * this is a programming mistake in a gate, not something the person making
+     * the request can act on, and naming the boundary in a response would
+     * describe an internal control to whoever tripped it.
      */
     throw new NextlyError({
       code: "INTERNAL_ERROR",
@@ -306,7 +316,7 @@ export function previewCallerAuthorized(
     });
   }
   return {
-    [AUTHORIZED_PREVIEW_CALLER]: { userId: auth.userId, scope: authorizedFor },
+    [AUTHORIZED_PREVIEW_CALLER]: { userId: principal.id, scope: authorizedFor },
   };
 }
 

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -17,6 +17,8 @@
  * @module domains/collections/services/preview-redirect-resolver
  */
 
+import { NextlyError } from "../../../errors/nextly-error";
+
 import {
   resolvePreviewUrl,
   type PreviewDeclaration,
@@ -42,6 +44,35 @@ export type PreviewDocumentRead =
   | { kind: "absent" }
   /** The read itself failed, so whether the document exists is UNKNOWN. */
   | { kind: "unreadable" };
+
+/**
+ * A read whose failures arrive as THROWN errors, as one of the three outcomes.
+ *
+ * The Direct API does not hand back a failure envelope: `findSingle` throws for
+ * every unsuccessful result. A loader that only checked for `null` therefore
+ * never produced `absent` OR `unreadable` — the throw travelled past it and the
+ * caller answered with a raw internal error instead of the refusal it had
+ * carefully prepared.
+ *
+ * Written ONCE and shared by every caller with a throwing loader, because two
+ * copies of "which status counts as absent" agree until one is edited. Only a
+ * 404 is evidence of absence; anything else means the question went unanswered,
+ * which is the same rule the entry loader applies to its envelope.
+ */
+export async function readOrReport(
+  load: () => Promise<Record<string, unknown> | null>
+): Promise<PreviewDocumentRead> {
+  try {
+    const document = await load();
+    return document === null
+      ? { kind: "absent" }
+      : { kind: "document", document };
+  } catch (error) {
+    return error instanceof NextlyError && error.statusCode === 404
+      ? { kind: "absent" }
+      : { kind: "unreadable" };
+  }
+}
 
 /** What this resolver needs from the outside world. */
 export interface PreviewRedirectDeps {
@@ -250,7 +281,7 @@ async function computePreviewRedirect(
  * of an origin comparison agree only until one is edited, at which point the
  * one that drifted still returns a plausible-looking path.
  */
-export function reduceToSitePath({
+function reduceToSitePath({
   preview,
   document,
   siteUrl,

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -256,7 +256,18 @@ const AUTHORIZED_PREVIEW_CALLER = Symbol("nextly.preview.authorizedCaller");
  */
 export type AuthorizedPreviewScope =
   | { collection: string; entryId: string }
-  | { single: string };
+  | { single: string; locale?: string | undefined };
+
+/*
+ * The locale is on the SINGLE arm only, and the asymmetry is the gates', not an
+ * oversight. `assertSinglePreviewable(single, locale, …)` runs a locale-specific
+ * readable check, so a grant that named only the Single would claim more than
+ * was verified: an `en` grant would answer for `fr`, whose custom read rule may
+ * deny it. `assertEntryPreviewable(collection, entryId, …)` takes no locale and
+ * checks none, so an entry grant carries none and the comparison below does not
+ * ask for one — requiring it there would refuse every entry preview for a
+ * precondition nothing establishes.
+ */
 
 /**
  * Proof that the caller was authorized FOR THIS DOCUMENT before a refusal
@@ -339,7 +350,11 @@ function assertGrantCovers(
   const granted = caller[AUTHORIZED_PREVIEW_CALLER].scope;
   const covers =
     "single" in asked
-      ? "single" in granted && granted.single === asked.single
+      ? "single" in granted &&
+        granted.single === asked.single &&
+        // Both undefined is a match: an unlocalized Single is checked and asked
+        // about without one. Anything else is a different translation.
+        granted.locale === asked.locale
       : "collection" in granted &&
         granted.collection === asked.collection &&
         granted.entryId === asked.entryId;
@@ -591,7 +606,12 @@ export async function explainSinglePreviewRedirect(
 ): Promise<PreviewPathOutcome> {
   // See {@link explainPreviewRedirect}: the grant is compared against the
   // document actually being asked about, not merely presented.
-  assertGrantCovers(caller, { single: scope.single });
+  assertGrantCovers(caller, {
+    single: scope.single,
+    // Carried so the grant is judged against the translation actually being
+    // asked about, which is the one the gate checked readability for.
+    ...(scope.locale === undefined ? {} : { locale: scope.locale }),
+  });
   return computeSinglePreviewRedirect(scope, deps, requestOrigin);
 }
 

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -22,10 +22,31 @@ import {
   type PreviewDeclaration,
 } from "./preview-url-resolver";
 
+/**
+ * What reading the previewed document produced.
+ *
+ * `absent` and `unreadable` are SEPARATE because they are different diagnoses
+ * with different remedies, and a loader that folds them together makes the
+ * resolver confidently wrong about which happened. A read that fails on a
+ * transient database error, a rate limit, or a throwing read hook says nothing
+ * about whether the document exists — reporting it as "this may have been
+ * deleted" tells an editor their work is gone when it is sitting there intact.
+ *
+ * The distinction has to be made HERE, by whoever performed the read, because
+ * only they hold the service's failure envelope. Once it is a `null` the
+ * information is gone and no amount of care downstream recovers it.
+ */
+export type PreviewDocumentRead =
+  | { kind: "document"; document: Record<string, unknown> }
+  /** The read succeeded and there is no such document. */
+  | { kind: "absent" }
+  /** The read itself failed, so whether the document exists is UNKNOWN. */
+  | { kind: "unreadable" };
+
 /** What this resolver needs from the outside world. */
 export interface PreviewRedirectDeps {
   /**
-   * The entry the token names, or `null` if it is gone.
+   * The entry the token names, and whether the read could answer at all.
    *
    * Read TRUSTED and with the lifecycle widened, because the caller is
    * anonymous: someone following a preview link has no session of their own.
@@ -42,7 +63,7 @@ export interface PreviewRedirectDeps {
     collection: string,
     entryId: string,
     locale: string | undefined
-  ) => Promise<Record<string, unknown> | null>;
+  ) => Promise<PreviewDocumentRead>;
   /** The collection's preview declaration, from whichever authoring path wrote it. */
   loadDeclaration: (
     collection: string
@@ -69,8 +90,17 @@ export interface PreviewRedirectScope {
  * editor was told to fill in a slug that was already correct.
  */
 export type PreviewRefusalCause =
-  /** The document the token names is gone, or was never readable. */
+  /** The document is confirmed absent — deleted, or never there. */
   | "documentGone"
+  /**
+   * The read FAILED, so whether the document exists is unknown.
+   *
+   * Kept apart from `documentGone` because the remedies are opposites: one is
+   * permanent and there is nothing to do, the other is usually transient and
+   * the answer is to try again. Reporting a database hiccup as a deletion is
+   * the same class of wrong diagnosis this whole type exists to end.
+   */
+  | "documentUnreadable"
   /** No `preview.url` or `urlTemplate` on this collection or Single at all. */
   | "notConfigured"
   /** Declared, but it yields no address for THIS document yet — usually an empty slug. */
@@ -107,7 +137,7 @@ export async function resolvePreviewRedirect(
   deps: PreviewRedirectDeps,
   requestOrigin?: string
 ): Promise<string | null> {
-  return pathOrNull(await explainPreviewRedirect(scope, deps, requestOrigin));
+  return pathOrNull(await computePreviewRedirect(scope, deps, requestOrigin));
 }
 
 /** The one place an outcome becomes the route's deliberately uninformative `null`. */
@@ -115,14 +145,68 @@ function pathOrNull(outcome: PreviewPathOutcome): string | null {
   return outcome.kind === "path" ? outcome.path : null;
 }
 
+/*
+ * The authenticated boundary, as a TYPE rather than a sentence.
+ *
+ * A docblock saying "authenticated callers only" is not a control: the correct
+ * path and the easy path differ, so the rule gets broken by someone who knows
+ * it — import the explaining form from an anonymous handler and the cause
+ * separates a deleted draft from an unconfigured one, which is the oracle this
+ * file exists to prevent.
+ *
+ * The symbol is NOT exported, so no other module can produce a value of this
+ * type. {@link previewCallerAuthorized} is the only constructor and it demands
+ * the authenticated principal, which an anonymous handler does not have — so
+ * reaching the cause now requires writing a fabricated user id at the call
+ * site, which is a deliberate act rather than an easy mistake.
+ */
+const AUTHORIZED_PREVIEW_CALLER = Symbol("nextly.preview.authorizedCaller");
+
+/** Proof that the caller was authorized before a refusal reason was handed over. */
+export interface AuthorizedPreviewCaller {
+  readonly [AUTHORIZED_PREVIEW_CALLER]: true;
+}
+
+/**
+ * Mint that proof. Call ONLY after the caller's own grant has been checked.
+ *
+ * Takes the principal rather than nothing at all, so the witness cannot be
+ * conjured by a handler that never authorized anybody.
+ */
+export function previewCallerAuthorized(auth: {
+  userId: string;
+}): AuthorizedPreviewCaller {
+  void auth;
+  return { [AUTHORIZED_PREVIEW_CALLER]: true };
+}
+
 /**
  * The same answer as {@link resolvePreviewRedirect}, saying why when it refuses.
  *
- * For AUTHENTICATED callers only. The cause distinguishes documents a stranger
+ * For AUTHENTICATED callers only, and the `caller` parameter is what enforces
+ * that rather than this sentence. The cause distinguishes documents a stranger
  * must not be able to tell apart, so handing it to an anonymous request would
  * rebuild the oracle the `null` above exists to prevent.
  */
 export async function explainPreviewRedirect(
+  scope: PreviewRedirectScope,
+  deps: PreviewRedirectDeps,
+  caller: AuthorizedPreviewCaller,
+  requestOrigin?: string
+): Promise<PreviewPathOutcome> {
+  // The parameter IS the control; nothing is read from it.
+  void caller;
+  return computePreviewRedirect(scope, deps, requestOrigin);
+}
+
+/**
+ * The shared computation both façades wrap.
+ *
+ * Private, so the flattening wrapper does not have to hold a witness to reach
+ * it — the route needs no authorization to be told `null`, and making it mint
+ * a proof it does not have would have turned the control into a formality.
+ */
+async function computePreviewRedirect(
   scope: PreviewRedirectScope,
   deps: PreviewRedirectDeps,
   requestOrigin?: string
@@ -139,10 +223,22 @@ export async function explainPreviewRedirect(
   ]);
 
   // A link outlives what it points at: an entry can be deleted between minting
-  // and clicking, and that is a refusal rather than a fault.
-  if (entry === null) return { kind: "refused", cause: "documentGone" };
+  // and clicking, and that is a refusal rather than a fault. A read that could
+  // not answer is a different refusal, because "gone" is a claim the failed
+  // read never established.
+  if (entry.kind === "absent") {
+    return { kind: "refused", cause: "documentGone" };
+  }
+  if (entry.kind === "unreadable") {
+    return { kind: "refused", cause: "documentUnreadable" };
+  }
 
-  return reduceToSitePath({ preview, document: entry, siteUrl, requestOrigin });
+  return reduceToSitePath({
+    preview,
+    document: entry.document,
+    siteUrl,
+    requestOrigin,
+  });
 }
 
 /**
@@ -260,8 +356,8 @@ function siteRelativePath(path: string): string | null {
 /** What resolving a Single's redirect needs from the outside world. */
 export interface SinglePreviewRedirectDeps {
   /**
-   * The Single's document in the locale the token names, or `null` if it cannot
-   * be read.
+   * The Single's document in the locale the token names, and whether the read
+   * could answer at all.
    *
    * A Single is addressed by slug, so unlike an entry there is nothing to look
    * up by id — but the document is still needed, because a declaration may
@@ -270,7 +366,7 @@ export interface SinglePreviewRedirectDeps {
   loadSingle: (
     slug: string,
     locale: string | undefined
-  ) => Promise<Record<string, unknown> | null>;
+  ) => Promise<PreviewDocumentRead>;
   /** The Single's preview declaration, from whichever authoring path wrote it. */
   loadDeclaration: (slug: string) => Promise<PreviewDeclaration | undefined>;
   /** The configured site URL, or `null` when none is set. */
@@ -297,7 +393,7 @@ export async function resolveSinglePreviewRedirect(
   requestOrigin?: string
 ): Promise<string | null> {
   return pathOrNull(
-    await explainSinglePreviewRedirect(scope, deps, requestOrigin)
+    await computeSinglePreviewRedirect(scope, deps, requestOrigin)
   );
 }
 
@@ -311,6 +407,18 @@ export async function resolveSinglePreviewRedirect(
 export async function explainSinglePreviewRedirect(
   scope: SinglePreviewRedirectScope,
   deps: SinglePreviewRedirectDeps,
+  caller: AuthorizedPreviewCaller,
+  requestOrigin?: string
+): Promise<PreviewPathOutcome> {
+  // The parameter IS the control; nothing is read from it.
+  void caller;
+  return computeSinglePreviewRedirect(scope, deps, requestOrigin);
+}
+
+/** The shared computation both Single façades wrap. See {@link computePreviewRedirect}. */
+async function computeSinglePreviewRedirect(
+  scope: SinglePreviewRedirectScope,
+  deps: SinglePreviewRedirectDeps,
   requestOrigin?: string
 ): Promise<PreviewPathOutcome> {
   const [document, preview, siteUrl] = await Promise.all([
@@ -320,8 +428,20 @@ export async function explainSinglePreviewRedirect(
   ]);
 
   // A Single is never deleted the way an entry is, but it can be removed from
-  // the configuration, and a link minted before that is a link to nothing.
-  if (document === null) return { kind: "refused", cause: "documentGone" };
+  // the configuration, and a link minted before that is a link to nothing. A
+  // read that failed is a different answer: it establishes nothing about
+  // whether the Single is still configured.
+  if (document.kind === "absent") {
+    return { kind: "refused", cause: "documentGone" };
+  }
+  if (document.kind === "unreadable") {
+    return { kind: "refused", cause: "documentUnreadable" };
+  }
 
-  return reduceToSitePath({ preview, document, siteUrl, requestOrigin });
+  return reduceToSitePath({
+    preview,
+    document: document.document,
+    siteUrl,
+    requestOrigin,
+  });
 }

--- a/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
@@ -73,7 +73,19 @@ export type PreviewUrlResolution =
    * returned. Both share one remedy: an administrator sets a real site URL. They
    * are merged for that reason and not because they are the same event.
    */
-  | { status: "noSiteUrl"; path: string };
+  | { status: "noSiteUrl"; path: string }
+  /**
+   * The declaration itself could not produce an address: the authored `url`
+   * function threw, or the pieces it returned do not compose into a URL under
+   * the site.
+   *
+   * Kept apart from `unavailable` because the two have opposite remedies. An
+   * `unavailable` document becomes previewable once someone fills in the field
+   * the URL is built from; this one cannot be fixed by editing the document at
+   * all, and telling an editor to fill in a slug sends them after a field that
+   * is already full.
+   */
+  | { status: "declarationFailed" };
 
 /**
  * True when a collection declares a preview by either route.
@@ -223,13 +235,15 @@ export function resolvePreviewUrl({
 
   if (typeof preview?.url === "function") {
     // The authored function is user code running inside a request. It may throw,
-    // and a throw here is the collection declining to preview rather than a
-    // server fault, so it is reported as `unavailable` — the same answer as a
-    // deliberate `return null` — instead of failing the request.
+    // and a throw here is the declaration being broken rather than a server
+    // fault, so it is reported rather than failing the request — and reported
+    // as its own status, because a deliberate `return null` is a document
+    // without an address yet while this is a declaration that cannot produce
+    // one for any document.
     try {
       path = preview.url(entry);
     } catch {
-      return { status: "unavailable" };
+      return { status: "declarationFailed" };
     }
   } else if (preview?.urlTemplate) {
     path = interpolate(preview.urlTemplate, entry);
@@ -257,8 +271,15 @@ export function resolvePreviewUrl({
 
   const joined = joinUnderSite(`${basePath}${suffix}`, base);
   // The pieces parsed separately and not together, which is a declaration this
-  // resolver cannot turn into an address.
-  if (joined === null) return { status: "unavailable" };
+  // resolver cannot turn into an address — for this document or any other, so
+  // it is the declaration's failure rather than the document's.
+  //
+  // DEFENSIVE: the candidate is built from an origin and path this function
+  // already parsed, so nothing an author can return reaches it today. It is
+  // held because that is a property of the composition above rather than of
+  // `joinUnderSite`, and an assertion over a value already in hand costs
+  // nothing while its rejection branch never runs.
+  if (joined === null) return { status: "declarationFailed" };
   return { status: "resolved", url: joined };
 }
 

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -23,6 +23,7 @@ import {
 } from "../../auth/preview/preview-token";
 import { container, getService } from "../../di";
 import {
+  readFromEnvelope,
   readOrReport,
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
@@ -176,24 +177,13 @@ export async function defaultRedirectTo(
 
         /*
          * The route flattens every refusal to one 404 regardless, so the
-         * distinction changes nothing it will say. It is drawn anyway because
-         * the loader is the only place that still HOLDS it: leaving the route's
-         * copy folding both into "absent" would leave a second definition of
-         * this read that answers differently from the mint's, and the next
-         * caller to want the reason would inherit whichever one it happened to
-         * be handed.
+         * distinction changes nothing it will say here. It is drawn anyway, and
+         * by the SAME translator the mint uses, because a second copy of "which
+         * envelope means absent" would agree only until one was edited — and
+         * the two would then disagree about the same entry, minting a link the
+         * route refuses.
          */
-        if (!read.success) {
-          return read.statusCode === 404
-            ? { kind: "absent" as const }
-            : { kind: "unreadable" as const };
-        }
-        return read.data === null
-          ? { kind: "absent" as const }
-          : {
-              kind: "document" as const,
-              document: read.data as Record<string, unknown>,
-            };
+        return readFromEnvelope(read);
       },
       loadDeclaration: previewDeclarationFor,
       loadSiteUrl: async () =>

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -123,7 +123,14 @@ export async function defaultRedirectTo(
         ...(scope.locale === undefined ? {} : { locale: scope.locale }),
       },
       {
-        loadSingle: loadSingleForPreview,
+        // `findSingle` reports no failure envelope, so absence is all this can
+        // ever distinguish. Same shape as the mint path's wrapper, deliberately.
+        loadSingle: async (slug, singleLocale) => {
+          const document = await loadSingleForPreview(slug, singleLocale);
+          return document === null
+            ? { kind: "absent" as const }
+            : { kind: "document" as const, document };
+        },
         loadDeclaration: singlePreviewDeclarationFor,
         loadSiteUrl: async () =>
           resolvePreviewSiteUrl(
@@ -169,8 +176,26 @@ export async function defaultRedirectTo(
           includeWorkingDraft: true,
         });
 
-        if (!read.success || read.data === null) return null;
-        return read.data as Record<string, unknown>;
+        /*
+         * The route flattens every refusal to one 404 regardless, so the
+         * distinction changes nothing it will say. It is drawn anyway because
+         * the loader is the only place that still HOLDS it: leaving the route's
+         * copy folding both into "absent" would leave a second definition of
+         * this read that answers differently from the mint's, and the next
+         * caller to want the reason would inherit whichever one it happened to
+         * be handed.
+         */
+        if (!read.success) {
+          return read.statusCode === 404
+            ? { kind: "absent" as const }
+            : { kind: "unreadable" as const };
+        }
+        return read.data === null
+          ? { kind: "absent" as const }
+          : {
+              kind: "document" as const,
+              document: read.data as Record<string, unknown>,
+            };
       },
       loadDeclaration: previewDeclarationFor,
       loadSiteUrl: async () =>

--- a/packages/nextly/src/runtime/preview/preview-route-defaults.ts
+++ b/packages/nextly/src/runtime/preview/preview-route-defaults.ts
@@ -23,6 +23,7 @@ import {
 } from "../../auth/preview/preview-token";
 import { container, getService } from "../../di";
 import {
+  readOrReport,
   resolvePreviewRedirect,
   resolveSinglePreviewRedirect,
 } from "../../domains/collections/services/preview-redirect-resolver";
@@ -123,14 +124,11 @@ export async function defaultRedirectTo(
         ...(scope.locale === undefined ? {} : { locale: scope.locale }),
       },
       {
-        // `findSingle` reports no failure envelope, so absence is all this can
-        // ever distinguish. Same shape as the mint path's wrapper, deliberately.
-        loadSingle: async (slug, singleLocale) => {
-          const document = await loadSingleForPreview(slug, singleLocale);
-          return document === null
-            ? { kind: "absent" as const }
-            : { kind: "document" as const, document };
-        },
+        // `findSingle` reports failure by THROWING, so the translation is
+        // shared rather than written twice — the route flattens both refusals
+        // to one 404 anyway, but an untranslated throw would escape as a 500.
+        loadSingle: (slug, singleLocale) =>
+          readOrReport(() => loadSingleForPreview(slug, singleLocale)),
         loadDeclaration: singlePreviewDeclarationFor,
         loadSiteUrl: async () =>
           resolvePreviewSiteUrl(


### PR DESCRIPTION
Follow-up to #1211. Implements `finding:preview-redirect-null-conflates-two-causes`, which turned out to conflate **five** causes rather than two.

## The defect

`resolvePreviewRedirect` returns `null` for five structurally distinct situations:

| cause | what is actually wrong | who can fix it |
|---|---|---|
| `documentGone` | the entry was deleted, or the Single left the config | nobody — the link outlived its target |
| `notConfigured` | the collection declares no preview at all | a developer |
| `unavailable` | declared, but no address for THIS document yet | the editor — usually one empty field |
| `foreignOrigin` | the declaration names a different site | whoever owns the preview URL or the site URL |
| `unresolvable` | the URL does not parse, or the path escapes the origin | a developer |

All five reached one refusal: *"This entry has no preview address yet … Filling in the fields its preview URL is built from — usually the slug — makes it shareable."*

For three of the five that is wrong **and** unactionable. An editor whose slug was already correct was sent to look at the one field that was not the problem, and a preview URL pointing at another origin is something no field on the entry can ever change.

## What changed

`reduceToSitePath` returns a discriminated `PreviewPathOutcome` instead of `string | null`, and each cause carries its own message and remedy in a `Record<PreviewRefusalCause, …>` — exhaustive, so a new cause is a type error rather than silently taking whichever ternary branch came last.

## What deliberately did NOT change, and why it is the load-bearing part

**The public preview route still answers all five with one 404.** The resolver's own docblock already said `null` is not an error channel there, and it is right: distinguishing causes on an anonymous path lets a stranger holding a forged token tell a deleted entry from an unpublished one from a collection that has no preview. That is an oracle for what exists in draft.

So rather than teaching every caller to re-flatten, `resolvePreviewRedirect` is kept as the route's entry point and now **derives** its `null` from `explainPreviewRedirect` through a single `pathOrNull`. Two functions each deciding when to refuse would agree until one was edited — and the one that drifted would be the one facing the public. `explainPreviewRedirect` is called only from the authenticated mint path in `api/preview-links.ts`, whose caller already holds `update` on the document and learns nothing by being told why.

## Evidence

**Break-verified seven ways, each with an asserted anchor** — the script refuses to run unless the anchor is present and unique, so a break that failed to apply cannot report as coverage.

The oracle break (leaking the cause through the route) fails **17** tests, including one asserting the five answers are byte-identical rather than merely each `null` — indistinguishability is the property, and five separate `toBeNull()` assertions do not state it.

**One break initially SURVIVED, and it found a real gap.** Reporting `unresolvable` as `foreignOrigin` changed no test result: nothing reached the branch where an absolute URL arrives with *no* site URL *and* no request origin, so there is nothing to compare against. That must read as unresolvable rather than as a foreign origin — telling a developer their URL points at another site when in fact nothing was configured to compare it to is the same wrong-diagnosis failure one level down. Test added, break now noticed.

Every refusal assertion is paired with a positive control (`explainPreviewRedirect` answers a path; `resolvePreviewRedirect` returns `/about`) so `null` means *refused* rather than *always null*.

## Gates

Full build, then: 40 tests in the resolver suite, `check-types` 22/22, `lint` 24/24, `lint:design` pass, comment convention pass, `changeset status` pass, `fallow audit` **pass with 0 introduced** across dead code, complexity, duplication and styling.

Unit failures in `src/domains/collections` and `src/api` were compared **by name** against a clean-tree run of the same suites: 15 baseline failures, all pre-existing stale-mock cases (`task:test-baseline-repair`). One extra name appeared — `rejects text/html upload with VALIDATION_ERROR` — which passes 5/5 in isolation, imports nothing this PR touches, and failed at exactly 10007ms; the baseline run tripped a *different* test at the same 10007ms. Load-sensitive timeout, not a regression.
