### PR TITLE
feat(plugin-page-builder): serialise two writers reconciling one subject

### DIFF
--- a/packages/plugin-page-builder/src/class-usage-generation.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-generation.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Whether claiming a subject actually serialises two writers.
+ *
+ * The store is observed rather than reimplemented: the cases assert the calls
+ * the code made, including the predicates, so a claim that stopped comparing
+ * against the observed value cannot go on passing.
+ *
+ * @module class-usage-generation.test
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  claimSubjectGeneration,
+  type SubjectGenerationStore,
+} from "./class-usage-generation";
+import type { ClassUsageSubject } from "./class-usage-reconcile";
+
+const page: ClassUsageSubject = {
+  scope: "collection",
+  entity: "pages",
+  entityKey: "page-1",
+  field: "content",
+  locale: "",
+  variant: "published",
+};
+
+/** A store answering fixed rows and recording every call in order. */
+function store(rows: unknown[], successCount = 1) {
+  const calls: string[] = [];
+  const api: SubjectGenerationStore = {
+    find: async args => {
+      calls.push(
+        `find:sort=${args.sort}:where=${Object.keys(args.where).sort().join(",")}`
+      );
+      return { items: rows, meta: { hasNext: false } };
+    },
+    create: async args => {
+      calls.push(`create:generation=${String(args.data.generation)}`);
+      return {};
+    },
+    update: async args => {
+      const w = args.where;
+      calls.push(
+        `update:id=${String(w.id?.equals)}:ifGeneration=${String(w.generation?.equals)}:to=${String(args.data.generation)}`
+      );
+      return { successCount };
+    },
+  };
+  return { api, calls };
+}
+
+describe("a subject nothing has reconciled yet", () => {
+  it("creates the row and claims the first generation", async () => {
+    const s = store([]);
+
+    const claim = await claimSubjectGeneration({
+      store: s.api,
+      collection: "nx_pb_class_usage_gen",
+      subject: page,
+    });
+
+    expect(claim).toEqual({ claimed: true, generation: 1 });
+    expect(s.calls).toEqual([
+      "find:sort=id:where=entity,entityKey,field,locale,scope,variant",
+      "create:generation=1",
+    ]);
+  });
+
+  it("keys the lookup by EVERY member of the subject", async () => {
+    // A generation keyed by less than the whole subject serialises unrelated
+    // documents against each other — one page's save would block another's —
+    // and one keyed by more could never be found again, so every claim would
+    // create a new row and serialise nothing at all.
+    const s = store([]);
+
+    await claimSubjectGeneration({
+      store: s.api,
+      collection: "nx_pb_class_usage_gen",
+      subject: page,
+    });
+
+    expect(s.calls[0]).toContain(
+      "where=entity,entityKey,field,locale,scope,variant"
+    );
+  });
+});
+
+describe("a subject another writer is already reconciling", () => {
+  it("advances the generation, comparing against the value it READ", async () => {
+    const s = store([{ id: "g1", generation: 4 }]);
+
+    const claim = await claimSubjectGeneration({
+      store: s.api,
+      collection: "nx_pb_class_usage_gen",
+      subject: page,
+    });
+
+    expect(claim).toEqual({ claimed: true, generation: 5 });
+    // The predicate is the mechanism. Updating by id alone would apply
+    // whatever the row now holds, which is the overwrite this exists to refuse.
+    expect(s.calls[1]).toBe("update:id=g1:ifGeneration=4:to=5");
+  });
+
+  it("does NOT claim when the compare-and-set matched nothing", async () => {
+    // Another writer advanced the generation between the read and the write.
+    // Reporting a claim here would let two callers reconcile one subject
+    // against different documents, and the loser's removals would delete rows
+    // the winner still needs.
+    const s = store([{ id: "g1", generation: 4 }], 0);
+
+    const claim = await claimSubjectGeneration({
+      store: s.api,
+      collection: "nx_pb_class_usage_gen",
+      subject: page,
+    });
+
+    expect(claim).toEqual({ claimed: false });
+  });
+});
+
+describe("two writers racing the same subject", () => {
+  it("lets exactly ONE of them through", async () => {
+    // The property the whole module exists for, driven from one fixture so the
+    // two outcomes cannot be produced by anything except the compare-and-set
+    // discriminating between them. A claim that ignored `successCount` would
+    // return claimed for both, and the assertion below could not hold.
+    const rows = [{ id: "g1", generation: 7 }];
+    let matched = 1;
+    const api: SubjectGenerationStore = {
+      find: async () => ({ items: rows, meta: { hasNext: false } }),
+      create: async () => ({}),
+      update: async () => {
+        // The first caller matches the row; the second finds it advanced.
+        const successCount = matched;
+        matched = 0;
+        return { successCount };
+      },
+    };
+
+    const first = await claimSubjectGeneration({
+      store: api,
+      collection: "gen",
+      subject: page,
+    });
+    const second = await claimSubjectGeneration({
+      store: api,
+      collection: "gen",
+      subject: page,
+    });
+
+    expect([first.claimed, second.claimed]).toEqual([true, false]);
+  });
+});
+
+describe("rows that cannot be read as a generation", () => {
+  it("treats a non-numeric generation as absent rather than as zero", async () => {
+    // Coercing would hand every caller the same claim, which is the
+    // serialisation failing OPEN — the one direction it must not fail in.
+    // Creating a fresh row instead is the same answer as for a subject nothing
+    // has touched, which is the safe reading of an unusable one.
+    const s = store([{ id: "g1", generation: "four" }]);
+
+    const claim = await claimSubjectGeneration({
+      store: s.api,
+      collection: "gen",
+      subject: page,
+    });
+
+    expect(claim).toEqual({ claimed: true, generation: 1 });
+    expect(s.calls[1]).toBe("create:generation=1");
+  });
+});
+
+describe("duplicate generation rows", () => {
+  it("serialises on the LOWEST id, so a duplicate is harmless", async () => {
+    // Two callers can create concurrently: the composite key this table
+    // describes cannot be enforced, because a collection's declared indexes
+    // never reach the schema pipeline, so no unique constraint exists to
+    // reject the second insert. Duplicates are made harmless rather than
+    // prevented — every caller picking the same row is what keeps them
+    // serialised whatever else is present.
+    const s = store([
+      { id: "g1", generation: 2 },
+      { id: "g2", generation: 9 },
+    ]);
+
+    const claim = await claimSubjectGeneration({
+      store: s.api,
+      collection: "gen",
+      subject: page,
+    });
+
+    // g1, not the one with the higher generation.
+    expect(claim).toEqual({ claimed: true, generation: 3 });
+    expect(s.calls[1]).toBe("update:id=g1:ifGeneration=2:to=3");
+  });
+
+  it("asks the store for a STABLE ordering rather than assuming one", async () => {
+    // "Lowest id" is only agreed if the query says so. Without a sort the
+    // query service emits no ORDER BY, so two callers can receive the same
+    // rows in different orders and pick different ones — and then neither is
+    // serialised against the other, silently.
+    const s = store([{ id: "g1", generation: 1 }]);
+
+    await claimSubjectGeneration({
+      store: s.api,
+      collection: "gen",
+      subject: page,
+    });
+
+    expect(s.calls[0]).toContain("sort=id");
+  });
+});

