### PR TITLE
fix(plugin-page-builder): require the bounds a class-usage rebuild derives under

### DIFF
--- a/.changeset/class-usage-maintenance.md
+++ b/.changeset/class-usage-maintenance.md
@@ -84,7 +84,12 @@ defaults while the host may have configured others, and the two directions fail 
 ways - raised bounds record a document the renderer draws whole as an undetermined marker
 instead of its classes, and lowered bounds count classes on nodes the page never draws.
 Passing the engine defaults explicitly is still available and is now a decision rather than
-an omission.
+an omission - and the page-builder package now RE-EXPORTS `DEFAULT_LIMITS` and its
+`DocumentLimits` type, so a host running the defaults has a value to name. It could not
+reach the engine by name: that is a dependency of this package rather than of the app, and
+the two moves left without it were both wrong - take a direct dependency on the engine to
+obtain one constant, or copy the numbers and let them drift away from the bounds the
+renderer applies.
 
 It stops at the first failure. Swallowing one and continuing would report a completed
 rebuild that repaired nothing, which is the report that stops anyone looking. Stopping is

--- a/.changeset/class-usage-maintenance.md
+++ b/.changeset/class-usage-maintenance.md
@@ -78,6 +78,14 @@ bypassed maintenance never appears in the walk, so its rows would otherwise surv
 rebuild that reported success. The sweep runs only after the walk completes, since against a
 partial one it would delete the rows of every document not yet reached.
 
