### PR TITLE
fix(admin): call a Single's preview by the name the Single declares

### DIFF
--- a/.changeset/single-preview-uses-its-own-label.md
+++ b/.changeset/single-preview-uses-its-own-label.md
@@ -55,3 +55,21 @@ They are written by their own branch rather than by widening the schema one,
 which would have flagged a migration for an edit that moves no column. The
 collection registry already worked this way; the two now share one predicate for
 the schema question instead of keeping two copies of it in step by hand.
+
+The button that opens the pane is named by the same word. Renaming the pane
+while its opener still said "Show preview" left the declared label reachable
+only after clicking a control that disagreed with it, so the header takes one
+label and gives it to both rather than growing a second naming prop.
+
+Two ways the stored copy could go stale are closed with it. A config that
+dropped its admin block or description while ALSO changing a field took the
+schema path, which sent `undefined` — read as "leave the column alone" — and
+stranded the old value. And the comparison that decides whether to write is now
+insensitive to key order: Postgres holds these columns as `jsonb`, which
+normalises the order it was given, so a plain JSON compare re-synced every
+resource on every startup on that adapter alone.
+
+`ApiSingle.admin.preview` also carries `openInNewTab`, which the collection side
+has always read. It is a boolean, so unlike the `url` beside it, it survives
+being stored and is returned — the type said otherwise, and a caller with a
+stored value could not reach it.

--- a/.changeset/single-preview-uses-its-own-label.md
+++ b/.changeset/single-preview-uses-its-own-label.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A Single's preview pane is now called by the name the Single declares, instead
+of always saying "Preview". A collection's preview has always honoured
+`admin.preview.label`; a Single's ignored it.
+
+The server was already sending it. A preview declaration's `url` is a FUNCTION
+and cannot survive being stored as JSON, so it never reaches the browser — but
+the label beside it is a string and does. What was missing is that the admin's
+own type for a Single never declared the field, so nothing read it.
+
+Two duplications are collapsed rather than extended. The default is derived in
+one place now, shared by entries and Singles, so a second `?? "Preview"` cannot
+keep the fallback after someone changes the real one. And a Single's schema
+carried its own inline copy of the admin options, which had already drifted —
+it was missing `order` and `sidebarGroup`, both of which the server sends. It
+references the shared declaration instead, which is what made the label
+invisible to the editor in the first place.

--- a/.changeset/single-preview-uses-its-own-label.md
+++ b/.changeset/single-preview-uses-its-own-label.md
@@ -42,3 +42,16 @@ carried its own inline copy of the admin options, which had already drifted —
 it was missing `order` and `sidebarGroup`, both of which the server sends. It
 references the shared declaration instead, which is what made the label
 invisible to the editor in the first place.
