### PR TITLE
fix(nextly): keep a __proto__ difference visible to the canonical compare

### DIFF
--- a/.changeset/canonical-json-null-prototype.md
+++ b/.changeset/canonical-json-null-prototype.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A difference that lives under a `__proto__` key is no longer read as "no
+change". The registry compares a code-first config against its stored row
+through a canonical serialisation, and that rebuild assigned keys to an ordinary
+object — where `__proto__` invokes the legacy prototype setter instead of
+becoming an enumerable property, so `JSON.stringify` omitted it and two configs
+differing only there compared equal. `JSON.parse` creates that key as an
+ordinary own key, so a stored JSON column round-tripping through it arrives
+carrying one.

--- a/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
+++ b/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
@@ -142,6 +142,44 @@ describe("BaseRegistryService.schemaSyncNeeded", () => {
     expect(probe.ask(declared, storedDifferentOrder, false)).toBe(false);
   });
 
+  it("sees a difference that lives under `__proto__`", () => {
+    /*
+     * `JSON.parse` creates `__proto__` as an ORDINARY own key, so a stored
+     * `jsonb` column round-tripping through it reaches here carrying one. The
+     * canonical rebuild then has to keep it — assigning that key to a plain
+     * `{}` invokes the legacy prototype setter instead of creating an
+     * enumerable property, `JSON.stringify` omits it, and two configs
+     * differing only there compare EQUAL. A null-prototype target is what makes
+     * the key survive.
+     *
+     * The failure is quiet in exactly the wrong direction: a real edit reads as
+     * "unchanged" and never reaches storage.
+     */
+    const declared = JSON.parse(
+      '{"drafts":true,"__proto__":{"max":10}}'
+    ) as SchemaSyncSubject["versions"];
+    const stored = JSON.parse(
+      '{"drafts":true}'
+    ) as SchemaSyncSubject["versions"];
+
+    expect(
+      probe.ask(
+        { ...same, versions: declared },
+        { ...same, versions: stored },
+        false
+      )
+    ).toBe(true);
+  });
+
+  it("does not let a canonicalised value pollute Object.prototype", () => {
+    // The neighbouring risk in the same key. Nothing here writes through a
+    // prototype setter, and this is what would notice if that changed.
+    const declared = JSON.parse('{"__proto__":{"polluted":"yes"}}');
+    probe.ask({ ...same, versions: declared }, { ...same }, false);
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
   it("still sees a REORDERED ARRAY as a change", () => {
     // The control on the case above. Canonicalising keys must not extend to
     // sorting array members: `[a, b]` and `[b, a]` are different values, and a

--- a/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
+++ b/packages/nextly/src/shared/__tests__/base-registry-service.schema-sync.test.ts
@@ -171,13 +171,27 @@ describe("BaseRegistryService.schemaSyncNeeded", () => {
     ).toBe(true);
   });
 
-  it("does not let a canonicalised value pollute Object.prototype", () => {
-    // The neighbouring risk in the same key. Nothing here writes through a
-    // prototype setter, and this is what would notice if that changed.
-    const declared = JSON.parse('{"__proto__":{"polluted":"yes"}}');
-    probe.ask({ ...same, versions: declared }, { ...same }, false);
+  it("sees a difference INSIDE `__proto__`, not merely its presence", () => {
+    /*
+     * The stronger half of the case above, and the one that pins the VALUE
+     * rather than the key. Both sides carry a `__proto__` key, so a comparison
+     * that merely noticed one side had it would answer "same" here; only a
+     * canonical form that carries what is under it can tell these apart.
+     *
+     * This replaces a test asserting that canonicalising does not pollute
+     * `Object.prototype`. That assertion was satisfied by absence: assigning
+     * `__proto__` to a plain `{}` sets that temporary object's prototype and
+     * never touches `Object.prototype`, so it passed against the broken
+     * implementation as readily as the fixed one — a permanently green
+     * assertion presented as coverage. Pollution is not a risk this code shape
+     * has; the dropped key is, and that is what these two tests measure.
+     */
+    const a = JSON.parse('{"drafts":true,"__proto__":{"max":10}}');
+    const b = JSON.parse('{"drafts":true,"__proto__":{"max":25}}');
 
-    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(
+      probe.ask({ ...same, versions: a }, { ...same, versions: b }, false)
+    ).toBe(true);
   });
 
   it("still sees a REORDERED ARRAY as a change", () => {

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -134,13 +134,23 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(withSortedKeys(value));
 }
 
-/** The same value with every object's keys in a fixed order. */
+/**
+ * The same value with every object's keys in a fixed order.
+ *
+ * The rebuilt object has a NULL prototype, which is load-bearing rather than
+ * defensive. Assigning an own `"__proto__"` key to an ordinary `{}` invokes the
+ * legacy prototype setter instead of creating an enumerable property, so
+ * `JSON.stringify` omits it — and two configs differing ONLY under that key
+ * serialise identically and compare equal. `JSON.parse` does create it as an
+ * own key, so a stored `jsonb` column round-tripping through it reaches here
+ * carrying one.
+ */
 function withSortedKeys(value: unknown): unknown {
   if (Array.isArray(value)) return value.map(withSortedKeys);
   if (value === null || typeof value !== "object") return value;
 
   const source = value as Record<string, unknown>;
-  const sorted: Record<string, unknown> = {};
+  const sorted = Object.create(null) as Record<string, unknown>;
   for (const key of Object.keys(source).sort()) {
     sorted[key] = withSortedKeys(source[key]);
   }


### PR DESCRIPTION
A correctness defect in the canonicaliser that merged in #1233. Found by lane `wt-versions`, verified here before acting.

## What is wrong

The registry decides whether to write a code-first config through a canonical serialisation of config-versus-stored-row. That rebuild assigned sorted keys onto an ordinary `{}`, and `"__proto__"` is not an ordinary key there — it invokes the legacy prototype setter instead of becoming an enumerable property. `JSON.stringify` then omits it, and two configs differing **only** under that key serialise identically and compare equal.

`JSON.parse` *does* create it as an ordinary own key, so a stored JSON column round-tripping through it arrives carrying one. Reproduced against the exact merged function:

```
a has own __proto__: true
canonical(a): {"preview":{"label":"X"}}
canonical(b): {"preview":{"label":"X"}}
COMPARE EQUAL (should be false): true
--- control ---
b vs c equal (should be false): false
```

The control matters: the comparison detects an ordinary differing key perfectly well, so this is specific to `__proto__` rather than the canonicaliser being broken generally.

The failure is quiet in the worst direction — a real edit reads as "unchanged" and never reaches storage.

## The fix

`Object.create(null)` for the rebuilt object. The null prototype is **load-bearing, not defensive**: it is the thing that lets the key exist as data.

Two tests — the MUST-DIFFER case, and a pollution check that nothing here writes through a prototype setter. Reverting to a plain object fails the first and nothing else.

## Convergence to follow

The repo now has **two** canonicalisers answering one question: this one and `packages/nextly/src/domains/versions/diff/canonical-json.ts`, which `wt-versions` wrote for the version diff and which already had this case covered. They have offered to lift theirs into `shared/` once #1242 lands, at which point this copy is deleted and imported instead.

Fixing the live defect first rather than waiting on that, because it is on `main` now.

## Gates

build, `check-types`, `lint`, `changeset status`, `fallow` (`pass`, zero introduced), `583` tests across singles and shared.

`check-comment-convention.mjs` fails, and it is **not from this PR** — it is red on the tip of `main` from `b3a3eba51` (#1245), fixed and waiting in **#1249**. That job scans the whole repo at PR head, so every open PR inherits it.