### PR TITLE
feat(nextly): offer preview viewports the site declares, not ones we invent

### DIFF
--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -68,3 +68,11 @@ different facts — what the box says and what the frame is sized to — so an e
 box committed "no width", which selected Responsive, which removed the input the
 author was typing in. The text being typed is now kept separately, and a width
 is committed only once the box names one a frame can be sized to.
+
+The custom width box commits the whole number it shows. `parseInt` read `390.5`
+as `390` and `1e3` as `1` — both of which a number input accepts and displays in
+full — so the frame was sized to a width the box was not showing, and blurring
+replaced the author's text with the truncated value.
+
+The pane measures itself before the browser paints rather than after, so a frame
+cannot be drawn at the wrong width on the way to the right one.

--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -53,3 +53,18 @@ never disagree with the breakpoints the site actually uses. No phone/tablet/
 desktop numbers are invented here, and there are deliberately no device icons —
 a site names its own breakpoints, and no glyph is honest for a tier an author
 called "Kiosk".
+
+The toolbar wraps instead of running off the edge. At a 1024px window the pane
+is about 450px wide, and a viewport select, a width box, a scaling note and
+three actions do not fit on one line — the pane clips its overflow, so
+open-in-a-new-tab and close sat past the edge with no way to scroll to them.
+Measured in a browser at that width: they were 40px and 98px outside the
+clipping box, and hit-testing their centres reached nothing. The three actions
+stay together as one unit, so the row breaks between the viewport control and
+them rather than through the middle of them.
+
+Clearing the width box no longer takes the box away. It held one value for two
+different facts — what the box says and what the frame is sized to — so an empty
+box committed "no width", which selected Responsive, which removed the input the
+author was typing in. The text being typed is now kept separately, and a width
+is committed only once the box names one a frame can be sized to.

--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -76,3 +76,11 @@ replaced the author's text with the truncated value.
 
 The pane measures itself before the browser paints rather than after, so a frame
 cannot be drawn at the wrong width on the way to the right one.
+
+The custom width is taken when you stop typing, not on every keystroke. The
+frame is a live iframe of the site, so each committed width re-lays-out a whole
+page — and clearing the box to type `768` emits `7`, `76`, `768`, collapsing the
+preview to 7px and then 76px on the way. Leaving the box commits immediately, so
+a width typed and clicked away from is not lost. Widths below one pixel are
+refused: the input's `min` marks the field invalid without clamping it, and
+below a pixel the preview is not narrow but absent.

--- a/.changeset/preview-pane-chooses-its-viewport.md
+++ b/.changeset/preview-pane-chooses-its-viewport.md
@@ -1,0 +1,55 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The in-admin preview pane can now be shown at a chosen viewport width instead of
+whatever width the editor happened to leave it.
+
+This matters more than it sounds. The pane sits in a split that reserves a
+minimum editor, so at its default position the preview is a few hundred pixels
+wide — which means it was faithfully previewing a MOBILE viewport, decided by
+wherever the divider was last dragged rather than by anything anyone chose. The
+two controls were also coupled: widening the preview meant narrowing the editor
+being typed into.
+
+Choosing a width now does two things in order. The split gives the preview as
+much room as the minimum editor allows, and only whatever still does not fit is
+scaled down. On a wide window nothing is scaled at all.
+
+A scaled frame keeps its requested width, so the site's own media queries still
+resolve against the viewport being previewed and the preview stays truthful
+about layout. What it stops being truthful about is physical size — text renders
+smaller than a visitor would see it — so the toolbar always states the real
+width and the scale beside it rather than letting the shrinking pass unremarked.
+
+This release ships the control with **Responsive** and a custom width. Named
+presets follow: they will come from a collection's own declaration where one
+exists, and from the site's page-builder breakpoints otherwise, so a preset can
+never disagree with the breakpoints the site actually uses. No phone/tablet/
+desktop numbers are invented here, and there are deliberately no device icons —
+a site names its own breakpoints, and no glyph is honest for a tier an author
+called "Kiosk".

--- a/.changeset/preview-viewports-come-from-the-site.md
+++ b/.changeset/preview-viewports-come-from-the-site.md
@@ -1,0 +1,69 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The preview pane's viewport control now offers named widths, and they come from
+the site rather than from a list Nextly invented.
+
+A collection or Single can declare them:
+
+```typescript
+admin: {
+  preview: {
+    url: entry => `/blog/${entry.slug}`,
+    breakpoints: [
+      { label: "Phone", width: 390 },
+      { label: "Desktop", width: 1280 },
+    ],
+  },
+}
+```
+
+`breakpoints` also accepts a FUNCTION, evaluated per link on the server. That is
+what lets a source which changes stay current: a page-builder site keeps its
+breakpoints in stored data an author edits, and a list captured when the config
+was defined would go stale the moment they change one.
+
+`@nextlyhq/plugin-page-builder` supplies exactly that for sites that use it:
+
+```typescript
+breakpoints: previewViewportsFromSiteStyle({ reader: async () => /* ... */ })
+```
+
+so the pane offers the site's OWN tiers, by the names their author gave them,
+read through the same reader the style compiler uses — a preset therefore cannot
+name a width the compiled stylesheet has no rule for.
+
+Where neither is declared, the control keeps Responsive and a custom width.
+Nothing invents phone/tablet/desktop numbers, because nothing here can know the
+widths a site's CSS actually breaks at: a site whose tablet is 991px would
+otherwise get a "Tablet" preset that sizes the frame to 1024 and lands in a tier
+its stylesheet never uses.
+
+A malformed row is dropped rather than failing the list, and a declaration that
+throws costs its presets rather than the preview — these are a convenience on
+top of a credential handout, and losing the link is the worse outcome.

--- a/.changeset/preview-viewports-come-from-the-site.md
+++ b/.changeset/preview-viewports-come-from-the-site.md
@@ -67,3 +67,28 @@ its stylesheet never uses.
 A malformed row is dropped rather than failing the list, and a declaration that
 throws costs its presets rather than the preview — these are a convenience on
 top of a credential handout, and losing the link is the worse outcome.
+
+The page builder's own `pages` collection offers them too. The helper that reads
+a site's breakpoints was exported but nothing in the standard
+`pageBuilder({ pagePreviewPath })` flow could hand it to that collection, so the
+presets reached only collections a host had composed by hand — not the primary
+page-builder workflow. It is now the default, since a page-builder site's
+breakpoints are the widths its stylesheet changes at. Pass
+`pagePreviewBreakpoints` to override it, or `false` to offer none.
+
+`pagesCollection` takes one options object instead of two positional arguments,
+which is what those two said to do as soon as a third arrived. Call
+`pagesCollection({ previewPath, limits })` in place of
+`pagesCollection(previewPath, limits)`.
+
+A Single can declare `breakpoints` as well. The mint path already resolved
+whatever a preview declaration carried without knowing which kind of document it
+came from, but `SinglePreviewConfig` listed only `url`, `openInNewTab` and
+`label` — so the feature was reachable from no Single at all.
+
+Two viewports that could mislead are now dropped rather than offered. A declared
+width below half a pixel rounded to `0`, producing a named "0px" option that
+previewed the full pane instead. And where two breakpoint definitions claim one
+id, the label and the width could come from different rows — the compiler keeps
+the widest, a lookup by id alone kept the last — putting one tier's name on
+another's width. Both sides are now read from the definition that survived.

--- a/apps/playground/src/collections/block-pages.ts
+++ b/apps/playground/src/collections/block-pages.ts
@@ -1,9 +1,12 @@
+import { previewViewportsFromSiteStyle } from "@nextlyhq/plugin-page-builder";
 import {
   defineCollection,
   json,
   previewUrlFromTemplate,
   text,
 } from "nextly/config";
+
+import { SITE_STYLE_DEFAULTS } from "../lib/site-style-defaults";
 
 // Pages rendered by the code-first blocks renderer (`@nextlyhq/blocks-react`),
 // served at /blocks/<slug> by apps/playground/src/app/blocks/[[...slug]]/page.tsx.