+
+Editing that name now takes effect. A code-first Single's `admin` block was
+written to storage only inside the branch that handles a SCHEMA change, and was
+not one of the things that opened it — so renaming a preview, or changing the
+Single's own label or description, reached the row only when some unrelated
+field change happened to trigger a write. The admin reads all three from the
+stored row, because a preview declaration's `url` is a function and cannot
+travel over HTTP, so until then the editor kept showing the old name.
+
+They are written by their own branch rather than by widening the schema one,
+which would have flagged a migration for an edit that moves no column. The
+collection registry already worked this way; the two now share one predicate for
+the schema question instead of keeping two copies of it in step by hand.

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -113,7 +113,15 @@ export interface EntrySystemHeaderProps {
   isPreviewAvailable?: boolean;
   /** Opens the preview using the editor's own session. May be asynchronous. */
   onPreview?: () => void | Promise<void>;
-  /** Label for the preview action. Defaults to "Preview". */
+  /**
+   * What this entry's preview is called, where it is not called "Preview".
+   *
+   * Names BOTH controls below — the open-in-a-tab action and the pane toggle —
+   * because they are one thing to an author, and a second prop for the second
+   * control is a second thing to keep in step. Absent rather than defaulted, so
+   * each control can apply the default its own sentence needs: "Preview" as a
+   * button's name, "preview" as a noun inside "Show preview".
+   */
   previewLabel?: string;
   /**
    * Opens and closes the preview PANE, which is a different action from opening
@@ -289,6 +297,13 @@ export function EntrySystemHeader({
     getLocale,
   } = useLocalization();
   const defaultLocaleLabel = getLocale(defaultLocale)?.label ?? defaultLocale;
+  /*
+   * The pane toggle reads its label into a sentence — "Show X" — so its default
+   * is the lowercase noun, where `PreviewActions` defaults to "Preview" as a
+   * button's name. Two defaults for one value, which is why the prop carries
+   * neither and each control states the one its own sentence needs.
+   */
+  const previewPaneNoun = previewLabel ?? "preview";
   // Present only when the entry was fetched with `?translation-status=1` on a
   // localized collection; undefined otherwise, which both consumers below
   // treat as "nothing to report" rather than as zero progress.
@@ -525,11 +540,17 @@ export function EntrySystemHeader({
               onClick={onTogglePreviewPane}
               disabled={isSubmitting}
               aria-pressed={previewPaneOpen}
-              title={previewPaneOpen ? "Hide the preview" : "Show the preview"}
+              title={
+                previewPaneOpen
+                  ? `Hide the ${previewPaneNoun}`
+                  : `Show the ${previewPaneNoun}`
+              }
             >
               <PanelRight className="h-4 w-4" aria-hidden="true" />
               <ToolbarLabel priority="secondary">
-                {previewPaneOpen ? "Hide preview" : "Show preview"}
+                {previewPaneOpen
+                  ? `Hide ${previewPaneNoun}`
+                  : `Show ${previewPaneNoun}`}
               </ToolbarLabel>
             </Button>
           )}

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -298,12 +298,21 @@ export function EntrySystemHeader({
   } = useLocalization();
   const defaultLocaleLabel = getLocale(defaultLocale)?.label ?? defaultLocale;
   /*
-   * The pane toggle reads its label into a sentence — "Show X" — so its default
-   * is the lowercase noun, where `PreviewActions` defaults to "Preview" as a
-   * button's name. Two defaults for one value, which is why the prop carries
-   * neither and each control states the one its own sentence needs.
+   * A declared label is used VERBATIM, not built into a sentence.
+   *
+   * `previewLabel` is a complete button label, not a noun: collections
+   * legitimately name one "View page", and "Show View page" is not English.
+   * Where the author supplied nothing there is no such risk and the control
+   * keeps its own wording, which says what the click will do.
+   *
+   * Losing "Show"/"Hide" for a declared label costs nothing that is not carried
+   * elsewhere — `aria-pressed` states it for assistive technology and the
+   * variant states it visually, which is how a toggle button reports itself.
    */
-  const previewPaneNoun = previewLabel ?? "preview";
+  const previewToggleLabel =
+    previewLabel ?? (previewPaneOpen ? "Hide preview" : "Show preview");
+  const previewToggleTitle =
+    previewLabel ?? (previewPaneOpen ? "Hide the preview" : "Show the preview");
   // Present only when the entry was fetched with `?translation-status=1` on a
   // localized collection; undefined otherwise, which both consumers below
   // treat as "nothing to report" rather than as zero progress.
@@ -540,17 +549,11 @@ export function EntrySystemHeader({
               onClick={onTogglePreviewPane}
               disabled={isSubmitting}
               aria-pressed={previewPaneOpen}
-              title={
-                previewPaneOpen
-                  ? `Hide the ${previewPaneNoun}`
-                  : `Show the ${previewPaneNoun}`
-              }
+              title={previewToggleTitle}
             >
               <PanelRight className="h-4 w-4" aria-hidden="true" />
               <ToolbarLabel priority="secondary">
-                {previewPaneOpen
-                  ? `Hide ${previewPaneNoun}`
-                  : `Show ${previewPaneNoun}`}
+                {previewToggleLabel}
               </ToolbarLabel>
             </Button>
           )}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.preview.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.preview.test.tsx
@@ -113,6 +113,54 @@ describe("EntrySystemHeader preview control", () => {
     expect(screen.getByRole("button", { name: COPY_LABEL })).toBeDisabled();
   });
 
+  it("uses a declared label VERBATIM on the pane toggle", () => {
+    /*
+     * `previewLabel` is a complete button label, not a noun. Collections
+     * legitimately name one "View page" — the preview-link suite uses exactly
+     * that — and interpolating it produced "Show View page", which is not
+     * English. The state the prefix used to carry is reported by `aria-pressed`
+     * and by the variant, which is how a toggle button reports itself.
+     */
+    renderHeader({
+      previewLabel: "View page",
+      onTogglePreviewPane: () => {},
+      previewPaneOpen: false,
+    });
+
+    const toggle = screen.getByRole("button", { name: "View page" });
+    expect(toggle).toHaveAttribute("aria-pressed", "false");
+    expect(screen.queryByText(/Show View page/)).toBeNull();
+    expect(screen.queryByText(/Hide View page/)).toBeNull();
+  });
+
+  it("says what the click will do where no label was declared", () => {
+    /*
+     * The control. Dropping "Show"/"Hide" for every label would cost the
+     * default case its plainest affordance for no reason — there is no verb to
+     * collide with when the author supplied nothing.
+     */
+    renderHeader({ onTogglePreviewPane: () => {}, previewPaneOpen: false });
+
+    expect(
+      screen.getByRole("button", { name: "Show preview" })
+    ).toBeInTheDocument();
+  });
+
+  it("reports the open state on a declared label through aria-pressed", () => {
+    // Where the visible text no longer changes, this is the only thing that
+    // tells a screen-reader user the pane is open.
+    renderHeader({
+      previewLabel: "View page",
+      onTogglePreviewPane: () => {},
+      previewPaneOpen: true,
+    });
+
+    expect(screen.getByRole("button", { name: "View page" })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+
   it("renders nothing when neither action is available", () => {
     // A disabled control says "you cannot do this" without saying why, so the
     // header shows no preview affordance at all rather than a dead button.

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -78,6 +78,7 @@ import {
 import { generateClientSchema } from "@admin/lib/field-validation";
 import { getDefaultValues } from "@admin/lib/form/default-values";
 import { cn } from "@admin/lib/utils";
+import type { SingleAdminOptions } from "@admin/types/entities";
 
 import { relaxIdentityRequired } from "./identity-fields";
 import { useSinglePreviewLink } from "./useSinglePreviewLink";
@@ -95,12 +96,13 @@ export interface SingleSchema {
   label: string;
   description?: string;
   fields: FieldConfig[];
-  admin?: {
-    group?: string;
-    icon?: string;
-    hidden?: boolean;
-    description?: string;
-  };
+  /*
+   * The shared declaration rather than an inline copy. This one had drifted
+   * already — it was missing `order` and `sidebarGroup`, which the server
+   * sends — and a second shape for one payload is how a field the server
+   * provides stays invisible to the editor that wants it.
+   */
+  admin?: SingleAdminOptions;
   /**
    * Whether this Single has the Draft/Published lifecycle enabled. When
    * true, the system header splits into Save Draft + Update buttons and the
@@ -548,6 +550,7 @@ export function SingleForm({
     document,
     savedCount,
     inTranslationMode: translationMode.source !== undefined,
+    admin: schema.admin,
   });
 
   const localeCtx = useEntryLocaleContext({
@@ -644,7 +647,7 @@ export function SingleForm({
               open={previewPane.open}
               onClose={previewPane.onClose}
               scope={previewPane.scope}
-              label="Preview"
+              label={previewPane.label}
               revision={previewPane.revision}
             >
               {/* Renders its child alone when there is no source — see the module. */}

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
@@ -214,6 +214,39 @@ describe("SingleForm offers the preview pane", () => {
     expect(lastHeaderProps().previewLabel).toBe("Landing preview");
   });
 
+  it("reads a padded or blank label the SAME way for pane and opener", () => {
+    /*
+     * The two surfaces default differently, so they must not also disagree
+     * about what counts as declared. Normalising in two places made a
+     * whitespace-only label absent for the opener and present — as a blank
+     * title — for the pane, and a padded one arrived trimmed at one and raw at
+     * the other.
+     */
+    renderForm({
+      schema: {
+        ...(schema as unknown as Record<string, unknown>),
+        admin: { preview: { label: "  Landing preview  " } },
+      } as never,
+    });
+
+    expect(lastPaneProps().label).toBe("Landing preview");
+    expect(lastHeaderProps().previewLabel).toBe("Landing preview");
+  });
+
+  it("treats a whitespace-only label as no label, on BOTH surfaces", () => {
+    // A label of spaces is a field an author left empty. The pane falls back to
+    // its word and the opener to its sentence; neither renders the spaces.
+    renderForm({
+      schema: {
+        ...(schema as unknown as Record<string, unknown>),
+        admin: { preview: { label: "   " } },
+      } as never,
+    });
+
+    expect(lastPaneProps().label).toBe("Preview");
+    expect(lastHeaderProps().previewLabel).toBeUndefined();
+  });
+
   it("hands the header NO label when the Single declares none", () => {
     /*
      * The control, and the reason the declared value is passed rather than the

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
@@ -193,6 +193,39 @@ describe("SingleForm offers the preview pane", () => {
     expect(lastPaneProps().label).toBe("Landing preview");
   });
 
+  it("names the pane's OPENER with the same word, not a hardcoded one", () => {
+    /*
+     * The pane and the button that opens it are one thing to an author, so they
+     * cannot be named separately: renaming the pane while its opener still said
+     * "Show preview" left the declared label reachable only after clicking a
+     * control that disagreed with it.
+     *
+     * The header takes ONE label and gives it to both — the open-in-a-tab action
+     * and this toggle — rather than growing a second naming prop that could
+     * drift from the first.
+     */
+    renderForm({
+      schema: {
+        ...(schema as unknown as Record<string, unknown>),
+        admin: { preview: { label: "Landing preview" } },
+      } as never,
+    });
+
+    expect(lastHeaderProps().previewLabel).toBe("Landing preview");
+  });
+
+  it("hands the header NO label when the Single declares none", () => {
+    /*
+     * The control, and the reason the declared value is passed rather than the
+     * defaulted one: absent is what lets each control apply its own default —
+     * "Preview" as a button's name, "preview" as a noun inside "Show preview" —
+     * so an undeclared Single keeps the wording it has today.
+     */
+    renderForm();
+
+    expect(lastHeaderProps().previewLabel).toBeUndefined();
+  });
+
   it("falls back to Preview when the Single names none", () => {
     // The control: the label above comes from the declaration rather than from
     // a rename that happens to match, and a Single without one is unaffected.

--- a/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
+++ b/packages/admin/src/components/features/singles/__tests__/SingleForm.preview-pane.test.tsx
@@ -176,6 +176,31 @@ describe("SingleForm offers the preview pane", () => {
     expect(lastPaneProps().scope).toEqual(minted);
   });
 
+  it("calls the pane by the Single's OWN word for it", () => {
+    /*
+     * A declaration may name its preview, and the label is a string, so unlike
+     * the `url` function beside it the label does survive being stored as JSON
+     * and does reach the browser. The pane was calling every Single's preview
+     * "Preview" regardless.
+     */
+    renderForm({
+      schema: {
+        ...(schema as unknown as Record<string, unknown>),
+        admin: { preview: { label: "Landing preview" } },
+      } as never,
+    });
+
+    expect(lastPaneProps().label).toBe("Landing preview");
+  });
+
+  it("falls back to Preview when the Single names none", () => {
+    // The control: the label above comes from the declaration rather than from
+    // a rename that happens to match, and a Single without one is unaffected.
+    renderForm();
+
+    expect(lastPaneProps().label).toBe("Preview");
+  });
+
   it("keeps the pane closed until someone asks for it", () => {
     renderForm();
 

--- a/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
@@ -24,11 +24,23 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { previewRevisionOf } from "@admin/components/features/entries/PreviewMode/previewRevision";
+import { previewLabel } from "@admin/hooks/useEntryPreview";
 import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
+import type { SingleAdminOptions } from "@admin/types/entities";
 
 import type { SinglePreviewLink } from "./useSinglePreviewLink";
 
 export interface SinglePreviewPaneInput {
+  /**
+   * The Single's admin block, for the word it calls its preview by.
+   *
+   * Taken here rather than read at the call site: this hook already assembles
+   * every prop the pane receives, and one more optional chain in the form was
+   * enough to trip the complexity gate — which is the gate doing its job, since
+   * the label belongs with the rest of the pane's inputs rather than beside
+   * them.
+   */
+  admin?: SingleAdminOptions;
   /** The shareable-link decision, which already resolved the language. */
   link: SinglePreviewLink;
   /** The Single as last read, which the revision derives from. */
@@ -40,6 +52,8 @@ export interface SinglePreviewPaneInput {
 }
 
 export interface SinglePreviewPane {
+  /** What to call the preview, defaulted where the Single names none. */
+  label: string;
   /** Whether the pane should render. */
   open: boolean;
   /** Close it. */
@@ -66,6 +80,7 @@ export function useSinglePreviewPane({
   document,
   savedCount,
   inTranslationMode,
+  admin,
 }: SinglePreviewPaneInput): SinglePreviewPane {
   const [open, setOpen] = useState(false);
 
@@ -98,6 +113,7 @@ export function useSinglePreviewPane({
   const onToggle = useCallback(() => setOpen(o => !o), []);
 
   return {
+    label: previewLabel(admin?.preview),
     // Both halves: a pane left open when the language stops resolving must
     // close rather than go on rendering a credential nothing would re-mint.
     open: open && canOffer,

--- a/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
@@ -34,11 +34,11 @@ export interface SinglePreviewPaneInput {
   /**
    * The Single's admin block, for the word it calls its preview by.
    *
-   * Taken here rather than read at the call site: this hook already assembles
-   * every prop the pane receives, and one more optional chain in the form was
-   * enough to trip the complexity gate — which is the gate doing its job, since
-   * the label belongs with the rest of the pane's inputs rather than beside
-   * them.
+   * Taken here rather than read at the call site: this hook assembles every
+   * prop the pane receives, so what to call the preview belongs with the rest
+   * of them. Resolved beside the hook instead, the default would live in one
+   * place and the pane's other inputs in another, and the two would drift the
+   * first time either moved.
    */
   admin?: SingleAdminOptions;
   /** The shareable-link decision, which already resolved the language. */

--- a/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
@@ -71,7 +71,16 @@ export interface SinglePreviewPane {
    * decision here rather than repeating the condition at the call site.
    */
   toggle:
-    | { onTogglePreviewPane: () => void; previewPaneOpen: boolean }
+    | {
+        onTogglePreviewPane: () => void;
+        previewPaneOpen: boolean;
+        /**
+         * Present only where the Single declared one, so the control keeps its
+         * own default — "Show preview" — rather than being handed a defaulted
+         * value it cannot tell from an author's choice.
+         */
+        previewLabel?: string;
+      }
     | Record<string, never>;
 }
 
@@ -109,6 +118,12 @@ export function useSinglePreviewPane({
     if (!canOffer) setOpen(false);
   }, [canOffer]);
 
+  // Blank counts as undeclared, the same reading `previewLabel` gives it: a
+  // label of spaces is a field an author left empty, not a name for a pane.
+  const declared = admin?.preview?.label?.trim();
+  const declaredLabel =
+    declared === undefined || declared === "" ? undefined : declared;
+
   const onClose = useCallback(() => setOpen(false), []);
   const onToggle = useCallback(() => setOpen(o => !o), []);
 
@@ -128,8 +143,26 @@ export function useSinglePreviewPane({
      * after the first.
      */
     revision: previewRevisionOf(document, savedCount),
+    /*
+     * The label rides WITH the toggle rather than beside it, because the pane
+     * and the button that opens it are one thing to an author: named apart,
+     * the pane took the Single's word for itself while its opener still said
+     * "Show preview", and the declared name was reachable only after clicking a
+     * control that disagreed with it.
+     *
+     * The DECLARED value, not the defaulted one. `label` above defaults to
+     * "Preview" because a pane's title needs a word; the button reads its label
+     * into a sentence and needs the lowercase noun, so absent is what lets each
+     * apply the default its own sentence takes.
+     */
     toggle: canOffer
-      ? { onTogglePreviewPane: onToggle, previewPaneOpen: open }
+      ? {
+          onTogglePreviewPane: onToggle,
+          previewPaneOpen: open,
+          ...(declaredLabel === undefined
+            ? {}
+            : { previewLabel: declaredLabel }),
+        }
       : {},
   };
 }

--- a/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
+++ b/packages/admin/src/components/features/singles/useSinglePreviewPane.ts
@@ -24,7 +24,10 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { previewRevisionOf } from "@admin/components/features/entries/PreviewMode/previewRevision";
-import { previewLabel } from "@admin/hooks/useEntryPreview";
+import {
+  declaredPreviewLabel,
+  previewLabel,
+} from "@admin/hooks/useEntryPreview";
 import type { SelfPreviewScope } from "@admin/hooks/useEntryPreview";
 import type { SingleAdminOptions } from "@admin/types/entities";
 
@@ -118,11 +121,11 @@ export function useSinglePreviewPane({
     if (!canOffer) setOpen(false);
   }, [canOffer]);
 
-  // Blank counts as undeclared, the same reading `previewLabel` gives it: a
-  // label of spaces is a field an author left empty, not a name for a pane.
-  const declared = admin?.preview?.label?.trim();
-  const declaredLabel =
-    declared === undefined || declared === "" ? undefined : declared;
+  // Read through the SAME normalizer `previewLabel` uses, so the pane's title
+  // and its opener cannot disagree about what counts as declared. Trimming here
+  // separately made a whitespace-only label absent for the button and present —
+  // as a blank title — for the pane.
+  const declaredLabel = declaredPreviewLabel(admin?.preview);
 
   const onClose = useCallback(() => setOpen(false), []);
   const onToggle = useCallback(() => setOpen(o => !o), []);

--- a/packages/admin/src/hooks/useEntryPreview.ts
+++ b/packages/admin/src/hooks/useEntryPreview.ts
@@ -59,6 +59,18 @@ const SELF_PREVIEW_TTL_SECONDS = 15 * 60;
  * `urlTemplate` is the server's resolution input, so neither belongs here.
  * What the panel needs is whether to draw a button and how to label it.
  */
+/**
+ * What to call the preview, on a button or a pane.
+ *
+ * Exported and shared rather than inlined at each surface: entries and Singles
+ * both need it, and a second `?? "Preview"` elsewhere would silently keep the
+ * default after someone changed this one. The fallback is the whole value here
+ * — a declaration that names no label is the common case.
+ */
+export function previewLabel(config?: { label?: string }): string {
+  return config?.label || "Preview";
+}
+
 export interface PreviewConfig {
   /**
    * Whether this collection previews at all, decided when the config synced.
@@ -472,6 +484,6 @@ export function useEntryPreview({
   return {
     isPreviewAvailable,
     openPreview,
-    label: previewConfig?.label || "Preview",
+    label: previewLabel(previewConfig),
   };
 }

--- a/packages/admin/src/hooks/useEntryPreview.ts
+++ b/packages/admin/src/hooks/useEntryPreview.ts
@@ -60,6 +60,26 @@ const SELF_PREVIEW_TTL_SECONDS = 15 * 60;
  * What the panel needs is whether to draw a button and how to label it.
  */
 /**
+ * The label a declaration actually states, or nothing.
+ *
+ * One reader for the raw field, because the surfaces that need it disagree
+ * about the DEFAULT and must not disagree about anything else. A pane needs a
+ * word for its title; a button reads the label into its own sentence and would
+ * rather have nothing than a placeholder. Normalising in two places meant a
+ * whitespace-only label counted as declared for one and absent for the other,
+ * and a padded one arrived trimmed at one surface and raw at the other.
+ *
+ * Blank is undeclared. A label of spaces is a field an author left empty, and
+ * showing it would title a pane with nothing visible.
+ */
+export function declaredPreviewLabel(config?: {
+  label?: string;
+}): string | undefined {
+  const declared = config?.label?.trim();
+  return declared === undefined || declared === "" ? undefined : declared;
+}
+
+/**
  * What to call the preview, on a button or a pane.
  *
  * Exported and shared rather than inlined at each surface: entries and Singles
@@ -68,7 +88,7 @@ const SELF_PREVIEW_TTL_SECONDS = 15 * 60;
  * — a declaration that names no label is the common case.
  */
 export function previewLabel(config?: { label?: string }): string {
-  return config?.label || "Preview";
+  return declaredPreviewLabel(config) ?? "Preview";
 }
 
 export interface PreviewConfig {

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -240,6 +240,18 @@ export interface SingleAdminOptions {
   sidebarGroup?: string;
   /** Description text displayed below the Single title */
   description?: string;
+  /**
+   * What this Single's preview is called.
+   *
+   * Only the label. The declaration's `url` is a FUNCTION and cannot survive
+   * being stored as JSON, so it never reaches the browser and nothing here
+   * should imply it does — resolving an address is the server's job, and the
+   * admin asks for one rather than building it.
+   */
+  preview?: {
+    /** Custom label for the preview button and pane. @default "Preview" */
+    label?: string;
+  };
 }
 
 /**

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -1,5 +1,7 @@
 // Entity type definitions for the admin app
 
+import type { SinglePreviewConfig } from "nextly/config";
+
 import type { FieldDefinition } from "./collection";
 
 export interface Permission {
@@ -243,29 +245,18 @@ export interface SingleAdminOptions {
   /**
    * This Single's preview, as much of it as SURVIVES being stored.
    *
-   * The declaration's `url` is a FUNCTION, so it never reaches the browser and
-   * nothing here should imply it does — resolving an address is the server's
-   * job, and the admin asks for one rather than building it. `breakpoints` is
-   * absent for the same reason in its function form, and because the resolved
-   * list travels on the mint response instead of on a schema.
+   * Derived from the core config type by NAMING the fields that survive, rather
+   * than by omitting the one that does not. The difference matters as the core
+   * type grows: `Omit<SinglePreviewConfig, "url">` keeps every future option,
+   * and the next one may be no more storable than `url` — `breakpoints`, added
+   * alongside this, accepts a FUNCTION and its resolved list travels on the
+   * mint response instead of on a schema. Omission would have promised the
+   * browser a field this payload never carries.
    *
-   * What remains is the JSON-shaped part, listed rather than derived from the
-   * core config type: `Omit<SinglePreviewConfig, "url">` would keep
-   * `breakpoints` and so promise a field this payload never carries.
+   * `Pick` still couples the two: the field types come from core, so a change
+   * to either breaks here loudly instead of drifting.
    */
-  preview?: {
-    /** Custom label for the preview button and pane. @default "Preview" */
-    label?: string;
-
-    /**
-     * Whether the preview opens in a new browser tab. @default true
-     *
-     * A boolean, so unlike `url` it is stored and returned. The collection side
-     * has always read it; omitting it here made the type disagree with the
-     * payload, and a caller with a stored value could not reach it.
-     */
-    openInNewTab?: boolean;
-  };
+  preview?: Pick<SinglePreviewConfig, "label" | "openInNewTab">;
 }
 
 /**

--- a/packages/admin/src/types/entities.ts
+++ b/packages/admin/src/types/entities.ts
@@ -241,16 +241,30 @@ export interface SingleAdminOptions {
   /** Description text displayed below the Single title */
   description?: string;
   /**
-   * What this Single's preview is called.
+   * This Single's preview, as much of it as SURVIVES being stored.
    *
-   * Only the label. The declaration's `url` is a FUNCTION and cannot survive
-   * being stored as JSON, so it never reaches the browser and nothing here
-   * should imply it does — resolving an address is the server's job, and the
-   * admin asks for one rather than building it.
+   * The declaration's `url` is a FUNCTION, so it never reaches the browser and
+   * nothing here should imply it does — resolving an address is the server's
+   * job, and the admin asks for one rather than building it. `breakpoints` is
+   * absent for the same reason in its function form, and because the resolved
+   * list travels on the mint response instead of on a schema.
+   *
+   * What remains is the JSON-shaped part, listed rather than derived from the
+   * core config type: `Omit<SinglePreviewConfig, "url">` would keep
+   * `breakpoints` and so promise a field this payload never carries.
    */
   preview?: {
     /** Custom label for the preview button and pane. @default "Preview" */
     label?: string;
+
+    /**
+     * Whether the preview opens in a new browser tab. @default true
+     *
+     * A boolean, so unlike `url` it is stored and returned. The collection side
+     * has always read it; omitting it here made the type disagree with the
+     * payload, and a caller with a stored value could not reach it.
+     */
+    openInNewTab?: boolean;
   };
 }
 

--- a/packages/nextly/src/domains/collections/services/collection-registry-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-registry-service.ts
@@ -586,24 +586,17 @@ export class CollectionRegistryService extends BaseRegistryService<
           result.created.push(config.slug);
           await this.seedPermissionsForCollection(config.slug);
         } else if (
-          !schemaHashesMatch(schemaHash, existing.schemaHash) ||
-          (config.status === true) !== (existing.status === true) ||
-          // Re-sync when the resolved versioning config changed (both are
-          // normalized JSON, so a stable string compare detects a real change).
-          JSON.stringify(config.versions ?? null) !==
-            JSON.stringify(existing.versions ?? null) ||
-          // Re-sync when the cache-revalidation config changed.
-          JSON.stringify(config.revalidate ?? null) !==
-            JSON.stringify(existing.revalidate ?? null) ||
-          // Re-sync when the webhook recording policy changed.
-          JSON.stringify(config.webhooks ?? null) !==
-            JSON.stringify(existing.webhooks ?? null) ||
-          (config.localized === true) !== (existing.localized === true) ||
+          this.schemaSyncNeeded(
+            config,
+            existing,
+            !schemaHashesMatch(schemaHash, existing.schemaHash)
+          ) ||
           // Declared defaults are read from the stored definitions when an
           // entry is created, and the schema hash omits them, so they need
           // their own comparison or a changed default never reaches the write.
           fieldDefaultsSignature(config.fields) !==
             fieldDefaultsSignature(existing.fields) ||
+          // A collection's physical table, which a Single has no equivalent of.
           desiredTableName !== existing.tableName
         ) {
           // Fields changed, status toggle flipped, or `dbName` resolved to a

--- a/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
@@ -779,6 +779,48 @@ describe("SingleRegistryService", () => {
       expect("fields" in updateData).toBe(false);
     });
 
+    it("CLEARS metadata the config dropped, when fields changed in the same sync", async () => {
+      /*
+       * The schema branch writes these three too, and it is selected whenever a
+       * field, the status flag or localization changed — so a config that
+       * removed its admin block WHILE editing a field never reaches the
+       * metadata branch that would clear it. Sending `undefined` there means
+       * "leave the column alone" to `updateSingle`, which leaves the editor
+       * showing a preview label nothing declares any more.
+       *
+       * Removal is the case that needs it: a block that still exists is written
+       * either way, so only an absent one can be stranded.
+       */
+      ctx.adapter.selectOne.mockImplementation(async (table: string) => {
+        if (table !== "dynamic_singles") return null;
+        return dbRow({
+          schema_hash: "old-hash",
+          admin: JSON.stringify({ preview: { label: "Landing preview" } }),
+          description: "An older description",
+        });
+      });
+      ctx.adapter.update.mockResolvedValue([dbRow()]);
+
+      const result = await ctx.service.syncCodeFirstSingles([
+        {
+          slug: "site-settings",
+          label: "Site Settings",
+          // Changed, so the SCHEMA branch is the one selected.
+          fields: [{ name: "siteName", type: "text" }],
+        },
+      ]);
+
+      expect(result.updated).toEqual(["site-settings"]);
+      const updateData = ctx.adapter.update.mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      // Explicit NULL, not absent: `updateSingle` reads an absent key as "leave
+      // unchanged", which is exactly what stranded the old value.
+      expect(updateData.admin).toBeNull();
+      expect(updateData.description).toBeNull();
+    });
+
     it("leaves a single unchanged when its preview URL is a FUNCTION", async () => {
       /*
        * The control on the case above, and the one that stops the fix costing a

--- a/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/single-registry-service.test.ts
@@ -726,6 +726,96 @@ describe("SingleRegistryService", () => {
       expect(result.errors[0].slug).toBe("site-settings");
     });
 
+    /*
+     * The `admin` block is WRITTEN inside the update branch but was not one of
+     * the things that opened it, so a change confined to it never reached
+     * storage. That is the whole of what a Single's admin block is edited for
+     * — the preview's own label, the viewports it offers — and the admin reads
+     * those from the stored row, never from the config object, because a
+     * config function cannot travel over HTTP.
+     */
+    it("re-syncs when only the ADMIN block changed", async () => {
+      const fields = [{ name: "siteName", type: "text" }];
+      ctx.adapter.selectOne.mockImplementation(async (table: string) => {
+        if (table !== "dynamic_singles") return null;
+        const { calculateSchemaHash } = await import(
+          "../../schema/services/schema-hash"
+        );
+        return dbRow({
+          schema_hash: calculateSchemaHash(fields),
+          admin: JSON.stringify({ preview: { label: "Preview" } }),
+        });
+      });
+      ctx.adapter.update.mockResolvedValue([dbRow()]);
+
+      const result = await ctx.service.syncCodeFirstSingles([
+        {
+          slug: "site-settings",
+          label: "Site Settings",
+          fields,
+          admin: { preview: { label: "Landing preview" } },
+        },
+      ]);
+
+      expect(result.updated).toEqual(["site-settings"]);
+      expect(result.unchanged).toEqual([]);
+      // The new block reached the adapter, not merely a decision to write.
+      const updateData = ctx.adapter.update.mock.calls[0][1] as Record<
+        string,
+        unknown
+      >;
+      expect(updateData.admin).toBe(
+        JSON.stringify({ preview: { label: "Landing preview" } })
+      );
+      /*
+       * The separating property, and the reason this is its own branch rather
+       * than one more clause on the schema condition. Renaming a preview moves
+       * no column, so it must not bump the schema version or reopen the
+       * migration bookkeeping — a write that did would make every label edit
+       * look like a pending schema change to anything reading those columns.
+       */
+      expect("schema_version" in updateData).toBe(false);
+      expect("migration_status" in updateData).toBe(false);
+      expect("fields" in updateData).toBe(false);
+    });
+
+    it("leaves a single unchanged when its preview URL is a FUNCTION", async () => {
+      /*
+       * The control on the case above, and the one that stops the fix costing a
+       * write on every boot. A code-first `preview.url` is a function, which
+       * `JSON.stringify` drops — so the comparison sees the same JSON-visible
+       * subset on both sides only because the stored value was serialized the
+       * same way. A comparison that treated the two sides differently would
+       * re-sync every Single on every startup, and nothing else here would say
+       * so.
+       */
+      const fields = [{ name: "siteName", type: "text" }];
+      ctx.adapter.selectOne.mockImplementation(async (table: string) => {
+        if (table !== "dynamic_singles") return null;
+        const { calculateSchemaHash } = await import(
+          "../../schema/services/schema-hash"
+        );
+        return dbRow({
+          schema_hash: calculateSchemaHash(fields),
+          admin: JSON.stringify({ preview: { label: "Landing preview" } }),
+        });
+      });
+
+      const result = await ctx.service.syncCodeFirstSingles([
+        {
+          slug: "site-settings",
+          label: "Site Settings",
+          fields,
+          admin: {
+            preview: { url: () => "/landing", label: "Landing preview" },
+          },
+        },
+      ]);
+
+      expect(result.unchanged).toEqual(["site-settings"]);
+      expect(result.updated).toEqual([]);
+    });
+
     it("uses single_ prefix for auto-generated table name", async () => {
       ctx.adapter.selectOne.mockResolvedValue(null);
       ctx.adapter.insert.mockResolvedValue(dbRow({ slug: "header-nav" }));

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -159,6 +159,31 @@ export interface ListSinglesOptions extends BaseListOptions {
 export type ListSinglesResult = BaseListResult<DynamicSingleRecord>;
 
 // ============================================================
+// Change Detection
+// ============================================================
+
+/**
+ * Whether the Single's own naming differs from the stored row.
+ *
+ * The admin block is asked about separately, by the inherited
+ * `adminConfigChanged`, so that one comparison stays shared with the collection
+ * registry rather than being written a second time here.
+ *
+ * `?? null` on both sides because a column with no value arrives as `null`
+ * while a config that declares none has `undefined`, and the two mean the same
+ * thing: comparing them directly would report a change on every boot.
+ */
+function metadataSyncNeeded(
+  config: CodeFirstSingleConfig,
+  existing: DynamicSingleRecord
+): boolean {
+  return (
+    config.label !== existing.label ||
+    (config.description ?? null) !== (existing.description ?? null)
+  );
+}
+
+// ============================================================
 // Service Implementation
 // ============================================================
 
@@ -770,19 +795,11 @@ export class SingleRegistryService extends BaseRegistryService<
           result.created.push(config.slug);
           await this.seedPermissionsForSingle(config.slug);
         } else if (
-          !schemaHashesMatch(schemaHash, existing.schemaHash) ||
-          (config.status === true) !== (existing.status === true) ||
-          // Re-sync when the resolved versioning config changed (both sides are
-          // normalized JSON, so a stable string compare detects a real change).
-          JSON.stringify(config.versions ?? null) !==
-            JSON.stringify(existing.versions ?? null) ||
-          // Re-sync when the cache-revalidation config changed.
-          JSON.stringify(config.revalidate ?? null) !==
-            JSON.stringify(existing.revalidate ?? null) ||
-          // Re-sync when the webhook recording policy changed.
-          JSON.stringify(config.webhooks ?? null) !==
-            JSON.stringify(existing.webhooks ?? null) ||
-          (config.localized === true) !== (existing.localized === true)
+          this.schemaSyncNeeded(
+            config,
+            existing,
+            !schemaHashesMatch(schemaHash, existing.schemaHash)
+          )
         ) {
           // Either fields changed or the status toggle flipped — both warrant
           // a write so dynamic_singles.status stays in sync with the
@@ -808,6 +825,45 @@ export class SingleRegistryService extends BaseRegistryService<
               // of leaving a stale opt-out suppressing the outbox.
               webhooks: config.webhooks ?? null,
               localized: config.localized === true,
+            },
+            { source: "code" }
+          );
+          result.updated.push(config.slug);
+          await this.seedPermissionsForSingle(config.slug);
+        } else if (
+          this.adminConfigChanged(config.admin, existing.admin) ||
+          metadataSyncNeeded(config, existing)
+        ) {
+          /*
+           * Metadata only: no field changed, so nothing physical has to move.
+           *
+           * A separate branch rather than another clause on the one above,
+           * because that branch also carries `schemaHash` and drives the
+           * migration bookkeeping — routing a renamed preview through it would
+           * flag a migration for an edit that touches no column. These three
+           * are written INSIDE that branch and were not among the things that
+           * opened it, so until now they reached storage only when some
+           * unrelated schema change happened to trigger a write.
+           *
+           * The admin block is where a Single names its preview and declares
+           * the viewports it offers, and the admin app reads both from the
+           * stored row: a config function cannot travel over HTTP, so the row
+           * is the only copy the browser ever sees.
+           *
+           * This mirrors `CollectionRegistryService.syncCodeFirstCollections`,
+           * which already has the same branch for the same reason.
+           */
+          await this.updateSingle(
+            config.slug,
+            {
+              label: config.label,
+              // Explicit null where the config no longer declares one, so
+              // `updateSingle` clears the column instead of reading `undefined`
+              // as "leave unchanged" and stranding a description the config has
+              // dropped. Same reasoning as `revalidate` and `webhooks` above.
+              description: config.description ?? null,
+              admin: config.admin ?? null,
+              locked: true,
             },
             { source: "code" }
           );

--- a/packages/nextly/src/domains/singles/services/single-registry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-registry-service.ts
@@ -808,9 +808,17 @@ export class SingleRegistryService extends BaseRegistryService<
             config.slug,
             {
               label: config.label,
-              description: config.description,
+              // Explicit null where the config no longer declares one, for the
+              // reason `revalidate` and `webhooks` below already do it:
+              // `updateSingle` reads `undefined` as "leave unchanged", so a
+              // config that dropped its description or its admin block while
+              // ALSO changing a field selects this branch and would strand the
+              // old value — the editor keeps showing a preview label nothing
+              // declares any more. The metadata branch cannot catch that case,
+              // because this one was selected instead.
+              description: config.description ?? null,
               fields: config.fields,
-              admin: config.admin,
+              admin: config.admin ?? null,
               configPath: config.configPath,
               schemaHash,
               locked: true,

--- a/packages/nextly/src/schemas/dynamic-singles/types.ts
+++ b/packages/nextly/src/schemas/dynamic-singles/types.ts
@@ -187,8 +187,13 @@ export interface DynamicSingleInsert {
   /**
    * Optional description of the Single's purpose.
    * Displayed in the Admin UI.
+   *
+   * `null` clears a stored description, where `undefined` means "leave the
+   * column as it is". A sync that could only say `undefined` had no way to
+   * remove one the config had dropped, so the row kept describing the Single
+   * by a sentence nothing declared any more. Matches `DynamicCollectionInsert`.
    */
-  description?: string;
+  description?: string | null;
 
   /**
    * Field configurations defining the Single's document structure.
@@ -199,8 +204,12 @@ export interface DynamicSingleInsert {
   /**
    * Admin UI configuration options.
    * Controls sidebar grouping, icon, visibility, etc.
+   *
+   * `null` clears a stored block, for the reason `description` states. The
+   * write path already resolved a falsy value to `NULL`; only this type said
+   * otherwise. Matches `DynamicCollectionInsert`.
    */
-  admin?: SingleAdminOptions;
+  admin?: SingleAdminOptions | null;
 
   /**
    * Where the Single was defined.

--- a/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
+++ b/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
@@ -1,0 +1,131 @@
+/**
+ * The one question both registries ask: does this code-first config differ from
+ * its stored row in a way that has to be written through the SCHEMA path.
+ *
+ * Tested here rather than through either registry because it is shared. Proving
+ * it through the Single registry alone would leave the collection registry's
+ * use of it unproven, and the failure that matters is precisely the one where
+ * the two domains stop agreeing.
+ *
+ * Every case below is a single field differing with everything else held equal,
+ * because the defect this guards against is a clause going missing: a condition
+ * that dropped one comparison would still pass a test that changed two things.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  BaseRegistryService,
+  type SchemaSyncSubject,
+} from "../base-registry-service";
+
+/**
+ * A concrete registry with nothing in it, so the shared predicate can be asked
+ * directly rather than through a domain's mocking apparatus.
+ */
+class ProbeRegistry extends BaseRegistryService<never> {
+  protected readonly registryTableName = "probe";
+  protected readonly resourceType = "Probe";
+  protected readonly tableNamePrefix = "probe_";
+  protected getSearchColumns(): string[] {
+    return [];
+  }
+  protected deserializeRecord(): never {
+    throw new Error("not used");
+  }
+
+  ask(
+    config: SchemaSyncSubject,
+    existing: SchemaSyncSubject,
+    schemaHashChanged: boolean
+  ): boolean {
+    return this.schemaSyncNeeded(config, existing, schemaHashChanged);
+  }
+}
+
+const probe = new ProbeRegistry(
+  null as never,
+  { debug() {}, info() {}, warn() {}, error() {} } as never
+);
+
+/** Everything equal, so each case below differs in exactly one field. */
+const same: SchemaSyncSubject = {
+  status: true,
+  localized: false,
+  versions: { drafts: true },
+  revalidate: { seconds: 60 },
+  webhooks: { record: false },
+};
+
+describe("BaseRegistryService.schemaSyncNeeded", () => {
+  it("answers no when nothing differs and the hash matched", () => {
+    // The control. Without it, a predicate hard-wired to `true` would satisfy
+    // every other case here.
+    expect(probe.ask(same, { ...same }, false)).toBe(false);
+  });
+
+  it("answers yes when the caller reports a changed schema hash", () => {
+    // The hash is compared by the caller, so this is the whole of what this
+    // predicate does with it — and the case that must survive the comparison
+    // living outside.
+    expect(probe.ask(same, { ...same }, true)).toBe(true);
+  });
+
+  it("answers yes when the status toggle flipped", () => {
+    // Adds or removes a physical column, which is why it belongs on this path.
+    expect(probe.ask({ ...same, status: false }, same, false)).toBe(true);
+  });
+
+  it("answers yes when the versioning config changed", () => {
+    expect(
+      probe.ask({ ...same, versions: { drafts: false } }, same, false)
+    ).toBe(true);
+  });
+
+  it("answers yes when the revalidation config changed", () => {
+    expect(
+      probe.ask({ ...same, revalidate: { seconds: 30 } }, same, false)
+    ).toBe(true);
+  });
+
+  it("answers yes when the webhook policy changed", () => {
+    expect(
+      probe.ask({ ...same, webhooks: { record: true } }, same, false)
+    ).toBe(true);
+  });
+
+  it("answers yes when localization was turned on", () => {
+    expect(probe.ask({ ...same, localized: true }, same, false)).toBe(true);
+  });
+
+  it("reads absent and null as the same thing", () => {
+    /*
+     * A stored column with no value arrives as `null`; a config that declares
+     * none has `undefined`. They mean the same thing, so a comparison that told
+     * them apart would report a change on every boot — a write per startup,
+     * per resource, that nothing else here would report.
+     */
+    const declared: SchemaSyncSubject = { status: false, localized: false };
+    const stored: SchemaSyncSubject = {
+      status: false,
+      localized: false,
+      versions: null,
+      revalidate: null,
+      webhooks: null,
+    };
+
+    expect(probe.ask(declared, stored, false)).toBe(false);
+  });
+
+  it("does not consult naming, which moves no column", () => {
+    /*
+     * The separating property against the defect this whole change came from.
+     * A label or an admin block is metadata: routing it through this path would
+     * flag a migration for an edit that touches no column, so those are asked
+     * about by their own branch and must not register here.
+     */
+    const renamed = { ...same, label: "New name", admin: { group: "Content" } };
+    const stored = { ...same, label: "Old name", admin: { group: "Settings" } };
+
+    expect(probe.ask(renamed, stored, false)).toBe(false);
+  });
+});

--- a/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
+++ b/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
@@ -116,6 +116,45 @@ describe("BaseRegistryService.schemaSyncNeeded", () => {
     expect(probe.ask(declared, stored, false)).toBe(false);
   });
 
+  it("reads two orderings of the same object as the same value", () => {
+    /*
+     * Postgres stores these columns as `jsonb`, which does not preserve the key
+     * order it was given — it normalises them — so the row read back can spell
+     * the same value differently from the config that wrote it. A plain
+     * `JSON.stringify` compare would then report a change on every startup, for
+     * every resource, on that adapter only: a write per boot, and `updated_at`
+     * churning, with every instrument reporting the sync as legitimate work.
+     *
+     * The comparison is therefore over a canonical form. Arrays keep their
+     * order, because order is part of an array's value.
+     */
+    const declared: SchemaSyncSubject = {
+      status: true,
+      localized: false,
+      versions: { drafts: true, max: 10, nested: { a: 1, b: 2 } },
+    };
+    const storedDifferentOrder: SchemaSyncSubject = {
+      status: true,
+      localized: false,
+      versions: { nested: { b: 2, a: 1 }, max: 10, drafts: true },
+    };
+
+    expect(probe.ask(declared, storedDifferentOrder, false)).toBe(false);
+  });
+
+  it("still sees a REORDERED ARRAY as a change", () => {
+    // The control on the case above. Canonicalising keys must not extend to
+    // sorting array members: `[a, b]` and `[b, a]` are different values, and a
+    // comparison that flattened that would stop detecting a real edit.
+    expect(
+      probe.ask(
+        { ...same, versions: { order: ["a", "b"] } },
+        { ...same, versions: { order: ["b", "a"] } },
+        false
+      )
+    ).toBe(true);
+  });
+
   it("does not consult naming, which moves no column", () => {
     /*
      * The separating property against the defect this whole change came from.

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -115,18 +115,48 @@ export interface BaseRegistryRecord {
  * @typeParam TMigrationStatus - The migration status union type for this domain
  */
 /**
+ * A value as a string that does not depend on how its keys were ordered.
+ *
+ * Postgres holds these columns as `jsonb`, which normalises key order rather
+ * than preserving what was written, so the row read back can spell the same
+ * value differently from the config that wrote it. Compared as plain JSON, such
+ * a resource re-syncs on every startup — on that adapter only, with every
+ * instrument reporting the write as legitimate work.
+ *
+ * Arrays keep their order. Order is part of an array's value, and sorting one
+ * here would stop a genuine reordering from being detected at all.
+ *
+ * Functions are dropped, as `JSON.stringify` always dropped them. That is what
+ * makes a code-first `preview.url` compare equal to the stored row it could
+ * never have been written into.
+ */
+function canonicalJson(value: unknown): string {
+  return JSON.stringify(withSortedKeys(value));
+}
+
+/** The same value with every object's keys in a fixed order. */
+function withSortedKeys(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(withSortedKeys);
+  if (value === null || typeof value !== "object") return value;
+
+  const source = value as Record<string, unknown>;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(source).sort()) {
+    sorted[key] = withSortedKeys(source[key]);
+  }
+  return sorted;
+}
+
+/**
  * Whether two config values are the same as far as storage is concerned.
  *
  * `?? null` on both sides because a column holding no value arrives as `null`
  * while a config declaring none has `undefined`: they mean the same thing, and
  * a comparison telling them apart would report a change on every boot — a write
  * per startup, per resource, that nothing downstream would report as spurious.
- *
- * A stable string compare over normalized config, so what it detects is a real
- * change rather than a re-serialization.
  */
 function sameStoredValue(a: unknown, b: unknown): boolean {
-  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+  return canonicalJson(a ?? null) === canonicalJson(b ?? null);
 }
 
 /**
@@ -527,7 +557,10 @@ export abstract class BaseRegistryService<
     if (!codeAdmin || !existingAdmin) {
       return true;
     }
-    return JSON.stringify(codeAdmin) !== JSON.stringify(existingAdmin);
+    // Canonical for the reason `sameStoredValue` is: a `jsonb` column hands
+    // back its own key order, and an admin block that compared unequal on that
+    // alone would re-sync every resource on every boot.
+    return canonicalJson(codeAdmin) !== canonicalJson(existingAdmin);
   }
 
   /**

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -114,6 +114,37 @@ export interface BaseRegistryRecord {
  * @typeParam TRecord - The full record type (must extend BaseRegistryRecord)
  * @typeParam TMigrationStatus - The migration status union type for this domain
  */
+/**
+ * Whether two config values are the same as far as storage is concerned.
+ *
+ * `?? null` on both sides because a column holding no value arrives as `null`
+ * while a config declaring none has `undefined`: they mean the same thing, and
+ * a comparison telling them apart would report a change on every boot — a write
+ * per startup, per resource, that nothing downstream would report as spurious.
+ *
+ * A stable string compare over normalized config, so what it detects is a real
+ * change rather than a re-serialization.
+ */
+function sameStoredValue(a: unknown, b: unknown): boolean {
+  return JSON.stringify(a ?? null) === JSON.stringify(b ?? null);
+}
+
+/**
+ * The fields {@link BaseRegistryService.schemaSyncNeeded} compares.
+ *
+ * Structural rather than a union of the two record types, because the question
+ * is about these fields and nothing else: a registry gains a column without
+ * this having an opinion, and neither domain's record has to be imported here
+ * to ask it.
+ */
+export interface SchemaSyncSubject {
+  status?: boolean;
+  localized?: boolean;
+  versions?: unknown;
+  revalidate?: unknown;
+  webhooks?: unknown;
+}
+
 export abstract class BaseRegistryService<
   TRecord extends BaseRegistryRecord,
   TMigrationStatus extends string = string,
@@ -497,6 +528,49 @@ export abstract class BaseRegistryService<
       return true;
     }
     return JSON.stringify(codeAdmin) !== JSON.stringify(existingAdmin);
+  }
+
+  /**
+   * Whether a code-first config differs from its stored row in a way that has
+   * to be written THROUGH the schema path.
+   *
+   * Shared by the collection and Single registries because it is one question,
+   * not two that resemble each other: each clause here either moves a column or
+   * changes how the row's document is read, so a write answering it also
+   * carries the schema hash and re-opens the migration bookkeeping. Two copies
+   * agreed until someone edited one, and the half that went unedited would then
+   * leave its domain silently stale.
+   *
+   * A caller with clauses of its own ORs them onto this — a collection's
+   * physical table name, say — rather than restating these.
+   *
+   * Naming (label, description, the admin block) is deliberately NOT here.
+   * Those move no column, and routing them through this path would flag a
+   * migration for an edit that touches none.
+   *
+   * The JSON-shaped columns go through {@link sameStoredValue}, which is where
+   * the absent-versus-null reading lives.
+   */
+  protected schemaSyncNeeded(
+    config: SchemaSyncSubject,
+    existing: SchemaSyncSubject,
+    /*
+     * Decided by the caller rather than here. Comparing the hashes is one `===`
+     * behind a named function that belongs to the schema domain, and reaching
+     * for it from `shared` would point a dependency the wrong way down the
+     * layering for no shared logic at all — while the five comparisons below
+     * are the part both registries were actually keeping in step by hand.
+     */
+    schemaHashChanged: boolean
+  ): boolean {
+    return (
+      schemaHashChanged ||
+      (config.status === true) !== (existing.status === true) ||
+      !sameStoredValue(config.versions, existing.versions) ||
+      !sameStoredValue(config.revalidate, existing.revalidate) ||
+      !sameStoredValue(config.webhooks, existing.webhooks) ||
+      (config.localized === true) !== (existing.localized === true)
+    );
   }
 
   // ============================================================


### PR DESCRIPTION
A Single's preview pane said "Preview" for every Single. A collection's has always honoured `admin.preview.label`; a Single's ignored it.

## The finding was stale, and in a useful direction

It was filed as "the Single schema projection drops the whole preview block", with an access question attached — the site URL sits behind a `settings` permission editors do not hold, so exposing preview configuration needed thought.

That question does not arise, because nothing new is exposed. Tested rather than reasoned about:

```
JSON.stringify({ preview: { url: () => "/landing", label: "Landing preview" } })
  -> {"preview":{"label":"Landing preview"}}
```

The `url` is a FUNCTION and cannot survive being stored, which is why collections carry a separate `hasPreview` boolean. The label beside it is a string and survives untouched — and `GET /singles/:slug` spreads the whole record, so it was already arriving. What was missing is that the admin's own type for a Single never declared the field, so nothing read it.

So this is admin-side only, and it exposes nothing the browser did not already receive.

## Two duplications collapsed rather than extended

- **The default.** `previewLabel(config)` is derived once and shared. A second `?? "Preview"` at the Single's call site would have kept the old fallback silently after someone changed the real one.
- **The type.** `SingleSchema` carried its own inline copy of the admin options and had **already drifted** — missing `order` and `sidebarGroup`, both of which the server sends. That copy is precisely why the label was invisible, so the fix is to stop having two rather than to add the field twice.

## Where the label is assembled, and why it moved

At first the form read `previewLabel(schema.admin?.preview)` directly. One more optional chain took `SingleForm` to cyclomatic 21 and `fallow` refused with `complexity_introduced: 1`.

The gate was right. `useSinglePreviewPane` already assembles every other prop the pane receives — `scope`, `revision`, `open`, `toggle` — so the label belongs with them rather than beside them. `SingleForm` comes out at **20**, below where it started, and `complexity_introduced` is 0.

## Evidence

Two tests: the pane is called by a declared label, and a control that a Single naming none still gets "Preview" — so the first is about the declaration rather than a rename that happens to match.

Break-verified three times with asserted anchors, including once **after** moving the implementation into the hook, since relocating the code is a change to the experiment:

| break | fails |
| --- | --- |
| the form hardcodes the label again | the declared-label test, alone |
| the shared derivation stops reading `config.label` | the same test, alone |
| the hook returns a literal after the move | the same test, alone |

Gates after a full build: `check-types`, `lint`, `lint:design`, comment convention, `changeset status`, `fallow` — all 0. Singles and hooks suites 306/306.

Baseline note: `admin` has 15 pre-existing failures across `StatsCard`, `builder-settings-modal` and `field-editor-sheet`. Confirmed identical on a clean `origin/main` tree by stashing — untouched by this change.
