### PR TITLE
feat(admin): preview a Single beside the page it becomes

### DIFF
--- a/.changeset/singles-preview-pane.md
+++ b/.changeset/singles-preview-pane.md
@@ -1,0 +1,51 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A Single can now be edited beside the page it becomes, the same way a collection
+entry can.
+
+The split-view preview shipped for entries and stopped there, so the same author
+doing the same job got two different experiences depending on which kind of
+document they had opened: an entry could be previewed in place, while a Single
+offered only "copy a shareable link". A Single has a draft lifecycle, an address
+on the site and a credential that reaches it — everything the pane needs — so the
+gap was in the wiring rather than in anything a Single lacks.
+
+Nothing was duplicated to do it. The pane, the credential's renewal timer, the
+cross-origin refusal and the one-session-per-browser warning are the same code
+serving both, because a second pane for Singles would have been a second
+implementation of all four, agreeing until one of them was edited. What changed
+is that the pieces now take a SCOPE — a collection entry, or a Single — instead
+of a collection name and an entry id.
+
+The preview and the shareable link beside it resolve that scope ONCE. Both need
+a language claim and both are wrong in the same way without one: on a localized
+Single opened in its default language the editor's active locale is absent, and
+an absent claim covers every translation rather than the default. Two surfaces
+resolving that separately would agree on the day they were written, so they now
+share one answer, and the pane is offered on exactly the terms the link is.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -35,10 +35,7 @@ import {
   autosaveScopeFor,
   useDocumentAutosave,
 } from "@admin/hooks/useDocumentAutosave";
-import {
-  PREVIEW_MESSAGES,
-  useEntryPreview,
-} from "@admin/hooks/useEntryPreview";
+import { previewMessage, useEntryPreview } from "@admin/hooks/useEntryPreview";
 import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePreviewLink } from "@admin/hooks/usePreviewLink";
