### PR TITLE
fix(nextly): keep a user's uploads when the account is deleted

### DIFF
--- a/.changeset/user-delete-keeps-their-uploads.md
+++ b/.changeset/user-delete-keeps-their-uploads.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Deleting a user no longer deletes the files they uploaded. `media.uploaded_by` carries a
+cascading foreign key to the account, so removing a person destroyed every image, document and
+video they had ever added — enforced by the database itself, beneath every service, hook and
+access check, with nothing to intercept it and no warning. A logo uploaded by someone who has
+since left is still the site's logo.
+
+Deleting an account now clears its name off those files first, in the same transaction, so the
+files stay and only the attribution goes. This applies on every database immediately, existing
+sites included, because it needs no schema migration.

--- a/packages/nextly/src/domains/media/__tests__/user-delete-keeps-media.integration.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/user-delete-keeps-media.integration.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Deleting a user must not destroy the files they uploaded.
+ *
+ * `media.uploadedBy` references `users.id`, and the reference carries an
+ * ON DELETE rule that the DATABASE enforces — below every service, every hook
+ * and every access check. Nothing in application code runs, so no test that
+ * drives a service can see it: the only way to observe the rule is to delete a
+ * user and look at what is left.
+ *
+ * An asset library is shared property. A logo uploaded by someone who has since
+ * left is still the site's logo, and losing every file with the account is a
+ * data-loss report rather than a tidy-up. The attribution is the part that
+ * belongs to the person, and it is the part that goes.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { MediaService as LegacyMediaService } from "../../../services/media";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+/** Upload one file attributed to `uploaderId`, and return its id. */
+async function uploadAttributedTo(
+  handle: TestNextly,
+  uploaderId: string,
+  filename: string
+): Promise<string> {
+  // The LEGACY service, because it is the only surface that takes `uploadedBy`
+  // directly. The Direct API derives it from the request context, which this
+  // harness has no session for — and an upload attributed to nobody cannot
+  // exercise a rule about the uploader's account.
+  const legacy = new LegacyMediaService(handle.adapter, console as never);
+  const result = await legacy.uploadMedia({
+    file: Buffer.from("x"),
+    filename,
+    mimeType: "application/pdf",
+    size: 1,
+    uploadedBy: uploaderId,
+  });
+  expect(result.success).toBe(true);
+  return (result.data as { id: string }).id;
+}
+
+/**
+ * The stored row, straight from the table — not through a service.
+ *
+ * The adapter maps columns back to their FIELD names, so this reads
+ * `uploadedBy` rather than the `uploaded_by` the column is called. Reading the
+ * column name yields `undefined`, which is indistinguishable from an upload
+ * that never recorded an uploader — and would fail the control below while the
+ * fixture was perfectly correct. It did, before this was fixed.
+ */
+async function readMediaRow(
+  handle: TestNextly,
+  mediaId: string
+): Promise<{ id: string; uploadedBy: string | null } | undefined> {
+  const rows = (await handle.adapter.select("media", {
+    where: { and: [{ column: "id", op: "=", value: mediaId }] },
+  })) as Array<{ id: string; uploadedBy?: string | null }>;
+  const row = rows[0];
+  return row ? { id: row.id, uploadedBy: row.uploadedBy ?? null } : undefined;
+}
+
+describe("deleting a user and their uploads", () => {
+  it("keeps the files and clears only the attribution", async () => {
+    current = await createTestNextly({});
+    const handle = current;
+
+    await handle.adapter.insert("users", {
+      id: "departing-1",
+      email: "departing-1@test.local",
+    });
+    const mediaId = await uploadAttributedTo(handle, "departing-1", "logo.pdf");
+
+    // The fixture control, and it carries the test. If the row were not stored
+    // against this user, deleting the user would leave it untouched for a
+    // reason that has nothing to do with the rule under test, and the
+    // assertion below would pass on a file no cascade could ever have reached.
+    const before = await readMediaRow(handle, mediaId);
+    expect(before?.uploadedBy).toBe("departing-1");
+
+    await handle.nextly.users.delete({ id: "departing-1" });
+
+    // The second control: the user really is gone. A delete that silently
+    // failed leaves the media row present for the wrong reason.
+    const remainingUsers = (await handle.adapter.select("users", {
+      where: { and: [{ column: "id", op: "=", value: "departing-1" }] },
+    })) as unknown[];
+    expect(remainingUsers).toHaveLength(0);
+
+    const after = await readMediaRow(handle, mediaId);
+    expect(after, "the file must outlive the account").toBeDefined();
+    expect(after?.uploadedBy).toBeNull();
+  });
+});

