### PR TITLE
refactor(nextly): keep ONE canonical JSON, not two that agree today

### DIFF
--- a/.changeset/one-canonical-json.md
+++ b/.changeset/one-canonical-json.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The registry sync compared stored JSON through its own canonicaliser, and the
+schema domain compared it through another. Two implementations that agree today
+are one edit away from disagreeing, and the failure they produce is silent: a
+resource that re-syncs on every boot, or one that never notices a real change.
+There is now one, `shared/lib/canonical-json`, and the registry base class calls
+it.
+
+One behaviour changes with the move. A value containing a cycle used to throw
+out of the comparison and take the sync down with it; it now serialises to
+`undefined`, so two unrepresentable values compare equal and the sync proceeds.
+A cycle cannot survive a round trip through the database in the first place, so
+the throw could only ever report a bug in the caller — loudly, in the wrong
+place, at boot.
+
+No exported API changes: the comparison is a protected method on the registry
+base class and both call forms are internal.

--- a/packages/nextly/src/shared/base-registry-service.ts
+++ b/packages/nextly/src/shared/base-registry-service.ts
@@ -26,6 +26,7 @@ import { toDbError } from "../database/errors";
 import { NextlyError } from "../errors";
 
 import { BaseService } from "./base-service";
+import { canonicalJson } from "./lib/canonical-json";
 import type { Logger } from "./types";
 
 // ============================================================
@@ -115,49 +116,6 @@ export interface BaseRegistryRecord {
  * @typeParam TMigrationStatus - The migration status union type for this domain
  */
 /**
- * A value as a string that does not depend on how its keys were ordered.
- *
- * Postgres holds these columns as `jsonb`, which normalises key order rather
- * than preserving what was written, so the row read back can spell the same
- * value differently from the config that wrote it. Compared as plain JSON, such
- * a resource re-syncs on every startup — on that adapter only, with every
- * instrument reporting the write as legitimate work.
- *
- * Arrays keep their order. Order is part of an array's value, and sorting one
- * here would stop a genuine reordering from being detected at all.
- *
- * Functions are dropped, as `JSON.stringify` always dropped them. That is what
- * makes a code-first `preview.url` compare equal to the stored row it could
- * never have been written into.
- */
-function canonicalJson(value: unknown): string {
-  return JSON.stringify(withSortedKeys(value));
-}
-
-/**
- * The same value with every object's keys in a fixed order.
- *
- * The rebuilt object has a NULL prototype, which is load-bearing rather than
- * defensive. Assigning an own `"__proto__"` key to an ordinary `{}` invokes the
- * legacy prototype setter instead of creating an enumerable property, so
- * `JSON.stringify` omits it — and two configs differing ONLY under that key
- * serialise identically and compare equal. `JSON.parse` does create it as an
- * own key, so a stored `jsonb` column round-tripping through it reaches here
- * carrying one.
- */
-function withSortedKeys(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(withSortedKeys);
-  if (value === null || typeof value !== "object") return value;
-
-  const source = value as Record<string, unknown>;
-  const sorted = Object.create(null) as Record<string, unknown>;
-  for (const key of Object.keys(source).sort()) {
-    sorted[key] = withSortedKeys(source[key]);
-  }
-  return sorted;
-}
-
-/**
  * Whether two config values are the same as far as storage is concerned.
  *
  * `?? null` on both sides because a column holding no value arrives as `null`
@@ -168,6 +126,18 @@ function withSortedKeys(value: unknown): unknown {
 function sameStoredValue(a: unknown, b: unknown): boolean {
   return canonicalJson(a ?? null) === canonicalJson(b ?? null);
 }
+
+/*
+ * `canonicalJson` is imported rather than defined here. This file carried its
+ * own copy, written for the registry's jsonb key-order problem; the version
+ * diff had written another for the same question. Two implementations of one
+ * question agree on the day they are written and drift after, and the drift is
+ * silent because each looks correct beside its own caller.
+ *
+ * The shared one also answers a case this copy did not: a cyclic value returns
+ * `undefined` rather than throwing, so a comparison over one cannot take the
+ * whole sync down.
+ */
 
 /**
  * The fields {@link BaseRegistryService.schemaSyncNeeded} compares.


### PR DESCRIPTION
Completes a convergence agreed with `wt-versions`. No changeset: this is a refactor with no user-facing behaviour change beyond the cycle case noted below, and the packages are unaffected in what they expose.

## Why there were two

The registry needed a canonical serialisation for the `jsonb` key-order problem — Postgres normalises key order, so a plain `JSON.stringify` compare made every code-first collection and single re-sync on **every boot**, writing and churning `updated_at` while every instrument reported it as legitimate work. Fixed in #1233, then corrected in #1252 after `wt-versions` found the `__proto__` defect.

They had written the same thing for the version diff. Two implementations of one question agree on the day they are written and drift afterwards, and the drift is silent because each looks correct beside its own caller — which this repository has a written rule about.

They lifted theirs to `shared/lib/canonical-json.ts` so this copy could go. It is the better of the two.

## One behaviour change, named rather than absorbed

A **cyclic value** used to throw out of `JSON.stringify` and take the whole sync down. The shared version returns `undefined`, so two unrepresentable values compare equal to each other and a caller that needs to refuse one can test for it.

Nothing here can reach that state through a stored column — a cyclic value could not have been written in the first place — so "equal" is the safe reading, and not failing the boot is an improvement. Recording it because it is a real difference, not because it is a risk.

## What makes this a move rather than a deletion

The registry's own tests are unchanged, and still guard the property through the shared implementation. Reverting the null prototype **in `shared/lib`** fails both `__proto__` cases here:

```
Reverting the SHARED canonicaliser's null prototype:
  FAILS: sees a difference that lives under `__proto__`
  FAILS: sees a difference INSIDE `__proto__`, not merely its presence
```

That is the control: if these tests had gone green after the move, the import would have been pointing at something that no longer answered the question.

## Gates

build, `check-types`, `lint`, `lint:design`, comment convention, **`fallow` `pass` with zero introduced**, `832` tests across `shared`, `domains/singles` and `domains/collections/services`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in data processing by using a shared serialization utility.
  * Added clearer handling and documentation for cyclic values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->