### PR TITLE
feat(admin): give version comparison a page of its own

### DIFF
--- a/.changeset/version-history-has-a-page.md
+++ b/.changeset/version-history-has-a-page.md
@@ -44,3 +44,27 @@ so you can find the change you remember without opening each one in turn.
 
 The history panel stays for a quick look beside the document you are editing,
 and gains a control that opens the full comparison.
+
+On a document translated into several languages, a comparison now stays within
+one language. The versions of every language share one numbered history, so the
+version before v5 English is often v4 French — a pair that is not a
+before-and-after of anything, and which the server refuses outright. Opening the
+history of a translated document, or choosing a version in it, compares against
+the previous version OF THAT LANGUAGE.
+
+A version whose predecessor has not been loaded yet no longer claims to be the
+first one ever recorded. It said so at the bottom of every page of a long
+history, and choosing that version then did nothing at all.
+
+"Open full comparison" is offered only once it knows which pair it would open.
+It previously appeared for every version and, where no pair had been resolved,
+opened a comparison of the two newest versions instead — something the reader
+had not asked to see.
+
+A history that fails to load no longer also says the document has no versions
+yet. The two now read differently, because "saving will record its first
+version" is the wrong thing to tell someone whose history is merely unreachable.
+
+Someone with permission to read a document but not to edit it can now use the
+back control. It pointed at the editor, which their permission refuses, so the
+one control always on screen led to a permission error.

--- a/.changeset/version-history-has-a-page.md
+++ b/.changeset/version-history-has-a-page.md
@@ -1,0 +1,46 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Version history now has a page of its own.
+
+Comparing two versions from the history panel meant opening a dialog on top of
+it — two floating surfaces at once, over a document you could no longer see,
+with a comparison squeezed into whatever the panel left over. The comparison
+now opens as a page: the list of versions on the left, the comparison filling
+the rest, and the browser's own back button as the way out.
+
+The pair being compared is part of the address, so a comparison can be sent to
+a colleague rather than described to them. Opening the page without naming a
+pair shows the most recent change, which is what someone arriving from a
+bookmark is looking for.
+
+Each version in the list now says what changed in it — the fields, by name —
+so you can find the change you remember without opening each one in turn.
+
+The history panel stays for a quick look beside the document you are editing,
+and gains a control that opens the full comparison.

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -24,7 +24,7 @@ import { navigateTo } from "@admin/lib/navigation";
 import type { VersionScope } from "@admin/services/versionApi";
 
 import { VersionDiffView } from "./diff/VersionDiffView";
-import { predecessorOf } from "./version-pairing";
+import { predecessorOf, type PairResolution } from "./version-pairing";
 import { resolvePair } from "./version-search-params";
 import { VersionTimelineRail } from "./VersionTimelineRail";
 
@@ -48,6 +48,27 @@ export interface VersionComparePageProps {
   to?: number;
 }
 
