### PR TITLE
fix(blocks-engine): give the literal and digested preview names disjoint namespaces

### DIFF
--- a/.changeset/separate-preview-name-namespaces.md
+++ b/.changeset/separate-preview-name-namespaces.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Give the literal and digested preview-container names disjoint namespaces.
+
+`previewContainerFor` carries a seed literally when the identifier reduction
+loses nothing and digests it otherwise, but both constructions shared one
+prefix — so a surface seeded with another surface's digest was carried
+literally onto the same name. Two unrelated boxes received one container, which
+is the collision the per-surface factory exists to prevent.
+
+Marking only one path would have moved the ambiguity rather than closing it,
+since a literal seed can begin with whatever single mark the digest uses. Both
+now carry a mark at a fixed offset, so no pair of inputs can meet.

--- a/packages/blocks-engine/src/style/breakpoint-preview.test.ts
+++ b/packages/blocks-engine/src/style/breakpoint-preview.test.ts
@@ -630,7 +630,29 @@ describe("a per-surface preview container", () => {
      * devtools — and the assertion there is about two values differing, which
      * two digests satisfy perfectly.
      */
-    expect(previewContainerFor("canvas-a")).toBe("nx-preview-canvas-a");
+    expect(previewContainerFor("canvas-a")).toBe("nx-preview-s-canvas-a");
+  });
+
+  it("cannot collide ACROSS the literal and digested paths", () => {
+    /*
+     * The two constructions share a prefix, so without a discriminator they
+     * share a namespace: a seed that must be digested produces some base-36
+     * string, and a second surface seeded with that very string is
+     * identifier-safe, carries literally, and lands on the same name. Two
+     * unrelated surfaces, one container, and the factory's whole purpose gone.
+     *
+     * Driven by taking the FIRST result's own tail as the second seed, so the
+     * collision is constructed rather than hoped for — a hand-picked pair would
+     * pass against a broken implementation whenever the digest happened not to
+     * equal it.
+     */
+    const digested = previewContainerFor("a/b");
+    const tail = digested.slice("nx-preview-".length);
+
+    // The population: the first seed really did take the digest path, so the
+    // case below is the cross-path one rather than two literals.
+    expect(previewContainerFor("a/b")).not.toBe("nx-preview-s-a-b");
+    expect(previewContainerFor(tail)).not.toBe(digested);
   });
 
   it("gives two long seeds DIFFERENT names, which is the whole point", () => {

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -519,12 +519,29 @@ export const PREVIEW_VIEWPORT_CONTAINER = "nx-preview-viewport";
 /**
  * What every minted preview name starts with.
  *
- * Named because the length check above and the two constructions below must
- * agree on it: a prefix counted as one length and written as another either
- * sanitises a seed it did not need to, or lets an over-bound name reach
+ * Named because the length check and the two constructions below must agree on
+ * it: a prefix counted as one length and written as another either sanitises a
+ * seed it did not need to, or lets an over-bound name reach
  * `previewContainerName` and take the digest path for the wrong reason.
  */
 const PREVIEW_SEED_PREFIX = "nx-preview-";
+
+/**
+ * Which of the two constructions produced the rest of the name.
+ *
+ * The mark is what makes the literal and digested namespaces DISJOINT, and
+ * without it they share one space and collide across paths: a surface seeded
+ * `"a/b"` digests to some base-36 string, and a second surface seeded with that
+ * very string is identifier-safe, carries literally, and lands on the same
+ * name. Marking only one side does not close it either — a literal seed can
+ * begin with whatever single mark the digest uses, so the ambiguity just moves.
+ *
+ * Marking BOTH at a FIXED position does close it, by construction rather than
+ * by argument: the character at that offset is `s` for one path and `d` for the
+ * other, whatever the seed contains, so no pair of inputs can meet.
+ */
+const LITERAL_MARK = "s-";
+const DIGEST_MARK = "d-";
 
 function digest(seed: string): string {
   let a = 0x811c9dc5;
@@ -555,7 +572,7 @@ function digest(seed: string): string {
 function losslessName(seed: string): string | undefined {
   const safe = seed.replace(/[^A-Za-z0-9_-]/g, "-");
   if (safe !== seed) return undefined;
-  return previewContainerName(`${PREVIEW_SEED_PREFIX}${safe}`);
+  return previewContainerName(`${PREVIEW_SEED_PREFIX}${LITERAL_MARK}${safe}`);
 }
 
 /**
@@ -600,7 +617,8 @@ export function previewContainerFor(seed: string): string {
    * work recurs rather than happening once.
    */
   const literal =
-    PREVIEW_SEED_PREFIX.length + seed.length > MAX_PREVIEW_CONTAINER_LENGTH
+    PREVIEW_SEED_PREFIX.length + LITERAL_MARK.length + seed.length >
+    MAX_PREVIEW_CONTAINER_LENGTH
       ? undefined
       : losslessName(seed);
   if (literal !== undefined) return literal;
@@ -610,8 +628,9 @@ export function previewContainerFor(seed: string): string {
    * become `a-b` — still produce different names.
    */
   return (
-    previewContainerName(`${PREVIEW_SEED_PREFIX}${digest(seed)}`) ??
-    PREVIEW_VIEWPORT_CONTAINER
+    previewContainerName(
+      `${PREVIEW_SEED_PREFIX}${DIGEST_MARK}${digest(seed)}`
+    ) ?? PREVIEW_VIEWPORT_CONTAINER
   );
 }
 


### PR DESCRIPTION
## What

Ships a fix that was **written, tested, reported as done, and never committed.** It belongs to #1214, where I replied to the review thread saying it was fixed and resolved the thread. #1214 then merged without it, so the defect is live on `main` now.

## How the gap happened, since it is the more useful half

I made the change, ran the suite, break-verified it in both directions, then wrote the reply from what I had *done* rather than from what was *committed*. Every step was real except the one that puts it in the branch. Nothing in the PR looked wrong: threads resolved, CI green, tests passing — on a tree that did not contain the change.

This is the shape `.claude/rules/instruments-that-never-looked.md` calls *a report written from the intention rather than from the state*, which I added to that file about an hour before doing it.

It was found by content-verifying the merge afterwards — grepping `main` for a marker unique to the fix, with a control marker that must NOT be present to prove the search discriminates. `LITERAL_MARK` came back absent while `losslessName` from the same PR came back present, which is what separated "the PR did not land" from "one commit of it did not exist".

## The defect, live on main

`previewContainerFor` mints a per-surface container name so one authored container cannot capture another surface's responsive queries. It carries a seed literally when the identifier reduction loses nothing, and digests it otherwise — but **both constructions shared one prefix, so they shared one namespace**:

```
previewContainerFor("a/b")            → nx-preview-<digest of "a/b">
previewContainerFor("<that digest>")  → nx-preview-<that digest>     ← same name
```

The second seed is identifier-safe, so it takes the literal path and lands on the first surface's name. Two unrelated boxes, one container.

Marking only one path moves the ambiguity rather than closing it: a literal seed can begin with whatever single mark the digest uses. Both paths now carry a mark at a **fixed offset**, so the character there is `s` for one and `d` for the other whatever the seed contains, and no pair of inputs can meet — disjoint by construction rather than by argument.

## Test plan

The test constructs the collision rather than hoping for one — a hand-picked pair passes against the broken implementation whenever the digest happens not to equal it, so the second seed is taken from the first result's own tail. The population is asserted first (that the first seed really did digest), since otherwise the case is two literals passing each other.

- `pnpm build`, `pnpm check-types` — pass
- `blocks-engine` 1462, `blocks-react` 811, `builder` 1892 — pass
- `pnpm test:scripts` 602, lints, comment convention, changeset, `fallow audit` — pass

**Break-verified against the state currently on `main`** — emptying both marks reproduces exactly what is deployed and fails 2 of 1462: `cannot collide ACROSS the literal and digested paths` and the lossless control. That is the demonstration that the defect is live rather than hypothetical.