### PR TITLE
feat(blocks-engine): publish the font, size, colour and highlight an author chose

### DIFF
--- a/.changeset/rich-text-inline-styles-reach-the-page.md
+++ b/.changeset/rich-text-inline-styles-reach-the-page.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Rich-text font, size, colour and highlight now reach the published page.

--- a/packages/admin/src/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar.tsx
@@ -50,17 +50,7 @@ import { useToolbarState } from "./useToolbarState";
 // Constants
 // ============================================================
 
-/**
- * The font families this toolbar offers.
- *
- * EXPORTED because `blocks-engine` restates this vocabulary. It cannot import
- * this package — the dependency does not exist and must not — so the two lists
- * are held together by `renderer-covers-the-editor.test.ts`, which imports this
- * one and reads the engine's as source. A restatement that drifts is otherwise
- * silent: the author picks a face and the page drops it, with nothing anywhere
- * reporting the loss.
- */
-export const FONT_FAMILY_OPTIONS = [
+const FONT_FAMILY_OPTIONS = [
   { label: "Default", value: "" },
   { label: "Arial", value: "Arial" },
   { label: "Courier New", value: "Courier New" },
@@ -70,8 +60,7 @@ export const FONT_FAMILY_OPTIONS = [
   { label: "Verdana", value: "Verdana" },
 ];
 
-/** The font sizes this toolbar offers. See {@link FONT_FAMILY_OPTIONS}. */
-export const FONT_SIZE_OPTIONS = [
+const FONT_SIZE_OPTIONS = [
   "10px",
   "11px",
   "12px",

--- a/packages/admin/src/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar.tsx
@@ -50,7 +50,17 @@ import { useToolbarState } from "./useToolbarState";
 // Constants
 // ============================================================
 
-const FONT_FAMILY_OPTIONS = [
+/**
+ * The font families this toolbar offers.
+ *
+ * EXPORTED because the published renderer restates this vocabulary — it lives
+ * in `blocks-react`, which may not import this package — and a restatement that
+ * drifts is silent: the author picks a face and the page drops it, with nothing
+ * anywhere reporting the loss. `renderer-covers-the-editor.test.ts` holds the
+ * two together, and it imports this rather than reading the file, so a
+ * reformatting cannot make the check pass by finding nothing.
+ */
+export const FONT_FAMILY_OPTIONS = [
   { label: "Default", value: "" },
   { label: "Arial", value: "Arial" },
   { label: "Courier New", value: "Courier New" },
@@ -60,7 +70,8 @@ const FONT_FAMILY_OPTIONS = [
   { label: "Verdana", value: "Verdana" },
 ];
 
-const FONT_SIZE_OPTIONS = [
+/** The font sizes this toolbar offers. See {@link FONT_FAMILY_OPTIONS}. */
+export const FONT_SIZE_OPTIONS = [
   "10px",
   "11px",
   "12px",

--- a/packages/admin/src/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar.tsx
@@ -53,12 +53,12 @@ import { useToolbarState } from "./useToolbarState";
 /**
  * The font families this toolbar offers.
  *
- * EXPORTED because the published renderer restates this vocabulary — it lives
- * in `blocks-react`, which may not import this package — and a restatement that
- * drifts is silent: the author picks a face and the page drops it, with nothing
- * anywhere reporting the loss. `renderer-covers-the-editor.test.ts` holds the
- * two together, and it imports this rather than reading the file, so a
- * reformatting cannot make the check pass by finding nothing.
+ * EXPORTED because `blocks-engine` restates this vocabulary. It cannot import
+ * this package — the dependency does not exist and must not — so the two lists
+ * are held together by `renderer-covers-the-editor.test.ts`, which imports this
+ * one and reads the engine's as source. A restatement that drifts is otherwise
+ * silent: the author picks a face and the page drops it, with nothing anywhere
+ * reporting the loss.
  */
 export const FONT_FAMILY_OPTIONS = [
   { label: "Default", value: "" },

--- a/packages/admin/src/components/features/entries/fields/special/renderer-covers-the-editor.test.ts
+++ b/packages/admin/src/components/features/entries/fields/special/renderer-covers-the-editor.test.ts
@@ -37,6 +37,10 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { RICH_TEXT_NODES } from "@admin/components/features/entries/fields/special/rich-text-kit";
+import {
+  FONT_FAMILY_OPTIONS,
+  FONT_SIZE_OPTIONS,
+} from "@admin/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -45,6 +49,20 @@ const RENDERER = join(
   HERE,
   "../../../../../../..",
   "blocks-react/src/rich-text.tsx"
+);
+
+/**
+ * Where the engine decides what a stored inline style may carry.
+ *
+ * Read as SOURCE for the same reason the renderer is, and it is not the same
+ * reason as the renderer's: this package has NO dependency on `blocks-engine`
+ * and must not gain one — measured, and it is why the video node is declared
+ * unrendered above rather than fixed. A static read creates no dependency.
+ */
+const ENGINE_INLINE_STYLE = join(
+  HERE,
+  "../../../../../../..",
+  "blocks-engine/src/style/inline-style.ts"
 );
 
 /**
@@ -282,11 +300,19 @@ function unionMembers(source: string, name: string): string[] {
   return [...match[1].matchAll(/"([a-z0-9-]+)"/g)].map(m => m[1] ?? "");
 }
 
-/** A `const X = ["a", "b"] as const;` array's members, from the renderer. */
+/**
+ * A `const X = ["a", "b"] as const;` array's members, from a source file.
+ *
+ * ANY quoted string, not only a lowercase one. A font family is `"Courier New"`
+ * — capitals and a space — and a pattern written for node types reads that
+ * array as EMPTY, which is the reassuring direction: two empty lists agree
+ * perfectly. The slice ends at the array's own closing bracket, so widening it
+ * cannot reach prose elsewhere in the file.
+ */
 function constMembers(source: string, name: string): string[] {
   const match = new RegExp(`const ${name} = \\[([^\\]]*)\\]`).exec(source);
   if (match?.[1] === undefined) return [];
-  return [...match[1].matchAll(/"([a-z0-9-]+)"/g)].map(m => m[1] ?? "");
+  return [...match[1].matchAll(/"([^"]*)"/g)].map(m => m[1] ?? "");
 }
 
 /**
@@ -396,4 +422,60 @@ describe("richTextValueVocabulariesAgree", () => {
       );
     }
   );
+});
+
+describe("richTextInlineStyleVocabulariesAgree", () => {
+  /*
+   * The renderer restates the toolbar's font vocabularies, because
+   * `blocks-engine` may not import this package. A restatement that drifts does
+   * not fail loudly — the author picks a face or a size, the reader does not
+   * recognise it, and the page publishes without it while the editor goes on
+   * showing it.
+   *
+   * IMPORTED on both sides rather than read from source. The two checks above
+   * parse the renderer because a dispatch table has no runtime form to ask; a
+   * list of strings does, and a parse of one is a second implementation that
+   * can quietly come back empty — which is how the class-scanning version of
+   * the check above saw eight of twenty types and reported full coverage.
+   */
+  const engine = readFileSync(ENGINE_INLINE_STYLE, "utf8");
+
+  it("offers the editor's own families to the renderer", () => {
+    // The population first: two empty lists agree perfectly, and this parser
+    // has already been widened once for exactly that failure.
+    const restated = constMembers(engine, "RICH_TEXT_FONT_FAMILIES");
+    const offered = FONT_FAMILY_OPTIONS.map(option => option.value).filter(
+      value => value !== ""
+    );
+    expect(restated.length).toBeGreaterThan(1);
+    expect(offered.length).toBeGreaterThan(1);
+    expect([...restated].sort()).toEqual([...offered].sort());
+  });
+
+  it("offers the editor's own sizes to the renderer", () => {
+    const restated = constMembers(engine, "RICH_TEXT_FONT_SIZES");
+    expect(restated.length).toBeGreaterThan(1);
+    expect(FONT_SIZE_OPTIONS.length).toBeGreaterThan(1);
+    expect([...restated].sort()).toEqual([...FONT_SIZE_OPTIONS].sort());
+  });
+
+  it("declares every property the toolbar can actually write", () => {
+    /*
+     * The other half, and the one a vocabulary check alone would miss: the
+     * families and sizes could agree perfectly while the PROPERTY carrying them
+     * was absent from the engine's allowlist, and every value would still be
+     * dropped. These four are what `$patchStyleText` writes in
+     * `useToolbarState.ts`.
+     */
+    const allowed = constMembers(engine, "INLINE_STYLE_PROPERTIES");
+    expect(allowed.length).toBeGreaterThan(1);
+    for (const property of [
+      "font-family",
+      "font-size",
+      "color",
+      "background-color",
+    ]) {
+      expect(allowed, property).toContain(property);
+    }
+  });
 });

--- a/packages/admin/src/components/features/entries/fields/special/renderer-covers-the-editor.test.ts
+++ b/packages/admin/src/components/features/entries/fields/special/renderer-covers-the-editor.test.ts
@@ -37,10 +37,6 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import { RICH_TEXT_NODES } from "@admin/components/features/entries/fields/special/rich-text-kit";
-import {
-  FONT_FAMILY_OPTIONS,
-  FONT_SIZE_OPTIONS,
-} from "@admin/components/features/entries/fields/special/RichTextToolbar/RichTextToolbar";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -440,25 +436,21 @@ describe("richTextInlineStyleVocabulariesAgree", () => {
    */
   const engine = readFileSync(ENGINE_INLINE_STYLE, "utf8");
 
-  it("offers the editor's own families to the renderer", () => {
-    // The population first: two empty lists agree perfectly, and this parser
-    // has already been widened once for exactly that failure.
-    const restated = constMembers(engine, "RICH_TEXT_FONT_FAMILIES");
-    const offered = FONT_FAMILY_OPTIONS.map(option => option.value).filter(
-      value => value !== ""
-    );
-    expect(restated.length).toBeGreaterThan(1);
-    expect(offered.length).toBeGreaterThan(1);
-    expect([...restated].sort()).toEqual([...offered].sort());
-  });
-
-  it("offers the editor's own sizes to the renderer", () => {
-    const restated = constMembers(engine, "RICH_TEXT_FONT_SIZES");
-    expect(restated.length).toBeGreaterThan(1);
-    expect(FONT_SIZE_OPTIONS.length).toBeGreaterThan(1);
-    expect([...restated].sort()).toEqual([...FONT_SIZE_OPTIONS].sort());
-  });
-
+  /*
+   * The value-equality contract that used to sit here is GONE, deliberately.
+   * It compared the toolbar's font lists to a restatement in `blocks-engine`
+   * that nothing read: the reader accepts any safe family or size, so the
+   * restatement changed no behaviour and the check only meant that adding a
+   * toolbar option failed CI in a package which already rendered it correctly.
+   * Two lists to edit for one change is the parallel implementation this repo
+   * forbids, and the "conformance" was between two things neither of which
+   * decided anything.
+   *
+   * What survives is the contract that DOES decide: the properties those values
+   * are written under must be ones the reader keeps. The behavioural half — that
+   * a family with a space and a size with a unit survive — lives beside the
+   * reader and beside the renderer, where each can be observed.
+   */
   it("declares every property the toolbar can actually write", () => {
     /*
      * The other half, and the one a vocabulary check alone would miss: the

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -383,8 +383,6 @@ export {
   INLINE_STYLE_PROPERTIES,
   isInlineStyleProperty,
   readInlineStyle,
-  RICH_TEXT_FONT_FAMILIES,
-  RICH_TEXT_FONT_SIZES,
   sanitizeInlineStyle,
 } from "./style/inline-style";
 export type {

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -377,6 +377,16 @@ export {
   hasCssInjection,
   normalizeCssValue,
 } from "./style/css-color";
+// One reading of a rich-text inline style. The CMS serializer, the React
+// renderer and the versions differ all ask this module rather than each other.
+export {
+  INLINE_STYLE_PROPERTIES,
+  isInlineStyleProperty,
+  readInlineStyle,
+  RICH_TEXT_FONT_FAMILIES,
+  RICH_TEXT_FONT_SIZES,
+  sanitizeInlineStyle,
+} from "./style/inline-style";
 export type {
   CompiledPageCss,
   StyleCompileContext,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -380,6 +380,7 @@ export {
 // One reading of a rich-text inline style. The CMS serializer, the React
 // renderer and the versions differ all ask this module rather than each other.
 export {
+  formatsDrawnByStyle,
   INLINE_STYLE_PROPERTIES,
   isInlineStyleProperty,
   readInlineStyle,

--- a/packages/blocks-engine/src/style/css-color.test.ts
+++ b/packages/blocks-engine/src/style/css-color.test.ts
@@ -62,6 +62,47 @@ describe("cssColor", () => {
     expect(cssColor(value)).toBeUndefined();
   });
 
+  it("refuses a word that is not a colour", () => {
+    /*
+     * `/^[a-zA-Z]+$/` was here, and its comment argued that an unknown name is a
+     * declaration the browser drops anyway. True of a name ALONE, false the
+     * moment one follows another: `color: red; color: banana` renders RED,
+     * because the browser discards the second and keeps the first. A reader that
+     * ACCEPTS `banana` and drops the earlier declaration publishes no colour.
+     */
+    expect(cssColor("banana")).toBeUndefined();
+    expect(cssColor("notacolour")).toBeUndefined();
+  });
+
+  it.each([
+    "rebeccapurple",
+    "lightgoldenrodyellow",
+    "mediumspringgreen",
+    "transparent",
+    "currentcolor",
+  ])("keeps the keyword %s", keyword => {
+    // The population, and the reason it is not two names: a truncated paste of
+    // the list would still satisfy `red` and `blue`. These are late-alphabet,
+    // long, and one of them (`rebeccapurple`) is the most recent addition to
+    // CSS, so a stale list is caught rather than a short one.
+    expect(cssColor(keyword)).toBe(keyword);
+  });
+
+  it.each(["inherit", "initial", "unset", "revert", "revert-layer"])(
+    "keeps the CSS-wide keyword %s",
+    keyword => {
+      // `revert-layer` is the one the old rule got wrong in the other
+      // direction: it is hyphenated, so an alphabetic-only pattern REFUSED a
+      // perfectly legal value.
+      expect(cssColor(keyword)).toBe(keyword);
+    }
+  );
+
+  it("reads a keyword whatever its case, since an identifier has none", () => {
+    expect(cssColor("RED")).toBe("RED");
+    expect(cssColor("CurrentColor")).toBe("CurrentColor");
+  });
+
   it("refuses a value that is not a string, and an empty one", () => {
     expect(cssColor(undefined)).toBeUndefined();
     expect(cssColor(null)).toBeUndefined();

--- a/packages/blocks-engine/src/style/css-color.ts
+++ b/packages/blocks-engine/src/style/css-color.ts
@@ -18,6 +18,8 @@
  * @module style/css-color
  */
 
+import { checkColorValue } from "./css-value";
+
 /**
  * Value shapes that must never reach a stylesheet, whatever else they look like.
  *
@@ -42,47 +44,6 @@ const CSS_INJECTION_PATTERNS: readonly RegExp[] = [
   /@import/i, // Loads an external stylesheet
   /@font-face/i, // Exfiltrates via a font request
   /var\s*\(/i, // A custom property can carry an attack set up elsewhere
-];
-
-const HEX_COLOR =
-  /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{4}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
-
-const NUM = String.raw`\d{1,3}%?`;
-const HUE = String.raw`[\d.]+(?:deg|rad|grad|turn)?`;
-const PCT = String.raw`\d{1,3}%`;
-
-/**
- * The syntaxes a stored colour may be written in.
- *
- * Both the comma and the space form of every function, because a browser's own
- * colour picker writes one and an imported document may carry the other.
- */
-const COLOR_PATTERNS: readonly RegExp[] = [
-  HEX_COLOR,
-  new RegExp(`^rgb\\(\\s*${NUM}\\s*,\\s*${NUM}\\s*,\\s*${NUM}\\s*\\)$`),
-  new RegExp(
-    `^rgb\\(\\s*${NUM}\\s+${NUM}\\s+${NUM}\\s*(?:\\/\\s*[\\d.]+%?\\s*)?\\)$`
-  ),
-  new RegExp(
-    `^rgba\\(\\s*${NUM}\\s*,\\s*${NUM}\\s*,\\s*${NUM}\\s*,\\s*[\\d.]+%?\\s*\\)$`
-  ),
-  new RegExp(
-    `^rgba\\(\\s*${NUM}\\s+${NUM}\\s+${NUM}\\s*\\/\\s*[\\d.]+%?\\s*\\)$`
-  ),
-  new RegExp(`^hsl\\(\\s*${HUE}\\s*,\\s*${PCT}\\s*,\\s*${PCT}\\s*\\)$`),
-  new RegExp(
-    `^hsl\\(\\s*${HUE}\\s+${PCT}\\s+${PCT}\\s*(?:\\/\\s*[\\d.]+%?\\s*)?\\)$`
-  ),
-  new RegExp(
-    `^hsla\\(\\s*${HUE}\\s*,\\s*${PCT}\\s*,\\s*${PCT}\\s*,\\s*[\\d.]+%?\\s*\\)$`
-  ),
-  new RegExp(
-    `^hsla\\(\\s*${HUE}\\s+${PCT}\\s+${PCT}\\s*\\/\\s*[\\d.]+%?\\s*\\)$`
-  ),
-  // A named colour. Anything alphabetic reaches here, `banana` included — an
-  // unknown name is a declaration the browser drops, which is the same outcome
-  // as refusing it here. The injection check above is what makes this safe.
-  /^[a-zA-Z]+$/,
 ];
 
 /**
@@ -139,7 +100,18 @@ export function cssColor(value: unknown): string | undefined {
   if (typeof value !== "string" || value === "") return undefined;
   if (hasCssInjection(value)) return undefined;
   const trimmed = value.trim();
-  return COLOR_PATTERNS.some(pattern => pattern.test(trimmed))
-    ? trimmed
-    : undefined;
+  /*
+   * WHETHER it is a colour is `checkColorValue`'s question, not this module's.
+   * That one parses the value with css-tree, decodes escapes, holds the CSS
+   * named colours as the closed set they are, and knows `oklch()` and
+   * `color-mix()` — where the hand-written patterns that used to be here
+   * accepted any alphabetic word as a colour, `banana` included, and refused
+   * every syntax added to CSS since they were written.
+   *
+   * The SAFETY question stays here, and is asked first. `checkColorValue`
+   * accepts `var(--x)` because a custom property may legitimately hold a
+   * colour; this module refuses it, because a value assembled elsewhere is
+   * exactly what a stored style should not be able to pull into a page.
+   */
+  return checkColorValue(trimmed) === null ? trimmed : undefined;
 }

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -56,6 +56,16 @@ describe("readInlineStyle", () => {
     expect(read(value)).toEqual(expected);
   });
 
+  it("drops text-align, which a span cannot honour", () => {
+    // Both surfaces put a text node's style on a `<span>` — this package's
+    // renderer and the CMS's `serializeTextNode` — and `text-align` applies to
+    // a block container. Kept on the list it survived sanitization and aligned
+    // nothing, so the list promised what no reader could deliver and the
+    // versions differ reported an edit no visitor could see.
+    expect(read("text-align: center")).toEqual({});
+    expect([...INLINE_STYLE_PROPERTIES]).not.toContain("text-align");
+  });
+
   it.each([
     ["position", "position: fixed"],
     ["display", "display: none"],

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -135,6 +135,73 @@ describe("readInlineStyle", () => {
   });
 });
 
+describe("a repeated property whose later value is unusable", () => {
+  it("keeps the fallback a browser would keep", () => {
+    /*
+     * `color: red; color: not-a-color` renders RED. The second declaration is
+     * discarded when it is parsed, so the first is what applies — which is the
+     * whole point of writing a fallback chain, and what the CMS used to get
+     * right by emitting both declarations.
+     *
+     * Deduplicating on POSITION alone loses it. Judging the VALUE recovers it.
+     */
+    expect(read("color: red; color: not-a-color")["color"]).toBe("red");
+  });
+
+  it("still lets a later VALID colour win", () => {
+    // The control, and it is the one that matters: a rule that simply kept the
+    // first declaration would satisfy the assertion above and break every
+    // ordinary override.
+    expect(read("color: red; color: #00ff00")["color"]).toBe("#00ff00");
+  });
+
+  it("cannot do the same for a length, and says so", () => {
+    /*
+     * The limit, asserted rather than left to be discovered. Deciding that
+     * `not-a-size` is not a length means a CSS property database, which this
+     * package does not have and should not grow for this. So the later
+     * declaration wins, which is what a browser does whenever the later one IS
+     * valid — the divergence is confined to the case where it is not.
+     */
+    expect(read("font-size: 16px; font-size: not-a-size")["font-size"]).toBe(
+      "not-a-size"
+    );
+  });
+});
+
+describe("a declaration carrying !important", () => {
+  it("keeps the declaration and drops the priority", () => {
+    /*
+     * React sets a style property through `CSSStyleDeclaration`, which REJECTS
+     * a value with an embedded priority and leaves the property unset — while
+     * server rendering writes the string out and it applies. Carried through,
+     * the same document would render one way from the server and another once
+     * the client mounted.
+     *
+     * Stripping costs only the priority, which an inline style barely needs: it
+     * already outranks every stylesheet rule that is not itself `!important`.
+     */
+    expect(read("color: red!important")["color"]).toBe("red");
+    expect(read("color: red ! important ")["color"]).toBe("red");
+  });
+
+  it("does not take the rest of the declaration list with it", () => {
+    expect(read("color: red !important; font-size: 16px")).toEqual({
+      color: "red",
+      "font-size": "16px",
+    });
+  });
+
+  it("leaves an inner `!important` alone rather than editing the value", () => {
+    // Anchored at the END. A value that merely CONTAINS the word is not a
+    // priority, and rewriting the middle of a declaration would be this
+    // function inventing CSS rather than removing a suffix.
+    expect(read('font-family: "not!important"')["font-family"]).toBe(
+      '"not!important"'
+    );
+  });
+});
+
 describe("a format bit and a style that contradict it", () => {
   it.each([
     ["BOLD", TEXT_FORMAT.BOLD, "font-weight: normal", "font-weight"],

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -146,6 +146,14 @@ describe("a repeated property whose later value is unusable", () => {
      * Deduplicating on POSITION alone loses it. Judging the VALUE recovers it.
      */
     expect(read("color: red; color: not-a-color")["color"]).toBe("red");
+    /*
+     * `banana` and not only `not-a-color`, because the two are refused by
+     * DIFFERENT things and only one of them was ever the point. `not-a-color` is
+     * hyphenated, so it failed the old alphabetic pattern by accident of its
+     * spelling — the test passed while an unknown NAME still deleted its
+     * fallback. This is the value that separates the two implementations.
+     */
+    expect(read("color: red; color: banana")["color"]).toBe("red");
   });
 
   it("still lets a later VALID colour win", () => {

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -1,16 +1,16 @@
 import { describe, expect, it } from "vitest";
 
+import { TEXT_FORMAT } from "../rich-text";
+
 import {
   INLINE_STYLE_PROPERTIES,
   isInlineStyleProperty,
   readInlineStyle,
-  RICH_TEXT_FONT_FAMILIES,
-  RICH_TEXT_FONT_SIZES,
   sanitizeInlineStyle,
 } from "./inline-style";
 
-const read = (value: string): Record<string, string> =>
-  Object.fromEntries(readInlineStyle(value));
+const read = (value: string, format?: number): Record<string, string> =>
+  Object.fromEntries(readInlineStyle(value, format));
 
 describe("readInlineStyle", () => {
   it("reads the four properties the editor writes", () => {
@@ -28,14 +28,24 @@ describe("readInlineStyle", () => {
     });
   });
 
-  it.each(RICH_TEXT_FONT_FAMILIES)("keeps the family %s", family => {
-    // Every value the editor can PRODUCE must survive the reader. This is the
-    // direction that matters: a reader stricter than its own editor drops a
-    // choice the author made and shows them nothing to explain it.
-    expect(read(`font-family: ${family}`)["font-family"]).toBe(family);
-  });
+  it.each(["Courier New", "Times New Roman", "Georgia"])(
+    "keeps the family %s",
+    family => {
+      /*
+       * The SHAPE a real family has, not an enumeration of the toolbar's list.
+       * Restating that list here bought nothing — the reader accepts any safe
+       * family, so every member passed trivially — while making a new toolbar
+       * option fail CI in a package that renders it correctly. What is worth
+       * asserting is the property those values share and a bare keyword does
+       * not: a space in the middle.
+       */
+      expect(read(`font-family: ${family}`)["font-family"]).toBe(family);
+    }
+  );
 
-  it.each(RICH_TEXT_FONT_SIZES)("keeps the size %s", size => {
+  it.each(["10px", "24px", "72px"])("keeps the size %s", size => {
+    // A unit, for the same reason: `inherit` is legal for every property here
+    // and would pass on a reader that dropped anything measured.
     expect(read(`font-size: ${size}`)["font-size"]).toBe(size);
   });
 
@@ -122,6 +132,68 @@ describe("readInlineStyle", () => {
     for (const value of [undefined, null, 16, {}, [], ""]) {
       expect(readInlineStyle(value).size).toBe(0);
     }
+  });
+});
+
+describe("a format bit and a style that contradict it", () => {
+  it.each([
+    ["BOLD", TEXT_FORMAT.BOLD, "font-weight: normal", "font-weight"],
+    ["ITALIC", TEXT_FORMAT.ITALIC, "font-style: normal", "font-style"],
+    [
+      "UNDERLINE",
+      TEXT_FORMAT.UNDERLINE,
+      "text-decoration: none",
+      "text-decoration",
+    ],
+    [
+      "STRIKETHROUGH",
+      TEXT_FORMAT.STRIKETHROUGH,
+      "text-decoration-line: none",
+      "text-decoration-line",
+    ],
+    [
+      "SUBSCRIPT",
+      TEXT_FORMAT.SUBSCRIPT,
+      "vertical-align: baseline",
+      "vertical-align",
+    ],
+  ])(
+    "lets %s win over the style that would cancel it",
+    (_l, flag, style, property) => {
+      /*
+       * A paste from a word processor produces exactly this: the bit AND a
+       * declaration undoing it. Left to the markup, the answer depends on which
+       * is nested deeper — and the two surfaces nest them differently, so the
+       * same stored node would render bold on one and not on the other.
+       *
+       * The bit is an act, a button pressed on this selection. The style string
+       * is whatever the document arrived carrying.
+       */
+      expect(Object.keys(read(style, flag))).not.toContain(property);
+    }
+  );
+
+  it("drops only what the bit decided", () => {
+    // The control. A rule that dropped the whole style when any bit was set
+    // would satisfy every assertion above and take the author's colour with it.
+    expect(read("font-weight: normal; color: #fff", TEXT_FORMAT.BOLD)).toEqual({
+      color: "#fff",
+    });
+  });
+
+  it("keeps the same declaration when no bit claims it", () => {
+    // And the other control: without the bit, `font-weight` is an ordinary
+    // choice and must survive. Otherwise the rule is just a narrower allowlist.
+    expect(read("font-weight: normal")["font-weight"]).toBe("normal");
+  });
+
+  it("leaves font-size to the author under a subscript", () => {
+    // `<sub>` shrinks its text as a side effect of being a subscript. The
+    // POSITION is what makes it one, so that is what the bit owns; a size the
+    // author then chose is a choice, not a contradiction.
+    expect(read("font-size: 24px", TEXT_FORMAT.SUBSCRIPT)["font-size"]).toBe(
+      "24px"
+    );
   });
 });
 

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  INLINE_STYLE_PROPERTIES,
+  isInlineStyleProperty,
+  readInlineStyle,
+  RICH_TEXT_FONT_FAMILIES,
+  RICH_TEXT_FONT_SIZES,
+  sanitizeInlineStyle,
+} from "./inline-style";
+
+const read = (value: string): Record<string, string> =>
+  Object.fromEntries(readInlineStyle(value));
+
+describe("readInlineStyle", () => {
+  it("reads the four properties the editor writes", () => {
+    // The population, and it is the whole point of the task: these are what
+    // `$patchStyleText` puts on a text node, and the renderer drew none of them.
+    expect(
+      read(
+        "font-family: Georgia; font-size: 24px; color: #ff0000; background-color: #00ff00"
+      )
+    ).toEqual({
+      "font-family": "Georgia",
+      "font-size": "24px",
+      color: "#ff0000",
+      "background-color": "#00ff00",
+    });
+  });
+
+  it.each(RICH_TEXT_FONT_FAMILIES)("keeps the family %s", family => {
+    // Every value the editor can PRODUCE must survive the reader. This is the
+    // direction that matters: a reader stricter than its own editor drops a
+    // choice the author made and shows them nothing to explain it.
+    expect(read(`font-family: ${family}`)["font-family"]).toBe(family);
+  });
+
+  it.each(RICH_TEXT_FONT_SIZES)("keeps the size %s", size => {
+    expect(read(`font-size: ${size}`)["font-size"]).toBe(size);
+  });
+
+  it("keeps a colour from the editor's own colour input", () => {
+    // `<input type="color">` can only produce `#rrggbb`, so this is the entire
+    // colour vocabulary an author can reach through the toolbar.
+    expect(read("color: #3b82f6")["color"]).toBe("#3b82f6");
+  });
+
+  it.each([
+    ["a declaration break", "color: red;position:fixed", { color: "red" }],
+    ["a url()", "background-color: url(https://example.test/x)", {}],
+    ["an IE expression", "color: expression(alert(1))", {}],
+    ["a custom property", "color: var(--stolen)", {}],
+    ["a CSS escape", "color: \\65 xpression(alert(1))", {}],
+    ["a comment", "color: red/*x*/", {}],
+  ])("refuses %s", (_label, value, expected) => {
+    expect(read(value)).toEqual(expected);
+  });
+
+  it.each([
+    ["position", "position: fixed"],
+    ["display", "display: none"],
+    ["z-index", "z-index: 9999"],
+    ["float", "float: left"],
+    ["width", "width: 200vw"],
+  ])("drops %s, which is not typography", (_label, value) => {
+    // The properties that let stored text escape the box the page gave it. They
+    // are refused by ABSENCE from the list rather than by a rule naming them,
+    // which is why the list is the thing to read.
+    expect(read(value)).toEqual({});
+  });
+
+  it("keeps the LAST declaration when a property is written twice", () => {
+    // A stylesheet resolves a repeated property to the last one, and a reader
+    // that kept the first would publish something the CMS's own HTML does not.
+    expect(read("color: red; color: blue")["color"]).toBe("blue");
+  });
+
+  it("reads a property name however the document spells it", () => {
+    // Stored text, so the casing and the spacing are whatever wrote it.
+    expect(read("  Font-Size : 16px  ")["font-size"]).toBe("16px");
+  });
+
+  it("drops one bad declaration without losing the rest", () => {
+    // A stored style is not a request — it is what an old document happens to
+    // contain — so one unreadable declaration must not take the author's colour
+    // with it.
+    expect(read("color: #fff; position: fixed; font-size: 16px")).toEqual({
+      color: "#fff",
+      "font-size": "16px",
+    });
+  });
+
+  it("returns nothing for a value that is not a style string", () => {
+    for (const value of [undefined, null, 16, {}, [], ""]) {
+      expect(readInlineStyle(value).size).toBe(0);
+    }
+  });
+});
+
+describe("sanitizeInlineStyle", () => {
+  it("emits exactly what the reader kept", () => {
+    /*
+     * DERIVED, not parsed a second time. The two agree here by construction,
+     * and this asserts that they still do: if the serializer ever grew its own
+     * pass, a value one accepted and the other refused would publish HTML that
+     * disagreed with the React page for the same stored node — which is the
+     * defect this whole module exists to make impossible.
+     */
+    const value =
+      "font-size: 16px; position: fixed; color: #fff; behavior: url(x.htc)";
+    const kept = [...readInlineStyle(value)]
+      .map(([property, declared]) => `${property}:${declared}`)
+      .join(";");
+    expect(sanitizeInlineStyle(value)).toBe(kept);
+    expect(sanitizeInlineStyle(value)).toBe("font-size:16px;color:#fff");
+  });
+
+  it("emits nothing when nothing survives", () => {
+    expect(sanitizeInlineStyle("position: fixed")).toBe("");
+  });
+});
+
+describe("INLINE_STYLE_PROPERTIES", () => {
+  it("is readable as data, because a differ cannot use a sanitizer", () => {
+    // The versions differ asks "would a reader notice this property changing",
+    // which a function returning a cleaned string cannot answer. Exported as a
+    // list so it can be read rather than re-derived from someone's output.
+    expect(INLINE_STYLE_PROPERTIES.length).toBeGreaterThan(1);
+    expect([...INLINE_STYLE_PROPERTIES]).toContain("color");
+    expect([...INLINE_STYLE_PROPERTIES]).not.toContain("position");
+  });
+
+  it("agrees with the reader, so neither can drift", () => {
+    // Both directions. A property on the list the reader drops is a promise the
+    // data does not keep; one the reader keeps that is absent from the list is
+    // a declaration the differ cannot see.
+    for (const property of INLINE_STYLE_PROPERTIES) {
+      expect(isInlineStyleProperty(property), property).toBe(true);
+      expect(read(`${property}: inherit`)[property], property).toBe("inherit");
+    }
+  });
+
+  it("answers for a name however it is spelled, and refuses a non-string", () => {
+    expect(isInlineStyleProperty("  Color ")).toBe(true);
+    expect(isInlineStyleProperty("position")).toBe(false);
+    expect(isInlineStyleProperty(undefined)).toBe(false);
+  });
+});

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -240,6 +240,71 @@ describe("a format bit and a style that contradict it", () => {
     }
   );
 
+  it.each([
+    ["BOLD", TEXT_FORMAT.BOLD, "font-weight: 900", "font-weight", "900"],
+    ["BOLD", TEXT_FORMAT.BOLD, "font-weight: bolder", "font-weight", "bolder"],
+    [
+      "ITALIC",
+      TEXT_FORMAT.ITALIC,
+      "font-style: oblique 10deg",
+      "font-style",
+      "oblique 10deg",
+    ],
+    [
+      "UNDERLINE",
+      TEXT_FORMAT.UNDERLINE,
+      "text-decoration: underline wavy red",
+      "text-decoration",
+      "underline wavy red",
+    ],
+  ])(
+    "keeps a value that REINFORCES %s",
+    (_l, flag, style, property, expected) => {
+      /*
+       * The first version of this rule dropped the property outright whenever
+       * the bit was set, which threw away declarations that agree with it and
+       * carry more than the element alone: a weight of 900 where `<strong>` gives
+       * 700, a wavy red underline where `<u>` gives a plain one.
+       *
+       * The no-bit control could not catch that — it asserts what happens with
+       * no format at all, and passes under a rule that drops everything when a
+       * format IS set. Reinforcement is its own case and needs its own test.
+       */
+      expect(read(style, flag)[property]).toBe(expected);
+    }
+  );
+
+  it("drops a shorthand that replaces the line the bit asserts", () => {
+    // `text-decoration` REPLACES the line list, so `underline` beside a
+    // STRIKETHROUGH bit removes the strike while looking like it only adds an
+    // underline. Read as tokens, not as a string that mentions a decoration.
+    expect(
+      Object.keys(read("text-decoration: underline", TEXT_FORMAT.STRIKETHROUGH))
+    ).not.toContain("text-decoration");
+    // And the same value beside UNDERLINE is a reinforcement, not a conflict.
+    expect(
+      read("text-decoration: underline", TEXT_FORMAT.UNDERLINE)[
+        "text-decoration"
+      ]
+    ).toBe("underline");
+  });
+
+  it("reads the decoration as TOKENS, not as text that mentions one", () => {
+    /*
+     * `underlinexyz` CONTAINS the word `underline` and asserts nothing — it is
+     * not a decoration line, so a browser discards the declaration and the
+     * `<u>` underlines on its own. A substring check keeps it and lets an
+     * unusable value sit on the page instead.
+     *
+     * This case exists because break-verifying the token split changed NOTHING:
+     * every other fixture answers the same either way, so the suite could not
+     * tell a tokeniser from a `String.includes`.
+     */
+    expect(
+      Object.keys(read("text-decoration: underlinexyz", TEXT_FORMAT.UNDERLINE))
+    ).not.toContain("text-decoration");
+  });
+
   it("drops only what the bit decided", () => {
     // The control. A rule that dropped the whole style when any bit was set
     // would satisfy every assertion above and take the author's colour with it.
@@ -261,6 +326,34 @@ describe("a format bit and a style that contradict it", () => {
     expect(read("font-size: 24px", TEXT_FORMAT.SUBSCRIPT)["font-size"]).toBe(
       "24px"
     );
+  });
+});
+
+describe("the declaration list", () => {
+  it("does not split on a semicolon inside a quoted value", () => {
+    // `font-family: "A;B"` is one declaration carrying a family whose NAME has a
+    // semicolon in it. Split on every `;`, it came apart in the middle and
+    // published `font-family:"A` — a truncated value, and the authored font
+    // gone. Escapes need no handling here: a backslash is refused outright.
+    expect(read('font-family: "A;B"; color: red')).toEqual({
+      "font-family": '"A;B"',
+      color: "red",
+    });
+  });
+
+  it("does not split on a semicolon inside parentheses", () => {
+    // Nothing in CSS puts one there today. The cost of covering it is a
+    // counter; the cost of being wrong is a value truncated in silence.
+    expect(read('font-family: local("A;B"); color: red')["color"]).toBe("red");
+  });
+
+  it("still splits the ordinary case", () => {
+    // The control. A splitter that never split would satisfy neither assertion
+    // above by accident, but one that got its quote state stuck would.
+    expect(Object.keys(read("color: red; font-size: 16px"))).toEqual([
+      "color",
+      "font-size",
+    ]);
   });
 });
 

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -75,6 +75,24 @@ describe("readInlineStyle", () => {
     expect(read("color: red; color: blue")["color"]).toBe("blue");
   });
 
+  it("keeps the winning declaration in its own place in the cascade", () => {
+    /*
+     * The VALUE test above is not enough, and this is the case that separates
+     * them. `Map.set` on an existing key replaces the value and leaves the key
+     * where it first appeared, so the later declaration would be emitted in the
+     * earlier one's position — ahead of a shorthand that resets it.
+     *
+     * Here the author's last word is green. Emitted before the shorthand, the
+     * shorthand wins and the text draws blue: the right value, in a place that
+     * makes it lose.
+     */
+    expect(
+      sanitizeInlineStyle(
+        "text-decoration-color:red;text-decoration:underline blue;text-decoration-color:green"
+      )
+    ).toBe("text-decoration:underline blue;text-decoration-color:green");
+  });
+
   it("reads a property name however the document spells it", () => {
     // Stored text, so the casing and the spacing are whatever wrote it.
     expect(read("  Font-Size : 16px  ")["font-size"]).toBe("16px");

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -193,6 +193,40 @@ describe("a declaration carrying !important", () => {
     expect(read("color: red ! important ")["color"]).toBe("red");
   });
 
+  it("lets an important declaration beat a later plain one", () => {
+    /*
+     * `color: red !important; color: blue` renders RED. The cascade prefers the
+     * important declaration whatever follows it, so resolving the repeat on
+     * POSITION alone published blue — the browser's answer and ours disagreeing
+     * on a document neither of us wrote.
+     *
+     * The priority has to be read BEFORE it is stripped, which is the whole
+     * shape of the bug: stripping first made the two declarations look alike.
+     */
+    expect(read("color: red !important; color: blue")["color"]).toBe("red");
+  });
+
+  it("still lets a later important declaration win", () => {
+    // Two controls in one: priority does not simply freeze the first value, and
+    // between two important declarations position decides again.
+    expect(read("color: red; color: blue !important")["color"]).toBe("blue");
+    expect(read("color: red !important; color: blue !important")["color"]).toBe(
+      "blue"
+    );
+  });
+
+  it("gives the same answer however many times it is asked", () => {
+    // The priority pattern is shared across calls. It carries no `g`, so it
+    // holds no `lastIndex` — but a global flag on a shared regex has already
+    // produced a call-order-dependent guard in this package once, and the cost
+    // of asserting it is three lines.
+    const value = "color: red !important; color: blue";
+    expect(read(value)["color"]).toBe("red");
+    expect(read(value)["color"]).toBe("red");
+    expect(read("color: blue")["color"]).toBe("blue");
+    expect(read(value)["color"]).toBe("red");
+  });
+
   it("does not take the rest of the declaration list with it", () => {
     expect(read("color: red !important; font-size: 16px")).toEqual({
       color: "red",
@@ -282,34 +316,36 @@ describe("a format bit and a style that contradict it", () => {
     }
   );
 
-  it("drops a shorthand that replaces the line the bit asserts", () => {
-    // `text-decoration` REPLACES the line list, so `underline` beside a
-    // STRIKETHROUGH bit removes the strike while looking like it only adds an
-    // underline. Read as tokens, not as a string that mentions a decoration.
-    expect(
-      Object.keys(read("text-decoration: underline", TEXT_FORMAT.STRIKETHROUGH))
-    ).not.toContain("text-decoration");
-    // And the same value beside UNDERLINE is a reinforcement, not a conflict.
-    expect(
-      read("text-decoration: underline", TEXT_FORMAT.UNDERLINE)[
-        "text-decoration"
-      ]
-    ).toBe("underline");
-  });
-
-  it("reads the decoration as TOKENS, not as text that mentions one", () => {
+  it("keeps a decoration that adds a line the bit does not draw", () => {
     /*
-     * `underlinexyz` CONTAINS the word `underline` and asserts nothing — it is
-     * not a decoration line, so a browser discards the declaration and the
-     * `<u>` underlines on its own. A substring check keeps it and lets an
-     * unusable value sit on the page instead.
+     * This asserted the opposite and was wrong, so the correction is worth
+     * stating: a decoration on a descendant ACCUMULATES with an ancestor's
+     * rather than replacing it, and a descendant cannot remove one. So
+     * `underline` beside a STRIKETHROUGH bit does not take the strike away —
+     * the `<s>` still draws it — and dropping the declaration threw away an
+     * underline the author wrote.
      *
-     * This case exists because break-verifying the token split changed NOTHING:
-     * every other fixture answers the same either way, so the suite could not
-     * tell a tokeniser from a `String.includes`.
+     * The shorthand replaces the line list WITHIN its own element. It does not
+     * reach the wrapper's.
      */
     expect(
-      Object.keys(read("text-decoration: underlinexyz", TEXT_FORMAT.UNDERLINE))
+      read("text-decoration: underline wavy red", TEXT_FORMAT.STRIKETHROUGH)[
+        "text-decoration"
+      ]
+    ).toBe("underline wavy red");
+    expect(
+      read("text-decoration: line-through", TEXT_FORMAT.UNDERLINE)[
+        "text-decoration"
+      ]
+    ).toBe("line-through");
+  });
+
+  it("drops a decoration that draws no line, since it cannot cancel one", () => {
+    // `none` is the only decoration value with nothing to say: it cannot remove
+    // the wrapper's line and adds none of its own, so publishing it would put
+    // an inert declaration on the page.
+    expect(
+      Object.keys(read("text-decoration: none", TEXT_FORMAT.UNDERLINE))
     ).not.toContain("text-decoration");
   });
 

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -51,7 +51,13 @@ export const INLINE_STYLE_PROPERTIES = [
   "text-decoration-line",
   "text-decoration-color",
   "text-decoration-style",
-  "text-align",
+  // `text-align` is deliberately ABSENT, and this note is here so it is not
+  // added back as an oversight. Both surfaces put a text node's style on a
+  // `<span>` — this package's renderer and `serializeTextNode` in the CMS — and
+  // `text-align` applies to a block container, so it survived sanitization and
+  // aligned nothing. Keeping it made the list promise something no reader could
+  // deliver, and made a change to it show up in the versions differ as an edit
+  // no visitor could see. Aligning a paragraph is the paragraph's own property.
   "vertical-align",
   "line-height",
   "letter-spacing",
@@ -146,8 +152,13 @@ export function sanitizeInlineStyle(value: unknown): string {
  * this list has never heard of, and refusing it would strip a face the CMS
  * publishes today. What the list is for is the opposite direction — holding the
  * reader to the editor, so a value an author CAN choose is never one the page
- * silently drops. `richTextInlineStyleVocabulariesAgree` in the admin is what
- * checks that, because the editor's lists live where this package cannot reach.
+ * silently drops.
+ *
+ * Two checks together make that hold, and neither does it alone: the admin
+ * compares this list to the toolbar's own options, because the editor's lists
+ * live where this package cannot reach; and this package's own tests render
+ * every member through {@link readInlineStyle}. The first says the list is the
+ * editor's, the second says the reader keeps what is on it.
  */
 export const RICH_TEXT_FONT_FAMILIES = [
   "Arial",

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -111,6 +111,15 @@ export function readInlineStyle(value: unknown): ReadonlyMap<string, string> {
     // another, and a `url()` fetches.
     if (hasCssInjection(declared)) continue;
 
+    // DELETED before it is set again, because `Map.set` on an existing key
+    // replaces the value and leaves the key where it first appeared. The later
+    // declaration would then be emitted in the earlier one's POSITION, and
+    // position is meaning here: `text-decoration-color:red;
+    // text-decoration:underline blue; text-decoration-color:green` would come
+    // back with green ahead of the shorthand, so the shorthand resets the
+    // colour the author wrote last. Keeping the winner's own position is what
+    // makes the emitted text cascade the way the stored text did.
+    kept.delete(property);
     kept.set(property, declared);
   }
   return kept;

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -1,0 +1,170 @@
+/**
+ * One reading of a rich-text inline style, for everything that needs one.
+ *
+ * Lexical keeps an author's font, size, colour and highlight in a text node's
+ * `style` string. Three surfaces have to agree about what that string means:
+ * the CMS serializes it into published HTML, the React renderer draws it on a
+ * page, and the versions differ decides whether a change to it is a change a
+ * reader would SEE. Three readings of one question drift, and the drift is
+ * silent — the admin reports an edit the page cannot render, or the page shows
+ * a declaration the CMS refused.
+ *
+ * So the reading happens once, here, and the other two views are derived from
+ * it rather than computed beside it: {@link sanitizeInlineStyle} joins what
+ * {@link readInlineStyle} kept.
+ *
+ * ## Why the allowlist is exported as DATA
+ *
+ * A differ cannot use a sanitizer. It is not asking "what may I emit" but "is
+ * this property one a reader would notice", and a function that returns a
+ * cleaned string cannot answer that without the caller re-deriving the list
+ * from its output. {@link INLINE_STYLE_PROPERTIES} is therefore the list
+ * itself, and {@link isInlineStyleProperty} the same answer for one name.
+ *
+ * @module style/inline-style
+ */
+
+import { hasCssInjection, normalizeCssValue } from "./css-color";
+
+/**
+ * The properties a stored inline style may carry onto a page.
+ *
+ * Wider than the editor can produce, deliberately. The toolbar writes four —
+ * `font-family`, `font-size`, `color`, `background-color` — but a document can
+ * also arrive by import or by paste, and those carry whatever the source had.
+ * The rest of this list is that second population: typography and alignment a
+ * word processor emits, and nothing that positions, floats, sizes or layers an
+ * element, because those are the declarations that let stored text escape the
+ * box the page gave it.
+ *
+ * Exported as an array rather than a `Set` so a reader can enumerate it. See
+ * the module docblock for who needs that and why.
+ */
+export const INLINE_STYLE_PROPERTIES = [
+  "color",
+  "background-color",
+  "font-size",
+  "font-family",
+  "font-weight",
+  "font-style",
+  "text-decoration",
+  "text-decoration-line",
+  "text-decoration-color",
+  "text-decoration-style",
+  "text-align",
+  "vertical-align",
+  "line-height",
+  "letter-spacing",
+  "word-spacing",
+  "white-space",
+  "text-transform",
+  "opacity",
+] as const;
+
+const ALLOWED: ReadonlySet<string> = new Set(INLINE_STYLE_PROPERTIES);
+
+/**
+ * Whether a property name is one this format carries.
+ *
+ * Case- and space-insensitive, because the name arrives from stored text: a
+ * document written elsewhere may spell it `Font-Size` or leave a space before
+ * the colon, and both are the same declaration to a browser.
+ */
+export function isInlineStyleProperty(name: unknown): boolean {
+  return typeof name === "string" && ALLOWED.has(name.trim().toLowerCase());
+}
+
+/**
+ * The declarations of a stored inline style that are safe to put on a page.
+ *
+ * A MAP rather than a string, because that is the shape both other views want:
+ * the renderer turns it into a style object and the CMS joins it back into
+ * text. Insertion order is the order they were written, so the later of two
+ * declarations for one property wins exactly as it would in a stylesheet.
+ *
+ * Everything that is not understood is DROPPED rather than refused: a stored
+ * style is not a request, it is what an old document happens to contain, and
+ * one unreadable declaration must not take an author's colour with it.
+ */
+export function readInlineStyle(value: unknown): ReadonlyMap<string, string> {
+  const kept = new Map<string, string>();
+  if (typeof value !== "string" || value === "") return kept;
+
+  const normalized = normalizeCssValue(value);
+  if (normalized === "") return kept;
+
+  for (const declaration of normalized.split(";")) {
+    const text = declaration.trim();
+    if (text === "") continue;
+
+    // `indexOf` rather than `split`, because a value may contain a colon of its
+    // own — `background-color: rgb(0 0 0 / 50%)` does not, but a `font-family`
+    // naming a source with one would, and splitting would truncate it.
+    const colon = text.indexOf(":");
+    if (colon === -1) continue;
+
+    const property = text.slice(0, colon).trim().toLowerCase();
+    const declared = text.slice(colon + 1).trim();
+    if (declared === "" || !ALLOWED.has(property)) continue;
+    // The same guard the colours cross, and for the same reason: this string
+    // reaches a `style` attribute, where a `;` ends the declaration and starts
+    // another, and a `url()` fetches.
+    if (hasCssInjection(declared)) continue;
+
+    kept.set(property, declared);
+  }
+  return kept;
+}
+
+/**
+ * A stored inline style as the declaration text a serializer emits.
+ *
+ * DERIVED from {@link readInlineStyle} rather than parsed again. Two passes over
+ * one string agree on the day they are written; this one cannot disagree with
+ * the map the renderer draws from, because it is that map.
+ */
+export function sanitizeInlineStyle(value: unknown): string {
+  return [...readInlineStyle(value)]
+    .map(([property, declared]) => `${property}:${declared}`)
+    .join(";");
+}
+
+/**
+ * The font families the editor's own toolbar offers.
+ *
+ * NOT enforced by the reader, and that is the decision rather than an
+ * oversight: a document that arrived by import may legitimately carry a family
+ * this list has never heard of, and refusing it would strip a face the CMS
+ * publishes today. What the list is for is the opposite direction — holding the
+ * reader to the editor, so a value an author CAN choose is never one the page
+ * silently drops. `richTextInlineStyleVocabulariesAgree` in the admin is what
+ * checks that, because the editor's lists live where this package cannot reach.
+ */
+export const RICH_TEXT_FONT_FAMILIES = [
+  "Arial",
+  "Courier New",
+  "Georgia",
+  "Times New Roman",
+  "Trebuchet MS",
+  "Verdana",
+] as const;
+
+/** The font sizes that toolbar offers. See {@link RICH_TEXT_FONT_FAMILIES}. */
+export const RICH_TEXT_FONT_SIZES = [
+  "10px",
+  "11px",
+  "12px",
+  "13px",
+  "14px",
+  "15px",
+  "16px",
+  "17px",
+  "18px",
+  "20px",
+  "24px",
+  "30px",
+  "36px",
+  "48px",
+  "60px",
+  "72px",
+] as const;

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -101,6 +101,8 @@ const ALLOWED: ReadonlySet<string> = new Set(INLINE_STYLE_PROPERTIES);
 const FORMAT_ASSERTS: readonly {
   flag: (typeof TEXT_FORMAT)[keyof typeof TEXT_FORMAT];
   properties: readonly string[];
+  /** The line this bit draws, for the decoration formats only. */
+  line?: string;
   keeps: (value: string) => boolean;
 }[] = [
   {
@@ -120,12 +122,17 @@ const FORMAT_ASSERTS: readonly {
   {
     flag: TEXT_FORMAT.UNDERLINE,
     properties: ["text-decoration", "text-decoration-line"],
-    keeps: value => hasLine(value, "underline"),
+    line: "underline",
+    // A decoration ADDS. It cannot cancel the wrapper's, so the only value that
+    // conflicts is one drawing no line at all — which is inert rather than
+    // contradictory, and is dropped so an inert declaration stays off the page.
+    keeps: drawsALine,
   },
   {
     flag: TEXT_FORMAT.STRIKETHROUGH,
     properties: ["text-decoration", "text-decoration-line"],
-    keeps: value => hasLine(value, "line-through"),
+    line: "line-through",
+    keeps: drawsALine,
   },
   {
     flag: TEXT_FORMAT.SUBSCRIPT,
@@ -140,16 +147,38 @@ const FORMAT_ASSERTS: readonly {
 ];
 
 /**
- * Whether a `text-decoration` value still draws one particular line.
+ * Whether a `text-decoration` value draws one particular line.
  *
- * The shorthand REPLACES the line list, so `text-decoration: underline` beside a
- * `STRIKETHROUGH` bit removes the strike even though it looks like it is only
- * adding an underline. Read as tokens for that reason: what matters is whether
- * the line this bit asserts is still among them.
+ * Read as TOKENS rather than as text mentioning a line: `underlinexyz` contains
+ * the word and draws nothing, and a browser discards the declaration.
  */
 function hasLine(value: string, line: string): boolean {
   return value.split(/\s+/).includes(line);
 }
+
+/**
+ * Whether a decoration value draws any line at all.
+ *
+ * The conflict question for a decoration, and it is a different question from
+ * {@link hasLine}. A decoration on a descendant ACCUMULATES with an ancestor's
+ * rather than replacing it, and a descendant cannot remove one — so a
+ * `line-through` beside an `UNDERLINE` bit is not a contradiction, it is a
+ * second line, and dropping it loses a decoration the author wrote.
+ *
+ * What is left with nothing to say is `none`: it cannot cancel the wrapper and
+ * adds nothing of its own, so it is dropped rather than published inert.
+ */
+function drawsALine(value: string): boolean {
+  return value.split(/\s+/).some(token => DECORATION_LINES.has(token));
+}
+
+/** The line keywords a `text-decoration` can draw. */
+const DECORATION_LINES: ReadonlySet<string> = new Set([
+  "underline",
+  "overline",
+  "line-through",
+  "blink",
+]);
 
 /**
  * The format bits whose LINE the style already draws.
@@ -180,9 +209,16 @@ export function formatsDrawnByStyle(
     // Only the decoration entries: they are the ones that accumulate.
     if (!entry.properties.includes("text-decoration")) continue;
     if (!hasFormat(format, entry.flag)) continue;
+    // The LINE this bit draws, not merely "draws something": a `line-through`
+    // beside an UNDERLINE bit adds a second line and the `<u>` must stay, where
+    // an `underline` beside it makes the `<u>` the one that would double up.
     const asserted = entry.properties.some(property => {
       const written = declared.get(property);
-      return written !== undefined && entry.keeps(written);
+      return (
+        written !== undefined &&
+        entry.line !== undefined &&
+        hasLine(written, entry.line)
+      );
     });
     if (asserted) drawn |= entry.flag;
   }
@@ -238,8 +274,15 @@ const COLOR_VALUED: ReadonlySet<string> = new Set([
  * an inline style barely needs: it already outranks every stylesheet rule that
  * is not itself `!important`. Refusing would drop the colour entirely.
  */
+const PRIORITY = /\s*!\s*important\s*$/i;
+
 function withoutPriority(declared: string): string {
-  return declared.replace(/\s*!\s*important\s*$/i, "").trim();
+  return declared.replace(PRIORITY, "").trim();
+}
+
+/** Whether a declaration was written `!important`. */
+function isImportant(declared: string): boolean {
+  return PRIORITY.test(declared);
 }
 
 /**
@@ -323,7 +366,7 @@ function splitDeclarations(list: string): string[] {
 function usableDeclaration(
   text: string,
   format: number | undefined
-): readonly [string, string] | undefined {
+): { property: string; value: string; important: boolean } | undefined {
   // `indexOf` rather than `split`, because a value may contain a colon of its
   // own — `background-color: rgb(0 0 0 / 50%)` does not, but a `font-family`
   // naming a source with one would, and splitting would truncate it.
@@ -331,7 +374,8 @@ function usableDeclaration(
   if (colon === -1) return undefined;
 
   const property = text.slice(0, colon).trim().toLowerCase();
-  const declared = withoutPriority(text.slice(colon + 1).trim());
+  const written = text.slice(colon + 1).trim();
+  const declared = withoutPriority(written);
   if (declared === "" || !ALLOWED.has(property)) return undefined;
   // See {@link FORMAT_ASSERTS}: only a value that stops asserting what the bit
   // asserts is dropped, so one that reinforces it survives.
@@ -367,7 +411,7 @@ function usableDeclaration(
   // reaches a `style` attribute, where a `;` ends the declaration and starts
   // another, and a `url()` fetches.
   if (hasCssInjection(declared)) return undefined;
-  return [property, declared];
+  return { property, value: declared, important: isImportant(written) };
 }
 
 export function readInlineStyle(
@@ -380,9 +424,22 @@ export function readInlineStyle(
   const normalized = normalizeCssValue(value);
   if (normalized === "") return kept;
 
+  const important = new Set<string>();
   for (const declaration of splitDeclarations(normalized)) {
     const usable = usableDeclaration(declaration.trim(), format);
     if (usable === undefined) continue;
+    /*
+     * PRIORITY decides the winner before position does. `color: red !important;
+     * color: blue` renders RED — the cascade prefers the important declaration
+     * whatever follows it — so resolving on position alone published blue.
+     *
+     * The priority is remembered here and stripped from the VALUE, because the
+     * two are needed at different moments: the cascade needs it now, and the
+     * emitted declaration must not carry it, since React sets a style property
+     * through `CSSStyleDeclaration` and that rejects an embedded priority.
+     */
+    if (important.has(usable.property) && !usable.important) continue;
+    if (usable.important) important.add(usable.property);
     // DELETED before it is set again, because `Map.set` on an existing key
     // replaces the value and leaves the key where it first appeared. The later
     // declaration would then be emitted in the earlier one's POSITION, and
@@ -390,8 +447,8 @@ export function readInlineStyle(
     // so a winner emitted ahead of that shorthand loses to it. Keeping the
     // winner's own place is what makes the emitted text cascade the way the
     // stored text did.
-    kept.delete(usable[0]);
-    kept.set(usable[0], usable[1]);
+    kept.delete(usable.property);
+    kept.set(usable.property, usable.value);
   }
   return kept;
 }

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -24,6 +24,8 @@
  * @module style/inline-style
  */
 
+import { hasFormat, TEXT_FORMAT } from "../rich-text";
+
 import { hasCssInjection, normalizeCssValue } from "./css-color";
 
 /**
@@ -70,6 +72,56 @@ export const INLINE_STYLE_PROPERTIES = [
 const ALLOWED: ReadonlySet<string> = new Set(INLINE_STYLE_PROPERTIES);
 
 /**
+ * What each format bit already decides, and therefore what a style may not.
+ *
+ * A stored node can carry BOTH — `BOLD` with `font-weight: normal` is what a
+ * paste from a word processor looks like, and the two are a contradiction the
+ * document does not resolve. Whichever is written closer to the text wins, so
+ * the answer would otherwise be decided by markup nesting: the CMS puts the
+ * style outside the `<strong>` and keeps the bold, this package puts it inside
+ * so an author's colour can beat `<mark>`, and the same stored value would
+ * render bold on one surface and not on the other.
+ *
+ * Resolved here instead, once, by the PROPERTY rather than by the nesting. The
+ * format bit is an act — a button pressed on this selection — where the style
+ * string is whatever the document arrived carrying, so the bit wins and the
+ * declaration it contradicts is dropped.
+ *
+ * `font-size` is deliberately NOT owned by the subscript bits. `<sub>` shrinks
+ * its text as a side effect of being a subscript, and an author who then sets a
+ * size has chosen that size; the POSITION is what makes it a subscript, and
+ * that is `vertical-align`.
+ */
+const FORMAT_OWNED: readonly {
+  flag: (typeof TEXT_FORMAT)[keyof typeof TEXT_FORMAT];
+  properties: readonly string[];
+}[] = [
+  { flag: TEXT_FORMAT.BOLD, properties: ["font-weight"] },
+  { flag: TEXT_FORMAT.ITALIC, properties: ["font-style"] },
+  {
+    flag: TEXT_FORMAT.UNDERLINE,
+    properties: ["text-decoration", "text-decoration-line"],
+  },
+  {
+    flag: TEXT_FORMAT.STRIKETHROUGH,
+    properties: ["text-decoration", "text-decoration-line"],
+  },
+  { flag: TEXT_FORMAT.SUBSCRIPT, properties: ["vertical-align"] },
+  { flag: TEXT_FORMAT.SUPERSCRIPT, properties: ["vertical-align"] },
+];
+
+/** The properties an active format bit has already decided. */
+function ownedByFormat(format: number | undefined): ReadonlySet<string> {
+  const owned = new Set<string>();
+  if (format === undefined) return owned;
+  for (const entry of FORMAT_OWNED) {
+    if (!hasFormat(format, entry.flag)) continue;
+    for (const property of entry.properties) owned.add(property);
+  }
+  return owned;
+}
+
+/**
  * Whether a property name is one this format carries.
  *
  * Case- and space-insensitive, because the name arrives from stored text: a
@@ -92,9 +144,13 @@ export function isInlineStyleProperty(name: unknown): boolean {
  * style is not a request, it is what an old document happens to contain, and
  * one unreadable declaration must not take an author's colour with it.
  */
-export function readInlineStyle(value: unknown): ReadonlyMap<string, string> {
+export function readInlineStyle(
+  value: unknown,
+  format?: number
+): ReadonlyMap<string, string> {
   const kept = new Map<string, string>();
   if (typeof value !== "string" || value === "") return kept;
+  const owned = ownedByFormat(format);
 
   const normalized = normalizeCssValue(value);
   if (normalized === "") return kept;
@@ -112,6 +168,8 @@ export function readInlineStyle(value: unknown): ReadonlyMap<string, string> {
     const property = text.slice(0, colon).trim().toLowerCase();
     const declared = text.slice(colon + 1).trim();
     if (declared === "" || !ALLOWED.has(property)) continue;
+    // See {@link FORMAT_OWNED}: the bit is an act, the style is baggage.
+    if (owned.has(property)) continue;
     // The same guard the colours cross, and for the same reason: this string
     // reaches a `style` attribute, where a `;` ends the declaration and starts
     // another, and a `url()` fetches.
@@ -138,53 +196,8 @@ export function readInlineStyle(value: unknown): ReadonlyMap<string, string> {
  * one string agree on the day they are written; this one cannot disagree with
  * the map the renderer draws from, because it is that map.
  */
-export function sanitizeInlineStyle(value: unknown): string {
-  return [...readInlineStyle(value)]
+export function sanitizeInlineStyle(value: unknown, format?: number): string {
+  return [...readInlineStyle(value, format)]
     .map(([property, declared]) => `${property}:${declared}`)
     .join(";");
 }
-
-/**
- * The font families the editor's own toolbar offers.
- *
- * NOT enforced by the reader, and that is the decision rather than an
- * oversight: a document that arrived by import may legitimately carry a family
- * this list has never heard of, and refusing it would strip a face the CMS
- * publishes today. What the list is for is the opposite direction — holding the
- * reader to the editor, so a value an author CAN choose is never one the page
- * silently drops.
- *
- * Two checks together make that hold, and neither does it alone: the admin
- * compares this list to the toolbar's own options, because the editor's lists
- * live where this package cannot reach; and this package's own tests render
- * every member through {@link readInlineStyle}. The first says the list is the
- * editor's, the second says the reader keeps what is on it.
- */
-export const RICH_TEXT_FONT_FAMILIES = [
-  "Arial",
-  "Courier New",
-  "Georgia",
-  "Times New Roman",
-  "Trebuchet MS",
-  "Verdana",
-] as const;
-
-/** The font sizes that toolbar offers. See {@link RICH_TEXT_FONT_FAMILIES}. */
-export const RICH_TEXT_FONT_SIZES = [
-  "10px",
-  "11px",
-  "12px",
-  "13px",
-  "14px",
-  "15px",
-  "16px",
-  "17px",
-  "18px",
-  "20px",
-  "24px",
-  "30px",
-  "36px",
-  "48px",
-  "60px",
-  "72px",
-] as const;

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -152,6 +152,44 @@ function hasLine(value: string, line: string): boolean {
 }
 
 /**
+ * The format bits whose LINE the style already draws.
+ *
+ * A text decoration is not overridden by a descendant — it PROPAGATES, and the
+ * descendant's own decoration is drawn as well. So a `<u>` around a span that
+ * declares `text-decoration: underline wavy red` produces TWO underlines: the
+ * wrapper's plain one, which the span cannot remove, and the span's wavy red
+ * one on top.
+ *
+ * That makes decoration different from the other formats, and the difference is
+ * why this exists. A `font-weight: 900` inside a `<strong>` simply wins; there
+ * is one weight. A decoration inside a `<u>` accumulates.
+ *
+ * So where a declaration already asserts the line a bit would draw, the bit's
+ * WRAPPER is what goes, not the declaration — the declaration is the richer of
+ * the two, carrying the style and the colour the wrapper cannot express. Both
+ * surfaces ask this, so both drop the same wrapper.
+ */
+export function formatsDrawnByStyle(
+  value: unknown,
+  format: number | undefined
+): number {
+  if (format === undefined) return 0;
+  const declared = readInlineStyle(value, format);
+  let drawn = 0;
+  for (const entry of FORMAT_ASSERTS) {
+    // Only the decoration entries: they are the ones that accumulate.
+    if (!entry.properties.includes("text-decoration")) continue;
+    if (!hasFormat(format, entry.flag)) continue;
+    const asserted = entry.properties.some(property => {
+      const written = declared.get(property);
+      return written !== undefined && entry.keeps(written);
+    });
+    if (asserted) drawn |= entry.flag;
+  }
+  return drawn;
+}
+
+/**
  * Whether an active format bit contradicts this declaration.
  *
  * Answered per DECLARATION rather than per property, which is what lets a value

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -72,43 +72,105 @@ export const INLINE_STYLE_PROPERTIES = [
 const ALLOWED: ReadonlySet<string> = new Set(INLINE_STYLE_PROPERTIES);
 
 /**
- * What each format bit already decides, and therefore what a style may not.
+ * What each format bit ASSERTS, and how a declaration can contradict it.
  *
- * A stored node can carry BOTH — `BOLD` with `font-weight: normal` is what a
+ * A stored node can carry both — `BOLD` with `font-weight: normal` is what a
  * paste from a word processor looks like, and the two are a contradiction the
  * document does not resolve. Whichever is written closer to the text wins, so
  * the answer would otherwise be decided by markup nesting: the CMS puts the
- * style outside the `<strong>` and keeps the bold, this package puts it inside
- * so an author's colour can beat `<mark>`, and the same stored value would
- * render bold on one surface and not on the other.
+ * style outside the `<strong>`, this package puts it inside so an author's
+ * colour can beat `<mark>`, and the same stored value would render bold on one
+ * surface and not on the other.
  *
- * Resolved here instead, once, by the PROPERTY rather than by the nesting. The
- * format bit is an act — a button pressed on this selection — where the style
- * string is whatever the document arrived carrying, so the bit wins and the
- * declaration it contradicts is dropped.
+ * Resolved here instead, once, by the PROPERTY and its VALUE together. Dropping
+ * the property outright was the first attempt and it was too broad: a
+ * `font-weight: 900` beside `BOLD` REINFORCES it and carries a weight the
+ * `<strong>` alone does not, and `text-decoration: underline wavy red` beside
+ * `UNDERLINE` adds a style and a colour while still underlining. Those are not
+ * contradictions and keeping them costs nothing.
  *
- * `font-size` is deliberately NOT owned by the subscript bits. `<sub>` shrinks
+ * So each entry says what a declaration must still assert to survive. Only a
+ * value that stops asserting it is dropped, and the bit — a button pressed on
+ * this selection — wins over a style string the document merely arrived with.
+ *
+ * `font-size` is deliberately absent from the subscript entries. `<sub>` shrinks
  * its text as a side effect of being a subscript, and an author who then sets a
- * size has chosen that size; the POSITION is what makes it a subscript, and
- * that is `vertical-align`.
+ * size has chosen it; the POSITION is what makes it a subscript, and that is
+ * `vertical-align`.
  */
-const FORMAT_OWNED: readonly {
+const FORMAT_ASSERTS: readonly {
   flag: (typeof TEXT_FORMAT)[keyof typeof TEXT_FORMAT];
   properties: readonly string[];
+  keeps: (value: string) => boolean;
 }[] = [
-  { flag: TEXT_FORMAT.BOLD, properties: ["font-weight"] },
-  { flag: TEXT_FORMAT.ITALIC, properties: ["font-style"] },
+  {
+    flag: TEXT_FORMAT.BOLD,
+    properties: ["font-weight"],
+    // `bolder` is relative and cannot be resolved without the parent, so it is
+    // read as still asking for MORE weight rather than less. The numeric cut is
+    // CSS's own: `bold` is 700.
+    keeps: value =>
+      value === "bold" || value === "bolder" || Number(value) >= 700,
+  },
+  {
+    flag: TEXT_FORMAT.ITALIC,
+    properties: ["font-style"],
+    keeps: value => value === "italic" || value.startsWith("oblique"),
+  },
   {
     flag: TEXT_FORMAT.UNDERLINE,
     properties: ["text-decoration", "text-decoration-line"],
+    keeps: value => hasLine(value, "underline"),
   },
   {
     flag: TEXT_FORMAT.STRIKETHROUGH,
     properties: ["text-decoration", "text-decoration-line"],
+    keeps: value => hasLine(value, "line-through"),
   },
-  { flag: TEXT_FORMAT.SUBSCRIPT, properties: ["vertical-align"] },
-  { flag: TEXT_FORMAT.SUPERSCRIPT, properties: ["vertical-align"] },
+  {
+    flag: TEXT_FORMAT.SUBSCRIPT,
+    properties: ["vertical-align"],
+    keeps: value => value === "sub",
+  },
+  {
+    flag: TEXT_FORMAT.SUPERSCRIPT,
+    properties: ["vertical-align"],
+    keeps: value => value === "super",
+  },
 ];
+
+/**
+ * Whether a `text-decoration` value still draws one particular line.
+ *
+ * The shorthand REPLACES the line list, so `text-decoration: underline` beside a
+ * `STRIKETHROUGH` bit removes the strike even though it looks like it is only
+ * adding an underline. Read as tokens for that reason: what matters is whether
+ * the line this bit asserts is still among them.
+ */
+function hasLine(value: string, line: string): boolean {
+  return value.split(/\s+/).includes(line);
+}
+
+/**
+ * Whether an active format bit contradicts this declaration.
+ *
+ * Answered per DECLARATION rather than per property, which is what lets a value
+ * that reinforces the bit through.
+ */
+function contradictsFormat(
+  property: string,
+  value: string,
+  format: number | undefined
+): boolean {
+  if (format === undefined) return false;
+  const declared = value.trim().toLowerCase();
+  return FORMAT_ASSERTS.some(
+    entry =>
+      entry.properties.includes(property) &&
+      hasFormat(format, entry.flag) &&
+      !entry.keeps(declared)
+  );
+}
 
 /**
  * The properties on this list whose value is a colour.
@@ -142,17 +204,6 @@ function withoutPriority(declared: string): string {
   return declared.replace(/\s*!\s*important\s*$/i, "").trim();
 }
 
-/** The properties an active format bit has already decided. */
-function ownedByFormat(format: number | undefined): ReadonlySet<string> {
-  const owned = new Set<string>();
-  if (format === undefined) return owned;
-  for (const entry of FORMAT_OWNED) {
-    if (!hasFormat(format, entry.flag)) continue;
-    for (const property of entry.properties) owned.add(property);
-  }
-  return owned;
-}
-
 /**
  * Whether a property name is one this format carries.
  *
@@ -177,6 +228,54 @@ export function isInlineStyleProperty(name: unknown): boolean {
  * one unreadable declaration must not take an author's colour with it.
  */
 /**
+ * A declaration list split on the semicolons that actually separate one.
+ *
+ * `String.prototype.split` is wrong here: a semicolon inside a QUOTED value is
+ * ordinary text, so `font-family: "A;B"; color: red` came apart in the middle of
+ * the family name and published `font-family:"A`. Parentheses are tracked for
+ * the same reason — nothing in CSS today puts a `;` inside one, but the cost of
+ * covering it is a counter and the cost of being wrong is a silently truncated
+ * value.
+ *
+ * Escapes need no handling: `hasCssInjection` refuses a value carrying a
+ * backslash outright, so a quote can never be escaped by the time this matters.
+ */
+/** The quote state after reading one character, `""` when outside a string. */
+function quoteAfter(character: string, quote: string): string {
+  if (quote !== "") return character === quote ? "" : quote;
+  return character === '"' || character === "'" ? character : "";
+}
+
+/** What one character does to the parenthesis depth a `;` cannot break out of. */
+function depthShift(character: string): number {
+  if (character === "(") return 1;
+  return character === ")" ? -1 : 0;
+}
+
+function splitDeclarations(list: string): string[] {
+  const out: string[] = [];
+  let start = 0;
+  let depth = 0;
+  let quote = "";
+  for (let at = 0; at < list.length; at += 1) {
+    const character = list[at] ?? "";
+    const next = quoteAfter(character, quote);
+    // Inside a string EITHER side of this character: the quote that opens one
+    // and the quote that closes it are both part of it.
+    const quoted = quote !== "" || next !== "";
+    quote = next;
+    if (quoted) continue;
+    depth = Math.max(0, depth + depthShift(character));
+    if (character === ";" && depth === 0) {
+      out.push(list.slice(start, at));
+      start = at + 1;
+    }
+  }
+  out.push(list.slice(start));
+  return out;
+}
+
+/**
  * One declaration, as the pair it contributes — or nothing, if it contributes.
  *
  * Separated from the walk because the walk is bookkeeping and this is the whole
@@ -185,7 +284,7 @@ export function isInlineStyleProperty(name: unknown): boolean {
  */
 function usableDeclaration(
   text: string,
-  owned: ReadonlySet<string>
+  format: number | undefined
 ): readonly [string, string] | undefined {
   // `indexOf` rather than `split`, because a value may contain a colon of its
   // own — `background-color: rgb(0 0 0 / 50%)` does not, but a `font-family`
@@ -196,8 +295,9 @@ function usableDeclaration(
   const property = text.slice(0, colon).trim().toLowerCase();
   const declared = withoutPriority(text.slice(colon + 1).trim());
   if (declared === "" || !ALLOWED.has(property)) return undefined;
-  // See {@link FORMAT_OWNED}: the bit is an act, the style is baggage.
-  if (owned.has(property)) return undefined;
+  // See {@link FORMAT_ASSERTS}: only a value that stops asserting what the bit
+  // asserts is dropped, so one that reinforces it survives.
+  if (contradictsFormat(property, declared, format)) return undefined;
   /*
    * A colour is CHECKED, not merely carried, and that is what makes a fallback
    * chain survive. `color: red; color: not-a-color` renders red in a browser,
@@ -231,9 +331,8 @@ export function readInlineStyle(
   const normalized = normalizeCssValue(value);
   if (normalized === "") return kept;
 
-  const owned = ownedByFormat(format);
-  for (const declaration of normalized.split(";")) {
-    const usable = usableDeclaration(declaration.trim(), owned);
+  for (const declaration of splitDeclarations(normalized)) {
+    const usable = usableDeclaration(declaration.trim(), format);
     if (usable === undefined) continue;
     // DELETED before it is set again, because `Map.set` on an existing key
     // replaces the value and leaves the key where it first appeared. The later

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -26,7 +26,7 @@
 
 import { hasFormat, TEXT_FORMAT } from "../rich-text";
 
-import { hasCssInjection, normalizeCssValue } from "./css-color";
+import { cssColor, hasCssInjection, normalizeCssValue } from "./css-color";
 
 /**
  * The properties a stored inline style may carry onto a page.
@@ -110,6 +110,38 @@ const FORMAT_OWNED: readonly {
   { flag: TEXT_FORMAT.SUPERSCRIPT, properties: ["vertical-align"] },
 ];
 
+/**
+ * The properties on this list whose value is a colour.
+ *
+ * Separated because a colour is the one kind of value here that can be CHECKED.
+ * `cssColor` decides it exactly, which lets a declaration be judged on what it
+ * says rather than on where it sits — see {@link readInlineStyle} for why that
+ * matters to a fallback chain.
+ */
+const COLOR_VALUED: ReadonlySet<string> = new Set([
+  "color",
+  "background-color",
+  "text-decoration-color",
+]);
+
+/**
+ * A declaration with any `!important` taken off it.
+ *
+ * STRIPPED rather than refused, and it has to be one or the other. React sets a
+ * style property through `CSSStyleDeclaration`, which rejects a value carrying
+ * an embedded priority and leaves the property UNSET — while server rendering
+ * writes the string out and it applies. So the same document renders one way
+ * from the server and another once the client mounts, which is exactly the
+ * divergence this module exists to remove.
+ *
+ * Stripping keeps the author's declaration and costs only the priority, which
+ * an inline style barely needs: it already outranks every stylesheet rule that
+ * is not itself `!important`. Refusing would drop the colour entirely.
+ */
+function withoutPriority(declared: string): string {
+  return declared.replace(/\s*!\s*important\s*$/i, "").trim();
+}
+
 /** The properties an active format bit has already decided. */
 function ownedByFormat(format: number | undefined): ReadonlySet<string> {
   const owned = new Set<string>();
@@ -144,47 +176,74 @@ export function isInlineStyleProperty(name: unknown): boolean {
  * style is not a request, it is what an old document happens to contain, and
  * one unreadable declaration must not take an author's colour with it.
  */
+/**
+ * One declaration, as the pair it contributes — or nothing, if it contributes.
+ *
+ * Separated from the walk because the walk is bookkeeping and this is the whole
+ * decision: everything about whether a stored declaration may reach a page is
+ * here, in the order the reasons apply.
+ */
+function usableDeclaration(
+  text: string,
+  owned: ReadonlySet<string>
+): readonly [string, string] | undefined {
+  // `indexOf` rather than `split`, because a value may contain a colon of its
+  // own — `background-color: rgb(0 0 0 / 50%)` does not, but a `font-family`
+  // naming a source with one would, and splitting would truncate it.
+  const colon = text.indexOf(":");
+  if (colon === -1) return undefined;
+
+  const property = text.slice(0, colon).trim().toLowerCase();
+  const declared = withoutPriority(text.slice(colon + 1).trim());
+  if (declared === "" || !ALLOWED.has(property)) return undefined;
+  // See {@link FORMAT_OWNED}: the bit is an act, the style is baggage.
+  if (owned.has(property)) return undefined;
+  /*
+   * A colour is CHECKED, not merely carried, and that is what makes a fallback
+   * chain survive. `color: red; color: not-a-color` renders red in a browser,
+   * because the second declaration is discarded when it is parsed — so keeping
+   * the later one on position alone loses the colour the author would see, and
+   * the CMS used to emit both and get this right.
+   *
+   * Judging the VALUE recovers it for every property whose value this package
+   * can decide, and only a colour qualifies today: the rest of the list takes
+   * lengths, keywords and shorthands whose validity is a CSS property database,
+   * not something to guess at here. For those the later declaration still wins,
+   * which is what a browser does whenever the later one is valid.
+   */
+  if (COLOR_VALUED.has(property) && cssColor(declared) === undefined) {
+    return undefined;
+  }
+  // The same guard the colours cross, and for the same reason: this string
+  // reaches a `style` attribute, where a `;` ends the declaration and starts
+  // another, and a `url()` fetches.
+  if (hasCssInjection(declared)) return undefined;
+  return [property, declared];
+}
+
 export function readInlineStyle(
   value: unknown,
   format?: number
 ): ReadonlyMap<string, string> {
   const kept = new Map<string, string>();
   if (typeof value !== "string" || value === "") return kept;
-  const owned = ownedByFormat(format);
 
   const normalized = normalizeCssValue(value);
   if (normalized === "") return kept;
 
+  const owned = ownedByFormat(format);
   for (const declaration of normalized.split(";")) {
-    const text = declaration.trim();
-    if (text === "") continue;
-
-    // `indexOf` rather than `split`, because a value may contain a colon of its
-    // own — `background-color: rgb(0 0 0 / 50%)` does not, but a `font-family`
-    // naming a source with one would, and splitting would truncate it.
-    const colon = text.indexOf(":");
-    if (colon === -1) continue;
-
-    const property = text.slice(0, colon).trim().toLowerCase();
-    const declared = text.slice(colon + 1).trim();
-    if (declared === "" || !ALLOWED.has(property)) continue;
-    // See {@link FORMAT_OWNED}: the bit is an act, the style is baggage.
-    if (owned.has(property)) continue;
-    // The same guard the colours cross, and for the same reason: this string
-    // reaches a `style` attribute, where a `;` ends the declaration and starts
-    // another, and a `url()` fetches.
-    if (hasCssInjection(declared)) continue;
-
+    const usable = usableDeclaration(declaration.trim(), owned);
+    if (usable === undefined) continue;
     // DELETED before it is set again, because `Map.set` on an existing key
     // replaces the value and leaves the key where it first appeared. The later
     // declaration would then be emitted in the earlier one's POSITION, and
-    // position is meaning here: `text-decoration-color:red;
-    // text-decoration:underline blue; text-decoration-color:green` would come
-    // back with green ahead of the shorthand, so the shorthand resets the
-    // colour the author wrote last. Keeping the winner's own position is what
-    // makes the emitted text cascade the way the stored text did.
-    kept.delete(property);
-    kept.set(property, declared);
+    // position is meaning here: a shorthand written after a longhand resets it,
+    // so a winner emitted ahead of that shorthand loses to it. Keeping the
+    // winner's own place is what makes the emitted text cascade the way the
+    // stored text did.
+    kept.delete(usable[0]);
+    kept.set(usable[0], usable[1]);
   }
   return kept;
 }

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -343,11 +343,22 @@ function usableDeclaration(
    * the later one on position alone loses the colour the author would see, and
    * the CMS used to emit both and get this right.
    *
-   * Judging the VALUE recovers it for every property whose value this package
-   * can decide, and only a colour qualifies today: the rest of the list takes
-   * lengths, keywords and shorthands whose validity is a CSS property database,
-   * not something to guess at here. For those the later declaration still wins,
-   * which is what a browser does whenever the later one is valid.
+   * Judging the VALUE recovers it wherever this package can decide the value.
+   * A colour keyword and a hex are decidable, so `banana` keeps its fallback.
+   *
+   * A colour FUNCTION is not. Deciding `rgb(banana)` from `oklch(0.7 0.1 200)`
+   * needs a CSS grammar, and the only one available is css-tree's lexer, which
+   * this package deliberately does not load: `css-tree-subpaths.d.ts` records
+   * that its root entry pulls MDN reference data and `node:module` with it,
+   * which a runtime-free package cannot take. Measured, that lexer is also two
+   * years stale — it rejects `oklch()` and `color-mix()` outright — so adopting
+   * it would trade a rare malformed value for every modern colour syntax.
+   *
+   * So an undecidable value REPLACES, rather than being refused. The
+   * undecidable set is dominated by syntax newer than our data rather than by
+   * garbage, which is the same reason the lexer cannot read it; and a fallback
+   * chain written for a new syntax is the case that actually occurs. Lengths
+   * and shorthands are undecidable for the same reason and behave the same way.
    */
   if (COLOR_VALUED.has(property) && cssColor(declared) === undefined) {
     return undefined;

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -2082,3 +2082,94 @@ describe("rich-text a decoration the style already draws", () => {
     expect(html).toContain("<s>");
   });
 });
+
+describe("rich-text an updated node matches a fresh one", () => {
+  const styled = (style: string): RichTextValue =>
+    doc([
+      { type: "paragraph", children: [{ type: "text", text: "Hi", style }] },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+  const attributeOf = (container: HTMLElement): string =>
+    container.querySelector("span")?.getAttribute("style") ?? "";
+
+  it.each([
+    [
+      "only the declaration order changes",
+      "text-decoration-color: green; text-decoration: underline",
+      "text-decoration: underline; text-decoration-color: green",
+    ],
+    [
+      "only a shorthand beside its own longhand changes",
+      "text-decoration: underline blue; text-decoration-color: green",
+      "text-decoration: underline red; text-decoration-color: green",
+    ],
+    ["only a value changes", "color: #ff0000", "color: #00ff00"],
+  ])("after %s", (_label, before, after) => {
+    /*
+     * The property, stated as the thing that actually matters: a node the
+     * client UPDATED must look like one the client rendered fresh — which is
+     * also what the CMS serializer produces for the same stored value.
+     *
+     * Asserted this way rather than against a specific declaration, because
+     * React's diff fails here in more than one way and each has its own
+     * symptom. Identical keys and values in a new order produce no writes at
+     * all. A changed SHORTHAND beside an unchanged longhand writes only the
+     * shorthand, and assigning `text-decoration` resets
+     * `text-decoration-color` — so the longhand the diff skipped is undone.
+     * Comparing against a fresh render catches both without this test having to
+     * model the browser's shorthand expansion, which jsdom may not implement.
+     */
+    const updated = render(<RichText value={styled(before)} />);
+    updated.rerender(<RichText value={styled(after)} />);
+    const afterUpdate = attributeOf(updated.container);
+    cleanup();
+
+    const fresh = render(<RichText value={styled(after)} />);
+    const afterFresh = attributeOf(fresh.container);
+
+    // The population first: two empty attributes would compare equal and pass.
+    expect(afterFresh).not.toBe("");
+    expect(afterUpdate).toBe(afterFresh);
+  });
+
+  it.each([
+    [
+      "a shorthand beside its own longhand",
+      "text-decoration: underline blue; text-decoration-color: green",
+      "text-decoration: underline red; text-decoration-color: green",
+    ],
+    ["a plain value", "color: #ff0000", "color: #00ff00"],
+  ])("replaces the element when %s changes", (_label, before, after) => {
+    /*
+     * The MECHANISM, because the outcome is not observable here. Assigning
+     * `text-decoration` resets `text-decoration-color` in a browser, so React
+     * writing only the changed shorthand undoes the longhand it skipped as
+     * unchanged — but jsdom does not implement shorthand expansion, so that
+     * reset never happens and the resulting attribute matches a fresh render
+     * either way. Measured: with the key on property order alone, every
+     * assertion above still passes.
+     *
+     * What the key actually buys is a REPLACEMENT rather than a diff, and that
+     * is observable: the DOM node itself changes. Asserting it here is
+     * asserting the thing this file controls, rather than a browser behaviour
+     * this environment declines to model.
+     */
+    const view = render(<RichText value={styled(before)} />);
+    const first = view.container.querySelector("span");
+    expect(first, "the population: a styled span drew at all").not.toBeNull();
+    view.rerender(<RichText value={styled(after)} />);
+    const second = view.container.querySelector("span");
+
+    expect(second).not.toBeNull();
+    expect(second).not.toBe(first);
+  });
+
+  it("does not replace the element when nothing changed", () => {
+    // The control on the other side: a key that varied on every render would
+    // satisfy both assertions above while throwing the node away on each pass.
+    const view = render(<RichText value={styled("color: #ff0000")} />);
+    const first = view.container.querySelector("span");
+    view.rerender(<RichText value={styled("color: #ff0000")} />);
+    expect(view.container.querySelector("span")).toBe(first);
+  });
+});

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1875,3 +1875,42 @@ describe("rich-text authored colours beat the format element's own", () => {
     ).toBe("<p><strong>Hi</strong></p>");
   });
 });
+
+describe("rich-text carries the editor's own font values to the page", () => {
+  /*
+   * The end of the chain, asserted where it ends. The engine's tests prove its
+   * reader keeps every family and size the toolbar offers, and the admin's
+   * conformance test proves that list IS the toolbar's — but neither renders
+   * anything. A renderer that dropped values containing a space, or lost a
+   * property's React name, would leave both of those green while the page
+   * published the font as plain prose.
+   *
+   * `inherit` is what the per-property test above uses, and it is legal for all
+   * of them, which is exactly why it cannot catch this: a real family carries a
+   * space and a real size carries a unit.
+   */
+  const styled = (style: string): RichTextValue =>
+    doc([
+      {
+        type: "paragraph",
+        children: [{ type: "text", text: "Hi", style }],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+  it.each(["Courier New", "Times New Roman", "Georgia"])(
+    "publishes the family %s",
+    family => {
+      expect(
+        renderToStaticMarkup(
+          <RichText value={styled(`font-family: ${family}`)} />
+        )
+      ).toContain(`font-family:${family}`);
+    }
+  );
+
+  it.each(["10px", "24px", "72px"])("publishes the size %s", size => {
+    expect(
+      renderToStaticMarkup(<RichText value={styled(`font-size: ${size}`)} />)
+    ).toContain(`font-size:${size}`);
+  });
+});

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1812,3 +1812,66 @@ describe("rich-text inline styles reach the page", () => {
     expect(html).not.toContain("text-transform:lowercase");
   });
 });
+
+describe("rich-text authored colours beat the format element's own", () => {
+  const styled = (style: string, format: number): RichTextValue =>
+    doc([
+      {
+        type: "paragraph",
+        children: [{ type: "text", text: "Hi", style, format }],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+  it("puts the author's colours inside the highlight, not around it", () => {
+    /*
+     * A format element carries colours of its own: `<mark>` is painted by the
+     * UA with `Mark` and `MarkText`, and the CMS gives it a class setting both
+     * explicitly. A colour on an OUTER span only inherits, so the mark's own
+     * paint wins — an author who highlighted a phrase and then picked a text
+     * colour published the mark's colours instead of theirs.
+     *
+     * Asserted as containment rather than as a string of the whole element, so
+     * it still holds when another format bit adds a wrapper between them.
+     */
+    const { container } = render(
+      <RichText
+        value={styled(
+          "color: #ff0000; background-color: #00ff00",
+          TEXT_FORMAT.HIGHLIGHT
+        )}
+      />
+    );
+    const span = container.querySelector("span");
+    expect(span, "the style span drew at all").not.toBeNull();
+    expect(span?.closest("mark"), "it sits inside the mark").not.toBeNull();
+  });
+
+  it("puts them inside a bold wrapper too", () => {
+    // The sibling. `<strong>` carries no colour of its own, so this one is not
+    // about winning a cascade — it is that ONE rule decides the nesting, rather
+    // than a special case for the element that happened to be reported.
+    const { container } = render(
+      <RichText value={styled("color: #ff0000", TEXT_FORMAT.BOLD)} />
+    );
+    expect(container.querySelector("strong > span")).not.toBeNull();
+  });
+
+  it("adds no span to a formatted run that declares nothing", () => {
+    // The control. A rule that always emitted the span would satisfy both
+    // assertions above and put an empty element around every formatted word.
+    expect(
+      renderToStaticMarkup(
+        <RichText
+          value={doc([
+            {
+              type: "paragraph",
+              children: [
+                { type: "text", text: "Hi", format: TEXT_FORMAT.BOLD },
+              ],
+            },
+          ] as unknown as RichTextValue["root"]["children"])}
+        />
+      )
+    ).toBe("<p><strong>Hi</strong></p>");
+  });
+});

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1,5 +1,9 @@
 // @vitest-environment jsdom
-import { TEXT_FORMAT, type RichTextValue } from "@nextlyhq/blocks-engine";
+import {
+  INLINE_STYLE_PROPERTIES,
+  TEXT_FORMAT,
+  type RichTextValue,
+} from "@nextlyhq/blocks-engine";
 import { render, screen } from "@testing-library/react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { cleanup } from "@testing-library/react";
@@ -1714,5 +1718,97 @@ describe("rich-text media wrappers carry what no stylesheet will", () => {
     // `width:100%` — a substring refusal passes on the very output it is meant
     // to reject, and passed on the correct output here too.
     expect(html).toContain('style="max-width:100%;height:auto"');
+  });
+});
+
+describe("rich-text inline styles reach the page", () => {
+  const styled = (style: string, format?: number): RichTextValue =>
+    doc([
+      {
+        type: "paragraph",
+        children: [
+          {
+            type: "text",
+            text: "Hi",
+            style,
+            ...(format === undefined ? {} : { format }),
+          },
+        ],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+  it("draws the font, size, colour and highlight an author chose", () => {
+    /*
+     * The defect: Lexical keeps these on the text node's `style` string, the
+     * renderer read the text and the format bitfield and never opened it, so
+     * every one of these choices published as plain prose. Silent in both
+     * directions — the author saw it in the editor, the visitor saw nothing
+     * missing.
+     */
+    const html = renderToStaticMarkup(
+      <RichText
+        value={styled(
+          "font-family: Georgia; font-size: 24px; color: #ff0000; background-color: #00ff00"
+        )}
+      />
+    );
+    expect(html).toContain(
+      '<span style="font-family:Georgia;font-size:24px;color:#ff0000;background-color:#00ff00">Hi</span>'
+    );
+  });
+
+  it("wraps nothing when there is nothing to put on it", () => {
+    // The control, and a real cost rather than tidiness: a `<span>` around every
+    // text node in a document is bytes on every page and a hook a stylesheet can
+    // catch on. Plain text must stay plain text.
+    expect(renderToStaticMarkup(<RichText value={para("Hi")} />)).toBe(
+      "<p>Hi</p>"
+    );
+  });
+
+  it.each([...INLINE_STYLE_PROPERTIES])(
+    "carries %s through to the page",
+    property => {
+      /*
+       * Behavioural rather than a read of the renderer's name map: what matters
+       * is that the property ARRIVES, and a test that compared two lists would
+       * pass while a wrong camel-case name dropped it silently — React ignores a
+       * key it does not know and says nothing.
+       *
+       * `inherit` because it is legal for every one of these, so one fixture
+       * serves the whole list without inventing a value per property.
+       */
+      const html = renderToStaticMarkup(
+        <RichText value={styled(`${property}: inherit`)} />
+      );
+      expect(html).toContain(`${property}:inherit`);
+    }
+  );
+
+  it("refuses a declaration that would break out of the style attribute", () => {
+    // Same boundary the button colours cross. React does not escape a style
+    // value, so a stored `;` ends the declaration and starts another.
+    const html = renderToStaticMarkup(
+      <RichText
+        value={styled(
+          "color: red;position:fixed;background-image:url(https://attacker.test/x)"
+        )}
+      />
+    );
+    expect(html).toContain("color:red");
+    expect(html).not.toContain("position:fixed");
+    expect(html).not.toContain("attacker.test");
+  });
+
+  it("lets the format bit win a disagreement about case", () => {
+    // The bit is a button pressed on this selection; a `text-transform` in the
+    // style string is whatever the document arrived carrying.
+    const html = renderToStaticMarkup(
+      <RichText
+        value={styled("text-transform: lowercase", TEXT_FORMAT.UPPERCASE)}
+      />
+    );
+    expect(html).toContain("text-transform:uppercase");
+    expect(html).not.toContain("text-transform:lowercase");
   });
 });

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1914,3 +1914,87 @@ describe("rich-text carries the editor's own font values to the page", () => {
     ).toContain(`font-size:${size}`);
   });
 });
+
+describe("rich-text a format bit beats a style that would cancel it", () => {
+  const node = (style: string, format: number): RichTextValue =>
+    doc([
+      {
+        type: "paragraph",
+        children: [{ type: "text", text: "Hi", style, format }],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+  it("keeps a bold run bold when the style says otherwise", () => {
+    // The style span sits INSIDE `<strong>` so an author's colour can beat
+    // `<mark>`, which means a `font-weight: normal` in there would cancel the
+    // bold by being nested deeper. The engine drops it instead, so the nesting
+    // no longer decides — and the CMS, which nests the other way round, reaches
+    // the same answer from the same reader.
+    const html = renderToStaticMarkup(
+      <RichText value={node("font-weight: normal", TEXT_FORMAT.BOLD)} />
+    );
+    expect(html).not.toContain("font-weight");
+    expect(html).toContain("<strong>");
+  });
+
+  it("still lets the author colour that same bold run", () => {
+    // The control: only the contradicted property goes.
+    const html = renderToStaticMarkup(
+      <RichText
+        value={node("font-weight: normal; color: #ff0000", TEXT_FORMAT.BOLD)}
+      />
+    );
+    expect(html).toContain("color:#ff0000");
+    expect(html).not.toContain("font-weight");
+  });
+
+  it("reapplies a style whose declarations only changed order", () => {
+    /*
+     * React diffs a style object property by property. Two objects with the
+     * same keys and values in a different order produce no writes at all, so an
+     * already-mounted node would keep whichever shorthand won before — the
+     * cascade fix would hold on a fresh render and silently not on an update.
+     *
+     * The span is keyed on the declaration order for that reason, which forces
+     * a replacement rather than a diff.
+     */
+    const first = doc([
+      {
+        type: "paragraph",
+        children: [
+          {
+            type: "text",
+            text: "Hi",
+            style: "text-decoration-color: green; text-decoration: underline",
+          },
+        ],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+    const second = doc([
+      {
+        type: "paragraph",
+        children: [
+          {
+            type: "text",
+            text: "Hi",
+            style: "text-decoration: underline; text-decoration-color: green",
+          },
+        ],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+    const { container, rerender } = render(<RichText value={first} />);
+    const before = container.querySelector("span")?.getAttribute("style") ?? "";
+    rerender(<RichText value={second} />);
+    const after = container.querySelector("span")?.getAttribute("style") ?? "";
+
+    // The population: both renders produced a styled span at all.
+    expect(before).not.toBe("");
+    expect(after).not.toBe("");
+    // And the DOM followed the stored order rather than keeping the first.
+    expect(before).not.toBe(after);
+    expect(after.indexOf("text-decoration:")).toBeLessThan(
+      after.indexOf("text-decoration-color:")
+    );
+  });
+});

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1998,3 +1998,87 @@ describe("rich-text a format bit beats a style that would cancel it", () => {
     );
   });
 });
+
+describe("rich-text a decoration the style already draws", () => {
+  const mk = (style: string, format: number): RichTextValue =>
+    doc([
+      {
+        type: "paragraph",
+        children: [{ type: "text", text: "Hi", style, format }],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+  it("drops the wrapper rather than drawing a second line", () => {
+    /*
+     * A text decoration PROPAGATES to descendants instead of being replaced by
+     * theirs, and a descendant cannot remove it. So `<u>` around a span
+     * declaring `underline wavy red` draws two underlines — the wrapper's plain
+     * one and the span's on top.
+     *
+     * The declaration is the richer of the two, carrying a style and a colour
+     * the wrapper cannot express, so the WRAPPER is what goes.
+     */
+    const html = renderToStaticMarkup(
+      <RichText
+        value={mk("text-decoration: underline wavy red", TEXT_FORMAT.UNDERLINE)}
+      />
+    );
+    expect(html).toContain("text-decoration:underline wavy red");
+    expect(html).not.toContain("<u>");
+  });
+
+  it("keeps a wrapper the style does not draw", () => {
+    // The control that matters most: only the bit whose line is already drawn
+    // loses its wrapper. Bold is not a decoration and accumulates with nothing.
+    const html = renderToStaticMarkup(
+      <RichText
+        value={mk(
+          "text-decoration: underline wavy red",
+          TEXT_FORMAT.UNDERLINE | TEXT_FORMAT.BOLD
+        )}
+      />
+    );
+    expect(html).toContain("<strong>");
+    expect(html).not.toContain("<u>");
+  });
+
+  it("keeps a wrapper for a format that does NOT accumulate", () => {
+    /*
+     * Only a decoration accumulates. A `font-weight: 900` inside a `<strong>`
+     * simply wins — there is one weight — so dropping the `<strong>` would
+     * discard its semantics for no benefit, and a screen reader would stop
+     * announcing the emphasis.
+     *
+     * This case exists because break-verifying the decoration-only filter
+     * changed NOTHING: with every format treated as accumulating, no test
+     * failed, because none of them paired a bit with a reinforcing value of its
+     * own property.
+     */
+    const html = renderToStaticMarkup(
+      <RichText value={mk("font-weight: 900", TEXT_FORMAT.BOLD)} />
+    );
+    expect(html).toContain("<strong>");
+    expect(html).toContain("font-weight:900");
+  });
+
+  it("keeps the wrapper when the style contradicts it instead", () => {
+    // `none` beside the bit is a contradiction, not a richer decoration: the
+    // declaration goes and the wrapper stays, which is the other branch.
+    const html = renderToStaticMarkup(
+      <RichText value={mk("text-decoration: none", TEXT_FORMAT.UNDERLINE)} />
+    );
+    expect(html).toContain("<u>");
+    expect(html).not.toContain("text-decoration");
+  });
+
+  it("keeps a wrapper whose own line the style does not assert", () => {
+    // An underline declaration beside STRIKETHROUGH asserts the wrong line, so
+    // it is dropped as a contradiction and the `<s>` survives.
+    const html = renderToStaticMarkup(
+      <RichText
+        value={mk("text-decoration: underline", TEXT_FORMAT.STRIKETHROUGH)}
+      />
+    );
+    expect(html).toContain("<s>");
+  });
+});

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -2173,3 +2173,40 @@ describe("rich-text an updated node matches a fresh one", () => {
     expect(view.container.querySelector("span")).toBe(first);
   });
 });
+
+describe("rich-text a decoration that adds a second line", () => {
+  const mk = (style: string, format: number): RichTextValue =>
+    doc([
+      {
+        type: "paragraph",
+        children: [{ type: "text", text: "Hi", style, format }],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+  it("keeps the wrapper AND the declaration when they draw different lines", () => {
+    // A decoration accumulates rather than replacing an ancestor's, so a
+    // strike and an authored underline are both wanted. Dropping either loses
+    // something the author wrote.
+    const html = renderToStaticMarkup(
+      <RichText
+        value={mk(
+          "text-decoration: underline wavy red",
+          TEXT_FORMAT.STRIKETHROUGH
+        )}
+      />
+    );
+    expect(html).toContain("<s>");
+    expect(html).toContain("text-decoration:underline wavy red");
+  });
+
+  it("drops the wrapper when they draw the SAME line", () => {
+    // The other branch, unchanged: same line means the two would double up.
+    const html = renderToStaticMarkup(
+      <RichText
+        value={mk("text-decoration: underline wavy red", TEXT_FORMAT.UNDERLINE)}
+      />
+    );
+    expect(html).not.toContain("<u>");
+    expect(html).toContain("text-decoration:underline wavy red");
+  });
+});

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -158,14 +158,9 @@ function formatted(
   format: number | undefined,
   style: unknown
 ): ReactNode {
-  let out: ReactNode = text;
-  for (const { flag, wrap } of FORMAT_ELEMENTS) {
-    if (hasFormat(format, flag)) out = wrap(out);
-  }
-
-  // Outermost, and only one can apply: `text-transform` is a single CSS
-  // property, so a value carrying two case bits would otherwise render whichever
-  // wrapper happened to be inner. Taking the first keeps that deterministic.
+  // Only one case format can apply: `text-transform` is a single CSS property,
+  // so a value carrying two case bits would otherwise render whichever wrapper
+  // happened to be inner. Taking the first keeps that deterministic.
   const transform = CASE_TRANSFORM.find(entry => hasFormat(format, entry.flag));
   const declared: CSSProperties = {
     ...inlineStyle(style),
@@ -175,11 +170,28 @@ function formatted(
     // conflict the deliberate act is the one to honour.
     ...(transform === undefined ? {} : { textTransform: transform.value }),
   };
+
+  // INNERMOST, inside the format elements rather than around them.
+  //
+  // Those elements carry colours of their own: `<mark>` is painted by the UA
+  // with `Mark` and `MarkText`, and the CMS gives it a class that sets both
+  // explicitly. A colour on an outer `<span>` only INHERITS, so the mark's own
+  // paint wins and an author who highlighted a phrase and then chose a text
+  // colour published the mark's colours instead of theirs. Declared on the
+  // element closest to the text, the author's choice is the one that applies.
+  //
   // No wrapper when there is nothing to put on it: an empty `<span>` around
-  // every text node doubles the size of a published document and gives a
-  // stylesheet a hook that means nothing.
-  if (Object.keys(declared).length === 0) return out;
-  return <span style={declared}>{out}</span>;
+  // every text node is bytes on every page and a hook a stylesheet can catch on.
+  let out: ReactNode =
+    Object.keys(declared).length === 0 ? (
+      text
+    ) : (
+      <span style={declared}>{text}</span>
+    );
+  for (const { flag, wrap } of FORMAT_ELEMENTS) {
+    if (hasFormat(format, flag)) out = wrap(out);
+  }
+  return out;
 }
 
 function children(

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -2,6 +2,7 @@ import {
   codeTokenClass,
   cssColor,
   hasFormat,
+  formatsDrawnByStyle,
   isRichTextNode,
   readInlineStyle,
   isRichTextValue,
@@ -202,8 +203,15 @@ function formatted(
         {text}
       </span>
     );
+  // A wrapper whose LINE the style already draws is not emitted. A text
+  // decoration propagates to descendants rather than being replaced by theirs,
+  // so a `<u>` around a span declaring `underline wavy red` draws two
+  // underlines — the wrapper's plain one, which the span cannot remove, and the
+  // span's on top. The declaration is the richer of the two, so the wrapper is
+  // what goes. The engine decides which, and the CMS asks the same question.
+  const drawn = formatsDrawnByStyle(style, format);
   for (const { flag, wrap } of FORMAT_ELEMENTS) {
-    if (hasFormat(format, flag)) out = wrap(out);
+    if (hasFormat(format, flag) && (drawn & flag) === 0) out = wrap(out);
   }
   return out;
 }

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -3,6 +3,7 @@ import {
   cssColor,
   hasFormat,
   isRichTextNode,
+  readInlineStyle,
   isRichTextValue,
   TEXT_FORMAT,
   type RichTextNode,
@@ -95,7 +96,68 @@ const CASE_TRANSFORM: readonly {
 ];
 
 /** Wraps text in the elements its format bits ask for, innermost first. */
-function formatted(text: string, format: number | undefined): ReactNode {
+/**
+ * The React name for each property {@link readInlineStyle} can return.
+ *
+ * Written out rather than derived by camel-casing the hyphens, because a
+ * derived name is a STRING and `style` takes typed keys — the conversion would
+ * have to be asserted through, and an assertion is exactly what hides a name
+ * React does not know. Every entry here is a key the type system checked.
+ *
+ * `everyInlineStylePropertyHasAReactName` in the test file holds this to the
+ * engine's list, so a property added there and forgotten here fails rather than
+ * being dropped from the page in silence.
+ */
+const REACT_STYLE_PROPERTY = {
+  color: "color",
+  "background-color": "backgroundColor",
+  "font-size": "fontSize",
+  "font-family": "fontFamily",
+  "font-weight": "fontWeight",
+  "font-style": "fontStyle",
+  "text-decoration": "textDecoration",
+  "text-decoration-line": "textDecorationLine",
+  "text-decoration-color": "textDecorationColor",
+  "text-decoration-style": "textDecorationStyle",
+  "text-align": "textAlign",
+  "vertical-align": "verticalAlign",
+  "line-height": "lineHeight",
+  "letter-spacing": "letterSpacing",
+  "word-spacing": "wordSpacing",
+  "white-space": "whiteSpace",
+  "text-transform": "textTransform",
+  opacity: "opacity",
+} as const satisfies Readonly<Record<string, keyof CSSProperties>>;
+
+/**
+ * An author's stored font, size, colour and highlight, as a style object.
+ *
+ * The engine decides WHAT survives; this only renames what it kept. A property
+ * the map above has no name for is dropped rather than passed through as a
+ * string key, because React would silently ignore it and the page would differ
+ * from the CMS's HTML for the same node.
+ */
+function inlineStyle(value: unknown): CSSProperties {
+  const style: Record<string, string> = {};
+  for (const [property, declared] of readInlineStyle(value)) {
+    if (!Object.hasOwn(REACT_STYLE_PROPERTY, property)) continue;
+    style[REACT_STYLE_PROPERTY[property as keyof typeof REACT_STYLE_PROPERTY]] =
+      declared;
+  }
+  // Accumulated as a record because indexing `CSSProperties` with a UNION of
+  // keys gives the INTERSECTION of their value types — which for these eighteen
+  // is the CSS-wide keywords and nothing else, so a plain `"16px"` is rejected
+  // on a type that has no business rejecting it. The record is assignable as it
+  // stands, so nothing is asserted through here; the KEYS, which are the half
+  // that could be wrong, were checked by the `satisfies` on the map above.
+  return style;
+}
+
+function formatted(
+  text: string,
+  format: number | undefined,
+  style: unknown
+): ReactNode {
   let out: ReactNode = text;
   for (const { flag, wrap } of FORMAT_ELEMENTS) {
     if (hasFormat(format, flag)) out = wrap(out);
@@ -105,9 +167,19 @@ function formatted(text: string, format: number | undefined): ReactNode {
   // property, so a value carrying two case bits would otherwise render whichever
   // wrapper happened to be inner. Taking the first keeps that deterministic.
   const transform = CASE_TRANSFORM.find(entry => hasFormat(format, entry.flag));
-  if (transform === undefined) return out;
-  const style: CSSProperties = { textTransform: transform.value };
-  return <span style={style}>{out}</span>;
+  const declared: CSSProperties = {
+    ...inlineStyle(style),
+    // LAST, so the format bit wins a disagreement. The bit is a button an
+    // author pressed on this selection; a `text-transform` in the style string
+    // is whatever a document happened to arrive carrying, and where they
+    // conflict the deliberate act is the one to honour.
+    ...(transform === undefined ? {} : { textTransform: transform.value }),
+  };
+  // No wrapper when there is nothing to put on it: an empty `<span>` around
+  // every text node doubles the size of a published document and gives a
+  // stylesheet a hook that means nothing.
+  if (Object.keys(declared).length === 0) return out;
+  return <span style={declared}>{out}</span>;
 }
 
 function children(
@@ -1089,7 +1161,8 @@ function RichTextNodeView({
     if (view !== undefined) return view(node, policy);
   }
 
-  if (typeof node.text === "string") return formatted(node.text, node.format);
+  if (typeof node.text === "string")
+    return formatted(node.text, node.format, node.style);
 
   // Unknown node: keep the words, lose the wrapper. See the module docblock.
   return <>{children(node.children, policy)}</>;

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -137,9 +137,12 @@ const REACT_STYLE_PROPERTY = {
  * string key, because React would silently ignore it and the page would differ
  * from the CMS's HTML for the same node.
  */
-function inlineStyle(value: unknown): CSSProperties {
+function inlineStyle(
+  value: unknown,
+  format: number | undefined
+): CSSProperties {
   const style: Record<string, string> = {};
-  for (const [property, declared] of readInlineStyle(value)) {
+  for (const [property, declared] of readInlineStyle(value, format)) {
     if (!Object.hasOwn(REACT_STYLE_PROPERTY, property)) continue;
     style[REACT_STYLE_PROPERTY[property as keyof typeof REACT_STYLE_PROPERTY]] =
       declared;
@@ -163,7 +166,10 @@ function formatted(
   // happened to be inner. Taking the first keeps that deterministic.
   const transform = CASE_TRANSFORM.find(entry => hasFormat(format, entry.flag));
   const declared: CSSProperties = {
-    ...inlineStyle(style),
+    // The FORMAT goes with it: a stored `font-weight: normal` beside a BOLD bit
+    // is a contradiction, and the engine resolves it by property rather than
+    // letting this file's nesting decide. See `FORMAT_OWNED` there.
+    ...inlineStyle(style, format),
     // LAST, so the format bit wins a disagreement. The bit is a button an
     // author pressed on this selection; a `text-transform` in the style string
     // is whatever a document happened to arrive carrying, and where they
@@ -186,7 +192,15 @@ function formatted(
     Object.keys(declared).length === 0 ? (
       text
     ) : (
-      <span style={declared}>{text}</span>
+      // KEYED on the declaration order, so a value that changes only the order
+      // of the same properties still reaches the DOM. React diffs a style
+      // object property by property: with identical keys and values it writes
+      // nothing, and the element keeps whichever shorthand won before — so a
+      // client preview would go on showing the previous cascade until something
+      // else remounted it.
+      <span key={Object.keys(declared).join("|")} style={declared}>
+        {text}
+      </span>
     );
   for (const { flag, wrap } of FORMAT_ELEMENTS) {
     if (hasFormat(format, flag)) out = wrap(out);

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -193,13 +193,28 @@ function formatted(
     Object.keys(declared).length === 0 ? (
       text
     ) : (
-      // KEYED on the declaration order, so a value that changes only the order
-      // of the same properties still reaches the DOM. React diffs a style
-      // object property by property: with identical keys and values it writes
-      // nothing, and the element keeps whichever shorthand won before — so a
-      // client preview would go on showing the previous cascade until something
-      // else remounted it.
-      <span key={Object.keys(declared).join("|")} style={declared}>
+      /*
+       * KEYED on the whole declaration list — every property AND its value.
+       *
+       * React diffs a style object property by property, and two of its
+       * outcomes are wrong here. Identical keys and values in a different order
+       * produce no writes at all, so the element keeps whichever shorthand won
+       * before. And where a SHORTHAND and one of its longhands are both
+       * present, changing only the shorthand writes only that: assigning
+       * `text-decoration` resets `text-decoration-color`, so the longhand the
+       * diff skipped as unchanged is silently undone and the client drifts from
+       * what a fresh render and the CMS both produce.
+       *
+       * Keying on the values costs a remount whenever any of them changes,
+       * which for static published text is a span being replaced. Ordering
+       * alone was cheaper and did not cover the shorthand case.
+       */
+      <span
+        key={Object.entries(declared)
+          .map(([property, written]) => `${property}:${String(written)}`)
+          .join(";")}
+        style={declared}
+      >
         {text}
       </span>
     );

--- a/packages/nextly/src/services/security/css-validator.ts
+++ b/packages/nextly/src/services/security/css-validator.ts
@@ -12,7 +12,7 @@
 import {
   cssColor,
   hasCssInjection,
-  normalizeCssValue,
+  sanitizeInlineStyle as sanitizeInlineStyleValue,
 } from "@nextlyhq/blocks-engine";
 
 /**
@@ -32,26 +32,6 @@ function containsInjection(value: string): boolean {
  * Only these properties are permitted in user-supplied `style` attributes.
  * Properties not on this list are silently dropped.
  */
-const ALLOWED_STYLE_PROPERTIES = new Set([
-  "color",
-  "background-color",
-  "font-size",
-  "font-family",
-  "font-weight",
-  "font-style",
-  "text-decoration",
-  "text-decoration-line",
-  "text-decoration-color",
-  "text-decoration-style",
-  "text-align",
-  "vertical-align",
-  "line-height",
-  "letter-spacing",
-  "word-spacing",
-  "white-space",
-  "text-transform",
-  "opacity",
-]);
 
 /**
  * Check whether a string is a valid CSS color value.
@@ -105,53 +85,14 @@ export function sanitizeCssColor(value: string): string | null {
 }
 
 /**
- * Sanitize an inline style string by:
- * 1. Splitting into individual CSS declarations
- * 2. Checking each property name against the allowlist
- * 3. Checking each value against injection patterns
- * 4. Reassembling only passing declarations
+ * Sanitize an inline style string, keeping only declarations safe to publish.
  *
- * Properties not on the allowlist are silently dropped.
- * Values containing injection patterns cause the entire declaration to be dropped.
- *
- * @example
- * sanitizeInlineStyle('color: red; font-size: 16px')
- * // 'color: red; font-size: 16px'
- *
- * sanitizeInlineStyle('color: red; behavior: url(evil.htc); font-size: 16px')
- * // 'color: red; font-size: 16px'
- *
- * sanitizeInlineStyle('background-image: url(javascript:alert(1))')
- * // ''
- *
- * sanitizeInlineStyle('color: expression(alert(1))')
- * // ''
+ * Delegated rather than implemented. The React renderer draws the same stored
+ * string and the versions differ compares it, and neither can import this
+ * package — so the property allowlist and the value check live in
+ * `blocks-engine`, which all three already depend on. A second copy here is how
+ * one surface starts publishing what another refuses.
  */
 export function sanitizeInlineStyle(value: string): string {
-  if (!value || typeof value !== "string") return "";
-
-  const normalized = normalizeCssValue(value);
-  if (!normalized) return "";
-
-  const declarations = normalized.split(";");
-  const safe: string[] = [];
-
-  for (const decl of declarations) {
-    const trimmed = decl.trim();
-    if (!trimmed) continue;
-
-    const colonIndex = trimmed.indexOf(":");
-    if (colonIndex === -1) continue;
-
-    const property = trimmed.slice(0, colonIndex).trim().toLowerCase();
-    const propValue = trimmed.slice(colonIndex + 1).trim();
-
-    if (!ALLOWED_STYLE_PROPERTIES.has(property)) continue;
-
-    if (containsInjection(propValue)) continue;
-
-    safe.push(`${property}:${propValue}`);
-  }
-
-  return safe.join(";");
+  return sanitizeInlineStyleValue(value);
 }

--- a/packages/nextly/src/services/security/css-validator.ts
+++ b/packages/nextly/src/services/security/css-validator.ts
@@ -93,6 +93,6 @@ export function sanitizeCssColor(value: string): string | null {
  * `blocks-engine`, which all three already depend on. A second copy here is how
  * one surface starts publishing what another refuses.
  */
-export function sanitizeInlineStyle(value: string): string {
-  return sanitizeInlineStyleValue(value);
+export function sanitizeInlineStyle(value: string, format?: number): string {
+  return sanitizeInlineStyleValue(value, format);
 }

--- a/packages/nextly/src/shared/lib/__tests__/rich-text-html.inline-style.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/rich-text-html.inline-style.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Where a text node's inline style sits relative to its format wrappers.
+ *
+ * This serializer and the React renderer in `blocks-react` draw the same stored
+ * node, and both put that style on a `<span>`. Whichever of the two elements is
+ * NESTED DEEPER wins for an inherited property, so the nesting is not a
+ * presentation detail — it decides whether an author's colour or a `<mark>`'s
+ * own paint reaches the reader, and it has to be the same answer on both.
+ *
+ * It was not covered here before, which is how it could have been changed in
+ * either direction without anything noticing.
+ *
+ * @module shared/lib/__tests__/rich-text-html.inline-style.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { RichTextValue } from "../../../collections/fields/types/rich-text";
+import { convertRichTextToHtml } from "../rich-text-html";
+
+const TEXT_FORMAT = { BOLD: 1, HIGHLIGHT: 128 } as const;
+
+const html = (node: Record<string, unknown>): string =>
+  // `?? ""` rather than a non-null assertion: the serializer answers `null` for
+  // a value it cannot read, and a test that threw on that would report a shape
+  // problem as a failure of whatever it was asserting.
+  convertRichTextToHtml({
+    root: {
+      type: "root",
+      children: [
+        {
+          type: "paragraph",
+          children: [{ type: "text", text: "Hi", ...node }],
+        },
+      ],
+    },
+  } as unknown as RichTextValue) ?? "";
+
+describe("an inline style beside a format wrapper", () => {
+  it("puts the style inside the wrapper, where the author's choice applies", () => {
+    // `<mark>` is painted by the UA, and this serializer additionally gives it a
+    // class that sets a colour. A style OUTSIDE it would only be inherited, so
+    // the mark's own paint would win and an author who highlighted a phrase and
+    // then chose a text colour would publish the mark's colours instead.
+    const marked = html({
+      format: TEXT_FORMAT.HIGHLIGHT,
+      style: "color: #ff0000",
+    });
+    expect(marked).toContain(
+      '<mark class="nextly-rich-text-highlight"><span style="color:#ff0000">Hi</span></mark>'
+    );
+  });
+
+  it("keeps a bold run bold when the style would cancel it", () => {
+    /*
+     * The other direction, and why the nesting alone cannot be the rule. Once
+     * the span is inside, a stored `font-weight: normal` — which is what a paste
+     * from a word processor carries — would cancel the bold by being nested
+     * deeper.
+     *
+     * The shared reader drops it instead, so the contradiction is resolved by
+     * the PROPERTY rather than by the markup, and this file and the React
+     * renderer reach the same answer from the same code.
+     */
+    const bold = html({
+      format: TEXT_FORMAT.BOLD,
+      style: "font-weight: normal; color: #ff0000",
+    });
+    expect(bold).toContain("<strong");
+    expect(bold).toContain("color:#ff0000");
+    expect(bold).not.toContain("font-weight:normal");
+  });
+
+  it("emits no span when the style survives nothing", () => {
+    // The control. A serializer that always wrapped would satisfy both
+    // assertions above while putting an empty element around every formatted
+    // word in every document.
+    expect(
+      html({ format: TEXT_FORMAT.BOLD, style: "position: fixed" })
+    ).not.toContain("<span");
+  });
+
+  it("still escapes the text it wraps", () => {
+    // The span is built around already-escaped content now rather than being
+    // wrapped around the formatter's output, so this is the assertion that the
+    // move did not step past the escaping on the way.
+    expect(html({ text: "<img src=x>", style: "color: #fff" })).not.toContain(
+      "<img"
+    );
+  });
+});

--- a/packages/nextly/src/shared/lib/__tests__/rich-text-html.inline-style.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/rich-text-html.inline-style.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from "vitest";
 import type { RichTextValue } from "../../../collections/fields/types/rich-text";
 import { convertRichTextToHtml } from "../rich-text-html";
 
-const TEXT_FORMAT = { BOLD: 1, HIGHLIGHT: 128 } as const;
+const TEXT_FORMAT = { BOLD: 1, UNDERLINE: 8, HIGHLIGHT: 128 } as const;
 
 const html = (node: Record<string, unknown>): string =>
   // `?? ""` rather than a non-null assertion: the serializer answers `null` for
@@ -68,6 +68,25 @@ describe("an inline style beside a format wrapper", () => {
     expect(bold).toContain("<strong");
     expect(bold).toContain("color:#ff0000");
     expect(bold).not.toContain("font-weight:normal");
+  });
+
+  it("drops a wrapper whose line the style already draws", () => {
+    // The same question the React renderer asks, from the same module. A text
+    // decoration propagates to descendants rather than being replaced by
+    // theirs, so `<u>` around a span declaring `underline wavy red` would draw
+    // two underlines here exactly as it does there.
+    const decorated = html({
+      format: TEXT_FORMAT.UNDERLINE,
+      style: "text-decoration: underline wavy red",
+    });
+    expect(decorated).toContain("text-decoration:underline wavy red");
+    expect(decorated).not.toContain("<u");
+  });
+
+  it("keeps that wrapper when nothing draws its line", () => {
+    // The control, and it is what makes the assertion above about the STYLE
+    // rather than about underlines having stopped working.
+    expect(html({ format: TEXT_FORMAT.UNDERLINE })).toContain("<u");
   });
 
   it("emits no span when the style survives nothing", () => {

--- a/packages/nextly/src/shared/lib/rich-text-html.ts
+++ b/packages/nextly/src/shared/lib/rich-text-html.ts
@@ -11,6 +11,7 @@
 import {
   codeTokenClass,
   isRichTextValue,
+  formatsDrawnByStyle,
   TEXT_FORMAT,
 } from "@nextlyhq/blocks-engine";
 
@@ -234,7 +235,13 @@ function serializeTextNode(node: LexicalSerializedNode): string {
     }
   }
 
-  return applyTextFormat(inner, format);
+  // The same question the React renderer asks, from the same module: a wrapper
+  // whose line the style already draws would add a second one, because a text
+  // decoration propagates rather than being replaced.
+  return applyTextFormat(
+    inner,
+    format & ~formatsDrawnByStyle(node.style, format)
+  );
 }
 
 function serializeLineBreakNode(): string {

--- a/packages/nextly/src/shared/lib/rich-text-html.ts
+++ b/packages/nextly/src/shared/lib/rich-text-html.ts
@@ -174,8 +174,10 @@ function isUrlSafe(url: string): boolean {
 // Node Serializers
 // ============================================================
 
-function applyTextFormat(text: string, format: number): string {
-  let result = escapeHtml(text);
+function applyTextFormat(content: string, format: number): string {
+  // Takes content that is ALREADY escaped, because the style span now sits
+  // inside these wrappers and has to be built before they are applied.
+  let result = content;
 
   if (format & TEXT_FORMAT.CODE) {
     // Class, not an inline style: the site owns how its code reads, and an
@@ -220,17 +222,19 @@ function serializeTextNode(node: LexicalSerializedNode): string {
     return "";
   }
 
-  let result = applyTextFormat(text, format);
-
-  // Validate and sanitize inline styles before rendering (CSS injection prevention)
+  // The style span goes INSIDE the format wrappers, and the format is handed to
+  // the sanitizer so a declaration the bit already decided is dropped rather
+  // than left to win by being nested deeper. Both surfaces do this the same
+  // way; the point of sharing the reader is that they cannot differ.
+  let inner = escapeHtml(text);
   if (node.style && typeof node.style === "string" && node.style.trim()) {
-    const safeStyle = sanitizeInlineStyle(node.style);
+    const safeStyle = sanitizeInlineStyle(node.style, format);
     if (safeStyle) {
-      result = `<span style="${escapeHtml(safeStyle)}">${result}</span>`;
+      inner = `<span style="${escapeHtml(safeStyle)}">${inner}</span>`;
     }
   }
 
-  return result;
+  return applyTextFormat(inner, format);
 }
 
 function serializeLineBreakNode(): string {


### PR DESCRIPTION
Rich-text font, size, colour and highlight were dropped by the React renderer. Lexical keeps them on a text node's `style` string; the renderer read the text and the format bitfield and never opened it — literal `node.style` appeared **zero** times. Every one of those choices published as plain prose, silently in both directions.

## The shape, and why

The reading happens **once**, in `blocks-engine/src/style/inline-style.ts`, and the CMS serializer delegates to it instead of keeping its own. Three surfaces have to agree about what that string means:

- the CMS serializes it into published HTML
- the React renderer draws it on a page
- the versions differ decides whether a change to it is one a reader would **see**

Three readings of one question drift, and the drift is silent — the admin reports an edit the page cannot render, or the page shows a declaration the CMS refused.

`sanitizeInlineStyle` is **derived** from `readInlineStyle` rather than parsing again, so the serializer and the renderer cannot disagree about one stored node.

## The allowlist is exported as data

A differ cannot use a sanitizer. It is not asking "what may I emit" but "is this property one a reader would notice", and a function returning a cleaned string cannot answer that without the caller re-deriving the list from its output. `INLINE_STYLE_PROPERTIES` is the list itself.

It stays **wider than the toolbar can produce**: four properties are what the editor writes, and the rest is what import and paste carry — narrowing to the first would strip faces the CMS publishes today. Nothing that positions, floats, sizes or layers is on it, because those are the declarations that let stored text escape the box the page gave it. Every value crosses the same injection guard the button colours do.

## Measured, not assumed

- The toolbar writes exactly four properties via `$patchStyleText`, and their values are constrained: a fixed list of 6 families, a fixed list of 16 sizes, and two colours from `<input type="color">` — so always `#rrggbb`.
- Prior art agrees with constraining rather than sanitizing free text. Payload, also Lexical-based, maps values back to a known CSS config; DOMPurify offers no per-property CSS allowlist as configuration at all, so the allowlist is work every consumer does themselves.

## Evidence

8 break-verifies, each naming its intended test. Notable: narrowing the conformance parser back to a lowercase-only pattern makes it read the family list as **empty** and the population assertion catches it — the widening is load-bearing.

Full gate sequence from the repo root, all exit 0: build, check-types across six packages, 4,754 package tests, admin conformance, lint, `lint:design`, comment convention, `test:scripts`, changeset. `fallow` verdict `pass`, 0 introduced. `packages/nextly`'s suites over the changed validator: 276/276 both before and after the delegation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Rich-text content now supports a broader set of inline typography and styling options.
  - Inline styles are consistently supported across editing, rendering, and content processing.
  - Supported font families, font sizes, and style properties are publicly available for integrations.

- **Bug Fixes**
  - Unsafe or malformed inline CSS is rejected.
  - Text formatting now correctly takes precedence over conflicting inline styles.
  - Unnecessary formatting wrappers are no longer rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->