### PR TITLE
fix(adapter-sqlite): classify a failure by the driver's error, not by the query text

### DIFF
--- a/.changeset/sqlite-says-what-actually-failed.md
+++ b/.changeset/sqlite-says-what-actually-failed.md
@@ -1,0 +1,54 @@
+---
+
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+
+On SQLite, a failed database write is now reported as what actually went wrong,
+instead of occasionally being reported as a timeout.
+
+A write that a unique constraint refused — saving a second record with a value
+that has to be one of a kind — was being described as the database being busy.
+The two mean opposite things. A busy database is a temporary condition worth
+trying again in a moment; a refused duplicate will be refused every single time.
+Anything that retried on a timeout could therefore retry a permanently
+impossible write over and over, and the log would blame the database rather than
+naming the duplicate.
+
+The cause was that the description was being read off the query itself rather
+than off the error. If the failing statement so much as mentioned a column whose
+name contained the word "locked" — and the tables that record sign-in lockouts
+and outgoing webhook deliveries both have one — the failure was read as a lock,
+whatever had really happened.
+
+This affected the accounts table and the webhook delivery table, so a sign-in
+lockout write or a webhook delivery that failed for any reason has been
+reporting the wrong cause. PostgreSQL and MySQL were never affected.
+
+Separately, the check for "was this a duplicate?" now looks all the way down a
+failure rather than one step in. A database error arrives wrapped twice before
+application code sees it, and the detail identifying a duplicate sits at the
+bottom, so the check had been answering "no" for genuine duplicates. It also now
+stops safely if a failure somehow refers back to itself, rather than looping.

--- a/packages/adapter-sqlite/src/__tests__/error-classification.integration.test.ts
+++ b/packages/adapter-sqlite/src/__tests__/error-classification.integration.test.ts
@@ -1,0 +1,94 @@
+// What a failing statement is REPORTED as, measured against a real database.
+//
+// The classifier reads the error it is handed, and by the time a query error
+// reaches it the driver's own error is two `cause` levels down: the adapter
+// sees a DrizzleQueryError whose message is the SQL statement, not the
+// driver's "UNIQUE constraint failed: ...". Classifying from that message
+// means classifying from the QUERY TEXT, which is how a unique violation came
+// to be reported as a timeout.
+//
+// A timeout is the kind most likely to be treated as transient and retried, so
+// misreporting a permanent failure as one turns a clean refusal into an
+// indefinite retry.
+
+import type { TableDefinition } from "@nextlyhq/adapter-drizzle/types";
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createSqliteAdapter } from "../index";
+
+const TABLE = "int_sqlite_error_kinds";
+
+/**
+ * The table carries `locked_by`/`locked_until` deliberately.
+ *
+ * Those names are not decoration: `nextly_users`, `nextly_webhook_deliveries`
+ * and `nextly_jobs` all carry a `locked_*` column, and it is their presence in
+ * the SQL text that triggered the misclassification. A fixture without them
+ * would exercise the same code path and never reproduce the defect.
+ */
+const TABLE_DEFINITION: TableDefinition = {
+  name: TABLE,
+  columns: [
+    { name: "id", type: "text", primaryKey: true },
+    { name: "dedupe_key", type: "text", unique: true },
+    { name: "locked_by", type: "text" },
+    { name: "locked_until", type: "integer" },
+  ],
+};
+
+const rows = sqliteTable(TABLE, {
+  id: text("id").primaryKey(),
+  dedupeKey: text("dedupe_key"),
+  lockedBy: text("locked_by"),
+  lockedUntil: integer("locked_until", { mode: "timestamp" }),
+});
+
+describe("SQLite error classification", () => {
+  let adapter: ReturnType<typeof createSqliteAdapter>;
+
+  beforeAll(async () => {
+    adapter = createSqliteAdapter({ memory: true });
+    await adapter.connect();
+    await adapter.createTable(TABLE_DEFINITION);
+    adapter.setTableResolver({
+      getTable: (name: string) => (name === TABLE ? rows : null),
+    });
+  });
+
+  afterAll(async () => {
+    await adapter.disconnect();
+  });
+
+  it("reports a duplicate key as a unique violation, not a timeout", async () => {
+    await adapter.insert(TABLE, { id: "a", dedupe_key: "K" });
+
+    let caught: unknown;
+    try {
+      await adapter.insert(TABLE, { id: "b", dedupe_key: "K" });
+    } catch (error) {
+      caught = error;
+    }
+
+    // The premise: something was actually refused. Without this the assertion
+    // below could pass against a database that accepted both rows.
+    expect(caught).toBeDefined();
+    expect((caught as { kind?: string }).kind).toBe("unique_violation");
+  });
+
+  it("still reports a genuinely locked database as a timeout", async () => {
+    // The control for the fix. Making the classifier stop matching the SQL
+    // text must not make it blind to the condition that matching was there to
+    // catch — otherwise the test above could be satisfied by a classifier that
+    // simply never says "timeout".
+    const busy = Object.assign(new Error("database is locked"), {
+      code: "SQLITE_BUSY",
+    });
+    const classified = (
+      adapter as unknown as {
+        classifyError(error: unknown, sql?: string): { kind: string };
+      }
+    ).classifyError(busy);
+    expect(classified.kind).toBe("timeout");
+  });
+});

