### PR TITLE
feat(plugin-page-builder): enumerate the index subjects one written document owns

### DIFF
--- a/packages/plugin-page-builder/src/class-usage-subjects.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-subjects.test.ts
@@ -1,0 +1,173 @@
+/**
+ * Whether a written document enumerates the subjects it actually owns.
+ *
+ * Each case names a way the enumeration can be wrong in a direction that is
+ * invisible afterwards: a subject that is never enumerated is never
+ * reconciled, so its rows stay as they were and a class it dropped goes on
+ * counting for ever; and a subject enumerated that cannot exist writes rows no
+ * query built from a real document can reach.
+ *
+ * @module class-usage-subjects.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { classUsageSubjectsFor } from "./class-usage-subjects";
+
+const base = {
+  collection: "pages",
+  entityKey: "page-1",
+  locales: [] as string[],
+  hasDrafts: false,
+};
+
+const localized = { name: "content", localized: true };
+const plain = { name: "content", localized: false };
+
+describe("a document with one unlocalized field and no drafts", () => {
+  it("owns exactly one subject", () => {
+    expect(classUsageSubjectsFor({ ...base, fields: [plain] })).toEqual([
+      {
+        scope: "collection",
+        entity: "pages",
+        entityKey: "page-1",
+        field: "content",
+        locale: "",
+        variant: "published",
+      },
+    ]);
+  });
+});
+
+describe("the locale dimension", () => {
+  it("gives a localized field one subject PER configured locale", () => {
+    const subjects = classUsageSubjectsFor({
+      ...base,
+      fields: [localized],
+      locales: ["en", "fr", "de"],
+    });
+
+    expect(subjects.map(s => s.locale)).toEqual(["en", "fr", "de"]);
+  });
+
+  it("gives an UNLOCALIZED field one subject even on a localized site", () => {
+    // The field decides this, not the collection. A collection can be localized
+    // while a given blocks field is not, and then one document serves the whole
+    // site. Enumerating per locale would file identical rows under every
+    // language and leave the `""` subject — the one a read actually resolves —
+    // holding none, so the document's classes would be invisible to the count
+    // that matters.
+    const subjects = classUsageSubjectsFor({
+      ...base,
+      fields: [plain],
+      locales: ["en", "fr", "de"],
+    });
+
+    expect(subjects).toHaveLength(1);
+    expect(subjects[0].locale).toBe("");
+  });
+
+  it("falls back to the sentinel when a localized field has no configured locales", () => {
+    // Localization off, or configured with none. There is one document, and it
+    // is the one a read with no locale resolves to — so the subject is the same
+    // one an unlocalized field gets, reached by a different route.
+    const subjects = classUsageSubjectsFor({
+      ...base,
+      fields: [localized],
+      locales: [],
+    });
+
+    expect(subjects).toHaveLength(1);
+    expect(subjects[0].locale).toBe("");
+  });
+});
+
+describe("the variant dimension", () => {
+  it("gives a drafting collection BOTH variants", () => {
+    const subjects = classUsageSubjectsFor({
+      ...base,
+      fields: [plain],
+      hasDrafts: true,
+    });
+
+    expect(subjects.map(s => s.variant)).toEqual(["published", "draft"]);
+  });
+
+  it("gives a collection WITHOUT drafts no draft subject", () => {
+    // A draft subject on a collection that keeps none describes a document that
+    // cannot exist. Its rows would be unreachable by every query built from a
+    // real document — reconciled by nothing and swept by nothing — which is the
+    // permanently-stranded state the index has no mechanism to repair.
+    const subjects = classUsageSubjectsFor({
+      ...base,
+      fields: [plain],
+      hasDrafts: false,
+    });
+
+    expect(subjects.map(s => s.variant)).toEqual(["published"]);
+  });
+});
+
+describe("the full product", () => {
+  it("enumerates every field, locale and variant together", () => {
+    // The dimensions multiply rather than compose in sequence, which is the
+    // property a nested loop can get wrong by reusing the inner list. Two
+    // fields with different localization on a two-locale drafting site is the
+    // smallest fixture where a wrong nesting produces a wrong COUNT rather than
+    // a wrong order.
+    const subjects = classUsageSubjectsFor({
+      ...base,
+      fields: [localized, { name: "sidebar", localized: false }],
+      locales: ["en", "fr"],
+      hasDrafts: true,
+    });
+
+    // content: 2 locales x 2 variants = 4. sidebar: 1 locale x 2 variants = 2.
+    expect(subjects).toHaveLength(6);
+
+    const keys = subjects.map(s => `${s.field}:${s.locale}:${s.variant}`);
+    expect(keys).toEqual([
+      "content:en:published",
+      "content:en:draft",
+      "content:fr:published",
+      "content:fr:draft",
+      "sidebar::published",
+      "sidebar::draft",
+    ]);
+  });
+
+  it("carries the collection and document id onto every subject", () => {
+    // A subject missing either is not merely incomplete: `entity` and
+    // `entityKey` are what scope every query the reconciler makes, so a blank
+    // one reconciles against another document's rows and deletes them.
+    const subjects = classUsageSubjectsFor({
+      ...base,
+      collection: "articles",
+      entityKey: "a-9",
+      fields: [localized],
+      locales: ["en", "fr"],
+      hasDrafts: true,
+    });
+
+    expect(subjects).toHaveLength(4);
+    for (const subject of subjects) {
+      expect(subject.entity).toBe("articles");
+      expect(subject.entityKey).toBe("a-9");
+      expect(subject.scope).toBe("collection");
+    }
+  });
+
+  it("owns nothing when the collection declares no blocks field", () => {
+    // The wildcard hook fires for EVERY collection, so most calls reach here
+    // with nothing to do. Returning an empty list rather than throwing is what
+    // makes the filter a property of this function instead of a branch every
+    // caller has to remember.
+    expect(
+      classUsageSubjectsFor({
+        ...base,
+        fields: [],
+        locales: ["en", "fr"],
+        hasDrafts: true,
+      })
+    ).toEqual([]);
+  });
+});

--- a/packages/plugin-page-builder/src/class-usage-subjects.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-subjects.test.ts
@@ -111,9 +111,18 @@ describe("the full product", () => {
   it("enumerates every field, locale and variant together", () => {
     // The dimensions multiply rather than compose in sequence, which is the
     // property a nested loop can get wrong by reusing the inner list. Two
-    // fields with different localization on a two-locale drafting site is the
-    // smallest fixture where a wrong nesting produces a wrong COUNT rather than
-    // a wrong order.
+    // fields with different localization is the smallest fixture where a wrong
+    // nesting produces a wrong COUNT rather than a wrong order.
+    //
+    // This fixture combines locales AND drafts, which core does not currently
+    // permit together: the draft/publish split requires the collection to be
+    // non-localized, so a real collection has at most one of the two dimensions
+    // above one. Stated rather than left to be assumed, because a reader would
+    // otherwise take this case as evidence about a configuration that can
+    // occur. It is kept because the enumeration must not depend on that
+    // constraint holding — a function that is only correct while a rule
+    // elsewhere is enforced fails silently the day the rule is relaxed, and
+    // nothing here would notice.
     const subjects = classUsageSubjectsFor({
       ...base,
       fields: [localized, { name: "sidebar", localized: false }],

--- a/packages/plugin-page-builder/src/class-usage-subjects.ts
+++ b/packages/plugin-page-builder/src/class-usage-subjects.ts
@@ -1,0 +1,137 @@
+/**
+ * Which index subjects one written document has.
+ *
+ * A save tells the write path that a document changed. It does not say WHICH
+ * translation or WHICH stored form changed, because a collection hook is handed
+ * only the collection, the operation and the data: the locale exists at the
+ * mutation service's call site and is not forwarded, and `_status` is stripped
+ * from the data on the way out as a companion-only column. So the hook cannot
+ * name the one subject that moved.
+ *
+ * This enumerates them all instead, and the cost is bounded and one-sided.
+ * Reconciliation issues NO writes when a subject's rows already agree with its
+ * document, so the locales and variants that did not change cost a read each
+ * and nothing more. Being unable to tell them apart is therefore a performance
+ * question rather than a correctness one — which is the whole reason this shape
+ * was chosen over teaching the hook to know.
+ *
+ * Pure, and deliberately so: it takes the configuration as values rather than
+ * reading it. The decisions here — that an unlocalized field has exactly one
+ * subject per variant, that a collection without drafts has no draft subject —
+ * are the ones worth testing without a database in the way.
+ *
+ * @module class-usage-subjects
+ */
+import type { ClassUsageSubject } from "./class-usage-reconcile";
+import type { ClassUsageVariant } from "./collections/class-usage-index";
+
+/** The locale sentinel for a field whose values are not per-language. */
+const NOT_LOCALIZED = "";
+
+/** One blocks field on the written collection, and whether it stores per locale. */
+export interface BlocksFieldDescriptor {
+  /** The field's name, which is the `field` column of every row it owns. */
+  name: string;
+  /**
+   * Whether this FIELD is localized, which is not the same as whether the
+   * collection is.
+   *
+   * A collection can be localized while a given blocks field is not, and then
+   * the field stores one document for the whole site. Enumerating a subject per
+   * locale for it would file identical rows under every language and leave the
+   * `""` subject — the one a read actually resolves — with none.
+   */
+  localized: boolean;
+}
+
+/** Everything about the written collection that decides its subjects. */
+export interface WrittenDocument {
+  /** The collection's slug, stored as `entity`. */
+  collection: string;
+  /** The document's id, stored as `entityKey`. */
+  entityKey: string;
+  /** Every blocks field declared on the collection. */
+  fields: readonly BlocksFieldDescriptor[];
+  /**
+   * The site's configured locales, or empty when localization is off.
+   *
+   * Used only for fields that are themselves localized. An empty list and an
+   * unlocalized field reach the same place — one subject under the `""`
+   * sentinel — but for different reasons, and both are exercised.
+   */
+  locales: readonly string[];
+  /**
+   * Whether this collection keeps a working draft beside its published row.
+   *
+   * When it does, one id addresses TWO documents that can apply different
+   * classes, and each is its own subject. When it does not, a draft subject
+   * would describe a document that cannot exist, and its rows could never be
+   * reconciled against anything — the unaddressable state the sweep cannot
+   * reach.
+   */
+  hasDrafts: boolean;
+}
+
+/**
+ * Every variant a document is stored in, given whether the collection drafts.
+ *
+ * Ordered published-first so the enumeration is stable, which matters because
+ * a caller reconciles in this order and a test asserting the sequence would
+ * otherwise be asserting a property of `Object.keys`.
+ */
+function variantsFor(hasDrafts: boolean): ClassUsageVariant[] {
+  return hasDrafts ? ["published", "draft"] : ["published"];
+}
+
+/**
+ * Every locale a FIELD is stored under.
+ *
+ * An unlocalized field answers the `""` sentinel whatever the site is
+ * configured with, and a localized field on a site with no configured locales
+ * answers the same — there is one document either way, and it is the one a read
+ * with no locale resolves to.
+ */
+function localesFor(
+  field: BlocksFieldDescriptor,
+  locales: readonly string[]
+): readonly string[] {
+  if (!field.localized) return [NOT_LOCALIZED];
+  return locales.length > 0 ? locales : [NOT_LOCALIZED];
+}
+
+/**
+ * Enumerate the subjects a written document owns.
+ *
+ * The product of fields, their locales and the collection's variants. A
+ * document with two blocks fields on a three-locale site with drafts has
+ * twelve; one with a single unlocalized field on a site without drafts has one.
+ *
+ * Every subject carries `scope: "collection"`. Singles are addressed by slug
+ * with an empty `entityKey` and are not reachable from a collection hook, so
+ * they are not enumerated here — a plugin has no supported way to read a
+ * Single's document, and inventing one would materialise every Single in the
+ * app as a side effect of reading it.
+ */
+export function classUsageSubjectsFor(
+  document: WrittenDocument
+): ClassUsageSubject[] {
+  const variants = variantsFor(document.hasDrafts);
+  const subjects: ClassUsageSubject[] = [];
+
+  for (const field of document.fields) {
+    for (const locale of localesFor(field, document.locales)) {
+      for (const variant of variants) {
+        subjects.push({
+          scope: "collection",
+          entity: document.collection,
+          entityKey: document.entityKey,
+          field: field.name,
+          locale,
+          variant,
+        });
+      }
+    }
+  }
+
+  return subjects;
+}

