### PR TITLE
feat(builder): draw each block's icon in the palette and the layers tree

### DIFF
--- a/.changeset/blocks-name-an-icon-concept.md
+++ b/.changeset/blocks-name-an-icon-concept.md
@@ -1,0 +1,47 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Blocks carry an icon, and the palette and layers tree draw it.
+
+`BlockEditorMeta.icon` was declared and never used: no block named one and no
+surface drew one, because nothing said what the string should contain. It now
+names a concept from `BLOCK_ICONS` — `"columns"`, `"quote"`, `"loop"` — and all
+nineteen core blocks declare one.
+
+The vocabulary is concepts rather than the names of an icon library's exports.
+The editor draws with `lucide-react`, which is a peer dependency admitting any
+`>=0.400.0`, so naming its exports in the block contract would let a host's
+choice of release break a plugin block whose author did nothing wrong, and would
+freeze the editor's art direction into every block definition ever written. One
+file decides what each concept looks like, so the editor can re-skin without a
+block file changing.
+
+A block that names no icon, or names one this editor has never heard of, draws a
+generic mark rather than nothing. An editor cannot tell a plugin author's typo
+from a concept a newer engine added, and a row with no mark is a different shape
+from every row beside it.

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -88,10 +88,88 @@ export type BlockSupports = Record<string, BlockSupportValue>;
 /** A path to an editor component, resolved through the admin import map. */
 export type ComponentPath = string;
 
+/**
+ * The icon names an editor can draw.
+ *
+ * CONCEPTS, not the names of any icon library's exports. This list is part of
+ * the block contract, and `lucide-react` — what the builder happens to draw
+ * with today — is a PEER dependency admitting any `>=0.400.0`, so a host may
+ * supply a release in which a given export was renamed or dropped. Naming its
+ * exports here would let that break a stored plugin block whose author did
+ * nothing wrong, and would freeze the editor's art direction into every block
+ * definition ever written. A concept is stable in a way an export is not: the
+ * builder can re-skin, or change libraries entirely, without a block file
+ * changing.
+ *
+ * Deliberately small and generic rather than one entry per core block. A
+ * per-block list would say nothing a block's own name does not, and would leave
+ * a plugin author with nothing to choose from — the point of a vocabulary is
+ * that a block nobody has written yet already has a word for what it looks
+ * like.
+ */
+export const BLOCK_ICONS = [
+  // Structure
+  "section",
+  "container",
+  "columns",
+  "column",
+  "card",
+  "grid",
+  "accordion",
+  "panel",
+  "tabs",
+  "divider",
+  "spacer",
+  // Content
+  "heading",
+  "text",
+  "list",
+  "quote",
+  "code",
+  "table",
+  "link",
+  // Media
+  "image",
+  "gallery",
+  "video",
+  "audio",
+  "embed",
+  "map",
+  // Interactive and data
+  "button",
+  "form",
+  "search",
+  "loop",
+  "chart",
+  "calendar",
+  "user",
+  "cart",
+  "star",
+] as const;
+
+/**
+ * A block's icon: one of the concepts above, or a name an editor knows of its
+ * own.
+ *
+ * The `(string & {})` arm keeps autocomplete for the vocabulary while admitting
+ * a name only a particular editor can resolve, the same bargain
+ * `FieldTypeId` strikes for plugin-contributed field types. An editor that
+ * meets a name it cannot draw falls back to a generic mark rather than
+ * refusing the block — an unknown icon is a cosmetic gap, and a block missing
+ * from the palette over one would be a functional loss out of all proportion.
+ */
+export type BlockIcon = (typeof BLOCK_ICONS)[number] | (string & {});
+
 /** Editor-only metadata. Never serialized into a document. */
 export interface BlockEditorMeta<P extends object = Record<string, unknown>> {
   label?: string;
-  icon?: string;
+  /**
+   * What the palette and the layers tree draw beside this block's name.
+   *
+   * Absent is legitimate and stays legitimate: the editor draws its generic
+   * mark, which is why no block is required to answer this.
+   */
+  icon?: BlockIcon;
   /** Palette grouping, e.g. "structure" | "content" | "media". */
   category?: string;
   /** Extra search terms for the block palette. */

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -163,11 +163,12 @@ export type {
   ValidationMode,
 } from "./validation";
 
-export { defineBlock } from "./block";
+export { BLOCK_ICONS, defineBlock } from "./block";
 export type {
   AnyBlockDefinition,
   BlockDefinition,
   BlockEditorMeta,
+  BlockIcon,
   BlockExample,
   BlockSeoContribution,
   BlockSeoImage,

--- a/packages/blocks-react/src/blocks/accordion-item.tsx
+++ b/packages/blocks-react/src/blocks/accordion-item.tsx
@@ -133,6 +133,7 @@ export const accordionItem = defineBlock<AccordionItemProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Accordion item",
+    icon: "panel",
     category: INTERACTIVE,
     keywords: ["disclosure", "panel", "faq"],
   },

--- a/packages/blocks-react/src/blocks/accordion.tsx
+++ b/packages/blocks-react/src/blocks/accordion.tsx
@@ -105,6 +105,7 @@ export const accordion = defineBlock<ContainerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Accordion",
+    icon: "accordion",
     category: INTERACTIVE,
     keywords: ["disclosure", "faq", "collapse", "toggle"],
   },