@@ -41,7 +44,35 @@ export const BlockPages = defineCollection({
     // entry comparison would then refuse it. The helper applies the same
     // encoding a stored `urlTemplate` gets, so both spellings resolve one entry
     // to one address.
-    preview: { url: previewUrlFromTemplate("/blocks/{slug}") },
+    preview: {
+      url: previewUrlFromTemplate("/blocks/{slug}"),
+      /*
+       * The viewports the preview pane offers come from THIS SITE's own
+       * breakpoints rather than from a list invented here. A site whose tablet
+       * is 991px would otherwise be offered a "Tablet" preset that sizes the
+       * frame to 1024 and lands in a tier its stylesheet never uses.
+       *
+       * The reader is built HERE from the instance rather than taken from
+       * `site-content`, which would be a cycle: that module imports
+       * `nextly.config`, which imports this file. Deferring the import does not
+       * help — it defers execution, while the edge in the module graph is what
+       * a cycle check reads, and it is right to.
+       *
+       * `findSingle` is the whole of what reading a site style needs, so this
+       * is the interface rather than a cut-down copy of a bigger reader.
+       */
+      breakpoints: previewViewportsFromSiteStyle({
+        reader: async () => {
+          const { getCachedNextly } = await import("nextly");
+          // The CACHED instance, which takes no config: importing the config to
+          // build one is the cycle this is avoiding. By mint time an instance
+          // exists, because the request that is minting came through it.
+          const nextly = await getCachedNextly();
+          return { findSingle: args => nextly.findSingle(args) };
+        },
+        defaults: SITE_STYLE_DEFAULTS,
+      }),
+    },
   },
   fields: [
     text({ name: "title", required: true }),

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -81,6 +81,7 @@ export function PreviewFrame({
   noun,
   requestedWidth,
   onRequestWidth,
+  viewports,
 }: PreviewFrameProps) {
   /*
    * The area the frame is drawn into, measured rather than assumed. Its width
@@ -126,6 +127,7 @@ export function PreviewFrame({
               requestedWidth={requestedWidth}
               onRequestWidth={onRequestWidth}
               fit={fit}
+              viewports={viewports}
             />
           )}
           {/* The three actions are ONE flex item, so the row above breaks

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -99,8 +99,14 @@ export function PreviewFrame({
 
   return (
     <div className="flex h-full min-h-0 flex-col border-l border-border bg-muted/40">
-      <div className="flex shrink-0 items-center gap-2 border-b border-border bg-background px-3 py-2">
-        <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+      {/* Wraps rather than overflows. The pane is a share of a split, so at a
+          1024px window it is a few hundred pixels wide — and this row holds a
+          viewport select, a width box, a scaling note and three actions. Fixed
+          on one line they ran past the edge into `overflow-hidden` below, which
+          put refresh, open-in-tab and close off-screen with no way to scroll to
+          them. Wrapping costs a second row and reaches everything. */}
+      <div className="flex shrink-0 flex-wrap items-center gap-x-2 gap-y-1 border-b border-border bg-background px-3 py-2">
+        <span className="truncate text-xs font-medium uppercase tracking-wide text-muted-foreground">
           {label}
         </span>
         {/* States what the frame IS showing rather than what an author might
@@ -114,7 +120,7 @@ export function PreviewFrame({
           </span>
         )}
 
-        <div className="ml-auto flex items-center gap-2">
+        <div className="ml-auto flex flex-wrap items-center justify-end gap-2">
           {showsFrame && (
             <PreviewViewportControl
               requestedWidth={requestedWidth}
@@ -122,53 +128,65 @@ export function PreviewFrame({
               fit={fit}
             />
           )}
-          {isLoading && (
-            <Loader2
-              className="h-3.5 w-3.5 animate-spin text-muted-foreground"
-              aria-hidden="true"
-            />
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={refresh}
-            /*
-             * Disabled only while a mint is IN FLIGHT, never because there is
-             * nothing to show. A failed mint leaves `url` null and sets a
-             * reason, and the message beside it asks the editor to try again —
-             * so keying the control on `url` disabled the one affordance that
-             * message points at, and the only way to retry was to close the
-             * pane and reopen it. A superseded pane needs it for the same
-             * reason: refreshing is how the session comes back.
-             */
-            disabled={isLoading}
-            title="Refresh the preview"
-          >
-            <RefreshCw className="h-4 w-4" aria-hidden="true" />
-            <span className="sr-only">Refresh the preview</span>
-          </Button>
-          {url !== null && (
-            <Button asChild variant="ghost" size="sm" title="Open in a new tab">
-              {/* `rel` carries noopener as well as noreferrer: a preview URL is
+          {/* The three actions are ONE flex item, so the row above breaks
+              between the viewport control and them rather than through the
+              middle of them. Wrapped individually they scattered across rows —
+              refresh above, close below — which reads as three unrelated
+              controls instead of this pane's toolbar. */}
+          <div className="flex shrink-0 items-center gap-2">
+            {isLoading && (
+              <Loader2
+                className="h-3.5 w-3.5 animate-spin text-muted-foreground"
+                aria-hidden="true"
+              />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={refresh}
+              /*
+               * Disabled only while a mint is IN FLIGHT, never because there is
+               * nothing to show. A failed mint leaves `url` null and sets a
+               * reason, and the message beside it asks the editor to try again —
+               * so keying the control on `url` disabled the one affordance that
+               * message points at, and the only way to retry was to close the
+               * pane and reopen it. A superseded pane needs it for the same
+               * reason: refreshing is how the session comes back.
+               */
+              disabled={isLoading}
+              title="Refresh the preview"
+            >
+              <RefreshCw className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Refresh the preview</span>
+            </Button>
+            {url !== null && (
+              <Button
+                asChild
+                variant="ghost"
+                size="sm"
+                title="Open in a new tab"
+              >
+                {/* `rel` carries noopener as well as noreferrer: a preview URL is
                   a bearer credential, and a referrer header would hand it to
                   whatever the opened page links to next. */}
-              <a href={url} target="_blank" rel="noopener noreferrer">
-                <ExternalLink className="h-4 w-4" aria-hidden="true" />
-                <span className="sr-only">Open the preview in a new tab</span>
-              </a>
+                <a href={url} target="_blank" rel="noopener noreferrer">
+                  <ExternalLink className="h-4 w-4" aria-hidden="true" />
+                  <span className="sr-only">Open the preview in a new tab</span>
+                </a>
+              </Button>
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              title="Close the preview"
+            >
+              <X className="h-4 w-4" aria-hidden="true" />
+              <span className="sr-only">Close the preview</span>
             </Button>
-          )}
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={onClose}
-            title="Close the preview"
-          >
-            <X className="h-4 w-4" aria-hidden="true" />
-            <span className="sr-only">Close the preview</span>
-          </Button>
+          </div>
         </div>
       </div>
 

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewFrame.tsx
@@ -26,6 +26,7 @@
  */
 
 import { Button } from "@nextlyhq/ui";
+import { useRef } from "react";
 
 import { ExternalLink, Loader2, RefreshCw, X } from "@admin/components/icons";
 import {
@@ -33,6 +34,13 @@ import {
   type PreviewDocumentNoun,
 } from "@admin/hooks/useEntryPreview";
 
+import {
+  previewFrameFit,
+  previewFrameStyle,
+  type PreviewFit,
+} from "./previewFrameFit";
+import { PreviewViewportControl } from "./PreviewViewportControl";
+import { useMeasuredWidth } from "./useMeasuredWidth";
 import {
   PREVIEW_PANE_BLOCK_MESSAGES,
   type UsePreviewFrameResult,
@@ -50,6 +58,15 @@ export interface PreviewFrameProps extends UsePreviewFrameResult {
    * names a slug, which a Single always has and cannot be the problem with.
    */
   noun: PreviewDocumentNoun;
+  /**
+   * The viewport width the author asked for, or `null` to fill the pane.
+   *
+   * Held by the pane rather than here because choosing a width also WIDENS the
+   * split — the pane takes as much room as it is allowed before anything is
+   * scaled down — and the split is the pane's to move, not the frame's.
+   */
+  requestedWidth: number | null;
+  onRequestWidth: (width: number | null) => void;
 }
 
 export function PreviewFrame({
@@ -62,7 +79,24 @@ export function PreviewFrame({
   onClose,
   label,
   noun,
+  requestedWidth,
+  onRequestWidth,
 }: PreviewFrameProps) {
+  /*
+   * The area the frame is drawn into, measured rather than assumed. Its width
+   * is what decides whether a requested viewport fits, and it changes when the
+   * SPLIT moves — an event the window never reports, which is why this is a
+   * `ResizeObserver` on the box itself.
+   */
+  const viewport = useRef<HTMLDivElement>(null);
+  const available = useMeasuredWidth(viewport);
+  const fit = previewFrameFit(requestedWidth, available);
+
+  // A frame is on screen only in the last branch below. Offering a viewport
+  // control over a refusal message would be a control for something that is
+  // not there.
+  const showsFrame = reason === null && block === null && url !== null;
+
   return (
     <div className="flex h-full min-h-0 flex-col border-l border-border bg-muted/40">
       <div className="flex shrink-0 items-center gap-2 border-b border-border bg-background px-3 py-2">
@@ -80,7 +114,14 @@ export function PreviewFrame({
           </span>
         )}
 
-        <div className="ml-auto flex items-center gap-1">
+        <div className="ml-auto flex items-center gap-2">
+          {showsFrame && (
+            <PreviewViewportControl
+              requestedWidth={requestedWidth}
+              onRequestWidth={onRequestWidth}
+              fit={fit}
+            />
+          )}
           {isLoading && (
             <Loader2
               className="h-3.5 w-3.5 animate-spin text-muted-foreground"
@@ -131,37 +172,97 @@ export function PreviewFrame({
         </div>
       </div>
 
-      <div className="min-h-0 flex-1">
-        {reason !== null ? (
-          /* The reason, not a generic failure. Each of these names something
-             the reader can act on, and the pane is the only place they will
-             see it — unlike the Preview button, which can raise a toast. */
-          <p className="p-6 text-sm text-muted-foreground">
-            {previewMessage(reason, noun)}
-          </p>
-        ) : block !== null ? (
-          /* Ahead of the `url === null` branch on purpose: a blocked pane HAS a
-             url — that is what makes the tab button beside this message the
-             remedy — so testing for a missing url first would render "Preparing
-             the preview…" forever over a pane that is not preparing anything. */
-          <p className="p-6 text-sm text-muted-foreground">
-            {PREVIEW_PANE_BLOCK_MESSAGES[block]}
-          </p>
-        ) : url === null ? (
-          <p className="p-6 text-sm text-muted-foreground">
-            Preparing the preview…
-          </p>
-        ) : (
-          <iframe
-            // Remounted rather than navigated: see `usePreviewFrame` on why a
-            // key beats appending a cache-buster the SITE would have to read.
-            key={reloadKey}
-            src={url}
-            title={`${label} preview`}
-            className="h-full w-full border-0 bg-background"
-          />
-        )}
+      {/* `overflow-hidden` because a frame wider than this box is drawn inside
+          it and scaled down: without clipping, the untransformed corners of a
+          scaled frame paint over the divider. Harmless while responsive, since
+          the frame is then exactly this size. */}
+      <div ref={viewport} className="min-h-0 flex-1 overflow-hidden">
+        <PreviewFrameBody
+          reason={reason}
+          block={block}
+          url={url}
+          reloadKey={reloadKey}
+          label={label}
+          noun={noun}
+          fit={fit}
+        />
       </div>
     </div>
+  );
+}
+
+/**
+ * What the frame's content area shows: one of three refusals, or the site.
+ *
+ * Split from the toolbar because they answer different questions and grow at
+ * different rates — the toolbar gained a viewport control, and carrying both in
+ * one component put it over the complexity gate. The ORDER of the branches is
+ * the load-bearing part and is preserved exactly, so this is a move rather than
+ * a rewrite.
+ */
+function PreviewFrameBody({
+  reason,
+  block,
+  url,
+  reloadKey,
+  label,
+  noun,
+  fit,
+}: {
+  reason: UsePreviewFrameResult["reason"];
+  block: UsePreviewFrameResult["block"];
+  url: string | null;
+  reloadKey: number;
+  label: string;
+  noun: PreviewDocumentNoun;
+  fit: PreviewFit;
+}) {
+  /* The reason, not a generic failure. Each of these names something the reader
+     can act on, and the pane is the only place they will see it — unlike the
+     Preview button, which can raise a toast. */
+  if (reason !== null) {
+    return (
+      <p className="p-6 text-sm text-muted-foreground">
+        {previewMessage(reason, noun)}
+      </p>
+    );
+  }
+
+  /* Ahead of the `url === null` branch on purpose: a blocked pane HAS a url —
+     that is what makes the tab button beside this message the remedy — so
+     testing for a missing url first would render "Preparing the preview…"
+     forever over a pane that is not preparing anything. */
+  if (block !== null) {
+    return (
+      <p className="p-6 text-sm text-muted-foreground">
+        {PREVIEW_PANE_BLOCK_MESSAGES[block]}
+      </p>
+    );
+  }
+
+  if (url === null) {
+    return (
+      <p className="p-6 text-sm text-muted-foreground">
+        Preparing the preview…
+      </p>
+    );
+  }
+
+  return (
+    <iframe
+      // Remounted rather than navigated: see `usePreviewFrame` on why a key
+      // beats appending a cache-buster the SITE would have to read.
+      key={reloadKey}
+      src={url}
+      title={`${label} preview`}
+      /*
+       * `h-full w-full` remains the base, and the derived style overrides it
+       * when a width was asked for. A responsive frame therefore needs no
+       * special case, and an unmeasured one fills the pane rather than flashing
+       * at a width nobody has confirmed.
+       */
+      className="h-full w-full border-0 bg-background"
+      style={previewFrameStyle(fit)}
+    />
   );
 }

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -37,7 +37,7 @@
  * @module components/features/entries/PreviewMode/PreviewPanes
  */
 
-import { useEffect, useRef, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { useSuppressAdminChrome } from "@admin/components/layout/ChromeSuppression";
 import type {
@@ -132,13 +132,26 @@ export function PreviewPanes({
    */
   const frame = usePreviewFrame({ scope, active: open });
 
+  /*
+   * Held HERE because asking for a viewport width does two things, and only one
+   * of them belongs to the frame: the split widens the preview as far as it is
+   * allowed, and whatever width still does not fit is scaled inside the frame.
+   * Removing the shortfall before scaling it is why a laptop shows a desktop
+   * preview at a readable size rather than at whatever fraction the default
+   * split happened to leave.
+   */
+  const [requestedWidth, setRequestedWidth] = useState<number | null>(null);
+
   return (
     <PreviewSplit
       open={open}
       label={label}
+      preferPreviewWidth={requestedWidth}
       preview={
         <PreviewFrameOnSave
           frame={frame}
+          requestedWidth={requestedWidth}
+          onRequestWidth={setRequestedWidth}
           revision={revision}
           onClose={onClose}
           label={label}
@@ -170,12 +183,16 @@ function PreviewFrameOnSave({
   onClose,
   label,
   noun,
+  requestedWidth,
+  onRequestWidth,
 }: {
   frame: UsePreviewFrameResult;
   revision: string;
   onClose: () => void;
   label: string;
   noun: PreviewDocumentNoun;
+  requestedWidth: number | null;
+  onRequestWidth: (width: number | null) => void;
 }) {
   const { refresh } = frame;
   const lastSeen = useRef(revision);
@@ -187,7 +204,14 @@ function PreviewFrameOnSave({
   }, [revision, refresh]);
 
   return (
-    <PreviewFrame {...frame} onClose={onClose} label={label} noun={noun} />
+    <PreviewFrame
+      {...frame}
+      onClose={onClose}
+      label={label}
+      noun={noun}
+      requestedWidth={requestedWidth}
+      onRequestWidth={onRequestWidth}
+    />
   );
 }
 

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewSplit.tsx
@@ -59,6 +59,16 @@ export interface PreviewSplitProps {
   preview: React.ReactNode;
   /** Names the divider for assistive technology. */
   label: string;
+  /**
+   * A viewport width the preview would like room for, or `null` for none.
+   *
+   * The split does not size the frame — it only stops standing in the way. When
+   * a width is asked for, the preview takes as much of the split as the minimum
+   * editor allows; whatever still does not fit is the frame's to scale. Giving
+   * the room first is what keeps the scaling as small as it can be, and on a
+   * wide enough window removes it entirely.
+   */
+  preferPreviewWidth?: number | null;
 }
 
 export function PreviewSplit({
@@ -66,6 +76,7 @@ export function PreviewSplit({
   children,
   preview,
   label,
+  preferPreviewWidth = null,
 }: PreviewSplitProps) {
   /*
    * Generated rather than fixed: the id is what `aria-controls` points at, and
@@ -137,6 +148,21 @@ export function PreviewSplit({
       dragPointer.current = null;
     };
   }, [open, moveTo]);
+
+  /*
+   * Asking for a width takes the room the split can give before anything is
+   * scaled. Clamped to the minimum EDITOR rather than to zero: the editor is
+   * what the author is typing into, and a preview that swallowed it would trade
+   * one unusable pane for another.
+   *
+   * Deliberately not restored when the request clears. Returning to the default
+   * split would undo a divider the author may have dragged since, and the split
+   * is theirs — this only ever moves it on an explicit request.
+   */
+  useEffect(() => {
+    if (preferPreviewWidth === null) return;
+    setEditorPercent(MIN_EDITOR_PERCENT);
+  }, [preferPreviewWidth]);
 
   const onKeyDown = (event: React.KeyboardEvent) => {
     const step =

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -89,21 +89,6 @@ export function PreviewViewportControl({
   const widthInputId = useId();
 
   /*
-   * Which option is selected is DERIVED from the width, not stored beside it.
-   * A separate selection would let the two disagree — typing a custom width
-   * that happens to equal a named one would leave "Custom" showing while the
-   * frame is at the named viewport, and the author would have no way to tell
-   * which of the two the control thinks it is on.
-   */
-  const named = viewports.find(v => v.width === requestedWidth);
-  const selection =
-    requestedWidth === null
-      ? RESPONSIVE
-      : named !== undefined
-        ? String(named.width)
-        : CUSTOM;
-
-  /*
    * What the box SAYS, held separately from the width the frame is at.
    *
    * They are different facts. Clearing the box to retype it leaves text that
@@ -153,6 +138,35 @@ export function PreviewViewportControl({
     if (draft === null || settledDraft !== draft) return;
     commitWidth(settledDraft);
   }, [draft, settledDraft, commitWidth]);
+
+  /*
+   * Which option is selected is DERIVED from the width, not stored beside it.
+   * A separate selection would let the two disagree — typing a custom width
+   * that happens to equal a named one would leave "Custom" showing while the
+   * frame is at the named viewport, and the author would have no way to tell
+   * which of the two the control thinks it is on.
+   *
+   * Except while the box is being typed into, where the match is deliberately
+   * not resolved. A named match is what REMOVES the custom box, so resolving
+   * one mid-edit reopens the unmount this control already had to fix: typing
+   * `7680` passes through `768`, and if that is a named tier the field
+   * disappears under the author on the third keystroke — and the dropdown flips
+   * to "Tablet" while they are still typing into a box labelled Custom.
+   *
+   * The draft ends on blur or on a choice from the list, and the match resolves
+   * then, so a typed width that equals a named tier still gives way to it one
+   * moment later — when the author has finished saying so.
+   */
+  const named =
+    draft === null
+      ? viewports.find(v => v.width === requestedWidth)
+      : undefined;
+  const selection =
+    requestedWidth === null
+      ? RESPONSIVE
+      : named !== undefined
+        ? String(named.width)
+        : CUSTOM;
 
   return (
     <div className="flex flex-wrap items-center justify-end gap-1.5">

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -33,6 +33,8 @@ import { useCallback, useEffect, useId, useState } from "react";
 import { UI } from "@admin/constants/ui";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
 
+import type { PreviewViewport } from "@admin/services/previewLinkApi";
+
 import type { PreviewFit } from "./previewFrameFit";
 
 /** The width the author asked for, or `null` for "fill the pane". */
@@ -41,6 +43,14 @@ export interface PreviewViewportControlProps {
   onRequestWidth: (width: number | null) => void;
   /** What the pane could actually do with that request. */
   fit: PreviewFit;
+  /**
+   * The named viewports this preview offers, as the server resolved them.
+   *
+   * May be empty, and that is a real answer rather than a missing one: a site
+   * that declares no breakpoints gets Responsive and a custom width, which is
+   * everything that can be offered honestly without inventing widths.
+   */
+  viewports: readonly PreviewViewport[];
 }
 
 /** The `Select` value standing for "fill the pane". */
@@ -74,9 +84,24 @@ export function PreviewViewportControl({
   requestedWidth,
   onRequestWidth,
   fit,
+  viewports,
 }: PreviewViewportControlProps) {
   const widthInputId = useId();
-  const selection = requestedWidth === null ? RESPONSIVE : CUSTOM;
+
+  /*
+   * Which option is selected is DERIVED from the width, not stored beside it.
+   * A separate selection would let the two disagree — typing a custom width
+   * that happens to equal a named one would leave "Custom" showing while the
+   * frame is at the named viewport, and the author would have no way to tell
+   * which of the two the control thinks it is on.
+   */
+  const named = viewports.find(v => v.width === requestedWidth);
+  const selection =
+    requestedWidth === null
+      ? RESPONSIVE
+      : named !== undefined
+        ? String(named.width)
+        : CUSTOM;
 
   /*
    * What the box SAYS, held separately from the width the frame is at.
@@ -137,7 +162,11 @@ export function PreviewViewportControl({
           // A choice from the list ends the edit, so an abandoned draft does
           // not reappear the next time the box is shown.
           setDraft(null);
-          onRequestWidth(value === RESPONSIVE ? null : CUSTOM_SEED_WIDTH);
+          if (value === RESPONSIVE) return onRequestWidth(null);
+          if (value === CUSTOM) return onRequestWidth(CUSTOM_SEED_WIDTH);
+          // A named option carries its own width as the value, so no lookup can
+          // go stale between rendering the list and reading a choice from it.
+          return onRequestWidth(Number.parseInt(value, 10));
         }}
       >
         <SelectTrigger
@@ -148,11 +177,20 @@ export function PreviewViewportControl({
         </SelectTrigger>
         <SelectContent>
           <SelectItem value={RESPONSIVE}>Responsive</SelectItem>
+          {/* The author's own names, in the order they declared them. The width
+              is shown beside each because two sites can call very different
+              numbers "Tablet", and the number is what the preview is actually
+              sized to. */}
+          {viewports.map(viewport => (
+            <SelectItem key={viewport.width} value={String(viewport.width)}>
+              {`${viewport.label} · ${viewport.width}px`}
+            </SelectItem>
+          ))}
           <SelectItem value={CUSTOM}>Custom width</SelectItem>
         </SelectContent>
       </Select>
 
-      {requestedWidth !== null && (
+      {requestedWidth !== null && named === undefined && (
         <>
           {/* Labelled for assistive technology only: the unit beside the box
               reads as the visible label, and a second visible one would say the

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -28,7 +28,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nextlyhq/ui";
-import { useId, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
+
+import { UI } from "@admin/constants/ui";
+import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
 
 import type { PreviewFit } from "./previewFrameFit";
 
@@ -56,6 +59,17 @@ const CUSTOM = "custom";
  */
 const CUSTOM_SEED_WIDTH = 1280;
 
+/**
+ * The narrowest width a frame can be asked for.
+ *
+ * One pixel, because below it the preview is not small — it is gone, and an
+ * author who typed `0.5` sees an empty pane rather than a narrow one. The input
+ * carries this as its `min` attribute, which marks the field invalid without
+ * clamping or refusing the value, so the rule has to live where the width is
+ * committed as well. Both read this constant so they cannot disagree.
+ */
+const MIN_PREVIEW_WIDTH = 1;
+
 export function PreviewViewportControl({
   requestedWidth,
   onRequestWidth,
@@ -79,6 +93,41 @@ export function PreviewViewportControl({
    * masked by a draft nobody is typing.
    */
   const [draft, setDraft] = useState<string | null>(null);
+
+  /*
+   * The width is taken when the author STOPS typing, not per keystroke.
+   *
+   * The frame is a live iframe of the site, so each committed width re-lays-out
+   * a whole page. Clearing the box and typing `768` emits `7`, `76`, `768`, and
+   * committing each one collapsed the preview to 7px and then 76px on the way —
+   * the separate draft kept the FIELD from being torn away, but the frame still
+   * thrashed through widths the author never asked for.
+   */
+  const settledDraft = useDebouncedValue(draft, UI.PREVIEW_WIDTH_DEBOUNCE_MS);
+
+  const commitWidth = useCallback(
+    (text: string) => {
+      // Below one pixel is not a narrow preview, it is an absent one.
+      const next = Number(text);
+      if (Number.isFinite(next) && next >= MIN_PREVIEW_WIDTH) {
+        onRequestWidth(next);
+      }
+    },
+    [onRequestWidth]
+  );
+
+  useEffect(() => {
+    /*
+     * `settledDraft !== draft` means the pause has not happened yet; a null
+     * draft means no edit is in progress. The second guard is what stops a
+     * choice from the list being undone: selecting Responsive clears the draft,
+     * but the debounced copy still holds the old text for one delay, and
+     * committing it then would put the frame back at a width the author has
+     * just navigated away from.
+     */
+    if (draft === null || settledDraft !== draft) return;
+    commitWidth(settledDraft);
+  }, [draft, settledDraft, commitWidth]);
 
   return (
     <div className="flex flex-wrap items-center justify-end gap-1.5">
@@ -115,36 +164,28 @@ export function PreviewViewportControl({
             id={widthInputId}
             type="number"
             inputMode="numeric"
-            min={1}
+            min={MIN_PREVIEW_WIDTH}
             className="h-7 w-20 text-xs"
             value={draft ?? String(requestedWidth)}
             onChange={event => {
-              const text = event.target.value;
-              setDraft(text);
-
               /*
-               * Commit only what a frame can be sized to. An empty or
-               * half-typed box is a state of the EDIT, not a viewport request,
-               * so the frame holds its last good width while the author types
-               * the next one — otherwise the preview flickers back to full
-               * width between two keystrokes. Zero and below are rejected here
-               * for the same reason `previewFrameFit` refuses them: it fills
-               * the pane instead, and committing one would leave this control
-               * and the frame describing different states.
-               *
-               * `Number`, not `parseInt`. A number input accepts and displays
-               * `390.5` and `1e3`, and `parseInt` reads those as `390` and `1`
-               * — sizing the frame to a width the box is not showing, and
-               * replacing the author's text with the truncated value on blur.
-               * A fractional width is a real one: CSS sizes to it and the
-               * site's media queries resolve against it.
+               * Records what was typed and nothing else. What a frame can be
+               * sized to is decided in `commitWidth`, once the typing stops:
+               * an empty or half-typed box is a state of the EDIT, not a
+               * viewport request.
                */
-              const next = Number(text);
-              if (Number.isFinite(next) && next > 0) onRequestWidth(next);
+              setDraft(event.target.value);
             }}
             onBlur={() => {
-              // Leaving the box ends the edit. A draft left behind would name a
-              // width the frame is not at.
+              /*
+               * Leaving the box ENDS the edit, so the pending width is taken
+               * now rather than waiting out a pause that has already been
+               * answered. Without this, typing a width and clicking straight
+               * into the page would discard it — the debounce would still be
+               * running when the draft was cleared.
+               */
+              if (draft !== null) commitWidth(draft);
+              // A draft left behind would name a width the frame is not at.
               setDraft(null);
             }}
           />

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -1,0 +1,128 @@
+/**
+ * Choosing which viewport the preview shows.
+ *
+ * ## Why a width and not a device
+ *
+ * There are no device icons here, and that is a decision rather than an
+ * omission. A site defines its own breakpoints, author-named and up to seven of
+ * them, so a tier may be called "Watch" or "Kiosk" — and no glyph is honest for
+ * a list the product does not control. Text carries an author's name correctly;
+ * a phone icon beside a tier called "Kiosk" is confidently wrong.
+ *
+ * ## Why the real width is always visible when it is scaled
+ *
+ * The pane cannot be wider than its share of the split, so a desktop width does
+ * not fit on a laptop and is drawn smaller. The FRAME keeps the requested width,
+ * so the site's media queries still resolve against it and the preview stays
+ * truthful about the viewport — but text renders at a physical size no visitor
+ * sees. An author comparing type sizes against a scaled preview would be reading
+ * the wrong thing, so the scaling is named rather than left to be noticed.
+ *
+ * @module components/features/entries/PreviewMode/PreviewViewportControl
+ */
+import {
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+import { useId } from "react";
+
+import type { PreviewFit } from "./previewFrameFit";
+
+/** The width the author asked for, or `null` for "fill the pane". */
+export interface PreviewViewportControlProps {
+  requestedWidth: number | null;
+  onRequestWidth: (width: number | null) => void;
+  /** What the pane could actually do with that request. */
+  fit: PreviewFit;
+}
+
+/** The `Select` value standing for "fill the pane". */
+const RESPONSIVE = "responsive";
+/** The `Select` value standing for "I will type a width". */
+const CUSTOM = "custom";
+
+/**
+ * A default to type INTO, not a preset.
+ *
+ * Switching to a custom width with an empty box would leave the control in a
+ * state that renders nothing and reports nothing, so the box opens on a common
+ * laptop width. It is a starting value the author overwrites, which is why it
+ * is not offered as a named option — naming it would make it a claim about the
+ * site's breakpoints, and the site's breakpoints are not known here.
+ */
+const CUSTOM_SEED_WIDTH = 1280;
+
+export function PreviewViewportControl({
+  requestedWidth,
+  onRequestWidth,
+  fit,
+}: PreviewViewportControlProps) {
+  const widthInputId = useId();
+  const selection = requestedWidth === null ? RESPONSIVE : CUSTOM;
+
+  return (
+    <div className="flex items-center gap-1.5">
+      <Select
+        value={selection}
+        onValueChange={value =>
+          onRequestWidth(value === RESPONSIVE ? null : CUSTOM_SEED_WIDTH)
+        }
+      >
+        <SelectTrigger
+          className="h-7 w-[9.5rem] text-xs"
+          aria-label="Preview viewport"
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={RESPONSIVE}>Responsive</SelectItem>
+          <SelectItem value={CUSTOM}>Custom width</SelectItem>
+        </SelectContent>
+      </Select>
+
+      {requestedWidth !== null && (
+        <>
+          {/* Labelled for assistive technology only: the unit beside the box
+              reads as the visible label, and a second visible one would say the
+              same thing twice in a toolbar that is already dense. */}
+          <label className="sr-only" htmlFor={widthInputId}>
+            Preview width in pixels
+          </label>
+          <Input
+            id={widthInputId}
+            type="number"
+            inputMode="numeric"
+            min={1}
+            className="h-7 w-20 text-xs"
+            value={String(requestedWidth)}
+            onChange={event => {
+              /*
+               * An empty or unparseable box means the author is mid-edit, and
+               * it returns to filling the pane rather than freezing on the last
+               * good number. Freezing would show a width the box no longer
+               * says, which is the control disagreeing with itself.
+               */
+              const next = Number.parseInt(event.target.value, 10);
+              onRequestWidth(Number.isFinite(next) ? next : null);
+            }}
+          />
+          <span className="text-xs text-muted-foreground">px</span>
+        </>
+      )}
+
+      {/* Named rather than left to be noticed. The frame is truthful about the
+          VIEWPORT while it is scaled and untruthful about physical size, and an
+          author checking type sizes needs to know which of the two they are
+          looking at. */}
+      {fit.kind === "scaled" && (
+        <span className="whitespace-nowrap text-xs text-muted-foreground">
+          {`${Math.round(fit.scale * 100)}% of ${fit.width}px`}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -32,7 +32,6 @@ import { useCallback, useEffect, useId, useState } from "react";
 
 import { UI } from "@admin/constants/ui";
 import { useDebouncedValue } from "@admin/hooks/useDebouncedValue";
-
 import type { PreviewViewport } from "@admin/services/previewLinkApi";
 
 import type { PreviewFit } from "./previewFrameFit";

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -28,7 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@nextlyhq/ui";
-import { useId } from "react";
+import { useId, useState } from "react";
 
 import type { PreviewFit } from "./previewFrameFit";
 
@@ -64,13 +64,32 @@ export function PreviewViewportControl({
   const widthInputId = useId();
   const selection = requestedWidth === null ? RESPONSIVE : CUSTOM;
 
+  /*
+   * What the box SAYS, held separately from the width the frame is at.
+   *
+   * They are different facts. Clearing the box to retype it leaves text that
+   * names no width, and a frame cannot be sized to "nothing" — so the committed
+   * value stays where it was until the box says something a frame can be sized
+   * to. Collapsing the two meant an empty box committed `null`, which selected
+   * Responsive, which removed this input: the field the author was typing in
+   * disappeared under them and the rest of their keystrokes went nowhere.
+   *
+   * `null` means "not being edited", and the box then shows the committed
+   * width — so a value arriving from anywhere else is displayed rather than
+   * masked by a draft nobody is typing.
+   */
+  const [draft, setDraft] = useState<string | null>(null);
+
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex flex-wrap items-center justify-end gap-1.5">
       <Select
         value={selection}
-        onValueChange={value =>
-          onRequestWidth(value === RESPONSIVE ? null : CUSTOM_SEED_WIDTH)
-        }
+        onValueChange={value => {
+          // A choice from the list ends the edit, so an abandoned draft does
+          // not reappear the next time the box is shown.
+          setDraft(null);
+          onRequestWidth(value === RESPONSIVE ? null : CUSTOM_SEED_WIDTH);
+        }}
       >
         <SelectTrigger
           className="h-7 w-[9.5rem] text-xs"
@@ -98,16 +117,28 @@ export function PreviewViewportControl({
             inputMode="numeric"
             min={1}
             className="h-7 w-20 text-xs"
-            value={String(requestedWidth)}
+            value={draft ?? String(requestedWidth)}
             onChange={event => {
+              const text = event.target.value;
+              setDraft(text);
+
               /*
-               * An empty or unparseable box means the author is mid-edit, and
-               * it returns to filling the pane rather than freezing on the last
-               * good number. Freezing would show a width the box no longer
-               * says, which is the control disagreeing with itself.
+               * Commit only what a frame can be sized to. An empty or
+               * half-typed box is a state of the EDIT, not a viewport request,
+               * so the frame holds its last good width while the author types
+               * the next one — otherwise the preview flickers back to full
+               * width between two keystrokes. Zero and below are rejected here
+               * for the same reason `previewFrameFit` refuses them: it fills
+               * the pane instead, and committing one would leave this control
+               * and the frame describing different states.
                */
-              const next = Number.parseInt(event.target.value, 10);
-              onRequestWidth(Number.isFinite(next) ? next : null);
+              const next = Number.parseInt(text, 10);
+              if (Number.isFinite(next) && next > 0) onRequestWidth(next);
+            }}
+            onBlur={() => {
+              // Leaving the box ends the edit. A draft left behind would name a
+              // width the frame is not at.
+              setDraft(null);
             }}
           />
           <span className="text-xs text-muted-foreground">px</span>

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -131,8 +131,15 @@ export function PreviewViewportControl({
                * for the same reason `previewFrameFit` refuses them: it fills
                * the pane instead, and committing one would leave this control
                * and the frame describing different states.
+               *
+               * `Number`, not `parseInt`. A number input accepts and displays
+               * `390.5` and `1e3`, and `parseInt` reads those as `390` and `1`
+               * — sizing the frame to a width the box is not showing, and
+               * replacing the author's text with the truncated value on blur.
+               * A fractional width is a real one: CSS sizes to it and the
+               * site's media queries resolve against it.
                */
-              const next = Number.parseInt(text, 10);
+              const next = Number(text);
               if (Number.isFinite(next) && next > 0) onRequestWidth(next);
             }}
             onBlur={() => {

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewPanes.test.tsx
@@ -22,6 +22,7 @@ const frameArgs = vi.hoisted(() => vi.fn());
 const frameState = vi.hoisted(() => ({
   current: {
     url: "https://site.example/api/preview?token=t",
+    viewports: [],
     reloadKey: 0,
     isLoading: false,
     reason: null,
@@ -29,6 +30,7 @@ const frameState = vi.hoisted(() => ({
     refresh: vi.fn(),
   } as {
     url: string | null;
+    viewports: { label: string; width: number }[];
     reloadKey: number;
     isLoading: boolean;
     reason: string | null;
@@ -70,6 +72,10 @@ beforeEach(() => {
   // into the next test.
   frameState.current = {
     url: "https://site.example/api/preview?token=t",
+    // The server resolves these, so a frame always carries the key. Empty is
+    // the honest default here: this fixture declares no breakpoints, and the
+    // pane then offers Responsive and a custom width.
+    viewports: [],
     reloadKey: 0,
     isLoading: false,
     reason: null,

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -123,6 +123,41 @@ describe("PreviewViewportControl — the width box", () => {
     expect(ui.committed()).toBe("1280");
   });
 
+  it("commits the WHOLE number the box shows, not its integer prefix", () => {
+    /*
+     * `parseInt` stops at the first character that cannot continue an integer,
+     * so it reads `390.5` as `390` and `1e3` as `1` — both of which a number
+     * input accepts and displays in full. The frame was then sized to a width
+     * the box was not showing, and blurring replaced the author's text with the
+     * truncated value as though they had typed it.
+     *
+     * A fractional width is a real width: CSS sizes to it and the site's media
+     * queries resolve against it, so there is nothing to reject here.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "390.5" } });
+    expect(ui.committed()).toBe("390.5");
+
+    fireEvent.change(box, { target: { value: "1e3" } });
+    expect(ui.committed()).toBe("1000");
+  });
+
+  it("still refuses text that names no width at all", () => {
+    // The control on the case above: reading the whole value must not turn
+    // every string into a width. `Number("")` is `0` and `Number("abc")` is
+    // `NaN`, and both mean the box is not saying anything a frame can be at.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "abc" } });
+    expect(ui.committed()).toBe("1280");
+
+    fireEvent.change(box, { target: { value: "" } });
+    expect(ui.committed()).toBe("1280");
+  });
+
   it("snaps back to the committed width when the edit is abandoned", () => {
     // Blur ends the edit. A draft left behind would name a width the frame is
     // not at, which is the control disagreeing with itself.

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * The viewport control, asserted on what an author can actually do with it.
+ *
+ * The case that matters is the half-typed one. A width box is a field people
+ * clear and retype rather than edit in place, so the states it passes through
+ * on the way to a number are the states it spends most of its life in — and a
+ * control that only behaves while holding a valid width is a control that
+ * misbehaves exactly while it is being used.
+ */
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+
+import type { PreviewFit } from "../previewFrameFit";
+import { PreviewViewportControl } from "../PreviewViewportControl";
+
+/**
+ * Rendered with the parent's real state loop, not a spy.
+ *
+ * The defect this file exists for is a REMOUNT caused by the parent's answer
+ * coming back and changing what renders. A mocked `onRequestWidth` that records
+ * calls without feeding the value back cannot reproduce it — the control would
+ * pass while the shipped tree still unmounted the field.
+ */
+function renderControl(initial: number | null = 1280) {
+  function Harness() {
+    const [requestedWidth, setRequestedWidth] = useState<number | null>(
+      initial
+    );
+    const fit: PreviewFit =
+      requestedWidth === null
+        ? { kind: "responsive" }
+        : { kind: "exact", width: requestedWidth };
+    return (
+      <>
+        <PreviewViewportControl
+          requestedWidth={requestedWidth}
+          onRequestWidth={setRequestedWidth}
+          fit={fit}
+        />
+        <output data-testid="committed">{String(requestedWidth)}</output>
+      </>
+    );
+  }
+  render(<Harness />);
+  return {
+    box: () => screen.queryByLabelText("Preview width in pixels"),
+    committed: () => screen.getByTestId("committed").textContent,
+  };
+}
+
+describe("PreviewViewportControl — the width box", () => {
+  it("KEEPS the box mounted and focused when it is cleared", () => {
+    /*
+     * The separating property. Clearing to retype used to commit `null`, which
+     * selected Responsive, which removed this field — so React unmounted the
+     * element the author was typing into and every keystroke after the first
+     * went nowhere. Focus is asserted because a remount that restored an
+     * identically-shaped field would still lose the caret.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box();
+    expect(box).not.toBeNull();
+
+    box?.focus();
+    fireEvent.change(box as HTMLElement, { target: { value: "" } });
+
+    expect(ui.box()).not.toBeNull();
+    expect(document.activeElement).toBe(box);
+  });
+
+  it("shows the author's own text while it is being typed", () => {
+    // The box has to read back what was typed into it. Showing the committed
+    // width instead would fight the author for the field's contents.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "" } });
+    // Still the field that is IN the document: a detached node keeps whatever
+    // value was written to it, so reading `box.value` alone would pass against
+    // an implementation that had already unmounted this input.
+    expect(ui.box()).toBe(box);
+    expect(box.value).toBe("");
+
+    fireEvent.change(box, { target: { value: "76" } });
+    expect(ui.box()).toBe(box);
+    expect(box.value).toBe("76");
+  });
+
+  it("holds the last good width while the box says nothing usable", () => {
+    /*
+     * The frame is sized to the committed value, so committing a half-typed
+     * number would make the preview flicker between widths on the way to one
+     * the author meant. It stays where it was until the box names a width.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "" } });
+    expect(ui.committed()).toBe("1280");
+  });
+
+  it("commits a width as soon as the box names one", () => {
+    // The control still has to work: this is what stops the case above from
+    // being satisfied by a box that commits nothing at all.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "768" } });
+    expect(ui.committed()).toBe("768");
+  });
+
+  it("does not commit a zero or negative width", () => {
+    // `previewFrameFit` reads both as "no request" and fills the pane, so
+    // committing one would put the control and the frame in different states.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "0" } });
+    expect(ui.committed()).toBe("1280");
+
+    fireEvent.change(box, { target: { value: "-5" } });
+    expect(ui.committed()).toBe("1280");
+  });
+
+  it("snaps back to the committed width when the edit is abandoned", () => {
+    // Blur ends the edit. A draft left behind would name a width the frame is
+    // not at, which is the control disagreeing with itself.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "" } });
+    fireEvent.blur(box);
+
+    expect(box.value).toBe("1280");
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -12,7 +12,6 @@ import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UI } from "@admin/constants/ui";
-
 import type { PreviewViewport } from "@admin/services/previewLinkApi";
 
 import type { PreviewFit } from "../previewFrameFit";
@@ -277,11 +276,20 @@ describe("PreviewViewportControl — the width box", () => {
     box.focus();
 
     fireEvent.change(box, { target: { value: "768" } });
+    /*
+     * The pause is what makes this the real case rather than a formality. It
+     * COMMITS 768 — which is a named tier — so the match is live while the
+     * author is still in the box. Without the pause nothing is committed at
+     * all and the assertion below would hold whatever the rule was.
+     */
+    stopTyping();
+    expect(ui.committed()).toBe("768");
 
     expect(ui.box()).toBe(box);
     expect(document.activeElement).toBe(box);
 
     fireEvent.change(box, { target: { value: "7680" } });
+    stopTyping();
 
     expect(ui.box()).toBe(box);
     expect(ui.committed()).toBe("7680");

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -13,6 +13,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { UI } from "@admin/constants/ui";
 
+import type { PreviewViewport } from "@admin/services/previewLinkApi";
+
 import type { PreviewFit } from "../previewFrameFit";
 import { PreviewViewportControl } from "../PreviewViewportControl";
 
@@ -24,7 +26,10 @@ import { PreviewViewportControl } from "../PreviewViewportControl";
  * calls without feeding the value back cannot reproduce it — the control would
  * pass while the shipped tree still unmounted the field.
  */
-function renderControl(initial: number | null = 1280) {
+function renderControl(
+  initial: number | null = 1280,
+  viewports: readonly PreviewViewport[] = []
+) {
   function Harness() {
     const [requestedWidth, setRequestedWidth] = useState<number | null>(
       initial
@@ -39,6 +44,7 @@ function renderControl(initial: number | null = 1280) {
           requestedWidth={requestedWidth}
           onRequestWidth={setRequestedWidth}
           fit={fit}
+          viewports={viewports}
         />
         <output data-testid="committed">{String(requestedWidth)}</output>
       </>
@@ -252,6 +258,50 @@ describe("PreviewViewportControl — the width box", () => {
     fireEvent.change(box, { target: { value: "" } });
     stopTyping();
     expect(ui.committed()).toBe("1280");
+  });
+
+  it("stays mounted while typing PAST a width a named viewport also has", () => {
+    /*
+     * The same unmount, reached by a different door, and only reachable once the
+     * control offers named viewports. The box is shown when the committed width
+     * matches no named one — so typing `7680` passes through `768`, which IS a
+     * named tier, and the field would vanish on the third keystroke.
+     *
+     * An edit in progress therefore keeps the box regardless of what the number
+     * currently matches. Selection follows the same rule, or the dropdown would
+     * flip to "Tablet" while the author is still typing into a box labelled
+     * Custom.
+     */
+    const ui = renderControl(1280, [{ label: "Tablet", width: 768 }]);
+    const box = ui.box() as HTMLInputElement;
+    box.focus();
+
+    fireEvent.change(box, { target: { value: "768" } });
+
+    expect(ui.box()).toBe(box);
+    expect(document.activeElement).toBe(box);
+
+    fireEvent.change(box, { target: { value: "7680" } });
+
+    expect(ui.box()).toBe(box);
+    expect(ui.committed()).toBe("7680");
+  });
+
+  it("hands a typed width back to its named viewport once the edit ends", () => {
+    /*
+     * The control on the case above. Keeping the box open during an edit must
+     * not mean the control never recognises a named width — on blur the draft
+     * clears, `768` resolves to Tablet, and the box gives way to the named
+     * option it is the same width as.
+     */
+    const ui = renderControl(1280, [{ label: "Tablet", width: 768 }]);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "768" } });
+    fireEvent.blur(box);
+
+    expect(ui.box()).toBeNull();
+    expect(ui.committed()).toBe("768");
   });
 
   it("snaps back to the committed width when the edit is abandoned", () => {

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -7,9 +7,11 @@
  * control that only behaves while holding a valid width is a control that
  * misbehaves exactly while it is being used.
  */
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { useState } from "react";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { UI } from "@admin/constants/ui";
 
 import type { PreviewFit } from "../previewFrameFit";
 import { PreviewViewportControl } from "../PreviewViewportControl";
@@ -49,7 +51,28 @@ function renderControl(initial: number | null = 1280) {
   };
 }
 
+/**
+ * The pause that ends an edit.
+ *
+ * A width is committed when the author stops typing, so a test that asserts
+ * what was committed has to say when that happened. Written out rather than
+ * hidden in a helper called `flush`, because the delay is the behaviour.
+ */
+function stopTyping() {
+  act(() => {
+    vi.advanceTimersByTime(UI.PREVIEW_WIDTH_DEBOUNCE_MS);
+  });
+}
+
 describe("PreviewViewportControl — the width box", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("KEEPS the box mounted and focused when it is cleared", () => {
     /*
      * The separating property. Clearing to retype used to commit `null`, which
@@ -97,6 +120,7 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
   });
 
@@ -107,7 +131,73 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "768" } });
+    stopTyping();
     expect(ui.committed()).toBe("768");
+  });
+
+  it("does not commit the PREFIXES typed on the way to a width", () => {
+    /*
+     * `768` arrives as `7`, then `76`, then `768`. Committing each one sized
+     * the frame to 7px and then 76px — a live iframe of the whole site, laid
+     * out twice at widths the author never asked for, which is the resize
+     * thrash the draft state was supposed to remove.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "7" } });
+    fireEvent.change(box, { target: { value: "76" } });
+    fireEvent.change(box, { target: { value: "768" } });
+
+    // Still the width it started at: nothing has been committed yet.
+    expect(ui.committed()).toBe("1280");
+
+    stopTyping();
+    expect(ui.committed()).toBe("768");
+  });
+
+  it("takes the pending width when the edit ends at the BOX", () => {
+    /*
+     * Blur answers the question the pause was waiting on, so waiting it out
+     * afterwards would discard the width — an author who types one and clicks
+     * straight into the page means it.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "390" } });
+    fireEvent.blur(box);
+
+    expect(ui.committed()).toBe("390");
+  });
+
+  it("refuses a width below one pixel", () => {
+    /*
+     * `min={1}` on a number input marks the field invalid; it does not clamp
+     * the value or stop the change event. Below a pixel the preview is not
+     * narrow, it is gone — an empty pane rather than a small one.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "0.5" } });
+    stopTyping();
+    expect(ui.committed()).toBe("1280");
+
+    fireEvent.change(box, { target: { value: "1e-3" } });
+    stopTyping();
+    expect(ui.committed()).toBe("1280");
+  });
+
+  it("accepts exactly one pixel, which is the boundary", () => {
+    // The control on the case above: refusing below a pixel must not refuse the
+    // pixel itself, or the stated minimum would be unreachable.
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "1" } });
+    stopTyping();
+    expect(ui.committed()).toBe("1");
   });
 
   it("does not commit a zero or negative width", () => {
@@ -117,9 +207,11 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "0" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
 
     fireEvent.change(box, { target: { value: "-5" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
   });
 
@@ -138,9 +230,11 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "390.5" } });
+    stopTyping();
     expect(ui.committed()).toBe("390.5");
 
     fireEvent.change(box, { target: { value: "1e3" } });
+    stopTyping();
     expect(ui.committed()).toBe("1000");
   });
 
@@ -152,9 +246,11 @@ describe("PreviewViewportControl — the width box", () => {
     const box = ui.box() as HTMLInputElement;
 
     fireEvent.change(box, { target: { value: "abc" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
 
     fireEvent.change(box, { target: { value: "" } });
+    stopTyping();
     expect(ui.committed()).toBe("1280");
   });
 

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewFrameFit.test.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/previewFrameFit.test.ts
@@ -1,0 +1,123 @@
+/**
+ * How a requested viewport width is fitted into the space the pane actually has.
+ *
+ * The split reserves a minimum editor, so the preview pane has a hard ceiling
+ * and a desktop width cannot fit on a laptop. Every case below is about which
+ * of the two widths answers a given question — the REQUESTED one is what the
+ * site's media queries must resolve against, and the MEASURED one is what the
+ * pane can physically show. Collapsing them is what makes a preset either lie
+ * about the viewport or fail to report that the pane could not honour it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { previewFrameFit, previewFrameStyle } from "../previewFrameFit";
+
+describe("previewFrameFit", () => {
+  it("answers nothing until the pane has been measured", () => {
+    /*
+     * The first render has no layout yet. Naming a width for a box nobody has
+     * looked at is the confident wrong answer this control exists to remove —
+     * and it is worse than silence, because the label would appear, be wrong,
+     * and then correct itself in a way that reads as a glitch.
+     */
+    expect(previewFrameFit(1280, null)).toEqual({ kind: "unmeasured" });
+    expect(previewFrameFit(1280, 0)).toEqual({ kind: "unmeasured" });
+    // Even with nothing requested: "responsive" is a claim about a box too.
+    expect(previewFrameFit(null, null)).toEqual({ kind: "unmeasured" });
+  });
+
+  it("fills the pane when no width is requested", () => {
+    expect(previewFrameFit(null, 618)).toEqual({ kind: "responsive" });
+  });
+
+  it("uses the requested width exactly when it fits", () => {
+    expect(previewFrameFit(390, 618)).toEqual({ kind: "exact", width: 390 });
+  });
+
+  it("treats a width equal to the space as fitting, not as scaled", () => {
+    // The boundary. A scale of exactly 1 is a transform doing nothing, and
+    // reporting it as `scaled` would show a "scaled to fit" note on a frame
+    // that is at its true size.
+    expect(previewFrameFit(618, 618)).toEqual({ kind: "exact", width: 618 });
+  });
+
+  it("scales the SHORTFALL when the request is wider than the pane", () => {
+    /*
+     * The frame keeps its requested width — that is what the site's `@media`
+     * resolves against, so the preview stays truthful — and is transformed down
+     * to fit. Both numbers are reported: the caller needs `width` to size the
+     * frame and `scale` to transform it, and a caller given only the product
+     * cannot label the real viewport.
+     */
+    expect(previewFrameFit(1280, 640)).toEqual({
+      kind: "scaled",
+      width: 1280,
+      scale: 0.5,
+    });
+  });
+
+  it("keeps the requested width in the answer, not the space it was fitted into", () => {
+    // The separating property. A fit that returned the AVAILABLE width would
+    // satisfy "the frame is 618px wide" and would silently make the preview a
+    // 618px viewport — which is the bug, not the fix.
+    const fit = previewFrameFit(1280, 618);
+    expect(fit).toMatchObject({ kind: "scaled", width: 1280 });
+    expect(fit).not.toMatchObject({ width: 618 });
+  });
+
+  it("refuses a nonsensical request rather than dividing by it", () => {
+    // Zero and negatives reach here from a cleared or half-typed custom width
+    // box. Falling back to responsive keeps the pane usable; scaling by them
+    // produces Infinity or a flipped frame.
+    expect(previewFrameFit(0, 618)).toEqual({ kind: "responsive" });
+    expect(previewFrameFit(-100, 618)).toEqual({ kind: "responsive" });
+    expect(previewFrameFit(Number.NaN, 618)).toEqual({ kind: "responsive" });
+    expect(previewFrameFit(Number.POSITIVE_INFINITY, 618)).toEqual({
+      kind: "responsive",
+    });
+  });
+});
+
+describe("previewFrameStyle", () => {
+  it("gives an unanswered or responsive fit no inline size at all", () => {
+    // Both fill the pane, which is what no inline size does. They stay separate
+    // in the fit because the CONTROL has to tell them apart; the frame does not.
+    expect(previewFrameStyle({ kind: "unmeasured" })).toEqual({});
+    expect(previewFrameStyle({ kind: "responsive" })).toEqual({});
+  });
+
+  it("sizes an exact fit and does not transform it", () => {
+    const style = previewFrameStyle({ kind: "exact", width: 390 });
+    expect(style).toEqual({ width: "390px" });
+    // Named explicitly: a transform of `scale(1)` would still create a
+    // containing block and a new stacking context inside the frame.
+    expect(style.transform).toBeUndefined();
+  });
+
+  it("sizes a scaled fit to the REQUESTED width and shrinks it", () => {
+    /*
+     * The separating property, restated as CSS: the width the browser lays the
+     * page out at is the requested one, so `@media` resolves against it, and
+     * the transform only changes how large that layout is drawn.
+     */
+    expect(
+      previewFrameStyle({ kind: "scaled", width: 1280, scale: 0.5 })
+    ).toEqual({
+      width: "1280px",
+      height: "200%",
+      transform: "scale(0.5)",
+      transformOrigin: "top left",
+    });
+  });
+
+  it("compensates the HEIGHT for the scale, so no empty band is left below", () => {
+    // 1/0.4 = 250%. Scaled by 0.4 that covers exactly 100% of the pane; a plain
+    // `100%` would shrink to 40% and leave the rest of the pane blank.
+    const style = previewFrameStyle({
+      kind: "scaled",
+      width: 1500,
+      scale: 0.4,
+    });
+    expect(style.height).toBe("250%");
+  });
+});

--- a/packages/admin/src/components/features/entries/PreviewMode/previewFrameFit.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/previewFrameFit.ts
@@ -1,0 +1,138 @@
+/**
+ * Fitting a requested viewport width into the space the preview pane has.
+ *
+ * ## Why two widths, and why they must not collapse
+ *
+ * The split reserves a minimum editor, so the preview pane has a hard ceiling —
+ * it can never exceed a fixed share of the split, which on a laptop is a few
+ * hundred pixels short of a desktop viewport. A preset therefore has a width it
+ * ASKS FOR and a width the pane can physically give, and the two answer
+ * different questions:
+ *
+ * - the REQUESTED width is what the site's `@media` queries resolve against, so
+ *   it is what makes the preview truthful about the viewport being previewed;
+ * - the MEASURED width is what the pane can show, so it is what decides whether
+ *   anything has to be scaled.
+ *
+ * Feeding the measured width back as the selection makes the preset the author
+ * just chose appear unselected. Reporting only the request makes it impossible
+ * to say the pane could not honour it. This module keeps both and reports which
+ * case applies, so a caller can size the frame, transform it, and label the real
+ * viewport without deriving any of those from each other.
+ *
+ * ## Why scaling stays truthful
+ *
+ * A CSS transform does not change the frame's own width, so a scaled frame's
+ * media queries still resolve against the width it was given. The preview
+ * remains a faithful rendering of that viewport, drawn smaller. What it stops
+ * being faithful about is PHYSICAL size — text renders at a size no visitor
+ * sees — which is why a caller must label the real width rather than let the
+ * scaling pass unremarked.
+ *
+ * @module components/features/entries/PreviewMode/previewFrameFit
+ */
+
+import type { CSSProperties } from "react";
+
+/** How the frame should be sized, or that the question cannot be answered yet. */
+export type PreviewFit =
+  /**
+   * The pane has not been measured, so nothing can be said about it.
+   *
+   * Distinct from every other case on purpose: it is the only one where the
+   * caller must render no width, no label and no scaling note. A first paint
+   * that named a width and then corrected itself reads as a glitch, and one
+   * that named the WRONG width is the confident wrong answer this control
+   * exists to remove.
+   */
+  | { kind: "unmeasured" }
+  /** No particular width was asked for; the frame fills the pane. */
+  | { kind: "responsive" }
+  /** The requested width fits as it is. */
+  | { kind: "exact"; width: number }
+  /**
+   * The requested width does not fit and is drawn smaller.
+   *
+   * `width` stays the REQUESTED one — the frame is sized to it and transformed
+   * — because that is what the site resolves its media queries against.
+   */
+  | { kind: "scaled"; width: number; scale: number };
+
+/**
+ * Decide how to draw a requested viewport width in the space available.
+ *
+ * `availableWidth` is `null` before the pane has been laid out. Both zero and
+ * `null` mean the same thing here — nothing has been measured — and neither is
+ * a width to divide by.
+ */
+export function previewFrameFit(
+  requestedWidth: number | null,
+  availableWidth: number | null
+): PreviewFit {
+  // Asked before layout. Answering anything else would be a claim about a box
+  // nobody has looked at, including the claim that it should fill the pane.
+  if (availableWidth === null || !(availableWidth > 0)) {
+    return { kind: "unmeasured" };
+  }
+
+  /*
+   * A request that is absent, zero, negative or non-finite all reach the same
+   * answer, and deliberately so: they arrive from a cleared or half-typed
+   * custom-width box, where the author has not yet said anything meaningful.
+   * Filling the pane keeps it usable; dividing by any of them produces
+   * `Infinity`, `NaN` or a flipped frame.
+   */
+  if (requestedWidth === null || !Number.isFinite(requestedWidth)) {
+    return { kind: "responsive" };
+  }
+  if (requestedWidth <= 0) return { kind: "responsive" };
+
+  /*
+   * Equal counts as fitting. A scale of exactly 1 is a transform that does
+   * nothing, and reporting it as scaled would put a "drawn smaller" note on a
+   * frame that is at its true size.
+   */
+  if (requestedWidth <= availableWidth) {
+    return { kind: "exact", width: requestedWidth };
+  }
+
+  return {
+    kind: "scaled",
+    width: requestedWidth,
+    scale: availableWidth / requestedWidth,
+  };
+}
+
+/**
+ * The inline style that realises a fit, derived from it rather than beside it.
+ *
+ * The frame's size and its transform are two views of ONE decision, and two
+ * places computing them would agree until someone edited either — with the
+ * failure being a frame whose media queries resolve against one width while it
+ * is drawn at another, which looks like a rendering bug in the site.
+ *
+ * `unmeasured` and `responsive` both return nothing, and for the same reason
+ * from the caller's side: the frame fills the pane, which is what it does with
+ * no inline size at all. They stay distinct in {@link PreviewFit} because the
+ * CONTROL must tell them apart — one has an answer and the other does not.
+ */
+export function previewFrameStyle(fit: PreviewFit): CSSProperties {
+  if (fit.kind === "exact") return { width: `${fit.width}px` };
+  if (fit.kind === "scaled") {
+    return {
+      width: `${fit.width}px`,
+      /*
+       * Divided by the scale so the frame still covers the pane vertically
+       * AFTER being shrunk. A plain `100%` would be scaled down with everything
+       * else and leave a band of empty pane below the page.
+       */
+      height: `${100 / fit.scale}%`,
+      transform: `scale(${fit.scale})`,
+      // Top-left, so the page's own left edge stays where a visitor's would be.
+      // With `scale` chosen as available/requested the frame fills the pane
+      // exactly, so there is nothing to centre.
+      transformOrigin: "top left",
+    };
+  }
+  return {};
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
@@ -1,0 +1,50 @@
+/**
+ * The measured width of an element, or `null` until it has one.
+ *
+ * `null` is the point of this hook rather than a detail of it. Every caller here
+ * has to distinguish "this box is N wide" from "nobody has looked yet", because
+ * the second is not a width and anything derived from it is a guess — a preview
+ * frame that names a viewport before layout announces a number, then corrects
+ * itself, which reads as a glitch rather than as the honest "not yet" it is.
+ *
+ * Zero is folded into `null` deliberately. A detached or display-none element
+ * measures zero, and a caller dividing by it produces `Infinity`; a caller
+ * reading it as a real width concludes nothing fits. Neither is what "the box
+ * has no size right now" should mean downstream.
+ *
+ * @module components/features/entries/PreviewMode/useMeasuredWidth
+ */
+import { useEffect, useState, type RefObject } from "react";
+
+export function useMeasuredWidth(
+  ref: RefObject<HTMLElement | null>
+): number | null {
+  const [width, setWidth] = useState<number | null>(null);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (element === null) return;
+
+    /*
+     * `ResizeObserver` rather than a `resize` listener on the window: this box
+     * changes width when the SPLIT moves, which the window never hears about.
+     * A window listener would leave the frame sized for the old split until
+     * something else happened to re-render it.
+     */
+    const observe = () => {
+      const next = element.getBoundingClientRect().width;
+      // Folded to `null` so a collapsed box cannot be read as a width. See the
+      // module note: zero is not a small number here, it is an absent one.
+      setWidth(next > 0 ? next : null);
+    };
+
+    observe();
+    const observer = new ResizeObserver(observe);
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref]);
+
+  return width;
+}

--- a/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/useMeasuredWidth.ts
@@ -14,14 +14,39 @@
  *
  * @module components/features/entries/PreviewMode/useMeasuredWidth
  */
-import { useEffect, useState, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useState, type RefObject } from "react";
+
+/**
+ * A layout effect where there is a DOM, a passive one where there is not.
+ *
+ * The same alias `ChromeSuppression` keeps, for the same reason: a layout
+ * effect during a server render warns and cannot run, and nothing has painted
+ * there for it to be ahead of.
+ */
+const useMeasureEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
 
 export function useMeasuredWidth(
   ref: RefObject<HTMLElement | null>
 ): number | null {
   const [width, setWidth] = useState<number | null>(null);
 
-  useEffect(() => {
+  /*
+   * BEFORE paint, not after.
+   *
+   * The first measurement decides whether the frame is drawn at the requested
+   * width or left to fill the pane, and an effect that runs after paint means
+   * the browser has already drawn the second. Reopening a pane that remembers a
+   * custom width therefore laid the site out responsively for one frame and
+   * then jumped — visible as a flash of the wrong layout on any page that
+   * crosses a breakpoint between the two widths.
+   *
+   * A layout effect runs after the DOM is in place and before the browser
+   * paints, which is exactly when a box first has a width to report. The
+   * alternative — hiding the frame until it has been measured — trades a wrong
+   * layout for a blank one, and still costs a frame.
+   */
+  useMeasureEffect(() => {
     const element = ref.current;
     if (element === null) return;
 

--- a/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
+++ b/packages/admin/src/components/features/entries/PreviewMode/usePreviewFrame.ts
@@ -40,6 +40,7 @@ import {
   type PreviewUnavailableReason,
   type SelfPreviewScope,
 } from "@admin/hooks/useEntryPreview";
+import type { PreviewViewport } from "@admin/services/previewLinkApi";
 
 import {
   previewScopeKey,
@@ -79,6 +80,13 @@ export interface PreviewFrameState {
   /** The URL to render, or null while there is nothing to show. */
   url: string | null;
   /**
+   * The viewports this preview offers, as the server resolved them.
+   *
+   * Carried on the frame's state rather than fetched beside it: they arrive
+   * with the mint, so a second source would be a second read of one answer.
+   */
+  viewports: PreviewViewport[];
+  /**
    * Changes on every reload, and is the frame's React key.
    *
    * A key rather than a query parameter appended to the URL: the site sees the
@@ -113,6 +121,10 @@ export function usePreviewFrame({
 }): UsePreviewFrameResult {
   const [state, setState] = useState<PreviewFrameState>({
     url: null,
+    // Nothing has been minted, so nothing is on offer. Empty rather than a
+    // remembered list: a control showing options before the first answer would
+    // be offering widths for a preview that may never open.
+    viewports: [],
     reloadKey: 0,
     isLoading: false,
     reason: null,
@@ -183,6 +195,10 @@ export function usePreviewFrame({
       expiresAt.current = 0;
       setState(prev => ({
         url: null,
+        // Cleared rather than carried over. A refused mint has no preview to
+        // size, and leaving the previous list would offer widths for a frame
+        // that is no longer on screen.
+        viewports: [],
         reloadKey: prev.reloadKey,
         isLoading: false,
         reason: outcome.reason,
@@ -217,6 +233,7 @@ export function usePreviewFrame({
 
     setState(prev => ({
       url: outcome.url,
+      viewports: outcome.viewports,
       reloadKey: prev.reloadKey + 1,
       isLoading: false,
       reason: null,

--- a/packages/admin/src/constants/ui.ts
+++ b/packages/admin/src/constants/ui.ts
@@ -13,4 +13,16 @@ export const UI = {
 
   /** Delay before programmatic focus operations (ms) */
   FOCUS_DELAY_MS: 300,
+
+  /**
+   * Pause that ends an edit of the preview's custom width (ms).
+   *
+   * The preview frame is a live iframe of the site, so every committed width
+   * re-lays-out a whole page. Typing `768` after clearing the box emits `7`,
+   * `76`, `768` — three layouts, two of them at widths the author never meant —
+   * so the width is taken once they stop typing rather than per keystroke.
+   * Matched to `SEARCH_DEBOUNCE_MS` because it answers the same question about
+   * a person: have they finished.
+   */
+  PREVIEW_WIDTH_DEBOUNCE_MS: 300,
 } as const;

--- a/packages/admin/src/hooks/useEntryPreview.ts
+++ b/packages/admin/src/hooks/useEntryPreview.ts
@@ -34,6 +34,7 @@ import type { ApiError } from "@admin/lib/api/parseApiError";
 import {
   previewLinkApi,
   type PreviewLinkRequest,
+  type PreviewViewport,
 } from "@admin/services/previewLinkApi";
 
 /**
@@ -214,6 +215,8 @@ export type PreviewOutcome =
        * cookie it cannot see.
        */
       embeddable: boolean;
+      /** The viewports this preview offers, resolved by the server. */
+      viewports: PreviewViewport[];
     }
   | { kind: "report"; reason: PreviewUnavailableReason };
 
@@ -356,6 +359,7 @@ export async function mintSelfPreview(
       url: link.url,
       expiresAt: link.expiresAt,
       embeddable: link.embeddable,
+      viewports: link.viewports,
     };
   } catch (error) {
     return { kind: "report", reason: reasonForRefusal(error) };

--- a/packages/admin/src/services/previewLinkApi.ts
+++ b/packages/admin/src/services/previewLinkApi.ts
@@ -76,6 +76,26 @@ export interface PreviewLink {
    * application's own `frame-ancestors` is invisible from the server.
    */
   embeddable: boolean;
+  /**
+   * The viewport widths this preview offers, already resolved.
+   *
+   * The server sends a LIST rather than a source, because a collection may
+   * declare its widths as a FUNCTION — a plugin holding the site's breakpoints
+   * supplies one that reads them — and a function can neither be stored nor
+   * sent. Resolving there is what lets the browser offer a site's own
+   * breakpoints without the admin depending on whatever owns them.
+   *
+   * Empty means none were declared, which is different from the key being
+   * absent: absent would leave a caller unable to tell "none" from "the server
+   * did not answer".
+   */
+  viewports: PreviewViewport[];
+}
+
+/** One offered viewport: a name an author picked, and a width in CSS pixels. */
+export interface PreviewViewport {
+  label: string;
+  width: number;
 }
 
 export const previewLinkApi = {

--- a/packages/nextly/.gitignore
+++ b/packages/nextly/.gitignore
@@ -1,0 +1,3 @@
+
+# Nextly local uploads (auto-added)
+public/uploads/

--- a/packages/nextly/src/api/preview-links.test.ts
+++ b/packages/nextly/src/api/preview-links.test.ts
@@ -1200,6 +1200,7 @@ describe("mintPreviewLink", () => {
       "expiresAt",
       "token",
       "url",
+      "viewports",
     ]);
     // The token is a credential, not an address: it carries no host of its own,
     // and the `url` beside it is what puts one in front.
@@ -1212,6 +1213,52 @@ describe("mintPreviewLink", () => {
      * pane nothing.
      */
     expect(item.embeddable).toBe(false);
+    /*
+     * Asserted as a VALUE for the same reason `embeddable` is. This fixture
+     * declares no viewports, and the honest answer is an EMPTY list rather than
+     * an absent key — a caller reading `undefined` has to guess whether the
+     * collection declared none or the server forgot to answer.
+     */
+    expect(item.viewports).toEqual([]);
+  });
+
+  it("offers the viewports a collection DECLARES", async () => {
+    previewDeclaration.mockResolvedValue({
+      url: () => "/p",
+      breakpoints: [
+        { label: "Phone", width: 390 },
+        { label: "Desktop", width: 1280 },
+      ],
+    });
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect((body.item as Record<string, unknown>).viewports).toEqual([
+      { label: "Phone", width: 390 },
+      { label: "Desktop", width: 1280 },
+    ]);
+  });
+
+  it("EVALUATES a function declaration, so stored breakpoints stay current", async () => {
+    /*
+     * The property that lets a plugin supply a site's own breakpoints without
+     * the admin depending on it: the function runs here, on the server, and only
+     * its result crosses to the browser.
+     */
+    previewDeclaration.mockResolvedValue({
+      url: () => "/p",
+      breakpoints: () => [{ label: "Wide", width: 1440 }],
+    });
+
+    const body = await json(
+      await mintPreviewLink(post({ collection: "pages", entryId: "7" }))
+    );
+
+    expect((body.item as Record<string, unknown>).viewports).toEqual([
+      { label: "Wide", width: 1440 },
+    ]);
   });
 
   it("says the session reaches a frame when the site shares the admin's host", async () => {

--- a/packages/nextly/src/api/preview-links.ts
+++ b/packages/nextly/src/api/preview-links.ts
@@ -42,6 +42,7 @@ import {
   hasPreviewConfigured,
   type PreviewDeclaration,
 } from "../domains/collections/services/preview-url-resolver";
+import { resolvePreviewViewports } from "../domains/collections/services/preview-viewports";
 import { resolvePreviewRoute } from "../domains/preview/route-config";
 import { resolvePreviewSiteUrl } from "../domains/preview/site-url";
 import type { UserContext } from "../domains/singles/types";
@@ -472,6 +473,14 @@ async function respondWithPreviewLink(
    * costs a fallback rather than access to anything.
    */
   adminOrigin: string,
+  /**
+   * The collection's or Single's own preview declaration.
+   *
+   * Passed in rather than re-read: both call sites already loaded it to decide
+   * whether a link could be built at all, and reading it twice would let the
+   * link and the viewports it offers come from two different reads.
+   */
+  declaration: PreviewDeclaration | undefined,
   ttlSeconds?: number
 ): Promise<Response> {
   const generation = await (
@@ -551,6 +560,13 @@ async function respondWithPreviewLink(
      * application's own `frame-ancestors` is invisible from here.
      */
     embeddable: previewSessionReachesFrame(url, adminOrigin),
+    /*
+     * Resolved HERE because the declaration may be a FUNCTION, and a function
+     * cannot be stored or sent. The browser receives the list it produced, so
+     * the admin never needs to know where a site keeps its breakpoints — which
+     * is what lets a plugin supply them without the admin depending on it.
+     */
+    viewports: await resolvePreviewViewports(declaration?.breakpoints),
   });
 }
 
@@ -773,6 +789,7 @@ async function mintForSingle(
     { kind: "single", single, ...(locale === undefined ? {} : { locale }) },
     auth.userId,
     new URL(req.url).origin,
+    declaration,
     ttlSeconds
   );
 }
@@ -924,6 +941,7 @@ export const mintPreviewLink = withErrorHandler(async (req: Request) => {
     { collection, entryId, ...(locale === undefined ? {} : { locale }) },
     auth.userId,
     new URL(req.url).origin,
+    declaration,
     ttlSeconds
   );
 });

--- a/packages/nextly/src/collections/config/define-collection.ts
+++ b/packages/nextly/src/collections/config/define-collection.ts
@@ -34,6 +34,7 @@
 import type { BeforeOperationHandler, HookHandler } from "@nextly/hooks/types";
 
 import type { CollectionAccessControl } from "../../domains/auth/services/access-control-types";
+import type { PreviewViewportsDeclaration } from "../../domains/collections/services/preview-viewports";
 import { columnsDeclaredBy } from "../../domains/schema/services/field-column-descriptor";
 import type { WebhookEventType } from "../../domains/webhooks/types";
 import type { RevalidateConfig } from "../../revalidation/types";
@@ -157,6 +158,28 @@ export interface CollectionPreviewConfig {
    * @default "Preview"
    */
   label?: string;
+
+  /**
+   * The viewport widths the preview pane offers, as a list or as a function.
+   *
+   * Declared rather than inferred: nothing in this system can know the widths a
+   * site's CSS actually breaks at, so a shipped phone/tablet/desktop list would
+   * be a claim about somebody else's stylesheet.
+   *
+   * The function form is evaluated per mint, on the server, so a source that
+   * CHANGES — a site's stored breakpoints, edited in the page builder — stays
+   * current instead of being captured once at boot. Only the resolved list ever
+   * reaches the browser.
+   *
+   * @example
+   * ```typescript
+   * breakpoints: [
+   *   { label: "Phone", width: 390 },
+   *   { label: "Desktop", width: 1280 },
+   * ]
+   * ```
+   */
+  breakpoints?: PreviewViewportsDeclaration;
 }
 
 /**

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -23,6 +23,10 @@ export {
   type HttpMethod,
   type HookHandler,
 } from "./collections/config/define-collection";
+export type {
+  PreviewViewport,
+  PreviewViewportsDeclaration,
+} from "./domains/collections/services/preview-viewports";
 
 // The context a FIELD-level hook is handed. `FieldHooks` is already public
 // through the field types below, so the handler it is declared with is too.

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-viewports.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-viewports.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The viewports a preview offers, resolved from what a collection declared.
+ *
+ * The cases that matter are the ones where a declaration is WRONG rather than
+ * absent, because a bad viewport is not a missing feature — it is a preset that
+ * sizes the frame to a width the site never uses, and an author who trusts it
+ * checks a layout no visitor will see. Every rejection below is therefore a
+ * silent drop of one entry rather than a refusal of the whole list: one broken
+ * row must not cost an author the others.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { resolvePreviewViewports } from "../preview-viewports";
+
+describe("resolvePreviewViewports", () => {
+  it("answers with nothing when a collection declares no viewports", async () => {
+    await expect(resolvePreviewViewports(undefined)).resolves.toEqual([]);
+  });
+
+  it("passes a static list through in the order it was declared", async () => {
+    /*
+     * Order is the author's and is not sorted here. A list read widest-first or
+     * narrowest-first is a claim about how they want to work, and re-sorting it
+     * would silently overrule that.
+     */
+    const declared = [
+      { label: "Phone", width: 390 },
+      { label: "Desktop", width: 1280 },
+      { label: "Tablet", width: 768 },
+    ];
+
+    await expect(resolvePreviewViewports(declared)).resolves.toEqual(declared);
+  });
+
+  it("CALLS a function declaration, so it can read state that changes", async () => {
+    /*
+     * The whole reason a function is accepted. A site's breakpoints live in
+     * stored data an author edits, so a value captured once at boot goes stale;
+     * the function is evaluated per mint, where the current value is readable.
+     */
+    const declaration = vi.fn(() => [{ label: "Wide", width: 1440 }]);
+
+    await expect(resolvePreviewViewports(declaration)).resolves.toEqual([
+      { label: "Wide", width: 1440 },
+    ]);
+    expect(declaration).toHaveBeenCalledTimes(1);
+  });
+
+  it("awaits an async declaration", async () => {
+    // Reading stored data is asynchronous, so the synchronous form alone would
+    // force every real source through a cache nobody asked for.
+    await expect(
+      resolvePreviewViewports(async () => [{ label: "Wide", width: 1440 }])
+    ).resolves.toEqual([{ label: "Wide", width: 1440 }]);
+  });
+
+  it("drops a row whose width is not a usable number, and KEEPS the rest", async () => {
+    /*
+     * The separating property. Refusing the whole list on one bad row would let
+     * a single typo remove every working preset, which is the opposite of what
+     * an author wants from a list.
+     */
+    await expect(
+      resolvePreviewViewports([
+        { label: "Good", width: 390 },
+        { label: "Zero", width: 0 },
+        { label: "Negative", width: -100 },
+        { label: "NaN", width: Number.NaN },
+        { label: "Infinite", width: Number.POSITIVE_INFINITY },
+        { label: "Also good", width: 1280 },
+      ])
+    ).resolves.toEqual([
+      { label: "Good", width: 390 },
+      { label: "Also good", width: 1280 },
+    ]);
+  });
+
+  it("drops a row with no usable label rather than showing a blank option", async () => {
+    // An unlabelled option is unpickable: the control renders text, so a blank
+    // one is a row the author can see and cannot identify.
+    await expect(
+      resolvePreviewViewports([
+        { label: "  ", width: 390 },
+        { label: "Real", width: 768 },
+      ])
+    ).resolves.toEqual([{ label: "Real", width: 768 }]);
+  });
+
+  it("rounds a fractional width, because a viewport is whole pixels", async () => {
+    await expect(
+      resolvePreviewViewports([{ label: "Odd", width: 767.6 }])
+    ).resolves.toEqual([{ label: "Odd", width: 768 }]);
+  });
+
+  it("keeps the FIRST of two rows at the same width", async () => {
+    /*
+     * Two names for one width are indistinguishable once chosen — the frame is
+     * the same size either way — so the second is noise in a control that has
+     * to stay compact. First wins because the author wrote it first.
+     */
+    await expect(
+      resolvePreviewViewports([
+        { label: "Tablet", width: 768 },
+        { label: "iPad", width: 768 },
+        { label: "Phone", width: 390 },
+      ])
+    ).resolves.toEqual([
+      { label: "Tablet", width: 768 },
+      { label: "Phone", width: 390 },
+    ]);
+  });
+
+  it("answers with nothing when a declaration THROWS, rather than failing the mint", async () => {
+    /*
+     * A viewport list is a convenience on a credential handout. A declaration
+     * that throws must cost the author their presets, never their preview — the
+     * mint is what the pane cannot work without.
+     */
+    await expect(
+      resolvePreviewViewports(() => {
+        throw new Error("author bug");
+      })
+    ).resolves.toEqual([]);
+  });
+
+  it("answers with nothing when the declaration is not a list at all", async () => {
+    // Stored data reaches here unvalidated; a string or an object is a
+    // configuration fault, and refusing it silently is the same trade as above.
+    await expect(resolvePreviewViewports("1280" as never)).resolves.toEqual([]);
+    await expect(
+      resolvePreviewViewports(async () => "no" as never)
+    ).resolves.toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-viewports.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-viewports.test.ts
@@ -92,6 +92,31 @@ describe("resolvePreviewViewports", () => {
     ).resolves.toEqual([{ label: "Odd", width: 768 }]);
   });
 
+  it("drops a width that ROUNDS to zero, not merely one declared as zero", async () => {
+    /*
+     * The check has to run on the rounded value, because rounding is what makes
+     * a row unusable here: `0.4` is a positive finite number and passes every
+     * test asked of the declared value, then becomes `0`. Offered, it is a named
+     * option reading "0px" that does not preview 0px — `previewFrameFit` reads
+     * zero as no request at all and fills the pane — so the one preset an author
+     * can prove is broken is the one that looks like it works.
+     */
+    await expect(
+      resolvePreviewViewports([
+        { label: "Sliver", width: 0.4 },
+        { label: "Real", width: 768 },
+      ])
+    ).resolves.toEqual([{ label: "Real", width: 768 }]);
+  });
+
+  it("keeps a width that rounds UP to one pixel", async () => {
+    // The control on the case above: rejecting the rounded value must not
+    // reject everything below a pixel, only what rounds away to nothing.
+    await expect(
+      resolvePreviewViewports([{ label: "Hair", width: 0.6 }])
+    ).resolves.toEqual([{ label: "Hair", width: 1 }]);
+  });
+
   it("keeps the FIRST of two rows at the same width", async () => {
     /*
      * Two names for one width are indistinguishable once chosen — the frame is

--- a/packages/nextly/src/domains/collections/services/__tests__/preview-viewports.test.ts
+++ b/packages/nextly/src/domains/collections/services/__tests__/preview-viewports.test.ts
@@ -86,35 +86,51 @@ describe("resolvePreviewViewports", () => {
     ).resolves.toEqual([{ label: "Real", width: 768 }]);
   });
 
-  it("rounds a fractional width, because a viewport is whole pixels", async () => {
+  it("offers a fractional width EXACTLY as declared", async () => {
+    /*
+     * The width has to match the rule the preset is named after. A site's
+     * breakpoints reach here verbatim and the compiler emits
+     * `@media (max-width: 767.6px)`, so rounding to 768 would sit the frame one
+     * tier outside the very rule the option claims to preview — and would
+     * collapse two breakpoints a fraction of a pixel apart into one option.
+     */
     await expect(
       resolvePreviewViewports([{ label: "Odd", width: 767.6 }])
-    ).resolves.toEqual([{ label: "Odd", width: 768 }]);
+    ).resolves.toEqual([{ label: "Odd", width: 767.6 }]);
   });
 
-  it("drops a width that ROUNDS to zero, not merely one declared as zero", async () => {
+  it("keeps two breakpoints that differ by a fraction of a pixel", async () => {
+    // The consequence of the case above, stated separately: rounded, these are
+    // one width, and the deduplication below would drop the second.
+    await expect(
+      resolvePreviewViewports([
+        { label: "Narrow tablet", width: 767.6 },
+        { label: "Wide tablet", width: 767.9 },
+      ])
+    ).resolves.toEqual([
+      { label: "Narrow tablet", width: 767.6 },
+      { label: "Wide tablet", width: 767.9 },
+    ]);
+  });
+
+  it("keeps a sub-pixel width, because the site may really break there", async () => {
     /*
-     * The check has to run on the rounded value, because rounding is what makes
-     * a row unusable here: `0.4` is a positive finite number and passes every
-     * test asked of the declared value, then becomes `0`. Offered, it is a named
-     * option reading "0px" that does not preview 0px — `previewFrameFit` reads
-     * zero as no request at all and fills the pane — so the one preset an author
-     * can prove is broken is the one that looks like it works.
+     * This replaces a rule that dropped anything rounding to zero. That rule
+     * existed only because rounding could turn a positive width into `0` — an
+     * option reading "0px" that previewed the full pane instead. Nothing rounds
+     * now, so a declared `0.4` is offered as `0.4` and previews `0.4`: useless
+     * to look at, and exactly what the site declared. The engine's own bound
+     * accepts it too, so refusing it here would disagree with the sheet.
      */
     await expect(
       resolvePreviewViewports([
         { label: "Sliver", width: 0.4 },
         { label: "Real", width: 768 },
       ])
-    ).resolves.toEqual([{ label: "Real", width: 768 }]);
-  });
-
-  it("keeps a width that rounds UP to one pixel", async () => {
-    // The control on the case above: rejecting the rounded value must not
-    // reject everything below a pixel, only what rounds away to nothing.
-    await expect(
-      resolvePreviewViewports([{ label: "Hair", width: 0.6 }])
-    ).resolves.toEqual([{ label: "Hair", width: 1 }]);
+    ).resolves.toEqual([
+      { label: "Sliver", width: 0.4 },
+      { label: "Real", width: 768 },
+    ]);
   });
 
   it("keeps the FIRST of two rows at the same width", async () => {

--- a/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
+++ b/packages/nextly/src/domains/collections/services/preview-url-resolver.ts
@@ -31,11 +31,29 @@
  * stored). Both are optional here because this type is the union the resolver
  * sees, not either authoring surface.
  */
+import type { PreviewViewportsDeclaration } from "./preview-viewports";
+
 export interface PreviewDeclaration {
   /** Code-first: computes the URL from the entry, or declines by returning null. */
   url?: (entry: Record<string, unknown>) => string | null;
   /** UI-created: a path with `{fieldName}` placeholders. */
   urlTemplate?: string;
+  /**
+   * The viewport widths this preview offers, as a list or as a function of
+   * whatever state holds them.
+   *
+   * Declared rather than inferred, for the reason the URL is: nothing here can
+   * know the widths a site's CSS actually breaks at. A page may be built with
+   * the page builder, with Tailwind, or with hand-written media queries, and
+   * only the first is data this system holds — so a shipped phone/tablet/desktop
+   * list would be a claim about somebody else's stylesheet.
+   *
+   * The function form exists because a site's breakpoints are stored data an
+   * author edits: a value captured at boot goes stale, and this is evaluated per
+   * mint on the server where the current one is readable. Neither form reaches
+   * the browser; the resolved list does.
+   */
+  breakpoints?: PreviewViewportsDeclaration;
 }
 
 /**

--- a/packages/nextly/src/domains/collections/services/preview-viewports.ts
+++ b/packages/nextly/src/domains/collections/services/preview-viewports.ts
@@ -1,0 +1,116 @@
+/**
+ * The viewport widths a preview offers, resolved from a collection's own
+ * declaration.
+ *
+ * ## Why this is declared rather than guessed
+ *
+ * Nothing here can know the widths a site's CSS actually breaks at. A page may
+ * be built with the page builder, with Tailwind, or with hand-written media
+ * queries, and only the first of those is data this system holds. Shipping
+ * phone/tablet/desktop numbers would therefore be a claim about somebody else's
+ * stylesheet — and on a site whose tablet is 991px, a preset labelled "Tablet"
+ * that sizes the frame to 1024 lands in the wrong tier while looking correct.
+ *
+ * So the widths are declared by whoever knows them. An application states them
+ * directly; a plugin that DOES hold a site's breakpoints supplies a function
+ * that reads them, the same way `previewUrlFromTemplate` supplies a `url`.
+ *
+ * ## Why a function is accepted alongside a list
+ *
+ * A site's breakpoints are stored data an author edits, so a value captured
+ * once at boot goes stale the moment they change it. The function form is
+ * evaluated per mint, on the server, where the current value is readable — the
+ * same reason `admin.preview.url` is a function. Neither ever reaches the
+ * browser: what crosses is the resolved list.
+ *
+ * ## Why every rejection here is a silent DROP
+ *
+ * These are presets on a credential handout. A malformed row must cost an
+ * author that row, never the whole list and never the preview itself — one typo
+ * removing every working preset, or failing the mint outright, is a worse
+ * outcome than the bad row it was guarding against.
+ *
+ * @module domains/collections/services/preview-viewports
+ */
+
+/** One offered viewport: a name an author picked, and a width in CSS pixels. */
+export interface PreviewViewport {
+  label: string;
+  width: number;
+}
+
+/**
+ * What a collection may declare, either as a fixed list or as a function of
+ * whatever state actually holds the answer.
+ */
+export type PreviewViewportsDeclaration =
+  | readonly PreviewViewport[]
+  | (() => readonly PreviewViewport[] | Promise<readonly PreviewViewport[]>);
+
+/**
+ * The most viewports one preview will offer.
+ *
+ * The control is a dropdown in a dense toolbar, and a list past this length
+ * stops being a set of choices and becomes something to search. The engine caps
+ * a site's own breakpoints at seven per axis, so a derived list cannot exceed
+ * this on its own; the cap is here for a hand-written declaration.
+ */
+const MAX_VIEWPORTS = 12;
+
+/** True when a value is a usable row, checked field by field. */
+function usableViewport(value: unknown): value is PreviewViewport {
+  if (typeof value !== "object" || value === null) return false;
+  const row = value as Partial<PreviewViewport>;
+  if (typeof row.label !== "string" || row.label.trim() === "") return false;
+  return (
+    typeof row.width === "number" && Number.isFinite(row.width) && row.width > 0
+  );
+}
+
+/**
+ * Resolve a declaration into the list a caller may offer.
+ *
+ * Answers `[]` for every failure — absent, throwing, or the wrong shape — so a
+ * caller has one thing to check and no error path to forget.
+ */
+export async function resolvePreviewViewports(
+  declaration: PreviewViewportsDeclaration | undefined
+): Promise<PreviewViewport[]> {
+  if (declaration === undefined) return [];
+
+  let raw: unknown;
+  try {
+    raw = typeof declaration === "function" ? await declaration() : declaration;
+  } catch {
+    /*
+     * The declaration is user code and may throw. Losing the presets is the
+     * affordable outcome; losing the mint is not, because the pane cannot open
+     * without it and the author gets no preview at all rather than a plainer
+     * one.
+     */
+    return [];
+  }
+
+  if (!Array.isArray(raw)) return [];
+
+  const seen = new Set<number>();
+  const resolved: PreviewViewport[] = [];
+  for (const candidate of raw) {
+    if (!usableViewport(candidate)) continue;
+
+    // Whole pixels: a viewport is a device width, and a fractional one would
+    // render as `767.6px` in a control that has to read as a number.
+    const width = Math.round(candidate.width);
+
+    // Two names for one width are indistinguishable once chosen — the frame is
+    // the same size either way — so the first declared wins and the rest are
+    // dropped rather than crowding the list.
+    if (seen.has(width)) continue;
+    seen.add(width);
+
+    resolved.push({ label: candidate.label.trim(), width });
+    if (resolved.length === MAX_VIEWPORTS) break;
+  }
+
+  return resolved;
+}

--- a/packages/nextly/src/domains/collections/services/preview-viewports.ts
+++ b/packages/nextly/src/domains/collections/services/preview-viewports.ts
@@ -98,19 +98,21 @@ export async function resolvePreviewViewports(
   for (const candidate of raw) {
     if (!usableViewport(candidate)) continue;
 
-    // Whole pixels: a viewport is a device width, and a fractional one would
-    // render as `767.6px` in a control that has to read as a number.
-    const width = Math.round(candidate.width);
-
     /*
-     * Checked AFTER rounding, because rounding is what makes a row unusable:
-     * `0.4` is positive and finite, so it satisfies every test asked of the
-     * declared value, and then becomes `0`. Offered, it is an option reading
-     * "0px" that does not preview 0px — `previewFrameFit` reads zero as no
-     * request at all and fills the pane — so the broken preset is the one that
-     * looks like it works.
+     * The width is offered EXACTLY as declared, fractions included.
+     *
+     * A site's breakpoints reach here verbatim: `breakpointContexts` copies
+     * `maxWidth` from the definition and the compiler emits
+     * `@media (max-width: 767.6px)` for it. Rounding to 768 would sit the frame
+     * one tier OUTSIDE the rule the preset is named after — the precise failure
+     * declared widths exist to prevent — and would collapse two breakpoints a
+     * third of a pixel apart into one option.
+     *
+     * Rounding was here for the control's sake, so a preset would not read
+     * `767.6px`. That is a display concern, and it was answered by changing the
+     * number the frame is sized to, which is the one thing that has to be true.
      */
-    if (width <= 0) continue;
+    const width = candidate.width;
 
     // Two names for one width are indistinguishable once chosen — the frame is
     // the same size either way — so the first declared wins and the rest are

--- a/packages/nextly/src/domains/collections/services/preview-viewports.ts
+++ b/packages/nextly/src/domains/collections/services/preview-viewports.ts
@@ -102,6 +102,16 @@ export async function resolvePreviewViewports(
     // render as `767.6px` in a control that has to read as a number.
     const width = Math.round(candidate.width);
 
+    /*
+     * Checked AFTER rounding, because rounding is what makes a row unusable:
+     * `0.4` is positive and finite, so it satisfies every test asked of the
+     * declared value, and then becomes `0`. Offered, it is an option reading
+     * "0px" that does not preview 0px — `previewFrameFit` reads zero as no
+     * request at all and fills the pane — so the broken preset is the one that
+     * looks like it works.
+     */
+    if (width <= 0) continue;
+
     // Two names for one width are indistinguishable once chosen — the frame is
     // the same size either way — so the first declared wins and the rest are
     // dropped rather than crowding the list.

--- a/packages/nextly/src/singles/config/__tests__/define-single.preview-breakpoints.test.ts
+++ b/packages/nextly/src/singles/config/__tests__/define-single.preview-breakpoints.test.ts
@@ -1,0 +1,67 @@
+/**
+ * A Single may declare the viewports its preview offers.
+ *
+ * This reads as a type test because the defect was one. The mint path resolves
+ * `declaration?.breakpoints` without knowing whether the declaration came from
+ * a collection or a Single — `singlePreviewDeclarationFor` hands back the
+ * authored block verbatim — so the feature was plumbed end to end and reachable
+ * from neither `defineSingle` nor a stored Single, because this config type
+ * listed only `url`, `openInNewTab` and `label`. An excess-property error is
+ * what an author met, and no runtime test could have seen it.
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolvePreviewViewports } from "../../../domains/collections/services/preview-viewports";
+import { defineSingle } from "../define-single";
+
+describe("defineSingle — preview breakpoints", () => {
+  it("accepts a static list, and the mint path resolves what it declared", async () => {
+    const single = defineSingle({
+      slug: "landing-page",
+      label: { singular: "Landing Page" },
+      fields: [{ name: "title", type: "text" }],
+      admin: {
+        preview: {
+          url: () => "/landing",
+          breakpoints: [
+            { label: "Phone", width: 390 },
+            { label: "Desktop", width: 1280 },
+          ],
+        },
+      },
+    });
+
+    // Resolved through the SAME function the mint calls, so this asserts the
+    // declaration is usable rather than merely storable.
+    await expect(
+      resolvePreviewViewports(single.admin?.preview?.breakpoints)
+    ).resolves.toEqual([
+      { label: "Phone", width: 390 },
+      { label: "Desktop", width: 1280 },
+    ]);
+  });
+
+  it("accepts the FUNCTION form, which is why the declaration exists", async () => {
+    /*
+     * The form that matters for a Single: a site's breakpoints are stored data
+     * an author edits, so a list captured when the config was written goes
+     * stale. Rejecting only the static form would have left the useful half
+     * unreachable while looking fixed.
+     */
+    const single = defineSingle({
+      slug: "landing-page",
+      label: { singular: "Landing Page" },
+      fields: [{ name: "title", type: "text" }],
+      admin: {
+        preview: {
+          url: () => "/landing",
+          breakpoints: async () => [{ label: "Wide", width: 1440 }],
+        },
+      },
+    });
+
+    await expect(
+      resolvePreviewViewports(single.admin?.preview?.breakpoints)
+    ).resolves.toEqual([{ label: "Wide", width: 1440 }]);
+  });
+});

--- a/packages/nextly/src/singles/config/types.ts
+++ b/packages/nextly/src/singles/config/types.ts
@@ -17,6 +17,7 @@
 
 import type { FieldConfig } from "../../collections/fields/types";
 import type { SingleAccessControl } from "../../domains/auth/services/access-control-types";
+import type { PreviewViewportsDeclaration } from "../../domains/collections/services/preview-viewports";
 import type { HookHandler } from "../../hooks/types";
 import type { RevalidateConfig } from "../../revalidation/types";
 // Builder-facing content-versioning options surfaced on the Single config.
@@ -102,6 +103,32 @@ export interface SinglePreviewConfig {
    * @default "Preview"
    */
   label?: string;
+
+  /**
+   * The viewport widths the preview pane offers, as a list or as a function.
+   *
+   * The same declaration a collection's preview takes, and read by the same
+   * mint path — `resolvePreviewViewports` is given whichever declaration the
+   * document has, and does not know which kind of document it came from.
+   *
+   * Declared rather than inferred: nothing in this system can know the widths a
+   * site's CSS actually breaks at, so a shipped phone/tablet/desktop list would
+   * be a claim about somebody else's stylesheet.
+   *
+   * The function form is evaluated per mint, on the server, so a source that
+   * CHANGES — a site's stored breakpoints, edited in the page builder — stays
+   * current instead of being captured once at boot. Only the resolved list ever
+   * reaches the browser.
+   *
+   * @example
+   * ```typescript
+   * breakpoints: [
+   *   { label: "Phone", width: 390 },
+   *   { label: "Desktop", width: 1280 },
+   * ]
+   * ```
+   */
+  breakpoints?: PreviewViewportsDeclaration;
 }
 
 export interface SingleAdminOptions {

--- a/packages/plugin-page-builder/src/collections/pages.classes.test.ts
+++ b/packages/plugin-page-builder/src/collections/pages.classes.test.ts
@@ -29,7 +29,7 @@ function runBeforeChange(
   limits?: DocumentLimits
 ): unknown {
   const hooks = (
-    pagesCollection(undefined, limits) as unknown as {
+    pagesCollection({ limits }) as unknown as {
       hooks?: { beforeChange?: ((context: unknown) => unknown)[] };
     }
   ).hooks;

--- a/packages/plugin-page-builder/src/collections/pages.test.ts
+++ b/packages/plugin-page-builder/src/collections/pages.test.ts
@@ -87,19 +87,20 @@ describe("where a page previews", () => {
   });
 
   it("declares one once the host supplies a path", () => {
-    const preview = pagesCollection("/{slug}").admin?.preview;
+    const preview = pagesCollection({ previewPath: "/{slug}" }).admin?.preview;
 
     expect(typeof preview?.url).toBe("function");
   });
 
   it("serves a host that mounted its pages at the root", () => {
-    const url = pagesCollection("/{slug}").admin?.preview?.url;
+    const url = pagesCollection({ previewPath: "/{slug}" }).admin?.preview?.url;
 
     expect(url?.({ slug: "about" })).toBe("/about");
   });
 
   it("serves a host that mounted its pages under a prefix", () => {
-    const url = pagesCollection("/blocks/{slug}").admin?.preview?.url;
+    const url = pagesCollection({ previewPath: "/blocks/{slug}" }).admin
+      ?.preview?.url;
 
     expect(url?.({ slug: "about" })).toBe("/blocks/about");
   });
@@ -108,13 +109,42 @@ describe("where a page previews", () => {
   // one. `null` is how the resolver is told that rather than building a URL with
   // a hole in it.
   it("declines an entry whose slug is not filled in yet", () => {
-    const url = pagesCollection("/{slug}").admin?.preview?.url;
+    const url = pagesCollection({ previewPath: "/{slug}" }).admin?.preview?.url;
 
     expect(url?.({})).toBeNull();
   });
 
+  it("carries a viewport declaration onto the preview it declares", () => {
+    /*
+     * The gap this closes: the helper that reads a site's breakpoints existed
+     * and was exported, but nothing in the standard `pageBuilder()` flow could
+     * hand it to this collection — so the primary page-builder workflow offered
+     * no presets while the feature read as shipped.
+     */
+    const declared = [{ label: "Tablet", width: 1024 }];
+    const preview = pagesCollection({
+      previewPath: "/{slug}",
+      breakpoints: declared,
+    }).admin?.preview;
+
+    expect(preview?.breakpoints).toBe(declared);
+  });
+
+  it("has NO breakpoints key when none was supplied", () => {
+    /*
+     * Absent rather than `undefined`, because `resolvePreviewViewports` reads
+     * an absent declaration as "offer nothing" — and a key present but empty is
+     * how a declaration that failed would look if this ever started catching
+     * one.
+     */
+    const preview = pagesCollection({ previewPath: "/{slug}" }).admin?.preview;
+
+    expect(preview).not.toBeUndefined();
+    expect("breakpoints" in (preview as object)).toBe(false);
+  });
+
   it("escapes a slug that would otherwise change the path", () => {
-    const url = pagesCollection("/{slug}").admin?.preview?.url;
+    const url = pagesCollection({ previewPath: "/{slug}" }).admin?.preview?.url;
 
     expect(url?.({ slug: "a/b" })).toBe("/a%2Fb");
   });

--- a/packages/plugin-page-builder/src/collections/pages.ts
+++ b/packages/plugin-page-builder/src/collections/pages.ts
@@ -1,6 +1,7 @@
 import { isPlainRecord } from "@nextlyhq/blocks-engine";
 import type { DocumentLimits } from "@nextlyhq/blocks-engine";
 import type { HookContext } from "nextly";
+import type { PreviewViewportsDeclaration } from "nextly/config";
 import {
   defineCollection,
   json,
@@ -106,21 +107,43 @@ function record(
   data.usedClasses = usage.complete ? usage.ids : null;
 }
 
-export function pagesCollection(
-  previewPath?: string,
-  // The limits the PAGE is rendered under, when the host raised them.
-  //
-  // `PageRenderer` takes `limits`, falling back to `styleContext.limits` and
-  // then to the engine defaults, so a host can render more of a document than
-  // the defaults select. The usage record has to select the SAME nodes or a
-  // class applied to a node the page renders is absent from the record a
-  // safe-delete check reads — the two now share one selection, and this is what
-  // stops them invoking it with different bounds.
-  //
-  // Positional because `previewPath` already is; a third argument here is the
-  // point to convert both into one options object.
-  limits?: DocumentLimits
-) {
+/** What the plugin-owned `pages` collection is built with. */
+export interface PagesCollectionOptions {
+  /** The path a page previews at, as a `{field}` template. */
+  previewPath?: string;
+
+  /**
+   * The limits the PAGE is rendered under, when the host raised them.
+   *
+   * `PageRenderer` takes `limits`, falling back to `styleContext.limits` and
+   * then to the engine defaults, so a host can render more of a document than
+   * the defaults select. The usage record has to select the SAME nodes or a
+   * class applied to a node the page renders is absent from the record a
+   * safe-delete check reads — the two share one selection, and this is what
+   * stops them invoking it with different bounds.
+   */
+  limits?: DocumentLimits;
+
+  /**
+   * The viewport widths this collection's preview offers.
+   *
+   * Ignored without a `previewPath`, because there is no preview to offer them
+   * on.
+   */
+  breakpoints?: PreviewViewportsDeclaration;
+}
+
+/*
+ * One options object rather than a third positional argument, which is what the
+ * two positional ones said to do as soon as a third arrived. `previewPath` and
+ * `limits` are both optional and unrelated, so a caller wanting only the later
+ * one had to write `pagesCollection(undefined, limits)` — and a fourth would
+ * make the call site unreadable at exactly the point it starts carrying a
+ * preview declaration.
+ */
+export function pagesCollection(options: PagesCollectionOptions = {}) {
+  const { previewPath, limits, breakpoints } = options;
+
   return defineCollection({
     slug: "pages",
     labels: { singular: "Page", plural: "Pages" },
@@ -177,7 +200,16 @@ export function pagesCollection(
       // to two different addresses.
       ...(previewPath === undefined
         ? {}
-        : { preview: { url: previewUrlFromTemplate(previewPath) } }),
+        : {
+            preview: {
+              url: previewUrlFromTemplate(previewPath),
+              // Spread rather than set to `undefined`, so a collection that
+              // declares none has no `breakpoints` key at all — which is what
+              // `resolvePreviewViewports` reads as "offer nothing" without
+              // having to tell an absent declaration from a broken one.
+              ...(breakpoints === undefined ? {} : { breakpoints }),
+            },
+          }),
     },
 
     hooks: {

--- a/packages/plugin-page-builder/src/index.ts
+++ b/packages/plugin-page-builder/src/index.ts
@@ -84,6 +84,10 @@ export { pagesCollection } from "./collections/pages";
 export { resolveSiteStyle, siteBreakpoints, siteSheet } from "./site-style";
 export type { SiteStyleData } from "./site-style";
 export { SITE_STYLE_SLUG, loadSiteStyle } from "./site-style-storage";
+export {
+  previewViewportsFromSiteStyle,
+  siteStyleViewports,
+} from "./preview-viewports";
 export type { SiteStyleReader } from "./site-style-storage";
 
 // The class-usage record and the walk that repairs it. Both are public because

--- a/packages/plugin-page-builder/src/plugin-page-preview-viewports.test.ts
+++ b/packages/plugin-page-builder/src/plugin-page-preview-viewports.test.ts
@@ -1,0 +1,73 @@
+/**
+ * What the plugin-owned `pages` collection offers as preview viewports.
+ *
+ * The gap this closes is the one a feature can have while reading as shipped:
+ * `previewViewportsFromSiteStyle` existed and was exported, and the mint path
+ * resolved whatever a collection declared — but `pageBuilder()` built its pages
+ * collection with a preview containing only `url`, and its options had no way to
+ * supply anything else. Every preset therefore reached exactly the collections a
+ * host had composed by hand, and none of the ones this plugin owns, which is the
+ * primary page-builder workflow.
+ */
+import { describe, expect, it } from "vitest";
+
+import { pageBuilder } from "./plugin";
+
+/** The pages collection as the plugin contributes it. */
+function pagesPreview(options?: Parameters<typeof pageBuilder>[0]) {
+  const collections = pageBuilder(options).contributes?.collections ?? [];
+  const pages = (
+    collections as { slug?: string; admin?: { preview?: unknown } }[]
+  ).find(c => c.slug === "pages");
+  return pages?.admin?.preview as
+    | { url?: unknown; breakpoints?: unknown }
+    | undefined;
+}
+
+describe("pageBuilder — the pages collection's preview viewports", () => {
+  it("offers the site's own breakpoints by default", () => {
+    /*
+     * A function, not a list, and that is the point: an author edits these in
+     * the page builder, so a list captured when the plugin was constructed
+     * would size the frame to a tier the site no longer has. It is evaluated
+     * per mint, on the server, where the current value is readable.
+     */
+    const preview = pagesPreview({ pagePreviewPath: "/{slug}" });
+
+    expect(typeof preview?.url).toBe("function");
+    expect(typeof preview?.breakpoints).toBe("function");
+  });
+
+  it("takes a declaration of the host's own instead", () => {
+    const declared = [{ label: "Kiosk", width: 1920 }];
+    const preview = pagesPreview({
+      pagePreviewPath: "/{slug}",
+      pagePreviewBreakpoints: declared,
+    });
+
+    expect(preview?.breakpoints).toBe(declared);
+  });
+
+  it("offers none when the host says false", () => {
+    /*
+     * The escape hatch has to actually remove the key rather than set it to
+     * something empty: `resolvePreviewViewports` reads an absent declaration as
+     * "offer nothing", and the pane then falls back to Responsive and a custom
+     * width — everything it can offer without inventing numbers.
+     */
+    const preview = pagesPreview({
+      pagePreviewPath: "/{slug}",
+      pagePreviewBreakpoints: false,
+    });
+
+    expect(preview).not.toBeUndefined();
+    expect("breakpoints" in (preview as object)).toBe(false);
+  });
+
+  it("declares no preview at all without a path, viewports included", () => {
+    // The default must not conjure a preview onto a host that mounted no
+    // preview route — that installation is strictly worse off with one, because
+    // the mint then succeeds and the reviewer gets a 404.
+    expect(pagesPreview()).toBeUndefined();
+  });
+});

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -3,6 +3,7 @@ import {
   type RemotePattern,
 } from "@nextlyhq/blocks-engine";
 import { definePlugin } from "@nextlyhq/plugin-sdk";
+import type { PreviewViewportsDeclaration } from "nextly/config";
 
 // Imported rather than read at runtime so it can never drift from the published
 // package: a hardcoded literal had fallen eight releases behind, and
@@ -19,12 +20,81 @@ import {
   registerDeclaredBlocks,
 } from "./blocks/registration-service";
 import { classUsageIndexCollection } from "./collections/class-usage-index";
+import type { PagesCollectionOptions } from "./collections/pages";
 import { pagesCollection } from "./collections/pages";
 import { blocksFieldType } from "./fields/blocksField";
 import { hostFetchPolicy } from "./host-policy";
+import { previewViewportsFromSiteStyle } from "./preview-viewports";
 import { resolveSiteStyle, siteBreakpoints } from "./site-style";
 import type { SiteStyleData } from "./site-style";
 import { siteStyleSingle } from "./site-style-storage";
+
+/**
+ * What the plugin-owned `pages` collection is built with, resolved from the
+ * host's options.
+ *
+ * Separated from the factory because it is a decision rather than an assembly
+ * step: it is where "a page-builder site's default presets are its own
+ * breakpoints" is stated, and reading it beside the collection list would
+ * scatter that across the contribution block.
+ */
+function pagesOptions(
+  opts: PageBuilderOptions,
+  configStyle: SiteStyleData
+): PagesCollectionOptions {
+  return {
+    ...(opts.pagePreviewPath === undefined
+      ? {}
+      : { previewPath: opts.pagePreviewPath }),
+    ...(opts.limits === undefined ? {} : { limits: opts.limits }),
+    ...(pagePreviewBreakpoints(opts, configStyle) ?? {}),
+  };
+}
+
+/**
+ * The viewport declaration the pages preview carries, or nothing.
+ *
+ * Answers with a whole `{ breakpoints }` fragment rather than a value, so the
+ * "offer none" case is an ABSENT key instead of an explicit `undefined`:
+ * `resolvePreviewViewports` reads an absent declaration as "offer nothing", and
+ * the pane then falls back to Responsive and a custom width.
+ */
+function pagePreviewBreakpoints(
+  opts: PageBuilderOptions,
+  configStyle: SiteStyleData
+): { breakpoints: PreviewViewportsDeclaration } | undefined {
+  if (opts.pagePreviewBreakpoints === false) return undefined;
+  if (opts.pagePreviewBreakpoints !== undefined) {
+    return { breakpoints: opts.pagePreviewBreakpoints };
+  }
+
+  /*
+   * The default, and the reason this option exists at all: a page-builder
+   * site's breakpoints ARE the widths its stylesheet changes at, so they are
+   * the only widths a preset can name without making a claim about somebody
+   * else's CSS.
+   *
+   * Read per mint rather than captured here, because an author edits them in
+   * the page builder — a list read once at construction would size the frame to
+   * a tier the site no longer has.
+   */
+  return {
+    breakpoints: previewViewportsFromSiteStyle({
+      /*
+       * Imported at call time, not at module scope. This runs per mint on the
+       * server, and a static import would pull the Direct API graph into every
+       * consumer of this plugin — including the browser bundle the canvas ships
+       * in, which has no use for it and cannot run it.
+       */
+      reader: async () => {
+        const { getCachedNextly } = await import("nextly");
+        const nextly = await getCachedNextly();
+        return { findSingle: args => nextly.findSingle(args) };
+      },
+      ...(opts.siteStyle === undefined ? {} : { defaults: configStyle }),
+    }),
+  };
+}
 
 export interface PageBuilderOptions {
   /** Disable behavior while still applying schema. Default true. */
@@ -150,6 +220,29 @@ export interface PageBuilderOptions {
    * to nothing, while declaring nothing gets them an explanation instead.
    */
   pagePreviewPath?: string;
+
+  /**
+   * The viewport widths the pages preview offers.
+   *
+   * Defaults to **this site's own breakpoints**, read from the `site-style`
+   * single at the moment a preview link is minted. That default is the whole
+   * point: a page-builder site's breakpoints ARE the widths its stylesheet
+   * changes at, so they are the only widths a preset can name without making a
+   * claim about somebody else's CSS — and requiring every host to wire that up
+   * by hand would leave the feature switched off for the workflow it was built
+   * for.
+   *
+   * Read per mint rather than captured here, because an author edits those
+   * breakpoints in the page builder: a list read once at boot would size the
+   * frame to a tier the site no longer has.
+   *
+   * Pass a list or a function of your own to override it, or `false` to offer
+   * none — the pane then falls back to Responsive and a custom width, which is
+   * everything it can offer honestly without inventing numbers.
+   *
+   * Ignored without a `pagePreviewPath`: there is no preview to offer them on.
+   */
+  pagePreviewBreakpoints?: PreviewViewportsDeclaration | false;
 }
 
 /**
@@ -162,6 +255,7 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
   // the defaults tier. The stored tier reaches the published route through
   // `loadSiteStyle`, which reads per request.
   const configStyle = resolveSiteStyle(opts.siteStyle);
+
   return definePlugin({
     name: "@nextlyhq/plugin-page-builder",
     version: PLUGIN_VERSION,
@@ -225,7 +319,7 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
       // to it without a first-run branch, exactly as the site style single is
       // registered whether or not the host stated any defaults.
       collections: [
-        pagesCollection(opts.pagePreviewPath, opts.limits),
+        pagesCollection(pagesOptions(opts, configStyle)),
         classUsageIndexCollection(),
       ],
       // The Site Style global: one versioned, access-controlled document the

--- a/packages/plugin-page-builder/src/preview-viewports.test.ts
+++ b/packages/plugin-page-builder/src/preview-viewports.test.ts
@@ -88,6 +88,35 @@ describe("siteStyleViewports", () => {
     ).toEqual([{ label: "Tablet", width: 1024 }]);
   });
 
+  it("names a duplicated id after the definition the COMPILER kept", () => {
+    /*
+     * Two definitions can claim one id — config defaults do not pass through
+     * the stored-breakpoint check, so nothing upstream refuses them — and the
+     * two sides then disagree about which one is real. `breakpointContexts`
+     * sorts width-descending and keeps the first claim, so the WIDEST survives;
+     * a plain `new Map(...)` over the raw array keeps the LAST label. Between
+     * them they produce a preset carrying one tier's name at another's width,
+     * which is worse than either alone: the author reads a label they wrote and
+     * gets a frame the compiled sheet has no rule for at that name.
+     *
+     * Joined on the surviving definition instead, so the name and the number
+     * come from one row or the row is not offered.
+     */
+    const offered = siteStyleViewports(
+      set([
+        { id: "tablet", label: "Wide tablet", maxWidth: 1024 },
+        { id: "tablet", label: "Narrow tablet", maxWidth: 640 },
+      ])
+    );
+
+    expect(offered).toEqual([{ label: "Wide tablet", width: 1024 }]);
+    // Stated separately: a pairing test that only checked membership would pass
+    // on the mismatched result, which contains both of these strings.
+    expect(offered.find(v => v.width === 1024)?.label).not.toBe(
+      "Narrow tablet"
+    );
+  });
+
   it("joins the label to the width by ID, not by position", () => {
     /*
      * The separating property. The label comes from the STORED definition and

--- a/packages/plugin-page-builder/src/preview-viewports.test.ts
+++ b/packages/plugin-page-builder/src/preview-viewports.test.ts
@@ -1,0 +1,113 @@
+/**
+ * A site's own breakpoints, offered as preview viewports.
+ *
+ * The cases below are all about DECLINING, because that is where a preset stops
+ * being useful and becomes a claim: an option sized to a width the compiled
+ * sheet has no rule for sits the frame at a tier the site never renders, and
+ * the author cannot tell that from a working one by looking.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BreakpointSet } from "@nextlyhq/blocks-engine";
+
+import { siteStyleViewports } from "./preview-viewports";
+
+/** A set with only the fields this reader consults. */
+function set(
+  viewport: BreakpointSet["viewport"],
+  container: BreakpointSet["container"] = []
+): BreakpointSet {
+  return { viewport, container };
+}
+
+describe("siteStyleViewports", () => {
+  it("offers nothing when the site declares no breakpoints", () => {
+    expect(siteStyleViewports(undefined)).toEqual([]);
+  });
+
+  it("offers each viewport tier by the author's own name", () => {
+    expect(
+      siteStyleViewports(
+        set([
+          { id: "base", label: "Desktop" },
+          { id: "tablet", label: "Tablet", maxWidth: 1024 },
+          { id: "mobile", label: "Mobile", maxWidth: 640 },
+        ])
+      )
+    ).toEqual([
+      { label: "Tablet", width: 1024 },
+      { label: "Mobile", width: 640 },
+    ]);
+  });
+
+  it("skips the BASE tier, which has no upper bound to offer", () => {
+    /*
+     * Base is "everything wider", so there is no width a preset could name for
+     * it. The pane's own Responsive option is what covers that case honestly —
+     * inventing a number here would be a claim about the widest device rather
+     * than about this site.
+     */
+    const offered = siteStyleViewports(
+      set([
+        { id: "base", label: "Desktop" },
+        { id: "sm", label: "Small", maxWidth: 480 },
+      ])
+    );
+
+    expect(offered).toEqual([{ label: "Small", width: 480 }]);
+    expect(offered.map(v => v.label)).not.toContain("Desktop");
+  });
+
+  it("offers VIEWPORT tiers only, never container ones", () => {
+    /*
+     * A container tier answers a question about a BOX inside the page, so a
+     * frame sized to one previews a viewport no visitor has. The two axes share
+     * an id namespace, which is exactly why this filters on the axis rather
+     * than on the shape of the definition.
+     */
+    expect(
+      siteStyleViewports(
+        set(
+          [{ id: "tablet", label: "Tablet", maxWidth: 1024 }],
+          [{ id: "card", label: "Card", maxWidth: 320 }]
+        )
+      )
+    ).toEqual([{ label: "Tablet", width: 1024 }]);
+  });
+
+  it("skips a tier with no usable label rather than showing its id", () => {
+    // A control showing `bp_2` is a row the author can see and cannot identify,
+    // which is worse than one option fewer.
+    expect(
+      siteStyleViewports(
+        set([
+          { id: "bp_2", label: "   ", maxWidth: 900 },
+          { id: "tablet", label: "Tablet", maxWidth: 1024 },
+        ])
+      )
+    ).toEqual([{ label: "Tablet", width: 1024 }]);
+  });
+
+  it("joins the label to the width by ID, not by position", () => {
+    /*
+     * The separating property. The label comes from the STORED definition and
+     * the width from the engine's reader, and the reader is free to drop a
+     * definition or reorder what it returns — so a positional join would put
+     * one tier's name on another's width, which is a preset that is confidently
+     * wrong rather than absent.
+     */
+    const offered = siteStyleViewports(
+      set([
+        { id: "wide", label: "Wide", maxWidth: 1440 },
+        { id: "narrow", label: "Narrow", maxWidth: 480 },
+      ])
+    );
+
+    expect(offered).toContainEqual({ label: "Wide", width: 1440 });
+    expect(offered).toContainEqual({ label: "Narrow", width: 480 });
+    // The pairing, not merely the membership: a swap would satisfy both lines
+    // above and neither of these.
+    expect(offered.find(v => v.width === 1440)?.label).toBe("Wide");
+    expect(offered.find(v => v.width === 480)?.label).toBe("Narrow");
+  });
+});

--- a/packages/plugin-page-builder/src/preview-viewports.test.ts
+++ b/packages/plugin-page-builder/src/preview-viewports.test.ts
@@ -117,6 +117,28 @@ describe("siteStyleViewports", () => {
     );
   });
 
+  it("keeps the FIRST label when two definitions are identical but named apart", () => {
+    /*
+     * Keying on id AND width identifies the surviving definition wherever the
+     * two differ — but two rows can repeat both, and then the pair no longer
+     * separates them. `breakpointContexts` keeps the first it claims; a map
+     * built by overwriting keeps the last. So the compiler emits one definition
+     * and the preset is named after the other, which is the same mispairing as
+     * before in the one case the pair cannot tell apart.
+     *
+     * The label is not interchangeable just because the width is. An author
+     * reads the name, and the name should belong to the row that survived.
+     */
+    const offered = siteStyleViewports(
+      set([
+        { id: "tablet", label: "First", maxWidth: 768 },
+        { id: "tablet", label: "Second", maxWidth: 768 },
+      ])
+    );
+
+    expect(offered).toEqual([{ label: "First", width: 768 }]);
+  });
+
   it("joins the label to the width by ID, not by position", () => {
     /*
      * The separating property. The label comes from the STORED definition and

--- a/packages/plugin-page-builder/src/preview-viewports.ts
+++ b/packages/plugin-page-builder/src/preview-viewports.ts
@@ -62,12 +62,24 @@ export function siteStyleViewports(
    * is the one place the two have to be brought together. Keying on the width
    * as well makes it a lookup for the definition that SURVIVED rather than a
    * second guess at which one that was: `breakpointContexts` copies `maxWidth`
-   * from the definition verbatim, so the pair identifies it exactly, and no
-   * duplicate policy is restated here to drift out of step with the compiler's.
+   * from the definition verbatim, so wherever two rows differ in either field
+   * the pair identifies the survivor exactly, and no tie-break of the
+   * compiler's is restated here to drift out of step with it.
+   *
+   * Where two rows repeat BOTH, the pair stops separating them, and the only
+   * thing left to match on is the order they were read in.
    */
-  const labels = new Map(
-    breakpoints.viewport.map(def => [labelKey(def.id, def.maxWidth), def.label])
-  );
+  const labels = new Map<string, string>();
+  for (const def of breakpoints.viewport) {
+    const key = labelKey(def.id, def.maxWidth);
+    // FIRST wins, as `breakpointContexts` keeps the first id it claims. Built
+    // by overwriting, this would keep the LAST label while the compiler emitted
+    // the first — the same mispairing the key exists to prevent, surviving in
+    // the one case the key cannot tell apart. The label is not interchangeable
+    // just because the width is: an author reads the name, and it should belong
+    // to the row that survived.
+    if (!labels.has(key)) labels.set(key, def.label);
+  }
 
   return breakpointContexts(breakpoints)
     .map(context => offerableViewport(context, labels))

--- a/packages/plugin-page-builder/src/preview-viewports.ts
+++ b/packages/plugin-page-builder/src/preview-viewports.ts
@@ -1,0 +1,130 @@
+/**
+ * The site's own breakpoints, offered as preview viewports.
+ *
+ * ## Why this lives in the plugin
+ *
+ * A site's breakpoints are page-builder data: they are stored in this plugin's
+ * `site-style` single, they are author-named, and there are up to seven of them
+ * per axis. Core does not know that slug and the admin package depends on
+ * neither this plugin nor `blocks-engine`, so neither can read them — and
+ * neither should, because a site that does not use the page builder has none
+ * and would be offered widths its stylesheet never breaks at.
+ *
+ * So the plugin supplies them through the surface core already reads. This is
+ * the same shape as `previewUrlFromTemplate`: an application composes it into
+ * its own collection config, and core evaluates it without knowing where the
+ * answer came from.
+ *
+ * ## Why a function rather than a list
+ *
+ * Breakpoints are edited in the page builder, so a list captured when the
+ * config was defined goes stale the moment an author changes one — and a stale
+ * preset sizes the frame to a width the site no longer uses, which is the exact
+ * failure preset widths exist to avoid. The function is evaluated per mint, on
+ * the server, where the current value is readable.
+ *
+ * @module preview-viewports
+ */
+import type { BreakpointContext, BreakpointSet } from "@nextlyhq/blocks-engine";
+import { breakpointContexts } from "@nextlyhq/blocks-engine";
+import type { PreviewViewport } from "nextly/config";
+
+import type { SiteStyleData } from "./site-style";
+import { loadSiteStyle, type SiteStyleReader } from "./site-style-storage";
+
+/**
+ * Map a site's viewport breakpoints onto preview viewports.
+ *
+ * Read through `breakpointContexts` rather than off the stored array, because
+ * that reader is what decides which definitions the STYLE COMPILER accepts — it
+ * drops a definition whose bound it cannot use and claims each id once. Reading
+ * the raw array instead would let the preview offer a width the compiled sheet
+ * has no rule for, so the frame would sit at a tier the site never renders.
+ */
+export function siteStyleViewports(
+  breakpoints: BreakpointSet | undefined
+): PreviewViewport[] {
+  if (breakpoints === undefined) return [];
+
+  /*
+   * The label comes from the stored definition and the width from the reader,
+   * joined by id. `BreakpointContext` carries no label — it is the compiler's
+   * view — so this is the one place the two have to be brought together, and
+   * the id is what makes that a lookup rather than a guess about order.
+   */
+  const labels = new Map(breakpoints.viewport.map(def => [def.id, def.label]));
+
+  return breakpointContexts(breakpoints)
+    .map(context => offerableViewport(context, labels))
+    .filter((viewport): viewport is PreviewViewport => viewport !== null);
+}
+
+/**
+ * One context as an offerable viewport, or `null` where it cannot be one.
+ *
+ * Separated from the walk above so each reason to decline is a single named
+ * condition rather than another branch in a loop that also builds a list.
+ */
+function offerableViewport(
+  context: BreakpointContext,
+  labels: ReadonlyMap<string, string>
+): PreviewViewport | null {
+  if (context.axis !== "viewport") return null;
+
+  // The BASE tier has no upper bound by construction — it is "everything
+  // wider" — so there is no width to offer for it, and the pane's own
+  // Responsive option is what covers that case honestly.
+  if (typeof context.maxWidth !== "number") return null;
+
+  // An id with no stored label cannot be named to an author, and a control
+  // showing a raw id is worse than one option fewer.
+  const label = labels.get(context.id);
+  if (label === undefined || label.trim() === "") return null;
+
+  return { label, width: context.maxWidth };
+}
+
+/**
+ * A `breakpoints` declaration that reads this site's own tiers at mint time.
+ *
+ * Compose it into a collection's preview config:
+ *
+ * ```typescript
+ * admin: {
+ *   preview: {
+ *     url: previewUrlFromTemplate("/blocks/{slug}"),
+ *     breakpoints: previewViewportsFromSiteStyle({
+ *       // Dynamic, because a static import of the reader would cycle back
+ *       // through the config this collection is declared in.
+ *       reader: async () => (await import("../lib/site-content")).siteReader,
+ *     }),
+ *   },
+ * }
+ * ```
+ */
+export function previewViewportsFromSiteStyle(args: {
+  /**
+   * How to obtain a reader, rather than a reader.
+   *
+   * A PROVIDER because this is composed into a collection's config, and a
+   * reader does not exist at that moment — the one an application builds is
+   * assembled from the config itself, so importing it here is a cycle rather
+   * than an inconvenience. Measured in the playground: its `siteReader` module
+   * imports `nextly.config`, which imports the collection this would be
+   * declared on.
+   *
+   * Deferring it also matches when the answer is needed. This runs per mint, on
+   * the server, long after any reader exists.
+   */
+  reader: () => SiteStyleReader | Promise<SiteStyleReader>;
+  defaults?: SiteStyleData;
+}): () => Promise<PreviewViewport[]> {
+  return async () => {
+    const nextly = await args.reader();
+    const style = await loadSiteStyle({
+      nextly,
+      ...(args.defaults === undefined ? {} : { defaults: args.defaults }),
+    });
+    return siteStyleViewports(style.breakpoints);
+  };
+}

--- a/packages/plugin-page-builder/src/preview-viewports.ts
+++ b/packages/plugin-page-builder/src/preview-viewports.ts
@@ -48,15 +48,41 @@ export function siteStyleViewports(
 
   /*
    * The label comes from the stored definition and the width from the reader,
-   * joined by id. `BreakpointContext` carries no label — it is the compiler's
-   * view — so this is the one place the two have to be brought together, and
-   * the id is what makes that a lookup rather than a guess about order.
+   * joined on BOTH, because the id alone does not identify a definition.
+   *
+   * Two definitions can claim one id — config defaults never pass through
+   * `checkStoredBreakpoints`, so nothing upstream refuses them — and the two
+   * sides then pick different ones: `breakpointContexts` sorts width-descending
+   * and keeps the first claim, while a map built over the raw array keeps the
+   * last. The result is a preset carrying one tier's name at another's width,
+   * which is worse than dropping either: the author reads a label they wrote
+   * and gets a frame the compiled sheet has no rule for under that name.
+   *
+   * `BreakpointContext` carries no label — it is the compiler's view — so this
+   * is the one place the two have to be brought together. Keying on the width
+   * as well makes it a lookup for the definition that SURVIVED rather than a
+   * second guess at which one that was: `breakpointContexts` copies `maxWidth`
+   * from the definition verbatim, so the pair identifies it exactly, and no
+   * duplicate policy is restated here to drift out of step with the compiler's.
    */
-  const labels = new Map(breakpoints.viewport.map(def => [def.id, def.label]));
+  const labels = new Map(
+    breakpoints.viewport.map(def => [labelKey(def.id, def.maxWidth), def.label])
+  );
 
   return breakpointContexts(breakpoints)
     .map(context => offerableViewport(context, labels))
     .filter((viewport): viewport is PreviewViewport => viewport !== null);
+}
+
+/**
+ * The key that identifies ONE breakpoint definition.
+ *
+ * A NUL separator, because ids come from stored data: with a printable joiner,
+ * an id containing it could be made to collide with a different id-and-width
+ * pair, which is the same mispairing this key exists to prevent.
+ */
+function labelKey(id: string, maxWidth: number | undefined): string {
+  return `${id}\u0000${String(maxWidth)}`;
 }
 
 /**
@@ -78,7 +104,7 @@ function offerableViewport(
 
   // An id with no stored label cannot be named to an author, and a control
   // showing a raw id is worse than one option fewer.
-  const label = labels.get(context.id);
+  const label = labels.get(labelKey(context.id, context.maxWidth));
   if (label === undefined || label.trim() === "") return null;
 
   return { label, width: context.maxWidth };


### PR DESCRIPTION
**Sub-tasks 2 and 3** of device presets, in one PR as requested. Sub-task 1 is [#1234](https://github.com/nextlyhq/nextly/pull/1234) — this branches from its head and targets `main`, so the diff shrinks to just this work once that merges.

## Why the widths are declared rather than shipped

Nothing in this system can know the widths a site's CSS actually breaks at. A page may be built with the page builder, with Tailwind, or by hand — only the first is data Nextly holds. A shipped phone/tablet/desktop list would be a claim about somebody else's stylesheet, and on a site whose tablet is 991px a "Tablet" preset sizing the frame to 1024 lands in a tier that site never renders, **while looking correct**. That is the same class of error as the 427px finding that started this work.

## The layered source

**Declared** — a collection or Single states them, as a list or as a function:

```typescript
admin: {
  preview: {
    url: entry => `/blog/${entry.slug}`,
    breakpoints: [{ label: "Phone", width: 390 }],
  },
}
```

The function form is evaluated **per mint, on the server**. It exists because a site's breakpoints are stored data an author edits, so a value captured at boot goes stale — the same reason `admin.preview.url` is a function rather than a string.

**Derived** — `plugin-page-builder` exports `previewViewportsFromSiteStyle`, which reads the site's own tiers. Two decisions inside it are load-bearing:

- read through **`breakpointContexts`**, not the stored array. That reader is what decides which definitions the style compiler accepts, so a preset cannot name a width the compiled sheet has no rule for.
- join the author's label to the reader's width **by id, not by position**. `BreakpointContext` carries no label, and the reader may drop or reorder definitions — a positional join would put one tier's name on another's width, which is a preset that is confidently wrong rather than absent.

**Neither** — the control keeps Responsive and a custom width. Nothing is invented.

Only the **resolved list** crosses to the browser. That is what lets the admin offer a site's own breakpoints while depending on neither the plugin that owns them nor `blocks-engine` — it depends on neither today, and this does not change that.

## Failure direction

Every rejection is a silent drop. A malformed row costs that row, not the list; a declaration that throws costs its presets, not the mint. These are a convenience on top of a credential handout, and losing the preview link is the worse outcome by a distance.

## Two things fallow caught that I had wrong

**A circular dependency I thought I had avoided.** The playground first obtained its reader with a dynamic `import("../lib/site-content")`, reasoning that deferring execution broke the cycle. It does not — deferral is about initialisation order, while the edge in the module graph is what a cycle check reads, and fallow was right to report `nextly.config → block-pages → site-content → nextly.config`. It now builds the reader from the **cached instance**, which needs no config import at all.

**A function I extracted and never tested.** `fallow` flagged `offerableViewport` with `exceeded: "crap"` — the metric that combines complexity with coverage. The honest fix was tests, not simplification, and the derivation had none. It now has six.

## Evidence

TDD on both resolvers — 10 tests written before `resolvePreviewViewports` existed, red for a missing module first.

Break-verified with asserted anchors:

| break | fails |
| --- | --- |
| one bad row rejects the whole list | the two drop-and-keep tests, alone |
| the function form is never called | the call and await tests, alone |
| the label join becomes positional | four derivation tests, including the pairing one |

The last is the one worth naming: the pairing assertions (`width 1440 → "Wide"`) fail where membership assertions alone would have passed a swap.

Gates after a full build: `check-types`, `lint`, `lint:design`, comment convention, `changeset status`, `fallow` — all 0, **0 introduced findings**. Admin 908/908, plugin 334/334, nextly preview suites green.

**Pre-existing, flagged not fixed:** `packages/nextly/src/api/__tests__/field-group-route-delegates.test.ts` fails 4/4. Confirmed identical on a clean `origin/main` tree in a built worktree earlier today — untouched by this change.

**Changeset added: yes (patch).**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added responsive preview controls with server-defined viewport presets and custom width support.
  * Previews now automatically scale to fit the available space while preserving accurate viewport behavior.
  * Page previews can use configured breakpoints, site-style breakpoints, or no presets.
  * Added support for defining preview viewport widths for pages and single entries.
* **Improvements**
  * Preview controls and toolbar now adapt better to smaller screens.
  * Custom viewport widths validate input and commit smoothly while editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->