### PR TITLE
feat(nextly): give the select parameter a writer, and refuse one it cannot read

### DIFF
--- a/.changeset/select-param-has-a-writer.md
+++ b/.changeset/select-param-has-a-writer.md
@@ -26,12 +26,12 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-The `select` query parameter has a writer, and a request it cannot read is refused rather than answered with every field.
+The `select` query parameter now does what the documentation says, and a request it cannot read is refused rather than answered with every field.
 
-`select` accepts a JSON object naming the fields you want — `{"title":true}` — and nothing else. That was never written down anywhere a caller could find, and only the reader existed, so every caller worked the format out for itself. The API Playground rediscovered it by probing a running server and recorded the answer in a comment; the form builder guessed a comma list and shipped it, downloading every field of up to fifty documents per collection to fill a dropdown that reads five.
+The REST reference documents one spelling — `?select=id,title,publishedAt` — and it has never worked. The reader accepted a JSON object and nothing else, so the documented request was parsed as nothing, discarded, and answered with the whole document. A caller following the documentation got a response that looked correct and carried every field of every row; the admin's API Playground had to probe a running server to find the form that does work, and recorded the answer in a comment.
 
-Neither caller was told. Anything the reader could not understand — a comma list, a bare field name, an array, an empty object — returned the whole document, which is exactly what a request asking for the whole document returns. `{"title":false}` was worse: it counted as a projection, then selected no field, and a projection selecting nothing is answered with every field. An author writing it to mean "everything except the title" got the opposite.
+Both spellings are now accepted, and both are documented. `?select=id,title` and `?select={"id":true,"title":true}` do the same thing.
 
-`nextly/query` now exports `encodeSelectParam` and `readSelectParam`, so a caller writes the parameter with the same code the server reads it with, and the reader distinguishes "no projection was asked for" from "I could not read your projection". The second is a 400 naming the format, instead of a correct-looking response carrying every row in full.
+Anything the reader still cannot understand is a 400 naming the format, instead of a response carrying every field. That covers the shapes that used to pass silently: an array, a truncated fragment, a map whose values are not booleans, and a map naming no fields at all — including `{"title":false}`, which counted as a projection, selected nothing, and was therefore answered with everything, the opposite of what its author meant.
 
-It is a leaf entry point rather than a root export: the admin's API Playground and plugin admin components import it from the browser, and the root entry would bring the server graph with it.
+`nextly/query` exports `encodeSelectParam` and `readSelectParam`, so a caller writes the parameter with the same code the server reads it with. It is a leaf entry point rather than a root export: the admin's API Playground and plugin admin components import it from the browser, and the root entry would bring the server graph with it.

--- a/.changeset/select-param-has-a-writer.md
+++ b/.changeset/select-param-has-a-writer.md
@@ -1,0 +1,37 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The `select` query parameter has a writer, and a request it cannot read is refused rather than answered with every field.
+
+`select` accepts a JSON object naming the fields you want — `{"title":true}` — and nothing else. That was never written down anywhere a caller could find, and only the reader existed, so every caller worked the format out for itself. The API Playground rediscovered it by probing a running server and recorded the answer in a comment; the form builder guessed a comma list and shipped it, downloading every field of up to fifty documents per collection to fill a dropdown that reads five.
+
+Neither caller was told. Anything the reader could not understand — a comma list, a bare field name, an array, an empty object — returned the whole document, which is exactly what a request asking for the whole document returns. `{"title":false}` was worse: it counted as a projection, then selected no field, and a projection selecting nothing is answered with every field. An author writing it to mean "everything except the title" got the opposite.
+
+`nextly/query` now exports `encodeSelectParam` and `readSelectParam`, so a caller writes the parameter with the same code the server reads it with, and the reader distinguishes "no projection was asked for" from "I could not read your projection". The second is a 400 naming the format, instead of a correct-looking response carrying every row in full.
+
+It is a leaf entry point rather than a root export: the admin's API Playground and plugin admin components import it from the browser, and the root entry would bring the server graph with it.

--- a/docs/api-reference/rest-api.mdx
+++ b/docs/api-reference/rest-api.mdx
@@ -675,11 +675,19 @@ Relationship population depth. `0` returns only IDs; `1+` populates referenced d
 
 ### select
 
-Comma-separated whitelist of fields to include:
+Whitelist of fields to include. Two spellings, both accepted:
 
 ```
-?select=id,title,publishedAt
+?select=id,title,publishedAt          # comma-separated
+?select={"id":true,"title":true}      # JSON object (URL-encode it)
 ```
+
+The `id` and the system timestamps come back whether or not they are named.
+
+A `select` the API cannot read is a `400`, rather than a response carrying every
+field — a projection that is silently discarded looks exactly like one that was
+never asked for. Naming no fields at all is unreadable for the same reason; omit
+the parameter to get every field.
 
 ### richTextFormat
 

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/query-fields.test.ts
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/query-fields.test.ts
@@ -156,12 +156,13 @@ describe("parseSelect", () => {
     expect(parseSelect('{"title":true,"slug":false}')).toEqual(["title"]);
   });
 
