### PR TITLE
fix(nextly): stop attributing a declaration's throw to the declaration

### DIFF
--- a/.changeset/preview-refusal-says-which.md
+++ b/.changeset/preview-refusal-says-which.md
@@ -26,13 +26,14 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Asking for a preview link that cannot be built now says which of six things is
-wrong, instead of telling every editor to fill in a slug.
+Asking for a preview link that cannot be built now says which of seven things
+is wrong, instead of telling every editor to fill in a slug.
 
-The resolver behind preview links refuses for six distinct reasons: the document
-is confirmed gone, the document could not be READ at all, the collection declares
-no preview, the declaration yields no address for this document yet, the address
-it yields is on a different site, or it does not parse. All of them arrived as
+The resolver behind preview links refuses for seven distinct reasons: the
+document is confirmed gone, the document could not be READ at all, the collection
+declares no preview, the declaration yields no address for this document yet, the
+declaration FAILED while running, the address it yields is on a different site,
+or it does not parse. All of them arrived as
 one message — "this entry has no preview address yet, so filling in the fields
 its preview URL is built from — usually the slug — makes it shareable." For most
 of them that is wrong and unactionable. An editor whose slug was already correct
@@ -52,7 +53,7 @@ telling an author their work may have been deleted while it sits there intact.
 Reads that report failure by throwing rather than by returning an envelope, which
 is how the Direct API answers for Singles, are translated the same way.
 
-**The public preview route is deliberately unchanged and still answers all six
+**The public preview route is deliberately unchanged and still answers all seven
 with the same 404.** That is not an oversight: distinguishing them there would
 let a stranger holding a forged token tell a deleted entry from an unpublished
 one from a collection that has no preview, which is an oracle for what exists in

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -624,6 +624,42 @@ describe("mintPreviewLink: a collection with nowhere to send a reviewer", () => 
     expect(message(collectionBody)).toMatch(/developer/i);
   });
 
