### PR TITLE
fix(builder): ask the renderer which breakpoints a page compiles against

### DIFF
--- a/.changeset/canvas-reuses-renderer-reconciliation.md
+++ b/.changeset/canvas-reuses-renderer-reconciliation.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The editor canvas asks the renderer which breakpoints a page compiles against,
+rather than working it out alongside it. The two answers agreed, and a second
+answer to one question is one that agrees until the day it does not.

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -341,6 +341,7 @@ describe("the root entry", () => {
       "rendersOwnMarkup",
       "resolvePageStyles",
       "resolvePageStylesWithTrace",
+      "sharedStyleInputs",
       "styleTextForInjection",
     ]);
   });

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -46,6 +46,7 @@ import type {
   PageContext,
   QueryBudget,
   ReactBlockDefinition,
+  ReconciledStyleInputs,
 } from "./index";
 
 /**
@@ -492,5 +493,30 @@ describe("the next entry", () => {
       "createPublicSinglePage",
       "createSinglePage",
     ]);
+  });
+});
+
+describe("the type published beside `sharedStyleInputs`", () => {
+  it("is the one that function returns", () => {
+    /*
+     * Two properties, and they are checked by different mechanisms.
+     *
+     * The ANNOTATION is the type half, and the TESTS PROJECT compiling this
+     * file is what asserts it — so this case going green is not the evidence
+     * for it; `check-types` is. A name published beside a function but
+     * describing something else leaves a consumer able to read the type and
+     * unable to use it, which no runtime assertion can observe. This package
+     * held two types under one name, and the exported one required
+     * `breakpoints` while the function may resolve nothing.
+     *
+     * The VALUE is the runtime half: `{}` is what "may resolve nothing" means,
+     * and it is the case the required field would have rejected.
+     */
+    const resolved: ReconciledStyleInputs = rootEntry.sharedStyleInputs(
+      undefined,
+      undefined
+    );
+
+    expect(resolved).toEqual({});
   });
 });

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -230,28 +230,27 @@ const SOURCE_MODULES: ReadonlyArray<{
   {
     name: "page-renderer",
     module: pageRendererModule,
-    // Crosses a module boundary inside this package and is not a consumer
-    // surface, the same case `prepare-document` records below: exported to
-    // DELETE a copy rather than to offer an API.
+    // `sharedStyleInputs` is PUBLISHED, so it is absent from the list below.
     //
-    // `sharedStyleInputs` reconciles the site tier with the route's context —
-    // named classes, block bases, the token prefix — and a THIRD compile needs
-    // the same answer: `pageStyleTrace` asks for the cascade behind the page so
-    // an editor can say where a value came from. Assembled separately there, the
-    // trace carries no named classes at all and every value from a class reports
-    // as set by nobody. Published instead of shared, it would be a second public
-    // way to build a compile context, which is what `compileContextFor` exists
-    // to prevent.
+    // It reconciles the site tier with the route's context — named classes,
+    // block bases, the token prefix — and the callers needing that answer are
+    // not all inside this package. A surface that decides anything from "the
+    // breakpoints this page compiles against" has to read the same answer the
+    // render will use, and a compile assembled independently is a second answer
+    // to one question. Publishing the RECONCILIATION is not publishing a way to
+    // build a compile context: `compileContextFor` remains the only one of
+    // those, and this returns a patch of already-reconciled inputs.
     //
-    // `pruneRenderedPlaceholders` is the same shape and the same third caller.
-    // It answers "which tree does this page's sheet describe" for the nodes a
-    // placeholder replaced, and the editor's cascade read has to ask exactly
-    // that: pruned harder, the trace withholds an account of markup that is on
-    // the page; pruned less, it names a source for markup that is not. Rebuilt
-    // there from `rendersOwnMarkup` it would be a second implementation of one
-    // pass, which is the drift the pass's own docblock argues against. An
-    // internal derivation, not something a host composes with.
-    internal: ["pruneRenderedPlaceholders", "sharedStyleInputs"],
+    // `pruneRenderedPlaceholders` is the case that stays internal, and the
+    // contrast is the point. It answers "which tree does this page's sheet
+    // describe" for the nodes a placeholder replaced, and the editor's cascade
+    // read has to ask exactly that: pruned harder, the trace withholds an
+    // account of markup that is on the page; pruned less, it names a source for
+    // markup that is not. Rebuilt from `rendersOwnMarkup` it would be a second
+    // implementation of one pass, which is the drift the pass's own docblock
+    // argues against — but it is an internal derivation rather than something a
+    // host composes with, so it crosses a module boundary and stops there.
+    internal: ["pruneRenderedPlaceholders"],
   },
   {
     name: "prepare-document",
@@ -260,10 +259,15 @@ const SOURCE_MODULES: ReadonlyArray<{
     // surface, and each was exported to DELETE a copy rather than to offer an
     // API.
     //
-    // `rendersOwnMarkup` and `pruneKnownPlaceholders` were defined a second time
-    // in `page-renderer`. Two implementations of one pass agree the day they are
-    // written and drift after, and this pair decides what a stored stylesheet may
-    // still describe — so the drift ships rules for markup that is gone.
+    // `rendersOwnMarkup` is NOT among them any more: it is published, because
+    // the editor asks it whether a node draws its own markup before reserving a
+    // dom id the page will never render. That is a question about this
+    // renderer's behaviour, which only this renderer can answer.
+    //
+    // `pruneKnownPlaceholders` was defined a second time in `page-renderer`.
+    // Two implementations of one pass agree the day they are written and drift
+    // after, and this one decides what a stored stylesheet may still describe —
+    // so the drift ships rules for markup that is gone.
     //
     // `prepareDocumentReadStages` is the pipeline reporting the states it passed
     // through, which one caller needs because it compares them by reference to
@@ -280,7 +284,6 @@ const SOURCE_MODULES: ReadonlyArray<{
       "prepareDocumentReadStages",
       "pruneKnownPlaceholders",
       "readingViewOf",
-      "rendersOwnMarkup",
     ],
   },
   {
@@ -383,6 +386,33 @@ describe("the root entry", () => {
         missing,
         `${source.name}.ts exports ${missing.join(", ")} but the entry does not. ` +
           `Re-export it, or add it to that module's \`internal\` list with a reason.`
+      ).toEqual([]);
+    }
+  });
+
+  it("keeps every `internal` classification TRUE", () => {
+    /*
+     * The other direction of the same claim, and the one that was missing.
+     *
+     * The case above asks whether a module export reached the entry, and takes
+     * `internal` as the reason it did not have to. Nothing asked whether a name
+     * on that list is still absent from the entry — so publishing a symbol left
+     * its own rationale standing, arguing in the file that publishing it would
+     * be a mistake. Measured: adding an exported name to `internal` changed no
+     * assertion, because the list is only ever read as an exemption.
+     *
+     * A classification nothing checks is a comment wearing a data structure's
+     * clothes, and it drifts in the direction that reads as deliberate.
+     */
+    const exported = new Set(Object.keys(rootEntry));
+
+    for (const source of SOURCE_MODULES) {
+      const stale = source.internal.filter(name => exported.has(name));
+
+      expect(
+        stale,
+        `${source.name}.ts lists ${stale.join(", ")} as internal, but the entry ` +
+          `publishes it. Remove it from that list and say why it is public.`
       ).toEqual([]);
     }
   });

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -77,11 +77,12 @@ export type {
  * `previewContainer`, and each skips only `undefined` — so a stored `null`
  * survives and means something.
  *
- * Measured before this was exported: a caller re-implementing the rule got it
- * wrong three times in one PR — the precedence inverted, then the fallthrough,
- * then the stated `null` — each time by reading it carefully rather than
- * calling it. A parallel implementation of a reconciliation is a second answer
- * that agrees until the day it does not.
+ * A parallel implementation of a reconciliation is a second answer that agrees
+ * until the day it does not, and this rule offers three separate ways to
+ * disagree — an inverted precedence, a wrong fallthrough, and a stated `null`
+ * discarded by a nullish coalesce. None of them is visible from the inputs, so
+ * a caller that reads the rule carefully and rewrites it is no safer than one
+ * that guesses.
  */
 export { sharedStyleInputs, type ReconciledStyleInputs } from "./page-renderer";
 

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -32,25 +32,6 @@ export {
 
 export { PageRenderer } from "./page-renderer";
 export type { PageRendererProps } from "./page-renderer";
-
-/**
- * How this renderer reconciles a route context and a stored site tier.
- *
- * Published because a surface deciding anything from "the breakpoints this page
- * compiles against" must read the SAME answer the render will use, and the
- * precedences are not guessable from the inputs: the site tier wins for
- * `breakpoints` and `blockBases`, the route wins for `namedClasses` and
- * `previewContainer`, and each skips only `undefined` — so a stored `null`
- * survives and means something.
- *
- * Measured before this was exported: a caller re-implementing the rule got it
- * wrong three times in one PR — the precedence inverted, then the fallthrough,
- * then the stated `null` — each time by reading it carefully rather than
- * calling it. A parallel implementation of a reconciliation is a second answer
- * that agrees until the day it does not.
- */
-export { sharedStyleInputs } from "./page-renderer";
-export type { SharedStyleInputs } from "./shared-style-inputs";
 // Re-exported because `PageRendererProps.siteStyles` NAMES it, and a prop a
 // consumer cannot type is a prop they cannot pass without reaching past this
 // package into the engine. The type-surface ratchet is what caught it: a public
@@ -85,6 +66,24 @@ export type {
   SiteTokenSet,
   TokenKind,
 } from "@nextlyhq/blocks-engine";
+
+/**
+ * How this renderer reconciles a route context and a stored site tier.
+ *
+ * Published because a surface deciding anything from "the breakpoints this page
+ * compiles against" must read the SAME answer the render will use, and the
+ * precedences are not guessable from the inputs: the site tier wins for
+ * `breakpoints` and `blockBases`, the route wins for `namedClasses` and
+ * `previewContainer`, and each skips only `undefined` — so a stored `null`
+ * survives and means something.
+ *
+ * Measured before this was exported: a caller re-implementing the rule got it
+ * wrong three times in one PR — the precedence inverted, then the fallthrough,
+ * then the stated `null` — each time by reading it carefully rather than
+ * calling it. A parallel implementation of a reconciliation is a second answer
+ * that agrees until the day it does not.
+ */
+export { sharedStyleInputs, type ReconciledStyleInputs } from "./page-renderer";
 
 export { BlockBoundary, BlockList } from "./block-boundary";
 // `NODE_ID_ATTRIBUTE` is published deliberately: an editor hit-testing on the

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -32,6 +32,25 @@ export {
 
 export { PageRenderer } from "./page-renderer";
 export type { PageRendererProps } from "./page-renderer";
+
+/**
+ * How this renderer reconciles a route context and a stored site tier.
+ *
+ * Published because a surface deciding anything from "the breakpoints this page
+ * compiles against" must read the SAME answer the render will use, and the
+ * precedences are not guessable from the inputs: the site tier wins for
+ * `breakpoints` and `blockBases`, the route wins for `namedClasses` and
+ * `previewContainer`, and each skips only `undefined` — so a stored `null`
+ * survives and means something.
+ *
+ * Measured before this was exported: a caller re-implementing the rule got it
+ * wrong three times in one PR — the precedence inverted, then the fallthrough,
+ * then the stated `null` — each time by reading it carefully rather than
+ * calling it. A parallel implementation of a reconciliation is a second answer
+ * that agrees until the day it does not.
+ */
+export { sharedStyleInputs } from "./page-renderer";
+export type { SharedStyleInputs } from "./shared-style-inputs";
 // Re-exported because `PageRendererProps.siteStyles` NAMES it, and a prop a
 // consumer cannot type is a prop they cannot pass without reaching past this
 // package into the engine. The type-surface ratchet is what caught it: a public

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -235,8 +235,18 @@ type ResolvedShared = {
     | undefined;
 };
 
-/** The same inputs as a context patch: unstated keys absent rather than undefined. */
-type SharedStyleInputs = Partial<ResolvedShared>;
+/**
+ * What {@link sharedStyleInputs} RETURNS: the same inputs as a context patch,
+ * with unstated keys absent rather than present and undefined.
+ *
+ * Named distinctly from the cache stamp's input projection in
+ * `shared-style-inputs.ts`, which is a different type for a different job and
+ * requires `breakpoints`. Under one name a caller writing
+ * `const value: Inputs = sharedStyleInputs(undefined, undefined)` does not
+ * compile, because the reconciler may legally resolve nothing — a published
+ * type unusable with the function published beside it.
+ */
+export type ReconciledStyleInputs = Partial<ResolvedShared>;
 
 /**
  * Resolve every shared input once, so the compiles cannot disagree.
@@ -269,7 +279,7 @@ type SharedStyleInputs = Partial<ResolvedShared>;
 export function sharedStyleInputs(
   styleContext: StyleCompileContext | undefined,
   site: SiteSheetInput | undefined
-): SharedStyleInputs {
+): ReconciledStyleInputs {
   // Both tiers normalised once. Every field below would otherwise repeat the
   // same two absence checks, and the resolution is easier to read as a list of
   // precedences than as a list of optional chains.
@@ -310,7 +320,7 @@ function firstStated<T>(...tiers: readonly (T | undefined)[]): T | undefined {
  * the context would then carry the key, and a reader asking whether it was
  * stated gets the wrong answer.
  */
-function defined(value: ResolvedShared): SharedStyleInputs {
+function defined(value: ResolvedShared): ReconciledStyleInputs {
   return Object.fromEntries(
     Object.entries(value).filter(([, stated]) => stated !== undefined)
   );

--- a/packages/builder/src/breakpoint-action-styles.test.ts
+++ b/packages/builder/src/breakpoint-action-styles.test.ts
@@ -11,8 +11,8 @@ import { describe, expect, it } from "vitest";
  * sheet is loaded beside a design system applying Preflight, which strips a
  * bare `<button>` to text — so a missing selector does not throw, does not fail
  * a render assertion, and ships an interactive control an author cannot tell
- * apart from the sentence beside it. Measured on this PR: the buttons were
- * added with no selector anywhere and every other gate stayed green.
+ * apart from the sentence beside it. Every other gate stays green while it
+ * happens, which is why this one exists.
  *
  * Read from the SOURCE stylesheet rather than the built one: `dist` is
  * gitignored, so a check against it answers differently before and after a

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -38,6 +38,7 @@ import {
   NODE_ID_ATTRIBUTE,
   PageRenderer,
   previewContainerStyle,
+  sharedStyleInputs,
 } from "@nextlyhq/blocks-react";
 import type { PageRendererProps } from "@nextlyhq/blocks-react";
 import { cn } from "@nextlyhq/ui/utils";
@@ -445,44 +446,31 @@ export interface CanvasPreview {
  * The breakpoints the compile will actually run against, or `undefined` when
  * nothing will be compiled at all.
  *
- * The SITE's when it has them, and the route context's otherwise — which is the
- * precedence `sharedStyleInputs` applies, in its own words because "the site
- * tier is the stored one, and stored overrides code, which is the layering
- * every global-styles system uses". Read the other way round, a route context
- * carrying viewport tiers beside a container-only stored set would turn preview
- * ON, and the compile that actually ran would then disable every container-axis
- * rule as `nx-not-previewable` with no viewport tier to show for it.
+ * ASKED of the renderer rather than worked out here. `sharedStyleInputs` is the
+ * function `PageRenderer` itself reconciles with, so this reads the answer the
+ * render will use instead of a second one that happens to agree.
  *
- * Deciding from the same reconciled inputs the renderer compiles is the point:
- * this is not a second opinion about which breakpoints matter, it is a reading
- * of the one the renderer will use.
+ * That distinction is not theoretical. A parallel implementation of this rule
+ * was wrong three times in one pull request — the precedence inverted, then the
+ * fallthrough, then a stated `null` that the renderer keeps and a nullish
+ * coalesce discarded — and each time it was wrong after being read carefully.
+ * The rule has more in it than it looks: the site tier wins for `breakpoints`,
+ * the route wins for `previewContainer`, and both skip only `undefined`.
  *
- * `undefined` is the state where a caller has neither binding site:
- * `siteStyles={false}` opts out of the shared sheet, and a stored artifact
- * arrives with no style context.
+ * `undefined` still means exactly what it did: neither binding site stated a
+ * set, which is `siteStyles={false}` beside a stored artifact carrying no style
+ * context.
  */
 function compiledBreakpoints(
   render: Omit<PageRendererProps, "document" | "siteStyles"> | undefined,
   siteStyles: NonNullable<PageRendererProps["siteStyles"]>
 ): BreakpointSet | undefined {
-  /*
-   * `firstStated`, not "the site if it has a sheet": that helper SKIPS an
-   * absent value, so a site sheet carrying no breakpoints falls through to the
-   * route context rather than answering `undefined` for both. Reading it as
-   * "site wins whenever a sheet exists" turns a stated route set into no set at
-   * all, and a canvas that should preview stays published.
-   */
-  const stored =
-    typeof siteStyles === "object" ? siteStyles.breakpoints : undefined;
-  /*
-   * `=== undefined`, never `??`. `firstStated` is `find(tier => tier !== undefined)`,
-   * so a stored `null` — which runtime or imported data can supply — is KEPT by
-   * the renderer and read as defining no viewport tiers. Nullish coalescing
-   * falls through to the route set instead, turning preview on for a canvas the
-   * renderer left on the unconditional tier: the box then measures and selects
-   * a route tier that is not on screen.
-   */
-  return stored === undefined ? render?.styleContext?.breakpoints : stored;
+  return sharedStyleInputs(
+    render?.styleContext,
+    // `false` is a host serving no site sheet, which states no breakpoints —
+    // not a sheet whose breakpoints are absent.
+    typeof siteStyles === "object" ? siteStyles : undefined
+  ).breakpoints;
 }
 
 /**

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -450,12 +450,12 @@ export interface CanvasPreview {
  * function `PageRenderer` itself reconciles with, so this reads the answer the
  * render will use instead of a second one that happens to agree.
  *
- * That distinction is not theoretical. A parallel implementation of this rule
- * was wrong three times in one pull request — the precedence inverted, then the
- * fallthrough, then a stated `null` that the renderer keeps and a nullish
- * coalesce discarded — and each time it was wrong after being read carefully.
- * The rule has more in it than it looks: the site tier wins for `breakpoints`,
- * the route wins for `previewContainer`, and both skip only `undefined`.
+ * That distinction is not theoretical, because the rule has more in it than it
+ * looks. The site tier wins for `breakpoints`, the route wins for
+ * `previewContainer`, and both skip only `undefined` — so a stated `null`
+ * survives, where a nullish coalesce would discard it. Three separate ways to
+ * be wrong, none of them visible from the inputs, and each one produces a
+ * canvas that compiles against a different set of tiers than the page does.
  *
  * `undefined` still means exactly what it did: neither binding site stated a
  * set, which is `siteStyles={false}` beside a stored artifact carrying no style

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -1109,6 +1109,34 @@ describe("a Reset beside a picker mid-gesture", () => {
     expect(editor.applyAll).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps a gesture when Reset is only FOCUSED, never pressed", async () => {
+    /*
+     * Radix dismisses on focus leaving the popover as well as on a press
+     * outside it. A keyboard author tabbing out of the picker lands on the
+     * Reset beside this very control — so a supersede decided from "the
+     * dismissal's target is a marked control" discards the gesture because of a
+     * button nobody activated, and tabbing onward loses it with nothing shown.
+     *
+     * Leaving a control is a COMMIT everywhere else in this panel; the text
+     * fields write on blur. The gesture is therefore written here, and the
+     * Reset writes nothing because it never ran.
+     */
+    const editor = mountWithResets([{ property: "color" }]);
+    await dragTo("#ff0000");
+    expect(editor.applyAll).not.toHaveBeenCalled();
+
+    // Focus alone: no pointer press, no click, so `onReset` never runs. Moved
+    // with `.focus()` rather than a synthetic event, because Radix listens for
+    // `focusin` on the document and decides from `document.activeElement` —
+    // dispatched at the button, the listener sees focus still inside the
+    // popover and dismisses nothing.
+    resetFor("Color").focus();
+    await settle();
+
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
+  });
+
   it("keeps a gesture ANOTHER control's Reset does not replace", async () => {
     /*
      * The supersede is scoped to the field whose value the press writes. A

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -14,6 +14,7 @@
  * @module style-colour-panel.test
  */
 import {
+  BASE_BREAKPOINT,
   clearBlocks,
   registerBlocks,
   type BlockDocument,
@@ -21,7 +22,13 @@ import {
   type NodeStyles,
   type SiteTokenSet,
 } from "@nextlyhq/blocks-engine";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
 import * as React from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -954,5 +961,187 @@ describe("a malformed stored document does not take the Style tab down", () => {
       "value",
       "#3b82f6"
     );
+  });
+});
+
+describe("a Reset beside a picker mid-gesture", () => {
+  /**
+   * A site with one viewport tier, so the panel previews and the cascade's
+   * entries are attributable to a breakpoint the badge can name.
+   */
+  const SITE = {
+    viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+    container: [],
+  } as never;
+
+  /**
+   * The Style tab with a CASCADE, which is what earns a control its Reset.
+   *
+   * `mount` above renders no cascade, so every control there reads as unset and
+   * offers no action at all — a fixture that cannot reach the mechanism these
+   * cases are about.
+   */
+  function mountWithResets(
+    authored: ReadonlyArray<{ property: string; descendant?: string }>
+  ) {
+    registerBlocks(
+      [
+        {
+          name: "acme/box",
+          version: 1,
+          description: "A box.",
+          example: { props: {} },
+          editor: { label: "Box" },
+          props: { text: { type: "text" } },
+          // `link` puts a SECOND colour control in the same section as the
+          // first. The accordion opens one section at a time, so a control in
+          // another section is not in the tree while this one's picker is open.
+          supports: { color: { text: true, link: true } },
+          render: () => null,
+        },
+      ] as never,
+      { source: "style-colour-panel-test" }
+    );
+    const document_: BlockDocument = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "a",
+          type: "acme/box",
+          version: 1,
+          props: {},
+          // BOTH colours stored, because a Reset on a property the document
+          // does not hold clears nothing and writes no operation — so the other
+          // control would press cleanly and record nothing to order against.
+          styles: {
+            base: { base: { color: "#3b82f6", linkColor: "#22c55e" } },
+          },
+        },
+      ] as BlockNode[],
+    } as BlockDocument;
+    const editor = editorFor(document_);
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        tokens={TOKENS}
+        breakpoints={SITE}
+        previewContainer="nx-preview-viewport"
+        liveBreakpoints={[BASE_BREAKPOINT, "tablet"] as never}
+        cascade={
+          {
+            entries: authored.map(entry => ({
+              origin: { kind: "node", id: "a" },
+              property: entry.property,
+              ...(entry.descendant === undefined
+                ? {}
+                : { descendant: entry.descendant }),
+              value: "#3b82f6",
+              state: "base",
+              breakpoint: BASE_BREAKPOINT,
+            })),
+            nodes: editor.document.nodes,
+          } as never
+        }
+      />
+    );
+    return editor;
+  }
+
+  /** The Reset button of the control whose action is named `actionName`. */
+  const resetFor = (actionName: string): HTMLElement => {
+    const found = screen
+      .getAllByRole("button")
+      .find(
+        button =>
+          button.dataset.action === "reset" &&
+          (button.getAttribute("aria-label") ?? "").startsWith(
+            `Reset ${actionName} at `
+          )
+      );
+    expect(found).toBeDefined();
+    return found as HTMLElement;
+  };
+
+  /** Move the picker without committing, leaving a gesture pending. */
+  const dragTo = async (hex: string): Promise<void> => {
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    // Radix arms its outside-pointerdown listener in a `setTimeout`. Until that
+    // has run nothing can dismiss the popover, so a case that presses a button
+    // outside it asserts against a picker that never closed.
+    await settle();
+    /*
+     * The PICKER's hex field, found INSIDE the open popover.
+     *
+     * Not "the textbox that is not this control's own": a panel with a second
+     * colour control has a third textbox, and that rule picks up the other
+     * control's field instead. Committing through a control's own field writes
+     * on blur and never reaches the pending gesture, so the case would then
+     * drive nothing the supersede can act on and assert against zero writes.
+     */
+    const picker = within(screen.getByRole("dialog")).getAllByRole(
+      "textbox"
+    )[0];
+    expect(picker).toBeDefined();
+    if (picker === undefined) return;
+    fireEvent.change(picker, { target: { value: hex } });
+  };
+
+  it("drops the gesture the Reset replaced, rather than queueing it", async () => {
+    /*
+     * Reset supersedes the gesture, so the picker must DISCARD it — not merely
+     * decline to write it there and then. Left queued, the unmount flush writes
+     * the old colour back over the reset as a later operation: the property the
+     * author cleared reappears, and one undo removes a write no gesture of
+     * theirs produced.
+     */
+    const editor = mountWithResets([{ property: "color" }]);
+    await dragTo("#ff0000");
+    expect(editor.applyAll).not.toHaveBeenCalled();
+
+    const reset = resetFor("Color");
+    fireEvent.pointerDown(reset);
+    fireEvent.click(reset);
+    await settle();
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+
+    cleanup();
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a gesture ANOTHER control's Reset does not replace", async () => {
+    /*
+     * The supersede is scoped to the field whose value the press writes. A
+     * Reset on the background colour replaces nothing the text-colour picker is
+     * holding, so that gesture is the author's edit and is written as the
+     * popover closes — before the reset, which is the order the two intents
+     * happened in.
+     *
+     * Marked globally instead, the picker treats every Reset in the panel as
+     * superseding it and the gesture is discarded silently.
+     */
+    // The link colour, which is the same CSS property at a DESCENDANT — so the
+    // trace attributes it separately and it earns its own Reset.
+    const editor = mountWithResets([
+      { property: "color" },
+      { property: "color", descendant: "a" },
+    ]);
+    await dragTo("#ff0000");
+
+    const resets = screen
+      .getAllByRole("button")
+      .filter(button => button.dataset.action === "reset");
+    // Two, or the case is not about one control's Reset versus another's.
+    expect(resets).toHaveLength(2);
+    const mine = resetFor("Color");
+    const other = resets.find(button => button !== mine);
+    expect(other).toBeDefined();
+    if (other === undefined) return;
+    fireEvent.pointerDown(other);
+    fireEvent.click(other);
+    await settle();
+
+    expect(editor.applyAll).toHaveBeenCalledTimes(2);
+    expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
   });
 });

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -2248,6 +2248,70 @@ describe("the action a control's breakpoint provenance earns", () => {
     expect(label).toContain("Reset");
   });
 
+  it("declares that it writes for itself, so a picker does not write twice", () => {
+    /*
+     * The colour picker commits its draft when the popover closes, and pressing
+     * anything outside it closes the popover first. Without this declaration
+     * one Reset gesture writes twice — the draft the author was discarding,
+     * then the clear — and the first undo restores the very colour they pressed
+     * Reset to be rid of.
+     *
+     * The MECHANISM is covered behaviourally by the token-clear supersede cases
+     * in `style-colour-panel.test.tsx`, which drive a real picker. What is only
+     * true here is that Reset makes the same promise.
+     */
+    mount({ stored: BASE_BREAKPOINT, entries: [entryAt(BASE_BREAKPOINT)] });
+
+    expect(action("reset")?.hasAttribute("data-nx-commits-itself")).toBe(true);
+  });
+
+  it("names the AXIS in the reset fallback, as the jump does", () => {
+    /*
+     * A container tier can share a label with a viewport one, which is why
+     * `BreakpointSource` carries the axis at all. A reset saying "showing the
+     * value from Tablet" beside a jump saying "Tablet (container)" leaves the
+     * author to work out that the two Tablets are different tiers.
+     */
+    register({ color: true });
+    const editor = editorFor(
+      documentOf({ base: { [BASE_BREAKPOINT]: { color: "#111" } } })
+    );
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        breakpoints={
+          {
+            viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+            container: [{ id: "card", label: "Tablet", maxWidth: 400 }],
+          } as never
+        }
+        previewContainer="nx-preview-viewport"
+        liveBreakpoints={[BASE_BREAKPOINT, "card"] as never}
+        cascade={
+          {
+            /*
+             * The container entry FIRST and the base entry after it, so base
+             * wins the cascade and the control reads as authored here — which
+             * is the only state that offers a reset. Reversed, the container
+             * declaration wins, the control reads as inherited, and this case
+             * would assert against a button that is not drawn.
+             */
+            entries: [entryAt("card"), entryAt(BASE_BREAKPOINT)],
+            nodes: editor.document.nodes,
+          } as never
+        }
+      />
+    );
+
+    const label = action("reset")?.getAttribute("aria-label") ?? "";
+    /*
+     * Asserted unconditionally. A guard like `if (label.includes("Tablet"))`
+     * would pass whenever the reveal came out empty, which is the failure this
+     * case is meant to catch dressed as a pass.
+     */
+    expect(label).toContain("Tablet (container)");
+  });
+
   it("offers a JUMP for a value that came from another tier", () => {
     mount({
       stored: BASE_BREAKPOINT,

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -2248,7 +2248,7 @@ describe("the action a control's breakpoint provenance earns", () => {
     expect(label).toContain("Reset");
   });
 
-  it("declares that it writes for itself, so a picker does not write twice", () => {
+  it("declares WHICH field it writes, so a picker does not write twice", () => {
     /*
      * The colour picker commits its draft when the popover closes, and pressing
      * anything outside it closes the popover first. Without this declaration
@@ -2256,13 +2256,25 @@ describe("the action a control's breakpoint provenance earns", () => {
      * then the clear — and the first undo restores the very colour they pressed
      * Reset to be rid of.
      *
-     * The MECHANISM is covered behaviourally by the token-clear supersede cases
-     * in `style-colour-panel.test.tsx`, which drive a real picker. What is only
-     * true here is that Reset makes the same promise.
+     * The field is NAMED rather than the promise being made bare, because a
+     * bare one is made to every picker in the panel: a Reset on one control
+     * would then discard an unfinished gesture on another that it replaces
+     * nothing of.
+     *
+     * The MECHANISM is covered behaviourally in `style-colour-panel.test.tsx`,
+     * which drives a real picker against both a Reset on its own control and a
+     * Reset on a different one. What is only true here is that Reset names the
+     * control it is drawn beside.
      */
     mount({ stored: BASE_BREAKPOINT, entries: [entryAt(BASE_BREAKPOINT)] });
 
-    expect(action("reset")?.hasAttribute("data-nx-commits-itself")).toBe(true);
+    const field = document.querySelector(
+      '[data-property="color"] input'
+    ) as HTMLInputElement | null;
+    expect(field?.id).toBeTruthy();
+    expect(action("reset")?.getAttribute("data-nx-commits-for")).toBe(
+      field?.id
+    );
   });
 
   it("names the AXIS in the reset fallback, as the jump does", () => {

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1245,6 +1245,21 @@ function BreakpointAction({
 }
 
 /**
+ * What to call a breakpoint source in front of an author.
+ *
+ * ONE naming for both actions. `BreakpointSource` carries the axis precisely
+ * because a site defining both makes a bare tier name ambiguous — and a
+ * container tier may share its label with a viewport one — so a reset saying
+ * "showing the value from Tablet" while a jump says "Tablet (container)" leaves
+ * the author to work out that the two Tablets are different tiers.
+ */
+function sourceLabel(source: BreakpointSource): string {
+  return source.axis === "container"
+    ? `${source.label} (container)`
+    : source.label;
+}
+
+/**
  * Clear this control at the tier being edited, saying what will show through.
  *
  * "Reset" alone asks an author to guess whether the control becomes unset or
@@ -1267,12 +1282,26 @@ function ResetAction({
   const reveals =
     revealed === undefined
       ? "leaving it unset"
-      : `showing the value from ${revealed.label}`;
+      : `showing the value from ${sourceLabel(revealed)}`;
   return (
     <button
       type="button"
       className="nx-style-inspector__breakpoint-action"
       data-action="reset"
+      /*
+       * This press writes for itself, which a picker mid-gesture needs to know.
+       *
+       * The colour picker commits its draft when the popover closes, and
+       * pressing anything outside it closes the popover first — so without this
+       * one Reset gesture writes twice: the draft the author was discarding,
+       * then the clear. The first undo would then restore the very colour they
+       * pressed Reset to be rid of.
+       *
+       * Declared on the element rather than held as a ref by each picker,
+       * because the rule is about what a CONTROL is, not about which specific
+       * button a particular field happens to know.
+       */
+      data-nx-commits-itself=""
       onClick={onReset}
       aria-label={`Reset ${label} at ${editing.labelOf(editing.breakpoint)}, ${reveals}`}
     >
@@ -1285,7 +1314,7 @@ function ResetAction({
         className="nx-style-inspector__breakpoint-reveals"
         aria-hidden="true"
       >
-        {revealed === undefined ? "to unset" : `to ${revealed.label}`}
+        {revealed === undefined ? "to unset" : `to ${sourceLabel(revealed)}`}
       </span>
     </button>
   );
@@ -1307,8 +1336,7 @@ function JumpAction({
   label: string;
   onJump: () => void;
 }): React.JSX.Element {
-  const where =
-    source.axis === "container" ? `${source.label} (container)` : source.label;
+  const where = sourceLabel(source);
   return (
     <button
       type="button"
@@ -2245,10 +2273,6 @@ function ColourField({
   // in state because the unmount flush below reads it from a cleanup that runs
   // once, where the closed-over `draft` would be the value at first render.
   const pending = React.useRef<string | null>(null);
-  // The clear beside a token reference. It sits OUTSIDE the popover, so pressing
-  // it dismisses the picker and then commits — two writes for one intent unless
-  // the close knows the press belongs to it.
-  const clear = React.useRef<HTMLButtonElement | null>(null);
   /*
    * A discrete choice, which SUPERSEDES anything the picker was mid-way through.
    *
@@ -2377,10 +2401,15 @@ function ColourField({
           }}
           // Committed when the picker CLOSES, which is where the gesture ends.
           onClosed={commitDraft}
+          /*
+           * Any control that writes for itself, declared on the element. The
+           * token clear beside this picker is one; a breakpoint Reset is
+           * another, and it lives in a different component that has no way to
+           * hand a ref down here.
+           */
           commitsItself={target =>
-            clear.current !== null &&
-            target instanceof Node &&
-            clear.current.contains(target)
+            target instanceof Element &&
+            target.closest("[data-nx-commits-itself]") !== null
           }
           // A preset is one discrete choice rather than a gesture, so it
           // commits immediately, exactly as the select and toggle controls do.
@@ -2407,7 +2436,6 @@ function ColourField({
           />
         ) : (
           <TokenName
-            buttonRef={clear}
             label={storedLabel}
             actionName={actionName}
             onClear={() => commitInstead(null)}
@@ -2589,13 +2617,10 @@ function storedTokenLabel(
  * rather than an empty space.
  */
 function TokenName({
-  buttonRef,
   label,
   actionName,
   onClear,
 }: {
-  /** Handed up so the picker can tell its own clear from any other dismissal. */
-  buttonRef: React.RefObject<HTMLButtonElement | null>;
   /**
    * What to show: the token's current name, qualified with its identity where
    * another offered token shares that name, and the identity alone when the
@@ -2610,7 +2635,13 @@ function TokenName({
     <>
       <span className="nx-style-inspector__colour-token">{label}</span>
       <button
-        ref={buttonRef}
+        /*
+         * This press writes for itself: it commits the clear, and the picker
+         * must not also write the draft its dismissal would otherwise flush.
+         * Declared rather than handed up as a ref, so any control making the
+         * same promise says so the same way.
+         */
+        data-nx-commits-itself=""
         type="button"
         onClick={onClear}
         aria-label={`Clear ${actionName}`}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1053,6 +1053,7 @@ function StyleControlField({
         answer={answer}
         label={actionName}
         editing={editing}
+        fieldId={id}
         onReset={() => commit(null)}
       />
       {issue === null ? null : (
@@ -1208,6 +1209,7 @@ function BreakpointAction({
   answer,
   label,
   editing,
+  fieldId,
   onReset,
 }: {
   answer: ProvenanceAnswer | undefined;
@@ -1222,6 +1224,8 @@ function BreakpointAction({
    */
   label: string;
   editing: EditedAddress;
+  /** The field this control's actions write, passed on to {@link ResetAction}. */
+  fieldId: string;
   onReset: () => void;
 }): React.JSX.Element | null {
   const badge = answer?.badge;
@@ -1234,6 +1238,7 @@ function BreakpointAction({
         revealed={badge.revealed}
         label={label}
         editing={editing}
+        fieldId={fieldId}
         onReset={onReset}
       />
     );
@@ -1268,15 +1273,66 @@ function sourceLabel(source: BreakpointSource): string {
  * name AND in visible text, because computing it exists to remove that guess
  * for everybody rather than for screen-reader users alone.
  */
+/**
+ * Which field a control writes the value of, when it is not that field.
+ *
+ * The colour picker commits its gesture when the popover closes, and pressing
+ * anything outside it closes the popover first. A control that writes the SAME
+ * value the picker is composing therefore has to say so, or one intent produces
+ * two edits and the first undo restores the value the author pressed the
+ * control to be rid of.
+ *
+ * Stated as the field's id rather than as a bare flag, because the question is
+ * not "does this control write" — every control does — but "does it write what
+ * this picker is holding". A bare flag makes Reset on `background-color`
+ * supersede an open picker on `color`, discarding a gesture nothing replaced.
+ *
+ * Declared on the element rather than handed down as a ref, because the
+ * controls making the promise live in components with no path to the picker:
+ * a breakpoint Reset is drawn beside the control, not inside it.
+ */
+const COMMITS_FOR = "data-nx-commits-for";
+
+/**
+ * How a picker's popover closed: with its gesture written, or superseded.
+ *
+ * Named rather than left as a boolean, because the two are not "did something
+ * happen" — both are outcomes the host must ACT on, and the discard is the one
+ * a boolean invites a caller to express by doing nothing.
+ */
+type PickerClose = "committed" | "superseded";
+
+/** The attributes marking a control as writing `fieldId`'s value itself. */
+function commitsFor(fieldId: string): Record<string, string> {
+  return { [COMMITS_FOR]: fieldId };
+}
+
+/**
+ * Whether an interaction outside the picker writes `fieldId`'s value itself.
+ *
+ * Asked of the ancestor chain rather than of the target alone: the press lands
+ * on whatever the control renders inside its button, and a control that puts a
+ * span or an icon in there would otherwise stop making the promise.
+ */
+function supersedes(target: EventTarget | null, fieldId: string): boolean {
+  if (!(target instanceof Element)) return false;
+  return (
+    target.closest(`[${COMMITS_FOR}]`)?.getAttribute(COMMITS_FOR) === fieldId
+  );
+}
+
 function ResetAction({
   revealed,
   label,
   editing,
+  fieldId,
   onReset,
 }: {
   revealed: BreakpointSource | undefined;
   label: string;
   editing: EditedAddress;
+  /** The field whose value this press writes. See {@link commitsFor}. */
+  fieldId: string;
   onReset: () => void;
 }): React.JSX.Element {
   const reveals =
@@ -1289,7 +1345,8 @@ function ResetAction({
       className="nx-style-inspector__breakpoint-action"
       data-action="reset"
       /*
-       * This press writes for itself, which a picker mid-gesture needs to know.
+       * This press writes THIS field's value, which a picker mid-gesture on it
+       * needs to know.
        *
        * The colour picker commits its draft when the popover closes, and
        * pressing anything outside it closes the popover first — so without this
@@ -1298,10 +1355,10 @@ function ResetAction({
        * pressed Reset to be rid of.
        *
        * Declared on the element rather than held as a ref by each picker,
-       * because the rule is about what a CONTROL is, not about which specific
+       * because the rule is about what a CONTROL does, not about which specific
        * button a particular field happens to know.
        */
-      data-nx-commits-itself=""
+      {...commitsFor(fieldId)}
       onClick={onReset}
       aria-label={`Reset ${label} at ${editing.labelOf(editing.breakpoint)}, ${reveals}`}
     >
@@ -2287,7 +2344,14 @@ function ColourField({
     onCommit(value);
   };
   /*
-   * The gesture, written when the picker closes.
+   * The picker closed, whichever outcome that close had.
+   *
+   * ONE handler for both, because the two differ only in whether the gesture is
+   * written — the pending value is dropped either way. Expressed as two
+   * handlers, the supersede path is the one that silently does nothing: it
+   * would leave the draft queued, and the unmount flush below would write it
+   * back OVER the edit that superseded it, as a later op with no gesture behind
+   * it.
    *
    * Synchronous, because an author can leave the editor entirely in the same
    * interaction that dismisses this popover: the page builder hands the current
@@ -2299,10 +2363,10 @@ function ColourField({
    * rather than by giving a later handler time to cancel a scheduled write. A
    * timer bought that cancellation and paid for it with this race.
    */
-  const commitDraft = (): void => {
+  const closed = (outcome: PickerClose): void => {
     const unwritten = pending.current;
     pending.current = null;
-    if (unwritten === null) return;
+    if (outcome === "superseded" || unwritten === null) return;
     if (onCommit(unwritten) === "unchanged") reset();
   };
   // The current writer, held so the teardown below depends on nothing. A
@@ -2399,18 +2463,15 @@ function ColourField({
             pending.current = value;
             setDraft(value);
           }}
-          // Committed when the picker CLOSES, which is where the gesture ends.
-          onClosed={commitDraft}
+          // The gesture ends where the picker closes, whichever way it closed.
+          onClosed={closed}
           /*
-           * Any control that writes for itself, declared on the element. The
-           * token clear beside this picker is one; a breakpoint Reset is
-           * another, and it lives in a different component that has no way to
-           * hand a ref down here.
+           * Any control that writes THIS field's value for itself, declared on
+           * the element. The token clear beside this picker is one; a
+           * breakpoint Reset is another, and it lives in a different component
+           * that has no way to hand a ref down here.
            */
-          commitsItself={target =>
-            target instanceof Element &&
-            target.closest("[data-nx-commits-itself]") !== null
-          }
+          supersededBy={target => supersedes(target, id)}
           // A preset is one discrete choice rather than a gesture, so it
           // commits immediately, exactly as the select and toggle controls do.
           onToken={identity => commitInstead({ $token: identity })}
@@ -2438,6 +2499,7 @@ function ColourField({
           <TokenName
             label={storedLabel}
             actionName={actionName}
+            fieldId={id}
             onClear={() => commitInstead(null)}
           />
         )}
@@ -2470,7 +2532,7 @@ function ColourPicker({
   unrepresented,
   onColour,
   onClosed,
-  commitsItself,
+  supersededBy,
   onToken,
 }: {
   /** The resolved colour, or `undefined` when nothing here can resolve one. */
@@ -2485,19 +2547,27 @@ function ColourPicker({
   unrepresented: boolean;
   /** The picker moved. Fires on every pointer event during a drag. */
   onColour: (hex: string) => void;
-  /** The picker closed, which is where a gesture ends and a write belongs. */
-  onClosed: () => void;
   /**
-   * Whether an interaction outside the popover will write for itself.
+   * The picker closed, and how.
+   *
+   * The outcome is a value rather than the presence or absence of a call,
+   * because "superseded" is an instruction to DISCARD the gesture, not an
+   * absence of one — and a host given only the write path has nowhere to drop
+   * what it was holding.
+   */
+  onClosed: (outcome: PickerClose) => void;
+  /**
+   * Whether an interaction outside the popover writes THIS field's value
+   * itself.
    *
    * Asked before the dismissal is turned into a write, so a control that both
-   * closes this picker and commits something of its own does not produce two
-   * edits for one intent. `onInteractOutside` is the single callback Radix
-   * fires for EVERY cause it dismisses on — pointer, focus and the rest — which
-   * is why the question is asked here rather than by hooking the causes one at
-   * a time and missing whichever is added next.
+   * closes this picker and commits the same value does not produce two edits
+   * for one intent. `onInteractOutside` is the single callback Radix fires for
+   * EVERY cause it dismisses on — pointer, focus and the rest — which is why
+   * the question is asked here rather than by hooking the causes one at a time
+   * and missing whichever is added next.
    */
-  commitsItself: (target: EventTarget | null) => boolean;
+  supersededBy: (target: EventTarget | null) => boolean;
   onToken: (identity: string) => void;
 }): React.JSX.Element {
   // Whether the dismissal in progress belongs to a control that writes for
@@ -2510,7 +2580,7 @@ function ColourPicker({
         if (open) return;
         const own = superseded.current;
         superseded.current = false;
-        if (!own) onClosed();
+        onClosed(own ? "superseded" : "committed");
       }}
     >
       <PopoverTrigger asChild>
@@ -2535,7 +2605,7 @@ function ColourPicker({
       <PopoverContent
         className="nx-style-inspector__picker"
         onInteractOutside={event => {
-          superseded.current = commitsItself(event.target);
+          superseded.current = supersededBy(event.target);
         }}
       >
         {unrepresented ? (
@@ -2619,6 +2689,7 @@ function storedTokenLabel(
 function TokenName({
   label,
   actionName,
+  fieldId,
   onClear,
 }: {
   /**
@@ -2629,6 +2700,8 @@ function TokenName({
    */
   label: string;
   actionName: string;
+  /** The field whose value this clear writes. See {@link commitsFor}. */
+  fieldId: string;
   onClear: () => void;
 }): React.JSX.Element {
   return (
@@ -2636,12 +2709,12 @@ function TokenName({
       <span className="nx-style-inspector__colour-token">{label}</span>
       <button
         /*
-         * This press writes for itself: it commits the clear, and the picker
-         * must not also write the draft its dismissal would otherwise flush.
-         * Declared rather than handed up as a ref, so any control making the
-         * same promise says so the same way.
+         * This press writes this field's value: it commits the clear, and the
+         * picker must not also write the draft its dismissal would otherwise
+         * flush. Declared rather than handed up as a ref, so any control making
+         * the same promise says so the same way.
          */
-        data-nx-commits-itself=""
+        {...commitsFor(fieldId)}
         type="button"
         onClick={onClear}
         aria-label={`Clear ${actionName}`}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -2557,15 +2557,17 @@ function ColourPicker({
    */
   onClosed: (outcome: PickerClose) => void;
   /**
-   * Whether an interaction outside the popover writes THIS field's value
-   * itself.
+   * Whether the control being PRESSED outside the popover writes THIS field's
+   * value itself.
    *
    * Asked before the dismissal is turned into a write, so a control that both
    * closes this picker and commits the same value does not produce two edits
-   * for one intent. `onInteractOutside` is the single callback Radix fires for
-   * EVERY cause it dismisses on — pointer, focus and the rest — which is why
-   * the question is asked here rather than by hooking the causes one at a time
-   * and missing whichever is added next.
+   * for one intent — the author would otherwise undo the reset and get back the
+   * colour they pressed it to be rid of.
+   *
+   * The target is a press rather than any interaction, because Radix dismisses
+   * on focus as well and a focused button has not written anything. See where
+   * this is bound.
    */
   supersededBy: (target: EventTarget | null) => boolean;
   onToken: (identity: string) => void;
@@ -2604,7 +2606,23 @@ function ColourPicker({
       </PopoverTrigger>
       <PopoverContent
         className="nx-style-inspector__picker"
-        onInteractOutside={event => {
+        /*
+         * A PRESS, not any dismissal whose target happens to be such a control.
+         *
+         * `onInteractOutside` also fires when focus merely LEAVES the popover —
+         * a keyboard author tabbing out lands on the Reset beside this control
+         * and dismisses it without activating anything. Read there, the gesture
+         * they were composing is discarded by a button they never pressed, and
+         * tabbing onward loses it silently.
+         *
+         * The question is not which cause dismissed the popover but whether a
+         * control is about to WRITE, and only a pointer press implies that: the
+         * press is followed by the click that runs the handler. Focus is not,
+         * so a focus dismissal falls through to the ordinary close and the
+         * gesture is committed — which is what leaving a control does
+         * everywhere else in this panel, the text fields included.
+         */
+        onPointerDownOutside={event => {
           superseded.current = supersededBy(event.target);
         }}
       >

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -681,6 +681,36 @@ describe("the breakpoint dimension of a control's provenance", () => {
     expect(badge).toEqual({ kind: "none" });
   });
 
+  it("keeps an UNBOUNDED container tier unselectable", () => {
+    /*
+     * An unbounded container definition has no `maxWidth`, exactly like the
+     * unconditional viewport tier — but `offeredTiers` and `widthForBreakpoint`
+     * exclude the container axis entirely, so a jump would hand the host
+     * `undefined` and release the canvas as though base had been chosen.
+     * Sizing a canvas cannot put an element's own query container at a width.
+     */
+    const badge = badgeFor(
+      query([entry({ breakpoint: "fluid" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["fluid", "mobile"],
+      }),
+      {
+        viewport: [{ id: "mobile", label: "Mobile", maxWidth: 575 }],
+        container: [{ id: "fluid", label: "Fluid" }],
+      } as never
+    );
+
+    expect(badge).toEqual({
+      kind: "inherited",
+      source: {
+        breakpoint: "fluid",
+        label: "Fluid",
+        axis: "container",
+        selectable: false,
+      },
+    });
+  });
+
   it("names the CONTAINER axis rather than reporting a bare breakpoint", () => {
     /*
      * `breakpointContexts` emits over both axes and a container context carries
@@ -821,6 +851,84 @@ describe("the breakpoint dimension of a control's provenance", () => {
     const badge = badgeFor(
       query([entry({ property: "background-image", value: "url(a.png)" })], {
         cssProperty: "background-image",
+      }),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "none" });
+  });
+
+  it("says nothing when the winner is another STATE at another breakpoint", () => {
+    /*
+     * The breakpoint check alone is not enough: a hover value at Tablet differs
+     * from the edited address in TWO dimensions, and passing it through would
+     * offer "go to Tablet" to an author editing the base state — where the
+     * field they are looking at holds nothing.
+     *
+     * The existing same-breakpoint case cannot catch this, because there the
+     * breakpoint guard fires first.
+     */
+    const badge = badgeFor(
+      query([entry({ state: "hover", breakpoint: "tablet" })], {
+        breakpoint: "mobile",
+        state: "base",
+        liveBreakpoints: ["tablet", "mobile"],
+        liveStates: ["base", "hover"],
+      } as never),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "none" });
+  });
+
+  it("says nothing when the winner belongs to an ENCLOSING node", () => {
+    /*
+     * `styleOrigin` deliberately returns an ancestor's declaration when it
+     * carries a descendant selector that reaches here. A bare `node` origin at
+     * another breakpoint is therefore not proof the value is this control's —
+     * and "go to Tablet and edit it there" would send the author to a tier
+     * where the field in front of them holds nothing, because the value lives
+     * on a different node.
+     *
+     * Measured while break-verifying: this case does NOT distinguish the id
+     * guard on its own. A subject naming no ancestors has an unrelated node's
+     * declaration filtered by `styleOrigin` before the guard is reached, so the
+     * badge is empty either way. It is kept because it pins the OUTCOME, and it
+     * would fail if that upstream filtering ever changed — but the guard itself
+     * is belt-and-braces here rather than load-bearing, and this comment says
+     * so instead of leaving the case reading as coverage it does not give.
+     */
+    const badge = badgeFor(
+      query(
+        [
+          entry({
+            origin: { kind: "node", id: "parent" },
+            breakpoint: "tablet",
+          }),
+        ],
+        {
+          breakpoint: "mobile",
+          liveBreakpoints: ["tablet", "mobile"],
+        }
+      ),
+      site
+    );
+
+    expect(badge).toEqual({ kind: "none" });
+  });
+
+  it("says nothing when the winner belongs to another CONTROL on this node", () => {
+    /*
+     * A rule on a more specific selector reaches this control without being
+     * written by it — ` a` reaches the link-hover control when no hover value
+     * exists. Same node, same state, another breakpoint, and still not a tier
+     * this control can be edited at.
+     */
+    const badge = badgeFor(
+      query([entry({ descendant: " a", breakpoint: "tablet" })], {
+        breakpoint: "mobile",
+        liveBreakpoints: ["tablet", "mobile"],
+        descendant: " a:hover",
       }),
       site
     );

--- a/packages/builder/src/style-provenance.test.ts
+++ b/packages/builder/src/style-provenance.test.ts
@@ -890,23 +890,38 @@ describe("the breakpoint dimension of a control's provenance", () => {
      * where the field in front of them holds nothing, because the value lives
      * on a different node.
      *
-     * Measured while break-verifying: this case does NOT distinguish the id
-     * guard on its own. A subject naming no ancestors has an unrelated node's
-     * declaration filtered by `styleOrigin` before the guard is reached, so the
-     * badge is empty either way. It is kept because it pins the OUTCOME, and it
-     * would fail if that upstream filtering ever changed — but the guard itself
-     * is belt-and-braces here rather than load-bearing, and this comment says
-     * so instead of leaving the case reading as coverage it does not give.
+     * The fixture has to REACH the guard, and three things are needed for that.
+     *
+     * The subject must NAME the ancestor, because `styleOrigin` only lets an
+     * enclosing node's rule through `reachesViaAncestor` — with no ancestors
+     * listed, an unrelated node's declaration is filtered upstream and the
+     * badge is empty whether or not the guard exists.
+     *
+     * That entry must carry a DESCENDANT selector, because a bare rule on
+     * another node reaches nothing here; `reachesViaAncestor` returns false for
+     * `descendant === undefined`.
+     *
+     * And the query must ask at the SAME descendant, or `inheritedBadge`'s
+     * descendant comparison rejects the entry first and the id check is again
+     * never the reason. With all three, the only thing standing between this
+     * trace and an `inherited` badge is the id.
      */
     const badge = badgeFor(
       query(
         [
           entry({
             origin: { kind: "node", id: "parent" },
+            descendant: " a",
             breakpoint: "tablet",
           }),
         ],
         {
+          subject: {
+            nodeId: "n1",
+            classIds: ["c1"],
+            ancestors: [{ nodeId: "parent" }],
+          },
+          descendant: " a",
           breakpoint: "mobile",
           liveBreakpoints: ["tablet", "mobile"],
         }

--- a/packages/builder/src/style-provenance.ts
+++ b/packages/builder/src/style-provenance.ts
@@ -519,10 +519,49 @@ export function breakpointSource(
      * the same list the switcher builds its options from, so "a tier a canvas
      * can be taken to" has one definition rather than two.
      */
+    /*
+     * The unconditional VIEWPORT tier is reachable — releasing the canvas is
+     * how it is shown. An unbounded CONTAINER definition is not: it has no
+     * `maxWidth` either, but `offeredTiers` and `widthForBreakpoint` exclude
+     * the container axis entirely, so a jump would hand the host `undefined`
+     * and release the canvas as though base had been chosen. Sizing a canvas
+     * cannot put an element's own query container at a width, whatever the
+     * definition looks like.
+     */
     selectable:
-      !isUsableWidth(context.maxWidth) ||
-      offeredTiers(breakpoints).some(tier => tier.id === breakpoint),
+      context.axis !== "container" &&
+      (!isUsableWidth(context.maxWidth) ||
+        offeredTiers(breakpoints).some(tier => tier.id === breakpoint)),
   };
+}
+
+/**
+ * The badge for a value that won from somewhere other than the edited address.
+ *
+ * Its own function because the question is one word — is this THIS control at
+ * another breakpoint? — and the answer needs the whole address checked.
+ * `styleOrigin` deliberately returns declarations from an enclosing node, from
+ * another state, and from a less specific sibling control, so a bare `node`
+ * origin proves none of what the action promises.
+ */
+function inheritedBadge(
+  query: StyleProvenanceQuery,
+  provenance: Extract<StyleProvenance, { kind: "inherited" }>,
+  breakpoints: BreakpointSet | undefined
+): BreakpointBadge {
+  const { from, entry } = provenance;
+  const sameAddress =
+    from.kind === "node" &&
+    from.id === query.subject.nodeId &&
+    entry.state === query.state &&
+    normalizeDescendant(entry.descendant) ===
+      normalizeDescendant(query.descendant);
+  if (!sameAddress) return { kind: "none" };
+  if (entry.breakpoint === query.breakpoint) return { kind: "none" };
+  const source = breakpointSource(entry.breakpoint, breakpoints);
+  return source === undefined
+    ? { kind: "none" }
+    : { kind: "inherited", source };
 }
 
 /**
@@ -558,20 +597,7 @@ export function breakpointBadge(
     return { kind: "none" };
   }
   if (provenance.kind === "inherited") {
-    /*
-     * A different TIER is the dot's answer, not this one. Only a value this
-     * node authored at another breakpoint belongs here — anything from a class,
-     * the block type or the page is reported by the origin dot, and repeating
-     * it as a breakpoint badge would say the same thing twice in two
-     * vocabularies.
-     */
-    if (provenance.from.kind !== "node") return { kind: "none" };
-    if (provenance.entry.breakpoint === query.breakpoint)
-      return { kind: "none" };
-    const source = breakpointSource(provenance.entry.breakpoint, breakpoints);
-    return source === undefined
-      ? { kind: "none" }
-      : { kind: "inherited", source };
+    return inheritedBadge(query, provenance, breakpoints);
   }
   /*
    * Authored here. What a reset would reveal is whatever wins once the


### PR DESCRIPTION
Follow-up to #1231, for a P1 Codex raised after that PR merged.

## The finding

`compiledBreakpoints` re-implemented `PageRenderer`'s `sharedStyleInputs`
reconciliation instead of calling it. Codex's point was structural rather than
about a remaining bug: the explicit `undefined` check fixed the case in hand,
but the next renderer-side change to normalisation or precedence can again
activate a preview box from different breakpoints than the sheet compiles.

It is right, and the history on that one small function is the evidence. It was
wrong three times in #1231:

1. **Precedence inverted** — I read the route context first; `sharedStyleInputs`
   gives the stored site tier precedence.
2. **Fallthrough wrong** — read as "the site wins whenever a sheet exists", a
   sheet carrying no breakpoints answered `undefined` for both tiers.
3. **A stated `null`** — `firstStated` skips only `undefined`, so `null` is kept
   and means "no viewport tiers"; `??` discarded it.

Each was wrong *after being read carefully*. That is the argument for calling
the function rather than reproducing it.

## What changed

`sharedStyleInputs` is now published from `@nextlyhq/blocks-react`, and the
canvas asks it. The parallel implementation is gone.

Publishing it is the point rather than a side effect: a surface deciding
anything from "the breakpoints this page compiles against" must read the same
answer the render will use, and the precedences are not guessable from the
inputs — the site tier wins for `breakpoints`, the route wins for
`previewContainer`, and each skips only `undefined`.

## Also here

`breakpoint-action-styles.test.ts` had a docblock stating what it had measured
about its own arrival rather than what the code does. That landed on `main` in
#1245 and `check-comment-convention` flags it there today — this removes it.

## Verification

No new tests: the swap is behaviour-preserving and the existing cases are the
discriminating ones. Both were break-verified against the new implementation —
swapping the arguments fails `decides from the SITE's breakpoints` and `treats a
stated NULL breakpoint set as the site having none`; ignoring the site sheet
fails three more.

The root entry's surface test lists `sharedStyleInputs`, which is what that test
is for.

Gates: build, check-types, builder (2030), blocks-engine (1504), blocks-react
(882), ui (1135), plugin-page-builder (376), test:scripts, lint, comment
convention, changeset, `fallow audit` at `complexity_introduced: 0`,
`duplication_introduced: 0`, `dead_code_introduced: 0`.