--- a/packages/plugin-page-builder/src/class-usage-generation.ts
+++ b/packages/plugin-page-builder/src/class-usage-generation.ts
@@ -1,0 +1,181 @@
+/**
+ * Claiming the right to reconcile one subject.
+ *
+ * Reconciliation compares a document against the rows currently filed for it
+ * and writes the difference. That is only sound while ONE writer is doing it:
+ * two saves to the same document can each read the same rows, each compute a
+ * difference against them, and each apply it — so the loser deletes a row the
+ * winner still needs. The index then under-counts, and an under-count is the
+ * direction that permits deleting a class a live page renders.
+ *
+ * ## Why a counter rather than a lock or a timestamp
+ *
+ * A lock held in memory is correct only inside one process, and these apps
+ * deploy to platforms that run many. It would pass every test on one machine
+ * and fail silently in production, which is worse than not having it.
+ *
+ * A timestamp cannot separate two writes that fall close together. Core already
+ * learned this and wrote it down where its own working drafts are stored: a
+ * timestamp's stored resolution differs per dialect and SQLite keeps whole
+ * epoch SECONDS, so the second writer's read observes exactly what the first
+ * wrote, its predicate matches, and it overwrites newer work believing the row
+ * untouched. A counter advances on every write however close together they
+ * fall.
+ *
+ * ## What it does NOT promise
+ *
+ * That the index ends up describing the document that WON the save. It cannot:
+ * a collection row carries no version this plugin can read, so "last reconcile
+ * wins" is not the same as "last save wins". What this does guarantee is that
+ * the index is never left holding a MIXTURE of two documents' rows, which is
+ * the state that under-counts. A rebuild is what closes the remaining gap, and
+ * the count a safe-delete shows should describe itself as best-effort rather
+ * than certain.
+ *
+ * @module class-usage-generation
+ */
+import { subjectWhere } from "./class-usage-maintenance";
+import type { ClassUsageSubject } from "./class-usage-reconcile";
+
+/** The generation a subject starts at, before anything has reconciled it. */
+const FIRST_GENERATION = 1;
+
+/**
+ * The store operations claiming needs, declared structurally.
+ *
+ * Not the generated Direct API types, for the reason `ClassUsageIndexStore` is
+ * not: those describe the HOST app's collections, which may not have been
+ * generated when this plugin is wired.
+ */
+export interface SubjectGenerationStore {
+  find(args: {
+    collection: string;
+    where: Record<string, { equals: string | number }>;
+    limit: number;
+    page: number;
+    /** Required, and it must be a column the writes here cannot move. */
+    sort: string;
+  }): Promise<{ items: unknown[]; meta: { hasNext: boolean } }>;
+  create(args: {
+    collection: string;
+    data: Record<string, unknown>;
+  }): Promise<unknown>;
+  /**
+   * Update every row matching `where`, reporting HOW MANY matched.
+   *
+   * The count is the whole mechanism rather than a diagnostic. A conditional
+   * update that cannot say whether it applied is not a compare-and-set: the
+   * caller would have to read back to find out, and another writer can act
+   * between the write and that read.
+   */
+  update(args: {
+    collection: string;
+    where: Record<string, { equals: string | number }>;
+    data: Record<string, unknown>;
+  }): Promise<{ successCount: number }>;
+}
+
+/** Whether this caller may reconcile, and under which generation. */
+export type GenerationClaim =
+  | { claimed: true; generation: number }
+  | { claimed: false };
+
+/** One stored generation row, once it has been read as one. */
+interface StoredGeneration {
+  id: string;
+  generation: number;
+}
+
+/** Whether a stored item can be read as a generation row. */
+function readGeneration(value: unknown): StoredGeneration | null {
+  if (typeof value !== "object" || value === null) return null;
+  const row = value as { id?: unknown; generation?: unknown };
+  if (typeof row.id !== "string") return null;
+  // Rejected rather than coerced. A non-numeric generation cannot be compared
+  // or advanced, and treating it as zero would hand every caller the same
+  // claim — which is the serialisation failing open.
+  if (typeof row.generation !== "number") return null;
+  return { id: row.id, generation: row.generation };
+}
+
+/**
+ * Claim the next generation for a subject, or report that somebody else did.
+ *
+ * A caller that is not claimed must NOT reconcile. It may retry, and a retry is
+ * cheap because the winner's reconciliation will already have run: the loser
+ * re-reads, finds the advanced generation, and either claims the one after it
+ * or discovers the work is done.
+ *
+ * The row is created when absent. Two callers can create concurrently, because
+ * the composite key this table describes cannot be enforced by the database —
+ * a collection's declared indexes never reach the schema pipeline, so no unique
+ * constraint exists to reject the second insert. Duplicates are therefore made
+ * HARMLESS rather than prevented: every caller selects the lowest id, so they
+ * agree on which row is the one that serialises them, whatever else is present.
+ */
+export async function claimSubjectGeneration(args: {
+  store: SubjectGenerationStore;
+  collection: string;
+  subject: ClassUsageSubject;
+}): Promise<GenerationClaim> {
+  const where = subjectWhere(args.subject);
+
+  const page = await args.store.find({
+    collection: args.collection,
+    where,
+    limit: 10,
+    // By id, which nothing here rewrites. The lowest is the agreed row, and an
+    // ordering the writes could move would let two callers disagree about
+    // which one that is — the disagreement this ordering exists to prevent.
+    sort: "id",
+    page: 1,
+  });
+
+  const rows = page.items
+    .map(readGeneration)
+    .filter((row): row is StoredGeneration => row !== null);
+
+  if (rows.length === 0) {
+    await args.store.create({
+      collection: args.collection,
+      data: { ...unwrapEquals(where), generation: FIRST_GENERATION },
+    });
+    // Claimed WITHOUT a compare-and-set, and only this once. There was no row
+    // to compare against, and a concurrent creator gets the same answer — but
+    // both then reconcile the same subject to the same rows from the same
+    // document, because reconciliation is idempotent. The generation exists to
+    // stop two DIFFERENT documents interleaving, and at creation there is only
+    // one.
+    return { claimed: true, generation: FIRST_GENERATION };
+  }
+
+  const [current] = rows;
+  const next = current.generation + 1;
+  const result = await args.store.update({
+    collection: args.collection,
+    // EQUALITY against the value this read observed, which is what
+    // compare-and-set means: a concurrent writer advances it, this matches
+    // nothing, and the slower caller is told it did not claim rather than
+    // proceeding to overwrite newer work.
+    where: {
+      id: { equals: current.id },
+      generation: { equals: current.generation },
+    },
+    data: { generation: next },
+  });
+
+  if (result.successCount === 0) return { claimed: false };
+  return { claimed: true, generation: next };
+}
+
+/** The subject columns as plain values, for the row being created. */
+function unwrapEquals(
+  where: Record<string, { equals: string }>
+): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(where).map(([column, predicate]) => [
+      column,
+      predicate.equals,
+    ])
+  );
+}