+/**
+ * Why there is nothing to compare, in the reader's terms.
+ *
+ * A table rather than nested conditionals, so adding a reason is data — and so
+ * that no reason can quietly fall through to another's sentence, which is how
+ * a document with no versions came to be told it had exactly one.
+ */
+const NO_PAIR_MESSAGE: Record<
+  Exclude<PairResolution["kind"], "pair">,
+  string
+> = {
+  // The rail already states that the history is empty and what to do about
+  // it. This side answers only why no COMPARISON is drawn, so the two
+  // surfaces say different things rather than the same thing twice.
+  "no-history": "There is nothing to compare yet.",
+  "only-version":
+    "There is only one version so far, so there is nothing to compare it with.",
+  "not-loaded":
+    "The version before this one has not been loaded yet. Choose Load more in the list to fetch it.",
+};
+
 /** What fills the comparison side: a failure, a reason there is no pair, or one. */
 function ComparisonPane({
   scope,
@@ -57,7 +78,7 @@ function ComparisonPane({
   onRetry,
 }: {
   scope: VersionScope;
-  pair: { from: number; to: number } | null;
+  pair: PairResolution;
   isError: boolean;
   isLoading: boolean;
   onRetry: () => void;
@@ -77,16 +98,15 @@ function ComparisonPane({
     );
   }
 
-  if (pair === null) {
-    // One version cannot be compared with anything. Said plainly rather than
-    // shown as an empty comparison, which would read as "nothing changed" — the
-    // answer this feature must never give by accident.
+  if (pair.kind !== "pair") {
+    // Said plainly rather than shown as an empty comparison, which would read
+    // as "nothing changed" — the answer this feature must never give by
+    // accident. Which sentence depends on WHY there is no pair: the three cases
+    // are different situations and a reader acts differently on each.
     return (
       <div className="px-4 py-8 text-center">
         <p className="text-sm text-muted-foreground">
-          {isLoading
-            ? "Loading history…"
-            : "There is only one version so far, so there is nothing to compare it with."}
+          {isLoading ? "Loading history…" : NO_PAIR_MESSAGE[pair.kind]}
         </p>
       </div>
     );
@@ -182,7 +202,7 @@ export function VersionComparePage({
           <VersionTimelineRail
             scope={scope}
             versions={versions}
-            selected={pair?.to ?? null}
+            selected={pair.kind === "pair" ? pair.to : null}
             onSelect={selectPair}
             isLoading={list.isLoading}
             isError={list.isError}

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -1,0 +1,173 @@
+/**
+ * A document's version history, as a page.
+ *
+ * A comparison is two columns of field values, and the history panel is 480px —
+ * which is why comparing from the panel had to escape into a dialog stacked
+ * over it. A page gives the comparison the width it needs, removes the second
+ * floating surface, and makes the browser's own back button the way out.
+ *
+ * The pair being compared lives in the URL (`?from=&to=`), so a comparison is
+ * addressable: it can be linked into a review rather than described. That is
+ * the concrete reason this is a route and not a larger dialog.
+ *
+ * @module components/features/versions/VersionComparePage
+ */
+
+import { ArrowLeft } from "lucide-react";
+import { useCallback, useMemo } from "react";
+
+import { Alert, AlertDescription, Button } from "@admin/components/ui";
+import { ROUTES, buildRoute, withQuery } from "@admin/constants/routes";
+import { useVersions } from "@admin/hooks/queries/useVersions";
+import { navigateTo } from "@admin/lib/navigation";
+import type { VersionScope } from "@admin/services/versionApi";
+
+import { VersionDiffView } from "./diff/VersionDiffView";
+import { resolvePair } from "./version-search-params";
+import { VersionTimelineRail } from "./VersionTimelineRail";
+
+export interface VersionComparePageProps {
+  scope: VersionScope;
+  /** Where the back control returns to — the document this history belongs to. */
+  documentHref: string;
+  /** The document's title, so the page says which document it is about. */
+  documentTitle?: string;
+  /** The pair from the URL. Either may be absent on a link that names none. */
+  from?: number;
+  to?: number;
+}
+
+export function VersionComparePage({
+  scope,
+  documentHref,
+  documentTitle,
+  from,
+  to,
+}: VersionComparePageProps) {
+  const list = useVersions({ scope });
+
+  // Autosave rows carry a null `versionNo` and cannot be compared, so they are
+  // not offered as either half of a pair.
+  const versions = useMemo(
+    () => list.data?.pages.flatMap(page => page.items) ?? [],
+    [list.data]
+  );
+  const comparable = useMemo(
+    () =>
+      versions
+        .map(version => version.versionNo)
+        .filter((n): n is number => n !== null),
+    [versions]
+  );
+
+  const pair = resolvePair(comparable, from, to);
+
+  // Choosing a row compares it against the version before it, and writes that
+  // choice to the URL so the comparison on screen is the one the address names.
+  const selectPair = useCallback(
+    (versionNo: number) => {
+      const index = comparable.indexOf(versionNo);
+      const previous = index >= 0 ? comparable[index + 1] : undefined;
+      if (previous === undefined) return;
+      navigateTo(
+        withQuery(window.location.pathname, { from: previous, to: versionNo })
+      );
+    },
+    [comparable]
+  );
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <header className="flex items-center gap-3 border-b border-border px-4 py-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          aria-label="Back to the document"
+          onClick={() => navigateTo(documentHref)}
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div className="min-w-0">
+          <h1 className="truncate text-base font-semibold text-foreground">
+            Version history
+          </h1>
+          {documentTitle ? (
+            <p className="truncate text-xs text-muted-foreground">
+              {documentTitle}
+            </p>
+          ) : null}
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <aside className="w-72 shrink-0 overflow-y-auto border-r border-border">
+          <VersionTimelineRail
+            scope={scope}
+            versions={versions}
+            selected={pair?.to ?? null}
+            onSelect={selectPair}
+            isLoading={list.isLoading}
+            hasNextPage={list.hasNextPage}
+            isFetchingNextPage={list.isFetchingNextPage}
+            onLoadMore={() => void list.fetchNextPage()}
+          />
+        </aside>
+
+        <main className="flex min-h-0 flex-1 flex-col">
+          {list.isError ? (
+            <div className="flex flex-col gap-3 p-4">
+              <Alert variant="destructive">
+                <AlertDescription>
+                  This document&apos;s history could not be loaded.
+                </AlertDescription>
+              </Alert>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => void list.refetch()}
+              >
+                Try again
+              </Button>
+            </div>
+          ) : pair === null ? (
+            // One version cannot be compared with anything. Said plainly rather
+            // than shown as an empty comparison, which would read as "nothing
+            // changed" — the answer this feature must never give by accident.
+            <div className="px-4 py-8 text-center">
+              <p className="text-sm text-muted-foreground">
+                {list.isLoading
+                  ? "Loading history…"
+                  : "There is only one version so far, so there is nothing to compare it with."}
+              </p>
+            </div>
+          ) : (
+            <VersionDiffView
+              // Keyed by the pair so a different comparison mounts fresh and a
+              // cached response for one pair can never paint under another's
+              // heading while the new one loads.
+              key={`${pair.from}-${pair.to}`}
+              scope={scope}
+              from={pair.from}
+              to={pair.to}
+            />
+          )}
+        </main>
+      </div>
+    </div>
+  );
+}
+
+/** The address of a document's history, with an optional pair already chosen. */
+export function versionsHref(
+  scope: VersionScope,
+  pair?: { from: number; to: number }
+): string {
+  const path =
+    scope.kind === "single"
+      ? buildRoute(ROUTES.SINGLE_VERSIONS, { slug: scope.slug })
+      : buildRoute(ROUTES.COLLECTION_ENTRY_VERSIONS, {
+          slug: scope.slug,
+          id: scope.entryId ?? "",
+        });
+  return pair ? withQuery(path, { from: pair.from, to: pair.to }) : path;
+}

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -18,11 +18,13 @@ import { useCallback, useMemo } from "react";
 
 import { Alert, AlertDescription, Button } from "@admin/components/ui";
 import { ROUTES, buildRoute, withQuery } from "@admin/constants/routes";
-import { useVersions } from "@admin/hooks/queries/useVersions";
+import { scopeKey, useVersions } from "@admin/hooks/queries/useVersions";
+import { useCan } from "@admin/hooks/useCan";
 import { navigateTo } from "@admin/lib/navigation";
 import type { VersionScope } from "@admin/services/versionApi";
 
 import { VersionDiffView } from "./diff/VersionDiffView";
+import { predecessorOf } from "./version-pairing";
 import { resolvePair } from "./version-search-params";
 import { VersionTimelineRail } from "./VersionTimelineRail";
 
@@ -30,6 +32,15 @@ export interface VersionComparePageProps {
   scope: VersionScope;
   /** Where the back control returns to — the document this history belongs to. */
   documentHref: string;
+  /**
+   * Where to return instead when the viewer may only READ this document.
+   *
+   * Reading a history needs `read-${slug}`; the document's own editor needs
+   * `update-${slug}`. So a colleague can open a shared comparison, read it, and
+   * be sent to a permission-denied page by the one control that is always on
+   * screen. This is the destination their permission does reach.
+   */
+  readOnlyHref: string;
   /** The document's title, so the page says which document it is about. */
   documentTitle?: string;
   /** The pair from the URL. Either may be absent on a link that names none. */
@@ -37,14 +48,80 @@ export interface VersionComparePageProps {
   to?: number;
 }
 
+/** What fills the comparison side: a failure, a reason there is no pair, or one. */
+function ComparisonPane({
+  scope,
+  pair,
+  isError,
+  isLoading,
+  onRetry,
+}: {
+  scope: VersionScope;
+  pair: { from: number; to: number } | null;
+  isError: boolean;
+  isLoading: boolean;
+  onRetry: () => void;
+}) {
+  if (isError) {
+    return (
+      <div className="flex flex-col gap-3 p-4">
+        <Alert variant="destructive">
+          <AlertDescription>
+            This document&apos;s history could not be loaded.
+          </AlertDescription>
+        </Alert>
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          Try again
+        </Button>
+      </div>
+    );
+  }
+
+  if (pair === null) {
+    // One version cannot be compared with anything. Said plainly rather than
+    // shown as an empty comparison, which would read as "nothing changed" — the
+    // answer this feature must never give by accident.
+    return (
+      <div className="px-4 py-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          {isLoading
+            ? "Loading history…"
+            : "There is only one version so far, so there is nothing to compare it with."}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <VersionDiffView
+      // Keyed by the DOCUMENT as well as the pair. Moving between two
+      // documents' histories can carry the same `from`/`to`, and the diff query
+      // keeps previous data while the new one loads — so without the scope here
+      // the previous document's comparison stays painted under the new
+      // document's heading.
+      key={`${scopeKey(scope).join(":")}:${pair.from}-${pair.to}`}
+      scope={scope}
+      from={pair.from}
+      to={pair.to}
+    />
+  );
+}
+
 export function VersionComparePage({
   scope,
   documentHref,
+  readOnlyHref,
   documentTitle,
   from,
   to,
 }: VersionComparePageProps) {
   const list = useVersions({ scope });
+  // `useCan` answers false while permissions load, which is the right default
+  // here: the read-only destination is reachable by everyone who can reach this
+  // page, so an unresolved permission costs a less specific target rather than
+  // a dead link.
+  const canEditDocument = useCan(`update-${scope.slug}`);
+  const backHref = canEditDocument ? documentHref : readOnlyHref;
 
   // Autosave rows carry a null `versionNo` and cannot be compared, so they are
   // not offered as either half of a pair.
@@ -52,28 +129,29 @@ export function VersionComparePage({
     () => list.data?.pages.flatMap(page => page.items) ?? [],
     [list.data]
   );
-  const comparable = useMemo(
-    () =>
-      versions
-        .map(version => version.versionNo)
-        .filter((n): n is number => n !== null),
-    [versions]
-  );
+  const pair = resolvePair(versions, from, to, list.hasNextPage ?? false);
 
-  const pair = resolvePair(comparable, from, to);
-
-  // Choosing a row compares it against the version before it, and writes that
-  // choice to the URL so the comparison on screen is the one the address names.
+  // Choosing a row compares it against the version before it IN ITS OWN LOCALE,
+  // and writes that choice to the URL so the comparison on screen is the one the
+  // address names. A localized document interleaves its languages in one
+  // numbered history, so the row below is routinely another language — a pair
+  // the server rejects outright.
   const selectPair = useCallback(
     (versionNo: number) => {
-      const index = comparable.indexOf(versionNo);
-      const previous = index >= 0 ? comparable[index + 1] : undefined;
-      if (previous === undefined) return;
+      const previous = predecessorOf(
+        versions,
+        versionNo,
+        list.hasNextPage ?? false
+      );
+      if (previous.kind !== "version") return;
       navigateTo(
-        withQuery(window.location.pathname, { from: previous, to: versionNo })
+        withQuery(window.location.pathname, {
+          from: previous.versionNo,
+          to: versionNo,
+        })
       );
     },
-    [comparable]
+    [versions, list.hasNextPage]
   );
 
   return (
@@ -82,8 +160,8 @@ export function VersionComparePage({
         <Button
           variant="ghost"
           size="sm"
-          aria-label="Back to the document"
-          onClick={() => navigateTo(documentHref)}
+          aria-label={canEditDocument ? "Back to the document" : "Back"}
+          onClick={() => navigateTo(backHref)}
         >
           <ArrowLeft className="h-4 w-4" />
         </Button>
@@ -107,51 +185,28 @@ export function VersionComparePage({
             selected={pair?.to ?? null}
             onSelect={selectPair}
             isLoading={list.isLoading}
+            isError={list.isError}
             hasNextPage={list.hasNextPage}
             isFetchingNextPage={list.isFetchingNextPage}
             onLoadMore={() => void list.fetchNextPage()}
           />
         </aside>
 
-        <main className="flex min-h-0 flex-1 flex-col">
-          {list.isError ? (
-            <div className="flex flex-col gap-3 p-4">
-              <Alert variant="destructive">
-                <AlertDescription>
-                  This document&apos;s history could not be loaded.
-                </AlertDescription>
-              </Alert>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => void list.refetch()}
-              >
-                Try again
-              </Button>
-            </div>
-          ) : pair === null ? (
-            // One version cannot be compared with anything. Said plainly rather
-            // than shown as an empty comparison, which would read as "nothing
-            // changed" — the answer this feature must never give by accident.
-            <div className="px-4 py-8 text-center">
-              <p className="text-sm text-muted-foreground">
-                {list.isLoading
-                  ? "Loading history…"
-                  : "There is only one version so far, so there is nothing to compare it with."}
-              </p>
-            </div>
-          ) : (
-            <VersionDiffView
-              // Keyed by the pair so a different comparison mounts fresh and a
-              // cached response for one pair can never paint under another's
-              // heading while the new one loads.
-              key={`${pair.from}-${pair.to}`}
-              scope={scope}
-              from={pair.from}
-              to={pair.to}
-            />
-          )}
-        </main>
+        {/* A labelled region rather than `main`: the dashboard shell already
+            provides the document's one primary landmark, and nesting a second
+            makes landmark navigation announce two. */}
+        <section
+          aria-label="Comparison"
+          className="flex min-h-0 flex-1 flex-col"
+        >
+          <ComparisonPane
+            scope={scope}
+            pair={pair}
+            isError={list.isError}
+            isLoading={list.isLoading}
+            onRetry={() => void list.refetch()}
+          />
+        </section>
       </div>
     </div>
   );

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -42,6 +42,7 @@ import type { VersionScope } from "@admin/services/versionApi";
 
 import { useDocumentHistory } from "./document-history-context";
 import { RestoreConfirmDialog } from "./RestoreConfirmDialog";
+import { predecessorOf, sameLocaleVersions } from "./version-pairing";
 import { VersionCompareDialog } from "./VersionCompareDialog";
 import { versionsHref } from "./VersionComparePage";
 import { VersionLabelDialog } from "./VersionLabelDialog";
@@ -284,24 +285,18 @@ export function VersionHistorySheet({
   // "current" and "previous" targets are drawn only from versions sharing the
   // selected row's locale. "Previous" is the next-older row in that set, not
   // `selected - 1`, since retention can leave gaps in the numbering.
-  const selectedLocale =
-    selected === null
-      ? null
-      : (versions.find(v => v.versionNo === selected)?.locale ?? null);
-  const sameLocaleVersions =
-    selected === null
-      ? []
-      : versions.filter(
-          v => v.versionNo !== null && (v.locale ?? null) === selectedLocale
-        );
-  const latestVersionNo = sameLocaleVersions[0]?.versionNo ?? null;
-  const sameLocaleIndex = sameLocaleVersions.findIndex(
-    v => v.versionNo === selected
-  );
+  const localeVersions =
+    selected === null ? [] : sameLocaleVersions(versions, selected);
+  const latestVersionNo = localeVersions[0]?.versionNo ?? null;
+  // The comparison page's rail asks this same question, so it is answered in
+  // one place. Passing `false` for "more pages exist" is deliberate here: this
+  // panel pages forward on its own below until the previous target resolves or
+  // the history runs out, so by the time this is read an absent predecessor
+  // means there is none rather than that none has loaded.
+  const previousTarget =
+    selected === null ? null : predecessorOf(versions, selected, false);
   const previousVersionNo =
-    sameLocaleIndex >= 0
-      ? (sameLocaleVersions[sameLocaleIndex + 1]?.versionNo ?? null)
-      : null;
+    previousTarget?.kind === "version" ? previousTarget.versionNo : null;
   // The previewed version must still be in the refreshed list. Retention can
   // prune it out from under the preview (a save in another tab, then a focus
   // refetch), and comparing a version that no longer exists would request a diff
@@ -603,22 +598,26 @@ export function VersionHistorySheet({
                 stays for a quick look without leaving the document; this is
                 for reading a change properly, and its address names the pair
                 so it can be shared. */}
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() =>
-                navigateTo(
-                  versionsHref(
-                    scope,
-                    previousVersionNo === null
-                      ? undefined
-                      : { from: previousVersionNo, to: selected }
+            {/* Only offered once the pair it would open is known. Omitting the
+                pair does not open "this version with nothing"; the destination
+                reads an absent pair as the two NEWEST versions, so the control
+                would silently show a comparison the reader did not ask for. */}
+            {canComparePrevious && previousVersionNo !== null ? (
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() =>
+                  navigateTo(
+                    versionsHref(scope, {
+                      from: previousVersionNo,
+                      to: selected,
+                    })
                   )
-                )
-              }
-            >
-              Open full comparison
-            </Button>
+                }
+              >
+                Open full comparison
+              </Button>
+            ) : null}
             {canComparePrevious && previousVersionNo !== null ? (
               <Button
                 variant="outline"

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -37,11 +37,13 @@ import {
   useVersions,
 } from "@admin/hooks/queries/useVersions";
 import { apiErrorMessage } from "@admin/lib/api/parseApiError";
+import { navigateTo } from "@admin/lib/navigation";
 import type { VersionScope } from "@admin/services/versionApi";
 
 import { useDocumentHistory } from "./document-history-context";
 import { RestoreConfirmDialog } from "./RestoreConfirmDialog";
 import { VersionCompareDialog } from "./VersionCompareDialog";
+import { versionsHref } from "./VersionComparePage";
 import { VersionLabelDialog } from "./VersionLabelDialog";
 import { VersionLocaleFilter } from "./VersionLocaleFilter";
 import { VersionRow } from "./VersionRow";
@@ -597,6 +599,26 @@ export function VersionHistorySheet({
             </Button>
             {/* Compare is offered from the preview, where a version is already
                   chosen: against the one before it, and against the current. */}
+            {/* The full comparison, on a page of its own. The dialog below
+                stays for a quick look without leaving the document; this is
+                for reading a change properly, and its address names the pair
+                so it can be shared. */}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() =>
+                navigateTo(
+                  versionsHref(
+                    scope,
+                    previousVersionNo === null
+                      ? undefined
+                      : { from: previousVersionNo, to: selected }
+                  )
+                )
+              }
+            >
+              Open full comparison
+            </Button>
             {canComparePrevious && previousVersionNo !== null ? (
               <Button
                 variant="outline"

--- a/packages/admin/src/components/features/versions/VersionSummaryLine.tsx
+++ b/packages/admin/src/components/features/versions/VersionSummaryLine.tsx
@@ -17,6 +17,8 @@
 import { useVersionDiff } from "@admin/hooks/queries/useVersions";
 import type { VersionScope } from "@admin/services/versionApi";
 
+import type { Predecessor } from "./version-pairing";
+
 /** How many field names are listed before the rest are counted instead. */
 const NAMED_FIELDS = 3;
 
@@ -25,11 +27,15 @@ export interface VersionSummaryLineProps {
   /** The version being summarised. */
   versionNo: number;
   /**
-   * The version it is compared against — the next-older one in the same locale.
-   * Null for the oldest version, which has nothing to be compared with and is
-   * described as the first record rather than as a change.
+   * What this version is compared against — the next-older one in the same
+   * locale, or why there is none.
+   *
+   * Three states rather than a nullable number, because "there is nothing
+   * older" and "nothing older has loaded yet" read identically to a consumer
+   * and point a reader in opposite directions: one is a fact about the
+   * document, the other is a fact about the scroll position.
    */
-  previousVersionNo: number | null;
+  previous: Predecessor;
   /**
    * Whether to fetch. A long history would otherwise issue one comparison
    * request per row on mount, so a caller fetches only for the rows a reader
@@ -46,24 +52,30 @@ function changedLabels(fields: readonly { label?: string; name: string }[]) {
 export function VersionSummaryLine({
   scope,
   versionNo,
-  previousVersionNo,
+  previous,
   enabled = true,
 }: VersionSummaryLineProps) {
+  const from = previous.kind === "version" ? previous.versionNo : null;
   const diff = useVersionDiff({
     scope,
-    from: previousVersionNo,
+    from,
     to: versionNo,
     modifiedOnly: true,
-    enabled: enabled && previousVersionNo !== null,
+    enabled: enabled && from !== null,
   });
 
-  if (previousVersionNo === null) {
+  if (previous.kind === "first") {
     return (
       <span className="text-xs text-muted-foreground">
         The first recorded version
       </span>
     );
   }
+
+  // Nothing older has loaded, which is not the same as nothing older existing.
+  // Silence is the honest answer: claiming this is the first recorded version
+  // would be a statement about the document made from the scroll position.
+  if (previous.kind === "unknown") return null;
 
   // Silent while unknown rather than guessing. A row that says "1 field
   // changed" and then corrects itself is worse than a row that says nothing

--- a/packages/admin/src/components/features/versions/VersionSummaryLine.tsx
+++ b/packages/admin/src/components/features/versions/VersionSummaryLine.tsx
@@ -1,0 +1,88 @@
+/**
+ * What changed in a version, in a few words.
+ *
+ * One component rather than one per surface: the comparison page's rail and the
+ * history panel ask exactly the same question, and two answers to it would
+ * agree on the day they were written and drift after — silently, because each
+ * would look right beside its own list.
+ *
+ * The summary is DERIVED from the comparison, never stored. Persisting it at
+ * capture time would need a schema migration and would hold a value that goes
+ * stale the moment the schema changes underneath it, so the field names it
+ * lists could name fields that no longer exist.
+ *
+ * @module components/features/versions/VersionSummaryLine
+ */
+
+import { useVersionDiff } from "@admin/hooks/queries/useVersions";
+import type { VersionScope } from "@admin/services/versionApi";
+
+/** How many field names are listed before the rest are counted instead. */
+const NAMED_FIELDS = 3;
+
+export interface VersionSummaryLineProps {
+  scope: VersionScope;
+  /** The version being summarised. */
+  versionNo: number;
+  /**
+   * The version it is compared against — the next-older one in the same locale.
+   * Null for the oldest version, which has nothing to be compared with and is
+   * described as the first record rather than as a change.
+   */
+  previousVersionNo: number | null;
+  /**
+   * Whether to fetch. A long history would otherwise issue one comparison
+   * request per row on mount, so a caller fetches only for the rows a reader
+   * can actually see.
+   */
+  enabled?: boolean;
+}
+
+/** The field labels a comparison reports as changed, in the order it gives them. */
+function changedLabels(fields: readonly { label?: string; name: string }[]) {
+  return fields.map(field => field.label || field.name);
+}
+
+export function VersionSummaryLine({
+  scope,
+  versionNo,
+  previousVersionNo,
+  enabled = true,
+}: VersionSummaryLineProps) {
+  const diff = useVersionDiff({
+    scope,
+    from: previousVersionNo,
+    to: versionNo,
+    modifiedOnly: true,
+    enabled: enabled && previousVersionNo !== null,
+  });
+
+  if (previousVersionNo === null) {
+    return (
+      <span className="text-xs text-muted-foreground">
+        The first recorded version
+      </span>
+    );
+  }
+
+  // Silent while unknown rather than guessing. A row that says "1 field
+  // changed" and then corrects itself is worse than a row that says nothing
+  // for a moment.
+  if (diff.isLoading || diff.isError || !diff.data) return null;
+
+  const labels = changedLabels(diff.data.fields);
+  if (labels.length === 0) {
+    return (
+      <span className="text-xs text-muted-foreground">No fields changed</span>
+    );
+  }
+
+  const named = labels.slice(0, NAMED_FIELDS);
+  const remaining = labels.length - named.length;
+  return (
+    <span className="text-xs text-muted-foreground">
+      {named.join(", ")}
+      {remaining > 0 ? ` +${remaining} more` : ""}
+    </span>
+  );
+}

--- a/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
+++ b/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
@@ -14,6 +14,7 @@ import { Badge, Button, Skeleton } from "@admin/components/ui";
 import { formatDateTime } from "@admin/lib/dates/format";
 import type { VersionMeta, VersionScope } from "@admin/services/versionApi";
 
+import { predecessorOf, type Predecessor } from "./version-pairing";
 import { VersionSummaryLine } from "./VersionSummaryLine";
 
 /** How many rows fetch their summary. Beyond this a reader has to scroll. */
@@ -26,6 +27,13 @@ export interface VersionTimelineRailProps {
   selected: number | null;
   onSelect: (versionNo: number) => void;
   isLoading?: boolean;
+  /**
+   * Whether the history could not be read. The pane beside this one reports the
+   * failure; without this the rail would answer the same empty list with "No
+   * versions yet", which is a claim about the document rather than about the
+   * request.
+   */
+  isError?: boolean;
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
@@ -74,14 +82,14 @@ function RowHeading({ version }: { version: VersionMeta }) {
 function TimelineRow({
   scope,
   version,
-  previousVersionNo,
+  previous,
   active,
   summarised,
   onSelect,
 }: {
   scope: VersionScope;
   version: VersionMeta;
-  previousVersionNo: number | null;
+  previous: Predecessor;
   active: boolean;
   summarised: boolean;
   onSelect: (versionNo: number) => void;
@@ -111,7 +119,7 @@ function TimelineRow({
             <VersionSummaryLine
               scope={scope}
               versionNo={versionNo}
-              previousVersionNo={previousVersionNo}
+              previous={previous}
               enabled={summarised}
             />
           )}
@@ -127,11 +135,18 @@ export function VersionTimelineRail({
   selected,
   onSelect,
   isLoading = false,
+  isError = false,
   hasNextPage = false,
   isFetchingNextPage = false,
   onLoadMore,
 }: VersionTimelineRailProps) {
   if (isLoading) return <RailSkeleton />;
+
+  // A failed read leaves the list empty exactly as an empty history does, and
+  // the two must not render alike: telling someone to save their first version
+  // beside a pane reporting that history could not be loaded is advice that
+  // would destroy nothing but would leave them believing their history is gone.
+  if (isError) return null;
 
   if (versions.length === 0) {
     return (
@@ -154,9 +169,16 @@ export function VersionTimelineRail({
             key={version.id}
             scope={scope}
             version={version}
-            // The next row down is the version before this one, which is what
-            // this row's summary describes and what choosing it compares against.
-            previousVersionNo={versions[index + 1]?.versionNo ?? null}
+            // Derived rather than read off the next row down: that row is the
+            // version before this one only when both are in the same locale,
+            // and at the bottom of a loaded page there may simply be no answer
+            // yet. Both consumers — this row's summary and selecting it — read
+            // the same result.
+            previous={predecessorOf(
+              versions,
+              version.versionNo ?? -1,
+              hasNextPage
+            )}
             active={
               version.versionNo !== null && version.versionNo === selected
             }

--- a/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
+++ b/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
@@ -1,0 +1,184 @@
+/**
+ * The version list beside a comparison.
+ *
+ * Newest first, each row naming its author, when it was written, and what
+ * changed in it. Choosing a row compares it against the version before it,
+ * which is the question a reader almost always has; the pair is then in the
+ * URL, so the choice is addressable rather than a state the page happens to
+ * hold.
+ *
+ * @module components/features/versions/VersionTimelineRail
+ */
+
+import { Badge, Button, Skeleton } from "@admin/components/ui";
+import { formatDateTime } from "@admin/lib/dates/format";
+import type { VersionMeta, VersionScope } from "@admin/services/versionApi";
+
+import { VersionSummaryLine } from "./VersionSummaryLine";
+
+/** How many rows fetch their summary. Beyond this a reader has to scroll. */
+const SUMMARISED_ROWS = 12;
+
+export interface VersionTimelineRailProps {
+  scope: VersionScope;
+  versions: readonly VersionMeta[];
+  /** The newer half of the pair on screen, which marks the active row. */
+  selected: number | null;
+  onSelect: (versionNo: number) => void;
+  isLoading?: boolean;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  onLoadMore?: () => void;
+}
+
+function RailSkeleton() {
+  return (
+    <div className="flex flex-col gap-4 p-4" aria-busy="true">
+      <span className="sr-only" role="status" aria-live="polite">
+        Loading history
+      </span>
+      {[0, 1, 2, 3].map(i => (
+        <div key={i} className="flex flex-col gap-1">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-3 w-36" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** A row's first line: which version it is, its status, and any name given it. */
+function RowHeading({ version }: { version: VersionMeta }) {
+  return (
+    <span className="flex items-center gap-2">
+      <span className="text-sm font-medium text-foreground">
+        {version.versionNo === null
+          ? "Autosave"
+          : `Version ${version.versionNo}`}
+      </span>
+      {version.status ? (
+        <Badge variant={version.status === "published" ? "success" : "outline"}>
+          {version.status}
+        </Badge>
+      ) : null}
+      {version.label ? (
+        <span className="truncate text-xs text-muted-foreground">
+          {version.label}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+/** One version in the rail. */
+function TimelineRow({
+  scope,
+  version,
+  previousVersionNo,
+  active,
+  summarised,
+  onSelect,
+}: {
+  scope: VersionScope;
+  version: VersionMeta;
+  previousVersionNo: number | null;
+  active: boolean;
+  summarised: boolean;
+  onSelect: (versionNo: number) => void;
+}) {
+  // An autosave carries no version number, so it cannot be compared and is
+  // shown without being selectable rather than hidden — it is still a record of
+  // the document having been touched.
+  const versionNo = version.versionNo;
+  return (
+    <li>
+      <button
+        type="button"
+        aria-current={active ? "true" : undefined}
+        disabled={versionNo === null}
+        onClick={() => versionNo !== null && onSelect(versionNo)}
+        className={`w-full border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/60 disabled:opacity-60 ${
+          active ? "bg-muted" : ""
+        }`}
+      >
+        <RowHeading version={version} />
+        <span className="mt-0.5 flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">
+            {version.author?.name ?? "Unknown author"} &middot;{" "}
+            {formatDateTime(version.createdAt)}
+          </span>
+          {versionNo === null ? null : (
+            <VersionSummaryLine
+              scope={scope}
+              versionNo={versionNo}
+              previousVersionNo={previousVersionNo}
+              enabled={summarised}
+            />
+          )}
+        </span>
+      </button>
+    </li>
+  );
+}
+
+export function VersionTimelineRail({
+  scope,
+  versions,
+  selected,
+  onSelect,
+  isLoading = false,
+  hasNextPage = false,
+  isFetchingNextPage = false,
+  onLoadMore,
+}: VersionTimelineRailProps) {
+  if (isLoading) return <RailSkeleton />;
+
+  if (versions.length === 0) {
+    return (
+      <div className="px-4 py-8 text-center">
+        <h3 className="text-base font-semibold text-foreground">
+          No versions yet
+        </h3>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Saving this document will record its first version.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <nav aria-label="Version history">
+      <ul className="flex flex-col">
+        {versions.map((version, index) => (
+          <TimelineRow
+            key={version.id}
+            scope={scope}
+            version={version}
+            // The next row down is the version before this one, which is what
+            // this row's summary describes and what choosing it compares against.
+            previousVersionNo={versions[index + 1]?.versionNo ?? null}
+            active={
+              version.versionNo !== null && version.versionNo === selected
+            }
+            summarised={index < SUMMARISED_ROWS}
+            onSelect={onSelect}
+          />
+        ))}
+      </ul>
+
+      {hasNextPage ? (
+        <div className="p-4">
+          <Button
+            variant="outline"
+            size="sm"
+            className="w-full"
+            disabled={isFetchingNextPage}
+            onClick={onLoadMore}
+          >
+            {isFetchingNextPage ? "Loading…" : "Load more"}
+          </Button>
+        </div>
+      ) : null}
+    </nav>
+  );
+}

--- a/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
@@ -6,10 +6,10 @@
  * viewer who may only READ the document to a page their permission refuses; and
  * nest a second primary landmark inside the one the dashboard shell provides.
  */
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { render, screen } from "@admin/__tests__/utils";
+import { render, screen, within } from "@admin/__tests__/utils";
 
 const { useVersionsMock, canMock, navigateMock, diffMountMock } = vi.hoisted(
   () => ({
@@ -29,11 +29,13 @@ const { useVersionsMock, canMock, navigateMock, diffMountMock } = vi.hoisted(
 // which is the broken behaviour it exists to catch.
 vi.mock("../diff/VersionDiffView", () => ({
   VersionDiffView: (props: Record<string, unknown>) => {
+    // The props as they were at MOUNT, held in a ref so the effect below needs
+    // no dependency on them. A ref is stable, so the empty dependency list is
+    // honest rather than suppressed — and mount-time props are exactly what a
+    // remount counter should record.
+    const mounted = useRef(props);
     useEffect(() => {
-      diffMountMock(props);
-      // Mount only: an empty dependency list is what makes this a remount
-      // counter rather than a render counter.
-      // eslint-disable-next-line react-hooks/exhaustive-deps
+      diffMountMock(mounted.current);
     }, []);
     return <div data-testid="diff-view" />;
   },
@@ -201,6 +203,66 @@ describe("VersionComparePage — one comparison never paints under another", () 
       diffMountMock.mock.calls as [{ scope: { entryId: string } }][]
     ).map(([props]) => props.scope.entryId);
     expect(scopes).toEqual(["e1", "e2"]);
+  });
+});
+
+describe("VersionComparePage — why there is nothing to compare", () => {
+  it("MUST NOT tell a document with no versions that it has one", () => {
+    // The rail says "No versions yet" in this state. The pane used to say
+    // "There is only one version so far" beside it, because both were derived
+    // from the same empty pair — two claims about the same document, one false.
+    useVersionsMock.mockReturnValue(listing([]));
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/a"
+        readOnlyHref="/list"
+      />
+    );
+
+    // Scoped to each surface, because the point is that they say DIFFERENT
+    // things: the rail reports the history, the pane reports the comparison.
+    const pane = within(screen.getByRole("region", { name: "Comparison" }));
+    expect(pane.queryByText(/only one version so far/)).not.toBeInTheDocument();
+    expect(pane.getByText(/nothing to compare yet/i)).toBeInTheDocument();
+    // The rail still owns that message, and now owns it alone.
+    expect(screen.getByText("No versions yet")).toBeInTheDocument();
+  });
+
+  it("says a genuine single-version history is exactly that", () => {
+    // The control: distinguishing the empty case must not stop this one being
+    // reported, which is the ordinary reason a comparison cannot be drawn.
+    useVersionsMock.mockReturnValue(listing([row(1)]));
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/a"
+        readOnlyHref="/list"
+      />
+    );
+
+    expect(screen.getByText(/only one version so far/)).toBeInTheDocument();
+  });
+
+  it("points at Load more when the predecessor is merely unfetched", () => {
+    // Neither "no versions" nor "only one version" is true here, and both send
+    // the reader to the wrong conclusion about their own document.
+    useVersionsMock.mockReturnValue(listing([row(9)], { hasNextPage: true }));
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/a"
+        readOnlyHref="/list"
+      />
+    );
+
+    expect(screen.getByText(/has not been loaded yet/)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/only one version so far/)
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * The comparison page. Three things it must not do, each of which reads as
+ * working software while being wrong:
+ *
+ * paint one document's comparison under another document's heading; send a
+ * viewer who may only READ the document to a page their permission refuses; and
+ * nest a second primary landmark inside the one the dashboard shell provides.
+ */
+import { useEffect } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+const { useVersionsMock, canMock, navigateMock, diffMountMock } = vi.hoisted(
+  () => ({
+    useVersionsMock: vi.fn(),
+    canMock: vi.fn(),
+    navigateMock: vi.fn(),
+    diffMountMock: vi.fn(),
+  })
+);
+
+// Stubbed so these tests stay about the page. The real view fetches a diff of
+// its own; what matters here is whether it is asked to START OVER.
+//
+// It records MOUNTS, not renders, and the distinction is the whole test. React
+// re-renders a reused instance with the new props, so a stub recording renders
+// sees the new document either way and cannot tell a remount from a reuse —
+// which is the broken behaviour it exists to catch.
+vi.mock("../diff/VersionDiffView", () => ({
+  VersionDiffView: (props: Record<string, unknown>) => {
+    useEffect(() => {
+      diffMountMock(props);
+      // Mount only: an empty dependency list is what makes this a remount
+      // counter rather than a render counter.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+    return <div data-testid="diff-view" />;
+  },
+}));
+
+vi.mock("@admin/hooks/queries/useVersions", () => ({
+  useVersions: (...a: unknown[]) => useVersionsMock(...a),
+  // The rail's summary lines fetch one of these each. They are not what these
+  // tests are about, so they answer nothing and stay quiet.
+  useVersionDiff: () => ({ data: undefined, isLoading: false, isError: false }),
+  scopeKey: (s: { kind: string; slug: string; entryId?: string }) => [
+    s.kind,
+    s.slug,
+    s.entryId ?? "",
+  ],
+}));
+
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (...a: unknown[]) => canMock(...a) as boolean,
+}));
+
+vi.mock("@admin/lib/navigation", () => ({
+  navigateTo: (...a: unknown[]) => navigateMock(...a),
+}));
+
+import { VersionComparePage } from "../VersionComparePage";
+
+const row = (versionNo: number, locale: string | null = null) => ({
+  id: `v${versionNo}`,
+  versionNo,
+  status: "draft" as const,
+  isAutosave: false,
+  label: null,
+  locale,
+  sourceVersionNo: null,
+  createdBy: "u1",
+  author: { id: "u1", name: "Ada Lovelace" },
+  createdAt: new Date("2026-01-01").toISOString(),
+  updatedAt: new Date("2026-01-01").toISOString(),
+});
+
+function listing(items: ReturnType<typeof row>[], overrides = {}) {
+  return {
+    data: { pages: [{ items }] },
+    isLoading: false,
+    isError: false,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+    refetch: vi.fn(),
+    ...overrides,
+  };
+}
+
+const collection = (entryId: string) => ({
+  kind: "collection" as const,
+  slug: "posts",
+  entryId,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  canMock.mockReturnValue(true);
+  useVersionsMock.mockReturnValue(listing([row(9), row(8)]));
+});
+
+describe("VersionComparePage — landmarks", () => {
+  it("does not nest a second primary landmark", () => {
+    // `DashboardLayout` already wraps every private page in the document's one
+    // `main`. A second inside it makes landmark navigation announce two
+    // primary regions on every comparison.
+    const { container } = render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+
+    expect(container.querySelectorAll("main")).toHaveLength(0);
+    expect(
+      screen.getByRole("region", { name: "Comparison" })
+    ).toBeInTheDocument();
+  });
+});
+
+describe("VersionComparePage — the back control", () => {
+  it("returns to the document when the viewer can edit it", () => {
+    canMock.mockReturnValue(true);
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+
+    screen.getByRole("button", { name: "Back to the document" }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/admin/collections/posts/e1");
+  });
+
+  it("MUST NOT send a read-only viewer to a page their permission refuses", () => {
+    // Reading a history needs `read-posts`; the editor needs `update-posts`. A
+    // colleague can open a shared comparison, read it, and be sent to
+    // permission-denied by the one control always on screen.
+    canMock.mockReturnValue(false);
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+
+    screen.getByRole("button", { name: "Back" }).click();
+    expect(navigateMock).toHaveBeenCalledWith("/admin/collections/posts");
+    expect(navigateMock).not.toHaveBeenCalledWith(
+      "/admin/collections/posts/e1"
+    );
+  });
+
+  it("asks about the permission the edit route actually guards", () => {
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+    expect(canMock).toHaveBeenCalledWith("update-posts");
+  });
+});
+
+describe("VersionComparePage — one comparison never paints under another", () => {
+  it("starts over when the DOCUMENT changes under the same pair", () => {
+    // Two entries' histories can carry the same version numbers, and the diff
+    // query keeps previous data while the next one loads. Without the document
+    // in the key the previous entry's comparison stays on screen under the new
+    // entry's heading.
+    const { rerender } = render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/a"
+        readOnlyHref="/list"
+        from={8}
+        to={9}
+      />
+    );
+    expect(diffMountMock).toHaveBeenCalledTimes(1);
+
+    rerender(
+      <VersionComparePage
+        scope={collection("e2")}
+        documentHref="/b"
+        readOnlyHref="/list"
+        from={8}
+        to={9}
+      />
+    );
+
+    // A second MOUNT is the evidence. Reusing the instance would leave the
+    // previous document's diff painted while the new one loads.
+    expect(diffMountMock).toHaveBeenCalledTimes(2);
+    const scopes = (
+      diffMountMock.mock.calls as [{ scope: { entryId: string } }][]
+    ).map(([props]) => props.scope.entryId);
+    expect(scopes).toEqual(["e1", "e2"]);
+  });
+});
+
+describe("VersionComparePage — a failed history is not an empty one", () => {
+  it("does not tell the reader to save their first version when the read failed", () => {
+    // React Query clears `isLoading` on failure while the list stays empty, so
+    // the rail's empty state renders beside a pane correctly reporting that the
+    // history could not be loaded.
+    useVersionsMock.mockReturnValue(
+      listing([], { isError: true, data: undefined })
+    );
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/a"
+        readOnlyHref="/list"
+      />
+    );
+
+    expect(screen.queryByText("No versions yet")).not.toBeInTheDocument();
+    expect(
+      screen.getByText("This document's history could not be loaded.")
+    ).toBeInTheDocument();
+  });
+
+  it("still shows the empty state for a document that genuinely has no history", () => {
+    // The control: suppressing the empty state on failure must not suppress it
+    // when the document really is new.
+    useVersionsMock.mockReturnValue(listing([]));
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/a"
+        readOnlyHref="/list"
+      />
+    );
+
+    expect(screen.getByText("No versions yet")).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -359,6 +359,50 @@ describe("VersionHistorySheet", () => {
     );
   });
 
+  it("offers the full comparison only once the pair it would open is known", async () => {
+    // Omitting the pair does not open "this version against nothing": the
+    // destination reads an absent pair as the two NEWEST versions, so the
+    // control would silently show a comparison the reader did not ask for.
+    // Version 1 is the oldest loaded and has no predecessor.
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [{ items: [version(1)], meta: { hasNext: false } }],
+        },
+      })
+    );
+    useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
+
+    renderSheet();
+    await userEvent.click(screen.getByRole("button", { name: /Version 1/ }));
+
+    expect(
+      screen.queryByRole("button", { name: /Open full comparison/ })
+    ).not.toBeInTheDocument();
+  });
+
+  it("offers it when a predecessor IS known", async () => {
+    // The control for the test above: gating on a resolved pair must not hide
+    // the action for every version.
+    useVersionsMock.mockReturnValue(
+      listState({
+        data: {
+          pages: [
+            { items: [version(3), version(2)], meta: { hasNext: false } },
+          ],
+        },
+      })
+    );
+    useVersionMock.mockReturnValue(detailState({ data: { snapshot: {} } }));
+
+    renderSheet();
+    await userEvent.click(screen.getByRole("button", { name: /Version 3/ }));
+
+    expect(
+      screen.getByRole("button", { name: /Open full comparison/ })
+    ).toBeInTheDocument();
+  });
+
   it("leaves the document reachable while its history is open", () => {
     useVersionsMock.mockReturnValue(
       listState({

--- a/packages/admin/src/components/features/versions/__tests__/version-pairing.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/version-pairing.test.ts
@@ -122,22 +122,37 @@ describe("sameLocaleVersions", () => {
 
 describe("defaultPair", () => {
   it("is the newest version and what precedes it in its locale", () => {
-    expect(defaultPair(interleaved, false)).toEqual({ from: 3, to: 5 });
+    expect(defaultPair(interleaved, false)).toEqual({
+      kind: "pair",
+      from: 3,
+      to: 5,
+    });
   });
 
   it("refuses rather than pairing the two newest ROWS", () => {
     // v5 is English and v4 is French. A pair of the two newest rows is what the
     // page used to default to, and the server rejects it.
-    const pair = defaultPair(interleaved, false);
-    expect(pair).not.toEqual({ from: 4, to: 5 });
+    expect(defaultPair(interleaved, false)).not.toEqual({
+      kind: "pair",
+      from: 4,
+      to: 5,
+    });
   });
 
-  it("has nothing to offer for a history of one", () => {
-    expect(defaultPair(plain(1), false)).toBeNull();
-    expect(defaultPair([], false)).toBeNull();
+  // The three reasons there is no pair are three different situations, and a
+  // reader acts differently on each. Collapsing them into one empty answer told
+  // a document with NO versions that it had exactly one.
+  it("distinguishes a document with no history at all", () => {
+    expect(defaultPair([], false)).toEqual({ kind: "no-history" });
   });
 
-  it("refuses while the newest version's predecessor is still unloaded", () => {
-    expect(defaultPair(plain(9), true)).toBeNull();
+  it("distinguishes a history that genuinely holds one version", () => {
+    expect(defaultPair(plain(1), false)).toEqual({ kind: "only-version" });
+  });
+
+  it("distinguishes a predecessor that has merely not loaded", () => {
+    // "Load more" would find it. Telling this reader they have one version is
+    // false, and telling them they have none is worse.
+    expect(defaultPair(plain(9), true)).toEqual({ kind: "not-loaded" });
   });
 });

--- a/packages/admin/src/components/features/versions/__tests__/version-pairing.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/version-pairing.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Guards which version a version is compared against.
+ *
+ * Two properties, and they fail in opposite directions. A pair must stay within
+ * ONE LOCALE — the server rejects a cross-locale pair, so getting this wrong
+ * renders an API error where a comparison should be. And a predecessor that has
+ * merely not LOADED must not be reported as one that does not exist, because
+ * that tells a reader a version with older siblings is the first ever recorded
+ * and then makes selecting it do nothing.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  defaultPair,
+  predecessorOf,
+  sameLocaleVersions,
+} from "../version-pairing";
+
+/** A history with no locales at all, which is every non-localized document. */
+const plain = (...numbers: number[]) =>
+  numbers.map(versionNo => ({ versionNo, locale: null }));
+
+/** English and French interleaved in one numbered history, newest first. */
+const interleaved = [
+  { versionNo: 5, locale: "en" },
+  { versionNo: 4, locale: "fr" },
+  { versionNo: 3, locale: "en" },
+  { versionNo: 2, locale: "fr" },
+];
+
+describe("predecessorOf — within one locale", () => {
+  it("takes the next-older row on a document with no locales", () => {
+    expect(predecessorOf(plain(9, 8, 7), 9, false)).toEqual({
+      kind: "version",
+      versionNo: 8,
+    });
+  });
+
+  it("MUST NOT pair across locales", () => {
+    // The row below v5 is French. Pairing them is rejected by the server, so
+    // this is an API error rather than a comparison.
+    expect(predecessorOf(interleaved, 5, false)).toEqual({
+      kind: "version",
+      versionNo: 3,
+    });
+    expect(predecessorOf(interleaved, 4, false)).toEqual({
+      kind: "version",
+      versionNo: 2,
+    });
+  });
+
+  it("treats an absent locale and a null locale as one locale", () => {
+    const mixed = [{ versionNo: 9 }, { versionNo: 8, locale: null }];
+    expect(predecessorOf(mixed, 9, false)).toEqual({
+      kind: "version",
+      versionNo: 8,
+    });
+  });
+
+  it("is the next-older row in the set, never `versionNo - 1`", () => {
+    // Retention prunes old versions and leaves gaps, so arithmetic on the
+    // number names a version that may no longer exist and would 404.
+    expect(predecessorOf(plain(9, 4), 9, false)).toEqual({
+      kind: "version",
+      versionNo: 4,
+    });
+  });
+
+  it("skips autosave rows, which carry no version number to compare", () => {
+    const withAutosave = [
+      { versionNo: 9, locale: null },
+      { versionNo: null, locale: null },
+      { versionNo: 8, locale: null },
+    ];
+    expect(predecessorOf(withAutosave, 9, false)).toEqual({
+      kind: "version",
+      versionNo: 8,
+    });
+  });
+});
+
+describe("predecessorOf — what has not loaded", () => {
+  it("says UNKNOWN at a pagination boundary rather than `first`", () => {
+    // The oldest loaded row of its locale, with pages still unfetched. Calling
+    // this the first recorded version is a claim about the document made from
+    // the scroll position.
+    expect(predecessorOf(plain(9, 8), 8, true)).toEqual({ kind: "unknown" });
+  });
+
+  it("says FIRST once the history is exhausted", () => {
+    expect(predecessorOf(plain(9, 8), 8, false)).toEqual({ kind: "first" });
+  });
+
+  it("says UNKNOWN when the locale has one loaded row but more pages exist", () => {
+    // Interleaving puts a predecessor beyond the page long before the selected
+    // row is the last one loaded overall — v4 is not the bottom row, and its
+    // French predecessor is still unfetched.
+    const oneFrench = [
+      { versionNo: 5, locale: "en" },
+      { versionNo: 4, locale: "fr" },
+      { versionNo: 3, locale: "en" },
+    ];
+    expect(predecessorOf(oneFrench, 4, true)).toEqual({ kind: "unknown" });
+  });
+
+  it("says UNKNOWN for a version that is not loaded at all", () => {
+    expect(predecessorOf(plain(9, 8), 2, false)).toEqual({ kind: "unknown" });
+  });
+});
+
+describe("sameLocaleVersions", () => {
+  it("keeps only the anchor's own locale, newest first", () => {
+    expect(sameLocaleVersions(interleaved, 5).map(v => v.versionNo)).toEqual([
+      5, 3,
+    ]);
+  });
+
+  it("is empty when the anchor is not loaded", () => {
+    expect(sameLocaleVersions(interleaved, 99)).toEqual([]);
+  });
+});
+
+describe("defaultPair", () => {
+  it("is the newest version and what precedes it in its locale", () => {
+    expect(defaultPair(interleaved, false)).toEqual({ from: 3, to: 5 });
+  });
+
+  it("refuses rather than pairing the two newest ROWS", () => {
+    // v5 is English and v4 is French. A pair of the two newest rows is what the
+    // page used to default to, and the server rejects it.
+    const pair = defaultPair(interleaved, false);
+    expect(pair).not.toEqual({ from: 4, to: 5 });
+  });
+
+  it("has nothing to offer for a history of one", () => {
+    expect(defaultPair(plain(1), false)).toBeNull();
+    expect(defaultPair([], false)).toBeNull();
+  });
+
+  it("refuses while the newest version's predecessor is still unloaded", () => {
+    expect(defaultPair(plain(9), true)).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
@@ -35,14 +35,18 @@ describe("readVersionParam", () => {
 });
 
 describe("resolvePair", () => {
+  /** A history of one locale, newest first. */
+  const rows = (...numbers: number[]) =>
+    numbers.map(versionNo => ({ versionNo, locale: null }));
+
   it("takes the pair the URL names", () => {
-    expect(resolvePair([9, 8, 7], 7, 9)).toEqual({ from: 7, to: 9 });
+    expect(resolvePair(rows(9, 8, 7), 7, 9, false)).toEqual({ from: 7, to: 9 });
   });
 
   it("defaults to the two newest versions when the URL names none", () => {
     // Arriving without a pair is the ordinary case, and the most recent change
     // is what that reader came for.
-    expect(resolvePair([9, 8, 7], undefined, undefined)).toEqual({
+    expect(resolvePair(rows(9, 8, 7), undefined, undefined, false)).toEqual({
       from: 8,
       to: 9,
     });
@@ -52,16 +56,48 @@ describe("resolvePair", () => {
     // History is paginated. Refusing an older pair because it has not been
     // fetched yet would break exactly the shared link this supports; the
     // request that follows is what decides whether those versions exist.
-    expect(resolvePair([9, 8], 2, 3)).toEqual({ from: 2, to: 3 });
+    expect(resolvePair(rows(9, 8), 2, 3, true)).toEqual({ from: 2, to: 3 });
   });
 
   it("refuses when only one half is named, rather than inventing the other", () => {
-    expect(resolvePair([9, 8], 5, undefined)).toEqual({ from: 8, to: 9 });
-    expect(resolvePair([9, 8], undefined, 5)).toEqual({ from: 8, to: 9 });
+    expect(resolvePair(rows(9, 8), 5, undefined, false)).toEqual({
+      from: 8,
+      to: 9,
+    });
+    expect(resolvePair(rows(9, 8), undefined, 5, false)).toEqual({
+      from: 8,
+      to: 9,
+    });
   });
 
   it("has nothing to compare with a single version", () => {
-    expect(resolvePair([1], undefined, undefined)).toBeNull();
-    expect(resolvePair([], undefined, undefined)).toBeNull();
+    expect(resolvePair(rows(1), undefined, undefined, false)).toBeNull();
+    expect(resolvePair([], undefined, undefined, false)).toBeNull();
+  });
+
+  it("MUST NOT default to a pair spanning two locales", () => {
+    // The server rejects a cross-locale pair outright, so defaulting to the two
+    // newest ROWS renders an API error on a page opened with no parameters —
+    // which is how every reader arrives from the history panel.
+    const interleaved = [
+      { versionNo: 5, locale: "en" },
+      { versionNo: 4, locale: "fr" },
+      { versionNo: 3, locale: "en" },
+    ];
+    expect(resolvePair(interleaved, undefined, undefined, false)).toEqual({
+      from: 3,
+      to: 5,
+    });
+  });
+
+  it("refuses a default when the newest version's predecessor has not loaded", () => {
+    // Its locale has one loaded row and more pages exist, so whether anything
+    // older exists is not yet known. Guessing the row below is what produced a
+    // cross-locale pair.
+    const interleaved = [
+      { versionNo: 5, locale: "en" },
+      { versionNo: 4, locale: "fr" },
+    ];
+    expect(resolvePair(interleaved, undefined, undefined, true)).toBeNull();
   });
 });

--- a/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
@@ -40,13 +40,18 @@ describe("resolvePair", () => {
     numbers.map(versionNo => ({ versionNo, locale: null }));
 
   it("takes the pair the URL names", () => {
-    expect(resolvePair(rows(9, 8, 7), 7, 9, false)).toEqual({ from: 7, to: 9 });
+    expect(resolvePair(rows(9, 8, 7), 7, 9, false)).toEqual({
+      kind: "pair",
+      from: 7,
+      to: 9,
+    });
   });
 
   it("defaults to the two newest versions when the URL names none", () => {
     // Arriving without a pair is the ordinary case, and the most recent change
     // is what that reader came for.
     expect(resolvePair(rows(9, 8, 7), undefined, undefined, false)).toEqual({
+      kind: "pair",
       from: 8,
       to: 9,
     });
@@ -56,23 +61,33 @@ describe("resolvePair", () => {
     // History is paginated. Refusing an older pair because it has not been
     // fetched yet would break exactly the shared link this supports; the
     // request that follows is what decides whether those versions exist.
-    expect(resolvePair(rows(9, 8), 2, 3, true)).toEqual({ from: 2, to: 3 });
+    expect(resolvePair(rows(9, 8), 2, 3, true)).toEqual({
+      kind: "pair",
+      from: 2,
+      to: 3,
+    });
   });
 
   it("refuses when only one half is named, rather than inventing the other", () => {
     expect(resolvePair(rows(9, 8), 5, undefined, false)).toEqual({
+      kind: "pair",
       from: 8,
       to: 9,
     });
     expect(resolvePair(rows(9, 8), undefined, 5, false)).toEqual({
+      kind: "pair",
       from: 8,
       to: 9,
     });
   });
 
   it("has nothing to compare with a single version", () => {
-    expect(resolvePair(rows(1), undefined, undefined, false)).toBeNull();
-    expect(resolvePair([], undefined, undefined, false)).toBeNull();
+    expect(resolvePair(rows(1), undefined, undefined, false)).toEqual({
+      kind: "only-version",
+    });
+    expect(resolvePair([], undefined, undefined, false)).toEqual({
+      kind: "no-history",
+    });
   });
 
   it("MUST NOT default to a pair spanning two locales", () => {
@@ -85,6 +100,7 @@ describe("resolvePair", () => {
       { versionNo: 3, locale: "en" },
     ];
     expect(resolvePair(interleaved, undefined, undefined, false)).toEqual({
+      kind: "pair",
       from: 3,
       to: 5,
     });
@@ -98,6 +114,8 @@ describe("resolvePair", () => {
       { versionNo: 5, locale: "en" },
       { versionNo: 4, locale: "fr" },
     ];
-    expect(resolvePair(interleaved, undefined, undefined, true)).toBeNull();
+    expect(resolvePair(interleaved, undefined, undefined, true)).toEqual({
+      kind: "not-loaded",
+    });
   });
 });

--- a/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Guards reading a comparison out of the address bar.
+ *
+ * The pair lives in the URL so it can be shared, which means anyone can type
+ * it. These functions therefore treat the query as untrusted input: the
+ * headline is that nothing a person can put in the address bar reaches a
+ * request as a version number, and that arriving without a pair still shows
+ * something useful rather than an error.
+ */
+import { describe, expect, it } from "vitest";
+
+import { readVersionParam, resolvePair } from "../version-search-params";
+
+describe("readVersionParam", () => {
+  it("reads a version number", () => {
+    expect(readVersionParam("7")).toBe(7);
+  });
+
+  it("takes the first value of a repeated parameter, as a browser does", () => {
+    expect(readVersionParam(["3", "9"])).toBe(3);
+  });
+
+  it("rejects anything that is not a version number", () => {
+    // Version numbers start at one, so zero and negatives are as meaningless
+    // as a word and must not reach a request.
+    for (const value of ["0", "-1", "1.5", "abc", "", "  ", "1e3abc"]) {
+      expect(readVersionParam(value)).toBeUndefined();
+    }
+  });
+
+  it("is undefined when the parameter is absent", () => {
+    expect(readVersionParam(undefined)).toBeUndefined();
+    expect(readVersionParam([])).toBeUndefined();
+  });
+});
+
+describe("resolvePair", () => {
+  it("takes the pair the URL names", () => {
+    expect(resolvePair([9, 8, 7], 7, 9)).toEqual({ from: 7, to: 9 });
+  });
+
+  it("defaults to the two newest versions when the URL names none", () => {
+    // Arriving without a pair is the ordinary case, and the most recent change
+    // is what that reader came for.
+    expect(resolvePair([9, 8, 7], undefined, undefined)).toEqual({
+      from: 8,
+      to: 9,
+    });
+  });
+
+  it("honours a named pair that is not in the loaded page of history", () => {
+    // History is paginated. Refusing an older pair because it has not been
+    // fetched yet would break exactly the shared link this supports; the
+    // request that follows is what decides whether those versions exist.
+    expect(resolvePair([9, 8], 2, 3)).toEqual({ from: 2, to: 3 });
+  });
+
+  it("refuses when only one half is named, rather than inventing the other", () => {
+    expect(resolvePair([9, 8], 5, undefined)).toEqual({ from: 8, to: 9 });
+    expect(resolvePair([9, 8], undefined, 5)).toEqual({ from: 8, to: 9 });
+  });
+
+  it("has nothing to compare with a single version", () => {
+    expect(resolvePair([1], undefined, undefined)).toBeNull();
+    expect(resolvePair([], undefined, undefined)).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/versions/version-pairing.ts
+++ b/packages/admin/src/components/features/versions/version-pairing.ts
@@ -94,20 +94,37 @@ export function predecessorOf(
 }
 
 /**
+ * A pair to compare, or the reason there is none.
+ *
+ * The reasons are kept apart because they are three different situations and a
+ * reader acts differently on each: a document with no history at all, one whose
+ * history holds a single version, and one whose older versions simply have not
+ * been fetched. Collapsing them into a null pair made the pane tell someone
+ * with no versions that they had exactly one.
+ */
+export type PairResolution =
+  | { kind: "pair"; from: number; to: number }
+  | { kind: "no-history" }
+  | { kind: "only-version" }
+  | { kind: "not-loaded" };
+
+/**
  * The pair to compare when the address names none: the newest version and what
  * precedes it, within one locale.
- *
- * Null when there is nothing to compare — a history of one, or a newest version
- * whose predecessor has not loaded. The page says so in words rather than
- * rendering an empty comparison, which would read as "nothing changed".
  */
 export function defaultPair(
   versions: readonly PairableVersion[],
   hasMore: boolean
-): { from: number; to: number } | null {
+): PairResolution {
   const newest = versions.find(v => v.versionNo !== null);
-  if (newest?.versionNo == null) return null;
+  if (newest?.versionNo == null) return { kind: "no-history" };
   const previous = predecessorOf(versions, newest.versionNo, hasMore);
-  if (previous.kind !== "version") return null;
-  return { from: previous.versionNo, to: newest.versionNo };
+  if (previous.kind === "version") {
+    return { kind: "pair", from: previous.versionNo, to: newest.versionNo };
+  }
+  // `first` means this document really does hold one version; `unknown` means
+  // its predecessor is beyond the loaded pages and "Load more" would find it.
+  return previous.kind === "first"
+    ? { kind: "only-version" }
+    : { kind: "not-loaded" };
 }

--- a/packages/admin/src/components/features/versions/version-pairing.ts
+++ b/packages/admin/src/components/features/versions/version-pairing.ts
@@ -1,0 +1,113 @@
+/**
+ * Which version a version is compared against.
+ *
+ * One implementation, because three surfaces ask it — the history panel, the
+ * comparison page's rail, and the page itself — and they had begun to disagree.
+ * The panel answered it within one locale; the page answered it by position in
+ * the flat list, which pairs a version with whatever happens to sit below it.
+ * On a localized document that is a version in another language, and the server
+ * rejects the pair outright.
+ *
+ * Two rules the flat answer cannot express, both of them content rather than
+ * presentation:
+ *
+ * A comparison must stay within ONE LOCALE. A localized document interleaves
+ * its languages in one numbered history, so consecutive numbers routinely
+ * belong to different languages and are not a before-and-after of anything.
+ *
+ * The predecessor is the next-older row IN THAT SET, never `versionNo - 1`.
+ * Retention prunes old versions and leaves gaps in the numbering, so arithmetic
+ * on the number names a version that may no longer exist.
+ *
+ * @module components/features/versions/version-pairing
+ */
+
+/** The least a row must carry to be paired. */
+export interface PairableVersion {
+  versionNo: number | null;
+  locale?: string | null;
+}
+
+/**
+ * What sits before a version in its own locale.
+ *
+ * `unknown` is the entry that matters and the one a boolean cannot hold. A row
+ * at the bottom of a loaded page has no predecessor IN HAND, which is not the
+ * same as having none — and collapsing the two tells a reader that a version
+ * with ten older siblings is the first ever recorded, then makes selecting it
+ * do nothing. The two answers point a reader in opposite directions, so they
+ * are kept apart here rather than repaired in each consumer.
+ */
+export type Predecessor =
+  | { kind: "version"; versionNo: number }
+  | { kind: "first" }
+  | { kind: "unknown" };
+
+/** A row's locale, with an absent one and a null one meaning the same thing. */
+function localeOf(version: PairableVersion): string | null {
+  return version.locale ?? null;
+}
+
+/**
+ * The versions sharing one version's locale, newest first.
+ *
+ * Autosave rows carry a null `versionNo` and cannot be compared, so they are
+ * not in the set — a pair must name two versions the server can fetch.
+ */
+export function sameLocaleVersions<T extends PairableVersion>(
+  versions: readonly T[],
+  versionNo: number
+): T[] {
+  const anchor = versions.find(v => v.versionNo === versionNo);
+  if (anchor === undefined) return [];
+  const locale = localeOf(anchor);
+  return versions.filter(v => v.versionNo !== null && localeOf(v) === locale);
+}
+
+/**
+ * What `versionNo` is compared against.
+ *
+ * `hasMore` is whether the history has pages still unloaded. It is what
+ * separates "there is nothing older" from "nothing older has been fetched", and
+ * a caller that cannot say should pass `true` — claiming a version is the first
+ * on record is the answer that misleads.
+ */
+export function predecessorOf(
+  versions: readonly PairableVersion[],
+  versionNo: number,
+  hasMore: boolean
+): Predecessor {
+  const sameLocale = sameLocaleVersions(versions, versionNo);
+  const index = sameLocale.findIndex(v => v.versionNo === versionNo);
+  // The row itself is not loaded, so nothing about what precedes it is known.
+  if (index === -1) return { kind: "unknown" };
+
+  const previous = sameLocale[index + 1];
+  if (previous?.versionNo != null) {
+    return { kind: "version", versionNo: previous.versionNo };
+  }
+  // Nothing older IN THIS LOCALE has loaded. Whether that is the end of the
+  // history or the end of the page is a question only the pager can answer, and
+  // interleaved locales put a predecessor beyond the page long before the
+  // selected row is the last one loaded overall.
+  return hasMore ? { kind: "unknown" } : { kind: "first" };
+}
+
+/**
+ * The pair to compare when the address names none: the newest version and what
+ * precedes it, within one locale.
+ *
+ * Null when there is nothing to compare — a history of one, or a newest version
+ * whose predecessor has not loaded. The page says so in words rather than
+ * rendering an empty comparison, which would read as "nothing changed".
+ */
+export function defaultPair(
+  versions: readonly PairableVersion[],
+  hasMore: boolean
+): { from: number; to: number } | null {
+  const newest = versions.find(v => v.versionNo !== null);
+  if (newest?.versionNo == null) return null;
+  const previous = predecessorOf(versions, newest.versionNo, hasMore);
+  if (previous.kind !== "version") return null;
+  return { from: previous.versionNo, to: newest.versionNo };
+}

--- a/packages/admin/src/components/features/versions/version-search-params.ts
+++ b/packages/admin/src/components/features/versions/version-search-params.ts
@@ -9,7 +9,11 @@
  * @module components/features/versions/version-search-params
  */
 
-import { defaultPair, type PairableVersion } from "./version-pairing";
+import {
+  defaultPair,
+  type PairableVersion,
+  type PairResolution,
+} from "./version-pairing";
 
 /**
  * One numeric search parameter, or undefined for anything that is not a version
@@ -48,8 +52,8 @@ export function resolvePair(
   from: number | undefined,
   to: number | undefined,
   hasMore: boolean
-): { from: number; to: number } | null {
-  if (from !== undefined && to !== undefined) return { from, to };
+): PairResolution {
+  if (from !== undefined && to !== undefined) return { kind: "pair", from, to };
   // The default pair is derived rather than read off the top of the list: on a
   // localized document the two newest rows are routinely different languages,
   // and the server rejects a cross-locale pair — so a page opened with no

--- a/packages/admin/src/components/features/versions/version-search-params.ts
+++ b/packages/admin/src/components/features/versions/version-search-params.ts
@@ -9,6 +9,8 @@
  * @module components/features/versions/version-search-params
  */
 
+import { defaultPair, type PairableVersion } from "./version-pairing";
+
 /**
  * One numeric search parameter, or undefined for anything that is not a version
  * number. A repeated parameter takes its first value, matching how a browser
@@ -42,12 +44,15 @@ export function readVersionParam(
  * whether the versions exist.
  */
 export function resolvePair(
-  versionNumbers: readonly number[],
+  versions: readonly PairableVersion[],
   from: number | undefined,
-  to: number | undefined
+  to: number | undefined,
+  hasMore: boolean
 ): { from: number; to: number } | null {
   if (from !== undefined && to !== undefined) return { from, to };
-  const [newest, previous] = versionNumbers;
-  if (newest === undefined || previous === undefined) return null;
-  return { from: previous, to: newest };
+  // The default pair is derived rather than read off the top of the list: on a
+  // localized document the two newest rows are routinely different languages,
+  // and the server rejects a cross-locale pair — so a page opened with no
+  // parameters would render an API error instead of the most recent change.
+  return defaultPair(versions, hasMore);
 }

--- a/packages/admin/src/components/features/versions/version-search-params.ts
+++ b/packages/admin/src/components/features/versions/version-search-params.ts
@@ -1,0 +1,53 @@
+/**
+ * Reading a comparison out of the address bar.
+ *
+ * The pair being compared lives in the URL, which makes it something a reader
+ * can send to a colleague — and something anyone can type. So these are written
+ * as pure functions that treat the query as untrusted input and always answer
+ * with something the page can render.
+ *
+ * @module components/features/versions/version-search-params
+ */
+
+/**
+ * One numeric search parameter, or undefined for anything that is not a version
+ * number. A repeated parameter takes its first value, matching how a browser
+ * resolves one.
+ *
+ * Rejects zero and negatives as well as non-numbers: version numbers start at
+ * one, so those are as meaningless as a word and must not reach a request.
+ */
+export function readVersionParam(
+  value: string | string[] | undefined
+): number | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (raw === undefined || raw.trim() === "") return undefined;
+  const parsed = Number(raw);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+/**
+ * The pair to compare: the one the URL names, or the two newest versions.
+ *
+ * Defaulting rather than refusing, because arriving without a pair is the
+ * ordinary case — from the history panel, or from a bookmark of the history
+ * itself — and "the most recent change" is what that reader came for. Null only
+ * when there is genuinely nothing to compare, which the page states in words
+ * rather than showing as an empty comparison.
+ *
+ * A pair the URL names is taken as given even if those versions are not in the
+ * loaded page of history: the list is paginated, and refusing a valid older
+ * pair because it has not been fetched yet would break exactly the shared link
+ * this feature exists to support. The request that follows is what decides
+ * whether the versions exist.
+ */
+export function resolvePair(
+  versionNumbers: readonly number[],
+  from: number | undefined,
+  to: number | undefined
+): { from: number; to: number } | null {
+  if (from !== undefined && to !== undefined) return { from, to };
+  const [newest, previous] = versionNumbers;
+  if (newest === undefined || previous === undefined) return null;
+  return { from: previous, to: newest };
+}

--- a/packages/admin/src/constants/routes.ts
+++ b/packages/admin/src/constants/routes.ts
@@ -66,6 +66,10 @@ export const ROUTES = {
   COLLECTION_ENTRY_CREATE: "/admin/collections/[slug]/create",
   COLLECTION_ENTRY_EDIT: "/admin/collections/[slug]/[id]",
   COLLECTION_ENTRY_API: "/admin/collections/[slug]/api",
+  // A comparison is addressable: the pair being compared lives in the query
+  // (`?from=&to=`), so a reader can send a colleague the exact comparison
+  // rather than a description of how to reach it.
+  COLLECTION_ENTRY_VERSIONS: "/admin/collections/[slug]/[id]/versions",
 
   // Security & Roles routes
   SECURITY_ROLES: "/admin/security/roles",
@@ -76,6 +80,7 @@ export const ROUTES = {
   // CONTENT urls, not Builder urls; they stay under /admin/singles/*).
   SINGLE_EDIT: "/admin/singles/[slug]",
   SINGLE_API: "/admin/singles/[slug]/api",
+  SINGLE_VERSIONS: "/admin/singles/[slug]/versions",
 
   // Settings routes
   SETTINGS: "/admin/settings",

--- a/packages/admin/src/hooks/queries/useVersions.ts
+++ b/packages/admin/src/hooks/queries/useVersions.ts
@@ -43,7 +43,7 @@ const PAGE_SIZE = 25;
  * only on the slug would let a client that fetched before the recreation
  * re-render those cached pages without asking again.
  */
-function scopeKey(scope: VersionScope): readonly string[] {
+export function scopeKey(scope: VersionScope): readonly string[] {
   return scope.kind === "single"
     ? ["single", scope.slug, scope.documentId]
     : ["collection", scope.slug, scope.entryId];

--- a/packages/admin/src/lib/routing.ts
+++ b/packages/admin/src/lib/routing.ts
@@ -155,11 +155,19 @@ function getDynamicRequiredPermission(
   if (pattern === ROUTES.COLLECTION_ENTRY_API) {
     return slug ? `read-${slug}` : undefined;
   }
+  // Reading a document's history is a read of that document, and restoring
+  // from it goes through the ordinary update path with its own check.
+  if (pattern === ROUTES.COLLECTION_ENTRY_VERSIONS) {
+    return slug ? `read-${slug}` : undefined;
+  }
 
   if (pattern === ROUTES.SINGLE_EDIT) {
     return slug ? `update-${slug}` : undefined;
   }
   if (pattern === ROUTES.SINGLE_API) {
+    return slug ? `read-${slug}` : undefined;
+  }
+  if (pattern === ROUTES.SINGLE_VERSIONS) {
     return slug ? `read-${slug}` : undefined;
   }
 

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
@@ -1,0 +1,30 @@
+/**
+ * A collection entry's version history, as a page.
+ *
+ * Accessible via /admin/collections/[slug]/[id]/versions, optionally with the
+ * pair to compare in the query (`?from=&to=`).
+ *
+ * A wrapper rather than an implementation: the collection and single routes
+ * show the same page, and keeping two copies is how they drift.
+ *
+ * @module pages/dashboard/entries/[slug]/[id]/versions
+ */
+
+import { readVersionParam } from "@admin/components/features/versions/version-search-params";
+import { VersionComparePage } from "@admin/components/features/versions/VersionComparePage";
+import { ROUTES, buildRoute } from "@admin/constants/routes";
+import type { PageProps } from "@admin/lib/routing";
+
+export default function EntryVersionsPage({ params, searchParams }: PageProps) {
+  const slug = typeof params?.slug === "string" ? params.slug : "";
+  const id = typeof params?.id === "string" ? params.id : "";
+
+  return (
+    <VersionComparePage
+      scope={{ kind: "collection", slug, entryId: id }}
+      documentHref={buildRoute(ROUTES.COLLECTION_ENTRY_EDIT, { slug, id })}
+      from={readVersionParam(searchParams?.from)}
+      to={readVersionParam(searchParams?.to)}
+    />
+  );
+}

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
@@ -23,6 +23,10 @@ export default function EntryVersionsPage({ params, searchParams }: PageProps) {
     <VersionComparePage
       scope={{ kind: "collection", slug, entryId: id }}
       documentHref={buildRoute(ROUTES.COLLECTION_ENTRY_EDIT, { slug, id })}
+      // Reaching this page needs `read-${slug}`; the editor needs
+      // `update-${slug}`. The entry list needs only the former, so it is where a
+      // read-only viewer can actually go back to.
+      readOnlyHref={buildRoute(ROUTES.COLLECTION_ENTRIES, { slug })}
       from={readVersionParam(searchParams?.from)}
       to={readVersionParam(searchParams?.to)}
     />

--- a/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
@@ -47,9 +47,12 @@ export default function SingleVersionsPage({
       scope={{ kind: "single", slug, documentId: String(documentId) }}
       documentHref={buildRoute(ROUTES.SINGLE_EDIT, { slug })}
       // Reaching this page needs `read-${slug}`; the single's own editor needs
-      // `update-${slug}`. The singles index carries no per-document permission,
-      // so it is reachable by anyone who could open this history.
-      readOnlyHref={ROUTES.SINGLES}
+      // `update-${slug}`. `/admin/singles` is NOT the readable alternative it
+      // looks like: it redirects straight to the first single the viewer can
+      // READ, and that destination is guarded on `update-`. So a read-only
+      // viewer would land on permission-denied by a longer route. The dashboard
+      // is reachable by anyone who can reach this page at all.
+      readOnlyHref={ROUTES.DASHBOARD}
       from={readVersionParam(searchParams?.from)}
       to={readVersionParam(searchParams?.to)}
     />

--- a/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
@@ -46,6 +46,10 @@ export default function SingleVersionsPage({
     <VersionComparePage
       scope={{ kind: "single", slug, documentId: String(documentId) }}
       documentHref={buildRoute(ROUTES.SINGLE_EDIT, { slug })}
+      // Reaching this page needs `read-${slug}`; the single's own editor needs
+      // `update-${slug}`. The singles index carries no per-document permission,
+      // so it is reachable by anyone who could open this history.
+      readOnlyHref={ROUTES.SINGLES}
       from={readVersionParam(searchParams?.from)}
       to={readVersionParam(searchParams?.to)}
     />

--- a/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
@@ -1,0 +1,53 @@
+/**
+ * A single's version history, as a page.
+ *
+ * Accessible via /admin/singles/[slug]/versions, optionally with the pair to
+ * compare in the query (`?from=&to=`). Wraps the same page the collection
+ * route shows.
+ *
+ * A single is addressed by slug, but its version scope also carries the live
+ * document's id — not to reach the server, which resolves the document itself,
+ * but so a client cache can tell one incarnation of a Single from a recreated
+ * one. So this route reads the document before it can name the scope.
+ *
+ * @module pages/dashboard/singles/[slug]/versions
+ */
+
+import { readVersionParam } from "@admin/components/features/versions/version-search-params";
+import { VersionComparePage } from "@admin/components/features/versions/VersionComparePage";
+import { ROUTES, buildRoute } from "@admin/constants/routes";
+import { useSingleDocument } from "@admin/hooks/queries/useSingles";
+import type { PageProps } from "@admin/lib/routing";
+
+export default function SingleVersionsPage({
+  params,
+  searchParams,
+}: PageProps) {
+  const slug = typeof params?.slug === "string" ? params.slug : "";
+  const document = useSingleDocument(slug);
+  const documentId = document.data?.id;
+
+  // Nothing is rendered until the document's identity is known: a scope built
+  // with a placeholder id would key the cache to a document that does not
+  // exist, and the comparison it served would belong to nothing.
+  if (documentId === undefined) {
+    return (
+      <div className="px-4 py-8 text-center">
+        <p className="text-sm text-muted-foreground">
+          {document.isError
+            ? "This document could not be loaded."
+            : "Loading history…"}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <VersionComparePage
+      scope={{ kind: "single", slug, documentId: String(documentId) }}
+      documentHref={buildRoute(ROUTES.SINGLE_EDIT, { slug })}
+      from={readVersionParam(searchParams?.from)}
+      to={readVersionParam(searchParams?.to)}
+    />
+  );
+}

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -18,6 +18,7 @@ import SetupPage from "./(auth)/setup";
 import VerifyEmailPage from "./(auth)/verify-email";
 import CollectionsPage from "./dashboard/collection/index";
 import EditEntryPage from "./dashboard/entries/[slug]/[id]/index";
+import EntryVersionsPage from "./dashboard/entries/[slug]/[id]/versions";
 import APIPlaygroundPage from "./dashboard/entries/[slug]/api";
 import CreateEntryPage from "./dashboard/entries/[slug]/create";
 import CollectionEntriesPage from "./dashboard/entries/[slug]/index";
@@ -55,6 +56,7 @@ import EditWebhookPage from "./dashboard/settings/webhooks/edit/[id]";
 import WebhooksPage from "./dashboard/settings/webhooks/index";
 import SingleAPIPlaygroundPage from "./dashboard/singles/[slug]/api";
 import SingleEditPage from "./dashboard/singles/[slug]/index";
+import SingleVersionsPage from "./dashboard/singles/[slug]/versions";
 import SinglesPage from "./dashboard/singles/index";
 import CreateUserPage from "./dashboard/users/create";
 import EditUserPage from "./dashboard/users/edit";
@@ -253,6 +255,15 @@ export const routeConfig: Record<string, RouteConfig> = {
     type: "private",
     section: collectionContentSection,
   },
+  // Before the wildcard [id] route, matching the convention above. The
+  // matcher's patterns are anchored so a four-segment path cannot be taken by
+  // the two-segment edit route, but keeping the order makes that independent of
+  // how the matcher is written.
+  [ROUTES.COLLECTION_ENTRY_VERSIONS]: {
+    component: EntryVersionsPage,
+    type: "private",
+    section: collectionContentSection,
+  },
   [ROUTES.COLLECTION_ENTRY_EDIT]: {
     component: EditEntryPage,
     type: "private",
@@ -306,6 +317,11 @@ export const routeConfig: Record<string, RouteConfig> = {
   // IMPORTANT: literal segments like /api must be registered before the wildcard [slug].
   [ROUTES.SINGLE_API]: {
     component: SingleAPIPlaygroundPage,
+    type: "private",
+    section: overridableBy("singles"),
+  },
+  [ROUTES.SINGLE_VERSIONS]: {
+    component: SingleVersionsPage,
     type: "private",
     section: overridableBy("singles"),
   },


### PR DESCRIPTION
## Summary

Version comparison gets a page. This is the surface decision from the R-12
design — Option B.

Comparing from the history panel meant opening a dialog **on top of** it: two
floating surfaces at once, over a document you could no longer see, with the
comparison squeezed into whatever a 480px panel left over. That stacking, not
the missing close button, was most of what made it confusing.

**The pair is in the URL** (`?from=&to=`), which is the concrete reason this is
a route rather than a bigger dialog: a comparison can be linked into a review
rather than described. Selecting a row rewrites the address, so what is on
screen is always what the address names.

## What is here

- `/admin/collections/[slug]/[id]/versions` and `/admin/singles/[slug]/versions`
- **Timeline rail** — versions newest-first, each row naming its author, when
  it was written, and **what changed in it, by field name**
- **Full-width comparison** beside it, no floating surfaces
- The history panel keeps its place for a quick look beside the document, and
  gains an **Open full comparison** control

## Independent of #1242, deliberately

This branches off `main`, not off #1242. The page is a **surface** that hosts
`VersionDiffView`, which is already on main — so it gets full CI rather than
the nothing a stacked PR gets on this repo (`ci.yml`, `integration.yml` and two
others are `pull_request: branches: [main]`, so a PR based on a feature branch
never triggers them).

**Consequence, stated plainly:** the screenshots below show the comparison
rendering as unmarked Before/After, because the rich-text and source renderers
live in #1242. Nothing is wrong — when #1242 merges, this page shows the marked
comparison with no further change. The two PRs are orthogonal and can merge in
either order.

## Decisions worth reviewing

**Row summaries are derived, never stored.** Persisting "2 fields changed" at
capture time would need a schema migration and would hold a value that goes
stale when the schema changes underneath it — it could name fields that no
longer exist. `VersionSummaryLine` is ONE component used by both the rail and
(later) the panel: two answers to the same question drift, silently, because
each looks right beside its own list. Only the first 12 rows fetch, so a long
history does not issue a request per row on mount.

**A named pair is honoured even when it is not in the loaded page of history.**
History is paginated; refusing an older pair because it has not been fetched
would break exactly the shared link this exists to support. The request decides
whether those versions exist.

**The singles route reads the document before it can name its scope.** A single
is addressed by slug, but `VersionScope` also carries the live document's id —
not to reach the server, which resolves the document itself, but so a client
cache can tell one incarnation of a Single from a recreated one. Rendering with
a placeholder id would key the cache to a document that does not exist.

**`EntrySystemHeader.tsx` is untouched** — it is held by another lane for R-11,
and I yielded it. The entry point to this page is the history panel instead.

## Test plan

`version-search-params.ts` holds the pure logic, tested separately from any
render. The query is treated as **untrusted input**, since a shareable URL is
one anyone can type: `0`, `-1`, `1.5`, `abc`, `""`, `"  "` and a repeated
parameter are all covered, and nothing that is not a version number reaches a
request.

**Verified in the running admin**, both themes:

| checked | result |
| --- | --- |
| direct navigation to `?from=10&to=11` | page renders, correct pair |
| selecting a rail row | URL becomes `?from=6&to=7` |
| browser back | returns to the previous comparison |
| back-to-document control | returns to the entry |
| panel's "Open full comparison" | opens the page with the pair pre-selected |
| dark mode | reads correctly |
| console | clean |

| check | result |
| --- | --- |
| `pnpm build` | EXIT=0 |
| `pnpm check-types` | EXIT=0 |
| `pnpm lint` | EXIT=0 |
| `pnpm lint:design` | EXIT=0 |
| `pnpm --filter @nextlyhq/admin test -- versions` | 211/211 |
| `fallow audit --gate-marker agent` | **pass** — 0 introduced |

## Changeset

Changeset added: **yes (patch)**, all published packages, alpha lockstep.

## Pre-existing failures, listed so they are not read as regressions

`pnpm --filter @nextlyhq/admin test` reports 15 failures across 4 files —
`dashboard/StatsCard`, `schema-builder/BasicsTab`, `SlugInput`,
`DefaultValueField`. Proven pre-existing on #1236 by stashing and re-running on
a clean tree. None is in `features/versions/**`.

## Context

Task 6 of 6, the last in R-12. #1236 (panel close) merged; #1239 (alignment)
merged; #1242 (rich text + json/code + renderers) open.