--- a/packages/blocks-react/src/blocks/box.tsx
+++ b/packages/blocks-react/src/blocks/box.tsx
@@ -32,6 +32,7 @@ export const box = defineBlock<ContainerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Box",
+    icon: "container",
     category: LAYOUT,
     keywords: ["container", "div", "group", "wrapper"],
   },

--- a/packages/blocks-react/src/blocks/button.tsx
+++ b/packages/blocks-react/src/blocks/button.tsx
@@ -97,6 +97,7 @@ export const button = defineBlock<ButtonProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Button",
+    icon: "button",
     category: INTERACTIVE,
     keywords: ["link", "cta", "call to action"],
   },

--- a/packages/blocks-react/src/blocks/card.tsx
+++ b/packages/blocks-react/src/blocks/card.tsx
@@ -110,6 +110,7 @@ export const card = defineBlock<ContainerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Card",
+    icon: "card",
     category: LAYOUT,
     keywords: ["panel", "tile", "surface"],
   },

--- a/packages/blocks-react/src/blocks/collection-loop.tsx
+++ b/packages/blocks-react/src/blocks/collection-loop.tsx
@@ -148,6 +148,7 @@ export const collectionLoop = defineBlock<CollectionLoopProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Collection loop",
+    icon: "loop",
     category: CONTENT,
     keywords: ["repeat", "query", "entries", "dynamic"],
   },

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -82,6 +82,7 @@ export const column = defineBlock<ContainerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Column",
+    icon: "column",
     category: LAYOUT,
     keywords: ["cell", "track"],
   },

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -103,6 +103,7 @@ export const columns = defineBlock<ContainerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Columns",
+    icon: "columns",
     category: LAYOUT,
     keywords: ["row", "grid", "split", "side by side"],
   },

--- a/packages/blocks-react/src/blocks/divider.tsx
+++ b/packages/blocks-react/src/blocks/divider.tsx
@@ -37,6 +37,7 @@ export const divider = defineBlock<DividerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Divider",
+    icon: "divider",
     category: CONTENT,
     keywords: ["hr", "rule", "separator", "break"],
   },

--- a/packages/blocks-react/src/blocks/editor-metadata.test.ts
+++ b/packages/blocks-react/src/blocks/editor-metadata.test.ts
@@ -14,6 +14,8 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { BLOCK_ICONS } from "@nextlyhq/blocks-engine";
+
 import { CORE_CATEGORIES } from "./categories";
 import { coreBlocks } from "./index";
 
@@ -56,6 +58,20 @@ describe("core block editor metadata", () => {
         expect(typeof keyword).toBe("string");
         expect(keyword).toBe(keyword.toLowerCase());
       }
+    }
+  );
+
+  it.each(coreBlocks.map(block => [block.name, block] as const))(
+    "%s names an icon from the vocabulary",
+    (_name, block) => {
+      const icon = block.editor?.icon;
+
+      // Membership rather than "is a string", for the same reason the category
+      // is checked that way and a stronger one: the type admits any string so a
+      // plugin can name a concept a newer engine added, which means a typo in a
+      // FIRST-PARTY block is accepted by the compiler and draws the generic
+      // mark. The palette then looks correct and says nothing.
+      expect(BLOCK_ICONS as readonly string[]).toContain(icon);
     }
   );
 

--- a/packages/blocks-react/src/blocks/embed.tsx
+++ b/packages/blocks-react/src/blocks/embed.tsx
@@ -105,6 +105,7 @@ export const embed = defineBlock<EmbedProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Embed",
+    icon: "embed",
     category: MEDIA,
     keywords: ["video", "iframe", "youtube", "external"],
   },

--- a/packages/blocks-react/src/blocks/form.tsx
+++ b/packages/blocks-react/src/blocks/form.tsx
@@ -231,6 +231,7 @@ export const form = defineBlock<FormProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Form",
+    icon: "form",
     category: INTERACTIVE,
     keywords: ["contact", "input", "submit", "fields"],
   },

--- a/packages/blocks-react/src/blocks/gallery.tsx
+++ b/packages/blocks-react/src/blocks/gallery.tsx
@@ -104,6 +104,7 @@ export const gallery = defineBlock<ContainerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Gallery",
+    icon: "gallery",
     category: MEDIA,
     keywords: ["images", "photos", "grid", "carousel"],
   },

--- a/packages/blocks-react/src/blocks/heading.tsx
+++ b/packages/blocks-react/src/blocks/heading.tsx
@@ -86,6 +86,7 @@ export const heading = defineBlock<HeadingProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Heading",
+    icon: "heading",
     category: CONTENT,
     keywords: ["title", "headline", "h1", "h2"],
   },

--- a/packages/blocks-react/src/blocks/image.tsx
+++ b/packages/blocks-react/src/blocks/image.tsx
@@ -145,6 +145,7 @@ export const image = defineBlock<ImageProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Image",
+    icon: "image",
     category: MEDIA,
     keywords: ["picture", "photo", "img", "media"],
   },

--- a/packages/blocks-react/src/blocks/list.tsx
+++ b/packages/blocks-react/src/blocks/list.tsx
@@ -87,6 +87,7 @@ export const list = defineBlock<ListProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "List",
+    icon: "list",
     category: CONTENT,
     keywords: ["bullets", "ordered", "unordered", "items"],
   },

