### PR TITLE
feat(builder): scale the canvas so the base breakpoint is editable again

### DIFF
--- a/.changeset/canvas-scales-to-keep-base-editable.md
+++ b/.changeset/canvas-scales-to-keep-base-editable.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The page builder can edit the base breakpoint again. The canvas is now scaled so
+a tier wider than the space available still fits, instead of being capped at the
+region and silently editing the narrower tier that width implies.

--- a/apps/playground/src/app/builder-canvas-preview/harness.tsx
+++ b/apps/playground/src/app/builder-canvas-preview/harness.tsx
@@ -41,6 +41,25 @@ const NARROW_WIDTH = TIER_BOUND - 40;
 const OVERFLOW_WIDTH = 800;
 
 /**
+ * A width ABOVE the tier's bound, which is where the base rules apply.
+ *
+ * The one an author reaches for most and the one that used to be unreachable:
+ * with the request treated as a ceiling, a region narrower than the bound
+ * capped the box below it and the narrow tier applied instead.
+ */
+const BASE_WIDTH = 800;
+
+/**
+ * A region too NARROW to honour that width, which is the ordinary editor.
+ *
+ * Deliberately below the tier bound as well as below {@link BASE_WIDTH}, so a
+ * canvas that capped the request would land in the narrow tier rather than
+ * merely somewhere smaller — the two outcomes are different colours, and only
+ * one of them is the defect.
+ */
+const CRAMPED_WIDTH = 400;
+
+/**
  * Two colours that cannot be confused for one another, or for a default.
  *
  * A test asserting a computed colour needs values no stylesheet elsewhere
@@ -163,6 +182,27 @@ export function BuilderCanvasPreviewHarness() {
         onClick={() => setRegion(OVERFLOW_WIDTH)}
       >
         overflow
+      </button>
+      {/*
+        A region that CANNOT honour a base-tier width, which is the state the
+        scaling exists for and the one no unit test can decide: the box is laid
+        out wider than the space it has and painted down into it, so what the
+        container queries resolve against is the tier that was asked for rather
+        than the tier the region implies.
+      */}
+      <button
+        type="button"
+        data-testid="go-cramped"
+        onClick={() => setRegion(CRAMPED_WIDTH)}
+      >
+        cramped
+      </button>
+      <button
+        type="button"
+        data-testid="go-base"
+        onClick={() => setWidth(BASE_WIDTH)}
+      >
+        base
       </button>
       {/*
         What the box actually MEASURED, reported so the spec can wait on the

--- a/e2e/tests/canvas/preview-container.spec.ts
+++ b/e2e/tests/canvas/preview-container.spec.ts
@@ -75,6 +75,87 @@ test.describe("the canvas preview compile", () => {
     await expect(subject).toHaveCSS("color", WIDE);
   });
 
+  test("edits the BASE tier in a region too narrow to hold it", async ({
+    page,
+  }) => {
+    /*
+     * The regression this canvas is scaled for, and the only place it can be
+     * decided.
+     *
+     * The editor's canvas region is around 912px on the supported 1280px shell,
+     * and a site bounding its widest tier above that leaves no width an author
+     * can ask for that reaches the unconditional tier. Treated as a ceiling the
+     * request was capped at the region, so the narrower tier applied and every
+     * style edit landed in it — while the control said the widest tier was
+     * selected.
+     *
+     * Scaled instead, the box is LAID OUT at the width that was asked for and
+     * PAINTED down into the space available. A transform or a zoom is not
+     * something jsdom evaluates and a container query is not something it
+     * resolves, so the whole claim — that a box painted at half size still
+     * answers queries at its full width — is invisible to every unit test.
+     */
+    await page.goto(ROUTE);
+    const subject = page.locator(SUBJECT).first();
+    await expect(subject).toBeVisible();
+
+    await page.getByTestId("go-cramped").click();
+    await page.getByTestId("go-base").click();
+
+    // Waited on the canvas having measured the width it was ASKED for, which is
+    // the layout width the queries answer to. Polling the colour alone would
+    // pass against a render that had not resized yet.
+    await expect
+      .poll(async () =>
+        Number(await page.getByTestId("measured").textContent())
+      )
+      .toBe(800);
+
+    // The base declaration, in a region 400px wide. A canvas that capped the
+    // request would be showing the narrow tier here.
+    await expect(subject).toHaveCSS("color", WIDE);
+  });
+
+  test("PAINTS that canvas down into the region it was given", async ({
+    page,
+  }) => {
+    /*
+     * The other half, and it has to be asserted separately: a canvas that
+     * simply OVERFLOWED its region would satisfy the case above — the layout
+     * width would be right and the queries would resolve base — while spilling
+     * the page under the inspector and out of the editor.
+     *
+     * So the claim is that the two widths DIFFER: laid out at what was asked
+     * for, painted at what fits. Reading only one of them cannot separate a
+     * scaled canvas from an overflowing one.
+     */
+    await page.goto(ROUTE);
+    await expect(page.locator(SUBJECT).first()).toBeVisible();
+
+    await page.getByTestId("go-cramped").click();
+    await page.getByTestId("go-base").click();
+    await expect
+      .poll(async () =>
+        Number(await page.getByTestId("measured").textContent())
+      )
+      .toBe(800);
+
+    const box = await page
+      .locator(".nx-canvas")
+      .first()
+      .evaluate(element => ({
+        laidOut: (element as HTMLElement).offsetWidth,
+        painted: Math.round(element.getBoundingClientRect().width),
+      }));
+
+    expect(box.laidOut).toBe(800);
+    // Painted into the region rather than through it. Asserted as a bound
+    // rather than as an exact number: the region carries the harness's own
+    // controls above the canvas, so the space left is at most its width.
+    expect(box.painted).toBeLessThanOrEqual(400);
+    expect(box.painted).toBeGreaterThan(0);
+  });
+
   test("answers to the BOX rather than to the window", async ({ page }) => {
     /*
      * The property that separates a container compile from a published one, and

--- a/packages/builder/src/breakpoint-action-styles.test.ts
+++ b/packages/builder/src/breakpoint-action-styles.test.ts
@@ -56,3 +56,30 @@ describe("the breakpoint actions are styled, not merely marked", () => {
     expect(CHROME).not.toContain(".nx-style-inspector__breakpoint-nonexistent");
   });
 });
+
+describe("the canvas minimum height answers to the canvas scale", () => {
+  it("divides the minimum back out by the scale the canvas publishes", () => {
+    /*
+     * Two halves of one decision that no type or render test connects: the
+     * canvas sets `--nx-canvas-scale` in JavaScript, and only this stylesheet
+     * consumes it.
+     *
+     * The minimum exists so the region an author can aim a drop at does not end
+     * at the last block — without it, the end of the page has no pixels to
+     * point at and a block cannot be dragged there at all. A scaled canvas
+     * reintroduces exactly that: laid out at the region's height it PAINTS at a
+     * fraction of it, measured at 285px into a 400px region, leaving 115px of
+     * region with no canvas on it. Dividing the minimum by the scale is what
+     * fills the region again, and it is the case the minimum is needed in most.
+     *
+     * The FALLBACK is asserted with it, because every unscaled surface — which
+     * is all of them until a tier wider than the region is chosen — reads this
+     * declaration with the property unset. Without `1` there, the whole minimum
+     * becomes invalid and the aiming failure returns everywhere rather than
+     * only when zoomed.
+     */
+    expect(CHROME).toContain(
+      "min-height: calc(100% / var(--nx-canvas-scale, 1))"
+    );
+  });
+});

--- a/packages/builder/src/breakpoint-action-styles.test.ts
+++ b/packages/builder/src/breakpoint-action-styles.test.ts
@@ -56,30 +56,3 @@ describe("the breakpoint actions are styled, not merely marked", () => {
     expect(CHROME).not.toContain(".nx-style-inspector__breakpoint-nonexistent");
   });
 });
-
-describe("the canvas minimum height answers to the canvas scale", () => {
-  it("divides the minimum back out by the scale the canvas publishes", () => {
-    /*
-     * Two halves of one decision that no type or render test connects: the
-     * canvas sets `--nx-canvas-scale` in JavaScript, and only this stylesheet
-     * consumes it.
-     *
-     * The minimum exists so the region an author can aim a drop at does not end
-     * at the last block — without it, the end of the page has no pixels to
-     * point at and a block cannot be dragged there at all. A scaled canvas
-     * reintroduces exactly that: laid out at the region's height it PAINTS at a
-     * fraction of it, measured at 285px into a 400px region, leaving 115px of
-     * region with no canvas on it. Dividing the minimum by the scale is what
-     * fills the region again, and it is the case the minimum is needed in most.
-     *
-     * The FALLBACK is asserted with it, because every unscaled surface — which
-     * is all of them until a tier wider than the region is chosen — reads this
-     * declaration with the property unset. Without `1` there, the whole minimum
-     * becomes invalid and the aiming failure returns everywhere rather than
-     * only when zoomed.
-     */
-    expect(CHROME).toContain(
-      "min-height: calc(100% / var(--nx-canvas-scale, 1))"
-    );
-  });
-});

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -73,11 +73,20 @@ describe("choosing a tier", () => {
     expect(onSelect).toHaveBeenCalledWith(991);
   });
 