--- a/packages/plugin-page-builder/src/class-usage-subjects.ts
+++ b/packages/plugin-page-builder/src/class-usage-subjects.ts
@@ -68,6 +68,18 @@ export interface WrittenDocument {
    * would describe a document that cannot exist, and its rows could never be
    * reconciled against anything — the unaddressable state the sweep cannot
    * reach.
+   *
+   * NOT `status === true`. The draft/publish split resolves from five
+   * conditions together: `status: true`, versioning resolving `drafts.enabled`
+   * to true, the collection being non-localized, every reachable component
+   * schema resolving and being non-localized, and no reachable field being a
+   * password. A caller that reads `status` alone will enumerate a draft subject
+   * for a collection that stores no draft.
+   *
+   * One consequence is worth stating because it bounds the cost of this whole
+   * approach: **drafts and localization are mutually exclusive**, so a real
+   * collection has at most one of `locales` and `variants` above one. The
+   * product below is a product of at most one multiplying dimension, not two.
    */
   hasDrafts: boolean;
 }


### PR DESCRIPTION
First piece of the class-usage **write path**, built to the two founder rulings recorded today.

## Why this shape

A collection hook is handed `collection`, `operation`, `data` and `originalData`. Measured, not assumed:

- `locale` exists at the mutation service's call site as `localizedUpdate?.writeLocale` and is **not forwarded** to the hook.
- `_status` is **deliberately stripped** from the data on the way out — `collection-mutation-service.ts`: `if (column === "_status") continue;` with the comment "`_status` is a companion-only column, not an entry field".

