### PR TITLE
feat(builder): per-control breakpoint actions — jump and reset

### DIFF
--- a/.changeset/control-breakpoint-actions.md
+++ b/.changeset/control-breakpoint-actions.md
@@ -1,0 +1,41 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Each style control can now say which breakpoint its value came from, and act on
+it: a value set at the tier you are editing offers to reset, and a value
+arriving from another tier offers to go there.
+
+Only controls that have earned an action get one. An unset control offers
+nothing, so a panel does not fill with buttons for values nobody has touched.
+
+Reset names what it will reveal rather than only that it clears — in a
+desktop-first cascade a value usually falls back to a wider tier, and not
+always to the base one.
+
+Going to a tier sizes the canvas to it. There is no second setting for which
+breakpoint you are editing, so the canvas and the inspector cannot disagree.

--- a/packages/builder/src/breakpoint-action-styles.test.ts
+++ b/packages/builder/src/breakpoint-action-styles.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The breakpoint actions have styles, which nothing else here can check.
+ *
+ * A class name in a component and a selector in a stylesheet are two halves of
+ * one decision that no type, render test or lint rule connects. The editor's
+ * sheet is loaded beside a design system applying Preflight, which strips a
+ * bare `<button>` to text — so a missing selector does not throw, does not fail
+ * a render assertion, and ships an interactive control an author cannot tell
+ * apart from the sentence beside it. Measured on this PR: the buttons were
+ * added with no selector anywhere and every other gate stayed green.
+ *
+ * Read from the SOURCE stylesheet rather than the built one: `dist` is
+ * gitignored, so a check against it answers differently before and after a
+ * build, which is the shape that makes CI and a laptop disagree.
+ *
+ * @module breakpoint-action-styles.test
+ */
+const CHROME = readFileSync(
+  fileURLToPath(new URL("./styles/builder-chrome.css", import.meta.url)),
+  "utf8"
+);
+
+describe("the breakpoint actions are styled, not merely marked", () => {
+  it("gives the action button a rule of its own", () => {
+    expect(CHROME).toContain(".nx-style-inspector__breakpoint-action {");
+  });
+
+  it("gives it a hover and a visible focus ring", () => {
+    /*
+     * Both, because they answer to different people: hover tells a pointer the
+     * text is pressable, and a focus ring is the only way a sighted keyboard
+     * user locates a control that appears on some fields and not others.
+     */
+    expect(CHROME).toContain(".nx-style-inspector__breakpoint-action:hover");
+    expect(CHROME).toContain(
+      ".nx-style-inspector__breakpoint-action:focus-visible"
+    );
+  });
+
+  it("styles the visible reset fallback beside it", () => {
+    expect(CHROME).toContain(".nx-style-inspector__breakpoint-reveals");
+  });
+
+  it("finds nothing for a class that was never written", () => {
+    /*
+     * The control. `toContain` over a 1600-line file is exactly the assertion
+     * that passes for the wrong reason if the haystack is wrong or the needle
+     * is a substring of something else — so one needle that MUST be absent
+     * establishes the search can come out empty.
+     */
+    expect(CHROME).not.toContain(".nx-style-inspector__breakpoint-nonexistent");
+  });
+});

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -125,6 +125,14 @@ export interface InspectorPanelProps {
    */
   liveBreakpoints?: readonly BreakpointId[];
   /**
+   * Move the canvas to a breakpoint, forwarded to the Style tab.
+   *
+   * Only the surface owning the canvas width can do this, and it sits above
+   * this panel — so the capability is passed down and each control whose value
+   * came from another tier offers to use it.
+   */
+  onJumpToBreakpoint?: (breakpoint: BreakpointId) => void;
+  /**
    * The site's design tokens, forwarded to the Style tab's colour controls.
    *
    * Carried rather than defaulted, as `policy` is: omitting it means the
@@ -164,6 +172,7 @@ export function InspectorPanel({
   breakpoints,
   previewContainer,
   liveBreakpoints,
+  onJumpToBreakpoint,
   tokens,
   blocks,
 }: InspectorPanelProps): React.JSX.Element {
@@ -306,6 +315,7 @@ export function InspectorPanel({
             breakpoints={breakpoints}
             previewContainer={previewContainer}
             liveBreakpoints={liveBreakpoints}
+            onJumpToBreakpoint={onJumpToBreakpoint}
             tokens={tokens}
           />
         </TabsContent>

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -2074,3 +2074,163 @@ describe("naming the place a value came from", () => {
     expect(describeProvenance(undefined, editing as never)).toBeNull();
   });
 });
+
+describe("the action a control's breakpoint provenance earns", () => {
+  const SITE = {
+    viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+    container: [],
+  } as never;
+
+  const action = (kind: "reset" | "jump") =>
+    document.querySelector(
+      `[data-property="color"] [data-action="${kind}"]`
+    ) as HTMLElement | null;
+
+  const entryAt = (breakpoint: string) =>
+    ({
+      origin: { kind: "node", id: "a" },
+      property: "color",
+      value: "#111",
+      state: "base",
+      breakpoint,
+    }) as never;
+
+  function mount(opts: {
+    stored: string;
+    entries: readonly unknown[];
+    onJump?: (breakpoint: string) => void;
+    /** Which tier the panel is editing; base unless a case needs otherwise. */
+    editing?: string;
+  }) {
+    register({ color: true });
+    const editor = editorFor(
+      documentOf({ base: { [opts.stored]: { color: "#111" } } })
+    );
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={SITE}
+        {...(opts.editing === undefined
+          ? {}
+          : { breakpoint: opts.editing as never })}
+        /*
+         * PREVIEWING, which is what makes the host's live set authoritative.
+         * Published, the window decides and a supplied set is ignored — so
+         * without this the panel asks jsdom's absent `matchMedia`, gets the
+         * base context alone, and every control reads as unset. The real mount
+         * previews whenever the site defines a viewport tier.
+         */
+        previewContainer="nx-preview-viewport"
+        liveBreakpoints={[BASE_BREAKPOINT, "tablet"] as never}
+        cascade={
+          { entries: opts.entries, nodes: editor.document.nodes } as never
+        }
+        {...(opts.onJump === undefined
+          ? {}
+          : { onJumpToBreakpoint: opts.onJump as never })}
+      />
+    );
+    return editor;
+  }
+
+  it("offers NOTHING on a control the author has not touched", () => {
+    /*
+     * The bound the whole design rests on. `ProvenanceDot` refuses to be
+     * focusable because a stop per control would double the presses to cross a
+     * section of eight or more, and a button on every control would spend that
+     * same cost. Unset controls are the large majority of a panel, and they
+     * earn no action.
+     */
+    /*
+     * The jump handler IS supplied, so this asserts the absence for the reason
+     * it claims: the control earns no action, rather than the host merely being
+     * unable to honour one.
+     *
+     * Measured while break-verifying: the `none` early exit cannot be
+     * distinguished by any test, because the jump handler is bound per leaf and
+     * only for an `inherited` badge — so a `none` badge reaches the jump branch
+     * with nothing to call and returns anyway. The guard is a readable exit
+     * rather than a load-bearing one, and this case does not pretend to cover
+     * it.
+     */
+    mount({ stored: BASE_BREAKPOINT, entries: [], onJump: () => {} });
+
+    expect(action("reset")).toBeNull();
+    expect(action("jump")).toBeNull();
+  });
+
+  it("offers a RESET for a value authored at the tier being edited", () => {
+    mount({ stored: BASE_BREAKPOINT, entries: [entryAt(BASE_BREAKPOINT)] });
+
+    expect(action("reset")).not.toBeNull();
+    expect(action("jump")).toBeNull();
+  });
+
+  it("names what the reset will REVEAL, rather than only that it clears", () => {
+    /*
+     * "Reset" alone asks an author to guess whether the control becomes unset
+     * or falls back to a wider tier's value. In a desktop-first cascade it is
+     * usually the second, and not always base.
+     */
+    /*
+     * Editing the NARROW tier, which is the only arrangement where a control is
+     * authored here AND something wider shows through. At base the narrower
+     * entry wins the cascade instead, so the control reads as inherited and
+     * earns a jump rather than a reset.
+     */
+    mount({
+      stored: "tablet",
+      editing: "tablet",
+      entries: [entryAt(BASE_BREAKPOINT), entryAt("tablet")],
+    });
+
+    const label = action("reset")?.getAttribute("aria-label");
+    expect(label).toContain("Reset");
+    /*
+     * The tier a reset falls back to is NAMED, not left to be guessed. The
+     * unconditional tier has no authored definition to take a label from, so it
+     * is called by its id here — the same name every other sentence in this
+     * panel gives it, which is the point: one naming, not a second one invented
+     * for this button.
+     */
+    expect(label).toContain("from base");
+  });
+
+  it("offers a JUMP for a value that came from another tier", () => {
+    mount({
+      stored: BASE_BREAKPOINT,
+      entries: [entryAt("tablet")],
+      onJump: () => {},
+    });
+
+    expect(action("jump")).not.toBeNull();
+  });
+
+  it("withholds the jump when the host cannot move the canvas", () => {
+    /*
+     * A button that does nothing reads as broken rather than as absent, and a
+     * host with no canvas width to move has no way to honour it.
+     */
+    mount({ stored: BASE_BREAKPOINT, entries: [entryAt("tablet")] });
+
+    expect(action("jump")).toBeNull();
+  });
+
+  it("jumps to the tier the VALUE came from, not to a fixed one", () => {
+    /*
+     * The target is this control's own source: a different control on the same
+     * panel jumps somewhere else, which is why the handler is bound per leaf
+     * rather than threaded as one prop.
+     */
+    const jumped: string[] = [];
+    mount({
+      stored: BASE_BREAKPOINT,
+      entries: [entryAt("tablet")],
+      onJump: id => jumped.push(id),
+    });
+
+    fireEvent.click(action("jump") as HTMLElement);
+
+    expect(jumped).toEqual(["tablet"]);
+  });
+});

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -2185,7 +2185,13 @@ describe("the action a control's breakpoint provenance earns", () => {
     });
 
     const label = action("reset")?.getAttribute("aria-label");