+The bounds a rebuild derives under are REQUIRED rather than optional, on every entry point a
+caller invokes. Omitting them is not neutral: the derivation falls back to the engine
+defaults while the host may have configured others, and the two directions fail in opposite
+ways - raised bounds record a document the renderer draws whole as an undetermined marker
+instead of its classes, and lowered bounds count classes on nodes the page never draws.
+Passing the engine defaults explicitly is still available and is now a decision rather than
+an omission.
+
 It stops at the first failure. Swallowing one and continuing would report a completed
 rebuild that repaired nothing, which is the report that stops anyone looking. Stopping is
 affordable because reconciliation is idempotent: a rerun writes the same rows.

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.test.ts
@@ -88,6 +88,7 @@ describe("rebuilding the class-usage index", () => {
     const index = indexStore();
 
     const report = await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents: docs.store,
       index: index.store,
       collection: "pages",
@@ -119,6 +120,7 @@ describe("rebuilding the class-usage index", () => {
     ]);
 
     await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents: docs.store,
       index: indexStore().store,
       collection: "pages",
@@ -154,6 +156,7 @@ describe("rebuilding the class-usage index", () => {
     ]);
 
     const report = await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents: docs.store,
       index: index.store,
       collection: "pages",
@@ -221,6 +224,7 @@ describe("rebuilding the class-usage index", () => {
     const index = indexStore();
 
     const report = await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents: docs.store,
       index: index.store,
       collection: "pages",
@@ -251,6 +255,7 @@ describe("rebuilding the class-usage index", () => {
 
     await expect(
       rebuildClassUsageIndex({
+        limits: DEFAULT_LIMITS,
         documents: endless,
         index: indexStore().store,
         collection: "pages",
@@ -276,6 +281,7 @@ describe("the locale a rebuild reads under", () => {
     const index = indexStore();
 
     await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents: docs.store,
       index: index.store,
       collection: "pages",
@@ -302,6 +308,7 @@ describe("the variant a rebuild reads under", () => {
     ]);
 
     await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents: docs.store,
       index: indexStore().store,
       collection: "pages",
@@ -340,6 +347,7 @@ describe("the variant a rebuild reads under", () => {
     const rowsFor = async (variant: "published" | "draft") => {
       const index = indexStore();
       await rebuildClassUsageIndex({
+        limits: DEFAULT_LIMITS,
         documents,
         index: index.store,
         collection: "pages",
@@ -412,6 +420,7 @@ describe("rows whose document no longer exists", () => {
     };
 
     const report = await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents: docs.store,
       index,
       collection: "pages",
@@ -474,6 +483,7 @@ describe("a document the walk missed but which still exists", () => {
     };
 
     const report = await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents,
       index,
       collection: "pages",
@@ -539,6 +549,7 @@ describe("a variant of a document that no longer exists", () => {
     };
 
     const report = await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents,
       index,
       collection: "pages",
@@ -617,6 +628,7 @@ describe("the coordinates an existence check is asked in", () => {
     };
 
     await rebuildClassUsageIndex({
+      limits: DEFAULT_LIMITS,
       documents,
       index,
       collection: "pages",

--- a/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
+++ b/packages/plugin-page-builder/src/class-usage-index-rebuild.ts
@@ -195,7 +195,7 @@ async function rebuildOnePage(
     field: string;
     locale: string;
     variant: ClassUsageVariant;
-    limits?: DocumentLimits;
+    limits: DocumentLimits;
   },
   visited: Set<string>
 ): Promise<PageTally> {
@@ -293,14 +293,23 @@ export async function rebuildClassUsageIndex(args: {
    */
   variant: ClassUsageVariant;
   /**
-   * The bounds the documents are rendered under, when not the engine defaults.
+   * The bounds the documents are rendered under — the SAME value the plugin and
+   * the renderer are given.
    *
-   * The SAME value the plugin and the renderer are given. A rebuild deriving
-   * under different bounds than the renderer would record a class applied to a
-   * node the page draws as absent, and a usage-based delete reads that absence
-   * as "not used".
+   * Required rather than optional, because omitting it is not neutral and the
+   * disagreement is silent. An omitted value derives under the engine defaults
+   * while the host may have configured others, and the two directions fail
+   * differently: raised bounds mean a document the renderer draws whole is
+   * recorded as a marker instead of its classes, and lowered bounds mean
+   * classes on nodes the page never draws are counted as used.
+   *
+   * Making it required does not stop a caller passing bounds that differ from
+   * the renderer's, and nothing here can — only the caller knows what the
+   * renderer was given. What it does is force that to be a decision rather than
+   * an omission. Pass `DEFAULT_LIMITS` explicitly when the host configured
+   * none.
    */
-  limits?: DocumentLimits;
+  limits: DocumentLimits;
 }): Promise<ClassUsageRebuildReport> {
   let scanned = 0;
   let repaired = 0;

--- a/packages/plugin-page-builder/src/class-usage-limits.test-d.ts
+++ b/packages/plugin-page-builder/src/class-usage-limits.test-d.ts
@@ -1,0 +1,76 @@
+/**
+ * Whether the bounds a rebuild derives under can be omitted.
+ *
+ * A type-level test rather than a runtime one, because requiredness is not
+ * observable at runtime: an omitted argument and an explicitly-passed default
+ * produce identical behaviour, so no assertion on a report could separate them.
+ * The compiler is the only oracle for this property.
+ *
+ * Written as an assignment the checker EVALUATES rather than as
+ * `@ts-expect-error`, which suppresses whatever error happens to land on the
+ * line that follows — including one arriving for an unrelated reason, and
+ * including none at all once the rejection stops happening. `RequiredKey` is
+ * false exactly when the key admits `undefined`, so a signature that goes back
+ * to optional fails this file rather than passing it quietly.
+ *
+ * This file is `.test-d.ts` rather than `.test.ts` deliberately: the package's
+ * `tsconfig.json` excludes test files by glob and its `tsconfig.tests.json`
+ * excludes them too, so a `.test.ts` here would be in NO TypeScript program and
+ * this file would assert nothing.
+ *
+ * @module class-usage-limits.test-d
+ */
+import type { rebuildClassUsageIndex } from "./class-usage-index-rebuild";
+import type { maintainClassUsage } from "./class-usage-maintenance";
+import type { rebuildClassUsage } from "./class-usage-rebuild";
+
+/** True when `K` must be supplied — that is, when it does not admit `undefined`. */
+type RequiredKey<T, K extends keyof T> = undefined extends T[K] ? false : true;
+
+type RebuildIndexArgs = Parameters<typeof rebuildClassUsageIndex>[0];
+type MaintainArgs = Parameters<typeof maintainClassUsage>[0];
+type RebuildUsedClassesArgs = Parameters<typeof rebuildClassUsage>[0];
+
+/**
+ * Every boundary a caller invokes demands the bounds explicitly.
+ *
+ * Omitting them is not neutral: the derivation falls back to the engine
+ * defaults while the host may have configured others, and the two directions
+ * fail in opposite ways. Raised bounds record a document the renderer draws
+ * whole as an undetermined marker instead of its classes; lowered bounds count
+ * classes on nodes the page never draws. Neither is visible from the rows.
+ */
+const rebuildIndexDemandsLimits: RequiredKey<RebuildIndexArgs, "limits"> = true;
+const maintainDemandsLimits: RequiredKey<MaintainArgs, "limits"> = true;
+const rebuildUsedClassesDemandsLimits: RequiredKey<
+  RebuildUsedClassesArgs,
+  "limits"
+> = true;
+
+/**
+ * The positive control, and it is load-bearing.
+ *
+ * `RequiredKey` returning `true` for everything would satisfy the three
+ * assertions above without discriminating, so a key that IS optional has to
+ * come out `false`. `collection` on the legacy rebuild is optional today; if it
+ * ever becomes required this line fails and says so, which is the correct
+ * outcome — the control has to be re-pointed at something still optional
+ * rather than deleted.
+ */
+const optionalKeyReadsAsOptional: RequiredKey<
+  RebuildUsedClassesArgs,
+  "collection"
+> = false;
+
+export type {
+  RebuildIndexArgs,
+  MaintainArgs,
+  RebuildUsedClassesArgs,
+  RequiredKey,
+};
+export {
+  rebuildIndexDemandsLimits,
+  maintainDemandsLimits,
+  rebuildUsedClassesDemandsLimits,
+  optionalKeyReadsAsOptional,
+};

--- a/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
@@ -70,6 +70,7 @@ describe("maintaining one subject's rows", () => {
     const { store, calls } = recordingStore([]);
 
     const report = await maintainClassUsage({
+      limits: DEFAULT_LIMITS,
       store,
       subject: page,
       document: documentUsing("hero", "card"),
@@ -93,6 +94,7 @@ describe("maintaining one subject's rows", () => {
     ]);
 
     const report = await maintainClassUsage({
+      limits: DEFAULT_LIMITS,
       store,
       subject: page,
       document: documentUsing("hero", "card"),
@@ -113,6 +115,7 @@ describe("maintaining one subject's rows", () => {
     const { store, calls } = recordingStore([{ id: "r1", classId: "old" }]);
 
     await maintainClassUsage({
+      limits: DEFAULT_LIMITS,
       store,
       subject: page,
       document: documentUsing("new"),
@@ -169,6 +172,7 @@ describe("maintaining one subject's rows", () => {
 
     await expect(
       maintainClassUsage({
+        limits: DEFAULT_LIMITS,
         store,
         subject: page,
         document: documentUsing("hero"),
@@ -192,6 +196,7 @@ describe("maintaining one subject's rows", () => {
 
     await expect(
       maintainClassUsage({
+        limits: DEFAULT_LIMITS,
         store,
         subject: page,
         document: documentUsing("hero"),
@@ -241,6 +246,7 @@ describe("a row written before the locale column existed", () => {
     // needs no write at all. Were it discarded, the row would be invisible and
     // `hero` would be inserted a second time.
     const report = await maintainClassUsage({
+      limits: DEFAULT_LIMITS,
       store,
       subject: page,
       document: documentUsing("hero"),
@@ -281,6 +287,7 @@ describe("a row carrying a variant outside the two the index models", () => {
     };
 
     const report = await maintainClassUsage({
+      limits: DEFAULT_LIMITS,
       store,
       subject: page,
       document: documentUsing("hero"),
@@ -322,6 +329,7 @@ describe("a subject whose rows span several pages", () => {
     };
 
     const report = await maintainClassUsage({
+      limits: DEFAULT_LIMITS,
       store,
       subject: page,
       document: documentUsing("hero", "card"),

--- a/packages/plugin-page-builder/src/class-usage-maintenance.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.ts
@@ -349,7 +349,7 @@ export async function maintainClassUsage(args: {
   store: ClassUsageIndexStore;
   subject: ClassUsageSubject;
   document: unknown;
-  limits?: DocumentLimits;
+  limits: DocumentLimits;
 }): Promise<ClassUsageMaintenanceReport> {
   const { store, subject } = args;
   const derivation = deriveClassUsageRows(subject, args.document, args.limits);

--- a/packages/plugin-page-builder/src/class-usage-rebuild.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-rebuild.test.ts
@@ -12,6 +12,8 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
+
 import { rebuildClassUsage, type PageUsageStore } from "./class-usage-rebuild";
 
 /** One node carrying the class ids given. */
@@ -60,7 +62,7 @@ describe("rebuildClassUsage", () => {
     // produces, so the absent case has to be repaired rather than skipped.
     const { store, writes } = storeOf([[page("a", ["hero", "card"])]]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 1, undetermined: 0 });
       expect(writes).toEqual([
         { id: "a", data: { usedClasses: ["card", "hero"] } },
@@ -76,7 +78,7 @@ describe("rebuildClassUsage", () => {
       [page("a", ["hero", "card"], ["card", "hero"])],
     ]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 0, undetermined: 0 });
       expect(writes).toEqual([]);
     });
@@ -93,7 +95,7 @@ describe("rebuildClassUsage", () => {
       [page("a", ["hero", "card"], JSON.stringify(["card", "hero"]))],
     ]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 0, undetermined: 0 });
       expect(writes).toEqual([]);
     });
@@ -113,7 +115,7 @@ describe("rebuildClassUsage", () => {
       ],
     ]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 1, undetermined: 0 });
       expect(writes).toEqual([{ id: "a", data: { usedClasses: ["hero"] } }]);
     });
@@ -122,7 +124,7 @@ describe("rebuildClassUsage", () => {
   it("repairs a record that disagrees with the document", () => {
     const { store, writes } = storeOf([[page("a", ["hero"], ["stale"])]]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 1, undetermined: 0 });
       expect(writes).toEqual([{ id: "a", data: { usedClasses: ["hero"] } }]);
     });
@@ -134,7 +136,7 @@ describe("rebuildClassUsage", () => {
     // lists here hold exactly one id.
     const { store, writes } = storeOf([[page("a", ["hero"], ["card"])]]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report.repaired).toBe(1);
       expect(writes).toEqual([{ id: "a", data: { usedClasses: ["hero"] } }]);
     });
@@ -153,10 +155,14 @@ describe("rebuildClassUsage", () => {
       // stopping the run at the first one.
       const { store, writes } = storeOf([[page("a", ["hero"], stored)]]);
 
-      return rebuildClassUsage({ store }).then(report => {
-        expect(report.repaired).toBe(1);
-        expect(writes).toEqual([{ id: "a", data: { usedClasses: ["hero"] } }]);
-      });
+      return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(
+        report => {
+          expect(report.repaired).toBe(1);
+          expect(writes).toEqual([
+            { id: "a", data: { usedClasses: ["hero"] } },
+          ]);
+        }
+      );
     }
   );
 
@@ -165,7 +171,7 @@ describe("rebuildClassUsage", () => {
     // this walk happened to read, discarding an edit made in between.
     const { store, writes } = storeOf([[page("a", ["hero"])]]);
 
-    return rebuildClassUsage({ store }).then(() => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(() => {
       expect(Object.keys(writes[0]?.data ?? {})).toEqual(["usedClasses"]);
     });
   });
@@ -180,7 +186,7 @@ describe("rebuildClassUsage", () => {
       [page("c", ["hero"])],
     ]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 3, repaired: 3, undetermined: 0 });
       expect(writes.map(write => write.id)).toEqual(["a", "b", "c"]);
       expect(queries).toEqual([
@@ -196,7 +202,7 @@ describe("rebuildClassUsage", () => {
     // both report zero repairs, and only the scan count separates them.
     const { store } = storeOf([[]]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 0, repaired: 0, undetermined: 0 });
     });
   });
@@ -209,7 +215,7 @@ describe("rebuildClassUsage", () => {
       [null, { content: {} }, page("b", ["hero"])],
     ]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 1, undetermined: 0 });
       expect(writes.map(write => write.id)).toEqual(["b"]);
     });
@@ -230,9 +236,9 @@ describe("rebuildClassUsage", () => {
       update: () => Promise.resolve({}),
     };
 
-    return expect(rebuildClassUsage({ store: endless })).rejects.toThrow(
-      /were not read/
-    );
+    return expect(
+      rebuildClassUsage({ store: endless, limits: DEFAULT_LIMITS })
+    ).rejects.toThrow(/were not read/);
   });
 
   it("reports normally when the store DOES report an end, so the refusal is not unconditional", () => {
@@ -240,7 +246,7 @@ describe("rebuildClassUsage", () => {
     // case above while never completing for anyone.
     const { store } = storeOf([[page("a", ["hero"])]]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 1, undetermined: 0 });
     });
   });
@@ -274,7 +280,7 @@ describe("rebuildClassUsage", () => {
     // above while repairing nothing for anyone.
     const { store, writes } = storeOf([[page("a", ["hero"])]]);
 
-    return rebuildClassUsage({ store }).then(report => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(report => {
       expect(report).toEqual({ scanned: 1, repaired: 1, undetermined: 0 });
       expect(writes).toHaveLength(1);
     });
@@ -292,7 +298,7 @@ describe("rebuildClassUsage", () => {
     // a draft nobody asked to publish.
     const { store, writes } = storeOf([[page("a", ["hero"])]]);
 
-    return rebuildClassUsage({ store }).then(() => {
+    return rebuildClassUsage({ store, limits: DEFAULT_LIMITS }).then(() => {
       expect(writes).toHaveLength(1);
       expect(Object.keys(writes[0]?.data ?? {})).toEqual(["usedClasses"]);
       expect(writes[0]?.id).toBe("a");
@@ -313,8 +319,8 @@ describe("rebuildClassUsage", () => {
       update: () => Promise.reject(new Error("connection lost")),
     };
 
-    return expect(rebuildClassUsage({ store: failing })).rejects.toThrow(
-      "connection lost"
-    );
+    return expect(
+      rebuildClassUsage({ store: failing, limits: DEFAULT_LIMITS })
+    ).rejects.toThrow("connection lost");
   });
 });

--- a/packages/plugin-page-builder/src/class-usage-rebuild.ts
+++ b/packages/plugin-page-builder/src/class-usage-rebuild.ts
@@ -165,7 +165,7 @@ type PageVerdict = "undetermined" | "repaired" | "agreed";
 async function repairPage(
   item: StoredPage,
   collection: string,
-  args: { store: PageUsageStore; limits?: DocumentLimits }
+  args: { store: PageUsageStore; limits: DocumentLimits }
 ): Promise<PageVerdict> {
   const usage = classUsageOf(item.content, args.limits);
   if (!usage.complete) {
@@ -199,7 +199,7 @@ async function repairPage(
 async function scanOnePage(
   items: readonly unknown[],
   collection: string,
-  args: { store: PageUsageStore; limits?: DocumentLimits }
+  args: { store: PageUsageStore; limits: DocumentLimits }
 ): Promise<{ scanned: number; repaired: number; undetermined: number }> {
   let scanned = 0;
   let repaired = 0;
@@ -242,7 +242,7 @@ export async function rebuildClassUsage(args: {
    * list the hook then disagrees with, and the two would take turns correcting
    * each other on every save.
    */
-  limits?: DocumentLimits;
+  limits: DocumentLimits;
 }): Promise<RebuildReport> {
   const collection = args.collection ?? "pages";
   let scanned = 0;

--- a/packages/plugin-page-builder/src/class-usage-reconcile.ts
+++ b/packages/plugin-page-builder/src/class-usage-reconcile.ts
@@ -154,6 +154,15 @@ export interface ClassUsageReconciliation {
 export function deriveClassUsageRows(
   subject: ClassUsageSubject,
   document: unknown,
+  /**
+   * Optional HERE, and required on every function that calls this one.
+   *
+   * The difference is whether omitting it is neutral. This derives from one
+   * document and nothing else reads the result, so an absent value meaning the
+   * engine defaults is the same answer the engine would give. A boundary
+   * function has a second reader — the renderer — and an omission there is a
+   * silent disagreement with it.
+   */
   limits?: DocumentLimits
 ): ClassUsageDerivation {
   const usage = classUsageOf(document, limits);

--- a/packages/plugin-page-builder/src/index.ts
+++ b/packages/plugin-page-builder/src/index.ts
@@ -38,6 +38,21 @@ export type {
   BlockNode,
   DocumentKind,
 } from "@nextlyhq/blocks-engine";
+
+// The bounds a rebuild derives under, for the same reason and by the same rule.
+// They are REQUIRED arguments on this package's rebuild entry points, so a host
+// running the engine defaults has to name a value — and the only correct value
+// lived in a package it has no guarantee of resolving. Without this the two
+// available moves are both wrong: take a direct dependency on the engine to
+// obtain one constant, or copy the numbers and let them drift silently away
+// from the bounds the renderer actually applies.
+//
+// Re-exported rather than redeclared. A second definition of these numbers is
+// the drift itself, and `public-limits-export.test.ts` asserts by REFERENCE
+// identity that this is the engine's own object rather than a copy that happens
+// to agree today.
+export { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
+export type { DocumentLimits } from "@nextlyhq/blocks-engine";
 export {
   BLOCKS_FIELD_TYPE,
   BLOCKS_TYPE,

--- a/packages/plugin-page-builder/src/public-limits-export.test.ts
+++ b/packages/plugin-page-builder/src/public-limits-export.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Whether the bounds this package re-exports are the ENGINE'S bounds.
+ *
+ * The rebuild entry points require `limits`, so a host running the engine
+ * defaults has to name a value. It cannot reach `@nextlyhq/blocks-engine` by
+ * name — that is a dependency of this package rather than of the app, and pnpm
+ * does not put a transitive dependency on an app's resolution path — so this
+ * package has to supply one.
+ *
+ * Asserted by REFERENCE identity rather than by value. Two objects holding the
+ * same numbers today satisfy a deep-equality check and drift apart the moment
+ * the engine changes one, which is the failure a re-export exists to prevent;
+ * only identity separates a re-export from a copy that happens to agree.
+ *
+ * @module public-limits-export.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_LIMITS as engineDefaults } from "@nextlyhq/blocks-engine";
+
+import { DEFAULT_LIMITS as publicDefaults } from "./index";
+
+describe("the bounds this package publishes", () => {
+  it("are the engine's own object, not a copy of its numbers", () => {
+    expect(publicDefaults).toBe(engineDefaults);
+  });
+
+  it("carry the fields a caller has to supply", () => {
+    // A control on the assertion above: `toBe` would also pass if both sides
+    // were undefined, which is what a re-export of a name the engine had
+    // renamed would produce. Naming the fields makes that case fail.
+    expect(publicDefaults).toEqual(
+      expect.objectContaining({
+        maxNodes: expect.any(Number),
+        maxDepth: expect.any(Number),
+        maxBytes: expect.any(Number),
+      })
+    );
+  });
+});


### PR DESCRIPTION
Re-lands the final commit of #1221, which was **stranded by the merge**.

## What happened

#1221 merged as `4c625854`. Its second parent is `f2181671b`, but the branch tip at merge time was `185920bb3` — so the last commit never landed. Verified three ways:

- `git merge-base --is-ancestor 185920bb3 origin/main` → not an ancestor
- content control 1: `class-usage-limits.test-d.ts` is **absent** from main
- content control 2: a marker from the *previous* commit **is present** on main, which is what proves the grep discriminates rather than matching nothing

Substantively: `limits?: DocumentLimits` still appears twice on main, so the P2 below is unfixed there.

## The defect this fixes

`plugin.ts` passes the host's configured `limits` into the page collection, while the rebuild took them as optional. A host that configured bounds could call the rebuild the natural way and derive under the engine defaults instead — and the two directions fail in opposite ways:

- **raised bounds** → a document the renderer draws whole is recorded as an undetermined marker instead of its classes
- **lowered bounds** → classes on nodes the page never draws are counted as used

Neither is visible from the rows themselves, which is why the type has to refuse it.

`limits` is now required on every entry point a caller invokes. It stays optional on `deriveClassUsageRows`, documented there: that function derives from one document with no second reader, so an absent value meaning the engine defaults is the same answer the engine would give. A boundary function has a second reader — the renderer — and an omission there is a silent disagreement with it.

## Test plan

Requiredness has no runtime signature — an omitted argument and an explicitly-passed default behave identically — so the contract is asserted in the type system by `class-usage-limits.test-d.ts`, using an assignment the checker **evaluates**:

```ts
type RequiredKey<T, K extends keyof T> = undefined extends T[K] ? false : true;
const maintainDemandsLimits: RequiredKey<MaintainArgs, "limits"> = true;
```

Not `@ts-expect-error`, which absorbs whatever error lands on the following line — including one arriving for an unrelated reason, and including none at all once the rejection stops happening. It carries a positive control: a key that *is* optional (`collection`) must come out `false`, or `RequiredKey` could be returning `true` for everything.

`.test-d.ts` rather than `.test.ts` is load-bearing: this package's `tsconfig.json` excludes test files by glob **and** its `tsconfig.tests.json` excludes them too, so a `.test.ts` would be in no TypeScript program and would assert nothing.

Break-verified against a clean baseline: making `limits` optional again on one boundary produces TS2322 at the exact assertion line.

Gates, each exit status read separately: build 0 · vitest 0 (353 passing) · check-types 0 · lint 0 · root eslint 0 · comment convention 0 · fallow `verdict: pass` with all four `*_introduced` at 0.

## Changeset

Added: yes — the existing `class-usage-maintenance.md` gains the paragraph describing this behaviour. Patch, all packages, per the repo's lockstep rule.

## Pre-existing failures, flagged

`host-policy.test.ts(25,3)` and `site-style-record.test.ts` at 729, 778 and 811 do not typecheck. Established as pre-existing with a control — the same harness on the stashed baseline reports the identical four locations. Unrelated to this change and untouched by it. They are invisible to CI because this package's unit tests are in no TypeScript program; filed separately as `finding:package-unit-tests-in-no-typescript-program`.