@@ -628,7 +625,7 @@ export function EntryForm({
     // translations, which is what this answers.
     ...(linkLocale.kind === "scoped" ? { locale: linkLocale.locale } : {}),
     onUnavailable: reason => {
-      toast.error(PREVIEW_MESSAGES[reason]);
+      toast.error(previewMessage(reason));
     },
   });
 

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -755,11 +755,13 @@ export function EntryForm({
                */
               open={previewOpen && translationMode.source === undefined}
               onClose={() => setPreviewOpen(false)}
-              collection={collection.name}
-              entryId={savedEntryId}
-              {...(linkLocale.kind === "scoped"
-                ? { locale: linkLocale.locale }
-                : {})}
+              scope={{
+                collection: collection.name,
+                entryId: savedEntryId,
+                ...(linkLocale.kind === "scoped"
+                  ? { locale: linkLocale.locale }
+                  : {}),
+              }}
               label={entryPreview.label}
               revision={previewRevision}
             >

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -28,7 +28,10 @@
 import { Button } from "@nextlyhq/ui";
 
 import { ExternalLink, Loader2, RefreshCw, X } from "@admin/components/icons";
-import { PREVIEW_MESSAGES } from "@admin/hooks/useEntryPreview";
+import {
+  previewMessage,
+  type PreviewDocumentNoun,
+} from "@admin/hooks/useEntryPreview";
 
 import {
   PREVIEW_PANE_BLOCK_MESSAGES,
@@ -40,6 +43,13 @@ export interface PreviewFrameProps extends UsePreviewFrameResult {
   onClose: () => void;
   /** The label the collection chose for its preview, for the frame's title. */
   label: string;
+  /**
+   * Which kind of document this frame is showing.
+   *
+   * Carried so a refusal is worded for the document in hand: the entry advice
+   * names a slug, which a Single always has and cannot be the problem with.
+   */
+  noun: PreviewDocumentNoun;
 }
 
 export function PreviewFrame({
@@ -51,6 +61,7 @@ export function PreviewFrame({
   refresh,
   onClose,
   label,
+  noun,
 }: PreviewFrameProps) {
   return (
     <div className="flex h-full min-h-0 flex-col border-l border-border bg-muted/40">
@@ -126,7 +137,7 @@ export function PreviewFrame({
              the reader can act on, and the pane is the only place they will
              see it — unlike the Preview button, which can raise a toast. */
           <p className="p-6 text-sm text-muted-foreground">
-            {PREVIEW_MESSAGES[reason]}
+            {previewMessage(reason, noun)}
           </p>
         ) : block !== null ? (
           /* Ahead of the `url === null` branch on purpose: a blocked pane HAS a

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -1,7 +1,13 @@
 "use client";
 
 /**
- * The entry being edited, beside the page it becomes.
+ * The document being edited, beside the page it becomes.
+ *
+ * Serves a collection entry and a Single alike. Nothing below the scope prop
+ * distinguishes them: both are one document with a draft, an address on the
+ * site and a credential that reaches it, so a second pane for Singles would
+ * have been a second implementation of the split, the chrome request, the
+ * renewal timer and both refusal states.
  *
  * A WRAPPER rather than a second editor, for the reason `TranslationPanes` is
  * one: the document keeps the form it already had — same context, same unsaved
@@ -39,6 +45,7 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@admin/components/ui";
+import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
 
 import { PreviewFrame } from "./PreviewFrame";
 import { usePreviewFrame, type UsePreviewFrameResult } from "./usePreviewFrame";
@@ -48,12 +55,16 @@ export interface PreviewPanesProps {
   open: boolean;
   /** Close the pane. Rendered by this component, so it cannot be forgotten. */
   onClose: () => void;
-  collection: string;
-  /** The SAVED entry id. */
-  entryId: string;
-  /** The language to scope the preview credential to, when there is one. */
-  locale?: string | undefined;
-  /** The collection's own word for its preview. */
+  /**
+   * The document to preview: a collection entry, or a Single.
+   *
+   * One prop rather than three, because the pane does not care which kind it
+   * is — everything below this line is identical for both — and three loose
+   * strings would let a caller name a collection AND a single, which is not a
+   * narrower request but a different document.
+   */
+  scope: SelfPreviewScope;
+  /** The document type's own word for its preview. */
   label: string;
   /**
    * What the preview would render, as a value that changes when it does.
@@ -88,9 +99,7 @@ export function PreviewPanes({ open, children, ...rest }: PreviewPanesProps) {
  */
 function ActivePreviewPanes({
   onClose,
-  collection,
-  entryId,
-  locale,
+  scope,
   label,
   revision,
   children,
@@ -105,7 +114,7 @@ function ActivePreviewPanes({
    */
   useSuppressAdminChrome({ layers: ["pageFrame"], canExit: true });
 
-  const frame = usePreviewFrame({ collection, entryId, locale, active: true });
+  const frame = usePreviewFrame({ scope, active: true });
 
   return (
     <ResizablePanelGroup

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -45,7 +45,10 @@ import {
   ResizablePanel,
   ResizablePanelGroup,
 } from "@admin/components/ui";
-import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
+import type {
+  PreviewDocumentNoun,
+  SelfPreviewScope,
+} from "@admin/hooks/useEntryPreview";
 
 import { PreviewFrame } from "./PreviewFrame";
 import { usePreviewFrame, type UsePreviewFrameResult } from "./usePreviewFrame";
@@ -149,6 +152,9 @@ function ActivePreviewPanes({
           revision={revision}
           onClose={onClose}
           label={label}
+          // Derived from the scope rather than passed in beside it: two answers
+          // to "which kind of document is this" would be one answer too many.
+          noun={scope.single === undefined ? "entry" : "single"}
         />
       </ResizablePanel>
     </ResizablePanelGroup>
@@ -171,11 +177,13 @@ function PreviewFrameOnSave({
   revision,
   onClose,
   label,
+  noun,
 }: {
   frame: UsePreviewFrameResult;
   revision: string;
   onClose: () => void;
   label: string;
+  noun: PreviewDocumentNoun;
 }) {
   const { refresh } = frame;
   const lastSeen = useRef(revision);
@@ -186,7 +194,9 @@ function PreviewFrameOnSave({
     refresh();
   }, [revision, refresh]);
 
-  return <PreviewFrame {...frame} onClose={onClose} label={label} />;
+  return (
+    <PreviewFrame {...frame} onClose={onClose} label={label} noun={noun} />
+  );
 }
 
 export { PreviewFrame };

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -52,8 +52,7 @@ import { PreviewPanes } from "../PreviewPanes";
 
 const props = {
   onClose: vi.fn(),
-  collection: "pages",
-  entryId: "7",
+  scope: { collection: "pages", entryId: "7" },
   label: "Preview",
   revision: "r1",
 };

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -249,6 +249,49 @@ describe("a pane that holds a url it must not frame", () => {
   });
 });
 
+describe("a refusal is worded for the document in hand", () => {
+  /*
+   * The pane serves an entry and a Single alike, so a message naming the wrong
+   * kind sends someone to a field they cannot change — and for a Single the
+   * entry advice is exactly wrong, since it is addressed by a slug it always
+   * has. The noun is DERIVED from the scope here rather than passed beside it.
+   */
+  it("tells a Single's author about the preview URL, not a slug", () => {
+    frameState.current = {
+      ...frameState.current,
+      url: null,
+      reason: "unavailable",
+    };
+
+    render(
+      <PreviewPanes {...props} scope={{ single: "home" }} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(screen.getByText(/this single/i)).toBeInTheDocument();
+    expect(screen.queryByText(/slug/i)).toBeNull();
+  });
+
+  it("still tells an ENTRY's author about the slug", () => {
+    // The control: the refusal above is about the scope rather than the pane
+    // having stopped mentioning slugs at all.
+    frameState.current = {
+      ...frameState.current,
+      url: null,
+      reason: "unavailable",
+    };
+
+    render(
+      <PreviewPanes {...props} open>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    expect(screen.getByText(/slug/i)).toBeInTheDocument();
+  });
+});
+
 describe("the document change that refreshes the frame", () => {
   it("does not reload on the first render", () => {
     // The frame has just minted and loaded. Treating the token's initial value

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewSessionLock.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewSessionLock.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Which two panes are previewing the SAME thing.
+ *
+ * The site keeps one preview cookie per browser, so a pane whose scope has been
+ * superseded is showing content it can no longer prove. The key is what decides
+ * "superseded", and it fails in both directions: too coarse and two different
+ * documents look like one, so a pane goes on rendering a session that was taken
+ * from it; too fine and one document looks like two, so the same entry open in
+ * two tabs reports a conflict the browser does not have.
+ */
+import { describe, expect, it } from "vitest";
+
+import { previewScopeKey } from "../previewSessionLock";
+
+describe("previewScopeKey", () => {
+  it("gives one document one key, whichever object literal carries it", () => {
+    expect(previewScopeKey({ collection: "pages", entryId: "7" })).toBe(
+      previewScopeKey({ collection: "pages", entryId: "7" })
+    );
+  });
+
+  it("separates a Single from a collection entry whose parts CONCATENATE to it", () => {
+    /*
+     * The case the kind prefix exists for, and it has to be built deliberately.
+     * The parts are joined by spaces, so a Single named `pages 7` and entry `7`
+     * of collection `pages` produce the identical string once the prefix is
+     * gone — and each pane then believes the other's cookie is its own, which
+     * is the one failure this lock exists to detect, produced by the lock.
+     *
+     * A Single whose slug merely EQUALS a collection name does not collide
+     * (`"home "` versus `"home home "`), so a test written that way passes
+     * whether or not the prefix is there. This one was, until removing the
+     * prefix changed nothing and said so.
+     */
+    expect(previewScopeKey({ single: "pages 7" })).not.toBe(
+      previewScopeKey({ collection: "pages", entryId: "7" })
+    );
+  });
+
+  it("separates two entries in one collection", () => {
+    expect(previewScopeKey({ collection: "pages", entryId: "7" })).not.toBe(
+      previewScopeKey({ collection: "pages", entryId: "8" })
+    );
+  });
+
+  it("separates one entry id across two collections", () => {
+    // Ids are not unique across collections, so the collection has to be in the
+    // key or a grant would appear to travel between them.
+    expect(previewScopeKey({ collection: "pages", entryId: "7" })).not.toBe(
+      previewScopeKey({ collection: "posts", entryId: "7" })
+    );
+  });
+
+  it("separates two languages of one document", () => {
+    // A token is scoped per locale, so two languages are two sessions — and the
+    // second opening would silently take the cookie from the first.
+    expect(
+      previewScopeKey({ collection: "pages", entryId: "7", locale: "en" })
+    ).not.toBe(
+      previewScopeKey({ collection: "pages", entryId: "7", locale: "fr" })
+    );
+    expect(previewScopeKey({ single: "home", locale: "en" })).not.toBe(
+      previewScopeKey({ single: "home", locale: "fr" })
+    );
+  });
+
+  it("treats an absent locale as its own scope rather than matching any", () => {
+    // An unscoped token is not "the default language" — it covers every locale,
+    // so it is a different session from one scoped to a language.
+    expect(previewScopeKey({ single: "home" })).not.toBe(
+      previewScopeKey({ single: "home", locale: "en" })
+    );
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
@@ -15,6 +15,8 @@
  * each is asserted here on the state the pane renders from.
  */
 import { act, renderHook, waitFor } from "@testing-library/react";
+
+import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mint = vi.hoisted(() => vi.fn());
@@ -23,6 +25,7 @@ vi.mock("@admin/hooks/useEntryPreview", () => ({
   PREVIEW_MESSAGES: {},
 }));
 
+import { previewScopeKey } from "../previewSessionLock";
 import { usePreviewFrame } from "../usePreviewFrame";
 
 /*
@@ -42,15 +45,24 @@ function expiringIn(ms: number, url = `${ORIGIN}/blog/post?preview=1`) {
   };
 }
 
-const args = { collection: "pages", entryId: "7", active: true };
+const args = { scope: { collection: "pages", entryId: "7" }, active: true };
 
 /** The channel the panes announce on. Must match `previewSessionLock`. */
 const CHANNEL = "nextly.preview.session";
 
-/** Another pane, on another entry, taking the browser's one preview session. */
-function anotherPaneClaims(scopeKey = "pages 9 ") {
+/**
+ * Another pane taking the browser's one preview session.
+ *
+ * The key is DERIVED rather than spelled out, because a hand-written one pins
+ * the format: when the key gained a kind prefix, a literal `"pages 7 "` stopped
+ * meaning "the same scope" and silently started meaning "a different one" —
+ * turning the control below into another instance of the case it controls for.
+ */
+function anotherPaneClaims(
+  scope: SelfPreviewScope = { collection: "pages", entryId: "9" }
+) {
   const other = new BroadcastChannel(CHANNEL);
-  other.postMessage({ scopeKey });
+  other.postMessage({ scopeKey: previewScopeKey(scope) });
   other.close();
 }
 
@@ -154,6 +166,62 @@ describe("usePreviewFrame", () => {
     expect(mint).toHaveBeenCalledTimes(1);
   });
 
+  it("mints again when the language being previewed changes", async () => {
+    /*
+     * A token is scoped per locale, so switching language inside the editor
+     * makes the held credential the wrong one — it opens the language the
+     * author just left. Nothing navigates on a locale switch, so this is the
+     * only thing that can notice.
+     */
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { rerender } = renderHook(
+      ({ scope }: { scope: SelfPreviewScope }) =>
+        usePreviewFrame({ scope, active: true }),
+      {
+        initialProps: {
+          scope: { collection: "pages", entryId: "7", locale: "en" },
+        },
+      }
+    );
+    await waitFor(() => expect(mint).toHaveBeenCalledTimes(1));
+
+    rerender({ scope: { collection: "pages", entryId: "7", locale: "fr" } });
+
+    await waitFor(() => expect(mint).toHaveBeenCalledTimes(2));
+  });
+
+  it("mints NOTHING for a scope that is merely a new object", async () => {
+    /*
+     * The control for the case above, and the reason the dependency is a KEY
+     * rather than the scope itself. Callers build the scope inline, so its
+     * identity changes on every render — depending on it would issue a
+     * credential and an audit row for every keystroke in the editor beside the
+     * pane, which is the failure that would hide behind the test above passing.
+     */
+    mint.mockResolvedValue(expiringIn(15 * 60_000));
+
+    const { rerender } = renderHook(
+      ({ scope }: { scope: SelfPreviewScope }) =>
+        usePreviewFrame({ scope, active: true }),
+      {
+        initialProps: {
+          scope: { collection: "pages", entryId: "7", locale: "en" },
+        },
+      }
+    );
+    await waitFor(() => expect(mint).toHaveBeenCalledTimes(1));
+
+    // Equal by value, different by identity — three times over, so a single
+    // render slipping through would not be mistaken for stability.
+    rerender({ scope: { collection: "pages", entryId: "7", locale: "en" } });
+    rerender({ scope: { collection: "pages", entryId: "7", locale: "en" } });
+    rerender({ scope: { collection: "pages", entryId: "7", locale: "en" } });
+    await act(async () => {});
+
+    expect(mint).toHaveBeenCalledTimes(1);
+  });
+
   it("reports the reason a mint refused, and shows no frame", async () => {
     mint.mockResolvedValue({ kind: "report", reason: "noSiteUrl" });
 
@@ -240,7 +308,7 @@ describe("another pane taking the browser's one preview session", () => {
     const { result } = renderHook(() => usePreviewFrame(args));
     await waitFor(() => expect(result.current.url).not.toBeNull());
 
-    act(() => anotherPaneClaims("pages 7 "));
+    act(() => anotherPaneClaims({ collection: "pages", entryId: "7" }));
     await act(async () => {});
 
     expect(result.current.block).toBeNull();

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/usePreviewFrame.test.ts
@@ -22,7 +22,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mint = vi.hoisted(() => vi.fn());
 vi.mock("@admin/hooks/useEntryPreview", () => ({
   mintSelfPreview: mint,
-  PREVIEW_MESSAGES: {},
+  previewMessage: (r: string) => r,
 }));
 
 import { previewScopeKey } from "../previewSessionLock";

--- a/packages/admin/src/components/features/entries/PreviewMode/previewSessionLock.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/previewSessionLock.ts
@@ -29,6 +29,8 @@
  * @module components/features/entries/PreviewMode/previewSessionLock
  */
 
+import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
+
 /** Shared by every admin tab on this origin. */
 const CHANNEL = "nextly.preview.session";
 
@@ -38,12 +40,14 @@ const CHANNEL = "nextly.preview.session";
  * A string rather than the parts, because it is only ever compared for equality
  * and a structured payload invites a reader to match on one field.
  */
-export function previewScopeKey(
-  collection: string,
-  entryId: string,
-  locale: string | undefined
-): string {
-  return `${collection} ${entryId} ${locale ?? ""}`;
+export function previewScopeKey(scope: SelfPreviewScope): string {
+  const locale = scope.locale ?? "";
+  // The KIND is part of the key. A Single and a collection can carry the same
+  // slug, and two panes previewing genuinely different documents that compared
+  // equal here would each believe the other's cookie was its own.
+  return scope.single === undefined
+    ? `collection ${scope.collection} ${scope.entryId} ${locale}`
+    : `single ${scope.single} ${locale}`;
 }
 
 export interface PreviewSessionLock {

--- a/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
@@ -146,12 +146,23 @@ export function usePreviewFrame({
 
   /*
    * Kept current so the mint reads today's scope rather than the one captured
-   * when the callback was last rebuilt. Without this the key and the value
-   * could disagree for a render — which is the stale closure the key exists to
-   * avoid, reintroduced by the fix for it.
+   * when the callback was last rebuilt.
+   *
+   * Written in a COMMIT effect, never during render. A render can be abandoned
+   * — interrupted, or thrown away by a concurrent update — and a ref written
+   * there would publish a scope no commit ever accepted, while `scopeKey` and
+   * the session lock still describe the committed one. The mint would then
+   * issue a credential for one document and announce the session key of
+   * another, which is precisely the key/value disagreement this ref exists to
+   * prevent, arrived at from the opposite direction.
+   *
+   * Declared BEFORE the effects that mint, so within one commit React runs it
+   * first and they read the scope that commit actually carried.
    */
   const scopeRef = useRef(scope);
-  scopeRef.current = scope;
+  useEffect(() => {
+    scopeRef.current = scope;
+  }, [scope]);
 
   /*
    * The lock this pane announces through. A ref because `mint` claims through

--- a/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
@@ -38,6 +38,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import {
   mintSelfPreview,
   type PreviewUnavailableReason,
+  type SelfPreviewScope,
 } from "@admin/hooks/useEntryPreview";
 
 import {
@@ -101,20 +102,14 @@ export interface UsePreviewFrameResult extends PreviewFrameState {
 }
 
 /**
- * @param collection - the collection slug the entry belongs to
- * @param entryId - the SAVED entry id; the frame shows nothing without one
- * @param locale - the language to scope the token to, on a localized collection
+ * @param scope - the document to preview: a collection entry, or a Single
  * @param active - whether the pane is open; nothing is minted while it is not
  */
 export function usePreviewFrame({
-  collection,
-  entryId,
-  locale,
+  scope,
   active,
 }: {
-  collection: string;
-  entryId: string;
-  locale?: string | undefined;
+  scope: SelfPreviewScope;
   active: boolean;
 }): UsePreviewFrameResult {
   const [state, setState] = useState<PreviewFrameState>({
@@ -139,7 +134,24 @@ export function usePreviewFrame({
    */
   const generation = useRef(0);
 
-  const scopeKey = previewScopeKey(collection, entryId, locale);
+  /*
+   * The scope as a comparable VALUE, and the only dependency the mint takes.
+   *
+   * Callers build the scope inline, so its object identity changes on every
+   * render — depending on it would re-mint a credential, and write an audit
+   * row, for every keystroke in the editor beside the pane. The key changes
+   * exactly when the document being previewed does.
+   */
+  const scopeKey = previewScopeKey(scope);
+
+  /*
+   * Kept current so the mint reads today's scope rather than the one captured
+   * when the callback was last rebuilt. Without this the key and the value
+   * could disagree for a render — which is the stale closure the key exists to
+   * avoid, reintroduced by the fix for it.
+   */
+  const scopeRef = useRef(scope);
+  scopeRef.current = scope;
 
   /*
    * The lock this pane announces through. A ref because `mint` claims through
@@ -152,7 +164,7 @@ export function usePreviewFrame({
     const mine = ++generation.current;
     setState(prev => ({ ...prev, isLoading: true, reason: null, block: null }));
 
-    const outcome = await mintSelfPreview(collection, entryId, locale);
+    const outcome = await mintSelfPreview(scopeRef.current);
 
     // A newer mint started, or the pane closed, while this one was in flight.
     if (mine !== generation.current) return;
@@ -199,7 +211,11 @@ export function usePreviewFrame({
       reason: null,
       block: framable ? null : "crossOrigin",
     }));
-  }, [collection, entryId, locale]);
+    // No dependencies: the scope is read through the ref, so this callback is
+    // correct for every scope and never needs rebuilding. What must react to a
+    // changed scope is the effect that OPENS the pane, and that is where the
+    // key belongs — a dependency here would only be a proxy for it.
+  }, []);
 
   /*
    * Subscribed for the whole time the pane is open, not per mint: the message
@@ -243,7 +259,12 @@ export function usePreviewFrame({
       return;
     }
     void mint();
-  }, [active, mint]);
+    // `scopeKey` and not `scope`: the caller builds the scope inline, so its
+    // identity changes every render and depending on it would re-mint — and
+    // write an audit row — for every keystroke in the editor beside the pane.
+    // The key changes exactly when the document or its language does, which is
+    // exactly when a fresh credential is owed.
+  }, [active, scopeKey, mint]);
 
   /*
    * Renewal on a TIMER, not only when someone asks.

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -24,7 +24,7 @@
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { FieldConfig } from "nextly/config";
 import type React from "react";
-import { useEffect, useMemo, useCallback, useRef } from "react";
+import { useEffect, useMemo, useCallback, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -54,6 +54,7 @@ import {
 import { useRailCollapsed } from "@admin/components/features/entries/EntryForm/useRailCollapsed";
 import { EntryLocaleProvider } from "@admin/components/features/entries/EntryLocaleContext";
 import { LanguagePanel } from "@admin/components/features/entries/LanguagePanel";
+import { PreviewPanes } from "@admin/components/features/entries/PreviewMode/PreviewPanes";
 import { TranslationPanes } from "@admin/components/features/entries/TranslationMode/TranslationPanes";
 import { useTranslationSource } from "@admin/components/features/entries/TranslationMode/useTranslationSource";
 import { useEntryLocaleContext } from "@admin/components/features/entries/useEntryLocaleContext";
@@ -80,6 +81,7 @@ import { cn } from "@admin/lib/utils";
 
 import { relaxIdentityRequired } from "./identity-fields";
 import { useSinglePreviewLink } from "./useSinglePreviewLink";
+import { useSinglePreviewPane } from "./useSinglePreviewPane";
 
 // ============================================================================
 // Types
@@ -334,6 +336,18 @@ export function SingleForm({
   // Handlers
   // ---------------------------------------------------------------------------
 
+  /*
+   * Whether the preview pane is open, and how many times this form has saved.
+   *
+   * The count feeds the preview revision, and it is needed for the reason the
+   * entry editor needs it: a status-less save of a PUBLISHED document writes
+   * the working-draft sidecar and leaves the live row alone, so from the second
+   * such save onward the document's own `updatedAt` and its working-draft flag
+   * both stand still while its content changes underneath them. Counting saves
+   * is the only signal to that write available on this side of the wire.
+   */
+  const [savedCount, setSavedCount] = useState(0);
+
   // Submit handler. The intent arg names the user's button click and
   // determines payload shape — same intent set as the collection
   // EntryForm (see EntryFormIntent). Mirrors the EntryForm pattern.
@@ -350,6 +364,10 @@ export function SingleForm({
 
         try {
           await onSubmit(data);
+          // After the write lands and before the reset: this is the only point
+          // that knows a save succeeded, and a revision that misses one leaves
+          // the pane showing the previous draft.
+          setSavedCount(n => n + 1);
           form.reset(data);
         } catch (error) {
           console.error("Form submission error:", error);
@@ -524,6 +542,14 @@ export function SingleForm({
     getLocale,
   });
 
+  // Every part of the in-place preview, decided together — see the module.
+  const previewPane = useSinglePreviewPane({
+    link: previewLink,
+    document,
+    savedCount,
+    inTranslationMode: translationMode.source !== undefined,
+  });
+
   const localeCtx = useEntryLocaleContext({
     locale,
     defaultLocale,
@@ -605,181 +631,205 @@ export function SingleForm({
           }}
         >
           <EntryLocaleProvider value={localeCtx}>
-            {/* Renders its child alone when there is no source — see the module. */}
-            <TranslationPanes
-              source={translationMode.source}
-              onExit={translationMode.onExit}
-              control={form.control}
+            {/* Renders its child alone when it is closed — see the module. */}
+            <PreviewPanes
+              /*
+               * Withheld while translation mode is on, and while the preview
+               * cannot be offered at all. That mode already splits the editor,
+               * and a third pane inside it would produce two nested resizable
+               * groups and two chrome requests disagreeing about how much of
+               * the admin is left — the same reason the entry editor withholds
+               * it there.
+               */
+              open={previewPane.open}
+              onClose={previewPane.onClose}
+              scope={previewPane.scope}
+              label="Preview"
+              revision={previewPane.revision}
             >
-              <div className={cn("space-y-0", className)}>
-                <EntryFormProvider form={form} onSubmit={handleSubmit}>
-                  <FormErrorSummary
-                    errors={errors}
-                    submitCount={submitCount}
-                    className="mx-6 mt-3"
-                  />
+              {/* Renders its child alone when there is no source — see the module. */}
+              <TranslationPanes
+                source={translationMode.source}
+                onExit={translationMode.onExit}
+                control={form.control}
+              >
+                <div className={cn("space-y-0", className)}>
+                  <EntryFormProvider form={form} onSubmit={handleSubmit}>
+                    <FormErrorSummary
+                      errors={errors}
+                      submitCount={submitCount}
+                      className="mx-6 mt-3"
+                    />
 
-                  <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-my-8">
-                    {/* Main column */}
-                    <div className="flex-1 min-w-0 flex flex-col">
-                      {/* No horizontal compensation here, and none needed. The
+                    <div className="flex flex-col @4xl/content:flex-row @4xl/content:min-h-[calc(100vh-4rem)] items-stretch @4xl/content:-my-8">
+                      {/* Main column */}
+                      <div className="flex-1 min-w-0 flex flex-col">
+                        {/* No horizontal compensation here, and none needed. The
                 parent's `-my-8` cancels the page's VERTICAL inset only; the
                 horizontal inset is spent as grid columns on a measured page and
                 is not a padding any margin can pull back from. A horizontal one here
                 would not cancel anything — it would push the header and meta
                 strip past the content column, which is what it did when the
                 parent still cancelled both axes. */}
-                      <EntrySystemHeader
-                        autosaveEnabled={autosaveScope !== null}
-                        autosaveStatus={autosave.status}
-                        autosaveLastSavedAt={autosave.lastSavedAt}
-                        mode="edit"
-                        titleField={titleField}
-                        historyFields={schema.fields}
-                        historyEnabled={historyEnabledFrom(schema)}
-                        hasStatus={hasStatus}
-                        isSubmitting={isSubmitting}
-                        isDirty={isDirty}
-                        entry={entryLike}
-                        collectionSlug={schema.slug}
-                        /* i18n: forward the active locale + switch handler so a localized single shows
+                        <EntrySystemHeader
+                          autosaveEnabled={autosaveScope !== null}
+                          autosaveStatus={autosave.status}
+                          autosaveLastSavedAt={autosave.lastSavedAt}
+                          mode="edit"
+                          titleField={titleField}
+                          historyFields={schema.fields}
+                          historyEnabled={historyEnabledFrom(schema)}
+                          hasStatus={hasStatus}
+                          isSubmitting={isSubmitting}
+                          isDirty={isDirty}
+                          entry={entryLike}
+                          collectionSlug={schema.slug}
+                          /* i18n: forward the active locale + switch handler so a localized single shows
                    the primary header language switcher (the sidebar pills are unavailable when
                    the rail is collapsed or on narrow layouts). The switcher self-hides when the
                    single isn't localized / localization isn't configured. */
-                        locale={locale}
-                        onLocaleChange={onLocaleChange}
-                        localized={schema.localized === true}
-                        /* A Single has a draft lifecycle, so it has drafts worth
+                          locale={locale}
+                          onLocaleChange={onLocaleChange}
+                          localized={schema.localized === true}
+                          /* A Single has a draft lifecycle, so it has drafts worth
                    sharing. The control is offered whenever the Single carries
                    that lifecycle; whether a link can actually be minted is the
                    server's call, and it refuses with a message naming what is
                    missing rather than handing out one that 404s. */
-                        isLinkAvailable={previewLink.isAvailable}
-                        onCopyLink={previewLink.copy}
-                        isCopyingLink={previewLink.isCopying}
-                        toolbarSlot={
-                          <EntryFormToolbarSlots
-                            context="single"
-                            controllerField={controllerNames[0]}
-                          />
-                        }
-                        onSaveDraft={() => {
-                          void handleSubmit(undefined, "save-draft");
-                        }}
-                        onPublish={() => {
-                          void handleSubmit(undefined, "publish");
-                        }}
-                        onSaveChanges={() => {
-                          void handleSubmit(undefined, "save-changes");
-                        }}
-                        /* The draft/published split. Without this the header
+                          isLinkAvailable={previewLink.isAvailable}
+                          onCopyLink={previewLink.copy}
+                          isCopyingLink={previewLink.isCopying}
+                          /* The pane is offered on exactly the terms the
+                           shareable link is: a Single with a draft lifecycle
+                           and a resolvable language. Withheld in translation
+                           mode, where the pane itself is withheld — a button
+                           that toggles a flag nothing reads is worse than no
+                           button. */
+                          {...previewPane.toggle}
+                          toolbarSlot={
+                            <EntryFormToolbarSlots
+                              context="single"
+                              controllerField={controllerNames[0]}
+                            />
+                          }
+                          onSaveDraft={() => {
+                            void handleSubmit(undefined, "save-draft");
+                          }}
+                          onPublish={() => {
+                            void handleSubmit(undefined, "publish");
+                          }}
+                          onSaveChanges={() => {
+                            void handleSubmit(undefined, "save-changes");
+                          }}
+                          /* The draft/published split. Without this the header
                    takes its `draftsEnabled: false` branch, whose Save names the
                    status — and a write that names one is never held, so the
                    engine's pending-change support stayed dark for every Single.
                    The label is the visible tell: "Save changes" rather than
                    "Save". */
-                        draftsEnabled={schema.draftsEnabled === true}
-                        onSaveWorkingDraft={() => {
-                          void handleSubmit(undefined, "save-working-draft");
-                        }}
-                        onUnpublish={() => {
-                          void handleSubmit(undefined, "unpublish");
-                        }}
-                        onDiscardWorkingDraft={async () => {
-                          await discardMutation.mutateAsync();
-                        }}
-                        onCancel={handleCancel}
-                        onViewApi={onViewApi}
-                        /* Why: Singles share the Show JSON dialog with collections,
+                          draftsEnabled={schema.draftsEnabled === true}
+                          onSaveWorkingDraft={() => {
+                            void handleSubmit(undefined, "save-working-draft");
+                          }}
+                          onUnpublish={() => {
+                            void handleSubmit(undefined, "unpublish");
+                          }}
+                          onDiscardWorkingDraft={async () => {
+                            await discardMutation.mutateAsync();
+                          }}
+                          onCancel={handleCancel}
+                          onViewApi={onViewApi}
+                          /* Why: Singles share the Show JSON dialog with collections,
                  but at the /api/singles/{slug} URL pattern. Passing
                  `scope="single"` routes the dialog through singleApi
                  instead of entryApi. */
-                        scope="single"
-                        lockIdentity
-                        isRailCollapsed={railCollapsed}
-                        onToggleRail={toggleRail}
-                      />
-                      <EntryMetaStrip
-                        slugField={slugField}
-                        hasStatus={hasStatus}
-                        status={documentStatus}
-                        isRailCollapsed={railCollapsed}
-                        lockSlug
-                      />
+                          scope="single"
+                          lockIdentity
+                          isRailCollapsed={railCollapsed}
+                          onToggleRail={toggleRail}
+                        />
+                        <EntryMetaStrip
+                          slugField={slugField}
+                          hasStatus={hasStatus}
+                          status={documentStatus}
+                          isRailCollapsed={railCollapsed}
+                          lockSlug
+                        />
 
-                      {/* Inside the main column, below the header, matching the entry
+                        {/* Inside the main column, below the header, matching the entry
                   editor. Placed above the flex row it sat UNDER the sticky
                   header, which intercepted pointer events: the offer was
                   visible and its buttons were not clickable. */}
-                      {recovery.offer ? (
-                        <AutosaveRecoveryBanner
-                          savedAt={recovery.offer.savedAt}
-                          onRestore={restoreRecovery}
-                          onDismiss={recovery.dismiss}
-                          className="mx-6 mt-3"
-                        />
-                      ) : null}
+                        {recovery.offer ? (
+                          <AutosaveRecoveryBanner
+                            savedAt={recovery.offer.savedAt}
+                            onRestore={restoreRecovery}
+                            onDismiss={recovery.dismiss}
+                            className="mx-6 mt-3"
+                          />
+                        ) : null}
 
-                      {/* The language panel, inline. The rail that otherwise carries it
+                        {/* The language panel, inline. The rail that otherwise carries it
                   is `hidden @4xl/content:flex`, so this is the exact
                   complement: shown only where the rail is not, and rendered
                   unconditionally once the author collapses the rail. Without
                   it a single loses its language workflow entirely at narrow
                   widths, which is the failure this panel exists to remove. */}
-                      {localizationEnabled && (
-                        <div
-                          className={cn(
-                            "px-6 pt-4",
-                            !railCollapsed && "@4xl/content:hidden"
-                          )}
-                        >
-                          <LanguagePanel
-                            {...(singleTranslations === undefined
-                              ? {}
-                              : { translations: singleTranslations })}
-                            {...(locale === undefined
-                              ? {}
-                              : { activeLocale: locale })}
-                            {...(onLocaleChange === undefined
-                              ? {}
-                              : { onSelect: onLocaleChange })}
-                            hasStatus={hasStatus}
-                          />
-                        </div>
-                      )}
+                        {localizationEnabled && (
+                          <div
+                            className={cn(
+                              "px-6 pt-4",
+                              !railCollapsed && "@4xl/content:hidden"
+                            )}
+                          >
+                            <LanguagePanel
+                              {...(singleTranslations === undefined
+                                ? {}
+                                : { translations: singleTranslations })}
+                              {...(locale === undefined
+                                ? {}
+                                : { activeLocale: locale })}
+                              {...(onLocaleChange === undefined
+                                ? {}
+                                : { onSelect: onLocaleChange })}
+                              hasStatus={hasStatus}
+                            />
+                          </div>
+                        )}
 
-                      {mainFields.length > 0 && (
-                        <div className="@4xl/content:p-8 pt-6">
-                          <EntryFormContent
-                            fields={mainFields}
-                            disabled={isSubmitting}
-                            withCard
-                          />
+                        {mainFields.length > 0 && (
+                          <div className="@4xl/content:p-8 pt-6">
+                            <EntryFormContent
+                              fields={mainFields}
+                              disabled={isSubmitting}
+                              withCard
+                            />
+                          </div>
+                        )}
+                      </div>
+
+                      {/* Rail (collapsible). Same shape and width as collections. */}
+                      {!railCollapsed && (
+                        <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
+                          <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
+                            <EntryFormSidebar
+                              mode="edit"
+                              entry={entryLike}
+                              hasStatus={hasStatus}
+                              isDirty={isDirty}
+                              {...(locale === undefined ? {} : { locale })}
+                              {...(onLocaleChange === undefined
+                                ? {}
+                                : { onLocaleChange })}
+                            />
+                          </div>
                         </div>
                       )}
                     </div>
-
-                    {/* Rail (collapsible). Same shape and width as collections. */}
-                    {!railCollapsed && (
-                      <div className="hidden @4xl/content:flex w-[320px] shrink-0 border-l border-border bg-background flex-col relative z-10">
-                        <div className="@4xl/content:sticky @4xl/content:top-0 @4xl/content:h-[calc(100vh-4rem)] overflow-y-auto [&::-webkit-scrollbar]:hidden [-ms-overflow-style:none] [scrollbar-width:none] flex flex-col">
-                          <EntryFormSidebar
-                            mode="edit"
-                            entry={entryLike}
-                            hasStatus={hasStatus}
-                            isDirty={isDirty}
-                            {...(locale === undefined ? {} : { locale })}
-                            {...(onLocaleChange === undefined
-                              ? {}
-                              : { onLocaleChange })}
-                          />
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </EntryFormProvider>
-              </div>
-            </TranslationPanes>
+                  </EntryFormProvider>
+                </div>
+              </TranslationPanes>
+            </PreviewPanes>
           </EntryLocaleProvider>
         </EntryFormContextProvider>
       </UnsavedWorkProvider>

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
@@ -58,10 +58,7 @@ vi.mock("@admin/components/features/entries/PreviewMode/PreviewPanes", () => ({
   },
 }));
 
-/*
- * Recorded, not replaced in spirit: the real builder still runs, so a revision
- * asserted below is the one the pane would really receive.
- */
+/* Recorded, not replaced: the real builder still runs beneath the spy. */
 vi.mock(
   "@admin/components/features/entries/PreviewMode/previewRevision",
   async importOriginal => {
@@ -109,7 +106,11 @@ const schema = {
   fields: [{ name: "title", type: "text", label: "Title" }],
 } as never;
 
-const document = { id: "s1", title: "Hello" } as never;
+const document = {
+  id: "s1",
+  title: "Hello",
+  status: "published",
+} as never;
 
 function renderForm(props: Record<string, unknown> = {}) {
   return render(
@@ -184,21 +185,19 @@ describe("SingleForm offers the preview pane", () => {
     expect(screen.getByTestId("pane").dataset.open).toBe("false");
   });
 
-  it("builds the revision from the document AND this form's save count", () => {
+  it("threads this form's save count into the revision", () => {
     /*
-     * The seam that carries the defect. A status-less save of a PUBLISHED
-     * Single writes the working-draft sidecar and leaves the live row alone, so
-     * `updatedAt` and the working-draft flag both stand still while the content
-     * changes underneath them — and a revision built from the document alone
-     * stops moving from the second such save onward, leaving the pane showing
-     * the previous draft with nothing to say so.
+     * Half of the property; the other half lives in
+     * `useSinglePreviewPane.test.ts`, which asserts the count MOVES the answer.
+     * Split because driving a real save is not possible from here: the header
+     * is replaced, and although `onSaveChanges` — the callback the form wires
+     * to its own `handleSubmit` — can be invoked, the submit never reaches
+     * `onSubmit`, because the form's fields do not render under this harness
+     * and the validated callback therefore never runs. Measured, not assumed.
      *
-     * Asserted on the ARGUMENTS rather than by driving a save: the save button
-     * lives inside a `toolbarSlot` on the header this file replaces, so a
-     * submit here would exercise the harness rather than the form. What this
-     * catches is the count being dropped from the call or never threaded to it,
-     * which is the realistic regression. That the count CHANGES the answer is
-     * proven where the function lives, in `previewRevision.test.ts`.
+     * What this catches is the count being dropped from the call or never
+     * threaded to it. What it cannot catch alone is a count frozen at zero —
+     * which is exactly what the hook test covers.
      */
     renderForm();
 

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * The join between `SingleForm`, its header, and the in-admin preview pane.
+ *
+ * The pane itself is covered where it lives — `PreviewPanes.test.tsx` pins what
+ * it costs closed and what it asks for open — and none of that sees the
+ * conjunction this file is about: whether a Single is offered the pane at all,
+ * and whether the pane and the shareable link beside it are pointed at the SAME
+ * document in the SAME language.
+ *
+ * That second one is the sharp case. Both surfaces need a locale claim, both
+ * are wrong in the same way without one — on a localized Single opened in its
+ * default language the editor's active locale is `undefined`, and an absent
+ * claim authorizes every translation rather than the default. Two callers
+ * resolving that separately would agree the day it was written; these assert
+ * they are the same object rather than that each is individually plausible.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { act, render, screen } from "@admin/__tests__/utils";
+
+const { headerProps, paneProps, mintArgs, revisionArgs, localization } =
+  vi.hoisted(() => ({
+    headerProps: vi.fn(),
+    revisionArgs: vi.fn(),
+    paneProps: vi.fn(),
+    mintArgs: vi.fn(),
+    localization: { current: { defaultLocale: "en" } },
+  }));
+
+vi.mock(
+  "@admin/components/features/entries/EntryForm/EntrySystemHeader",
+  () => ({
+    EntrySystemHeader: (props: Record<string, unknown>) => {
+      headerProps(props);
+      return null;
+    },
+  })
+);
+
+/*
+ * The pane is replaced by a recorder that still renders its children, because
+ * the form below it must keep rendering either way — a stub returning null
+ * would make every assertion about the editor pass for the wrong reason.
+ */
+vi.mock("@admin/components/features/entries/PreviewMode/PreviewPanes", () => ({
+  PreviewPanes: ({
+    children,
+    ...rest
+  }: {
+    children: React.ReactNode;
+  } & Record<string, unknown>) => {
+    paneProps(rest);
+    return (
+      <div data-testid="pane" data-open={String(rest.open)}>
+        {children}
+      </div>
+    );
+  },
+}));
+
+/*
+ * Recorded, not replaced in spirit: the real builder still runs, so a revision
+ * asserted below is the one the pane would really receive.
+ */
+vi.mock(
+  "@admin/components/features/entries/PreviewMode/previewRevision",
+  async importOriginal => {
+    const actual =
+      await importOriginal<
+        typeof import("@admin/components/features/entries/PreviewMode/previewRevision")
+      >();
+    return {
+      previewRevisionOf: (doc: unknown, count: number) => {
+        revisionArgs(doc, count);
+        return actual.previewRevisionOf(doc, count);
+      },
+    };
+  }
+);
+
+vi.mock("@admin/hooks/useLocalization", () => ({
+  useLocalization: () => ({
+    enabled: true,
+    locales: [],
+    defaultLocale: localization.current.defaultLocale,
+    fallback: true,
+    getLocale: () => undefined,
+  }),
+}));
+
+vi.mock("@admin/hooks/usePreviewLink", () => ({
+  usePreviewLink: (args: unknown) => {
+    mintArgs(args);
+    return { mutate: vi.fn(), isPending: false };
+  },
+}));
+
+import { SingleForm } from "../SingleForm";
+
+/**
+ * A localized Single with a publish lifecycle — the combination that makes a
+ * preview both available and locale-sensitive.
+ */
+const schema = {
+  slug: "landing-page",
+  label: { singular: "Landing Page" },
+  localized: true,
+  status: true,
+  fields: [{ name: "title", type: "text", label: "Title" }],
+} as never;
+
+const document = { id: "s1", title: "Hello" } as never;
+
+function renderForm(props: Record<string, unknown> = {}) {
+  return render(
+    <SingleForm
+      schema={schema}
+      document={document}
+      onSubmit={vi.fn()}
+      {...props}
+    />
+  );
+}
+
+function lastHeaderProps(): Record<string, unknown> {
+  const calls = headerProps.mock.calls;
+  expect(calls.length, "the header was never rendered").toBeGreaterThan(0);
+  return calls[calls.length - 1]?.[0] as Record<string, unknown>;
+}
+
+function lastPaneProps(): Record<string, unknown> {
+  const calls = paneProps.mock.calls;
+  expect(calls.length, "the pane was never rendered").toBeGreaterThan(0);
+  return calls[calls.length - 1]?.[0] as Record<string, unknown>;
+}
+
+describe("SingleForm offers the preview pane", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localization.current = { defaultLocale: "en" };
+  });
+
+  it("hands the header a toggle once the language resolves", () => {
+    renderForm();
+
+    // A Single previously got only "copy a link". The toggle is what makes the
+    // in-place pane reachable at all, and the header draws its button purely on
+    // this prop being present.
+    expect(typeof lastHeaderProps().onTogglePreviewPane).toBe("function");
+    expect(lastHeaderProps().previewPaneOpen).toBe(false);
+  });
+
+  it("withholds the toggle on exactly the terms the shareable link is withheld", () => {
+    /*
+     * `useLocalization` reports `""` until the config loads, and a preview
+     * minted then is either refused or a grant over every translation. Offering
+     * a pane toggle there would put a button beside a link the form has already
+     * decided not to offer — two answers to one question.
+     */
+    localization.current = { defaultLocale: "" };
+    renderForm();
+
+    expect(lastHeaderProps().isLinkAvailable).toBe(false);
+    expect(lastHeaderProps().onTogglePreviewPane).toBeUndefined();
+  });
+
+  it("points the pane at the same scope the link mints against", () => {
+    renderForm({ locale: "fr" });
+
+    // The property, asserted as an EQUALITY rather than as two independently
+    // plausible values: the pane's scope and the link's request are one object,
+    // so they cannot drift into previewing different languages.
+    const minted = mintArgs.mock.calls[0]?.[0];
+    expect(minted).toEqual({ single: "landing-page", locale: "fr" });
+    expect(lastPaneProps().scope).toEqual(minted);
+  });
+
+  it("keeps the pane closed until someone asks for it", () => {
+    renderForm();
+
+    // Closed is not merely invisible: the pane mints no credential and writes
+    // no audit row while it is shut, which is only true if `open` is false.
+    expect(lastPaneProps().open).toBe(false);
+    expect(screen.getByTestId("pane").dataset.open).toBe("false");
+  });
+
+  it("builds the revision from the document AND this form's save count", () => {
+    /*
+     * The seam that carries the defect. A status-less save of a PUBLISHED
+     * Single writes the working-draft sidecar and leaves the live row alone, so
+     * `updatedAt` and the working-draft flag both stand still while the content
+     * changes underneath them — and a revision built from the document alone
+     * stops moving from the second such save onward, leaving the pane showing
+     * the previous draft with nothing to say so.
+     *
+     * Asserted on the ARGUMENTS rather than by driving a save: the save button
+     * lives inside a `toolbarSlot` on the header this file replaces, so a
+     * submit here would exercise the harness rather than the form. What this
+     * catches is the count being dropped from the call or never threaded to it,
+     * which is the realistic regression. That the count CHANGES the answer is
+     * proven where the function lives, in `previewRevision.test.ts`.
+     */
+    renderForm();
+
+    expect(revisionArgs).toHaveBeenCalledWith(document, expect.any(Number));
+  });
+
+  it("closes a pane that is already open when the preview stops being available", () => {
+    /*
+     * Opening is a user action and availability is not — the language can stop
+     * resolving underneath an open pane. Left alone it would keep rendering a
+     * credential nothing would re-mint, which is the silent-staleness failure
+     * this whole surface is built to avoid; and the toggle is withheld at the
+     * same moment, so there would be no control left to close it with.
+     */
+    const { rerender } = renderForm();
+
+    act(() => {
+      (lastHeaderProps().onTogglePreviewPane as () => void)();
+    });
+    expect(lastPaneProps().open).toBe(true);
+
+    localization.current = { defaultLocale: "" };
+    rerender(
+      <SingleForm schema={schema} document={document} onSubmit={vi.fn()} />
+    );
+
+    expect(lastPaneProps().open).toBe(false);
+  });
+
+  it("still renders the editor through the pane wrapper", () => {
+    // The control for every assertion above: the form is inside the wrapper, so
+    // these are statements about a rendered editor rather than about a subtree
+    // that never mounted.
+    renderForm();
+
+    expect(screen.getByTestId("pane")).toBeInTheDocument();
+    expect(paneProps).toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/components/features/singles/__tests__/useSinglePreviewPane.test.ts
+++ b/packages/admin/src/components/features/singles/__tests__/useSinglePreviewPane.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Whether the pane's revision actually MOVES when a save lands.
+ *
+ * Tested here rather than through the form, and the reason is worth recording
+ * because the obvious place does not work. `SingleForm.preview-pane.test.tsx`
+ * replaces the header, and `onSaveChanges` — the callback the form wires to its
+ * own `handleSubmit` — can be invoked from there, but the submit never reaches
+ * `onSubmit`: the form's fields do not render under that harness, so
+ * `handleSubmit`'s validated callback never runs. Driving a save there proves
+ * nothing about this.
+ *
+ * So the form test asserts the count is THREADED, and this one asserts the
+ * count MOVES the answer. Neither alone is the property: a count threaded but
+ * frozen satisfies the first, and a revision that moves for a count nothing
+ * supplies satisfies the second.
+ */
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { useSinglePreviewPane } from "../useSinglePreviewPane";
+import type { SinglePreviewLink } from "../useSinglePreviewLink";
+
+const link: SinglePreviewLink = {
+  isAvailable: true,
+  copy: () => {},
+  isCopying: false,
+  scope: { single: "landing-page", locale: "en" },
+};
+
+/**
+ * A PUBLISHED Single whose sidecar save moves nothing the document exposes.
+ *
+ * `updatedAt` and the working-draft flag are deliberately constant across every
+ * case below: a status-less save writes the working-draft row and leaves the
+ * live one alone, so this is the shape the admin really receives, and the count
+ * is the only thing that can distinguish one save from the next.
+ */
+const document = {
+  id: "s1",
+  updatedAt: "2026-08-26T10:00:00.000Z",
+  _isWorkingDraft: true,
+};
+
+function revisionAt(savedCount: number): string {
+  const { result } = renderHook(() =>
+    useSinglePreviewPane({
+      link,
+      document,
+      savedCount,
+      inTranslationMode: false,
+    })
+  );
+  return result.current.revision;
+}
+
+describe("the revision a Single's pane refreshes on", () => {
+  it("moves when a save lands, though the document has not changed", () => {
+    expect(revisionAt(1)).not.toBe(revisionAt(0));
+  });
+
+  it("keeps moving across a run of saves", () => {
+    const seen = [0, 1, 2, 3, 4].map(revisionAt);
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  it("does NOT move when nothing saved", () => {
+    // The control: the revision is a function of its inputs rather than
+    // something that changes on every render, which would refresh the frame
+    // continuously and reload the site on every keystroke.
+    expect(revisionAt(3)).toBe(revisionAt(3));
+  });
+
+  it("still moves when the DOCUMENT changes under an unchanged count", () => {
+    /*
+     * The other half of the union. Discarding a working draft persists through
+     * its own mutation, so the count does not move — and only the flag going
+     * false says the frame is showing content that no longer exists.
+     */
+    const { result } = renderHook(() =>
+      useSinglePreviewPane({
+        link,
+        document: { ...document, _isWorkingDraft: false },
+        savedCount: 3,
+        inTranslationMode: false,
+      })
+    );
+
+    expect(result.current.revision).not.toBe(revisionAt(3));
+  });
+});

--- a/packages/admin/src/components/features/singles/__tests__/useSinglePreviewPane.test.ts
+++ b/packages/admin/src/components/features/singles/__tests__/useSinglePreviewPane.test.ts
@@ -14,7 +14,7 @@
  * frozen satisfies the first, and a revision that moves for a count nothing
  * supplies satisfies the second.
  */
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { useSinglePreviewPane } from "../useSinglePreviewPane";
@@ -86,5 +86,73 @@ describe("the revision a Single's pane refreshes on", () => {
     );
 
     expect(result.current.revision).not.toBe(revisionAt(3));
+  });
+});
+
+describe("availability disappearing under an OPEN pane", () => {
+  function paneWith(isAvailable: boolean, inTranslationMode = false) {
+    return renderHook(
+      ({
+        available,
+        translating,
+      }: {
+        available: boolean;
+        translating: boolean;
+      }) =>
+        useSinglePreviewPane({
+          link: { ...link, isAvailable: available },
+          document,
+          savedCount: 0,
+          inTranslationMode: translating,
+        }),
+      {
+        initialProps: {
+          available: isAvailable,
+          translating: inTranslationMode,
+        },
+      }
+    );
+  }
+
+  it("does not spring back open when availability returns", () => {
+    /*
+     * Masking is not closing. `open && canOffer` hides the pane while leaving
+     * the state true, so ending translation mode — or the locale resolving —
+     * reopens it and mints a credential nobody asked for. Observing only the
+     * unavailable render cannot tell the two apart, which is why this rerenders
+     * BACK to an available state: that is the only moment they differ.
+     */
+    const { result, rerender } = paneWith(true);
+
+    act(() => {
+      (
+        result.current.toggle as { onTogglePreviewPane: () => void }
+      ).onTogglePreviewPane();
+    });
+    expect(result.current.open).toBe(true);
+
+    rerender({ available: false, translating: false });
+    expect(result.current.open).toBe(false);
+
+    // The moment that separates closed from masked.
+    rerender({ available: true, translating: false });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("reopens on a deliberate toggle, so the state is not stuck shut", () => {
+    // The control: closing it was availability doing its job, not the pane
+    // losing the ability to open.
+    const { result, rerender } = paneWith(true);
+
+    rerender({ available: false, translating: false });
+    rerender({ available: true, translating: false });
+
+    act(() => {
+      (
+        result.current.toggle as { onTogglePreviewPane: () => void }
+      ).onTogglePreviewPane();
+    });
+
+    expect(result.current.open).toBe(true);
   });
 });

--- a/packages/admin/src/components/features/singles/useSinglePreviewLink.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewLink.ts
@@ -17,8 +17,8 @@
  */
 
 import { previewLinkLocale } from "@admin/components/features/entries/EntryForm/entry-address";
+import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
 import { usePreviewLink } from "@admin/hooks/usePreviewLink";
-import type { UsePreviewLinkOptions } from "@admin/hooks/usePreviewLink";
 
 export interface SinglePreviewLinkInput {
   /** The Single's slug, which is its identity — there is no id to wait for. */
@@ -34,12 +34,27 @@ export interface SinglePreviewLinkInput {
 }
 
 export interface SinglePreviewLink {
-  /** Whether to offer the control at all. */
+  /** Whether to offer either preview control at all. */
   isAvailable: boolean;
   /** Mint and copy. */
   copy: () => void;
   /** Whether a mint is in flight. */
   isCopying: boolean;
+  /**
+   * What an in-admin PANE should mint against.
+   *
+   * Returned from here rather than rebuilt by the form, because the locale
+   * resolution above is the delicate part and two callers resolving it
+   * separately is exactly how a pane ends up scoped to a different language
+   * than the link beside it. The shareable link and the pane are two surfaces
+   * onto one document; the scope is decided once.
+   *
+   * Always present, because the slug always is. `isAvailable` is the separate
+   * question of whether to OFFER a preview, and a caller must gate on it: a
+   * scope built while the locale is unresolved deliberately carries no locale,
+   * and minting against that would grant every translation.
+   */
+  scope: SelfPreviewScope;
 }
 
 export function useSinglePreviewLink({
@@ -54,7 +69,7 @@ export function useSinglePreviewLink({
   // is silent because both look correct.
   const linkLocale = previewLinkLocale({ localized, locale, defaultLocale });
 
-  const target: UsePreviewLinkOptions = {
+  const target: SelfPreviewScope = {
     single: slug,
     ...(linkLocale.kind === "scoped" ? { locale: linkLocale.locale } : {}),
   };
@@ -62,6 +77,9 @@ export function useSinglePreviewLink({
   const link = usePreviewLink(target);
 
   return {
+    // The same object the shareable link mints against, so the pane cannot open
+    // a different language than the link would have shared.
+    scope: target,
     // A Single with no publish lifecycle has no pending state to show anyone,
     // so there is nothing to share and the control is not offered.
     isAvailable: hasStatus && linkLocale.kind !== "unresolved",

--- a/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
@@ -1,0 +1,106 @@
+"use client";
+
+/**
+ * The in-place preview wiring for a Single, as one decision rather than five
+ * scattered through the form.
+ *
+ * The same argument `useSinglePreviewLink` makes for the shareable link, and it
+ * applies harder here because the parts are only correct TOGETHER: whether the
+ * pane may be offered, whether the header may draw a toggle for it, which
+ * document it points at, and what makes it refresh. Left in the form those were
+ * two copies of one condition and a piece of state read three lines apart —
+ * and a toggle offered where the pane is withheld is a button that flips a flag
+ * nothing reads, while a pane opened where the toggle is absent is a split view
+ * with no way back.
+ *
+ * It deliberately does NOT own the save count. That is bumped by the submit
+ * handler, which the form declares long before it reaches any of this, so the
+ * count is passed in — a hook that owned it would have to be called earlier
+ * than its own inputs exist.
+ *
+ * @module components/features/singles/useSinglePreviewPane
+ */
+
+import { useCallback, useState } from "react";
+
+import { previewRevisionOf } from "@admin/components/features/entries/PreviewMode/previewRevision";
+import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
+
+import type { SinglePreviewLink } from "./useSinglePreviewLink";
+
+export interface SinglePreviewPaneInput {
+  /** The shareable-link decision, which already resolved the language. */
+  link: SinglePreviewLink;
+  /** The Single as last read, which the revision derives from. */
+  document: unknown;
+  /** How many times this form has saved. See the module note. */
+  savedCount: number;
+  /** Whether the editor is currently split for translation. */
+  inTranslationMode: boolean;
+}
+
+export interface SinglePreviewPane {
+  /** Whether the pane should render. */
+  open: boolean;
+  /** Close it. */
+  onClose: () => void;
+  /** The document it previews — the SAME scope the shareable link mints. */
+  scope: SelfPreviewScope;
+  /** What the preview would render, as a value that changes when it does. */
+  revision: string;
+  /**
+   * The header's toggle props, ready to spread.
+   *
+   * EMPTY when the pane cannot be offered, because the header draws its button
+   * purely on `onTogglePreviewPane` being present — so absence is how the
+   * control is withheld, and returning it as a spreadable object keeps that
+   * decision here rather than repeating the condition at the call site.
+   */
+  toggle:
+    | { onTogglePreviewPane: () => void; previewPaneOpen: boolean }
+    | Record<string, never>;
+}
+
+export function useSinglePreviewPane({
+  link,
+  document,
+  savedCount,
+  inTranslationMode,
+}: SinglePreviewPaneInput): SinglePreviewPane {
+  const [open, setOpen] = useState(false);
+
+  /*
+   * Withheld in translation mode for the reason the entry editor withholds it
+   * there: that mode already splits the editor, and a third pane inside it
+   * would nest two resizable groups and two chrome requests that disagree about
+   * how much of the admin is left.
+   *
+   * Otherwise offered on exactly the terms the shareable link is, because both
+   * need the same thing — a draft lifecycle and a resolvable language — and a
+   * second answer to that question would drift from the first.
+   */
+  const canOffer = link.isAvailable && !inTranslationMode;
+
+  const onClose = useCallback(() => setOpen(false), []);
+  const onToggle = useCallback(() => setOpen(o => !o), []);
+
+  return {
+    // Both halves: a pane left open when the language stops resolving must
+    // close rather than go on rendering a credential nothing would re-mint.
+    open: open && canOffer,
+    onClose,
+    scope: link.scope,
+    /*
+     * The SAME builder the entry editor uses, and both of its halves matter.
+     * Deriving from the document catches writes nobody announced — discarding a
+     * working draft persists through its own mutation and moves no timestamp —
+     * while the save count catches announced writes that move nothing the
+     * document exposes, which is every status-less save of a published Single
+     * after the first.
+     */
+    revision: previewRevisionOf(document, savedCount),
+    toggle: canOffer
+      ? { onTogglePreviewPane: onToggle, previewPaneOpen: open }
+      : {},
+  };
+}

--- a/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
@@ -21,7 +21,7 @@
  * @module components/features/singles/useSinglePreviewPane
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { previewRevisionOf } from "@admin/components/features/entries/PreviewMode/previewRevision";
 import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
@@ -80,6 +80,19 @@ export function useSinglePreviewPane({
    * second answer to that question would drift from the first.
    */
   const canOffer = link.isAvailable && !inTranslationMode;
+
+  /*
+   * Availability disappearing CLOSES the pane rather than masking it.
+   *
+   * `open && canOffer` alone only hides it: the state stays true, so when
+   * translation mode ends or the locale resolves again the pane springs back
+   * open and mints a credential nobody asked for. An author who entered
+   * translation mode with the preview open did not ask to reopen it on the way
+   * out, and a credential is an audit row.
+   */
+  useEffect(() => {
+    if (!canOffer) setOpen(false);
+  }, [canOffer]);
 
   const onClose = useCallback(() => setOpen(false), []);
   const onToggle = useCallback(() => setOpen(o => !o), []);

--- a/packages/admin/src/hooks/__tests__/previewMessage.test.ts
+++ b/packages/admin/src/hooks/__tests__/previewMessage.test.ts
@@ -1,0 +1,49 @@
+/**
+ * What a refused preview tells the person whose document it is.
+ *
+ * The pane serves both an entry and a Single, so a message naming the wrong
+ * kind sends someone to a field they cannot change. A Single is addressed by a
+ * slug it always has, which makes "check the slug" the one piece of advice that
+ * cannot be the problem there.
+ */
+import { describe, expect, it } from "vitest";
+
+import { previewMessage } from "../useEntryPreview";
+
+describe("previewMessage", () => {
+  it("sends an ENTRY's author to the slug", () => {
+    expect(previewMessage("unavailable", "entry")).toMatch(/slug/i);
+  });
+
+  it("sends a SINGLE's author to the preview URL, never the slug", () => {
+    const message = previewMessage("unavailable", "single");
+
+    expect(message).toMatch(/preview url/i);
+    expect(message).not.toMatch(/slug/i);
+    // Named for what it is, so the reader recognises their own document.
+    expect(message).toMatch(/this single/i);
+    expect(message).not.toMatch(/this entry/i);
+  });
+
+  it("names the document in the generic failure too", () => {
+    expect(previewMessage("failed", "single")).toMatch(/this single/i);
+    expect(previewMessage("failed", "entry")).toMatch(/this entry/i);
+  });
+
+  it("leaves the document-neutral reasons alone for both", () => {
+    // The control: not every message differs, so the two above are a real
+    // distinction rather than a wholesale duplication keyed on the noun.
+    expect(previewMessage("noSiteUrl", "single")).toBe(
+      previewMessage("noSiteUrl", "entry")
+    );
+    expect(previewMessage("popupBlocked", "single")).toBe(
+      previewMessage("popupBlocked", "entry")
+    );
+  });
+
+  it("defaults to the entry wording, which is what the tab has always shown", () => {
+    expect(previewMessage("unavailable")).toBe(
+      previewMessage("unavailable", "entry")
+    );
+  });
+});

--- a/packages/admin/src/hooks/useEntryPreview.ts
+++ b/packages/admin/src/hooks/useEntryPreview.ts
@@ -31,7 +31,10 @@
 import { useCallback, useMemo } from "react";
 
 import type { ApiError } from "@admin/lib/api/parseApiError";
-import { previewLinkApi } from "@admin/services/previewLinkApi";
+import {
+  previewLinkApi,
+  type PreviewLinkRequest,
+} from "@admin/services/previewLinkApi";
 
 /**
  * How long a token minted for the editor's own preview stays valid.
@@ -148,15 +151,37 @@ export type PreviewUnavailableReason =
  * Each names what the reader can do about it, because a reason they cannot act
  * on reads as the admin being broken.
  */
-export const PREVIEW_MESSAGES: Record<PreviewUnavailableReason, string> = {
-  unavailable:
-    "This entry cannot be previewed yet. Check that it has a slug and a status the site publishes.",
-  noSiteUrl:
-    "No site URL is configured, so there is nowhere to open. An administrator can set it in Settings.",
-  popupBlocked:
-    "Your browser blocked the preview tab. Allow pop-ups for this site and try again.",
-  failed: "Could not work out where this entry previews. Please try again.",
-};
+/** Which kind of document a message is about. */
+export type PreviewDocumentNoun = "entry" | "single";
+
+/**
+ * What to tell someone a preview refused, in the words of THEIR document.
+ *
+ * A function of the noun rather than two message maps, because the reasons are
+ * the same reasons and only the remedy's subject differs — and two maps drift
+ * the first time one is edited. The advice differs where it genuinely must: an
+ * entry that cannot be addressed usually has an empty slug, while a Single is
+ * addressed by a slug it always has, so what is missing there is the preview
+ * declaration. Sending a Single's editor to check a slug points them at the one
+ * field that cannot be the problem.
+ */
+export function previewMessage(
+  reason: PreviewUnavailableReason,
+  noun: PreviewDocumentNoun = "entry"
+): string {
+  switch (reason) {
+    case "unavailable":
+      return noun === "single"
+        ? "This single cannot be previewed yet. Check that it has a preview URL configured and a status the site publishes."
+        : "This entry cannot be previewed yet. Check that it has a slug and a status the site publishes.";
+    case "noSiteUrl":
+      return "No site URL is configured, so there is nowhere to open. An administrator can set it in Settings.";
+    case "popupBlocked":
+      return "Your browser blocked the preview tab. Allow pop-ups for this site and try again.";
+    case "failed":
+      return `Could not work out where this ${noun} previews. Please try again.`;
+  }
+}
 
 /**
  * What the server's answer means for the tab that has already been claimed.
@@ -256,20 +281,26 @@ function reasonForRefusal(error: unknown): PreviewUnavailableReason {
  * Spread straight into the request, so a field added on one side of the API's
  * union cannot be silently dropped on the way through.
  */
-export type SelfPreviewScope =
-  | {
-      collection: string;
-      entryId: string;
-      single?: never;
-      /** Scopes the credential to one language, where there is one. */
-      locale?: string | undefined;
-    }
-  | {
-      single: string;
-      collection?: never;
-      entryId?: never;
-      locale?: string | undefined;
-    };
+/**
+ * Which document a self-preview is being minted for.
+ *
+ * DERIVED from the mint API's own request type rather than restated, so a field
+ * or a variant added there reaches this without anyone remembering: a hand-kept
+ * copy compiles happily while the service moves underneath it, and spreading
+ * the narrower object would silently omit the new requirement.
+ *
+ * `Omit` does not distribute over a union — it would collapse both arms into
+ * their common keys and lose the `?: never` discrimination that makes "both"
+ * and "neither" unrepresentable — so the conditional distributes it first.
+ */
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown
+  ? Omit<T, K>
+  : never;
+
+export type SelfPreviewScope = DistributiveOmit<
+  PreviewLinkRequest,
+  "ttlSeconds"
+>;
 
 /**
  * Mints the credential a preview surface opens with.

--- a/packages/admin/src/hooks/useEntryPreview.ts
+++ b/packages/admin/src/hooks/useEntryPreview.ts
@@ -246,13 +246,45 @@ function reasonForRefusal(error: unknown): PreviewUnavailableReason {
 }
 
 /**
+ * Which document a self-preview is being minted for.
+ *
+ * A union, mirroring the mint API's own request type: an entry and a Single are
+ * different documents, so naming both is not a narrower request and naming
+ * neither is not a request at all. `?: never` on the absent half is what makes
+ * the compiler say so, rather than a runtime check discovering it later.
+ *
+ * Spread straight into the request, so a field added on one side of the API's
+ * union cannot be silently dropped on the way through.
+ */
+export type SelfPreviewScope =
+  | {
+      collection: string;
+      entryId: string;
+      single?: never;
+      /** Scopes the credential to one language, where there is one. */
+      locale?: string | undefined;
+    }
+  | {
+      single: string;
+      collection?: never;
+      entryId?: never;
+      locale?: string | undefined;
+    };
+
+/**
  * Mints the credential a preview surface opens with.
  *
  * Exported because there is more than one surface — a tab and an in-admin
- * pane — and "a self-preview credential for this document" is ONE question. A
- * pane that minted its own would be a second implementation of the TTL, the
- * refusal mapping and the null-url case, and the two would agree until one of
- * them was edited.
+ * pane, over two kinds of document — and "a self-preview credential for this
+ * document" is ONE question. A pane that minted its own would be a second
+ * implementation of the TTL, the refusal mapping and the null-url case, and the
+ * two would agree until one of them was edited.
+ *
+ * A SCOPE rather than positional arguments, for the reason the API's own
+ * request type is a union: a collection entry and a Single are different
+ * documents, and three optional strings would make "both" and "neither"
+ * representable and then have to validate them away. Taking the union means a
+ * caller cannot express a request the server would refuse.
  *
  * The mint is the ONLY question asked, and that is deliberate. It already
  * resolves the destination through the same function the preview route will
@@ -266,15 +298,11 @@ function reasonForRefusal(error: unknown): PreviewUnavailableReason {
  * default language whichever one was being edited.
  */
 export async function mintSelfPreview(
-  collection: string,
-  entryId: string,
-  locale: string | undefined
+  scope: SelfPreviewScope
 ): Promise<PreviewOutcome> {
   try {
     const link = await previewLinkApi.mint({
-      collection,
-      entryId,
-      ...(locale === undefined ? {} : { locale }),
+      ...scope,
       ttlSeconds: SELF_PREVIEW_TTL_SECONDS,
     });
 
@@ -387,7 +415,11 @@ export function useEntryPreview({
 
     settle(
       claimed.target,
-      await mintSelfPreview(collection.name, target.entryId, locale),
+      await mintSelfPreview({
+        collection: collection.name,
+        entryId: target.entryId,
+        ...(locale === undefined ? {} : { locale }),
+      }),
       onUnavailable
     );
   }, [collection.name, entry, locale, onUnavailable, previewConfig]);


### PR DESCRIPTION
Implements the remaining half of `task:live-preview-singles` — and the ledger's description of that task turned out to be stale, which is worth stating because it changes what this PR is.

## What was actually missing

The task body says a Single has "no preview path at all". That is no longer true: `preview-links.ts` branches on `"single" in scope`, `resolveSinglePreviewRedirect` and `previewSingleDraftGate` exist, `blocks-react` carries the draft hook, and `useSinglePreviewLink` is wired into `SingleForm`. All of that landed since the task was written.

What remained is the **pane**. #1211 gave collection entries an in-place split view and Singles were not included, so the same author doing the same job got two different experiences depending on which kind of document they opened:

| | collection entry | Single (before) |
|---|---|---|
| copy a shareable link | ✅ | ✅ |
| preview in place, beside the editor | ✅ | ❌ |

A Single has a draft lifecycle, an address on the site and a credential that reaches it. The gap was wiring.

## Generalised rather than duplicated

The pane, the credential's renewal timer, the cross-origin refusal and the one-session-per-browser warning are now the same code serving both. A second pane for Singles would have been a second implementation of all four — agreeing on the day it was written, drifting the first time one was edited.

What changed is that they take a **scope** instead of a collection name and an entry id:

```ts
export type SelfPreviewScope =
  | { collection: string; entryId: string; single?: never; locale?: string }
  | { single: string; collection?: never; entryId?: never; locale?: string };
```

A union mirroring the one the mint API already used, so "both" and "neither" stay unrepresentable rather than being validated away later.

## One locale resolution, not two

Both surfaces need a language claim and both are wrong the same way without one: on a localized Single opened in its default language the editor's active locale is `undefined`, and an absent claim authorizes **every** translation rather than the default. `useSinglePreviewLink` already owned that resolution, so it now returns the scope and the pane uses it. The test asserts the two are the same object rather than that each is separately plausible.

## Two things the session key needed

**It carries the document kind.** A Single named `pages 7` and entry `7` of collection `pages` produced the identical key once the parts were joined by spaces — each pane would then have believed the other's cookie was its own, which is the single failure this lock exists to detect, produced by the lock itself.

**The pane re-mints when the previewed language changes.** A token is scoped per locale and a locale switch does not navigate, so nothing else would notice; the pane would go on holding a credential for the language the author just left. The dependency is the scope KEY rather than the scope object, because callers build it inline — depending on identity would issue a credential and an audit row for every keystroke in the editor beside the pane. Both directions have tests.

## Evidence

**Break-verified eleven ways with asserted anchors.** Two SURVIVED, and both found real gaps rather than confirming the work:

- The collision test did not collide. A Single whose slug merely *equals* a collection name yields a different key anyway (`"home "` vs `"home home "`), so it passed with the prefix removed — necessary-but-insufficient, exactly what AGENTS.md:205 describes. Rewritten to the case that actually concatenates.
- Nothing covered a pane **already open** when availability drops. The code claims to close it; without a test it would have gone on rendering a credential nothing re-mints, with the toggle withheld at the same moment so there would be no control left to close it with.

**One honest limit, stated rather than papered over.** The save-count assertion is on the arguments `previewRevisionOf` receives, not on a driven save: the save button lives inside a `toolbarSlot` on the header the test replaces, so submitting there would exercise the harness. What it catches is the count being dropped or never threaded — the realistic regression. That the count *changes* the answer is proven where the function lives.

## Gates

Full build, then `check-types` 22/22, `lint` 24/24, `lint:design`, comment convention, `changeset status` 26 packages, `fallow audit` **pass with 0 introduced**, and 878 admin tests across `entries`, `singles` and `hooks`.

`fallow` initially **failed** on complexity introduced: my two copies of one condition pushed `SingleForm` over the threshold. Extracting the pane wiring into `useSinglePreviewPane` — the same "one decision rather than several scattered through the form" argument `useSinglePreviewLink` already makes in that file — took it from 23 to **20**, below where it started.

One unrelated failure appeared in the full run: `useSnapshotAutosave` → "shows a refusal as idle rather than as an error". It passes 18/18 in isolation and imports nothing this PR touches; a load-sensitive timing flake in autosave.
