### PR TITLE
feat(nextly): align two sequences of units for content diffing

### DIFF
--- a/.changeset/one-way-to-align-two-sequences.md
+++ b/.changeset/one-way-to-align-two-sequences.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Comparing two versions of a document means comparing two sequences: rich text
+is a sequence of blocks, and formatted JSON or code is a sequence of lines.
+Both need the same operation — work out which units correspond, which were
+added, which were removed, and which are the same unit edited — before anything
+can say what changed inside one.
+
+This adds that operation once, as a shared internal step, rather than letting
+the rich-text and source comparisons each grow their own. Two implementations
+of one question agree on the day they are written and drift silently
+afterwards.
+
+Inserting a paragraph now marks only that paragraph added, instead of marking
+every paragraph after it as changed. An edited unit is reported as one changed
+row rather than as a deletion sitting beside an unrelated addition, so a
+word-level comparison can run within it.
+
+Where the two sides are too large to align, it says so rather than returning a
+partial result: "I could not compare these" and "these are identical" are
+different answers, and a silently truncated comparison reads as a confident
+one.
+
+Nothing uses this yet, so no comparison changes shape. The rich-text and
+JSON comparisons that build on it follow.

--- a/packages/nextly/src/domains/versions/diff/__tests__/align-units.test.ts
+++ b/packages/nextly/src/domains/versions/diff/__tests__/align-units.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Guards unit alignment. The headline is that inserting one unit must not mark
+ * every following unit changed, and that an edited unit pairs as `changed`
+ * rather than as a removal sitting beside an unrelated addition.
+ *
+ * The refusal case is the other half: a caller that cannot align must be told
+ * so, because "no pairs" and "these are identical" are different answers and
+ * folding them together lets an unreadable document read as an unchanged one.
+ */
+import { describe, expect, it } from "vitest";
+
+import { alignUnits } from "../align-units";
+
+describe("alignUnits", () => {
+  it("reports identical sequences as unchanged", () => {
+    const { aligned, pairs } = alignUnits(["a", "b"], ["a", "b"]);
+    expect(aligned).toBe(true);
+    expect(pairs.map(p => p.status)).toEqual(["unchanged", "unchanged"]);
+  });
+
+  it("marks only the inserted unit added, not everything after it", () => {
+    // The differentiator against index-based comparison, which would report
+    // "b" as changed simply because it moved down one place.
+    const { pairs } = alignUnits(["a", "b"], ["a", "x", "b"]);
+    expect(pairs.map(p => p.status)).toEqual([
+      "unchanged",
+      "added",
+      "unchanged",
+    ]);
+    expect(pairs[1]).toMatchObject({ status: "added", after: "x", toIndex: 1 });
+  });
+
+  it("marks a removed unit removed and leaves its neighbours alone", () => {
+    const { pairs } = alignUnits(["a", "b", "c"], ["a", "c"]);
+    expect(pairs.map(p => p.status)).toEqual([
+      "unchanged",
+      "removed",
+      "unchanged",
+    ]);
+    expect(pairs[1]).toMatchObject({
+      status: "removed",
+      before: "b",
+      fromIndex: 1,
+    });
+  });
+
+  it("pairs an edited unit as changed rather than removed beside added", () => {
+    // Without the pairing pass the caller gets two rows to join by eye, and
+    // cannot run a word-level diff over the pair.
+    const { pairs } = alignUnits(["a", "hello world"], ["a", "hello there"]);
+    expect(pairs.map(p => p.status)).toEqual(["unchanged", "changed"]);
+    expect(pairs[1]).toMatchObject({
+      status: "changed",
+      before: "hello world",
+      after: "hello there",
+      fromIndex: 1,
+      toIndex: 1,
+    });
+  });
+
+  it("carries indices that address the correct side of each pair", () => {
+    // An insertion desynchronises the two sides, so a pair after it must name
+    // a different index on each side. One shared index would silently address
+    // the wrong unit from here on.
+    const { pairs } = alignUnits(["a", "b"], ["x", "a", "b"]);
+    const last = pairs[pairs.length - 1];
+    expect(last).toMatchObject({
+      status: "unchanged",
+      before: "b",
+      after: "b",
+      fromIndex: 1,
+      toIndex: 2,
+    });
+  });
+
+  it("handles a unit repeated many times without confusing indices", () => {
+    const { pairs } = alignUnits(["x", "x", "x"], ["x", "x"]);
+    expect(pairs.filter(p => p.status === "removed")).toHaveLength(1);
+    expect(pairs.filter(p => p.status === "unchanged")).toHaveLength(2);
+  });
+
+  it("handles an empty side in each direction", () => {
+    expect(alignUnits([], ["a"]).pairs).toEqual([
+      { status: "added", after: "a", toIndex: 0 },
+    ]);
+    expect(alignUnits(["a"], []).pairs).toEqual([
+      { status: "removed", before: "a", fromIndex: 0 },
+    ]);
+    expect(alignUnits([], []).pairs).toEqual([]);
+  });
+
+  it("aligns units that contain private-use characters of its own alphabet", () => {
+    // Content is mapped THROUGH the alphabet rather than compared against it,
+    // so a unit that happens to contain one of these characters is ordinary
+    // text. A mapping that leaked content into the synthetic string would
+    // mis-align here.
+    const marker = "\u{E000}";
+    const { aligned, pairs } = alignUnits(
+      [`before ${marker}`, "b"],
+      [`before ${marker}`, "c"]
+    );
+    expect(aligned).toBe(true);
+    expect(pairs.map(p => p.status)).toEqual(["unchanged", "changed"]);
+  });
+
+  it("refuses rather than degrading when its alphabet is exhausted", () => {
+    // A silently truncated alignment reads as a confident answer, so the
+    // caller is told it could not be done and reports "not comparable".
+    const many = Array.from({ length: 200_000 }, (_, i) => `u${i}`);
+    const result = alignUnits(many, many.slice(0, 10));
+    expect(result.aligned).toBe(false);
+    expect(result.pairs).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/versions/diff/align-units.ts
+++ b/packages/nextly/src/domains/versions/diff/align-units.ts
@@ -1,0 +1,259 @@
+/**
+ * Align two sequences of opaque string units into pairs.
+ *
+ * Rich text is a sequence of blocks and formatted source is a sequence of
+ * lines; both need the same operation, so it lives here once and is called
+ * twice rather than growing two implementations that agree on the day they are
+ * written.
+ *
+ * Each DISTINCT unit is mapped to a private-use code point and the two
+ * synthetic strings are diffed with the same engine that diffs prose. That is
+ * the standard "line mode" technique, and it reuses a dependency this package
+ * already has instead of adding a second edit-distance implementation.
+ *
+ * Adjacent delete/insert runs are then paired positionally, so an edited unit
+ * reports as one `changed` row rather than as a removal the reader has to join
+ * to an addition by eye. What changed WITHIN a pair is left to the caller: a
+ * block wants a word diff, a line may want something else, and this function
+ * knows about neither.
+ *
+ * @module domains/versions/diff/align-units
+ */
+
+import { makeDiff } from "@sanity/diff-match-patch";
+
+import { NextlyError } from "../../../errors/nextly-error";
+
+/** One aligned unit, discriminated by which sides hold it. */
+export type UnitPair =
+  | {
+      status: "unchanged";
+      before: string;
+      after: string;
+      fromIndex: number;
+      toIndex: number;
+    }
+  | {
+      status: "changed";
+      before: string;
+      after: string;
+      fromIndex: number;
+      toIndex: number;
+    }
+  | { status: "added"; after: string; toIndex: number }
+  | { status: "removed"; before: string; fromIndex: number };
+
+export interface AlignResult {
+  /**
+   * False when the two sides together held more distinct units than the
+   * private-use alphabet can name. `pairs` is then empty and the caller reports
+   * "not comparable" rather than a partial result: a silently truncated
+   * alignment produces a confident answer about content it never read.
+   */
+  aligned: boolean;
+  pairs: UnitPair[];
+}
+
+/**
+ * Unicode private-use planes, which carry no assigned characters, so a mapped
+ * unit can never be confused with one the differ produced. Authored text MAY
+ * contain these code points; that is harmless, because content is mapped
+ * THROUGH this alphabet by identity rather than compared against it — two units
+ * are the same unit only when their full strings match.
+ *
+ * The BMP block alone caps at 6400 distinct units, which a long document can
+ * exceed, so the two supplementary planes are included as well.
+ */
+const PUA_RANGES: readonly (readonly [number, number])[] = [
+  [0xe000, 0xf8ff],
+  [0xf0000, 0xffffd],
+  [0x100000, 0x10fffd],
+];
+
+const ALPHABET_SIZE = PUA_RANGES.reduce(
+  (total, [lo, hi]) => total + (hi - lo + 1),
+  0
+);
+
+/** The nth code point of the concatenated private-use ranges. */
+function codePointAt(index: number): number {
+  let remaining = index;
+  for (const [lo, hi] of PUA_RANGES) {
+    const size = hi - lo + 1;
+    if (remaining < size) return lo + remaining;
+    remaining -= size;
+  }
+  // Callers check ALPHABET_SIZE before asking, so this cannot be reached today.
+  // It is an assertion over a value already in hand rather than a lookup, so
+  // the guard costs nothing on the path that never rejects — and unreachability
+  // is a property of the current call graph, not of this function.
+  throw NextlyError.internal({
+    logContext: { reason: "align-units-index-beyond-alphabet", index },
+  });
+}
+
+/**
+ * Encode both sides against ONE shared unit-to-code-point table, so the same
+ * unit is the same character on both sides. Returns null once the table would
+ * outgrow the alphabet.
+ */
+function encode(
+  before: readonly string[],
+  after: readonly string[]
+): { a: string; b: string } | null {
+  const table = new Map<string, string>();
+
+  const encodeSide = (units: readonly string[]): string | null => {
+    const out: string[] = [];
+    for (const unit of units) {
+      let ch = table.get(unit);
+      if (ch === undefined) {
+        if (table.size >= ALPHABET_SIZE) return null;
+        ch = String.fromCodePoint(codePointAt(table.size));
+        table.set(unit, ch);
+      }
+      out.push(ch);
+    }
+    return out.join("");
+  };
+
+  const a = encodeSide(before);
+  if (a === null) return null;
+  const b = encodeSide(after);
+  if (b === null) return null;
+  return { a, b };
+}
+
+/**
+ * One unit's position in the edit script, before removals and insertions pair
+ * up. Discriminated by `op` so each variant carries exactly the indices it has:
+ * a removal has no position on the "after" side and an insertion none on the
+ * "before" side, and a shape admitting both would need a fallback at every
+ * read.
+ */
+type Entry =
+  | { op: 0; fromIndex: number; toIndex: number }
+  | { op: -1; fromIndex: number }
+  | { op: 1; toIndex: number };
+
+/**
+ * Read a unit the edit script has already proved is present.
+ *
+ * Indices are produced by counters bounded by these same arrays, so a miss is
+ * an internal inconsistency rather than a case to handle — one assertion here
+ * beats a fallback at every call site, which would silently substitute an empty
+ * unit and report a spurious change.
+ */
+function unitAt(units: readonly string[], index: number): string {
+  const unit = units[index];
+  if (unit === undefined) {
+    throw NextlyError.internal({
+      logContext: { reason: "align-units-index-out-of-range", index },
+    });
+  }
+  return unit;
+}
+
+/**
+ * Expand the diff's runs into one entry per unit, tracking the index on each
+ * side separately. The two sides desynchronise at the first insertion or
+ * removal, so a single shared counter would address the wrong unit from there
+ * onwards.
+ */
+function toEntries(ops: readonly [number, string][]): Entry[] {
+  const entries: Entry[] = [];
+  let fromIndex = 0;
+  let toIndex = 0;
+  for (const [op, text] of ops) {
+    // Iterating a string yields whole code points, so a supplementary-plane
+    // marker counts as one unit rather than as two surrogate halves.
+    for (const _unit of text) {
+      if (op === 0) {
+        entries.push({ op: 0, fromIndex: fromIndex++, toIndex: toIndex++ });
+      } else if (op === -1) {
+        entries.push({ op: -1, fromIndex: fromIndex++ });
+      } else {
+        entries.push({ op: 1, toIndex: toIndex++ });
+      }
+    }
+  }
+  return entries;
+}
+
+/**
+ * Turn the edit script into pairs, joining a removal that is directly followed
+ * by an insertion into one `changed` row: that shape is a unit the author
+ * edited, and reporting it as a removal beside an unrelated addition leaves the
+ * reader to join the two by eye and gives the caller nothing to diff within.
+ */
+function buildPairs(
+  entries: readonly Entry[],
+  before: readonly string[],
+  after: readonly string[]
+): UnitPair[] {
+  const pairs: UnitPair[] = [];
+
+  for (let i = 0; i < entries.length; i += 1) {
+    const entry = entries[i];
+    if (entry === undefined) continue;
+
+    if (entry.op === 0) {
+      pairs.push({
+        status: "unchanged",
+        before: unitAt(before, entry.fromIndex),
+        after: unitAt(after, entry.toIndex),
+        fromIndex: entry.fromIndex,
+        toIndex: entry.toIndex,
+      });
+      continue;
+    }
+
+    if (entry.op === 1) {
+      pairs.push({
+        status: "added",
+        after: unitAt(after, entry.toIndex),
+        toIndex: entry.toIndex,
+      });
+      continue;
+    }
+
+    const next = entries[i + 1];
+    if (next !== undefined && next.op === 1) {
+      pairs.push({
+        status: "changed",
+        before: unitAt(before, entry.fromIndex),
+        after: unitAt(after, next.toIndex),
+        fromIndex: entry.fromIndex,
+        toIndex: next.toIndex,
+      });
+      // The insertion has been consumed by the pair above.
+      i += 1;
+      continue;
+    }
+
+    pairs.push({
+      status: "removed",
+      before: unitAt(before, entry.fromIndex),
+      fromIndex: entry.fromIndex,
+    });
+  }
+
+  return pairs;
+}
+
+export function alignUnits(
+  before: readonly string[],
+  after: readonly string[]
+): AlignResult {
+  if (before.length === 0 && after.length === 0) {
+    return { aligned: true, pairs: [] };
+  }
+
+  const encoded = encode(before, after);
+  if (encoded === null) return { aligned: false, pairs: [] };
+
+  // No semantic cleanup pass: these are opaque markers, and the heuristics that
+  // make prose runs readable would coalesce unrelated units.
+  const entries = toEntries(makeDiff(encoded.a, encoded.b));
+  return { aligned: true, pairs: buildPairs(entries, before, after) };
+}


### PR DESCRIPTION
## Summary

Comparing two versions means comparing two sequences: rich text is a sequence of
blocks, formatted JSON or code is a sequence of lines. Both need the same
operation first — which units correspond, which were added, which removed, and
which are one unit that was edited — before anything can say what changed
*inside* a unit.

This adds that operation **once**, so the rich-text and source comparisons that
follow do not each grow their own. Two implementations of one question agree on
the day they are written and drift silently after.

**Mechanism.** Each distinct unit maps to a private-use code point and the two
synthetic strings go through `@sanity/diff-match-patch` — already a dependency,
so no second edit-distance implementation. That is the standard "line mode"
technique. Adjacent delete/insert runs are then paired positionally, so an
edited unit reports as one `changed` row the caller can word-diff within,
rather than a deletion beside an unrelated addition.

`reconcile-list.ts` is not reusable here and that is worth saying: it matches by
**stable id**, and rich-text blocks have none. Content alignment is a genuinely
new primitive, not a duplicate.

**It refuses rather than degrading.** Past the alphabet's capacity it returns
`aligned: false` with no pairs, so the caller reports "not comparable". A
silently truncated alignment produces a confident answer about content it never
read — and "I could not compare these" must not collapse into "these are
identical".

Nothing imports this yet, so **no comparison changes shape**. Rich text (which
is not diffed at all today) and JSON follow in separate PRs.

## Test plan

9 tests. Each was **individually break-verified** — a suite going red hides the
one test that can never fail, so each break was checked for the failing test
*names*, not just a red run:

| break | fails |
| --- | --- |
| drop the removal+insertion pairing | `pairs an edited unit as changed`, `private-use characters` |
| share one index counter across both sides | `carries indices that address the correct side`, + pairing |
| remove the alphabet guard | `refuses rather than degrading` — alone |
| report every equal unit as changed | 7 of 9 |
| make the both-empty early return emit a pair | `handles an empty side` — alone |

Every one of the 9 has been seen to fail for its intended reason. Restored,
9/9 pass.

The breaks were then **re-run against the refactored structure** (see below),
since a refactor moves the break points and a test verified against the old
shape is not evidence about the new one.

**Checks**, each read by exit status rather than by grepping output:

| check | result |
| --- | --- |
| `pnpm build` | EXIT=0 |
| `pnpm check-types` | EXIT=0 |
| `pnpm lint` | EXIT=0 |
| `pnpm --filter nextly test -- align-units` | 9/9 |
| `fallow audit --gate-marker agent` | **pass** — 0 introduced |

## Two things fallow and lint caught, both real

**Cyclomatic complexity 28.** The first version inlined pair-building into
`alignUnits` with `?? 0` / `?? ""` fallbacks at every array read — fourteen of
them, each a branch. Fixed by making `Entry` a discriminated union so each
variant carries only the indices it actually has, and adding one `unitAt`
assertion instead of a fallback per call site. That is better code, not a
metric worked around: a fallback there would have substituted an empty unit and
reported a spurious change. Complexity finding now gone entirely.

**Two bare `RangeError` throws.** `packages/nextly` product code must throw
`NextlyError` — a bare error carries no code, so the API layer reports it as a
500 even when it is caller-fixable. Now `NextlyError.internal` with a
`logContext` reason, matching `versions-repository.ts`.

## Changeset

Changeset added: **yes (patch)**, all published packages, alpha lockstep.

## Pre-existing failures, so they are not read as regressions

`pnpm --filter nextly test -- versions` reports **2 failures**, both in
`src/dispatcher/handlers/__tests__/versions-methods.test.ts`:

- `listVersionsForDocument > gates on the live document before reading history`
- `getVersionForDocument > redacts the snapshot before returning it`

Both are pre-existing. Proven, not inferred: I stashed this branch, confirmed
the tree was clean, and re-ran that file on `origin/main` — the same 2 failed.
This PR adds one new module and imports nothing, so it cannot reach them.

## Context

Task 2 of 6 in R-12. Task 1 is [#1236](https://github.com/nextlyhq/nextly/pull/1236)
(panel close control) and is independent of this one. Tasks 3 and 4 — the
rich-text and JSON comparisons — both build on this and are independent of each
other.
