### PR TITLE
feat(admin): let the preview pane be shown at a chosen viewport width

### DIFF
--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -68,3 +68,11 @@ different facts — what the box says and what the frame is sized to — so an e
 box committed "no width", which selected Responsive, which removed the input the
 author was typing in. The text being typed is now kept separately, and a width
 is committed only once the box names one a frame can be sized to.
+
+The custom width box commits the whole number it shows. `parseInt` read `390.5`
+as `390` and `1e3` as `1` — both of which a number input accepts and displays in
+full — so the frame was sized to a width the box was not showing, and blurring
+replaced the author's text with the truncated value.
+
+The pane measures itself before the browser paints rather than after, so a frame
+cannot be drawn at the wrong width on the way to the right one.

--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -53,3 +53,18 @@ never disagree with the breakpoints the site actually uses. No phone/tablet/
 desktop numbers are invented here, and there are deliberately no device icons —
 a site names its own breakpoints, and no glyph is honest for a tier an author
 called "Kiosk".
+
+The toolbar wraps instead of running off the edge. At a 1024px window the pane
+is about 450px wide, and a viewport select, a width box, a scaling note and
+three actions do not fit on one line — the pane clips its overflow, so
+open-in-a-new-tab and close sat past the edge with no way to scroll to them.
+Measured in a browser at that width: they were 40px and 98px outside the
+clipping box, and hit-testing their centres reached nothing. The three actions
+stay together as one unit, so the row breaks between the viewport control and
+them rather than through the middle of them.
+
+Clearing the width box no longer takes the box away. It held one value for two
+different facts — what the box says and what the frame is sized to — so an empty
+box committed "no width", which selected Responsive, which removed the input the
+author was typing in. The text being typed is now kept separately, and a width
+is committed only once the box names one a frame can be sized to.

--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -76,3 +76,11 @@ replaced the author's text with the truncated value.
 
 The pane measures itself before the browser paints rather than after, so a frame
 cannot be drawn at the wrong width on the way to the right one.
+
+The custom width is taken when you stop typing, not on every keystroke. The
+frame is a live iframe of the site, so each committed width re-lays-out a whole
+page — and clearing the box to type `768` emits `7`, `76`, `768`, collapsing the
+preview to 7px and then 76px on the way. Leaving the box commits immediately, so
+a width typed and clicked away from is not lost. Widths below one pixel are
+refused: the input's `min` marks the field invalid without clamping it, and
+below a pixel the preview is not narrow but absent.

