### PR TITLE
feat(builder): make empty containers visible and clickable on the canvas

### DIFF
--- a/.changeset/empty-container-canvas-affordance.md
+++ b/.changeset/empty-container-canvas-affordance.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Empty containers on the page-builder canvas now show as a dashed box you can
+click, instead of being invisible. A canvas setting turns the boxes off when
+you want to see the page as a visitor will.

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -169,6 +169,20 @@ export const NODE_ID_ATTRIBUTE = "data-nx-node";
 export const PROP_ATTRIBUTE = "data-nx-prop";
 
 /**
+ * Marks a block whose definition declares at least one slot.
+ *
+ * The editor needs to find containers without knowing their names: a list of
+ * built-in types would exclude every container a plugin contributes, and would
+ * have to be kept in step with packages this one does not own. Whether a block
+ * declares slots is the structural fact underneath that list, and it is
+ * available here for nothing.
+ *
+ * Rides `nodeAttribute` for the same reason {@link NODE_ID_ATTRIBUTE} does: it
+ * is the editor's own namespace and has no business on a published page.
+ */
+export const SLOTS_ATTRIBUTE = "data-nx-slots";
+
+/**
  * The prefix every marker the editor puts on a rendered element shares.
  *
  * A NAMESPACE rather than a list, because a list is a thing to keep in sync
@@ -197,10 +211,22 @@ function propMarker(
   };
 }
 
+// Merges several independently-gated field sources onto one element's props —
+// the author's allowed attributes, the modelled `cssId`, and now two
+// editor-only markers — so this boundary carries one conditional per source
+// rather than disorganized branching. Splitting the sources into separate
+// functions would move that count rather than remove it, and each split-out
+// piece would still need the same node and the same `nodeAttribute` gate in
+// scope. The parameter and branch counts here track how many things an
+// element can carry, not incidental complexity.
+// fallow-ignore-next-line complexity
 function withNodeAttributes(
   output: ReactNode,
   node: BlockNode,
-  nodeAttribute = false
+  nodeAttribute = false,
+  // Whether the block's definition declares at least one slot, decided once by
+  // the caller and carried down rather than re-read from the definition here.
+  declaresSlots = false
 ): ReactNode {
   const cssId = typeof node.cssId === "string" ? node.cssId : undefined;
   // A stored envelope is whatever the database returned: `attributes: null`
@@ -257,6 +283,10 @@ function withNodeAttributes(
   // The modelled field wins over an attribute of the same name: `cssId` is what
   // the editor writes, and the attribute bag is the escape hatch beside it.
   if (cssId !== undefined) extra.id = cssId;
+  // Before the node address rather than after it, so the two editor markers sit
+  // together and the "LAST, so it cannot be overwritten" reasoning below still
+  // describes the line it is attached to.
+  if (nodeAttribute && declaresSlots) extra[SLOTS_ATTRIBUTE] = "";
   /*
    * LAST, so it cannot be overwritten. This was written first, with a comment
    * saying that made it safe — the opposite of what the code did: the author's
@@ -685,6 +715,8 @@ function checkedOutput(
   isBlockRoot: boolean,
   /** What the block declared about these props, decided once by the caller. */
   declaresNothing: boolean,
