### PR TITLE
feat(plugin-form-builder): mark unpublished redirect targets, and refuse only the pairing that 404s

### DIFF
--- a/.changeset/redirect-draft-target-rule.md
+++ b/.changeset/redirect-draft-target-rule.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Form redirect: mark unpublished pages in the picker, and refuse only the pairing that would send a visitor to a 404.
+
+The picker offers unpublished pages on purpose — a form is usually configured beside the page it points at — but nothing said which of them were drafts. Unpublished pages are now marked, so an author can tell what is live before choosing it.
+
+Saving is refused only when a **published** form points at an unpublished page, which is the one combination a visitor can actually reach. A draft form pointing at a draft page saves normally, since the two go live together. The rule is judged on the state a write leaves behind, so it also catches publishing a form over a draft target in a later save that never touches its settings.

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -32,7 +32,10 @@ import { formBuilder } from "../plugin";
  *
  * The field path is the thing that identifies WHICH rule fired.
  */
-async function expectRedirectRefusal(write: Promise<unknown>) {
+async function expectRedirectRefusal(
+  write: Promise<unknown>,
+  field = "settings.redirectPage"
+) {
   let refusal: unknown;
   try {
     await write;
@@ -44,7 +47,7 @@ async function expectRedirectRefusal(write: Promise<unknown>) {
   const errors =
     (refusal as { publicData?: { errors?: { path?: string }[] } })?.publicData
       ?.errors ?? [];
-  expect(errors.map(entry => entry.path)).toContain("settings.redirectPage");
+  expect(errors.map(entry => entry.path)).toContain(field);
 }
 
 let current: TestNextly | undefined;
@@ -897,6 +900,80 @@ describe("a target collection with the publish lifecycle", () => {
         data: { status: "published", ...formData("published", live) },
       })
     );
+  });
+
+  it("guards the relation the URL option falls back to", async () => {
+    // `confirmationType: "redirect"` with no URL resolves `redirectRelation`
+    // exactly like the picker's own field, and the save rule used to match
+    // only "relationship" — so this pairing was resolved at submit time and
+    // inspected by nothing. The author heard about it only by the redirect
+    // silently not happening.
+    await bootWithDraftingPages();
+    const target = await page("draft", "draft-page");
+
+    await expectRedirectRefusal(
+      current!.nextly.create({
+        collection: "forms",
+        data: {
+          name: "Contact",
+          slug: "contact",
+          status: "published",
+          fields: [{ type: "text", name: "message", label: "Message" }],
+          settings: {
+            confirmationType: "redirect",
+            redirectRelation: { relationTo: "pages", value: target },
+          },
+        },
+      }),
+      // The refusal names the field the author filled in, not the one the
+      // picker would have written.
+      "settings.redirectRelation"
+    );
+  });
+
+  it("accepts that same relation when its page is published", async () => {
+    // The control: without it the refusal above passes just as well against a
+    // rule that refuses every `redirect`-with-relation form.
+    await bootWithDraftingPages();
+    const target = await page("published", "live-page");
+
+    const saved = await current!.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings: {
+          confirmationType: "redirect",
+          redirectRelation: { relationTo: "pages", value: target },
+        },
+      },
+    });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+
+  it("leaves a typed URL alone even with a relation stored beside it", async () => {
+    // The URL wins, so nothing here names a document and the draft page is
+    // not this write's business.
+    await bootWithDraftingPages();
+    const target = await page("draft", "draft-page");
+
+    const saved = await current!.nextly.create({
+      collection: "forms",
+      data: {
+        name: "Contact",
+        slug: "contact",
+        status: "published",
+        fields: [{ type: "text", name: "message", label: "Message" }],
+        settings: {
+          confirmationType: "redirect",
+          redirectUrl: "https://example.test/thanks",
+          redirectRelation: { relationTo: "pages", value: target },
+        },
+      },
+    });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
   });
 
   it("lets a rename through after the stored target is deleted", async () => {

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -600,11 +600,13 @@ describe("updating a form that already redirects to a page", () => {
 
 describe("a target collection with the publish lifecycle", () => {
   /**
-   * The picker offers drafts deliberately (`status=all`), so the save
-   * invariant must accept one. Pinned because the two reads are different code
-   * paths and could drift: if a by-id read ever became published-only, this
-   * would refuse a page the picker had just offered, telling the author it
-   * "no longer exists" while it is on screen.
+   * The picker offers drafts deliberately (`status=all`), and the save rule is
+   * conditional rather than absolute: refused only when a PUBLISHED form
+   * points at an unpublished page, which is the one pairing that sends a
+   * visitor to a "page not found". A draft form pointing at a draft page is
+   * allowed, because the two go live together.
+   *
+   * Founder ruling, 2026-08-25 (decision:form-redirect-draft-targets).
    */
   const draftingPages = defineCollection({
     slug: "pages",
@@ -613,7 +615,7 @@ describe("a target collection with the publish lifecycle", () => {
     fields: [text({ name: "title" }), text({ name: "slug" })],
   } as never);
 
-  it("accepts a draft page as a redirect target", async () => {
+  async function bootWithDraftingPages() {
     const { plugin } = formBuilder({
       redirectRelationships: { pages: "/{slug}" },
     });
@@ -621,14 +623,187 @@ describe("a target collection with the publish lifecycle", () => {
       plugins: [plugin],
       collections: [draftingPages],
     });
+    return current;
+  }
 
-    const made = await current.nextly.create({
+  async function page(status: "draft" | "published", slug: string) {
+    const made = await current!.nextly.create({
       collection: "pages",
-      data: { title: "Draft page", slug: "draft-page", status: "draft" },
+      data: { title: slug, slug, status },
     });
-    const draft = made as { item: { id: string; status?: string } };
-    // The fixture is only meaningful if it really is a draft.
-    expect(draft.item.status).toBe("draft");
+    const row = made as { item: { id: string; status?: string } };
+    // The fixture is only meaningful if it really carries the status it names.
+    // A collection whose lifecycle was not actually enabled would answer
+    // `undefined` here and every assertion below would pass for the wrong
+    // reason.
+    expect(row.item.status).toBe(status);
+    return row.item.id;
+  }
+
+  const formData = (
+    status: string,
+    pageId: string
+  ): Record<string, unknown> => ({
+    name: "Contact",
+    slug: "contact",
+    status,
+    fields: [{ type: "text", name: "message", label: "Message" }],
+    settings: {
+      confirmationType: "relationship",
+      redirectPage: { relationTo: "pages", value: pageId },
+    },
+  });
+
+  it("accepts a draft page when the form is itself a draft", async () => {
+    // Also pins that a by-id read REACHES drafts at all. If it ever became
+    // published-only this would refuse a page the picker had just offered,
+    // telling the author it "no longer exists" while it is on screen.
+    await bootWithDraftingPages();
+    const target = await page("draft", "draft-page");
+
+    const saved = await current!.nextly.create({
+      collection: "forms",
+      data: formData("draft", target),
+    });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+
+  it("refuses a published form pointing at a draft page", async () => {
+    // The pairing the rule exists for: this form accepts submissions, so a
+    // visitor really would be redirected to a page the public route 404s.
+    await bootWithDraftingPages();
+    const target = await page("draft", "draft-page");
+
+    await expectRedirectRefusal(
+      current!.nextly.create({
+        collection: "forms",
+        data: formData("published", target),
+      })
+    );
+  });
+
+  it("accepts a published form pointing at a published page", async () => {
+    // The control. Without it the refusal above passes just as well against a
+    // rule that refuses every published form, and nothing would say so.
+    await bootWithDraftingPages();
+    const target = await page("published", "live-page");
+
+    const saved = await current!.nextly.create({
+      collection: "forms",
+      data: formData("published", target),
+    });
+    expect(saved).toMatchObject({ item: { id: expect.any(String) } });
+  });
+
+  it("refuses publishing a form over a draft target it never touches", async () => {
+    // Publishing is a separate save that carries `status` and nothing else.
+    // Judging only the write that PICKS a page would guard one path and leave
+    // this one open, while looking like it covered both.
+    await bootWithDraftingPages();
+    const target = await page("draft", "draft-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("draft", target),
+    })) as { item: { id: string } };
+
+    await expectRedirectRefusal(
+      current!.nextly.update({
+        collection: "forms",
+        id: created.item.id,
+        data: { status: "published" },
+      })
+    );
+  });
+
+  it("refuses repointing a published form at a draft page", async () => {
+    // This write carries `settings` and NOT `status`, so the form's published
+    // state can only come from the stored row. Reading an absent `status` as
+    // "not published" would wave this through — the same broken redirect,
+    // reached by editing rather than by publishing.
+    await bootWithDraftingPages();
+    const live = await page("published", "live-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("published", live),
+    })) as { item: { id: string } };
+
+    const draftTarget = await page("draft", "draft-page");
+    await expectRedirectRefusal(
+      current!.nextly.update({
+        collection: "forms",
+        id: created.item.id,
+        data: {
+          settings: {
+            confirmationType: "relationship",
+            redirectPage: { relationTo: "pages", value: draftTarget },
+          },
+        },
+      })
+    );
+  });
+
+  it("lets a rename through after the stored target is deleted", async () => {
+    // A write that does not name a page does not answer for that page still
+    // existing. Refusing here would make a deleted target block every future
+    // edit to the form, with a message about a setting the author never
+    // touched.
+    await bootWithDraftingPages();
+    const target = await page("draft", "draft-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("draft", target),
+    })) as { item: { id: string } };
+
+    await current!.nextly.delete({ collection: "pages", id: target });
+
+    const renamed = await current!.nextly.update({
+      collection: "forms",
+      id: created.item.id,
+      data: { name: "Renamed" },
+    });
+    expect(renamed).toMatchObject({ item: { id: created.item.id } });
+  });
+
+  it("lets an unrelated edit through while the target is still a draft", async () => {
+    // The other half of the partial-update trap: a rename inherits the stored
+    // target and does not answer for it. Refusing here would block editing a
+    // form's name because of a setting the write never mentioned.
+    await bootWithDraftingPages();
+    const target = await page("draft", "draft-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("draft", target),
+    })) as { item: { id: string } };
+
+    const renamed = await current!.nextly.update({
+      collection: "forms",
+      id: created.item.id,
+      data: { name: "Renamed" },
+    });
+    expect(renamed).toMatchObject({ item: { id: created.item.id } });
+  });
+});
+
+describe("a target collection with NO publish lifecycle", () => {
+  it("never refuses a published form, because nothing there can be a draft", async () => {
+    // A collection without the lifecycle carries no `status` field at all.
+    // Read for truthiness that is the same absence as a draft and means the
+    // opposite: every one of its documents is reachable. Getting this backwards
+    // would refuse every redirect on every site that never turned drafts on.
+    const { plugin } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [pagesCollection],
+    });
+
+    const made = (await current.nextly.create({
+      collection: "pages",
+      data: { title: "Thanks", slug: "thanks" },
+    })) as { item: { id: string; status?: string } };
+    // The fixture only proves anything if this collection really has no status.
+    expect(made.item.status).toBeUndefined();
 
     const saved = await current.nextly.create({
       collection: "forms",
@@ -639,7 +814,7 @@ describe("a target collection with the publish lifecycle", () => {
         fields: [{ type: "text", name: "message", label: "Message" }],
         settings: {
           confirmationType: "relationship",
-          redirectPage: { relationTo: "pages", value: draft.item.id },
+          redirectPage: { relationTo: "pages", value: made.item.id },
         },
       },
     });

--- a/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
+++ b/packages/plugin-form-builder/src/__tests__/redirect-to-page.integration.test.ts
@@ -605,8 +605,6 @@ describe("a target collection with the publish lifecycle", () => {
    * points at an unpublished page, which is the one pairing that sends a
    * visitor to a "page not found". A draft form pointing at a draft page is
    * allowed, because the two go live together.
-   *
-   * Founder ruling, 2026-08-25 (decision:form-redirect-draft-targets).
    */
   const draftingPages = defineCollection({
     slug: "pages",
@@ -738,6 +736,165 @@ describe("a target collection with the publish lifecycle", () => {
             redirectPage: { relationTo: "pages", value: draftTarget },
           },
         },
+      })
+    );
+  });
+
+  it("lets an unrelated edit through on a published form with a draft target", async () => {
+    // A published form can acquire a draft target without being touched: the
+    // page is unpublished later. Refusing every rename after that holds the
+    // form hostage to a state the write neither created nor mentions — and the
+    // submission path already declines to send anyone there.
+    await bootWithDraftingPages();
+    const live = await page("published", "live-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("published", live),
+    })) as { item: { id: string } };
+
+    await current!.nextly.update({
+      collection: "pages",
+      id: live,
+      data: { status: "draft" },
+    });
+
+    const renamed = await current!.nextly.update({
+      collection: "forms",
+      id: created.item.id,
+      data: { name: "Renamed" },
+    });
+    expect(renamed).toMatchObject({ item: { id: created.item.id } });
+  });
+
+  it("lets a published form turn its page redirect OFF while the target is a draft", async () => {
+    // The edit an author in that state actually needs to make. Inheriting the
+    // old target here refuses the only write that removes the bad redirect.
+    await bootWithDraftingPages();
+    const live = await page("published", "live-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("published", live),
+    })) as { item: { id: string } };
+
+    await current!.nextly.update({
+      collection: "pages",
+      id: live,
+      data: { status: "draft" },
+    });
+
+    const switched = await current!.nextly.update({
+      collection: "forms",
+      id: created.item.id,
+      data: { settings: { confirmationType: "message" } },
+    });
+    expect(switched).toMatchObject({ item: { id: created.item.id } });
+  });
+
+  it("sends nobody to a page that was unpublished after the form was saved", async () => {
+    // Nothing runs a forms hook when the TARGET changes, so the save-time rule
+    // never sees this. Without a submit-time check the visitor receives a
+    // redirect to a page the public route 404s — the exact outcome the save
+    // rule exists to prevent, reached by a path it cannot watch. The
+    // submission itself must still succeed: the destination is what degrades.
+    const { plugin, config } = formBuilder({
+      redirectRelationships: { pages: "/{slug}" },
+    });
+    current = await createTestNextly({
+      plugins: [plugin],
+      collections: [draftingPages],
+    });
+
+    const target = await page("published", "live-page");
+    await current.nextly.create({
+      collection: "forms",
+      data: formData("published", target),
+    });
+
+    const getService = ((name: string) =>
+      name === "db" ? {} : current?.getService(name as never)) as never;
+    const pluginContext = createPluginContext(
+      getService,
+      current.hooks as never
+    );
+
+    // The control: while the page is published the redirect resolves, so a
+    // missing redirect below is the unpublishing and not a broken fixture.
+    const before = await submitForm(
+      { formSlug: "contact", data: { message: "hello" } },
+      { pluginContext, pluginConfig: config }
+    );
+    expect(before.redirect).toBe("/live-page");
+
+    await current.nextly.update({
+      collection: "pages",
+      id: target,
+      data: { status: "draft" },
+    });
+
+    const after = await submitForm(
+      { formSlug: "contact", data: { message: "hello" } },
+      { pluginContext, pluginConfig: config }
+    );
+    expect(after.success).toBe(true);
+    expect(after.submission).toBeDefined();
+    expect(after.redirect).toBeUndefined();
+  });
+
+  it("lets one save both publish the form and turn its page redirect off", async () => {
+    // The sharpest form of the same case, and the one that needs the stored
+    // target skipped rather than merely unjudged: this write DOES publish, so
+    // the inherited-target check applies — and the target it would inherit is
+    // one this very write is removing. Refusing it leaves the author unable to
+    // publish and unable to fix the redirect in the same breath.
+    //
+    // Separated from the rename above deliberately: that one passes whether or
+    // not the stored target is skipped, because a rename is not judged at all.
+    await bootWithDraftingPages();
+    const live = await page("published", "live-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("draft", live),
+    })) as { item: { id: string } };
+
+    await current!.nextly.update({
+      collection: "pages",
+      id: live,
+      data: { status: "draft" },
+    });
+
+    const saved = await current!.nextly.update({
+      collection: "forms",
+      id: created.item.id,
+      data: {
+        status: "published",
+        settings: { confirmationType: "message" },
+      },
+    });
+    expect(saved).toMatchObject({ item: { id: created.item.id } });
+  });
+
+  it("still refuses when that same save keeps the page redirect", async () => {
+    // The control for the test above: identical write except that `settings`
+    // still names the draft page. Without this, skipping the stored target
+    // could be skipping the check entirely and nothing would say so.
+    await bootWithDraftingPages();
+    const live = await page("published", "live-page");
+    const created = (await current!.nextly.create({
+      collection: "forms",
+      data: formData("draft", live),
+    })) as { item: { id: string } };
+
+    await current!.nextly.update({
+      collection: "pages",
+      id: live,
+      data: { status: "draft" },
+    });
+
+    await expectRedirectRefusal(
+      current!.nextly.update({
+        collection: "forms",
+        id: created.item.id,
+        data: { status: "published", ...formData("published", live) },
       })
     );
   });

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
@@ -278,6 +278,13 @@ describe("selectFieldsFor", () => {
     expect(selectFieldsFor("headline")).toContain("status");
   });
 