-    expect(label).toContain("Reset");
+    /*
+     * Named by the PROPERTY, not the leaf alone. `margin` and `padding` both
+     * have a block start, so two controls would offer buttons called "Reset
+     * Block start" and a screen-reader user could not tell which style each
+     * removes — the same reason the panel computes an action name for `Clear`.
+     */
+    expect(label).toContain("Color");
     /*
      * The tier a reset falls back to is NAMED, not left to be guessed. The
      * unconditional tier has no authored definition to take a label from, so it
@@ -2196,6 +2202,52 @@ describe("the action a control's breakpoint provenance earns", () => {
     expect(label).toContain("from base");
   });
 
+  it("names the action by its PROPERTY, not by the leaf alone", () => {
+    /*
+     * `margin` and `padding` both have a block start, so a button named from
+     * the leaf alone reads "Reset Block start" on both and a screen-reader user
+     * cannot tell which style each removes. The panel already computes an
+     * action name for exactly this — `Clear` on a token value uses it — and a
+     * simple property like `color` cannot show the difference, because there
+     * the property label and the leaf label are the same word.
+     */
+    register({ spacing: true });
+    const editor = editorFor(
+      documentOf({
+        base: { [BASE_BREAKPOINT]: { padding: { blockStart: "8px" } } },
+      })
+    );
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={SITE}
+        previewContainer="nx-preview-viewport"
+        liveBreakpoints={[BASE_BREAKPOINT] as never}
+        cascade={
+          {
+            entries: [
+              {
+                origin: { kind: "node", id: "a" },
+                property: "padding-block-start",
+                value: "8px",
+                state: "base",
+                breakpoint: BASE_BREAKPOINT,
+              },
+            ],
+            nodes: editor.document.nodes,
+          } as never
+        }
+      />
+    );
+
+    const label = document
+      .querySelector('[data-property="padding"] [data-action="reset"]')
+      ?.getAttribute("aria-label");
+
+    expect(label).toContain("Padding");
+    expect(label).toContain("Reset");
+  });
+
   it("offers a JUMP for a value that came from another tier", () => {
     mount({
       stored: BASE_BREAKPOINT,
@@ -2204,6 +2256,58 @@ describe("the action a control's breakpoint provenance earns", () => {
     });
 
     expect(action("jump")).not.toBeNull();
+  });
+
+  it("withholds the jump for a tier the canvas cannot be taken to", () => {
+    /*
+     * Two ids can carry one bound, and only the winner is offered as a choice —
+     * but a declaration stored under the loser can still be what a control is
+     * showing. A jump there cannot be honoured: the width lookup answers
+     * `undefined`, which the host reads as the unconditional tier and RELEASES
+     * the canvas, so the value the author was chasing can disappear.
+     *
+     * Naming the tier stays right; travelling to it does not.
+     */
+    register({ color: true });
+    const editor = editorFor(
+      documentOf({ base: { [BASE_BREAKPOINT]: { color: "#111" } } })
+    );
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={
+          {
+            viewport: [
+              { id: "alpha", label: "Alpha", maxWidth: 991 },
+              { id: "beta", label: "Beta", maxWidth: 991 },
+            ],
+            container: [],
+          } as never
+        }
+        previewContainer="nx-preview-viewport"
+        liveBreakpoints={[BASE_BREAKPOINT, "alpha"] as never}
+        cascade={
+          {
+            entries: [
+              {
+                origin: { kind: "node", id: "a" },
+                property: "color",
+                value: "#111",
+                state: "base",
+                breakpoint: "alpha",
+              },
+            ],
+            nodes: editor.document.nodes,
+          } as never
+        }
+        onJumpToBreakpoint={(() => {}) as never}
+      />
+    );
+
+    // `beta` is the tier the compiler kept for 991, so `alpha` is unreachable.
+    expect(
+      document.querySelector('[data-property="color"] [data-action="jump"]')
+    ).toBeNull();
   });
 
   it("withholds the jump when the host cannot move the canvas", () => {

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -112,6 +112,7 @@ import {
   propertiesWriting,
   styleProvenance,
   type BreakpointBadge,
+  type BreakpointSource,
   type StyleProvenance,
 } from "./style-provenance";
 import { styleSubjectFor } from "./style-subject";
@@ -1050,7 +1051,7 @@ function StyleControlField({
       />
       <BreakpointAction
         answer={answer}
-        label={label}
+        label={actionName}
         editing={editing}
         onReset={() => commit(null)}
       />
@@ -1161,8 +1162,16 @@ function provenanceReader({
      */
     const provenance = styleProvenance(query);
     const badge = breakpointBadge(query, provenance, breakpoints);
+    /*
+     * Offered only for a tier a canvas can actually be taken to. A declaration
+     * stored under an id that lost its bound still names a real tier — worth
+     * saying — but a jump to it cannot be honoured, and the host would read the
+     * absent width as the unconditional tier and release the canvas instead.
+     */
     const target =
-      badge.kind === "inherited" ? badge.source.breakpoint : undefined;
+      badge.kind === "inherited" && badge.source.selectable
+        ? badge.source.breakpoint
+        : undefined;
     return {
       provenance,
       badge,
@@ -1202,44 +1211,104 @@ function BreakpointAction({
   onReset,
 }: {
   answer: ProvenanceAnswer | undefined;
-  /** The property's own label, so several of these are told apart by name. */
+  /**
+   * The control's ACTION NAME — the containing property and the leaf together.
+   *
+   * The leaf label alone is not unique: `margin` and `padding` both have a
+   * block start, so two controls would offer buttons called "Reset Block start"
+   * and a screen-reader user could not tell which style each removes. The panel
+   * already computes this for exactly that reason, and `Clear` on a token value
+   * uses it.
+   */
   label: string;
   editing: EditedAddress;
   onReset: () => void;
 }): React.JSX.Element | null {
   const badge = answer?.badge;
-  const onJump = answer?.jump;
   // `none` is also refused below, by having no handler bound for it — this is
   // the readable exit rather than the load-bearing one.
   if (badge === undefined || badge.kind === "none") return null;
   if (badge.kind === "authored") {
-    /*
-     * What the reset REVEALS is named where there is one. "Reset" alone asks an
-     * author to guess whether the control becomes unset or falls back to a
-     * wider tier's value, and in a desktop-first cascade it is usually the
-     * second — but not always, and not always base.
-     */
-    const reveals =
-      badge.revealed === undefined
-        ? "leaving it unset"
-        : `showing the value from ${badge.revealed.label}`;
     return (
-      <button
-        type="button"
-        className="nx-style-inspector__breakpoint-action"
-        data-action="reset"
-        onClick={onReset}
-        aria-label={`Reset ${label} at ${editing.labelOf(editing.breakpoint)}, ${reveals}`}
-      >
-        Reset
-      </button>
+      <ResetAction
+        revealed={badge.revealed}
+        label={label}
+        editing={editing}
+        onReset={onReset}
+      />
     );
   }
-  if (onJump === undefined) return null;
+  if (answer?.jump === undefined) return null;
+  return (
+    <JumpAction source={badge.source} label={label} onJump={answer.jump} />
+  );
+}
+
+/**
+ * Clear this control at the tier being edited, saying what will show through.
+ *
+ * "Reset" alone asks an author to guess whether the control becomes unset or
+ * falls back to a wider tier's value. In a desktop-first cascade it is usually
+ * the second, and not always base — so the fallback is named, in the accessible
+ * name AND in visible text, because computing it exists to remove that guess
+ * for everybody rather than for screen-reader users alone.
+ */
+function ResetAction({
+  revealed,
+  label,
+  editing,
+  onReset,
+}: {
+  revealed: BreakpointSource | undefined;
+  label: string;
+  editing: EditedAddress;
+  onReset: () => void;
+}): React.JSX.Element {
+  const reveals =
+    revealed === undefined
+      ? "leaving it unset"
+      : `showing the value from ${revealed.label}`;
+  return (
+    <button
+      type="button"
+      className="nx-style-inspector__breakpoint-action"
+      data-action="reset"
+      onClick={onReset}
+      aria-label={`Reset ${label} at ${editing.labelOf(editing.breakpoint)}, ${reveals}`}
+    >
+      Reset
+      {/*
+       * `aria-hidden`, because the accessible name above already carries this
+       * sentence: read out twice it is a stutter rather than emphasis.
+       */}
+      <span
+        className="nx-style-inspector__breakpoint-reveals"
+        aria-hidden="true"
+      >
+        {revealed === undefined ? "to unset" : `to ${revealed.label}`}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * Take the canvas to the tier this control's value was authored at.
+ *
+ * The AXIS is named beside the tier, since a site defining both makes a bare
+ * tier name ambiguous and the container axis is the one an author is least
+ * likely to be holding in mind.
+ */
+function JumpAction({
+  source,
+  label,
+  onJump,
+}: {
+  source: BreakpointSource;
+  label: string;
+  onJump: () => void;
+}): React.JSX.Element {
   const where =
-    badge.source.axis === "container"
-      ? `${badge.source.label} (container)`
-      : badge.source.label;
+    source.axis === "container" ? `${source.label} (container)` : source.label;
   return (
     <button
       type="button"

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -30,7 +30,6 @@
  */
 
 import {
-  breakpointContexts,
   findNode,
   isTokenRef,
   trimCssWhitespace,
@@ -45,6 +44,7 @@ import {
   type StyleShape,
   type StyleOrigin,
   type StyleState,
+  type StyleSubject,
   type StyleTraceEntry,
   type StyleValue,
   previewContainerName,
@@ -107,8 +107,11 @@ import {
   withUnit,
 } from "./style-numeric";
 import {
+  breakpointBadge,
+  breakpointSource,
   propertiesWriting,
   styleProvenance,
+  type BreakpointBadge,
   type StyleProvenance,
 } from "./style-provenance";
 import { styleSubjectFor } from "./style-subject";
@@ -129,7 +132,26 @@ import {
  *
  * `undefined` means nothing can answer, which is not the same as "unset".
  */
-type ProvenanceOf = (leaf: StyleLeaf) => StyleProvenance | undefined;
+/** What one control knows about where its value came from, and what to do. */
+interface ProvenanceAnswer {
+  provenance: StyleProvenance;
+  badge: BreakpointBadge;
+  /**
+   * Move the canvas to the tier this control's value came from.
+   *
+   * Carried per LEAF rather than threaded as its own prop, because the
+   * target is this control's own source: a different control on the same
+   * panel jumps somewhere else. Bundling it here also keeps three
+   * intermediate components from gaining a prop they only pass on.
+   *
+   * Absent when the host supplies no handler, which is a host that cannot
+   * move its canvas — and a button that does nothing reads as broken rather
+   * than as missing.
+   */
+  jump?: () => void;
+}
+
+type ProvenanceOf = (leaf: StyleLeaf) => ProvenanceAnswer | undefined;
 
 export interface StyleInspectorPanelProps {
   /**
@@ -222,6 +244,18 @@ export interface StyleInspectorPanelProps {
    * which is worse than naming none.
    */
   liveBreakpoints?: readonly BreakpointId[];
+  /**
+   * Move the canvas to a breakpoint, for a control offering to go where its
+   * value was set.
+   *
+   * The panel cannot do this itself: which tier the canvas shows is a fact
+   * about the surface that OWNS the canvas width, and this panel sits several
+   * layers below it. Supplied, each control whose value came from another tier
+   * offers the jump; omitted, none does — a host with no canvas to move would
+   * otherwise draw a button that does nothing, which reads as broken rather
+   * than absent.
+   */
+  onJumpToBreakpoint?: (breakpoint: BreakpointId) => void;
 }
 
 export function StyleInspectorPanel({
@@ -234,6 +268,7 @@ export function StyleInspectorPanel({
   breakpoints,
   previewContainer,
   liveBreakpoints,
+  onJumpToBreakpoint,
 }: StyleInspectorPanelProps): React.JSX.Element {
   // `null` is "the author has not chosen yet", which is NOT the same as the
   // empty string the accordion sends when they collapse the open section. The
@@ -363,20 +398,7 @@ export function StyleInspectorPanel({
    * is: both are only valid against the document they were read from, and an
    * edit anywhere changes the document and the values shown together.
    */
-  const subject =
-    editor.selectedId === null
-      ? undefined
-      : styleSubjectFor(
-          /*
-           * The cascade's OWN tree where there is one. Asking the raw document
-           * instead would answer about a node the declarations may not describe,
-           * and the fallback below is only for a panel with no cascade at all —
-           * where no indicator is drawn and the subject is read for the block
-           * type alone.
-           */
-          cascade?.nodes ?? editor.document.nodes,
-          editor.selectedId
-        );
+  const subject = selectedSubject(editor, cascade);
   /*
    * What the panel is editing, so an inherited label can say what DIFFERS from
    * it. Built once beside the subject for the same reason: every control is
@@ -389,52 +411,15 @@ export function StyleInspectorPanel({
     breakpoint: inspection.breakpoint,
     labelOf: id => breakpointLabel(breakpoints, id),
   };
-  const provenanceOf: ProvenanceOf = leaf => {
-    // Absent means the question was never asked. A host that supplies no cascade
-    // gets no indicators, which is the honest answer for a surface that cannot
-    // compile — and not the same as "nothing is inherited".
-    if (cascade === undefined || subject === undefined) return undefined;
-    /*
-     * The same answer while the canvas is previewing and nobody has said which
-     * tier the preview BOX is showing.
-     *
-     * Under a preview compile the viewport tiers are container queries, and a
-     * `matchMedia` caller cannot evaluate them — so the window-derived set is
-     * the base context alone. Passed on, that is not silence: `["base"]` is the
-     * CLAIM that base is what the browser is applying, and a narrow box showing
-     * the mobile tier would have every mobile declaration excluded and the base
-     * value reported as the visible winner.
-     *
-     * No dot says "not asked", which is true until a caller observes the box.
-     */
-    if (live === undefined) return undefined;
-    return styleProvenance({
-      trace: cascade.entries,
-      subject,
-      // The control's own leaf, never the catalog key: two keys can write one
-      // CSS property, and the trace records what was WRITTEN.
-      cssProperty: leaf.cssProperty,
-      descendant: leaf.descendant,
-      state: inspection.state,
-      breakpoint: inspection.breakpoint,
-      /*
-       * What the BROWSER is applying, and ONLY that. The edited breakpoint is a
-       * different fact and travels separately in `breakpoint`: it says where a
-       * write lands, not what is on screen.
-       *
-       * An earlier version forced the edited breakpoint into this set so a value
-       * authored there could be called "authored here". That inverted the
-       * premise — a host editing `mobile` while the canvas sits at desktop width
-       * would have the mobile declaration reported as the visible winner, which
-       * is a value the browser is not showing.
-       *
-       * The consequence is deliberate: editing a breakpoint whose query does not
-       * match reports its controls as unset. That is the honest answer, because
-       * the dot describes what is DISPLAYED rather than what is stored.
-       */
-      liveBreakpoints: live,
-    });
-  };
+  const provenanceOf = provenanceReader({
+    cascade,
+    subject,
+    live,
+    state: inspection.state,
+    breakpoint: inspection.breakpoint,
+    breakpoints,
+    onJumpToBreakpoint,
+  });
 
   const groups = inspection.sections.map(section => section.group);
   // Held rather than left to the accordion, so the open section survives a
@@ -1012,6 +997,11 @@ function StyleControlField({
 
   const commit = (value: StyleValue | null): CommitOutcome =>
     writeStyleValue({ editor, nodeId, address, policy, value, setIssue });
+  /*
+   * The provenance and its breakpoint reading, from ONE ranking of the trace.
+   * The dot and the action are two readings of one answer, not two answers.
+   */
+  const answer = provenanceOf(control.leaf);
 
   const readOnly = showsNoField(control, stored, clearOnly);
   const labelId = `${id}-label`;
@@ -1039,7 +1029,7 @@ function StyleControlField({
       <Label id={labelId} htmlFor={readOnly ? undefined : id} title={summary}>
         {label}
         <ProvenanceDot
-          provenance={provenanceOf(control.leaf)}
+          answer={answer}
           editing={editing}
           descendant={control.leaf.descendant}
         />
@@ -1058,12 +1048,208 @@ function StyleControlField({
         describedBy={describedBy}
         onCommit={commit}
       />
+      <BreakpointAction
+        answer={answer}
+        label={label}
+        editing={editing}
+        onReset={() => commit(null)}
+      />
       {issue === null ? null : (
         <p className="nx-inspector__error" id={errorId} role="alert">
           {issue}
         </p>
       )}
     </div>
+  );
+}
+
+/**
+ * The node the declarations describe, or `undefined` with nothing selected.
+ *
+ * Read from the CASCADE's own tree where there is one. Asking the raw document
+ * instead would answer about a node the declarations may not describe — read
+ * time repair can drop or replace one — and the fallback is only for a panel
+ * with no cascade at all, where no indicator is drawn and the subject is read
+ * for the block type alone.
+ */
+function selectedSubject(
+  editor: EditorState,
+  cascade: PageStyleCascade | undefined
+): StyleSubject | undefined {
+  if (editor.selectedId === null) return undefined;
+  return styleSubjectFor(
+    cascade?.nodes ?? editor.document.nodes,
+    editor.selectedId
+  );
+}
+
+/**
+ * The reader that answers, per control, where its value came from.
+ *
+ * Built OUTSIDE the panel because nothing in it is React: it is a pure function
+ * of inputs the panel has already resolved — one subject, one live set, one
+ * trace — and closing over them inside the component put the whole derivation
+ * into a body that also renders.
+ */
+function provenanceReader({
+  cascade,
+  subject,
+  live,
+  state,
+  breakpoint,
+  breakpoints,
+  onJumpToBreakpoint,
+}: {
+  cascade: PageStyleCascade | undefined;
+  subject: StyleSubject | undefined;
+  live: readonly BreakpointId[] | undefined;
+  state: StyleState;
+  breakpoint: BreakpointId;
+  breakpoints: BreakpointSet | undefined;
+  onJumpToBreakpoint: ((breakpoint: BreakpointId) => void) | undefined;
+}): ProvenanceOf {
+  return leaf => {
+    // Absent means the question was never asked. A host that supplies no cascade
+    // gets no indicators, which is the honest answer for a surface that cannot
+    // compile — and not the same as "nothing is inherited".
+    if (cascade === undefined || subject === undefined) return undefined;
+    /*
+     * The same answer while the canvas is previewing and nobody has said which
+     * tier the preview BOX is showing.
+     *
+     * Under a preview compile the viewport tiers are container queries, and a
+     * `matchMedia` caller cannot evaluate them — so the window-derived set is
+     * the base context alone. Passed on, that is not silence: `["base"]` is the
+     * CLAIM that base is what the browser is applying, and a narrow box showing
+     * the mobile tier would have every mobile declaration excluded and the base
+     * value reported as the visible winner.
+     *
+     * No dot says "not asked", which is true until a caller observes the box.
+     */
+    if (live === undefined) return undefined;
+    const query = {
+      trace: cascade.entries,
+      subject,
+      // The control's own leaf, never the catalog key: two keys can write one
+      // CSS property, and the trace records what was WRITTEN.
+      cssProperty: leaf.cssProperty,
+      descendant: leaf.descendant,
+      state: state,
+      breakpoint: breakpoint,
+      /*
+       * What the BROWSER is applying, and ONLY that. The edited breakpoint is a
+       * different fact and travels separately in `breakpoint`: it says where a
+       * write lands, not what is on screen.
+       *
+       * An earlier version forced the edited breakpoint into this set so a value
+       * authored there could be called "authored here". That inverted the
+       * premise — a host editing `mobile` while the canvas sits at desktop width
+       * would have the mobile declaration reported as the visible winner, which
+       * is a value the browser is not showing.
+       *
+       * The consequence is deliberate: editing a breakpoint whose query does not
+       * match reports its controls as unset. That is the honest answer, because
+       * the dot describes what is DISPLAYED rather than what is stored.
+       */
+      liveBreakpoints: live,
+    };
+    /*
+     * ONE query, ONE ranking, read twice. The badge is the breakpoint dimension
+     * of the same answer rather than a second opinion about it — two rankings
+     * of one trace would first disagree at exactly the boundaries the trace
+     * exists to settle.
+     */
+    const provenance = styleProvenance(query);
+    const badge = breakpointBadge(query, provenance, breakpoints);
+    const target =
+      badge.kind === "inherited" ? badge.source.breakpoint : undefined;
+    return {
+      provenance,
+      badge,
+      ...(onJumpToBreakpoint === undefined || target === undefined
+        ? {}
+        : { jump: () => onJumpToBreakpoint(target) }),
+    };
+  };
+}
+
+/**
+ * The action a control's breakpoint provenance earns, or nothing.
+ *
+ * Rendered ONLY where it means something: a Reset for a value authored at the
+ * tier being edited, a Jump for a value that arrived from another tier, and
+ * nothing at all for the unset controls that are the large majority of a panel.
+ *
+ * That bound is the whole design. {@link ProvenanceDot} refuses to be focusable
+ * because a stop per control would double the presses to cross a section of
+ * eight or more — and the same objection would apply here if every control
+ * carried a button. Tying the affordance to the state that makes it meaningful
+ * puts the cost only on controls the author has actually touched.
+ *
+ * AFTER the input in DOM order, so a keyboard user reaches the value first and
+ * the action second. Before it, every control would answer its own question in
+ * the wrong order: what to do about a value, then the value.
+ *
+ * Jump is withheld when no handler is supplied rather than rendered inert. A
+ * host that cannot move the canvas — one with no width to move — would
+ * otherwise offer a button that does nothing, which is worse than a missing
+ * affordance because it reads as a broken one.
+ */
+function BreakpointAction({
+  answer,
+  label,
+  editing,
+  onReset,
+}: {
+  answer: ProvenanceAnswer | undefined;
+  /** The property's own label, so several of these are told apart by name. */
+  label: string;
+  editing: EditedAddress;
+  onReset: () => void;
+}): React.JSX.Element | null {
+  const badge = answer?.badge;
+  const onJump = answer?.jump;
+  // `none` is also refused below, by having no handler bound for it — this is
+  // the readable exit rather than the load-bearing one.
+  if (badge === undefined || badge.kind === "none") return null;
+  if (badge.kind === "authored") {
+    /*
+     * What the reset REVEALS is named where there is one. "Reset" alone asks an
+     * author to guess whether the control becomes unset or falls back to a
+     * wider tier's value, and in a desktop-first cascade it is usually the
+     * second — but not always, and not always base.
+     */
+    const reveals =
+      badge.revealed === undefined
+        ? "leaving it unset"
+        : `showing the value from ${badge.revealed.label}`;
+    return (
+      <button
+        type="button"
+        className="nx-style-inspector__breakpoint-action"
+        data-action="reset"
+        onClick={onReset}
+        aria-label={`Reset ${label} at ${editing.labelOf(editing.breakpoint)}, ${reveals}`}
+      >
+        Reset
+      </button>
+    );
+  }
+  if (onJump === undefined) return null;
+  const where =
+    badge.source.axis === "container"
+      ? `${badge.source.label} (container)`
+      : badge.source.label;
+  return (
+    <button
+      type="button"
+      className="nx-style-inspector__breakpoint-action"
+      data-action="jump"
+      onClick={onJump}
+      aria-label={`Edit ${label} at ${where}, where its value was set`}
+    >
+      Go to {where}
+    </button>
   );
 }
 
@@ -1565,16 +1751,16 @@ function writeStyleValue({
  * reporting the case rather than guessing.
  */
 function ProvenanceDot({
-  provenance,
+  answer,
   editing,
   descendant,
 }: {
-  provenance: StyleProvenance | undefined;
+  answer: ProvenanceAnswer | undefined;
   editing: EditedAddress;
   /** The control's own descendant selector, to tell its rules from a sibling's. */
   descendant: string | undefined;
 }): React.JSX.Element | null {
-  const described = describeProvenance(provenance, editing, descendant);
+  const described = describeProvenance(answer?.provenance, editing, descendant);
   if (described === null) return null;
   return (
     <>
@@ -1738,18 +1924,10 @@ export function breakpointLabel(
   breakpoints: BreakpointSet | undefined,
   id: BreakpointId
 ): string {
-  const context = breakpointContexts(breakpoints).find(
-    found => found.id === id
-  );
-  if (context === undefined) return id;
-  const axis =
-    context.axis === "container"
-      ? breakpoints?.container
-      : breakpoints?.viewport;
-  const survivor = (axis ?? []).find(
-    def => def.id === id && def.maxWidth === context.maxWidth
-  );
-  return survivor?.label ?? id;
+  // One matcher, in `style-provenance`. The survivor is found by BOUND as well
+  // as id — among definitions sharing an id the compiler keeps one — and a
+  // second lookup here would be a second place to lose that.
+  return breakpointSource(id, breakpoints)?.label ?? id;
 }
 
 /**

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -11,6 +11,7 @@ import { describe, expect, it } from "vitest";
 import {
   breakpointBadge,
   styleProvenance,
+  type BreakpointBadge,
   type StyleProvenanceQuery,
 } from "./style-provenance";
 
@@ -603,6 +604,14 @@ describe("a caller that states which states are live", () => {
   });
 });
 
+/** The badge for a query, with the provenance the caller would already hold. */
+function badgeFor(
+  q: StyleProvenanceQuery,
+  set: BreakpointSet | undefined
+): BreakpointBadge {
+  return breakpointBadge(q, styleProvenance(q), set);
+}
+
 describe("the breakpoint dimension of a control's provenance", () => {
   /*
    * A site with both axes, so a badge naming a breakpoint without naming its
@@ -617,7 +626,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
   };
 
   it("says nothing when the control is unset", () => {
-    expect(breakpointBadge(query([]), site)).toEqual({ kind: "none" });
+    expect(badgeFor(query([]), site)).toEqual({ kind: "none" });
   });
 
   it("names the breakpoint a value was authored at, when it is not this one", () => {
@@ -627,7 +636,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * right here, which is the one thing an author needs told apart because the
      * next action differs.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "tablet" })], {
         breakpoint: "mobile",
         liveBreakpoints: ["tablet", "mobile"],
@@ -648,7 +657,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * also the control on the case above: without it, a badge that fired on
      * every `inherited` provenance would satisfy that one.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query(
         [
           entry({
@@ -674,7 +683,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * that reads as precise and does not say which axis it means is worse than
      * one that says less.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "narrow" })], {
         breakpoint: "mobile",
         liveBreakpoints: ["narrow", "mobile"],
@@ -693,7 +702,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
   });
 
   it("reports a value authored HERE as resettable", () => {
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "mobile" })], {
         breakpoint: "mobile",
         liveBreakpoints: ["mobile"],
@@ -715,7 +724,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * wider" that would have to re-derive tier order, both axes and
      * specificity.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query(
         [
           entry({ breakpoint: "tablet", value: "16px" }),
@@ -738,7 +747,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * would satisfy it while telling an author a reset restores a value that
      * does not exist. Here the control simply becomes unset.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "mobile" })], {
         breakpoint: "mobile",
         liveBreakpoints: ["tablet", "mobile"],
@@ -757,7 +766,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * was not looking at, so the badge withholds rather than guesses — the same
      * refusal the origin dot already makes.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ property: "background-image", value: "url(a.png)" })], {
         cssProperty: "background-image",
       }),
@@ -775,7 +784,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * is editing Mobile — a label that is not merely unhelpful but false, and
      * whose jump would go nowhere.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "mobile", state: "hover" })], {
         breakpoint: "mobile",
         state: "base",
@@ -794,7 +803,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * does not define would offer a jump to a width nothing responds to, and
      * the honest answer is that there is nothing to say.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "watch" })], {
         breakpoint: "mobile",
         liveBreakpoints: ["watch", "mobile"],
@@ -812,7 +821,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * the row the sheet discarded. The discarded row is stored FIRST here, so a
      * by-id lookup cannot pass by accident.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "tablet" })], {
         breakpoint: "mobile",
         liveBreakpoints: ["tablet", "mobile"],
@@ -838,7 +847,7 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * is not a good name, but inventing one, or borrowing another row's label,
      * would attach a name to a tier it does not describe.
      */
-    const badge = breakpointBadge(
+    const badge = badgeFor(
       query([entry({ breakpoint: "tablet" })], {
         breakpoint: "mobile",
         liveBreakpoints: ["tablet", "mobile"],

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -2,12 +2,17 @@ import {
   compilePageCss,
   nodeClassName,
   type BlockDocument,
+  type BreakpointSet,
   type NodeStyles,
   type StyleTraceEntry,
 } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
-import { styleProvenance, type StyleProvenanceQuery } from "./style-provenance";
+import {
+  breakpointBadge,
+  styleProvenance,
+  type StyleProvenanceQuery,
+} from "./style-provenance";
 
 /** One declaration the compiler wrote, with the fields the trace records. */
 function entry(over: Partial<StyleTraceEntry> = {}): StyleTraceEntry {
@@ -595,5 +600,255 @@ describe("a caller that states which states are live", () => {
       liveStates: ["hover"],
     });
     expect(result.kind).toBe("inherited");
+  });
+});
+
+describe("the breakpoint dimension of a control's provenance", () => {
+  /*
+   * A site with both axes, so a badge naming a breakpoint without naming its
+   * axis would be ambiguous — which is the case the axis is carried for.
+   */
+  const site: BreakpointSet = {
+    viewport: [
+      { id: "tablet", label: "Tablet", maxWidth: 991 },
+      { id: "mobile", label: "Mobile", maxWidth: 575 },
+    ],
+    container: [{ id: "narrow", label: "Narrow card", maxWidth: 400 }],
+  };
+
+  it("says nothing when the control is unset", () => {
+    expect(breakpointBadge(query([]), site)).toEqual({ kind: "none" });
+  });
+
+  it("names the breakpoint a value was authored at, when it is not this one", () => {
+    /*
+     * The case the badge exists for. `StyleOrigin` records only the TIER, so
+     * this arrives as a bare `node` origin — indistinguishable from a value set
+     * right here, which is the one thing an author needs told apart because the
+     * next action differs.
+     */
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "tablet" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["tablet", "mobile"],
+      }),
+      site
+    );
+
+    expect(badge).toEqual({
+      kind: "inherited",
+      source: { breakpoint: "tablet", label: "Tablet", axis: "viewport" },
+    });
+  });
+
+  it("says nothing when the value came from another TIER rather than another breakpoint", () => {
+    /*
+     * A class's value is the origin dot's answer, and repeating it as a
+     * breakpoint badge would say one thing twice in two vocabularies. This is
+     * also the control on the case above: without it, a badge that fired on
+     * every `inherited` provenance would satisfy that one.
+     */
+    const badge = breakpointBadge(
+      query(
+        [
+          entry({
+            origin: { kind: "class", id: "c1", slug: "card" },
+            breakpoint: "tablet",
+          }),
+        ],
+        {
+          breakpoint: "mobile",
+          liveBreakpoints: ["tablet", "mobile"],
+        }
+      ),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "none" });
+  });
+
+  it("names the CONTAINER axis rather than reporting a bare breakpoint", () => {
+    /*
+     * `breakpointContexts` emits over both axes and a container context carries
+     * a query even at its widest, so two tiers can be in play at once. A label
+     * that reads as precise and does not say which axis it means is worse than
+     * one that says less.
+     */
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "narrow" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["narrow", "mobile"],
+      }),
+      site
+    );
+
+    expect(badge).toEqual({
+      kind: "inherited",
+      source: {
+        breakpoint: "narrow",
+        label: "Narrow card",
+        axis: "container",
+      },
+    });
+  });
+
+  it("reports a value authored HERE as resettable", () => {
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "mobile" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["mobile"],
+      }),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "authored" });
+  });
+
+  it("names what a reset would REVEAL, rather than assuming the base tier", () => {
+    /*
+     * In a desktop-first model values flow wider to narrower and a chain can
+     * hold values at several breakpoints, so what shows through is whatever the
+     * next one holding a value is — not necessarily base.
+     *
+     * Computed by asking the same question with this breakpoint out of the live
+     * set, which is the engine's own ranking rather than a hand-rolled "next
+     * wider" that would have to re-derive tier order, both axes and
+     * specificity.
+     */
+    const badge = breakpointBadge(
+      query(
+        [
+          entry({ breakpoint: "tablet", value: "16px" }),
+          entry({ breakpoint: "mobile", value: "8px" }),
+        ],
+        { breakpoint: "mobile", liveBreakpoints: ["tablet", "mobile"] }
+      ),
+      site
+    );
+
+    expect(badge).toEqual({
+      kind: "authored",
+      revealed: { breakpoint: "tablet", label: "Tablet", axis: "viewport" },
+    });
+  });
+
+  it("reveals NOTHING when this is the only breakpoint holding a value", () => {
+    /*
+     * The control on the case above: a version that always named some fallback
+     * would satisfy it while telling an author a reset restores a value that
+     * does not exist. Here the control simply becomes unset.
+     */
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "mobile" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["tablet", "mobile"],
+      }),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "authored" });
+  });
+
+  it("says nothing for a declaration two controls could have written", () => {
+    /*
+     * `background-image` is written by both `background.url` and
+     * `backgroundGradient`, on the node itself, with nothing in the trace to
+     * separate them. Offering a reset there would clear a control the author
+     * was not looking at, so the badge withholds rather than guesses — the same
+     * refusal the origin dot already makes.
+     */
+    const badge = breakpointBadge(
+      query([entry({ property: "background-image", value: "url(a.png)" })], {
+        cssProperty: "background-image",
+      }),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "none" });
+  });
+
+  it("says nothing when the value came from another STATE at this breakpoint", () => {
+    /*
+     * `inherited` does not mean "another breakpoint": a value can win from the
+     * same node at the SAME breakpoint in a different state. Reported as a
+     * breakpoint badge it would read "inherited from Mobile" while the author
+     * is editing Mobile — a label that is not merely unhelpful but false, and
+     * whose jump would go nowhere.
+     */
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "mobile", state: "hover" })], {
+        breakpoint: "mobile",
+        state: "base",
+        liveBreakpoints: ["mobile"],
+        liveStates: ["base", "hover"],
+      } as never),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "none" });
+  });
+
+  it("says nothing about a breakpoint the stored set no longer describes", () => {
+    /*
+     * A trace outlives an edit to the breakpoint set. Naming a tier the site
+     * does not define would offer a jump to a width nothing responds to, and
+     * the honest answer is that there is nothing to say.
+     */
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "watch" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["watch", "mobile"],
+      }),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "none" });
+  });
+
+  it("labels a shared id from the definition the compiler KEPT", () => {
+    /*
+     * Among rows sharing an id the compiler keeps the WIDEST, not the first
+     * stored, so a label looked up by id alone names the surviving tier after
+     * the row the sheet discarded. The discarded row is stored FIRST here, so a
+     * by-id lookup cannot pass by accident.
+     */
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "tablet" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["tablet", "mobile"],
+      }),
+      {
+        viewport: [
+          { id: "tablet", label: "Draft", maxWidth: 700 },
+          { id: "tablet", label: "Tablet", maxWidth: 991 },
+        ],
+        container: [],
+      }
+    );
+
+    expect(badge).toEqual({
+      kind: "inherited",
+      source: { breakpoint: "tablet", label: "Tablet", axis: "viewport" },
+    });
+  });
+
+  it("falls back to the id when no definition carries that bound", () => {
+    /*
+     * A trace can name a breakpoint the stored set no longer describes. The id
+     * is not a good name, but inventing one, or borrowing another row's label,
+     * would attach a name to a tier it does not describe.
+     */
+    const badge = breakpointBadge(
+      query([entry({ breakpoint: "tablet" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["tablet", "mobile"],
+      }),
+      { viewport: [{ id: "tablet", maxWidth: 991 } as never], container: [] }
+    );
+
+    expect(badge).toEqual({
+      kind: "inherited",
+      source: { breakpoint: "tablet", label: "tablet", axis: "viewport" },
+    });
   });
 });

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -646,7 +646,12 @@ describe("the breakpoint dimension of a control's provenance", () => {
 
     expect(badge).toEqual({
       kind: "inherited",
-      source: { breakpoint: "tablet", label: "Tablet", axis: "viewport" },
+      source: {
+        breakpoint: "tablet",
+        label: "Tablet",
+        axis: "viewport",
+        selectable: true,
+      },
     });
   });
 
@@ -697,6 +702,12 @@ describe("the breakpoint dimension of a control's provenance", () => {
         breakpoint: "narrow",
         label: "Narrow card",
         axis: "container",
+        /*
+         * NOT selectable, and that is the honest answer: sizing the canvas
+         * cannot put an element's own query container at a width. Naming the
+         * tier is still right; offering to travel to it is not.
+         */
+        selectable: false,
       },
     });
   });
