### PR TITLE
docs(plugin-page-builder): drafts and localization are not mutually exclusive

### DIFF
--- a/packages/plugin-page-builder/src/class-usage-subjects.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-subjects.test.ts
@@ -114,15 +114,11 @@ describe("the full product", () => {
     // fields with different localization is the smallest fixture where a wrong
     // nesting produces a wrong COUNT rather than a wrong order.
     //
-    // This fixture combines locales AND drafts, which core does not currently
-    // permit together: the draft/publish split requires the collection to be
-    // non-localized, so a real collection has at most one of the two dimensions
-    // above one. Stated rather than left to be assumed, because a reader would
-    // otherwise take this case as evidence about a configuration that can
-    // occur. It is kept because the enumeration must not depend on that
-    // constraint holding — a function that is only correct while a rule
-    // elsewhere is enforced fails silently the day the rule is relaxed, and
-    // nothing here would notice.
+    // Locales AND drafts together is a REACHABLE configuration. The draft split
+    // does not ask whether a document is localized — a snapshot holds exactly
+    // one locale's values and the draft is keyed by that locale — so both
+    // dimensions can exceed one at once and this is the ordinary case rather
+    // than a defensive one.
     const subjects = classUsageSubjectsFor({
       ...base,
       fields: [localized, { name: "sidebar", localized: false }],

--- a/packages/plugin-page-builder/src/class-usage-subjects.ts
+++ b/packages/plugin-page-builder/src/class-usage-subjects.ts
@@ -69,17 +69,20 @@ export interface WrittenDocument {
    * reconciled against anything — the unaddressable state the sweep cannot
    * reach.
    *
-   * NOT `status === true`. The draft/publish split resolves from five
-   * conditions together: `status: true`, versioning resolving `drafts.enabled`
-   * to true, the collection being non-localized, every reachable component
-   * schema resolving and being non-localized, and no reachable field being a
-   * password. A caller that reads `status` alone will enumerate a draft subject
-   * for a collection that stores no draft.
+   * NOT `status === true`. The split resolves from five conditions together:
+   * versioning resolving `drafts.enabled`, `status: true`, no reachable
+   * password field on the collection, every reachable component schema
+   * resolving, and no component carrying a password field. A caller that reads
+   * `status` alone enumerates a draft subject for a collection that stores no
+   * draft, and those rows are reachable by nothing.
    *
-   * One consequence is worth stating because it bounds the cost of this whole
-   * approach: **drafts and localization are mutually exclusive**, so a real
-   * collection has at most one of `locales` and `variants` above one. The
-   * product below is a product of at most one multiplying dimension, not two.
+   * Localization is NOT among those conditions, and it is worth saying so
+   * because two comments in core assert the opposite. `evaluateDraftSplitEligibility`
+   * has no localization check and its own comment explains why — a snapshot
+   * holds exactly one locale's values and the draft is keyed by that locale —
+   * which is why `working-draft-locale.ts` exists at all. So a localized
+   * collection can draft, both dimensions below can exceed one at once, and the
+   * enumeration really is a product.
    */
   hasDrafts: boolean;
 }


### PR DESCRIPTION
Re-lands the correction stranded by #1240's merge, and **removes a false claim currently on `main`**.

## What is wrong on main right now

`class-usage-subjects.ts` on `main` asserts that the draft/publish split requires a non-localized collection, so a collection has at most one of locales and variants above one. **That is false.** It is a docblock stating a constraint — the most believable form a wrong claim can take, and the next reader has no reason to doubt it.

I wrote it an hour ago on the strength of two comments in core, and both are wrong about the function they name:

- `define-collection.ts:790-801` — "The split additionally requires the collection to be non-localized"
- `collection-mutation-service.ts` at the `isDraftSplitEligible` call site — "A localized document or component ... rule it out — see `isDraftSplitEligible`"

## What the code actually does

`evaluateDraftSplitEligibility` has **no localization check**. Its own comment gives the reason:

> A LOCALIZED component is representable, because a snapshot holds exactly one locale's values and the draft is keyed by that locale.

Its tests say it outright — `it("does not ask whether the document is localized")` and `it("stays eligible with a localized component")` — and `working-draft-locale.ts` exists precisely because a working draft is keyed by locale.

So a localized collection can draft, both dimensions can exceed one at once, and the subject enumeration is a real product rather than a defensive one.

The five conditions the docblock now lists are the ones the implementation actually applies: versioning resolving `drafts.enabled`, `status: true`, no reachable password field on the collection, every reachable component schema resolving, and no component carrying a password field. My earlier version had the right COUNT and substituted "non-localized" for the last one — a way of being wrong that a count cannot catch.

## Why it was stranded

#1240 merged as `bea3a2dd6`, whose second parent is `8d4fb9790`. The correction `1da2cb168` was pushed 45 seconds earlier and is not an ancestor of `main`. Verified by content with both controls: "mutually exclusive" IS present on main, and the corrected text is ABSENT.

## Test plan

Documentation and one test comment; no behaviour changes. The nine enumeration cases are unchanged and still pass — including the full-product case, which is now labelled as the ordinary reachable configuration rather than an impossible one it was previously (wrongly) described as.

Gates, each exit status read separately: build 0 · vitest 0 (364 passing) · check-types 0 · lint 0 · root eslint 0 · comment convention 0 · fallow `verdict: pass` with all four `*_introduced` at 0.

## Changeset

**Skipped** — comments only, no API or behaviour change, and `class-usage-subjects.ts` remains internal.

## Worth fixing separately

The two core comments are still wrong and will mislead the next reader the way they misled me. They are in `packages/nextly`, which several lanes are active in, so I have not touched them here.