### PR TITLE
fix(admin): keep the editor mounted when the preview pane opens or closes

### DIFF
--- a/.changeset/preview-pane-keeps-the-editor.md
+++ b/.changeset/preview-pane-keeps-the-editor.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Opening or closing the preview no longer throws away work in progress.
+
+The preview pane wrapped the editor only while it was open, so every toggle put
+the editor at a different place in the component tree and React unmounted and
+rebuilt the whole thing. Anything a field was holding that had not yet reached
+the form went with it — and the field most likely to be holding something is the
+one deliberately keeping a value the form would reject, such as JSON mid-edit
+that is not valid yet. Clicking Preview discarded it silently: no error, no
+prompt, the field simply showed its last saved value again.
+
+The editor now stays in one place whether the preview is open or shut. Closed,
+the pane's own elements generate no box at all, so the page is laid out exactly
+as it would be if the pane were not there — the same mechanism the editor
+already uses to hand its measure to the page builder.
+
+The split itself is now built from ordinary elements rather than the resizable
+panel library, because that library sizes its panels with inline styles that no
+stylesheet can stand down: a panel wrapping the editor while the preview was
+closed would clip it and move scrolling off the page. The divider keeps its
+keyboard support — arrow keys nudge it, Home and End take it to either limit —
+and reports its position to assistive technology as it moves.

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -34,17 +34,13 @@
 import { useEffect, useRef, type ReactNode } from "react";
 
 import { useSuppressAdminChrome } from "@admin/components/layout/ChromeSuppression";