--- a/packages/adapter-sqlite/src/index.ts
+++ b/packages/adapter-sqlite/src/index.ts
@@ -902,11 +902,14 @@ export class SqliteAdapter extends DrizzleAdapter {
     // fields. Re-wrapping it here would erase those fields.
     if (isDatabaseError(error)) return error;
 
-    const sqliteError = error as {
-      code?: string;
-      message?: string;
-      name?: string;
-    };
+    // Classify from the DRIVER's error, which is not necessarily the one handed
+    // in. A query failure arrives wrapped: DrizzleQueryError carries the SQL
+    // statement as its message and no code, and better-sqlite3's own error —
+    // the only object that knows what actually went wrong — sits below it in
+    // the `cause` chain. Classifying the wrapper means classifying the QUERY
+    // TEXT, which reported a unique violation on a table with a `locked_by`
+    // column as a "timeout", because the statement contains the word LOCKED.
+    const sqliteError = findDriverError(error);
 
     // Determine error kind from SQLite error code
     let kind: DatabaseErrorKind = "unknown";
@@ -914,7 +917,9 @@ export class SqliteAdapter extends DrizzleAdapter {
     if (sqliteError.code) {
       kind = SQLITE_ERROR_CODES[sqliteError.code] || "unknown";
     } else if (sqliteError.message) {
-      // Try to extract error type from message
+      // Try to extract error type from message. Safe to match loosely now:
+      // `sqliteError` is the driver's error, so its message is the driver's
+      // description of the failure and never a SQL statement.
       const msg = sqliteError.message.toUpperCase();
       if (msg.includes("UNIQUE CONSTRAINT")) {
         kind = "unique_violation";
@@ -934,7 +939,8 @@ export class SqliteAdapter extends DrizzleAdapter {
       }
     }
 
-    // Build error message
+    // Build error message from the driver's description, for the same reason
+    // the classification uses it: the wrapper's message is the SQL statement.
     let message = sqliteError.message ?? String(error);
     if (sql && kind === "query") {
       message = `Query failed: ${message}`;
@@ -947,6 +953,38 @@ export class SqliteAdapter extends DrizzleAdapter {
       cause: error instanceof Error ? error : undefined,
     });
   }
+}
+
+/** The fields this classifier reads off an error, at any depth in the chain. */
+interface DriverErrorShape {
+  code?: string;
+  message?: string;
+  name?: string;
+  cause?: unknown;
+}
+
+/**
+ * The deepest error in the `cause` chain that carries a SQLite error code, or
+ * the outermost error when none does.
+ *
+ * better-sqlite3 sets `code` (`SQLITE_CONSTRAINT_UNIQUE`, `SQLITE_BUSY`, ...);
+ * the wrappers around it do not. Walking to the code is therefore walking to
+ * the only object that knows what failed. The walk is depth-bounded rather than
+ * unbounded because an error chain can be made cyclic, and a classifier that
+ * can hang is worse than one that occasionally gives up.
+ *
+ * Falls back to the outermost error so a driver error that genuinely carries no
+ * code — one constructed from a message alone — still classifies exactly as it
+ * did before.
+ */
+function findDriverError(error: unknown): DriverErrorShape {
+  let cursor = error as DriverErrorShape | null | undefined;
+  for (let depth = 0; depth < 10 && cursor != null; depth++) {
+    if (typeof cursor.code === "string" && cursor.code.length > 0)
+      return cursor;
+    cursor = cursor.cause as DriverErrorShape | null | undefined;
+  }
+  return error ?? {};
 }
 
 /**

--- a/packages/nextly/src/domains/versions/__tests__/version-conflict.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/version-conflict.test.ts
@@ -15,6 +15,7 @@ import { VersionCaptureService } from "../version-capture-service";
 import {
   VersionConflictError,
   hasVersionConflict,
+  isUniqueViolation,
   withVersionConflictRetry,
 } from "../version-conflict";
 
@@ -174,5 +175,61 @@ describe("VersionConflictError — NextlyError contract", () => {
     const wrapped = new Error("transaction aborted");
     (wrapped as { cause?: unknown }).cause = new VersionConflictError();
     expect(hasVersionConflict(wrapped)).toBe(true);
+  });
+});
+
+/**
+ * `isUniqueViolation` had no coverage at all, which is how a one-level `cause`
+ * walk survived: its only caller catches at the tx-insert site, where the
+ * driver error is still near the surface. Anywhere else — the job queue was the
+ * first — the driver error sits deeper and the answer came back `false` for a
+ * real duplicate key.
+ */
+describe("isUniqueViolation across the wrapping the adapter actually does", () => {
+  const driverError = () =>
+    Object.assign(
+      new Error("UNIQUE constraint failed: nextly_jobs.dedupe_key"),
+      {
+        code: "SQLITE_CONSTRAINT_UNIQUE",
+      }
+    );
+
+  it("finds a raw driver error", () => {
+    expect(isUniqueViolation(driverError())).toBe(true);
+  });
+
+  it("finds one wrapped a single level down", () => {
+    expect(
+      isUniqueViolation(new Error("wrapper", { cause: driverError() }))
+    ).toBe(true);
+  });
+
+  it("finds one wrapped TWO levels down, which is what a real query error is", () => {
+    // Measured shape, not invented: an adapter DatabaseError wraps a
+    // DrizzleQueryError, which wraps the driver's error. Two levels is the
+    // ordinary case for any query, not an edge case.
+    const wrapped = new Error("DatabaseError", {
+      cause: new Error("DrizzleQueryError", { cause: driverError() }),
+    });
+    expect(isUniqueViolation(wrapped)).toBe(true);
+  });
+
+  it("still says no when nothing in the chain is a duplicate key", () => {
+    // The control. A walk that returned true for everything would satisfy every
+    // assertion above while detecting nothing.
+    const wrapped = new Error("outer", {
+      cause: new Error("middle", {
+        cause: Object.assign(new Error("disk full"), { code: "SQLITE_FULL" }),
+      }),
+    });
+    expect(isUniqueViolation(wrapped)).toBe(false);
+  });
+
+  it("terminates on a cyclic cause chain instead of hanging", () => {
+    const a = new Error("a") as Error & { cause?: unknown };
+    const b = new Error("b") as Error & { cause?: unknown };
+    a.cause = b;
+    b.cause = a;
+    expect(isUniqueViolation(a)).toBe(false);
   });
 });

--- a/packages/nextly/src/domains/versions/version-conflict.ts
+++ b/packages/nextly/src/domains/versions/version-conflict.ts
@@ -81,14 +81,30 @@ function isUniqueViolationShape(err: unknown): boolean {
 }
 
 /**
- * True when `err` (or its immediate `cause`) is a unique-constraint violation.
- * The one-level `cause` walk covers repo/driver wrappers that nest the original
- * error.
+ * True when `err`, or anything in its `cause` chain, is a unique-constraint
+ * violation.
+ *
+ * The walk is depth-bounded rather than one level deep, matching
+ * {@link findVersionConflict} below. One level is not enough for the ordinary
+ * case: a failed query arrives as the adapter's `DatabaseError` wrapping a
+ * `DrizzleQueryError` wrapping the driver's error, so the only object carrying
+ * `SQLITE_CONSTRAINT_UNIQUE` sits at depth TWO. This returned `false` for a
+ * real duplicate key until that was measured.
+ *
+ * The existing caller was unaffected because version capture catches at the
+ * tx-insert site, where the driver error is still near the surface — which is
+ * why the gap stayed latent rather than harmless.
+ *
+ * The bound also guards a cyclic chain: an error whose `cause` points back at
+ * itself would otherwise hang the check.
  */
 export function isUniqueViolation(err: unknown): boolean {
-  if (isUniqueViolationShape(err)) return true;
-  const cause = (err as { cause?: unknown } | null)?.cause;
-  return cause !== undefined && isUniqueViolationShape(cause);
+  let cursor: unknown = err;
+  for (let depth = 0; depth < 10 && cursor != null; depth++) {
+    if (isUniqueViolationShape(cursor)) return true;
+    cursor = (cursor as { cause?: unknown }).cause;
+  }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

On SQLite, a **unique-constraint violation was being reported as a `timeout`**. The two mean opposite things — a timeout invites a retry, a duplicate key will be refused every time — so anything retrying on `timeout` could retry a permanently impossible write indefinitely while the logs blamed the database.

Found while building the R-2 job queue. **Not introduced by that work**; both defects are live on `main`.

### Defect 1 — the classifier matched its own SQL text

`classifyError` reads the error it is handed. For a query failure that is a `DrizzleQueryError` whose **message is the SQL statement**, with no `code`; the driver's real error sits two `cause` levels below. So the message fallback was matching the statement:

```ts
} else if (msg.includes("BUSY") || msg.includes("LOCKED")) { kind = "timeout"; }
```

`"locked_by"` uppercases to `"LOCKED_BY"`, which contains `"LOCKED"`. **Any failing statement naming a `locked_*` column was classified as a timeout, whatever actually failed.**

Measured cause chain for a real duplicate key:

```
0: DatabaseError      kind=timeout    code=undefined     <- what callers saw
1: DrizzleQueryError  kind=undefined  code=undefined
2: SqliteError        kind=undefined  code=SQLITE_CONSTRAINT_UNIQUE   <- the truth
```

**Already shipping, not just hypothetical.** `locked_*` columns exist on:

| table | column | affected path |
| --- | --- | --- |
| `nextly_users` | `locked_until` | sign-in lockout write |
| `nextly_webhook_deliveries` | `locked_by`, `locked_until` | every webhook delivery claim |

PostgreSQL and MySQL are **not** affected — verified, neither adapter uses a message-substring fallback.

**Fix:** walk the `cause` chain to the first error carrying a SQLite `code` and classify from that. The message fallback now only ever sees the driver's own message, never SQL. The walk is depth-bounded so a cyclic chain cannot hang the classifier.

### Defect 2 — the canonical duplicate check walked one level

`version-conflict.ts#isUniqueViolation` recognises raw driver codes, the adapter's `unique_violation` and nextly's `unique-violation` — but walked a single `cause` level while the driver error sits at two, so it **returned `false` for real duplicate keys**. It had **no test coverage at all**, which is how this survived; its only caller catches nearer the driver, so the gap was latent rather than harmless.

**Fix:** depth-bounded walk, reusing the `findVersionConflict` pattern from the same module.

## Test plan

New `packages/adapter-sqlite/src/__tests__/error-classification.integration.test.ts` — a real double-insert against a table deliberately carrying `locked_by`/`locked_until`, since a fixture without them exercises the same code path and never reproduces the defect. Plus a **control** asserting a genuine `SQLITE_BUSY` is still a `timeout`, so the fix cannot be satisfied by a classifier that simply never says "timeout".

Five new cases for `isUniqueViolation`: raw, one level, **two levels**, a control that must stay `false`, and a cyclic chain that must terminate.

**Break-verified individually.** Reverting the classifier to the wrapper cast fails exactly the duplicate-key test and leaves the control passing. Reverting the walk to depth 2 fails exactly the two-level test.

Run locally:
- `@nextlyhq/adapter-sqlite`: 66 unit + 23 integration, all pass. `lint` clean, `check-types` clean.
- `nextly` versions suite: **33 files / 492 tests**, all pass. `lint` clean, `check-types` clean.

> Note on that count: an unbuilt worktree first reported `28 files / 443 tests` with five files failing to **load**. Building the sibling packages first is required or the suite silently collects less than it appears to.

## Changeset

Changeset added: **patch** (repo-wide, all 25 packages).

## Pre-existing failures

- **CI has produced no verdict repo-wide for several hours** — runs are `queued`, with `startup_failure` on some workflows. A `startup_failure` never started, so a query filtering `conclusion == "failure"` returns nothing and the commit reads green. Everything above was run **locally**; CI has not answered.
- `@nextlyhq/plugin-sdk`'s `plugin-surface` snapshot is red on `main` (`collectionDraftSplit` exported twice, in the snapshot zero times). Because CI scans `refs/pull/N/merge`, that red reaches every open PR regardless of what it touches. Not from this branch.