### PR TITLE
fix(admin): give the version history panel a reachable close control

### DIFF
--- a/.changeset/version-history-can-be-closed.md
+++ b/.changeset/version-history-can-be-closed.md
@@ -1,0 +1,45 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Version history could be opened but not easily closed. The panel offered no
+close control where one is normally found, clicking the page behind it was
+deliberately ignored, and the only button that did close it sat in the row of
+actions at the bottom — a row that gains three more buttons the moment a
+version is selected, wraps at the panel's width, and carried that button off
+the edge of the screen. Escape worked, but nothing said so.
+
+The panel now closes from a control beside its title, where a dismissible
+surface is expected to keep one, and it stays there whichever state the panel
+is in. The action row no longer holds an exit, so the compare controls are
+free to wrap onto a second visible line instead of pushing one off-screen, and
+the row itself is gone entirely while no version is selected rather than
+sitting empty below the list.
+
+Nothing else about the panel changes: it stays beside the document rather than
+over it, so the document it describes is still readable and scrollable while
+history is open.

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -14,6 +14,7 @@
  * @module components/features/versions/VersionHistorySheet
  */
 
+import { X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import {
@@ -21,6 +22,7 @@ import {
   AlertDescription,
   Button,
   Sheet,
+  SheetClose,
   SheetContent,
   SheetDescription,
   SheetHeader,
@@ -429,18 +431,35 @@ export function VersionHistorySheet({
                 already locale-fixed) and only for a document whose own history
                 carries locales — so it never appears on a non-localized
                 document in an otherwise localized app. */}
-            {selected === null && isLocalizedDocument && (
-              <VersionLocaleFilter
-                value={localeFilter}
-                onChange={locale => {
-                  // Changing the visible locale set can drop the previewed or
-                  // compared version out of view, so clear both modes.
-                  setLocaleFilter(locale);
-                  setSelected(null);
-                  setComparing(null);
-                }}
-              />
-            )}
+            <div className="flex items-center gap-1">
+              {selected === null && isLocalizedDocument && (
+                <VersionLocaleFilter
+                  value={localeFilter}
+                  onChange={locale => {
+                    // Changing the visible locale set can drop the previewed or
+                    // compared version out of view, so clear both modes.
+                    setLocaleFilter(locale);
+                    setSelected(null);
+                    setComparing(null);
+                  }}
+                />
+              )}
+              {/* The sheet primitive renders no close icon of its own, so the
+                  panel supplies one. It sits beside the title rather than in
+                  the footer because the footer's action row gains the compare
+                  controls once a version is selected and wraps at this width,
+                  which carried the only exit off-screen. */}
+              <SheetClose asChild>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 w-8 shrink-0 p-0"
+                  aria-label="Close"
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </SheetClose>
+            </div>
           </div>
           <SheetDescription className="sr-only">
             Past versions of this document, newest first.
@@ -553,58 +572,62 @@ export function VersionHistorySheet({
           )}
         </div>
 
-        <div className="p-4 border-t border-border flex flex-wrap items-center gap-2">
-          {selected !== null ? (
-            <>
+        {/* The action row exists only while a version is selected. Rendering it
+            unconditionally left an empty bordered strip below the list once the
+            close control moved to the header, since these actions are the only
+            other thing it ever held.
+
+            It wraps, which is safe now and was not before. These three controls
+            exceed 480px, so they either wrap or scroll; wrapping puts the
+            overflow on a second visible line, while a horizontal scroll leaves
+            the last control half-drawn at the panel's edge and reachable only
+            by a gesture nothing advertises. What made wrapping unusable before
+            was the close control sitting here with `ml-auto`: it landed alone
+            on the wrapped line, against the panel edge, where the viewport
+            clipped it. With the exit in the header, a second line costs
+            nothing. */}
+        {selected !== null ? (
+          <div className="p-4 border-t border-border flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setSelected(null)}
+            >
+              Back to history
+            </Button>
+            {/* Compare is offered from the preview, where a version is already
+                  chosen: against the one before it, and against the current. */}
+            {canComparePrevious && previousVersionNo !== null ? (
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => setSelected(null)}
+                onClick={() =>
+                  setComparing({ from: previousVersionNo, to: selected })
+                }
               >
-                Back to history
+                Compare with previous
               </Button>
-              {/* Compare is offered from the preview, where a version is already
-                  chosen: against the one before it, and against the current. */}
-              {canComparePrevious && previousVersionNo !== null ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    setComparing({ from: previousVersionNo, to: selected })
-                  }
-                >
-                  Compare with previous
-                </Button>
-              ) : null}
-              {canCompareCurrent && latestVersionNo !== null ? (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={() =>
-                    setComparing({ from: selected, to: latestVersionNo })
-                  }
-                >
-                  Compare with current
-                </Button>
-              ) : null}
-              {/* Restoring is offered in the BANNER over the version being
+            ) : null}
+            {canCompareCurrent && latestVersionNo !== null ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  setComparing({ from: selected, to: latestVersionNo })
+                }
+              >
+                Compare with current
+              </Button>
+            ) : null}
+            {/* Restoring is offered in the BANNER over the version being
                   read, not here. The panel only ever offered it while a
                   version was selected, which is exactly when the banner is on
                   screen — so a button here would be a second control with the
                   same label, and the further one from what it acts on. This
                   component still owns the mutation and its confirmation; the
                   banner holds the trigger. */}
-            </>
-          ) : null}
-          <Button
-            variant="ghost"
-            size="sm"
-            className="ml-auto"
-            onClick={() => onOpenChange(false)}
-          >
-            Close
-          </Button>
-        </div>
+          </div>
+        ) : null}
       </SheetContent>
 
       {/* Rendered inside the sheet but outside its content, so its own portal

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -7,7 +7,7 @@ import userEvent from "@testing-library/user-event";
 import type { FieldConfig } from "nextly/config";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { render, screen, waitFor } from "@admin/__tests__/utils";
+import { render, screen, waitFor, within } from "@admin/__tests__/utils";
 
 const {
   useVersionsMock,
@@ -96,10 +96,29 @@ function version(versionNo: number) {
   };
 }
 
-function renderSheet() {
+function renderSheet(props: Record<string, unknown> = {}) {
   return render(
-    <VersionHistorySheet open onOpenChange={vi.fn()} scope={scope} />
+    <VersionHistorySheet open onOpenChange={vi.fn()} scope={scope} {...props} />
   );
+}
+
+/**
+ * The row the panel's title sits in, located from the title itself.
+ *
+ * The close control's LOCATION is the property under test, not merely its
+ * existence: a control that lives in the footer's action row is the defect,
+ * because that row gains three compare buttons on selection and wraps at this
+ * width, carrying the only exit off-screen. So the tests ask which region
+ * holds the control. Scoping by the title's own row rather than by a class
+ * keeps the assertion about structure the reader can see.
+ */
+function titleRow(): HTMLElement {
+  const title = screen.getByRole("heading", {
+    name: /^(Version history|Version \d+)$/,
+  });
+  const row = title.closest("div");
+  if (!row) throw new Error("panel title row not found");
+  return row;
 }
 
 /**
@@ -681,6 +700,43 @@ describe("VersionHistorySheet — what it publishes to the document", () => {
       expect(
         screen.getByRole("button", { name: /Version 3/ })
       ).not.toHaveAttribute("aria-current", "true")
+    );
+  });
+
+  it("closes from a control beside its title", async () => {
+    const onOpenChange = vi.fn();
+    renderSheet({ onOpenChange });
+
+    // The sheet primitive renders no close icon of its own, so the panel has
+    // to supply one. Beside the title is where a dismissible surface keeps it.
+    const close = within(titleRow()).getByRole("button", { name: /close/i });
+    await userEvent.click(close);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it("keeps the close control beside the title once a version is selected", async () => {
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [
+            { items: [version(2), version(1)], meta: { hasNext: false } },
+          ],
+        },
+      })
+    );
+    renderSheet();
+
+    await userEvent.click(screen.getByRole("button", { name: /Version 2/ }));
+
+    // Selecting adds the compare actions to the footer. The exit must not be
+    // among them: that row wraps at this width, which is what put the only
+    // close control off-screen. Exactly one close control, and it is beside
+    // the title.
+    const closes = screen.getAllByRole("button", { name: /close/i });
+    expect(closes).toHaveLength(1);
+    expect(within(titleRow()).getByRole("button", { name: /close/i })).toBe(
+      closes[0]
     );
   });
 });


### PR DESCRIPTION
## Summary

The version history panel could be opened but not easily closed.

`Sheet` renders no close icon by default and documents that the consumer must
supply one — this consumer never did. Click-outside is deliberately cancelled
(`onInteractOutside` → `preventDefault`), which is correct and stays: the panel
is non-modal so the document beside it remains readable and scrollable. That
left `Escape` and a ghost button in the footer's action row.

That row gains three more buttons the moment a version is selected, wraps at
480px, and `ml-auto` put the close button alone on the wrapped line against the
panel edge — off-screen in practice. So both exits were hidden.

**What changed**

- The close control moves to the header, beside the title, where a dismissible
  surface is expected to keep one. It stays there in both panel states.
- The footer's action row no longer holds an exit, so the compare controls are
  free to wrap onto a second **visible** line. (I first made the row scroll
  horizontally instead; the render showed that left the third control
  half-drawn at the panel edge, reachable only by an unadvertised gesture.
  Wrapping is strictly better now that the exit is elsewhere.)
- The row is not rendered at all while no version is selected — with the close
  button gone it was otherwise an empty bordered strip below the list.

Nothing else about the panel changes. It stays non-modal.

## Test plan

Both new tests assert the control's **location**, not merely its existence — a
close control in the footer is the defect, so "a button named Close exists"
passes on the broken code.

- `closes from a control beside its title` — scopes to the title's own row.
- `keeps the close control beside the title once a version is selected` —
  exactly one close control, and it is the one in the title row.

**Break-verified:** removing the `SheetClose` block fails both new tests by
name and leaves the 23 pre-existing tests passing. Restored, 25/25 pass.

**Checks** (build first, then each read by exit status, not by grepping output):

| check | result |
| --- | --- |
| `pnpm build` | 19/19 |
| `pnpm check-types` | EXIT=0, 22/22 |
| `pnpm lint` | EXIT=0, 24/24 |
| `pnpm lint:design` | EXIT=0 — 1012 files |
| `pnpm --filter @nextlyhq/admin test -- versions` | 202/202 across 15 files |
| `fallow audit --gate-marker agent` | **pass** — 0 introduced (dead code / complexity / duplication / styling) |

**Visual** — verified in the running playground, light and dark:
close control present in the header in both the list and the selected state;
all three compare actions fully visible on two lines; no empty strip when
nothing is selected. Browser console clean on a fresh load. The header control
was also clicked in the real app, not only in jsdom.

## Changeset

Changeset added: **yes (patch)**, all published packages, per the alpha
lockstep convention.

## Pre-existing failures, listed so they are not read as regressions

`pnpm --filter @nextlyhq/admin test` reports **15 failures across 4 files**.
All 15 are pre-existing. Proven rather than inferred from paths: I stashed this
branch's changes, confirmed the tree was clean at `origin/main`, and re-ran
those four files — the same 15 failed.

- `features/dashboard/StatsCard.test.tsx` (2)
- `features/schema-builder/builder-settings-modal/__tests__/BasicsTab.test.tsx` (1)
- `features/schema-builder/builder-settings-modal/__tests__/SlugInput.test.tsx` (4)
- `features/schema-builder/field-editor-sheet/__tests__/DefaultValueField.test.tsx` (8)

None is in `features/versions/**`; this PR touches nothing else.

## Note on the local fallow run

`fallow audit` passes with the workspace built. Run with `packages/ui/dist`
moved aside — the state CI audits in, since it audits after install and before
build — it fails, reporting 290 "introduced" styling findings and 114
duplication groups across the repository. That is a repo-wide misattribution
from missing build output rather than anything in this diff, and it would
affect any PR equally. Flagging it because the local and CI runs genuinely
disagree, and a reviewer comparing the two should know which is which.

## Context

First of six tasks in the R-12 versioning work. Design and plan approved by the
founder; the remaining five cover the diff engine (rich text and JSON are not
diffed at all today) and a full-page comparison route. This one is deliberately
independent of all of them.
