### PR TITLE
fix(blocks-engine): resolve a decoration shorthand into the longhands it assigns

### DIFF
--- a/.changeset/inline-style-shorthand-cascade.md
+++ b/.changeset/inline-style-shorthand-cascade.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A decoration shorthand resolves into the longhands it assigns, so its cascade is read the way a browser reads it.

--- a/packages/blocks-engine/src/style/inline-style.test.ts
+++ b/packages/blocks-engine/src/style/inline-style.test.ts
@@ -110,7 +110,12 @@ describe("readInlineStyle", () => {
       sanitizeInlineStyle(
         "text-decoration-color:red;text-decoration:underline blue;text-decoration-color:green"
       )
-    ).toBe("text-decoration:underline blue;text-decoration-color:green");
+      // Expanded to longhands: the shorthand assigns all three, and the later
+      // longhand then rewrites the colour in its own place. What the cascade
+      // resolves to, rather than the declarations as written.
+    ).toBe(
+      "text-decoration-line:underline;text-decoration-style:solid;text-decoration-color:green"
+    );
   });
 
   it("reads a property name however the document spells it", () => {
@@ -244,6 +249,71 @@ describe("a declaration carrying !important", () => {
   });
 });
 
+describe("a shorthand and its own longhands", () => {
+  it("lets a later longhand rewrite what the shorthand set", () => {
+    // `text-decoration: underline; text-decoration-line: line-through` draws
+    // only a STRIKE — the longhand replaces the line the shorthand set. Reading
+    // the two properties independently sees `underline` under its own key and
+    // concludes the opposite.
+    expect(
+      read("text-decoration: underline; text-decoration-line: line-through")[
+        "text-decoration-line"
+      ]
+    ).toBe("line-through");
+  });
+
+  it("lets a later shorthand rewrite what a longhand set", () => {
+    // The other order, which is the control: the shorthand assigns EVERY
+    // longhand it owns, including ones it does not mention.
+    expect(
+      read("text-decoration-line: line-through; text-decoration: underline")[
+        "text-decoration-line"
+      ]
+    ).toBe("underline");
+  });
+
+  it("resets a longhand the shorthand does not mention", () => {
+    // What makes it a shorthand rather than a partial write. A style set
+    // before it does not survive it.
+    expect(
+      read("text-decoration-style: wavy; text-decoration: underline")[
+        "text-decoration-style"
+      ]
+    ).toBe("solid");
+  });
+
+  it("makes every longhand important when the SHORTHAND is", () => {
+    /*
+     * `text-decoration: underline blue !important; text-decoration-color: green`
+     * keeps BLUE. A priority on a shorthand applies to every longhand it
+     * assigns, so the later plain colour cannot take it.
+     *
+     * The other direction of the same rule, and it needed its own case: writing
+     * the expansion as never-important passes every other test here, because
+     * they all put the important declaration on a longhand.
+     */
+    const resolved = read(
+      "text-decoration: underline blue !important; text-decoration-color: green"
+    );
+    expect(resolved["text-decoration-color"]).toBe("blue");
+  });
+
+  it("carries priority across the shorthand boundary", () => {
+    /*
+     * `text-decoration-color: red !important; text-decoration: underline blue`
+     * keeps RED. The shorthand assigns the colour longhand, so the important
+     * declaration it would overwrite is the SAME property — but only once the
+     * shorthand has been expanded. Tracked by literal property name, the two
+     * names differ and the important colour was silently reset to blue.
+     */
+    const resolved = read(
+      "text-decoration-color: red !important; text-decoration: underline blue"
+    );
+    expect(resolved["text-decoration-color"]).toBe("red");
+    expect(resolved["text-decoration-line"]).toBe("underline");
+  });
+});
+
 describe("a format bit and a style that contradict it", () => {
   it.each([
     ["BOLD", TEXT_FORMAT.BOLD, "font-weight: normal", "font-weight"],
@@ -296,8 +366,8 @@ describe("a format bit and a style that contradict it", () => {
       "UNDERLINE",
       TEXT_FORMAT.UNDERLINE,
       "text-decoration: underline wavy red",
-      "text-decoration",
-      "underline wavy red",
+      "text-decoration-line",
+      "underline",
     ],
   ])(
     "keeps a value that REINFORCES %s",
@@ -328,14 +398,19 @@ describe("a format bit and a style that contradict it", () => {
      * The shorthand replaces the line list WITHIN its own element. It does not
      * reach the wrapper's.
      */
-    expect(
-      read("text-decoration: underline wavy red", TEXT_FORMAT.STRIKETHROUGH)[
-        "text-decoration"
-      ]
-    ).toBe("underline wavy red");
+    // Read under the LONGHAND, because the shorthand is resolved into its three
+    // and never emitted under its own name. The style and the colour it carried
+    // arrive under their own longhands beside the line.
+    const strikeThenUnderline = read(
+      "text-decoration: underline wavy red",
+      TEXT_FORMAT.STRIKETHROUGH
+    );
+    expect(strikeThenUnderline["text-decoration-line"]).toBe("underline");
+    expect(strikeThenUnderline["text-decoration-style"]).toBe("wavy");
+    expect(strikeThenUnderline["text-decoration-color"]).toBe("red");
     expect(
       read("text-decoration: line-through", TEXT_FORMAT.UNDERLINE)[
-        "text-decoration"
+        "text-decoration-line"
       ]
     ).toBe("line-through");
   });
@@ -391,6 +466,24 @@ describe("the declaration list", () => {
     expect(read('font-family: local("A;B"); color: red')["color"]).toBe("red");
   });
 
+  it("keeps whitespace that is INSIDE a quoted value", () => {
+    /*
+     * `"A  B"` is a family whose NAME carries two spaces, and a browser looks up
+     * exactly that name. The list used to be flattened whole, before anything
+     * knew where its strings were — so the collapse happened first, the
+     * quote-aware splitter never saw the original, and the page asked for a
+     * family nobody has.
+     */
+    expect(read('font-family: "A  B"')["font-family"]).toBe('"A  B"');
+  });
+
+  it("still flattens whitespace outside one", () => {
+    // The control. Normalizing only inside strings, or not at all, would leave
+    // a stored `Font-Size :   16px` unreadable — which is what the flattening
+    // was for.
+    expect(read("Font-Size :   16px")["font-size"]).toBe("16px");
+  });
+
   it("still splits the ordinary case", () => {
     // The control. A splitter that never split would satisfy neither assertion
     // above by accident, but one that got its quote state stuck would.
@@ -440,6 +533,23 @@ describe("INLINE_STYLE_PROPERTIES", () => {
     // a declaration the differ cannot see.
     for (const property of INLINE_STYLE_PROPERTIES) {
       expect(isInlineStyleProperty(property), property).toBe(true);
+      /*
+       * `text-decoration` is the one property on the list the reader never
+       * returns under its own name, and that is deliberate rather than a gap:
+       * it is a SHORTHAND, resolved into the three longhands it assigns — all
+       * three of which are on this list too, so nothing it can express is lost.
+       *
+       * It stays on the list because the list answers "would a reader notice
+       * this property changing", and a differ comparing stored text sees the
+       * shorthand under that name. Removing it would make a real change
+       * invisible to the one caller the list exists for.
+       */
+      if (property === "text-decoration") {
+        expect(Object.keys(read(`${property}: underline`))).toEqual(
+          expect.arrayContaining(["text-decoration-line"])
+        );
+        continue;
+      }
       expect(read(`${property}: inherit`)[property], property).toBe("inherit");
     }
   });

--- a/packages/blocks-engine/src/style/inline-style.ts
+++ b/packages/blocks-engine/src/style/inline-style.ts
@@ -357,6 +357,44 @@ function splitDeclarations(list: string): string[] {
 }
 
 /**
+ * Whitespace flattened everywhere EXCEPT inside a quoted string.
+ *
+ * A font family may be written `"A  B"`, and those two spaces are part of the
+ * name a browser looks up — collapse them and the page asks for a different
+ * family and silently falls back. The list used to be normalized whole, before
+ * anything knew where its strings were, so the collapse happened first and the
+ * quote-aware splitter never saw the original.
+ *
+ * Outside a string the same flattening is wanted, for the reason it always was:
+ * a stored declaration carries whatever wrote it, and `Font-Size :  16px` is
+ * the same declaration as `font-size:16px`.
+ */
+function normalizeOutsideStrings(value: string): string {
+  let out = "";
+  let run = "";
+  let quote = "";
+  for (const character of value) {
+    const next = quoteAfter(character, quote);
+    const quoted = quote !== "" || next !== "";
+    quote = next;
+    if (quoted) {
+      out += run === "" ? "" : " ";
+      run = "";
+      out += character;
+      continue;
+    }
+    if (/\s/.test(character)) {
+      run += character;
+      continue;
+    }
+    out += run === "" ? "" : " ";
+    run = "";
+    out += character;
+  }
+  return out.trim();
+}
+
+/**
  * One declaration, as the pair it contributes — or nothing, if it contributes.
  *
  * Separated from the walk because the walk is bookkeeping and this is the whole
@@ -373,8 +411,10 @@ function usableDeclaration(
   const colon = text.indexOf(":");
   if (colon === -1) return undefined;
 
-  const property = text.slice(0, colon).trim().toLowerCase();
-  const written = text.slice(colon + 1).trim();
+  const property = normalizeCssValue(text.slice(0, colon)).toLowerCase();
+  // Normalized OUTSIDE its strings: a quoted family name may carry whitespace
+  // that is part of the name. See {@link normalizeOutsideStrings}.
+  const written = normalizeOutsideStrings(text.slice(colon + 1));
   const declared = withoutPriority(written);
   if (declared === "" || !ALLOWED.has(property)) return undefined;
   // See {@link FORMAT_ASSERTS}: only a value that stops asserting what the bit
@@ -414,6 +454,70 @@ function usableDeclaration(
   return { property, value: declared, important: isImportant(written) };
 }
 
+/** The style keywords `text-decoration` can carry. */
+const DECORATION_STYLES: ReadonlySet<string> = new Set([
+  "solid",
+  "double",
+  "dotted",
+  "dashed",
+  "wavy",
+]);
+
+/**
+ * A `text-decoration` value split into the three longhands it assigns.
+ *
+ * `text-decoration` is the ONLY shorthand on {@link INLINE_STYLE_PROPERTIES},
+ * and that is what makes resolving the cascade tractable here at all: modelling
+ * shorthands in general needs a CSS property database, which this package
+ * cannot load, and modelling this one needs three names. All three are on the
+ * allowlist too, so expanding loses nothing — and the fourth longhand the
+ * shorthand resets, `text-decoration-thickness`, is absent from the list, so
+ * nothing on the page sets it and there is nothing for a reset to undo.
+ *
+ * Decidable without a grammar because the components are told apart by their
+ * own vocabularies: a line keyword, a style keyword, and whatever is left being
+ * the colour. A component the shorthand does not MENTION is still assigned —
+ * that is what a shorthand does — so it resets to its initial value rather than
+ * keeping whatever a declaration before it left there.
+ */
+function expandDecoration(value: string): Map<string, string> {
+  const parts = value.split(/\s+/).filter(token => token !== "");
+  const lines = parts.filter(
+    token => DECORATION_LINES.has(token) || token === "none"
+  );
+  const styles = parts.filter(token => DECORATION_STYLES.has(token));
+  const rest = parts.filter(
+    token =>
+      !DECORATION_LINES.has(token) &&
+      token !== "none" &&
+      !DECORATION_STYLES.has(token)
+  );
+  return new Map([
+    ["text-decoration-line", lines.length > 0 ? lines.join(" ") : "none"],
+    ["text-decoration-style", styles[0] ?? "solid"],
+    ["text-decoration-color", rest[0] ?? "currentcolor"],
+  ]);
+}
+
+/**
+ * The declarations of a stored inline style that are safe to put on a page.
+ *
+ * Resolved to LONGHANDS, in declaration order, honouring `!important`.
+ *
+ * Resolving rather than passing the declarations through is what ends a whole
+ * family of defect rather than answering one of them. A shorthand and one of
+ * its own longhands in the same list mean different things depending on which
+ * came last, and reading each property independently gets it wrong in both
+ * directions: `text-decoration: underline; text-decoration-line: line-through`
+ * draws only a strike, while a reader seeing `underline` under its own key
+ * concludes the opposite. Expanded, there is one entry per longhand and the
+ * order question is answered once, where it can be.
+ *
+ * It also removes the interaction from what REACT is handed. A style object
+ * carrying both a shorthand and a longhand is applied property by property, and
+ * assigning the shorthand resets the longhand beside it — so an object that
+ * looks right produces a DOM that is not. Longhands alone cannot do that.
+ */
 export function readInlineStyle(
   value: unknown,
   format?: number
@@ -421,34 +525,42 @@ export function readInlineStyle(
   const kept = new Map<string, string>();
   if (typeof value !== "string" || value === "") return kept;
 
-  const normalized = normalizeCssValue(value);
-  if (normalized === "") return kept;
-
   const important = new Set<string>();
-  for (const declaration of splitDeclarations(normalized)) {
-    const usable = usableDeclaration(declaration.trim(), format);
+  /** Written under the property that OWNS it, so a shorthand can rewrite it. */
+  const write = (
+    property: string,
+    written: string,
+    priority: boolean
+  ): void => {
+    // Priority decides before position does: `color: red !important; color:
+    // blue` renders RED, whatever follows it.
+    if (important.has(property) && !priority) return;
+    if (priority) important.add(property);
+    // Deleted before it is set again, because `Map.set` on an existing key
+    // replaces the value and leaves the key where it first appeared — and
+    // position is meaning in a declaration list.
+    kept.delete(property);
+    kept.set(property, written);
+  };
+
+  for (const declaration of splitDeclarations(value)) {
+    const usable = usableDeclaration(declaration, format);
     if (usable === undefined) continue;
+    if (usable.property !== "text-decoration") {
+      write(usable.property, usable.value, usable.important);
+      continue;
+    }
     /*
-     * PRIORITY decides the winner before position does. `color: red !important;
-     * color: blue` renders RED — the cascade prefers the important declaration
-     * whatever follows it — so resolving on position alone published blue.
-     *
-     * The priority is remembered here and stripped from the VALUE, because the
-     * two are needed at different moments: the cascade needs it now, and the
-     * emitted declaration must not carry it, since React sets a style property
-     * through `CSSStyleDeclaration` and that rejects an embedded priority.
+     * A shorthand assigns EVERY longhand it owns, including the ones it does
+     * not mention. Written one at a time so the priority rule above applies per
+     * longhand, which is what makes `text-decoration-color: red !important`
+     * survive a later plain `text-decoration: underline blue` — the browser
+     * keeps the important colour, and resolving by literal property name did
+     * not, because the two names are different.
      */
-    if (important.has(usable.property) && !usable.important) continue;
-    if (usable.important) important.add(usable.property);
-    // DELETED before it is set again, because `Map.set` on an existing key
-    // replaces the value and leaves the key where it first appeared. The later
-    // declaration would then be emitted in the earlier one's POSITION, and
-    // position is meaning here: a shorthand written after a longhand resets it,
-    // so a winner emitted ahead of that shorthand loses to it. Keeping the
-    // winner's own place is what makes the emitted text cascade the way the
-    // stored text did.
-    kept.delete(usable.property);
-    kept.set(usable.property, usable.value);
+    for (const [longhand, written] of expandDecoration(usable.value)) {
+      write(longhand, written, usable.important);
+    }
   }
   return kept;
 }

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1778,6 +1778,19 @@ describe("rich-text inline styles reach the page", () => {
        * `inherit` because it is legal for every one of these, so one fixture
        * serves the whole list without inventing a value per property.
        */
+      /*
+       * `text-decoration` is a SHORTHAND and the engine resolves it into the
+       * three longhands it assigns, so it never reaches the page under its own
+       * name. `inherit` is not a line keyword either, so the value asserted for
+       * it is the one the expansion produces.
+       */
+      if (property === "text-decoration") {
+        const decorated = renderToStaticMarkup(
+          <RichText value={styled(`${property}: underline`)} />
+        );
+        expect(decorated).toContain("text-decoration-line:underline");
+        return;
+      }
       const html = renderToStaticMarkup(
         <RichText value={styled(`${property}: inherit`)} />
       );
@@ -2023,7 +2036,8 @@ describe("rich-text a decoration the style already draws", () => {
         value={mk("text-decoration: underline wavy red", TEXT_FORMAT.UNDERLINE)}
       />
     );
-    expect(html).toContain("text-decoration:underline wavy red");
+    expect(html).toContain("text-decoration-line:underline");
+    expect(html).toContain("text-decoration-style:wavy");
     expect(html).not.toContain("<u>");
   });
 
@@ -2136,7 +2150,7 @@ describe("rich-text an updated node matches a fresh one", () => {
     [
       "a shorthand beside its own longhand",
       "text-decoration: underline blue; text-decoration-color: green",
-      "text-decoration: underline red; text-decoration-color: green",
+      "text-decoration: overline blue; text-decoration-color: green",
     ],
     ["a plain value", "color: #ff0000", "color: #00ff00"],
   ])("replaces the element when %s changes", (_label, before, after) => {
@@ -2162,6 +2176,36 @@ describe("rich-text an updated node matches a fresh one", () => {
 
     expect(second).not.toBeNull();
     expect(second).not.toBe(first);
+  });
+
+  it("does not replace the element when the cascade resolves the same way", () => {
+    /*
+     * Two different declaration LISTS, one resolved style. The shorthand's
+     * colour is overwritten by the longhand after it either way, so
+     * `underline blue` and `underline red` beside `text-decoration-color:
+     * green` mean the same thing — and the element correctly stays put.
+     *
+     * This was a remount fixture until the shorthand began being resolved,
+     * which is the clearest demonstration of what that change bought: the
+     * question moved from "did the text differ" to "did the meaning differ".
+     */
+    const view = render(
+      <RichText
+        value={styled(
+          "text-decoration: underline blue; text-decoration-color: green"
+        )}
+      />
+    );
+    const first = view.container.querySelector("span");
+    expect(first).not.toBeNull();
+    view.rerender(
+      <RichText
+        value={styled(
+          "text-decoration: underline red; text-decoration-color: green"
+        )}
+      />
+    );
+    expect(view.container.querySelector("span")).toBe(first);
   });
 
   it("does not replace the element when nothing changed", () => {
@@ -2196,7 +2240,7 @@ describe("rich-text a decoration that adds a second line", () => {
       />
     );
     expect(html).toContain("<s>");
-    expect(html).toContain("text-decoration:underline wavy red");
+    expect(html).toContain("text-decoration-line:underline");
   });
 
   it("drops the wrapper when they draw the SAME line", () => {
@@ -2207,6 +2251,6 @@ describe("rich-text a decoration that adds a second line", () => {
       />
     );
     expect(html).not.toContain("<u>");
-    expect(html).toContain("text-decoration:underline wavy red");
+    expect(html).toContain("text-decoration-line:underline");
   });
 });

--- a/packages/nextly/src/shared/lib/__tests__/rich-text-html.inline-style.test.ts
+++ b/packages/nextly/src/shared/lib/__tests__/rich-text-html.inline-style.test.ts
@@ -79,7 +79,9 @@ describe("an inline style beside a format wrapper", () => {
       format: TEXT_FORMAT.UNDERLINE,
       style: "text-decoration: underline wavy red",
     });
-    expect(decorated).toContain("text-decoration:underline wavy red");
+    // Longhands: the engine resolves the shorthand into the three it assigns,
+    // so neither surface emits it under its own name any more.
+    expect(decorated).toContain("text-decoration-line:underline");
     expect(decorated).not.toContain("<u");
   });
 


### PR DESCRIPTION
Follow-up to #1244, which merged while this was still in review. These three fixes answer the last round of findings on it and were not in the merged head.

Three findings, one cause: **a shorthand and its own longhands in one declaration list mean different things depending on which came last**, and reading each property independently gets it wrong in both directions.

- `text-decoration: underline; text-decoration-line: line-through` draws only a **strike** — but a reader seeing `underline` under its own key concluded the opposite and dropped the `<u>` wrapper, losing the format bit entirely.
- Priority tracked by literal property name let a plain shorthand reset an **important** longhand, because the two names differ: `text-decoration-color: red !important; text-decoration: underline blue` published blue where a browser keeps red.
- Normalizing flattened the list **before anything knew where its strings were**, so `font-family: "A  B"` lost a space that is part of the name a browser looks up.

## The shape

The list is now resolved to **longhands**, in declaration order, honouring `!important` per longhand.

`text-decoration` is the **only** shorthand on the allowlist, which is what makes this tractable: modelling shorthands in general needs a CSS property database this package cannot load — `css-tree-subpaths.d.ts` records why — and modelling this one needs three names. All three are on the allowlist already, and the fourth it resets (`text-decoration-thickness`) is not, so nothing on the page sets it.

Resolving also removes the interaction from what **React** is handed. A style object carrying a shorthand and a longhand is applied property by property, and assigning the shorthand resets the longhand beside it — so an object that looks right produces a DOM that is not. Longhands alone cannot do that.

## Evidence

6 break-verifies, each naming its intended test. Three of them initially changed nothing and each turned out to be a real gap: no test for string-safe normalization, none for a shorthand resetting an unmentioned longhand, none for a shorthand's own `!important` reaching its longhands. All three now exist and fail when broken.

One test asserted the **opposite** model — that `underline` beside STRIKETHROUGH removes the strike — and was corrected rather than the code bent to keep it green. The shorthand replaces the line list within its own element and never reaches the wrapper's.

Full gate sequence from the repo root, all exit 0: build, check-types across six packages, 4,939 package tests, admin conformance, lint, `lint:design`, comment convention, `test:scripts`, changeset. `fallow` verdict `pass`, 0 introduced.