+  /** Whether the block's definition declares at least one slot, decided once by the caller. */
+  declaresSlots: boolean,
   /** Whether the editor asked for a per-node DOM address. */
   nodeAttribute = false
 ): ReactNode {
@@ -702,6 +734,7 @@ function checkedOutput(
           fallback={fallback}
           isBlockRoot={false}
           declaresNothing={declaresNothing}
+          declaresSlots={declaresSlots}
           nodeAttribute={nodeAttribute}
         />
       </Suspense>
@@ -766,7 +799,7 @@ function checkedOutput(
   // nothing can be substituted into an element that already exists. React
   // suspends on them, so they still need a boundary above.
   const withAttributes = isBlockRoot
-    ? withNodeAttributes(result.node, node, nodeAttribute)
+    ? withNodeAttributes(result.node, node, nodeAttribute, declaresSlots)
     : result.node;
   if (!result.hasUnwrappedThenable) return withAttributes;
   return <Suspense fallback={fallback}>{withAttributes}</Suspense>;
@@ -788,6 +821,7 @@ async function AsyncBlockOutput({
   fallback,
   isBlockRoot,
   declaresNothing,
+  declaresSlots,
   nodeAttribute,
 }: {
   pending: PromiseLike<unknown>;
@@ -796,6 +830,8 @@ async function AsyncBlockOutput({
   isBlockRoot: boolean;
   /** Carried from the caller, which asked the definition once before rendering. */
   declaresNothing: boolean;
+  /** Carried from the caller, which asked the definition once before rendering. */
+  declaresSlots: boolean;
   /** Whether the editor asked for a per-node DOM address. */
   nodeAttribute?: boolean;
 }): Promise<ReactNode> {
@@ -806,6 +842,7 @@ async function AsyncBlockOutput({
       fallback,
       isBlockRoot,
       declaresNothing,
+      declaresSlots,
       nodeAttribute
     );
   } catch (error) {
@@ -916,6 +953,20 @@ export function BlockBoundary({
     declaresNothing = false;
   }
 
+  // Contained for the same reason `declaresNothing` above is: `slots` is a
+  // property on an object a plugin author wrote, so a getter or a proxy can
+  // throw. A declaration that throws is no declaration, never the page's error.
+  let declaresSlots = false;
+  try {
+    const slots: unknown = definition.slots;
+    declaresSlots =
+      typeof slots === "object" &&
+      slots !== null &&
+      Object.keys(slots).length > 0;
+  } catch {
+    declaresSlots = false;
+  }
+
   const marker = propMarker(definition, nodeAttribute === true);
 
   let output: unknown;
@@ -975,6 +1026,7 @@ export function BlockBoundary({
       fallback,
       true,
       declaresNothing,
+      declaresSlots,
       nodeAttribute
     );
   }
@@ -987,6 +1039,7 @@ export function BlockBoundary({
         fallback={fallback}
         isBlockRoot
         declaresNothing={declaresNothing}
+        declaresSlots={declaresSlots}
         nodeAttribute={nodeAttribute}
       />
     </Suspense>

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -211,15 +211,41 @@ function propMarker(
   };
 }
 
-// Merges several independently-gated field sources onto one element's props —
-// the author's allowed attributes, the modelled `cssId`, and now two
-// editor-only markers — so this boundary carries one conditional per source
-// rather than disorganized branching. Splitting the sources into separate
-// functions would move that count rather than remove it, and each split-out
-// piece would still need the same node and the same `nodeAttribute` gate in
-// scope. The parameter and branch counts here track how many things an
-// element can carry, not incidental complexity.
-// fallow-ignore-next-line complexity
+/**
+ * Applies the two editor-only markers to an element's attribute bag, in the
+ * order that keeps the node address last.
+ *
+ * Split out of `withNodeAttributes` so the two markers read as one small,
+ * obviously-total step: every branch here is gated on `nodeAttribute`, so
+ * this function's own count stays fixed regardless of how many editor
+ * markers exist, while the merge of author-set fields in `withNodeAttributes`
+ * is where that function's complexity actually comes from.
+ */
+function applyEditorMarkers(
+  extra: Record<string, string>,
+  node: BlockNode,
+  nodeAttribute: boolean,
+  declaresSlots: boolean
+): void {
+  // Before the node address rather than after it, so the two editor markers
+  // sit together and the "LAST, so it cannot be overwritten" reasoning below
+  // still describes the line it is attached to.
+  if (nodeAttribute && declaresSlots) extra[SLOTS_ATTRIBUTE] = "";
+  /*
+   * LAST, so it cannot be overwritten. This was written first, with a
+   * comment saying that made it safe — the opposite of what the code did:
+   * the author's loop in `withNodeAttributes` ran afterwards and assigning
+   * the same key simply replaced it. A document could therefore hand every
+   * block the same address, or one block another's, and the editor's
+   * hit-testing reads exactly this value to decide which block was clicked.
+   *
+   * It is the editor's address for a node, not a value the document may
+   * set, so the position enforces that rather than a note asking the loop
+   * above to.
+   */
+  if (nodeAttribute) extra[NODE_ID_ATTRIBUTE] = node.id;
+}
+
 function withNodeAttributes(
   output: ReactNode,
   node: BlockNode,
@@ -283,22 +309,7 @@ function withNodeAttributes(
   // The modelled field wins over an attribute of the same name: `cssId` is what
   // the editor writes, and the attribute bag is the escape hatch beside it.
   if (cssId !== undefined) extra.id = cssId;
-  // Before the node address rather than after it, so the two editor markers sit
-  // together and the "LAST, so it cannot be overwritten" reasoning below still
-  // describes the line it is attached to.
-  if (nodeAttribute && declaresSlots) extra[SLOTS_ATTRIBUTE] = "";
-  /*
-   * LAST, so it cannot be overwritten. This was written first, with a comment
-   * saying that made it safe — the opposite of what the code did: the author's
-   * loop ran afterwards and assigning the same key simply replaced it. A
-   * document could therefore hand every block the same address, or one block
-   * another's, and the editor's hit-testing reads exactly this value to decide
-   * which block was clicked.
-   *
-   * It is the editor's address for a node, not a value the document may set, so
-   * the position enforces that rather than a note asking the loop above to.
-   */
-  if (nodeAttribute) extra[NODE_ID_ATTRIBUTE] = node.id;
+  applyEditorMarkers(extra, node, nodeAttribute, declaresSlots);
 
   return Object.keys(extra).length > 0 ? cloneElement(output, extra) : output;
 }

--- a/packages/blocks-react/src/empty-container-marker.test.tsx
+++ b/packages/blocks-react/src/empty-container-marker.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The marker that lets the editor find a container without knowing its name.
+ *
+ * A block-name list would exclude every plugin container, so the canvas asks a
+ * structural question instead: does this block declare slots at all.
+ */
+import { renderToReadableStream } from "react-dom/server";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { SLOTS_ATTRIBUTE } from "./block-boundary";
+import { coreBlocks } from "./blocks";
+import { PageRenderer } from "./page-renderer";
+import { createBlockResolver } from "./resolver";
+import type {
+  AnyBlockDefinition,
+  BlockDocument,
+} from "@nextlyhq/blocks-engine";
+
+async function renderToHtml(element: ReactElement): Promise<string> {
+  const stream = await renderToReadableStream(element, {
+    onError(error) {
+      throw error;
+    },
+  });
+  await stream.allReady;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let html = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    html += decoder.decode(value, { stream: true });
+  }
+  return html + decoder.decode();
+}
+
+function doc(nodes: BlockDocument["nodes"]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes };
+}
+
+function html(document: BlockDocument, forEditor: boolean): Promise<string> {
+  return renderToHtml(
+    <PageRenderer
+      document={document}
+      blocks={createBlockResolver(coreBlocks as AnyBlockDefinition[])}
+      {...(forEditor ? { nodeAttribute: true } : {})}
+    />
+  );
+}
+
+const emptyBox = {
+  id: "box-1",
+  type: "core/box",
+  version: 1,
+  props: {},
+  // A node with neither `cssId` nor an author attribute takes an early return
+  // inside the boundary whenever the render is not for the editor, before any
+  // editor marker is even considered — so a bare node would pass the published
+  // render below regardless of whether the slots gate itself is correct.
+  // Setting `cssId` routes the render through the same code path a real page
+  // takes once its author sets an anchor, which is where that gate runs.
+  cssId: "box-1",
+};
+
+const spacer = {
+  id: "spacer-1",
+  type: "core/spacer",
+  version: 1,
+  props: {},
+};
+
+describe("the container marker", () => {
+  it("marks a block that declares slots", async () => {
+    const markup = await html(doc([emptyBox]), true);
+    expect(markup).toContain(SLOTS_ATTRIBUTE);
+  });
+
+  it("does NOT mark a block that declares no slots", async () => {
+    // The positive control sits in the same render: `core/spacer` is
+    // deliberately empty, and marking it would give the canvas a dashed box
+    // around something that is meant to be invisible space.
+    const markup = await html(doc([emptyBox, spacer]), true);
+    const marks = markup.split(SLOTS_ATTRIBUTE).length - 1;
+    expect(marks).toBe(1);
+  });
+
+  it("never marks a published render", async () => {
+    const markup = await html(doc([emptyBox]), false);
+    expect(markup).not.toContain(SLOTS_ATTRIBUTE);
+  });
+});

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -325,6 +325,9 @@ describe("the root entry", () => {
       "PROP_ATTRIBUTE",
       "PageRenderer",
       "RichText",
+      // The container marker. Public so an editor asks whether a block declares
+      // slots instead of keeping a hardcoded list of container type names.
+      "SLOTS_ATTRIBUTE",
       "UNPREVIEWABLE_CONTAINER",
       "createBlockResolver",
       "createStandaloneContext",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -90,10 +90,15 @@ export { BlockBoundary, BlockList } from "./block-boundary";
 // `NODE_ID_ATTRIBUTE` is published deliberately: an editor hit-testing on the
 // attribute must not hard-code its spelling, or the renderer and the editor hold
 // two copies of one string and the editor breaks silently when it moves.
+//
+// `SLOTS_ATTRIBUTE` is public for the same reason: an editor looking for a
+// container to draw an affordance on asks this attribute rather than keeping
+// its own copy of the string the renderer emits.
 export {
   EDITOR_NAMESPACE,
   NODE_ID_ATTRIBUTE,
   PROP_ATTRIBUTE,
+  SLOTS_ATTRIBUTE,
 } from "./block-boundary";
 // The render-safe attribute rule, public so an editor asks it instead of
 // keeping a second copy that would accept names the renderer drops.

--- a/packages/builder/src/builder-chrome-attributes.test.ts
+++ b/packages/builder/src/builder-chrome-attributes.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { SLOTS_ATTRIBUTE } from "@nextlyhq/blocks-react";
+import { describe, expect, it } from "vitest";
+
+import { EMPTY_ELEMENTS_ATTRIBUTE } from "./shell-state";
+
+/**
+ * `builder-chrome.css` keys the empty-container affordance off two markers —
+ * `SLOTS_ATTRIBUTE` from `@nextlyhq/blocks-react` and this package's own
+ * `EMPTY_ELEMENTS_ATTRIBUTE` — and a stylesheet has no module system, so it
+ * cannot import either constant. Its selectors spell them out as literal
+ * strings instead, which makes the CSS and the constants two independent
+ * copies of one spelling: correct only for as long as nobody renames either
+ * constant, and a rename is silent when it happens. TypeScript still compiles
+ * — the identifier is still a valid string wherever it is used — and the
+ * selector simply stops matching anything, with no failed build and no error
+ * to notice. Only an author asking for the affordance discovers it is gone.
+ *
+ * So this file is the enforcement the CSS cannot provide for itself: every
+ * selector fragment is built from the constant, the same way the runtime code
+ * that consumes these markers already does (`` `[${NODE_ID_ATTRIBUTE}]` `` in
+ * `canvas.tsx`), rather than retyped — so renaming a constant moves this
+ * test's expectation with it, and only a stylesheet that actually fell out of
+ * step fails.
+ *
+ * Read from the SOURCE stylesheet rather than the built one, for the same
+ * reason `breakpoint-action-styles.test.ts` beside this file does: `dist` is
+ * gitignored, so a check against it answers differently before and after a
+ * build, which is the shape that makes CI and a laptop disagree.
+ *
+ * @module builder-chrome-attributes.test
+ */
+const CHROME = readFileSync(
+  fileURLToPath(new URL("./styles/builder-chrome.css", import.meta.url)),
+  "utf8"
+);
+
+describe("the empty-container affordance is keyed off the exported constants", () => {
+  it("matches the slots marker by the constant, not a retyped copy", () => {
+    expect(CHROME).toContain(`[${SLOTS_ATTRIBUTE}]`);
+  });
+
+  it("guards the affordance behind the hide-preference's attribute and value, by the constant", () => {
+    expect(CHROME).toContain(`[${EMPTY_ELEMENTS_ATTRIBUTE}="hidden"]`);
+  });
+
+  it("finds nothing for a marker that was never written", () => {
+    /*
+     * The control. `toContain` over a file this size passes for the wrong
+     * reason if the haystack were misread or the needle were a substring of
+     * something else entirely — so one needle that MUST be absent establishes
+     * that the search can come out empty at all.
+     */
+    expect(CHROME).not.toContain("[data-nx-nonexistent-marker]");
+  });
+});

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -420,6 +420,33 @@ describe("preferences", () => {
     expect(chrome).not.toBeNull();
     expect(chrome?.getAttribute(EMPTY_ELEMENTS_ATTRIBUTE)).toBe("hidden");
   });
+
+  it("offers a labelled control for showEmptyElements, reflecting its state", () => {
+    // By NAME and by role, the same way the exit button above is asserted —
+    // an unlabelled control for a visibility affordance would repeat the exact
+    // failure this feature exists to fix.
+    renderShell();
+
+    const toggle = screen.getByRole("switch", {
+      name: "Show empty containers",
+    });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+  });
+
+  it("writes showEmptyElements through the store when the control is toggled", () => {
+    const store = memoryStore();
+    stubContainerFits(true);
+    render(<BuilderShell onExit={vi.fn()} store={store} />);
+
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show empty containers" })
+    );
+
+    expect(store.value).not.toBeNull();
+    expect(JSON.parse(store.value as string)).toMatchObject({
+      showEmptyElements: false,
+    });
+  });
 });
 
 describe("where overlays inside the shell portal to", () => {

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -27,6 +27,7 @@ import { BuilderShell } from "./builder-shell";
 import { CommandPalette } from "./command-palette";
 import {
   DEFAULT_PREFERENCES,
+  EMPTY_ELEMENTS_ATTRIBUTE,
   fitsFullShell,
   MIN_SHELL_WIDTH,
   type PreferenceStore,
@@ -417,7 +418,7 @@ describe("preferences", () => {
     // not the property under test.
     const chrome = document.querySelector(".nx-builder-chrome");
     expect(chrome).not.toBeNull();
-    expect(chrome?.getAttribute("data-nx-empty-elements")).toBe("hidden");
+    expect(chrome?.getAttribute(EMPTY_ELEMENTS_ATTRIBUTE)).toBe("hidden");
   });
 });
 

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -398,6 +398,27 @@ describe("preferences", () => {
 
     expect(screen.queryByText(/panel$/)).toBeNull();
   });
+
+  it("restores a stored showEmptyElements even when every other field matches the default", () => {
+    // The restore-on-load effect gates on `shallowEqualPreferences`, which
+    // compares fields one at a time. A field that comparator does not name
+    // reads as "unchanged" for any two records differing only in it — so a
+    // fresh session, with no panel ever opened and no layout ever dragged,
+    // matches the default on every field THIS store record sets except this
+    // one, and is exactly the case where a missing clause drops it silently.
+    const store = memoryStore(
+      JSON.stringify({ ...DEFAULT_PREFERENCES, showEmptyElements: false })
+    );
+    stubContainerFits(true);
+    render(<BuilderShell onExit={vi.fn()} store={store} />);
+
+    // Queried rather than assumed present: a selector that matched nothing
+    // would make the attribute assertion below pass on `undefined`, which is
+    // not the property under test.
+    const chrome = document.querySelector(".nx-builder-chrome");
+    expect(chrome).not.toBeNull();
+    expect(chrome?.getAttribute("data-nx-empty-elements")).toBe("hidden");
+  });
 });
 
 describe("where overlays inside the shell portal to", () => {

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import {
+  Label,
   PortalProvider,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
   ShortcutProvider,
+  Switch,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -697,6 +699,10 @@ function ShellRegions({
   useRegionCycling(regionRefs, chromeRef, active);
   const onKeyDownCapture = useSeparatorRegionEscape(regionRefs, active);
   useDesignSystemStylesheet(chromeRef);
+  // Pairs the header's visibility-toggle label with its switch. Generated
+  // rather than a literal so two shells mounted on one page — unlikely, but
+  // nothing here forbids it — cannot collide on the same id.
+  const emptyElementsToggleId = React.useId();
 
   /**
    * Whether the host can fill a panel. One predicate, so the rail's disabled
@@ -772,6 +778,30 @@ function ShellRegions({
           </button>
         ) : null}
         <div className="flex min-w-0 flex-1 items-center gap-2">{topBar}</div>
+        {/*
+         * The only reachable control for `showEmptyElements` — before this it
+         * changed only by an author editing storage by hand. Lives on the
+         * shell's own chrome rather than inside a switched panel, because it
+         * has to stay visible whichever panel is open or closed, and because
+         * it is this component's own state rather than a slot a host fills.
+         *
+         * A labelled switch rather than an icon: the control governs a
+         * VISIBILITY affordance, and one an author cannot read at a glance
+         * would repeat the exact failure this feature exists to fix.
+         */}
+        <Label
+          htmlFor={emptyElementsToggleId}
+          className="text-[color:var(--nx-builder-text-muted)] shrink-0"
+        >
+          Show empty containers
+          <Switch
+            id={emptyElementsToggleId}
+            checked={preferences.showEmptyElements}
+            onCheckedChange={checked =>
+              update(current => ({ ...current, showEmptyElements: checked }))
+            }
+          />
+        </Label>
       </header>
 
       <div className="flex min-h-0 flex-1">

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -360,6 +360,13 @@ function usePreferences(store: PreferenceStore) {
 /**
  * Whether two preference records say the same thing.
  *
+ * EVERY field has to be compared here, because this is what the restore
+ * effect gates on: a field missing from this function reads as "unchanged"
+ * for any two records that differ only in it, so a stored non-default value
+ * for that field is silently dropped on mount whenever the rest of the record
+ * already matches the default — which a fresh session with nothing else
+ * customised does by construction.
+ *
  * The layout is compared by its entries rather than by identity: `readPreferences`
  * builds a fresh object every call, so identity is always false and the restore
  * effect would set state on every mount even when nothing changed.
@@ -368,7 +375,11 @@ function shallowEqualPreferences(
   a: ShellPreferences,
   b: ShellPreferences
 ): boolean {
-  if (a.leftPanel !== b.leftPanel || a.leftPinned !== b.leftPinned) {
+  if (
+    a.leftPanel !== b.leftPanel ||
+    a.leftPinned !== b.leftPinned ||
+    a.showEmptyElements !== b.showEmptyElements
+  ) {
     return false;
   }
   if (a.layouts === b.layouts) return true;
@@ -731,6 +742,13 @@ function ShellRegions({
         "nx-builder-chrome flex h-full w-full flex-col overflow-hidden",
         className
       )}
+      // Absent when empty containers are shown, which is the default. A state
+      // name rather than a boolean attribute so the shown case needs nothing
+      // written: a rule that depended on an attribute being present would
+      // silently stop applying anywhere the shell had not written one yet.
+      {...(preferences.showEmptyElements
+        ? {}
+        : { "data-nx-empty-elements": "hidden" })}
     >
       <header
         className="border-[color:var(--nx-builder-border)] flex h-12 shrink-0 items-center gap-2 border-b px-2"

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -27,6 +27,7 @@ import * as React from "react";
 import { devWarnOnce } from "./dev-warn";
 import {
   DEFAULT_PREFERENCES,
+  EMPTY_ELEMENTS_ATTRIBUTE,
   browserStore,
   fitsFullShell,
   LEFT_PANELS,
@@ -748,7 +749,7 @@ function ShellRegions({
       // silently stop applying anywhere the shell had not written one yet.
       {...(preferences.showEmptyElements
         ? {}
-        : { "data-nx-empty-elements": "hidden" })}
+        : { [EMPTY_ELEMENTS_ATTRIBUTE]: "hidden" })}
     >
       <header
         className="border-[color:var(--nx-builder-border)] flex h-12 shrink-0 items-center gap-2 border-b px-2"

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -132,6 +132,7 @@ export type { BuilderShellProps } from "./builder-shell";
  * bounds handed to the panel library, and the preference port.
  */
 export {
+  EMPTY_ELEMENTS_ATTRIBUTE,
   LEFT_PANELS,
   MIN_CANVAS_WIDTH,
   MIN_SHELL_WIDTH,

--- a/packages/builder/src/shell-state.test.ts
+++ b/packages/builder/src/shell-state.test.ts
@@ -144,6 +144,10 @@ describe("preferences round-trip", () => {
     layouts: {
       "canvas,inspector,left": { left: 22, canvas: 54, inspector: 24 },
     },
+    // Non-default like its neighbours above, so the round trip below actually
+    // exercises this field rather than passing on the strength of a default
+    // that both the write and a no-op read would agree on.
+    showEmptyElements: false,
   };
 
   it("restores what was written", () => {
@@ -193,6 +197,9 @@ describe("preferences round-trip", () => {
       leftPanel: "layers",
       leftPinned: DEFAULT_PREFERENCES.leftPinned,
       layouts: { "canvas,inspector": { canvas: 70, inspector: 30 } },
+      // Absent from the stored JSON above, so it falls back the same way
+      // `leftPinned` does here rather than surfacing as `undefined`.
+      showEmptyElements: DEFAULT_PREFERENCES.showEmptyElements,
     });
   });
 
@@ -215,5 +222,45 @@ describe("preferences round-trip", () => {
       );
       expect(readPreferences(store).layouts).toEqual({});
     }
+  });
+});
+
+describe("the show-empty-elements preference", () => {
+  it("defaults to showing them", () => {
+    const store = { read: () => null, write: () => undefined };
+    expect(readPreferences(store).showEmptyElements).toBe(true);
+  });
+
+  it("reads a stored false", () => {
+    const store = {
+      read: () => JSON.stringify({ showEmptyElements: false }),
+      write: () => undefined,
+    };
+    expect(readPreferences(store).showEmptyElements).toBe(false);
+  });
+
+  it("falls back to the default for a non-boolean", () => {
+    // A stored value can arrive from a hand-edited localStorage entry or an
+    // older shape. Anything that is not a boolean says nothing about intent.
+    const store = {
+      read: () => JSON.stringify({ showEmptyElements: "no" }),
+      write: () => undefined,
+    };
+    expect(readPreferences(store).showEmptyElements).toBe(true);
+  });
+
+  it("round-trips through a write", () => {
+    let written = "";
+    const store = {
+      read: () => written,
+      write: (v: string) => {
+        written = v;
+      },
+    };
+    writePreferences(store, {
+      ...DEFAULT_PREFERENCES,
+      showEmptyElements: false,
+    });
+    expect(readPreferences(store).showEmptyElements).toBe(false);
   });
 });

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -142,6 +142,16 @@ export interface ShellPreferences {
    * Inner: panel id to percentage.
    */
   layouts: Record<string, Record<string, number>>;
+  /**
+   * Whether the canvas draws a box for containers that have no children yet.
+   *
+   * ON by default: a container with nothing in it has no height, so with this
+   * off it is invisible and unclickable, which is the state an author is most
+   * likely to need help with. It is a preference rather than a hardcode
+   * because the box is editor chrome the visitor never sees, and an author
+   * checking how the page really looks needs a way to take it away.
+   */
+  showEmptyElements: boolean;
 }
 
 /**
@@ -160,6 +170,7 @@ export const DEFAULT_PREFERENCES: ShellPreferences = {
   leftPanel: null,
   leftPinned: true,
   layouts: {},
+  showEmptyElements: true,
 };
 
 /**
@@ -273,6 +284,10 @@ export function readPreferences(store: PreferenceStore): ShellPreferences {
         ? record.leftPinned
         : DEFAULT_PREFERENCES.leftPinned,
     layouts: readLayouts(record.layouts),
+    showEmptyElements:
+      typeof record.showEmptyElements === "boolean"
+        ? record.showEmptyElements
+        : DEFAULT_PREFERENCES.showEmptyElements,
   };
 }
 

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -155,6 +155,19 @@ export interface ShellPreferences {
 }
 
 /**
+ * The DOM attribute the shell stamps on `.nx-builder-chrome` when
+ * {@link ShellPreferences.showEmptyElements} is off.
+ *
+ * `builder-chrome.css` has no module system, so it cannot import this and its
+ * selector spells the same string out literally. Exported so every reader of
+ * that spelling — the shell that writes it and the test that pins the
+ * stylesheet against it — takes it from one place: a rename here that missed
+ * the CSS would otherwise leave the selector matching nothing, silently, with
+ * no type error and no failed import to notice.
+ */
+export const EMPTY_ELEMENTS_ATTRIBUTE = "data-nx-empty-elements";
+
+/**
  * The identity of a panel arrangement, from the panels themselves.
  *
  * Sorted and joined rather than taken from `leftPanel`, so it is derived from

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -371,20 +371,25 @@
  * measurement collapsed an already-working `block`-authored empty container
  * from full width down to a few pixels.
  *
- * `!important`, because the author's own value does not reach this stylesheet
- * as an ordinary class: this repository's block-style compiler doubles its
- * page-scoping class on every rule it emits
- * (`.nx-pb-page.nx-pb-page .nx-pb-<hash>`) specifically so a page's authored
- * styles reliably outrank arbitrary host CSS — which also outranks an
- * ordinary override written here. That selector shape belongs to a different
- * package's compiler and can change without notice; racing it on specificity
- * would be a second, silent implementation of a question that package already
- * owns. `!important` wins regardless of a shape this stylesheet does not, and
- * should not have to, know.
+ * No important flag on `display`, checked rather than assumed. The compiled
+ * per-node rule that carries an author's `display` repeats the page-scoping
+ * class — `.nx-pb-page.nx-pb-page .nx-pb-<hash>`, three classes, specificity
+ * `(0,3,0)`. This selector is five: two classes (`.nx-builder-chrome`,
+ * `.nx-canvas`), the attribute selector inside `:not()`, `[data-nx-slots]`
+ * and `:empty` — `(0,5,0)`, which already outranks it. Verified with no
+ * important flag anywhere on the declaration: an author-chosen `inline`
+ * still computed to `block` at 44px, hit-testable across the full box. Left
+ * that way — that flag is worth reaching for only where ordinary specificity
+ * cannot do the job, and measured here, it can.
  *
- * The trade-off this accepts, rather than hides: for a container authored as
- * `inline`, the canvas shows a full-width rectangle where the published page
- * would show nothing at all, for as long as it stays empty. Bounded twice —
+ * The trade-off this accepts, rather than hides, is a FLOW change, not a
+ * visibility one. Every empty container already diverges from its published
+ * appearance — that is the entire feature this rule belongs to: a `block`
+ * one gains a 44px dashed box the visitor never sees. Forcing `display` on
+ * an `inline` one is the same act, not a new category of one, but it moves
+ * something a border and a background do not: an inline box sits IN a line;
+ * a block one breaks it. This is the one place the canvas deliberately lays
+ * an empty container out differently from how the page will. Bounded twice —
  * gone the instant a child is added, since this rule stops matching `:empty`
  * then; and absent entirely once the author asks to see the page as a
  * visitor will, since the guard above already suppresses this whole rule,
@@ -395,7 +400,7 @@
 .nx-builder-chrome:not([data-nx-empty-elements="hidden"])
   .nx-canvas
   [data-nx-slots]:empty {
-  display: block !important;
+  display: block;
   min-height: 2.75rem;
   border: 1px dashed var(--nx-border);
   border-radius: var(--radius-sm);

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -361,22 +361,6 @@
 }
 
 /*
- * The author asked to see the page as a visitor will.
- *
- * `revert-layer` rather than restating the published values: the published
- * appearance of a container is whatever the site stylesheet and the block's
- * own base styles say, which this file does not know and must not guess.
- */
-.nx-builder-chrome[data-nx-empty-elements="hidden"]
-  .nx-canvas
-  [data-nx-slots]:empty {
-  min-height: revert-layer;
-  border: revert-layer;
-  border-radius: revert-layer;
-  background: revert-layer;
-}
-
-/*
  * Available to assistive technology, absent from the page.
  *
  * `display: none` and `visibility: hidden` both remove an element from the

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -350,10 +350,52 @@
  * otherwise — so the condition rides the SELECTOR rather than a value inside
  * the declaration block, and showing the box (the default) is the absence of
  * an attribute rather than a rule that has to negate one.
+ *
+ * `display: block` on top of whatever the author chose, and only while empty.
+ * `min-height` does not apply to a non-replaced INLINE box, so a container
+ * authored as `inline` (or `inline-block`/`inline-flex`/`inline-grid`) kept a
+ * target sized by inherited line-height instead of this rule's 44px — 23px in
+ * one measurement, smaller wherever the site's line-height is tighter, never
+ * the deliberate minimum this rule promises everywhere else. Measured in a
+ * real browser rather than assumed: a `::before` carrying the `min-height`
+ * instead of the container measured no better, because a non-replaced
+ * inline box's own fragment does not grow to fit a taller inline-level
+ * child — `elementFromPoint` swept across the extra height that child
+ * reserves in the surrounding line resolved to an ANCESTOR, never to the
+ * container, at every point past the line-height sliver. `block`, never
+ * `inline-block`: an EMPTY container has no children to lay out, so forcing
+ * `block` on one already `block`, `flex` or `grid` changes nothing
+ * observable (confirmed byte-identical box before and after, all three).
+ * `inline-block` does not have that property — it also switches the
+ * INLINE-direction sizing to shrink-to-content, which in the same
+ * measurement collapsed an already-working `block`-authored empty container
+ * from full width down to a few pixels.
+ *
+ * `!important`, because the author's own value does not reach this stylesheet
+ * as an ordinary class: this repository's block-style compiler doubles its
+ * page-scoping class on every rule it emits
+ * (`.nx-pb-page.nx-pb-page .nx-pb-<hash>`) specifically so a page's authored
+ * styles reliably outrank arbitrary host CSS — which also outranks an
+ * ordinary override written here. That selector shape belongs to a different
+ * package's compiler and can change without notice; racing it on specificity
+ * would be a second, silent implementation of a question that package already
+ * owns. `!important` wins regardless of a shape this stylesheet does not, and
+ * should not have to, know.
+ *
+ * The trade-off this accepts, rather than hides: for a container authored as
+ * `inline`, the canvas shows a full-width rectangle where the published page
+ * would show nothing at all, for as long as it stays empty. Bounded twice —
+ * gone the instant a child is added, since this rule stops matching `:empty`
+ * then; and absent entirely once the author asks to see the page as a
+ * visitor will, since the guard above already suppresses this whole rule,
+ * `display` included. A follow-up that draws a real positioned element over
+ * each empty container, rather than styling the container itself, closes
+ * this case by construction instead of by trade-off.
  */
 .nx-builder-chrome:not([data-nx-empty-elements="hidden"])
   .nx-canvas
   [data-nx-slots]:empty {
+  display: block !important;
   min-height: 2.75rem;
   border: 1px dashed var(--nx-border);
   border-radius: var(--radius-sm);

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -343,6 +343,13 @@
  * materially narrower than the region around it — a percentage here would
  * measure a different box at every breakpoint tier. 2.75rem is 44px at the
  * default root size, the smallest comfortable pointer target.
+ *
+ * The `:not([data-nx-empty-elements="hidden"])` guard is what makes this
+ * rule optional. The shell stamps that attribute on `.nx-builder-chrome` when
+ * an author asks to see the page as a visitor will, and leaves it off
+ * otherwise — so the condition rides the SELECTOR rather than a value inside
+ * the declaration block, and showing the box (the default) is the absence of
+ * an attribute rather than a rule that has to negate one.
  */
 .nx-builder-chrome:not([data-nx-empty-elements="hidden"])
   .nx-canvas
@@ -351,6 +358,22 @@
   border: 1px dashed var(--nx-border);
   border-radius: var(--radius-sm);
   background: var(--nx-muted);
+}
+
+/*
+ * The author asked to see the page as a visitor will.
+ *
+ * `revert-layer` rather than restating the published values: the published
+ * appearance of a container is whatever the site stylesheet and the block's
+ * own base styles say, which this file does not know and must not guess.
+ */
+.nx-builder-chrome[data-nx-empty-elements="hidden"]
+  .nx-canvas
+  [data-nx-slots]:empty {
+  min-height: revert-layer;
+  border: revert-layer;
+  border-radius: revert-layer;
+  background: revert-layer;
 }
 
 /*

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -325,6 +325,35 @@
 }
 
 /*
+ * An empty CONTAINER, which is a different thing from a block that draws
+ * nothing.
+ *
+ * `core/spacer` and `core/divider` are deliberately empty and are handled by
+ * the rule above: they get enough height to be selectable and nothing else.
+ * A container is empty only until an author fills it, and with no children it
+ * has no height at all — so it is invisible AND unclickable, and the canvas
+ * hit-test never sees the element it would have resolved to. This is what
+ * gives it an area.
+ *
+ * Matched on the marker rather than on a list of block names, so a container
+ * a plugin contributes behaves the same as a built-in one.
+ *
+ * ABSOLUTE units, deliberately. The canvas root sets `container-type:
+ * inline-size` whenever the site emits a viewport tier, so it can be
+ * materially narrower than the region around it — a percentage here would
+ * measure a different box at every breakpoint tier. 2.75rem is 44px at the
+ * default root size, the smallest comfortable pointer target.
+ */
+.nx-builder-chrome:not([data-nx-empty-elements="hidden"])
+  .nx-canvas
+  [data-nx-slots]:empty {
+  min-height: 2.75rem;
+  border: 1px dashed var(--nx-border);
+  border-radius: var(--radius-sm);
+  background: var(--nx-muted);
+}
+
+/*
  * Available to assistive technology, absent from the page.
  *
  * `display: none` and `visibility: hidden` both remove an element from the


### PR DESCRIPTION
## What and why

Dropping a `core/box`, `core/card`, `core/section` or `core/columns` on the page-builder canvas appears to do nothing. The block is created and the Layers panel lists it, but nothing shows up.

The cause is one geometric fact, and it is narrower than the symptom suggests:

> An empty container renders an element with no children, so it has zero height. It is therefore neither visible **nor hittable** — and every downstream behaviour that would handle it correctly is already built, sitting behind a box that does not exist.

`insertionPointFor` has always put a new block *inside* a selected empty container rather than beside it, and its comment names this exact symptom: *"every insert lands as a sibling, so `core/columns` arrives empty and stays empty, and the seven container blocks in the library are decorative."* The canvas hit-test already resolves a click to the nearest `data-nx-node`, which the container's own element carries. It failed only because there was no area to press.

So this PR gives the element a box, and the rest of the chain completes on its own: visible → hittable → click selects → the inserter targets the slot → the block lands inside.

## How

- **`data-nx-slots`** is emitted on a block whose definition declares slots, under the existing `nodeAttribute` opt-in that only the editor sets — so it never reaches a published page. Identified by **structure, not by a block-name list**: a hardcoded `core/box, core/card, core/section` list would exclude every container a plugin contributes.
- **One CSS rule** under `.nx-canvas` gives any marked, empty element a 44px box (the smallest comfortable pointer target). `core/spacer` and `core/divider` declare no slots, so they are untouched and keep their existing 2px rule, which answers a different question.
- **`showEmptyElements`** joins `ShellPreferences`, default on. The boxes are editor chrome a visitor never sees, so an author checking how the page really looks needs a way to take them away — Webflow ships exactly this as a canvas setting. The condition rides the selector itself, so hiding is the *absence* of a rule rather than the negation of one.

## Test plan

- **Browser-verified through the real admin page-builder route**, not a harness. Both playground canvas harnesses mount `<Canvas>` with no `.nx-builder-chrome` ancestor, so the rule structurally cannot fire there — verifying in one would have shown nothing happening while reporting a clean run.
- Empty Box measured **44px via `getBoundingClientRect().height`** (not a screenshot; jsdom reports every element as zero-sized) in **both layout branches**: `containerType: inline-size` with viewport tiers declared, and `normal` with a container-only breakpoint. That branch is picked silently by the fixture, so both were exercised rather than one described twice.
- Click-to-select, the "Adds inside Box" placement line, and a Heading nesting *inside* the Box all confirmed by DOM inspection. Both themes. Console clean throughout.
- Preference toggle: off → 0px and the attribute present; on → 44px. Exercised in the exact "fresh session, all else default" shape described below.
- `2044` + `933` tests passing, `check-types` and `lint` clean on both packages, `fallow audit` clean on all changed files, comment convention exits 0.
- Every test break-verified. One break left all three of its tests green and was chased rather than waved through — see below.

## Two defects found by verification rather than by review

**A test that was passing for the wrong reason.** The specified break for the `nodeAttribute` guard left all three marker tests green. Cause: a pre-existing early return in `withNodeAttributes` fires *before* the new code for a fixture carrying no `cssId`, so the test's green came from an outer guard rather than the clause its name claims. It would have gone on passing with that clause deleted. Fixture repaired; the break now fails correctly.

**A preference that would have silently failed to restore.** `shallowEqualPreferences` gates the restore-on-load effect and compared only `leftPanel`, `leftPinned` and `layouts`. Without a clause for the new field, a stored "off" is dropped on mount whenever the other three happen to match — which a fresh session with no panel opened and a default layout does exactly. That comparator had **zero** test coverage; it now has a test that fails without the clause.

## Changeset

Added: yes (`patch`, all 25 published packages).

## Pre-existing, not introduced

- An unused-import warning in `packages/builder`'s tsup build, unrelated to these files.
- `pnpm --filter @nextlyhq/admin build:css` is a no-op for this diff — admin's stylesheet has no import path to builder's CSS. Run anyway per the standing gate instruction.

## Scope

This PR makes empty containers visible and clickable, which makes the existing insert path reachable. Two follow-ups are planned and deliberately out of scope: a "+" appender inside the box for a one-gesture insert, and a default child so a new Columns row arrives with columns instead of empty.