--- a/packages/plugin-page-builder/src/class-usage-maintenance.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.ts
@@ -301,7 +301,7 @@ function assertRowMatches(
 }
 
 /** Every column that identifies one subject, as a query. */
-function subjectWhere(
+export function subjectWhere(
   subject: ClassUsageSubject
 ): Record<string, { equals: string }> {
   return {


### PR DESCRIPTION
Founder-ruled (option D of four). The concurrency guard the class-usage write path needs.

## The failure it prevents

Two editors save the same page at nearly the same moment. Both look at the index and see the same rows. Each works out a difference against them and applies it — so the loser deletes a row the winner still needs. The index then reports a class as used by nobody while a live page renders it, and a safe-delete gives the one answer that breaks the page.

Over-counting is the harmless direction; under-counting is not. This closes the under-count.

## Why a counter, and not the two obvious alternatives

**Not an in-memory lock.** Correct only inside one process, and these apps deploy to platforms that run many. It would pass every test on a laptop and fail silently in production, which is worse than not having it.

**Not a timestamp.** Core already learned this and wrote it down where its own working drafts are stored: a timestamp's stored resolution differs per dialect and SQLite keeps whole epoch SECONDS, so the second writer's read observes exactly what the first wrote, its predicate matches, and it overwrites newer work believing the row untouched. A counter advances on every write however close together they fall.

**Verified the primitive is expressible with the public API before building it:** `update({ where })` routes through the bulk service and returns `successCount`, so a caller can tell whether its conditional write applied. Without that count this would not be a compare-and-set at all — the caller would have to read back, and another writer can act in between.

## Two design points worth reviewing

**Duplicates are made harmless rather than prevented.** Two callers can create a generation row concurrently, and the composite key this describes cannot be enforced: a collection's declared indexes never reach the schema pipeline, so no unique constraint exists to reject the second insert. Every caller therefore selects the LOWEST id, so they agree on which row serialises them whatever else is present.

**A non-numeric generation is rejected, not coerced.** Treating it as zero would hand every caller the same claim, which is the serialisation failing OPEN — the one direction it must not fail in.

## What it does NOT promise, stated so nobody reads more into it

That the index ends up describing the document that WON the save. It cannot: a collection row carries no version this plugin can read, so "last reconcile wins" is not "last save wins". What it guarantees is that the index is never left holding a MIXTURE of two documents' rows, which is the state that under-counts. A rebuild closes the rest, and a safe-delete count should describe itself as best-effort rather than certain.

## Test plan

Eight cases. Three properties break-verified individually, **each break confirmed to compile against a clean baseline**:

| break | tests killed |
| --- | --- |
| ignore `successCount` | "does NOT claim when the compare-and-set matched nothing", "lets exactly ONE of them through" |
| update by id only, dropping the compare | "advances the generation, comparing against the value it READ", "serialises on the LOWEST id" |
| order by a column the writes MOVE | "creates the row and claims the first generation", "asks the store for a STABLE ordering" |

The racing case drives both outcomes from ONE fixture, so they cannot be produced by anything except the compare-and-set discriminating between them.

**The first break-verification run was invalid and is worth recording.** All three breaks reported as not compiling — but the baseline was already red: `BlocksField.tsx` could not resolve `@nextlyhq/builder/shell` exports because #1231 had merged minutes earlier and the local `builder` dist was stale. A red that appears with and without the change is evidence of nothing. Rebuilt with `--filter <pkg>... build`, re-ran, then it meant something.

## A duplication finding, fixed by extraction

fallow reported `duplication_introduced: 1`: this module's subject-to-predicate mapping was a third copy of one `class-usage-maintenance` already had. Exported the existing one and imported it — one question, one implementation.

Deliberately NOT merged with maintenance's five-column sweep predicate. That answers a different question — a subject FAMILY rather than one subject — and sharing a predicate across two questions is how they come to disagree.

Gates, each exit status read separately: build 0 · vitest 0 (382 passing) · check-types 0 · lint 0 · root eslint 0 · comment convention 0 · fallow `verdict: pass` with all four `*_introduced` at 0.

## Changeset

Skipped — `class-usage-generation.ts` is internal, not exported from the package entry, and adds no API a host can call. The changeset lands with the hook that consumes it, where the behaviour becomes user-facing.