+  it("names the ENTRY when a declaration throws, not the collection that declares it", async () => {
+    /*
+     * The message points at a value the reader should go and look at, and that
+     * value lives on the DOCUMENT. Naming the collection sends them to the
+     * wrong screen — there is no field there to check.
+     *
+     * The refusal's other noun, used for a message about CONFIGURATION, is
+     * correctly the collection. This is why the two are derived separately
+     * rather than sharing one word.
+     */
+    previewDeclaration.mockResolvedValue({
+      url: () => {
+        throw new Error("author bug");
+      },
+    });
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+    const text = String(
+      (body.error as { message?: string } | undefined)?.message ?? ""
+    );
+
+    expect(text).toMatch(/this entry/i);
+    expect(text).not.toMatch(/this collection/i);
+
+    /*
+     * And it does not hand the whole thing to a developer. A caught error
+     * cannot tell a broken declaration from a field this document never filled
+     * in, so a message that blames the declaration alone is wrong exactly when
+     * the reader is the one person who could fix it.
+     */
+    expect(text).toMatch(/this entry's fields/i);
+    expect(text).toMatch(/developer/i);
+  });
+
   it("mints normally once the collection declares one", async () => {
     previewDeclaration.mockResolvedValue({ url: () => "/somewhere" });
 

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -300,15 +300,19 @@ const REFUSALS: Record<
   },
   declarationFailed: {
     message: (_subject, noun) =>
-      `This ${noun}'s preview URL could not be built, so a shared link would ` +
-      "have nowhere to open. Nothing on the document can fix it — a developer " +
-      "needs to correct the preview declaration.",
+      `This ${noun}'s preview URL could not be built: the preview declaration ` +
+      "failed while producing an address. That is a developer's to look at — " +
+      `either the declaration itself, or a value on this ${noun} it did not ` +
+      "expect.",
     reason: "preview-declaration-failed",
     remedy:
       "The declaration threw while running, or returned pieces that do not " +
-      "compose into a URL under the site. Both are faults in " +
-      "`admin.preview.url` / `admin.preview.urlTemplate` rather than in this " +
-      "document, so they reproduce for every document in the collection.",
+      "compose into a URL under the site. Whether it fails for EVERY document " +
+      "or only for this one is NOT observable from a caught throw — a " +
+      "declaration reading a field that happens to be empty here raises the " +
+      "same error a broken one does — so this names neither. Check " +
+      "`admin.preview.url` / `admin.preview.urlTemplate` and the fields it " +
+      "reads.",
   },
   foreignOrigin: {
     message: (_subject, noun) =>

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -218,6 +218,22 @@ function sharedRedirectDeps(declaration: PreviewDeclaration | undefined): {
  * {@link PreviewRefusalCause} is a type error here rather than silently taking
  * whichever branch happened to be last.
  */
+/**
+ * The word for the DOCUMENT, as against the word for the thing that DECLARES
+ * the preview.
+ *
+ * Two messages need it and an inline copy in each would drift, which for a
+ * one-word difference is the drift nobody notices: `noun` elsewhere in this map
+ * is the declaring object — a collection or a Single — and that is correct for
+ * a message about configuration. It is wrong for a message about a value on the
+ * document, because an entry's data belongs to the entry rather than to its
+ * collection, and a reader sent to look at "this collection" for a field goes
+ * to the wrong screen.
+ */
+function documentNoun(subject: "collection" | "single"): "entry" | "single" {
+  return subject === "single" ? "single" : "entry";
+}
+
 const REFUSALS: Record<
   PreviewRefusalCause,
   {
@@ -287,7 +303,7 @@ const REFUSALS: Record<
   },
   unavailable: {
     message: subject =>
-      `This ${subject === "single" ? "single" : "entry"} has no preview ` +
+      `This ${documentNoun(subject)} has no preview ` +
       "address yet, so a shared link would have nowhere to open. Filling in " +
       "the fields its preview URL is built from — usually the slug — makes " +
       "it shareable.",
@@ -298,18 +314,34 @@ const REFUSALS: Record<
       "field is empty, both mean 'not previewable yet'. A declaration that " +
       "threw or produced an unusable address is `declarationFailed` instead.",
   },
+  /*
+   * Deliberately neutral, and neutral in BOTH directions.
+   *
+   * A caught error cannot identify whether the declaration or this document's
+   * data caused it, so this names neither. Saying it is a developer's to
+   * investigate would be wrong whenever a field on this document is the cause,
+   * and it would send the one person who can fix it away from the fix.
+   *
+   * The DOCUMENT noun rather than `noun`: `noun` is the thing that DECLARES the
+   * preview — a collection or a Single — which is right for a message about
+   * configuration and wrong here, because an entry's data belongs to the entry
+   * rather than to its collection.
+   */
   declarationFailed: {
-    message: (_subject, noun) =>
-      `This ${noun}'s preview URL could not be built: the preview declaration ` +
-      "failed while producing an address. That is a developer's to look at — " +
-      `either the declaration itself, or a value on this ${noun} it did not ` +
-      "expect.",
+    message: subject =>
+      `This ${documentNoun(subject)}'s preview URL could not be built: the ` +
+      "preview declaration failed while producing an address. That can be a " +
+      "fault in the declaration, or a value on this " +
+      `${documentNoun(subject)} it did not expect — the error does not say ` +
+      "which, so it is worth checking this " +
+      `${documentNoun(subject)}'s fields as well as raising it with a ` +
+      "developer.",
     reason: "preview-declaration-failed",
     remedy:
       "The declaration threw while running, or returned pieces that do not " +
       "compose into a URL under the site. Whether it fails for EVERY document " +
       "or only for this one is NOT observable from a caught throw — a " +
-      "declaration reading a field that happens to be empty here raises the " +
+      "declaration reading a field this document never filled in raises the " +
       "same error a broken one does — so this names neither. Check " +
       "`admin.preview.url` / `admin.preview.urlTemplate` and the fields it " +
       "reads.",

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-url-resolver.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-url-resolver.test.ts
@@ -99,11 +99,12 @@ describe("resolvePreviewUrl", () => {
   });
 
   it("separates a THROWN declaration from one that declines", () => {
-    // User code runs inside a request here. A throw is the collection failing to
-    // produce a URL, not the server failing, so it must not escape as a 500 —
-    // and not as `unavailable` either, which tells the editor to fill in the
-    // field the URL is built from. A declaration that throws does so for every
-    // document, so no field on this one is the remedy.
+    // User code runs inside a request here. A throw is the declaration failing
+    // to produce a URL, not the server failing, so it must not escape as a 500 —
+    // and not as `unavailable` either, which states there is no address YET and
+    // sends the editor to the field the URL is built from. A throw states only
+    // that producing an address did not work, and does not say whose fault that
+    // is.
     expect(
       resolvePreviewUrl({
         preview: {

--- a/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-redirect-resolver.ts
@@ -197,9 +197,11 @@ export type PreviewRefusalCause =
   /**
    * The declaration threw, or produced pieces that do not compose into a URL.
    *
-   * Kept apart from `unavailable` for the reason that type exists: one is an
-   * empty field on this document and the other is broken code, and only the
-   * first is something the editor holding the document can act on.
+   * Kept apart from `unavailable` for the reason that type exists: one is the
+   * declaration DECLINING, which is a definite statement that this document has
+   * no address yet, and the other is it FAILING, which a caught throw cannot
+   * attribute to the declaration or to the document's data. Naming them apart
+   * is what stops the second being answered with the first's remedy.
    */
   | "declarationFailed";
 

--- a/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
@@ -79,11 +79,17 @@ export type PreviewUrlResolution =
    * function threw, or the pieces it returned do not compose into a URL under
    * the site.
    *
-   * Kept apart from `unavailable` because the two have opposite remedies. An
-   * `unavailable` document becomes previewable once someone fills in the field
-   * the URL is built from; this one cannot be fixed by editing the document at
-   * all, and telling an editor to fill in a slug sends them after a field that
-   * is already full.
+   * Kept apart from `unavailable` because the two are different EVENTS, and the
+   * separation is deliberately not a claim about the remedy. `unavailable` is
+   * the declaration DECLINING — it returned null, or a placeholder has no value
+   * — which is a definite statement that there is no address yet. This one is
+   * the declaration FAILING, and a caught throw does not say whether the fault
+   * is in the declaration or in a value on this document that it did not
+   * expect: `entry.slug.toUpperCase()` raises the same error on a broken
+   * declaration and on an empty slug.
+   *
+   * So a caller may say the declaration failed. It may not say which document
+   * that is true for.
    */
   | { status: "declarationFailed" };
 
@@ -235,11 +241,11 @@ export function resolvePreviewUrl({
 
   if (typeof preview?.url === "function") {
     // The authored function is user code running inside a request. It may throw,
-    // and a throw here is the declaration being broken rather than a server
-    // fault, so it is reported rather than failing the request — and reported
-    // as its own status, because a deliberate `return null` is a document
-    // without an address yet while this is a declaration that cannot produce
-    // one for any document.
+    // and a throw here is the declaration failing rather than the server
+    // failing, so it is reported rather than escaping the request — and
+    // reported as its own status, because a deliberate `return null` states
+    // that there is no address yet while a throw states only that producing one
+    // did not work.
     try {
       path = preview.url(entry);
     } catch {
@@ -271,8 +277,7 @@ export function resolvePreviewUrl({
 
   const joined = joinUnderSite(`${basePath}${suffix}`, base);
   // The pieces parsed separately and not together, which is a declaration this
-  // resolver cannot turn into an address — for this document or any other, so
-  // it is the declaration's failure rather than the document's.
+  // resolver cannot turn into an address.
   //
   // DEFENSIVE: the candidate is built from an origin and path this function
   // already parsed, so nothing an author can return reaches it today. It is

--- a/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
@@ -85,8 +85,12 @@ export type PreviewUrlResolution =
    * — which is a definite statement that there is no address yet. This one is
    * the declaration FAILING, and a caught throw does not say whether the fault
    * is in the declaration or in a value on this document that it did not
-   * expect: `entry.slug.toUpperCase()` raises the same error on a broken
-   * declaration and on an empty slug.
+   * expect: `entry.slug.toUpperCase()` raises the same `TypeError` on a
+   * declaration reading the wrong field name as it does on a document whose
+   * `slug` was never filled in. (Note what the example is NOT — an EMPTY slug
+   * does not throw, since `"".toUpperCase()` is `""`. The data-dependent case
+   * is a MISSING value, not a blank one, and getting that wrong makes the
+   * whole distinction sound hypothetical when it is not.)
    *
    * So a caller may say the declaration failed. It may not say which document
    * that is true for.


### PR DESCRIPTION
`#1217` merged as a two-parent merge whose second parent is `b3fdb6055` — the head *before* its last push. The final commit is stranded on the branch, so what is on `main` is the version Codex flagged, not the answer to it.

This carries that commit onto `main` unchanged.

## What is wrong on main right now

The `declarationFailed` diagnosis tells the editor **"Nothing on the document can fix it"** and tells the operator it **"reproduce[s] for every document in the collection."** Neither is knowable. `entry.slug.toUpperCase()` raises the same error on a broken declaration and on a document whose slug happens to be empty, so a caught throw does not separate a fault in the code from data the code did not expect — and both readers are sent to the wrong remedy.

The message now names the EVENT and says the throw attributes it to neither, and the remedy says so outright rather than picking a side.

The separation from `unavailable` stands, on a different footing than the merged version claimed: the two are different **events**, not opposite remedies. Declining — `return null`, an empty placeholder — is a definite statement that this document has no address yet. Failing is not a statement about the document at all. That is the property the code can actually witness, and the doc comments on `PreviewUrlResolution`, `PreviewRefusalCause` and the test naming the split all carried the overclaim and are corrected with it.

The changeset also said six causes after a seventh was added, and omitted the new one from its enumeration; both are fixed in three places.

## How the strand was established

Screened with `git log <headRefOid>..<ls-remote tip>`, then confirmed by CONTENT, because the screen only names candidates:

| check | result |
| --- | --- |
| marker at branch tip (control — the search CAN find it) | HIT |
| marker in merge commit `636c9cb75` | absent |
| marker in `origin/main` | absent |
| `preview-declaration-failed` in the merge (discriminating control) | HIT |

The last row is what makes the absence mean something: text from the EARLIER commit is present at the same path in the same tree, so the path resolves and the merge did land #1217's other work. Zero force-push or branch-delete events on the timeline.

## Gates

Full `pnpm build`, then `check-types`, `lint`, `lint:design`, comment convention, `changeset status`, and `fallow audit` — all exit 0. Unit 911/911 across every preview suite; the preview integration suite 36 passed / 6 skipped under `vitest.integration.config.ts` (its own config — the unit config does not select `*.integration.test.ts`).

No changeset: the existing `preview-refusal-says-which.md` is still unreleased on `main` and this corrects it in place.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated preview-link failure messages to more accurately distinguish declaration/runtime failures from document-specific issues.
  - Clarified that failures may result from either URL declarations or document data, without incorrectly attributing the cause.

- **Documentation**
  - Improved descriptions of preview-link refusal states and URL resolution behavior.
  - Clarified the distinction between unavailable previews and declaration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->