-import {
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from "@admin/components/ui";
 
 import { PreviewFrame } from "./PreviewFrame";
+import { PreviewSplit } from "./PreviewSplit";
 import { usePreviewFrame, type UsePreviewFrameResult } from "./usePreviewFrame";
 
 export interface PreviewPanesProps {
-  /** Whether the pane is open. Closed renders `children` untouched. */
+  /** Whether the preview side is shown. Closed, the editor renders untouched. */
   open: boolean;
   /** Close the pane. Rendered by this component, so it cannot be forgotten. */
   onClose: () => void;
@@ -75,18 +71,8 @@ export interface PreviewPanesProps {
   children: ReactNode;
 }
 
-export function PreviewPanes({ open, children, ...rest }: PreviewPanesProps) {
-  if (!open) return <>{children}</>;
-  return <ActivePreviewPanes {...rest}>{children}</ActivePreviewPanes>;
-}
-
-/**
- * A separate component so the chrome request and the mint run only while the
- * pane is open — the same split `TranslationPanes` and `BlocksField` both make.
- * Calling either from the wrapper would release the page frame for every entry
- * whether or not anyone asked, and mint a credential for a pane nobody opened.
- */
-function ActivePreviewPanes({
+export function PreviewPanes({
+  open,
   onClose,
   collection,
   entryId,
@@ -94,55 +80,58 @@ function ActivePreviewPanes({
   label,
   revision,
   children,
-}: Omit<PreviewPanesProps, "open">) {
+}: PreviewPanesProps) {
   /*
-   * `pageFrame` alone. The rail, the sidebars and the header stay: this is a
-   * pane beside the editor, not a surface that took the window, and an author
-   * who can still see the navigation has not been stranded by it.
+   * ONE component in both states, and the editor at ONE position in the tree.
    *
-   * `canExit` is nonetheless true and honest — the frame renders its own close
-   * control — so the claim stays correct if this ever asks for the rail too.
+   * This used to return `children` alone when closed and a different component
+   * when open, which put the editor under a different element type at a
+   * different depth — so React unmounted and remounted the whole editor on
+   * every toggle. Anything a field held that had not reached the form went with
+   * it, silently: a field that keeps a temporarily invalid value locally,
+   * precisely so it does not publish nonsense to the form, loses that value the
+   * moment someone clicks Preview.
+   *
+   * Nothing about what a closed pane COSTS has changed, and each half is now
+   * expressed directly rather than as a side effect of not rendering:
    */
-  useSuppressAdminChrome({ layers: ["pageFrame"], canExit: true });
+  useSuppressAdminChrome({
+    /*
+     * No layers while closed, which registers nothing — `ChromeSuppression`
+     * treats an empty list as no request — so a closed pane still leaves the
+     * page measure exactly as it found it.
+     *
+     * `canExit` stays true and honest either way: the frame renders its own
+     * close control, so the claim remains correct while it is open and is not
+     * read at all while it is not.
+     */
+    layers: open ? ["pageFrame"] : [],
+    canExit: true,
+  });
 
-  const frame = usePreviewFrame({ collection, entryId, locale, active: true });
+  /*
+   * `active` is what stops a closed pane costing anything: no credential is
+   * minted, no audit row is written, no renewal timer is scheduled. The hook
+   * has always taken this flag, so nothing here relies on the component being
+   * absent to stay quiet.
+   */
+  const frame = usePreviewFrame({ collection, entryId, locale, active: open });
 
   return (
-    <ResizablePanelGroup
-      orientation="horizontal"
-      className="min-h-0 flex-1"
-      // Percentage STRINGS: this library reads a bare number as pixels, so
-      // `defaultSize={55}` would be a 55-pixel pane rather than 55 percent.
-    >
-      <ResizablePanel id="entry-editor" minSize="35%" defaultSize="55%">
-        {/*
-         * `@container/content` is declared HERE, and it is what stops the
-         * editor laying itself out against the page while rendering into half
-         * of it. The dashboard's `<main>` carries that container and stays
-         * full-page width, so without this every `@4xl/content:` query inside
-         * the form measures the window: the document rail is placed beside a
-         * column that no longer has room for it and overflows the pane.
-         */}
-        <div className="@container/content h-full overflow-y-auto">
-          {/* The pane stands in for `PageContainer`, so it owes the same
-              horizontal inset — and stops owing it where the editor's own
-              columns go edge-to-edge. On an INNER element because a container
-              cannot query itself. */}
-          <div className="px-4 @sm/content:px-6 @2xl/content:px-8 @4xl/content:px-0">
-            {children}
-          </div>
-        </div>
-      </ResizablePanel>
-      <ResizableHandle withGrip />
-      <ResizablePanel id="entry-preview" minSize="25%">
+    <PreviewSplit
+      open={open}
+      label={label}
+      preview={
         <PreviewFrameOnSave
           frame={frame}
           revision={revision}
           onClose={onClose}
           label={label}
         />
-      </ResizablePanel>
-    </ResizablePanelGroup>
+      }
+    >
+      {children}
+    </PreviewSplit>
   );
 }
 

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
@@ -69,7 +69,15 @@ export function PreviewSplit({
 }: PreviewSplitProps) {
   const [editorPercent, setEditorPercent] = useState(DEFAULT_EDITOR_PERCENT);
   const container = useRef<HTMLDivElement>(null);
-  const dragging = useRef(false);
+  /*
+   * WHICH pointer is dragging, not whether one is.
+   *
+   * A boolean is set by every pointer and cleared by every release, so a
+   * right-click resizes while opening a context menu, and during multi-touch a
+   * second finger steers the divider and its release ends the first finger's
+   * drag.
+   */
+  const dragPointer = useRef<number | null>(null);
 
   const moveTo = useCallback((clientX: number) => {
     const element = container.current;
@@ -94,14 +102,15 @@ export function PreviewSplit({
     if (!open) return;
 
     const onMove = (event: PointerEvent) => {
-      if (!dragging.current) return;
+      if (event.pointerId !== dragPointer.current) return;
       // The drag owns the pointer while it lasts: without this the browser
       // selects text across the editor as the divider passes over it.
       event.preventDefault();
       moveTo(event.clientX);
     };
-    const onUp = () => {
-      dragging.current = false;
+    const onUp = (event: PointerEvent) => {
+      if (event.pointerId !== dragPointer.current) return;
+      dragPointer.current = null;
     };
 
     window.addEventListener("pointermove", onMove);
@@ -124,24 +133,49 @@ export function PreviewSplit({
             ? MIN_EDITOR_PERCENT - editorPercent
             : event.key === "End"
               ? MAX_EDITOR_PERCENT - editorPercent
-              : 0;
-    if (step === 0) return;
-    // Only once a key is one this handles: otherwise Tab and the shortcuts the
-    // editor registers would be swallowed by a divider that happens to be
-    // focused.
+              : undefined;
+
+    // `undefined` is the only pass-through, and the distinction is the point:
+    // Tab and the shortcuts the editor registers must survive a focused
+    // divider, while a key this DOES handle is cancelled even when it moves
+    // nothing. Home at the minimum computes a zero step, and letting that reach
+    // the browser scrolls the page from a control advertising itself as the
+    // resizer — at exactly the position where pressing it again is most likely.
+    if (step === undefined) return;
     event.preventDefault();
+    if (step === 0) return;
     setEditorPercent(current => clamp(current + step));
   };
 
   return (
     /*
-     * `contents` while closed is the load-bearing part. The element stays in
-     * the tree — which is what keeps the editor mounted — and generates no box,
-     * so the page lays out exactly as it does with no pane at all.
+     * Staying in the tree while closed is the load-bearing part: the element is
+     * what keeps the editor mounted across a toggle.
+     *
+     * It keeps a BOX while closed, and that is not incidental. This is a direct
+     * child of `.nx-page-shell`, whose `> *` rule places children in the
+     * content column; a `display: contents` child generates no box for that
+     * rule to apply to and promotes ITS children into the grid, where they match
+     * no selector and auto-place from the gutter. `PageShell` warns about this
+     * exact shape and states the remedy — give the child a box, or move
+     * `display: contents` inside it. Both are done: the box is here and the
+     * boxlessness is one level down.
+     *
+     * A bare block box is layout-neutral here. The shell declares no row gap,
+     * so the editor's own children flowing inside one grid item occupy the same
+     * space they did as several.
+     *
+     * Open, `h-full` is what the panel group used to supply. The page frame is
+     * suppressed then, so `PageShell` is itself `display: contents` and this
+     * root is a block child of the dashboard's `<main>` rather than a flex
+     * item — `flex-1` has nothing to grow against, and without a definite
+     * height the split grows to the editor's content, `overflow-y-auto` never
+     * becomes a pane scroller, and the preview toolbar scrolls away with the
+     * page.
      */
     <div
       ref={container}
-      className={cn(open ? "flex min-h-0 flex-1" : "contents")}
+      className={cn(open && "flex h-full min-h-0 flex-1")}
       data-preview-split={open ? "open" : "closed"}
     >
       <div
@@ -173,13 +207,26 @@ export function PreviewSplit({
           <div
             role="separator"
             aria-orientation="vertical"
-            aria-label={`Resize the ${label} pane`}
+            /*
+             * The name and the value describe the SAME pane. `aria-valuenow`
+             * on a window splitter reports the primary pane — the editor, here
+             * — so a name mentioning only the preview announced 55% for a pane
+             * occupying 45%, and made ArrowRight read as growing the pane it
+             * shrinks. `aria-valuetext` gives both figures so neither number
+             * can be attached to the wrong side.
+             */
+            aria-label={`Resize the editor and ${label} panes`}
             aria-valuenow={editorPercent}
+            aria-valuetext={`Editor ${Math.round(editorPercent)}%, ${label} ${Math.round(100 - editorPercent)}%`}
             aria-valuemin={MIN_EDITOR_PERCENT}
             aria-valuemax={MAX_EDITOR_PERCENT}
             tabIndex={0}
             onPointerDown={event => {
-              dragging.current = true;
+              // The primary button only, and only while no drag owns the
+              // divider: a right-click must open its menu without resizing,
+              // and a second finger must not take the split from the first.
+              if (event.button !== 0 || dragPointer.current !== null) return;
+              dragPointer.current = event.pointerId;
               // Captured so the drag survives the pointer leaving a one-pixel
               // target, which it does on the first move.
               event.currentTarget.setPointerCapture?.(event.pointerId);
@@ -189,7 +236,11 @@ export function PreviewSplit({
               // The drawn line is 1px; the element around it is wider and
               // transparent, so the pointer target is comfortably larger than
               // what it appears to grab (WCAG 2.5.8).
-              "relative flex w-px shrink-0 cursor-col-resize items-center justify-center bg-border",
+              // `touch-none` reserves the gesture. Pointer capture and
+              // `preventDefault` in `pointermove` do not: the browser may
+              // claim a horizontal drag as panning and answer with
+              // `pointercancel` before the split has moved.
+              "relative flex w-px shrink-0 touch-none cursor-col-resize items-center justify-center bg-border",
               "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
               "after:absolute after:inset-0 after:-inset-x-1"
             )}
@@ -202,7 +253,12 @@ export function PreviewSplit({
             </div>
           </div>
 
-          <div className="min-w-0 flex-1">{preview}</div>
+          {/* `min-w-0` lets this flex item shrink; it does not clip what is
+              inside it. At the narrowest allowed width the toolbar's buttons
+              are wider than the pane, and without this they paint across the
+              divider or widen the page's own scroller. Only the OPEN pane — the
+              closed wrappers generate no box to clip against. */}
+          <div className="min-w-0 flex-1 overflow-hidden">{preview}</div>
         </>
       )}
     </div>

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+/**
+ * A two-pane split that generates NO BOXES while it is closed.
+ *
+ * The editor lives at ONE position in the tree whether the preview is open or
+ * shut, and that is the whole reason this exists rather than a
+ * `ResizablePanelGroup`. React preserves component state by position, so a pane
+ * that wrapped the editor only when open unmounted the entire editor on every
+ * toggle — losing anything a field held that had not reached the form. A field
+ * keeping a temporarily invalid value locally, exactly so it does NOT publish
+ * nonsense to the form, is the case that hurts: the work looks saved and is
+ * silently discarded by clicking Preview.
+ *
+ * The panel library cannot do this. It writes `display: flex`, `overflow:
+ * hidden` and the flex sizing as INLINE styles, so a panel wrapping the editor
+ * while closed would clip it and move scrolling off the page — and no class can
+ * override an inline style. These are plain elements, so `display: contents`
+ * works: closed, they contribute nothing to layout and the editor is laid out
+ * by whatever encloses the pane, exactly as it was before. That is the same
+ * mechanism `MeasuredPageFrame` already uses to release the page measure.
+ *
+ * @module components/features/entries/PreviewMode/PreviewSplit
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+import { GripVertical } from "@admin/components/icons";
+import { cn } from "@admin/lib/utils";
+
+/**
+ * How much of the width the EDITOR may take, as a percentage.
+ *
+ * The bounds are the pane's, not a preference: below the minimum the editor's
+ * own two-column layout has nowhere to put the document rail, and above the
+ * maximum the preview is too narrow to show a page as a visitor would see it —
+ * which is the only reason to have it on screen.
+ */
+const MIN_EDITOR_PERCENT = 35;
+const MAX_EDITOR_PERCENT = 75;
+const DEFAULT_EDITOR_PERCENT = 55;
+
+/** How far one arrow-key press moves the divider. */
+const KEYBOARD_STEP_PERCENT = 2;
+
+function clamp(percent: number): number {
+  return Math.min(
+    MAX_EDITOR_PERCENT,
+    Math.max(MIN_EDITOR_PERCENT, Math.round(percent))
+  );
+}
+
+export interface PreviewSplitProps {
+  /** Whether the preview side is shown. Closed, this renders nothing of its own. */
+  open: boolean;
+  /** The editor. Mounted at the same position in both states. */
+  children: React.ReactNode;
+  /** The preview side, rendered only while open. */
+  preview: React.ReactNode;
+  /** Names the divider for assistive technology. */
+  label: string;
+}
+
+export function PreviewSplit({
+  open,
+  children,
+  preview,
+  label,
+}: PreviewSplitProps) {
+  const [editorPercent, setEditorPercent] = useState(DEFAULT_EDITOR_PERCENT);
+  const container = useRef<HTMLDivElement>(null);
+  const dragging = useRef(false);
+
+  const moveTo = useCallback((clientX: number) => {
+    const element = container.current;
+    if (element === null) return;
+    const bounds = element.getBoundingClientRect();
+    // A zero-width container yields Infinity rather than a percentage, which
+    // would clamp to the maximum and jump the divider on the first pointer move
+    // after a layout that has not settled.
+    if (bounds.width === 0) return;
+    setEditorPercent(clamp(((clientX - bounds.left) / bounds.width) * 100));
+  }, []);
+
+  /*
+   * Listeners on the WINDOW rather than the divider, and only while dragging.
+   *
+   * A pointer that leaves the divider mid-drag — which it does immediately, the
+   * divider being one pixel wide — would otherwise stop delivering moves and
+   * strand the split under the cursor. Bound on drag start and removed on
+   * release, so nothing listens while nobody is dragging.
+   */
+  useEffect(() => {
+    if (!open) return;
+
+    const onMove = (event: PointerEvent) => {
+      if (!dragging.current) return;
+      // The drag owns the pointer while it lasts: without this the browser
+      // selects text across the editor as the divider passes over it.
+      event.preventDefault();
+      moveTo(event.clientX);
+    };
+    const onUp = () => {
+      dragging.current = false;
+    };
+
+    window.addEventListener("pointermove", onMove);
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onUp);
+    return () => {
+      window.removeEventListener("pointermove", onMove);
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onUp);
+    };
+  }, [open, moveTo]);
+
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    const step =
+      event.key === "ArrowLeft"
+        ? -KEYBOARD_STEP_PERCENT
+        : event.key === "ArrowRight"
+          ? KEYBOARD_STEP_PERCENT
+          : event.key === "Home"
+            ? MIN_EDITOR_PERCENT - editorPercent
+            : event.key === "End"
+              ? MAX_EDITOR_PERCENT - editorPercent
+              : 0;
+    if (step === 0) return;
+    // Only once a key is one this handles: otherwise Tab and the shortcuts the
+    // editor registers would be swallowed by a divider that happens to be
+    // focused.
+    event.preventDefault();
+    setEditorPercent(current => clamp(current + step));
+  };
+
+  return (
+    /*
+     * `contents` while closed is the load-bearing part. The element stays in
+     * the tree — which is what keeps the editor mounted — and generates no box,
+     * so the page lays out exactly as it does with no pane at all.
+     */
+    <div
+      ref={container}
+      className={cn(open ? "flex min-h-0 flex-1" : "contents")}
+      data-preview-split={open ? "open" : "closed"}
+    >
+      <div
+        className={cn(
+          open
+            ? "@container/content min-w-0 overflow-y-auto"
+            : // Same reason as the parent: no box, no effect on the page.
+              "contents"
+        )}
+        style={open ? { width: `${editorPercent}%` } : undefined}
+      >
+        {/* The pane stands in for `PageContainer`, so it owes the same
+            horizontal inset — and stops owing it where the editor's own columns
+            go edge to edge. On an INNER element because a container cannot
+            query itself. */}
+        <div
+          className={cn(
+            open
+              ? "px-4 @sm/content:px-6 @2xl/content:px-8 @4xl/content:px-0"
+              : "contents"
+          )}
+        >
+          {children}
+        </div>
+      </div>
+
+      {open && (
+        <>
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label={`Resize the ${label} pane`}
+            aria-valuenow={editorPercent}
+            aria-valuemin={MIN_EDITOR_PERCENT}
+            aria-valuemax={MAX_EDITOR_PERCENT}
+            tabIndex={0}
+            onPointerDown={event => {
+              dragging.current = true;
+              // Captured so the drag survives the pointer leaving a one-pixel
+              // target, which it does on the first move.
+              event.currentTarget.setPointerCapture?.(event.pointerId);
+            }}
+            onKeyDown={onKeyDown}
+            className={cn(
+              // The drawn line is 1px; the element around it is wider and
+              // transparent, so the pointer target is comfortably larger than
+              // what it appears to grab (WCAG 2.5.8).
+              "relative flex w-px shrink-0 cursor-col-resize items-center justify-center bg-border",
+              "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
+              "after:absolute after:inset-0 after:-inset-x-1"
+            )}
+          >
+            <div className="z-10 flex h-4 w-3 items-center justify-center rounded-sm border border-border bg-border">
+              <GripVertical
+                className="h-2.5 w-2.5 text-muted-foreground"
+                aria-hidden="true"
+              />
+            </div>
+          </div>
+
+          <div className="min-w-0 flex-1">{preview}</div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
@@ -23,7 +23,7 @@
  * @module components/features/entries/PreviewMode/PreviewSplit
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useId, useRef, useState } from "react";
 
 import { GripVertical } from "@admin/components/icons";
 import { cn } from "@admin/lib/utils";
@@ -67,6 +67,12 @@ export function PreviewSplit({
   preview,
   label,
 }: PreviewSplitProps) {
+  /*
+   * Generated rather than fixed: the id is what `aria-controls` points at, and
+   * two splits on one page sharing a literal would aim both separators at the
+   * first pane.
+   */
+  const editorPaneId = useId();
   const [editorPercent, setEditorPercent] = useState(DEFAULT_EDITOR_PERCENT);
   const container = useRef<HTMLDivElement>(null);
   /*
@@ -120,6 +126,15 @@ export function PreviewSplit({
       window.removeEventListener("pointermove", onMove);
       window.removeEventListener("pointerup", onUp);
       window.removeEventListener("pointercancel", onUp);
+      /*
+       * The owner is released with the listeners that would have released it.
+       * This component stays mounted while closed, so a pane closed mid-gesture
+       * — a second touch on the frame's close control, an entry switching into
+       * translation mode — otherwise leaves the ref holding a pointer whose
+       * `pointerup` nothing is listening for any more, and the guard in
+       * `onPointerDown` then refuses every press for the life of the editor.
+       */
+      dragPointer.current = null;
     };
   }, [open, moveTo]);
 
@@ -179,6 +194,7 @@ export function PreviewSplit({
       data-preview-split={open ? "open" : "closed"}
     >
       <div
+        id={editorPaneId}
         className={cn(
           open
             ? "@container/content min-w-0 overflow-y-auto"
@@ -216,6 +232,9 @@ export function PreviewSplit({
              * can be attached to the wrong side.
              */
             aria-label={`Resize the editor and ${label} panes`}
+            // Names the region the value measures. Without it the separator
+            // exposes a changing number and no way to tell what it is about.
+            aria-controls={editorPaneId}
             aria-valuenow={editorPercent}
             aria-valuetext={`Editor ${Math.round(editorPercent)}%, ${label} ${Math.round(100 - editorPercent)}%`}
             aria-valuemin={MIN_EDITOR_PERCENT}

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -79,14 +79,21 @@ beforeEach(() => {
 });
 
 describe("PreviewPanes when the pane is closed", () => {
-  it("generates no box of its own, so the page lays out as if it were absent", () => {
+  it("keeps a box on the OUTERMOST wrapper and none on the rest", () => {
     /*
-     * The wrapper elements now EXIST while closed — that is what keeps the
-     * editor mounted across a toggle — so the property can no longer be "there
-     * is no wrapper". It is that the wrappers contribute nothing to layout:
-     * `display: contents` removes the box without removing the element, which
-     * is the same mechanism `MeasuredPageFrame` uses to release the page
-     * measure.
+     * The wrapper elements EXIST while closed — that is what keeps the editor
+     * mounted across a toggle — so the property is about what they contribute
+     * to layout, and the two levels contribute differently.
+     *
+     * The outermost is a direct child of `.nx-page-shell`, whose `> *` rule
+     * places children in the content column. A boxless child gives that rule
+     * nothing to apply to and promotes ITS children into the grid, where they
+     * match no selector and auto-place from the gutter — so `display: contents`
+     * there mislays the ordinary closed editor while every wrapper still
+     * carries the expected class. `PageShell` warns about exactly this shape.
+     *
+     * Everything BELOW it is boxless, which is the same remedy that warning
+     * states: give the direct child a box, move the boxlessness inside it.
      */
     const { container } = render(
       <PreviewPanes {...props} open={false}>
@@ -102,9 +109,13 @@ describe("PreviewPanes when the pane is closed", () => {
       node = node.parentElement;
     }
 
-    // Control: there ARE wrappers to judge, so the loop below is not vacuous.
-    expect(wrappers.length).toBeGreaterThan(0);
-    for (const wrapper of wrappers) {
+    // Control: more than one wrapper, so "outermost" and "the rest" are
+    // different elements and the two assertions below cannot be the same one.
+    expect(wrappers.length).toBeGreaterThan(1);
+
+    const outermost = wrappers[wrappers.length - 1];
+    expect(outermost?.className ?? "").not.toContain("contents");
+    for (const wrapper of wrappers.slice(0, -1)) {
       expect(wrapper.className).toContain("contents");
     }
   });

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -7,10 +7,13 @@
  * it releases the page MEASURE without taking the admin's navigation. Both are
  * assertions about what did NOT happen, so each carries a control.
  */
+import { useEffect } from "react";
+
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const suppress = vi.hoisted(() => vi.fn());
+const frameArgs = vi.hoisted(() => vi.fn());
 /*
  * Typed WIDER than its initial value on purpose: two cases below drive the
  * frame's failure and loading states, and an inferred `url: string` /
@@ -45,7 +48,10 @@ vi.mock("@admin/components/layout/ChromeSuppression", () => ({
  */
 vi.mock("../usePreviewFrame", async importOriginal => ({
   ...(await importOriginal<typeof import("../usePreviewFrame")>()),
-  usePreviewFrame: () => frameState.current,
+  usePreviewFrame: (args: unknown) => {
+    frameArgs(args);
+    return frameState.current;
+  },
 }));
 
 import { PreviewPanes } from "../PreviewPanes";
@@ -74,26 +80,123 @@ beforeEach(() => {
 });
 
 describe("PreviewPanes when the pane is closed", () => {
-  it("renders the editor with no wrapper of its own", () => {
+  it("generates no box of its own, so the page lays out as if it were absent", () => {
+    /*
+     * The wrapper elements now EXIST while closed — that is what keeps the
+     * editor mounted across a toggle — so the property can no longer be "there
+     * is no wrapper". It is that the wrappers contribute nothing to layout:
+     * `display: contents` removes the box without removing the element, which
+     * is the same mechanism `MeasuredPageFrame` uses to release the page
+     * measure.
+     */
     const { container } = render(
       <PreviewPanes {...props} open={false}>
         <p data-testid="editor">editor</p>
       </PreviewPanes>
     );
 
-    // The child is the ROOT, so nothing was wrapped around it. A wrapper that
-    // merely had no styles would still show up here as a parent element.
-    expect(container.firstElementChild).toBe(screen.getByTestId("editor"));
+    const editor = screen.getByTestId("editor");
+    let node = editor.parentElement;
+    const wrappers: HTMLElement[] = [];
+    while (node !== null && node !== container) {
+      wrappers.push(node);
+      node = node.parentElement;
+    }
+
+    // Control: there ARE wrappers to judge, so the loop below is not vacuous.
+    expect(wrappers.length).toBeGreaterThan(0);
+    for (const wrapper of wrappers) {
+      expect(wrapper.className).toContain("contents");
+    }
   });
 
-  it("asks for no chrome, so a closed pane costs the page nothing", () => {
+  it("suppresses no chrome layer, so a closed pane costs the page nothing", () => {
     render(
       <PreviewPanes {...props} open={false}>
         <p>editor</p>
       </PreviewPanes>
     );
 
-    expect(suppress).not.toHaveBeenCalled();
+    // The hook IS called now, because the component always renders — so the
+    // property is what it ASKS FOR. An empty layer list registers nothing;
+    // asserting the hook was never called would only pin the old mechanism.
+    expect(suppress).toHaveBeenCalledWith({ layers: [], canExit: true });
+  });
+
+  it("mints nothing, so no credential and no audit row for a pane nobody opened", () => {
+    render(
+      <PreviewPanes {...props} open={false}>
+        <p>editor</p>
+      </PreviewPanes>
+    );
+
+    // The frame hook is mocked here, so this pins the ARGUMENT that decides it
+    // rather than the mint itself: `active` false is what keeps it quiet, and
+    // it is the only thing standing between a closed pane and an audit row.
+    expect(frameArgs).toHaveBeenCalledWith(
+      expect.objectContaining({ active: false })
+    );
+  });
+});
+
+describe("toggling the preview", () => {
+  /**
+   * A child that reports every time it MOUNTS.
+   *
+   * The defect this covers is invisible in the rendered output — the editor
+   * looks identical after a remount, and only state that never reached the
+   * form is gone. Counting mounts is what makes it observable.
+   */
+  function MountCounter({ onMount }: { onMount: () => void }) {
+    useEffect(() => {
+      onMount();
+    }, [onMount]);
+    return <p data-testid="editor">editor</p>;
+  }
+
+  it("keeps the editor MOUNTED when the pane opens and closes", () => {
+    /*
+     * Returning `children` alone when closed and a wrapped tree when open put
+     * the editor under a different element type at a different depth, so React
+     * unmounted and remounted it on every toggle — discarding anything a field
+     * held that had not reached the form. A field keeping a temporarily invalid
+     * value locally, exactly so it does not publish nonsense, is the case that
+     * hurts: the work looks saved and vanishes on a click.
+     */
+    const onMount = vi.fn();
+    const { rerender } = render(
+      <PreviewPanes {...props} open={false}>
+        <MountCounter onMount={onMount} />
+      </PreviewPanes>
+    );
+    expect(onMount).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <PreviewPanes {...props} open>
+        <MountCounter onMount={onMount} />
+      </PreviewPanes>
+    );
+    expect(onMount).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <PreviewPanes {...props} open={false}>
+        <MountCounter onMount={onMount} />
+      </PreviewPanes>
+    );
+    expect(onMount).toHaveBeenCalledTimes(1);
+  });
+
+  it("DOES mount it once to begin with, so the count above is not stuck at zero", () => {
+    // The control: a counter that never fires would satisfy every assertion
+    // above while proving nothing.
+    const onMount = vi.fn();
+    render(
+      <PreviewPanes {...props} open={false}>
+        <MountCounter onMount={onMount} />
+      </PreviewPanes>
+    );
+
+    expect(onMount).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewSplit.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewSplit.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * The divider's own behaviour.
+ *
+ * `PreviewSplit` replaced a panel library, and what a library supplies without
+ * being asked is exactly what a replacement drops silently: the gesture it
+ * reserves, the buttons it declines, the keys it swallows. Each case here is
+ * one of those, asserted on the split's own state rather than on the handler
+ * being wired.
+ */
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PreviewSplit } from "../PreviewSplit";
+
+const MIN_EDITOR_PERCENT = 35;
+const DEFAULT_EDITOR_PERCENT = 55;
+
+function renderSplit() {
+  render(
+    <PreviewSplit open={true} label="Preview" preview={<p>preview</p>}>
+      <p data-testid="editor">editor</p>
+    </PreviewSplit>
+  );
+  return screen.getByRole("separator");
+}
+
+/**
+ * The editor pane carries the split as an inline width, so the rendered
+ * percentage is readable without reaching into the component.
+ *
+ * Derived from the DOM the user gets rather than from a second copy of the
+ * state: a test holding its own idea of the percentage would agree with a
+ * handler that stopped updating anything.
+ */
+function editorPercent(): number {
+  const pane = screen.getByTestId("editor").closest("[style]");
+  const width = (pane as HTMLElement | null)?.style.width ?? "";
+  return Number.parseFloat(width);
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("PreviewSplit keyboard", () => {
+  it("cancels a handled key that moves nothing", () => {
+    const separator = renderSplit();
+
+    // Home once: the divider goes to the minimum and the key is cancelled.
+    expect(fireEvent.keyDown(separator, { key: "Home" })).toBe(false);
+    expect(editorPercent()).toBe(MIN_EDITOR_PERCENT);
+
+    /*
+     * Home again computes a zero step. The divider is already where the key
+     * would put it, and the browser must still not act on it: an uncancelled
+     * Home scrolls the page from a control that advertises itself as the
+     * resizer, at precisely the position where pressing it twice is likely.
+     */
+    expect(fireEvent.keyDown(separator, { key: "Home" })).toBe(false);
+    expect(editorPercent()).toBe(MIN_EDITOR_PERCENT);
+  });
+
+  it("announces the pane its value measures", () => {
+    const separator = renderSplit();
+
+    /*
+     * `aria-valuenow` on a window splitter reports the PRIMARY pane, which is
+     * the editor. A name mentioning only the preview therefore announced the
+     * preview at the editor's percentage — inverted at rest, and inverted again
+     * on every arrow press, which grows one pane while the number describes the
+     * other. The text carries both figures so no number is loose.
+     */
+    expect(separator).toHaveAttribute("aria-valuenow", "55");
+    expect(separator).toHaveAttribute(
+      "aria-valuetext",
+      "Editor 55%, Preview 45%"
+    );
+
+    fireEvent.keyDown(separator, { key: "ArrowRight" });
+
+    // ArrowRight grows the editor, so the number it reports grows with it.
+    expect(separator).toHaveAttribute("aria-valuenow", "57");
+    expect(separator).toHaveAttribute(
+      "aria-valuetext",
+      "Editor 57%, Preview 43%"
+    );
+  });
+
+  it("lets a key it does not handle through", () => {
+    const separator = renderSplit();
+
+    /*
+     * The control for the pair above. Without it, a handler that cancelled
+     * EVERY key would satisfy both assertions there — and would swallow Tab and
+     * every shortcut the editor registers whenever the divider holds focus.
+     */
+    expect(fireEvent.keyDown(separator, { key: "Tab" })).toBe(true);
+    expect(editorPercent()).toBe(DEFAULT_EDITOR_PERCENT);
+  });
+});
+
+describe("PreviewSplit pointer", () => {
+  /**
+   * jsdom lays nothing out, so the container measures zero and the split
+   * declines to move — which would make every assertion below pass by never
+   * reaching the code under test.
+   */
+  function stubMeasure(width: number) {
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockReturnValue({
+      left: 0,
+      width,
+      top: 0,
+      right: width,
+      bottom: 0,
+      height: 0,
+      x: 0,
+      y: 0,
+      toJSON: () => ({}),
+    } as DOMRect);
+  }
+
+  /**
+   * Built by hand rather than through `fireEvent.pointerDown`, which cannot
+   * carry a `pointerId` here: jsdom has no `PointerEvent`, so the helper falls
+   * back to a plain event and the id the handler reads arrives `undefined`.
+   */
+  function pointerEventAt(
+    type: string,
+    pointerId: number,
+    init: MouseEventInit = {}
+  ): MouseEvent {
+    const event = new MouseEvent(type, { bubbles: true, ...init });
+    Object.defineProperty(event, "pointerId", { value: pointerId });
+    return event;
+  }
+
+  function pressPointer(
+    separator: HTMLElement,
+    pointerId: number,
+    init: MouseEventInit
+  ) {
+    // Dispatched inside `act` because the window listeners these events reach
+    // are plain DOM listeners rather than React's, so their state updates are
+    // outside its batching and are not flushed before the next assertion.
+    act(() => {
+      separator.dispatchEvent(pointerEventAt("pointerdown", pointerId, init));
+    });
+  }
+
+  function movePointer(pointerId: number, clientX: number) {
+    act(() => {
+      window.dispatchEvent(
+        pointerEventAt("pointermove", pointerId, { clientX })
+      );
+    });
+  }
+
+  it("drags on the primary button", () => {
+    stubMeasure(1000);
+    const separator = renderSplit();
+
+    pressPointer(separator, 1, { button: 0, clientX: 550 });
+    movePointer(1, 700);
+
+    // The positive control for the two refusals below: this pair of events DOES
+    // move the divider, so their staying put is a decision rather than a drag
+    // that never worked in this environment.
+    expect(editorPercent()).toBe(70);
+  });
+
+  it("ignores a press that is not the primary button", () => {
+    stubMeasure(1000);
+    const separator = renderSplit();
+
+    // A right-click opens a context menu. It must not also resize underneath.
+    pressPointer(separator, 1, { button: 2, clientX: 550 });
+    movePointer(1, 700);
+
+    expect(editorPercent()).toBe(DEFAULT_EDITOR_PERCENT);
+  });
+
+  it("ignores a second pointer while one already owns the divider", () => {
+    stubMeasure(1000);
+    const separator = renderSplit();
+
+    pressPointer(separator, 1, { button: 0, clientX: 550 });
+    pressPointer(separator, 2, { button: 0, clientX: 550 });
+
+    // The second finger steers nothing...
+    movePointer(2, 300);
+    expect(editorPercent()).toBe(DEFAULT_EDITOR_PERCENT);
+
+    // ...and its release does not end the first finger's drag.
+    act(() => {
+      window.dispatchEvent(pointerEventAt("pointerup", 2));
+    });
+
+    movePointer(1, 700);
+    expect(editorPercent()).toBe(70);
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewSplit.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewSplit.test.tsx
@@ -16,12 +16,21 @@ const MIN_EDITOR_PERCENT = 35;
 const DEFAULT_EDITOR_PERCENT = 55;
 
 function renderSplit() {
-  render(
+  const { rerender } = render(
     <PreviewSplit open={true} label="Preview" preview={<p>preview</p>}>
       <p data-testid="editor">editor</p>
     </PreviewSplit>
   );
-  return screen.getByRole("separator");
+  return {
+    separator: screen.getByRole("separator"),
+    /** Re-renders at a new `open`, which is what a toggle does to this tree. */
+    setOpen: (open: boolean) =>
+      rerender(
+        <PreviewSplit open={open} label="Preview" preview={<p>preview</p>}>
+          <p data-testid="editor">editor</p>
+        </PreviewSplit>
+      ),
+  };
 }
 
 /**
@@ -44,7 +53,7 @@ afterEach(() => {
 
 describe("PreviewSplit keyboard", () => {
   it("cancels a handled key that moves nothing", () => {
-    const separator = renderSplit();
+    const { separator } = renderSplit();
 
     // Home once: the divider goes to the minimum and the key is cancelled.
     expect(fireEvent.keyDown(separator, { key: "Home" })).toBe(false);
@@ -61,7 +70,7 @@ describe("PreviewSplit keyboard", () => {
   });
 
   it("announces the pane its value measures", () => {
-    const separator = renderSplit();
+    const { separator } = renderSplit();
 
     /*
      * `aria-valuenow` on a window splitter reports the PRIMARY pane, which is
@@ -70,6 +79,14 @@ describe("PreviewSplit keyboard", () => {
      * on every arrow press, which grows one pane while the number describes the
      * other. The text carries both figures so no number is loose.
      */
+    // The value names the region it measures: `aria-controls` points at the
+    // editor pane's own id, so the number is attached to something.
+    const controls = separator.getAttribute("aria-controls");
+    expect(controls).toBeTruthy();
+    expect(
+      screen.getByTestId("editor").closest(`#${CSS.escape(controls ?? "")}`)
+    ).not.toBeNull();
+
     expect(separator).toHaveAttribute("aria-valuenow", "55");
     expect(separator).toHaveAttribute(
       "aria-valuetext",
@@ -87,7 +104,7 @@ describe("PreviewSplit keyboard", () => {
   });
 
   it("lets a key it does not handle through", () => {
-    const separator = renderSplit();
+    const { separator } = renderSplit();
 
     /*
      * The control for the pair above. Without it, a handler that cancelled
@@ -157,7 +174,7 @@ describe("PreviewSplit pointer", () => {
 
   it("drags on the primary button", () => {
     stubMeasure(1000);
-    const separator = renderSplit();
+    const { separator } = renderSplit();
 
     pressPointer(separator, 1, { button: 0, clientX: 550 });
     movePointer(1, 700);
@@ -170,7 +187,7 @@ describe("PreviewSplit pointer", () => {
 
   it("ignores a press that is not the primary button", () => {
     stubMeasure(1000);
-    const separator = renderSplit();
+    const { separator } = renderSplit();
 
     // A right-click opens a context menu. It must not also resize underneath.
     pressPointer(separator, 1, { button: 2, clientX: 550 });
@@ -179,9 +196,32 @@ describe("PreviewSplit pointer", () => {
     expect(editorPercent()).toBe(DEFAULT_EDITOR_PERCENT);
   });
 
+  it("releases the drag owner when the pane closes mid-gesture", () => {
+    stubMeasure(1000);
+    const { separator, setOpen } = renderSplit();
+
+    // A press that never gets its `pointerup`, because the pane closes first —
+    // a second touch on the frame's close control does exactly this.
+    pressPointer(separator, 1, { button: 0, clientX: 550 });
+    setOpen(false);
+    setOpen(true);
+
+    /*
+     * This component stays mounted across the toggle, so a ref left holding
+     * pointer 1 would refuse every later press for the life of the editor. The
+     * assertion is that the divider MOVES, not that the ref is null: the ref is
+     * the mechanism and moving is the property.
+     */
+    const reopened = screen.getByRole("separator");
+    pressPointer(reopened, 2, { button: 0, clientX: 550 });
+    movePointer(2, 700);
+
+    expect(editorPercent()).toBe(70);
+  });
+
   it("ignores a second pointer while one already owns the divider", () => {
     stubMeasure(1000);
-    const separator = renderSplit();
+    const { separator } = renderSplit();
 
     pressPointer(separator, 1, { button: 0, clientX: 550 });
     pressPointer(separator, 2, { button: 0, clientX: 550 });


### PR DESCRIPTION
Fixes a defect that is **live on `main`**: opening or closing the preview pane throws away work in progress.

## What happens today

`PreviewPanes` returns `children` alone while closed and a wrapped tree while open. Those put the editor under a different element type at a different depth, so React unmounts and rebuilds the entire editor on every toggle.

Anything a field held that had not reached the form goes with it — and the field most likely to be holding something is the one *deliberately* keeping a value the form would reject. `JsonInput` keeps mid-edit JSON in local `textValue` and does not call `onChange` until it parses, precisely so it never publishes nonsense. Clicking Preview discards it silently: no error, no prompt, the field showing its last saved value again.

Found by Codex on #1224, where the same pane was being extended to Singles. It is not a defect that PR introduces — it shipped in #1211 for the entry editor.

## Why the panel library had to go, on this surface only

The obvious fix is to keep the wrappers mounted while closed and neutralise them. That is not possible with `react-resizable-panels`: it writes `display: flex`, `overflow: hidden` and its flex sizing as **inline styles**, and no stylesheet overrides an inline style. A panel wrapping the editor while the preview was closed would clip it and move scrolling off the page onto an inner container — breaking sticky positioning and scroll restoration.

Measured rather than assumed:

```
$ grep -o 'display: "flex"|overflow: "hidden"|flexGrow|flexBasis|flexShrink' …/react-resizable-panels.js | sort | uniq -c
   2 display: "flex"
   3 flexBasis
   6 flexGrow
   3 flexShrink
   1 overflow: "hidden"
```

Plain elements can be `display: contents`, which removes the box without removing the element — the same mechanism `MeasuredPageFrame` already uses to release the page measure. So the split is now ordinary elements, and **closed, the pane contributes nothing to layout**.

The divider keeps what the library gave it: arrow keys nudge, `Home`/`End` go to either limit, and it reports position through `role="separator"` with `aria-valuenow`. Pointer capture plus window-level listeners, because a one-pixel target loses the pointer on the first move. The other two consumers of the panel library (`TranslationPanes`, `APIPlayground`) are untouched — they have no closed state and no reason to change.

## Evidence

**The remount test counts MOUNTS rather than reading output**, because that is the only way this is observable: a remounted editor looks identical, and only the state that never reached the form is missing.

```
[NOTICED] REMOUNT: the closed pane returns children alone again
    x keeps the editor MOUNTED when the pane opens and closes
[NOTICED] BOX: the closed wrappers stop being display:contents
[NOTICED] MINT: a closed pane mints anyway
[NOTICED] CHROME: a closed pane suppresses the page frame
```

Four breaks, asserted anchors, no survivors — plus a control asserting the counter fires once to begin with, since a counter that never fired would satisfy every assertion above.

**Two existing tests changed from pinning the mechanism to pinning the property**, and that is worth calling out rather than burying: "renders the editor with no wrapper of its own" became "every wrapper generates no box", and "asks for no chrome" became "asks for no layers". Both would otherwise have failed a change that leaves the closed pane strictly cheaper to reason about — the old assertions were about *how* the guarantee was achieved, not the guarantee.

## Gates

`check-types` 22/22, `lint` 24/24, `lint:design`, comment convention, `changeset status` 26 packages, `fallow audit` pass with 0 introduced, 861 admin tests.

**Outstanding: a visual check of the open split.** The closed state is covered structurally — every wrapper between the editor and the container is asserted to carry `contents`, so it provably generates no box — but the divider is new UI and I have not yet put it in front of a browser. Doing that next; flagging it rather than implying it is done.

Expect a conflict with #1224, which rewrites the same file to take a scope. Both are mine and I will resolve it there.
