### PR TITLE
fix(plugin-form-builder): give every form tab a surface to sit on

### DIFF
--- a/.changeset/forms-tabs-sit-on-a-surface.md
+++ b/.changeset/forms-tabs-sit-on-a-surface.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Form editor: give every tab a surface, and balance the metadata card.
+
+The Settings, Preview and Notifications tabs drew no background of their own, so their content sat directly on the page's grey while the metadata card above them was white — the panels read as holes in the page rather than as sheets on it. Each tab now sits on the same white card the rest of the admin uses for form content, and the Settings tab gets there by adopting the shared `FormSection` instead of a heading it had rolled itself, so its sections look like every other settings page in the product.
+
+The metadata card's padding was even at 20px top and bottom, but the first thing inside it is a label and the last is a control: a label's line box carries leading above its glyphs, so the visible gap measured 24px above and 21px below. The bottom step is now one larger, which makes the two read as equal.

--- a/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
+++ b/packages/plugin-form-builder/src/admin/FormBuilderView.tsx
@@ -407,7 +407,13 @@ function FormBuilderViewInner({
           have a surface to sit on. The builder canvas below is deliberately
           NOT carded: it draws its own drop zone, and a frame around a frame
           reads as a nested box rather than as structure. */}
-      <Card className="mb-6 px-6 py-5">
+      {/* `pb-6` against `pt-5`: the box padding is equal at 20px, but the
+          first thing inside is a LABEL and the last is a control. A label's
+          line box carries 3px of leading above its glyphs, so the ink starts
+          lower than the box does while the control's border ends flush —
+          measured 24px of visible space above and 21px below. The extra step
+          on the bottom is what makes the two read as equal. */}
+      <Card className="mb-6 px-6 pt-5 pb-6">
         <div className="flex flex-wrap gap-4">
           <FieldShell
             label="Form Name"

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
@@ -256,7 +256,11 @@ function NotificationCard({
   }
 
   return (
-    <div className="border border-border bg-background">
+    // `bg-card` and the container radius, which is what every other surface in
+    // this admin sits on. `bg-background` is the PAGE's colour, so a panel
+    // painted with it reads as a bordered hole in the page rather than as a
+    // sheet on top of it.
+    <div className="rounded-lg border border-border bg-card">
       {/* The dimming is the SUMMARY's, not the card's. A disabled rule reads as
           inactive at a glance, but an expanded editor inside a faded card fades
           every label, input and validation message the author is reading while

--- a/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormNotificationsTab.tsx
@@ -15,6 +15,7 @@
 
 import {
   Badge,
+  Card,
   Button,
   DropdownMenu,
   DropdownMenuContent,
@@ -256,11 +257,13 @@ function NotificationCard({
   }
 
   return (
-    // `bg-card` and the container radius, which is what every other surface in
-    // this admin sits on. `bg-background` is the PAGE's colour, so a panel
-    // painted with it reads as a bordered hole in the page rather than as a
-    // sheet on top of it.
-    <div className="rounded-lg border border-border bg-card">
+    // `Card` rather than its classes written out again: the primitive owns the
+    // surface colour, the radius, the foreground and the transition, and a
+    // second spelling of them drifts the moment the shared surface changes.
+    //
+    // `overflow-hidden` because an expanded editor paints a full-width tinted
+    // child; without clipping it squares off the corners the card just rounded.
+    <Card className="overflow-hidden p-0">
       {/* The dimming is the SUMMARY's, not the card's. A disabled rule reads as
           inactive at a glance, but an expanded editor inside a faded card fades
           every label, input and validation message the author is reading while
@@ -382,7 +385,7 @@ function NotificationCard({
           closed one mounted would keep a stale draft alive behind a summary
           that has moved on. */}
       {expanded && children}
-    </div>
+    </Card>
   );
 }
 

--- a/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
@@ -342,7 +342,11 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
           <Eye className="h-4 w-4" aria-hidden="true" />
           Preview — a simulation of this form. Nothing here submits anywhere.
         </div>
-        <div className="flex items-center gap-2">
+        {/* Wraps rather than holding one row. The card around this clips, and
+            at a ~360px panel the inset leaves less width than the device
+            toggle and Reset need side by side — so an unwrapped row loses its
+            right edge instead of overflowing visibly. */}
+        <div className="flex flex-wrap items-center justify-end gap-2">
           <Tabs
             value={device}
             onValueChange={value => setDevice(value as "desktop" | "mobile")}

--- a/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormPreview.tsx
@@ -18,6 +18,7 @@ import {
   Button,
   Checkbox,
   Input,
+  Card,
   Label,
   RadioGroup,
   RadioGroupItem,
@@ -330,9 +331,13 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
   };
 
   return (
-    <div className="space-y-4">
+    // One surface for the whole tab. The chrome and the stage are the same
+    // panel seen twice, and leaving the chrome unbacked put it on the page's
+    // grey while the stage below it had a frame — reading as a control strip
+    // that had lost its box.
+    <Card className="overflow-hidden p-0">
       {/* Preview chrome: honest framing + device toggle + reset */}
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="flex flex-col gap-3 border-b border-border px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Eye className="h-4 w-4" aria-hidden="true" />
           Preview — a simulation of this form. Nothing here submits anywhere.
@@ -362,8 +367,10 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
         </div>
       </div>
 
-      {/* The simulated form */}
-      <div className="flex justify-center border border-border bg-muted/30 p-6">
+      {/* The simulated form, on a tinted stage so the sheet inside reads as a
+          page rather than as more of this panel. The stage draws no border of
+          its own — the card around it already does. */}
+      <div className="flex justify-center bg-muted/30 p-6">
         <div
           className={`w-full space-y-5 border border-border bg-background p-6 ${
             device === "mobile" ? "max-w-95" : "max-w-2xl"
@@ -473,7 +480,7 @@ export function FormPreview({ fields, formData }: FormPreviewProps) {
           )}
         </div>
       </div>
-    </div>
+    </Card>
   );
 }
 

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -13,6 +13,7 @@
  */
 
 import {
+  FormSection,
   Input,
   Label,
   RadioGroup,
@@ -48,7 +49,7 @@ function SettingRow({
   children: React.ReactNode;
 }) {
   return (
-    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-6 py-2">
+    <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-6">
       <div className="space-y-1">
         <Label
           htmlFor={htmlFor}
@@ -65,16 +66,6 @@ function SettingRow({
       <div className="shrink-0 flex items-center justify-end min-w-25">
         {children}
       </div>
-    </div>
-  );
-}
-
-function SectionHeading({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="border-b border-border pb-3">
-      <h3 className="text-[16px] font-bold text-foreground tracking-tight">
-        {children}
-      </h3>
     </div>
   );
 }
@@ -286,164 +277,153 @@ export function FormSettingsTab({
     // The measure belongs to the page's shell, not to this tab.
     <div className="flex flex-col gap-10">
       {/* Submission */}
-      <section>
-        <SectionHeading>Submission</SectionHeading>
-        <div className="flex flex-col gap-1 pt-2">
-          <SettingRow
-            label="Submit button text"
-            description="Label on the form's primary action button"
-            htmlFor="settings-submit-text"
-          >
-            <Input
-              id="settings-submit-text"
-              type="text"
-              className="w-56"
-              value={settings.submitButtonText ?? ""}
-              onChange={e =>
-                updateSettings({ submitButtonText: e.target.value })
-              }
-            />
-          </SettingRow>
+      <FormSection label="Submission">
+        <SettingRow
+          label="Submit button text"
+          description="Label on the form's primary action button"
+          htmlFor="settings-submit-text"
+        >
+          <Input
+            id="settings-submit-text"
+            type="text"
+            className="w-56"
+            value={settings.submitButtonText ?? ""}
+            onChange={e => updateSettings({ submitButtonText: e.target.value })}
+          />
+        </SettingRow>
 
-          <SettingRow
-            label="Allow multiple submissions"
-            description="When off, the same visitor (by IP) can submit this form only once. Best-effort: IP-based, so shared networks count as one visitor."
-            htmlFor="settings-multiple"
-          >
-            <Switch
-              id="settings-multiple"
-              checked={settings.allowMultipleSubmissions ?? true}
-              onCheckedChange={checked =>
-                updateSettings({ allowMultipleSubmissions: checked })
-              }
-            />
-          </SettingRow>
-        </div>
-      </section>
+        <SettingRow
+          label="Allow multiple submissions"
+          description="When off, the same visitor (by IP) can submit this form only once. Best-effort: IP-based, so shared networks count as one visitor."
+          htmlFor="settings-multiple"
+        >
+          <Switch
+            id="settings-multiple"
+            checked={settings.allowMultipleSubmissions ?? true}
+            onCheckedChange={checked =>
+              updateSettings({ allowMultipleSubmissions: checked })
+            }
+          />
+        </SettingRow>
+      </FormSection>
 
       {/* After submission */}
-      <section>
-        <SectionHeading>After submission</SectionHeading>
-        <div className="flex flex-col gap-4 pt-4">
-          <RadioGroup
-            value={settings.confirmationType ?? "message"}
-            onValueChange={value =>
-              updateSettings({
-                confirmationType: value as
-                  | "message"
-                  | "redirect"
-                  | "relationship",
-              })
-            }
-            className="flex flex-col gap-3"
-          >
-            <div className="flex items-start gap-3">
-              <RadioGroupItem
-                value="message"
-                id="settings-confirm-message"
-                className="mt-0.5"
-              />
-              <div className="w-full space-y-2">
-                <Label htmlFor="settings-confirm-message">Show a message</Label>
-                {(settings.confirmationType ?? "message") === "message" && (
-                  <Textarea
-                    aria-label="Success message"
-                    value={settings.successMessage ?? ""}
-                    onChange={e =>
-                      updateSettings({ successMessage: e.target.value })
-                    }
-                    rows={3}
-                    placeholder="Thank you for your submission!"
-                  />
-                )}
-              </div>
-            </div>
-            <div className="flex items-start gap-3">
-              <RadioGroupItem
-                value="redirect"
-                id="settings-confirm-redirect"
-                className="mt-0.5"
-              />
-              <div className="w-full space-y-2">
-                <Label htmlFor="settings-confirm-redirect">
-                  Redirect to a URL
-                </Label>
-                {settings.confirmationType === "redirect" && (
-                  <Input
-                    aria-label="Redirect URL"
-                    type="url"
-                    value={settings.redirectUrl ?? ""}
-                    onChange={e =>
-                      updateSettings({
-                        redirectUrl: e.target.value || undefined,
-                      })
-                    }
-                    placeholder="https://example.com/thanks"
-                  />
-                )}
-              </div>
-            </div>
-            <PageRedirectOption
-              redirectCollections={redirectCollections}
-              configFailed={redirectConfigFailed}
-              settings={settings}
-              updateSettings={updateSettings}
+      <FormSection label="After submission">
+        <RadioGroup
+          value={settings.confirmationType ?? "message"}
+          onValueChange={value =>
+            updateSettings({
+              confirmationType: value as
+                | "message"
+                | "redirect"
+                | "relationship",
+            })
+          }
+          className="flex flex-col gap-3"
+        >
+          <div className="flex items-start gap-3">
+            <RadioGroupItem
+              value="message"
+              id="settings-confirm-message"
+              className="mt-0.5"
             />
-          </RadioGroup>
-        </div>
-      </section>
+            <div className="w-full space-y-2">
+              <Label htmlFor="settings-confirm-message">Show a message</Label>
+              {(settings.confirmationType ?? "message") === "message" && (
+                <Textarea
+                  aria-label="Success message"
+                  value={settings.successMessage ?? ""}
+                  onChange={e =>
+                    updateSettings({ successMessage: e.target.value })
+                  }
+                  rows={3}
+                  placeholder="Thank you for your submission!"
+                />
+              )}
+            </div>
+          </div>
+          <div className="flex items-start gap-3">
+            <RadioGroupItem
+              value="redirect"
+              id="settings-confirm-redirect"
+              className="mt-0.5"
+            />
+            <div className="w-full space-y-2">
+              <Label htmlFor="settings-confirm-redirect">
+                Redirect to a URL
+              </Label>
+              {settings.confirmationType === "redirect" && (
+                <Input
+                  aria-label="Redirect URL"
+                  type="url"
+                  value={settings.redirectUrl ?? ""}
+                  onChange={e =>
+                    updateSettings({
+                      redirectUrl: e.target.value || undefined,
+                    })
+                  }
+                  placeholder="https://example.com/thanks"
+                />
+              )}
+            </div>
+          </div>
+          <PageRedirectOption
+            redirectCollections={redirectCollections}
+            configFailed={redirectConfigFailed}
+            settings={settings}
+            updateSettings={updateSettings}
+          />
+        </RadioGroup>
+      </FormSection>
 
       {/* Spam protection */}
-      <section>
-        <SectionHeading>Spam protection</SectionHeading>
-        <div className="flex flex-col gap-1 pt-2">
+      <FormSection label="Spam protection">
+        <SettingRow
+          label="Honeypot"
+          description="Invisible trap field for bots. Inherits the plugin default unless overridden here."
+          htmlFor="settings-honeypot"
+        >
+          <InheritToggle
+            id="settings-honeypot"
+            value={settings.honeypotEnabled}
+            inherited={spamDefaults?.honeypot}
+            onChange={honeypotEnabled => updateSettings({ honeypotEnabled })}
+          />
+        </SettingRow>
+
+        <SettingRow
+          label="reCAPTCHA"
+          description="Challenge-based bot check. Inherits the plugin default unless overridden here."
+          htmlFor="settings-captcha"
+        >
+          <InheritToggle
+            id="settings-captcha"
+            value={settings.captchaEnabled}
+            inherited={spamDefaults?.recaptchaEnabled}
+            onChange={captchaEnabled => updateSettings({ captchaEnabled })}
+          />
+        </SettingRow>
+
+        {settings.captchaEnabled === true && (
           <SettingRow
-            label="Honeypot"
-            description="Invisible trap field for bots. Inherits the plugin default unless overridden here."
-            htmlFor="settings-honeypot"
+            label="reCAPTCHA site key"
+            description="The client-facing site key for this form"
+            htmlFor="settings-captcha-key"
           >
-            <InheritToggle
-              id="settings-honeypot"
-              value={settings.honeypotEnabled}
-              inherited={spamDefaults?.honeypot}
-              onChange={honeypotEnabled => updateSettings({ honeypotEnabled })}
+            <Input
+              id="settings-captcha-key"
+              type="text"
+              className="w-72 font-mono"
+              value={settings.captchaSiteKey ?? ""}
+              onChange={e =>
+                updateSettings({
+                  captchaSiteKey: e.target.value || undefined,
+                })
+              }
             />
           </SettingRow>
-
-          <SettingRow
-            label="reCAPTCHA"
-            description="Challenge-based bot check. Inherits the plugin default unless overridden here."
-            htmlFor="settings-captcha"
-          >
-            <InheritToggle
-              id="settings-captcha"
-              value={settings.captchaEnabled}
-              inherited={spamDefaults?.recaptchaEnabled}
-              onChange={captchaEnabled => updateSettings({ captchaEnabled })}
-            />
-          </SettingRow>
-
-          {settings.captchaEnabled === true && (
-            <SettingRow
-              label="reCAPTCHA site key"
-              description="The client-facing site key for this form"
-              htmlFor="settings-captcha-key"
-            >
-              <Input
-                id="settings-captcha-key"
-                type="text"
-                className="w-72 font-mono"
-                value={settings.captchaSiteKey ?? ""}
-                onChange={e =>
-                  updateSettings({
-                    captchaSiteKey: e.target.value || undefined,
-                  })
-                }
-              />
-            </SettingRow>
-          )}
-        </div>
-      </section>
+        )}
+      </FormSection>
     </div>
   );
 }

--- a/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx
@@ -413,7 +413,10 @@ export function FormSettingsTab({
             <Input
               id="settings-captcha-key"
               type="text"
-              className="w-72 font-mono"
+              // Full width below the breakpoint: 288px does not fit inside the
+              // section's 24px insets on a ~360px panel, and the card clips
+              // rather than scrolling.
+              className="w-full font-mono sm:w-72"
               value={settings.captchaSiteKey ?? ""}
               onChange={e =>
                 updateSettings({

--- a/packages/ui/src/components/__tests__/form-measure-contract.test.ts
+++ b/packages/ui/src/components/__tests__/form-measure-contract.test.ts
@@ -98,10 +98,13 @@ const FORM_BODY = /<(FormSection|FormActions|FieldShell)\b/;
  * A tab body of plain elements renders no part of the kit, so the scan cannot
  * find it the way it finds the rest. Each entry is here because it is a form
  * body, not because it once was: check that before adding one.
+ *
+ * Empty at present. It held the form-builder settings tab until that tab
+ * adopted `FormSection`, which is what makes a body discoverable — the entry
+ * came out in the same change, which is the edit the assertion below exists to
+ * force.
  */
-const UNMARKED = [
-  "packages/plugin-form-builder/src/admin/components/builder/FormSettingsTab.tsx",
-];
+const UNMARKED: string[] = [];
 
 /** Every `.tsx` under `dir`, recursively, as repo-relative paths. */
 function tsxFilesIn(dir: string): string[] {


### PR DESCRIPTION
Two issues the founder reported on the form editor, both verified in a running admin and both measured rather than eyeballed.

## The tabs had no surface

**Before** — Settings, Preview and Notifications painted no background, so their content sat directly on the page's grey while the metadata card above them was white:

```
carded surfaces inside each tab panel, measured in the browser
  Builder        1   (its field rows are cards of their own)
  Preview        toolbar on bare grey, stage framed below it
  Settings       0   over 637px of panel
  Notifications  bg-background — lab(98.84) — the PAGE's colour, not a card's
```

The page ground is `.nx-page-shell` at `lab(96.52)`; the admin's own cards are `lab(100 0 0)`. A panel coloured like the page reads as a hole in it rather than a sheet on top.

**The fix follows the admin's existing answer rather than inventing one.** A settings page in this product renders each section as a small uppercase label over a white card — measured on `/admin/settings/webhooks/create`, three `bg-card rounded-lg border` surfaces. `FormSection` is the primitive that does exactly that and it is already exported from `@nextlyhq/ui`. The Settings tab had rolled its own `SectionHeading` instead, so adopting `FormSection` **removes a second implementation** rather than adding a wrapper — the AGENTS.md rule about one question having one implementation.

`SettingRow` drops its own `py-2`, because `FormSection` documents that it owns the vertical rhythm and that a row padding itself doubles it.

Preview keeps **one** surface for the whole tab: its chrome and its stage are the same panel seen twice, and the stage stops drawing its own border now that the card around it does — no card inside a card, which is the nesting the founder rejected when choosing this layout.

## The metadata card read bottom-tight

Not a CSS asymmetry — the padding was already even:

| | before | after |
|---|---|---|
| padding, box | 20px / 20px | 20px / 24px |
| **visible space above the label's ink** | **24px** | 24px |
| **visible space below the control** | **21px** | 25px |

The first thing in the card is a label and the last is a control. A 14px label in a 20px line box carries 3px of leading above its glyphs, so the ink starts lower than the box while the control's border ends flush. `pb-6` against `pt-5` closes it to within a pixel.

## Verification

- Measured in a running admin before and after, per tab, including which ancestor actually paints the ground
- Settings now measures 3 white cards; Notifications `lab(100 0 0)`; Preview's panel is the card itself (`bg-card`, 8px radius)
- `pnpm lint:design` passes — 1007 files, zero hardcoded colours
- 203 tests, `tsc --noEmit` clean, `fallow` **verdict: pass** with `styling_introduced: 0`

Independent of #1215: no file overlap, so the two can merge in either order.