So the hook cannot name which translation or which stored form changed. Rather than teach it to know — which would mean editing a core API used by every hook — this enumerates every subject the document owns and reconciles them all.

**The cost is one-sided, which is what makes that acceptable.** Reconciliation issues no writes when a subject's rows already agree with its document, so a locale or variant that did not change costs a read and nothing more. Being unable to tell them apart is therefore a performance question, not a correctness one. Passing `locale` and `status` into the hook context is filed as the future optimisation, to be taken when there is measured evidence it is needed rather than a guess.

## The two distinctions that carry correctness

**A field's own localization decides its locales, not the collection's.** A collection can be localized while a given blocks field is not, and then one document serves the whole site. Enumerating per locale there would file identical rows under every language and leave the `""` subject — the one a read actually resolves — holding none, so the document's classes would be invisible to the count that decides whether a class is safe to delete.

**A collection without drafts gets no draft subject.** One would describe a document that cannot exist, and its rows would be unreachable by every query built from a real one — reconciled by nothing and swept by nothing. That is the permanently-stranded state the index has no mechanism to repair.

## Test plan

Nine cases, each naming a way the enumeration can be wrong in a direction that is invisible afterwards. Break-verified individually, each break confirmed to compile:

- removing the per-field localization branch → fails `gives an UNLOCALIZED field one subject even on a localized site` and the full-product case
- always emitting both variants → fails the single-subject, per-locale and unlocalized cases

The full-product case uses two fields with **different** localization on a two-locale drafting site — the smallest fixture where a wrong loop nesting produces a wrong COUNT rather than merely a wrong order, since a count that happens to match is the failure a shape assertion cannot see.

Gates, each exit status read separately: build 0 · vitest 0 (364 passing) · check-types 0 · lint 0 · root eslint 0 · comment convention 0 · fallow `verdict: pass` with all four `*_introduced` at 0, including `dead_code_introduced`.

## Changeset

**Skipped**, deliberately. `class-usage-subjects.ts` is internal — it is not exported from the package's public entry and adds no API a host can call. The changeset lands with the hook that consumes it, where the behaviour becomes user-facing.

## Scope

Pure logic only. It takes configuration as values rather than reading it, so the decisions worth testing are testable without a database in the way. The hook registration, the config read and the store adapter follow separately.