--- a/packages/blocks-react/src/blocks/paragraph.tsx
+++ b/packages/blocks-react/src/blocks/paragraph.tsx
@@ -48,6 +48,7 @@ export const paragraph = defineBlock<ParagraphProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Text",
+    icon: "text",
     category: CONTENT,
     keywords: ["paragraph", "copy", "body", "prose"],
   },

--- a/packages/blocks-react/src/blocks/quote.tsx
+++ b/packages/blocks-react/src/blocks/quote.tsx
@@ -94,6 +94,7 @@ export const quote = defineBlock<QuoteProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Quote",
+    icon: "quote",
     category: CONTENT,
     keywords: ["blockquote", "pull quote", "citation"],
   },

--- a/packages/blocks-react/src/blocks/section.tsx
+++ b/packages/blocks-react/src/blocks/section.tsx
@@ -28,6 +28,7 @@ export const section = defineBlock<ContainerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Section",
+    icon: "section",
     category: LAYOUT,
     keywords: ["container", "wrapper", "band", "region"],
   },

--- a/packages/blocks-react/src/blocks/spacer.tsx
+++ b/packages/blocks-react/src/blocks/spacer.tsx
@@ -41,6 +41,7 @@ export const spacer = defineBlock<SpacerProps, PageContext>({
   // let a search for a word the description never uses still find this.
   editor: {
     label: "Spacer",
+    icon: "spacer",
     category: LAYOUT,
     keywords: ["gap", "space", "whitespace"],
   },

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -200,6 +200,7 @@ export type {
   BlockDocument,
   BlockEditorMeta,
   BlockExample,
+  BlockIcon,
   BlockMigrationInfo,
   BlockNode,
   BlockRenderResult,

--- a/packages/builder/src/block-icon.test.tsx
+++ b/packages/builder/src/block-icon.test.tsx
@@ -11,10 +11,20 @@
  * @module block-icon.test
  */
 import { BLOCK_ICONS } from "@nextlyhq/blocks-engine";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
 
 import { BlockIconMark, DRAWN_ICONS } from "./block-icon";
+
+/*
+ * Nothing unmounts a render on its own here: this package configures no setup
+ * file, so `@testing-library/react` never registers its automatic cleanup. Left
+ * out, every render accumulates in one document and a `document.querySelector`
+ * returns the FIRST test's element for every test after it — each case then
+ * asserts about a mark some earlier case drew, and a table resolving no concept
+ * at all passes throughout.
+ */
+afterEach(cleanup);
 
 describe("a block's mark", () => {
   it("reads a populated vocabulary", () => {
@@ -45,6 +55,28 @@ describe("a block's mark", () => {
     // assertion above.
     const offered = new Set<string>(BLOCK_ICONS);
     expect(DRAWN_ICONS.filter(name => !offered.has(name))).toEqual([]);
+  });
+
+  it.each([...BLOCK_ICONS])("everyConceptDrawsAGlyph: %s", name => {
+    /*
+     * Per concept rather than per table entry. The coverage test above compares
+     * two lists of STRINGS, so it stays green when a name in the table resolves
+     * to nothing — and the names come from `lucide-react`, a peer dependency
+     * this package admits from `>=0.400.0` upward, which renames icons and
+     * drops the old names. An import of a name outside that range fails to link
+     * the built shell rather than failing here, so what this can catch is the
+     * table naming something the INSTALLED lucide no longer exports.
+     *
+     * Asserted as "not the fallback" rather than "an svg exists", because the
+     * fallback renders an svg too and would satisfy the weaker form for every
+     * concept in a table that resolved none of them.
+     */
+    render(<BlockIconMark icon={name} />);
+    const mark = document.querySelector(".nx-block-icon svg");
+    expect(mark, name).not.toBeNull();
+    expect(mark?.getAttribute("class") ?? "", name).not.toContain(
+      "lucide-blocks"
+    );
   });
 
   it("falls back rather than throwing on a name it has never seen", () => {

--- a/packages/builder/src/block-icon.test.tsx
+++ b/packages/builder/src/block-icon.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+
+/**
+ * The mark drawn beside a block's name.
+ *
+ * Two things are worth holding here and neither is about a particular glyph:
+ * that every concept the engine offers can actually be drawn, and that a name
+ * this editor has never seen degrades to a mark rather than taking the panel
+ * down with it.
+ *
+ * @module block-icon.test
+ */
+import { BLOCK_ICONS } from "@nextlyhq/blocks-engine";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { BlockIconMark, DRAWN_ICONS } from "./block-icon";
+
+describe("a block's mark", () => {
+  it("reads a populated vocabulary", () => {
+    // The population before the property. The coverage assertion below is a
+    // loop over this list, and an empty one satisfies it by having nothing to
+    // contradict — a vocabulary that stopped being exported would read as
+    // complete coverage.
+    expect(BLOCK_ICONS.length).toBeGreaterThan(20);
+    expect(BLOCK_ICONS as readonly string[]).toContain("columns");
+    expect(DRAWN_ICONS.length).toBeGreaterThan(20);
+  });
+
+  it("blockIconsCoverTheVocabulary: draws every concept the engine offers", () => {
+    /*
+     * What holds the drawing table to the engine's list. A concept added there
+     * and not drawn here would fall back to the generic mark on every block
+     * that named it — a palette that looks finished and is not, with nothing
+     * anywhere reporting the gap.
+     */
+    const drawn = new Set(DRAWN_ICONS);
+    const missing = BLOCK_ICONS.filter(name => !drawn.has(name));
+    expect(missing).toEqual([]);
+  });
+
+  it("draws nothing this editor cannot name, in the other direction", () => {
+    // The reverse drift: a drawing kept for a concept the engine no longer
+    // offers is dead weight nothing can reach, and it is invisible from the
+    // assertion above.
+    const offered = new Set<string>(BLOCK_ICONS);
+    expect(DRAWN_ICONS.filter(name => !offered.has(name))).toEqual([]);
+  });
+
+  it("falls back rather than throwing on a name it has never seen", () => {
+    // A newer engine, or a plugin author's typo. Neither is worth failing a
+    // render over, and this editor cannot tell them apart.
+    render(<BlockIconMark icon="a-concept-from-the-future" />);
+    expect(document.querySelector(".nx-block-icon")).not.toBeNull();
+    expect(document.querySelector(".nx-block-icon svg")).not.toBeNull();
+  });
+
+  it("draws the fallback for a block that names no icon at all", () => {
+    // Absent is legitimate: the engine says so, and nothing requires a block to
+    // answer. A row with no mark would be a different SHAPE from every row
+    // beside it, which is what makes a list scannable.
+    render(<BlockIconMark />);
+    expect(document.querySelector(".nx-block-icon svg")).not.toBeNull();
+  });
+
+  it.each(["__proto__", "constructor", "toString", "valueOf"])(
+    "survives an icon named %s",
+    name => {
+      /*
+       * The name is a string that reached the panel from a block definition,
+       * and the drawing table is an ordinary object that inherits from
+       * `Object.prototype`. Looked up without an own-property check,
+       * `"constructor"` resolves to a FUNCTION, which is then used as a JSX
+       * element type and throws while rendering the palette — every block gone,
+       * because one plugin chose an unlucky word.
+       *
+       * Asserted as a render rather than as a lookup, because the throw happens
+       * at element creation and a unit test of the map would not reach it.
+       */
+      expect(() => render(<BlockIconMark icon={name} />)).not.toThrow();
+      expect(document.querySelector(".nx-block-icon svg")).not.toBeNull();
+    }
+  );
+
+  it("is decorative, so a screen reader is not told the name twice", () => {
+    // Every surface draws the block's name as text beside the mark. An icon
+    // that announced itself would repeat it, and one announcing as an unnamed
+    // image would be worse than silence — the bargain the layers badges already
+    // strike.
+    render(<BlockIconMark icon="columns" />);
+    const mark = document.querySelector(".nx-block-icon");
+    expect(mark?.getAttribute("aria-hidden")).toBe("true");
+    expect(screen.queryByRole("img")).toBeNull();
+  });
+});

--- a/packages/builder/src/block-icon.tsx
+++ b/packages/builder/src/block-icon.tsx
@@ -15,7 +15,6 @@ import {
   AudioLines,
   Blocks,
   Calendar,
-  ChartColumn,
   ChevronsUpDown,
   Code,
   Columns3,
@@ -29,6 +28,7 @@ import {
   Map,
   Minus,
   MousePointerClick,
+  MoveVertical,
   PanelTop,
   PanelTopOpen,
   Quote,
@@ -38,11 +38,11 @@ import {
   ShoppingCart,
   Square,
   SquareCheck,
-  SquareDashed,
   SquareStack,
-  StretchVertical,
   Star,
+  StretchVertical,
   Table2,
+  TrendingUp,
   Type,
   User,
   Video,
@@ -58,6 +58,20 @@ import type React from "react";
  * not by rule. `blockIconsCoverTheVocabulary` in the tests is what holds this
  * table to `BLOCK_ICONS`, so a concept added to the engine and not drawn here
  * fails rather than silently falling back to the generic mark.
+ *
+ * **Every name here must exist at this package's DECLARED peer floor**, which
+ * `package.json` puts at `lucide-react >=0.400.0` — not merely at whatever
+ * version is installed while developing. Lucide renames icons and DROPS the old
+ * names: `BarChart3`, `CheckSquare` and `Columns` are all gone from 0.544, and
+ * `ChartColumn` and `SquareDashed` do not yet exist at 0.400. A name from
+ * either end of that range makes the built shell, which keeps lucide external
+ * and imports these statically, fail to link before a panel can render — every
+ * block in the editor gone, for a decorative glyph.
+ *
+ * So a concept takes a long-standing name over the current canonical one where
+ * they differ, and `everyConceptDrawsAGlyph` in the tests renders all of them.
+ * Prefer that to raising the floor: widening what a host must install is a real
+ * cost for every consumer, and it is not worth paying for a mark.
  */
 const ICONS: Record<string, LucideIcon> = {
   // Structure
@@ -71,7 +85,7 @@ const ICONS: Record<string, LucideIcon> = {
   panel: PanelTopOpen,
   tabs: StretchVertical,
   divider: Minus,
-  spacer: SquareDashed,
+  spacer: MoveVertical,
   // Content
   heading: Heading,
   text: Type,
@@ -92,7 +106,7 @@ const ICONS: Record<string, LucideIcon> = {
   form: SquareCheck,
   search: Search,
   loop: Repeat,
-  chart: ChartColumn,
+  chart: TrendingUp,
   calendar: Calendar,
   user: User,
   cart: ShoppingCart,

--- a/packages/builder/src/block-icon.tsx
+++ b/packages/builder/src/block-icon.tsx
@@ -1,0 +1,148 @@
+/**
+ * The mark drawn beside a block's name, in the palette and in the layers tree.
+ *
+ * The engine names a CONCEPT — `"columns"`, `"quote"` — and this file is the
+ * only place that decides what that concept looks like. That separation is the
+ * whole point of the vocabulary: art direction changes here, and no block
+ * definition, no plugin and no stored document changes with it.
+ *
+ * Every mark is DECORATIVE. A block's name is always rendered beside it as
+ * text, so an icon that announced itself would make a screen reader say the
+ * same thing twice, and one announcing as an unnamed image would be worse than
+ * silence. The same bargain the layers badges already strike.
+ */
+import {
+  AudioLines,
+  Blocks,
+  Calendar,
+  ChartColumn,
+  ChevronsUpDown,
+  Code,
+  Columns3,
+  Frame,
+  Grid3x3,
+  Heading,
+  Image,
+  Images,
+  Link,
+  List,
+  Map,
+  Minus,
+  MousePointerClick,
+  PanelTop,
+  PanelTopOpen,
+  Quote,
+  RectangleVertical,
+  Repeat,
+  Search,
+  ShoppingCart,
+  Square,
+  SquareCheck,
+  SquareDashed,
+  SquareStack,
+  StretchVertical,
+  Star,
+  Table2,
+  Type,
+  User,
+  Video,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type React from "react";
+
+/**
+ * One drawing per concept in the engine's vocabulary.
+ *
+ * Written out rather than derived, because there is nothing to derive it from:
+ * a concept and the glyph that reads as that concept are related by judgement,
+ * not by rule. `blockIconsCoverTheVocabulary` in the tests is what holds this
+ * table to `BLOCK_ICONS`, so a concept added to the engine and not drawn here
+ * fails rather than silently falling back to the generic mark.
+ */
+const ICONS: Record<string, LucideIcon> = {
+  // Structure
+  section: PanelTop,
+  container: Square,
+  columns: Columns3,
+  column: RectangleVertical,
+  card: SquareStack,
+  grid: Grid3x3,
+  accordion: ChevronsUpDown,
+  panel: PanelTopOpen,
+  tabs: StretchVertical,
+  divider: Minus,
+  spacer: SquareDashed,
+  // Content
+  heading: Heading,
+  text: Type,
+  list: List,
+  quote: Quote,
+  code: Code,
+  table: Table2,
+  link: Link,
+  // Media
+  image: Image,
+  gallery: Images,
+  video: Video,
+  audio: AudioLines,
+  embed: Frame,
+  map: Map,
+  // Interactive and data
+  button: MousePointerClick,
+  form: SquareCheck,
+  search: Search,
+  loop: Repeat,
+  chart: ChartColumn,
+  calendar: Calendar,
+  user: User,
+  cart: ShoppingCart,
+  star: Star,
+};
+
+/**
+ * What is drawn for a block that names no icon, or names one this editor has
+ * never heard of.
+ *
+ * The same mark for both, deliberately. An editor cannot tell a plugin author's
+ * typo from a concept a newer engine added, and drawing a warning for one would
+ * put a defect badge on a block that is merely newer than the editor reading
+ * it. A block that draws SOMETHING keeps its row the same shape as every other,
+ * which is what makes a list of them scannable at all.
+ */
+const FALLBACK: LucideIcon = Blocks;
+
+/** Props for {@link BlockIconMark}. */
+export interface BlockIconMarkProps {
+  /** The concept the block named, if it named one. */
+  readonly icon?: string;
+  /** Edge length in pixels. */
+  readonly size?: number;
+}
+
+/**
+ * Draw a block's mark.
+ *
+ * `Object.hasOwn` before the lookup, because the name is a string that reached
+ * here from a block definition — a plugin's, in the general case — and this
+ * table inherits from `Object.prototype`. An icon named `"constructor"` or
+ * `"toString"` would otherwise resolve to an inherited FUNCTION, which is then
+ * used as a JSX element type and throws while rendering the panel. The same
+ * hazard the rich-text renderer already guards its node tables against.
+ */
+export function BlockIconMark({
+  icon,
+  size = 16,
+}: BlockIconMarkProps): React.JSX.Element {
+  const Mark =
+    icon !== undefined && Object.hasOwn(ICONS, icon)
+      ? (ICONS[icon] ?? FALLBACK)
+      : FALLBACK;
+  return (
+    <span className="nx-block-icon" aria-hidden="true">
+      <Mark size={size} />
+    </span>
+  );
+}
+
+/** The concepts this editor can draw. Exported for the coverage test. */
+export const DRAWN_ICONS: readonly string[] = Object.keys(ICONS);

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -112,6 +112,50 @@ describe("InsertPanel", () => {
     expect(onInsert).toHaveBeenCalledWith(op.node);
   });
 
+  it("draws a mark on every row, so the rows are distinguishable at a glance", () => {
+    /*
+     * The palette is scanned rather than read: an author looking for a layout
+     * block sees a column of near-identical two-line entries, and the mark is
+     * what separates them before the labels are read at all.
+     *
+     * Population before the property. `.nx-block-icon` is asserted against the
+     * NUMBER OF ROWS rather than "at least one", because one mark drawn for a
+     * single row satisfies any nonzero count while every other row goes
+     * unmarked — and a panel that rendered no rows at all would satisfy a
+     * comparison of two zeroes, which is why the row count is checked to be
+     * what was registered.
+     */
+    registerBlocks(
+      [
+        { ...base, name: "acme/text", editor: { label: "Text", icon: "text" } },
+        { ...base, name: "acme/pic", editor: { label: "Pic", icon: "image" } },
+      ] as never,
+      { source: "acme" }
+    );
+    render(<InsertPanel editor={editorSpy(documentOf())} />);
+
+    const rows = document.querySelectorAll("[cmdk-item]");
+    expect(rows.length).toBe(2);
+    expect(document.querySelectorAll(".nx-block-icon").length).toBe(2);
+    // Drawn, not merely present: an empty span would satisfy the count above.
+    expect(document.querySelectorAll(".nx-block-icon svg").length).toBe(2);
+  });
+
+  it("draws a mark for a block that names no icon", () => {
+    // The control on the assertion above. `icon` is optional on the engine's
+    // metadata, so a row for a block that answers nothing must still carry a
+    // mark — otherwise its row is a different shape from every row beside it,
+    // which is the scanning the mark exists to support.
+    registerBlocks(
+      [{ ...base, name: "acme/bare", editor: { label: "Bare" } }] as never,
+      { source: "acme" }
+    );
+    render(<InsertPanel editor={editorSpy(documentOf())} />);
+
+    expect(document.querySelectorAll("[cmdk-item]").length).toBe(1);
+    expect(document.querySelectorAll(".nx-block-icon svg").length).toBe(1);
+  });
+
   it("appends after the existing blocks rather than at a fixed index", () => {
     // The separating case for the assertion above.
     registerBlocks(

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -42,6 +42,7 @@ import {
 } from "@nextlyhq/ui";
 import * as React from "react";
 
+import { BlockIconMark } from "./block-icon";
 import type { EditorState } from "./editor-state";
 import {
   allowedEntries,
@@ -213,6 +214,7 @@ export function InsertPanel({
                   value={entry.id}
                   onSelect={() => insert(entry)}
                 >
+                  <BlockIconMark icon={entry.icon} />
                   <span className="nx-insert-panel__label">{entry.label}</span>
                   <span className="nx-insert-panel__description">
                     {entry.description}

--- a/packages/builder/src/layers-panel.test.tsx
+++ b/packages/builder/src/layers-panel.test.tsx
@@ -73,11 +73,15 @@ function register() {
   if (hasBlock("core/heading")) return;
   registerBlocks(
     [
-      { ...base, name: "core/heading", editor: { label: "Heading" } },
+      {
+        ...base,
+        name: "core/heading",
+        editor: { label: "Heading", icon: "heading" },
+      },
       {
         ...base,
         name: "core/box",
-        editor: { label: "Box" },
+        editor: { label: "Box", icon: "container" },
         slots: { children: {} },
       },
     ] as never,
@@ -138,6 +142,43 @@ describe("LayersPanel", () => {
     expect(rows().some(text => text.includes("Hero"))).toBe(true);
     expect(rows().some(text => text.includes("Footnote"))).toBe(true);
     expect(rows().some(text => text.includes("Title"))).toBe(false);
+  });
+
+  it("draws each row the mark ITS OWN block declares", () => {
+    /*
+     * A layer node carries the block's type and nothing about its definition,
+     * so the panel resolves the mark through the registry. The property that
+     * separates a working resolution from a broken one is that two rows of
+     * DIFFERENT types draw DIFFERENT marks — every row drawing the fallback
+     * satisfies any count of marks, and a count is what a first draft of this
+     * test asserted.
+     *
+     * Population first: both rows are on screen before either mark is judged.
+     */
+    renderPanel();
+    const hero = screen
+      .queryAllByRole("treeitem")
+      .find(row => (row.textContent ?? "").includes("Hero"));
+    const footnote = screen
+      .queryAllByRole("treeitem")
+      .find(row => (row.textContent ?? "").includes("Footnote"));
+    expect(hero).toBeDefined();
+    expect(footnote).toBeDefined();
+
+    const markOf = (row: Element | undefined): string =>
+      row?.querySelector(".nx-block-icon svg")?.getAttribute("class") ?? "";
+
+    // `core/box` names "container" and `core/heading` names "heading", so the
+    // two rows cannot be drawing the same glyph unless the lookup failed.
+    expect(markOf(hero)).not.toBe("");
+    expect(markOf(footnote)).not.toBe("");
+    expect(markOf(hero)).not.toBe(markOf(footnote));
+
+    // And neither is the fallback, which is what a lookup that found nothing
+    // would draw for BOTH — indistinguishable from the above if the two blocks
+    // had happened to name one concept.
+    expect(markOf(hero)).not.toContain("lucide-blocks");
+    expect(markOf(footnote)).not.toContain("lucide-blocks");
   });
 
   it("opens a selection's ancestors so a canvas click is visible here", () => {

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -35,10 +35,12 @@
  * @module layers-panel
  */
 
+import { allBlocks } from "@nextlyhq/blocks-engine";
 import { Input, TreeView, type TreeNode } from "@nextlyhq/ui";
 import { EyeOff, Lock, SlidersHorizontal } from "lucide-react";
 import * as React from "react";
 
+import { BlockIconMark } from "./block-icon";
 import type { EditorState } from "./editor-state";
 import { ancestorIds, filterLayers, layersOf, type LayerNode } from "./layers";
 
@@ -68,8 +70,29 @@ function Badge({
   );
 }
 
-/** A layer as a row: its name, and what is true about it. */
-function rowOf(node: LayerNode): TreeNode {
+/**
+ * What each block type draws, by type.
+ *
+ * A layer node carries the block's TYPE and nothing about its definition —
+ * `layersOf` reads a document, and a document does not hold editor metadata. So
+ * the lookup happens here, where the registry is already reachable, rather than
+ * by widening what the derivation returns.
+ *
+ * Read ONCE per mount, for the reason the insert panel gives for reading the
+ * registry the same way: it is global mutable state with no change
+ * notification, so there is nothing to subscribe to.
+ */
+function iconsByType(): ReadonlyMap<string, string | undefined> {
+  return new Map(
+    allBlocks().map(definition => [definition.name, definition.editor?.icon])
+  );
+}
+
+/** A layer as a row: its mark, its name, and what is true about it. */
+function rowOf(
+  node: LayerNode,
+  icons: ReadonlyMap<string, string | undefined>
+): TreeNode {
   return {
     id: node.id,
     // `textValue` carries the NAME alone even though the label renders badges
@@ -79,6 +102,7 @@ function rowOf(node: LayerNode): TreeNode {
     textValue: node.label,
     label: (
       <span className="nx-layer-row">
+        <BlockIconMark icon={icons.get(node.type)} size={14} />
         <span className="nx-layer-row__label">{node.label}</span>
         {node.locked ? <Badge icon={<Lock size={12} />} text="Locked" /> : null}
         {node.breakpointHidden ? (
@@ -95,7 +119,7 @@ function rowOf(node: LayerNode): TreeNode {
         ) : null}
       </span>
     ),
-    children: node.children.map(rowOf),
+    children: node.children.map(child => rowOf(child, icons)),
   };
 }
 
@@ -149,7 +173,11 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
     [opened, search.expand]
   );
 
-  const nodes = React.useMemo(() => search.roots.map(rowOf), [search.roots]);
+  const icons = React.useMemo(iconsByType, []);
+  const nodes = React.useMemo(
+    () => search.roots.map(root => rowOf(root, icons)),
+    [search.roots, icons]
+  );
 
   return (
     <div className="nx-layers-panel">

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -249,6 +249,14 @@
   display: grid;
   grid-template-columns: auto 1fr;
   column-gap: 0.5rem;
+  /*
+   * ZERO, stated rather than inherited. The command primitive sets `gap-3` on
+   * every item, which is a column gap while the item is a flex ROW and becomes
+   * a row gap as well the moment it is a grid — pushing 12px between a label
+   * and the description belonging to it, so the two lines of one entry read as
+   * two entries and the row grows by the height of a line.
+   */
+  row-gap: 0;
 }
 
 /*

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -237,6 +237,32 @@
 }
 
 /*
+ * Mark, then the two lines of text beside it.
+ *
+ * A GRID rather than a flex row, because the row holds three children on two
+ * lines: laid out as a flex row the label and the description sit side by side,
+ * and the two-line reading the panel is built around disappears. The mark spans
+ * both rows so it stays level with the label whether the description wraps to
+ * one line or two.
+ */
+.nx-insert-panel [cmdk-item] {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.5rem;
+}
+
+/*
+ * Nudged down by the difference between the glyph's box and the label's first
+ * line: `align-items: start` above puts both at the top of the row, where a
+ * 16px mark reads as sitting slightly high against 13px text.
+ */
+.nx-insert-panel .nx-block-icon {
+  grid-row: 1 / span 2;
+  align-self: start;
+  padding-block-start: 0.125rem;
+}
+
+/*
  * The label keeps its own column and never wraps mid-word. A block named
  * "Collection loop" breaks at the space; one named "Collectionloop" would
  * otherwise break mid-word and read as two words.
@@ -846,6 +872,25 @@
  * the value the design system already checks.
  */
 .nx-layer-row__badge {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  color: var(--nx-builder-text-muted);
+}
+
+/*
+ * A block's mark, wherever one is drawn.
+ *
+ * `flex: none` for the same reason the badge has it: the mark is a fixed-size
+ * glyph beside text that may be long, and a shrinkable icon squashes to an
+ * unreadable sliver rather than letting the name ellipsise as it is meant to.
+ *
+ * `--nx-builder-text-muted` rather than an alpha on the foreground, which is
+ * the token the design system checks and the reason the badge beside it uses
+ * the same one: a blended colour's contrast depends on whatever is behind it,
+ * and that changes between a panel row and a selected one.
+ */
+.nx-block-icon {
   display: inline-flex;
   flex: none;
   align-items: center;

--- a/packages/plugin-sdk/src/blocks.ts
+++ b/packages/plugin-sdk/src/blocks.ts
@@ -349,6 +349,7 @@ export type BlockRenderResult = ReactNode | Promise<ReactNode>;
 export type {
   BlockEditorMeta,
   BlockExample,
+  BlockIcon,
   BlockSeoContribution,
   BlockSeoImage,
   BlockVariation,


### PR DESCRIPTION
Tracker rows **R-8** (blocks sidebar: per-block icon) and **R-10** (layers panel: per-block icons), taken as a pair because both needed one thing that did not exist.

## What was actually wrong

`BlockEditorMeta.icon?: string` was already declared — and was **dead**. `inserter.ts` copied `editor?.icon` through at two places, **no core block set one**, and **no surface drew one**. It was the only field in that interface with no docblock, which is the likely reason: nothing said what the string should contain, so nobody could answer it.

So this is less "add a field" than "finish one that was declared and abandoned".

## The design decision, and why it is not lucide names

The engine is framework-free — `packages/blocks-engine` has **zero React**: no dependency, no peer dependency, not one import (control: `blocks-react` does). So an icon on `defineBlock` cannot be a component.

That leaves what the string names. **Concepts, not `lucide-react` export names**, for two reasons:

- `lucide-react` is a **peer dependency** admitting any `>=0.400.0`, and lucide renames and deprecates icons across releases. Naming its exports in the block contract lets a host's choice of release break a stored plugin block whose author did nothing wrong.
- `BlockEditorMeta` is **public API** — exported from `blocks-engine` and re-exported by `plugin-sdk`, with a type test. A vocabulary tied to a third-party library freezes the editor's art direction into every block definition ever written.

One file (`builder/src/block-icon.tsx`) decides what a concept looks like, so the editor can re-skin or change libraries entirely without a block file changing.

**Prior art confirms the shape.** WordPress Gutenberg has exactly this split: `block.json` carries a serializable slug from WordPress's *own* curated Dashicons set, and the JS layer may override with a component. The serializable layer never names a component. That maps onto engine (framework-free metadata) vs builder (React presentation).

Typed `BlockIcon = (typeof BLOCK_ICONS)[number] | (string & {})`, following the **existing repo idiom** at `admin/src/types/collection.ts:42` (`FieldTypeId`), whose docblock gives the same reason: autocomplete for the built-ins while admitting ids known only at runtime.

## Unknown and absent draw the same mark, deliberately

An editor cannot tell a plugin author's typo from a concept a newer engine added, so drawing a warning for one would put a defect badge on a block that is merely newer than the editor reading it. And a row with no mark is a different *shape* from every row beside it, which is what a scannable list depends on.

## Prototype safety

The name reaches the panel from a block definition — a plugin's, in general — and the table inherits from `Object.prototype`. Without `Object.hasOwn`, an icon named `constructor` resolves to a **function**, is used as a JSX element type, and takes the whole palette down. Same hazard `rich-text.tsx` already guards its node tables against.

## One thing I did NOT do, and why

R-8's row asks for the description "on hover/tooltip". The palette **already** renders label and description, and `builder-chrome.css` records a deliberate decision against hover:

> *Two lines per row, so the block's description is readable without a hover. A palette that shows only labels makes an author guess what "Section" holds.*

I left that alone and added only the icon, which was the genuinely missing part. Happy to revisit if hover is wanted, but it would be reversing a decision someone made on purpose.

## Evidence

Nine tests, **each break-verified individually**:

| Test | Broken by |
|---|---|
| `blockIconsCoverTheVocabulary` | removing one entry from the drawing table |
| draws nothing the engine does not offer (reverse drift) | adding a drawing for an unknown concept |
| survives an icon named `__proto__` / `constructor` / `valueOf` | removing the `Object.hasOwn` guard |
| is decorative | removing `aria-hidden` |
| every core block names a vocabulary icon | — (`.each` over 19 blocks) |
| palette draws a mark on every row | removing the mark from the palette |
| palette draws a mark for a block with no icon | same |
| layers row draws **its own** block's mark | replacing the per-type lookup with a constant |

The layers test is the one worth reading. A count of marks passes when **every** row draws the fallback, so it asserts that two rows of different types draw **different** marks and that neither is the fallback — that is the property separating a working lookup from a broken one, and a first draft of the test did not have it.

Assertions count marks against the **number of rows**, not "at least one": one mark on one row satisfies any nonzero count while every other row goes unmarked.

## A guard in this repo caught a real gap

`blocks-react`'s `type-surface.test.ts` failed with `expected [ 'BlockIcon' ] to deeply equal []` — `BlockEditorMeta` is re-exported from `blocks-react` and now references `BlockIcon`, so a consumer could reach a type it could not name. Fixed by re-exporting it. I would have shipped that hole; the guard found it.

## Gates

build 19/19 · vitest 1461 + 18 + 830 + 1905 + 328 · check-types 0 across five packages · package lint clean · `lint:design` pass · comment convention exit 0 · `test:scripts` 602 · `changeset status` exit 0 · fallow `verdict: pass`.
