### PR TITLE
fix(admin): four follow-ups on the preview viewport control

### DIFF
--- a/.changeset/preview-viewport-followups.md
+++ b/.changeset/preview-viewport-followups.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The pane toggle says what clicking it will do again. A collection that declares
+no preview label was handed the defaulted "Preview", so the button read
+"Preview" in both the open and closed states instead of "Show preview" and
+"Hide preview". The declared label now travels and absence is preserved, which
+is what lets the button and the pane each apply the wording its own sentence
+takes.
+
+Choosing "Custom width" always opens the box. It commits a seed width, and where
+a site declared a viewport at that same width — 1280 is the seed and an ordinary
+desktop tier — the control resolved it as that preset and never showed the
+input, so a custom width could not be entered at all.
+
+A named viewport is previewed at exactly the width it declares. Widths are no
+longer rounded, so a site can offer 767.6 — and reading the chosen option with
+`parseInt` sized the frame to 767, one side of the site's own
+`@media (max-width: 767.6px)` boundary, then matched no viewport and showed
+"Custom" for an option just picked by name.
+
+A fractional custom width no longer reads as invalid. A number input steps by 1
+unless told otherwise, so the browser reported a committed `390.5` as a step
+mismatch while the preview was using that exact width.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -820,7 +820,9 @@ export function EntryForm({
                             onLocaleChange={onLocaleChange}
                             localized={collection.localized === true}
                             isPreviewAvailable={canPreview}
-                            previewLabel={entryPreview.label}
+                            {...(entryPreview.declaredLabel === undefined
+                              ? {}
+                              : { previewLabel: entryPreview.declaredLabel })}
                             {...(canPreview &&
                             translationMode.source === undefined
                               ? {

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.preview-link.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntryForm.preview-link.test.tsx
@@ -205,6 +205,23 @@ describe("EntryForm wires the preview action into its header", () => {
     expect(lastHeaderProps().previewLabel).toBe("View page");
   });
 
+  it("hands the header NO label where the collection declares none", () => {
+    /*
+     * The header gives one label to both the open-in-a-tab action and the pane
+     * toggle, and the two default differently: "Preview" as a button's name,
+     * "Show preview" as a sentence saying what the click does. Passing the
+     * already-defaulted value made the toggle read "Preview" in BOTH states —
+     * the one wording that reports nothing about what clicking will do — and
+     * the fallback was unreachable for every ordinary collection.
+     *
+     * So the DECLARED value travels and absence is preserved, which is what
+     * lets each control apply the default its own sentence takes.
+     */
+    renderForm();
+
+    expect(lastHeaderProps().previewLabel).toBeUndefined();
+  });
+
   it("offers nothing for a collection that declares no preview", () => {
     // The negative control. Without it, a wiring that hardcoded `true` would
     // satisfy every assertion above.

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewViewportControl.tsx
@@ -102,6 +102,8 @@ export function PreviewViewportControl({
    * masked by a draft nobody is typing.
    */
   const [draft, setDraft] = useState<string | null>(null);
+  /** Whether the author asked for a custom width, rather than landing on one. */
+  const [editingCustom, setEditingCustom] = useState(false);
 
   /*
    * The width is taken when the author STOPS typing, not per keystroke.
@@ -155,11 +157,20 @@ export function PreviewViewportControl({
    * The draft ends on blur or on a choice from the list, and the match resolves
    * then, so a typed width that equals a named tier still gives way to it one
    * moment later — when the author has finished saying so.
+   *
+   * `editingCustom` is the same exception held for longer. Choosing "Custom
+   * width" is a statement the WIDTH cannot carry: it commits a seed, and if the
+   * site declares a viewport at that width — 1280 is the seed and an entirely
+   * ordinary desktop tier — the lookup resolved it on the next render, showed
+   * that preset's name and never rendered the box, so a custom width could not
+   * be entered at all. The flag records what the author asked for; every other
+   * choice clears it, so the two cannot drift into disagreeing about the width
+   * itself, which is what deriving the selection is for.
    */
   const named =
-    draft === null
-      ? viewports.find(v => v.width === requestedWidth)
-      : undefined;
+    editingCustom || draft !== null
+      ? undefined
+      : viewports.find(v => v.width === requestedWidth);
   const selection =
     requestedWidth === null
       ? RESPONSIVE
@@ -175,11 +186,21 @@ export function PreviewViewportControl({
           // A choice from the list ends the edit, so an abandoned draft does
           // not reappear the next time the box is shown.
           setDraft(null);
+          setEditingCustom(value === CUSTOM);
           if (value === RESPONSIVE) return onRequestWidth(null);
           if (value === CUSTOM) return onRequestWidth(CUSTOM_SEED_WIDTH);
-          // A named option carries its own width as the value, so no lookup can
-          // go stale between rendering the list and reading a choice from it.
-          return onRequestWidth(Number.parseInt(value, 10));
+          /*
+           * A named option carries its own width as the value, so no lookup can
+           * go stale between rendering the list and reading a choice from it.
+           *
+           * `Number`, not `parseInt`: a declared width is offered exactly as
+           * the site declares it, fractions included, and truncating `767.6` to
+           * `767` would size the frame one side of the site's own
+           * `@media (max-width: 767.6px)` boundary — and then match no viewport
+           * at all, so the control would show Custom for an option the author
+           * had just picked by name.
+           */
+          return onRequestWidth(Number(value));
         }}
       >
         <SelectTrigger
@@ -216,6 +237,14 @@ export function PreviewViewportControl({
             type="number"
             inputMode="numeric"
             min={MIN_PREVIEW_WIDTH}
+            /*
+             * A number input steps by 1 unless told otherwise, so the browser
+             * reports a committed `390.5` as `stepMismatch`: the field reads as
+             * invalid to native validation and to assistive technology while
+             * the preview is using that exact width. Fractional widths are real
+             * here, so the step has to say so.
+             */
+            step="any"
             className="h-7 w-20 text-xs"
             value={draft ?? String(requestedWidth)}
             onChange={event => {

--- a/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/__tests__/PreviewViewportControl.test.tsx
@@ -69,6 +69,100 @@ function stopTyping() {
   });
 }
 
+describe("PreviewViewportControl — choosing a viewport", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  /** Opens the list and picks the option with this exact visible text. */
+  function choose(name: string | RegExp) {
+    fireEvent.click(screen.getByLabelText("Preview viewport"));
+    fireEvent.click(screen.getByRole("option", { name }));
+  }
+
+  it("keeps Custom reachable when its seed matches a declared viewport", () => {
+    /*
+     * Entering custom mode commits a seed width. If the site happens to declare
+     * a viewport at that width — 1280 is the seed and a very ordinary desktop
+     * tier — the named lookup resolved it on the next render, flipped the
+     * selection to that preset's name and never rendered the input. The author
+     * could then not enter a custom width at all.
+     *
+     * Choosing Custom is a statement the width alone cannot carry, so it opens
+     * an edit rather than relying on the number being unrecognised.
+     */
+    renderControl(null, [{ label: "Desktop", width: 1280 }]);
+
+    choose("Custom width");
+
+    expect(
+      screen.getByLabelText("Preview width in pixels")
+    ).toBeInTheDocument();
+  });
+
+  it("STAYS in custom mode after typing a width a viewport also declares", () => {
+    /*
+     * The deliberate consequence of recording the choice. Having asked for a
+     * custom width, an author who then types one that happens to equal a
+     * declared tier keeps the box: they said "custom", and resolving the number
+     * against the list would take the control away from them on the strength of
+     * a coincidence. Picking an option from the list is how they leave.
+     */
+    renderControl(null, [{ label: "Tablet", width: 768 }]);
+
+    choose("Custom width");
+    const box = screen.getByLabelText(
+      "Preview width in pixels"
+    ) as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "768" } });
+    fireEvent.blur(box);
+
+    expect(
+      screen.getByLabelText("Preview width in pixels")
+    ).toBeInTheDocument();
+
+    // ...and choosing the named option is what hands it back.
+    choose(/Tablet/);
+    expect(screen.queryByLabelText("Preview width in pixels")).toBeNull();
+  });
+
+  it("commits a named viewport at its EXACT declared width", () => {
+    /*
+     * Declared widths are no longer rounded on the server, so a site can offer
+     * `767.6` — and `parseInt` on the option's value committed `767`. The frame
+     * then sat one side of the site's own `@media (max-width: 767.6px)`
+     * boundary while the control displayed the tier it was not in.
+     */
+    const ui = renderControl(null, [{ label: "Tablet", width: 767.6 }]);
+
+    choose(/Tablet/);
+
+    expect(ui.committed()).toBe("767.6");
+  });
+
+  it("shows a named viewport as selected once it is committed", () => {
+    /*
+     * The control on the case above: committing the exact width is only right
+     * if the lookup then RECOGNISES it. Truncated to 767 it matched nothing and
+     * the control fell back to Custom, which is how the rounding disagreement
+     * would have been visible had anyone looked.
+     */
+    renderControl(null, [{ label: "Tablet", width: 767.6 }]);
+
+    choose(/Tablet/);
+
+    expect(screen.queryByLabelText("Preview width in pixels")).toBeNull();
+    expect(screen.getByLabelText("Preview viewport")).toHaveTextContent(
+      /Tablet/
+    );
+  });
+});
+
 describe("PreviewViewportControl — the width box", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -241,6 +335,25 @@ describe("PreviewViewportControl — the width box", () => {
     fireEvent.change(box, { target: { value: "1e3" } });
     stopTyping();
     expect(ui.committed()).toBe("1000");
+  });
+
+  it("reports a fractional width as VALID to the browser", () => {
+    /*
+     * A number input steps by 1 unless told otherwise, so a committed `390.5`
+     * raised `stepMismatch`: native validation and assistive technology both
+     * called the field invalid while the preview was using that exact width.
+     * Asserted through `validity` rather than by reading the `step` attribute,
+     * because the attribute is the mechanism and this is the consequence.
+     */
+    const ui = renderControl(1280);
+    const box = ui.box() as HTMLInputElement;
+
+    fireEvent.change(box, { target: { value: "390.5" } });
+    stopTyping();
+
+    expect(ui.committed()).toBe("390.5");
+    expect(box.validity.stepMismatch).toBe(false);
+    expect(box.checkValidity()).toBe(true);
   });
 
   it("still refuses text that names no width at all", () => {

--- a/packages/admin/src/hooks/useEntryPreview.ts
+++ b/packages/admin/src/hooks/useEntryPreview.ts
@@ -433,8 +433,18 @@ export interface UseEntryPreviewResult {
   isPreviewAvailable: boolean;
   /** Resolve and open. Asynchronous: the URL comes from the server. */
   openPreview: () => Promise<void>;
-  /** Label for the preview button. */
+  /** Label for the preview button, defaulted where none was declared. */
   label: string;
+  /**
+   * The label the collection actually DECLARED, or nothing.
+   *
+   * Carried beside the defaulted one because the surfaces that show it default
+   * differently: a button is named "Preview", while a pane toggle reads its
+   * label into "Show ..." and wants the sentence instead. Handing the defaulted
+   * value to both made the toggle say "Preview" in either state, which is the
+   * one wording that reports nothing about what clicking does.
+   */
+  declaredLabel: string | undefined;
 }
 
 // ============================================================================
@@ -509,5 +519,6 @@ export function useEntryPreview({
     isPreviewAvailable,
     openPreview,
     label: previewLabel(previewConfig),
+    declaredLabel: declaredPreviewLabel(previewConfig),
   };
 }


### PR DESCRIPTION
Review feedback that arrived on #1233, #1234 and #1237 after they merged. Four defects, all reproduced before fixing and all break-verified.

## The pane toggle stopped saying what it does

Unifying the two naming surfaces onto one prop was right; passing the **already-defaulted** value through it was not. `EntryForm` handed the header `entryPreview.label`, which `useEntryPreview` defaults to `"Preview"` — so for every collection that declares no label the toggle read `"Preview"` in **both** states, and the `Show preview` / `Hide preview` wording was unreachable.

The hook now carries the declared value beside the defaulted one. Each control applies the default its own sentence takes: a button is *named* `"Preview"`; a toggle *says what clicking it will do*.

I predicted this exact case in review on #1233 and chose to leave it as cosmetic. It is not cosmetic — the control reports nothing about its own state.

## Choosing "Custom width" could leave no box to type in

Entering custom mode commits a seed width. Where the site declares a viewport at that width — `1280` is the seed and an entirely ordinary desktop tier — the named lookup resolved it on the next render, showed that preset's name, and never rendered the input. A custom width could not be entered at all.

Choosing Custom is a statement the **width cannot carry**, so it is now recorded rather than inferred. Every other choice clears it, so the flag cannot drift into disagreeing about the width itself — which is the whole reason the selection is derived. An author who then types a width a tier also declares keeps the box; picking the named option is how they leave.

## A named viewport was previewed at the wrong width

Declared widths are no longer rounded (#1237), so a site can offer `767.6`. Reading the chosen option with `parseInt` committed `767` — one side of that site's own `@media (max-width: 767.6px)` boundary — and then matched no viewport, so the control displayed `"Custom"` for an option just picked by name.

## A fractional custom width reported as invalid

A number input steps by `1` unless told otherwise, so the browser raised `stepMismatch` on a committed `390.5` while the preview was using that exact width — native validation and assistive technology both calling the field invalid. Asserted through `validity`, not by reading the `step` attribute: the attribute is the mechanism, the validity is the consequence.

## Verification

Each fix reverted fails its own tests and no others:

| reverted | tests that fail |
| --- | --- |
| declared label | `hands the header NO label where the collection declares none` |
| exact named width | `commits a named viewport at its EXACT declared width`, `shows a named viewport as selected once it is committed` |
| explicit custom mode | `keeps Custom reachable when its seed matches a declared viewport`, `STAYS in custom mode after typing a width a viewport also declares` |
| `step="any"` | `reports a fractional width as VALID to the browser` |

Gates: build, `check-types`, `lint`, `lint:design`, `changeset status`, `fallow` (verdict `pass`, zero introduced), admin suite `926 passed`.

**One gate fails and it is not from this PR.** `check-comment-convention.mjs` is red on the tip of `main` from `b3a3eba51` (#1245), in `packages/builder/src/breakpoint-action-styles.test.ts`. This diff touches neither `packages/builder/**` nor the allowlist, and it reproduces with these commits absent. Reported to that lane.