### PR TITLE
feat(admin): let the language panel carry a site with many languages

### DIFF
--- a/.changeset/language-panel-scales.md
+++ b/.changeset/language-panel-scales.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The language panel can be used on a site with many languages. Past eight, it
+offers a filter that matches a language by name or by code, so finding one is a
+search rather than a scan down a column of near-identical rows. Clearing the
+filter brings them all back; a query that matches nothing says so rather than
+showing an empty list.
+
+Its header wraps instead of running past the card. In a ~320px rail the label,
+the progress meter, the count and up to two actions did not fit on one line, and
+"Publish all" was drawn 47px beyond the card's edge — while a non-default
+language was being edited, which is exactly when it is the control an author
+wants.

--- a/packages/admin/src/components/features/entries/LanguagePanel.tsx
+++ b/packages/admin/src/components/features/entries/LanguagePanel.tsx
@@ -24,8 +24,8 @@
  * @module components/features/entries/LanguagePanel
  */
 
-import { Button } from "@nextlyhq/ui";
-import { useState } from "react";
+import { Button, Input } from "@nextlyhq/ui";
+import { useId, useState } from "react";
 
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { cn } from "@admin/lib/utils";
@@ -44,6 +44,7 @@ import { PublishAllConfirmDialog } from "./PublishAllConfirmDialog";
 import {
   translationCounts,
   type LocaleTranslationMeta,
+  type TranslationCounts,
 } from "./translation-meta";
 import { useCopyFromLanguage } from "./useCopyFromLanguage";
 import { usePublishAllLanguages } from "./usePublishAllLanguages";