+  it("requests what says the collection has a lifecycle at all", () => {
+    // Without `firstPublishedAt` every row comes back looking unmanaged, and
+    // an unmanaged row is always reachable — so the projection alone would
+    // silently disable every Draft marker.
+    expect(selectFieldsFor("headline")).toContain("firstPublishedAt");
+  });
+
   it("requests everything the label needs", () => {
     // Derived from the label list rather than written out again: a field added
     // for labelling that is never requested comes back absent, and the label

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   documentLabel,
   labelFieldsFor,
+  selectFieldsFor,
   selectParam,
   selectionKey,
   groupChoices,
@@ -269,5 +270,31 @@ describe("documentLabel with a collection's own title field", () => {
       "pg1"
     );
     expect(documentLabel({}, labelFieldsFor("headline"))).toBe("Untitled");
+  });
+});
+
+describe("selectFieldsFor", () => {
+  it("requests the status, so a draft can be marked as one", () => {
+    expect(selectFieldsFor("headline")).toContain("status");
+  });
+
+  it("requests everything the label needs", () => {
+    // Derived from the label list rather than written out again: a field added
+    // for labelling that is never requested comes back absent, and the label
+    // falls silently to the id.
+    for (const field of labelFieldsFor("headline")) {
+      expect(selectFieldsFor("headline")).toContain(field);
+    }
+  });
+
+  it("never lets the status become a document's name", () => {
+    // `documentLabel` walks whatever list it is handed, in order. If `status`
+    // were a label field, a page with no title would be offered to an author
+    // as "draft" — which reads as a page called Draft.
+    expect(labelFieldsFor("headline")).not.toContain("status");
+    expect(labelFieldsFor(undefined)).not.toContain("status");
+    expect(documentLabel({ id: "1", status: "draft" }, labelFieldsFor())).toBe(
+      "1"
+    );
   });
 });

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+
+/**
+ * The path from a collection's own metadata to what an author sees.
+ *
+ * The unit tests beside this file assert `labelFieldsFor` and `selectParam` in
+ * isolation, and every one of them stays green if the metadata request reads
+ * the wrong endpoint, or misreads the response, or stops feeding its answer
+ * into the listing. In each of those cases the shipped picker still shows
+ * opaque ids — the exact defect the unit tests were written for. What separates
+ * a working picker from that one is whether the CONFIGURED field reaches the
+ * request and the label, so these observe the request the component actually
+ * makes and the text it actually renders.
+ *
+ * jsdom is requested per file rather than in the shared vitest config: the
+ * integration suites in this package boot a real Nextly instance and have no
+ * use for a DOM.
+ */
+import "@testing-library/jest-dom/vitest";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { RedirectPagePicker } from "./RedirectPagePicker";
+
+// Radix calls all four when a Select opens and jsdom implements none, so
+// without them a test dies on a missing method rather than failing an
+// assertion.
+beforeAll(() => {
+  Element.prototype.hasPointerCapture = () => false;
+  Element.prototype.setPointerCapture = () => undefined;
+  Element.prototype.releasePointerCapture = () => undefined;
+  Element.prototype.scrollIntoView = () => undefined;
+});
+
+/** Every URL the component requested, in order. */
+let requested: string[] = [];
+
+/**
+ * A server whose `pages` collection is titled by `headline`.
+ *
+ * Deliberately NOT one of the conventional names the picker falls back to: a
+ * fixture titled by `title` returns the same green whether the configured
+ * field was honoured or ignored.
+ */
+function serve(rows: Record<string, unknown>[], useAsTitle?: string) {
+  requested = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => {
+      requested.push(url);
+      if (url.includes("/entries")) {
+        return {
+          ok: true,
+          json: async () => ({ items: rows, meta: { totalPages: 1 } }),
+        };
+      }
+      return {
+        ok: true,
+        json: async () => (useAsTitle ? { admin: { useAsTitle } } : {}),
+      };
+    })
+  );
+}
+
+const entriesRequest = () => requested.find(url => url.includes("/entries"));
+
+/** The projection the server would actually apply, from the URL as sent. */
+function projection(url: string): Record<string, boolean> {
+  const select = new URL(url, "https://test.local").searchParams.get("select");
+  return JSON.parse(select ?? "{}") as Record<string, boolean>;
+}
+
+beforeEach(() => {
+  requested = [];
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+describe("the configured title field reaches the request and the label", () => {
+  it("asks the metadata endpoint for the collection", async () => {
+    serve([], "headline");
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(entriesRequest()).toBeDefined());
+    expect(requested[0]).toContain("/admin/api/collections/pages");
+    expect(requested[0]).not.toContain("/entries");
+  });
+
+  it("projects the field the collection configures", async () => {
+    serve([{ id: "p1", headline: "Launch day" }], "headline");
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await waitFor(() => expect(entriesRequest()).toBeDefined());
+    // The property that separates a working picker from one showing ids: the
+    // request asks for `headline`, in the encoding the dispatcher accepts.
+    expect(projection(entriesRequest()!)).toMatchObject({
+      id: true,
+      headline: true,
+      status: true,
+    });
+  });
+
+  it("labels a document by its configured field, not by its id", async () => {
+    serve([{ id: "p1", headline: "Launch day" }], "headline");
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText("Redirect page"));
+    expect(await screen.findByText("Launch day")).toBeInTheDocument();
+    expect(screen.queryByText("p1")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the conventional names when the collection configures none", async () => {
+    serve([{ id: "p1", title: "About" }], undefined);
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText("Redirect page"));
+    expect(await screen.findByText("About")).toBeInTheDocument();
+  });
+});
+
+describe("what the picker says about a page that is not live", () => {
+  it("marks an unpublished page as a draft", async () => {
+    // Unpublished pages are offered on purpose. The marker is what stops
+    // "offered" reading as "live" — and a published form saved against one is
+    // refused, so an author who cannot see this has no way to predict that.
+    serve([{ id: "p1", headline: "Launch day", status: "draft" }], "headline");
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText("Redirect page"));
+    const option = await screen.findByRole("option", { name: /Launch day/ });
+    expect(option).toHaveTextContent("Draft");
+  });
+
+  it("does not mark a published page", async () => {
+    serve(
+      [{ id: "p1", headline: "Launch day", status: "published" }],
+      "headline"
+    );
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText("Redirect page"));
+    const option = await screen.findByRole("option", { name: /Launch day/ });
+    expect(option).not.toHaveTextContent("Draft");
+  });
+
+  it("does not mark a collection that has no publish lifecycle", async () => {
+    // No `status` field at all. Marking these would put "Draft" beside every
+    // page on every site that never turned drafts on.
+    serve([{ id: "p1", headline: "Launch day" }], "headline");
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText("Redirect page"));
+    const option = await screen.findByRole("option", { name: /Launch day/ });
+    expect(option).not.toHaveTextContent("Draft");
+  });
+});

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.test.tsx
@@ -159,7 +159,17 @@ describe("what the picker says about a page that is not live", () => {
     // Unpublished pages are offered on purpose. The marker is what stops
     // "offered" reading as "live" — and a published form saved against one is
     // refused, so an author who cannot see this has no way to predict that.
-    serve([{ id: "p1", headline: "Launch day", status: "draft" }], "headline");
+    serve(
+      [
+        {
+          id: "p1",
+          headline: "Launch day",
+          status: "draft",
+          firstPublishedAt: null,
+        },
+      ],
+      "headline"
+    );
     render(
       <RedirectPagePicker
         collections={["pages"]}
@@ -178,6 +188,24 @@ describe("what the picker says about a page that is not live", () => {
       [{ id: "p1", headline: "Launch day", status: "published" }],
       "headline"
     );
+    render(
+      <RedirectPagePicker
+        collections={["pages"]}
+        value={undefined}
+        onChange={vi.fn()}
+      />
+    );
+
+    await userEvent.click(await screen.findByLabelText("Redirect page"));
+    const option = await screen.findByRole("option", { name: /Launch day/ });
+    expect(option).not.toHaveTextContent("Draft");
+  });
+
+  it("does not mark a page whose collection merely has a status field", async () => {
+    // `status: "draft"` on a collection with no publish lifecycle is an
+    // ordinary field value, not a publish state. Marking it would put "Draft"
+    // beside a page that is live, and the save rule would then refuse it.
+    serve([{ id: "p1", headline: "Launch day", status: "draft" }], "headline");
     render(
       <RedirectPagePicker
         collections={["pages"]}

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -75,7 +75,8 @@ export function labelFieldsFor(useAsTitle?: string): readonly string[] {
  * appearing to project it.
  */
 /**
- * The fields to REQUEST, which is the label fields plus `status`.
+ * The fields to REQUEST, which is the label fields plus what decides
+ * reachability.
  *
  * Kept apart from `labelFieldsFor` on purpose. `status` decides whether a page
  * is marked as a draft; it must never become a document's name, and
@@ -86,7 +87,11 @@ export function labelFieldsFor(useAsTitle?: string): readonly string[] {
  * for labelling is still requested.
  */
 export function selectFieldsFor(useAsTitle?: string): readonly string[] {
-  return [...labelFieldsFor(useAsTitle), "status"];
+  // `firstPublishedAt` as well as `status`: it is what says the collection has
+  // a publish lifecycle at all, and without it a page whose collection merely
+  // has a field called `status` would be marked as a draft. See
+  // `hasPublishLifecycle`.
+  return [...labelFieldsFor(useAsTitle), "status", "firstPublishedAt"];
 }
 
 export function selectParam(fields: readonly string[]): string {

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -23,7 +23,10 @@ import {
 } from "@nextlyhq/ui";
 import { useEffect, useState } from "react";
 
-import { parseRedirectReference } from "../../../utils/redirect-reference";
+import {
+  documentIsReachable,
+  parseRedirectReference,
+} from "../../../utils/redirect-reference";
 
 /** Rows per request. Search, not paging, is how the rest are reached. */
 const PAGE_SIZE = 50;
@@ -71,6 +74,21 @@ export function labelFieldsFor(useAsTitle?: string): readonly string[] {
  * so the encoding is the whole difference between projecting a read and
  * appearing to project it.
  */
+/**
+ * The fields to REQUEST, which is the label fields plus `status`.
+ *
+ * Kept apart from `labelFieldsFor` on purpose. `status` decides whether a page
+ * is marked as a draft; it must never become a document's name, and
+ * `documentLabel` walks whatever list it is given — so a page with no title
+ * would otherwise be offered to an author as "draft".
+ *
+ * Derived from the label list rather than written out again, so a field added
+ * for labelling is still requested.
+ */
+export function selectFieldsFor(useAsTitle?: string): readonly string[] {
+  return [...labelFieldsFor(useAsTitle), "status"];
+}
+
 export function selectParam(fields: readonly string[]): string {
   return encodeURIComponent(
     JSON.stringify(Object.fromEntries(fields.map(field => [field, true])))
@@ -82,6 +100,13 @@ interface Choice {
   collection: string;
   id: string;
   label: string;
+  /**
+   * Whether a visitor could reach this page today. Unpublished pages are
+   * offered on purpose — a form is usually configured beside the page it
+   * points at — but an author choosing one should be able to see that it is
+   * not live yet.
+   */
+  reachable: boolean;
 }
 
 interface RedirectPagePickerProps {
@@ -134,7 +159,7 @@ async function fetchChoices(
   collection: string,
   query: string,
   page: number,
-  fields: readonly string[]
+  titleField: string | undefined
 ): Promise<{ rows: Choice[]; hasMore: boolean } | null> {
   const search = query ? `&search=${encodeURIComponent(query)}` : "";
   try {
@@ -145,7 +170,7 @@ async function fetchChoices(
     const response = await fetch(
       `/admin/api/collections/${collection}/entries` +
         `?limit=${PAGE_SIZE}&page=${page}&status=all&depth=0` +
-        `&select=${selectParam(fields)}${search}`,
+        `&select=${selectParam(selectFieldsFor(titleField))}${search}`,
       { credentials: "include" }
     );
     if (!response.ok) return null;
@@ -159,7 +184,8 @@ async function fetchChoices(
         .map(row => ({
           collection,
           id: row.id as string,
-          label: documentLabel(row, fields),
+          label: documentLabel(row, labelFieldsFor(titleField)),
+          reachable: documentIsReachable(row as { id: string }),
         })),
       // Reported rather than assumed, so the control can offer the rest
       // instead of truncating where the author cannot see it.
@@ -196,7 +222,19 @@ function renderChoice(choice: Choice) {
       key={`${choice.collection}:${choice.id}`}
       value={`${choice.collection}:${choice.id}`}
     >
-      {choice.label}
+      <span className="inline-flex items-center gap-2">
+        <span>{choice.label}</span>
+        {/* Unpublished pages are offered deliberately — a form is usually
+            configured beside the page it points at — so the marker is what
+            keeps "offered" from reading as "live". A published form saved
+            against one is refused, and an author who cannot see which pages
+            are drafts has no way to predict that. */}
+        {!choice.reachable && (
+          <span className="shrink-0 rounded-sm border px-1 py-px text-[10px] uppercase tracking-wide text-muted-foreground">
+            Draft
+          </span>
+        )}
+      </span>
     </SelectItem>
   );
 }
@@ -248,7 +286,7 @@ async function fetchTitleField(
 function useTitleFields(key: string) {
   const [fields, setFields] = useState<Record<
     string,
-    readonly string[]
+    string | undefined
   > | null>(null);
 
   useEffect(() => {
@@ -258,8 +296,7 @@ function useTitleFields(key: string) {
 
     void Promise.all(
       wanted.map(async collection => {
-        const configured = await fetchTitleField(collection);
-        return [collection, labelFieldsFor(configured)] as const;
+        return [collection, await fetchTitleField(collection)] as const;
       })
     ).then(pairs => {
       if (!cancelled) setFields(Object.fromEntries(pairs));
@@ -280,7 +317,7 @@ function useTitleFields(key: string) {
 function useChoices(
   key: string,
   applied: string,
-  titleFields: Record<string, readonly string[]> | null
+  titleFields: Record<string, string | undefined> | null
 ) {
   const [choices, setChoices] = useState<Choice[] | null>(null);
   const [failed, setFailed] = useState<readonly string[]>([]);
@@ -320,7 +357,7 @@ function useChoices(
           collection,
           applied,
           pages[collection] ?? 1,
-          titleFields[collection] ?? labelFieldsFor(undefined)
+          titleFields[collection]
         )
       )
     ).then(results => {
@@ -402,7 +439,7 @@ function useSelectedChoice(
   selected: string | undefined,
   choices: Choice[] | null,
   setChoices: (update: (current: Choice[] | null) => Choice[]) => void,
-  titleFields: Record<string, readonly string[]> | null
+  titleFields: Record<string, string | undefined> | null
 ) {
   // Whether the stored selection could not be read. A controlled `Select`
   // holding a value with no matching option renders BLANK, which looks
@@ -457,7 +494,11 @@ function useSelectedChoice(
             // The same fields the listing labels by. Labelling the recovered
             // document differently would show one document under two names
             // depending on whether the listing happened to reach it.
-            label: documentLabel(row, titleFields?.[collection]),
+            label: documentLabel(
+              row,
+              labelFieldsFor(titleFields?.[collection])
+            ),
+            reachable: documentIsReachable(row as { id: string }),
           },
           ...(current ?? []),
         ]);

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -24,6 +24,8 @@ import type { ResolvedFormBuilderConfig } from "../types";
 import {
   documentIsReachable,
   parseRedirectReference,
+  pickedDocumentField,
+  type PickedDocumentField,
 } from "../utils/redirect-reference";
 import {
   applyRedirectPattern,
@@ -156,21 +158,22 @@ function withHostHooks<T>(
  * rather than the merged document, so treating an absent `settings` as empty
  * would refuse a rename for a setting it never touched.
  */
-function relationshipSettings(
+function documentRedirectSettings(
   settings: unknown
-): Record<string, unknown> | null {
+): { settings: Record<string, unknown>; field: PickedDocumentField } | null {
   if (typeof settings !== "object" || settings === null) return null;
   const record = settings as Record<string, unknown>;
-  return record.confirmationType === "relationship" ? record : null;
+  const field = pickedDocumentField(record);
+  return field ? { settings: record, field } : null;
 }
 
 function pageRedirectSettings(
   data: Record<string, unknown> | undefined,
   operation: string
-): Record<string, unknown> | null {
+): { settings: Record<string, unknown>; field: PickedDocumentField } | null {
   if (!data) return null;
   if (operation !== "create" && data.settings === undefined) return null;
-  return relationshipSettings(data.settings);
+  return documentRedirectSettings(data.settings);
 }
 
 /**
@@ -204,15 +207,17 @@ export function formAcceptsSubmissions(
  * every form that has one — silently, and indistinguishably from a form that
  * genuinely has none.
  */
-function storedSettings(value: unknown): Record<string, unknown> | null {
+function storedSettings(
+  value: unknown
+): { settings: Record<string, unknown>; field: PickedDocumentField } | null {
   if (typeof value === "string") {
     try {
-      return relationshipSettings(JSON.parse(value));
+      return documentRedirectSettings(JSON.parse(value));
     } catch {
       return null;
     }
   }
-  return relationshipSettings(value);
+  return documentRedirectSettings(value);
 }
 
 /**
@@ -231,14 +236,20 @@ function storedSettings(value: unknown): Record<string, unknown> | null {
 function storedRedirectReference(
   originalData: Record<string, unknown> | undefined,
   patterns: RedirectRelationships
-): { collection: string; id: string } | null {
-  const settings = storedSettings(originalData?.settings);
-  if (!settings) return null;
+): {
+  reference: { collection: string; id: string };
+  field: PickedDocumentField;
+} | null {
+  const picked = storedSettings(originalData?.settings);
+  if (!picked) return null;
 
   const collections = Object.keys(patterns);
-  const reference = parseRedirectReference(settings.redirectPage, collections);
+  const reference = parseRedirectReference(
+    picked.settings[picked.field],
+    collections
+  );
   return reference && collections.includes(reference.collection)
-    ? reference
+    ? { reference, field: picked.field }
     : null;
 }
 
@@ -252,12 +263,13 @@ function storedRedirectReference(
  */
 function normalizeStoredReference(
   settings: Record<string, unknown>,
+  field: PickedDocumentField,
   reference: { collection: string; id: string }
 ) {
-  const stored = settings.redirectPage;
+  const stored = settings[field];
 
   if (typeof stored === "string") {
-    if (stored !== reference.id) settings.redirectPage = reference.id;
+    if (stored !== reference.id) settings[field] = reference.id;
     return;
   }
   if (typeof stored !== "object" || stored === null || Array.isArray(stored)) {
@@ -266,7 +278,7 @@ function normalizeStoredReference(
 
   const record = stored as Record<string, unknown>;
   if (record.relationTo !== reference.collection) {
-    settings.redirectPage = { ...record, relationTo: reference.collection };
+    settings[field] = { ...record, relationTo: reference.collection };
   }
 }
 
@@ -274,21 +286,26 @@ function assertRedirectTargetNamed(
   data: Record<string, unknown> | undefined,
   operation: string,
   patterns: RedirectRelationships
-): { collection: string; id: string } | null {
-  const settings = pageRedirectSettings(data, operation);
-  if (!settings) return null;
+): {
+  reference: { collection: string; id: string };
+  field: PickedDocumentField;
+} | null {
+  const picked = pageRedirectSettings(data, operation);
+  if (!picked) return null;
+  const { settings, field } = picked;
 
   const collections = Object.keys(patterns);
-  const reference = parseRedirectReference(settings.redirectPage, collections);
+  const reference = parseRedirectReference(settings[field], collections);
   if (!reference || !collections.includes(reference.collection)) {
     throw redirectRefusal(
-      "Choose a page to redirect to, or pick a different confirmation."
+      "Choose a page to redirect to, or pick a different confirmation.",
+      field
     );
   }
 
-  normalizeStoredReference(settings, reference);
+  normalizeStoredReference(settings, field, reference);
 
-  return reference;
+  return { reference, field };
 }
 
 /**
@@ -349,13 +366,17 @@ function publishesForm(data: Record<string, unknown> | undefined): boolean {
 function redirectReferenceForWrite(
   context: HookContext,
   patterns: RedirectRelationships
-): { reference: { collection: string; id: string }; chosen: boolean } | null {
+): {
+  reference: { collection: string; id: string };
+  field: PickedDocumentField;
+  chosen: boolean;
+} | null {
   const chosen = assertRedirectTargetNamed(
     context.data,
     context.operation,
     patterns
   );
-  if (chosen) return { reference: chosen, chosen: true };
+  if (chosen) return { ...chosen, chosen: true };
 
   // A write that REPLACES `settings` has answered the question: this form no
   // longer redirects to a page. Inheriting the old target there would refuse
@@ -369,7 +390,7 @@ function redirectReferenceForWrite(
     context.originalData as Record<string, unknown> | undefined,
     patterns
   );
-  return stored ? { reference: stored, chosen: false } : null;
+  return stored ? { ...stored, chosen: false } : null;
 }
 
 /**
@@ -384,6 +405,7 @@ function redirectReferenceForWrite(
 function assertPatternBuildsUrl(
   patterns: RedirectRelationships,
   reference: { collection: string; id: string },
+  field: PickedDocumentField,
   target: RedirectTargetDocument
 ) {
   let url: string | undefined;
@@ -401,7 +423,8 @@ function assertPatternBuildsUrl(
   throw redirectRefusal(
     `No URL could be built for that page from the pattern configured for ` +
       `"${reference.collection}". Choose another page, or ask a developer ` +
-      `to check that collection's redirect pattern.`
+      `to check that collection's redirect pattern.`,
+    field
   );
 }
 
@@ -411,7 +434,7 @@ export async function assertRedirectTargetUsable(
 ) {
   const write = redirectReferenceForWrite(context, patterns);
   if (!write) return;
-  const { reference, chosen } = write;
+  const { reference, field, chosen } = write;
 
   const nextly = context.req?.nextly;
   if (!nextly) return;
@@ -438,7 +461,8 @@ export async function assertRedirectTargetUsable(
     // edit for a setting it never touched.
     if (!chosen) return;
     throw redirectRefusal(
-      `That page no longer exists in "${reference.collection}". Pick another.`
+      `That page no longer exists in "${reference.collection}". Pick another.`,
+      field
     );
   }
 
@@ -463,13 +487,15 @@ export async function assertRedirectTargetUsable(
     throw redirectRefusal(
       `That page is not published yet, and this form is. A visitor sent ` +
         `there would reach a "page not found". Publish the page, or save ` +
-        `this form as a draft until you do.`
+        `this form as a draft until you do.`,
+      field
     );
   }
 
   // The pattern belongs to the write that CHOOSES a page. A form being
   // published does not get refused for a pattern its author never edited.
-  if (chosen) assertPatternBuildsUrl(patterns, reference, found.document);
+  if (chosen)
+    assertPatternBuildsUrl(patterns, reference, field, found.document);
 }
 
 /**
@@ -522,9 +548,12 @@ export function isMissingTarget(error: unknown): boolean {
 }
 
 /** One shape for every refusal this rule makes, so callers see one field. */
-function redirectRefusal(message: string) {
+function redirectRefusal(message: string, field: PickedDocumentField) {
+  // The path names the field the author actually filled in. Reporting every
+  // refusal against `redirectPage` points a form configured through the URL
+  // option at a control it does not show.
   return NextlyError.validation({
-    errors: [{ path: "settings.redirectPage", code: "REQUIRED", message }],
+    errors: [{ path: `settings.${field}`, code: "REQUIRED", message }],
   });
 }
 

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -327,6 +327,18 @@ export function wouldStrandVisitors(
 }
 
 /**
+ * Whether this write is the one that makes the form able to receive
+ * submissions.
+ *
+ * Distinct from {@link formAcceptsSubmissions}, which answers what the form
+ * WILL be: this asks what the write itself does, which is what decides whether
+ * an inherited target is any of its business.
+ */
+function publishesForm(data: Record<string, unknown> | undefined): boolean {
+  return data?.status === "published";
+}
+
+/**
  * The page this write leaves the form pointing at, and whether the write
  * CHOSE it.
  *
@@ -344,6 +356,14 @@ function redirectReferenceForWrite(
     patterns
   );
   if (chosen) return { reference: chosen, chosen: true };
+
+  // A write that REPLACES `settings` has answered the question: this form no
+  // longer redirects to a page. Inheriting the old target there would refuse
+  // the very edit that removes an invalid redirect, which is the one edit an
+  // author in that state needs to make. Only a write that omits `settings`
+  // inherits.
+  const data = context.data as Record<string, unknown> | undefined;
+  if (data?.settings !== undefined) return null;
 
   const stored = storedRedirectReference(
     context.originalData as Record<string, unknown> | undefined,
@@ -422,7 +442,18 @@ export async function assertRedirectTargetUsable(
     );
   }
 
+  // An inherited target is only judged by the write that PUBLISHES the form.
+  // A published form can acquire a draft target without being touched — the
+  // page is unpublished later, or the pairing predates this rule — and
+  // refusing every subsequent rename would hold the form hostage to a state
+  // the write neither created nor mentions. A write that CHOOSES a target
+  // answers for it whatever else it does.
+  const judged =
+    chosen ||
+    publishesForm(context.data as Record<string, unknown> | undefined);
+
   if (
+    judged &&
     wouldStrandVisitors(
       context.data as Record<string, unknown> | undefined,
       context.originalData as Record<string, unknown> | undefined,

--- a/packages/plugin-form-builder/src/collections/forms.ts
+++ b/packages/plugin-form-builder/src/collections/forms.ts
@@ -21,7 +21,10 @@ import {
 } from "nextly";
 
 import type { ResolvedFormBuilderConfig } from "../types";
-import { parseRedirectReference } from "../utils/redirect-reference";
+import {
+  documentIsReachable,
+  parseRedirectReference,
+} from "../utils/redirect-reference";
 import {
   applyRedirectPattern,
   type RedirectRelationships,
@@ -153,14 +156,90 @@ function withHostHooks<T>(
  * rather than the merged document, so treating an absent `settings` as empty
  * would refuse a rename for a setting it never touched.
  */
+function relationshipSettings(
+  settings: unknown
+): Record<string, unknown> | null {
+  if (typeof settings !== "object" || settings === null) return null;
+  const record = settings as Record<string, unknown>;
+  return record.confirmationType === "relationship" ? record : null;
+}
+
 function pageRedirectSettings(
   data: Record<string, unknown> | undefined,
   operation: string
 ): Record<string, unknown> | null {
   if (!data) return null;
   if (operation !== "create" && data.settings === undefined) return null;
-  const settings = data.settings as Record<string, unknown> | undefined;
-  return settings?.confirmationType === "relationship" ? settings : null;
+  return relationshipSettings(data.settings);
+}
+
+/**
+ * Whether the form this write leaves behind can receive a submission.
+ *
+ * A form's `status` is its own lifecycle — draft, published, closed — and only
+ * a published form accepts submissions, so only a published form can send a
+ * visitor anywhere at all. That is the whole reason this rule is conditional:
+ * a draft form pointing at a draft page is fine, because the two go live
+ * together.
+ *
+ * The stored status is consulted when the write does not carry one. Publishing
+ * a form and editing its settings are separate saves, and an update that never
+ * mentions `status` leaves the stored one standing — so reading an absent
+ * field as "not published" would wave through exactly the case this rule
+ * exists to catch.
+ */
+export function formAcceptsSubmissions(
+  data: Record<string, unknown> | undefined,
+  originalData: Record<string, unknown> | undefined
+): boolean {
+  return (data?.status ?? originalData?.status) === "published";
+}
+
+/**
+ * The stored `settings`, which is not the shape the payload uses.
+ *
+ * Measured on 2026-08-25: the incoming write carries `settings` as an OBJECT,
+ * and the same field on `originalData` comes back as JSON TEXT. Reading the
+ * stored row with the payload's reader answers "no redirect configured" for
+ * every form that has one — silently, and indistinguishably from a form that
+ * genuinely has none.
+ */
+function storedSettings(value: unknown): Record<string, unknown> | null {
+  if (typeof value === "string") {
+    try {
+      return relationshipSettings(JSON.parse(value));
+    } catch {
+      return null;
+    }
+  }
+  return relationshipSettings(value);
+}
+
+/**
+ * The redirect target already stored on the form, for a write that does not
+ * mention it.
+ *
+ * Publishing a form is such a write: it carries `status` and nothing else, and
+ * the target it inherits is the one a visitor will be sent to. Without this,
+ * the rule would guard the save that PICKS a draft page and ignore the save
+ * that makes that same pairing reachable — protecting one path while appearing
+ * to protect both.
+ *
+ * Nothing here is written back. `originalData` is the stored row, not the
+ * payload; normalising it would edit a document this write never touched.
+ */
+function storedRedirectReference(
+  originalData: Record<string, unknown> | undefined,
+  patterns: RedirectRelationships
+): { collection: string; id: string } | null {
+  const settings = storedSettings(originalData?.settings);
+  if (!settings) return null;
+
+  const collections = Object.keys(patterns);
+  const reference = parseRedirectReference(settings.redirectPage, collections);
+  return reference && collections.includes(reference.collection)
+    ? reference
+    : null;
 }
 
 /**
@@ -226,16 +305,93 @@ function assertRedirectTargetNamed(
  * is in front of them, rather than leaving a form that saves cleanly and
  * redirects nobody.
  */
-async function assertRedirectTargetUsable(
+/**
+ * Whether this write leaves a form that would send visitors to a page they
+ * cannot reach.
+ *
+ * One question, so it has one implementation and one name. It is the whole
+ * rule: a form that accepts submissions is the only kind that redirects
+ * anyone, and an unreachable target is the only thing that 404s them. A draft
+ * form pointing at a draft page satisfies neither half and is allowed — the
+ * picker offers unpublished pages on purpose, because a form is usually
+ * configured beside the page it points at and the two go live together.
+ */
+export function wouldStrandVisitors(
+  data: Record<string, unknown> | undefined,
+  originalData: Record<string, unknown> | undefined,
+  target: RedirectTargetDocument
+): boolean {
+  return (
+    formAcceptsSubmissions(data, originalData) && !documentIsReachable(target)
+  );
+}
+
+/**
+ * The page this write leaves the form pointing at, and whether the write
+ * CHOSE it.
+ *
+ * The distinction decides which refusals apply. A write that names a page
+ * answers for that page; a write that only publishes the form, or renames it,
+ * inherits whatever is stored and must not be refused for it.
+ */
+function redirectReferenceForWrite(
   context: HookContext,
   patterns: RedirectRelationships
-) {
-  const reference = assertRedirectTargetNamed(
+): { reference: { collection: string; id: string }; chosen: boolean } | null {
+  const chosen = assertRedirectTargetNamed(
     context.data,
     context.operation,
     patterns
   );
-  if (!reference) return;
+  if (chosen) return { reference: chosen, chosen: true };
+
+  const stored = storedRedirectReference(
+    context.originalData as Record<string, unknown> | undefined,
+    patterns
+  );
+  return stored ? { reference: stored, chosen: false } : null;
+}
+
+/**
+ * Whether the collection's configured pattern can build a URL for this
+ * document.
+ *
+ * A pattern may be a FUNCTION, which is host code and can throw. Authoring
+ * must not be blocked by that: the submission path contains the same throw and
+ * degrades to no redirect with a log line, so a broken pattern costs a
+ * destination rather than the ability to edit forms.
+ */
+function assertPatternBuildsUrl(
+  patterns: RedirectRelationships,
+  reference: { collection: string; id: string },
+  target: RedirectTargetDocument
+) {
+  let url: string | undefined;
+  try {
+    url = applyRedirectPattern(patterns[reference.collection], target);
+  } catch {
+    return;
+  }
+  if (url) return;
+
+  // Pattern-agnostic. The configured pattern may depend on any field, or be a
+  // function that declines for its own reasons, so naming a slug states a
+  // remedy that often cannot fix the actual failure — and the save is
+  // correctly blocked either way, leaving the author following wrong advice.
+  throw redirectRefusal(
+    `No URL could be built for that page from the pattern configured for ` +
+      `"${reference.collection}". Choose another page, or ask a developer ` +
+      `to check that collection's redirect pattern.`
+  );
+}
+
+export async function assertRedirectTargetUsable(
+  context: HookContext,
+  patterns: RedirectRelationships
+) {
+  const write = redirectReferenceForWrite(context, patterns);
+  if (!write) return;
+  const { reference, chosen } = write;
 
   const nextly = context.req?.nextly;
   if (!nextly) return;
@@ -257,34 +413,32 @@ async function assertRedirectTargetUsable(
   const found = await readRedirectTarget(nextly, reference);
   if (found.status === "unreadable") return;
   if (found.status === "missing") {
+    // Only the write that NAMES a page answers for that page still existing.
+    // A rename inherits whatever is stored, and refusing it would block an
+    // edit for a setting it never touched.
+    if (!chosen) return;
     throw redirectRefusal(
       `That page no longer exists in "${reference.collection}". Pick another.`
     );
   }
-  const target = found.document;
 
-  // A pattern may be a FUNCTION, which is host code and can throw. Authoring
-  // must not be blocked by that: the submission path contains the same throw
-  // and degrades to no redirect with a log line, so a broken pattern costs a
-  // destination rather than the ability to edit forms.
-  let url: string | undefined;
-  try {
-    url = applyRedirectPattern(patterns[reference.collection], target);
-  } catch {
-    return;
-  }
-
-  if (!url) {
-    // Pattern-agnostic. The configured pattern may depend on any field, or be
-    // a function that declines for its own reasons, so naming a slug states a
-    // remedy that often cannot fix the actual failure — and the save is
-    // correctly blocked either way, leaving the author following wrong advice.
+  if (
+    wouldStrandVisitors(
+      context.data as Record<string, unknown> | undefined,
+      context.originalData as Record<string, unknown> | undefined,
+      found.document
+    )
+  ) {
     throw redirectRefusal(
-      `No URL could be built for that page from the pattern configured for ` +
-        `"${reference.collection}". Choose another page, or ask a developer ` +
-        `to check that collection's redirect pattern.`
+      `That page is not published yet, and this form is. A visitor sent ` +
+        `there would reach a "page not found". Publish the page, or save ` +
+        `this form as a draft until you do.`
     );
   }
+
+  // The pattern belongs to the write that CHOOSES a page. A form being
+  // published does not get refused for a pattern its author never edited.
+  if (chosen) assertPatternBuildsUrl(patterns, reference, found.document);
 }
 
 /**

--- a/packages/plugin-form-builder/src/collections/redirect-invariant.test.ts
+++ b/packages/plugin-form-builder/src/collections/redirect-invariant.test.ts
@@ -44,9 +44,15 @@ describe("formAcceptsSubmissions", () => {
 });
 
 describe("wouldStrandVisitors", () => {
-  const live = { id: "p1", status: "published" };
-  const draft = { id: "p1", status: "draft" };
+  const live = {
+    id: "p1",
+    status: "published",
+    firstPublishedAt: "2026-08-25T00:00:00.000Z",
+  };
+  const draft = { id: "p1", status: "draft", firstPublishedAt: null };
   const noLifecycle = { id: "p1" };
+  // An unmanaged collection carrying its OWN field named `status`.
+  const ownStatusField = { id: "p1", status: "draft" };
 
   it("is true only for a published form pointing at an unpublished page", () => {
     expect(wouldStrandVisitors({ status: "published" }, undefined, draft)).toBe(
@@ -76,6 +82,14 @@ describe("wouldStrandVisitors", () => {
     // turned drafts on.
     expect(
       wouldStrandVisitors({ status: "published" }, undefined, noLifecycle)
+    ).toBe(false);
+  });
+
+  it("allows a target whose collection merely has a status field", () => {
+    // Not a lifecycle, so not a draft. Refusing here would block a save for a
+    // page that is perfectly reachable, on nothing but a field name.
+    expect(
+      wouldStrandVisitors({ status: "published" }, undefined, ownStatusField)
     ).toBe(false);
   });
 
@@ -215,7 +229,12 @@ describe("assertRedirectTargetUsable", () => {
               settings: JSON.stringify(picks("p1").settings),
             },
           },
-          () => ({ id: "p1", slug: "thanks", status: "draft" })
+          () => ({
+            id: "p1",
+            slug: "thanks",
+            status: "draft",
+            firstPublishedAt: null,
+          })
         ),
         patterns
       )
@@ -239,7 +258,11 @@ describe("assertRedirectTargetUsable", () => {
               settings: JSON.stringify(picks("p1").settings),
             },
           },
-          () => ({ id: "p1", status: "published" })
+          () => ({
+            id: "p1",
+            status: "published",
+            firstPublishedAt: "2026-08-25T00:00:00.000Z",
+          })
         ),
         { pages: () => undefined }
       )

--- a/packages/plugin-form-builder/src/collections/redirect-invariant.test.ts
+++ b/packages/plugin-form-builder/src/collections/redirect-invariant.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertRedirectTargetUsable,
+  formAcceptsSubmissions,
+  wouldStrandVisitors,
+} from "./forms";
+
+describe("formAcceptsSubmissions", () => {
+  it("reads the status the write carries", () => {
+    expect(formAcceptsSubmissions({ status: "published" }, undefined)).toBe(
+      true
+    );
+    expect(formAcceptsSubmissions({ status: "draft" }, undefined)).toBe(false);
+  });
+
+  it("falls back to the stored status when the write does not carry one", () => {
+    // Publishing a form and editing its settings are separate saves. An update
+    // that never mentions `status` leaves the stored one standing, so reading
+    // an absent field as "not published" would wave through the very pairing
+    // the rule exists to catch.
+    expect(
+      formAcceptsSubmissions({ name: "Renamed" }, { status: "published" })
+    ).toBe(true);
+  });
+
+  it("lets the write override the stored status in both directions", () => {
+    expect(
+      formAcceptsSubmissions({ status: "published" }, { status: "draft" })
+    ).toBe(true);
+    expect(
+      formAcceptsSubmissions({ status: "draft" }, { status: "published" })
+    ).toBe(false);
+  });
+
+  it("treats closed and unknown states as not accepting submissions", () => {
+    // Only a published form receives a submission, so only a published form
+    // can redirect anyone. "Closed" shows a message instead.
+    for (const status of ["closed", "archived", undefined, ""]) {
+      expect(formAcceptsSubmissions({ status }, undefined)).toBe(false);
+    }
+    expect(formAcceptsSubmissions(undefined, undefined)).toBe(false);
+  });
+});
+
+describe("wouldStrandVisitors", () => {
+  const live = { id: "p1", status: "published" };
+  const draft = { id: "p1", status: "draft" };
+  const noLifecycle = { id: "p1" };
+
+  it("is true only for a published form pointing at an unpublished page", () => {
+    expect(wouldStrandVisitors({ status: "published" }, undefined, draft)).toBe(
+      true
+    );
+  });
+
+  it("allows a draft form to point at a draft page", () => {
+    // They go live together, which is why the rule is conditional rather than
+    // an outright ban on draft targets.
+    expect(wouldStrandVisitors({ status: "draft" }, undefined, draft)).toBe(
+      false
+    );
+  });
+
+  it("allows a published form to point at a published page", () => {
+    // The control: without it, everything above passes just as well against a
+    // rule that refuses every published form.
+    expect(wouldStrandVisitors({ status: "published" }, undefined, live)).toBe(
+      false
+    );
+  });
+
+  it("allows a collection with no publish lifecycle", () => {
+    // No `status` field at all means every document is reachable. Reading that
+    // absence as "draft" would refuse every redirect on every site that never
+    // turned drafts on.
+    expect(
+      wouldStrandVisitors({ status: "published" }, undefined, noLifecycle)
+    ).toBe(false);
+  });
+
+  it("catches publishing a form over a target it never mentions", () => {
+    // The write carries `status` and nothing else; the target comes from the
+    // stored row.
+    expect(
+      wouldStrandVisitors({ status: "published" }, { status: "draft" }, draft)
+    ).toBe(true);
+  });
+
+  it("catches repointing an already-published form at a draft", () => {
+    // The mirror case: the write carries settings and no status, so the
+    // published state can only come from the stored row.
+    expect(
+      wouldStrandVisitors({ name: "x" }, { status: "published" }, draft)
+    ).toBe(true);
+  });
+});
+
+describe("assertRedirectTargetUsable", () => {
+  const patterns = { pages: "/{slug}" };
+  const picks = (id: string) => ({
+    settings: {
+      confirmationType: "relationship",
+      redirectPage: { relationTo: "pages", value: id },
+    },
+  });
+
+  /** A context around one canned answer from `findByID`. */
+  const context = (
+    over: Record<string, unknown>,
+    findByID: () => unknown = () => ({ id: "p1", slug: "thanks" })
+  ) =>
+    ({
+      collection: "forms",
+      operation: "create",
+      context: {},
+      req: { nextly: { findByID: async () => findByID() } },
+      ...over,
+    }) as never;
+
+  it("does nothing without a nextly to read through", async () => {
+    // `req.nextly` is optional. Refusing here would block authoring wherever
+    // the plugin is driven without one, for a page nobody could check.
+    await expect(
+      assertRedirectTargetUsable(
+        {
+          collection: "forms",
+          operation: "create",
+          context: {},
+          data: picks("p1"),
+        } as never,
+        patterns
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("skips the read inside a caller-owned transaction", async () => {
+    // A pooled read cannot see the transaction's own uncommitted rows, so a
+    // page created in the same transaction would read as missing and this
+    // would refuse a correct write. The reader must never run here — a
+    // findByID that throws proves it did not.
+    await expect(
+      assertRedirectTargetUsable(
+        context(
+          {
+            data: picks("p1"),
+            executor: {},
+          },
+          () => {
+            throw new Error("read attempted inside a transaction");
+          }
+        ),
+        patterns
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("does not refuse when the target could not be read", async () => {
+    // Unreadable is not missing. Refusing on any failure blocks a save that a
+    // retry would complete.
+    await expect(
+      assertRedirectTargetUsable(
+        context({ data: picks("p1") }, () => {
+          throw Object.assign(new Error("db down"), { code: "ECONNRESET" });
+        }),
+        patterns
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses when the write names a page that is gone", async () => {
+    await expect(
+      assertRedirectTargetUsable(
+        context({ data: picks("p1") }, () => {
+          throw Object.assign(new Error("nope"), { code: "NOT_FOUND" });
+        }),
+        patterns
+      )
+    ).rejects.toMatchObject({
+      publicData: { errors: [{ path: "settings.redirectPage" }] },
+    });
+  });
+
+  it("lets a write that names no page through when the stored one is gone", async () => {
+    // A rename inherits the stored target and does not answer for it.
+    await expect(
+      assertRedirectTargetUsable(
+        context(
+          {
+            operation: "update",
+            data: { name: "Renamed" },
+            originalData: {
+              status: "draft",
+              settings: JSON.stringify(picks("p1").settings),
+            },
+          },
+          () => {
+            throw Object.assign(new Error("nope"), { code: "NOT_FOUND" });
+          }
+        ),
+        patterns
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses a published form whose stored target is a draft", async () => {
+    await expect(
+      assertRedirectTargetUsable(
+        context(
+          {
+            operation: "update",
+            data: { status: "published" },
+            originalData: {
+              status: "draft",
+              settings: JSON.stringify(picks("p1").settings),
+            },
+          },
+          () => ({ id: "p1", slug: "thanks", status: "draft" })
+        ),
+        patterns
+      )
+    ).rejects.toMatchObject({
+      publicData: { errors: [{ path: "settings.redirectPage" }] },
+    });
+  });
+
+  it("does not refuse a publish for a pattern the author never edited", async () => {
+    // The pattern belongs to the write that CHOOSES a page. This one only
+    // publishes, and the submit path degrades an unusable pattern to no
+    // redirect with a log line.
+    await expect(
+      assertRedirectTargetUsable(
+        context(
+          {
+            operation: "update",
+            data: { status: "published" },
+            originalData: {
+              status: "draft",
+              settings: JSON.stringify(picks("p1").settings),
+            },
+          },
+          () => ({ id: "p1", status: "published" })
+        ),
+        { pages: () => undefined }
+      )
+    ).resolves.toBeUndefined();
+  });
+
+  it("refuses when the write picks a page its pattern cannot describe", async () => {
+    await expect(
+      assertRedirectTargetUsable(
+        context({ data: picks("p1") }, () => ({
+          id: "p1",
+          status: "published",
+        })),
+        { pages: () => undefined }
+      )
+    ).rejects.toMatchObject({
+      publicData: { errors: [{ path: "settings.redirectPage" }] },
+    });
+  });
+});

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -27,6 +27,7 @@ import {
   applyRedirectPattern,
   documentIsReachable,
   parseRedirectReference,
+  pickedDocumentField,
   type RedirectTargetDocument,
   type RedirectUrlPattern,
 } from "../utils/redirect-target";
@@ -428,21 +429,22 @@ async function resolveRedirectUrl(
   const settings = form.settings;
   if (!settings) return undefined;
 
-  const { confirmationType } = settings;
-  if (confirmationType !== "redirect" && confirmationType !== "relationship") {
-    return undefined;
-  }
-
   // A typed URL is returned verbatim: it is the whole point of that option,
   // and it may legitimately point off-site.
-  if (confirmationType === "redirect" && settings.redirectUrl) {
+  if (settings.confirmationType === "redirect" && settings.redirectUrl) {
     return settings.redirectUrl;
   }
 
+  // Otherwise whichever key names a document, read through the SAME function
+  // the save-time rule uses. Two readers here would let this path redirect to
+  // a document the rule never inspected — which it did: the rule matched only
+  // `relationship`, so a `redirect`-with-relation form was resolved here and
+  // guarded nowhere.
+  const field = pickedDocumentField(settings as Record<string, unknown>);
+  if (!field) return undefined;
+
   return urlForPickedDocument(
-    confirmationType === "relationship"
-      ? settings.redirectPage
-      : settings.redirectRelation,
+    (settings as Record<string, unknown>)[field],
     form,
     pluginConfig,
     pluginContext

--- a/packages/plugin-form-builder/src/handlers/submit-form.ts
+++ b/packages/plugin-form-builder/src/handlers/submit-form.ts
@@ -25,6 +25,7 @@ import {
 } from "../utils/generate-schema";
 import {
   applyRedirectPattern,
+  documentIsReachable,
   parseRedirectReference,
   type RedirectTargetDocument,
   type RedirectUrlPattern,
@@ -484,6 +485,21 @@ async function urlForPickedDocument(
 
   const target = await readTarget(reference, form, pluginContext);
   if (!target) return undefined;
+
+  // Reachability is re-decided HERE, not inherited from the save. Nothing runs
+  // a forms hook when the target itself changes, so a page that was published
+  // when the form was saved can be unpublished afterwards and the save-time
+  // rule never sees it. Sending a visitor there produces exactly the "page not
+  // found" that rule exists to prevent, so this degrades to no redirect — the
+  // submission is still stored and still succeeds.
+  if (!documentIsReachable(target)) {
+    logger.warn?.("Form redirects to a page that is no longer published", {
+      form: form.slug,
+      collection: reference.collection,
+      target: reference.id,
+    });
+    return undefined;
+  }
 
   return buildUrl(pattern, target, reference.collection, form, pluginContext);
 }

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -79,23 +79,47 @@ function referenceId(value: unknown): string | null {
 }
 
 /**
+ * The field the publish lifecycle puts on every row it manages.
+ *
+ * A collection without the lifecycle may legally define an ordinary field
+ * named `status` — "active", "archived", anything — so the NAME `status` does
+ * not identify a lifecycle and reading it as one marks live documents as
+ * drafts. This field does identify it: it is written by the framework, not by
+ * a schema author.
+ *
+ * Measured on 2026-08-25, creating one document in each kind of collection:
+ * a `status: true` collection returns
+ * `[createdAt, firstPublishedAt, id, slug, status, title, updatedAt]`, and a
+ * plain collection carrying its own `status` text field returns the same list
+ * WITHOUT `firstPublishedAt`. It is present on a never-published draft too, so
+ * presence marks the lifecycle rather than the act of publishing.
+ */
+const PUBLISH_LIFECYCLE_FIELD = "firstPublishedAt";
+
+/**
+ * Whether this document comes from a collection with the publish lifecycle.
+ *
+ * Callers that project their reads must request
+ * {@link PUBLISH_LIFECYCLE_FIELD}; a projection that omits it makes every
+ * document look unmanaged, which reads as "always reachable".
+ */
+export function hasPublishLifecycle(document: RedirectTargetDocument): boolean {
+  return PUBLISH_LIFECYCLE_FIELD in document;
+}
+
+/**
  * Whether a visitor can reach this document.
  *
- * A collection with no publish lifecycle carries no `status` field at all and
- * its documents are always reachable; a collection that HAS the lifecycle
- * carries the field on every row. Read for truthiness the two are the same
- * absence of `"published"`, and they mean opposite things — so this asks
- * whether the field is THERE, not whether it says yes. Treating the first as
- * unpublished would refuse every redirect on every site that never turned
- * drafts on.
+ * Unmanaged documents are always reachable: there is no unpublished state for
+ * them to be in. Managed ones are reachable only when published — every other
+ * lifecycle state is one the public route does not serve.
  *
- * Lives here, beside the reference parser, because the save rule and the
- * admin picker have to agree about which pages are reachable. Two readers
- * that agree today would drift, and a picker marking the wrong rows as drafts
- * still looks like a working picker.
+ * Lives here, beside the reference parser, because the save rule and the admin
+ * picker have to agree about which pages are reachable. Two readers that agree
+ * today would drift, and a picker marking the wrong rows as drafts still looks
+ * like a working picker.
  */
 export function documentIsReachable(document: RedirectTargetDocument): boolean {
-  const status = document.status;
-  if (typeof status !== "string") return true;
-  return status === "published";
+  if (!hasPublishLifecycle(document)) return true;
+  return document.status === "published";
 }

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -123,3 +123,36 @@ export function documentIsReachable(document: RedirectTargetDocument): boolean {
   if (!hasPublishLifecycle(document)) return true;
   return document.status === "published";
 }
+
+/** The settings keys that can carry the document a form redirects to. */
+export type PickedDocumentField = "redirectPage" | "redirectRelation";
+
+/**
+ * Which settings key names the document this form redirects to, if any.
+ *
+ * TWO options carry one. "Redirect to a page" stores `redirectPage`, and the
+ * URL option falls back to `redirectRelation` when no URL is typed — the shape
+ * code-first and legacy forms use, and one the submission path has always
+ * resolved. One definition of the question, so the rule that guards a target
+ * cannot recognise fewer shapes than the resolver that acts on it: a form the
+ * rule skips is a form the resolver still redirects.
+ *
+ * The two are not equally strict about being EMPTY, deliberately. Naming
+ * nothing under "Redirect to a page" contradicts the option itself, so it is
+ * reported. Under the URL option an absent relation only means no destination
+ * is configured yet — `validateFormConfig` already governs that, and refusing
+ * it here would reject saves this rule never governed.
+ */
+export function pickedDocumentField(
+  settings: Record<string, unknown>
+): PickedDocumentField | null {
+  if (settings.confirmationType === "relationship") return "redirectPage";
+  if (
+    settings.confirmationType === "redirect" &&
+    !settings.redirectUrl &&
+    settings.redirectRelation != null
+  ) {
+    return "redirectRelation";
+  }
+  return null;
+}

--- a/packages/plugin-form-builder/src/utils/redirect-reference.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-reference.ts
@@ -77,3 +77,25 @@ function referenceId(value: unknown): string | null {
   }
   return null;
 }
+
+/**
+ * Whether a visitor can reach this document.
+ *
+ * A collection with no publish lifecycle carries no `status` field at all and
+ * its documents are always reachable; a collection that HAS the lifecycle
+ * carries the field on every row. Read for truthiness the two are the same
+ * absence of `"published"`, and they mean opposite things — so this asks
+ * whether the field is THERE, not whether it says yes. Treating the first as
+ * unpublished would refuse every redirect on every site that never turned
+ * drafts on.
+ *
+ * Lives here, beside the reference parser, because the save rule and the
+ * admin picker have to agree about which pages are reachable. Two readers
+ * that agree today would drift, and a picker marking the wrong rows as drafts
+ * still looks like a working picker.
+ */
+export function documentIsReachable(document: RedirectTargetDocument): boolean {
+  const status = document.status;
+  if (typeof status !== "string") return true;
+  return status === "published";
+}

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   applyRedirectPattern,
+  documentIsReachable,
   DEFAULT_REDIRECT_PATTERN,
   normalizeRedirectRelationships,
   parseRedirectReference,
@@ -215,5 +216,37 @@ describe("applyRedirectPattern", () => {
   it("returns nothing when the function declines", () => {
     expect(applyRedirectPattern(() => undefined, page)).toBeUndefined();
     expect(applyRedirectPattern(() => "", page)).toBeUndefined();
+  });
+});
+
+describe("documentIsReachable", () => {
+  it("treats a collection with no publish lifecycle as reachable", () => {
+    // No `status` FIELD at all — the ordinary case for a site that never
+    // turned drafts on. Reading this as "not published" would refuse every
+    // redirect on every such site.
+    expect(documentIsReachable({ id: "1", slug: "thanks" })).toBe(true);
+  });
+
+  it("reads a published document as reachable", () => {
+    expect(documentIsReachable({ id: "1", status: "published" })).toBe(true);
+  });
+
+  it("reads a draft as unreachable", () => {
+    expect(documentIsReachable({ id: "1", status: "draft" })).toBe(false);
+  });
+
+  it("reads any other lifecycle state as unreachable", () => {
+    // Whatever a collection adds to its lifecycle, only "published" is a
+    // promise that the public route serves the page. Anything else is a state
+    // this rule has never seen and must not assume is live.
+    for (const status of ["archived", "scheduled", "", "review"]) {
+      expect(documentIsReachable({ id: "1", status })).toBe(false);
+    }
+  });
+
+  it("does not mistake a non-string status for a lifecycle answer", () => {
+    // A field that is present but not a string is not a lifecycle this
+    // function understands; the absence check is on the TYPE for that reason.
+    expect(documentIsReachable({ id: "1", status: null })).toBe(true);
   });
 });

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   applyRedirectPattern,
   documentIsReachable,
+  hasPublishLifecycle,
   DEFAULT_REDIRECT_PATTERN,
   normalizeRedirectRelationships,
   parseRedirectReference,
@@ -219,34 +220,69 @@ describe("applyRedirectPattern", () => {
   });
 });
 
+describe("hasPublishLifecycle", () => {
+  it("recognises a document the lifecycle manages", () => {
+    // `firstPublishedAt` is written by the framework and is present even on a
+    // never-published draft, so it marks the lifecycle rather than the act of
+    // publishing.
+    expect(hasPublishLifecycle({ id: "1", firstPublishedAt: null })).toBe(true);
+  });
+
+  it("does not mistake an ordinary field named status for a lifecycle", () => {
+    // A collection without the lifecycle may legally define its own `status`
+    // field. Reading the NAME as a lifecycle marks live documents as drafts.
+    expect(hasPublishLifecycle({ id: "1", status: "active" })).toBe(false);
+  });
+});
+
 describe("documentIsReachable", () => {
   it("treats a collection with no publish lifecycle as reachable", () => {
-    // No `status` FIELD at all — the ordinary case for a site that never
-    // turned drafts on. Reading this as "not published" would refuse every
-    // redirect on every such site.
+    // The ordinary case for a site that never turned drafts on. Reading this
+    // as "not published" would refuse every redirect on every such site.
     expect(documentIsReachable({ id: "1", slug: "thanks" })).toBe(true);
   });
 
+  it("treats a document with its own status field as reachable", () => {
+    // The case that matters most: `status: "active"` on an unmanaged
+    // collection is not a draft, and marking it one both labels a live page
+    // "Draft" in the picker and refuses a perfectly good save.
+    expect(documentIsReachable({ id: "1", status: "active" })).toBe(true);
+    expect(documentIsReachable({ id: "1", status: "draft" })).toBe(true);
+  });
+
   it("reads a published document as reachable", () => {
-    expect(documentIsReachable({ id: "1", status: "published" })).toBe(true);
+    expect(
+      documentIsReachable({
+        id: "1",
+        status: "published",
+        firstPublishedAt: "2026-08-25T00:00:00.000Z",
+      })
+    ).toBe(true);
   });
 
-  it("reads a draft as unreachable", () => {
-    expect(documentIsReachable({ id: "1", status: "draft" })).toBe(false);
+  it("reads a managed draft as unreachable", () => {
+    expect(
+      documentIsReachable({ id: "1", status: "draft", firstPublishedAt: null })
+    ).toBe(false);
   });
 
-  it("reads any other lifecycle state as unreachable", () => {
-    // Whatever a collection adds to its lifecycle, only "published" is a
-    // promise that the public route serves the page. Anything else is a state
-    // this rule has never seen and must not assume is live.
+  it("reads any other managed state as unreachable", () => {
+    // Only "published" is a promise that the public route serves the page.
+    // Anything else is a state this rule has never seen and must not assume
+    // is live — and on a managed collection, guessing wrong sends visitors to
+    // a 404 rather than merely inconveniencing an author.
     for (const status of ["archived", "scheduled", "", "review"]) {
-      expect(documentIsReachable({ id: "1", status })).toBe(false);
+      expect(
+        documentIsReachable({ id: "1", status, firstPublishedAt: null })
+      ).toBe(false);
     }
   });
 
-  it("does not mistake a non-string status for a lifecycle answer", () => {
-    // A field that is present but not a string is not a lifecycle this
-    // function understands; the absence check is on the TYPE for that reason.
-    expect(documentIsReachable({ id: "1", status: null })).toBe(true);
+  it("reads a managed document with a non-string status as unreachable", () => {
+    // The lifecycle is present, so the absence of "published" is meaningful
+    // here in a way it is not on an unmanaged collection.
+    expect(
+      documentIsReachable({ id: "1", status: null, firstPublishedAt: null })
+    ).toBe(false);
   });
 });

--- a/packages/plugin-form-builder/src/utils/redirect-target.test.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.test.ts
@@ -4,6 +4,7 @@ import {
   applyRedirectPattern,
   documentIsReachable,
   hasPublishLifecycle,
+  pickedDocumentField,
   DEFAULT_REDIRECT_PATTERN,
   normalizeRedirectRelationships,
   parseRedirectReference,
@@ -284,5 +285,58 @@ describe("documentIsReachable", () => {
     expect(
       documentIsReachable({ id: "1", status: null, firstPublishedAt: null })
     ).toBe(false);
+  });
+});
+
+describe("pickedDocumentField", () => {
+  it("names the field the page picker writes", () => {
+    expect(pickedDocumentField({ confirmationType: "relationship" })).toBe(
+      "redirectPage"
+    );
+  });
+
+  it("names the relation the URL option falls back to", () => {
+    // The shape code-first and legacy forms use. The submission path has
+    // always resolved it; before this it was the one picked document the save
+    // rule never inspected.
+    expect(
+      pickedDocumentField({
+        confirmationType: "redirect",
+        redirectRelation: { relationTo: "pages", value: "p1" },
+      })
+    ).toBe("redirectRelation");
+  });
+
+  it("prefers a typed URL over a relation left beside it", () => {
+    // A stored relation from an earlier edit does not make the form redirect
+    // to a document; the URL does, and the resolver returns it verbatim.
+    expect(
+      pickedDocumentField({
+        confirmationType: "redirect",
+        redirectUrl: "https://example.test/thanks",
+        redirectRelation: { relationTo: "pages", value: "p1" },
+      })
+    ).toBeNull();
+  });
+
+  it("names nothing when the URL option carries no relation", () => {
+    // Not an error here: an absent relation means no destination is
+    // configured yet, which `validateFormConfig` governs. Reporting it would
+    // refuse saves this rule never governed.
+    expect(pickedDocumentField({ confirmationType: "redirect" })).toBeNull();
+  });
+
+  it("names nothing for a form that shows a message", () => {
+    expect(pickedDocumentField({ confirmationType: "message" })).toBeNull();
+    expect(pickedDocumentField({})).toBeNull();
+  });
+
+  it("still names the page field when the picker stored nothing", () => {
+    // "Redirect to a page" naming no page contradicts the option itself, so
+    // the field is returned and the caller reports it — unlike the URL option,
+    // where an absent relation is merely unfinished.
+    expect(pickedDocumentField({ confirmationType: "relationship" })).toBe(
+      "redirectPage"
+    );
   });
 });

--- a/packages/plugin-form-builder/src/utils/redirect-target.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.ts
@@ -25,6 +25,7 @@ import type { RedirectTargetDocument } from "./redirect-reference";
 
 export type { RedirectTargetDocument } from "./redirect-reference";
 export {
+  documentIsReachable,
   parseRedirectReference,
   type RedirectReference,
 } from "./redirect-reference";

--- a/packages/plugin-form-builder/src/utils/redirect-target.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.ts
@@ -28,6 +28,8 @@ export {
   documentIsReachable,
   hasPublishLifecycle,
   parseRedirectReference,
+  pickedDocumentField,
+  type PickedDocumentField,
   type RedirectReference,
 } from "./redirect-reference";
 

--- a/packages/plugin-form-builder/src/utils/redirect-target.ts
+++ b/packages/plugin-form-builder/src/utils/redirect-target.ts
@@ -26,6 +26,7 @@ import type { RedirectTargetDocument } from "./redirect-reference";
 export type { RedirectTargetDocument } from "./redirect-reference";
 export {
   documentIsReachable,
+  hasPublishLifecycle,
   parseRedirectReference,
   type RedirectReference,
 } from "./redirect-reference";


### PR DESCRIPTION
Implements the founder's ruling on `decision:form-redirect-draft-targets` (2026-08-25).

**Stacked on #1215** — base is `fix/redirect-picker-projection`, so review that first. GitHub retargets this to `main` when #1215 merges.

## On screen

The picker offered unpublished pages with nothing saying so. Now:

```
Redirect to  ▾
  Pages
    Test 1                        DRAFT
    Thanks for getting in touch
```

Verified in a real browser against the playground, with one draft page and one published page — screenshot behaviour confirmed, console clean.

## The decision

Three options were put to the founder. They chose: **offer drafts, mark them, and refuse the save only when a published form points at an unpublished page.**

That is the one pairing a visitor can actually reach. A form's `status` is its own lifecycle — draft, published, closed — and the field's own description says it: *"Only published forms can receive submissions."* So a draft form pointing at a draft page is fine, because the two go live together, and the rule only fires where a visitor would really land on a 404.

Rejected: warn-only (a published form could still sit pointing at a 404 with nothing stopping it) and published-only (restores the complaint that opened this — an author who drafted the thank-you page a minute ago opens the picker, sees nothing, and is told to publish first).

## What this changes

**`wouldStrandVisitors` is judged on what a write leaves behind, not on what it carries.** Guarding only the save that *picks* a draft page would protect one path while appearing to protect both: publishing a form is a separate save that carries `status` and nothing else, and it makes an existing draft pairing reachable. Both directions are now covered, and so is the mirror case — repointing an already-published form, where the published state can only come from the stored row.

**That needed the stored row, which is not the shape the payload uses.** Measured: the write carries `settings` as an **object**, and the same field on `originalData` comes back as **JSON text**. Reading the stored row with the payload's reader answers "no redirect configured" for every form that has one — silently, and indistinguishably from a form that genuinely has none. That is why the publish-later test failed before `storedSettings` existed.

**Reachability has one implementation**, in `redirect-reference.ts` — the dependency-free half both the save rule and the browser picker import. A collection with no publish lifecycle carries no `status` field at all; read for truthiness that is the same absence as a draft and means the opposite. Getting it backwards refuses every redirect on every site that never turned drafts on, which is why the check is on the field's *type*, not its truthiness.

**The projection and the label fields are deliberately separate.** `status` must be requested and must never be labelled: `documentLabel` walks whatever list it is handed, so a page with no title would otherwise be offered to an author as "draft".

**A write that names no page is not refused for one.** A rename inherits the stored target and does not answer for it — refusing there would block editing a form's name because of a setting the write never mentioned.

## An existing test changed, deliberately

`accepts a draft page as a redirect target` created a **published** form pointing at a draft — exactly the pairing now refused. It encoded the behaviour this ruling overturns. Its underlying property was real and is preserved in `accepts a draft page when the form is itself a draft`: that a by-id read reaches drafts at all, so the rule cannot tell an author a page "no longer exists" while it is on screen.

## Evidence

28 new tests. Every one break-verified — code broken, the named test confirmed failing at runtime, code restored:

| Break | Tests that failed |
|---|---|
| reachability refusal removed | the 3 refusal tests |
| `documentIsReachable` drops the no-lifecycle guard | no-lifecycle test, plus 11 unrelated suites — the guard is load-bearing |
| every non-draft state treated as live | `reads any other lifecycle state as unreachable` |
| `formAcceptsSubmissions` ignores the stored status | `refuses repointing a published form at a draft page` |
| `storedRedirectReference` always null | `refuses publishing a form over a draft target it never touches` |
| `storedSettings` stops parsing the stored JSON text | same |
| missing-target guard removed | `lets a rename through after the stored target is deleted` |
| metadata request reads the wrong endpoint | 6 component tests |
| metadata response misread (flat vs nested) | 5 component tests |
| `useTitleFields` stops feeding `fetchChoices` | 5 component tests |
| Draft marker removed | `marks an unpublished page as a draft` |
| reachability inverted | draft + no-lifecycle marking tests |

One mutation initially reported "nothing failed". That was **my harness targeting a file the function had moved out of**, not a coverage gap — re-run against the right file, it fails two tests. Reported because a passing mutation that was never applied is worse than no mutation at all.

## Addresses Codex P1 on #1215

**"Cover the metadata-to-picker path"** — done here, since the same wiring carries the draft marker. `RedirectPagePicker.test.tsx` mocks the metadata response, renders the component, and asserts the request the component actually makes and the text it actually renders. The fixture is titled by `headline` on purpose: a fixture titled by `title` returns the same green whether the configured field was honoured or ignored. All three of Codex's named failure modes are break-verified above.

**"Exercise the real server select parser"** is not addressed here and needs its own PR — see below.

## Checks

- 255 tests passed, 31 files
- `tsc --noEmit` clean; pre-push declaration build green
- `fallow audit --changed-since origin/main --gate new-only` — **verdict: pass**, `complexity_introduced: 0`

The gate initially failed on `assertRedirectTargetUsable` (CRAP 56.3, introduced). Cleared honestly rather than suppressed: the function was decomposed into `redirectReferenceForWrite`, `wouldStrandVisitors` and `assertPatternBuildsUrl` (CRAP 56.3 → 31.6), then given direct tests for the branches integration tests cannot reach — no `req.nextly`, the transaction short-circuit, and an unreadable target. The transaction test uses a `findByID` that throws if called, so it is a positive control rather than an assertion satisfied by absence.

## Still open

`finding:select-param-has-no-shared-encoder` — the `select` wire format has a parser and no encoder, and `parseSelectParam` has no tests anywhere in the repo. Codex's remaining P1 on #1215 is the same point: mirroring the parser in a test violates AGENTS.md's own rule that one question has one implementation. The fix is a shared codec beside the parser in `packages/nextly/src/dispatcher/**`, which is unclaimed territory and warrants its own PR rather than being smuggled into a picker change.

Meanwhile the projection was verified against the **running server**, which is the strongest oracle available without that change:

| `select` sent | fields returned |
|---|---|
| JSON-encoded | `id, title, slug, status, createdAt, updatedAt, firstPublishedAt` |
| comma list (what shipped) | the same **plus `content` and `usedClasses`** |

`content` is the entire page-builder block tree.