-  // The API REFUSES the bare form now, rather than accepting it and returning
-  // every field. Reading it as a selection would still be wrong — it shows a
-  // state no response will ever have — but the screen is no longer the only
-  // place the mistake surfaces.
-  it("treats the bare form the API refuses as no selection", () => {
-    expect(parseSelect("title")).toEqual([]);
+  // The comma-separated form is what the REST reference documents, and it now
+  // does what it says. This screen reads it the same way the server does, so a
+  // URL a caller pasted in shows the selection it will actually get — where
+  // before it showed nothing and the request returned every field.
+  it("reads the documented comma-separated form", () => {
+    expect(parseSelect("title")).toEqual(["title"]);
+    expect(parseSelect("id,title")).toEqual(["id", "title"]);
   });
 
   it("treats malformed or empty input as no selection", () => {

--- a/packages/admin/src/components/features/entries/APIPlayground/__tests__/query-fields.test.ts
+++ b/packages/admin/src/components/features/entries/APIPlayground/__tests__/query-fields.test.ts
@@ -156,9 +156,11 @@ describe("parseSelect", () => {
     expect(parseSelect('{"title":true,"slug":false}')).toEqual(["title"]);
   });
 
-  // The API accepts `select=title` and then returns every field, so reading it
-  // as a selection would show a state the request does not have.
-  it("treats the bare form the API ignores as no selection", () => {
+  // The API REFUSES the bare form now, rather than accepting it and returning
+  // every field. Reading it as a selection would still be wrong — it shows a
+  // state no response will ever have — but the screen is no longer the only
+  // place the mistake surfaces.
+  it("treats the bare form the API refuses as no selection", () => {
     expect(parseSelect("title")).toEqual([]);
   });
 

--- a/packages/admin/src/components/features/entries/APIPlayground/query-fields.ts
+++ b/packages/admin/src/components/features/entries/APIPlayground/query-fields.ts
@@ -12,6 +12,8 @@
  * @module components/entries/APIPlayground/query-fields
  */
 
+import { encodeSelectParam, readSelectParam } from "nextly/query";
+
 /** The parts of a field definition the playground needs. */
 export interface PlaygroundField {
   name: string;
@@ -113,29 +115,23 @@ export function formatSort(sort: SortValue | null): string {
 /**
  * Read the API's `select` format.
  *
- * Only the object form does anything — a bare `select=title` is accepted and
- * then ignored by the API, so anything that is not an object of truthy keys
- * reads as "no selection".
+ * Delegated so this screen reads the parameter with the same code the server
+ * reads it with. It used to carry its own reader, worked out by probing a
+ * running API and written down in a comment — which is how the format came to
+ * have four implementations, two of which disagreed about what `false` means.
+ *
+ * A value this cannot read shows as nothing selected. That is now honest
+ * rather than misleading: the server refuses such a request instead of
+ * answering it with every field, so the user finds out.
  */
 export function parseSelect(value?: string): string[] {
-  if (!value?.trim()) return [];
-  try {
-    const parsed: unknown = JSON.parse(value);
-    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-      return [];
-    }
-    return Object.entries(parsed as Record<string, unknown>)
-      .filter(([, v]) => v === true)
-      .map(([k]) => k);
-  } catch {
-    return [];
-  }
+  const request = readSelectParam(value);
+  return request.kind === "fields" ? Object.keys(request.fields) : [];
 }
 
 /** Write the API's `select` format. Nothing chosen means the param is dropped. */
 export function formatSelect(names: string[]): string {
-  if (names.length === 0) return "";
-  return JSON.stringify(Object.fromEntries(names.map(n => [n, true])));
+  return encodeSelectParam(names);
 }
 
 // ── where ───────────────────────────────────────────────────────────────────

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -47,6 +47,10 @@
       "types": "./dist/field-catalog.d.ts",
       "import": "./dist/collections/fields/catalog.mjs"
     },
+    "./query": {
+      "types": "./dist/query/index.d.ts",
+      "import": "./dist/query/index.mjs"
+    },
     "./observability": {
       "types": "./dist/observability/index.d.ts",
       "import": "./dist/observability/index.mjs"

--- a/packages/nextly/src/dispatcher/helpers/__tests__/parse-select-param.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/parse-select-param.test.ts
@@ -1,0 +1,73 @@
+/**
+ * What the REST layer does with a `select` it cannot read.
+ *
+ * The parser had no tests anywhere in the repository, and the behaviour they
+ * would have pinned was the defect: every unreadable spelling returned
+ * `undefined`, which is also what "no projection was asked for" returns, so the
+ * read proceeded unprojected and answered with every field of every row.
+ *
+ * @module dispatcher/helpers/__tests__/parse-select-param
+ */
+import { describe, expect, it } from "vitest";
+
+import { encodeSelectParam } from "../../../query/select-param";
+import { parseSelectParam } from "../validation";
+
+describe("parseSelectParam - a select the layer can honour", () => {
+  it("returns the field map for the encoder's own output", () => {
+    // The round trip is the contract: whatever the shared encoder writes, this
+    // reads. Before it existed, callers wrote the format from memory.
+    expect(parseSelectParam(encodeSelectParam(["id", "title"]))).toEqual({
+      id: true,
+      title: true,
+    });
+  });
+
+  it("returns nothing when no projection was asked for", () => {
+    // The one case that legitimately reads as "send every field".
+    expect(parseSelectParam(undefined)).toBeUndefined();
+    expect(parseSelectParam("")).toBeUndefined();
+  });
+});
+
+describe("parseSelectParam - a select the layer cannot honour", () => {
+  const refused = (raw: string): unknown => {
+    try {
+      parseSelectParam(raw);
+    } catch (error) {
+      return error;
+    }
+    return undefined;
+  };
+
+  it("refuses a comma list instead of answering with every field", () => {
+    // The spelling the form builder shipped. It was accepted and discarded, so
+    // the response looked correct and carried the whole document.
+    expect(refused("id,title")).toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("refuses a bare field name", () => {
+    expect(refused("title")).toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("refuses an array", () => {
+    expect(refused('["title"]')).toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("refuses a projection that would select nothing", () => {
+    // `{"title":false}` counted as a selection and then selected no field, and
+    // a projection selecting nothing is answered with the whole document — the
+    // opposite of what its author asked for.
+    expect(refused('{"title":false}')).toMatchObject({
+      code: "INVALID_INPUT",
+    });
+    expect(refused("{}")).toMatchObject({ code: "INVALID_INPUT" });
+  });
+
+  it("says what the format is, in the message the caller receives", () => {
+    // The reason a caller could not find anywhere else: the format was never
+    // documented and had no encoder to read.
+    const error = refused("id,title") as { publicMessage?: string };
+    expect(error.publicMessage).toContain('{"title":true}');
+  });
+});

--- a/packages/nextly/src/dispatcher/helpers/__tests__/parse-select-param.test.ts
+++ b/packages/nextly/src/dispatcher/helpers/__tests__/parse-select-param.test.ts
@@ -23,6 +23,12 @@ describe("parseSelectParam - a select the layer can honour", () => {
     });
   });
 
+  it("honours the comma-separated form the REST reference documents", () => {
+    // It reached this layer, was discarded, and the read proceeded unprojected
+    // — so a caller following the documentation was answered with every field.
+    expect(parseSelectParam("id,title")).toEqual({ id: true, title: true });
+  });
+
   it("returns nothing when no projection was asked for", () => {
     // The one case that legitimately reads as "send every field".
     expect(parseSelectParam(undefined)).toBeUndefined();
@@ -40,16 +46,6 @@ describe("parseSelectParam - a select the layer cannot honour", () => {
     return undefined;
   };
 
-  it("refuses a comma list instead of answering with every field", () => {
-    // The spelling the form builder shipped. It was accepted and discarded, so
-    // the response looked correct and carried the whole document.
-    expect(refused("id,title")).toMatchObject({ code: "INVALID_INPUT" });
-  });
-
-  it("refuses a bare field name", () => {
-    expect(refused("title")).toMatchObject({ code: "INVALID_INPUT" });
-  });
-
   it("refuses an array", () => {
     expect(refused('["title"]')).toMatchObject({ code: "INVALID_INPUT" });
   });
@@ -65,9 +61,7 @@ describe("parseSelectParam - a select the layer cannot honour", () => {
   });
 
   it("says what the format is, in the message the caller receives", () => {
-    // The reason a caller could not find anywhere else: the format was never
-    // documented and had no encoder to read.
-    const error = refused("id,title") as { publicMessage?: string };
+    const error = refused('["title"]') as { publicMessage?: string };
     expect(error.publicMessage).toContain('{"title":true}');
   });
 });

--- a/packages/nextly/src/dispatcher/helpers/validation.ts
+++ b/packages/nextly/src/dispatcher/helpers/validation.ts
@@ -11,6 +11,7 @@
 import { NextlyError } from "../../errors";
 import type { RichTextOutputFormat } from "../../lib/rich-text-html";
 import type { StatusOption } from "../../lib/status-filter";
+import { readSelectParam } from "../../query/select-param";
 import type { WhereFilter } from "../../services/collections/query-operators";
 import type { Params } from "../types";
 
@@ -59,34 +60,27 @@ export const toDate = (v?: string): Date | undefined =>
 // ============================================================
 
 /**
- * Parse a JSON-encoded select map from a query string parameter.
- * Returns only keys whose values are booleans so the select object is
- * always a valid field map.
+ * The select map a request asked for, or nothing when it asked for no
+ * projection.
+ *
+ * REFUSES a select it cannot read, rather than falling back to the whole
+ * document. Those two answers were the same value here, so a caller who wrote
+ * the parameter in any shape but the one accepted got a correct-looking
+ * response carrying every field of every row — the format has no writer that
+ * callers could reach, so working it out wrong was the normal case rather than
+ * the exceptional one. See ../../query/select-param, which is now that writer.
  */
 export const parseSelectParam = (
   selectParam?: string
 ): Record<string, boolean> | undefined => {
-  if (!selectParam) return undefined;
-
-  try {
-    const parsed: unknown = JSON.parse(selectParam);
-    if (
-      typeof parsed !== "object" ||
-      parsed === null ||
-      Array.isArray(parsed)
-    ) {
-      return undefined;
-    }
-    const result: Record<string, boolean> = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      if (typeof value === "boolean") {
-        result[key] = value;
-      }
-    }
-    return Object.keys(result).length > 0 ? result : undefined;
-  } catch {
-    return undefined;
+  const request = readSelectParam(selectParam);
+  if (request.kind === "unreadable") {
+    throw NextlyError.invalidInput({
+      message: request.reason,
+      logContext: { param: "select" },
+    });
   }
+  return request.kind === "fields" ? request.fields : undefined;
 };
 
 /**

--- a/packages/nextly/src/query/__tests__/select-param.test.ts
+++ b/packages/nextly/src/query/__tests__/select-param.test.ts
@@ -33,14 +33,41 @@ describe("readSelectParam - what a caller is actually asking", () => {
     expect(readSelectParam("   ")).toEqual({ kind: "all" });
   });
 
-  it("refuses a comma list rather than ignoring it", () => {
-    // What the form builder shipped. It was accepted and discarded, so the
-    // response looked correct and carried every field of every row.
-    expect(readSelectParam("id,title,slug").kind).toBe("unreadable");
+  it("reads the comma-separated form the REST reference documents", () => {
+    // `?select=id,title,publishedAt` is the ONLY form the documentation shows,
+    // and it never worked: the reader took JSON objects alone, so a caller
+    // following the docs had their projection discarded and was answered with
+    // every field. That is why the one caller that followed them shipped a
+    // select that selected nothing.
+    expect(readSelectParam("id,title,slug")).toEqual({
+      kind: "fields",
+      fields: { id: true, title: true, slug: true },
+    });
   });
 
-  it("refuses a bare field name", () => {
-    expect(readSelectParam("title").kind).toBe("unreadable");
+  it("reads a single field name", () => {
+    expect(readSelectParam("title")).toEqual({
+      kind: "fields",
+      fields: { title: true },
+    });
+  });
+
+  it("tolerates spacing around the commas", () => {
+    expect(readSelectParam("id, title")).toEqual({
+      kind: "fields",
+      fields: { id: true, title: true },
+    });
+  });
+
+  it("refuses a comma list with an empty segment", () => {
+    expect(readSelectParam("id,,title").kind).toBe("unreadable");
+  });
+
+  it("refuses debris that is neither spelling", () => {
+    // Truncated JSON does not parse, so it reaches the comma reader — where,
+    // without a guard, `{not json` would be accepted as the name of a field.
+    expect(readSelectParam("{not json").kind).toBe("unreadable");
+    expect(readSelectParam('{"title":').kind).toBe("unreadable");
   });
 
   it("refuses an array", () => {
@@ -59,19 +86,31 @@ describe("readSelectParam - what a caller is actually asking", () => {
     expect(readSelectParam('{"title":1}').kind).toBe("unreadable");
   });
 
+  it("refuses a map whose bad entry sits beside a good one", () => {
+    // The separating case. Skipping what it cannot read would accept this as a
+    // projection over `title` alone — answering a different question than the
+    // caller asked, quietly, which is the defect this module removes rather
+    // than relocates. A map with NO valid sibling is refused by a weaker rule
+    // and cannot tell the two implementations apart.
+    expect(readSelectParam('{"title":true,"body":"yes"}').kind).toBe(
+      "unreadable"
+    );
+  });
+
   it("keeps the fields a caller did ask for alongside ones it did not", () => {
-    // A mixed map is readable: the `true` entries are a real request, and the
-    // `false` entries never did anything.
+    // The control for the case above: `false` IS a boolean, so a map mixing
+    // wanted and unwanted fields is a readable request, not a malformed one.
     expect(readSelectParam('{"title":true,"body":false}')).toEqual({
       kind: "fields",
       fields: { title: true },
     });
   });
 
-  it("says why, in words a caller can act on", () => {
-    const answer = readSelectParam("id,title");
+  it("says both accepted spellings when it refuses one", () => {
+    const answer = readSelectParam('["title"]');
     expect(answer.kind).toBe("unreadable");
     if (answer.kind === "unreadable") {
+      expect(answer.reason).toContain("id,title");
       expect(answer.reason).toContain('{"title":true}');
     }
   });

--- a/packages/nextly/src/query/__tests__/select-param.test.ts
+++ b/packages/nextly/src/query/__tests__/select-param.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { encodeSelectParam, readSelectParam } from "../select-param";
+
+describe("encodeSelectParam / readSelectParam round trip", () => {
+  it("reads back exactly the fields that were written", () => {
+    const written = encodeSelectParam(["id", "title", "slug"]);
+    expect(readSelectParam(written)).toEqual({
+      kind: "fields",
+      fields: { id: true, title: true, slug: true },
+    });
+  });
+
+  it("writes a value a caller can put in a URL", () => {
+    const url = new URL("https://example.test/e");
+    url.searchParams.set("select", encodeSelectParam(["id", "title"]));
+    expect(
+      readSelectParam(new URL(url.href).searchParams.get("select") ?? undefined)
+    ).toEqual({ kind: "fields", fields: { id: true, title: true } });
+  });
+
+  it("writes nothing for an empty selection", () => {
+    // Rather than `{}`, which reads as a projection that selects nothing and
+    // is answered with every field — the opposite of what it appears to say.
+    expect(encodeSelectParam([])).toBe("");
+  });
+});
+
+describe("readSelectParam - what a caller is actually asking", () => {
+  it("treats an absent parameter as asking for everything", () => {
+    expect(readSelectParam(undefined)).toEqual({ kind: "all" });
+    expect(readSelectParam("")).toEqual({ kind: "all" });
+    expect(readSelectParam("   ")).toEqual({ kind: "all" });
+  });
+
+  it("refuses a comma list rather than ignoring it", () => {
+    // What the form builder shipped. It was accepted and discarded, so the
+    // response looked correct and carried every field of every row.
+    expect(readSelectParam("id,title,slug").kind).toBe("unreadable");
+  });
+
+  it("refuses a bare field name", () => {
+    expect(readSelectParam("title").kind).toBe("unreadable");
+  });
+
+  it("refuses an array", () => {
+    expect(readSelectParam('["title"]').kind).toBe("unreadable");
+  });
+
+  it("refuses a projection that names no fields", () => {
+    // `{}` and `{"title":false}` both selected nothing, and a projection that
+    // selects nothing is answered with the whole document.
+    expect(readSelectParam("{}").kind).toBe("unreadable");
+    expect(readSelectParam('{"title":false}').kind).toBe("unreadable");
+  });
+
+  it("refuses values that are not booleans", () => {
+    expect(readSelectParam('{"title":"yes"}').kind).toBe("unreadable");
+    expect(readSelectParam('{"title":1}').kind).toBe("unreadable");
+  });
+
+  it("keeps the fields a caller did ask for alongside ones it did not", () => {
+    // A mixed map is readable: the `true` entries are a real request, and the
+    // `false` entries never did anything.
+    expect(readSelectParam('{"title":true,"body":false}')).toEqual({
+      kind: "fields",
+      fields: { title: true },
+    });
+  });
+
+  it("says why, in words a caller can act on", () => {
+    const answer = readSelectParam("id,title");
+    expect(answer.kind).toBe("unreadable");
+    if (answer.kind === "unreadable") {
+      expect(answer.reason).toContain('{"title":true}');
+    }
+  });
+});

--- a/packages/nextly/src/query/index.ts
+++ b/packages/nextly/src/query/index.ts
@@ -1,0 +1,21 @@
+/**
+ * The query-parameter formats, read and written by one piece of code.
+ *
+ * A leaf: no server imports, so a browser bundle reaching `nextly/query` does
+ * not pull the Direct API graph behind it.
+ *
+ * `select` lives here because it had a reader and no writer, and every caller
+ * that needed to write one worked the format out for itself — four
+ * implementations, two of which disagreed. `sort` and `where` have the same
+ * shape today, spelled out again in the admin's API Playground; they belong
+ * here too, and are deliberately left for their own change rather than moved
+ * in passing.
+ *
+ * @module query
+ */
+
+export {
+  encodeSelectParam,
+  readSelectParam,
+  type SelectRequest,
+} from "./select-param";

--- a/packages/nextly/src/query/select-param.ts
+++ b/packages/nextly/src/query/select-param.ts
@@ -49,47 +49,103 @@ export function encodeSelectParam(fields: readonly string[]): string {
 }
 
 /**
- * Read the parameter's value, saying which of the three answers it is.
+ * Characters that cannot occur in a field name and do occur in the other
+ * spellings of this parameter.
  *
- * `false` values are dropped rather than honoured. The read path filters them
- * out before applying the projection, so `{"title":false}` selected nothing
- * while still counting as a selection — and a projection that selects nothing
- * returns the whole document. A caller who wrote it meaning "everything except
- * the title" got the exact opposite.
+ * A rejection set rather than an acceptance pattern, deliberately. Three
+ * different field-name patterns already exist in this repository and one of
+ * them disagrees with the other two, so a fourth would be a fourth thing to
+ * drift — and the direction that drift fails in matters here: this reader
+ * REFUSES what it does not accept, so a pattern stricter than the config
+ * validator's would reject a select naming a field the config allows. A set of
+ * characters no field name can contain cannot make that mistake.
  */
-export function readSelectParam(raw: string | undefined): SelectRequest {
-  if (raw === undefined || raw.trim() === "") return { kind: "all" };
+const NOT_IN_A_FIELD_NAME = /[{}[\]":\s]/;
 
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return {
-      kind: "unreadable",
-      reason:
-        'select must be a JSON object naming fields, such as {"title":true}',
-    };
+function unreadable(reason: string): SelectRequest {
+  return { kind: "unreadable", reason };
+}
+
+/**
+ * The comma-separated form, which is the one the REST reference documents:
+ * `?select=id,title,publishedAt`.
+ *
+ * It has never worked. The reader accepted only a JSON object, so the
+ * documented request was parsed as nothing, discarded, and answered with every
+ * field — which is why the one caller that followed the documentation shipped a
+ * projection that projected nothing, and why the admin's API Playground had to
+ * probe a running server to find the form that does work.
+ */
+function fromCommaList(value: string): SelectRequest {
+  const names = value.split(",").map(name => name.trim());
+  if (names.some(name => name === "" || NOT_IN_A_FIELD_NAME.test(name))) {
+    return unreadable(
+      "select must be a comma-separated list of field names, such as " +
+        '"id,title", or a JSON object naming them, such as {"title":true}'
+    );
   }
+  return {
+    kind: "fields",
+    fields: Object.fromEntries(names.map(n => [n, true])),
+  };
+}
 
-  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-    return {
-      kind: "unreadable",
-      reason:
-        'select must be a JSON OBJECT naming fields, such as {"title":true}',
-    };
-  }
-
+/**
+ * The JSON object form: `{"title":true}`.
+ *
+ * EVERY entry has to be a boolean. Skipping the ones that are not would accept
+ * `{"title":true,"body":"yes"}` as a valid projection over `title` alone —
+ * quietly answering a different question than the caller asked, which is the
+ * defect this module exists to remove rather than relocate.
+ */
+function fromFieldMap(map: Record<string, unknown>): SelectRequest {
   const fields: Record<string, true> = {};
-  for (const [name, wanted] of Object.entries(parsed)) {
-    if (wanted === true) fields[name] = true;
+  for (const [name, wanted] of Object.entries(map)) {
+    if (typeof wanted !== "boolean") {
+      return unreadable(
+        `select values must be true or false; the value for "${name}" is neither`
+      );
+    }
+    if (wanted) fields[name] = true;
   }
 
   if (Object.keys(fields).length === 0) {
-    return {
-      kind: "unreadable",
-      reason: "select named no fields to return; omit it to return every field",
-    };
+    return unreadable(
+      "select named no fields to return; omit it to return every field"
+    );
+  }
+  return { kind: "fields", fields };
+}
+
+/**
+ * Read the parameter's value, saying which of the three answers it is.
+ *
+ * Both documented spellings are accepted. Which one a value is gets decided by
+ * whether it is JSON at all, rather than by looking for a comma: a JSON object
+ * containing one is still JSON.
+ *
+ * `false` entries select nothing, because the read path filters them out before
+ * applying the projection — so `{"title":false}` counted as a selection, chose
+ * no field, and a projection choosing nothing returns the whole document. A
+ * caller who wrote it meaning "everything except the title" got the opposite.
+ */
+export function readSelectParam(raw: string | undefined): SelectRequest {
+  if (raw === undefined || raw.trim() === "") return { kind: "all" };
+  const value = raw.trim();
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(value);
+  } catch {
+    return fromCommaList(value);
   }
 
-  return { kind: "fields", fields };
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return unreadable(
+      "select must be a comma-separated list of field names, such as " +
+        '"id,title", or a JSON object naming them, such as {"title":true}'
+    );
+  }
+
+  return fromFieldMap(parsed as Record<string, unknown>);
 }

--- a/packages/nextly/src/query/select-param.ts
+++ b/packages/nextly/src/query/select-param.ts
@@ -1,0 +1,95 @@
+/**
+ * The `select` query parameter, read and written in one place.
+ *
+ * It is a JSON object naming the fields a caller wants — `{"title":true}` —
+ * and nothing else is accepted. That was never written down anywhere a caller
+ * could find it, and the format had a reader and no writer, so every caller
+ * worked it out for itself: the admin's API Playground rediscovered it by
+ * probing a running server and recorded the answer in a comment; the form
+ * builder guessed a comma list, shipped it, and downloaded every field of up
+ * to fifty documents per collection to fill a dropdown reading five.
+ *
+ * Neither caller was told. A request the reader could not understand was
+ * answered with the whole document, which looks exactly like a request that
+ * asked for the whole document.
+ *
+ * Client-safe by construction: no imports, no Node built-ins, reachable from a
+ * browser bundle through `nextly/query` without pulling the server graph.
+ *
+ * @module query/select-param
+ */
+
+/**
+ * What a caller asked for.
+ *
+ * Three answers rather than a nullable map, because the absent case and the
+ * unreadable case want opposite treatment and used to be the same value. "No
+ * projection was requested" is a caller getting what they asked for; "I could
+ * not read your projection" is a caller getting the opposite of what they
+ * asked for, silently and at the cost of every field of every row.
+ */
+export type SelectRequest =
+  | { kind: "all" }
+  | { kind: "fields"; fields: Record<string, true> }
+  | { kind: "unreadable"; reason: string };
+
+/**
+ * Write the parameter's VALUE. Encoding it for a URL is the caller's job —
+ * pass it through `URLSearchParams`, or `encodeURIComponent` when building a
+ * query string by hand.
+ *
+ * An empty list yields an empty string, which callers drop rather than send:
+ * a projection naming no fields cannot be honoured, and sending one would be
+ * asking for everything by a route that reads as asking for nothing.
+ */
+export function encodeSelectParam(fields: readonly string[]): string {
+  const named = fields.filter(field => field.length > 0);
+  if (named.length === 0) return "";
+  return JSON.stringify(Object.fromEntries(named.map(field => [field, true])));
+}
+
+/**
+ * Read the parameter's value, saying which of the three answers it is.
+ *
+ * `false` values are dropped rather than honoured. The read path filters them
+ * out before applying the projection, so `{"title":false}` selected nothing
+ * while still counting as a selection — and a projection that selects nothing
+ * returns the whole document. A caller who wrote it meaning "everything except
+ * the title" got the exact opposite.
+ */
+export function readSelectParam(raw: string | undefined): SelectRequest {
+  if (raw === undefined || raw.trim() === "") return { kind: "all" };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return {
+      kind: "unreadable",
+      reason:
+        'select must be a JSON object naming fields, such as {"title":true}',
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return {
+      kind: "unreadable",
+      reason:
+        'select must be a JSON OBJECT naming fields, such as {"title":true}',
+    };
+  }
+
+  const fields: Record<string, true> = {};
+  for (const [name, wanted] of Object.entries(parsed)) {
+    if (wanted === true) fields[name] = true;
+  }
+
+  if (Object.keys(fields).length === 0) {
+    return {
+      kind: "unreadable",
+      reason: "select named no fields to return; omit it to return every field",
+    };
+  }
+
+  return { kind: "fields", fields };
+}

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -90,6 +90,10 @@ const clientEntries = [
   "src/field-group-reconcile.ts",
   // Pure serializable data, consumed by the admin's field pickers and by plugins.
   "src/collections/fields/catalog.ts",
+  // The query-parameter formats, so a caller writes one with the same code the
+  // server reads it with. Imported by the admin's API Playground and by plugin
+  // admin components, which is why it is a leaf rather than a root export.
+  "src/query/index.ts",
 ];
 
 // Shared config options

--- a/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
+++ b/packages/plugin-form-builder/src/admin/components/builder/RedirectPagePicker.tsx
@@ -21,6 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nextlyhq/ui";
+import { encodeSelectParam } from "nextly/query";
 import { useEffect, useState } from "react";
 
 import {
@@ -95,10 +96,16 @@ export function selectFieldsFor(useAsTitle?: string): readonly string[] {
   return [...labelFieldsFor(useAsTitle), "status", "firstPublishedAt"];
 }
 
+/**
+ * The `select` parameter, ready to sit in a hand-built query string.
+ *
+ * The format itself comes from core rather than from here. This module once
+ * spelled it out, having first shipped a comma list the server accepted and
+ * discarded — every field of up to fifty documents per collection, to fill a
+ * dropdown reading five.
+ */
 export function selectParam(fields: readonly string[]): string {
-  return encodeURIComponent(
-    JSON.stringify(Object.fromEntries(fields.map(field => [field, true])))
-  );
+  return encodeURIComponent(encodeSelectParam(fields));
 }
 
 /** One selectable document, reduced to what the control shows and stores. */


### PR DESCRIPTION
`select` accepts a JSON object naming the fields you want — `{"title":true}` — and nothing else. That was never written down anywhere a caller could find it, and **only the reader existed**, so every caller worked the format out for itself.

Measured against the real parser, before this change:

| `select=` | parser | what the caller received |
|---|---|---|
| `{"title":true}` | `{title:true}` | the projection ✓ |
| `{"title":false}` | `{title:false}` | **the whole document** |
| `id,title` | `undefined` | the whole document |
| `title` | `undefined` | the whole document |
| `["title"]` | `undefined` | the whole document |
| `{}` | `undefined` | the whole document |
| `{"title":"yes"}` | `undefined` | the whole document |
| *absent* | `undefined` | the whole document ✓ |

Only the last row is a caller getting what they asked for. Six are mistakes answered identically to "I did not ask for a projection", and none produced an error, a warning or a log.

`{"title":false}` reaches the same place by a different route, which is worth separating: it is accepted, it passes the `Object.keys(select).length > 0` guard, and then `applyFieldSelection` filters to the `true` entries and finds none — and a projection that selects nothing returns the entry unchanged. An author writing it to mean "everything except the title" gets the exact opposite.

## Four implementations, and the two readers disagreed

| where | half | behaviour |
|---|---|---|
| `dispatcher/helpers/validation.ts` | reader | kept `false` entries |
| `APIPlayground/query-fields.ts` | reader | discarded them |
| `APIPlayground/query-fields.ts` | writer | raw JSON |
| `RedirectPagePicker.tsx` | writer | JSON, URL-encoded |

The API Playground's own comments record it rediscovering the format by probing a running server — *"Verified against the running API: `select={"title":true}` comes back with `id`, `title`, `createdAt` and `updatedAt`"*, and *"a bare `select=title` is accepted and then ignored by the API"*. That is what a wire format with no writer costs: the format was discovered independently, twice, and written down in two places that then drifted.

The form builder's guess shipped. `select=id,title,name,label,slug` was accepted and discarded, downloading every scalar and JSON field of up to fifty documents per collection — for page-builder targets the whole block tree — to fill a dropdown reading five fields.

## What changed

`nextly/query` exports the pair, so a caller writes the parameter with the same code the server reads it with:

```ts
export type SelectRequest =
  | { kind: "all" }
  | { kind: "fields"; fields: Record<string, true> }
  | { kind: "unreadable"; reason: string };
```

Three answers rather than a nullable map, because the absent case and the unreadable case want opposite treatment and used to be the same value. The REST layer turns `unreadable` into a 400 naming the format, instead of a correct-looking response carrying every row in full.

`false` entries are dropped rather than honoured, and a map with no `true` is unreadable — because the read path already ignored them, so accepting one meant accepting a request that could only be answered wrongly.

**A leaf entry point rather than a root export.** The admin's API Playground and plugin admin components import this from the browser, and the root entry brings the server graph with it — `packages/nextly/src/query/index.ts` is on `tsup`'s client list beside `field-catalog`, and the built module pulls ~1.5KB of chunks and nothing else. The subpath is `query` rather than `select` because `sort` and `where` have the same shape today, spelled out again in the same playground module; they belong here too and are deliberately left for their own change.

## Verification

`parseSelectParam` had **no tests anywhere in the repository** before this. Break-verified in three directions, each failing a distinct named test:

| mutation | test that fails |
|---|---|
| unreadable falls back to no projection (the defect) | `refuses a comma list instead of answering with every field`, `refuses a bare field name`, `refuses an array`, `refuses a projection that would select nothing`, `says what the format is, in the message the caller receives` |
| everything refused, absent included | `treats an absent parameter as asking for everything`, `returns nothing when no projection was asked for` |
| `false` counts as a selection again | `refuses a projection that names no fields`, `keeps the fields a caller did ask for alongside ones it did not`, `refuses a projection that would select nothing` |

The second is the control the refusal needs: "refuses what it cannot read" is otherwise satisfied by a reader that refuses everything, including the absent parameter that legitimately means "send every field". The round trip — `readSelectParam(encodeSelectParam([...]))` — is what pins the two halves to each other rather than to a literal either could drift from.

## Behaviour change worth calling out

**A request whose `select` cannot be read is now a 400 rather than a 200 carrying the whole document.** I think that is right — silently returning more data than was asked for is the failure this exists to fix, and a caller cannot discover the mistake from a response that looks correct — but it is a change to a public endpoint and I would rather flag it than have it found.

One test comment in the API Playground documented the old behaviour as a contract (*"The API accepts `select=title` and then returns every field"*) and is corrected rather than left to mislead the next reader.

`check-types` clean on `nextly`, `@nextlyhq/admin` and `@nextlyhq/plugin-form-builder`. `src/dispatcher` failures identical before and after by name (verified by stashing); the API Playground's 106 tests and the form builder's 327 pass unchanged against the delegated implementations.