@@ -737,7 +748,48 @@ describe("the breakpoint dimension of a control's provenance", () => {
 
     expect(badge).toEqual({
       kind: "authored",
-      revealed: { breakpoint: "tablet", label: "Tablet", axis: "viewport" },
+      revealed: {
+        breakpoint: "tablet",
+        label: "Tablet",
+        axis: "viewport",
+        selectable: true,
+      },
+    });
+  });
+
+  it("reveals a LOWER-TIER value at the same breakpoint, which a reset does not clear", () => {
+    /*
+     * A reset clears ONE address — this node, this state, this breakpoint, this
+     * control. Everything else at that breakpoint survives, so a class value
+     * the node overrode at Mobile is exactly what appears afterwards.
+     *
+     * Simulating the reset by dropping the whole breakpoint from the live set
+     * discards that class declaration too, and the control then promises to
+     * leave the value unset while the class value is what the author will see.
+     */
+    const badge = badgeFor(
+      query(
+        [
+          entry({
+            origin: { kind: "class", id: "c1", slug: "card" },
+            breakpoint: "mobile",
+            value: "4px",
+          }),
+          entry({ breakpoint: "mobile", value: "8px" }),
+        ],
+        { breakpoint: "mobile", liveBreakpoints: ["mobile"] }
+      ),
+      site
+    );
+
+    expect(badge).toEqual({
+      kind: "authored",
+      revealed: {
+        breakpoint: "mobile",
+        label: "Mobile",
+        axis: "viewport",
+        selectable: true,
+      },
     });
   });
 