--- a/packages/nextly/src/domains/media/__tests__/user-delete-keeps-media.integration.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/user-delete-keeps-media.integration.test.ts
@@ -1,24 +1,35 @@
 /**
  * Deleting a user must not destroy the files they uploaded.
  *
- * `media.uploadedBy` references `users.id`, and the reference carries an
- * ON DELETE rule that the DATABASE enforces — below every service, every hook
- * and every access check. Nothing in application code runs, so no test that
- * drives a service can see it: the only way to observe the rule is to delete a
- * user and look at what is left.
+ * `media.uploaded_by` declares ON DELETE CASCADE, and that rule is still in the
+ * schema — this is NOT a test that the database keeps the rows. It covers the
+ * application detach: `UserMutationService.deleteUser` sets `uploaded_by` to
+ * null inside its own transaction, so by the time the user row goes the cascade
+ * has nothing left to act on.
  *
- * An asset library is shared property. A logo uploaded by someone who has since
- * left is still the site's logo, and losing every file with the account is a
- * data-loss report rather than a tidy-up. The attribution is the part that
- * belongs to the person, and it is the part that goes.
+ * That boundary is the point. Every deletion path today goes through
+ * `deleteUser`, so every path is covered; a future one that removes a user row
+ * without it — a raw statement, a cascade arriving from somewhere else — would
+ * still destroy the files, and nothing here would notice. Moving the guarantee
+ * beneath the application layer needs the constraint changed, which is blocked
+ * on the schema pipeline being able to carry a foreign-key change on
+ * PostgreSQL.
+ *
+ * Run against every dialect the process is configured for, because the detach
+ * is a transactional write and transactions are where the three dialects differ
+ * most. A run with no server URL set covers SQLite only.
  */
 import { afterEach, describe, expect, it } from "vitest";
 
