### PR TITLE
feat(plugin-page-builder): find the blocks fields the index is responsible for

### DIFF
--- a/.changeset/class-usage-blocks-field-filter.md
+++ b/.changeset/class-usage-blocks-field-filter.md
@@ -49,11 +49,18 @@ the fields declared after the cycle, and an empty result is indistinguishable fr
 collection that declares no blocks field - every class the document applies would have read
 as unused.
 
-A group with a very long field list is read without failing. The walk holds a cursor into each
-list where it lies rather than moving children into a queue: moving them passes each one as an
-argument, which reaches the engine's limit at around a hundred thousand and throws before the
-visit bound can apply. Maintenance runs after the document has committed, so a throw there
-reports a failed save for one that succeeded.
+A group with a very long field list is read whole. The walk holds a cursor into each list where
+it lies rather than moving children into a queue: moving them passes each one as an argument,
+which reaches the engine's limit at around a hundred thousand and throws. Maintenance runs
+after the document has committed, so a throw there reports a failed save for one that
+succeeded.
+
+There is no cap on how many declarations are visited. Expanding each group at most once is
+what makes the walk finite, and it is sufficient - a cap beside it would end a cyclic walk
+without reaching the fields the cycle hides, and on a merely LONG list it stops partway and
+returns fewer descriptors while reporting nothing, so those documents' classes go unindexed
+and read as unused. Nothing validates a field count, so a long list is legal configuration
+rather than evidence the config is wrong.
 
 Whether a field stores per language is decided by the collection's localization master switch
 together with the field's own flag, through the same classifier storage obeys. A field flagged

--- a/.changeset/class-usage-blocks-field-filter.md
+++ b/.changeset/class-usage-blocks-field-filter.md
@@ -37,8 +37,29 @@ entirely, and a class the page still renders would then read as unused. A NAMED 
 repeater stay excluded, because their children are reachable only through a path the rebuild
 cannot resolve - indexing those would write rows nothing could ever reconcile or sweep.
 
+A group whose name is the EMPTY STRING is presentational too. That is what a host writes for
+a layout group it gave no key, and core resolves references and redacts paths through such a
+group at the parent level - so one definition of "has a name" now answers both questions this
+filter asks, and a group cannot be read as named while the blocks field inside it is read as
+unaddressable.
+
+A group that contains itself no longer hides its siblings. Expansion is tracked by identity,
+so a cyclic group is descended into once; a bound alone ended the walk without ever reaching
+the fields declared after the cycle, and an empty result is indistinguishable from a
+collection that declares no blocks field - every class the document applies would have read
+as unused.
+
+Whether a field stores per language is decided by the collection's localization master switch
+together with the field's own flag, through the same classifier storage obeys. A field flagged
+localized on a collection that stores no translations is held ONCE, under the empty locale
+key; reading the flag alone enumerated a subject per configured language and left the single
+subject a read resolves to holding no rows at all. The filter therefore takes the collection
+rather than its field list, because pairing one collection's fields with another's switch
+would produce subjects under locales that collection never stores.
+
 Configuration is read defensively, because it arrives as whatever the host wrote, including
-from untyped JavaScript and the Schema Builder's stored JSON. A localized flag is read as a
-strict boolean, so a stored string does not file one document's classes under every language.
-A field with no usable name is skipped rather than defaulted, since the name is the column
-every row is keyed by. A duplicate name yields one subject rather than two.
+from untyped JavaScript and the Schema Builder's stored JSON. The localized flag and the
+master switch are both read as strict booleans, so a stored string does not file one
+document's classes under every language. A field with no usable name is skipped rather than
+defaulted, since the name is the column every row is keyed by. A duplicate name yields one
+subject rather than two.

--- a/.changeset/class-usage-blocks-field-filter.md
+++ b/.changeset/class-usage-blocks-field-filter.md
@@ -1,0 +1,44 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The class-usage index now finds the blocks fields it is responsible for by reading a
+collection's LIVE configuration, so a collection created after the plugin was wired - or a
+blocks field added to an existing one - is tracked rather than missed.
+
+A blocks field inside a PRESENTATIONAL group is found. A group without a name stores nothing
+of its own and its children live at the parent path, so such a field is reached the same way
+a top-level one is; skipping it would leave that document's classes out of the index
+entirely, and a class the page still renders would then read as unused. A NAMED group and a
+repeater stay excluded, because their children are reachable only through a path the rebuild
+cannot resolve - indexing those would write rows nothing could ever reconcile or sweep.
+
+Configuration is read defensively, because it arrives as whatever the host wrote, including
+from untyped JavaScript and the Schema Builder's stored JSON. A localized flag is read as a
+strict boolean, so a stored string does not file one document's classes under every language.
+A field with no usable name is skipped rather than defaulted, since the name is the column
+every row is keyed by. A duplicate name yields one subject rather than two.

--- a/.changeset/class-usage-blocks-field-filter.md
+++ b/.changeset/class-usage-blocks-field-filter.md
@@ -49,6 +49,12 @@ the fields declared after the cycle, and an empty result is indistinguishable fr
 collection that declares no blocks field - every class the document applies would have read
 as unused.
 