@@ -837,7 +889,12 @@ describe("the breakpoint dimension of a control's provenance", () => {
 
     expect(badge).toEqual({
       kind: "inherited",
-      source: { breakpoint: "tablet", label: "Tablet", axis: "viewport" },
+      source: {
+        breakpoint: "tablet",
+        label: "Tablet",
+        axis: "viewport",
+        selectable: true,
+      },
     });
   });
 
@@ -857,7 +914,12 @@ describe("the breakpoint dimension of a control's provenance", () => {
 
     expect(badge).toEqual({
       kind: "inherited",
-      source: { breakpoint: "tablet", label: "tablet", axis: "viewport" },
+      source: {
+        breakpoint: "tablet",
+        label: "tablet",
+        axis: "viewport",
+        selectable: true,
+      },
     });
   });
 });

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -511,9 +511,18 @@ function sourceOf(
  */
 export function breakpointBadge(
   query: StyleProvenanceQuery,
+  /**
+   * What {@link styleProvenance} already answered for this control.
+   *
+   * Taken rather than recomputed, because the badge is the breakpoint READING
+   * of a provenance and not a second opinion about it. A caller placing a dot
+   * has one in hand, and computing another here would be a second ranking of
+   * the same trace — the two would first disagree at exactly the boundaries the
+   * trace exists to settle.
+   */
+  provenance: StyleProvenance,
   breakpoints: BreakpointSet | undefined
 ): BreakpointBadge {
-  const provenance = styleProvenance(query);
   if (provenance.kind === "unset" || provenance.kind === "ambiguous") {
     return { kind: "none" };
   }

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -37,6 +37,9 @@ import {
   type StyleTraceEntry,
 } from "@nextlyhq/blocks-engine";
 
+import { isUsableWidth } from "./breakpoints";
+import { offeredTiers } from "./canvas-width";
+
 /** What a control's dot reports. */
 export type StyleProvenance =
   /**
@@ -407,6 +410,20 @@ export interface BreakpointSource {
    * that reads as precise and is not.
    */
   readonly axis: BreakpointAxis;
+  /**
+   * Whether a canvas can actually be taken to this tier.
+   *
+   * Two ids can carry one bound, and only the tier that WINS is offered as a
+   * choice — but a declaration stored under the loser can still be what a
+   * control is showing, and would otherwise earn a "go to" that cannot be
+   * honoured: the width lookup answers `undefined` for it, which a host reads
+   * as the unconditional tier and releases the canvas instead. Naming the tier
+   * is still right; offering to travel to it is not.
+   *
+   * The unconditional tier IS selectable: releasing the canvas is how it is
+   * shown, so `undefined` means something there.
+   */
+  readonly selectable: boolean;
 }
 
 /**
@@ -496,6 +513,15 @@ export function breakpointSource(
     breakpoint,
     label: named?.label ?? breakpoint,
     axis: context.axis,
+    /*
+     * Unbounded is the unconditional tier and always reachable. A bounded tier
+     * is reachable only if it is the one `offeredTiers` kept for that width —
+     * the same list the switcher builds its options from, so "a tier a canvas
+     * can be taken to" has one definition rather than two.
+     */
+    selectable:
+      !isUsableWidth(context.maxWidth) ||
+      offeredTiers(breakpoints).some(tier => tier.id === breakpoint),
   };
 }
 