-import { MediaService as LegacyMediaService } from "../../../services/media";
 import {
   createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+
+/** When the fixture rows claim to have been written. Deliberately long past. */
+const STORED_AT = new Date("2020-01-01T00:00:00Z");
 
 let current: TestNextly | undefined;
 
@@ -27,26 +38,34 @@ afterEach(async () => {
   current = undefined;
 });
 
-/** Upload one file attributed to `uploaderId`, and return its id. */
-async function uploadAttributedTo(
+/**
+ * A media row written straight to the table, never through the upload path.
+ *
+ * An upload would run the local-storage adapter, which writes a real file into
+ * `packages/nextly/public/uploads/` and adds a `.gitignore` beside it — neither
+ * of which `destroy()` removes, so every run would leave the checkout dirtier
+ * than it found it. Nothing here is about uploading; the row is the fixture.
+ */
+async function insertMediaOwnedBy(
   handle: TestNextly,
   uploaderId: string,
-  filename: string
-): Promise<string> {
-  // The LEGACY service, because it is the only surface that takes `uploadedBy`
-  // directly. The Direct API derives it from the request context, which this
-  // harness has no session for — and an upload attributed to nobody cannot
-  // exercise a rule about the uploader's account.
-  const legacy = new LegacyMediaService(handle.adapter, console as never);
-  const result = await legacy.uploadMedia({
-    file: Buffer.from("x"),
-    filename,
+  id: string
+): Promise<void> {
+  await handle.adapter.insert("media", {
+    id,
+    filename: `${id}.pdf`,
+    originalFilename: `${id}.pdf`,
     mimeType: "application/pdf",
     size: 1,
+    url: `/uploads/${id}.pdf`,
     uploadedBy: uploaderId,
+    uploadedAt: STORED_AT,
+    // A fixed date in the past, so "the detach refreshed this" is a claim a
+    // stalled timestamp fails. Stamping it with `new Date()` would leave the
+    // before and after equal when nothing updates it, which any
+    // greater-than-or-equal assertion accepts — a test that cannot fail.
+    updatedAt: STORED_AT,
   });
-  expect(result.success).toBe(true);
-  return (result.data as { id: string }).id;
 }
 
 /**
@@ -54,8 +73,8 @@ async function uploadAttributedTo(
  *
  * The adapter maps columns back to their FIELD names, so this reads
  * `uploadedBy` rather than the `uploaded_by` the column is called. Reading the
- * column name yields `undefined`, which is indistinguishable from an upload
- * that never recorded an uploader — and would fail the control below while the
+ * column name yields `undefined`, which is indistinguishable from a row that
+ * never recorded an uploader — and would fail the control below while the
  * fixture was perfectly correct. It did, before this was fixed.
  */
 async function readMediaRow(
@@ -69,35 +88,112 @@ async function readMediaRow(
   return row ? { id: row.id, uploadedBy: row.uploadedBy ?? null } : undefined;
 }
 
-describe("deleting a user and their uploads", () => {
-  it("keeps the files and clears only the attribution", async () => {
-    current = await createTestNextly({});
-    const handle = current;
+describe.each(getConfiguredTestDialects())(
+  "deleting a user and their uploads (%s)",
+  (dialect: TestDialect) => {
+    it("keeps the files and clears only the attribution", async () => {
+      current = await createTestNextly({ dialect });
+      const handle = current;
 
-    await handle.adapter.insert("users", {
-      id: "departing-1",
-      email: "departing-1@test.local",
+      await handle.adapter.insert("users", {
+        id: "departing-1",
+        email: "departing-1@test.local",
+      });
+      await insertMediaOwnedBy(handle, "departing-1", "kept-logo");
+
+      // The fixture control, and it carries the test. If the row were not
+      // stored against this user, deleting the user would leave it untouched
+      // for a reason that has nothing to do with the detach under test, and the
+      // assertion below would pass on a file no cascade could ever have
+      // reached.
+      const before = await readMediaRow(handle, "kept-logo");
+      expect(before?.uploadedBy).toBe("departing-1");
+
+      await handle.nextly.users.delete({ id: "departing-1" });
+
+      // The second control: the user really is gone. A delete that silently
+      // failed leaves the media row present for the wrong reason.
+      const remainingUsers = (await handle.adapter.select("users", {
+        where: { and: [{ column: "id", op: "=", value: "departing-1" }] },
+      })) as unknown[];
+      expect(remainingUsers).toHaveLength(0);
+
+      const after = await readMediaRow(handle, "kept-logo");
+      expect(after, "the file must outlive the account").toBeDefined();
+      expect(after?.uploadedBy).toBeNull();
     });
-    const mediaId = await uploadAttributedTo(handle, "departing-1", "logo.pdf");
 
-    // The fixture control, and it carries the test. If the row were not stored
-    // against this user, deleting the user would leave it untouched for a
-    // reason that has nothing to do with the rule under test, and the
-    // assertion below would pass on a file no cascade could ever have reached.
-    const before = await readMediaRow(handle, mediaId);
-    expect(before?.uploadedBy).toBe("departing-1");
+    it("records the detach as a media change, not a silent write", async () => {
+      // A detach IS a metadata change, and `updateMedia` emits two things for
+      // any other one: a fresh `updatedAt` and a `media.updated` outbox row.
+      // Without them a timestamp-based sync sees an unchanged row and media
+      // subscribers are never told, so a downstream replica goes on serving the
+      // attribution of an account that no longer exists — the erasure holding
+      // on this side of the wire and not on the other.
+      current = await createTestNextly({ dialect });
+      const handle = current;
 
-    await handle.nextly.users.delete({ id: "departing-1" });
+      await handle.adapter.insert("users", {
+        id: "departing-3",
+        email: "departing-3@test.local",
+      });
+      await insertMediaOwnedBy(handle, "departing-3", "evented");
 
-    // The second control: the user really is gone. A delete that silently
-    // failed leaves the media row present for the wrong reason.
-    const remainingUsers = (await handle.adapter.select("users", {
-      where: { and: [{ column: "id", op: "=", value: "departing-1" }] },
-    })) as unknown[];
-    expect(remainingUsers).toHaveLength(0);
+      // The control on the timestamp assertion: the row really starts stamped
+      // in the past, so a detach that does not touch it cannot pass below.
+      const stampBefore = (
+        (await handle.adapter.select("media", {
+          where: { and: [{ column: "id", op: "=", value: "evented" }] },
+        })) as Array<{ updatedAt: Date | string }>
+      )[0]?.updatedAt;
+      expect(new Date(stampBefore as string).getTime()).toBe(
+        STORED_AT.getTime()
+      );
 
-    const after = await readMediaRow(handle, mediaId);
-    expect(after, "the file must outlive the account").toBeDefined();
-    expect(after?.uploadedBy).toBeNull();
-  });
-});
+      await handle.nextly.users.delete({ id: "departing-3" });
+
+      const events = (await handle.adapter.select("nextly_events", {
+        where: { and: [{ column: "type", op: "=", value: "media.updated" }] },
+      })) as Array<{ type: string; resourceId?: string }>;
+      expect(
+        events.some(event => event.resourceId === "evented"),
+        "the detach must appear in the outbox as a media change"
+      ).toBe(true);
+
+      const stampAfter = (
+        (await handle.adapter.select("media", {
+          where: { and: [{ column: "id", op: "=", value: "evented" }] },
+        })) as Array<{ updatedAt: Date | string }>
+      )[0]?.updatedAt;
+      // Strictly greater, against a fixed past stamp. Comparing against a
+      // freshly-written one would be satisfied by a timestamp that never moved.
+      expect(new Date(stampAfter as string).getTime()).toBeGreaterThan(
+        STORED_AT.getTime()
+      );
+    });
+
+    it("leaves another account's files attributed", async () => {
+      current = await createTestNextly({ dialect });
+      const handle = current;
+
+      for (const id of ["departing-2", "staying-2"]) {
+        await handle.adapter.insert("users", {
+          id,
+          email: `${id}@test.local`,
+        });
+      }
+      await insertMediaOwnedBy(handle, "departing-2", "theirs");
+      await insertMediaOwnedBy(handle, "staying-2", "not-theirs");
+
+      await handle.nextly.users.delete({ id: "departing-2" });
+
+      // The detach is scoped by uploader. A `where` that lost its predicate
+      // would still pass the test above — every file survives — while silently
+      // stripping the attribution off the whole library.
+      expect((await readMediaRow(handle, "theirs"))?.uploadedBy).toBeNull();
+      expect((await readMediaRow(handle, "not-theirs"))?.uploadedBy).toBe(
+        "staying-2"
+      );
+    });
+  }
+);

--- a/packages/nextly/src/domains/media/__tests__/user-delete-keeps-media.integration.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/user-delete-keeps-media.integration.test.ts
@@ -21,6 +21,7 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
+import { UsersService } from "../../../services/users";
 import {
   createTestNextly,
   getConfiguredTestDialects,
@@ -154,11 +155,18 @@ describe.each(getConfiguredTestDialects())(
 
       const events = (await handle.adapter.select("nextly_events", {
         where: { and: [{ column: "type", op: "=", value: "media.updated" }] },
-      })) as Array<{ type: string; resourceId?: string }>;
+      })) as Array<{ type: string; resourceId?: string; actorType?: string }>;
+      const detachEvent = events.find(event => event.resourceId === "evented");
       expect(
-        events.some(event => event.resourceId === "evented"),
+        detachEvent,
         "the detach must appear in the outbox as a media change"
-      ).toBe(true);
+      ).toBeDefined();
+
+      // Attributed the way every canonical media write attributes an
+      // uninitiated write. A null actor here would mean the same media change
+      // reaches subscribers and the audit differently depending on whether it
+      // came from an account deletion or from `updateMedia`.
+      expect(detachEvent?.actorType).toBe("system");
 
       const stampAfter = (
         (await handle.adapter.select("media", {
@@ -170,6 +178,43 @@ describe.each(getConfiguredTestDialects())(
       expect(new Date(stampAfter as string).getTime()).toBeGreaterThan(
         STORED_AT.getTime()
       );
+    });
+
+    it("attributes an uninitiated detach to the system, not to nobody", async () => {
+      // Driven through `userService.deleteUser(id)` with NO actor argument,
+      // which is the path the Direct API does not take: it resolves an actor
+      // before calling, so a test going through `nextly.users.delete` cannot
+      // tell a normalised actor from a forwarded one — the assertion passes
+      // either way and proves nothing. This is the internal path where the
+      // actor is genuinely absent.
+      current = await createTestNextly({ dialect });
+      const handle = current;
+
+      await handle.adapter.insert("users", {
+        id: "departing-4",
+        email: "departing-4@test.local",
+      });
+      await insertMediaOwnedBy(handle, "departing-4", "unattributed");
+
+      // Constructed the way an internal caller does, and called with no actor
+      // argument at all — `deleteUser(userId, actor?)` leaves it undefined.
+      const users = new UsersService(handle.adapter, console as never);
+      await users.deleteUser("departing-4");
+
+      const events = (await handle.adapter.select("nextly_events", {
+        where: { and: [{ column: "type", op: "=", value: "media.updated" }] },
+      })) as Array<{ resourceId?: string; actorType?: string | null }>;
+      const detachEvent = events.find(
+        event => event.resourceId === "unattributed"
+      );
+
+      // The control: the detach happened at all on this path.
+      expect(detachEvent, "the detach must be recorded").toBeDefined();
+
+      // The envelope keeps a null actor null — it applies no system default —
+      // so without normalisation at the call site the same media change is
+      // attributed to nobody here and to `system` through `updateMedia`.
+      expect(detachEvent?.actorType).toBe("system");
     });
 
     it("leaves another account's files attributed", async () => {

--- a/packages/nextly/src/domains/users/services/user-mutation-service.ts
+++ b/packages/nextly/src/domains/users/services/user-mutation-service.ts
@@ -58,6 +58,7 @@ import {
 import { affectedRowCount } from "../../auth/services/auth-service";
 import { deliveriesTableFor } from "../../email/deliveries-table";
 import { eraseRecipientDeliveries } from "../../email/erase-recipient";
+import { revalidateMedia } from "../../media/revalidate-media";
 import { introspectLiveSnapshot } from "../../schema/pipeline/diff/introspect-live";
 import { VersionsRepository } from "../../versions/versions-repository";
 import { recordMutationEventInTx } from "../../webhooks/record-mutation-event";
@@ -116,6 +117,15 @@ interface DrizzleTransactionLike {
     set(data: unknown): { where(condition: unknown): Promise<unknown> };
   };
   delete(table: unknown): { where(condition: unknown): Promise<unknown> };
+  // Whole-row read, which Drizzle spells as `select()` with no projection.
+  // Named as its own overload rather than widening the one below: the
+  // projected form ends in `.limit()`, and collapsing the two would make a
+  // caller that forgot the limit type-check.
+  select(): {
+    from(table: unknown): {
+      where(condition: unknown): Promise<Record<string, unknown>[]>;
+    };
+  };
   select(fields: unknown): {
     from(table: unknown): {
       where(condition: unknown): {
@@ -310,6 +320,19 @@ function userExtValueError(name: string, expected: string): NextlyError {
       },
     ],
   });
+}
+
+/**
+ * The media columns the detach reads back.
+ *
+ * Deliberately loose: the row is forwarded whole as the event's `previous` and,
+ * with two fields overlaid, as its `data`. Naming each column here would be a
+ * second declaration of the media shape that nothing keeps in step with the
+ * schema — the event only needs the id and the identity of the row.
+ */
+interface MediaRow {
+  id: string;
+  [column: string]: unknown;
 }
 
 export class UserMutationService extends BaseService {
@@ -1473,6 +1496,10 @@ export class UserMutationService extends BaseService {
     // all three driver packages); the fluent query API is identical across
     // dialects.
     let userDeletedRecorded = false;
+    // Collected inside the transaction, used after it commits: the cache bust
+    // must not run until the detach is durable, and the rows cannot be found
+    // afterwards because the column that named them is exactly what changed.
+    let detachedMediaIds: string[] = [];
     try {
       await this.withTransaction(async tx => {
         const txDb = tx as DrizzleTransactionLike;
@@ -1563,10 +1590,41 @@ export class UserMutationService extends BaseService {
         // Inside the transaction, so files are never detached from an account
         // whose removal then rolls back.
         if (mediaExists) {
-          await txDb
-            .update(media)
-            .set({ uploadedBy: null })
-            .where(eq(media.uploadedBy as Column, userId));
+          // Read before writing: the event carries a before and an after, and
+          // the ids cannot be recovered once the column naming them is null.
+          const detaching = (await txDb
+            .select()
+            .from(media)
+            .where(
+              eq(media.uploadedBy as Column, userId)
+            )) as unknown[] as MediaRow[];
+
+          if (detaching.length > 0) {
+            const detachedAt = new Date();
+            await txDb
+              .update(media)
+              .set({ uploadedBy: null, updatedAt: detachedAt })
+              .where(eq(media.uploadedBy as Column, userId));
+
+            // `updatedAt` and the outbox row are what `updateMedia` emits for
+            // any other metadata change, and a detach is one. Without them a
+            // timestamp-based sync sees an unchanged row and media subscribers
+            // are never told, so a downstream replica keeps serving the
+            // attribution of an account that no longer exists — the erasure
+            // holding on this side and not on the other.
+            for (const row of detaching) {
+              await recordMutationEventInTx(txDb, this.dialect, {
+                type: "media.updated",
+                resource: { kind: "media", id: String(row.id) },
+                data: { ...row, uploadedBy: null, updatedAt: detachedAt },
+                previous: row,
+                fields: [],
+                actor: actor ?? null,
+              });
+            }
+
+            detachedMediaIds = detaching.map(row => String(row.id));
+          }
         }
 
         // Strip the person out of the delivery log for the same reason, and in
@@ -1631,6 +1689,16 @@ export class UserMutationService extends BaseService {
       if (NextlyError.is(err)) throw err;
       // Normalise raw driver errors so fk/etc. produce the right NextlyError kind.
       throw NextlyError.fromDatabaseError(toDbError(this.dialect, err));
+    }
+
+    // The detached files changed, so anything cached against them is stale —
+    // `uploadedBy` is part of the media shape a read returns. AFTER the commit,
+    // because a bust for a detach that then rolled back would be a lie about
+    // rows that never moved; best-effort, because the deletion has already
+    // happened and reporting it as failed would invite a retry that answers
+    // not-found.
+    if (detachedMediaIds.length > 0) {
+      await revalidateMedia(detachedMediaIds, this.logger);
     }
 
     // The removed account's recovery points, swept once the deletion is

--- a/packages/nextly/src/domains/users/services/user-mutation-service.ts
+++ b/packages/nextly/src/domains/users/services/user-mutation-service.ts
@@ -1370,7 +1370,7 @@ export class UserMutationService extends BaseService {
     userId: number | string,
     actor?: RequestActor
   ): Promise<void> {
-    const { users, accounts, userRoles } = this.tables;
+    const { users, accounts, userRoles, media } = this.tables;
 
     // Asked once, before the transaction opens, because a failed statement
     // aborts an open Postgres transaction and there would be no way back.
@@ -1427,6 +1427,26 @@ export class UserMutationService extends BaseService {
       deliveriesExist = await this.adapter.tableExists("email_deliveries");
     } catch {
       deliveriesExist = true;
+    }
+
+    // Asked out here for the same reason, and treated as present when the
+    // probe cannot answer, for the same reason too. `media.uploaded_by`
+    // cascades, so skipping the detach on a transient metadata failure would
+    // delete the account and let the database destroy its files — silently and
+    // permanently, since no later run revisits a deletion that has happened.
+    // Attempting it against a genuinely absent table fails the UPDATE and takes
+    // the deletion with it, which is the invariant the audit erasure protects:
+    // an account is never removed while data belonging to it is left behind.
+    //
+    // Databases without the table exist. The SQLite fallback bootstrap in
+    // earlier releases created a subset of the core tables, and neither
+    // first-run setup nor boot repairs an existing database that is missing
+    // one.
+    let mediaExists: boolean;
+    try {
+      mediaExists = await this.adapter.tableExists("media");
+    } catch {
+      mediaExists = true;
     }
     // The two answer a legacy shape differently, because what happens to an
     // un-erased row differs. A legacy `activity_log` still cascades from the
@@ -1524,6 +1544,29 @@ export class UserMutationService extends BaseService {
             new Date(),
             unstampedAuditTables
           );
+        }
+
+        // Detach the account's uploads before the row goes.
+        //
+        // `media.uploaded_by` declares ON DELETE CASCADE, so without this the
+        // database destroys every image, document and video the account ever
+        // added — beneath every service, hook and access check, with nothing
+        // able to intercept it and nothing to warn the admin who asked only to
+        // remove a person. An asset library is shared property: a logo uploaded
+        // by someone who has since left is still the site's logo, and the
+        // attribution is the only part that belonged to them.
+        //
+        // Nulling the column first leaves the cascade nothing to act on, which
+        // is why this is a write rather than a change to the constraint: the
+        // rule itself cannot be altered on an existing PostgreSQL database
+        // without resolver support the schema pipeline does not have yet.
+        // Inside the transaction, so files are never detached from an account
+        // whose removal then rolls back.
+        if (mediaExists) {
+          await txDb
+            .update(media)
+            .set({ uploadedBy: null })
+            .where(eq(media.uploadedBy as Column, userId));
         }
 
         // Strip the person out of the delivery log for the same reason, and in

--- a/packages/nextly/src/domains/users/services/user-mutation-service.ts
+++ b/packages/nextly/src/domains/users/services/user-mutation-service.ts
@@ -41,7 +41,7 @@ import type {
 
 // PR 4 of unified-error-system migration: ServiceError result-shapes →
 // NextlyError throws. Methods now return data directly or throw.
-import type { RequestActor } from "../../../auth/request-actor";
+import { actorForWrite, type RequestActor } from "../../../auth/request-actor";
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
 import { BaseService } from "../../../services/base-service";
@@ -123,7 +123,11 @@ interface DrizzleTransactionLike {
   // caller that forgot the limit type-check.
   select(): {
     from(table: unknown): {
-      where(condition: unknown): Promise<Record<string, unknown>[]>;
+      // Awaitable as-is, and lockable where the dialect has row locks — the
+      // same shape the projected form carries below, for the same reason.
+      where(condition: unknown): Promise<Record<string, unknown>[]> & {
+        for(strength: "update"): Promise<Record<string, unknown>[]>;
+      };
     };
   };
   select(fields: unknown): {
@@ -1592,12 +1596,25 @@ export class UserMutationService extends BaseService {
         if (mediaExists) {
           // Read before writing: the event carries a before and an after, and
           // the ids cannot be recovered once the column naming them is null.
-          const detaching = (await txDb
+          // Under a row lock, for the same reason the canonical media write
+          // takes one before recording. Read unlocked, a concurrent
+          // `updateMedia` or `deleteMedia` can commit between this snapshot and
+          // the write below — and the events would then carry state already
+          // superseded: metadata a subscriber would roll back, or an update for
+          // a row that has since been deleted, which downstream reads as the
+          // file coming back. The lock makes the snapshot the rows are updated
+          // FROM the same one they are evented from.
+          //
+          // SQLite has no row lock and needs none: its write transaction
+          // serialises writers, which is the argument the preimage read above
+          // already makes.
+          const detachQuery = txDb
             .select()
             .from(media)
-            .where(
-              eq(media.uploadedBy as Column, userId)
-            )) as unknown[] as MediaRow[];
+            .where(eq(media.uploadedBy as Column, userId));
+          const detaching = (this.dialect === "sqlite"
+            ? await detachQuery
+            : await detachQuery.for("update")) as unknown[] as MediaRow[];
 
           if (detaching.length > 0) {
             const detachedAt = new Date();
@@ -1619,7 +1636,14 @@ export class UserMutationService extends BaseService {
                 data: { ...row, uploadedBy: null, updatedAt: detachedAt },
                 previous: row,
                 fields: [],
-                actor: actor ?? null,
+                // Normalised the way every canonical media write normalises
+                // it: a deletion reaching this without an explicit actor is a
+                // write nobody initiated, which `actorForWrite` represents as
+                // `system`. Passing null instead would attribute the same media
+                // change differently depending on whether it arrived here or
+                // through `updateMedia`, in the durable audit as well as to
+                // subscribers.
+                actor: actorForWrite(actor, null),
               });
             }
 


### PR DESCRIPTION
## What changes

Deleting a user no longer deletes the files they uploaded.

`media.uploaded_by` declared `ON DELETE CASCADE` on all three dialects, so removing a user destroyed every image, document and video they had ever added. The rule is enforced by the database, beneath every service, hook and access check — no application code runs, nothing warns, and nothing can intercept it. An admin removing a departing colleague's account silently loses their uploads.

An asset library is shared property. A logo uploaded by someone who has since left is still the site's logo. The files now outlive the account and only the attribution is cleared.

## Why SET NULL and not dropping the key

This repository already fixed the identical defect once, for the activity trail (#495): `activity_log.user_id` cascaded, so deleting a user erased their audit history. That fix **dropped the foreign key** and erased the identifying fields in place, explicitly rejecting set-null "which discards the reference that keeps two deleted actors distinguishable".

That reasoning is about an audit subject and does not carry over here. An activity row needs to stay attributable so two deleted actors do not merge in the feed, and it carries a name and email to erase. A media row carries no identifying fields at all — the reference **is** the attribution — so there is nothing to erase, and a dangling id would let a reader do nothing an empty one would not. Set-null also matches `folder_id` on the same table, which already nulls when its parent folder is deleted.

## Does it reach existing installs?

Yes, and this was worth measuring rather than asserting, because two facts argue the opposite:

- `ensureCoreTables` returns early once `users` exists and pushes nothing.
- The classifier's snapshot diff models columns and indexes and carries **no foreign keys at all** — `TableSpec` has no field for them.

Reasoning from those gives the wrong answer. What actually decides it is drizzle-kit's push, which the reconcile applies through. Replaying the 0.45-era DDL an upgrading user really has (`fixtures-045`, shared with the upgrade simulation) and reading `sqlite_master` back shows:

```
before: FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE cascade
after:  FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
```

That is pinned as a test rather than left as a claim.

## Evidence

Two integration tests, both break-verified against a restored cascade:

- **the behaviour** — a user is deleted and the file survives with its attribution cleared. Dies at *"the file must outlive the account"*.
- **the upgrade** — an 0.45-era database is reconciled and the stored constraint changes. Dies at *"on delete set null"*, with a control asserting the fixture really carries the old rule first.

The behaviour test also carries a fixture control that earned its place: it failed first because my reader used the column name `uploaded_by` where the adapter returns the field name `uploadedBy`, which is indistinguishable from an upload that never recorded an uploader.

## What I could not verify locally

The Postgres and MySQL legs of the upgrade test are SQLite-only here — Docker was not running, so those two dialects self-skipped. CI's three-dialect matrix covers them. The #495 precedent records that a reconcile removing a MySQL foreign key emits `DROP CONSTRAINT`, so the mechanism is known to work there; I have not measured it for this constraint.

Both typechecks clean, lint clean, `fallow` passes with `complexity_introduced: 0`.