+A group with a very long field list is read without failing. The walk holds a cursor into each
+list where it lies rather than moving children into a queue: moving them passes each one as an
+argument, which reaches the engine's limit at around a hundred thousand and throws before the
+visit bound can apply. Maintenance runs after the document has committed, so a throw there
+reports a failed save for one that succeeded.
+
 Whether a field stores per language is decided by the collection's localization master switch
 together with the field's own flag, through the same classifier storage obeys. A field flagged
 localized on a collection that stores no translations is held ONCE, under the empty locale

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Whether the write path's filter finds the fields it is responsible for, and
+ * only those.
+ *
+ * Both directions cost something specific. A field missed is a field whose
+ * classes are never counted, so they read as unused and can be deleted while a
+ * page still renders them. A field wrongly included writes rows under a subject
+ * no document backs, and nothing downstream can tell them from real ones.
+ *
+ * @module class-usage-blocks-fields.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { blocksFieldsOf } from "./class-usage-blocks-fields";
+
+describe("finding the blocks fields on a collection", () => {
+  it("returns the blocks fields and ignores every other type", () => {
+    const fields = blocksFieldsOf([
+      { type: "text", name: "title" },
+      { type: "blocks", name: "content" },
+      { type: "richText", name: "summary" },
+      { type: "blocks", name: "sidebar" },
+    ]);
+
+    expect(fields).toEqual([
+      { name: "content", localized: false },
+      { name: "sidebar", localized: false },
+    ]);
+  });
+
+  it("returns nothing for a collection that declares none", () => {
+    // The common case. The hook fires for EVERY collection, so most calls reach
+    // here with nothing to do, and an empty list is what makes the filter live
+    // in one place instead of in every caller.
+    expect(blocksFieldsOf([{ type: "text", name: "title" }])).toEqual([]);
+  });
+
+  it("carries a field's own localized flag", () => {
+    const fields = blocksFieldsOf([
+      { type: "blocks", name: "content", localized: true },
+      { type: "blocks", name: "sidebar", localized: false },
+    ]);
+
+    expect(fields).toEqual([
+      { name: "content", localized: true },
+      { name: "sidebar", localized: false },
+    ]);
+  });
+});
+
+describe("configuration that did not come from TypeScript", () => {
+  it('reads a STRING "true" as not localized rather than as localized', () => {
+    // Config reaches a hook as whatever the host wrote, and the Schema
+    // Builder's stored payloads are JSON. A truthiness check would read this as
+    // localized and file one document's classes under every language, leaving
+    // the subject a read actually resolves holding none.
+    const fields = blocksFieldsOf([
+      { type: "blocks", name: "content", localized: "true" },
+    ]);
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("skips a field with no usable name", () => {
+    // The name IS the `field` column of every row. Defaulting it would collect
+    // every unnamed field's rows into one subject, and the reconciler would
+    // then delete each field's rows on behalf of the others.
+    const fields = blocksFieldsOf([
+      { type: "blocks" },
+      { type: "blocks", name: "" },
+      { type: "blocks", name: 42 },
+      { type: "blocks", name: "content" },
+    ]);
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("survives entries that are not objects at all", () => {
+    const fields = blocksFieldsOf([
+      null,
+      undefined,
+      "blocks",
+      7,
+      { type: "blocks", name: "content" },
+    ]);
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("returns nothing when `fields` is absent or not an array", () => {
+    expect(blocksFieldsOf(undefined)).toEqual([]);
+    expect(blocksFieldsOf("content" as unknown as unknown[])).toEqual([]);
+  });
+});
+
+describe("two fields declared under one name", () => {
+  it("yields ONE subject rather than two", () => {
+    // A duplicate name addresses one subject. Enumerating it twice reconciles
+    // the same rows twice in a single pass, and the second pass reads the
+    // first's inserts as rows the document no longer justifies — so a correct
+    // document would end with its own classes deleted.
+    const fields = blocksFieldsOf([
+      { type: "blocks", name: "content" },
+      { type: "blocks", name: "content", localized: true },
+    ]);
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+});

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
@@ -15,12 +15,14 @@ import { blocksFieldsOf } from "./class-usage-blocks-fields";
 
 describe("finding the blocks fields on a collection", () => {
   it("returns the blocks fields and ignores every other type", () => {
-    const fields = blocksFieldsOf([
-      { type: "text", name: "title" },
-      { type: "blocks", name: "content" },
-      { type: "richText", name: "summary" },
-      { type: "blocks", name: "sidebar" },
-    ]);
+    const fields = blocksFieldsOf({
+      fields: [
+        { type: "text", name: "title" },
+        { type: "blocks", name: "content" },
+        { type: "richText", name: "summary" },
+        { type: "blocks", name: "sidebar" },
+      ],
+    });
 
     expect(fields).toEqual([
       { name: "content", localized: false },
@@ -32,19 +34,61 @@ describe("finding the blocks fields on a collection", () => {
     // The common case. The hook fires for EVERY collection, so most calls reach
     // here with nothing to do, and an empty list is what makes the filter live
     // in one place instead of in every caller.
-    expect(blocksFieldsOf([{ type: "text", name: "title" }])).toEqual([]);
+    expect(
+      blocksFieldsOf({ fields: [{ type: "text", name: "title" }] })
+    ).toEqual([]);
   });
 
-  it("carries a field's own localized flag", () => {
-    const fields = blocksFieldsOf([
-      { type: "blocks", name: "content", localized: true },
-      { type: "blocks", name: "sidebar", localized: false },
-    ]);
+  it("carries a field's own localized flag on a localized collection", () => {
+    const fields = blocksFieldsOf({
+      localized: true,
+      fields: [
+        { type: "blocks", name: "content", localized: true },
+        { type: "blocks", name: "sidebar", localized: false },
+      ],
+    });
 
     expect(fields).toEqual([
       { name: "content", localized: true },
       { name: "sidebar", localized: false },
     ]);
+  });
+});
+
+describe("the collection's localization master switch", () => {
+  it("reads a localized FIELD as shared when the COLLECTION is not localized", () => {
+    // The switch is what storage obeys: a collection that stores no
+    // translations keeps one value for this field under the empty locale key,
+    // whatever the field declares. Reading the field flag alone would enumerate
+    // a subject per configured language and leave the one subject a read
+    // resolves to holding no rows — so the document's classes would be absent
+    // from every count that matters.
+    const fields = blocksFieldsOf({
+      localized: false,
+      fields: [{ type: "blocks", name: "content", localized: true }],
+    });
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("treats an ABSENT switch as off, which is the schema's default", () => {
+    const fields = blocksFieldsOf({
+      fields: [{ type: "blocks", name: "content", localized: true }],
+    });
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("leaves an unflagged field shared even when the collection is localized", () => {
+    // The control on the pair above: a switch that simply overwrote the field's
+    // answer would satisfy those two and this one would come out localized.
+    // A blocks field has no per-type default, so it stays shared until asked.
+    const fields = blocksFieldsOf({
+      localized: true,
+      fields: [{ type: "blocks", name: "content" }],
+    });
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
   });
 });
 
@@ -54,9 +98,19 @@ describe("configuration that did not come from TypeScript", () => {
     // Builder's stored payloads are JSON. A truthiness check would read this as
     // localized and file one document's classes under every language, leaving
     // the subject a read actually resolves holding none.
-    const fields = blocksFieldsOf([
-      { type: "blocks", name: "content", localized: "true" },
-    ]);
+    const fields = blocksFieldsOf({
+      localized: true,
+      fields: [{ type: "blocks", name: "content", localized: "true" }],
+    });
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("reads a STRING master switch as off rather than as on", () => {
+    const fields = blocksFieldsOf({
+      localized: "true",
+      fields: [{ type: "blocks", name: "content", localized: true }],
+    });
 
     expect(fields).toEqual([{ name: "content", localized: false }]);
   });
@@ -65,31 +119,37 @@ describe("configuration that did not come from TypeScript", () => {
     // The name IS the `field` column of every row. Defaulting it would collect
     // every unnamed field's rows into one subject, and the reconciler would
     // then delete each field's rows on behalf of the others.
-    const fields = blocksFieldsOf([
-      { type: "blocks" },
-      { type: "blocks", name: "" },
-      { type: "blocks", name: 42 },
-      { type: "blocks", name: "content" },
-    ]);
+    const fields = blocksFieldsOf({
+      fields: [
+        { type: "blocks" },
+        { type: "blocks", name: "" },
+        { type: "blocks", name: 42 },
+        { type: "blocks", name: "content" },
+      ],
+    });
 
     expect(fields).toEqual([{ name: "content", localized: false }]);
   });
 
   it("survives entries that are not objects at all", () => {
-    const fields = blocksFieldsOf([
-      null,
-      undefined,
-      "blocks",
-      7,
-      { type: "blocks", name: "content" },
-    ]);
+    const fields = blocksFieldsOf({
+      fields: [
+        null,
+        undefined,
+        "blocks",
+        7,
+        { type: "blocks", name: "content" },
+      ],
+    });
 
     expect(fields).toEqual([{ name: "content", localized: false }]);
   });
 
-  it("returns nothing when `fields` is absent or not an array", () => {
+  it("returns nothing when the collection or its `fields` is absent", () => {
     expect(blocksFieldsOf(undefined)).toEqual([]);
-    expect(blocksFieldsOf("content" as unknown as unknown[])).toEqual([]);
+    expect(blocksFieldsOf(null)).toEqual([]);
+    expect(blocksFieldsOf({})).toEqual([]);
+    expect(blocksFieldsOf({ fields: "content" })).toEqual([]);
   });
 });
 
@@ -99,10 +159,13 @@ describe("two fields declared under one name", () => {
     // the same rows twice in a single pass, and the second pass reads the
     // first's inserts as rows the document no longer justifies — so a correct
     // document would end with its own classes deleted.
-    const fields = blocksFieldsOf([
-      { type: "blocks", name: "content" },
-      { type: "blocks", name: "content", localized: true },
-    ]);
+    const fields = blocksFieldsOf({
+      localized: true,
+      fields: [
+        { type: "blocks", name: "content" },
+        { type: "blocks", name: "content", localized: true },
+      ],
+    });
 
     expect(fields).toEqual([{ name: "content", localized: false }]);
   });
@@ -115,10 +178,31 @@ describe("a blocks field inside a group", () => {
     // top-level declaration, and skipping it would leave the document's classes
     // out of the index entirely: a class the page still renders would read as
     // unused and could be deleted.
-    const fields = blocksFieldsOf([
-      { type: "text", name: "title" },
-      { type: "group", fields: [{ type: "blocks", name: "content" }] },
-    ]);
+    const fields = blocksFieldsOf({
+      fields: [
+        { type: "text", name: "title" },
+        { type: "group", fields: [{ type: "blocks", name: "content" }] },
+      ],
+    });
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("is FOUND when the group's name is the empty string", () => {
+    // An empty name is what a host writes for a layout group it gave no key,
+    // and core resolves references and redacts paths through such a group at
+    // the PARENT level. Treating it as named here would put the child behind a
+    // path storage never uses, so the document's classes would be missing from
+    // the index while the page still renders them.
+    const fields = blocksFieldsOf({
+      fields: [
+        {
+          type: "group",
+          name: "",
+          fields: [{ type: "blocks", name: "content" }],
+        },
+      ],
+    });
 
     expect(fields).toEqual([{ name: "content", localized: false }]);
   });
@@ -129,46 +213,80 @@ describe("a blocks field inside a group", () => {
     // would file rows no rebuild could reconcile or sweep — the permanently
     // stranded state.
     //
-    // This is the control on the case above: without it, a walk that descended
-    // into EVERY group would satisfy that assertion just as well.
-    const fields = blocksFieldsOf([
-      {
-        type: "group",
-        name: "seo",
-        fields: [{ type: "blocks", name: "body" }],
-      },
-    ]);
+    // This is the control on the cases above: without it, a walk that descended
+    // into EVERY group would satisfy those assertions just as well.
+    const fields = blocksFieldsOf({
+      fields: [
+        {
+          type: "group",
+          name: "seo",
+          fields: [{ type: "blocks", name: "body" }],
+        },
+      ],
+    });
 
     expect(fields).toEqual([]);
   });
 
   it("descends through presentational groups nested in each other", () => {
-    const fields = blocksFieldsOf([
-      {
-        type: "group",
-        fields: [{ type: "group", fields: [{ type: "blocks", name: "deep" }] }],
-      },
-    ]);
+    const fields = blocksFieldsOf({
+      fields: [
+        {
+          type: "group",
+          fields: [
+            { type: "group", fields: [{ type: "blocks", name: "deep" }] },
+          ],
+        },
+      ],
+    });
 
     expect(fields).toEqual([{ name: "deep", localized: false }]);
   });
 
   it("does not descend into a repeater", () => {
     // A repeater's children are per-row, so there is no single parent path.
-    const fields = blocksFieldsOf([
-      { type: "repeater", fields: [{ type: "blocks", name: "row" }] },
-    ]);
+    const fields = blocksFieldsOf({
+      fields: [{ type: "repeater", fields: [{ type: "blocks", name: "row" }] }],
+    });
 
     expect(fields).toEqual([]);
   });
+});
 
-  it("terminates on a group that contains itself", () => {
-    // Configuration is author-supplied and can be cyclic. Without a bound this
-    // walk would spin, and the failure would be a hung save rather than a
-    // visible error.
+describe("a group that contains itself", () => {
+  it("still returns the sibling declared AFTER the cycle", () => {
+    // Configuration is author-supplied and can be cyclic. Terminating is not
+    // enough on its own: a walk that only counted iterations would put the
+    // group back at the front of the queue every time, exhaust its bound
+    // without ever reaching this sibling, and return an empty list — which is
+    // indistinguishable from a collection that declares no blocks field, so
+    // every class the document applies would read as unused.
+    //
+    // The cycle is listed FIRST deliberately. Behind it, the sibling is only
+    // reachable once the group stops being re-expanded.
     const cyclic: Record<string, unknown> = { type: "group" };
     cyclic.fields = [cyclic, { type: "blocks", name: "content" }];
 
-    expect(() => blocksFieldsOf([cyclic])).not.toThrow();
+    const fields = blocksFieldsOf({ fields: [cyclic] });
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("terminates rather than throwing", () => {
+    const cyclic: Record<string, unknown> = { type: "group" };
+    cyclic.fields = [cyclic];
+
+    expect(() => blocksFieldsOf({ fields: [cyclic] })).not.toThrow();
+  });
+
+  it("finds a field through two groups that contain each other", () => {
+    const outer: Record<string, unknown> = { type: "group" };
+    const inner: Record<string, unknown> = { type: "group" };
+    outer.fields = [inner];
+    inner.fields = [outer, { type: "blocks", name: "content" }];
+
+    expect(blocksFieldsOf({ fields: [outer] })).toEqual([
+      { name: "content", localized: false },
+    ]);
   });
 });

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
@@ -315,4 +315,26 @@ describe("a presentational group with a very large field list", () => {
       { name: "content", localized: false },
     ]);
   });
+
+  it("returns a field declared AFTER the wide filler, not only before it", () => {
+    // The case a visit bound silently loses. Nothing validates a field count,
+    // so a long list is legal configuration, and a walk that stops partway
+    // returns fewer descriptors while reporting nothing — the document's
+    // classes are then absent from the index and read as unused.
+    //
+    // Placing the field last is the whole point: with it first, a truncating
+    // walk satisfies the assertion above and the loss is invisible.
+    const filler = { type: "text", name: "filler" };
+    const wide = {
+      type: "group",
+      fields: [
+        ...new Array<unknown>(200_000).fill(filler),
+        { type: "blocks", name: "content" },
+      ],
+    };
+
+    expect(blocksFieldsOf({ fields: [wide] })).toEqual([
+      { name: "content", localized: false },
+    ]);
+  });
 });

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
@@ -290,3 +290,29 @@ describe("a group that contains itself", () => {
     ]);
   });
 });
+
+describe("a presentational group with a very large field list", () => {
+  it("reads it without throwing, and still returns the field inside", () => {
+    // The bound cannot protect a list that fails while being MOVED. Passing a
+    // group's children as arguments reaches the engine's argument limit — a
+    // measured 125,000 on the supported runtime — and the throw happens before
+    // any visit is counted. This runs after the document has committed, so a
+    // throw there reports a failed save for one that succeeded.
+    //
+    // Asserting the field is returned rather than only that nothing threw: a
+    // walk that gave up on the group would satisfy `not.toThrow` while leaving
+    // the document's classes out of the index entirely.
+    const filler = { type: "text", name: "filler" };
+    const wide = {
+      type: "group",
+      fields: [
+        { type: "blocks", name: "content" },
+        ...new Array<unknown>(200_000).fill(filler),
+      ],
+    };
+
+    expect(blocksFieldsOf({ fields: [wide] })).toEqual([
+      { name: "content", localized: false },
+    ]);
+  });
+});

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.test.ts
@@ -107,3 +107,68 @@ describe("two fields declared under one name", () => {
     expect(fields).toEqual([{ name: "content", localized: false }]);
   });
 });
+
+describe("a blocks field inside a group", () => {
+  it("is FOUND when the group is presentational (nameless)", () => {
+    // A group without a `name` stores nothing of its own — its children live at
+    // the parent path. So `item.content` resolves this exactly as it would a
+    // top-level declaration, and skipping it would leave the document's classes
+    // out of the index entirely: a class the page still renders would read as
+    // unused and could be deleted.
+    const fields = blocksFieldsOf([
+      { type: "text", name: "title" },
+      { type: "group", fields: [{ type: "blocks", name: "content" }] },
+    ]);
+
+    expect(fields).toEqual([{ name: "content", localized: false }]);
+  });
+
+  it("is NOT found when the group is named", () => {
+    // A named group nests its data under its own key, so the child is reachable
+    // only through a path neither this nor the rebuild resolves. Indexing it
+    // would file rows no rebuild could reconcile or sweep — the permanently
+    // stranded state.
+    //
+    // This is the control on the case above: without it, a walk that descended
+    // into EVERY group would satisfy that assertion just as well.
+    const fields = blocksFieldsOf([
+      {
+        type: "group",
+        name: "seo",
+        fields: [{ type: "blocks", name: "body" }],
+      },
+    ]);
+
+    expect(fields).toEqual([]);
+  });
+
+  it("descends through presentational groups nested in each other", () => {
+    const fields = blocksFieldsOf([
+      {
+        type: "group",
+        fields: [{ type: "group", fields: [{ type: "blocks", name: "deep" }] }],
+      },
+    ]);
+
+    expect(fields).toEqual([{ name: "deep", localized: false }]);
+  });
+
+  it("does not descend into a repeater", () => {
+    // A repeater's children are per-row, so there is no single parent path.
+    const fields = blocksFieldsOf([
+      { type: "repeater", fields: [{ type: "blocks", name: "row" }] },
+    ]);
+
+    expect(fields).toEqual([]);
+  });
+
+  it("terminates on a group that contains itself", () => {
+    // Configuration is author-supplied and can be cyclic. Without a bound this
+    // walk would spin, and the failure would be a hung save rather than a
+    // visible error.
+    const cyclic: Record<string, unknown> = { type: "group" };
+    cyclic.fields = [cyclic, { type: "blocks", name: "content" }];
+
+    expect(() => blocksFieldsOf([cyclic])).not.toThrow();
+  });
+});

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
@@ -41,22 +41,6 @@ import type { BlocksFieldDescriptor } from "./class-usage-subjects";
 import { isBlocksField } from "./fields/blocksHelper";
 
 /**
- * A bound on how many field declarations one collection can contribute.
- *
- * Groups nest and the shape is author-supplied, so a pathological depth or
- * breadth would otherwise spin here. Sized so that reaching it means the
- * configuration is wrong rather than large, and deliberately meaningless about
- * how many fields a real collection has.
- *
- * It is a backstop and neither of the two defences that matter. A cycle is
- * broken by identity below, because a bound alone ends the walk without ever
- * reaching the fields the cycle is hiding. Breadth is survived by reading each
- * list where it lies, because a bound cannot apply to a list that throws while
- * being moved.
- */
-const MAX_FIELDS_VISITED = 10_000;
-
-/**
  * The name a field is addressed by, or null when it has none usable.
  *
  * One definition, because two questions depend on it and they must not answer
@@ -167,11 +151,18 @@ export function blocksFieldsOf(
 
   const found: BlocksFieldDescriptor[] = [];
   const seen = new Set<string>();
-  // Groups already expanded, by IDENTITY. A group that lists itself would
-  // otherwise be re-entered every iteration, and the siblings behind it would
-  // never be reached — the walk would end at the bound having silently returned
-  // nothing, which is indistinguishable from a collection that declares no
-  // blocks field.
+  // Groups already expanded, by IDENTITY. This is what makes the walk finite,
+  // and it is the ONLY thing that does: a group listing itself would otherwise
+  // be re-entered forever. Expanding each group once bounds the visits at the
+  // number of declarations the configuration actually contains.
+  //
+  // There is no visit cap beside it, deliberately. A cap terminates a cyclic
+  // walk without ever reaching the fields the cycle hides, and on a merely LONG
+  // list it stops partway and returns fewer descriptors while reporting
+  // nothing — so the document's classes go unindexed and read as unused, which
+  // is the state that licences deleting a class a page still renders. Nothing
+  // validates a field count, so a long list is legal configuration rather than
+  // a signal that the config is wrong.
   const expanded = new WeakSet<object>();
 
   // Depth-first over a stack of CURSORS rather than recursion or a queue of
@@ -185,9 +176,8 @@ export function blocksFieldsOf(
   const stack: { fields: readonly unknown[]; index: number }[] = [
     { fields, index: 0 },
   ];
-  let visited = 0;
 
-  while (stack.length > 0 && visited < MAX_FIELDS_VISITED) {
+  while (stack.length > 0) {
     const frame = stack[stack.length - 1];
     if (frame === undefined || frame.index >= frame.fields.length) {
       stack.pop();
@@ -195,7 +185,6 @@ export function blocksFieldsOf(
     }
     const field = frame.fields[frame.index];
     frame.index += 1;
-    visited += 1;
 
     const children = presentationalChildren(field);
     if (children !== null) {

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
@@ -28,7 +28,40 @@
  * @module class-usage-blocks-fields
  */
 import type { BlocksFieldDescriptor } from "./class-usage-subjects";
-import { BLOCKS_TYPE } from "./fields/blocksField";
+import { isBlocksField } from "./fields/blocksHelper";
+
+/**
+ * A bound on how many field declarations one collection can contribute.
+ *
+ * Presentational groups nest, and the shape is author-supplied, so a cycle or a
+ * pathological depth would otherwise spin here. Sized so that reaching it means
+ * the configuration is wrong rather than large, and deliberately meaningless
+ * about how many fields a real collection has.
+ */
+const MAX_FIELDS_VISITED = 10_000;
+
+/**
+ * The children a NAMELESS group contributes to THIS level.
+ *
+ * A group without a `name` is presentational: it groups fields in the admin and
+ * stores nothing of its own, so its children live at the parent path. A blocks
+ * field inside one is reachable as `item[field]` exactly like a top-level
+ * declaration — so skipping it leaves that document's classes out of the index
+ * entirely, and a class it still renders reads as unused and can be deleted.
+ *
+ * A NAMED group is the opposite and stays excluded: it nests its data under its
+ * own key, so a child is reachable only through a path neither this nor the
+ * rebuild resolves. Same for a repeater, whose children are per-row. Descending
+ * into those would file rows no rebuild could reconcile or sweep.
+ */
+function presentationalChildren(value: unknown): readonly unknown[] | null {
+  if (typeof value !== "object" || value === null) return null;
+  const field = value as { type?: unknown; name?: unknown; fields?: unknown };
+  if (field.type !== "group") return null;
+  // A name is what makes a group store its own object. Absent, it is transparent.
+  if (field.name !== undefined) return null;
+  return Array.isArray(field.fields) ? field.fields : null;
+}
 
 /** Whether a configured field is one this index tracks. */
 function readBlocksField(value: unknown): BlocksFieldDescriptor | null {
@@ -38,7 +71,10 @@ function readBlocksField(value: unknown): BlocksFieldDescriptor | null {
     name?: unknown;
     localized?: unknown;
   };
-  if (field.type !== BLOCKS_TYPE) return null;
+  // The canonical guard rather than a second comparison against the type
+  // string. It answers this same question for every heterogeneous schema walk
+  // in this package, and two implementations of one question drift silently.
+  if (!isBlocksField(field)) return null;
   // A name is what the `field` column of every row holds, so a field without a
   // usable one has no addressable subject at all.
   if (typeof field.name !== "string" || field.name.length === 0) return null;
@@ -69,7 +105,21 @@ export function blocksFieldsOf(
   const found: BlocksFieldDescriptor[] = [];
   const seen = new Set<string>();
 
-  for (const field of fields) {
+  // Depth-first over a stack rather than recursion: the nesting is
+  // author-supplied, and a cycle must not take the process with it.
+  const pending: unknown[] = [...fields];
+  let visited = 0;
+
+  while (pending.length > 0 && visited < MAX_FIELDS_VISITED) {
+    visited += 1;
+    const field = pending.shift();
+
+    const children = presentationalChildren(field);
+    if (children !== null) {
+      pending.unshift(...children);
+      continue;
+    }
+
     const descriptor = readBlocksField(field);
     if (descriptor === null) continue;
     // A duplicate name is one subject, not two. Enumerating it twice would

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
@@ -6,6 +6,14 @@
  * configuration rather than a list captured when the plugin was wired: a
  * collection can be created, and a field added to one, after that moment.
  *
+ * ## Why it takes the collection rather than its fields
+ *
+ * Whether a field stores per language is decided by the field's flag AND the
+ * collection's master switch together, so the two have to arrive from the same
+ * collection. Separate parameters let a caller pair one collection's fields
+ * with another's switch, and the result would be subjects under locales that
+ * collection never stores.
+ *
  * ## Why it reads unvalidated
  *
  * Configuration reaches a hook as whatever the host wrote, including from
@@ -17,33 +25,58 @@
  *
  * ## The limit, stated because it has to match the rebuild
  *
- * Only TOP-LEVEL fields are read. A blocks field nested inside a group or a
- * repeater is not indexed, and that is deliberate rather than pending: the
- * rebuild reads `item[field]` and cannot resolve a nested path either, so
- * indexing one here would create rows that no rebuild could ever reconcile or
- * sweep. The two halves have to agree about what a subject is, and the cheapest
- * way to keep them agreeing is for both to look in the same place. Widening
- * them is one change, not two.
+ * Only fields addressable at the TOP LEVEL are read. A blocks field nested
+ * inside a named group or a repeater is not indexed, and that is deliberate
+ * rather than pending: the rebuild reads `item[field]` and cannot resolve a
+ * nested path either, so indexing one here would create rows that no rebuild
+ * could ever reconcile or sweep. The two halves have to agree about what a
+ * subject is, and the cheapest way to keep them agreeing is for both to look in
+ * the same place. Widening them is one change, not two.
  *
  * @module class-usage-blocks-fields
  */
+import { isFieldLocalized } from "nextly/config";
+
 import type { BlocksFieldDescriptor } from "./class-usage-subjects";
 import { isBlocksField } from "./fields/blocksHelper";
 
 /**
  * A bound on how many field declarations one collection can contribute.
  *
- * Presentational groups nest, and the shape is author-supplied, so a cycle or a
- * pathological depth would otherwise spin here. Sized so that reaching it means
- * the configuration is wrong rather than large, and deliberately meaningless
- * about how many fields a real collection has.
+ * Groups nest and the shape is author-supplied, so a pathological depth or
+ * breadth would otherwise spin here. Sized so that reaching it means the
+ * configuration is wrong rather than large, and deliberately meaningless about
+ * how many fields a real collection has. It is a backstop rather than the cycle
+ * defence: a cycle is broken by identity below, because a bound alone ends the
+ * walk without ever reaching the fields the cycle is hiding.
  */
 const MAX_FIELDS_VISITED = 10_000;
 
 /**
+ * The name a field is addressed by, or null when it has none usable.
+ *
+ * One definition, because two questions depend on it and they must not answer
+ * differently about the same field: whether a group is presentational, and
+ * whether a blocks field has an addressable subject. A group treated as named
+ * while its blocks child is treated as unaddressable would drop that child
+ * silently at both steps.
+ *
+ * An empty string is NOT a name. It is what a host writes for a layout group it
+ * gave no key, and the field's values then live at the parent level — which is
+ * how core resolves references and redacts paths through such a group, so
+ * reading it as a name here would disagree with where the values actually are.
+ */
+function fieldName(value: unknown): string | null {
+  if (typeof value !== "object" || value === null) return null;
+  const name = (value as { name?: unknown }).name;
+  if (typeof name !== "string" || name.length === 0) return null;
+  return name;
+}
+
+/**
  * The children a NAMELESS group contributes to THIS level.
  *
- * A group without a `name` is presentational: it groups fields in the admin and
+ * A group without a name is presentational: it groups fields in the admin and
  * stores nothing of its own, so its children live at the parent path. A blocks
  * field inside one is reachable as `item[field]` exactly like a top-level
  * declaration — so skipping it leaves that document's classes out of the index
@@ -56,40 +89,64 @@ const MAX_FIELDS_VISITED = 10_000;
  */
 function presentationalChildren(value: unknown): readonly unknown[] | null {
   if (typeof value !== "object" || value === null) return null;
-  const field = value as { type?: unknown; name?: unknown; fields?: unknown };
+  const field = value as { type?: unknown; fields?: unknown };
   if (field.type !== "group") return null;
-  // A name is what makes a group store its own object. Absent, it is transparent.
-  if (field.name !== undefined) return null;
+  if (fieldName(value) !== null) return null;
   return Array.isArray(field.fields) ? field.fields : null;
 }
 
-/** Whether a configured field is one this index tracks. */
-function readBlocksField(value: unknown): BlocksFieldDescriptor | null {
+/**
+ * Whether a configured field is one this index tracks.
+ *
+ * `collectionLocalized` is the collection's master switch, and the classifier
+ * folds it in: a field flagged localized on a collection that stores no
+ * translations is stored ONCE, under the empty locale key. Reading the flag
+ * alone would enumerate a subject per configured language for it and leave the
+ * one subject a read resolves to holding no rows at all.
+ */
+function readBlocksField(
+  value: unknown,
+  collectionLocalized: boolean
+): BlocksFieldDescriptor | null {
   if (typeof value !== "object" || value === null) return null;
-  const field = value as {
-    type?: unknown;
-    name?: unknown;
-    localized?: unknown;
-  };
+  const field = value as { type?: unknown; localized?: unknown };
   // The canonical guard rather than a second comparison against the type
   // string. It answers this same question for every heterogeneous schema walk
   // in this package, and two implementations of one question drift silently.
   if (!isBlocksField(field)) return null;
   // A name is what the `field` column of every row holds, so a field without a
   // usable one has no addressable subject at all.
-  if (typeof field.name !== "string" || field.name.length === 0) return null;
+  const name = fieldName(value);
+  if (name === null) return null;
   return {
-    name: field.name,
-    // Absent means not localized, which is the default the schema applies. Read
-    // as a strict boolean rather than for truthiness so a stored `"false"` — a
-    // string, which a JSON payload can carry — does not read as localized and
-    // file one document's classes under every language.
-    localized: field.localized === true,
+    name,
+    // The classifier core stores by, so this cannot disagree with where the
+    // values are. It reads `localized` only when it is a strict boolean, so a
+    // stored `"false"` — a string, which a JSON payload can carry — does not
+    // read as localized and file one document's classes under every language.
+    localized: isFieldLocalized(
+      {
+        type: field.type,
+        name,
+        localized:
+          typeof field.localized === "boolean" ? field.localized : undefined,
+      },
+      collectionLocalized
+    ),
   };
 }
 
+/** The collection configuration this filter reads, as the host wrote it. */
+export interface BlocksFieldsCollection {
+  /** Top-level field declarations, in their authored form. */
+  fields?: unknown;
+  /** The collection's localization master switch. */
+  localized?: unknown;
+}
+
 /**
- * Every blocks field declared on a collection, in declaration order.
+ * Every blocks field a collection stores at its top level, in declaration
+ * order.
  *
  * Returns an empty list for the collections this index does not track, which is
  * most of them. That makes the filter a property of this function rather than a
@@ -98,12 +155,20 @@ function readBlocksField(value: unknown): BlocksFieldDescriptor | null {
  * being off.
  */
 export function blocksFieldsOf(
-  fields: readonly unknown[] | undefined
+  collection: BlocksFieldsCollection | null | undefined
 ): BlocksFieldDescriptor[] {
+  const fields = collection?.fields;
   if (!Array.isArray(fields)) return [];
+  const collectionLocalized = collection?.localized === true;
 
   const found: BlocksFieldDescriptor[] = [];
   const seen = new Set<string>();
+  // Groups already expanded, by IDENTITY. A group that lists itself would
+  // otherwise be pushed back to the front of the queue every iteration, and the
+  // siblings behind it would never be reached — the walk would end at the bound
+  // having silently returned nothing, which is indistinguishable from a
+  // collection that declares no blocks field.
+  const expanded = new WeakSet<object>();
 
   // Depth-first over a stack rather than recursion: the nesting is
   // author-supplied, and a cycle must not take the process with it.
@@ -116,11 +181,14 @@ export function blocksFieldsOf(
 
     const children = presentationalChildren(field);
     if (children !== null) {
+      const group = field as object;
+      if (expanded.has(group)) continue;
+      expanded.add(group);
       pending.unshift(...children);
       continue;
     }
 
-    const descriptor = readBlocksField(field);
+    const descriptor = readBlocksField(field, collectionLocalized);
     if (descriptor === null) continue;
     // A duplicate name is one subject, not two. Enumerating it twice would
     // reconcile the same rows twice in one pass, and the second pass reads the

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
@@ -46,9 +46,13 @@ import { isBlocksField } from "./fields/blocksHelper";
  * Groups nest and the shape is author-supplied, so a pathological depth or
  * breadth would otherwise spin here. Sized so that reaching it means the
  * configuration is wrong rather than large, and deliberately meaningless about
- * how many fields a real collection has. It is a backstop rather than the cycle
- * defence: a cycle is broken by identity below, because a bound alone ends the
- * walk without ever reaching the fields the cycle is hiding.
+ * how many fields a real collection has.
+ *
+ * It is a backstop and neither of the two defences that matter. A cycle is
+ * broken by identity below, because a bound alone ends the walk without ever
+ * reaching the fields the cycle is hiding. Breadth is survived by reading each
+ * list where it lies, because a bound cannot apply to a list that throws while
+ * being moved.
  */
 const MAX_FIELDS_VISITED = 10_000;
 
@@ -164,27 +168,41 @@ export function blocksFieldsOf(
   const found: BlocksFieldDescriptor[] = [];
   const seen = new Set<string>();
   // Groups already expanded, by IDENTITY. A group that lists itself would
-  // otherwise be pushed back to the front of the queue every iteration, and the
-  // siblings behind it would never be reached — the walk would end at the bound
-  // having silently returned nothing, which is indistinguishable from a
-  // collection that declares no blocks field.
+  // otherwise be re-entered every iteration, and the siblings behind it would
+  // never be reached — the walk would end at the bound having silently returned
+  // nothing, which is indistinguishable from a collection that declares no
+  // blocks field.
   const expanded = new WeakSet<object>();
 
-  // Depth-first over a stack rather than recursion: the nesting is
-  // author-supplied, and a cycle must not take the process with it.
-  const pending: unknown[] = [...fields];
+  // Depth-first over a stack of CURSORS rather than recursion or a queue of
+  // fields. Recursion would let author-supplied nesting exhaust the call stack.
+  // A queue would have to move a group's children into it, and a list long
+  // enough makes that move throw before any bound can apply — passing them as
+  // arguments reaches the engine's argument limit. This runs after the document
+  // has committed, where a throw reports a failed save for one that succeeded.
+  // A cursor holds each list where it is and reads one field at a time, so no
+  // length is ever material.
+  const stack: { fields: readonly unknown[]; index: number }[] = [
+    { fields, index: 0 },
+  ];
   let visited = 0;
 
-  while (pending.length > 0 && visited < MAX_FIELDS_VISITED) {
+  while (stack.length > 0 && visited < MAX_FIELDS_VISITED) {
+    const frame = stack[stack.length - 1];
+    if (frame === undefined || frame.index >= frame.fields.length) {
+      stack.pop();
+      continue;
+    }
+    const field = frame.fields[frame.index];
+    frame.index += 1;
     visited += 1;
-    const field = pending.shift();
 
     const children = presentationalChildren(field);
     if (children !== null) {
       const group = field as object;
       if (expanded.has(group)) continue;
       expanded.add(group);
-      pending.unshift(...children);
+      stack.push({ fields: children, index: 0 });
       continue;
     }
 

--- a/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
+++ b/packages/plugin-page-builder/src/class-usage-blocks-fields.ts
@@ -1,0 +1,84 @@
+/**
+ * Which fields on a collection this index is responsible for.
+ *
+ * The write path registers ONE hook for every collection, so most calls reach
+ * it with nothing to do. This is the filter, and it reads the collection's LIVE
+ * configuration rather than a list captured when the plugin was wired: a
+ * collection can be created, and a field added to one, after that moment.
+ *
+ * ## Why it reads unvalidated
+ *
+ * Configuration reaches a hook as whatever the host wrote, including from
+ * untyped JavaScript and from the Schema Builder's stored payloads. A field
+ * missing a name, or carrying a non-string one, is skipped rather than
+ * defaulted: a subject keyed by an empty field name would collect rows from
+ * every unnamed field on the collection into one bucket, and the reconciler
+ * would then delete each field's rows on behalf of the others.
+ *
+ * ## The limit, stated because it has to match the rebuild
+ *
+ * Only TOP-LEVEL fields are read. A blocks field nested inside a group or a
+ * repeater is not indexed, and that is deliberate rather than pending: the
+ * rebuild reads `item[field]` and cannot resolve a nested path either, so
+ * indexing one here would create rows that no rebuild could ever reconcile or
+ * sweep. The two halves have to agree about what a subject is, and the cheapest
+ * way to keep them agreeing is for both to look in the same place. Widening
+ * them is one change, not two.
+ *
+ * @module class-usage-blocks-fields
+ */
+import type { BlocksFieldDescriptor } from "./class-usage-subjects";
+import { BLOCKS_TYPE } from "./fields/blocksField";
+
+/** Whether a configured field is one this index tracks. */
+function readBlocksField(value: unknown): BlocksFieldDescriptor | null {
+  if (typeof value !== "object" || value === null) return null;
+  const field = value as {
+    type?: unknown;
+    name?: unknown;
+    localized?: unknown;
+  };
+  if (field.type !== BLOCKS_TYPE) return null;
+  // A name is what the `field` column of every row holds, so a field without a
+  // usable one has no addressable subject at all.
+  if (typeof field.name !== "string" || field.name.length === 0) return null;
+  return {
+    name: field.name,
+    // Absent means not localized, which is the default the schema applies. Read
+    // as a strict boolean rather than for truthiness so a stored `"false"` — a
+    // string, which a JSON payload can carry — does not read as localized and
+    // file one document's classes under every language.
+    localized: field.localized === true,
+  };
+}
+
+/**
+ * Every blocks field declared on a collection, in declaration order.
+ *
+ * Returns an empty list for the collections this index does not track, which is
+ * most of them. That makes the filter a property of this function rather than a
+ * branch every caller has to remember — and a caller that forgets a branch
+ * indexes nothing silently, which is the failure that looks like the feature
+ * being off.
+ */
+export function blocksFieldsOf(
+  fields: readonly unknown[] | undefined
+): BlocksFieldDescriptor[] {
+  if (!Array.isArray(fields)) return [];
+
+  const found: BlocksFieldDescriptor[] = [];
+  const seen = new Set<string>();
+
+  for (const field of fields) {
+    const descriptor = readBlocksField(field);
+    if (descriptor === null) continue;
+    // A duplicate name is one subject, not two. Enumerating it twice would
+    // reconcile the same rows twice in one pass, and the second pass reads the
+    // first one's inserts as rows the document no longer justifies.
+    if (seen.has(descriptor.name)) continue;
+    seen.add(descriptor.name);
+    found.push(descriptor);
+  }
+
+  return found;
+}


### PR DESCRIPTION
Next piece of the class-usage write path. The filter that decides which collections the hook does anything for.

## Why it reads live configuration

The write path registers ONE hook for every collection, so most calls reach it with nothing to do. Reading a list captured when the plugin was wired would miss a collection created afterwards, and a blocks field added to an existing one — both of which happen through the Schema Builder at runtime.

## Why most of the tests are about malformed input

Configuration reaches a hook as whatever the host wrote, including from untyped JavaScript and from the Schema Builder's stored JSON payloads. Each case below is a way the filter can be wrong in a direction that is invisible afterwards:

- **A string `"true"` reads as NOT localized.** JSON carries strings; a truthiness check would read this as localized, file one document's classes under every language, and leave the `""` subject — the one a read actually resolves — holding none. The document's classes would then be invisible to the count that decides whether a class is safe to delete.
- **A field with no usable name is skipped, not defaulted.** The name IS the `field` column every row is keyed by, so an empty one collects every unnamed field's rows into a single subject — and the reconciler then deletes each field's rows on behalf of the others.
- **A duplicate name yields ONE subject.** Reconciling the same rows twice in one pass makes the second pass read the first's inserts as rows the document no longer justifies, so a correct document ends with its own classes deleted.

## The scope limit, and why it is deliberate rather than pending

**Top-level fields only.** A blocks field nested inside a group or repeater is not indexed — because the rebuild reads `item[field]` and cannot resolve a nested path either. Indexing one here would create rows that no rebuild could ever reconcile or sweep, which is the permanently-stranded state.

The two halves have to agree about what a subject IS, and the cheapest way to keep them agreeing is for both to look in the same place. Widening them is one change, not two. This also settles the nested-paths thread declined on #1221: the answer is symmetry, not deferral.

## Test plan

Eight cases. Three properties break-verified individually, **each break confirmed to compile against a clean baseline**:

| break | test killed |
| --- | --- |
| truthiness instead of a strict boolean | `reads a STRING "true" as not localized` |
| accept an empty field name | `skips a field with no usable name` |
| stop de-duplicating names | `yields ONE subject rather than two` |

The baseline was NOT clean on the first attempt — `BlocksField.tsx` could not resolve `@nextlyhq/builder/shell` exports because this branch was cut from a newer `main` without rebuilding. A red that appears with and without the change is evidence of nothing, so the breaks were re-run after `pnpm --filter <pkg>... build`.

Gates, each exit status read separately: build 0 · vitest 0 (384 passing) · check-types 0 · lint 0 · root eslint 0 · fallow `verdict: pass` with all four `*_introduced` at 0.

## Pre-existing failure, flagged rather than silenced

`node scripts/check-comment-convention.mjs` exits 1, on files this PR does not touch:

- `.github/workflows/code-hygiene.yml` — 3 offences
- `packages/builder/src/breakpoint-action-styles.test.ts` — 1 offence

**Established as pre-existing with a control:** the same script exits 1 on `origin/main` itself. This PR's diff is exactly two new files, neither of them these. The allowlist may only shrink and an entry must not be added to silence a comment, so these want rewriting by whoever owns them rather than suppressing here.

## Changeset

Skipped — the module is internal, not exported from the package entry, and adds no API a host can call. The changeset lands with the hook that consumes it, where the behaviour becomes user-facing.