@@ -548,20 +574,34 @@ export function breakpointBadge(
       : { kind: "inherited", source };
   }
   /*
-   * Authored here. What a reset would reveal is whatever wins once this
-   * breakpoint is out of the live set.
+   * Authored here. What a reset would reveal is whatever wins once the
+   * declarations the reset ACTUALLY CLEARS are gone.
    *
-   * The edited breakpoint is removed rather than the entry: two declarations
-   * can share a breakpoint, and dropping the winning ENTRY would let the loser
-   * at the same breakpoint stand in for what a reset reveals — while a reset
-   * clears the stored value at that breakpoint, which removes both.
+   * Simulated by removing those declarations from the trace, not by removing
+   * the breakpoint from the live set. A reset clears one address — this node,
+   * this state, this breakpoint, this control's property and path — and leaves
+   * every other origin at that breakpoint standing. Dropping the whole
+   * breakpoint discards a class, block-type or page declaration that would
+   * survive, so a node value overriding a class value at Mobile was described
+   * as "leaving it unset" while the class value is what actually appears.
+   *
+   * The descendant is matched too: a rule on a more specific selector reaches
+   * this control without being written BY it, so this control's reset does not
+   * remove it.
    */
-  const revealedBy = styleProvenance({
-    ...query,
-    liveBreakpoints: query.liveBreakpoints.filter(
-      live => live !== query.breakpoint
-    ),
-  });
+  const cleared = query.trace.filter(
+    entry =>
+      !(
+        entry.origin.kind === "node" &&
+        entry.origin.id === query.subject.nodeId &&
+        entry.state === query.state &&
+        entry.breakpoint === query.breakpoint &&
+        entry.property === query.cssProperty &&
+        normalizeDescendant(entry.descendant) ===
+          normalizeDescendant(query.descendant)
+      )
+  );
+  const revealedBy = styleProvenance({ ...query, trace: cleared });
   if (revealedBy.kind === "unset" || revealedBy.kind === "ambiguous") {
     return { kind: "authored" };
   }

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -27,7 +27,10 @@ import {
   shapeLeaves,
   STYLE_CATALOG,
   styleOrigin,
+  breakpointContexts,
+  type BreakpointAxis,
   type BreakpointId,
+  type BreakpointSet,
   type StyleOrigin,
   type StyleState,
   type StyleSubject,
@@ -377,4 +380,179 @@ export function styleProvenance(query: StyleProvenanceQuery): StyleProvenance {
   }
   if (isAuthoredHere(winner, query)) return { kind: "authored", entry: winner };
   return { kind: "inherited", entry: winner, from: winner.origin };
+}
+
+/** Where a value a control is showing was authored, in breakpoint terms. */
+export interface BreakpointSource {
+  /** The breakpoint's own id, as the trace records it. */
+  readonly breakpoint: BreakpointId;
+  /**
+   * What to call it in front of an author.
+   *
+   * The stored definition's label, never the id: an id is an addressing detail
+   * a site is free to spell `bp_2`, and putting it in front of an author at the
+   * one moment the control is explaining itself is the storage layer leaking.
+   * Falls back to the id only when no definition carries that bound, where
+   * there is no honest name to use instead.
+   */
+  readonly label: string;
+  /**
+   * Which axis it belongs to.
+   *
+   * Carried because a breakpoint NAMED without its axis is ambiguous whenever a
+   * site defines both: `breakpointContexts` emits over viewport and container
+   * separately, a container context emits a query even at its widest, and
+   * container is the axis an author is least likely to be holding in mind. A
+   * badge saying "Tablet" when two different tiers could be meant is a label
+   * that reads as precise and is not.
+   */
+  readonly axis: BreakpointAxis;
+}
+
+/**
+ * What a control's breakpoint badge reports, beside the origin dot.
+ *
+ * The dot answers WHICH TIER a value came from — this node, a class, the block
+ * type, the page. This answers the breakpoint DIMENSION of the same question,
+ * which the dot cannot: `StyleOrigin` records only the tier, so "from a class"
+ * and "from this node at desktop" arrive as the same `node`/`class` answer with
+ * nothing to separate them, and they are the two an author most needs told
+ * apart because the next action differs. One is "go and change it there", the
+ * other is "override it here".
+ */
+export type BreakpointBadge =
+  /**
+   * Nothing to say about breakpoints.
+   *
+   * The control is unset, or its value came from another TIER rather than
+   * another breakpoint, or the declaration cannot be attributed to one control
+   * at all. Ambiguous is deliberately included: a badge offering to reset a
+   * declaration two controls could have written would clear one the author was
+   * not looking at.
+   */
+  | { readonly kind: "none" }
+  /**
+   * Authored at the breakpoint being edited, so clearing it here is meaningful.
+   *
+   * `revealed` is what would then show through — the value the cascade falls
+   * back to once this one is gone. Absent when nothing would: the control
+   * becomes unset.
+   *
+   * Named rather than assumed to be the base tier. In a desktop-first model
+   * values flow from wider to narrower, and a chain can hold values at several
+   * breakpoints, so what a reset reveals is whatever the next one holding a
+   * value is.
+   */
+  | { readonly kind: "authored"; readonly revealed?: BreakpointSource }
+  /**
+   * The value on screen was authored by THIS NODE at another breakpoint.
+   *
+   * The case the badge exists for, and the one the origin dot reports as a bare
+   * `node` origin indistinguishable from a value set right here. Editing the
+   * control writes at the edited breakpoint and takes over from this one.
+   */
+  | { readonly kind: "inherited"; readonly source: BreakpointSource };
+
+/**
+ * Resolve a breakpoint id to something an author can be shown.
+ *
+ * The AXIS and the bound come from `breakpointContexts`, which is the reader
+ * that decides what a site's breakpoints are for the sheet; the label is then
+ * matched on the bound as well as the id, because among definitions sharing an
+ * id the compiler keeps one and a lookup by id alone can name the survivor
+ * after a row the sheet discarded.
+ */
+function sourceOf(
+  breakpoint: BreakpointId,
+  breakpoints: BreakpointSet | undefined
+): BreakpointSource | undefined {
+  const context = breakpointContexts(breakpoints).find(
+    candidate => candidate.id === breakpoint
+  );
+  /*
+   * No context, or one that does not say which axis it belongs to, yields no
+   * badge at all.
+   *
+   * `BreakpointContext.axis` is optional, and a badge is a claim about which
+   * axis a value came from — the one thing the research says a breakpoint name
+   * cannot be shown without. Defaulting it to the viewport would put a
+   * confident label on the axis an author is least likely to be holding in
+   * mind, which is the case the axis is carried for.
+   */
+  if (context?.axis === undefined) return undefined;
+  const defs =
+    context.axis === "container"
+      ? breakpoints?.container
+      : breakpoints?.viewport;
+  const named = (defs ?? []).find(
+    def => def?.id === breakpoint && def?.maxWidth === context.maxWidth
+  );
+  return {
+    breakpoint,
+    label: named?.label ?? breakpoint,
+    axis: context.axis,
+  };
+}
+
+/**
+ * The breakpoint badge for one control.
+ *
+ * Derived from {@link styleProvenance} rather than beside it, so there is one
+ * answer to "what is this control showing" and this adds only the breakpoint
+ * reading of it. A second ranking here would be a second cascade, and the two
+ * would disagree first at exactly the boundaries the trace exists to settle.
+ *
+ * What a reset REVEALS is computed by asking the same question again with the
+ * edited breakpoint removed from the live set — the engine's own ranking, run
+ * once more over an already-filtered trace, rather than a hand-rolled "next
+ * wider" that would have to re-derive tier order, both axes and specificity.
+ * Only reached for a control that is authored here, which is the small minority
+ * of them, so the cost is bounded by what an author has actually set.
+ */
+export function breakpointBadge(
+  query: StyleProvenanceQuery,
+  breakpoints: BreakpointSet | undefined
+): BreakpointBadge {
+  const provenance = styleProvenance(query);
+  if (provenance.kind === "unset" || provenance.kind === "ambiguous") {
+    return { kind: "none" };
+  }
+  if (provenance.kind === "inherited") {
+    /*
+     * A different TIER is the dot's answer, not this one. Only a value this
+     * node authored at another breakpoint belongs here — anything from a class,
+     * the block type or the page is reported by the origin dot, and repeating
+     * it as a breakpoint badge would say the same thing twice in two
+     * vocabularies.
+     */
+    if (provenance.from.kind !== "node") return { kind: "none" };
+    if (provenance.entry.breakpoint === query.breakpoint)
+      return { kind: "none" };
+    const source = sourceOf(provenance.entry.breakpoint, breakpoints);
+    return source === undefined
+      ? { kind: "none" }
+      : { kind: "inherited", source };
+  }
+  /*
+   * Authored here. What a reset would reveal is whatever wins once this
+   * breakpoint is out of the live set.
+   *
+   * The edited breakpoint is removed rather than the entry: two declarations
+   * can share a breakpoint, and dropping the winning ENTRY would let the loser
+   * at the same breakpoint stand in for what a reset reveals — while a reset
+   * clears the stored value at that breakpoint, which removes both.
+   */
+  const revealedBy = styleProvenance({
+    ...query,
+    liveBreakpoints: query.liveBreakpoints.filter(
+      live => live !== query.breakpoint
+    ),
+  });
+  if (revealedBy.kind === "unset" || revealedBy.kind === "ambiguous") {
+    return { kind: "authored" };
+  }
+  const source = sourceOf(revealedBy.entry.breakpoint, breakpoints);
+  return source === undefined
+    ? { kind: "authored" }
+    : { kind: "authored", revealed: source };
 }

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -456,13 +456,18 @@ export type BreakpointBadge =
 /**
  * Resolve a breakpoint id to something an author can be shown.
  *
+ * Exported because it is the ONE answer to "what is this breakpoint called" —
+ * the panel's own label helper reads it rather than repeating the lookup, which
+ * would be two matchers for a rule that has a subtlety in it (the survivor is
+ * matched on the BOUND as well as the id) and two places to lose it.
+ *
  * The AXIS and the bound come from `breakpointContexts`, which is the reader
  * that decides what a site's breakpoints are for the sheet; the label is then
  * matched on the bound as well as the id, because among definitions sharing an
  * id the compiler keeps one and a lookup by id alone can name the survivor
  * after a row the sheet discarded.
  */
