### PR TITLE
feat(builder): canvas breakpoint switcher — one width, everything derived

### DIFF
--- a/.changeset/canvas-breakpoint-switcher.md
+++ b/.changeset/canvas-breakpoint-switcher.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The editor canvas had no way to say which breakpoint you were editing, so every
+style edit landed in the widest tier no matter how the page looked on screen.
+
+Choosing a tier now sizes the canvas, and everything else follows from the width
+the box actually gets: which tier an edit writes to, and which tiers the Style
+tab reports as live. There is no second piece of state that could disagree with
+what is on the canvas.
+
+Because the width the box gets is what decides, an editor region narrower than
+the site's widest breakpoint now says so — the canvas reports the tier it is
+really in rather than the one that was asked for.

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -84,6 +84,16 @@
   //     colour control cannot drop the import: it is the WRITING half of hex
   //     and `blocks-engine` owns the reading half, so composing the notation
   //     inside `packages/builder` would put a third colour parser in the tree.
+  //   @nextlyhq/ui/utils = the same shape a third time, resolving to
+  //     `./dist/utils.mjs`, and measured the same way: `unresolved_imports: 0`
+  //     locally after a build, one error-severity finding in CI. Six files in
+  //     `packages/builder` already import it and none had been CHANGED in a
+  //     pull request before, so the gate — which reports introduced findings
+  //     only — had never had cause to name it. The import is `cn`, which is
+  //     `twMerge(clsx(...))`: dropping it does not merely lose a convenience,
+  //     it leaves conflicting Tailwind classes both present, so a conditional
+  //     `text-foreground` no longer overrides the `text-muted-foreground`
+  //     beside it and the selected state stops rendering as selected.
   //
   // Every entry is an exact specifier rather than a prefix. These match the
   // raw import string, so `../dist/**` would also swallow a typo like
@@ -96,6 +106,7 @@
     "../dist/render/index.js",
     "@nextlyhq/ui/styles.css",
     "@nextlyhq/ui/color",
+    "@nextlyhq/ui/utils",
     "@nextlyhq/builder/styles.css",
   ],
 

--- a/.fallowrc.jsonc
+++ b/.fallowrc.jsonc
@@ -85,15 +85,14 @@
   //     and `blocks-engine` owns the reading half, so composing the notation
   //     inside `packages/builder` would put a third colour parser in the tree.
   //   @nextlyhq/ui/utils = the same shape a third time, resolving to
-  //     `./dist/utils.mjs`, and measured the same way: `unresolved_imports: 0`
-  //     locally after a build, one error-severity finding in CI. Six files in
-  //     `packages/builder` already import it and none had been CHANGED in a
-  //     pull request before, so the gate — which reports introduced findings
-  //     only — had never had cause to name it. The import is `cn`, which is
-  //     `twMerge(clsx(...))`: dropping it does not merely lose a convenience,
-  //     it leaves conflicting Tailwind classes both present, so a conditional
-  //     `text-foreground` no longer overrides the `text-muted-foreground`
-  //     beside it and the selected state stops rendering as selected.
+  //     `./dist/utils.mjs`, and measured the same way: a local audit after
+  //     `pnpm build` resolves it while CI, which audits after install and
+  //     before build, reports it unresolved. The import is `cn`, which is
+  //     `twMerge(clsx(...))`, and `packages/builder` cannot drop it: without
+  //     the merge, conflicting Tailwind classes are both present, so a
+  //     conditional `text-foreground` no longer overrides the
+  //     `text-muted-foreground` beside it and a selected control renders as
+  //     unselected.
   //
   // Every entry is an exact specifier rather than a prefix. These match the
   // raw import string, so `../dist/**` would also swallow a typo like

--- a/apps/playground/src/app/builder-canvas-preview/harness.tsx
+++ b/apps/playground/src/app/builder-canvas-preview/harness.tsx
@@ -18,6 +18,19 @@ const HARNESS_SOURCE = "e2e-canvas-preview-harness";
 const TIER_BOUND = 600;
 
 /**
+ * A region WIDER than the bound, for the case that separates the two compiles.
+ *
+ * The canvas normally fills its region, so a narrow window means a narrow box
+ * and an `@media` implementation and a `@container` one agree. They disagree
+ * only when the window is BELOW the bound and the box is ABOVE it: the media
+ * query asks the window and applies the narrow tier, while a container query
+ * asked of this box does not. Nothing else in the fixture produces that state,
+ * because `preview.width` is a ceiling within the region and can only ever make
+ * the box narrower than the space available.
+ */
+const OVERFLOW_WIDTH = 800;
+
+/**
  * Two colours that cannot be confused for one another, or for a default.
  *
  * A test asserting a computed colour needs values no stylesheet elsewhere
@@ -82,6 +95,7 @@ export function BuilderCanvasPreviewHarness() {
   const editor = useEditorState({ initialDocument });
   const [width, setWidth] = useState<number | undefined>(undefined);
   const [measured, setMeasured] = useState<number | undefined>(undefined);
+  const [region, setRegion] = useState<number | undefined>(undefined);
 
   const container = useMemo(
     () => previewContainerFor("e2e-canvas-preview"),
@@ -102,7 +116,13 @@ export function BuilderCanvasPreviewHarness() {
   );
 
   return (
-    <div data-testid="canvas-preview-harness" style={{ height: "100vh" }}>
+    <div
+      data-testid="canvas-preview-harness"
+      style={{
+        height: "100vh",
+        ...(region === undefined ? {} : { width: `${region}px` }),
+      }}
+    >
       {/*
         The width is SET, never typed as a pixel value the test computes: the
         two buttons name the states the fixture is about, so a spec cannot
@@ -122,6 +142,17 @@ export function BuilderCanvasPreviewHarness() {
         onClick={() => setWidth(undefined)}
       >
         wide
+      </button>
+      {/*
+        Widens the REGION past the viewport, which is the only state in which a
+        container compile and a media compile give opposite answers.
+      */}
+      <button
+        type="button"
+        data-testid="go-overflow"
+        onClick={() => setRegion(OVERFLOW_WIDTH)}
+      >
+        overflow
       </button>
       {/*
         What the box actually MEASURED, reported so the spec can wait on the

--- a/apps/playground/src/app/builder-canvas-preview/harness.tsx
+++ b/apps/playground/src/app/builder-canvas-preview/harness.tsx
@@ -14,8 +14,18 @@ import "@nextlyhq/builder/styles.css";
 
 const HARNESS_SOURCE = "e2e-canvas-preview-harness";
 
-/** The tier the fixture narrows into, and the width that is inside it. */
+/** The narrow tier's own bound. */
 const TIER_BOUND = 600;
+
+/**
+ * The width the fixture actually asks for, strictly INSIDE the bound.
+ *
+ * Asking for the bound itself would make the case depend on whether the emitted
+ * comparison is inclusive — a property `compile-page` settles and this fixture
+ * has no business restating. A width below it is inside the tier under either
+ * reading.
+ */
+const NARROW_WIDTH = TIER_BOUND - 40;
 
 /**
  * A region WIDER than the bound, for the case that separates the two compiles.
@@ -132,7 +142,7 @@ export function BuilderCanvasPreviewHarness() {
       <button
         type="button"
         data-testid="go-narrow"
-        onClick={() => setWidth(TIER_BOUND)}
+        onClick={() => setWidth(NARROW_WIDTH)}
       >
         narrow
       </button>

--- a/apps/playground/src/app/builder-canvas-preview/harness.tsx
+++ b/apps/playground/src/app/builder-canvas-preview/harness.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import {
+  previewContainerFor,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { Canvas, useEditorState } from "@nextlyhq/builder/shell";
+import { useMemo, useState } from "react";
+
+import { useCoreBlocks } from "@/lib/use-core-blocks";
+
+import "@nextlyhq/ui/styles.css";
+import "@nextlyhq/builder/styles.css";
+
+const HARNESS_SOURCE = "e2e-canvas-preview-harness";
+
+/** The tier the fixture narrows into, and the width that is inside it. */
+const TIER_BOUND = 600;
+
+/**
+ * Two colours that cannot be confused for one another, or for a default.
+ *
+ * A test asserting a computed colour needs values no stylesheet elsewhere
+ * produces: `rgb(0, 0, 255)` at the base tier and `rgb(255, 0, 0)` below the
+ * bound. Equal values, or values a reset might land on, would let a canvas
+ * applying neither rule satisfy the assertion.
+ */
+const BASE_COLOUR = "#0000ff";
+const TIER_COLOUR = "#ff0000";
+
+const BREAKPOINTS = {
+  viewport: [{ id: "narrow", label: "Narrow", maxWidth: TIER_BOUND }],
+  container: [],
+};
+
+function previewDocument(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "subject",
+        type: "core/text",
+        version: 1,
+        props: { text: "subject" },
+        styles: {
+          base: {
+            base: { color: BASE_COLOUR },
+            narrow: { color: TIER_COLOUR },
+          },
+        },
+      },
+    ],
+  };
+}
+
+/**
+ * The canvas previewing, mounted for real, so a browser can decide the queries.
+ *
+ * SEPARATE from `/builder-canvas`, whose fixture states that it "asserts nothing
+ * responsive, and a breakpoint here would make the canvas's own width one more
+ * thing a drop coordinate depends on". Adding a tier to that route would put a
+ * width-sensitive rule underneath twenty-odd pointer tests measuring rectangles.
+ *
+ * What is ONLY observable here: that narrowing the box changes which declaration
+ * WINS. Every unit test of this feature asserts the sheet says the right thing
+ * and the element carries the right container name — but jsdom ships no `CSS`
+ * object and evaluates no container query, so a sheet that is correct and a box
+ * that establishes nothing produce identical green. The claim the whole compile
+ * exists to support is that resizing the box moves the breakpoint, and a browser
+ * is the only thing that can answer it.
+ *
+ * The width is driven by a control rather than by resizing the viewport, because
+ * the viewport is exactly what a container query must NOT answer to: a test that
+ * moved the window would pass against a canvas still compiling `@media`, which
+ * is the bug this mechanism was built to remove.
+ */
+export function BuilderCanvasPreviewHarness() {
+  useCoreBlocks(HARNESS_SOURCE);
+
+  const initialDocument = useMemo(() => previewDocument(), []);
+  const editor = useEditorState({ initialDocument });
+  const [width, setWidth] = useState<number | undefined>(undefined);
+  const [measured, setMeasured] = useState<number | undefined>(undefined);
+
+  const container = useMemo(
+    () => previewContainerFor("e2e-canvas-preview"),
+    []
+  );
+  const siteStyles = useMemo(() => ({ breakpoints: BREAKPOINTS }), []);
+  const render = useMemo(
+    () => ({ styleContext: { breakpoints: BREAKPOINTS } }),
+    []
+  );
+  const preview = useMemo(
+    () => ({
+      container,
+      ...(width === undefined ? {} : { width }),
+      onMeasured: setMeasured,
+    }),
+    [container, width]
+  );
+
+  return (
+    <div data-testid="canvas-preview-harness" style={{ height: "100vh" }}>
+      {/*
+        The width is SET, never typed as a pixel value the test computes: the
+        two buttons name the states the fixture is about, so a spec cannot
+        accidentally ask for a width on the boundary and depend on whether the
+        query is inclusive.
+      */}
+      <button
+        type="button"
+        data-testid="go-narrow"
+        onClick={() => setWidth(TIER_BOUND)}
+      >
+        narrow
+      </button>
+      <button
+        type="button"
+        data-testid="go-wide"
+        onClick={() => setWidth(undefined)}
+      >
+        wide
+      </button>
+      {/*
+        What the box actually MEASURED, reported so the spec can wait on the
+        canvas having observed its own resize rather than on a timeout. The
+        request is a ceiling and the measurement is what the queries resolve
+        against, so this is the number the assertion below is really about.
+      */}
+      <output data-testid="measured">{measured ?? ""}</output>
+      <Canvas
+        document={editor.document}
+        siteStyles={siteStyles}
+        render={render}
+        preview={preview}
+        selectedId={editor.selectedId}
+        onSelect={editor.select}
+      />
+    </div>
+  );
+}

--- a/apps/playground/src/app/builder-canvas-preview/page.tsx
+++ b/apps/playground/src/app/builder-canvas-preview/page.tsx
@@ -1,0 +1,27 @@
+import { notFound } from "next/navigation";
+
+import { BuilderCanvasPreviewHarness } from "./harness";
+
+/**
+ * A harness route for the canvas's PREVIEW compile.
+ *
+ * The editor canvas is not an iframe, so viewport breakpoints are emitted as
+ * container queries against a named box and the box's own width decides them.
+ * Nothing below a browser can check that: jsdom ships no `CSS` object, evaluates
+ * no container query, and reports every element as zero-sized — so a stylesheet
+ * that is correct and a box that establishes no container produce exactly the
+ * same green.
+ *
+ * Separate from `/builder-canvas`, whose fixture deliberately carries no
+ * breakpoints so that no drop coordinate depends on the canvas's width. A tier
+ * added there would sit underneath every pointer test on that route.
+ *
+ * Same env gate as the other harness routes, for the reason theirs give: a
+ * dev-only route under `src/app/` is otherwise reachable in `pnpm dev:app` and
+ * indistinguishable from product.
+ */
+export default async function BuilderCanvasPreviewHarnessRoute() {
+  if (process.env.NEXTLY_E2E_CANVAS_HARNESS !== "1") notFound();
+
+  return <BuilderCanvasPreviewHarness />;
+}

--- a/apps/playground/src/app/builder-canvas/harness.tsx
+++ b/apps/playground/src/app/builder-canvas/harness.tsx
@@ -1,11 +1,6 @@
 "use client";
 