--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -1,0 +1,55 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The in-admin preview pane can now be shown at a chosen viewport width instead of
+whatever width the editor happened to leave it.
+
+This matters more than it sounds. The pane sits in a split that reserves a
+minimum editor, so at its default position the preview is a few hundred pixels
+wide — which means it was faithfully previewing a MOBILE viewport, decided by
+wherever the divider was last dragged rather than by anything anyone chose. The
+two controls were also coupled: widening the preview meant narrowing the editor
+being typed into.
+
+Choosing a width now does two things in order. The split gives the preview as
+much room as the minimum editor allows, and only whatever still does not fit is
+scaled down. On a wide window nothing is scaled at all.
+
+A scaled frame keeps its requested width, so the site's own media queries still
+resolve against the viewport being previewed and the preview stays truthful
+about layout. What it stops being truthful about is physical size — text renders
+smaller than a visitor would see it — so the toolbar always states the real
+width and the scale beside it rather than letting the shrinking pass unremarked.
+
+This release ships the control with **Responsive** and a custom width. Named
+presets follow: they will come from a collection's own declaration where one
+exists, and from the site's page-builder breakpoints otherwise, so a preset can
+never disagree with the breakpoints the site actually uses. No phone/tablet/
+desktop numbers are invented here, and there are deliberately no device icons —
+a site names its own breakpoints, and no glyph is honest for a tier an author
+called "Kiosk".

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -99,8 +99,14 @@ export function PreviewFrame({
 
   return (
     <div className="flex h-full min-h-0 flex-col border-l border-border bg-muted/40">
-      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-background px-3 py-2">
-        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      {/* Wraps rather than overflows. The pane is a share of a split, so at a
+          1024px window it is a few hundred pixels wide — and this row holds a
+          viewport select, a width box, a scaling note and three actions. Fixed
+          on one line they ran past the edge into `overflow-hidden` below, which
+          put refresh, open-in-tab and close off-screen with no way to scroll to
+          them. Wrapping costs a second row and reaches everything. */}
+      <div className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 border-b border-border bg-background px-3 py-2">
+        <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
           {label}
         </span>
         {/* States what the frame IS showing rather than what an author might
@@ -114,7 +120,7 @@ export function PreviewFrame({
           </span>
         )}
 
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           {showsFrame && (
             <PreviewViewportControl
               requestedWidth={requestedWidth}
@@ -122,53 +128,65 @@ export function PreviewFrame({
               fit={fit}
             />
           )}
-          {isLoading && (
-            <Loader2
-              className="h-3.5 w-3.5 animate-spin text-muted-foreground"
-              aria-hidden="true"
-            />
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={refresh}
-            /*
-             * Disabled only while a mint is IN FLIGHT, never because there is
-             * nothing to show. A failed mint leaves `url` null and sets a
-             * reason, and the message beside it asks the editor to try again —
-             * so keying the control on `url` disabled the one affordance that
-             * message points at, and the only way to retry was to close the
-             * pane and reopen it. A superseded pane needs it for the same
-             * reason: refreshing is how the session comes back.
-             */
-            disabled={isLoading}
-            title="Refresh the preview"
-          >
-            <RefreshCw className="h-4 w-4" aria-hidden="true" />
-            <span className="sr-only">Refresh the preview</span>
-          </Button>
-          {url !== null && (
-            <Button asChild variant="ghost" size="sm" title="Open in a new tab">
-              {/* `rel` carries noopener as well as noreferrer: a preview URL is
+          {/* The three actions are ONE flex item, so the row above breaks
+              between the viewport control and them rather than through the
+              middle of them. Wrapped individually they scattered across rows —
+              refresh above, close below — which reads as three unrelated
+              controls instead of this pane's toolbar. */}
+          <div className="flex shrink-0 items-center gap-2">
+            {isLoading && (
+              <Loader2
+                className="h-3.5 w-3.5 animate-spin text-muted-foreground"
+                aria-hidden="true"
+              />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={refresh}
+              /*
+               * Disabled only while a mint is IN FLIGHT, never because there is
+               * nothing to show. A failed mint leaves `url` null and sets a
+               * reason, and the message beside it asks the editor to try again —
+               * so keying the control on `url` disabled the one affordance that
+               * message points at, and the only way to retry was to close the
+               * pane and reopen it. A superseded pane needs it for the same
+               * reason: refreshing is how the session comes back.
+               */
+              disabled={isLoading}
+              title="Refresh the preview"
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Refresh the preview</span>
+            </Button>
+            {url !== null && (
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                title="Open in a new tab"
+              >
+                {/* `rel` carries noopener as well as noreferrer: a preview URL is
                   a bearer credential, and a referrer header would hand it to
                   whatever the opened page links to next. */}
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="h-4 w-4" aria-hidden="true" />
-                <span className="sr-only">Open the preview in a new tab</span>
-              </a>
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  <span className="sr-only">Open the preview in a new tab</span>
+                </a>
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              title="Close the preview"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Close the preview</span>
             </Button>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={onClose}
-            title="Close the preview"
-          >
-            <X className="h-4 w-4" aria-hidden="true" />
-            <span className="sr-only">Close the preview</span>
-          </Button>
+          </div>
         </div>
       </div>
 

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -26,6 +26,7 @@
  */
 
 import { Button } from "@nextlyhq/ui";
+import { useRef } from "react";
 
 import { ExternalLink, Loader2, RefreshCw, X } from "@admin/components/icons";
 import {
@@ -33,6 +34,13 @@ import {
   type PreviewDocumentNoun,
 } from "@admin/hooks/useEntryPreview";
 
+import {
+  previewFrameFit,
+  previewFrameStyle,
+  type PreviewFit,
+} from "./previewFrameFit";
+import { PreviewViewportControl } from "./PreviewViewportControl";
+import { useMeasuredWidth } from "./useMeasuredWidth";
 import {
   PREVIEW_PANE_BLOCK_MESSAGES,
   type UsePreviewFrameResult,
@@ -50,6 +58,15 @@ export interface PreviewFrameProps extends UsePreviewFrameResult {
    * names a slug, which a Single always has and cannot be the problem with.
    */
   noun: PreviewDocumentNoun;
+  /**
+   * The viewport width the author asked for, or `null` to fill the pane.
+   *
+   * Held by the pane rather than here because choosing a width also WIDENS the
+   * split — the pane takes as much room as it is allowed before anything is
+   * scaled down — and the split is the pane's to move, not the frame's.
+   */
+  requestedWidth: number | null;
+  onRequestWidth: (width: number | null) => void;
 }
 
 export function PreviewFrame({
@@ -62,7 +79,24 @@ export function PreviewFrame({
   onClose,
   label,
   noun,
+  requestedWidth,
+  onRequestWidth,
 }: PreviewFrameProps) {
+  /*
+   * The area the frame is drawn into, measured rather than assumed. Its width
+   * is what decides whether a requested viewport fits, and it changes when the
+   * SPLIT moves — an event the window never reports, which is why this is a
+   * `ResizeObserver` on the box itself.
+   */
+  const viewport = useRef<HTMLDivElement>(null);
+  const available = useMeasuredWidth(viewport);
+  const fit = previewFrameFit(requestedWidth, available);
+
+  // A frame is on screen only in the last branch below. Offering a viewport
+  // control over a refusal message would be a control for something that is
+  // not there.
+  const showsFrame = reason === null && block === null && url !== null;
+
   return (
     <div className="flex h-full min-h-0 flex-col border-l border-border bg-muted/40">
       <div className="flex shrink-0 items-center gap-2 border-b border-border bg-background px-3 py-2">
@@ -80,7 +114,14 @@ export function PreviewFrame({
           </span>
         )}
 
-        <div className="ml-auto flex items-center gap-1">
+        <div className="ml-auto flex items-center gap-2">
+          {showsFrame && (
+            <PreviewViewportControl
+              requestedWidth={requestedWidth}
+              onRequestWidth={onRequestWidth}
+              fit={fit}
+            />
+          )}
           {isLoading && (
             <Loader2
               className="h-3.5 w-3.5 animate-spin text-muted-foreground"
@@ -131,37 +172,97 @@ export function PreviewFrame({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1">
-        {reason !== null ? (
-          /* The reason, not a generic failure. Each of these names something
-             the reader can act on, and the pane is the only place they will
-             see it — unlike the Preview button, which can raise a toast. */
-          <p className="p-6 text-sm text-muted-foreground">
-            {previewMessage(reason, noun)}
-          </p>
-        ) : block !== null ? (
-          /* Ahead of the `url === null` branch on purpose: a blocked pane HAS a
-             url — that is what makes the tab button beside this message the
-             remedy — so testing for a missing url first would render "Preparing
-             the preview…" forever over a pane that is not preparing anything. */
-          <p className="p-6 text-sm text-muted-foreground">
-            {PREVIEW_PANE_BLOCK_MESSAGES[block]}
-          </p>
-        ) : url === null ? (
-          <p className="p-6 text-sm text-muted-foreground">
-            Preparing the preview…
-          </p>
-        ) : (
-          <iframe
-            // Remounted rather than navigated: see `usePreviewFrame` on why a
-            // key beats appending a cache-buster the SITE would have to read.
-            key={reloadKey}
-            src={url}
-            title={`${label} preview`}
-            className="h-full w-full border-0 bg-background"
-          />
-        )}
+      {/* `overflow-hidden` because a frame wider than this box is drawn inside
+          it and scaled down: without clipping, the untransformed corners of a
+          scaled frame paint over the divider. Harmless while responsive, since
+          the frame is then exactly this size. */}
+      <div ref={viewport} className="min-h-0 flex-1 overflow-hidden">
+        <PreviewFrameBody
+          reason={reason}
+          block={block}
+          url={url}
+          reloadKey={reloadKey}
+          label={label}
+          noun={noun}
+          fit={fit}
+        />
       </div>
     </div>
+  );
+}
+
+/**
+ * What the frame's content area shows: one of three refusals, or the site.
+ *
+ * Split from the toolbar because they answer different questions and grow at
+ * different rates — the toolbar gained a viewport control, and carrying both in
+ * one component put it over the complexity gate. The ORDER of the branches is
+ * the load-bearing part and is preserved exactly, so this is a move rather than
+ * a rewrite.
+ */
+function PreviewFrameBody({
+  reason,
+  block,
+  url,
+  reloadKey,
+  label,
+  noun,
+  fit,
+}: {
+  reason: UsePreviewFrameResult["reason"];
+  block: UsePreviewFrameResult["block"];
+  url: string | null;
+  reloadKey: number;
+  label: string;
+  noun: PreviewDocumentNoun;
+  fit: PreviewFit;
+}) {
+  /* The reason, not a generic failure. Each of these names something the reader
+     can act on, and the pane is the only place they will see it — unlike the
+     Preview button, which can raise a toast. */
+  if (reason !== null) {
+    return (
+      <p className="p-6 text-sm text-muted-foreground">
+        {previewMessage(reason, noun)}
+      </p>
+    );
+  }
+
+  /* Ahead of the `url === null` branch on purpose: a blocked pane HAS a url —
+     that is what makes the tab button beside this message the remedy — so
+     testing for a missing url first would render "Preparing the preview…"
+     forever over a pane that is not preparing anything. */
+  if (block !== null) {
+    return (
+      <p className="p-6 text-sm text-muted-foreground">
+        {PREVIEW_PANE_BLOCK_MESSAGES[block]}
+      </p>
+    );
+  }
+
+  if (url === null) {
+    return (
+      <p className="p-6 text-sm text-muted-foreground">
+        Preparing the preview…
+      </p>
+    );
+  }
+
+  return (
+    <iframe
+      // Remounted rather than navigated: see `usePreviewFrame` on why a key
+      // beats appending a cache-buster the SITE would have to read.
+      key={reloadKey}
+      src={url}
+      title={`${label} preview`}
+      /*
+       * `h-full w-full` remains the base, and the derived style overrides it
+       * when a width was asked for. A responsive frame therefore needs no
+       * special case, and an unmeasured one fills the pane rather than flashing
+       * at a width nobody has confirmed.
+       */
+      className="h-full w-full border-0 bg-background"
+      style={previewFrameStyle(fit)}
+    />
   );
 }

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -37,7 +37,7 @@
  * @module components/features/entries/PreviewMode/PreviewPanes
  */
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { useSuppressAdminChrome } from "@admin/components/layout/ChromeSuppression";
 import type {
@@ -132,13 +132,26 @@ export function PreviewPanes({
    */
   const frame = usePreviewFrame({ scope, active: open });
 
+  /*
+   * Held HERE because asking for a viewport width does two things, and only one
+   * of them belongs to the frame: the split widens the preview as far as it is
+   * allowed, and whatever width still does not fit is scaled inside the frame.
+   * Removing the shortfall before scaling it is why a laptop shows a desktop
+   * preview at a readable size rather than at whatever fraction the default
+   * split happened to leave.
+   */
+  const [requestedWidth, setRequestedWidth] = useState<number | null>(null);
+
   return (
     <PreviewSplit
       open={open}
       label={label}
+      preferPreviewWidth={requestedWidth}
       preview={
         <PreviewFrameOnSave
           frame={frame}
+          requestedWidth={requestedWidth}
+          onRequestWidth={setRequestedWidth}
           revision={revision}
           onClose={onClose}
           label={label}
@@ -170,12 +183,16 @@ function PreviewFrameOnSave({
   onClose,
   label,
   noun,
+  requestedWidth,
+  onRequestWidth,
 }: {
   frame: UsePreviewFrameResult;
   revision: string;
   onClose: () => void;
   label: string;
   noun: PreviewDocumentNoun;
+  requestedWidth: number | null;
+  onRequestWidth: (width: number | null) => void;
 }) {
   const { refresh } = frame;
   const lastSeen = useRef(revision);
@@ -187,7 +204,14 @@ function PreviewFrameOnSave({
   }, [revision, refresh]);
 
   return (
-    <PreviewFrame {...frame} onClose={onClose} label={label} noun={noun} />
+    <PreviewFrame
+      {...frame}
+      onClose={onClose}
+      label={label}
+      noun={noun}
+      requestedWidth={requestedWidth}
+      onRequestWidth={onRequestWidth}
+    />
   );
 }
 

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
@@ -59,6 +59,16 @@ export interface PreviewSplitProps {
   preview: React.ReactNode;
   /** Names the divider for assistive technology. */
   label: string;
+  /**
+   * A viewport width the preview would like room for, or `null` for none.
+   *
+   * The split does not size the frame — it only stops standing in the way. When
+   * a width is asked for, the preview takes as much of the split as the minimum
+   * editor allows; whatever still does not fit is the frame's to scale. Giving
+   * the room first is what keeps the scaling as small as it can be, and on a
+   * wide enough window removes it entirely.
+   */
+  preferPreviewWidth?: number | null;
 }
 
 export function PreviewSplit({
@@ -66,6 +76,7 @@ export function PreviewSplit({
   children,
   preview,
   label,
+  preferPreviewWidth = null,
 }: PreviewSplitProps) {
   /*
    * Generated rather than fixed: the id is what `aria-controls` points at, and
@@ -137,6 +148,21 @@ export function PreviewSplit({
       dragPointer.current = null;
     };
   }, [open, moveTo]);
+
+  /*
+   * Asking for a width takes the room the split can give before anything is
+   * scaled. Clamped to the minimum EDITOR rather than to zero: the editor is
+   * what the author is typing into, and a preview that swallowed it would trade
+   * one unusable pane for another.
+   *
+   * Deliberately not restored when the request clears. Returning to the default
+   * split would undo a divider the author may have dragged since, and the split
+   * is theirs — this only ever moves it on an explicit request.
+   */
+  useEffect(() => {
+    if (preferPreviewWidth === null) return;
+    setEditorPercent(MIN_EDITOR_PERCENT);
+  }, [preferPreviewWidth]);
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     const step =

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -28,7 +28,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nextlyhq/ui";
-import { useId, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
+
+import { UI } from "@admin/constants/ui";
+import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
 
 import type { PreviewFit } from "./previewFrameFit";
 
@@ -56,6 +59,17 @@ const CUSTOM = "custom";
  */
 const CUSTOM_SEED_WIDTH = 1280;
 
+/**
+ * The narrowest width a frame can be asked for.
+ *
+ * One pixel, because below it the preview is not small — it is gone, and an
+ * author who typed `0.5` sees an empty pane rather than a narrow one. The input
+ * carries this as its `min` attribute, which marks the field invalid without
+ * clamping or refusing the value, so the rule has to live where the width is
+ * committed as well. Both read this constant so they cannot disagree.
+ */
+const MIN_PREVIEW_WIDTH = 1;
+
 export function PreviewViewportControl({
   requestedWidth,
   onRequestWidth,
@@ -79,6 +93,41 @@ export function PreviewViewportControl({
    * masked by a draft nobody is typing.
    */
   const [draft, setDraft] = useState<string | null>(null);
+
+  /*
+   * The width is taken when the author STOPS typing, not per keystroke.
+   *
+   * The frame is a live iframe of the site, so each committed width re-lays-out
+   * a whole page. Clearing the box and typing `768` emits `7`, `76`, `768`, and
+   * committing each one collapsed the preview to 7px and then 76px on the way —
+   * the separate draft kept the FIELD from being torn away, but the frame still
+   * thrashed through widths the author never asked for.
+   */
+  const settledDraft = useDebouncedValue(draft, UI.PREVIEW_WIDTH_DEBOUNCE_MS);
+
+  const commitWidth = useCallback(
+    (text: string) => {
+      // Below one pixel is not a narrow preview, it is an absent one.
+      const next = Number(text);
+      if (Number.isFinite(next) && next >= MIN_PREVIEW_WIDTH) {
+        onRequestWidth(next);
+      }
+    },
+    [onRequestWidth]
+  );
+
+  useEffect(() => {
+    /*
+     * `settledDraft !== draft` means the pause has not happened yet; a null
+     * draft means no edit is in progress. The second guard is what stops a
+     * choice from the list being undone: selecting Responsive clears the draft,
+     * but the debounced copy still holds the old text for one delay, and
+     * committing it then would put the frame back at a width the author has
+     * just navigated away from.
+     */
+    if (draft === null || settledDraft !== draft) return;
+    commitWidth(settledDraft);
+  }, [draft, settledDraft, commitWidth]);
 
   return (
     <div className="flex flex-wrap items-center justify-end gap-1.5">
@@ -115,36 +164,28 @@ export function PreviewViewportControl({
             id={widthInputId}
             type="number"
             inputMode="numeric"
-            min={1}
+            min={MIN_PREVIEW_WIDTH}
             className="h-7 w-20 text-xs"
             value={draft ?? String(requestedWidth)}
             onChange={event => {
-              const text = event.target.value;
-              setDraft(text);
-
               /*
-               * Commit only what a frame can be sized to. An empty or
-               * half-typed box is a state of the EDIT, not a viewport request,
-               * so the frame holds its last good width while the author types
-               * the next one — otherwise the preview flickers back to full
-               * width between two keystrokes. Zero and below are rejected here
-               * for the same reason `previewFrameFit` refuses them: it fills
-               * the pane instead, and committing one would leave this control
-               * and the frame describing different states.
-               *
-               * `Number`, not `parseInt`. A number input accepts and displays
-               * `390.5` and `1e3`, and `parseInt` reads those as `390` and `1`
-               * — sizing the frame to a width the box is not showing, and
-               * replacing the author's text with the truncated value on blur.
-               * A fractional width is a real one: CSS sizes to it and the
-               * site's media queries resolve against it.
+               * Records what was typed and nothing else. What a frame can be
+               * sized to is decided in `commitWidth`, once the typing stops:
+               * an empty or half-typed box is a state of the EDIT, not a
+               * viewport request.
                */
-              const next = Number(text);
-              if (Number.isFinite(next) && next > 0) onRequestWidth(next);
+              setDraft(event.target.value);
             }}
             onBlur={() => {
-              // Leaving the box ends the edit. A draft left behind would name a
-              // width the frame is not at.
+              /*
+               * Leaving the box ENDS the edit, so the pending width is taken
+               * now rather than waiting out a pause that has already been
+               * answered. Without this, typing a width and clicking straight
+               * into the page would discard it — the debounce would still be
+               * running when the draft was cleared.
+               */
+              if (draft !== null) commitWidth(draft);
+              // A draft left behind would name a width the frame is not at.
               setDraft(null);
             }}
           />

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -1,0 +1,128 @@
+/**
+ * Choosing which viewport the preview shows.
+ *
+ * ## Why a width and not a device
+ *
+ * There are no device icons here, and that is a decision rather than an
+ * omission. A site defines its own breakpoints, author-named and up to seven of
+ * them, so a tier may be called "Watch" or "Kiosk" — and no glyph is honest for
+ * a list the product does not control. Text carries an author's name correctly;
+ * a phone icon beside a tier called "Kiosk" is confidently wrong.
+ *
+ * ## Why the real width is always visible when it is scaled
+ *
+ * The pane cannot be wider than its share of the split, so a desktop width does
+ * not fit on a laptop and is drawn smaller. The FRAME keeps the requested width,
+ * so the site's media queries still resolve against it and the preview stays
+ * truthful about the viewport — but text renders at a physical size no visitor
+ * sees. An author comparing type sizes against a scaled preview would be reading
+ * the wrong thing, so the scaling is named rather than left to be noticed.
+ *
+ * @module components/features/entries/PreviewMode/PreviewViewportControl
+ */
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+import { useId } from "react";
+
+import type { PreviewFit } from "./previewFrameFit";
+
+/** The width the author asked for, or `null` for "fill the pane". */
+export interface PreviewViewportControlProps {
+  requestedWidth: number | null;
+  onRequestWidth: (width: number | null) => void;
+  /** What the pane could actually do with that request. */
+  fit: PreviewFit;
+}
+
+/** The `Select` value standing for "fill the pane". */
+const RESPONSIVE = "responsive";
+/** The `Select` value standing for "I will type a width". */
+const CUSTOM = "custom";
+
+/**
+ * A default to type INTO, not a preset.
+ *
+ * Switching to a custom width with an empty box would leave the control in a
+ * state that renders nothing and reports nothing, so the box opens on a common
+ * laptop width. It is a starting value the author overwrites, which is why it
+ * is not offered as a named option — naming it would make it a claim about the
+ * site's breakpoints, and the site's breakpoints are not known here.
+ */
+const CUSTOM_SEED_WIDTH = 1280;
+
+export function PreviewViewportControl({
+  requestedWidth,
+  onRequestWidth,
+  fit,
+}: PreviewViewportControlProps) {
+  const widthInputId = useId();
+  const selection = requestedWidth === null ? RESPONSIVE : CUSTOM;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Select
+        value={selection}
+        onValueChange={value =>
+          onRequestWidth(value === RESPONSIVE ? null : CUSTOM_SEED_WIDTH)
+        }
+      >
+        <SelectTrigger
+          className="h-7 w-[9.5rem] text-xs"
+          aria-label="Preview viewport"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={RESPONSIVE}>Responsive</SelectItem>
+          <SelectItem value={CUSTOM}>Custom width</SelectItem>
+        </SelectContent>
+      </Select>
+
+      {requestedWidth !== null && (
+        <>
+          {/* Labelled for assistive technology only: the unit beside the box
+              reads as the visible label, and a second visible one would say the
+              same thing twice in a toolbar that is already dense. */}
+          <label className="sr-only" htmlFor={widthInputId}>
+            Preview width in pixels
+          </label>
+          <Input
+            id={widthInputId}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            className="h-7 w-20 text-xs"
+            value={String(requestedWidth)}
+            onChange={event => {
+              /*
+               * An empty or unparseable box means the author is mid-edit, and
+               * it returns to filling the pane rather than freezing on the last
+               * good number. Freezing would show a width the box no longer
+               * says, which is the control disagreeing with itself.
+               */
+              const next = Number.parseInt(event.target.value, 10);
+              onRequestWidth(Number.isFinite(next) ? next : null);
+            }}
+          />
+          <span className="text-xs text-muted-foreground">px</span>
+        </>
+      )}
+
+      {/* Named rather than left to be noticed. The frame is truthful about the
+          VIEWPORT while it is scaled and untruthful about physical size, and an
+          author checking type sizes needs to know which of the two they are
+          looking at. */}
+      {fit.kind === "scaled" && (
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          {`${Math.round(fit.scale * 100)}% of ${fit.width}px`}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -28,7 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nextlyhq/ui";
-import { useId } from "react";
+import { useId, useState } from "react";
 
 import type { PreviewFit } from "./previewFrameFit";
 
@@ -64,13 +64,32 @@ export function PreviewViewportControl({
   const widthInputId = useId();
   const selection = requestedWidth === null ? RESPONSIVE : CUSTOM;
 
+  /*
+   * What the box SAYS, held separately from the width the frame is at.
+   *
+   * They are different facts. Clearing the box to retype it leaves text that
+   * names no width, and a frame cannot be sized to "nothing" — so the committed
+   * value stays where it was until the box says something a frame can be sized
+   * to. Collapsing the two meant an empty box committed `null`, which selected
+   * Responsive, which removed this input: the field the author was typing in
+   * disappeared under them and the rest of their keystrokes went nowhere.
+   *
+   * `null` means "not being edited", and the box then shows the committed
+   * width — so a value arriving from anywhere else is displayed rather than
+   * masked by a draft nobody is typing.
+   */
+  const [draft, setDraft] = useState<string | null>(null);
+
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex flex-wrap items-center justify-end gap-1.5">
       <Select
         value={selection}
-        onValueChange={value =>
-          onRequestWidth(value === RESPONSIVE ? null : CUSTOM_SEED_WIDTH)
-        }
+        onValueChange={value => {
+          // A choice from the list ends the edit, so an abandoned draft does
+          // not reappear the next time the box is shown.
+          setDraft(null);
+          onRequestWidth(value === RESPONSIVE ? null : CUSTOM_SEED_WIDTH);
+        }}
       >
         <SelectTrigger
           className="h-7 w-[9.5rem] text-xs"
@@ -98,16 +117,28 @@ export function PreviewViewportControl({
             inputMode="numeric"
             min={1}
             className="h-7 w-20 text-xs"
-            value={String(requestedWidth)}
+            value={draft ?? String(requestedWidth)}
             onChange={event => {
+              const text = event.target.value;
+              setDraft(text);
+
               /*
-               * An empty or unparseable box means the author is mid-edit, and
-               * it returns to filling the pane rather than freezing on the last
-               * good number. Freezing would show a width the box no longer
-               * says, which is the control disagreeing with itself.
+               * Commit only what a frame can be sized to. An empty or
+               * half-typed box is a state of the EDIT, not a viewport request,
+               * so the frame holds its last good width while the author types
+               * the next one — otherwise the preview flickers back to full
+               * width between two keystrokes. Zero and below are rejected here
+               * for the same reason `previewFrameFit` refuses them: it fills
+               * the pane instead, and committing one would leave this control
+               * and the frame describing different states.
                */
-              const next = Number.parseInt(event.target.value, 10);
-              onRequestWidth(Number.isFinite(next) ? next : null);
+              const next = Number.parseInt(text, 10);
+              if (Number.isFinite(next) && next > 0) onRequestWidth(next);
+            }}
+            onBlur={() => {
+              // Leaving the box ends the edit. A draft left behind would name a
+              // width the frame is not at.
+              setDraft(null);
             }}
           />
           <span className="text-xs text-muted-foreground">px</span>

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -131,8 +131,15 @@ export function PreviewViewportControl({
                * for the same reason `previewFrameFit` refuses them: it fills
                * the pane instead, and committing one would leave this control
                * and the frame describing different states.
+               *
+               * `Number`, not `parseInt`. A number input accepts and displays
+               * `390.5` and `1e3`, and `parseInt` reads those as `390` and `1`
+               * — sizing the frame to a width the box is not showing, and
+               * replacing the author's text with the truncated value on blur.
+               * A fractional width is a real one: CSS sizes to it and the
+               * site's media queries resolve against it.
                */
-              const next = Number.parseInt(text, 10);
+              const next = Number(text);
               if (Number.isFinite(next) && next > 0) onRequestWidth(next);
             }}
             onBlur={() => {

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -123,6 +123,41 @@ describe("PreviewViewportControl — the width box", () => {
     expect(ui.committed()).toBe("1280");
   });
 
+  it("commits the WHOLE number the box shows, not its integer prefix", () => {
+    /*
+     * `parseInt` stops at the first character that cannot continue an integer,
+     * so it reads `390.5` as `390` and `1e3` as `1` — both of which a number
+     * input accepts and displays in full. The frame was then sized to a width
+     * the box was not showing, and blurring replaced the author's text with the
+     * truncated value as though they had typed it.
+     *
+     * A fractional width is a real width: CSS sizes to it and the site's media
+     * queries resolve against it, so there is nothing to reject here.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "390.5" } });
+    expect(ui.committed()).toBe("390.5");
+
+    fireEvent.change(box, { target: { value: "1e3" } });
+    expect(ui.committed()).toBe("1000");
+  });
+
+  it("still refuses text that names no width at all", () => {
+    // The control on the case above: reading the whole value must not turn
+    // every string into a width. `Number("")` is `0` and `Number("abc")` is
+    // `NaN`, and both mean the box is not saying anything a frame can be at.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "abc" } });
+    expect(ui.committed()).toBe("1280");
+
+    fireEvent.change(box, { target: { value: "" } });
+    expect(ui.committed()).toBe("1280");
+  });
+
   it("snaps back to the committed width when the edit is abandoned", () => {
     // Blur ends the edit. A draft left behind would name a width the frame is
     // not at, which is the control disagreeing with itself.

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * The viewport control, asserted on what an author can actually do with it.
+ *
+ * The case that matters is the half-typed one. A width box is a field people
+ * clear and retype rather than edit in place, so the states it passes through
+ * on the way to a number are the states it spends most of its life in — and a
+ * control that only behaves while holding a valid width is a control that
+ * misbehaves exactly while it is being used.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { PreviewFit } from "../previewFrameFit";
+import { PreviewViewportControl } from "../PreviewViewportControl";
+
+/**
+ * Rendered with the parent's real state loop, not a spy.
+ *
+ * The defect this file exists for is a REMOUNT caused by the parent's answer
+ * coming back and changing what renders. A mocked `onRequestWidth` that records
+ * calls without feeding the value back cannot reproduce it — the control would
+ * pass while the shipped tree still unmounted the field.
+ */
+function renderControl(initial: number | null = 1280) {
+  function Harness() {
+    const [requestedWidth, setRequestedWidth] = useState<number | null>(
+      initial
+    );
+    const fit: PreviewFit =
+      requestedWidth === null
+        ? { kind: "responsive" }
+        : { kind: "exact", width: requestedWidth };
+    return (
+      <>
+        <PreviewViewportControl
+          requestedWidth={requestedWidth}
+          onRequestWidth={setRequestedWidth}
+          fit={fit}
+        />
+        <output data-testid="committed">{String(requestedWidth)}</output>
+      </>
+    );
+  }
+  render(<Harness />);
+  return {
+    box: () => screen.queryByLabelText("Preview width in pixels"),
+    committed: () => screen.getByTestId("committed").textContent,
+  };
+}
+
+describe("PreviewViewportControl — the width box", () => {
+  it("KEEPS the box mounted and focused when it is cleared", () => {
+    /*
+     * The separating property. Clearing to retype used to commit `null`, which
+     * selected Responsive, which removed this field — so React unmounted the
+     * element the author was typing into and every keystroke after the first
+     * went nowhere. Focus is asserted because a remount that restored an
+     * identically-shaped field would still lose the caret.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box();
+    expect(box).not.toBeNull();
+
+    box?.focus();
+    fireEvent.change(box as HTMLElement, { target: { value: "" } });
+
+    expect(ui.box()).not.toBeNull();
+    expect(document.activeElement).toBe(box);
+  });
+
+  it("shows the author's own text while it is being typed", () => {
+    // The box has to read back what was typed into it. Showing the committed
+    // width instead would fight the author for the field's contents.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "" } });
+    // Still the field that is IN the document: a detached node keeps whatever
+    // value was written to it, so reading `box.value` alone would pass against
+    // an implementation that had already unmounted this input.
+    expect(ui.box()).toBe(box);
+    expect(box.value).toBe("");
+
+    fireEvent.change(box, { target: { value: "76" } });
+    expect(ui.box()).toBe(box);
+    expect(box.value).toBe("76");
+  });
+
+  it("holds the last good width while the box says nothing usable", () => {
+    /*
+     * The frame is sized to the committed value, so committing a half-typed
+     * number would make the preview flicker between widths on the way to one
+     * the author meant. It stays where it was until the box names a width.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "" } });
+    expect(ui.committed()).toBe("1280");
+  });
+
+  it("commits a width as soon as the box names one", () => {
+    // The control still has to work: this is what stops the case above from
+    // being satisfied by a box that commits nothing at all.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "768" } });
+    expect(ui.committed()).toBe("768");
+  });
+
+  it("does not commit a zero or negative width", () => {
+    // `previewFrameFit` reads both as "no request" and fills the pane, so
+    // committing one would put the control and the frame in different states.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "0" } });
+    expect(ui.committed()).toBe("1280");
+
+    fireEvent.change(box, { target: { value: "-5" } });
+    expect(ui.committed()).toBe("1280");
+  });
+
+  it("snaps back to the committed width when the edit is abandoned", () => {
+    // Blur ends the edit. A draft left behind would name a width the frame is
+    // not at, which is the control disagreeing with itself.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "" } });
+    fireEvent.blur(box);
+
+    expect(box.value).toBe("1280");
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -7,9 +7,11 @@
  * control that only behaves while holding a valid width is a control that
  * misbehaves exactly while it is being used.
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UI } from "@admin/constants/ui";
 
 import type { PreviewFit } from "../previewFrameFit";
 import { PreviewViewportControl } from "../PreviewViewportControl";
@@ -49,7 +51,28 @@ function renderControl(initial: number | null = 1280) {
   };
 }
 
+/**
+ * The pause that ends an edit.
+ *
+ * A width is committed when the author stops typing, so a test that asserts
+ * what was committed has to say when that happened. Written out rather than
+ * hidden in a helper called `flush`, because the delay is the behaviour.
+ */
+function stopTyping() {
+  act(() => {
+    vi.advanceTimersByTime(UI.PREVIEW_WIDTH_DEBOUNCE_MS);
+  });
+}
+
 describe("PreviewViewportControl — the width box", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("KEEPS the box mounted and focused when it is cleared", () => {
     /*
      * The separating property. Clearing to retype used to commit `null`, which
@@ -97,6 +120,7 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
   });
 
@@ -107,7 +131,73 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "768" } });
+    stopTyping();
     expect(ui.committed()).toBe("768");
+  });
+
+  it("does not commit the PREFIXES typed on the way to a width", () => {
+    /*
+     * `768` arrives as `7`, then `76`, then `768`. Committing each one sized
+     * the frame to 7px and then 76px — a live iframe of the whole site, laid
+     * out twice at widths the author never asked for, which is the resize
+     * thrash the draft state was supposed to remove.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "7" } });
+    fireEvent.change(box, { target: { value: "76" } });
+    fireEvent.change(box, { target: { value: "768" } });
+
+    // Still the width it started at: nothing has been committed yet.
+    expect(ui.committed()).toBe("1280");
+
+    stopTyping();
+    expect(ui.committed()).toBe("768");
+  });
+
+  it("takes the pending width when the edit ends at the BOX", () => {
+    /*
+     * Blur answers the question the pause was waiting on, so waiting it out
+     * afterwards would discard the width — an author who types one and clicks
+     * straight into the page means it.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "390" } });
+    fireEvent.blur(box);
+
+    expect(ui.committed()).toBe("390");
+  });
+
+  it("refuses a width below one pixel", () => {
+    /*
+     * `min={1}` on a number input marks the field invalid; it does not clamp
+     * the value or stop the change event. Below a pixel the preview is not
+     * narrow, it is gone — an empty pane rather than a small one.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "0.5" } });
+    stopTyping();
+    expect(ui.committed()).toBe("1280");
+
+    fireEvent.change(box, { target: { value: "1e-3" } });
+    stopTyping();
+    expect(ui.committed()).toBe("1280");
+  });
+
+  it("accepts exactly one pixel, which is the boundary", () => {
+    // The control on the case above: refusing below a pixel must not refuse the
+    // pixel itself, or the stated minimum would be unreachable.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "1" } });
+    stopTyping();
+    expect(ui.committed()).toBe("1");
   });
 
   it("does not commit a zero or negative width", () => {
@@ -117,9 +207,11 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "0" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
 
     fireEvent.change(box, { target: { value: "-5" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
   });
 
@@ -138,9 +230,11 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "390.5" } });
+    stopTyping();
     expect(ui.committed()).toBe("390.5");
 
     fireEvent.change(box, { target: { value: "1e3" } });
+    stopTyping();
     expect(ui.committed()).toBe("1000");
   });
 
@@ -152,9 +246,11 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "abc" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
 
     fireEvent.change(box, { target: { value: "" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
   });
 

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewFrameFit.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewFrameFit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * How a requested viewport width is fitted into the space the pane actually has.
+ *
+ * The split reserves a minimum editor, so the preview pane has a hard ceiling
+ * and a desktop width cannot fit on a laptop. Every case below is about which
+ * of the two widths answers a given question — the REQUESTED one is what the
+ * site's media queries must resolve against, and the MEASURED one is what the
+ * pane can physically show. Collapsing them is what makes a preset either lie
+ * about the viewport or fail to report that the pane could not honour it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { previewFrameFit, previewFrameStyle } from "../previewFrameFit";
+
+describe("previewFrameFit", () => {
+  it("answers nothing until the pane has been measured", () => {
+    /*
+     * The first render has no layout yet. Naming a width for a box nobody has
+     * looked at is the confident wrong answer this control exists to remove —
+     * and it is worse than silence, because the label would appear, be wrong,
+     * and then correct itself in a way that reads as a glitch.
+     */
+    expect(previewFrameFit(1280, null)).toEqual({ kind: "unmeasured" });
+    expect(previewFrameFit(1280, 0)).toEqual({ kind: "unmeasured" });
+    // Even with nothing requested: "responsive" is a claim about a box too.
+    expect(previewFrameFit(null, null)).toEqual({ kind: "unmeasured" });
+  });
+
+  it("fills the pane when no width is requested", () => {
+    expect(previewFrameFit(null, 618)).toEqual({ kind: "responsive" });
+  });
+
+  it("uses the requested width exactly when it fits", () => {
+    expect(previewFrameFit(390, 618)).toEqual({ kind: "exact", width: 390 });
+  });
+
+  it("treats a width equal to the space as fitting, not as scaled", () => {
+    // The boundary. A scale of exactly 1 is a transform doing nothing, and
+    // reporting it as `scaled` would show a "scaled to fit" note on a frame
+    // that is at its true size.
+    expect(previewFrameFit(618, 618)).toEqual({ kind: "exact", width: 618 });
+  });
+
+  it("scales the SHORTFALL when the request is wider than the pane", () => {
+    /*
+     * The frame keeps its requested width — that is what the site's `@media`
+     * resolves against, so the preview stays truthful — and is transformed down
+     * to fit. Both numbers are reported: the caller needs `width` to size the
+     * frame and `scale` to transform it, and a caller given only the product
+     * cannot label the real viewport.
+     */
+    expect(previewFrameFit(1280, 640)).toEqual({
+      kind: "scaled",
+      width: 1280,
+      scale: 0.5,
+    });
+  });
+
+  it("keeps the requested width in the answer, not the space it was fitted into", () => {
+    // The separating property. A fit that returned the AVAILABLE width would
+    // satisfy "the frame is 618px wide" and would silently make the preview a
+    // 618px viewport — which is the bug, not the fix.
+    const fit = previewFrameFit(1280, 618);
+    expect(fit).toMatchObject({ kind: "scaled", width: 1280 });
+    expect(fit).not.toMatchObject({ width: 618 });
+  });
+
+  it("refuses a nonsensical request rather than dividing by it", () => {
+    // Zero and negatives reach here from a cleared or half-typed custom width
+    // box. Falling back to responsive keeps the pane usable; scaling by them
+    // produces Infinity or a flipped frame.
+    expect(previewFrameFit(0, 618)).toEqual({ kind: "responsive" });
+    expect(previewFrameFit(-100, 618)).toEqual({ kind: "responsive" });
+    expect(previewFrameFit(Number.NaN, 618)).toEqual({ kind: "responsive" });
+    expect(previewFrameFit(Number.POSITIVE_INFINITY, 618)).toEqual({
+      kind: "responsive",
+    });
+  });
+});
+
+describe("previewFrameStyle", () => {
+  it("gives an unanswered or responsive fit no inline size at all", () => {
+    // Both fill the pane, which is what no inline size does. They stay separate
+    // in the fit because the CONTROL has to tell them apart; the frame does not.
+    expect(previewFrameStyle({ kind: "unmeasured" })).toEqual({});
+    expect(previewFrameStyle({ kind: "responsive" })).toEqual({});
+  });
+
+  it("sizes an exact fit and does not transform it", () => {
+    const style = previewFrameStyle({ kind: "exact", width: 390 });
+    expect(style).toEqual({ width: "390px" });
+    // Named explicitly: a transform of `scale(1)` would still create a
+    // containing block and a new stacking context inside the frame.
+    expect(style.transform).toBeUndefined();
+  });
+
+  it("sizes a scaled fit to the REQUESTED width and shrinks it", () => {
+    /*
+     * The separating property, restated as CSS: the width the browser lays the
+     * page out at is the requested one, so `@media` resolves against it, and
+     * the transform only changes how large that layout is drawn.
+     */
+    expect(
+      previewFrameStyle({ kind: "scaled", width: 1280, scale: 0.5 })
+    ).toEqual({
+      width: "1280px",
+      height: "200%",
+      transform: "scale(0.5)",
+      transformOrigin: "top left",
+    });
+  });
+
+  it("compensates the HEIGHT for the scale, so no empty band is left below", () => {
+    // 1/0.4 = 250%. Scaled by 0.4 that covers exactly 100% of the pane; a plain
+    // `100%` would shrink to 40% and leave the rest of the pane blank.
+    const style = previewFrameStyle({
+      kind: "scaled",
+      width: 1500,
+      scale: 0.4,
+    });
+    expect(style.height).toBe("250%");
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/previewFrameFit.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/previewFrameFit.ts
@@ -1,0 +1,138 @@
+/**
+ * Fitting a requested viewport width into the space the preview pane has.
+ *
+ * ## Why two widths, and why they must not collapse
+ *
+ * The split reserves a minimum editor, so the preview pane has a hard ceiling —
+ * it can never exceed a fixed share of the split, which on a laptop is a few
+ * hundred pixels short of a desktop viewport. A preset therefore has a width it
+ * ASKS FOR and a width the pane can physically give, and the two answer
+ * different questions:
+ *
+ * - the REQUESTED width is what the site's `@media` queries resolve against, so
+ *   it is what makes the preview truthful about the viewport being previewed;
+ * - the MEASURED width is what the pane can show, so it is what decides whether
+ *   anything has to be scaled.
+ *
+ * Feeding the measured width back as the selection makes the preset the author
+ * just chose appear unselected. Reporting only the request makes it impossible
+ * to say the pane could not honour it. This module keeps both and reports which
+ * case applies, so a caller can size the frame, transform it, and label the real
+ * viewport without deriving any of those from each other.
+ *
+ * ## Why scaling stays truthful
+ *
+ * A CSS transform does not change the frame's own width, so a scaled frame's
+ * media queries still resolve against the width it was given. The preview
+ * remains a faithful rendering of that viewport, drawn smaller. What it stops
+ * being faithful about is PHYSICAL size — text renders at a size no visitor
+ * sees — which is why a caller must label the real width rather than let the
+ * scaling pass unremarked.
+ *
+ * @module components/features/entries/PreviewMode/previewFrameFit
+ */
+
+import type { CSSProperties } from "react";
+
+/** How the frame should be sized, or that the question cannot be answered yet. */
+export type PreviewFit =
+  /**
+   * The pane has not been measured, so nothing can be said about it.
+   *
+   * Distinct from every other case on purpose: it is the only one where the
+   * caller must render no width, no label and no scaling note. A first paint
+   * that named a width and then corrected itself reads as a glitch, and one
+   * that named the WRONG width is the confident wrong answer this control
+   * exists to remove.
+   */
+  | { kind: "unmeasured" }
+  /** No particular width was asked for; the frame fills the pane. */
+  | { kind: "responsive" }
+  /** The requested width fits as it is. */
+  | { kind: "exact"; width: number }
+  /**
+   * The requested width does not fit and is drawn smaller.
+   *
+   * `width` stays the REQUESTED one — the frame is sized to it and transformed
+   * — because that is what the site resolves its media queries against.
+   */
+  | { kind: "scaled"; width: number; scale: number };
+
+/**
+ * Decide how to draw a requested viewport width in the space available.
+ *
+ * `availableWidth` is `null` before the pane has been laid out. Both zero and
+ * `null` mean the same thing here — nothing has been measured — and neither is
+ * a width to divide by.
+ */
+export function previewFrameFit(
+  requestedWidth: number | null,
+  availableWidth: number | null
+): PreviewFit {
+  // Asked before layout. Answering anything else would be a claim about a box
+  // nobody has looked at, including the claim that it should fill the pane.
+  if (availableWidth === null || !(availableWidth > 0)) {
+    return { kind: "unmeasured" };
+  }
+
+  /*
+   * A request that is absent, zero, negative or non-finite all reach the same
+   * answer, and deliberately so: they arrive from a cleared or half-typed
+   * custom-width box, where the author has not yet said anything meaningful.
+   * Filling the pane keeps it usable; dividing by any of them produces
+   * `Infinity`, `NaN` or a flipped frame.
+   */
+  if (requestedWidth === null || !Number.isFinite(requestedWidth)) {
+    return { kind: "responsive" };
+  }
+  if (requestedWidth <= 0) return { kind: "responsive" };
+
+  /*
+   * Equal counts as fitting. A scale of exactly 1 is a transform that does
+   * nothing, and reporting it as scaled would put a "drawn smaller" note on a
+   * frame that is at its true size.
+   */
+  if (requestedWidth <= availableWidth) {
+    return { kind: "exact", width: requestedWidth };
+  }
+
+  return {
+    kind: "scaled",
+    width: requestedWidth,
+    scale: availableWidth / requestedWidth,
+  };
+}
+
+/**
+ * The inline style that realises a fit, derived from it rather than beside it.
+ *
+ * The frame's size and its transform are two views of ONE decision, and two
+ * places computing them would agree until someone edited either — with the
+ * failure being a frame whose media queries resolve against one width while it
+ * is drawn at another, which looks like a rendering bug in the site.
+ *
+ * `unmeasured` and `responsive` both return nothing, and for the same reason
+ * from the caller's side: the frame fills the pane, which is what it does with
+ * no inline size at all. They stay distinct in {@link PreviewFit} because the
+ * CONTROL must tell them apart — one has an answer and the other does not.
+ */
+export function previewFrameStyle(fit: PreviewFit): CSSProperties {
+  if (fit.kind === "exact") return { width: `${fit.width}px` };
+  if (fit.kind === "scaled") {
+    return {
+      width: `${fit.width}px`,
+      /*
+       * Divided by the scale so the frame still covers the pane vertically
+       * AFTER being shrunk. A plain `100%` would be scaled down with everything
+       * else and leave a band of empty pane below the page.
+       */
+      height: `${100 / fit.scale}%`,
+      transform: `scale(${fit.scale})`,
+      // Top-left, so the page's own left edge stays where a visitor's would be.
+      // With `scale` chosen as available/requested the frame fills the pane
+      // exactly, so there is nothing to centre.
+      transformOrigin: "top left",
+    };
+  }
+  return {};
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
@@ -1,0 +1,50 @@
+/**
+ * The measured width of an element, or `null` until it has one.
+ *
+ * `null` is the point of this hook rather than a detail of it. Every caller here
+ * has to distinguish "this box is N wide" from "nobody has looked yet", because
+ * the second is not a width and anything derived from it is a guess — a preview
+ * frame that names a viewport before layout announces a number, then corrects
+ * itself, which reads as a glitch rather than as the honest "not yet" it is.
+ *
+ * Zero is folded into `null` deliberately. A detached or display-none element
+ * measures zero, and a caller dividing by it produces `Infinity`; a caller
+ * reading it as a real width concludes nothing fits. Neither is what "the box
+ * has no size right now" should mean downstream.
+ *
+ * @module components/features/entries/PreviewMode/useMeasuredWidth
+ */
+import { useEffect, useState, type RefObject } from "react";
+
+export function useMeasuredWidth(
+  ref: RefObject<HTMLElement | null>
+): number | null {
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (element === null) return;
+
+    /*
+     * `ResizeObserver` rather than a `resize` listener on the window: this box
+     * changes width when the SPLIT moves, which the window never hears about.
+     * A window listener would leave the frame sized for the old split until
+     * something else happened to re-render it.
+     */
+    const observe = () => {
+      const next = element.getBoundingClientRect().width;
+      // Folded to `null` so a collapsed box cannot be read as a width. See the
+      // module note: zero is not a small number here, it is an absent one.
+      setWidth(next > 0 ? next : null);
+    };
+
+    observe();
+    const observer = new ResizeObserver(observe);
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref]);
+
+  return width;
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
@@ -14,14 +14,39 @@
  *
  * @module components/features/entries/PreviewMode/useMeasuredWidth
  */
-import { useEffect, useState, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
+
+/**
+ * A layout effect where there is a DOM, a passive one where there is not.
+ *
+ * The same alias `ChromeSuppression` keeps, for the same reason: a layout
+ * effect during a server render warns and cannot run, and nothing has painted
+ * there for it to be ahead of.
+ */
+const useMeasureEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 export function useMeasuredWidth(
   ref: RefObject<HTMLElement | null>
 ): number | null {
   const [width, setWidth] = useState<number | null>(null);
 
-  useEffect(() => {
+  /*
+   * BEFORE paint, not after.
+   *
+   * The first measurement decides whether the frame is drawn at the requested
+   * width or left to fill the pane, and an effect that runs after paint means
+   * the browser has already drawn the second. Reopening a pane that remembers a
+   * custom width therefore laid the site out responsively for one frame and
+   * then jumped — visible as a flash of the wrong layout on any page that
+   * crosses a breakpoint between the two widths.
+   *
+   * A layout effect runs after the DOM is in place and before the browser
+   * paints, which is exactly when a box first has a width to report. The
+   * alternative — hiding the frame until it has been measured — trades a wrong
+   * layout for a blank one, and still costs a frame.
+   */
+  useMeasureEffect(() => {
     const element = ref.current;
     if (element === null) return;
 

--- a/packages/admin/src/constants/ui.ts
+++ b/packages/admin/src/constants/ui.ts
@@ -13,4 +13,16 @@ export const UI = {
 
   /** Delay before programmatic focus operations (ms) */
   FOCUS_DELAY_MS: 300,
+
+  /**
+   * Pause that ends an edit of the preview's custom width (ms).
+   *
+   * The preview frame is a live iframe of the site, so every committed width
+   * re-lays-out a whole page. Typing `768` after clearing the box emits `7`,
+   * `76`, `768` — three layouts, two of them at widths the author never meant —
+   * so the width is taken once they stop typing rather than per keystroke.
+   * Matched to `SEARCH_DEBOUNCE_MS` because it answers the same question about
+   * a person: have they finished.
+   */
+  PREVIEW_WIDTH_DEBOUNCE_MS: 300,
 } as const;

--- a/packages/nextly/.gitignore
+++ b/packages/nextly/.gitignore
@@ -1,0 +1,3 @@
+
+# Nextly local uploads (auto-added)
+public/uploads/


### PR DESCRIPTION
**Sub-task 1 of 3** for device presets in the preview pane. Design and plan approved by the founder before any code.

## The problem, measured

The pane sits in a split reserving a minimum editor, so at rest the preview measured **427px** on a 952px split. It was faithfully previewing a *mobile* viewport — decided by wherever the divider was last dragged rather than by anything anyone chose. The two controls were coupled too: widening the preview meant narrowing the editor being typed into.

## What ships here

**Responsive** and a **custom width**, plus all the mechanics named presets will reuse.

Choosing a width does two things in order: the split gives the preview as much room as the minimum editor allows, then only what still does not fit is scaled. On a wide enough window nothing is scaled at all.

## The property this is built around

The **requested** width and the **measured** width answer different questions and are kept apart throughout:

- the request is what the site's `@media` resolves against — it is what makes the preview truthful;
- the measurement is what the pane can physically show.

A CSS transform does not change the frame's own width, so a scaled frame's media queries still resolve against the viewport being previewed. It stays truthful about **layout** and becomes untruthful about **physical size** — text renders smaller than a visitor sees — so the toolbar states the real width and the scale rather than letting the shrinking pass unremarked.

`previewFrameFit` answers `unmeasured` until the pane has a size. A first paint naming a width and then correcting itself reads as a glitch; one naming the *wrong* width is the confident wrong answer the control exists to remove.

## Browser-verified, not inferred

Driven against `pnpm dev:app`, reading the live DOM:

| | measured |
| --- | --- |
| auto-widen on choosing a width | `aria-valuenow` 35 — split at its minimum editor, preview 618px (its ceiling) |
| frame keeps the request | `width: 1280px` |
| only the shortfall scales | `scale(0.481885)` = 617/1280, rendered 617px |
| height compensated | `207.518%` = 1/0.4819 — no empty band below |
| the label is honest | "48% of 1280px" |
| a width that FITS | `width: 390px` and **no transform** |
| back to Responsive | inline style cleared, frame fills the pane |
| console | no errors, no warnings |

## Evidence

TDD: 11 tests written before the module existed, red for a missing import first. Break-verified on the separating property — a fit returning the **available** width instead of the requested one (the exact bug the design prevents) fails the two tests that name it, and nothing else.

Gates after a full build: `check-types`, `lint`, `lint:design`, comment convention, `changeset status`, `fallow` — all 0. Admin suites 908/908 across entries, singles and hooks.

`fallow` initially **refused** with `complexity_introduced: 1` — the toolbar's new control pushed `PreviewFrame` to cyclomatic 10. `PreviewFrameBody` is that extraction, with the branch order preserved exactly, so it is a move rather than a rewrite. Now 0 introduced.

## What deliberately is not here

No phone/tablet/desktop numbers and no device icons. A site defines its own breakpoints — author-named, up to seven — so shipping fixed widths would give a site whose tablet is 991px a preset labelled "Tablet" that sizes to 1024 and lands in the wrong tier. That is the same class of error as the 427px problem above. Named presets arrive in sub-tasks 2 and 3, sourced from a collection's declaration or the site's own page-builder breakpoints.

**Changeset added: yes (patch).** No pre-existing failures in the touched suites.