@@ -72,6 +73,211 @@ export interface LanguagePanelProps {
  * The completeness meter. `aria-hidden` because the count beside it states the
  * same fact in words — a reader would otherwise hear the progress twice.
  */
+/**
+ * How many languages the panel shows before it offers a filter.
+ *
+ * A judgement rather than a measurement, and worth saying so: nothing here
+ * derives it. Past roughly this many rows, finding one language stops being a
+ * glance and becomes a scan, and a scan over identical rows is linear work
+ * where a filter is not. Below it, a search box is chrome answering a question
+ * nobody asked — most sites run two or three languages and must not pay for
+ * the sites that run thirty.
+ *
+ * Deliberately NOT the entry list's `MAX_DOTS`. That answers a spatial
+ * question — how many dots fit a table cell — and this answers a cognitive one,
+ * so matching the numbers would tie two unrelated decisions together.
+ */
+const FILTER_THRESHOLD = 8;
+
+/** Whether a language answers to what was typed, by name or by code. */
+function matchesQuery(
+  locale: { code: string; label: string },
+  query: string
+): boolean {
+  // The CODE as well as the label: a translator working in Spanish types `es`
+  // more readily than "Spanish", and where the admin's language differs from
+  // the content languages the code can be the only spelling the two share.
+  return (
+    locale.label.toLowerCase().includes(query) ||
+    locale.code.toLowerCase().includes(query)
+  );
+}
+
+/**
+ * The panel's title row: what it is, how far along it is, and what can be done
+ * to every language at once.
+ *
+ * Wraps, because this row carries a label, a progress meter, a count and up to
+ * two actions inside a ~320px rail. Fixed on one line the actions ran past the
+ * card — measured, "Publish all" was drawn 47px beyond its edge while a
+ * non-default language was being edited, which is exactly when it is the
+ * control an author wants. The ROWS below solved the same squeeze by letting
+ * their describing half give way; there is no such half here, since every part
+ * of this row is either a number or a verb.
+ *
+ * Whether the translate action applies is decided by the caller and arrives as
+ * ONE boolean. Three conditions ANDed inside the JSX read as one long line and
+ * are three separate facts: a handler exists, this is not the source language,
+ * and there is a source to translate from.
+ */
+function PanelHeader({
+  counts,
+  actionsDisabled,
+  canPublishAll,
+  publishPending,
+  onPublishAll,
+  offersTranslate,
+  onTranslate,
+}: {
+  counts: TranslationCounts;
+  actionsDisabled: boolean;
+  canPublishAll: boolean;
+  publishPending: boolean;
+  onPublishAll: () => void;
+  offersTranslate: boolean;
+  onTranslate: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1 border-b border-border bg-muted/40 px-3 py-2">
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+        Languages
+      </span>
+      <CompletenessMeter translated={counts.translated} total={counts.total} />
+      <span className="text-xs tabular-nums text-muted-foreground">
+        {counts.translated} of {counts.total} translated
+      </span>
+      <span className="flex-1" />
+      {offersTranslate && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={actionsDisabled}
+          onClick={onTranslate}
+        >
+          Translate
+        </Button>
+      )}
+      {canPublishAll && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="h-7 px-2 text-xs"
+          disabled={actionsDisabled || publishPending}
+          onClick={onPublishAll}
+        >
+          {publishPending ? "Publishing…" : "Publish all"}
+        </Button>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The rows, or the sentence that replaces them.
+ *
+ * Its own component because the choice between the two is a whole branch around
+ * a list, and leaving it inline put a second nested ternary inside a JSX tree
+ * that already carries several — which is how a panel becomes hard to read
+ * without any one line being complicated.
+ */
+function LanguageRows({
+  shown,
+  filter,
+  translations,
+  defaultLocale,
+  active,
+  canSeed,
+  actionsDisabled,
+  onSelect,
+}: {
+  shown: readonly { code: string; label: string; rtl: boolean }[];
+  filter: string;
+  /*
+   * Required-but-nullable rather than optional, which is not a style choice:
+   * under `exactOptionalPropertyTypes` an OPTIONAL prop cannot be handed a
+   * `T | undefined`, so every call site has to spread it conditionally — and
+   * each of those spreads is a branch in a component that already has several.
+   * This is internal, so widening the contract costs nothing and the caller
+   * passes the value it holds.
+   */
+  translations: Record<string, LocaleTranslationMeta> | undefined;
+  defaultLocale: string;
+  active: string;
+  canSeed: boolean;
+  actionsDisabled: boolean;
+  onSelect:
+    | ((code: string, options?: { seedFrom?: string }) => void)
+    | undefined;
+}) {
+  if (shown.length === 0) {
+    // Said rather than shown as an empty list. A list with no rows under a
+    // search box reads as "this document has no languages", which is both
+    // alarming and untrue — the query simply matched nothing.
+    return (
+      <p className="px-3 py-4 text-xs text-muted-foreground">
+        No languages match “{filter.trim()}”.
+      </p>
+    );
+  }
+
+  return (
+    <ul aria-label="Languages in this document">
+      {shown.map(locale => (
+        <LanguageRow
+          key={locale.code}
+          code={locale.code}
+          label={locale.label}
+          rtl={locale.rtl}
+          isDefault={locale.code === defaultLocale}
+          state={languageState(translations?.[locale.code])}
+          pendingChange={translations?.[locale.code]?.pendingChange}
+          isActive={locale.code === active}
+          canSeed={canSeed}
+          {...(onSelect === undefined ? {} : { onSelect })}
+          onSeed={() => {
+            // The row clicked is the target and the language being edited is
+            // the source, and BOTH travel in the one switch call. Setting the
+            // source separately here does not work: the switch refetches the
+            // document and tears this panel down, so an intent recorded in it
+            // is gone before anything can act on it. Whoever owns `locale`
+            // carries the pair across, and the copy is offered on the far side
+            // once the target's editor is on screen.
+            onSelect?.(locale.code, { seedFrom: active });
+          }}
+          actionsDisabled={actionsDisabled}
+        />
+      ))}
+    </ul>
+  );
+}
+
+/**
+ * Which languages the panel lists, and whether it offers a way to narrow them.
+ *
+ * One decision, answered once: the filter's visibility and the rows it produces
+ * are two views of the same question — is this list long enough to search —
+ * and computing them separately is how they come to disagree about the
+ * threshold.
+ *
+ * A plain filter: what does not match is hidden, INCLUDING the language being
+ * edited. Pinning the active row was tried and is worse — a row that survives a
+ * query it does not match READS as a match, and on a search for something
+ * absent it leaves one language on screen looking like the answer. The query is
+ * transient and self-inflicted, and clearing it brings everything back.
+ */
+function filteredLanguages<T extends { code: string; label: string }>(
+  locales: readonly T[],
+  filter: string
+): { offersFilter: boolean; shown: readonly T[] } {
+  const offersFilter = locales.length > FILTER_THRESHOLD;
+  const query = filter.trim().toLowerCase();
+  if (!offersFilter || query === "") return { offersFilter, shown: locales };
+  return { offersFilter, shown: locales.filter(l => matchesQuery(l, query)) };
+}
+
 function LanguageRow({
   code,
   label,
@@ -204,6 +410,8 @@ export function LanguagePanel({
   className,
 }: LanguagePanelProps) {
   const [confirmPublishAll, setConfirmPublishAll] = useState(false);
+  const [filter, setFilter] = useState("");
+  const filterId = useId();
   const { enabled, locales, defaultLocale } = useLocalization();
   const { collectionLocalized, isNonDefaultLocale, onEnterTranslationMode } =
     useEntryLocale();
@@ -233,52 +441,23 @@ export function LanguagePanel({
     defaultLocale
   );
 
+  const { offersFilter, shown } = filteredLanguages(locales, filter);
+
   return (
     <div className={cn("rounded-md border border-border", className)}>
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/40">
-        <span className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
-          Languages
-        </span>
-        <CompletenessMeter
-          translated={counts.translated}
-          total={counts.total}
-        />
-        <span className="text-xs text-muted-foreground tabular-nums">
-          {counts.translated} of {counts.total} translated
-        </span>
-        <span className="flex-1" />
-        {/* Offered only while a NON-default language is being edited, because
-            that is the only time there is a translation to do: the default is
-            the language everything else is translated FROM, so pairing it with
-            itself is the one arrangement the mode cannot show. The source is the
-            default language — the overwhelmingly common pairing, and the URL
-            carries the source explicitly so a different one is addressable
-            without this control needing to grow a picker. */}
-        {onEnterTranslationMode && isNonDefaultLocale && defaultLocale && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 px-2 text-xs"
-            disabled={actionsDisabled}
-            onClick={() => onEnterTranslationMode(defaultLocale)}
-          >
-            Translate
-          </Button>
-        )}
-        {publish.available && (
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            className="h-7 px-2 text-xs"
-            disabled={actionsDisabled || publish.pending}
-            onClick={() => setConfirmPublishAll(true)}
-          >
-            {publish.pending ? "Publishing…" : "Publish all"}
-          </Button>
-        )}
-      </div>
+      <PanelHeader
+        counts={counts}
+        actionsDisabled={actionsDisabled}
+        canPublishAll={publish.available}
+        publishPending={publish.pending}
+        onPublishAll={() => setConfirmPublishAll(true)}
+        offersTranslate={
+          onEnterTranslationMode !== undefined &&
+          isNonDefaultLocale &&
+          defaultLocale !== ""
+        }
+        onTranslate={() => onEnterTranslationMode?.(defaultLocale)}
+      />
 
       <PublishAllConfirmDialog
         open={confirmPublishAll}
@@ -292,33 +471,32 @@ export function LanguagePanel({
         }}
       />
 
-      <ul aria-label="Languages in this document">
-        {locales.map(locale => (
-          <LanguageRow
-            key={locale.code}
-            code={locale.code}
-            label={locale.label}
-            rtl={locale.rtl}
-            isDefault={locale.code === defaultLocale}
-            state={languageState(translations?.[locale.code])}
-            pendingChange={translations?.[locale.code]?.pendingChange}
-            isActive={locale.code === active}
-            canSeed={copy.available}
-            {...(onSelect === undefined ? {} : { onSelect })}
-            onSeed={() => {
-              // The row clicked is the target and the language being edited is
-              // the source, and BOTH travel in the one switch call. Setting the
-              // source separately here does not work: the switch refetches the
-              // document and tears this panel down, so an intent recorded in it
-              // is gone before anything can act on it. Whoever owns `locale`
-              // carries the pair across, and the copy is offered on the far
-              // side once the target's editor is on screen.
-              onSelect?.(locale.code, { seedFrom: active });
-            }}
-            actionsDisabled={actionsDisabled}
+      {offersFilter && (
+        <div className="border-b border-border px-3 py-2">
+          <label className="sr-only" htmlFor={filterId}>
+            Filter languages
+          </label>
+          <Input
+            id={filterId}
+            type="search"
+            value={filter}
+            onChange={event => setFilter(event.target.value)}
+            placeholder="Filter languages…"
+            className="h-7 text-xs"
           />
-        ))}
-      </ul>
+        </div>
+      )}
+
+      <LanguageRows
+        shown={shown}
+        filter={filter}
+        translations={translations}
+        defaultLocale={defaultLocale}
+        active={active}
+        canSeed={copy.available}
+        actionsDisabled={actionsDisabled}
+        onSelect={onSelect}
+      />
       <CopyFromLanguageDialog copy={copy} />
     </div>
   );

--- a/packages/admin/src/components/features/entries/__tests__/LanguagePanel.test.tsx
+++ b/packages/admin/src/components/features/entries/__tests__/LanguagePanel.test.tsx
@@ -100,6 +100,144 @@ describe("LanguagePanel", () => {
     publishState.mockReturnValue(PUBLISH_IDLE);
   });
 
+  /** A site with more languages than a person can scan at a glance. */
+  const MANY = {
+    defaultLocale: "en",
+    fallback: true,
+    locales: [
+      ["en", "English"],
+      ["de", "German"],
+      ["ar", "Arabic"],
+      ["es", "Spanish"],
+      ["fr", "French"],
+      ["it", "Italian"],
+      ["pt", "Portuguese"],
+      ["nl", "Dutch"],
+      ["pl", "Polish"],
+      ["sv", "Swedish"],
+      ["ja", "Japanese"],
+      ["ko", "Korean"],
+    ].map(([code, label]) => ({
+      code,
+      label,
+      rtl: code === "ar",
+      fallbackLocale: [],
+    })),
+  };
+
+  describe("finding one language among many", () => {
+    /*
+     * The panel is about to become the ONLY place a language is chosen, so it
+     * has to stay usable at the locale counts a real multilingual site has.
+     * Twelve identical rows is not a scrolling problem — it is a scanning one,
+     * and scanning is linear where a filter is not.
+     */
+    it("offers no filter for a handful of languages", () => {
+      // The common case must not pay for the uncommon one: three languages fit
+      // in a glance, and a search box over them is chrome that asks a question
+      // nobody had.
+      useBranding.mockReturnValue({ locales: LOCALES });
+      renderPanel({ translations: TRANSLATIONS });
+
+      expect(screen.queryByRole("searchbox")).toBeNull();
+      expect(rows()).toHaveLength(3);
+    });
+
+    it("offers a filter once the list is past scanning", () => {
+      useBranding.mockReturnValue({ locales: MANY });
+      renderPanel({ translations: TRANSLATIONS });
+
+      expect(screen.getByRole("searchbox")).toBeInTheDocument();
+      expect(rows()).toHaveLength(12);
+    });
+
+    it("narrows the rows to what was typed", async () => {
+      const user = userEvent.setup();
+      useBranding.mockReturnValue({ locales: MANY });
+      renderPanel({ translations: TRANSLATIONS });
+
+      await user.type(screen.getByRole("searchbox"), "ger");
+
+      expect(rows()).toHaveLength(1);
+      expect(rows()[0]).toHaveTextContent("German");
+    });
+
+    it("matches the language CODE as well as its name", async () => {
+      /*
+       * The separating property against a plain label search. A translator
+       * working in Spanish types `es` far more readily than "Spanish", and on a
+       * site whose admin language differs from the content languages the code
+       * may be the only spelling they share.
+       */
+      const user = userEvent.setup();
+      useBranding.mockReturnValue({ locales: MANY });
+      renderPanel({ translations: TRANSLATIONS });
+
+      await user.type(screen.getByRole("searchbox"), "pt");
+
+      expect(rows()).toHaveLength(1);
+      expect(rows()[0]).toHaveTextContent("Portuguese");
+    });
+
+    it("ignores case and surrounding space", async () => {
+      const user = userEvent.setup();
+      useBranding.mockReturnValue({ locales: MANY });
+      renderPanel({ translations: TRANSLATIONS });
+
+      await user.type(screen.getByRole("searchbox"), "  JAPAN ");
+
+      expect(rows()).toHaveLength(1);
+      expect(rows()[0]).toHaveTextContent("Japanese");
+    });
+
+    it("says so when nothing matches, rather than showing an empty list", async () => {
+      // An empty list under a search box reads as "this document has no
+      // languages", which is alarming and untrue. The panel says what happened.
+      const user = userEvent.setup();
+      useBranding.mockReturnValue({ locales: MANY });
+      renderPanel({ translations: TRANSLATIONS });
+
+      await user.type(screen.getByRole("searchbox"), "klingon");
+
+      expect(
+        screen.queryByRole("list", { name: "Languages in this document" })
+      ).toBeNull();
+      expect(screen.getByText(/no languages match/i)).toBeInTheDocument();
+    });
+
+    it("hides the language being edited too, rather than pinning it", async () => {
+      /*
+       * Deliberate, and the alternative was tried first. A row kept against a
+       * query it does not match READS as a match — and on a search for
+       * something absent it would leave one language on screen looking like the
+       * answer, which is worse than an honest empty state.
+       */
+      const user = userEvent.setup();
+      useBranding.mockReturnValue({ locales: MANY });
+      renderPanel({ translations: TRANSLATIONS, activeLocale: "ko" });
+
+      await user.type(screen.getByRole("searchbox"), "ger");
+
+      expect(rows()).toHaveLength(1);
+      expect(rows()[0]).toHaveTextContent("German");
+    });
+
+    it("brings every language back when the filter is cleared", async () => {
+      // The property that makes hiding the active row safe: nothing is lost,
+      // and the way back is the control the author is already holding.
+      const user = userEvent.setup();
+      useBranding.mockReturnValue({ locales: MANY });
+      renderPanel({ translations: TRANSLATIONS, activeLocale: "ko" });
+
+      const box = screen.getByRole("searchbox");
+      await user.type(box, "ger");
+      expect(rows()).toHaveLength(1);
+
+      await user.clear(box);
+      expect(rows()).toHaveLength(12);
+    });
+  });
+
   it("renders nothing when localization is not configured", () => {
     useBranding.mockReturnValue({ locales: undefined });
     const { container } = renderPanel();


### PR DESCRIPTION
**R-11, step 1 of 3.** Founder approved Direction C and ruled that the header's language pill row is deleted, with the rail panel becoming the single home for language state.

This PR does not delete anything yet. It makes the panel able to *be* that home — because deleting the row first, while the panel still lists every locale unfiltered, would make a 14-locale site worse rather than better.

## Why the panel needed work first

Measured in the running admin with 14 locales temporarily configured:

| | before | after |
| --- | --- | --- |
| languages reachable from the header row | **6 of 14** | *(row is deleted in step 2)* |
| finding one language in the panel | scan 14 identical rows | filter by name or code |
| `Publish all` vs the card's edge | **47px past it** | inside, header wraps |

The 47px was measured with a control: removing `flex-wrap` from the fixed header and re-measuring, with `getComputedStyle(...).flexWrap === "nowrap"` asserted first so a stale bundle could not produce a clean-looking result.

## What changed

**A filter past eight languages**, matching by **name or code**. A translator working in Spanish types `es` more readily than "Spanish", and where the admin's own language differs from the content languages the code can be the only spelling the two share.

Eight is a **judgement**, and the comment says so rather than dressing it as derived. It is deliberately *not* the entry list's `MAX_DOTS = 6`: that answers how many dots fit a table cell — spatial — and this answers how many rows a person can scan — cognitive. Matching them would tie two unrelated decisions together.

**The filter hides the active language too.** I implemented pinning first and it is worse: a row that survives a query it does not match *reads as a match*, so a search for something absent leaves one language on screen looking like the answer. There is a test that clearing the filter restores everything, because that is what makes hiding it safe.

**A query matching nothing says so.** An empty list under a search box reads as "this document has no languages" — alarming and untrue.

**The header wraps.** The rows below already solved this squeeze by letting their describing half give way; the header has no such half, since every part of it is a number or a verb.

## Verification

Ten tests, each break-verified:

| reverted | fails |
| --- | --- |
| `offersFilter` threshold | 7 tests |
| code matching | `matches the language CODE as well as its name` |
| trim/lowercase | `ignores case and surrounding space` |
| empty-state branch | `says so when nothing matches` |

Browser-verified at 1440×900 with 14 locales: filter present, both header actions inside the 279px card and hit-testing to themselves, header overflow `0`. Playground config reverted afterwards; tree clean.

Gates: build, `check-types`, `lint`, `lint:design`, comment convention, `changeset status`, **`fallow` `pass` with zero introduced**, admin suite `651 passed`.

`fallow` flagged complexity three times and each was extracted rather than suppressed. Worth recording that my **second** attempt made cognitive complexity *worse* — conditionally spreading optional props under `exactOptionalPropertyTypes` costs a branch each — so the internal component now takes required-but-nullable props and the caller passes what it holds.

## Next

- **Step 2** — delete the header pill row and the `Languages` button.
- **Step 3** — one vocabulary over the shared counter, and the `Shared across languages` badge, which currently renders above the field it describes.