-import {
-  hasBlock,
-  registerBlocks,
-  registryNestingSource,
-} from "@nextlyhq/blocks-engine";
-import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { registryNestingSource } from "@nextlyhq/blocks-engine";
 import { registrySlotSource } from "@nextlyhq/builder";
 import {
   Canvas,
@@ -22,6 +17,8 @@ import { useMemo } from "react";
 // both and a second copy would make the result depend on which one won.
 import "@nextlyhq/ui/styles.css";
 import "@nextlyhq/builder/styles.css";
+
+import { useCoreBlocks } from "@/lib/use-core-blocks";
 
 import { canvasHarnessDocument } from "./seed";
 
@@ -50,18 +47,7 @@ const HARNESS_SOURCE = "e2e-canvas-harness";
  * test. A harness that positioned its own indicator would certify itself.
  */
 export function BuilderCanvasHarness() {
-  /*
-   * Register the core blocks before anything reads the registry.
-   *
-   * Only the ones missing, and through the same guarded call the production
-   * host uses: the registry is process-wide, so a second unconditional
-   * registration throws on a dev-server hot reload where the module is
-   * re-evaluated but the registry survives.
-   */
-  useMemo(() => {
-    const missing = coreBlocks.filter(block => !hasBlock(block.name));
-    if (missing.length > 0) registerBlocks(missing, { source: HARNESS_SOURCE });
-  }, []);
+  useCoreBlocks(HARNESS_SOURCE);
 
   const initialDocument = useMemo(() => canvasHarnessDocument(), []);
   const editor = useEditorState({ initialDocument });

--- a/apps/playground/src/lib/use-core-blocks.ts
+++ b/apps/playground/src/lib/use-core-blocks.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { hasBlock, registerBlocks } from "@nextlyhq/blocks-engine";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { useMemo } from "react";
+
+/**
+ * Register the core blocks before anything reads the registry.
+ *
+ * Shared by the harness routes rather than repeated in each, because the guard
+ * is the interesting part and a second copy is a second place to lose it: the
+ * registry is process-wide, so an unconditional registration throws on a dev
+ * server hot reload where the module is re-evaluated and the registry survives.
+ * Only the blocks actually missing are registered, through the same guarded call
+ * the production host uses.
+ *
+ * `useMemo` rather than an effect, so the registry is populated during the
+ * render that first reads it. An effect runs after, and the first paint would
+ * resolve every block to a placeholder.
+ *
+ * The SOURCE stays a per-caller argument: it is what the registry reports when
+ * two registrations disagree, and a shared constant would name one harness in
+ * the other's error.
+ */
+export function useCoreBlocks(source: string): void {
+  useMemo(() => {
+    const missing = coreBlocks.filter(block => !hasBlock(block.name));
+    if (missing.length > 0) registerBlocks(missing, { source });
+  }, [source]);
+}

--- a/e2e/tests/canvas/preview-container.spec.ts
+++ b/e2e/tests/canvas/preview-container.spec.ts
@@ -78,20 +78,35 @@ test.describe("the canvas preview compile", () => {
   test("answers to the BOX rather than to the window", async ({ page }) => {
     /*
      * The property that separates a container compile from a published one, and
-     * the one no unit test can reach. The window is made narrower than the tier
-     * bound while the box stays unconstrained: under `@media` the narrow rule
-     * would now apply, and under `@container` against a box wider than the
-     * bound it must not.
+     * the only case in which the two give OPPOSITE answers.
      *
-     * The viewport is set below the fixture's 600px bound and the canvas fills
-     * the page, so this also pins that the box is measured rather than assumed
-     * — a canvas reporting its requested width would read as unbounded here.
+     * The viewport is set BELOW the fixture's 600px bound and the region is
+     * then widened past it, so the box is 800px inside a 500px window:
+     *
+     *   `@media (max-width: 600px)`      asks the window, 500 -> MATCHES  -> red
+     *   `@container … (max-width: 600px)` asks the box,    800 -> no match -> blue
+     *
+     * A window wider than the bound would not discriminate: neither
+     * implementation applies the narrow tier there, so the case would stay green
+     * against the exact regression it names.
      */
-    await page.setViewportSize({ width: 900, height: 800 });
+    await page.setViewportSize({ width: 500, height: 800 });
     await page.goto(ROUTE);
     const subject = page.locator(SUBJECT).first();
     await expect(subject).toBeVisible();
-    await expect(page.getByTestId("measured")).not.toHaveText("");
+
+    await page.getByTestId("go-overflow").click();
+
+    /*
+     * Waited on the canvas having MEASURED a box wider than the bound, so the
+     * assertion cannot run against the region before it widened — which would
+     * be the narrow state, and would pass for the wrong reason.
+     */
+    await expect
+      .poll(async () =>
+        Number(await page.getByTestId("measured").textContent())
+      )
+      .toBeGreaterThan(600);
 
     await expect(subject).toHaveCSS("color", WIDE);
   });

--- a/e2e/tests/canvas/preview-container.spec.ts
+++ b/e2e/tests/canvas/preview-container.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * The preview compile, measured in a browser because nowhere else can decide it.
+ *
+ * `canvas.test.tsx` asserts the emitted sheet names the box and the element
+ * establishes that container; `compile-page.test.ts` asserts the at-rule text.
+ * Neither can say whether the browser then APPLIES it. jsdom ships no `CSS`
+ * object and evaluates no container query, so a correct stylesheet over a box
+ * that establishes nothing produces exactly the same green as a working one.
+ *
+ * The claim this whole mechanism exists to support is a single sentence:
+ * narrowing the canvas changes which declaration wins. It is the reason the
+ * viewport tiers are compiled as `@container` at all, and this is the only
+ * place it can be checked.
+ *
+ * The width is driven by the harness's own control rather than by resizing the
+ * VIEWPORT, and that is load-bearing rather than convenient: a spec that moved
+ * the window would pass just as well against a canvas still compiling `@media`,
+ * which is precisely the bug the container compile removes. Moving the box while
+ * the window holds still is the only motion that separates the two.
+ */
+
+const ROUTE = "/builder-canvas-preview";
+const SUBJECT = '[data-nx-node="subject"]';
+
+/** The two colours the fixture authors, one per tier. */
+const WIDE = "rgb(0, 0, 255)";
+const NARROW = "rgb(255, 0, 0)";
+
+test.describe("the canvas preview compile", () => {
+  test("changes which declaration wins when the BOX narrows", async ({
+    page,
+  }) => {
+    await page.goto(ROUTE);
+    const subject = page.locator(SUBJECT).first();
+    await expect(subject).toBeVisible();
+
+    /*
+     * Waited on the canvas's own measurement rather than on a timeout: the
+     * request is a ceiling and what the queries resolve against is the width the
+     * box actually got, so this is the number the assertions are about.
+     */
+    await expect(page.getByTestId("measured")).not.toHaveText("");
+
+    await expect(subject).toHaveCSS("color", WIDE);
+
+    await page.getByTestId("go-narrow").click();
+
+    /*
+     * The window has not moved. Only the box has. A canvas compiling `@media`
+     * reaches this line still showing the wide colour.
+     */
+    await expect(subject).toHaveCSS("color", NARROW);
+  });
+
+  test("returns to the wider declaration when the box is released", async ({
+    page,
+  }) => {
+    /*
+     * The control. Without it a canvas that applied the narrow rule
+     * unconditionally — a container established at a width nothing ever
+     * exceeds, say — would satisfy the case above, and the suite would certify
+     * a preview that is simply always narrow.
+     */
+    await page.goto(ROUTE);
+    const subject = page.locator(SUBJECT).first();
+    await expect(subject).toBeVisible();
+
+    await page.getByTestId("go-narrow").click();
+    await expect(subject).toHaveCSS("color", NARROW);
+
+    await page.getByTestId("go-wide").click();
+
+    await expect(subject).toHaveCSS("color", WIDE);
+  });
+
+  test("answers to the BOX rather than to the window", async ({ page }) => {
+    /*
+     * The property that separates a container compile from a published one, and
+     * the one no unit test can reach. The window is made narrower than the tier
+     * bound while the box stays unconstrained: under `@media` the narrow rule
+     * would now apply, and under `@container` against a box wider than the
+     * bound it must not.
+     *
+     * The viewport is set below the fixture's 600px bound and the canvas fills
+     * the page, so this also pins that the box is measured rather than assumed
+     * — a canvas reporting its requested width would read as unbounded here.
+     */
+    await page.setViewportSize({ width: 900, height: 800 });
+    await page.goto(ROUTE);
+    const subject = page.locator(SUBJECT).first();
+    await expect(subject).toBeVisible();
+    await expect(page.getByTestId("measured")).not.toHaveText("");
+
+    await expect(subject).toHaveCSS("color", WIDE);
+  });
+});

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -510,6 +510,37 @@ describe("a stored set the compiler has to reconcile", () => {
     expect(options()).toHaveLength(2);
   });
 
+  it("offers ONE radio when two tiers share a bound", () => {
+    /*
+     * Distinct ids, so `breakpointContexts` emits BOTH — this is not the
+     * duplicate-id case. Selecting a tier only sets a width, so two radios
+     * emitting 991 are not two choices: the match resolves to one and clicking
+     * the other silently selects it.
+     *
+     * The one kept is the tier the browser paints: both are emitted into a
+     * single at-rule in order, so the later declaration wins.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={{
+          viewport: [
+            { id: "alpha", label: "Alpha", maxWidth: 991 },
+            { id: "beta", label: "Beta", maxWidth: 991 },
+          ],
+          container: [],
+        }}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(options()).toHaveLength(2); // Full width, and one of the two.
+    expect(
+      screen.getByRole("radio", { name: "Beta, up to 991 pixels" })
+    ).toBeDefined();
+  });
+
   it("labels the surviving tier from the definition the compiler KEPT", () => {
     /*
      * Measured: among rows sharing an id the compiler keeps the WIDEST, not the

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -1,0 +1,376 @@
+// @vitest-environment jsdom
+/**
+ * What the switcher is responsible for, which is narrower than it looks.
+ *
+ * It SETS a width and reports which option that width corresponds to. Which
+ * tier an edit lands in is `canvas-width.ts`'s answer and has its own suite;
+ * what is only true here is that choosing an option emits the tier's own bound,
+ * that a width no option could have set selects NOTHING, and that the control
+ * is operable from a keyboard.
+ *
+ * @module breakpoint-switcher.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BreakpointSet } from "./breakpoints";
+import { BreakpointSwitcher } from "./breakpoint-switcher";
+
+afterEach(cleanup);
+
+const site = (): BreakpointSet => ({
+  viewport: [
+    { id: "tablet", label: "Tablet", maxWidth: 991 },
+    { id: "mobile", label: "Mobile", maxWidth: 575 },
+  ],
+  container: [],
+});
+
+const options = (): HTMLElement[] => screen.getAllByRole("radio");
+const checked = (): HTMLElement[] =>
+  options().filter(option => option.getAttribute("aria-checked") === "true");
+
+describe("choosing a tier", () => {
+  it("emits the tier's OWN bound, not an index or an id", () => {
+    /*
+     * The width is the whole output of this control. Emitting an id would push
+     * the width lookup onto every host, which is a second place for the
+     * canvas's size and the selected tier to disagree.
+     */
+    const onSelect = vi.fn();
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={onSelect}
+        status="ready"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: /Tablet/ }));
+
+    expect(onSelect).toHaveBeenCalledWith(991);
+  });
+
+  it("emits UNDEFINED for the widest, rather than a number", () => {
+    /*
+     * The unconditional tier has no upper bound, so any number here would be
+     * invented — and would make the widest option narrower than the region,
+     * putting gutters around a canvas that was already the right size.
+     */
+    const onSelect = vi.fn();
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={575}
+        onSelect={onSelect}
+        status="ready"
+      />
+    );
+
+    fireEvent.click(screen.getByRole("radio", { name: "Full width" }));
+
+    expect(onSelect).toHaveBeenCalledWith(undefined);
+  });
+
+  it("says the WIDTH in each option's accessible name", () => {
+    // "Tablet" alone does not say what choosing it will do, and the number is
+    // the entire content of the choice. In the name rather than a tooltip, so a
+    // screen-reader user gets it.
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(
+      screen.getByRole("radio", { name: "Tablet, up to 991 pixels" })
+    ).toBeDefined();
+  });
+});
+
+describe("what the control reports as selected", () => {
+  it("selects the option whose bound the canvas is EXACTLY at", () => {
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={991}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(checked()).toHaveLength(1);
+    expect(checked()[0]?.getAttribute("aria-label")).toBe(
+      "Tablet, up to 991 pixels"
+    );
+  });
+
+  it("selects NOTHING at a width no option could have set", () => {
+    /*
+     * The property that separates this control from one that merely reports the
+     * live tier. At 700 the tablet rules ARE applying, and the canvas is not at
+     * the tablet width — so showing Tablet as chosen would tell an author the
+     * box is 991 when it is 700, and clicking Tablet would then look like a
+     * no-op that silently resizes.
+     *
+     * Asserted as an empty set rather than "Tablet is not checked", so a
+     * version that selected Mobile instead would also fail.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={700}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(checked()).toHaveLength(0);
+  });
+
+  it("still names the tier that IS applying at that width", () => {
+    // The counterpart to the case above: selecting nothing must not mean saying
+    // nothing. The width changed which declarations are live, and that is the
+    // fact this control exists to make legible.
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={700}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(screen.getByText(/700px/)).toBeDefined();
+    expect(screen.getByText(/tablet/)).toBeDefined();
+  });
+
+  it("selects the widest when the canvas is UNBOUNDED, which is the control", () => {
+    /*
+     * Without this, a control that selected nothing under every circumstance
+     * would satisfy the empty-set assertion above — the negative there is
+     * satisfied by absence, so its meaning depends on this.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(checked()).toHaveLength(1);
+    expect(checked()[0]?.getAttribute("aria-label")).toBe("Full width");
+  });
+});
+
+describe("the gate on the saved read", () => {
+  it("is INERT until the saved set has been read", () => {
+    /*
+     * The same gate the manager beside it carries, and for a reason that is
+     * stronger here: until the read answers, the value in hand is the host's
+     * config defaults, so sizing the canvas to one of those bounds would make
+     * every subsequent edit land in a tier the author never chose.
+     *
+     * Asserted on the callback as well as on `disabled` — a disabled attribute
+     * that some other handler ignores is not a gate.
+     */
+    const onSelect = vi.fn();
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={onSelect}
+        status="loading"
+      />
+    );
+
+    const tablet = screen.getByRole("radio", { name: /Tablet/ });
+    expect((tablet as HTMLButtonElement).disabled).toBe(true);
+    fireEvent.click(tablet);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("reports nothing as selected while it cannot be trusted", () => {
+    // Showing a selection derived from config defaults would state which tier
+    // the canvas is at, on the strength of a set the site may never have saved.
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="unavailable"
+      />
+    );
+
+    expect(checked()).toHaveLength(0);
+  });
+});
+
+describe("keyboard operation", () => {
+  it("moves the selection with the arrow keys", () => {
+    // A radio group's expected behaviour, and the reason the roles are worth
+    // having: a row of plain buttons gives a keyboard user no way to move
+    // between options without leaving and re-entering the group.
+    const onSelect = vi.fn();
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={onSelect}
+        status="ready"
+      />
+    );
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowRight" });
+
+    expect(onSelect).toHaveBeenCalledWith(991);
+  });
+
+  it("WRAPS at the end rather than stopping", () => {
+    // Three options and a left-arrow from the first reaches the last. Stopping
+    // dead at an edge is the behaviour a roving tabindex most often gets wrong,
+    // and it strands a keyboard user at whichever end they entered from.
+    const onSelect = vi.fn();
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={onSelect}
+        status="ready"
+      />
+    );
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowLeft" });
+
+    expect(onSelect).toHaveBeenCalledWith(575);
+  });
+
+  it("keeps exactly ONE option in the tab order", () => {
+    /*
+     * The roving tabindex. Every option reachable by Tab would cost a keyboard
+     * user one stop per breakpoint to cross a control they may not be using —
+     * and a site may define up to seven per axis.
+     *
+     * Asserted as a count over the whole group rather than on one element, so a
+     * version that gave every option `tabIndex={0}` fails here.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(options().filter(option => option.tabIndex === 0)).toHaveLength(1);
+  });
+
+  it("leaves a stop in the tab order at a width matching NO option", () => {
+    /*
+     * The case a roving tabindex keyed only on the selection gets wrong: with
+     * nothing selected there is nothing carrying `tabIndex={0}`, and the whole
+     * control drops out of the tab order — unreachable by keyboard at exactly
+     * the widths an author reaches by dragging.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={700}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(options().filter(option => option.tabIndex === 0)).toHaveLength(1);
+  });
+});
+
+describe("a site with no viewport breakpoints", () => {
+  it("renders NOTHING rather than a control offering one option", () => {
+    // "Full width" alone is not a choice; it occupies top-bar space to say the
+    // canvas is the width it visibly is. The manager beside it is where tiers
+    // are added, so the affordance appears when there is something to switch.
+    const { container } = render(
+      <BreakpointSwitcher
+        breakpoints={{ viewport: [], container: [] }}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("DROPS a tier the compiler emits no bound for", () => {
+    /*
+     * The switcher offers what the SHEET can respond to, not what storage
+     * happens to hold. `breakpointContexts` applies its own reading of a stored
+     * axis, so a definition it declines to emit a bounded context for has no
+     * query anywhere in the compiled page.
+     *
+     * Offered anyway, picking it resizes the canvas to a width nothing responds
+     * to: the box changes size and the page does not reflow, which reads as the
+     * feature being broken rather than as a definition the compiler rejected.
+     *
+     * A non-positive bound is the reachable case — `isUsableWidth` refuses it,
+     * and storage is an ordinary record the API or an import can write.
+     */
+    const rejected = {
+      viewport: [
+        { id: "tablet", label: "Tablet", maxWidth: 991 },
+        { id: "broken", label: "Broken", maxWidth: 0 },
+      ],
+      container: [],
+    } as unknown as BreakpointSet;
+
+    render(
+      <BreakpointSwitcher
+        breakpoints={rejected}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    // The accepted tier is asserted alongside, so a version rendering no
+    // options at all would not pass by dropping this one.
+    expect(screen.getByRole("radio", { name: /Tablet/ })).toBeDefined();
+    expect(screen.queryByRole("radio", { name: /Broken/ })).toBeNull();
+  });
+
+  it("does not count a stored row using the RESERVED base id", () => {
+    /*
+     * The plugin's own README documents a host config carrying
+     * `{ id: "base", label: "Base" }`, and a stored set can hold one too.
+     * Passed through, it appears as a tier named "Base" beside the "Full width"
+     * option this control already offers — two entries for one thing, one of
+     * which cannot be selected meaningfully.
+     *
+     * Asserted through the rendering rather than on a count, because the count
+     * is the mechanism and what the author sees is the property.
+     */
+    const withReserved = {
+      viewport: [{ id: "base", label: "Base", maxWidth: undefined }],
+      container: [],
+    } as unknown as BreakpointSet;
+
+    const { container } = render(
+      <BreakpointSwitcher
+        breakpoints={withReserved}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -191,8 +191,7 @@ describe("what the control reports as selected", () => {
      *
      * Without this the author sees "Full width" selected, edits what they
      * believe is the base tier, and every value silently goes to tablet — the
-     * exact "what you edit disagrees with what you see" state the founder's
-     * 2026-08-24 ruling deferred this control over.
+     * exact state where what you edit disagrees with what you see.
      *
      * The selection is asserted alongside, because the honest answer is BOTH:
      * the author did ask for the full width, and the box is in tablet.
@@ -476,5 +475,121 @@ describe("a site with no viewport breakpoints", () => {
     );
 
     expect(container.firstChild).toBeNull();
+  });
+});
+
+describe("a stored set the compiler has to reconcile", () => {
+  it("offers ONE option per id when a set carries the id twice", () => {
+    /*
+     * A set written through the API or an import can carry two rows with one
+     * id. `breakpointContexts` claims each id once, so the sheet has a single
+     * tier — but a control built from the raw definitions keeps both, giving
+     * two radios that share a React key and a bound, one of which can never be
+     * selected because the match resolves to the first.
+     *
+     * Asserted as a count over the whole group rather than "Tablet appears
+     * once", so a version emitting two DIFFERENTLY-labelled duplicates fails
+     * here too.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={{
+          viewport: [
+            { id: "tablet", label: "Tablet", maxWidth: 991 },
+            { id: "tablet", label: "Tablet Copy", maxWidth: 700 },
+          ],
+          container: [],
+        }}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    // Full width, and one tablet.
+    expect(options()).toHaveLength(2);
+  });
+
+  it("labels the surviving tier from the definition the compiler KEPT", () => {
+    /*
+     * Measured: among rows sharing an id the compiler keeps the WIDEST, not the
+     * first stored. A label looked up by id alone therefore names the surviving
+     * tier after the row the sheet discarded — here the control would offer a
+     * 991px tier called "Draft".
+     *
+     * The stored order puts the discarded row FIRST deliberately: with the kept
+     * row first, a by-id lookup would produce the right answer by accident and
+     * this case could not fail.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={{
+          viewport: [
+            { id: "tablet", label: "Draft", maxWidth: 700 },
+            { id: "tablet", label: "Tablet", maxWidth: 991 },
+          ],
+          container: [],
+        }}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(
+      screen.getByRole("radio", { name: "Tablet, up to 991 pixels" })
+    ).toBeDefined();
+    expect(screen.queryByRole("radio", { name: /Draft/ })).toBeNull();
+  });
+});
+
+describe("where focus goes when the keyboard moves the selection", () => {
+  it("moves FOCUS to the option the arrow key selected", () => {
+    /*
+     * The roving tabindex makes every unselected option `tabIndex={-1}`, so
+     * focus left behind is stranded on a button that is neither checked nor in
+     * the tab order. Assistive technology announces nothing for the option that
+     * just became selected, and every further arrow press changes a radio the
+     * user cannot hear.
+     *
+     * Asserted on `document.activeElement` rather than on a focus handler
+     * firing, because what matters is where focus ENDED UP.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    const group = screen.getByRole("radiogroup");
+    options()[0]?.focus();
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+
+    expect(document.activeElement).toBe(options()[1]);
+  });
+
+  it("leaves focus alone when the control is not ready", () => {
+    /*
+     * The control. Without it, a version that focused on every key event —
+     * including while disabled, where no selection can be made — would satisfy
+     * the case above.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="loading"
+      />
+    );
+
+    const group = screen.getByRole("radiogroup");
+    const before = document.activeElement;
+    fireEvent.keyDown(group, { key: "ArrowRight" });
+
+    expect(document.activeElement).toBe(before);
   });
 });

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -26,6 +26,16 @@ const site = (): BreakpointSet => ({
   container: [],
 });
 
+/*
+ * The tier indicator, read from the live region rather than by text.
+ *
+ * A text query would match the option BUTTON of the same name — "Tablet"
+ * appears on both — so an assertion phrased that way passes whether or not the
+ * indicator rendered at all, which is the one thing these cases are about.
+ */
+const appliedNote = (root: HTMLElement): HTMLElement | null =>
+  root.querySelector<HTMLElement>("[aria-live]");
+
 const options = (): HTMLElement[] => screen.getAllByRole("radio");
 const checked = (): HTMLElement[] =>
   options().filter(option => option.getAttribute("aria-checked") === "true");
@@ -136,7 +146,102 @@ describe("what the control reports as selected", () => {
     // The counterpart to the case above: selecting nothing must not mean saying
     // nothing. The width changed which declarations are live, and that is the
     // fact this control exists to make legible.
-    render(
+    const { container } = render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={700}
+        appliedWidth={700}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(appliedNote(container)?.textContent).toBe("700px · Tablet");
+  });
+
+  it("names the tier by its LABEL, not by its stored id", () => {
+    /*
+     * The id is an addressing detail an author never chose and may never have
+     * seen — a site is free to key its tablet tier `bp_2`. Reporting it here
+     * would put a string from the storage layer in front of the author at the
+     * one moment the control is explaining itself.
+     */
+    const { container } = render(
+      <BreakpointSwitcher
+        breakpoints={{
+          viewport: [{ id: "bp_2", label: "Tablet", maxWidth: 991 }],
+          container: [],
+        }}
+        width={700}
+        appliedWidth={700}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(appliedNote(container)?.textContent).toBe("700px · Tablet");
+  });
+
+  it("reports the tier a NARROW REGION put the canvas in, at the widest option", () => {
+    /*
+     * The case the mount actually produces, and the one this indicator exists
+     * for. `undefined` width asks for the full region; a region narrower than
+     * the widest tier's bound hands the box less, and the narrower tier is then
+     * what the browser paints and what an edit lands in.
+     *
+     * Without this the author sees "Full width" selected, edits what they
+     * believe is the base tier, and every value silently goes to tablet — the
+     * exact "what you edit disagrees with what you see" state the founder's
+     * 2026-08-24 ruling deferred this control over.
+     *
+     * The selection is asserted alongside, because the honest answer is BOTH:
+     * the author did ask for the full width, and the box is in tablet.
+     */
+    const { container } = render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        appliedWidth={900}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(checked()[0]?.getAttribute("aria-label")).toBe("Full width");
+    expect(appliedNote(container)?.textContent).toBe("900px · Tablet");
+  });
+
+  it("says NOTHING at the widest option when the region honoured it", () => {
+    /*
+     * The control on the case above, and Gutenberg's own finding: a badge at
+     * the widest tier is actively confusing, because edits there apply to every
+     * breakpoint rather than overriding one.
+     *
+     * Without this, a version that showed the indicator unconditionally would
+     * satisfy every assertion above.
+     */
+    const { container } = render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={undefined}
+        appliedWidth={1400}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(appliedNote(container)).toBeNull();
+  });
+
+  it("says nothing about a box that has NOT been measured", () => {
+    /*
+     * `appliedWidth` is undefined until the canvas reports its first
+     * measurement, and that is a real state rather than a missing default.
+     * Falling back to the REQUESTED width here would state a tier for a box
+     * nobody has looked at — and the request is a ceiling the region may not
+     * have honoured, so it is precisely the number that could be wrong.
+     */
+    const { container } = render(
       <BreakpointSwitcher
         breakpoints={site()}
         width={700}
@@ -145,8 +250,7 @@ describe("what the control reports as selected", () => {
       />
     );
 
-    expect(screen.getByText(/700px/)).toBeDefined();
-    expect(screen.getByText(/tablet/)).toBeDefined();
+    expect(appliedNote(container)).toBeNull();
   });
 
   it("selects the widest when the canvas is UNBOUNDED, which is the control", () => {

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -36,6 +36,17 @@ const site = (): BreakpointSet => ({
 const appliedNote = (root: HTMLElement): HTMLElement | null =>
   root.querySelector<HTMLElement>("[aria-live]");
 
+/**
+ * What the live region is SAYING, which is what varies.
+ *
+ * The element itself is mounted from the first render — a live region is
+ * registered when it enters the accessibility tree, and content arriving in the
+ * same insertion is often not announced — so its presence is not the signal and
+ * asserting on it would pass whatever the control reports.
+ */
+const applied = (root: HTMLElement): string =>
+  appliedNote(root)?.textContent ?? "";
+
 const options = (): HTMLElement[] => screen.getAllByRole("radio");
 const checked = (): HTMLElement[] =>
   options().filter(option => option.getAttribute("aria-checked") === "true");
@@ -156,7 +167,7 @@ describe("what the control reports as selected", () => {
       />
     );
 
-    expect(appliedNote(container)?.textContent).toBe("700px · Tablet");
+    expect(applied(container)).toBe("700px · Tablet");
   });
 
   it("names the tier by its LABEL, not by its stored id", () => {
@@ -179,7 +190,7 @@ describe("what the control reports as selected", () => {
       />
     );
 
-    expect(appliedNote(container)?.textContent).toBe("700px · Tablet");
+    expect(applied(container)).toBe("700px · Tablet");
   });
 
   it("reports the tier a NARROW REGION put the canvas in, at the widest option", () => {
@@ -207,7 +218,7 @@ describe("what the control reports as selected", () => {
     );
 
     expect(checked()[0]?.getAttribute("aria-label")).toBe("Full width");
-    expect(appliedNote(container)?.textContent).toBe("900px · Tablet");
+    expect(applied(container)).toBe("900px · Tablet");
   });
 
   it("says NOTHING at the widest option when the region honoured it", () => {
@@ -229,7 +240,14 @@ describe("what the control reports as selected", () => {
       />
     );
 
-    expect(appliedNote(container)).toBeNull();
+    expect(applied(container)).toBe("");
+    /*
+     * MOUNTED while empty. A live region is registered when it enters the
+     * accessibility tree, so one that appears together with its first text is
+     * often not announced — and the first tier change is the announcement that
+     * matters most.
+     */
+    expect(appliedNote(container)).not.toBeNull();
   });
 
   it("says nothing about a box that has NOT been measured", () => {
@@ -249,7 +267,14 @@ describe("what the control reports as selected", () => {
       />
     );
 
-    expect(appliedNote(container)).toBeNull();
+    expect(applied(container)).toBe("");
+    /*
+     * MOUNTED while empty. A live region is registered when it enters the
+     * accessibility tree, so one that appears together with its first text is
+     * often not announced — and the first tier change is the announcement that
+     * matters most.
+     */
+    expect(appliedNote(container)).not.toBeNull();
   });
 
   it("selects the widest when the canvas is UNBOUNDED, which is the control", () => {

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -33,15 +33,14 @@
 
 import {
   BASE_BREAKPOINT,
-  breakpointContexts,
   type BreakpointId,
   type BreakpointSet,
 } from "@nextlyhq/blocks-engine";
 import { cn } from "@nextlyhq/ui/utils";
 import * as React from "react";
 
-import { authoredBreakpoints, isUsableWidth } from "./breakpoints";
-import { editedBreakpointAtWidth } from "./canvas-width";
+import { authoredBreakpoints } from "./breakpoints";
+import { editedBreakpointAtWidth, offeredTiers } from "./canvas-width";
 
 /**
  * Props for BreakpointSwitcher.
@@ -122,9 +121,11 @@ export function BreakpointSwitcher({
    * to, and the page would not change — which reads as the feature being
    * broken rather than as the definition being unusable.
    *
-   * The contexts arrive widest-first, which is the order the cascade resolves
-   * in and the order every builder surveyed presents, so no second sort is
-   * applied here.
+   * `offeredTiers` also collapses tiers sharing a bound to the one the browser
+   * paints, because selecting a tier sets a WIDTH: two radios emitting the same
+   * number are not two choices, and clicking the second would select the first.
+   * It returns them widest-first, which is the order the cascade resolves in
+   * and the order every builder surveyed presents.
    *
    * The viewport axis only. A container tier is a question about an element's
    * query container, which sizing the canvas cannot answer — the same exclusion
@@ -153,19 +154,14 @@ export function BreakpointSwitcher({
     const authored = authoredBreakpoints(
       breakpoints ?? { viewport: [], container: [] }
     ).viewport;
-    return breakpointContexts(breakpoints)
-      .filter(
-        (context): context is typeof context & { maxWidth: number } =>
-          context.axis !== "container" && isUsableWidth(context.maxWidth)
-      )
-      .map(context => ({
-        id: context.id,
-        label:
-          authored.find(
-            def => def.id === context.id && def.maxWidth === context.maxWidth
-          )?.label ?? context.id,
-        bound: context.maxWidth,
-      }));
+    return offeredTiers(breakpoints).map(tier => ({
+      id: tier.id,
+      label:
+        authored.find(
+          def => def.id === tier.id && def.maxWidth === tier.maxWidth
+        )?.label ?? tier.id,
+      bound: tier.maxWidth,
+    }));
   }, [breakpoints]);
 
   /*

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -7,9 +7,9 @@
  * which tiers the page is applying are both derived from that width by
  * `canvas-width.ts`, so this component holds no notion of a "current
  * breakpoint" that could disagree with the box on screen. Gutenberg arrived at
- * the same arrangement in PR #75121 by unifying a device menu and a resizable
- * canvas that had been mutually exclusive: canvas width became the single
- * source of truth and the device menu was demoted to a way of setting one.
+ * the same arrangement by unifying a device menu and a resizable canvas that
+ * had been mutually exclusive: canvas width became the single source of truth
+ * and the device menu was demoted to a way of setting one.
  *
  * The founder's 2026-08-24 ruling deferred this control until canvas width
  * simulation existed, on the grounds that a selector changing which values you
@@ -51,6 +51,19 @@ export interface BreakpointSwitcherProps {
    * the widest tier, filling whatever the region allows.
    */
   width: number | undefined;
+  /**
+   * The box's MEASURED inline size, or `undefined` before anything was
+   * observed.
+   *
+   * Separate from {@link BreakpointSwitcherProps.width}, because the two are
+   * different facts and only one of them is a choice. The request is a CEILING:
+   * an editor region narrower than the tier asked for hands the box less, and
+   * what the container queries resolve against is the width the box got. Fed
+   * back in as `width` it would unselect the option the author just clicked;
+   * left out entirely, this control would state a tier for a box nobody looked
+   * at.
+   */
+  appliedWidth?: number;
   /** Size the canvas. `undefined` releases it back to the full region. */
   onSelect: (width: number | undefined) => void;
   /**
@@ -82,6 +95,7 @@ export interface BreakpointSwitcherProps {
 export function BreakpointSwitcher({
   breakpoints,
   width,
+  appliedWidth,
   onSelect,
   status,
 }: BreakpointSwitcherProps): React.JSX.Element | null {
@@ -106,7 +120,20 @@ export function BreakpointSwitcher({
     return inCascadeOrder(authored.viewport);
   }, [breakpoints]);
 
-  const edited = editedBreakpointAtWidth(breakpoints, width);
+  /*
+   * The tier the box is APPLYING, and the tier the SELECTION claims.
+   *
+   * Two derivations rather than one, because they answer to different widths
+   * and the whole point of the indicator below is the case where they differ.
+   * `undefined` applied means nothing has been measured, which is a real state:
+   * this control then says nothing rather than describing a box nobody looked
+   * at.
+   */
+  const appliedTier =
+    appliedWidth === undefined
+      ? undefined
+      : editedBreakpointAtWidth(breakpoints, appliedWidth);
+  const claimedTier = editedBreakpointAtWidth(breakpoints, width);
   /*
    * Whether the width is one this control could have SET.
    *
@@ -175,6 +202,29 @@ export function BreakpointSwitcher({
   // Falls back to the widest, which always exists: a roving tabindex with no
   // stop at all removes the control from the tab order entirely.
   const activeIndex = matchedIndex >= 0 ? matchedIndex : 0;
+
+  /*
+   * Whether the selection already accounts for what is applying.
+   *
+   * Two ways it does not, and both need saying. An unmatched width — one no
+   * option could have set — leaves every option unselected, and selecting
+   * nothing must not mean saying nothing. And a matched option whose tier the
+   * box is not actually in is the narrow-region case: the author asked for the
+   * full width, the region handed the box less than the widest tier's bound,
+   * and their edits are landing in a narrower tier with nothing on screen to
+   * say so. That is the confusion the founder's 2026-08-24 ruling named, and
+   * the reason this indicator is not merely decorative.
+   */
+  const describedBySelection = matchedIndex >= 0 && appliedTier === claimedTier;
+  /*
+   * The tier's own label, never its id. A bounded tier is found among the
+   * options; anything else is the unconditional one, whose id a site may spell
+   * differently and which this control already names "Full width".
+   */
+  const appliedLabel =
+    options.find(
+      option => option.bound !== undefined && option.id === appliedTier
+    )?.label ?? "Full width";
 
   const move = (delta: number): void => {
     const next =
@@ -249,21 +299,22 @@ export function BreakpointSwitcher({
         );
       })}
       {/*
-       * What the canvas is APPLYING, which is not always what was selected.
+       * What the canvas is APPLYING, shown only when the selection does not
+       * already say it.
        *
-       * Announced politely rather than drawn silently: an author who resizes to
-       * a width between two bounds has changed which declarations are live, and
-       * that is exactly the fact this whole control exists to make legible.
-       * Hidden at the widest tier, where Gutenberg found a badge actively
-       * confusing — edits there apply to every breakpoint, so it is the default
-       * rather than an override, and labelling it as a tier suggests otherwise.
+       * Announced politely rather than drawn silently: which declarations are
+       * live has changed, and that is exactly the fact this whole control
+       * exists to make legible. Hidden when the selected option already
+       * describes the applying tier — which at the widest tier is the case
+       * Gutenberg found a badge actively confusing, since edits there apply to
+       * every breakpoint and labelling that as a tier suggests otherwise.
        */}
-      {ready && !exact && !atWidest ? (
+      {ready && appliedTier !== undefined && !describedBySelection ? (
         <span
           className="text-muted-foreground px-1 text-xs tabular-nums"
           aria-live="polite"
         >
-          {width}px · {edited}
+          {appliedWidth}px · {appliedLabel}
         </span>
       ) : null}
     </div>

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -345,19 +345,25 @@ export function BreakpointSwitcher({
        *
        * Announced politely rather than drawn silently: which declarations are
        * live has changed, and that is exactly the fact this whole control
-       * exists to make legible. Hidden when the selected option already
+       * exists to make legible. Empty when the selected option already
        * describes the applying tier — which at the widest tier is the case
        * Gutenberg found a badge actively confusing, since edits there apply to
        * every breakpoint and labelling that as a tier suggests otherwise.
+       *
+       * The element is MOUNTED from the first render and only its text changes.
+       * A live region is registered when it enters the accessibility tree, and
+       * content arriving in the same insertion is often not announced — so
+       * rendering the span only once there is something to say would lose the
+       * first tier change, which is the one that matters most.
        */}
-      {ready && appliedTier !== undefined && !describedBySelection ? (
-        <span
-          className="text-muted-foreground px-1 text-xs tabular-nums"
-          aria-live="polite"
-        >
-          {appliedWidth}px · {appliedLabel}
-        </span>
-      ) : null}
+      <span
+        className="text-muted-foreground px-1 text-xs tabular-nums"
+        aria-live="polite"
+      >
+        {ready && appliedTier !== undefined && !describedBySelection
+          ? `${appliedWidth}px · ${appliedLabel}`
+          : ""}
+      </span>
     </div>
   );
 }

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -11,19 +11,18 @@
  * had been mutually exclusive: canvas width became the single source of truth
  * and the device menu was demoted to a way of setting one.
  *
- * The founder's 2026-08-24 ruling deferred this control until canvas width
- * simulation existed, on the grounds that a selector changing which values you
- * edit while the canvas still shows desktop is confusing. That is precisely the
- * state deriving both facts from one width makes unrepresentable.
+ * A selector that changed which values you edit while the canvas still showed
+ * desktop would leave the author editing one tier and looking at another.
+ * Deriving both facts from one width makes that state unrepresentable rather
+ * than merely unlikely.
  *
  * **A breakpoint selector, not a device preview.** It says which of the site's
  * tiers the canvas is sized to; it does not promise that the result matches
  * what a visitor sees. It cannot: the canvas is not an iframe, so a page sized
  * in `vw`/`vh`, a hand-authored `@media` rule, or a block reading
- * `window.innerWidth` still answers to the admin window. `decision:preview-truth-is-the-iframe`
- * settles that the iframe is the authoritative preview and this is the correct
- * interim, so the labels here stay in the vocabulary of breakpoints and make no
- * fidelity claim.
+ * `window.innerWidth` still answers to the admin window. An iframe is what can
+ * make a preview authoritative; until the canvas is one, the labels here stay
+ * in the vocabulary of breakpoints and make no fidelity claim.
  *
  * **In the top bar beside the manager**, which `breakpoint-manager.tsx` chose
  * its own placement to leave room for: the two read as one control — what the
@@ -32,12 +31,17 @@
  * @module breakpoint-switcher
  */
 
-import type { BreakpointId, BreakpointSet } from "@nextlyhq/blocks-engine";
+import {
+  BASE_BREAKPOINT,
+  breakpointContexts,
+  type BreakpointId,
+  type BreakpointSet,
+} from "@nextlyhq/blocks-engine";
 import { cn } from "@nextlyhq/ui/utils";
 import * as React from "react";
 
-import { authoredBreakpoints, inCascadeOrder } from "./breakpoints";
-import { editedBreakpointAtWidth, widthForBreakpoint } from "./canvas-width";
+import { authoredBreakpoints, isUsableWidth } from "./breakpoints";
+import { editedBreakpointAtWidth } from "./canvas-width";
 
 /**
  * Props for BreakpointSwitcher.
@@ -101,23 +105,67 @@ export function BreakpointSwitcher({
 }: BreakpointSwitcherProps): React.JSX.Element | null {
   const ready = status === "ready";
   /*
-   * The AUTHORED set, in cascade order.
+   * The tiers this control offers, taken from the COMPILER's contexts rather
+   * than from the stored definitions.
    *
-   * `authoredBreakpoints` strips a stored row using the reserved base id — the
-   * plugin's own README documents a host config carrying one — which would
-   * otherwise appear here as a tier named "Base" beside the unconditional tier
-   * this control already offers, two entries for one thing. `inCascadeOrder`
-   * puts them widest-first, which is the order the cascade resolves in and the
-   * order every builder surveyed presents.
+   * `breakpointContexts` is the only reader that decides what a site's
+   * breakpoints ARE for the sheet: it drops a definition whose bound it cannot
+   * use, and — the case that matters here — it claims each id ONCE, so a stored
+   * set carrying two rows with the same id yields one context. Built from the
+   * raw definitions instead, this list keeps both: two radios sharing a React
+   * key, sharing a bound, and one of them permanently unselectable because the
+   * match resolves to the first. The stylesheet has one tier and the control
+   * offers two, only one of which does anything.
+   *
+   * A tier the compiler emits no bound for is DROPPED for the same reason. The
+   * author would pick it, the canvas would resize to a number nothing responds
+   * to, and the page would not change — which reads as the feature being
+   * broken rather than as the definition being unusable.
+   *
+   * The contexts arrive widest-first, which is the order the cascade resolves
+   * in and the order every builder surveyed presents, so no second sort is
+   * applied here.
+   *
+   * The viewport axis only. A container tier is a question about an element's
+   * query container, which sizing the canvas cannot answer — the same exclusion
+   * `canvas-width.ts` makes, for the same reason.
    */
   const tiers = React.useMemo(() => {
+    /*
+     * Labels come from the authored set, because a context carries none — and
+     * are matched on the BOUND as well as the id.
+     *
+     * Measured: among rows sharing an id, `breakpointContexts` keeps the
+     * WIDEST rather than the first stored. So a lookup by id alone can label
+     * the surviving tier after a definition the sheet discarded — stored as
+     * `[{tablet, 700, "Draft"}, {tablet, 991, "Tablet"}]`, the sheet has the
+     * 991 tier and the control would call it "Draft".
+     *
+     * Falling back to the id rather than to another row's label: a context with
+     * no authored definition at that bound has no honest name here, and
+     * borrowing one would attach a label to a tier it does not describe.
+     *
+     * `authoredBreakpoints` strips a stored row using the reserved base id —
+     * the plugin's own README documents a host config carrying one — so its
+     * label cannot be picked up for the unconditional tier this control
+     * already names.
+     */
     const authored = authoredBreakpoints(
       breakpoints ?? { viewport: [], container: [] }
-    );
-    // The viewport axis only. A container tier is a question about an element's
-    // query container, which sizing the canvas cannot answer — the same
-    // exclusion `canvas-width.ts` makes, for the same reason.
-    return inCascadeOrder(authored.viewport);
+    ).viewport;
+    return breakpointContexts(breakpoints)
+      .filter(
+        (context): context is typeof context & { maxWidth: number } =>
+          context.axis !== "container" && isUsableWidth(context.maxWidth)
+      )
+      .map(context => ({
+        id: context.id,
+        label:
+          authored.find(
+            def => def.id === context.id && def.maxWidth === context.maxWidth
+          )?.label ?? context.id,
+        bound: context.maxWidth,
+      }));
   }, [breakpoints]);
 
   /*
@@ -148,9 +196,7 @@ export function BreakpointSwitcher({
    * nothing while the tier indicator still reports what is applying. Gutenberg
    * needed the same distinction once it allowed free resizing.
    */
-  const exact = tiers.some(
-    tier => widthForBreakpoint(breakpoints, tier.id) === width
-  );
+  const exact = tiers.some(tier => tier.bound === width);
   const atWidest = width === undefined;
 
   /*
@@ -160,32 +206,9 @@ export function BreakpointSwitcher({
    * user one Tab per breakpoint to cross a control they may not be using, and
    * assistive technology announces the group's size for them anyway.
    */
-  /*
-   * The bound comes from the COMPILER, not from the stored definition.
-   *
-   * They are the same number whenever the compiler accepted the definition, and
-   * the case that matters is the one where it did not: `breakpointContexts`
-   * applies its own reading of a stored axis, so a definition it declines to
-   * emit a bounded context for has no query in the sheet at all. Sizing the
-   * canvas to that stored width would put the box at a number nothing responds
-   * to — the author picks a tier, the canvas resizes, and the page does not
-   * change, which reads as the whole feature being broken.
-   *
-   * A tier the compiler emits no bound for is therefore DROPPED rather than
-   * offered, which is the honest answer: there is nothing to switch to.
-   */
   const options: Array<{ id: BreakpointId; label: string; bound?: number }> = [
-    { id: "base", label: "Full width" },
-    ...tiers
-      .map(tier => ({
-        id: tier.id,
-        label: tier.label,
-        bound: widthForBreakpoint(breakpoints, tier.id),
-      }))
-      .filter(
-        (option): option is typeof option & { bound: number } =>
-          option.bound !== undefined
-      ),
+    { id: BASE_BREAKPOINT, label: "Full width" },
+    ...tiers,
   ];
   /*
    * Which option the current width CORRESPONDS to, or -1 for none.
@@ -212,8 +235,8 @@ export function BreakpointSwitcher({
    * box is not actually in is the narrow-region case: the author asked for the
    * full width, the region handed the box less than the widest tier's bound,
    * and their edits are landing in a narrower tier with nothing on screen to
-   * say so. That is the confusion the founder's 2026-08-24 ruling named, and
-   * the reason this indicator is not merely decorative.
+   * say so. That is what makes this indicator load-bearing rather than
+   * decorative.
    */
   const describedBySelection = matchedIndex >= 0 && appliedTier === claimedTier;
   /*
@@ -226,10 +249,29 @@ export function BreakpointSwitcher({
       option => option.bound !== undefined && option.id === appliedTier
     )?.label ?? "Full width";
 
+  /*
+   * The rendered radios, so an arrow key can move FOCUS as well as selection.
+   *
+   * A roving tabindex makes the unselected options `tabIndex={-1}`, so leaving
+   * focus where it was after an arrow press strands it on a button that is no
+   * longer checked and no longer in the tab order. Assistive technology then
+   * announces nothing for the option that just became selected, and every
+   * further arrow press changes a radio the user cannot hear — which is the
+   * failure mode the roving pattern exists to avoid rather than a refinement
+   * of it.
+   */
+  const radios = React.useRef<Array<HTMLButtonElement | null>>([]);
+
   const move = (delta: number): void => {
-    const next =
-      options[(activeIndex + delta + options.length) % options.length];
+    const index = (activeIndex + delta + options.length) % options.length;
+    const next = options[index];
     if (next === undefined) return;
+    /*
+     * Focused BEFORE the selection is raised, while the element is still the
+     * one this render drew. Raising first re-renders the group, and the ref
+     * this reads may then point at a node React has already replaced.
+     */
+    radios.current[index]?.focus();
     onSelect(next.bound);
   };
 
@@ -264,6 +306,9 @@ export function BreakpointSwitcher({
         return (
           <button
             key={option.id}
+            ref={element => {
+              radios.current[index] = element;
+            }}
             type="button"
             role="radio"
             aria-checked={selected}

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+/**
+ * The control that sizes the canvas, and thereby chooses the tier being edited.
+ *
+ * **It sets a WIDTH, and nothing else.** Which tier the inspector edits and
+ * which tiers the page is applying are both derived from that width by
+ * `canvas-width.ts`, so this component holds no notion of a "current
+ * breakpoint" that could disagree with the box on screen. Gutenberg arrived at
+ * the same arrangement in PR #75121 by unifying a device menu and a resizable
+ * canvas that had been mutually exclusive: canvas width became the single
+ * source of truth and the device menu was demoted to a way of setting one.
+ *
+ * The founder's 2026-08-24 ruling deferred this control until canvas width
+ * simulation existed, on the grounds that a selector changing which values you
+ * edit while the canvas still shows desktop is confusing. That is precisely the
+ * state deriving both facts from one width makes unrepresentable.
+ *
+ * **A breakpoint selector, not a device preview.** It says which of the site's
+ * tiers the canvas is sized to; it does not promise that the result matches
+ * what a visitor sees. It cannot: the canvas is not an iframe, so a page sized
+ * in `vw`/`vh`, a hand-authored `@media` rule, or a block reading
+ * `window.innerWidth` still answers to the admin window. `decision:preview-truth-is-the-iframe`
+ * settles that the iframe is the authoritative preview and this is the correct
+ * interim, so the labels here stay in the vocabulary of breakpoints and make no
+ * fidelity claim.
+ *
+ * **In the top bar beside the manager**, which `breakpoint-manager.tsx` chose
+ * its own placement to leave room for: the two read as one control — what the
+ * site's breakpoints ARE, and which one you are looking at.
+ *
+ * @module breakpoint-switcher
+ */
+
+import type { BreakpointId, BreakpointSet } from "@nextlyhq/blocks-engine";
+import { cn } from "@nextlyhq/ui/utils";
+import * as React from "react";
+
+import { authoredBreakpoints, inCascadeOrder } from "./breakpoints";
+import { editedBreakpointAtWidth, widthForBreakpoint } from "./canvas-width";
+
+/**
+ * Props for BreakpointSwitcher.
+ * @experimental
+ */
+export interface BreakpointSwitcherProps {
+  /** The site's saved breakpoints, as the canvas is compiled against them. */
+  breakpoints: BreakpointSet | undefined;
+  /**
+   * The canvas's current width in CSS pixels, or `undefined` for unbounded —
+   * the widest tier, filling whatever the region allows.
+   */
+  width: number | undefined;
+  /** Size the canvas. `undefined` releases it back to the full region. */
+  onSelect: (width: number | undefined) => void;
+  /**
+   * What the saved set's read has actually done, mirroring
+   * {@link BreakpointManagerProps.status} — and disabled for the same reason,
+   * which is stronger here than it looks.
+   *
+   * Until the read answers, the value in hand is the host's CONFIG DEFAULTS. A
+   * switcher offering those would size the canvas to a bound the site never
+   * chose, and every edit made at that width would land in whichever tier the
+   * default bound implies — writing to a breakpoint the author never selected,
+   * with nothing on screen to say so.
+   */
+  status: "loading" | "unavailable" | "ready";
+}
+
+/**
+ * A segmented control over the site's viewport tiers, widest first.
+ *
+ * `radiogroup` rather than a row of buttons or a `tablist`: this is a
+ * single-choice control over a small set, which is what a radio group means,
+ * and it buys arrow-key navigation that assistive technology already announces.
+ * A `tablist` would be wrong — no panel is being switched — and plain buttons
+ * would leave a screen-reader user with no indication that choosing one
+ * deselects the others.
+ *
+ * @experimental
+ */
+export function BreakpointSwitcher({
+  breakpoints,
+  width,
+  onSelect,
+  status,
+}: BreakpointSwitcherProps): React.JSX.Element | null {
+  const ready = status === "ready";
+  /*
+   * The AUTHORED set, in cascade order.
+   *
+   * `authoredBreakpoints` strips a stored row using the reserved base id — the
+   * plugin's own README documents a host config carrying one — which would
+   * otherwise appear here as a tier named "Base" beside the unconditional tier
+   * this control already offers, two entries for one thing. `inCascadeOrder`
+   * puts them widest-first, which is the order the cascade resolves in and the
+   * order every builder surveyed presents.
+   */
+  const tiers = React.useMemo(() => {
+    const authored = authoredBreakpoints(
+      breakpoints ?? { viewport: [], container: [] }
+    );
+    // The viewport axis only. A container tier is a question about an element's
+    // query container, which sizing the canvas cannot answer — the same
+    // exclusion `canvas-width.ts` makes, for the same reason.
+    return inCascadeOrder(authored.viewport);
+  }, [breakpoints]);
+
+  const edited = editedBreakpointAtWidth(breakpoints, width);
+  /*
+   * Whether the width is one this control could have SET.
+   *
+   * A canvas can be sized to anything — a drag handle, a narrowed window, a
+   * region that simply is not as wide as the widest tier's bound. Reporting the
+   * derived tier as though it had been chosen would then be a claim the author
+   * did not make: at 700px on a site whose tablet bound is 991, the tablet
+   * rules are live and the canvas is NOT at the tablet width, and an author
+   * reading a selected "Tablet" would reasonably expect the box to be 991.
+   *
+   * So the selection is exact-match, and a width between bounds selects
+   * nothing while the tier indicator still reports what is applying. Gutenberg
+   * needed the same distinction once it allowed free resizing.
+   */
+  const exact = tiers.some(
+    tier => widthForBreakpoint(breakpoints, tier.id) === width
+  );
+  const atWidest = width === undefined;
+
+  /*
+   * Roving tabindex: one stop for the whole group, arrows move within it.
+   *
+   * A radio group that put every option in the tab order would cost a keyboard
+   * user one Tab per breakpoint to cross a control they may not be using, and
+   * assistive technology announces the group's size for them anyway.
+   */
+  /*
+   * The bound comes from the COMPILER, not from the stored definition.
+   *
+   * They are the same number whenever the compiler accepted the definition, and
+   * the case that matters is the one where it did not: `breakpointContexts`
+   * applies its own reading of a stored axis, so a definition it declines to
+   * emit a bounded context for has no query in the sheet at all. Sizing the
+   * canvas to that stored width would put the box at a number nothing responds
+   * to — the author picks a tier, the canvas resizes, and the page does not
+   * change, which reads as the whole feature being broken.
+   *
+   * A tier the compiler emits no bound for is therefore DROPPED rather than
+   * offered, which is the honest answer: there is nothing to switch to.
+   */
+  const options: Array<{ id: BreakpointId; label: string; bound?: number }> = [
+    { id: "base", label: "Full width" },
+    ...tiers
+      .map(tier => ({
+        id: tier.id,
+        label: tier.label,
+        bound: widthForBreakpoint(breakpoints, tier.id),
+      }))
+      .filter(
+        (option): option is typeof option & { bound: number } =>
+          option.bound !== undefined
+      ),
+  ];
+  /*
+   * Which option the current width CORRESPONDS to, or -1 for none.
+   *
+   * Separate from the keyboard's landing spot below, because they answer
+   * different questions and collapsing them makes a custom width look chosen.
+   * At 700px on a site whose tablet bound is 991 no option is selected — the
+   * tablet rules are live and the canvas is not at the tablet width — while the
+   * keyboard still needs somewhere to land.
+   */
+  const matchedIndex = options.findIndex(option =>
+    option.bound === undefined ? atWidest : exact && option.bound === width
+  );
+  // Falls back to the widest, which always exists: a roving tabindex with no
+  // stop at all removes the control from the tab order entirely.
+  const activeIndex = matchedIndex >= 0 ? matchedIndex : 0;
+
+  const move = (delta: number): void => {
+    const next =
+      options[(activeIndex + delta + options.length) % options.length];
+    if (next === undefined) return;
+    onSelect(next.bound);
+  };
+
+  /*
+   * Nothing at all when the site defines no viewport breakpoints.
+   *
+   * A control offering one option is not a choice, and "Full width" alone
+   * occupies top-bar space to say the canvas is the width it visibly is. The
+   * manager beside it is where an author adds tiers, so the affordance is not
+   * lost — it appears when there is something to switch between.
+   */
+  if (tiers.length === 0) return null;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Canvas width"
+      className="nx-breakpoint-switcher inline-flex items-center gap-0.5 rounded-md border p-0.5"
+      onKeyDown={event => {
+        if (!ready) return;
+        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
+          event.preventDefault();
+          move(1);
+        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
+          event.preventDefault();
+          move(-1);
+        }
+      }}
+    >
+      {options.map((option, index) => {
+        const selected = ready && index === matchedIndex;
+        return (
+          <button
+            key={option.id}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            disabled={!ready}
+            /*
+             * The WIDTH is in the accessible name, not only in the tooltip.
+             * "Tablet" alone does not say what selecting it will do, and the
+             * number is the whole content of the choice.
+             */
+            aria-label={
+              option.bound === undefined
+                ? "Full width"
+                : `${option.label}, up to ${option.bound} pixels`
+            }
+            title={
+              ready
+                ? undefined
+                : status === "loading"
+                  ? "Available once the site's saved styles have loaded."
+                  : "Your site's saved styles could not be read, so the canvas cannot be sized against them."
+            }
+            tabIndex={index === activeIndex ? 0 : -1}
+            onClick={() => onSelect(option.bound)}
+            className={cn(
+              "rounded px-2 py-1 text-xs",
+              selected
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground"
+            )}
+          >
+            <span aria-hidden="true">{option.label}</span>
+          </button>
+        );
+      })}
+      {/*
+       * What the canvas is APPLYING, which is not always what was selected.
+       *
+       * Announced politely rather than drawn silently: an author who resizes to
+       * a width between two bounds has changed which declarations are live, and
+       * that is exactly the fact this whole control exists to make legible.
+       * Hidden at the widest tier, where Gutenberg found a badge actively
+       * confusing — edits there apply to every breakpoint, so it is the default
+       * rather than an override, and labelling it as a tier suggests otherwise.
+       */}
+      {ready && !exact && !atWidest ? (
+        <span
+          className="text-muted-foreground px-1 text-xs tabular-nums"
+          aria-live="polite"
+        >
+          {width}px · {edited}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/builder/src/canvas-width.test.ts
+++ b/packages/builder/src/canvas-width.test.ts
@@ -1,0 +1,213 @@
+/**
+ * That a canvas width decides which tiers apply and which one an edit lands in,
+ * and that this module's arithmetic still agrees with the query the compiler
+ * emits.
+ *
+ * The last one is the point of the file. Everything else here could be correct
+ * against a compiler that has moved, and the failure would be silent: the
+ * canvas would size a box, report a tier, and the sheet inside it would be
+ * obeying a different condition.
+ *
+ * @module canvas-width.test
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  breakpointContexts,
+  type BreakpointSet,
+} from "@nextlyhq/blocks-engine";
+
+import {
+  breakpointsAtWidth,
+  editedBreakpointAtWidth,
+  widthForBreakpoint,
+} from "./canvas-width";
+
+const site = (): BreakpointSet => ({
+  viewport: [
+    { id: "tablet", label: "Tablet", maxWidth: 991 },
+    { id: "mobile", label: "Mobile", maxWidth: 575 },
+  ],
+  container: [],
+});
+
+describe("which tiers a canvas of a given width is applying", () => {
+  it("applies a tier AT its bound, because the query is inclusive", () => {
+    /*
+     * The boundary, and the direction that matters. `(max-width: 991px)` applies
+     * at exactly 991, so an off-by-one here puts the canvas one pixel outside
+     * the tier the switcher just selected — the author picks Tablet, the box is
+     * sized to the tablet bound, and the page renders desktop.
+     *
+     * Asserted at 991 and at 992 together, so a version that simply always
+     * included the tier passes neither.
+     */
+    expect(breakpointsAtWidth(site(), 991)).toContain("tablet");
+    expect(breakpointsAtWidth(site(), 992)).not.toContain("tablet");
+  });
+
+  it("applies EVERY tier the width is inside, not just the narrowest", () => {
+    // Desktop-first: at 500 the base, tablet and mobile declarations are all in
+    // play and the cascade decides between them. Reporting only the narrowest
+    // would tell the panel that a value authored at tablet is not live, when it
+    // is exactly what the browser falls back to for anything mobile omits.
+    const live = breakpointsAtWidth(site(), 500);
+
+    expect(live).toContain("base");
+    expect(live).toContain("tablet");
+    expect(live).toContain("mobile");
+  });
+
+  it("applies the unconditional tier ALONE at a width above every bound", () => {
+    // The control for the case above: without it, a function returning every
+    // id at every width would satisfy the containment assertions there.
+    expect(breakpointsAtWidth(site(), 1600)).toEqual(["base"]);
+  });
+
+  it("reports the unconditional tier alone when nothing has been MEASURED", () => {
+    /*
+     * `undefined` is "no layout has run yet", which is a different fact from any
+     * particular width and must not be guessed at.
+     *
+     * Reporting the widest preset here would be a claim about a box nobody has
+     * measured, and it would also disagree with the server render — React
+     * discards a subtree whose two renders differ, which would take the Style
+     * tab with it.
+     */
+    expect(breakpointsAtWidth(site(), undefined)).toEqual(["base"]);
+  });
+
+  it("EXCLUDES the container axis, which a width cannot answer for", () => {
+    /*
+     * Even at its widest a container context emits `@container (min-width: 0)`,
+     * which matches only an element that HAS a query container above it.
+     * Whether the selected block does is a fact about the rendered tree, so a
+     * width cannot decide it — and including it would report a container
+     * declaration as live for a block the browser applies nothing to.
+     *
+     * The viewport tier of the same width is asserted alongside, so a function
+     * that dropped every tier would not pass by excluding this one.
+     */
+    const withContainer: BreakpointSet = {
+      viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+      container: [{ id: "card", label: "Card", maxWidth: 991 }],
+    };
+
+    const live = breakpointsAtWidth(withContainer, 500);
+
+    expect(live).toContain("tablet");
+    expect(live).not.toContain("card");
+  });
+});
+
+describe("which tier an edit lands in", () => {
+  it("lands in the NARROWEST tier applying, which is what the browser paints", () => {
+    /*
+     * At 500 both tablet and mobile apply and mobile is what wins. An edit that
+     * landed in tablet there would change a value the author cannot see change,
+     * because the mobile declaration is still covering it.
+     */
+    expect(editedBreakpointAtWidth(site(), 500)).toBe("mobile");
+    expect(editedBreakpointAtWidth(site(), 800)).toBe("tablet");
+  });
+
+  it("lands in the unconditional tier above every bound", () => {
+    expect(editedBreakpointAtWidth(site(), 1600)).toBe("base");
+  });
+
+  it("lands in the unconditional tier for a site defining NO breakpoints", () => {
+    // Not an error and not a guess: a site with no tiers edits the tier it has.
+    expect(editedBreakpointAtWidth({ viewport: [], container: [] }, 400)).toBe(
+      "base"
+    );
+  });
+
+  it("never lands in a CONTAINER tier, however narrow the canvas", () => {
+    // The counterpart to the exclusion above, stated where it would do damage:
+    // an edit addressed to a container tier is written into a context the
+    // canvas cannot show, so the author sees nothing happen.
+    const withContainer: BreakpointSet = {
+      viewport: [],
+      container: [{ id: "card", label: "Card", maxWidth: 300 }],
+    };
+
+    expect(editedBreakpointAtWidth(withContainer, 200)).toBe("base");
+  });
+});
+
+describe("the width a tier is shown at", () => {
+  it("is the tier's OWN bound, where it is at its roomiest", () => {
+    // Inclusive, so the bound is inside the tier — and it is the width at which
+    // a layout decision for that tier is actually made.
+    expect(widthForBreakpoint(site(), "tablet")).toBe(991);
+    expect(widthForBreakpoint(site(), "mobile")).toBe(575);
+  });
+
+  it("is UNBOUNDED for the unconditional tier, not a number", () => {
+    /*
+     * `undefined` means "as wide as the region allows". Pinning the widest tier
+     * to a number would invent a bound the site never declared and make the
+     * widest preset narrower than the space available — the canvas would gain
+     * empty gutters on selecting the tier it was already showing.
+     */
+    expect(widthForBreakpoint(site(), "base")).toBeUndefined();
+  });
+
+  it("is UNBOUNDED for an id the site does not define", () => {
+    // Refusing to size rather than sizing to a guess: an unknown id is a
+    // caller's mistake, and a canvas that silently narrowed would look like the
+    // switcher worked.
+    expect(widthForBreakpoint(site(), "watch")).toBeUndefined();
+  });
+});
+
+describe("the arithmetic still agrees with the query the compiler emits", () => {
+  it("matches the emitted at-rule at every boundary, for every tier", () => {
+    /*
+     * The test this file exists for.
+     *
+     * `matchedBreakpoints` deliberately evaluates each context's OWN at-rule
+     * text and its docblock warns that width arithmetic beside it would be a
+     * second implementation of the same condition. This module does its
+     * arithmetic on `maxWidth` — the structured field the compiler DERIVES that
+     * text from — so the two are downstream of one value rather than two
+     * readings of one string.
+     *
+     * That is an argument, not a guarantee. This pins it: the emitted text is
+     * parsed back and compared against this module's answer at each tier's
+     * bound and one pixel either side. A compiler that moved to `min-width`, to
+     * a different unit, to a half-open bound, or to a range syntax fails here —
+     * rather than silently sizing a box the sheet inside it disagrees with.
+     */
+    const set = site();
+    const contexts = breakpointContexts(set).filter(
+      context => context.axis !== "container" && context.maxWidth !== undefined
+    );
+
+    // The population, asserted before the property: an empty context list would
+    // satisfy every comparison below without comparing anything.
+    expect(contexts).toHaveLength(2);
+
+    for (const context of contexts) {
+      const emitted = /^@media \(max-width: (\d+)px\)$/.exec(
+        context.atRule ?? ""
+      );
+      // The emitted FORM is part of the claim, not incidental to it. A context
+      // whose at-rule this cannot read is a compiler change, and failing here
+      // is the whole point.
+      expect(
+        emitted,
+        `unreadable at-rule: ${context.atRule ?? "none"}`
+      ).not.toBeNull();
+      const bound = Number(emitted?.[1]);
+      expect(bound).toBe(context.maxWidth);
+
+      for (const width of [bound - 1, bound, bound + 1]) {
+        expect(
+          breakpointsAtWidth(set, width).includes(context.id),
+          `${context.id} at ${width}px`
+        ).toBe(width <= bound);
+      }
+    }
+  });
+});

--- a/packages/builder/src/canvas-width.test.ts
+++ b/packages/builder/src/canvas-width.test.ts
@@ -257,6 +257,18 @@ describe("two tiers sharing one bound", () => {
     expect(editedBreakpointAtWidth(shared(), 991)).toBe("beta");
   });
 
+  it("resolves NO width for the tier that lost the bound", () => {
+    /*
+     * `offeredTiers` collapses the two to the one the browser paints, and
+     * `editedBreakpointAtWidth` writes there. A width lookup that still
+     * answered for the loser would let a host set that width believing it
+     * selected `alpha` while every edit lands in `beta` — the disagreement
+     * between the control and the write that collapsing exists to remove.
+     */
+    expect(widthForBreakpoint(shared(), "beta")).toBe(991);
+    expect(widthForBreakpoint(shared(), "alpha")).toBeUndefined();
+  });
+
   it("still separates tiers whose bounds DIFFER", () => {
     /*
      * The control. Without it, a collapse keyed on something other than the

--- a/packages/builder/src/canvas-width.test.ts
+++ b/packages/builder/src/canvas-width.test.ts
@@ -21,6 +21,7 @@ import {
   breakpointsAtWidth,
   editedBreakpointAtWidth,
   widthForBreakpoint,
+  offeredTiers,
 } from "./canvas-width";
 
 const site = (): BreakpointSet => ({
@@ -209,5 +210,70 @@ describe("the arithmetic still agrees with the query the compiler emits", () => 
         ).toBe(width <= bound);
       }
     }
+  });
+});
+
+describe("two tiers sharing one bound", () => {
+  /*
+   * A stored set can carry two viewport ids with the same `maxWidth` — written
+   * through the API or an import, which the document model calls an error and
+   * compilation does not assume validation caught.
+   *
+   * Measured against the compiler: both are emitted, in order, into a SINGLE
+   * at-rule, so the LATER one's declarations are what the browser paints.
+   */
+  const shared = (): BreakpointSet => ({
+    viewport: [
+      { id: "alpha", label: "Alpha", maxWidth: 991 },
+      { id: "beta", label: "Beta", maxWidth: 991 },
+    ],
+    container: [],
+  });
+
+  it("offers ONE of them, since selecting a tier only sets a width", () => {
+    /*
+     * Two radios emitting the same number are not two choices: the match
+     * resolves to one, and clicking the other silently selects the first.
+     */
+    expect(offeredTiers(shared())).toHaveLength(1);
+  });
+
+  it("offers the one the browser PAINTS, not the one stored first", () => {
+    /*
+     * The discriminating half. A collapse keeping the first would satisfy the
+     * count above while naming a tier whose value is overridden by the one
+     * below it in the same at-rule — the author edits `alpha`, the page shows
+     * `beta`, and nothing on screen says why.
+     */
+    expect(offeredTiers(shared())[0]?.id).toBe("beta");
+  });
+
+  it("lands an edit in the tier that WINS at that width", () => {
+    /*
+     * The same rule read through the other derivation, which has to agree with
+     * the list above or the control offers one tier and the inspector writes to
+     * another.
+     */
+    expect(editedBreakpointAtWidth(shared(), 991)).toBe("beta");
+  });
+
+  it("still separates tiers whose bounds DIFFER", () => {
+    /*
+     * The control. Without it, a collapse keyed on something other than the
+     * bound — or one that kept a single tier unconditionally — would satisfy
+     * every case above.
+     */
+    const distinct: BreakpointSet = {
+      viewport: [
+        { id: "tablet", label: "Tablet", maxWidth: 991 },
+        { id: "mobile", label: "Mobile", maxWidth: 575 },
+      ],
+      container: [],
+    };
+
+    expect(offeredTiers(distinct).map(tier => tier.id)).toEqual([
+      "tablet",
+      "mobile",
+    ]);
   });
 });

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -1,0 +1,180 @@
+/**
+ * What a canvas of a given width is showing, and which tier an edit lands in.
+ *
+ * ## The width is the single source of truth
+ *
+ * There is no second piece of state saying which breakpoint the inspector
+ * edits. The canvas owns a width in CSS pixels; the edited tier and the live
+ * tiers are both DERIVED from it, so they cannot disagree with each other or
+ * with what is on screen.
+ *
+ * That is not a stylistic preference. The alternative — a stored "current
+ * breakpoint" beside a canvas width — is two facts about one thing, and the
+ * founder's 2026-08-24 ruling deferred this control precisely because a
+ * selector that changes which values you edit while the canvas still shows
+ * desktop is confusing. Deriving removes the state that could drift rather
+ * than keeping the two in step.
+ *
+ * Gutenberg reached the same answer from the opposite direction: its device
+ * dropdown and its resizable canvas were mutually exclusive surfaces until
+ * PR #75121 unified them by treating canvas width as the source of truth, with
+ * the device menu demoted to a way of SETTING a width and the viewport derived
+ * from it as a range. An intermediate width then needs no preset to exist.
+ *
+ * ## Why this reads `maxWidth` and not the emitted query text
+ *
+ * {@link matchedBreakpoints} evaluates each context's OWN at-rule through a
+ * `matches` callback, and its docblock is emphatic that width arithmetic beside
+ * it would be a second implementation of the same condition. That warning is
+ * about parsing the emitted STRING, which is a second reading of what the
+ * compiler wrote.
+ *
+ * This module does something different: it reads `maxWidth` off the context the
+ * compiler produced, which is the same structured field `liveBreakpointsFor`
+ * already decides with. The compiler derives its query text from that number,
+ * so both are downstream of one value rather than two readings of one string.
+ * `agreesWithTheEmittedQuery` in the tests pins them together, so a compiler
+ * that changed to `min-width`, to a different unit, or to a half-open bound
+ * fails here rather than silently disagreeing.
+ *
+ * ## The container axis is excluded
+ *
+ * For the reason {@link liveBreakpointsFor} gives: even at its widest a
+ * container context emits `@container (min-width: 0)`, which matches only an
+ * element that HAS a query container above it. Whether the selected block does
+ * is a fact about the rendered tree that width arithmetic cannot see, so
+ * including it would let a container declaration be reported live for a block
+ * the browser is applying nothing to — wrong rather than quiet.
+ *
+ * @module canvas-width
+ */
+
+import {
+  BASE_BREAKPOINT,
+  breakpointContexts,
+  type BreakpointId,
+  type BreakpointSet,
+} from "@nextlyhq/blocks-engine";
+
+import { isUsableWidth } from "./breakpoints";
+
+/**
+ * The viewport tiers a canvas of this width is applying, widest first.
+ *
+ * The same question {@link matchedBreakpoints} answers for the browser window,
+ * asked of a box whose width the editor owns instead. Under a preview compile
+ * the window cannot answer at all — the tiers are container queries and
+ * `matchMedia` has nothing to say about an element — which is why the canvas
+ * has to answer for itself, and why the panel withholds its provenance
+ * indicator until something does.
+ *
+ * Note the set is read WITHOUT the preview option. That is deliberate and it is
+ * the whole point: the preview option decides how the sheet is EMITTED, and
+ * this decides what a box of a given width shows. A canvas at 800px shows what
+ * a real viewport at 800px would show, and the preview compile exists so that
+ * remains true inside a box.
+ *
+ * @experimental
+ */
+export function breakpointsAtWidth(
+  set: BreakpointSet | undefined,
+  width: number | undefined
+): BreakpointId[] {
+  const contexts = breakpointContexts(set).filter(
+    context => context.axis !== "container"
+  );
+  return contexts
+    .filter(context => {
+      // The unconditional context applies at every width, which is what makes
+      // it the base: it is the only tier that is never a query.
+      if (!isUsableWidth(context.maxWidth)) return true;
+      /*
+       * An unmeasured canvas reports the unconditional context alone rather
+       * than guessing.
+       *
+       * Nothing has been observed yet on the first render, before layout has
+       * run — and reporting the widest PRESET there would be a claim about a
+       * box nobody has measured. The tier this yields is the honest one, and it
+       * is also what the server render produces, so the two agree and React
+       * does not discard the subtree.
+       */
+      if (width === undefined) return false;
+      // Desktop-first: the compiler emits `(max-width: Npx)`, which applies at
+      // N and below. Inclusive, matching the query rather than approximating it.
+      return width <= context.maxWidth;
+    })
+    .map(context => context.id);
+}
+
+/**
+ * The tier an edit lands in at this width: the NARROWEST one applying.
+ *
+ * Narrowest rather than widest, because that is the one whose declaration wins.
+ * At 800px on a site defining tablet (991) and mobile (575), both the base and
+ * tablet contexts apply and tablet is what the browser paints — so an edit made
+ * while looking at 800px must land in tablet, or the author changes a value they
+ * cannot see change.
+ *
+ * Falls back to {@link BASE_BREAKPOINT} rather than to whatever came first: a
+ * site that has defined no breakpoints, or a width above every bound, is
+ * editing the unconditional tier, and that is a real answer rather than a
+ * default standing in for a missing one.
+ *
+ * @experimental
+ */
+export function editedBreakpointAtWidth(
+  set: BreakpointSet | undefined,
+  width: number | undefined
+): BreakpointId {
+  const contexts = breakpointContexts(set).filter(
+    context => context.axis !== "container"
+  );
+  const live = new Set(breakpointsAtWidth(set, width));
+  let narrowest: { id: BreakpointId; maxWidth: number } | undefined;
+  for (const context of contexts) {
+    if (!live.has(context.id)) continue;
+    if (!isUsableWidth(context.maxWidth)) continue;
+    if (narrowest === undefined || context.maxWidth < narrowest.maxWidth) {
+      narrowest = { id: context.id, maxWidth: context.maxWidth };
+    }
+  }
+  if (narrowest !== undefined) return narrowest.id;
+  /*
+   * The unconditional context's own id, not the constant, when the set has one.
+   *
+   * `breakpointContexts` names that context, and a site whose stored set spells
+   * the unconditional tier differently would otherwise be told it is editing an
+   * id its own document does not use — a write addressed to a tier that is not
+   * there.
+   */
+  const unconditional = contexts.find(
+    context => !isUsableWidth(context.maxWidth)
+  );
+  return unconditional?.id ?? BASE_BREAKPOINT;
+}
+
+/**
+ * The canvas width that puts a tier on screen, or `undefined` for the widest.
+ *
+ * The switcher's whole job in one function: choosing a tier SETS a width, and
+ * everything else follows from the width. `undefined` means "as wide as the
+ * region allows" — the unconditional tier has no upper bound, so pinning it to
+ * a number would invent one and make the widest preset narrower than the space
+ * available.
+ *
+ * The tier's own `maxWidth` rather than one pixel below it. The query is
+ * `(max-width: Npx)` and therefore inclusive, so N is inside the tier — and it
+ * is the width at which the author sees the tier at its roomiest, which is
+ * where a layout decision is actually made.
+ *
+ * @experimental
+ */
+export function widthForBreakpoint(
+  set: BreakpointSet | undefined,
+  id: BreakpointId
+): number | undefined {
+  const context = breakpointContexts(set).find(
+    candidate => candidate.axis !== "container" && candidate.id === id
+  );
+  return isUsableWidth(context?.maxWidth) ? context.maxWidth : undefined;
+}

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -133,7 +133,18 @@ export function editedBreakpointAtWidth(
   for (const context of contexts) {
     if (!live.has(context.id)) continue;
     if (!isUsableWidth(context.maxWidth)) continue;
-    if (narrowest === undefined || context.maxWidth < narrowest.maxWidth) {
+    /*
+     * `<=`, so among tiers sharing a bound the LAST one wins.
+     *
+     * Two viewport ids can carry the same `maxWidth` — a stored set written
+     * through the API can say so — and the compiler emits both, in order, into
+     * one at-rule. Measured: `alpha` then `beta` at 991 produce two
+     * declarations in a single `@media (max-width: 991px)` block, so `beta` is
+     * what the browser paints. Taking the first would write the author's edit
+     * into a tier whose value is then overridden by the one below it, and the
+     * control would look correct while nothing changed on screen.
+     */
+    if (narrowest === undefined || context.maxWidth <= narrowest.maxWidth) {
       narrowest = { id: context.id, maxWidth: context.maxWidth };
     }
   }
@@ -150,6 +161,42 @@ export function editedBreakpointAtWidth(
     context => !isUsableWidth(context.maxWidth)
   );
   return unconditional?.id ?? BASE_BREAKPOINT;
+}
+
+/**
+ * The tiers a canvas width can actually select, widest first.
+ *
+ * ONE per distinct bound. Selecting a tier sets a WIDTH and everything else is
+ * derived from it, so two tiers sharing a bound are not two choices: both
+ * radios would emit the same number, the match would resolve to one of them,
+ * and clicking the other would silently select the first.
+ *
+ * Among tiers sharing a bound the LAST is kept, because that is the one the
+ * browser paints — the compiler emits both into a single at-rule in order, so
+ * the later declaration wins. Keeping the first would name a tier whose value
+ * is overridden by the one below it, and {@link editedBreakpointAtWidth} would
+ * disagree with this list about which tier an edit lands in.
+ *
+ * Taken from the compiler's contexts rather than the stored definitions, so a
+ * definition it declines to emit a bounded context for is not offered: sizing
+ * the canvas to a number nothing responds to reads as the feature being broken
+ * rather than as the definition being unusable.
+ *
+ * @experimental
+ */
+export function offeredTiers(
+  set: BreakpointSet | undefined
+): Array<{ id: BreakpointId; maxWidth: number }> {
+  const byWidth = new Map<number, BreakpointId>();
+  for (const context of breakpointContexts(set)) {
+    if (context.axis === "container") continue;
+    if (!isUsableWidth(context.maxWidth)) continue;
+    // Later assignment wins, which is the collapse rule stated above.
+    byWidth.set(context.maxWidth, context.id);
+  }
+  return [...byWidth.entries()]
+    .map(([maxWidth, id]) => ({ id, maxWidth }))
+    .sort((a, b) => b.maxWidth - a.maxWidth);
 }
 
 /**

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -16,10 +16,10 @@
  * than keeping the two in step.
  *
  * Gutenberg reached the same answer from the opposite direction: its device
- * dropdown and its resizable canvas were mutually exclusive surfaces until
- * PR #75121 unified them by treating canvas width as the source of truth, with
- * the device menu demoted to a way of SETTING a width and the viewport derived
- * from it as a range. An intermediate width then needs no preset to exist.
+ * dropdown and its resizable canvas were mutually exclusive surfaces until it
+ * unified them by treating canvas width as the source of truth, with the device
+ * menu demoted to a way of SETTING a width and the viewport derived from it as
+ * a range. An intermediate width then needs no preset to exist.
  *
  * ## Why this reads `maxWidth` and not the emitted query text
  *

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -9,11 +9,10 @@
  * with what is on screen.
  *
  * That is not a stylistic preference. The alternative — a stored "current
- * breakpoint" beside a canvas width — is two facts about one thing, and the
- * founder's 2026-08-24 ruling deferred this control precisely because a
- * selector that changes which values you edit while the canvas still shows
- * desktop is confusing. Deriving removes the state that could drift rather
- * than keeping the two in step.
+ * breakpoint" beside a canvas width — is two facts about one thing, and they
+ * drift: a selector that changes which values you edit while the canvas still
+ * shows desktop leaves the author editing one tier and looking at another.
+ * Deriving removes the state that could drift rather than keeping two in step.
  *
  * Gutenberg reached the same answer from the opposite direction: its device
  * dropdown and its resizable canvas were mutually exclusive surfaces until it

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -219,8 +219,19 @@ export function widthForBreakpoint(
   set: BreakpointSet | undefined,
   id: BreakpointId
 ): number | undefined {
-  const context = breakpointContexts(set).find(
-    candidate => candidate.axis !== "container" && candidate.id === id
-  );
-  return isUsableWidth(context?.maxWidth) ? context.maxWidth : undefined;
+  /*
+   * Read from {@link offeredTiers}, not from the contexts directly.
+   *
+   * Two ids can carry the same bound, and only one of them is what a canvas at
+   * that width is showing: the compiler emits both into one at-rule and the
+   * later declaration wins. Answering from the contexts would hand back the
+   * bound for the LOSING id too — so a caller sets that width believing it
+   * selected `alpha`, and every edit made there is written to `beta`, which is
+   * the disagreement between the control and the write that collapsing the
+   * choice exists to remove.
+   *
+   * `undefined` for an id that is not offered is the honest answer: there is no
+   * width that puts that tier on screen, because another tier owns it.
+   */
+  return offeredTiers(set).find(tier => tier.id === id)?.maxWidth;
 }

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -1039,6 +1039,46 @@ describe("what the canvas reports about the box it got", () => {
     expect(first).not.toHaveBeenCalledWith(undefined);
   });
 
+  it("does not preview when there is nowhere to BIND the container", () => {
+    /*
+     * A preview has exactly two binding sites: the page tier's style context
+     * and the site tier's sheet. `siteStyles={false}` opts out of the shared
+     * sheet and no `styleContext` is the stored-artifact path — so nothing is
+     * compiled against this box, its viewport rules stay `@media` and follow
+     * the window, and a box that established a container and reported its width
+     * anyway would have a caller deriving edits for a tier the canvas is not
+     * displaying.
+     *
+     * The name here is perfectly VALID, which is what separates this from the
+     * refused-name case: the failure is having nowhere to put it.
+     */
+    const onMeasured = vi.fn();
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={false as never}
+        preview={{
+          container: "nx-preview-viewport",
+          width: 991,
+          onMeasured,
+        }}
+      />
+    );
+
+    const style = (
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement | null
+    )?.style;
+    expect(style?.containerName).toBe("");
+    expect(style?.maxWidth).toBe("");
+    expect(FakeResizeObserver.last).toBeUndefined();
+  });
+
   it("observes NOTHING when no reporter was given", () => {
     /*
      * The control. Without it, an implementation that observed unconditionally

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -435,3 +435,89 @@ describe("the gesture a click's modifiers meant", () => {
     expect(onSelect).toHaveBeenCalledWith("a", "replace");
   });
 });
+
+describe("the preview box the canvas establishes", () => {
+  /** A canvas with nothing selected, so only the box props vary. */
+  function boxed(props: Record<string, unknown>) {
+    return render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        {...props}
+      />
+    );
+  }
+
+  const root = (container: HTMLElement): HTMLElement => {
+    const found = container.querySelector(`.${CANVAS_ROOT_CLASS}`);
+    if (!(found instanceof HTMLElement)) throw new Error("no canvas root");
+    return found;
+  };
+
+  it("carries the container NAME and TYPE together, or neither", () => {
+    /*
+     * Either alone does nothing and the failure is silent: a named container
+     * left at the default `container-type: normal` is not a size-query
+     * container, so every rule the preview compile emitted stays inactive while
+     * the sheet is valid and the name matches. Resizing the box then changes
+     * nothing, with no error anywhere to say why.
+     */
+    const { container } = boxed({ previewContainer: "nx-preview-viewport" });
+    const style = root(container).style;
+
+    expect(style.containerName).toBe("nx-preview-viewport");
+    expect(style.containerType).toBe("inline-size");
+  });
+
+  it("establishes NO container when the compiler would refuse the name", () => {
+    /*
+     * The symmetry is load-bearing rather than tidy. A refused name makes the
+     * compile PUBLISHED — viewport tiers emit `@media` and container tiers emit
+     * UNNAMED `@container` rules — so a box that established a query container
+     * anyway would let those unnamed rules resolve against IT. Viewport tiers
+     * would then follow the window while container tiers followed the box: a
+     * hybrid neither mode intends.
+     */
+    const { container } = boxed({ previewContainer: "none" });
+    const style = root(container).style;
+
+    expect(style.containerName).toBe("");
+    expect(style.containerType).toBe("");
+  });
+
+  it("constrains the box to a MAXIMUM, not a fixed width", () => {
+    /*
+     * The region can be narrower than the tier being asked for — a wide
+     * breakpoint inside a half-width editor pane cannot be honoured. A fixed
+     * width would push the page under the inspector rather than admitting the
+     * request could not be met.
+     */
+    const { container } = boxed({ previewWidth: 991 });
+    const style = root(container).style;
+
+    expect(style.maxWidth).toBe("991px");
+    expect(style.width).toBe("");
+    // Centred: an off-centre narrow box reads as a broken layout rather than as
+    // a viewport being simulated.
+    expect(style.marginInline).toBe("auto");
+  });
+
+  it("leaves the box UNCONSTRAINED when no width was asked for", () => {
+    /*
+     * The control. Without it, a canvas that always constrained would satisfy
+     * the case above while making the widest tier narrower than its region —
+     * the box would gain gutters on selecting the tier it was already showing.
+     */
+    const { container } = boxed({});
+    const style = root(container).style;
+
+    expect(style.maxWidth).toBe("");
+    expect(style.marginInline).toBe("");
+  });
+});

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -1141,6 +1141,64 @@ describe("what the canvas reports about the box it got", () => {
     expect(FakeResizeObserver.last).toBeUndefined();
   });
 
+  it("decides from the SITE's breakpoints, which are the ones that compile", () => {
+    /*
+     * `sharedStyleInputs` resolves `breakpoints` as
+     * `firstStated(stored.breakpoints, route.breakpoints)` — the site tier
+     * wins, "because stored overrides code, which is the layering every
+     * global-styles system uses".
+     *
+     * Read the other way round, a route context carrying viewport tiers beside
+     * a container-only stored set turns preview ON, and the compile that
+     * actually runs then disables every container-axis rule as
+     * `nx-not-previewable` with no viewport tier to show for it — the exact
+     * loss the eligibility rule exists to prevent, caused by deciding it from
+     * inputs the renderer does not use.
+     *
+     * The two sets DISAGREE here deliberately: equal ones could not tell which
+     * was consulted.
+     */
+    const onMeasured = vi.fn();
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={
+          {
+            css: "",
+            classes: {},
+            breakpoints: {
+              viewport: [],
+              container: [{ id: "narrow", label: "Narrow", maxWidth: 400 }],
+            },
+          } as never
+        }
+        render={
+          {
+            styleContext: {
+              breakpoints: {
+                viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+                container: [],
+              },
+            },
+          } as never
+        }
+        preview={{ container: "nx-preview-viewport", width: 991, onMeasured }}
+      />
+    );
+
+    const style = (
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement | null
+    )?.style;
+    expect(style?.containerName).toBe("");
+    expect(FakeResizeObserver.last).toBeUndefined();
+  });
+
   it("observes NOTHING when no reporter was given", () => {
     /*
      * The control. Without it, an implementation that observed unconditionally

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -743,6 +743,93 @@ describe("what the canvas reports about the box it got", () => {
     expect(onMeasured).toHaveBeenLastCalledWith(undefined);
   });
 
+  it("compiles the sheet against the container the BOX establishes", () => {
+    /*
+     * Registered here, because this describe does not otherwise need blocks and
+     * an UNregistered type renders as a placeholder whose styles never compile
+     * — which would leave this asserting against an empty sheet and passing on
+     * the `not.toContain` half alone.
+     */
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/leaf",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+      ] as never,
+      { source: "canvas-coupling-test" }
+    );
+    /*
+     * The two are one fact with two places to say it, and a caller saying it
+     * twice can say it differently. A box establishing `a` while the sheet was
+     * compiled against `b` observes and constrains a query container whose
+     * rules nothing wrote: the window decides what is rendered, the measured
+     * width decides what is reported, and nothing anywhere reads as wrong.
+     *
+     * Asserted against the EMITTED SHEET rather than against the props the
+     * canvas passed on, because the sheet is the artifact that either names
+     * this box or does not — comparing the canvas's own inputs to its own
+     * output would be two readings of one value.
+     *
+     * The host is given a DIFFERENT name deliberately, so this fails on a
+     * version that defaults rather than overwrites.
+     */
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              {
+                id: "a",
+                type: "acme/leaf",
+                version: 1,
+                props: {},
+                styles: { base: { tablet: { color: "#f00" } } },
+              },
+            ],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        preview={{ container: "nx-preview-box" }}
+        render={{
+          styleContext: {
+            breakpoints: {
+              viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+              container: [],
+            },
+            previewContainer: "nx-preview-somewhere-else",
+          },
+        }}
+      />
+    );
+
+    // `forEach` rather than spreading: a `NodeList` is only iterable under a
+    // lib this package does not compile with, which `canvas.tsx` records for
+    // the same reason. The suite transpiles without type checking, so the
+    // spread ran green here and failed only under `tsc`.
+    const sheets: string[] = [];
+    container.querySelectorAll("style").forEach(node => {
+      sheets.push(node.textContent ?? "");
+    });
+    const sheet = sheets.join("\n");
+
+    expect(sheet).toContain("@container nx-preview-box");
+    expect(sheet).not.toContain("nx-preview-somewhere-else");
+    // And the element the queries resolve against is the same one.
+    const box = container.querySelector(`.${CANVAS_ROOT_CLASS}`);
+    expect((box as HTMLElement | null)?.style.containerName).toBe(
+      "nx-preview-box"
+    );
+    clearBlocks();
+  });
+
   it("observes NOTHING when no reporter was given", () => {
     /*
      * The control. Without it, an implementation that observed unconditionally

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -721,6 +721,28 @@ describe("what the canvas reports about the box it got", () => {
     expect(observer?.disconnected).toBe(true);
   });
 
+  it("reports UNDEFINED when the canvas goes away", () => {
+    /*
+     * The box is gone, so the last width it reported describes nothing.
+     *
+     * The editor unmounts this canvas whenever the site's stored styles stop
+     * being readable, which a cached query can do on a refocus long after the
+     * first measurement. Left standing, the caller keeps deriving a tier from a
+     * width no element has — so the inspector writes into that tier with no
+     * preview box on screen and the control that sets it disabled.
+     */
+    const onMeasured = vi.fn();
+    const { unmount } = measured(onMeasured);
+    FakeResizeObserver.last?.deliver({
+      contentBoxSize: [{ inlineSize: 900, blockSize: 500 }],
+    });
+    expect(onMeasured).toHaveBeenLastCalledWith(900);
+
+    unmount();
+
+    expect(onMeasured).toHaveBeenLastCalledWith(undefined);
+  });
+
   it("observes NOTHING when no reporter was given", () => {
     /*
      * The control. Without it, an implementation that observed unconditionally

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -517,12 +517,42 @@ describe("the preview box the canvas establishes", () => {
      * The control. Without it, a canvas that always constrained would satisfy
      * the case above while making the widest tier narrower than its region —
      * the box would gain gutters on selecting the tier it was already showing.
+     *
+     * PREVIEWING, with no width. Not "no preview at all": those are different
+     * states and only this one reaches the width decision. Asserted from an
+     * absent preview instead, this case returns before the width is ever
+     * consulted, and a canvas that constrained every previewing box would
+     * satisfy it — the test would carry the name of a branch it no longer
+     * enters.
      */
-    const { container } = boxed({});
+    const { container } = boxed({
+      preview: { container: "nx-preview-viewport" },
+    });
     const style = root(container).style;
 
     expect(style.maxWidth).toBe("");
     expect(style.marginInline).toBe("");
+    // Previewing, though: the state under test is "no width", and a box that
+    // established no container would satisfy the two assertions above by not
+    // previewing at all.
+    expect(style.containerName).toBe("nx-preview-viewport");
+  });
+
+  it("establishes NO box at all when the canvas is not previewing", () => {
+    /*
+     * Distinct from the case above, and the distinction is the whole contract:
+     * a canvas rendering at the region's own width against a published sheet
+     * must not establish a query container. One that did would let the
+     * UNNAMED `@container` rules a published compile emits for container tiers
+     * resolve against the canvas, so those would follow the box while viewport
+     * tiers followed the window.
+     */
+    const { container } = boxed({});
+    const style = root(container).style;
+
+    expect(style.containerName).toBe("");
+    expect(style.containerType).toBe("");
+    expect(style.maxWidth).toBe("");
   });
 });
 

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -468,7 +468,9 @@ describe("the preview box the canvas establishes", () => {
      * the sheet is valid and the name matches. Resizing the box then changes
      * nothing, with no error anywhere to say why.
      */
-    const { container } = boxed({ previewContainer: "nx-preview-viewport" });
+    const { container } = boxed({
+      preview: { container: "nx-preview-viewport" },
+    });
     const style = root(container).style;
 
     expect(style.containerName).toBe("nx-preview-viewport");
@@ -484,7 +486,7 @@ describe("the preview box the canvas establishes", () => {
      * would then follow the window while container tiers followed the box: a
      * hybrid neither mode intends.
      */
-    const { container } = boxed({ previewContainer: "none" });
+    const { container } = boxed({ preview: { container: "none" } });
     const style = root(container).style;
 
     expect(style.containerName).toBe("");
@@ -498,7 +500,9 @@ describe("the preview box the canvas establishes", () => {
      * width would push the page under the inspector rather than admitting the
      * request could not be met.
      */
-    const { container } = boxed({ previewWidth: 991 });
+    const { container } = boxed({
+      preview: { container: "nx-preview-viewport", width: 991 },
+    });
     const style = root(container).style;
 
     expect(style.maxWidth).toBe("991px");
@@ -519,5 +523,157 @@ describe("the preview box the canvas establishes", () => {
 
     expect(style.maxWidth).toBe("");
     expect(style.marginInline).toBe("");
+  });
+});
+
+describe("what the canvas reports about the box it got", () => {
+  /**
+   * A `ResizeObserver` that records what it was asked to watch and hands the
+   * test the callback, so a measurement can be delivered on demand.
+   *
+   * jsdom ships none at all, which is not merely an inconvenience: the canvas
+   * guards on the global being CALLABLE and silently reports nothing when it is
+   * not, so without a stub every assertion here would pass on absence.
+   */
+  class FakeResizeObserver {
+    static last: FakeResizeObserver | undefined;
+    readonly observed: Element[] = [];
+    disconnected = false;
+    constructor(readonly callback: ResizeObserverCallback) {
+      FakeResizeObserver.last = this;
+    }
+    observe(element: Element): void {
+      this.observed.push(element);
+    }
+    disconnect(): void {
+      this.disconnected = true;
+    }
+    unobserve(): void {}
+    /** Deliver one entry, as the browser would after a layout. */
+    deliver(entry: Partial<ResizeObserverEntry>): void {
+      this.callback([entry as ResizeObserverEntry], this as never);
+    }
+  }
+
+  const original = globalThis.ResizeObserver;
+
+  beforeAll(() => {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver =
+      FakeResizeObserver;
+  });
+
+  afterAll(() => {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = original;
+  });
+
+  afterEach(() => {
+    FakeResizeObserver.last = undefined;
+  });
+
+  /** A canvas previewing, with a reporter the test can read. */
+  function measured(onMeasured: (width: number | undefined) => void) {
+    return render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        preview={{ container: "nx-preview-viewport", onMeasured }}
+      />
+    );
+  }
+
+  it("reports the box's CONTENT-box inline size", () => {
+    /*
+     * `contentBoxSize` rather than the bounding rect, because the editor
+     * applies a canvas zoom and the rect is the TRANSFORMED size. A container
+     * query asks the element's own layout size, so at any zoom but 100% the
+     * visual number names a different tier than the one the browser is
+     * applying — and the canvas would look right while the inspector wrote to
+     * the wrong breakpoint.
+     *
+     * The two are given DIFFERENT values here deliberately: equal ones would
+     * let an implementation reading either satisfy this.
+     */
+    const onMeasured = vi.fn();
+    measured(onMeasured);
+
+    FakeResizeObserver.last?.deliver({
+      contentBoxSize: [{ inlineSize: 900, blockSize: 500 }],
+      contentRect: { width: 450 } as DOMRectReadOnly,
+    });
+
+    expect(onMeasured).toHaveBeenCalledWith(900);
+  });
+
+  it("observes the canvas ROOT, which is the box the sheet queries", () => {
+    /*
+     * The element carrying the container name is the element the queries
+     * resolve against. Observing anything else would report a width that
+     * decides nothing — and would do it convincingly, since the number moves
+     * whenever the editor is resized.
+     */
+    const onMeasured = vi.fn();
+    const { container } = measured(onMeasured);
+
+    expect(FakeResizeObserver.last?.observed).toEqual([
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`),
+    ]);
+  });
+
+  it("says UNDEFINED rather than a number when the entry carries no size", () => {
+    /*
+     * An entry without `contentBoxSize` is a real answer from older engines,
+     * and `undefined` is what the caller must be told: it means nothing has
+     * been observed, which is the state where a caller must not name a tier.
+     * Reporting 0 instead would put the box in the narrowest tier the site
+     * defines.
+     */
+    const onMeasured = vi.fn();
+    measured(onMeasured);
+
+    FakeResizeObserver.last?.deliver({ contentBoxSize: [] });
+
+    expect(onMeasured).toHaveBeenCalledWith(undefined);
+  });
+
+  it("stops observing when the canvas goes away", () => {
+    /*
+     * The observer outlives the element otherwise, and reports into a caller
+     * whose surface has been unmounted.
+     */
+    const { unmount } = measured(vi.fn());
+    const observer = FakeResizeObserver.last;
+
+    unmount();
+
+    expect(observer?.disconnected).toBe(true);
+  });
+
+  it("observes NOTHING when no reporter was given", () => {
+    /*
+     * The control. Without it, an implementation that observed unconditionally
+     * would satisfy every case above while costing a `ResizeObserver` to every
+     * canvas that is not previewing.
+     */
+    render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        preview={{ container: "nx-preview-viewport" }}
+      />
+    );
+
+    expect(FakeResizeObserver.last).toBeUndefined();
   });
 });

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -437,6 +437,24 @@ describe("the gesture a click's modifiers meant", () => {
   });
 });
 
+/**
+ * A site sheet with one viewport tier, which is what makes a canvas previewable.
+ *
+ * A preview compile rewrites every container-axis rule to a query that matches
+ * nothing, so the canvas refuses to enter preview mode for a set with no
+ * viewport tier to simulate — the price would buy nothing. A fixture without
+ * one therefore exercises the published path however the preview props are set,
+ * which is a fine thing to test and is NOT what the cases below are about.
+ */
+const PREVIEWABLE = {
+  css: "",
+  classes: {},
+  breakpoints: {
+    viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+    container: [],
+  },
+} as never;
+
 describe("the preview box the canvas establishes", () => {
   /** A canvas with nothing selected, so only the box props vary. */
   function boxed(props: Record<string, unknown>) {
@@ -449,7 +467,7 @@ describe("the preview box the canvas establishes", () => {
             nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
           } as never
         }
-        siteStyles={{ css: "", classes: {} } as never}
+        siteStyles={PREVIEWABLE}
         {...props}
       />
     );
@@ -612,7 +630,7 @@ describe("what the canvas reports about the box it got", () => {
             nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
           } as never
         }
-        siteStyles={{ css: "", classes: {} } as never}
+        siteStyles={PREVIEWABLE}
         preview={{ container: "nx-preview-viewport", onMeasured }}
       />
     );
@@ -948,7 +966,7 @@ describe("what the canvas reports about the box it got", () => {
             nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
           } as never
         }
-        siteStyles={{ css: "", classes: {} } as never}
+        siteStyles={PREVIEWABLE}
         preview={{ container: "none", width: 991, onMeasured }}
       />
     );
@@ -992,7 +1010,7 @@ describe("what the canvas reports about the box it got", () => {
               nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
             } as never
           }
-          siteStyles={{ css: "", classes: {} } as never}
+          siteStyles={PREVIEWABLE}
           preview={{
             container: "nx-preview-viewport",
             onMeasured: (width: number | undefined) => onMeasured(width),
@@ -1024,7 +1042,7 @@ describe("what the canvas reports about the box it got", () => {
             nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
           } as never
         }
-        siteStyles={{ css: "", classes: {} } as never}
+        siteStyles={PREVIEWABLE}
         preview={{ container: "nx-preview-viewport", onMeasured: report }}
       />
     );
@@ -1079,6 +1097,50 @@ describe("what the canvas reports about the box it got", () => {
     expect(FakeResizeObserver.last).toBeUndefined();
   });
 
+  it("stays PUBLISHED for a set with no viewport tier to simulate", () => {
+    /*
+     * A preview compile rewrites every container-axis rule to
+     * `@container nx-not-previewable (width < 0px)`, which matches nothing.
+     * With viewport tiers to gain that is a fair trade; with none it costs a
+     * container-only site every breakpoint it has on the canvas while they keep
+     * working on the published page.
+     *
+     * Decided HERE rather than at one mount, so every consumer of this API gets
+     * it. The container name is valid and the sheet is bindable — the only
+     * thing missing is anything to simulate.
+     */
+    const onMeasured = vi.fn();
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={
+          {
+            css: "",
+            classes: {},
+            breakpoints: {
+              viewport: [],
+              container: [{ id: "narrow", label: "Narrow", maxWidth: 400 }],
+            },
+          } as never
+        }
+        preview={{ container: "nx-preview-viewport", width: 991, onMeasured }}
+      />
+    );
+
+    const style = (
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement | null
+    )?.style;
+    expect(style?.containerName).toBe("");
+    expect(style?.maxWidth).toBe("");
+    expect(FakeResizeObserver.last).toBeUndefined();
+  });
+
   it("observes NOTHING when no reporter was given", () => {
     /*
      * The control. Without it, an implementation that observed unconditionally
@@ -1094,7 +1156,7 @@ describe("what the canvas reports about the box it got", () => {
             nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
           } as never
         }
-        siteStyles={{ css: "", classes: {} } as never}
+        siteStyles={PREVIEWABLE}
         preview={{ container: "nx-preview-viewport" }}
       />
     );

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -1199,6 +1199,120 @@ describe("what the canvas reports about the box it got", () => {
     expect(FakeResizeObserver.last).toBeUndefined();
   });
 
+  it("treats a stated NULL breakpoint set as the site having none", () => {
+    /*
+     * `firstStated` is `find(tier => tier !== undefined)`, so a stored `null` —
+     * which runtime or imported data can supply — is KEPT by the renderer and
+     * read as defining no viewport tiers. Nullish coalescing falls through to
+     * the route set instead, turning preview on for a canvas the renderer left
+     * on the unconditional tier: the box then measures and selects a route tier
+     * that is not on screen.
+     *
+     * The route set carries a viewport tier deliberately, so the two readings
+     * give opposite answers.
+     */
+    const onMeasured = vi.fn();
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {}, breakpoints: null } as never}
+        render={
+          {
+            styleContext: {
+              breakpoints: {
+                viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+                container: [],
+              },
+            },
+          } as never
+        }
+        preview={{ container: "nx-preview-viewport", width: 991, onMeasured }}
+      />
+    );
+
+    const style = (
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement | null
+    )?.style;
+    expect(style?.containerName).toBe("");
+    expect(FakeResizeObserver.last).toBeUndefined();
+  });
+
+  it("does not re-render the page when only the box WIDTH changes", () => {
+    /*
+     * The width changes on every switcher selection and alters no emitted rule,
+     * but rebuilding the compile inputs rebuilds the rendered page — which
+     * re-runs `PageRenderer` and recompiles the document and site sheet
+     * synchronously. On a large document that is a whole compile per width
+     * change, and continuous resizing pays it per frame.
+     *
+     * Counted at a BLOCK's own render function, which is the only thing here
+     * that runs if and only if the page re-rendered. Asserting on DOM identity
+     * would not do it: React reuses the element across a re-render, so the node
+     * is the same whether the page was rebuilt or not — measured, that version
+     * of this case passed against the defect.
+     */
+    let drawn = 0;
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/counted",
+          version: 1,
+          description: "A block that reports being drawn.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) => {
+            drawn += 1;
+            return createElement("div", { className });
+          },
+        },
+      ] as never,
+      { source: "canvas-memo-test" }
+    );
+
+    /*
+     * ONE document object across both renders. The rendered page is memoised on
+     * the document's identity, so a fresh literal per render rebuilds it for a
+     * reason that has nothing to do with the width — measured, that version of
+     * this fixture reported the defect while the code was correct.
+     */
+    const doc = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "a", type: "acme/counted", version: 1, props: {} }],
+    } as never;
+    const tree = (width: number | undefined) => (
+      <Canvas
+        document={doc}
+        siteStyles={PREVIEWABLE}
+        preview={{
+          container: "nx-preview-viewport",
+          ...(width === undefined ? {} : { width }),
+        }}
+      />
+    );
+    const view = render(tree(undefined));
+    const before = drawn;
+    expect(before).toBeGreaterThan(0);
+
+    React.act(() => {
+      view.rerender(tree(640));
+    });
+
+    expect(drawn).toBe(before);
+    // And the width really did change, or this proves nothing.
+    expect(
+      (view.container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement)
+        .style.maxWidth
+    ).toBe("640px");
+    clearBlocks();
+  });
+
   it("observes NOTHING when no reporter was given", () => {
     /*
      * The control. Without it, an implementation that observed unconditionally

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -26,6 +26,7 @@ import {
   it,
   vi,
 } from "vitest";
+import * as React from "react";
 import { createElement } from "react";
 
 import { clearBlocks, registerBlocks } from "@nextlyhq/blocks-engine";
@@ -924,6 +925,118 @@ describe("what the canvas reports about the box it got", () => {
 
     expect(sheet).toContain("@media (max-width: 991px)");
     expect(sheet).not.toContain("@container");
+  });
+
+  it("neither constrains nor measures when the NAME is refused", () => {
+    /*
+     * `previewContainerStyle` turns down a reserved name, so no query container
+     * exists and the sheet falls back to published `@media`. A box that went on
+     * narrowing and measuring itself would then resize without changing a
+     * single tier — and a caller deriving an edit target from the measurement
+     * would write to a breakpoint the canvas is not displaying.
+     *
+     * A refused name is therefore not a preview at all, for the width and the
+     * measurement as much as for the container.
+     */
+    const onMeasured = vi.fn();
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        preview={{ container: "none", width: 991, onMeasured }}
+      />
+    );
+
+    const style = (
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement | null
+    )?.style;
+    expect(style?.containerName).toBe("");
+    expect(style?.maxWidth).toBe("");
+    expect(FakeResizeObserver.last).toBeUndefined();
+  });
+
+  it("does not report a removal when the CALLBACK identity changes", () => {
+    /*
+     * A host writing `onMeasured={w => setWidth(w)}` inline hands a new
+     * function every render. If the observer effect depended on it, each real
+     * measurement would update the parent, produce a new identity, tear the
+     * observer down — reporting `undefined` as if the canvas had gone — and
+     * rebuild it, so the derived tier oscillates and the churn can sustain a
+     * render loop, on a host that did nothing wrong.
+     *
+     * Asserted as "never called with undefined while mounted" rather than on a
+     * call count, because the count is allowed to grow: what must not happen is
+     * the false removal.
+     */
+    const onMeasured = vi.fn();
+    const view = measured(onMeasured);
+    FakeResizeObserver.last?.deliver({
+      contentBoxSize: [{ inlineSize: 900, blockSize: 500 }],
+    });
+
+    // A re-render with a BRAND NEW callback identity, which is what an inline
+    // arrow produces.
+    React.act(() => {
+      view.rerender(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={{ css: "", classes: {} } as never}
+          preview={{
+            container: "nx-preview-viewport",
+            onMeasured: (width: number | undefined) => onMeasured(width),
+          }}
+        />
+      );
+    });
+
+    expect(onMeasured).not.toHaveBeenCalledWith(undefined);
+  });
+
+  it("tells the CURRENT reporter about the removal, not the one it started with", () => {
+    /*
+     * The effect deliberately does not re-run when the callback identity
+     * changes, so the reporter captured when the observer was built can be
+     * stale by the time the canvas goes away. Notifying that one leaves the
+     * host that is actually listening holding the last real width, deriving a
+     * tier from a box that no longer exists — the same stale-measurement bug
+     * the removal notice was added to prevent, arrived at one layer down.
+     */
+    const first = vi.fn();
+    const second = vi.fn();
+    const tree = (report: (width: number | undefined) => void) => (
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        preview={{ container: "nx-preview-viewport", onMeasured: report }}
+      />
+    );
+
+    const view = render(tree(first));
+    React.act(() => {
+      view.rerender(tree(second));
+    });
+    view.unmount();
+
+    expect(second).toHaveBeenCalledWith(undefined);
+    expect(first).not.toHaveBeenCalledWith(undefined);
   });
 
   it("observes NOTHING when no reporter was given", () => {

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -830,6 +830,102 @@ describe("what the canvas reports about the box it got", () => {
     clearBlocks();
   });
 
+  it("compiles the SITE sheet against the box as well as the page's", () => {
+    /*
+     * Two tiers emit breakpoint rules, not one: the page's node styles and the
+     * site's named classes. Bound on only the page tier, a class's tablet rule
+     * stays an `@media` answered by the WINDOW while the node's tablet rule
+     * became a `@container` answered by the box — so narrowing the canvas moves
+     * one and not the other, and a block styled by a class does not respond at
+     * all.
+     *
+     * Driven through `siteStyles` with NO `render.styleContext`, which is the
+     * stored-artifact path a host can legitimately use, and the branch the page
+     * tier's coupling skips.
+     */
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={
+          {
+            breakpoints: {
+              viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+              container: [],
+            },
+            classes: [
+              {
+                id: "c1",
+                slug: "card",
+                styles: { base: { tablet: { color: "#f00" } } },
+              },
+            ],
+          } as never
+        }
+        preview={{ container: "nx-preview-box" }}
+      />
+    );
+
+    const sheets: string[] = [];
+    container.querySelectorAll("style").forEach(node => {
+      sheets.push(node.textContent ?? "");
+    });
+    const sheet = sheets.join("\n");
+
+    expect(sheet).toContain("@container nx-preview-box");
+    // The published form must NOT survive beside it: a sheet carrying both
+    // would answer the same tier from two different boxes.
+    expect(sheet).not.toContain("@media (max-width: 991px)");
+  });
+
+  it("leaves the SITE sheet alone when the canvas is not previewing", () => {
+    /*
+     * The control. Without it, a canvas that rewrote the site sheet
+     * unconditionally would satisfy the case above while turning every
+     * published canvas into a preview one.
+     */
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={
+          {
+            breakpoints: {
+              viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+              container: [],
+            },
+            classes: [
+              {
+                id: "c1",
+                slug: "card",
+                styles: { base: { tablet: { color: "#f00" } } },
+              },
+            ],
+          } as never
+        }
+      />
+    );
+
+    const sheets: string[] = [];
+    container.querySelectorAll("style").forEach(node => {
+      sheets.push(node.textContent ?? "");
+    });
+    const sheet = sheets.join("\n");
+
+    expect(sheet).toContain("@media (max-width: 991px)");
+    expect(sheet).not.toContain("@container");
+  });
+
   it("observes NOTHING when no reporter was given", () => {
     /*
      * The control. Without it, an implementation that observed unconditionally

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -655,6 +655,43 @@ describe("what the canvas reports about the box it got", () => {
     ]);
   });
 
+  it("falls back to contentRect when contentBoxSize is absent", () => {
+    /*
+     * Polyfills and older engines expose only `contentRect`. Read as an array
+     * alone, they report `undefined` on every notification — and the caller
+     * cannot tell that from "nothing measured yet", so the canvas applies a
+     * narrower tier's rules while the inspector stays on base and the author's
+     * edits land in a breakpoint they are not looking at.
+     *
+     * `contentRect` is a LAYOUT size like `contentBoxSize`, so the canvas zoom
+     * does not scale it; it is a fallback, not a compromise.
+     */
+    const onMeasured = vi.fn();
+    measured(onMeasured);
+
+    FakeResizeObserver.last?.deliver({
+      contentRect: { width: 880 } as DOMRectReadOnly,
+    });
+
+    expect(onMeasured).toHaveBeenCalledWith(880);
+  });
+
+  it("reads contentBoxSize when it is a single object rather than a sequence", () => {
+    /*
+     * The spec settled on a sequence; Firefox shipped a single object first and
+     * that shape is still reachable. Indexing `[0]` on it yields `undefined`,
+     * which is the same silent stall as having no size at all.
+     */
+    const onMeasured = vi.fn();
+    measured(onMeasured);
+
+    FakeResizeObserver.last?.deliver({
+      contentBoxSize: { inlineSize: 640, blockSize: 480 } as never,
+    });
+
+    expect(onMeasured).toHaveBeenCalledWith(640);
+  });
+
   it("says UNDEFINED rather than a number when the entry carries no size", () => {
     /*
      * An entry without `contentBoxSize` is a real answer from older engines,

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -174,6 +174,212 @@ export function nodeElements(root: HTMLElement): readonly Element[] {
   return found;
 }
 
+/**
+ * Report a box's real inline size to its owner whenever it changes.
+ *
+ * `ResizeObserver` rather than a resize listener on the window: the box changes
+ * width when the inspector opens, when a rail panel is toggled and when the
+ * pane is dragged, none of which resize the window. A window listener would
+ * report the same number across all three.
+ *
+ * `contentBoxSize` rather than `getBoundingClientRect().width`, because the
+ * editor applies a canvas zoom transform and the rect is the TRANSFORMED size —
+ * which is what a reader sees but not what the container queries resolve
+ * against. A container query asks the element's own layout size, so reporting
+ * the visual one would name the wrong tier at any zoom but 100%.
+ */
+function useReportedInlineWidth(
+  box: React.RefObject<HTMLElement | null>,
+  report: ((width: number | undefined) => void) | undefined
+): void {
+  useEffect(() => {
+    const element = box.current;
+    if (element === null || report === undefined) return;
+    // Guarded by CALLABILITY rather than presence: jsdom defines the global on
+    // some setups without a working constructor, so a property test passes and
+    // the construction throws.
+    if (typeof ResizeObserver !== "function") return;
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry === undefined) return;
+      const inline = entry.contentBoxSize[0]?.inlineSize;
+      report(typeof inline === "number" ? inline : undefined);
+    });
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [box, report]);
+}
+
+/**
+ * The canvas root's own style: the container the sheet queries, and the width
+ * the box is being asked to show.
+ *
+ * A MAXIMUM with an auto inline margin rather than a fixed width, because the
+ * region may be narrower than the tier asked for — a wide breakpoint inside a
+ * half-width editor pane cannot be honoured, and stretching the box past its
+ * region would put the page under the inspector.
+ *
+ * Centred rather than left-aligned, which is what every builder surveyed does
+ * and is not merely cosmetic: an off-centre narrow box reads as a layout that
+ * has broken rather than as a viewport being simulated.
+ */
+function previewBoxStyle(
+  preview: CanvasPreview | undefined
+): React.CSSProperties {
+  if (preview === undefined) return {};
+  return {
+    ...previewContainerStyle(preview.container),
+    ...(preview.width === undefined
+      ? {}
+      : { maxWidth: `${preview.width}px`, marginInline: "auto" }),
+  };
+}
+
+/**
+ * Mark the selected elements on the rendered tree.
+ *
+ * Applied AFTER the renderer has produced them, rather than asked of
+ * `PageRenderer`. Which node an editor considers current is an editor's
+ * concern, and a published route renders the same document without one —
+ * pushing it into the renderer's contract would put editor state in the
+ * component that serves live pages.
+ *
+ * Ids are COMPARED in JavaScript rather than matched with a selector built from
+ * one. A node id reaches this from stored data, and interpolating it into
+ * `querySelector` makes any character CSS treats specially either throw or,
+ * worse, match something else.
+ *
+ * `page` is a dependency because the rendered tree is what carries the markers:
+ * a re-render replaces the elements, and an effect keyed on the selection alone
+ * would leave the new tree carrying none at all.
+ */
+function useSelectionMarkers(
+  box: React.RefObject<HTMLElement | null>,
+  marked: readonly string[],
+  selectedId: string | null,
+  page: React.ReactNode
+): void {
+  useEffect(() => {
+    const container = box.current;
+    if (container === null) return;
+    // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
+    // that declares its iterator, and this package compiles without one — so the
+    // loop that reads more naturally does not type-check here.
+    container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+      const id = element.getAttribute(NODE_ID_ATTRIBUTE);
+      if (id === null || !marked.includes(id)) {
+        element.removeAttribute(SELECTED_ATTRIBUTE);
+        return;
+      }
+      // The VALUE carries which member the panels answer for. A boolean
+      // attribute could not, and a second attribute for the primary would be a
+      // state where a block is primary without being selected.
+      element.setAttribute(
+        SELECTED_ATTRIBUTE,
+        id === selectedId ? "primary" : ""
+      );
+    });
+  }, [box, selectedId, marked, page]);
+}
+
+/**
+ * Which ids to mark, given what the host supplied.
+ *
+ * The primary alone when a host has not adopted the set yet, which keeps every
+ * existing caller correct without a change. `[]` rather than `[null]` for an
+ * empty selection: the marker is applied by id, and a null in the set would
+ * match the elements carrying no id at all.
+ */
+function markedIds(
+  selectedIds: readonly string[] | undefined,
+  selectedId: string | null
+): readonly string[] {
+  if (selectedIds !== undefined) return selectedIds;
+  return selectedId === null ? [] : [selectedId];
+}
+
+/**
+ * The canvas's pointer handlers, which share one rule: chrome is not the page.
+ *
+ * Together rather than separately, because that rule is the whole of what they
+ * have in common and a version where each handler remembers it for itself is
+ * the version where the next one does not. Pressing a control drawn over the
+ * canvas would otherwise resolve to "no node" and deselect the very block that
+ * control acts on.
+ */
+function useCanvasPointer(
+  onSelect: ((id: string | null, mode: SelectionMode) => void) | undefined,
+  onDoubleClick: ((event: React.MouseEvent<HTMLDivElement>) => void) | undefined
+): {
+  onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onDoubleClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+} {
+  const click = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (onSelect === undefined || isChrome(event.target)) return;
+      // A click on the canvas background resolves to null, which CLEARS the
+      // selection rather than being ignored. Ignoring it leaves an inspector
+      // showing a node the author believes they have deselected.
+      onSelect(nodeIdFromEvent(event.target), selectionModeFor(event));
+    },
+    [onSelect]
+  );
+  const doubleClick = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (isChrome(event.target)) return;
+      onDoubleClick?.(event);
+    },
+    [onDoubleClick]
+  );
+  return { onClick: click, onDoubleClick: doubleClick };
+}
+
+/**
+ * A canvas showing the page inside a resizable box rather than at the browser's
+ * own width.
+ *
+ * The container is REQUIRED and the rest is not, because it is what makes the
+ * other two mean anything: the editor canvas is not an iframe, so the sheet is
+ * emitted into the admin document and `@media` asks the WINDOW. Only a sheet
+ * compiled against a container name has rules this box can answer.
+ */
+export interface CanvasPreview {
+  /**
+   * The container name the sheet was compiled against.
+   *
+   * Passed through {@link previewContainerStyle}, which supplies the
+   * `container-type` alongside the name: a named container left at the default
+   * `normal` is not a size-query container, so every rule the preview compile
+   * emitted stays inactive while the sheet is valid and the name matches.
+   */
+  container: string;
+  /**
+   * The width to constrain the box to, in CSS pixels, or absent to fill the
+   * region.
+   *
+   * A MAXIMUM rather than a fixed width, because the region may be narrower
+   * than the tier being asked for — a wide breakpoint inside a half-width
+   * editor pane cannot be honoured, and stretching the box past its region
+   * would put the page under the inspector instead.
+   */
+  width?: number;
+  /**
+   * The box's MEASURED inline size, reported whenever it changes.
+   *
+   * Reported rather than derived from {@link CanvasPreview.width}, because
+   * those are different numbers and only one of them decides anything. The
+   * requested width is a ceiling; what the container queries resolve against is
+   * the width the box actually got. A caller that assumed the request was
+   * honoured would name a tier the box is not showing — the same
+   * confident-wrong-answer this whole preview mechanism exists to remove.
+   *
+   * `undefined` until the first measurement, which is a real state rather than
+   * a default: nothing has been observed yet, and a caller must not report a
+   * tier as live on the strength of a box nobody has looked at.
+   */
+  onMeasured?: (width: number | undefined) => void;
+}
+
 export interface CanvasProps {
   /** The document being edited. */
   document: BlockDocument;
@@ -183,40 +389,17 @@ export interface CanvasProps {
    */
   siteStyles: NonNullable<PageRendererProps["siteStyles"]>;
   /**
-   * The width to constrain the page box to, in CSS pixels, or `undefined` to
-   * fill the region.
+   * The preview box this canvas establishes, or absent to render at the
+   * region's own width against a published sheet.
    *
-   * A MAXIMUM rather than a fixed width, because the region may be narrower
-   * than the tier being asked for — a wide breakpoint inside a half-width
-   * editor pane cannot be honoured, and stretching the box past its region
-   * would put the page under the inspector instead.
+   * One object rather than three props, for the reason
+   * {@link CanvasProps.dragHandlers} is one: the set cannot then be PARTIALLY
+   * wired, and every partial wiring here fails silently. A width without a
+   * container resizes a box whose sheet still queries the window, so the page
+   * reflows and not one breakpoint changes. A container nobody observes leaves
+   * the surface that owns the box unable to say which tier is live.
    */
-  previewWidth?: number;
-  /**
-   * The container name this box establishes, when the sheet was compiled as a
-   * preview.
-   *
-   * Passed through {@link previewContainerStyle}, which supplies the
-   * `container-type` alongside the name: a named container left at the default
-   * `normal` is not a size-query container, so every rule the preview compile
-   * emitted stays inactive while the sheet is valid and the name matches.
-   */
-  previewContainer?: string;
-  /**
-   * The box's MEASURED inline size, reported whenever it changes.
-   *
-   * Reported rather than derived from {@link previewWidth}, because those are
-   * different numbers and only one of them decides anything. The requested
-   * width is a ceiling; what the container queries resolve against is the width
-   * the box actually got. A caller that assumed the request was honoured would
-   * name a tier the box is not showing — the same confident-wrong-answer this
-   * whole preview mechanism exists to remove.
-   *
-   * `undefined` until the first measurement, which is a real state rather than
-   * a default: nothing has been observed yet, and a caller must not report a
-   * tier as live on the strength of a box nobody has looked at.
-   */
-  onMeasuredWidth?: (width: number | undefined) => void;
+  preview?: CanvasPreview;
   /**
    * The PRIMARY selected node's id, or null when the selection is empty.
    *
@@ -301,65 +484,21 @@ export function Canvas({
   dragHandlers,
   onDoubleClick,
   overlay,
-  previewWidth,
-  previewContainer,
-  onMeasuredWidth,
+  preview,
 }: CanvasProps) {
   const root = useRef<HTMLDivElement | null>(null);
 
-  /*
-   * The box's real inline size, observed rather than assumed.
-   *
-   * `ResizeObserver` rather than a resize listener on the window: the box
-   * changes width when the inspector opens, when a rail panel is toggled and
-   * when the pane is dragged, none of which resize the window. A window
-   * listener would report the same number across all three.
-   *
-   * `contentBoxSize` rather than `getBoundingClientRect().width`, because the
-   * editor applies a canvas zoom transform and the rect is the TRANSFORMED
-   * size — which is what a reader sees but not what the container queries
-   * resolve against. A container query asks the element's own layout size, so
-   * reporting the visual one would name the wrong tier at any zoom but 100%.
-   */
-  useEffect(() => {
-    const box = root.current;
-    if (box === null || onMeasuredWidth === undefined) return;
-    // Guarded by CALLABILITY rather than presence: jsdom defines the global on
-    // some setups without a working constructor, so a property test passes and
-    // the construction throws.
-    if (typeof ResizeObserver !== "function") return;
-    const observer = new ResizeObserver(entries => {
-      const entry = entries[0];
-      if (entry === undefined) return;
-      const inline = entry.contentBoxSize[0]?.inlineSize;
-      onMeasuredWidth(typeof inline === "number" ? inline : undefined);
-    });
-    observer.observe(box);
-    return () => observer.disconnect();
-  }, [onMeasuredWidth]);
+  useReportedInlineWidth(root, preview?.onMeasured);
 
   /*
    * What to mark. The primary alone when a host has not adopted the set yet,
    * which keeps every existing caller correct without a change.
    */
   const marked = useMemo(
-    () => selectedIds ?? (selectedId === null ? [] : [selectedId]),
+    () => markedIds(selectedIds, selectedId),
     [selectedIds, selectedId]
   );
-  const handleClick = useCallback(
-    (event: React.MouseEvent<HTMLDivElement>) => {
-      if (!onSelect) return;
-      // Chrome is not the page. Pressing a button drawn over the canvas is not
-      // a click on the background, and treating it as one would deselect the
-      // block that button acts on.
-      if (isChrome(event.target)) return;
-      // A click on the canvas background resolves to null, which CLEARS the
-      // selection rather than being ignored. Ignoring it leaves an inspector
-      // showing a node the author believes they have deselected.
-      onSelect(nodeIdFromEvent(event.target), selectionModeFor(event));
-    },
-    [onSelect]
-  );
+  const pointer = useCanvasPointer(onSelect, onDoubleClick);
 
   // Keyed on the document identity so a re-render for an unrelated reason —
   // a selection change, a hover — does not rebuild the rendered tree.
@@ -381,78 +520,25 @@ export function Canvas({
     [render, document, siteStyles]
   );
 
-  // Marked on the rendered element AFTER the renderer has produced it, rather
-  // than asked of `PageRenderer`. Which node an editor considers current is an
-  // editor's concern, and a published route renders the same document without
-  // one — pushing it into the renderer's contract would put editor state in the
-  // component that serves live pages.
-  //
-  // Compared in JavaScript rather than matched with a selector built from the
-  // id. A node id reaches this from stored data, and interpolating it into
-  // `querySelector` makes any character CSS treats specially either throw or,
-  // worse, match something else.
-  useEffect(() => {
-    const container = root.current;
-    if (container === null) return;
-    // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
-    // that declares its iterator, and this package compiles without one — so the
-    // loop that reads more naturally does not type-check here.
-    container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
-      const id = element.getAttribute(NODE_ID_ATTRIBUTE);
-      const isSelected = id !== null && marked.includes(id);
-      if (!isSelected) {
-        element.removeAttribute(SELECTED_ATTRIBUTE);
-        return;
-      }
-      // The VALUE carries which member the panels answer for. A boolean
-      // attribute could not, and a second attribute for the primary would be a
-      // state where a block is primary without being selected.
-      element.setAttribute(
-        SELECTED_ATTRIBUTE,
-        id === selectedId ? "primary" : ""
-      );
-    });
-    // Re-marked whenever the rendered tree changes as well as when the
-    // selection does: a re-render replaces the elements, and an effect keyed on
-    // the selection alone would leave the new tree carrying no marker at all.
-  }, [selectedId, marked, page]);
+  useSelectionMarkers(root, marked, selectedId, page);
 
   return (
     <div
       ref={root}
       className={cn(CANVAS_ROOT_CLASS, className)}
-      /*
-       * The preview box: the container the sheet queries, and the width it is
-       * being asked to show.
-       *
-       * Centred rather than left-aligned, which is what every builder surveyed
-       * does and is not merely cosmetic — an off-centre narrow box reads as a
-       * layout that has broken rather than as a viewport being simulated.
-       *
-       * On the canvas ROOT rather than an inner wrapper, because the overlays
-       * are positioned in this element's own content coordinates: a box inside
-       * it would size the page while leaving the drop indicator and the
-       * selection chrome measuring the region instead.
-       */
-      style={{
-        ...previewContainerStyle(previewContainer),
-        ...(previewWidth === undefined
-          ? {}
-          : { maxWidth: `${previewWidth}px`, marginInline: "auto" }),
-      }}
+      // On the canvas ROOT rather than an inner wrapper, because the overlays
+      // are positioned in this element's own content coordinates: a box inside
+      // it would size the page while leaving the drop indicator and the
+      // selection chrome measuring the region instead.
+      style={previewBoxStyle(preview)}
       // The id the canvas believes is current, for a caller that wants the
       // answer without walking the tree. Named apart from the per-element
       // marker deliberately: one carries an id and the other is a boolean, and
       // a single name meaning both is the kind of thing that reads correctly
       // right up until someone writes a selector against the wrong one.
       data-nx-selected-id={selectedId ?? undefined}
-      onClick={handleClick}
-      // Chrome is excluded for the same reason it is on click: a double-click
-      // on a control drawn over the page is not a double-click on the page.
-      onDoubleClick={event => {
-        if (isChrome(event.target)) return;
-        onDoubleClick?.(event);
-      }}
+      onClick={pointer.onClick}
+      onDoubleClick={pointer.onDoubleClick}
       // Spread rather than merged with a handler of this component's own: the
       // canvas has no pointer behaviour of its own apart from the drag, so
       // there is nothing to combine, and merging would create a second place

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -175,18 +175,40 @@ export function nodeElements(root: HTMLElement): readonly Element[] {
 }
 
 /**
+ * The observed entry's inline size, across the shapes `ResizeObserver` has had.
+ *
+ * `contentBoxSize` was specified as a SEQUENCE, and Firefox shipped it as a
+ * single object first; both shapes are still reachable, and polyfills predating
+ * it expose only `contentRect`. Read as an array alone, every one of those
+ * reports `undefined` on every notification — and the caller cannot tell that
+ * from "nothing has been measured yet", so the canvas would apply tablet rules
+ * while the inspector stayed on the base tier and the author's edits landed in
+ * a breakpoint they were not looking at.
+ *
+ * `contentRect` is the right fallback rather than a lesser one: like
+ * `contentBoxSize` it is a LAYOUT size, so the editor's canvas zoom does not
+ * scale it — which `getBoundingClientRect()` would, reporting what a reader
+ * sees rather than what a container query resolves against. `builder-shell.tsx`
+ * measures on the same property for the same reason. It carries `width` rather
+ * than an inline size, so the two agree only in a horizontal writing mode; the
+ * admin is one, and the sequence shape above is preferred wherever it exists.
+ */
+function inlineSizeOf(entry: ResizeObserverEntry): number | undefined {
+  const box: unknown = entry.contentBoxSize;
+  const first: unknown = Array.isArray(box) ? box[0] : box;
+  const inline = (first as ResizeObserverSize | undefined)?.inlineSize;
+  if (typeof inline === "number") return inline;
+  const width = entry.contentRect?.width;
+  return typeof width === "number" ? width : undefined;
+}
+
+/**
  * Report a box's real inline size to its owner whenever it changes.
  *
  * `ResizeObserver` rather than a resize listener on the window: the box changes
  * width when the inspector opens, when a rail panel is toggled and when the
  * pane is dragged, none of which resize the window. A window listener would
  * report the same number across all three.
- *
- * `contentBoxSize` rather than `getBoundingClientRect().width`, because the
- * editor applies a canvas zoom transform and the rect is the TRANSFORMED size —
- * which is what a reader sees but not what the container queries resolve
- * against. A container query asks the element's own layout size, so reporting
- * the visual one would name the wrong tier at any zoom but 100%.
  */
 function useReportedInlineWidth(
   box: React.RefObject<HTMLElement | null>,
@@ -202,8 +224,7 @@ function useReportedInlineWidth(
     const observer = new ResizeObserver(entries => {
       const entry = entries[0];
       if (entry === undefined) return;
-      const inline = entry.contentBoxSize[0]?.inlineSize;
-      report(typeof inline === "number" ? inline : undefined);
+      report(inlineSizeOf(entry));
     });
     observer.observe(element);
     return () => observer.disconnect();

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -445,9 +445,17 @@ export interface CanvasPreview {
  * The breakpoints the compile will actually run against, or `undefined` when
  * nothing will be compiled at all.
  *
- * The page tier's when it has one and the site sheet's otherwise, which is the
- * same order the container itself is bound in — so this answers for the compile
- * that will really happen rather than for the inputs a caller passed.
+ * The SITE's when it has them, and the route context's otherwise — which is the
+ * precedence `sharedStyleInputs` applies, in its own words because "the site
+ * tier is the stored one, and stored overrides code, which is the layering
+ * every global-styles system uses". Read the other way round, a route context
+ * carrying viewport tiers beside a container-only stored set would turn preview
+ * ON, and the compile that actually ran would then disable every container-axis
+ * rule as `nx-not-previewable` with no viewport tier to show for it.
+ *
+ * Deciding from the same reconciled inputs the renderer compiles is the point:
+ * this is not a second opinion about which breakpoints matter, it is a reading
+ * of the one the renderer will use.
  *
  * `undefined` is the state where a caller has neither binding site:
  * `siteStyles={false}` opts out of the shared sheet, and a stored artifact
@@ -457,9 +465,16 @@ function compiledBreakpoints(
   render: Omit<PageRendererProps, "document" | "siteStyles"> | undefined,
   siteStyles: NonNullable<PageRendererProps["siteStyles"]>
 ): BreakpointSet | undefined {
-  if (render?.styleContext !== undefined)
-    return render.styleContext.breakpoints;
-  return typeof siteStyles === "object" ? siteStyles.breakpoints : undefined;
+  /*
+   * `firstStated`, not "the site if it has a sheet": that helper SKIPS an
+   * absent value, so a site sheet carrying no breakpoints falls through to the
+   * route context rather than answering `undefined` for both. Reading it as
+   * "site wins whenever a sheet exists" turns a stated route set into no set at
+   * all, and a canvas that should preview stays published.
+   */
+  const stored =
+    typeof siteStyles === "object" ? siteStyles.breakpoints : undefined;
+  return stored ?? render?.styleContext?.breakpoints;
 }
 
 /**

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -417,6 +417,61 @@ export interface CanvasPreview {
   onMeasured?: (width: number | undefined) => void;
 }
 
+/**
+ * The renderer's inputs, made to agree with the box the canvas establishes.
+ *
+ * BOTH tiers, from one hook, because they are one decision read twice. A page's
+ * node styles and a site's named classes each emit their own breakpoint rules
+ * and each carry their own `previewContainer`; bound on only one, a class's
+ * tablet rule stays an `@media` answered by the WINDOW while the node's tablet
+ * rule became a `@container` answered by the box — so narrowing the canvas
+ * moves one and not the other, and a block styled by a class does not respond.
+ *
+ * The container is written IN rather than asked for: it and the container this
+ * element establishes are the same fact, and a caller holding two places to say
+ * it has two chances to say it differently. Overwritten rather than defaulted,
+ * so a host supplying a different name is corrected instead of believed.
+ */
+function usePreviewedInputs(
+  render: Omit<PageRendererProps, "document" | "siteStyles"> | undefined,
+  siteStyles: NonNullable<PageRendererProps["siteStyles"]>,
+  preview: CanvasPreview | undefined
+): {
+  rendered: Omit<PageRendererProps, "document" | "siteStyles"> | undefined;
+  sheet: NonNullable<PageRendererProps["siteStyles"]>;
+} {
+  return useMemo(() => {
+    if (preview === undefined) return { rendered: render, sheet: siteStyles };
+    return {
+      /*
+       * `styleContext` absent is left alone: without it the renderer compiles
+       * no per-node sheet, so there are no page rules for a container to
+       * answer.
+       */
+      rendered:
+        render?.styleContext === undefined
+          ? render
+          : {
+              ...render,
+              styleContext: {
+                ...render.styleContext,
+                previewContainer: preview.container,
+              },
+            },
+      /*
+       * `false` is a real value — a host saying it serves NO site sheet — and
+       * spreading it would turn that refusal into an object carrying a
+       * container name and nothing else, compiling an empty sheet where the
+       * caller asked for none.
+       */
+      sheet:
+        typeof siteStyles === "object"
+          ? { ...siteStyles, previewContainer: preview.container }
+          : siteStyles,
+    };
+  }, [render, siteStyles, preview]);
+}
+
 export interface CanvasProps {
   /** The document being edited. */
   document: BlockDocument;
@@ -544,41 +599,14 @@ export function Canvas({
 
   // Keyed on the document identity so a re-render for an unrelated reason —
   // a selection change, a hover — does not rebuild the rendered tree.
-  /*
-   * The compile is MADE to agree with the box, not trusted to.
-   *
-   * The container the sheet is compiled against and the container this element
-   * establishes are the same fact, and a caller holding two places to say it
-   * has two chances to say it differently. Passing `preview.container` without
-   * the matching compile option leaves the box observing and constraining a
-   * query container while the sheet still emits `@media` — so the window
-   * decides which tier is rendered and the measured width decides which tier
-   * the caller reports, with nothing anywhere reading as wrong.
-   *
-   * Overwritten rather than defaulted, so a host that supplies a DIFFERENT name
-   * is corrected instead of silently believed. `styleContext` absent is left
-   * alone: without it the renderer compiles no per-node sheet at all, so there
-   * are no preview rules for a container to answer.
-   */
-  const rendered = useMemo(() => {
-    if (preview === undefined || render?.styleContext === undefined) {
-      return render;
-    }
-    return {
-      ...render,
-      styleContext: {
-        ...render.styleContext,
-        previewContainer: preview.container,
-      },
-    };
-  }, [render, preview]);
+  const { rendered, sheet } = usePreviewedInputs(render, siteStyles, preview);
 
   const page = useMemo(
     () => (
       <PageRenderer
         {...rendered}
         document={document}
-        siteStyles={siteStyles}
+        siteStyles={sheet}
         // What makes the hit-testing above possible at all. The renderer emits
         // the node attribute only when asked, because a PUBLISHED page should
         // not carry an editor's addressing — so the canvas asks and a route
@@ -588,7 +616,7 @@ export function Canvas({
         nodeAttribute
       />
     ),
-    [rendered, document, siteStyles]
+    [rendered, document, sheet]
   );
 
   useSelectionMarkers(root, marked, selectedId, page);

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -227,7 +227,23 @@ function useReportedInlineWidth(
       report(inlineSizeOf(entry));
     });
     observer.observe(element);
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      /*
+       * The box is gone, so the last number it reported describes nothing.
+       *
+       * Left standing, a caller goes on deriving a tier from a width no
+       * element has — and the editor unmounts this canvas whenever the site's
+       * stored styles stop being readable, which a cached query can do on a
+       * refocus long after the first measurement. The inspector would keep
+       * writing into whichever tier the stale width implied, with no preview
+       * box on screen and the control that sets it disabled.
+       *
+       * `undefined` is the honest report and the one the caller already
+       * handles: nothing has been observed.
+       */
+      report(undefined);
+    };
   }, [box, report]);
 }
 

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -32,6 +32,7 @@
 import {
   previewContainerName,
   type BlockDocument,
+  type BreakpointSet,
 } from "@nextlyhq/blocks-engine";
 import {
   NODE_ID_ATTRIBUTE,
@@ -43,6 +44,7 @@ import { cn } from "@nextlyhq/ui/utils";
 import { useCallback, useEffect, useMemo, useRef } from "react";
 
 import type { CanvasDragHandlers } from "./canvas-drag";
+import { offeredTiers } from "./canvas-width";
 import { selectionModeFor, type SelectionMode } from "./selection";
 
 /**
@@ -440,6 +442,27 @@ export interface CanvasPreview {
 }
 
 /**
+ * The breakpoints the compile will actually run against, or `undefined` when
+ * nothing will be compiled at all.
+ *
+ * The page tier's when it has one and the site sheet's otherwise, which is the
+ * same order the container itself is bound in — so this answers for the compile
+ * that will really happen rather than for the inputs a caller passed.
+ *
+ * `undefined` is the state where a caller has neither binding site:
+ * `siteStyles={false}` opts out of the shared sheet, and a stored artifact
+ * arrives with no style context.
+ */
+function compiledBreakpoints(
+  render: Omit<PageRendererProps, "document" | "siteStyles"> | undefined,
+  siteStyles: NonNullable<PageRendererProps["siteStyles"]>
+): BreakpointSet | undefined {
+  if (render?.styleContext !== undefined)
+    return render.styleContext.breakpoints;
+  return typeof siteStyles === "object" ? siteStyles.breakpoints : undefined;
+}
+
+/**
  * Whether this canvas is previewing at all, and under what name.
  *
  * Asked once, here, so the sheet, the box and the measurement cannot disagree
@@ -457,6 +480,15 @@ export interface CanvasPreview {
  * site tier's sheet — and a caller can legitimately have neither:
  * `siteStyles={false}` opts out of the shared sheet, and a stored artifact
  * arrives with no style context.
+ *
+ * NOTHING TO SIMULATE is the third. A preview compile rewrites every
+ * CONTAINER-axis rule to `@container nx-not-previewable (width < 0px)`, which
+ * matches nothing — the engine refusing a question a preview box cannot answer,
+ * and the right trade when there are viewport tiers to gain in exchange. With
+ * no emitted viewport tier the same price buys nothing: a container-only site
+ * would have every one of its breakpoints stop matching here while they keep
+ * working on the published page. Decided in the component rather than at one
+ * mount, so every consumer of this API keeps published mode for that set.
  */
 function activePreview(
   render: Omit<PageRendererProps, "document" | "siteStyles"> | undefined,
@@ -465,9 +497,14 @@ function activePreview(
 ): CanvasPreview | undefined {
   const container = previewContainerName(preview?.container);
   if (preview === undefined || container === undefined) return undefined;
-  const bindable =
-    render?.styleContext !== undefined || typeof siteStyles === "object";
-  return bindable ? { ...preview, container } : undefined;
+  const breakpoints = compiledBreakpoints(render, siteStyles);
+  // Undefined here IS "nowhere to bind": the two binding sites are the only
+  // places a breakpoint set can come from, so their absence is one condition
+  // rather than two that have to be kept in step.
+  if (breakpoints === undefined) return undefined;
+  return offeredTiers(breakpoints).length === 0
+    ? undefined
+    : { ...preview, container };
 }
 
 /**

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -435,6 +435,11 @@ export interface CanvasProps {
    * container resizes a box whose sheet still queries the window, so the page
    * reflows and not one breakpoint changes. A container nobody observes leaves
    * the surface that owns the box unable to say which tier is live.
+   *
+   * The container also travels INTO the compile from here rather than being
+   * asked for twice: `render.styleContext.previewContainer` is overwritten with
+   * `container`, so the box the queries are written against and the box this
+   * element establishes cannot be different names.
    */
   preview?: CanvasPreview;
   /**
@@ -539,10 +544,39 @@ export function Canvas({
 
   // Keyed on the document identity so a re-render for an unrelated reason —
   // a selection change, a hover — does not rebuild the rendered tree.
+  /*
+   * The compile is MADE to agree with the box, not trusted to.
+   *
+   * The container the sheet is compiled against and the container this element
+   * establishes are the same fact, and a caller holding two places to say it
+   * has two chances to say it differently. Passing `preview.container` without
+   * the matching compile option leaves the box observing and constraining a
+   * query container while the sheet still emits `@media` — so the window
+   * decides which tier is rendered and the measured width decides which tier
+   * the caller reports, with nothing anywhere reading as wrong.
+   *
+   * Overwritten rather than defaulted, so a host that supplies a DIFFERENT name
+   * is corrected instead of silently believed. `styleContext` absent is left
+   * alone: without it the renderer compiles no per-node sheet at all, so there
+   * are no preview rules for a container to answer.
+   */
+  const rendered = useMemo(() => {
+    if (preview === undefined || render?.styleContext === undefined) {
+      return render;
+    }
+    return {
+      ...render,
+      styleContext: {
+        ...render.styleContext,
+        previewContainer: preview.container,
+      },
+    };
+  }, [render, preview]);
+
   const page = useMemo(
     () => (
       <PageRenderer
-        {...render}
+        {...rendered}
         document={document}
         siteStyles={siteStyles}
         // What makes the hit-testing above possible at all. The renderer emits
@@ -554,7 +588,7 @@ export function Canvas({
         nodeAttribute
       />
     ),
-    [render, document, siteStyles]
+    [rendered, document, siteStyles]
   );
 
   useSelectionMarkers(root, marked, selectedId, page);

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -440,6 +440,37 @@ export interface CanvasPreview {
 }
 
 /**
+ * Whether this canvas is previewing at all, and under what name.
+ *
+ * Asked once, here, so the sheet, the box and the measurement cannot disagree
+ * about it. Two things make a preview inert despite a caller asking for one,
+ * and they fail the same way — the box constrains and measures while the rules
+ * still answer to the WINDOW, so a caller deriving an edit target from the
+ * measurement writes to a tier the canvas is not displaying.
+ *
+ * A REFUSED name is the first: `previewContainerName` turns down an empty,
+ * reserved, malformed or oversized value, and the compile falls back to
+ * published `@media`.
+ *
+ * NOWHERE TO BIND is the second, and the name is perfectly good in that one.
+ * There are exactly two binding sites — the page tier's style context and the
+ * site tier's sheet — and a caller can legitimately have neither:
+ * `siteStyles={false}` opts out of the shared sheet, and a stored artifact
+ * arrives with no style context.
+ */
+function activePreview(
+  render: Omit<PageRendererProps, "document" | "siteStyles"> | undefined,
+  siteStyles: NonNullable<PageRendererProps["siteStyles"]>,
+  preview: CanvasPreview | undefined
+): CanvasPreview | undefined {
+  const container = previewContainerName(preview?.container);
+  if (preview === undefined || container === undefined) return undefined;
+  const bindable =
+    render?.styleContext !== undefined || typeof siteStyles === "object";
+  return bindable ? { ...preview, container } : undefined;
+}
+
+/**
  * The renderer's inputs, made to agree with the box the canvas establishes.
  *
  * BOTH tiers, from one hook, because they are one decision read twice. A page's
@@ -478,11 +509,10 @@ function usePreviewedInputs(
   active: CanvasPreview | undefined;
 } {
   return useMemo(() => {
-    const container = previewContainerName(preview?.container);
-    if (preview === undefined || container === undefined) {
+    const active = activePreview(render, siteStyles, preview);
+    if (active === undefined) {
       return { rendered: render, sheet: siteStyles, active: undefined };
     }
-    const active = { ...preview, container };
     return {
       active,
       /*
@@ -497,7 +527,7 @@ function usePreviewedInputs(
               ...render,
               styleContext: {
                 ...render.styleContext,
-                previewContainer: container,
+                previewContainer: active.container,
               },
             },
       /*
@@ -508,7 +538,7 @@ function usePreviewedInputs(
        */
       sheet:
         typeof siteStyles === "object"
-          ? { ...siteStyles, previewContainer: container }
+          ? { ...siteStyles, previewContainer: active.container }
           : siteStyles,
     };
   }, [render, siteStyles, preview]);

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -29,7 +29,10 @@
  * @module canvas
  */
 
-import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import {
+  previewContainerName,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
 import {
   NODE_ID_ATTRIBUTE,
   PageRenderer,
@@ -214,9 +217,28 @@ function useReportedInlineWidth(
   box: React.RefObject<HTMLElement | null>,
   report: ((width: number | undefined) => void) | undefined
 ): void {
+  /*
+   * The reporter is held in a ref, and the effect does NOT depend on it.
+   *
+   * A host writing `onMeasured={w => setWidth(w)}` inline hands a new function
+   * on every render. Depended on directly, every real measurement would update
+   * the parent, produce a new identity, tear the observer down — reporting
+   * `undefined` from the cleanup, as if the canvas had gone — and build a new
+   * one that immediately reports the real width again. The derived tier
+   * oscillates and the observer churn can sustain a render loop, on a host that
+   * did nothing wrong.
+   *
+   * So the effect keys on whether a reporter EXISTS, which is the only part of
+   * it that changes what the observer should do.
+   */
+  const latest = useRef(report);
+  useEffect(() => {
+    latest.current = report;
+  }, [report]);
+  const measuring = report !== undefined;
   useEffect(() => {
     const element = box.current;
-    if (element === null || report === undefined) return;
+    if (element === null || !measuring) return;
     // Guarded by CALLABILITY rather than presence: jsdom defines the global on
     // some setups without a working constructor, so a property test passes and
     // the construction throws.
@@ -224,7 +246,7 @@ function useReportedInlineWidth(
     const observer = new ResizeObserver(entries => {
       const entry = entries[0];
       if (entry === undefined) return;
-      report(inlineSizeOf(entry));
+      latest.current?.(inlineSizeOf(entry));
     });
     observer.observe(element);
     return () => {
@@ -242,9 +264,9 @@ function useReportedInlineWidth(
        * `undefined` is the honest report and the one the caller already
        * handles: nothing has been observed.
        */
-      report(undefined);
+      latest.current?.(undefined);
     };
-  }, [box, report]);
+  }, [box, measuring]);
 }
 
 /**
@@ -439,10 +461,30 @@ function usePreviewedInputs(
 ): {
   rendered: Omit<PageRendererProps, "document" | "siteStyles"> | undefined;
   sheet: NonNullable<PageRendererProps["siteStyles"]>;
+  /**
+   * The preview that is actually in force, or `undefined` when none is.
+   *
+   * A NAME the compiler refuses is not a preview. `previewContainerName` turns
+   * down an empty, reserved, malformed or oversized value, and the compile then
+   * falls back to published `@media` — so a box that went on constraining and
+   * measuring itself would resize without changing a single tier, and a caller
+   * deriving an edit target from the measurement would write to a breakpoint
+   * the canvas is not displaying. That is the same confident-wrong-answer the
+   * whole mechanism exists to remove, arrived at through the refusal path.
+   *
+   * Normalised HERE and nowhere else, so the sheet, the box and the measurement
+   * cannot disagree about whether this canvas is previewing at all.
+   */
+  active: CanvasPreview | undefined;
 } {
   return useMemo(() => {
-    if (preview === undefined) return { rendered: render, sheet: siteStyles };
+    const container = previewContainerName(preview?.container);
+    if (preview === undefined || container === undefined) {
+      return { rendered: render, sheet: siteStyles, active: undefined };
+    }
+    const active = { ...preview, container };
     return {
+      active,
       /*
        * `styleContext` absent is left alone: without it the renderer compiles
        * no per-node sheet, so there are no page rules for a container to
@@ -455,7 +497,7 @@ function usePreviewedInputs(
               ...render,
               styleContext: {
                 ...render.styleContext,
-                previewContainer: preview.container,
+                previewContainer: container,
               },
             },
       /*
@@ -466,7 +508,7 @@ function usePreviewedInputs(
        */
       sheet:
         typeof siteStyles === "object"
-          ? { ...siteStyles, previewContainer: preview.container }
+          ? { ...siteStyles, previewContainer: container }
           : siteStyles,
     };
   }, [render, siteStyles, preview]);
@@ -585,8 +627,6 @@ export function Canvas({
 }: CanvasProps) {
   const root = useRef<HTMLDivElement | null>(null);
 
-  useReportedInlineWidth(root, preview?.onMeasured);
-
   /*
    * What to mark. The primary alone when a host has not adopted the set yet,
    * which keeps every existing caller correct without a change.
@@ -599,7 +639,13 @@ export function Canvas({
 
   // Keyed on the document identity so a re-render for an unrelated reason —
   // a selection change, a hover — does not rebuild the rendered tree.
-  const { rendered, sheet } = usePreviewedInputs(render, siteStyles, preview);
+  const { rendered, sheet, active } = usePreviewedInputs(
+    render,
+    siteStyles,
+    preview
+  );
+
+  useReportedInlineWidth(root, active?.onMeasured);
 
   const page = useMemo(
     () => (
@@ -629,7 +675,7 @@ export function Canvas({
       // are positioned in this element's own content coordinates: a box inside
       // it would size the page while leaving the drop indicator and the
       // selection chrome measuring the region instead.
-      style={previewBoxStyle(preview)}
+      style={previewBoxStyle(active)}
       // The id the canvas believes is current, for a caller that wants the
       // answer without walking the tree. Named apart from the per-element
       // marker deliberately: one carries an id and the other is a boolean, and

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -474,7 +474,15 @@ function compiledBreakpoints(
    */
   const stored =
     typeof siteStyles === "object" ? siteStyles.breakpoints : undefined;
-  return stored ?? render?.styleContext?.breakpoints;
+  /*
+   * `=== undefined`, never `??`. `firstStated` is `find(tier => tier !== undefined)`,
+   * so a stored `null` — which runtime or imported data can supply — is KEPT by
+   * the renderer and read as defining no viewport tiers. Nullish coalescing
+   * falls through to the route set instead, turning preview on for a canvas the
+   * renderer left on the unconditional tier: the box then measures and selects
+   * a route tier that is not on screen.
+   */
+  return stored === undefined ? render?.styleContext?.breakpoints : stored;
 }
 
 /**
@@ -560,13 +568,28 @@ function usePreviewedInputs(
    */
   active: CanvasPreview | undefined;
 } {
-  return useMemo(() => {
-    const active = activePreview(render, siteStyles, preview);
-    if (active === undefined) {
-      return { rendered: render, sheet: siteStyles, active: undefined };
+  const active = activePreview(render, siteStyles, preview);
+  /*
+   * Keyed on the container NAME, not on the preview object.
+   *
+   * `preview.width` changes on every switcher selection and an inline
+   * `onMeasured` changes on every render, and neither alters a single emitted
+   * rule — but depending on the object rebuilds these inputs, which rebuilds
+   * the rendered page, which recompiles the document and the site sheet
+   * synchronously. On a large document that is the cost of a whole compile per
+   * width change, and continuous resizing pays it per frame.
+   *
+   * The box's own inputs travel outside this memo, in `active`, where being a
+   * fresh object costs nothing: the style is recomputed from it directly and
+   * the measurement effect keys on whether a reporter EXISTS rather than on its
+   * identity.
+   */
+  const container = active?.container;
+  const compiled = useMemo(() => {
+    if (container === undefined) {
+      return { rendered: render, sheet: siteStyles };
     }
     return {
-      active,
       /*
        * `styleContext` absent is left alone: without it the renderer compiles
        * no per-node sheet, so there are no page rules for a container to
@@ -579,7 +602,7 @@ function usePreviewedInputs(
               ...render,
               styleContext: {
                 ...render.styleContext,
-                previewContainer: active.container,
+                previewContainer: container,
               },
             },
       /*
@@ -590,10 +613,11 @@ function usePreviewedInputs(
        */
       sheet:
         typeof siteStyles === "object"
-          ? { ...siteStyles, previewContainer: active.container }
+          ? { ...siteStyles, previewContainer: container }
           : siteStyles,
     };
-  }, [render, siteStyles, preview]);
+  }, [render, siteStyles, container]);
+  return { ...compiled, active };
 }
 
 export interface CanvasProps {

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -30,7 +30,11 @@
  */
 
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
-import { NODE_ID_ATTRIBUTE, PageRenderer } from "@nextlyhq/blocks-react";
+import {
+  NODE_ID_ATTRIBUTE,
+  PageRenderer,
+  previewContainerStyle,
+} from "@nextlyhq/blocks-react";
 import type { PageRendererProps } from "@nextlyhq/blocks-react";
 import { cn } from "@nextlyhq/ui/utils";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -179,6 +183,41 @@ export interface CanvasProps {
    */
   siteStyles: NonNullable<PageRendererProps["siteStyles"]>;
   /**
+   * The width to constrain the page box to, in CSS pixels, or `undefined` to
+   * fill the region.
+   *
+   * A MAXIMUM rather than a fixed width, because the region may be narrower
+   * than the tier being asked for — a wide breakpoint inside a half-width
+   * editor pane cannot be honoured, and stretching the box past its region
+   * would put the page under the inspector instead.
+   */
+  previewWidth?: number;
+  /**
+   * The container name this box establishes, when the sheet was compiled as a
+   * preview.
+   *
+   * Passed through {@link previewContainerStyle}, which supplies the
+   * `container-type` alongside the name: a named container left at the default
+   * `normal` is not a size-query container, so every rule the preview compile
+   * emitted stays inactive while the sheet is valid and the name matches.
+   */
+  previewContainer?: string;
+  /**
+   * The box's MEASURED inline size, reported whenever it changes.
+   *
+   * Reported rather than derived from {@link previewWidth}, because those are
+   * different numbers and only one of them decides anything. The requested
+   * width is a ceiling; what the container queries resolve against is the width
+   * the box actually got. A caller that assumed the request was honoured would
+   * name a tier the box is not showing — the same confident-wrong-answer this
+   * whole preview mechanism exists to remove.
+   *
+   * `undefined` until the first measurement, which is a real state rather than
+   * a default: nothing has been observed yet, and a caller must not report a
+   * tier as live on the strength of a box nobody has looked at.
+   */
+  onMeasuredWidth?: (width: number | undefined) => void;
+  /**
    * The PRIMARY selected node's id, or null when the selection is empty.
    *
    * The one the inspector edits. Marked `data-nx-selected="primary"` so a
@@ -262,8 +301,42 @@ export function Canvas({
   dragHandlers,
   onDoubleClick,
   overlay,
+  previewWidth,
+  previewContainer,
+  onMeasuredWidth,
 }: CanvasProps) {
   const root = useRef<HTMLDivElement | null>(null);
+
+  /*
+   * The box's real inline size, observed rather than assumed.
+   *
+   * `ResizeObserver` rather than a resize listener on the window: the box
+   * changes width when the inspector opens, when a rail panel is toggled and
+   * when the pane is dragged, none of which resize the window. A window
+   * listener would report the same number across all three.
+   *
+   * `contentBoxSize` rather than `getBoundingClientRect().width`, because the
+   * editor applies a canvas zoom transform and the rect is the TRANSFORMED
+   * size — which is what a reader sees but not what the container queries
+   * resolve against. A container query asks the element's own layout size, so
+   * reporting the visual one would name the wrong tier at any zoom but 100%.
+   */
+  useEffect(() => {
+    const box = root.current;
+    if (box === null || onMeasuredWidth === undefined) return;
+    // Guarded by CALLABILITY rather than presence: jsdom defines the global on
+    // some setups without a working constructor, so a property test passes and
+    // the construction throws.
+    if (typeof ResizeObserver !== "function") return;
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry === undefined) return;
+      const inline = entry.contentBoxSize[0]?.inlineSize;
+      onMeasuredWidth(typeof inline === "number" ? inline : undefined);
+    });
+    observer.observe(box);
+    return () => observer.disconnect();
+  }, [onMeasuredWidth]);
 
   /*
    * What to mark. The primary alone when a host has not adopted the set yet,
@@ -348,6 +421,25 @@ export function Canvas({
     <div
       ref={root}
       className={cn(CANVAS_ROOT_CLASS, className)}
+      /*
+       * The preview box: the container the sheet queries, and the width it is
+       * being asked to show.
+       *
+       * Centred rather than left-aligned, which is what every builder surveyed
+       * does and is not merely cosmetic — an off-centre narrow box reads as a
+       * layout that has broken rather than as a viewport being simulated.
+       *
+       * On the canvas ROOT rather than an inner wrapper, because the overlays
+       * are positioned in this element's own content coordinates: a box inside
+       * it would size the page while leaving the drop indicator and the
+       * selection chrome measuring the region instead.
+       */
+      style={{
+        ...previewContainerStyle(previewContainer),
+        ...(previewWidth === undefined
+          ? {}
+          : { maxWidth: `${previewWidth}px`, marginInline: "auto" }),
+      }}
       // The id the canvas believes is current, for a caller that wants the
       // answer without walking the tree. Named apart from the per-element
       // marker deliberately: one carries an id and the other is a boolean, and

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -72,7 +72,7 @@ export type { BuilderCommand, CommandPaletteProps } from "./command-palette";
  * of one contract that could then be versioned apart.
  */
 export { CANVAS_ROOT_CLASS, Canvas, nodeIdFromEvent } from "./canvas";
-export type { CanvasProps } from "./canvas";
+export type { CanvasPreview, CanvasProps } from "./canvas";
 
 /**
  * The inserter, behind the same client banner as the shell it fills: it holds

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -130,6 +130,29 @@ export { BreakpointManager } from "./breakpoint-manager";
 export type { BreakpointManagerProps } from "./breakpoint-manager";
 
 /**
+ * The control that sizes the canvas, and the derivations behind it.
+ *
+ * Published together because they are one answer read from two places. The
+ * switcher SETS a width; `editedBreakpointAtWidth` and `breakpointsAtWidth`
+ * turn the width the box actually got into the tier an edit lands in and the
+ * tiers that are live. A host given only the control would have to derive those
+ * itself, and a second derivation of "which tier is this box in" is exactly the
+ * disagreement between the canvas and the inspector that deriving from one
+ * width exists to make unrepresentable.
+ *
+ * On the CLIENT entry: the switcher is a component, and the derivations travel
+ * with it rather than from the root barrel so a host imports the pair from one
+ * place.
+ */
+export { BreakpointSwitcher } from "./breakpoint-switcher";
+export type { BreakpointSwitcherProps } from "./breakpoint-switcher";
+export {
+  breakpointsAtWidth,
+  editedBreakpointAtWidth,
+  widthForBreakpoint,
+} from "./canvas-width";
+
+/**
  * The editor's keyboard actions — moving, deleting, undoing — behind the same
  * client banner.
  *

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -149,6 +149,7 @@ export type { BreakpointSwitcherProps } from "./breakpoint-switcher";
 export {
   breakpointsAtWidth,
   editedBreakpointAtWidth,
+  offeredTiers,
   widthForBreakpoint,
 } from "./canvas-width";
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -1,0 +1,325 @@
+// @vitest-environment jsdom
+
+/**
+ * The canvas width reaching the three surfaces that answer to it.
+ *
+ * `canvas-width.test.ts` in the builder asserts the DERIVATIONS — which tiers a
+ * box of a given width applies, and which one an edit lands in. What is only
+ * true HERE is the wiring: that one width drives the canvas box, the control
+ * that sets it and the panel that writes into the tier it implies, and that the
+ * panel is told about the same container the canvas was compiled against.
+ *
+ * Every derivation can be correct while the props are absent or crossed, and
+ * the failure is silent in the worst direction — the canvas resizes, the author
+ * watches the page reflow, and their edits go on landing in the widest tier.
+ *
+ * The builder shell is replaced with recorders rather than rendered, as
+ * `BlocksField.policy.test` does and for its reason: what is under test is
+ * which props this component passes.
+ *
+ * @module admin/BlocksField.breakpoints.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/*
+ * Declared here rather than in a setup file, because neither this package nor
+ * the builder configures one. `React.act` refuses to run without it, and the
+ * refusal is a warning rather than a failure — so a version of this file
+ * missing it would drive nothing and still assert against the FIRST render's
+ * props, passing for two of the cases below.
+ */
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+/*
+ * ONE document object for the life of the mount.
+ *
+ * The editor replaces its state rather than mutating it, so this component
+ * treats a new document IDENTITY as an edit and asks for a checkpoint. Rebuilt
+ * inside the hook stub it would be a fresh object on every render, and every
+ * width change below would be read as the author having typed.
+ */
+const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
+
+/** Props the recorders captured on the most recent render. */
+const seen: {
+  inspector: Record<string, unknown> | undefined;
+  canvas: Record<string, unknown> | undefined;
+  switcher: Record<string, unknown> | undefined;
+} = { inspector: undefined, canvas: undefined, switcher: undefined };
+
+/** What `usePluginClientConfig` answers with for the test in hand. */
+let clientConfig: Record<string, unknown> | undefined;
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  /*
+   * The real module SPREAD, with only the surfaces this file drives replaced —
+   * which also keeps the DERIVATIONS real. `editedBreakpointAtWidth` and
+   * `breakpointsAtWidth` are what turn a measured width into the values
+   * asserted below, and stubbing them would leave this file asserting its own
+   * fixtures.
+   */
+  const real = await importOriginal<Record<string, unknown>>();
+  const record =
+    (key: "inspector" | "canvas" | "switcher") =>
+    (props: Record<string, unknown>): React.JSX.Element => {
+      seen[key] = props;
+      return <div data-recorder={key} />;
+    };
+  const nothing = (): null => null;
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    BuilderShell: ({
+      inspector,
+      topBar,
+      children,
+    }: {
+      inspector: React.ReactNode;
+      topBar?: React.ReactNode;
+      children?: React.ReactNode;
+    }): React.JSX.Element => (
+      <div>
+        {topBar}
+        {inspector}
+        {children}
+      </div>
+    ),
+    BreakpointManager: nothing,
+    BreakpointSwitcher: record("switcher"),
+    InspectorPanel: record("inspector"),
+    Canvas: record("canvas"),
+    BlockKeyboardActions: passthrough,
+    BlockToolbar: nothing,
+    EditorCommandPalette: nothing,
+    DropIndicator: nothing,
+    InsertPanel: nothing,
+    LayersPanel: nothing,
+    OnboardingChecklist: nothing,
+    SelectionBreadcrumb: nothing,
+    SpacingOverlay: nothing,
+    useBuilderChecklist: () => ({
+      visible: false,
+      steps: [],
+      dismiss: () => {},
+    }),
+    useCanvasDrag: () => ({ handlers: {}, target: null }),
+    useEditorState: () => ({
+      document: DOCUMENT,
+      selectedId: null,
+      selection: { ids: [], primary: null },
+      apply: () => null,
+      applyAll: () => null,
+      select: () => {},
+      undo: () => {},
+      redo: () => {},
+      canUndo: false,
+      canRedo: false,
+      undoDepth: 0,
+    }),
+    useInlineText: () => ({ onDoubleClick: () => {} }),
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  usePluginClientConfig: () => clientConfig,
+  useDocumentCheckpoint: () => ({ schedule: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  // Nothing stored, read successfully — so the merged style is the host's
+  // config alone and `status` is "ready". A pending read would disable the
+  // switcher, which is a different test's subject.
+  useSingleDocument: () => ({ data: undefined, isPending: false, error: null }),
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async () => ({ success: true }),
+    isPending: false,
+  }),
+}));
+
+const { BlocksField } = await import("./BlocksField");
+
+/**
+ * A site defining two viewport tiers, supplied through the host's config.
+ *
+ * Real numbers rather than round ones, because the boundary is inclusive and a
+ * bound of 1000 would let an off-by-one comparison pass against a measured
+ * 1000.
+ */
+const SITE = {
+  breakpoints: {
+    viewport: [
+      { id: "tablet", label: "Tablet", maxWidth: 991 },
+      { id: "mobile", label: "Mobile", maxWidth: 575 },
+    ],
+    container: [],
+  },
+};
+
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+function openEditor(): void {
+  render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+}
+
+/** The box inputs the canvas was handed. */
+function box(): {
+  container?: string;
+  width?: number;
+  onMeasured?: (width: number | undefined) => void;
+} {
+  return (seen.canvas?.preview ?? {}) as {
+    container?: string;
+    width?: number;
+    onMeasured?: (width: number | undefined) => void;
+  };
+}
+
+/** What the canvas reports its box actually measured. */
+function measure(width: number | undefined): void {
+  const report = box().onMeasured;
+  if (report === undefined) throw new Error("the canvas was given no reporter");
+  React.act(() => {
+    report(width);
+  });
+}
+
+/** What the author asks the switcher for. */
+function choose(width: number | undefined): void {
+  const select = seen.switcher?.onSelect as
+    | ((width: number | undefined) => void)
+    | undefined;
+  if (select === undefined)
+    throw new Error("the switcher was given no handler");
+  React.act(() => {
+    select(width);
+  });
+}
+
+beforeEach(() => {
+  seen.inspector = undefined;
+  seen.canvas = undefined;
+  seen.switcher = undefined;
+  clientConfig = { siteStyle: SITE };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the container the canvas is compiled against", () => {
+  it("tells the inspector about the SAME one it compiled with", () => {
+    /*
+     * The panel decides whether the window may answer for which tiers are live.
+     * Given a name the canvas did not compile with — or given none while the
+     * canvas compiled with one — it evaluates `@media` rules a container-query
+     * compile never wrote, and a wide admin window around a narrow canvas then
+     * reports the desktop tier live while the box is painting tablet.
+     *
+     * Asserted as equality AND as present, because two `undefined`s are equal
+     * and would pass a comparison alone while nothing was previewing at all.
+     */
+    openEditor();
+
+    const context = (
+      seen.canvas?.render as {
+        styleContext?: { previewContainer?: string };
+      }
+    )?.styleContext;
+    expect(context?.previewContainer).toBeTypeOf("string");
+    expect(seen.inspector?.previewContainer).toBe(context?.previewContainer);
+    /*
+     * And the BOX establishes that same container. The sheet's rules name it;
+     * an element establishing a different one — or none — leaves every preview
+     * rule matching nothing, with the sheet valid and the canvas resizing.
+     */
+    expect(box().container).toBe(context?.previewContainer);
+  });
+});
+
+describe("what one width drives", () => {
+  it("sizes the canvas to the tier the author chooses", () => {
+    openEditor();
+
+    choose(991);
+
+    expect(box().width).toBe(991);
+  });
+
+  it("releases the canvas back to the region at the widest tier", () => {
+    /*
+     * The control on the case above: a mount that pinned a number here would
+     * satisfy it while making the widest option narrower than the space
+     * available, which is a permanent gutter around a canvas that was already
+     * the right size.
+     */
+    openEditor();
+
+    choose(991);
+    choose(undefined);
+
+    expect(box().width).toBeUndefined();
+  });
+
+  it("edits the tier the box was MEASURED in, not the one requested", () => {
+    /*
+     * The property this whole mount exists for. The request is a ceiling: an
+     * editor region narrower than the widest tier hands the box less, and the
+     * narrower tier is then what the browser paints.
+     *
+     * Deriving the edited tier from the request instead would tell an author at
+     * the full width that they are editing the base tier while every value they
+     * type lands in tablet — invisible, because the canvas looks correct.
+     */
+    openEditor();
+
+    choose(undefined);
+    measure(900);
+
+    expect(seen.inspector?.breakpoint).toBe("tablet");
+    expect(seen.inspector?.liveBreakpoints).toContain("tablet");
+  });
+
+  it("names no narrower tier before the box has been measured", () => {
+    /*
+     * The control on the case above, and an honest state rather than a default:
+     * nothing has been observed on the first render, and a panel that named a
+     * tier there would be describing a box nobody has looked at.
+     */
+    openEditor();
+
+    expect(seen.inspector?.breakpoint).toBe("base");
+    expect(seen.inspector?.liveBreakpoints).not.toContain("tablet");
+  });
+
+  it("keeps the requested and the measured width APART at the switcher", () => {
+    /*
+     * The two are different facts and the control needs both. Fed the measured
+     * width as its selection, it would unselect the option the author just
+     * clicked whenever the region could not honour it — the tier would look
+     * unchosen while the canvas was showing it. Fed only the request, its tier
+     * indicator could never report the narrow-region case, which is the one
+     * case it exists for.
+     */
+    openEditor();
+
+    choose(991);
+    measure(900);
+
+    expect(seen.switcher?.width).toBe(991);
+    expect(seen.switcher?.appliedWidth).toBe(900);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -371,3 +371,61 @@ describe("a width the site stops offering", () => {
     expect(box().width).toBe(991);
   });
 });
+
+describe("a site with nothing to simulate", () => {
+  it("stays PUBLISHED when no viewport tier is emitted", () => {
+    /*
+     * A preview compile rewrites every CONTAINER-axis rule to
+     * `@container nx-not-previewable (width < 0px)`, which matches nothing.
+     * That is the engine refusing to answer a question a preview box cannot —
+     * a container query resolves against an element's own query container —
+     * and it is the right trade when there are viewport tiers to gain.
+     *
+     * With none, the same price is paid for nothing: a site whose only
+     * breakpoints are container ones would have every one of them silently
+     * stop matching on the canvas while they keep working on the published
+     * page.
+     */
+    clientConfig = {
+      siteStyle: {
+        breakpoints: {
+          viewport: [],
+          container: [{ id: "narrow", label: "Narrow", maxWidth: 400 }],
+        },
+      },
+    };
+
+    openEditor();
+
+    const context = (
+      seen.canvas?.render as { styleContext?: { previewContainer?: string } }
+    )?.styleContext;
+    expect(context?.previewContainer).toBeUndefined();
+    expect(seen.canvas?.preview).toBeUndefined();
+    expect(seen.inspector?.previewContainer).toBeUndefined();
+  });
+
+  it("PREVIEWS when the site emits a viewport tier alongside a container one", () => {
+    /*
+     * The control. Without it, a mount that never previewed would satisfy the
+     * case above — and the whole feature would be off with every assertion
+     * about it still green.
+     */
+    clientConfig = {
+      siteStyle: {
+        breakpoints: {
+          viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+          container: [{ id: "narrow", label: "Narrow", maxWidth: 400 }],
+        },
+      },
+    };
+
+    openEditor();
+
+    const context = (
+      seen.canvas?.render as { styleContext?: { previewContainer?: string } }
+    )?.styleContext;
+    expect(context?.previewContainer).toBeTypeOf("string");
+    expect(box().container).toBe(context?.previewContainer);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -170,9 +170,16 @@ function Host(): React.JSX.Element {
   return <BlocksField name="body" control={control} />;
 }
 
-function openEditor(): void {
-  render(<Host />);
+function openEditor(): { rerender: () => void } {
+  const view = render(<Host />);
   fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  return {
+    rerender: () => {
+      React.act(() => {
+        view.rerender(<Host />);
+      });
+    },
+  };
 }
 
 /** The box inputs the canvas was handed. */
@@ -321,5 +328,46 @@ describe("what one width drives", () => {
 
     expect(seen.switcher?.width).toBe(991);
     expect(seen.switcher?.appliedWidth).toBe(900);
+  });
+});
+
+describe("a width the site stops offering", () => {
+  it("releases the canvas when the selected tier is deleted", () => {
+    /*
+     * The switcher renders nothing once a site defines no viewport tiers, and
+     * it cannot clear state it does not own. So an author who selects a tier
+     * and then deletes it is left with a canvas pinned to a bound the
+     * stylesheet no longer has, and no control on screen to release it — the
+     * only way out is to close the editor and reopen it.
+     *
+     * Driven through the CONFIG the editor reads its breakpoints from, rather
+     * than by calling the release directly, because what is under test is that
+     * the width is reconciled against the site as it now stands.
+     */
+    const view = openEditor();
+    choose(991);
+    expect(box().width).toBe(991);
+
+    clientConfig = {
+      siteStyle: { breakpoints: { viewport: [], container: [] } },
+    };
+    view.rerender();
+
+    expect(box().width).toBeUndefined();
+  });
+
+  it("KEEPS a width the site still offers", () => {
+    /*
+     * The control. Without it, a version that released on every breakpoint
+     * change — or on every render — would satisfy the case above while making
+     * the switcher unusable: every selection would be undone by the next
+     * render.
+     */
+    const view = openEditor();
+    choose(991);
+
+    view.rerender();
+
+    expect(box().width).toBe(991);
   });
 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -809,9 +809,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    *
    * Only the MEASURED one decides which tier is edited. Deriving that from the
    * request would tell an author they are editing the tier they picked while
-   * the box is in a narrower one — the disagreement between what you see and
-   * what you edit that the founder's 2026-08-24 ruling deferred this control
-   * over.
+   * the box is in a narrower one, which is the disagreement between what you
+   * see and what you edit that this control exists to remove.
    */
   const [requestedWidth, setRequestedWidth] = useState<number | undefined>(
     undefined

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -841,18 +841,22 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     undefined
   );
 
-  const canvasPreviewContainer = useMemo(
-    () =>
-      offeredTiers(siteBreakpoints(canvasSiteStyle)).length === 0
-        ? undefined
-        : previewContainer,
-    [canvasSiteStyle, previewContainer]
-  );
-
-  const canvasRender = useMemo(
-    () => ({
+  const canvasRender = useMemo(() => {
+    /*
+     * ONE read of the site's breakpoints, feeding both the context and the
+     * decision about whether to preview at all.
+     *
+     * Two calls returned equal sets today and would stop the day `siteBreakpoints`
+     * normalises or defaults anything — and then preview eligibility would be
+     * answering from a different set than the canvas renders, which is the
+     * box/compile mismatch this whole seam exists to make unrepresentable. The
+     * docblock above already says this about the context's THREE readers; the
+     * eligibility question is a fourth.
+     */
+    const breakpoints = siteBreakpoints(canvasSiteStyle);
+    return {
       styleContext: {
-        breakpoints: siteBreakpoints(canvasSiteStyle),
+        breakpoints,
         /*
          * Carried on the SAME context the cascade and the inspector read, so
          * all three describe one compile. Supplied unconditionally rather than
@@ -862,16 +866,21 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
          * admin WINDOW instead — a wide window around a narrow canvas reports
          * the desktop tier live while the box paints the tablet one.
          */
-        ...(canvasPreviewContainer === undefined
-          ? {}
-          : { previewContainer: canvasPreviewContainer }),
+        ...(offeredTiers(breakpoints).length === 0 ? {} : { previewContainer }),
       },
       ...(remotePatterns === undefined
         ? {}
         : { hostPolicy: { remotePatterns } }),
-    }),
-    [canvasSiteStyle, remotePatterns, canvasPreviewContainer]
-  );
+    };
+  }, [canvasSiteStyle, remotePatterns, previewContainer]);
+
+  /*
+   * What the canvas is previewing under, read back from the ONE context that
+   * decided it rather than recomputed. The box and the inspector must be told
+   * the same thing the sheet was compiled with, and a second derivation here
+   * would be a second chance to answer differently.
+   */
+  const canvasPreviewContainer = canvasRender.styleContext.previewContainer;
 
   /*
    * Which tier an edit lands in, and which tiers the box is applying.

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -794,6 +794,27 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * make one.
    */
   const canvasBoxId = useId();
+  /*
+   * The name this canvas would establish, and whether it establishes one AT
+   * ALL.
+   *
+   * Previewing is not free: a preview compile rewrites every CONTAINER-axis
+   * rule to `@container nx-not-previewable (width < 0px)`, which matches
+   * nothing. That is the engine refusing to answer a question it cannot — a
+   * container query resolves against an element's own query container, which a
+   * preview box is not — and it is the right refusal when there are viewport
+   * tiers to gain in exchange.
+   *
+   * With NO emitted viewport tier there is nothing to gain and the same price
+   * is paid: a site whose only breakpoints are container ones would have every
+   * one of them silently stop matching on the canvas while they keep working on
+   * the published page. So a canvas with nothing to simulate stays published,
+   * which is also what it looked like before any of this existed.
+   *
+   * `offeredTiers` rather than a second reading of the set, because it is
+   * already the answer to "which tiers can this canvas be sized to" — and if
+   * none can, there is no width to simulate.
+   */
   const previewContainer = useMemo(
     () => previewContainerFor(canvasBoxId),
     [canvasBoxId]
@@ -820,6 +841,14 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     undefined
   );
 
+  const canvasPreviewContainer = useMemo(
+    () =>
+      offeredTiers(siteBreakpoints(canvasSiteStyle)).length === 0
+        ? undefined
+        : previewContainer,
+    [canvasSiteStyle, previewContainer]
+  );
+
   const canvasRender = useMemo(
     () => ({
       styleContext: {
@@ -833,13 +862,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
          * admin WINDOW instead — a wide window around a narrow canvas reports
          * the desktop tier live while the box paints the tablet one.
          */
-        previewContainer,
+        ...(canvasPreviewContainer === undefined
+          ? {}
+          : { previewContainer: canvasPreviewContainer }),
       },
       ...(remotePatterns === undefined
         ? {}
         : { hostPolicy: { remotePatterns } }),
     }),
-    [canvasSiteStyle, remotePatterns, previewContainer]
+    [canvasSiteStyle, remotePatterns, canvasPreviewContainer]
   );
 
   /*
@@ -882,12 +913,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * re-subscribes on the reporter's identity.
    */
   const canvasPreview = useMemo(
-    () => ({
-      container: previewContainer,
-      ...(requestedWidth === undefined ? {} : { width: requestedWidth }),
-      onMeasured: setMeasuredWidth,
-    }),
-    [previewContainer, requestedWidth]
+    () =>
+      canvasPreviewContainer === undefined
+        ? undefined
+        : {
+            container: canvasPreviewContainer,
+            ...(requestedWidth === undefined ? {} : { width: requestedWidth }),
+            onMeasured: setMeasuredWidth,
+          },
+    [canvasPreviewContainer, requestedWidth]
   );
 
   const liveBreakpoints = useMemo(
@@ -1086,7 +1120,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             // can observe them. The container name travels with them because
             // that is what tells the panel the window is not the authority.
             breakpoint={editedBreakpoint}
-            previewContainer={previewContainer}
+            previewContainer={canvasPreviewContainer}
             liveBreakpoints={liveBreakpoints}
             tokens={offerableTokens(
               canvasSiteStyle,

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -53,6 +53,7 @@ import {
   BreakpointSwitcher,
   breakpointsAtWidth,
   editedBreakpointAtWidth,
+  offeredTiers,
   EditorCommandPalette,
   BuilderShell,
   Canvas,
@@ -853,6 +854,26 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     canvasRender.styleContext.breakpoints,
     measuredWidth
   );
+  /*
+   * Release a requested width the site no longer offers.
+   *
+   * The switcher renders nothing once a site defines no viewport tiers, and it
+   * cannot clear state it does not own — so an author who selects a tier and
+   * then deletes it, or deletes the last one, is left with a canvas pinned to a
+   * bound the stylesheet no longer has and no control on screen to release it.
+   * The only way out would be to close the editor and reopen it.
+   *
+   * Compared against `offeredTiers`, which is the same list the switcher builds
+   * its options from, so "a width this control could have set" has one
+   * definition rather than two that can disagree.
+   */
+  useEffect(() => {
+    if (requestedWidth === undefined) return;
+    const offered = offeredTiers(canvasRender.styleContext.breakpoints);
+    if (offered.some(tier => tier.maxWidth === requestedWidth)) return;
+    setRequestedWidth(undefined);
+  }, [requestedWidth, canvasRender]);
+
   /*
    * The box's own inputs, as one object.
    *

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -38,6 +38,7 @@ import {
   hasBlock,
   registerBlocks,
   registryNestingSource,
+  previewContainerFor,
   type BlockDocument,
   type BreakpointSet,
   type SiteTokenSet,
@@ -49,6 +50,9 @@ import {
   authoredBreakpoints,
   BlockToolbar,
   BreakpointManager,
+  BreakpointSwitcher,
+  breakpointsAtWidth,
+  editedBreakpointAtWidth,
   EditorCommandPalette,
   BuilderShell,
   Canvas,
@@ -73,7 +77,14 @@ import {
   useReportUnsavedWork,
   useSuppressAdminChrome,
 } from "@nextlyhq/plugin-sdk/admin";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import {
   useController,
   useWatch,
@@ -766,14 +777,103 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * inline call handed the inspector a new object every render and the panel
    * re-subscribed a media query per breakpoint on every keystroke.
    */
+  /*
+   * The name the canvas box establishes as a query container.
+   *
+   * The editor canvas is not an iframe — the renderer emits its sheet into the
+   * admin document — so `@media` asks the browser WINDOW and resizing the box
+   * cannot change which tier applies. Compiled against a container name, the
+   * viewport tiers become `@container` rules about THIS box, and the box's own
+   * width decides them.
+   *
+   * Minted from `useId` rather than spelled here, because the name identifies
+   * one mounted surface: two editors on a page sharing a literal would each
+   * answer the other's queries. `previewContainerFor` is what turns the seed
+   * into a name the compiler will accept, and it is the only supported way to
+   * make one.
+   */
+  const canvasBoxId = useId();
+  const previewContainer = useMemo(
+    () => previewContainerFor(canvasBoxId),
+    [canvasBoxId]
+  );
+
+  /*
+   * The two widths, which are two facts and not one.
+   *
+   * `requestedWidth` is what the author asked the switcher for — a ceiling, and
+   * `undefined` for the full region. `measuredWidth` is what the box actually
+   * got, reported by the canvas: the editor region may be narrower than the
+   * tier requested, and what the container queries resolve against is the width
+   * the box has, not the width it was offered.
+   *
+   * Only the MEASURED one decides which tier is edited. Deriving that from the
+   * request would tell an author they are editing the tier they picked while
+   * the box is in a narrower one — the disagreement between what you see and
+   * what you edit that the founder's 2026-08-24 ruling deferred this control
+   * over.
+   */
+  const [requestedWidth, setRequestedWidth] = useState<number | undefined>(
+    undefined
+  );
+  const [measuredWidth, setMeasuredWidth] = useState<number | undefined>(
+    undefined
+  );
+
   const canvasRender = useMemo(
     () => ({
-      styleContext: { breakpoints: siteBreakpoints(canvasSiteStyle) },
+      styleContext: {
+        breakpoints: siteBreakpoints(canvasSiteStyle),
+        /*
+         * Carried on the SAME context the cascade and the inspector read, so
+         * all three describe one compile. Supplied unconditionally rather than
+         * only while a tier is selected: at the full width the box is still a
+         * box, and a region narrower than the widest tier is already showing a
+         * narrower tier's rules. Compiling `@media` there would answer for the
+         * admin WINDOW instead — a wide window around a narrow canvas reports
+         * the desktop tier live while the box paints the tablet one.
+         */
+        previewContainer,
+      },
       ...(remotePatterns === undefined
         ? {}
         : { hostPolicy: { remotePatterns } }),
     }),
-    [canvasSiteStyle, remotePatterns]
+    [canvasSiteStyle, remotePatterns, previewContainer]
+  );
+
+  /*
+   * Which tier an edit lands in, and which tiers the box is applying.
+   *
+   * Both derived from the MEASURED width and from the one breakpoint set above,
+   * so the inspector cannot disagree with the canvas about either. Memoised
+   * because `breakpointsAtWidth` builds a fresh array: passed inline it would be
+   * a new identity every render, and the panel re-derives on it.
+   */
+  const editedBreakpoint = editedBreakpointAtWidth(
+    canvasRender.styleContext.breakpoints,
+    measuredWidth
+  );
+  /*
+   * The box's own inputs, as one object.
+   *
+   * Memoised because the canvas takes them as a group: rebuilt inline it would
+   * be a fresh object every render, and the measurement effect behind it
+   * re-subscribes on the reporter's identity.
+   */
+  const canvasPreview = useMemo(
+    () => ({
+      container: previewContainer,
+      ...(requestedWidth === undefined ? {} : { width: requestedWidth }),
+      onMeasured: setMeasuredWidth,
+    }),
+    [previewContainer, requestedWidth]
+  );
+
+  const liveBreakpoints = useMemo(
+    () =>
+      breakpointsAtWidth(canvasRender.styleContext.breakpoints, measuredWidth),
+    [canvasRender, measuredWidth]
   );
 
   /*
@@ -916,6 +1016,26 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
               onSave={saveBreakpoints}
               status={siteStyleStatus(siteStylePending, siteStyleError)}
             />
+            {/*
+             * Beside the manager, and gated on the same read for the same
+             * reason it is: until the stored style has answered, the set in
+             * hand is the host's config defaults, so this would size the canvas
+             * to a bound the site never chose and every edit made there would
+             * land in whichever tier that bound implies.
+             *
+             * It is handed BOTH widths. The requested one is what the author
+             * chose and is what the control reports as selected; the measured
+             * one is what the box got and is what it names a tier from. Fed
+             * only the measured width it would unselect the option just
+             * clicked whenever the region could not honour it.
+             */}
+            <BreakpointSwitcher
+              breakpoints={canvasRender.styleContext.breakpoints}
+              width={requestedWidth}
+              appliedWidth={measuredWidth}
+              onSelect={setRequestedWidth}
+              status={siteStyleStatus(siteStylePending, siteStyleError)}
+            />
           </>
         }
         // The shell owns the region; this fills it. Rendered unconditionally
@@ -939,6 +1059,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             policy={stylePolicy}
             cascade={styleCascade}
             breakpoints={canvasRender.styleContext.breakpoints}
+            // Which tier the Style tab writes to, and which tiers it may call
+            // live. Both are the canvas's answer rather than the panel's: the
+            // queries are about the preview box, and `matchMedia` cannot
+            // evaluate a container query, so only the surface that owns the box
+            // can observe them. The container name travels with them because
+            // that is what tells the panel the window is not the authority.
+            breakpoint={editedBreakpoint}
+            previewContainer={previewContainer}
+            liveBreakpoints={liveBreakpoints}
             tokens={offerableTokens(
               canvasSiteStyle,
               siteStylePending,
@@ -1058,6 +1187,11 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
               // The style context and the host policy, derived above so both are
               // one object with one identity rather than rebuilt per render.
               render={canvasRender}
+              // The box the tiers are compiled against, the width it is asked
+              // to take, and the reporter that closes the loop: the request is
+              // a ceiling, and everything downstream is derived from what the
+              // box actually got rather than from what it was offered.
+              preview={canvasPreview}
               dragHandlers={drag.handlers}
               // The pointer route into typing a block's text. Its keyboard
               // counterpart is the Enter binding above, registered in the same


### PR DESCRIPTION
The editor had no way to say which breakpoint it was editing, so every style
edit landed in the widest tier however the page looked on screen. C-6's badge
half was blocked behind it: a badge saying "this came from tablet" had nowhere
to jump to.

## The shape

**Canvas width is the single source of truth.** The switcher SETS a width. The
tier an edit writes to and the tiers the Style tab may report as live are both
DERIVED from the width the box actually got. There is no stored "current
breakpoint" beside the canvas, so the two cannot disagree.

That is what makes this buildable now. The 2026-08-24 ruling deferred a
selector because "a selector that changes which values you edit while the
canvas still shows desktop is confusing" — deriving both facts from one width
makes that state unrepresentable rather than keeping two in step.

Prior art (`research:canvas-breakpoint-switcher-shape`): Webflow changes what
you see and what you edit together, with no mode where they disagree.
Gutenberg had a device menu and a resizable canvas as mutually exclusive
surfaces and unified them the same way — canvas width as the source of truth,
the device menu demoted to a way of setting one, the viewport derived as a
range.

## Two widths, not one

The request is a **ceiling**. An editor region narrower than the tier asked for
hands the box less, and what container queries resolve against is the width the
box got.

- The **requested** width drives selection — what the author chose.
- The **measured** width drives everything else — which tier is edited, which
  are live, and what the indicator reports.

Collapsed into one, either the option the author just clicked shows unselected,
or the tier indicator can never fire: every width the control sets is an exact
bound or unbounded, so the case it exists for was unreachable.

## The preview compile is unconditional

Not switched on when a tier is selected. The canvas is not an iframe, so a
published compile answers for the admin WINDOW — a wide window around a narrow
canvas reported the desktop tier live while the box painted the tablet one.
Compiled against the box, a region narrower than the widest tier now says which
tier it is really in, which is what both Webflow and Gutenberg do.

## Also here

`Canvas` takes its three preview inputs as one object, for the reason
`dragHandlers` is one: the set cannot be partially wired, and every partial
wiring fails silently. A width without a container resizes a box whose sheet
still queries the window; a container nobody observes leaves the surface owning
the box unable to say which tier is live.

The measurement path gains the coverage it never had — that it reports the
content box rather than the zoom-transformed rect, and observes the root the
sheet queries.

## Verification

Every new test was break-verified by mutating the exact branch its name claims,
with the mutation asserted to have applied and a clean control run first:
4 on the switcher, 5 on the measurement path, 11 on the mount. All caught.

Gates: build, check-types, builder (1980), blocks-engine (1462), blocks-react
(830), ui (1135), plugin-page-builder (334), test:scripts, lint, comment
convention, changeset, `fallow audit` with `complexity_introduced: 0`.

`Canvas` was over the cognitive threshold after the box commit. Resolved by
extraction and by grouping the preview props — not suppressed.

## Territory

`BlocksField.tsx` is lane `pb-editor`'s, held for this one PR: one element
added beside `BreakpointManager`, props threaded into the existing `Canvas` and
`InspectorPanel` calls, no restructuring of the fragment or the shell's slot
contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive canvas preview support with accurate container-based breakpoint rendering.
  * Added an accessible breakpoint switcher for selecting canvas widths and viewing the currently applied tier.
  * Preview sizing now reflects measured canvas width and updates as the canvas changes.
  * Added clearer handling for unavailable, unmatched, or unsupported breakpoint configurations.
* **Bug Fixes**
  * Improved breakpoint selection, cascading behavior, and duplicate-width handling for more predictable responsive editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->