-function sourceOf(
+export function breakpointSource(
   breakpoint: BreakpointId,
   breakpoints: BreakpointSet | undefined
 ): BreakpointSource | undefined {
@@ -537,7 +542,7 @@ export function breakpointBadge(
     if (provenance.from.kind !== "node") return { kind: "none" };
     if (provenance.entry.breakpoint === query.breakpoint)
       return { kind: "none" };
-    const source = sourceOf(provenance.entry.breakpoint, breakpoints);
+    const source = breakpointSource(provenance.entry.breakpoint, breakpoints);
     return source === undefined
       ? { kind: "none" }
       : { kind: "inherited", source };
@@ -560,7 +565,7 @@ export function breakpointBadge(
   if (revealedBy.kind === "unset" || revealedBy.kind === "ambiguous") {
     return { kind: "authored" };
   }
-  const source = sourceOf(revealedBy.entry.breakpoint, breakpoints);
+  const source = breakpointSource(revealedBy.entry.breakpoint, breakpoints);
   return source === undefined
     ? { kind: "authored" }
     : { kind: "authored", revealed: source };

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -716,6 +716,61 @@
 }
 
 /*
+ * The breakpoint actions on a control: reset here, or go to the tier a value
+ * came from.
+ *
+ * Styled at all because Preflight strips a bare button to text, and these sit
+ * beside explanatory copy — unstyled, an author cannot tell the one they can
+ * press from the sentence they cannot. Tokens rather than literals, so the pair
+ * follows the admin's light and dark themes like everything else in the panel.
+ *
+ * Quiet by default and only definite on hover or focus. The panel already
+ * carries a dot, a label and a value per control; an action drawn as a filled
+ * button would outweigh the value it acts on, and these appear on several
+ * controls at once.
+ */
+.nx-style-inspector__breakpoint-action {
+  align-self: flex-start;
+  margin-top: 0.25rem;
+  padding: 0.125rem 0.375rem;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  font-size: 0.75rem;
+  color: var(--nx-muted-foreground);
+  background: transparent;
+  cursor: pointer;
+}
+
+.nx-style-inspector__breakpoint-action:hover {
+  color: var(--nx-foreground);
+  border-color: var(--nx-border);
+  background: var(--nx-muted);
+}
+
+/*
+ * A visible focus ring, not only a colour change. The panel is reachable by
+ * keyboard and these are the only controls in it that appear conditionally, so
+ * a focus a sighted keyboard user cannot locate is the failure that matters.
+ */
+.nx-style-inspector__breakpoint-action:focus-visible {
+  outline: 2px solid var(--nx-ring);
+  outline-offset: 1px;
+  color: var(--nx-foreground);
+}
+
+/*
+ * What a reset falls back to, beside the button rather than only in its
+ * accessible name. The whole point of computing it is to remove a guess, and
+ * putting it in `aria-label` alone removes the guess for screen-reader users
+ * and leaves it for everyone else.
+ */
+.nx-style-inspector__breakpoint-reveals {
+  margin-left: 0.375rem;
+  font-size: 0.6875rem;
+  color: var(--nx-muted-foreground);
+}
+
+/*
  * The canvas root is the positioning context for editor chrome drawn over the
  * page.
  *

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -429,3 +429,50 @@ describe("a site with nothing to simulate", () => {
     expect(box().container).toBe(context?.previewContainer);
   });
 });
+
+describe("going to the tier a value came from", () => {
+  it("SIZES THE CANVAS to that tier rather than storing a second answer", () => {
+    /*
+     * The whole architecture is one width with everything derived from it. A
+     * jump that wrote its own "which tier am I editing" would put the two back
+     * in the disagreement deriving them from one width exists to remove — the
+     * canvas would keep showing one tier while the inspector claimed another.
+     *
+     * Asserted on the BOX's requested width, which is the only thing a jump is
+     * allowed to change.
+     */
+    openEditor();
+
+    const jump = seen.inspector?.onJumpToBreakpoint as
+      | ((breakpoint: string) => void)
+      | undefined;
+    expect(jump).toBeTypeOf("function");
+    React.act(() => {
+      jump?.("tablet");
+    });
+
+    expect(box().width).toBe(991);
+  });
+
+  it("RELEASES the canvas for a tier the compiler emits no bound for", () => {
+    /*
+     * The control, and the honest answer for the unconditional tier: there is
+     * no width that puts it on screen, so the box goes back to the region
+     * rather than being pinned to a number nothing responds to.
+     */
+    openEditor();
+    const jump = seen.inspector?.onJumpToBreakpoint as
+      | ((breakpoint: string) => void)
+      | undefined;
+    React.act(() => {
+      jump?.("tablet");
+    });
+    expect(box().width).toBe(991);
+
+    React.act(() => {
+      jump?.("base");
+    });
+
+    expect(box().width).toBeUndefined();
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -54,6 +54,7 @@ import {
   breakpointsAtWidth,
   editedBreakpointAtWidth,
   offeredTiers,
+  widthForBreakpoint,
   EditorCommandPalette,
   BuilderShell,
   Canvas,
@@ -1128,6 +1129,26 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             // evaluate a container query, so only the surface that owns the box
             // can observe them. The container name travels with them because
             // that is what tells the panel the window is not the authority.
+            /*
+             * Going to a tier is SIZING THE CANVAS to it, never setting a
+             * second piece of state saying which tier is being edited. The
+             * edited tier is derived from the width the box gets, so a jump
+             * that wrote its own answer would put the two back in the
+             * disagreement deriving them from one width exists to remove.
+             *
+             * A tier the compiler emits no bound for resolves to `undefined`
+             * and releases the canvas to the region rather than pinning it to a
+             * number nothing responds to — which is also what the unconditional
+             * tier means.
+             */
+            onJumpToBreakpoint={target => {
+              setRequestedWidth(
+                widthForBreakpoint(
+                  canvasRender.styleContext.breakpoints,
+                  target
+                )
+              );
+            }}
             breakpoint={editedBreakpoint}
             previewContainer={canvasPreviewContainer}
             liveBreakpoints={liveBreakpoints}


### PR DESCRIPTION
Closes C-6's remaining half. The provenance dot already said which TIER a value
came from; this says which BREAKPOINT, and lets an author act on it.

## What a control offers

- Authored at the tier being edited → **Reset**, naming what it will reveal.
- Value from another tier → **Go to <tier>**, which sizes the canvas to it.
- Anything else → nothing.

That last line is the design rather than a limitation. `ProvenanceDot` refuses
to be focusable because a stop per control would double the presses to cross a
section of eight or more, and a button on every control spends exactly that
cost. Tying each action to the state that makes it meaningful puts the cost
only on controls the author has actually touched. Placed after the input, so a
keyboard user reaches the value first and the action second.

## Why the dot could not already answer this

`StyleOrigin` records only the tier, so "from a class" and "from this block at
desktop" arrive as the same origin with nothing to separate them — and they are
the two an author most needs told apart, because the next action differs. One is
"go and change it there", the other is "override it here".

Per `research:breakpoint-badges-shape`, this is a READ of the record rather than
a second cascade walk: `StyleTraceEntry` already carries `breakpoint` and
`atRule`. `breakpointBadge` takes the provenance the caller already holds, so
there is one ranking of the trace and not two that could disagree.

## Details that took measuring

**Reset names what it reveals.** In a desktop-first cascade a value usually
falls back to a wider tier, and not always to base — so the fallback is computed
by asking the same question with the edited breakpoint removed from the live
set, which is the engine's own ranking rather than a hand-rolled "next wider".

**The axis travels with the tier name.** A container context emits a query even
at its widest, so a bare "Tablet" is ambiguous exactly when both axes are in
play — and container is the axis an author is least likely to be holding in
mind.

**The jump target is carried per leaf**, because it is that control's own
source: a different control on the same panel goes somewhere else. That also
kept three intermediate components from gaining a prop they would only pass on.
Withheld entirely when the host supplies no handler, since a button that does
nothing reads as broken rather than absent.

**Going to a tier sizes the canvas.** No second state for "which breakpoint am I
editing" — it stays derived from the width the box gets. A tier the compiler
emits no bound for releases the canvas to its region rather than pinning it to a
number nothing responds to.

**`breakpointLabel` now delegates to the badge's resolver.** Both were finding
the definition a context survived from, matching on the BOUND as well as the id,
and two matchers for one rule with a subtlety in it is two places to lose it.

## Verification

Every new test break-verified by mutating the exact branch its name claims,
against a clean control, with `(exit != 0) == (names non-empty)` asserted.
Three came back UNPROTECTED on the first pass and earned tests they did not
have; one is honestly reported as uncoverable rather than papered over — the
`none` early exit cannot be distinguished, because the jump handler is bound
per leaf and only for an `inherited` badge.

Gates: build, check-types, builder (2023), blocks-engine (1504), blocks-react
(882), ui (1135), plugin-page-builder (376), test:scripts, lint, comment
convention, changeset, `fallow audit` at `complexity_introduced: 0` and
`duplication_introduced: 0`, and the canvas e2e suite at 100 passed.

`StyleInspectorPanel` sat exactly at the cognitive threshold and one added prop
tipped it; extracting the subject derivation brought it back under.

## Known gap this does not close

Base is uneditable when the canvas region is narrower than the site's widest
bound — `task:pb-canvas-base-tier-unreachable`, shipped knowingly with #1231.
A jump to a narrower tier works; a jump back to base lands on a canvas that may
still be showing a narrower tier.