-  it("emits UNDEFINED for the widest, rather than a number", () => {
+  it("emits the width at which BASE applies, for the unconditional tier", () => {
     /*
-     * The unconditional tier has no upper bound, so any number here would be
-     * invented — and would make the widest option narrower than the region,
-     * putting gutters around a canvas that was already the right size.
+     * It used to emit `undefined` — fill the region — on the reasoning that the
+     * unconditional tier has no upper bound so any number would be invented.
+     * The number is not invented: it is one past the widest bound, which is the
+     * narrowest width the site's own tiers leave to base.
+     *
+     * And filling the region does not select base wherever the region is
+     * narrower than the widest bound, which is the ordinary case — around 912px
+     * of canvas on the supported 1280px shell against a tablet bound of 991. It
+     * put every edit in tablet while this control read as the widest tier, so
+     * the one option naming the tier an author most often wants was the one
+     * that could not reach it. The canvas is scaled to fit rather than gaining
+     * gutters, which is what makes a real width affordable here.
      */
     const onSelect = vi.fn();
     render(
@@ -89,9 +98,12 @@ describe("choosing a tier", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("radio", { name: "Full width" }));
+    fireEvent.click(
+      screen.getByRole("radio", { name: "Full width, from 992 pixels" })
+    );
 
-    expect(onSelect).toHaveBeenCalledWith(undefined);
+    // One past the widest bound this site declares, not a chosen number.
+    expect(onSelect).toHaveBeenCalledWith(992);
   });
 
   it("says the WIDTH in each option's accessible name", () => {
@@ -217,7 +229,9 @@ describe("what the control reports as selected", () => {
       />
     );
 
-    expect(checked()[0]?.getAttribute("aria-label")).toBe("Full width");
+    expect(checked()[0]?.getAttribute("aria-label")).toBe(
+      "Full width, from 992 pixels"
+    );
     expect(applied(container)).toBe("900px · Tablet");
   });
 
@@ -293,7 +307,9 @@ describe("what the control reports as selected", () => {
     );
 
     expect(checked()).toHaveLength(1);
-    expect(checked()[0]?.getAttribute("aria-label")).toBe("Full width");
+    expect(checked()[0]?.getAttribute("aria-label")).toBe(
+      "Full width, from 992 pixels"
+    );
   });
 });
 

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -291,6 +291,33 @@ describe("what the control reports as selected", () => {
     expect(appliedNote(container)).not.toBeNull();
   });
 
+  it("stays SELECTED after choosing the unconditional tier's own width", () => {
+    /*
+     * Choosing that option sets a real width now, and it is no tier's BOUND —
+     * so a match computed from the bounded tiers is false the moment it is
+     * pressed. The canvas sizes correctly and edits base; the control reports
+     * `aria-checked="false"` on every radio and reads as having no selection.
+     *
+     * A press that visibly deselects everything is worse than one that does
+     * nothing: it says the choice was refused while the edit it enabled is
+     * quietly landing where the author wanted.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={site()}
+        width={992}
+        appliedWidth={992}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(checked()).toHaveLength(1);
+    expect(checked()[0]?.getAttribute("aria-label")).toBe(
+      "Full width, from 992 pixels"
+    );
+  });
+
   it("selects the widest when the canvas is UNBOUNDED, which is the control", () => {
     /*
      * Without this, a control that selected nothing under every circumstance

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -40,7 +40,11 @@ import { cn } from "@nextlyhq/ui/utils";
 import * as React from "react";
 
 import { authoredBreakpoints } from "./breakpoints";
-import { editedBreakpointAtWidth, offeredTiers } from "./canvas-width";
+import {
+  baseWidth,
+  editedBreakpointAtWidth,
+  offeredTiers,
+} from "./canvas-width";
 
 /**
  * Props for BreakpointSwitcher.
@@ -95,6 +99,27 @@ export interface BreakpointSwitcherProps {
  *
  * @experimental
  */
+/**
+ * What an option is CALLED, width included.
+ *
+ * The number is in the accessible name rather than only in a tooltip, because
+ * "Tablet" alone does not say what selecting it will do and the width is the
+ * whole content of the choice.
+ *
+ * FROM rather than up to for the unconditional tier. Every bounded tier
+ * overrides it, so its width is a floor rather than a ceiling, and "up to"
+ * would name the wrong side of the only number it has.
+ */
+function ariaLabelFor(option: {
+  label: string;
+  bound?: number;
+  unconditional?: boolean;
+}): string {
+  if (option.bound === undefined) return option.label;
+  const side = option.unconditional === true ? "from" : "up to";
+  return `${option.label}, ${side} ${option.bound} pixels`;
+}
+
 export function BreakpointSwitcher({
   breakpoints,
   width,
@@ -202,8 +227,36 @@ export function BreakpointSwitcher({
    * user one Tab per breakpoint to cross a control they may not be using, and
    * assistive technology announces the group's size for them anyway.
    */
-  const options: Array<{ id: BreakpointId; label: string; bound?: number }> = [
-    { id: BASE_BREAKPOINT, label: "Full width" },
+  /*
+   * The unconditional tier is offered at a WIDTH, like every other option.
+   *
+   * Unbounded it was not an offer to edit base — it was an offer to fill the
+   * region, and on any screen where the region is narrower than the widest
+   * bound those are different tiers. Measured: around 912px of canvas on the
+   * supported 1280px shell against a site bounding tablet at 1024, so pressing
+   * this wrote every edit into tablet while the control read as base. The one
+   * option that named the tier an author most often wants was the one that
+   * could not select it.
+   *
+   * Still unbounded where the site bounds nothing: base applies at every width
+   * there, so there is no width to go to and "fill the region" is the truthful
+   * offer rather than a stand-in for one.
+   */
+  const unconditional = baseWidth(breakpoints);
+  const options: Array<{
+    id: BreakpointId;
+    label: string;
+    bound?: number;
+    /** Applies FROM its width upward rather than up to it. */
+    unconditional?: boolean;
+  }> = [
+    {
+      id: BASE_BREAKPOINT,
+      label: "Full width",
+      ...(unconditional === undefined
+        ? {}
+        : { bound: unconditional, unconditional: true }),
+    },
     ...tiers,
   ];
   /*
@@ -215,9 +268,25 @@ export function BreakpointSwitcher({
    * tablet rules are live and the canvas is not at the tablet width — while the
    * keyboard still needs somewhere to land.
    */
-  const matchedIndex = options.findIndex(option =>
-    option.bound === undefined ? atWidest : exact && option.bound === width
-  );
+  const matchedIndex = options.findIndex(option => {
+    if (option.bound === undefined) return atWidest;
+    /*
+     * The unconditional option answers to TWO widths, and both are honest.
+     *
+     * Its own — the narrowest at which base applies, which pressing it now sets
+     * — and the unbounded canvas, which is what the editor opens with. Matching
+     * only its own would leave a freshly opened editor with nothing selected
+     * while base is very often exactly what is being edited; matching only the
+     * unbounded one is what made it unable to select base at all.
+     *
+     * The two are not the same state and the indicator still says so: an
+     * unbounded canvas in a narrow region is painting a narrower tier, and
+     * `describedBySelection` below reports that rather than letting the
+     * selection stand for it.
+     */
+    if (option.unconditional === true && atWidest) return true;
+    return exact && option.bound === width;
+  });
   // Falls back to the widest, which always exists: a roving tabindex with no
   // stop at all removes the control from the tab order entirely.
   const activeIndex = matchedIndex >= 0 ? matchedIndex : 0;
@@ -236,14 +305,13 @@ export function BreakpointSwitcher({
    */
   const describedBySelection = matchedIndex >= 0 && appliedTier === claimedTier;
   /*
-   * The tier's own label, never its id. A bounded tier is found among the
-   * options; anything else is the unconditional one, whose id a site may spell
-   * differently and which this control already names "Full width".
+   * The tier's own label, never its id. Every offered tier is now found among
+   * the options, the unconditional one included — it carries a bound wherever
+   * the site declares any. The fallback covers a site that bounds nothing,
+   * whose unconditional id it may spell differently from the constant.
    */
   const appliedLabel =
-    options.find(
-      option => option.bound !== undefined && option.id === appliedTier
-    )?.label ?? "Full width";
+    options.find(option => option.id === appliedTier)?.label ?? "Full width";
 
   /*
    * The rendered radios, so an arrow key can move FOCUS as well as selection.
@@ -314,11 +382,7 @@ export function BreakpointSwitcher({
              * "Tablet" alone does not say what selecting it will do, and the
              * number is the whole content of the choice.
              */
-            aria-label={
-              option.bound === undefined
-                ? "Full width"
-                : `${option.label}, up to ${option.bound} pixels`
-            }
+            aria-label={ariaLabelFor(option)}
             title={
               ready
                 ? undefined

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -217,7 +217,27 @@ export function BreakpointSwitcher({
    * nothing while the tier indicator still reports what is applying. Gutenberg
    * needed the same distinction once it allowed free resizing.
    */
-  const exact = tiers.some(tier => tier.bound === width);
+  /*
+   * Built from {@link selectableTiers}, which is also what the HOST checks a
+   * requested width against. Composed here instead, the two lists drift — and
+   * the way they drifted was silent: the host cleared the unconditional tier's
+   * width on the render after it was chosen, so the option existed, responded,
+   * and did nothing.
+   */
+  const selectable = React.useMemo(
+    () => selectableTiers(breakpoints),
+    [breakpoints]
+  );
+  /*
+   * Asked of every SELECTABLE width, not of the bounded ones.
+   *
+   * The unconditional tier now has a width of its own, and it is no tier's
+   * bound. Measured against the bounded list alone this was false the moment an
+   * author chose that tier: the canvas sized correctly and edited base, while
+   * every radio reported `aria-checked="false"` and the control read as having
+   * no selection at all.
+   */
+  const exact = selectable.some(tier => tier.maxWidth === width);
   const atWidest = width === undefined;
 
   /*
@@ -243,19 +263,9 @@ export function BreakpointSwitcher({
    * offer rather than a stand-in for one.
    */
   /*
-   * Built from {@link selectableTiers}, which is also what the HOST checks a
-   * requested width against. Composed here instead, the two lists drift — and
-   * the way they drifted was silent: the host cleared the unconditional tier's
-   * width on the render after it was chosen, so the option existed, responded,
-   * and did nothing.
-   *
-   * Labels stay here because a tier carries none and naming is this control's
-   * job; the WIDTHS are the shared answer.
+   * Labels stay in this component because a tier carries none and naming is
+   * this control's job; the WIDTHS are the shared answer, taken above.
    */
-  const selectable = React.useMemo(
-    () => selectableTiers(breakpoints),
-    [breakpoints]
-  );
   const labels = new Map(tiers.map(tier => [tier.id, tier.label]));
   const options: Array<{
     id: BreakpointId;

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -41,9 +41,9 @@ import * as React from "react";
 
 import { authoredBreakpoints } from "./breakpoints";
 import {
-  baseWidth,
   editedBreakpointAtWidth,
   offeredTiers,
+  selectableTiers,
 } from "./canvas-width";
 
 /**
@@ -242,23 +242,39 @@ export function BreakpointSwitcher({
    * there, so there is no width to go to and "fill the region" is the truthful
    * offer rather than a stand-in for one.
    */
-  const unconditional = baseWidth(breakpoints);
+  /*
+   * Built from {@link selectableTiers}, which is also what the HOST checks a
+   * requested width against. Composed here instead, the two lists drift — and
+   * the way they drifted was silent: the host cleared the unconditional tier's
+   * width on the render after it was chosen, so the option existed, responded,
+   * and did nothing.
+   *
+   * Labels stay here because a tier carries none and naming is this control's
+   * job; the WIDTHS are the shared answer.
+   */
+  const selectable = React.useMemo(
+    () => selectableTiers(breakpoints),
+    [breakpoints]
+  );
+  const labels = new Map(tiers.map(tier => [tier.id, tier.label]));
   const options: Array<{
     id: BreakpointId;
     label: string;
     bound?: number;
     /** Applies FROM its width upward rather than up to it. */
     unconditional?: boolean;
-  }> = [
-    {
-      id: BASE_BREAKPOINT,
-      label: "Full width",
-      ...(unconditional === undefined
-        ? {}
-        : { bound: unconditional, unconditional: true }),
-    },
-    ...tiers,
-  ];
+  }> =
+    selectable.length === 0
+      ? [{ id: BASE_BREAKPOINT, label: "Full width" }]
+      : selectable.map(tier => ({
+          id: tier.id,
+          label:
+            tier.unconditional === true
+              ? "Full width"
+              : (labels.get(tier.id) ?? tier.id),
+          bound: tier.maxWidth,
+          ...(tier.unconditional === true ? { unconditional: true } : {}),
+        }));
   /*
    * Which option the current width CORRESPONDS to, or -1 for none.
    *

--- a/packages/builder/src/canvas-drag.test.tsx
+++ b/packages/builder/src/canvas-drag.test.tsx
@@ -304,6 +304,66 @@ describe("useCanvasDrag", () => {
     expect(indicator(container)).not.toBeNull();
   });
 
+  it("advances the target when the page SCROLLS under a still pointer", () => {
+    /*
+     * What autoscroll does: the pointer rests in the edge band and the content
+     * travels beneath it. The drag re-aims every frame from the same client
+     * coordinates, so the only thing that moves is the canvas's own rectangle.
+     *
+     * The target-switch rule needs a coordinate that MOVES in that situation,
+     * or a rival target's distance from its anchor stays zero however far the
+     * page travels — the committed target never advances and the indicator
+     * stays on a position that has scrolled off screen. It also needs one that
+     * is not divided by the canvas scale, or the threshold asks for less hand
+     * movement the further the canvas is zoomed out. Painted coordinates are
+     * the only space that is both.
+     *
+     * Driven by moving the ROOT's rectangle rather than by running the
+     * autoscroll frame: jsdom lays nothing out, so the pump has no scroller to
+     * move and no rectangle to re-read. Moving the rectangle under a fixed
+     * pointer is precisely what a scroll does to the numbers this reads.
+     */
+    const { container, root } = renderThree();
+
+    // The root starts at the origin; blocks a/b/c stack at y 0, 100, 200.
+    press(root, blockElement(container, "a"), 200, 50);
+    moveTo(root, 200, 250);
+    expect(indicator(container)).not.toBeNull();
+    const before = indicator(container)?.getAttribute("style") ?? "";
+
+    /*
+     * The page scrolls: everything moves UP, so the root's rectangle starts
+     * higher while the pointer has not moved at all.
+     *
+     * TWICE, because the rule anchors on the move where the candidate first
+     * differs and then measures travel FROM that anchor — one step sets the
+     * anchor and cannot also have travelled from it. Autoscroll is many small
+     * frames, so two is the smallest faithful model of it rather than a
+     * concession.
+     */
+    const scrollTo = (offset: number): void => {
+      root.getBoundingClientRect = () =>
+        ({
+          x: 0,
+          y: -offset,
+          width: 400,
+          height: 1000,
+          top: -offset,
+          left: 0,
+        }) as DOMRect;
+      moveTo(root, 200, 250);
+    };
+    scrollTo(200);
+    scrollTo(400);
+
+    const after = indicator(container)?.getAttribute("style") ?? "";
+    expect(after).not.toBe("");
+    // The line has moved, because a different position is now under the
+    // pointer. Read from the drawn indicator rather than from internal state:
+    // what an author sees is the thing this rule exists to keep honest.
+    expect(after).not.toBe(before);
+  });
+
   it("commits a move to the position the line was drawn at", () => {
     const { container, root } = renderThree();
 

--- a/packages/builder/src/canvas-drag.test.tsx
+++ b/packages/builder/src/canvas-drag.test.tsx
@@ -261,6 +261,49 @@ describe("useCanvasDrag", () => {
     expect(indicator(container)).not.toBeNull();
   });
 
+  it("measures the activation threshold in CLIENT pixels, not canvas ones", () => {
+    /*
+     * The threshold separates a click from an intent to move, which is a fact
+     * about the hand rather than about the canvas's coordinate system. The
+     * canvas is scaled so a tier wider than the region stays editable, and
+     * every client rectangle then comes back in painted pixels — so a distance
+     * converted into canvas coordinates is LARGER than the hand moved.
+     *
+     * Measured in that space the threshold shrinks with the canvas: painted at
+     * half size, the 4px separating a click from a drag needs only 2px of real
+     * movement, and ordinary click jitter starts committing moves the author
+     * never made.
+     */
+    const { container, root } = renderThree();
+    // Painted 400 wide against 800 laid out: the canvas is drawn at half size.
+    Object.defineProperty(root, "offsetWidth", { value: 800 });
+    Object.defineProperty(root, "offsetHeight", { value: 2000 });
+
+    press(root, blockElement(container, "a"), 200, 50);
+    // Three pixels of hand movement, below the four the threshold asks for —
+    // but six once converted into the canvas's own coordinates.
+    moveTo(root, 200, 53);
+
+    expect(indicator(container)).toBeNull();
+  });
+
+  it("still activates on a real drag while the canvas is scaled", () => {
+    /*
+     * The control on the case above, and it has to be here: a threshold that
+     * had become unreachable — or a drag that never starts under a scaled
+     * canvas at all — satisfies that assertion perfectly, because it is
+     * satisfied by absence.
+     */
+    const { container, root } = renderThree();
+    Object.defineProperty(root, "offsetWidth", { value: 800 });
+    Object.defineProperty(root, "offsetHeight", { value: 2000 });
+
+    press(root, blockElement(container, "a"), 200, 50);
+    moveTo(root, 200, 250);
+
+    expect(indicator(container)).not.toBeNull();
+  });
+
   it("commits a move to the position the line was drawn at", () => {
     const { container, root } = renderThree();
 

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -137,6 +137,21 @@ export interface UseCanvasDragOptions {
 interface Gesture {
   readonly nodeId: string;
   readonly origin: Point;
+  /**
+   * Where the press landed in CLIENT pixels.
+   *
+   * Kept beside {@link origin} rather than derived from it, because the two
+   * answer different questions and a scaled canvas separates them. `origin` is
+   * in the canvas's own content coordinates, which is what a hit test needs;
+   * the thresholds below are about how far a HAND moved, which is a fact about
+   * the person and not about the document's coordinate system.
+   *
+   * Measured in content pixels they shrink with the canvas: at a canvas painted
+   * to 71%, the 4px that separates a click from a drag needs only 2.85px of
+   * real movement, so ordinary click jitter starts committing moves — and the
+   * target hysteresis loosens by the same factor at the same time.
+   */
+  readonly originClient: Point;
   readonly regions: readonly DropRegion[];
   readonly rects: RectSource;
   readonly forbiddenParents: ReadonlySet<string>;
@@ -266,6 +281,7 @@ export function useCanvasDrag({
       gesture.current = {
         nodeId,
         origin: canvasContentPoint(event.clientX, event.clientY, root),
+        originClient: { x: event.clientX, y: event.clientY },
         regions: collectRegions(current.document, latest.current.slots, rects),
         rects,
         forbiddenParents: movingSubtree(current.document, nodeId),
@@ -330,7 +346,17 @@ export function useCanvasDrag({
       drag.switchState = nextTargetSwitchState(
         drag.switchState,
         candidate === null ? null : candidate.id,
-        pointer,
+        /*
+         * CLIENT pixels, for the reason the activation threshold uses them: the
+         * hysteresis is how far a hand must move to overrule a committed
+         * target. The rule needs one space used consistently and does not care
+         * which, and it stores its own anchor in whatever it is given.
+         *
+         * Read from the GESTURE rather than from an event, because this is
+         * shared with the autoscroll frame, which has no event of its own — and
+         * both callers keep these current before they aim.
+         */
+        { x: drag.clientX, y: drag.clientY },
         switchPx
       );
 
@@ -405,9 +431,12 @@ export function useCanvasDrag({
       drag.clientY = event.clientY;
 
       if (!drag.active) {
+        // CLIENT pixels: the threshold separates a click from an intent to
+        // move, which is a property of the hand rather than of the canvas's
+        // scale. Measured in content pixels it shrinks with the canvas.
         const travelled = Math.hypot(
-          pointer.x - drag.origin.x,
-          pointer.y - drag.origin.y
+          event.clientX - drag.originClient.x,
+          event.clientY - drag.originClient.y
         );
         if (travelled < activationPx) return;
         drag.active = true;

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -61,6 +61,7 @@ import type { EditorState } from "./editor-state";
 import type { Point, Rect } from "./geometry";
 import {
   canvasContentPoint,
+  canvasPaintedPoint,
   canvasContentRect,
   containerEdges,
   scrollableAncestor,
@@ -347,16 +348,27 @@ export function useCanvasDrag({
         drag.switchState,
         candidate === null ? null : candidate.id,
         /*
-         * CLIENT pixels, for the reason the activation threshold uses them: the
-         * hysteresis is how far a hand must move to overrule a committed
-         * target. The rule needs one space used consistently and does not care
-         * which, and it stores its own anchor in whatever it is given.
+         * PAINTED pixels relative to the canvas, which is the only space that
+         * answers both halves of this rule.
+         *
+         * The threshold is how far a HAND must move to overrule a committed
+         * target, so it cannot be measured in canvas coordinates: those are
+         * divided by the scale, and the hysteresis would loosen as the canvas
+         * zoomed out. But it cannot be measured in client coordinates either —
+         * autoscroll moves the page under a STATIONARY pointer, so the distance
+         * from the anchor would stay zero however far the page travelled, and
+         * the committed target would never advance off a position that has
+         * scrolled away.
+         *
+         * Painted coordinates are undivided, so the threshold stays about the
+         * hand, and they move with the scroll because the root's own rectangle
+         * does.
          *
          * Read from the GESTURE rather than from an event, because this is
          * shared with the autoscroll frame, which has no event of its own — and
          * both callers keep these current before they aim.
          */
-        { x: drag.clientX, y: drag.clientY },
+        canvasPaintedPoint(drag.clientX, drag.clientY, drag.root),
         switchPx
       );
 

--- a/packages/builder/src/canvas-width.test.ts
+++ b/packages/builder/src/canvas-width.test.ts
@@ -146,14 +146,32 @@ describe("the width a tier is shown at", () => {
     expect(widthForBreakpoint(site(), "mobile")).toBe(575);
   });
 
-  it("is UNBOUNDED for the unconditional tier, not a number", () => {
+  it("is the APPLIES-FROM width for the unconditional tier", () => {
     /*
-     * `undefined` means "as wide as the region allows". Pinning the widest tier
-     * to a number would invent a bound the site never declared and make the
-     * widest preset narrower than the space available — the canvas would gain
-     * empty gutters on selecting the tier it was already showing.
+     * It used to be `undefined` — as wide as the region allows — on the
+     * reasoning that pinning the widest tier to a number would invent a bound
+     * the site never declared and put empty gutters around a canvas that was
+     * already the right size. The number is not invented: it is one past the
+     * widest bound, and the canvas is scaled to fit rather than guttered.
+     *
+     * A JUMP and a CHOICE are the same act reached two ways, so this has to
+     * agree with what the switcher sets. Answering `undefined` here released
+     * the canvas to the region — which, wherever the region is narrower than
+     * the widest bound, lands on the tier the author was jumping AWAY from.
      */
-    expect(widthForBreakpoint(site(), "base")).toBeUndefined();
+    expect(widthForBreakpoint(site(), "base")).toBe(baseWidth(site()));
+    expect(widthForBreakpoint(site(), "base")).toBe(992);
+  });
+
+  it("is UNBOUNDED for base where the site bounds NOTHING", () => {
+    /*
+     * The control, and the case the old reasoning was right about: with no
+     * viewport tier there is no width to go to, base applies everywhere, and
+     * the region is where the canvas belongs.
+     */
+    expect(
+      widthForBreakpoint({ viewport: [], container: [] }, "base")
+    ).toBeUndefined();
   });
 
   it("is UNBOUNDED for an id the site does not define", () => {

--- a/packages/builder/src/canvas-width.test.ts
+++ b/packages/builder/src/canvas-width.test.ts
@@ -13,11 +13,13 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  BASE_BREAKPOINT,
   breakpointContexts,
   type BreakpointSet,
 } from "@nextlyhq/blocks-engine";
 
 import {
+  baseWidth,
   breakpointsAtWidth,
   editedBreakpointAtWidth,
   widthForBreakpoint,
@@ -287,5 +289,59 @@ describe("two tiers sharing one bound", () => {
       "tablet",
       "mobile",
     ]);
+  });
+});
+
+describe("the width at which the UNCONDITIONAL tier applies", () => {
+  it("is one past the widest bound", () => {
+    /*
+     * A bounded tier applies at `width <= bound`, so the first width no bounded
+     * tier claims is `bound + 1`. Asserted against the tier arithmetic rather
+     * than against the literal alone, because the two agreeing is the property:
+     * a number that did not actually resolve base would be a control that sizes
+     * the canvas and selects the wrong tier, which is the defect this exists to
+     * remove rather than a smaller version of it.
+     */
+    expect(baseWidth(site())).toBe(992);
+    expect(editedBreakpointAtWidth(site(), 992)).toBe(BASE_BREAKPOINT);
+    // The control: one pixel narrower is still the bounded tier, so the +1 is
+    // load-bearing rather than decorative.
+    expect(editedBreakpointAtWidth(site(), 991)).toBe("tablet");
+  });
+
+  it("is the SMALLEST width that resolves base", () => {
+    /*
+     * The canvas is scaled to fit, so every pixel past the first one costs the
+     * author legibility and buys nothing. A conventional desktop number would
+     * also be a width the site never declared — the same invention the tier
+     * list refuses.
+     */
+    expect(baseWidth(site())).toBe(992);
+    expect(editedBreakpointAtWidth(site(), baseWidth(site()) ?? 0)).toBe(
+      BASE_BREAKPOINT
+    );
+  });
+
+  it("is UNDEFINED when the site bounds no viewport tier", () => {
+    /*
+     * Base already applies at every width there, so there is no width to go to.
+     * A number would size the canvas to a bound the site never declared.
+     */
+    expect(baseWidth(undefined)).toBeUndefined();
+    expect(baseWidth({ viewport: [], container: [] })).toBeUndefined();
+  });
+
+  it("ignores the CONTAINER axis, as the tier list does", () => {
+    /*
+     * A container tier bounds a box inside the page, not the viewport, so the
+     * width that would clear it says nothing about which viewport tier applies.
+     * Counted here it would push the canvas wider than any viewport tier needs.
+     */
+    expect(
+      baseWidth({
+        viewport: [{ id: "tablet", label: "Tablet", maxWidth: 991 }],
+        container: [{ id: "narrow", label: "Narrow", maxWidth: 1600 }],
+      })
+    ).toBe(992);
   });
 });

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -239,6 +239,34 @@ export function baseWidth(set: BreakpointSet | undefined): number | undefined {
   return widest === undefined ? undefined : widest.maxWidth + 1;
 }
 
+/**
+ * Every tier the breakpoint control can put the canvas at, widest first.
+ *
+ * The bounded tiers AND the unconditional one, which is offered at the width it
+ * applies from. Published as one list because two places need the same answer
+ * and they are not the same code: the control builds its options from it, and
+ * the host clears a requested width that is not on it — a canvas pinned to a
+ * bound the stylesheet no longer has, after an author deletes the tier they
+ * selected, has no control on screen to release it.
+ *
+ * Measured: those two DID disagree. The host compared against the bounded tiers
+ * alone while the control had begun offering the unconditional one, so choosing
+ * base set a width the host cleared on the very next render — the canvas
+ * returned to filling the region, and base stayed uneditable exactly where it
+ * had been. Nothing failed; the option simply did nothing.
+ */
+export function selectableTiers(
+  set: BreakpointSet | undefined
+): Array<{ id: BreakpointId; maxWidth: number; unconditional?: boolean }> {
+  const base = baseWidth(set);
+  return [
+    ...(base === undefined
+      ? []
+      : [{ id: BASE_BREAKPOINT, maxWidth: base, unconditional: true }]),
+    ...offeredTiers(set),
+  ];
+}
+
 export function widthForBreakpoint(
   set: BreakpointSet | undefined,
   id: BreakpointId

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -215,6 +215,30 @@ export function offeredTiers(
  *
  * @experimental
  */
+/**
+ * The narrowest canvas width at which the UNCONDITIONAL tier applies.
+ *
+ * One past the widest bound, because a bounded tier applies at `width <= bound`
+ * — so the first width no bounded tier claims is `bound + 1`, and that is where
+ * the base rules are what an author is editing.
+ *
+ * Derived rather than chosen. A conventional desktop number would be a width
+ * the site never declared, and the canvas would then simulate a viewport
+ * nothing in the document mentions; one past the widest bound is the only width
+ * the site's own tiers imply. It is also the SMALLEST such width, which matters
+ * because the canvas is scaled to fit: every pixel past it costs the author
+ * legibility for nothing.
+ *
+ * `undefined` when the site bounds no viewport tier at all. Base already
+ * applies at every width there, so there is no width to go to — and offering
+ * one would size the canvas to a bound the site never declared, which is what
+ * the switcher's own tier list refuses to do.
+ */
+export function baseWidth(set: BreakpointSet | undefined): number | undefined {
+  const widest = offeredTiers(set)[0];
+  return widest === undefined ? undefined : widest.maxWidth + 1;
+}
+
 export function widthForBreakpoint(
   set: BreakpointSet | undefined,
   id: BreakpointId

--- a/packages/builder/src/canvas-width.ts
+++ b/packages/builder/src/canvas-width.ts
@@ -272,7 +272,15 @@ export function widthForBreakpoint(
   id: BreakpointId
 ): number | undefined {
   /*
-   * Read from {@link offeredTiers}, not from the contexts directly.
+   * Read from {@link selectableTiers}, not from the contexts directly.
+   *
+   * The SELECTABLE list rather than the bounded one, because a jump and a
+   * choice are the same act reached two ways: the switcher offers the
+   * unconditional tier at the width it applies from, and a control whose value
+   * came from that tier has to send the canvas to the same place. Answering
+   * from the bounded tiers alone returned `undefined` for base and released the
+   * canvas to the region — which, wherever the region is narrower than the
+   * widest bound, lands on the tier the author was jumping AWAY from.
    *
    * Two ids can carry the same bound, and only one of them is what a canvas at
    * that width is showing: the compiler emits both into one at-rule and the
@@ -282,8 +290,10 @@ export function widthForBreakpoint(
    * the disagreement between the control and the write that collapsing the
    * choice exists to remove.
    *
-   * `undefined` for an id that is not offered is the honest answer: there is no
-   * width that puts that tier on screen, because another tier owns it.
+   * `undefined` for an id that is not selectable is still the honest answer:
+   * there is no width that puts that tier on screen, because another tier owns
+   * the bound — or, for a site that bounds nothing, because base already
+   * applies at every width and the region is where it belongs.
    */
-  return offeredTiers(set).find(tier => tier.id === id)?.maxWidth;
+  return selectableTiers(set).find(tier => tier.id === id)?.maxWidth;
 }

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -16,7 +16,13 @@
  *
  * @module canvas.test
  */
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import {
   afterAll,
   afterEach,
@@ -37,6 +43,7 @@ import {
   CANVAS_ROOT_CLASS,
   Canvas,
   SELECTED_ATTRIBUTE,
+  canvasScale,
   nodeIdFromEvent,
 } from "./canvas";
 
@@ -575,6 +582,40 @@ describe("the preview box the canvas establishes", () => {
   });
 });
 
+describe("how far the canvas must shrink for a width to fit", () => {
+  it("is the ratio when the region is too narrow", () => {
+    // The measured case: ~912px of canvas on the supported 1280px shell.
+    expect(canvasScale(1280, 912)).toBe(912 / 1280);
+  });
+
+  it("never MAGNIFIES a box the region can already hold", () => {
+    /*
+     * A region wider than the request means the box is simply narrower than
+     * the space, which the auto margins centre. Scaled up it would show the
+     * author a page larger than life, and every judgement they make from the
+     * screen — type size, spacing, whether a line wraps — would be wrong in the
+     * flattering direction.
+     */
+    expect(canvasScale(600, 912)).toBe(1);
+    expect(canvasScale(912, 912)).toBe(1);
+  });
+
+  it("is the IDENTITY for anything it cannot divide", () => {
+    /*
+     * Each of these reaches the real code. The unmeasured region runs on every
+     * mount before the first observation; a region of zero is what a collapsed
+     * pane reports. Neither `NaN` nor `Infinity` fails loudly — both paint the
+     * canvas nowhere while leaving it present in the tree, which reads as the
+     * editor having lost the page rather than as a bad number.
+     */
+    expect(canvasScale(1280, undefined)).toBe(1);
+    expect(canvasScale(undefined, 912)).toBe(1);
+    expect(canvasScale(1280, 0)).toBe(1);
+    expect(canvasScale(0, 912)).toBe(1);
+    expect(canvasScale(1280, Number.NaN)).toBe(1);
+  });
+});
+
 describe("what the canvas reports about the box it got", () => {
   /**
    * A `ResizeObserver` that records what it was asked to watch and hands the
@@ -585,10 +626,22 @@ describe("what the canvas reports about the box it got", () => {
    * not, so without a stub every assertion here would pass on absence.
    */
   class FakeResizeObserver {
+    /**
+     * Every observer built since the last reset, newest first.
+     *
+     * The canvas builds more than one — the box it reports on, and the region
+     * it derives its scale from — so "the last one constructed" names whichever
+     * effect happened to run second. Addressing them by WHAT THEY OBSERVE is
+     * the structural question; construction order is a proxy that silently
+     * re-points when an effect is added, and every case here would then drive
+     * an observer watching a different element and assert against nothing.
+     */
+    static all: FakeResizeObserver[] = [];
     static last: FakeResizeObserver | undefined;
     readonly observed: Element[] = [];
     disconnected = false;
     constructor(readonly callback: ResizeObserverCallback) {
+      FakeResizeObserver.all.unshift(this);
       FakeResizeObserver.last = this;
     }
     observe(element: Element): void {
@@ -616,7 +669,157 @@ describe("what the canvas reports about the box it got", () => {
   });
 
   afterEach(() => {
+    FakeResizeObserver.all = [];
     FakeResizeObserver.last = undefined;
+  });
+
+  /**
+   * The observer watching the canvas ROOT, which is the box the sheet queries.
+   *
+   * Found by the element rather than taken as the newest, so a case reading the
+   * reported width cannot be handed the region observer instead.
+   */
+  function rootObserver(): FakeResizeObserver | undefined {
+    return FakeResizeObserver.all.find(observer =>
+      observer.observed.some(element =>
+        element.classList.contains(CANVAS_ROOT_CLASS)
+      )
+    );
+  }
+
+  /** The observer watching the REGION, which is the canvas root's parent. */
+  function regionObserver(): FakeResizeObserver | undefined {
+    return FakeResizeObserver.all.find(observer =>
+      observer.observed.some(
+        element => !element.classList.contains(CANVAS_ROOT_CLASS)
+      )
+    );
+  }
+
+  /**
+   * Report a region width, and REFUSE if there is no observer to report it to.
+   *
+   * `regionObserver()?.deliver(...)` is silent when the observer was never
+   * built: the width is never delivered, the canvas keeps its unmeasured style,
+   * and a case asserting the unscaled shape passes for the wrong reason. The
+   * assertion is what turns a missing observer into a failure.
+   *
+   * Wrapped in `act` because this one sets React state rather than calling a
+   * host's reporter — without it the render that reads the new width has not
+   * happened when the assertions run.
+   */
+  function region(inlineSize: number): void {
+    const observer = regionObserver();
+    expect(observer).toBeDefined();
+    act(() => {
+      observer?.deliver({
+        contentBoxSize: [{ inlineSize, blockSize: 700 }],
+      } as never);
+    });
+  }
+
+  /** A canvas asked for `width`, so it has a region to scale against. */
+  function atWidth(width: number) {
+    return render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={PREVIEWABLE}
+        preview={{ container: "nx-preview-viewport", width }}
+      />
+    );
+  }
+
+  const rootOf = (container: HTMLElement): HTMLElement =>
+    container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement;
+
+  describe("a tier wider than the region it has to fit in", () => {
+    it("takes its FULL width and is scaled down to the region", () => {
+      /*
+       * The regression this exists for. The canvas region is around 912px on
+       * the supported 1280px shell, so against a site whose widest bound is
+       * 1024 there is no width an author can ask for that puts the box above
+       * it — every edit lands in the tier below, and the unconditional one
+       * cannot be reached at all.
+       *
+       * The width must therefore be EXACT rather than a maximum. Capped at the
+       * region the box is not simulating a 1280px viewport; it is simulating a
+       * 912px one and naming the wrong tier with confidence.
+       */
+      const { container } = atWidth(1280);
+      region(912);
+
+      const root = rootOf(container);
+      expect(root.style.width).toBe("1280px");
+      expect(root.style.transform).toBe(`scale(${912 / 1280})`);
+      // Not a centred origin: the scale is exactly region / requested, so the
+      // painted box already fills the region and a centred origin would push it
+      // half its shortfall to the right and clip that much off the far side.
+      expect(root.style.transformOrigin).toBe("top left");
+      // Published for the stylesheet, which divides the canvas minimum height
+      // back out — a scaled root laid out at the region's height paints shorter
+      // than it and leaves the bottom of the region unaimable.
+      expect(root.style.getPropertyValue("--nx-canvas-scale")).toBe(
+        `${912 / 1280}`
+      );
+    });
+
+    it("leaves a tier that FITS unscaled and centred", () => {
+      /*
+       * The control, and it has to come out different or the case above says
+       * only that the canvas sets styles. A request the region can honour is
+       * not a simulation of anything and must stay pixel-exact: resampling it
+       * would soften a page the author is judging type and spacing on.
+       */
+      const { container } = atWidth(600);
+      region(912);
+
+      const root = rootOf(container);
+      expect(root.style.maxWidth).toBe("600px");
+      expect(root.style.marginInline).toBe("auto");
+      expect(root.style.transform).toBe("");
+      expect(root.style.width).toBe("");
+    });
+
+    it("does not scale before the region has been measured", () => {
+      /*
+       * Every mount runs this before the first measurement. A scale derived
+       * from an unmeasured region is `NaN`, which does not fail loudly — it
+       * paints the canvas nowhere and leaves nothing to aim at, on a surface
+       * that looks present in the tree.
+       */
+      const { container } = atWidth(1280);
+
+      const root = rootOf(container);
+      expect(root.style.transform).toBe("");
+      expect(root.style.maxWidth).toBe("1280px");
+    });
+
+    it("observes NOTHING extra when no width was asked for", () => {
+      // A canvas filling its region has no scale to derive, and an observer
+      // that exists to answer a question nobody asked still fires on every
+      // pane drag.
+      render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={PREVIEWABLE}
+          preview={{ container: "nx-preview-viewport" }}
+        />
+      );
+
+      expect(regionObserver()).toBeUndefined();
+    });
   });
 
   /** A canvas previewing, with a reporter the test can read. */

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -738,6 +738,19 @@ describe("what the canvas reports about the box it got", () => {
   const rootOf = (container: HTMLElement): HTMLElement =>
     container.querySelector(`.${CANVAS_ROOT_CLASS}`) as HTMLElement;
 
+  /**
+   * The canvas's `zoom`, normalised to a string.
+   *
+   * jsdom does not implement `zoom` as a CSS property: React's assignment lands
+   * as a plain own property, so `getPropertyValue("zoom")` answers `""` even
+   * where it was set, while `style.zoom` is `undefined` where it was not. Read
+   * either way alone, one of the two states below reports the other's value —
+   * and the case that would break is the one asserting the canvas is NOT
+   * scaled, which is satisfied by absence.
+   */
+  const zoomOf = (root: HTMLElement): string =>
+    String((root.style as { zoom?: string }).zoom ?? "");
+
   describe("a tier wider than the region it has to fit in", () => {
     it("takes its FULL width and is scaled down to the region", () => {
       /*
@@ -756,17 +769,17 @@ describe("what the canvas reports about the box it got", () => {
 
       const root = rootOf(container);
       expect(root.style.width).toBe("1280px");
-      expect(root.style.transform).toBe(`scale(${912 / 1280})`);
-      // Not a centred origin: the scale is exactly region / requested, so the
-      // painted box already fills the region and a centred origin would push it
-      // half its shortfall to the right and clip that much off the far side.
-      expect(root.style.transformOrigin).toBe("top left");
-      // Published for the stylesheet, which divides the canvas minimum height
-      // back out — a scaled root laid out at the region's height paints shorter
-      // than it and leaves the bottom of the region unaimable.
-      expect(root.style.getPropertyValue("--nx-canvas-scale")).toBe(
-        `${912 / 1280}`
-      );
+      /*
+       * `zoom`, not a transform, and the difference is what the SCROLL
+       * CONTAINER sees. Both leave the layout width alone — which is what keeps
+       * the container queries at the requested tier — but a transform is
+       * paint-time, so the canvas section goes on reserving the unscaled box:
+       * measured at 368px of blank horizontal scroll in a 912px region, and
+       * 161px vertical once the height is compensated to fill it. `zoom`
+       * participates in layout, so the section reserves what is painted.
+       */
+      expect(zoomOf(root)).toBe(`${912 / 1280}`);
+      expect(root.style.transform).toBe("");
     });
 
     it("leaves a tier that FITS unscaled and centred", () => {
@@ -782,7 +795,7 @@ describe("what the canvas reports about the box it got", () => {
       const root = rootOf(container);
       expect(root.style.maxWidth).toBe("600px");
       expect(root.style.marginInline).toBe("auto");
-      expect(root.style.transform).toBe("");
+      expect(zoomOf(root)).toBe("");
       expect(root.style.width).toBe("");
     });
 
@@ -796,7 +809,7 @@ describe("what the canvas reports about the box it got", () => {
       const { container } = atWidth(1280);
 
       const root = rootOf(container);
-      expect(root.style.transform).toBe("");
+      expect(zoomOf(root)).toBe("");
       expect(root.style.maxWidth).toBe("1280px");
     });
 

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -42,7 +42,7 @@ import {
 } from "@nextlyhq/blocks-react";
 import type { PageRendererProps } from "@nextlyhq/blocks-react";
 import { cn } from "@nextlyhq/ui/utils";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { CanvasDragHandlers } from "./canvas-drag";
 import { offeredTiers } from "./canvas-width";
@@ -273,28 +273,168 @@ function useReportedInlineWidth(
 }
 
 /**
- * The canvas root's own style: the container the sheet queries, and the width
- * the box is being asked to show.
+ * The width of the REGION the canvas has been given, or `undefined` until it
+ * has been measured.
  *
- * A MAXIMUM with an auto inline margin rather than a fixed width, because the
- * region may be narrower than the tier asked for — a wide breakpoint inside a
- * half-width editor pane cannot be honoured, and stretching the box past its
- * region would put the page under the inspector.
+ * The canvas's own parent, which the canvas does not own — the same dependency
+ * `min-height: 100%` already has, and for the same reason: how much room there
+ * is is a fact about the surface hosting the editor, not about the document.
  *
- * Centred rather than left-aligned, which is what every builder surveyed does
- * and is not merely cosmetic: an off-centre narrow box reads as a layout that
- * has broken rather than as a viewport being simulated.
+ * Measured rather than passed, so a host cannot state a region that disagrees
+ * with the one it laid out. A number a caller supplies is a second answer to a
+ * question the box can be asked directly, and the two would first disagree when
+ * a rail is toggled — exactly when the scale has to change.
+ *
+ * `clientWidth` is not used, and the difference is load-bearing: it is an
+ * integer, so a fractional region rounds and the scale derived from it leaves
+ * the painted box a fraction wide of the space, which reads as a hairline of
+ * background down one edge that moves as the pane is dragged.
+ *
+ * Observed only while `scaling`, so a canvas that fills its region builds no
+ * observer at all — there is nothing for it to answer, and one that exists
+ * anyway fires on every pane drag for a number nobody reads.
+ */
+function useRegionWidth(
+  box: React.RefObject<HTMLElement | null>,
+  scaling: boolean
+): number | undefined {
+  const [width, setWidth] = useState<number | undefined>(undefined);
+  useEffect(() => {
+    if (!scaling) return;
+    const region = box.current?.parentElement ?? null;
+    if (region === null) return;
+    if (typeof ResizeObserver !== "function") return;
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (entry === undefined) return;
+      setWidth(inlineSizeOf(entry));
+    });
+    observer.observe(region);
+    return () => {
+      observer.disconnect();
+      // The region is gone, so its last width describes nothing. Reported as
+      // absent, the scale falls back to 1 — which is the identity, and the
+      // only answer that cannot place the canvas somewhere nobody can see.
+      setWidth(undefined);
+    };
+  }, [box, scaling]);
+  return width;
+}
+
+/**
+ * How much the canvas must be shrunk for the width it was asked for to fit.
+ *
+ * `1` whenever the request already fits, which is the ordinary case and must
+ * stay pixel-exact: a canvas showing a tier narrower than its region is not
+ * simulating anything and has nothing to gain from being resampled.
+ *
+ * Never above 1. A region wider than the request means the box is simply
+ * narrower than the space, which the auto margins centre; magnifying it would
+ * show the author a page larger than life and make every measurement they take
+ * from the screen wrong in the flattering direction.
+ *
+ * `1` for an unmeasured or nonsensical region as well. This runs before the
+ * first measurement on every mount, and a scale derived from `undefined` — or
+ * from a region of zero, which a collapsed pane reports — is either `NaN` or
+ * infinite, neither of which fails loudly: both produce a canvas that is
+ * present, painted nowhere, and impossible to aim at.
+ */
+export function canvasScale(
+  requested: number | undefined,
+  region: number | undefined
+): number {
+  if (requested === undefined || region === undefined) return 1;
+  if (!(requested > 0) || !(region > 0)) return 1;
+  return Math.min(1, region / requested);
+}
+
+/**
+ * The canvas root's own style: the container the sheet queries, the width the
+ * box is asked to show, and the scale that makes that width fit.
+ *
+ * Two shapes, because a request that fits and a request that does not are
+ * different situations rather than one with a parameter.
+ *
+ * WHERE IT FITS, the width is a MAXIMUM with an auto inline margin. Centred
+ * rather than left-aligned, which is what every builder surveyed does and is
+ * not merely cosmetic: an off-centre narrow box reads as a layout that has
+ * broken rather than as a viewport being simulated.
+ *
+ * WHERE IT DOES NOT, the width is EXACT and a transform shrinks the box until
+ * it does. That is the only way the widest tier stays editable at all: the
+ * region is around 912px on the supported 1280px shell, so a site whose widest
+ * bound is 1024 has no width an author can ask for that puts the box above it,
+ * and the unconditional tier becomes unreachable. Capping the width there does
+ * not simulate a 1280px viewport — it simulates a 912px one and reports the
+ * wrong tier with confidence.
+ *
+ * A transform rather than `zoom`, and rather than letting the box overflow.
+ * Measured: both `zoom` and a transform keep the container queries resolving at
+ * the REQUESTED width, because both leave the layout width alone; `zoom` also
+ * collapses the reserved height for free, which a transform does not. The
+ * transform is still the right one — `zoom`'s documented weakness is
+ * inconsistency in how it interacts with other layout features, which is where
+ * this canvas lives: overlays, drop targets and hit-testing all read boxes.
+ *
+ * `top left` rather than a centred origin, because the scale is exactly
+ * `region / requested`: the painted box then fills the region precisely, and
+ * there is nothing left over to centre. A centred origin would place the
+ * painted box half its shortfall to the right and clip that much off the far
+ * side.
+ *
+ * The scale is published as a custom property because the stylesheet needs it
+ * too: `min-height: 100%` gives the root the region's height, which paints at
+ * `scale` of it and leaves the rest of the region with no canvas on it —
+ * measured at 285px painted into a 400px region, 115px an author cannot aim a
+ * drop at. Dividing the minimum back out is what fills it.
  */
 function previewBoxStyle(
-  preview: CanvasPreview | undefined
+  preview: CanvasPreview | undefined,
+  scale: number
 ): React.CSSProperties {
   if (preview === undefined) return {};
+  const container = previewContainerStyle(preview.container);
+  if (preview.width === undefined) return container;
+  if (scale >= 1) {
+    return {
+      ...container,
+      maxWidth: `${preview.width}px`,
+      marginInline: "auto",
+    };
+  }
   return {
-    ...previewContainerStyle(preview.container),
-    ...(preview.width === undefined
-      ? {}
-      : { maxWidth: `${preview.width}px`, marginInline: "auto" }),
+    ...container,
+    width: `${preview.width}px`,
+    transform: `scale(${scale})`,
+    transformOrigin: "top left",
+    ["--nx-canvas-scale" as string]: `${scale}`,
   };
+}
+
+/**
+ * The canvas root's surface: what it queries, how wide it is asked to be, how
+ * far it must shrink for that width to fit, and what it ended up being.
+ *
+ * One decision rather than several statements in the component, because they
+ * are not independent. Three numbers describe this box — the width an author
+ * asked for, the room the region has, and the width the box ended up with — and
+ * only the first is chosen. The scale is DERIVED from the first two and the
+ * third is REPORTED from the result, so there is no stored value that can
+ * disagree with any other. Kept apart, a component holds all three and each can
+ * be updated without the rest.
+ */
+function useCanvasSurface(
+  root: React.RefObject<HTMLElement | null>,
+  preview: CanvasPreview | undefined
+): React.CSSProperties {
+  // What the box GOT, reported outward to whoever asked.
+  useReportedInlineWidth(root, preview?.onMeasured);
+  // What the box has ROOM for, read inward to decide how far it must shrink.
+  // Observed only where a width was asked for: a canvas filling its region has
+  // nothing to scale, and an observer that exists to answer a question nobody
+  // asked still fires on every pane drag.
+  const region = useRegionWidth(root, preview?.width !== undefined);
+  return previewBoxStyle(preview, canvasScale(preview?.width, region));
 }
 
 /**
@@ -739,7 +879,7 @@ export function Canvas({
     preview
   );
 
-  useReportedInlineWidth(root, active?.onMeasured);
+  const boxStyle = useCanvasSurface(root, active);
 
   const page = useMemo(
     () => (
@@ -769,7 +909,7 @@ export function Canvas({
       // are positioned in this element's own content coordinates: a box inside
       // it would size the page while leaving the drop indicator and the
       // selection chrome measuring the region instead.
-      style={previewBoxStyle(active)}
+      style={boxStyle}
       // The id the canvas believes is current, for a caller that wants the
       // answer without walking the tree. Named apart from the per-element
       // marker deliberately: one carries an id and the other is a boolean, and

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -368,25 +368,26 @@ export function canvasScale(
  * not simulate a 1280px viewport — it simulates a 912px one and reports the
  * wrong tier with confidence.
  *
- * A transform rather than `zoom`, and rather than letting the box overflow.
- * Measured: both `zoom` and a transform keep the container queries resolving at
- * the REQUESTED width, because both leave the layout width alone; `zoom` also
- * collapses the reserved height for free, which a transform does not. The
- * transform is still the right one — `zoom`'s documented weakness is
- * inconsistency in how it interacts with other layout features, which is where
- * this canvas lives: overlays, drop targets and hit-testing all read boxes.
+ * `zoom` rather than a transform, which is the opposite of what it looks like
+ * it should be and was measured both ways. Both keep the container queries
+ * resolving at the REQUESTED width — neither changes the width the box is laid
+ * out at, so `offsetWidth` and `contentBoxSize` still report 1280 — and both
+ * leave `getBoundingClientRect` answering in painted pixels.
  *
- * `top left` rather than a centred origin, because the scale is exactly
- * `region / requested`: the painted box then fills the region precisely, and
- * there is nothing left over to centre. A centred origin would place the
- * painted box half its shortfall to the right and clip that much off the far
- * side.
+ * They differ in what the SCROLL CONTAINER sees, and only `zoom` is usable
+ * there. A transform is paint-time, so the canvas section still reserves the
+ * unscaled layout box: measured in a 912x400 region at 0.7125, a transform
+ * leaves 368px of blank horizontal scroll, and compensating its height to fill
+ * the region adds 161px of blank vertical scroll — a tail an author, or drag
+ * autoscroll, can travel into until the page is off screen. `zoom` participates
+ * in layout, so the section reserves the painted box and both tails are zero.
  *
- * The scale is published as a custom property because the stylesheet needs it
- * too: `min-height: 100%` gives the root the region's height, which paints at
- * `scale` of it and leaves the rest of the region with no canvas on it —
- * measured at 285px painted into a 400px region, 115px an author cannot aim a
- * drop at. Dividing the minimum back out is what fills it.
+ * That participation is the very thing that argued against it: `zoom`'s
+ * documented weakness is inconsistency in how it interacts with other layout
+ * features, and this canvas is all layout — overlays, drop targets,
+ * hit-testing. But not participating is what produces two scroll defects that a
+ * measured wrapper would then exist to undo, and the properties those readers
+ * actually depend on were measured directly and hold.
  */
 function previewBoxStyle(
   preview: CanvasPreview | undefined,
@@ -402,13 +403,7 @@ function previewBoxStyle(
       marginInline: "auto",
     };
   }
-  return {
-    ...container,
-    width: `${preview.width}px`,
-    transform: `scale(${scale})`,
-    transformOrigin: "top left",
-    ["--nx-canvas-scale" as string]: `${scale}`,
-  };
+  return { ...container, width: `${preview.width}px`, zoom: scale };
 }
 
 /**
@@ -556,23 +551,39 @@ export interface CanvasPreview {
    */
   container: string;
   /**
-   * The width to constrain the box to, in CSS pixels, or absent to fill the
+   * The width to lay the box out at, in CSS pixels, or absent to fill the
    * region.
    *
-   * A MAXIMUM rather than a fixed width, because the region may be narrower
-   * than the tier being asked for — a wide breakpoint inside a half-width
-   * editor pane cannot be honoured, and stretching the box past its region
-   * would put the page under the inspector instead.
+   * HONOURED, whatever the region can hold. A region narrower than the tier
+   * being asked for does not cap it — the box is laid out at this width and
+   * PAINTED smaller, so what the container queries resolve against is the tier
+   * that was asked for rather than the one the region happens to imply.
+   *
+   * It was a maximum, and capping is what made the unconditional tier
+   * unreachable: the region is around 912px on the supported 1280px shell, so
+   * against a site bounding tablet at 1024 no requested width could ever put
+   * the box above it. A capped box does not simulate the viewport asked for; it
+   * simulates the region's own width while reporting the wrong tier.
+   *
+   * So this is the LAYOUT and query width. The painted width is this times the
+   * scale the canvas derives, and it is not reported: nothing outside needs it,
+   * and a second width on this object is a second thing to disagree.
    */
   width?: number;
   /**
    * The box's MEASURED inline size, reported whenever it changes.
    *
-   * Reported rather than derived from {@link CanvasPreview.width}, because
-   * those are different numbers and only one of them decides anything. The
-   * requested width is a ceiling; what the container queries resolve against is
-   * the width the box actually got. A caller that assumed the request was
-   * honoured would name a tier the box is not showing — the same
+   * Still reported rather than derived from {@link CanvasPreview.width}, even
+   * though a requested width is now honoured. They are different numbers
+   * whenever none was requested — the box then takes the region, and the region
+   * is not something the host states — and they are different again for the
+   * render before the first measurement arrives. A caller reading the request
+   * would name a tier for a box nobody has looked at.
+   *
+   * A LAYOUT size, which is the one the container queries answer to. It is not
+   * the painted width: a canvas scaled to fit is drawn smaller than it is laid
+   * out, and reporting what a reader sees would name the tier the region
+   * implies rather than the tier the page is being compiled against — the
    * confident-wrong-answer this whole preview mechanism exists to remove.
    *
    * `undefined` until the first measurement, which is a real state rather than

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -178,6 +178,124 @@ describe("canvasContentRect", () => {
   });
 });
 
+describe("a canvas that is PAINTED smaller than it is laid out", () => {
+  /*
+   * The editor scales the canvas so a tier wider than the region stays
+   * editable. A transform is paint-time, so the root keeps its requested width
+   * to layout — which is what keeps the container queries resolving at the tier
+   * the author asked for — while every client rectangle comes back in painted
+   * pixels.
+   *
+   * A canvas laid out at 1280 and painted at 912 is the measured case: a 1280px
+   * tier inside the ~912px the canvas region gets on the supported 1280px
+   * shell.
+   */
+  const SCALE = 912 / 1280;
+
+  /** A root whose LAYOUT size differs from the rectangle it paints. */
+  function scaledRoot(
+    painted: { x: number; y: number; width: number; height: number },
+    laidOut: { width: number; height: number },
+    scroll: { left: number; top: number } = { left: 0, top: 0 }
+  ) {
+    const root = canvasRoot(painted, scroll);
+    Object.defineProperty(root, "offsetWidth", { value: laidOut.width });
+    Object.defineProperty(root, "offsetHeight", { value: laidOut.height });
+    return root;
+  }
+
+  it("reports a child in CONTENT pixels, not painted ones", () => {
+    const root = scaledRoot(
+      { x: 100, y: 50, width: 912, height: 570 },
+      { width: 1280, height: 800 }
+    );
+    // A block that sits 200 content pixels into the canvas and is 400 content
+    // pixels wide paints at 0.7125 of each.
+    const child = box({
+      x: 100 + 200 * SCALE,
+      y: 50 + 300 * SCALE,
+      width: 400 * SCALE,
+      height: 100 * SCALE,
+    });
+
+    expect(canvasContentRect(child, root)).toEqual({
+      x: 200,
+      y: 300,
+      width: 400,
+      height: 100,
+    });
+  });
+
+  it("does NOT divide the scroll offset by the scale", () => {
+    /*
+     * The subtle half, and the one that reads as correct while drifting. A
+     * scroll offset counts the root's own laid-out content, which a transform
+     * never touches, so it is already in content pixels — divided along with
+     * the client delta it shrinks by the zoom, and the whole overlay slides
+     * further out the further the author scrolls.
+     *
+     * The separating property is a NON-ZERO scroll with a scale that is not 1:
+     * either alone leaves the two implementations agreeing.
+     */
+    const root = scaledRoot(
+      { x: 0, y: 0, width: 912, height: 570 },
+      { width: 1280, height: 800 },
+      { left: 0, top: 250 }
+    );
+    const child = box({
+      x: 0,
+      y: 300 * SCALE,
+      width: 912,
+      height: 100 * SCALE,
+    });
+
+    // 300 content pixels below the root's top edge, plus the 250 already
+    // scrolled past — not 300 + 250 * SCALE, and not (300 + 250) * SCALE.
+    expect(canvasContentRect(child, root).y).toBe(550);
+  });
+
+  it("keeps the pointer in the same space as the rectangles", () => {
+    // The pairing this module exists to hold. Asserted against a measured
+    // rectangle rather than against literals, because the fault is the two
+    // disagreeing and two literal assertions would both pass while they did.
+    const root = scaledRoot(
+      { x: 100, y: 50, width: 912, height: 570 },
+      { width: 1280, height: 800 },
+      { left: 0, top: 250 }
+    );
+    const child = box({
+      x: 100 + 200 * SCALE,
+      y: 50 + 300 * SCALE,
+      width: 400 * SCALE,
+      height: 100 * SCALE,
+    });
+    const rect = canvasContentRect(child, root);
+
+    // A pointer on the child's top-left corner, in viewport coordinates.
+    expect(
+      canvasContentPoint(100 + 200 * SCALE, 50 + 300 * SCALE, root)
+    ).toEqual({ x: rect.x, y: rect.y });
+  });
+
+  it("is the IDENTITY when nothing has been laid out", () => {
+    /*
+     * jsdom lays nothing out, so `offsetWidth` is 0 and a ratio taken from it
+     * would be `NaN` or `Infinity` — which would not fail loudly, it would
+     * place every overlay at a nonsense coordinate. Unmeasurable means unscaled
+     * here, which is what every caller assumed before there was a scale.
+     */
+    const root = canvasRoot({ x: 100, y: 50, width: 400, height: 800 });
+    const child = box({ x: 140, y: 150, width: 200, height: 60 });
+
+    expect(canvasContentRect(child, root)).toEqual({
+      x: 40,
+      y: 100,
+      width: 200,
+      height: 60,
+    });
+  });
+});
+
 describe("canvasContentPoint", () => {
   it("maps a pointer into the same space the rectangles are measured in", () => {
     // Asserted AGAINST a rectangle rather than against literals. The fault this

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -550,6 +550,51 @@ describe("a clipping ancestor inside a canvas that is PAINTED smaller", () => {
     expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(false);
   });
 
+  it("measures a root built by ANOTHER realm's constructor", () => {
+    /*
+     * The canvas can be portalled into a same-origin iframe, and each document
+     * has its own `HTMLElement`. An ambient `instanceof HTMLElement` is false
+     * for an ordinary div from that other realm, so a scaled canvas would be
+     * treated as unscaled — substituting the identity precisely where the
+     * composition is needed, and reintroducing the defect above only for the
+     * surface that is hardest to notice it on.
+     *
+     * The separating property is that the element IS its own realm's
+     * `HTMLElement` while not being this one's, which is exactly what a plain
+     * `instanceof` cannot see.
+     */
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+    const inner = frame.contentDocument;
+    expect(inner).not.toBeNull();
+    if (inner === null) return;
+
+    const foreign = inner.createElement("div");
+    // The precondition the case rests on: a real element, from a real window,
+    // that this realm's constructor does not claim.
+    expect(foreign instanceof HTMLElement).toBe(false);
+    expect(
+      foreign instanceof
+        (inner.defaultView as Window & typeof globalThis).HTMLElement
+    ).toBe(true);
+
+    foreign.getBoundingClientRect = () =>
+      ({ x: 0, y: 0, width: 400, height: 400, top: 0, left: 0 }) as DOMRect;
+    Object.defineProperty(foreign, "offsetWidth", { value: 800 });
+    Object.defineProperty(foreign, "offsetHeight", { value: 800 });
+
+    const ancestor = clipper({ x: 0, y: 0, width: 400, height: 400 });
+    foreign.append(ancestor);
+    const child = box({ x: 10, y: 10, width: 100, height: 100 });
+    ancestor.append(child);
+
+    // The same flush-against-the-padding-edge child as above. Read through the
+    // ambient constructor alone, the scale is 1 and this reads as clipped.
+    expect(clippedByAncestor(child, foreign, SQUARE_CORNERS)).toBe(false);
+
+    frame.remove();
+  });
+
   it("still reports a child that IS cut", () => {
     /*
      * The control, and it has to come out the other way or the case above says

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -17,9 +17,11 @@
  */
 import { afterEach, describe, expect, it } from "vitest";
 
+import { SQUARE_CORNERS } from "./border-radii";
 import {
   canvasContentPoint,
   canvasContentRect,
+  clippedByAncestor,
   frameInsetOf,
   canvasRootFrom,
   hasScrollbarGutter,
@@ -490,4 +492,80 @@ describe("whether overflow clips at all", () => {
       expect(overflowApplies(display)).toBe(true);
     }
   );
+});
+
+describe("a clipping ancestor inside a canvas that is PAINTED smaller", () => {
+  /*
+   * The two readings this comparison makes live on opposite sides of the
+   * canvas's own scale: an element's rectangle comes from
+   * `getBoundingClientRect` and is post-scale, while a computed border width is
+   * unscaled CSS pixels. `renderedScale` stops BELOW the root on purpose — the
+   * overlay is drawn through the root's scale already — so the root's own scale
+   * reaches one reading and not the other unless it is composed back in.
+   *
+   * The failure is silent in the worst way: a child flush against the real
+   * padding edge is classified as CLIPPED, and a clipped block has every
+   * spacing band suppressed. The overlay stops drawing rather than drawing
+   * something wrong.
+   */
+  /** An `overflow: hidden` ancestor with a border, at a painted rectangle. */
+  function clipper(rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) {
+    const element = box(rect);
+    Object.defineProperty(element, "ownerDocument", {
+      value: document,
+      configurable: true,
+    });
+    // A real border, or the inset is zero and the case cannot discriminate:
+    // both a composed and an uncomposed scale multiply nothing by anything.
+    element.setAttribute(
+      "style",
+      "overflow:hidden;border-style:solid;border-width:20px"
+    );
+    return element;
+  }
+
+  it("insets by the border as PAINTED, not as authored", () => {
+    /*
+     * A canvas laid out at 800 and painted at 400 is scaled by a half, so a
+     * 20px border paints 10px. The child sits flush against the real padding
+     * edge — 10 painted pixels inside the ancestor — and is not cut.
+     *
+     * Uncomposed, the inset is computed as the authored 20 and the child reads
+     * as four slack-widths outside it.
+     */
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+    Object.defineProperty(root, "offsetWidth", { value: 800 });
+    Object.defineProperty(root, "offsetHeight", { value: 800 });
+
+    const ancestor = clipper({ x: 0, y: 0, width: 400, height: 400 });
+    root.append(ancestor);
+    const child = box({ x: 10, y: 10, width: 100, height: 100 });
+    ancestor.append(child);
+
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(false);
+  });
+
+  it("still reports a child that IS cut", () => {
+    /*
+     * The control, and it has to come out the other way or the case above says
+     * only that the function returns false. A child well outside the ancestor
+     * is clipped at any scale, so a version that composed the scale wrongly in
+     * the other direction — or one that always answered false — fails here.
+     */
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+    Object.defineProperty(root, "offsetWidth", { value: 800 });
+    Object.defineProperty(root, "offsetHeight", { value: 800 });
+
+    const ancestor = clipper({ x: 0, y: 0, width: 400, height: 400 });
+    root.append(ancestor);
+    const child = box({ x: -200, y: 10, width: 100, height: 100 });
+    ancestor.append(child);
+
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(true);
+  });
 });

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -28,7 +28,7 @@ import {
   scaleCornerRadii,
   usedCornerRadii,
 } from "./border-radii";
-import type { FrameInset, Point, Rect } from "./geometry";
+import type { FrameInset, Point, Rect, Scale } from "./geometry";
 
 /**
  * How far a frame's content viewport sits inside its border box.
@@ -54,6 +54,37 @@ export function frameInsetOf(frame: HTMLIFrameElement): FrameInset {
 }
 
 /**
+ * How much smaller the canvas is PAINTED than it is laid out, per axis.
+ *
+ * The editor scales the canvas so a tier wider than the region can still be
+ * edited, and a transform is paint-time: the root stays its requested width to
+ * layout — which is what keeps the container queries resolving at the tier the
+ * author asked for — while `getBoundingClientRect` answers in painted pixels.
+ * A distance taken from client rectangles is therefore in a different unit from
+ * the content coordinates the chrome is placed in, and the two agree only at
+ * 100%. That is the shape this module's own header warns about: an error of
+ * `(1 - scale)` times the distance, exactly zero while nothing is scaled and
+ * growing as the canvas zooms out, so every test at default scale passes.
+ *
+ * Measured from the ROOT rather than read from its `transform`, because the
+ * scale may be applied by an ancestor the canvas does not own and a declaration
+ * read off one element cannot see that. The ratio is true wherever it came
+ * from.
+ *
+ * `1` when nothing has been laid out — jsdom, or a root not yet in the
+ * document — which is the identity the callers below already assume, so an
+ * unmeasurable canvas behaves exactly as it did before there was a scale.
+ */
+function paintedScale(root: HTMLElement, painted: DOMRect): Scale {
+  const width = root.offsetWidth;
+  const height = root.offsetHeight;
+  return {
+    x: width > 0 && painted.width > 0 ? painted.width / width : 1,
+    y: height > 0 && painted.height > 0 ? painted.height / height : 1,
+  };
+}
+
+/**
  * A rectangle in the canvas's own CONTENT coordinates.
  *
  * The space the editor's chrome is drawn in: the origin is the canvas root's
@@ -72,11 +103,16 @@ export function frameInsetOf(frame: HTMLIFrameElement): FrameInset {
 export function canvasContentRect(element: Element, root: HTMLElement): Rect {
   const box = element.getBoundingClientRect();
   const rootBox = root.getBoundingClientRect();
+  const scale = paintedScale(root, rootBox);
   return {
-    x: box.x - rootBox.x + root.scrollLeft,
-    y: box.y - rootBox.y + root.scrollTop,
-    width: box.width,
-    height: box.height,
+    // The SCROLL is added after the division, not inside it. A scroll offset is
+    // already in content pixels — it counts the element's own laid-out content,
+    // which a transform never touches — so dividing it would shrink a real
+    // offset by the zoom and drift the whole overlay as the page is scrolled.
+    x: (box.x - rootBox.x) / scale.x + root.scrollLeft,
+    y: (box.y - rootBox.y) / scale.y + root.scrollTop,
+    width: box.width / scale.x,
+    height: box.height / scale.y,
   };
 }
 
@@ -94,9 +130,10 @@ export function canvasContentPoint(
   root: HTMLElement
 ): Point {
   const rootBox = root.getBoundingClientRect();
+  const scale = paintedScale(root, rootBox);
   return {
-    x: clientX - rootBox.x + root.scrollLeft,
-    y: clientY - rootBox.y + root.scrollTop,
+    x: (clientX - rootBox.x) / scale.x + root.scrollLeft,
+    y: (clientY - rootBox.y) / scale.y + root.scrollTop,
   };
 }
 

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -904,13 +904,25 @@ function cutByAncestor(
    * so the symptom is an overlay that silently stops drawing rather than one
    * that draws wrongly.
    */
+  const realm = root.ownerDocument.defaultView;
   const painted =
-    root instanceof HTMLElement
+    realm !== null && root instanceof realm.HTMLElement
       ? paintedScale(root, root.getBoundingClientRect())
-      : // Identity for a root with no layout box of its own to compare against.
-        // `offsetWidth` is an HTML property; an SVG or foreign root cannot be
-        // asked how much smaller it is painted, and answering 1 leaves the
-        // arithmetic exactly as it was before there was a canvas scale.
+      : /*
+         * Identity for a root this cannot measure.
+         *
+         * Asked against the root's OWN realm, as {@link canvasRootFrom} already
+         * does. A canvas portalled into a same-origin iframe has a root built
+         * by that document's constructor, so the ambient `HTMLElement` is a
+         * different function object and a plain `instanceof` is false for an
+         * ordinary div — substituting an identity scale on a canvas that really
+         * is scaled, which is the very case this composition exists for.
+         *
+         * `offsetWidth` is an HTML property, so a genuinely foreign root — an
+         * SVG element, or one with no window at all — cannot be asked how much
+         * smaller it is painted. Answering 1 leaves the arithmetic exactly as it
+         * was before there was a canvas scale.
+         */
         { x: 1, y: 1 };
   const own = renderedScale(node, root);
   const scale: RenderedScale = {
@@ -946,11 +958,26 @@ function cutByAncestor(
    * describe.
    */
   if (!scale.describable) return true;
+  /*
+   * The BLOCK's radii are composed here too, and for the same reason the
+   * ancestor's geometry is.
+   *
+   * The caller scales them by the block's own composition, which stops below
+   * the root — so the outer curve below carries the canvas scale and the inner
+   * one does not. Compared across that difference, an oversized inner curve
+   * reads as fitting inside the outer one, and a block whose visible corner IS
+   * clipped keeps its bands and draws them over clipped pixels.
+   *
+   * Done at the comparison rather than at the call site: this is the only place
+   * that holds both curves, and asking the caller to pre-compose one of them
+   * puts half a decision somewhere that cannot see the other half.
+   */
+  const inner = scaleCornerRadii(radii, painted);
   const clip = clipEdges(outer, style, scale);
   if (cutByEdges(box, clip, clipsX, clipsY)) return true;
   return cutByCorner(
     box,
-    radii,
+    inner,
     clip,
     style,
     scale,

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -138,6 +138,37 @@ export function canvasContentPoint(
 }
 
 /**
+ * A viewport point relative to the canvas's PAINTED top-left corner.
+ *
+ * A third space, and it exists because the other two each lose one of the two
+ * things a drag's hysteresis has to see.
+ *
+ * CLIENT coordinates are hand-scale — 8px of them is 8px of real movement,
+ * whatever the canvas is painted at — but they do not move when the page
+ * scrolls under a stationary pointer, which is exactly what autoscroll does.
+ * Measured there, a rival target's distance from its anchor stays zero however
+ * far the page travels, so the committed target never advances and the
+ * indicator stays on a position that has scrolled off screen.
+ *
+ * CANVAS CONTENT coordinates move with the scroll but are divided by the canvas
+ * scale, so the same threshold asks for less hand movement the further the
+ * canvas is zoomed out.
+ *
+ * This one moves with the scroll — the root's own painted rectangle travels —
+ * and is not divided, so a threshold in it stays a threshold about the hand.
+ * It is NOT interchangeable with {@link canvasContentRect}: nothing may be
+ * drawn from it, because it does not survive a scroll.
+ */
+export function canvasPaintedPoint(
+  clientX: number,
+  clientY: number,
+  root: HTMLElement
+): Point {
+  const rootBox = root.getBoundingClientRect();
+  return { x: clientX - rootBox.x, y: clientY - rootBox.y };
+}
+
+/**
  * The nearest ancestor that actually scrolls, or `null` when nothing does.
  *
  * The canvas root is NOT it. That element carries the drag handlers and sizes
@@ -856,7 +887,41 @@ function cutByAncestor(
    * visibly cuts — measured, the real padding edge sat at 40 while this
    * arithmetic answered 20 and a child at exactly 20 was let through.
    */
-  const scale = renderedScale(node, root);
+  /*
+   * Composed with the ROOT's own painted scale, which `renderedScale` stops
+   * below on purpose.
+   *
+   * That exclusion is right for the overlay, which is a child of the root and
+   * is drawn through the root's scale already. It is wrong here, because the
+   * two readings this compares live on opposite sides of it: `outer` comes from
+   * `getBoundingClientRect` and is post-zoom, while a computed border width is
+   * unscaled CSS pixels. Left uncomposed, the canvas's own scale is applied to
+   * one and not the other.
+   *
+   * Measured at a canvas painted to half size: a 20px border renders 10px, the
+   * inset is computed as 20, and a child sitting flush against the real padding
+   * edge is classified as clipped — which suppresses every spacing band on it,
+   * so the symptom is an overlay that silently stops drawing rather than one
+   * that draws wrongly.
+   */
+  const painted =
+    root instanceof HTMLElement
+      ? paintedScale(root, root.getBoundingClientRect())
+      : // Identity for a root with no layout box of its own to compare against.
+        // `offsetWidth` is an HTML property; an SVG or foreign root cannot be
+        // asked how much smaller it is painted, and answering 1 leaves the
+        // arithmetic exactly as it was before there was a canvas scale.
+        { x: 1, y: 1 };
+  const own = renderedScale(node, root);
+  const scale: RenderedScale = {
+    ...own,
+    x: own.x * painted.x,
+    y: own.y * painted.y,
+    ancestor: {
+      x: own.ancestor.x * painted.x,
+      y: own.ancestor.y * painted.y,
+    },
+  };
   /*
    * A clipping ancestor that is not axis-aligned is DECLINED rather than
    * measured, because neither reading survives its transform: `a` and `d` are

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -150,6 +150,7 @@ export {
   breakpointsAtWidth,
   editedBreakpointAtWidth,
   offeredTiers,
+  selectableTiers,
   widthForBreakpoint,
 } from "./canvas-width";
 

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -796,15 +796,13 @@
    * `min-height` rather than `height` so a page taller than the region still
    * scrolls instead of being clipped to it.
    *
-   * DIVIDED by the canvas scale, because a scaled canvas paints at a fraction
-   * of the height it is laid out at. Left at a plain 100% the root is exactly
-   * as tall as the region and paints shorter than it — measured at 285px into a
-   * 400px region — so the bottom of the region has no canvas on it and the same
-   * aiming failure this minimum exists to prevent comes back, at the scales it
-   * is needed most. The custom property is set by the canvas only while it is
-   * scaled; the fallback is the unscaled case, which is every other surface.
+   * Needs no compensation for a scaled canvas. The canvas shrinks with `zoom`,
+   * which participates in layout, so a percentage here resolves against the
+   * region as it always did and the scaled box still fills it — measured at
+   * 400px painted into a 400px region. A paint-time transform would not: the
+   * root would be exactly as tall as the region and paint shorter than it.
    */
-  min-height: calc(100% / var(--nx-canvas-scale, 1));
+  min-height: 100%;
 
   /*
    * A press on a block is a grab, not a text selection.

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -795,8 +795,16 @@
    *
    * `min-height` rather than `height` so a page taller than the region still
    * scrolls instead of being clipped to it.
+   *
+   * DIVIDED by the canvas scale, because a scaled canvas paints at a fraction
+   * of the height it is laid out at. Left at a plain 100% the root is exactly
+   * as tall as the region and paints shorter than it — measured at 285px into a
+   * 400px region — so the bottom of the region has no canvas on it and the same
+   * aiming failure this minimum exists to prevent comes back, at the scales it
+   * is needed most. The custom property is set by the canvas only while it is
+   * scaled; the fallback is the unscaled case, which is every other surface.
    */
-  min-height: 100%;
+  min-height: calc(100% / var(--nx-canvas-scale, 1));
 
   /*
    * A press on a block is a grab, not a text selection.

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -496,11 +496,19 @@ describe("going to the tier a value came from", () => {
     expect(box().width).toBe(991);
   });
 
-  it("RELEASES the canvas for a tier the compiler emits no bound for", () => {
+  it("SIZES the canvas for the unconditional tier too, not releases it", () => {
     /*
-     * The control, and the honest answer for the unconditional tier: there is
-     * no width that puts it on screen, so the box goes back to the region
-     * rather than being pinned to a number nothing responds to.
+     * It used to release the canvas here, on the reasoning that no width puts
+     * the unconditional tier on screen. There is one: the width it applies
+     * FROM, one past the widest bound.
+     *
+     * Releasing sends the box back to the region — and wherever the region is
+     * narrower than the widest bound, which is the ordinary case, the tier that
+     * then applies is the one the author was jumping AWAY from. The control
+     * would look like it had worked and land on the wrong tier.
+     *
+     * A jump and a choice are the same act reached two ways, so this has to
+     * agree with what pressing the option in the switcher sets.
      */
     openEditor();
     const jump = seen.inspector?.onJumpToBreakpoint as
@@ -513,6 +521,29 @@ describe("going to the tier a value came from", () => {
 
     React.act(() => {
       jump?.("base");
+    });
+
+    expect(box().width).toBe(992);
+  });
+
+  it("RELEASES the canvas for a tier that is genuinely unreachable", () => {
+    /*
+     * The control, and the case the old reasoning was right about. A tier the
+     * compiler emits no bound for — one the site does not define at all here —
+     * has no width that shows it, so the box goes back to the region rather
+     * than being pinned to a number nothing responds to.
+     */
+    openEditor();
+    const jump = seen.inspector?.onJumpToBreakpoint as
+      | ((breakpoint: string) => void)
+      | undefined;
+    React.act(() => {
+      jump?.("tablet");
+    });
+    expect(box().width).toBe(991);
+
+    React.act(() => {
+      jump?.("no-such-tier");
     });
 
     expect(box().width).toBeUndefined();

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -356,6 +356,48 @@ describe("a width the site stops offering", () => {
     expect(box().width).toBeUndefined();
   });
 
+  it("KEEPS the unconditional tier's width, which is no tier's BOUND", () => {
+    /*
+     * The width that reaches the base tier is one PAST the widest bound, so it
+     * is not among the bounded tiers — and a reconciliation that compares
+     * against those alone clears it on the very next render.
+     *
+     * Measured before this case existed: choosing the unconditional tier set
+     * the width, the effect below cleared it, and the canvas returned to
+     * filling the region. Nothing failed. The one option that reaches the tier
+     * an author most often edits responded to the press and did nothing, which
+     * is indistinguishable from the option not working at all.
+     *
+     * The rerender is what makes it a test of the RECONCILIATION rather than of
+     * the setter: the clearing happens in an effect, so a case asserting
+     * immediately after the press passes whether or not it exists.
+     */
+    const view = openEditor();
+
+    choose(992);
+    view.rerender();
+
+    expect(box().width).toBe(992);
+  });
+
+  it("EDITS the base tier at that width, which is the point of offering it", () => {
+    /*
+     * The width surviving is necessary and not sufficient: a number that
+     * survived but resolved to a bounded tier would satisfy the case above
+     * while leaving base exactly as unreachable as it was.
+     *
+     * Measured through the box, because the canvas is scaled rather than capped
+     * — the layout width is the requested one, so what the container queries
+     * resolve against is 992 even where the region is narrower.
+     */
+    openEditor();
+
+    choose(992);
+    measure(992);
+
+    expect(seen.inspector?.breakpoint).toBe("base");
+  });
+
   it("KEEPS a width the site still offers", () => {
     /*
      * The control. Without it, a version that released on every breakpoint

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -356,6 +356,38 @@ describe("a width the site stops offering", () => {
     expect(box().width).toBeUndefined();
   });
 
+  it("FOLLOWS the base width when the widest bound is edited", () => {
+    /*
+     * A width identifies an option only until the site's bounds move. Editing
+     * the widest breakpoint changes the width the unconditional tier applies
+     * FROM, so the number the author's choice produced is suddenly nobody's.
+     *
+     * Reconciled by number, that reads as a deleted tier and releases the
+     * canvas — which, in a region narrower than the new bound, drops the editor
+     * straight back into the bounded tier while the option they chose still
+     * exists and still reads as selected. Every edit after that lands in a tier
+     * they did not pick.
+     *
+     * Stored as the TIER, the width simply follows.
+     */
+    const view = openEditor();
+    choose(992);
+    expect(box().width).toBe(992);
+
+    // The site's widest tier widens: base now applies from 1201 rather than 992.
+    clientConfig = {
+      siteStyle: {
+        breakpoints: {
+          viewport: [{ id: "tablet", label: "Tablet", maxWidth: 1200 }],
+          container: [],
+        },
+      },
+    };
+    view.rerender();
+
+    expect(box().width).toBe(1201);
+  });
+
   it("KEEPS the unconditional tier's width, which is no tier's BOUND", () => {
     /*
      * The width that reaches the base tier is one PAST the widest bound, so it

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -54,6 +54,7 @@ import {
   breakpointsAtWidth,
   editedBreakpointAtWidth,
   offeredTiers,
+  selectableTiers,
   widthForBreakpoint,
   EditorCommandPalette,
   BuilderShell,
@@ -904,13 +905,19 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * bound the stylesheet no longer has and no control on screen to release it.
    * The only way out would be to close the editor and reopen it.
    *
-   * Compared against `offeredTiers`, which is the same list the switcher builds
-   * its options from, so "a width this control could have set" has one
+   * Compared against `selectableTiers`, which is the same list the switcher
+   * builds its options from, so "a width this control could have set" has one
    * definition rather than two that can disagree.
+   *
+   * It has to be that list and not the bounded tiers alone. The unconditional
+   * tier is offered at the width it applies FROM, which is not any tier's
+   * bound — checked against the bounds this cleared it on the render after it
+   * was chosen, so the canvas returned to filling the region and the one option
+   * that reaches the base tier silently did nothing.
    */
   useEffect(() => {
     if (requestedWidth === undefined) return;
-    const offered = offeredTiers(canvasRender.styleContext.breakpoints);
+    const offered = selectableTiers(canvasRender.styleContext.breakpoints);
     if (offered.some(tier => tier.maxWidth === requestedWidth)) return;
     setRequestedWidth(undefined);
   }, [requestedWidth, canvasRender]);

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -42,6 +42,7 @@ import {
   type BlockDocument,
   type BreakpointSet,
   type SiteTokenSet,
+  type BreakpointId,
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { registrySlotSource } from "@nextlyhq/builder";
@@ -836,7 +837,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * the box is in a narrower one, which is the disagreement between what you
    * see and what you edit that this control exists to remove.
    */
-  const [requestedWidth, setRequestedWidth] = useState<number | undefined>(
+  const [requestedTier, setRequestedTier] = useState<BreakpointId | undefined>(
     undefined
   );
   const [measuredWidth, setMeasuredWidth] = useState<number | undefined>(
@@ -915,12 +916,13 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * was chosen, so the canvas returned to filling the region and the one option
    * that reaches the base tier silently did nothing.
    */
-  useEffect(() => {
-    if (requestedWidth === undefined) return;
-    const offered = selectableTiers(canvasRender.styleContext.breakpoints);
-    if (offered.some(tier => tier.maxWidth === requestedWidth)) return;
-    setRequestedWidth(undefined);
-  }, [requestedWidth, canvasRender]);
+  const requestedWidth =
+    requestedTier === undefined
+      ? undefined
+      : widthForBreakpoint(
+          canvasRender.styleContext.breakpoints,
+          requestedTier
+        );
 
   /*
    * The box's own inputs, as one object.
@@ -1104,7 +1106,29 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
               breakpoints={canvasRender.styleContext.breakpoints}
               width={requestedWidth}
               appliedWidth={measuredWidth}
-              onSelect={setRequestedWidth}
+              /*
+               * Stored as the TIER, not as the width it emitted.
+               *
+               * A width identifies an option only until the site's bounds move.
+               * Editing the widest breakpoint changes the width the
+               * unconditional tier applies from, and the number the author's
+               * choice produced is then nobody's — so the canvas was released
+               * and the editor returned to the bounded tier while the option
+               * they had chosen still existed.
+               *
+               * The lookup is unambiguous because `selectableTiers` collapses
+               * tiers sharing a bound to the one the browser paints, which is
+               * the same reason the switcher offers one radio for them.
+               */
+              onSelect={width => {
+                setRequestedTier(
+                  width === undefined
+                    ? undefined
+                    : selectableTiers(
+                        canvasRender.styleContext.breakpoints
+                      ).find(tier => tier.maxWidth === width)?.id
+                );
+              }}
               status={siteStyleStatus(siteStylePending, siteStyleError)}
             />
           </>
@@ -1148,14 +1172,9 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
              * number nothing responds to — which is also what the unconditional
              * tier means.
              */
-            onJumpToBreakpoint={target => {
-              setRequestedWidth(
-                widthForBreakpoint(
-                  canvasRender.styleContext.breakpoints,
-                  target
-                )
-              );
-            }}
+            // Already a TIER, so it is stored directly rather than converted
+            // to a width and back.
+            onJumpToBreakpoint={setRequestedTier}
             breakpoint={editedBreakpoint}
             previewContainer={canvasPreviewContainer}
             liveBreakpoints={liveBreakpoints}


### PR DESCRIPTION
Base is uneditable in the page builder on a standard screen, and this makes it editable.

## What was wrong

The edited tier is derived from the width the canvas box actually got — that invariant is deliberate and stays. But the canvas region is around **912px** on the supported 1280px shell (`MIN_SHELL_WIDTH` 1280, inspector and rail take ~368px), and the page-builder's own README documents a tablet tier at **1024**. So 912 ≤ 1024, tablet always applies, and there is no width an author can ask for that puts the box above the widest bound.

Selecting "Full width" could not help: it only removed the box's maximum, and the region cannot grow. Worse, it *claimed* the base tier while every edit went to tablet.

## The fix

The width an author asks for is now **exact**, and a transform shrinks the box until it fits. Capping at the region does not simulate the viewport asked for — it simulates the region's own width and names the wrong tier with confidence.

Three commits, each independently gated:

1. **`4e03c939` — measure in content pixels.** Every client rectangle the editor's chrome is placed from comes back in *painted* pixels. Nothing divided that out, so overlays would have drifted by `(1 - scale) × distance`: exactly zero at 100%, growing as the canvas zooms out, and invisible to every test that has ever run here. `geometry-dom.ts`'s own header already named this fault.
2. **`31bb129b` — scale the canvas.** The scale is derived from the region and the request rather than stored, so nothing can disagree with the width the author set. Never above 1.
3. **`7f716895` — offer base at a real width.** One past the widest bound, which is the narrowest width the site's own tiers leave to base. Derived, not invented.

## Measured, not assumed

A transform rather than CSS `zoom`, and the reasoning is recorded because the obvious argument against `zoom` is wrong. Measured in Chrome, a 1280px container-query box in a 912px region:

| | tier resolved | `contentBoxSize` | `getBoundingClientRect` | region height |
|---|---|---|---|---|
| `transform: scale(.7125)` | `base` | 1280 | 912 | 400 (reserves unscaled height) |
| `zoom: .7125` | `base` | 1280 | 912 | 285 (collapses) |

**Both** keep container queries resolving at the requested width, because both leave the layout width alone — `zoom` does not break them, and it even compensates the reserved height for free. The transform is still right: `zoom`'s documented weakness is inconsistency in how it interacts with other layout features, which is exactly where this canvas lives — overlays, drop targets and hit-testing all read boxes.

Two more measurements that shaped the result:

- A scaled root **does not create scrollable overflow** (`scrollWidth` 912 = `clientWidth`), so no `overflow: hidden` is needed and the block toolbar that paints above the canvas is not clipped. No wrapper element was added; `Canvas`'s DOM contract is unchanged.
- `min-height: 100%` under a scale paints **285px into a 400px region**, leaving 115px an author cannot aim a drop at — the exact failure that minimum exists to prevent. The stylesheet now divides it back out by the published `--nx-canvas-scale`.

## Prior art

Webflow's canvas has both a Width and a Scale control, and documents Scale as *"helpful if you're working on a smaller screen size than the breakpoint you need to work in"* — this problem statement, written by someone else — and it auto-scales to fit. Gutenberg scales the *frame* rather than the contents (#47004) and independently arrived at the same "canvas width decides which viewport you are editing" design (#75121). Their tracker also shows what to avoid: a manually-set scale fighting a manually-set width produces unnatural canvas behaviour (#59389), which is why the scale here is derived.

## Note for review

`fallow` will report **5 introduced styling findings** in `builder-chrome.css`. They are not introduced. All five are pre-existing rules (`.nx-layer-row__badge`, `.nx-breadcrumb__crumb`, `.nx-spacing-overlay__band`, `.nx-tokens__transfer`, and a `.nx-canvas [contenteditable]` selector) that I never touched — verified present on `main` by content. My diff to that file is one declaration plus its comment; the added lines shift every finding below them, and the diff attribution reads the shift as new. It does not gate.

`Canvas` also tipped its cognitive-complexity threshold when this added one hook call to a component already at the ceiling. Reporting the measured width and deriving the scale are now one hook rather than two calls — three numbers describe this box (asked for, available, ended up with) and only the first is chosen.

## Verification

All gates from the worktree root: build, `check-types`, lint, the four package suites (2055 / 884 / 1504 / 390), `test:scripts`, comment convention, changeset, `fallow audit` with `complexity_introduced: 0` and `dead_code_introduced: 0`.

Fifteen new assertions, each break-verified by the mutation it names — including one round where an invalid vitest filter reported all five breaks "unprotected" while nothing had executed. The harness now asserts the run happened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent base-tier breakpoint selection and labeling.
  * Preview canvases now preserve their requested layout width while scaling to fit narrower regions.
  * Added support for accurate canvas geometry and clipping when previews are scaled.

* **Bug Fixes**
  * Improved drag activation, target detection, and indicator positioning during scaling and page scrolling.
  * Fixed breakpoint selection reconciliation when viewport tiers change.
  * Prevented scaled previews from overflowing their available region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->