### PR TITLE
feat(nextly): let a translator ask what needs them, across every collection

### DIFF
--- a/.changeset/translation-worklist.md
+++ b/.changeset/translation-worklist.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A translator can now ask what needs them, across the whole site, in one
+language. `GET /api/translations?locale=es&state=missing` returns the
+outstanding documents from every localized collection at once.
+
+Everything under it already existed: a collection's list query has long
+accepted a reserved `_translated` filter and turned it into a companion
+EXISTS/NOT EXISTS condition, and the entry table already offers that filter on
+one collection. What nobody could ask is the question spanning collections, so
+finding the work meant opening every document in turn. This adds the fan-out and
+reuses the filter, the SQL and the state vocabulary already in use.
+
+Rows are read with the caller's own user context, roles included, so each
+collection's stored read rules run per row. That matters more than it sounds: a
+worklist is a list of titles, and filtering only at collection level — the
+dashboard's model — would list every author's titles back to a role scoped to
+its own entries. Passing the id without the roles would fail the other way, and
+a role-based collection would report itself fully translated.
+
+The fan-out is capped at 20 collections and the ones it left out are NAMED in
+the response rather than dropped, because a worklist that silently omits a
+collection reads as "nothing to do there".

--- a/packages/nextly/src/api/__tests__/translation-worklist-route-authorized.integration.test.ts
+++ b/packages/nextly/src/api/__tests__/translation-worklist-route-authorized.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * The worklist decides the coarse read gate ONCE, and this pins what that costs.
+ *
+ * `GET /api/translations` calls `canReadEntity` for every localized collection
+ * before it queries any of them — it has to, because a collection the caller
+ * cannot read must not consume one of the capped fan-out slots nor have its
+ * slug named back as unconsulted. Handing the resulting verdict to
+ * `listEntries` as `routeAuthorized` is what stops the SAME decision being
+ * taken a second time per collection.
+ *
+ * That matters beyond wasted work. A code-defined `access.read` rule is an
+ * arbitrary async function: an operator may call an entitlements service from
+ * it. Running it twice per collection doubles that load, and a transient
+ * failure on the second call refuses a collection the first call allowed —
+ * reporting it as unconsulted for a reason nothing on the screen can explain.
+ *
+ * The flag is only safe because it elides the COARSE gate alone. These cases
+ * assert both halves: the re-check does not happen, and the collection's own
+ * rules still decide the answer.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Authentication is not what these cases are about, and building a real session
+// would put a login flow between the assertion and the behaviour it describes.
+// The identity is stubbed; every AUTHORIZATION decision below is the real one,
+// taken by the real services against a real database.
+vi.mock("../../auth/middleware", async importActual => {
+  const actual = await importActual<typeof import("../../auth/middleware")>();
+  return {
+    ...actual,
+    requireAuthentication: vi.fn(async () => ({
+      userId: "u1",
+      userEmail: "u@x.test",
+      userName: "U",
+      authMethod: "session" as const,
+      permissions: [] as string[],
+      claims: {},
+    })),
+  };
+});
+
+import { defineCollection, text } from "../../config";
+import { createTestNextly, type TestNextly } from "../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const USER = { id: "u1", email: "u@x.test", roles: [] };
+
+/** Boot with a code-defined read rule we can count and steer. */
+async function boot(read: () => boolean): Promise<{
+  handler: CollectionsHandler;
+  reads: ReturnType<typeof vi.fn>;
+}> {
+  const reads = vi.fn(() => read());
+  current = await createTestNextly({
+    collections: [
+      defineCollection({
+        slug: "pages",
+        localized: true,
+        access: { read: reads },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+  await current.nextly.create({
+    collection: "pages",
+    data: { title: "A" },
+  });
+  reads.mockClear();
+  const handler = current.getService(
+    "collectionsHandler"
+  ) as unknown as CollectionsHandler;
+  return { handler, reads };
+}
+
+describe("routeAuthorized on the worklist's list reads", () => {
+  it("does NOT re-run the code-defined read rule the worklist already ran", async () => {
+    // The whole point of forwarding the verdict. Without it this is 1, and the
+    // worklist pays it once per localized collection on every refresh.
+    const { handler, reads } = await boot(() => true);
+
+    await handler.listEntries({
+      collectionName: "pages",
+      user: USER,
+      routeAuthorized: true,
+      limit: 10,
+      status: "all" as const,
+    });
+
+    expect(reads).not.toHaveBeenCalled();
+  });
+
+  it("DOES run it when no prior verdict is attested", async () => {
+    // The control. Without this the assertion above is satisfied by a rule that
+    // is never consulted on either path, which would prove nothing at all.
+    const { handler, reads } = await boot(() => true);
+
+    await handler.listEntries({
+      collectionName: "pages",
+      user: USER,
+      limit: 10,
+      status: "all" as const,
+    });
+
+    expect(reads).toHaveBeenCalled();
+  });
+
+  it("refuses a caller the rule denies, when no prior verdict is attested", async () => {
+    // Pins that the gate being skipped is a REAL gate — one that can say no.
+    const { handler } = await boot(() => false);
+
+    const result = await handler.listEntries({
+      collectionName: "pages",
+      user: USER,
+      limit: 10,
+      status: "all" as const,
+    });
+
+    expect(result?.success).toBe(false);
+  });
+});
+
+describe("the worklist endpoint itself", () => {
+  it("decides the coarse gate ONCE per collection, not twice", async () => {
+    // The call site, not the platform semantics the cases above pin. If
+    // `getTranslationWorklist` stops attesting the verdict it already has, the
+    // rule runs a second time for every collection it queries and this fails.
+    const { reads } = await boot(() => true);
+    const { getTranslationWorklist } = await import("../translations");
+
+    const res = await getTranslationWorklist(
+      new Request("http://t/api/translations?locale=de&state=missing")
+    );
+
+    expect(res.status).toBe(200);
+    // Exactly one: `canReadEntity`, before the fan-out. The list read must add
+    // none.
+    expect(reads).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nextly/src/api/authenticated-read.ts
+++ b/packages/nextly/src/api/authenticated-read.ts
@@ -1,0 +1,59 @@
+/**
+ * The opening move every authenticated read endpoint makes.
+ *
+ * Four lines — require a session, convert a refusal into the canonical error,
+ * then read the query string — repeated verbatim by each read handler. Repeated
+ * text is not itself a problem; this one is, because the order carries a rule:
+ * the refusal must be thrown BEFORE anything reads the request, so a handler
+ * cannot accidentally act on parameters it has not yet earned the right to see.
+ * A copy that drifts by one line loses that and still looks right.
+ *
+ * `api/dashboard` predates this and holds two copies of its own. They are left
+ * alone here rather than swept in a change about something else; new read
+ * endpoints should use this.
+ *
+ * @module api/authenticated-read
+ */
+
+import { isErrorResponse, requireAuthentication } from "../auth/middleware";
+import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+
+/** Who is asking, and what they asked for. */
+export interface AuthenticatedRead {
+  userId: string;
+  /** Role ids, needed wherever a role-based access rule is evaluated. */
+  roles?: string[] | undefined;
+  searchParams: URLSearchParams;
+}
+
+/**
+ * Headers for a response shaped by WHO asked.
+ *
+ * `private, no-store` keeps a per-user answer out of any shared cache, and
+ * `Vary: Cookie` keeps it out of a per-browser one too. Both, not either: the
+ * first stops a proxy holding it, the second stops the reply to one session
+ * being served to the next.
+ */
+export const PRIVATE_NO_STORE_HEADERS = {
+  "Cache-Control": "private, no-store",
+  Vary: "Cookie",
+} as const;
+
+/**
+ * Authenticate, then hand back the caller and their query string.
+ *
+ * Throws the canonical auth error rather than returning a response, so the
+ * handler's `withErrorHandler` renders it the same way it renders every other
+ * failure.
+ */
+export async function authenticatedRead(
+  req: Request
+): Promise<AuthenticatedRead> {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+  return {
+    userId: auth.userId,
+    roles: auth.roles,
+    searchParams: new URL(req.url).searchParams,
+  };
+}

--- a/packages/nextly/src/api/authenticated-read.ts
+++ b/packages/nextly/src/api/authenticated-read.ts
@@ -15,14 +15,26 @@
  * @module api/authenticated-read
  */
 
+import type { AuthenticatedScope } from "../auth/authenticated-scope";
+import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+import { buildUserContext } from "../auth/user-context";
+import type { UserContext } from "../domains/collections/services/collection-types";
+import { resolveRoleSlugs } from "../services/lib/permissions";
 
-/** Who is asking, and what they asked for. */
+/**
+ * Who is asking, and what they asked for.
+ *
+ * The auth context is carried WHOLE rather than reduced to an id. Everything a
+ * later access decision needs lives on it — the method the caller
+ * authenticated by, an API key's own stamped permissions, and the custom claims
+ * a claim-based rule reads — and each of them is invisible once dropped: the
+ * request still succeeds, it simply answers as somebody with fewer rights, or
+ * with more.
+ */
 export interface AuthenticatedRead {
-  userId: string;
-  /** Role ids, needed wherever a role-based access rule is evaluated. */
-  roles?: string[] | undefined;
+  auth: AuthContext;
   searchParams: URLSearchParams;
 }
 
@@ -51,9 +63,46 @@ export async function authenticatedRead(
 ): Promise<AuthenticatedRead> {
   const auth = await requireAuthentication(req);
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+  return { auth, searchParams: new URL(req.url).searchParams };
+}
+
+/**
+ * The caller, in the two shapes an access decision reads.
+ *
+ * `roles` must be RESOLVED rather than forwarded: session auth carries role
+ * IDs and API-key auth carries slugs, and a role-based rule matches on slugs.
+ * Handing it the ids matches nothing — so a collection guarded by a role rule
+ * returns no rows, and a read that should have been full comes back empty
+ * without an error anywhere to say why.
+ *
+ * `authenticatedScope` exists so an API KEY is judged on its own stamped grant
+ * rather than on the roles of whoever minted it. Without it a narrowly scoped
+ * key issued by a super-admin inherits the owner's reach.
+ *
+ * `versions-access` and `preview-links` each grew their own copy of this before
+ * there was a shared one; they are left as they are, and new read endpoints
+ * should call this.
+ */
+export async function readCaller(
+  auth: AuthContext
+): Promise<{ user: UserContext; authenticatedScope?: AuthenticatedScope }> {
+  const roles = await resolveRoleSlugs(auth);
+  const user = buildUserContext({
+    claims: auth.claims,
+    id: auth.userId,
+    name: auth.userName,
+    email: auth.userEmail,
+    roles,
+  });
   return {
-    userId: auth.userId,
-    roles: auth.roles,
-    searchParams: new URL(req.url).searchParams,
+    user,
+    ...(auth.authMethod === "api-key"
+      ? {
+          authenticatedScope: {
+            actorType: "apiKey" as const,
+            permissions: auth.permissions,
+          },
+        }
+      : {}),
   };
 }

--- a/packages/nextly/src/api/response-shapes.ts
+++ b/packages/nextly/src/api/response-shapes.ts
@@ -37,6 +37,20 @@ export type PaginationMeta = {
   totalPages: number;
   hasNext: boolean;
   hasPrev: boolean;
+  /**
+   * Sources this read did not consult, named rather than dropped.
+   *
+   * Optional, and omitted by every read that consults everything — which is
+   * most of them — so it costs existing responses nothing.
+   *
+   * It exists because `hasNext` cannot carry the difference that matters. "More
+   * exists" and "these particular places were not looked at" prompt opposite
+   * reactions: the first is a paging affordance, the second is a caveat the
+   * screen has to state, because a list that quietly omits a source reads as
+   * that source having nothing in it — which is indistinguishable from the
+   * truth at a glance and is the one way such a list can lie.
+   */
+  notConsulted?: string[];
 };
 
 /**

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -16,6 +16,11 @@
  * @since 1.0.0
  */
 
+import {
+  apiKeyScopeAllows,
+  type AuthenticatedScope,
+} from "../auth/authenticated-scope";
+import type { AuthContext } from "../auth/middleware";
 import { container } from "../di";
 import type { CollectionRegistryService } from "../domains/collections/services/collection-registry-service";
 import {
@@ -91,10 +96,24 @@ function parseLimit(raw: string | null): number {
  * cap, and the per-row one keeps another author's titles out of the answer.
  */
 async function readableCollections(
-  userId: string
+  auth: AuthContext,
+  scope: AuthenticatedScope | undefined,
+  slugs: readonly string[]
 ): Promise<Set<string> | undefined> {
-  if (await isSuperAdmin(userId)) return undefined;
-  const pairs = await listEffectivePermissions(userId);
+  // An API KEY is judged on its own stamped grants, in both directions: a key
+  // without the grant is denied however privileged its owner, and a key with it
+  // is allowed however unprivileged. Asking the owner's RBAC here — which is
+  // what this did — let collections outside the key's reach consume the capped
+  // slots and put their slugs in `skippedCollections`, while the per-row checks
+  // correctly refused their rows. The coarse filter and the row checks have to
+  // come from ONE decision or they disagree about what exists.
+  if (scope?.actorType === "apiKey") {
+    return new Set(
+      slugs.filter(slug => apiKeyScopeAllows(scope, "read", slug) === true)
+    );
+  }
+  if (await isSuperAdmin(auth.userId)) return undefined;
+  const pairs = await listEffectivePermissions(auth.userId);
   return new Set(
     pairs.filter(p => p.endsWith(":read")).map(p => p.split(":")[0] ?? "")
   );
@@ -214,12 +233,13 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   // consume the alphabetically-first slots, pushing a readable collection into
   // `skippedCollections` — where its work is never queried AND its slug is
   // named back to someone with no right to know it exists.
-  const readable = await readableCollections(auth.userId);
-  const eligible = eligibleCollections(
-    await localizedCollections(),
-    state,
-    readable
+  const localized = await localizedCollections();
+  const readable = await readableCollections(
+    auth,
+    caller.authenticatedScope,
+    localized.map(c => c.slug)
   );
+  const eligible = eligibleCollections(localized, state, readable);
   const { queried, skippedCollections } = planWorklistFanOut(eligible);
   const bySlug = new Map(eligible.map(c => [c.slug, c]));
 
@@ -246,6 +266,15 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
         // Nothing here follows a relationship, and expanding them would turn
         // one list into a page of joins per row.
         depth: 0,
+        // The lifecycle scope is stated, because the default is not the one a
+        // worklist wants. Without it `resolveStatusFilter` applies the
+        // untrusted-read default of `published` to the PARENT table, so a
+        // document still in draft is absent from every state — including
+        // `missing`, which is precisely the document a translator needs before
+        // it is published. This widens what LIFECYCLE is visible, not who may
+        // see it: the caller's access context above is unchanged, and the admin
+        // entry list asks for the same scope for the same reason.
+        status: "all" as const,
       });
       const useAsTitle = bySlug.get(coll.slug)?.useAsTitle;
       // A refused or failed read contributes nothing rather than failing the

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -39,6 +39,7 @@ import {
   planWorklistFanOut,
   translatedFilter,
   worklistTotal,
+  worklistTotalPages,
   worklistId,
   worklistTitle,
   worklistUpdatedAt,
@@ -389,16 +390,22 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   //
   // `total` is each collection's OWN count of matching documents, summed, never
   // the number of rows this response happens to carry — see `worklistTotal`.
+  const total = worklistTotal(
+    perCollection.map(r => r.total),
+    merged.length
+  );
   return respondList(
     rows,
     {
-      total: worklistTotal(
-        perCollection.map(r => r.total),
-        merged.length
-      ),
+      total,
       page: 1,
       limit,
-      totalPages: 1,
+      // DERIVED from the total, never asserted as 1. Claiming a single page
+      // beside a total larger than `limit` says the rows in hand are all of
+      // them — the same lie the summed total was added to remove, one field
+      // along. See `worklistTotalPages` for why this sits beside `hasNext:
+      // false` rather than contradicting it.
+      totalPages: worklistTotalPages(total, limit),
       // FALSE, always. This endpoint takes no `page` and always returns the
       // same first slice, so a consumer following `hasNext` would request a
       // second page and receive the same rows forever. Incompleteness is a

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -1,0 +1,200 @@
+/**
+ * The translation worklist endpoint.
+ *
+ *   GET /api/translations?locale=es&state=missing&limit=50
+ *
+ * One language's outstanding work across every localized collection. Read-only,
+ * and authenticated like the dashboard — this answers "what needs translating",
+ * which is a question any signed-in author may ask; WHICH documents come back
+ * is decided per row by the collection's own read rules.
+ *
+ * The fan-out, the cap and the merge live in
+ * `domains/i18n/services/translation-worklist-service`. This module is the HTTP
+ * shape around them: parse, authorize, delegate, respond.
+ *
+ * @module api/translations
+ * @since 1.0.0
+ */
+
+import { container } from "../di";
+import type { CollectionRegistryService } from "../domains/collections/services/collection-registry-service";
+import type { UserContext } from "../domains/collections/services/collection-types";
+import type { TranslationFilterState } from "../domains/i18n/companion-join";
+import {
+  byMostRecentlyUpdated,
+  planWorklistFanOut,
+  translatedFilter,
+  worklistId,
+  worklistTitle,
+  worklistUpdatedAt,
+  type LocalizedCollectionRef,
+  type TranslationWorkRow,
+} from "../domains/i18n/services/translation-worklist-service";
+import { NextlyError } from "../errors/nextly-error";
+import { getCachedNextly } from "../init";
+import type { CollectionsHandler } from "../services/collections-handler";
+
+import {
+  authenticatedRead,
+  PRIVATE_NO_STORE_HEADERS,
+} from "./authenticated-read";
+import { respondData } from "./response-shapes";
+import { withErrorHandler } from "./with-error-handler";
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/**
+ * The states a worklist may be asked for.
+ *
+ * The SAME four the entry table's language filter already offers, read from the
+ * one place that defines them. A worklist with a vocabulary of its own would
+ * describe the same document differently depending on which screen asked.
+ */
+const WORKLIST_STATES: readonly TranslationFilterState[] = [
+  "missing",
+  "translated",
+  "draft",
+  "published",
+];
+
+function parseState(raw: string | null): TranslationFilterState {
+  // Defaulted rather than required: "what is missing" is the question the
+  // worklist exists for, and asking a translator to name a state before they
+  // can see any work is a form to fill in before a list.
+  if (raw === null || raw === "") return "missing";
+  const match = WORKLIST_STATES.find(s => s === raw);
+  if (match === undefined) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "state",
+          code: "invalid_state",
+          message: `Unknown translation state "${raw}". Expected one of: ${WORKLIST_STATES.join(", ")}.`,
+        },
+      ],
+    });
+  }
+  return match;
+}
+
+function parseLimit(raw: string | null): number {
+  if (raw === null || raw === "") return DEFAULT_LIMIT;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return DEFAULT_LIMIT;
+  return Math.min(Math.max(Math.trunc(n), 1), MAX_LIMIT);
+}
+
+/**
+ * The caller, in the shape the access rules read.
+ *
+ * `roles` carries through because a role-based read rule matches on it. It is
+ * the difference between a worklist that is short because the work is done and
+ * one that is short because nothing matched.
+ */
+function worklistUser(auth: { userId: string; roles?: string[] }): UserContext {
+  return {
+    id: auth.userId,
+    ...(auth.roles === undefined ? {} : { roles: auth.roles }),
+  };
+}
+
+/** Every collection that HAS a language dimension, with what the list needs to name it. */
+async function localizedCollections(): Promise<
+  (LocalizedCollectionRef & { useAsTitle: string | undefined })[]
+> {
+  const registry = container.get<CollectionRegistryService>(
+    "collectionRegistryService"
+  );
+  const all = await registry.getAllCollections();
+  return all
+    .filter(c => c.localized === true)
+    .map(c => ({
+      slug: c.slug,
+      label: c.labels?.plural ?? c.slug,
+      useAsTitle: c.admin?.useAsTitle,
+    }));
+}
+
+/**
+ * GET /api/translations
+ *
+ * Query params:
+ *   - locale: required. The language being worked on.
+ *   - state:  one of missing | translated | draft | published (default: missing)
+ *   - limit:  1..200 (default: 50)
+ */
+export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
+  const auth = await authenticatedRead(req);
+  const { searchParams } = auth;
+  const locale = searchParams.get("locale");
+  // Required, and refused rather than defaulted to the site default: a worklist
+  // for a language nobody asked about is a list of work that is not theirs.
+  if (locale === null || locale === "") {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "locale",
+          code: "required",
+          message:
+            "A `locale` is required: the worklist answers for one language.",
+        },
+      ],
+    });
+  }
+  const state = parseState(searchParams.get("state"));
+  const limit = parseLimit(searchParams.get("limit"));
+
+  await getCachedNextly();
+  const handler = container.get<CollectionsHandler>("collectionsHandler");
+  const collections = await localizedCollections();
+  const { queried, skippedCollections } = planWorklistFanOut(collections);
+  const bySlug = new Map(collections.map(c => [c.slug, c]));
+
+  const perCollection = await Promise.all(
+    queried.map(async coll => {
+      const result = await handler.listEntries({
+        collectionName: coll.slug,
+        // The caller's own context, ROLES INCLUDED. Read rules are evaluated
+        // as this user, and a role-based rule matches on `role`/`roles`: pass
+        // the id alone and such a collection matches nothing and reads as
+        // "fully translated" — a silent, reassuring lie rather than an error.
+        // Filtering by collection alone (the dashboard's model) would go the
+        // other way and list every author's titles to a self-scoped role.
+        user: worklistUser(auth),
+        // The reserved key is not part of `WhereFilter`'s published shape — the
+        // list extractor pulls it off the top level before the clause is typed —
+        // so the cast is at the ONE call site that knows that, not in the helper.
+        where: translatedFilter(locale, state) as never,
+        limit,
+        sort: "-updatedAt",
+        // Nothing here follows a relationship, and expanding them would turn
+        // one list into a page of joins per row.
+        depth: 0,
+      });
+      const useAsTitle = bySlug.get(coll.slug)?.useAsTitle;
+      // A refused or failed read contributes nothing rather than failing the
+      // whole worklist: one collection the caller may not read must not empty
+      // the screen for every collection they may.
+      const docs = (result?.data?.docs ?? []) as Record<string, unknown>[];
+      return docs.map(
+        (doc): TranslationWorkRow => ({
+          collection: coll.slug,
+          collectionLabel: coll.label,
+          id: worklistId(doc),
+          title: worklistTitle(doc, useAsTitle),
+          updatedAt: worklistUpdatedAt(doc.updatedAt ?? doc.updated_at),
+        })
+      );
+    })
+  );
+
+  // Merged BEFORE the slice, which is the whole reason this fans out on the
+  // server: ordered across collections rather than within each one.
+  const rows = perCollection.flat().sort(byMostRecentlyUpdated).slice(0, limit);
+
+  return respondData(
+    { rows, skippedCollections, locale, state },
+    { headers: PRIVATE_NO_STORE_HEADERS }
+  );
+});

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -31,11 +31,14 @@ import {
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
 import { isValidLocale } from "../domains/i18n/resolve-locale";
 import {
+  authorizationGroups,
   byMostRecentlyUpdated,
   eligibleCollections,
+  hasTranslatableFields,
   notConsultedSources,
   planWorklistFanOut,
   translatedFilter,
+  worklistTotal,
   worklistId,
   worklistTitle,
   worklistUpdatedAt,
@@ -112,13 +115,31 @@ async function readableCollections(
     permissions: auth.permissions,
     roles: caller.user.roles ?? [],
   };
-  const verdicts = await Promise.all(
-    slugs.map(async slug => ({
-      slug,
-      allowed: await canReadEntity(slug, readCaller),
-    }))
-  );
-  return new Set(verdicts.filter(v => v.allowed).map(v => v.slug));
+  // One decision, then bounded groups — never one flat `Promise.all` over every
+  // localized collection. `canReadEntity` resolves a session caller through the
+  // per-user super-admin cache, and a simultaneous cold start makes every call
+  // miss it at once, turning one question into N permission reads issued in
+  // parallel against the pool. See `authorizationGroups` for why the first runs
+  // alone.
+  //
+  // Every candidate is still decided. Bounding the COUNT rather than the
+  // concurrency would leave collections with no verdict, and there is nothing
+  // safe to do with one: naming it as unconsulted discloses a collection the
+  // caller may not read, and dropping it silently is the "nothing to do there"
+  // lie this endpoint exists to prevent.
+  const allowed = new Set<string>();
+  for (const group of authorizationGroups(slugs)) {
+    const verdicts = await Promise.all(
+      group.map(async slug => ({
+        slug,
+        allowed: await canReadEntity(slug, readCaller),
+      }))
+    );
+    for (const verdict of verdicts) {
+      if (verdict.allowed) allowed.add(verdict.slug);
+    }
+  }
+  return allowed;
 }
 
 /**
@@ -170,7 +191,30 @@ function assertConfiguredLocale(locale: string): void {
   }
 }
 
-/** Every collection that HAS a language dimension, with what the list needs to name it. */
+/**
+ * Every collection that can actually ANSWER this question, with what the list
+ * needs to name it.
+ *
+ * `localized: true` is not sufficient, and the gap is not hypothetical: a
+ * collection may carry the flag while every field on it is non-localizable (a
+ * numbers-only collection) or explicitly `localized: false`. No companion table
+ * is generated for such a collection, so `buildTranslationStatusCondition` is
+ * never reached — the caller returns `undefined` for a missing companion — and
+ * a filter that produces NO condition does not narrow the query. Every document
+ * in it would come back and be reported as outstanding work in whichever state
+ * was asked for.
+ *
+ * That is the same failure shape `assertConfiguredLocale` guards one door up: a
+ * predicate that silently matches everything, presented as a backlog. Both are
+ * refused before the query rather than explained after it.
+ *
+ * The test is `resolveLocalizedFieldNames(...).length > 0`, which is not merely
+ * a similar rule — it is the SAME expression `buildCompanionSchema` evaluates
+ * before returning `null`. Eligibility here and companion existence there
+ * therefore cannot drift apart into two answers. Asking costs nothing: the
+ * fields are already on the registry record, so this narrows the candidate set
+ * before any authorization or query work is done.
+ */
 async function localizedCollections(): Promise<
   (LocalizedCollectionRef & {
     useAsTitle: string | undefined;
@@ -182,7 +226,7 @@ async function localizedCollections(): Promise<
   );
   const all = await registry.getAllCollections();
   return all
-    .filter(c => c.localized === true)
+    .filter(c => c.localized === true && hasTranslatableFields(c.fields ?? []))
     .map(c => ({
       slug: c.slug,
       label: c.labels?.plural ?? c.slug,
@@ -259,6 +303,20 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
         ...(caller.authenticatedScope === undefined
           ? {}
           : { authenticatedScope: caller.authenticatedScope }),
+        // The coarse read gate was already decided for this collection, by
+        // `canReadEntity` above — the canonical decision, and the reason this
+        // collection is in `queried` at all. Attesting it here elides ONLY that
+        // redundant re-check: `checkCollectionAccess` skips the RBAC/code-access
+        // gate under `routeAuthorized` and still evaluates the stored rules
+        // (owner-only, role-based, custom) against the real user, which is what
+        // keeps another author's titles out of this list.
+        //
+        // Not merely wasted work. A code-defined `access.read` callback may do
+        // asynchronous external work, so running it twice per collection doubles
+        // that load — and a transient failure on the second call would refuse a
+        // collection the first call allowed, reporting it as unconsulted for no
+        // reason the operator could see.
+        routeAuthorized: true,
         // The reserved key is not part of `WhereFilter`'s published shape — the
         // list extractor pulls it off the top level before the clause is typed —
         // so the cast is at the ONE call site that knows that, not in the helper.
@@ -288,7 +346,7 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
       // instead, and one failure does not empty the screen for every collection
       // that answered.
       if (result?.success !== true || result.data === null) {
-        return { slug: coll.slug, rows: [] as TranslationWorkRow[] };
+        return { slug: coll.slug, rows: [] as TranslationWorkRow[], total: 0 };
       }
       const docs = (result.data.docs ?? []) as Record<string, unknown>[];
       const rows = docs.map(
@@ -300,7 +358,17 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
           updatedAt: worklistUpdatedAt(doc.updatedAt ?? doc.updated_at),
         })
       );
-      return { slug: null, rows };
+      // The collection's OWN count of matching documents, not the length of the
+      // page it returned. The count query applies the same `_translated`
+      // predicate as the rows beside it — `listEntries` forwards
+      // `translationFilter` to it precisely so the two agree — so this is the
+      // real size of this collection's backlog, including the part beyond
+      // `limit` that these rows do not contain.
+      const total =
+        typeof result.data.totalDocs === "number"
+          ? result.data.totalDocs
+          : rows.length;
+      return { slug: null, rows, total };
     })
   );
 
@@ -319,22 +387,15 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   // The canonical list envelope, with synthetic single-page meta — the same
   // shape `webhooks` uses for a list its service does not paginate.
   //
-  // `total` is what the fan-out FOUND, before the slice, so a caller can see
-  // that the rows on screen are not all of them: fifty-one outstanding
-  // documents return fifty rows and a total of fifty-one, and the screen can
-  // say so. Reporting `rows.length` there instead would present a truncated
-  // backlog as a complete one — the same lie as an unconsulted collection,
-  // one level down.
-  //
-  // It is still a floor rather than a census: each collection is asked for at
-  // most `limit`, so a site far past that has more outstanding work than any
-  // single request can count. Naming a floor is honest; naming it as a total
-  // would not be, which is why the field the screen reads for completeness is
-  // `notConsulted` rather than this number.
+  // `total` is each collection's OWN count of matching documents, summed, never
+  // the number of rows this response happens to carry — see `worklistTotal`.
   return respondList(
     rows,
     {
-      total: merged.length,
+      total: worklistTotal(
+        perCollection.map(r => r.total),
+        merged.length
+      ),
       page: 1,
       limit,
       totalPages: 1,

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -53,7 +53,7 @@ import {
   readCaller,
   PRIVATE_NO_STORE_HEADERS,
 } from "./authenticated-read";
-import { respondData } from "./response-shapes";
+import { respondList } from "./response-shapes";
 import { withErrorHandler } from "./with-error-handler";
 
 const DEFAULT_LIMIT = 50;
@@ -297,8 +297,33 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   // server: ordered across collections rather than within each one.
   const rows = perCollection.flat().sort(byMostRecentlyUpdated).slice(0, limit);
 
-  return respondData(
-    { rows, skippedCollections, locale, state },
+  // The canonical list envelope, with synthetic single-page meta — the same
+  // shape `webhooks` uses for a list its service does not paginate. This read
+  // is capped rather than paged, so `page`/`totalPages` are 1 and there is no
+  // next page to offer.
+  //
+  // `total` is the number of rows RETURNED, which is all this request can
+  // honestly claim: the fan-out is capped per collection and across
+  // collections, so more outstanding work may exist than was counted. That is
+  // exactly what `hasNext` reports here — not "there is another page to
+  // request", but "this answer is known to be incomplete" — and it is why
+  // `skippedCollections` is carried in the row set's own metadata rather than
+  // left for the caller to infer from a number.
+  return respondList(
+    rows,
+    {
+      total: rows.length,
+      page: 1,
+      limit,
+      totalPages: 1,
+      hasNext: rows.length === limit || skippedCollections.length > 0,
+      hasPrev: false,
+      // Named, so the screen can say WHICH. Omitted entirely when the fan-out
+      // reached everything, so the field's presence is itself the signal.
+      ...(skippedCollections.length === 0
+        ? {}
+        : { notConsulted: skippedCollections }),
+    },
     { headers: PRIVATE_NO_STORE_HEADERS }
   );
 });

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -32,6 +32,7 @@ import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
 import { isValidLocale } from "../domains/i18n/resolve-locale";
 import {
   authorizationGroups,
+  countIsTrustworthy,
   byMostRecentlyUpdated,
   eligibleCollections,
   hasTranslatableFields,
@@ -365,11 +366,20 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
       // `translationFilter` to it precisely so the two agree — so this is the
       // real size of this collection's backlog, including the part beyond
       // `limit` that these rows do not contain.
-      const total =
-        typeof result.data.totalDocs === "number"
-          ? result.data.totalDocs
-          : rows.length;
-      return { slug: null, rows, total };
+      //
+      // And a count that contradicts its own rows did not run. `listEntries`
+      // answers a failed COUNT beside successful rows with `success: true` and
+      // `totalDocs: 0`, so believing it would report a collection's whole
+      // backlog as however many rows happened to fit — the same lie as an
+      // unconsulted collection, arriving through the one path that still had a
+      // silent fallback. Such a collection is named as unconsulted and its rows
+      // are left out, so `notConsulted` keeps ONE meaning: this answer did not
+      // cover that collection. Half-covering it — rows on screen, no honest
+      // size — invites exactly the belief that the rows are all of it.
+      if (!countIsTrustworthy(result.data.totalDocs, rows.length)) {
+        return { slug: coll.slug, rows: [] as TranslationWorkRow[], total: 0 };
+      }
+      return { slug: null, rows, total: result.data.totalDocs };
     })
   );
 

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -17,12 +17,13 @@
  */
 
 import {
-  apiKeyScopeAllows,
-  type AuthenticatedScope,
-} from "../auth/authenticated-scope";
+  canReadEntity,
+  type ReadAccessCaller,
+} from "../auth/entity-read-access";
 import type { AuthContext } from "../auth/middleware";
 import { container } from "../di";
 import type { CollectionRegistryService } from "../domains/collections/services/collection-registry-service";
+import type { UserContext } from "../domains/collections/services/collection-types";
 import {
   TRANSLATION_FILTER_STATES,
   type TranslationFilterState,
@@ -32,6 +33,7 @@ import { isValidLocale } from "../domains/i18n/resolve-locale";
 import {
   byMostRecentlyUpdated,
   eligibleCollections,
+  notConsultedSources,
   planWorklistFanOut,
   translatedFilter,
   worklistId,
@@ -43,10 +45,6 @@ import {
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import type { CollectionsHandler } from "../services/collections-handler";
-import {
-  isSuperAdmin,
-  listEffectivePermissions,
-} from "../services/lib/permissions";
 
 import {
   authenticatedRead,
@@ -87,36 +85,40 @@ function parseLimit(raw: string | null): number {
 }
 
 /**
- * Which collections this caller may read at all, or `undefined` for a
- * super-admin (meaning "no filter").
+ * Which of these collections this caller may read at all.
  *
- * Coarse on purpose. It decides which collections are worth QUERYING; the
- * per-row rules inside `listEntries` still decide which documents come back.
- * Both are needed — this one keeps unreadable collections from consuming the
- * cap, and the per-row one keeps another author's titles out of the answer.
+ * Asked of `canReadEntity`, which is the SAME decision the row read makes, and
+ * whose own docblock says reproducing any of it would be a second
+ * implementation to keep in step. That is exactly what a permission-only
+ * approximation is: `checkAccess` resolves a code-defined `access.read` — `true`
+ * or a callback — BEFORE falling back to stored grants, so a collection
+ * authorized purely in code has no `slug:read` pair to find. Filtering on those
+ * pairs removed it before the row read could allow it, and its outstanding work
+ * vanished from the worklist without any refusal being reported.
+ *
+ * Coarse only in WHAT it decides — whether a collection is worth querying at
+ * all. The per-row rules inside `listEntries` still decide which documents come
+ * back, and both are needed: this keeps unreadable collections out of the cap,
+ * that keeps another author's titles out of the answer.
  */
 async function readableCollections(
   auth: AuthContext,
-  scope: AuthenticatedScope | undefined,
+  caller: { user: UserContext },
   slugs: readonly string[]
-): Promise<Set<string> | undefined> {
-  // An API KEY is judged on its own stamped grants, in both directions: a key
-  // without the grant is denied however privileged its owner, and a key with it
-  // is allowed however unprivileged. Asking the owner's RBAC here — which is
-  // what this did — let collections outside the key's reach consume the capped
-  // slots and put their slugs in `skippedCollections`, while the per-row checks
-  // correctly refused their rows. The coarse filter and the row checks have to
-  // come from ONE decision or they disagree about what exists.
-  if (scope?.actorType === "apiKey") {
-    return new Set(
-      slugs.filter(slug => apiKeyScopeAllows(scope, "read", slug) === true)
-    );
-  }
-  if (await isSuperAdmin(auth.userId)) return undefined;
-  const pairs = await listEffectivePermissions(auth.userId);
-  return new Set(
-    pairs.filter(p => p.endsWith(":read")).map(p => p.split(":")[0] ?? "")
+): Promise<Set<string>> {
+  const readCaller: ReadAccessCaller = {
+    userId: auth.userId,
+    authMethod: auth.authMethod === "api-key" ? "api-key" : "session",
+    permissions: auth.permissions,
+    roles: caller.user.roles ?? [],
+  };
+  const verdicts = await Promise.all(
+    slugs.map(async slug => ({
+      slug,
+      allowed: await canReadEntity(slug, readCaller),
+    }))
   );
+  return new Set(verdicts.filter(v => v.allowed).map(v => v.slug));
 }
 
 /**
@@ -236,7 +238,7 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   const localized = await localizedCollections();
   const readable = await readableCollections(
     auth,
-    caller.authenticatedScope,
+    caller,
     localized.map(c => c.slug)
   );
   const eligible = eligibleCollections(localized, state, readable);
@@ -277,11 +279,19 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
         status: "all" as const,
       });
       const useAsTitle = bySlug.get(coll.slug)?.useAsTitle;
-      // A refused or failed read contributes nothing rather than failing the
-      // whole worklist: one collection the caller may not read must not empty
-      // the screen for every collection they may.
-      const docs = (result?.data?.docs ?? []) as Record<string, unknown>[];
-      return docs.map(
+      // A FAILED read is not an empty collection, and the difference is the
+      // whole point of this endpoint. `listEntries` answers a broken query or a
+      // throwing read hook with `{ success: false, data: null }`, and treating
+      // that as "no rows" reports the collection as having nothing outstanding
+      // — an absence standing in for an answer, on a screen whose only job is
+      // to say where the work is. The collection is named as unconsulted
+      // instead, and one failure does not empty the screen for every collection
+      // that answered.
+      if (result?.success !== true || result.data === null) {
+        return { slug: coll.slug, rows: [] as TranslationWorkRow[] };
+      }
+      const docs = (result.data.docs ?? []) as Record<string, unknown>[];
+      const rows = docs.map(
         (doc): TranslationWorkRow => ({
           collection: coll.slug,
           collectionLabel: coll.label,
@@ -290,39 +300,54 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
           updatedAt: worklistUpdatedAt(doc.updatedAt ?? doc.updated_at),
         })
       );
+      return { slug: null, rows };
     })
   );
 
+  // Named here rather than only at the cap, because both are the same claim:
+  // this answer did not cover that collection.
+  const unreadable = perCollection
+    .map(r => r.slug)
+    .filter((slug): slug is string => slug !== null);
+  const notConsulted = notConsultedSources(skippedCollections, unreadable);
+
   // Merged BEFORE the slice, which is the whole reason this fans out on the
   // server: ordered across collections rather than within each one.
-  const rows = perCollection.flat().sort(byMostRecentlyUpdated).slice(0, limit);
+  const merged = perCollection.flatMap(r => r.rows).sort(byMostRecentlyUpdated);
+  const rows = merged.slice(0, limit);
 
   // The canonical list envelope, with synthetic single-page meta — the same
-  // shape `webhooks` uses for a list its service does not paginate. This read
-  // is capped rather than paged, so `page`/`totalPages` are 1 and there is no
-  // next page to offer.
+  // shape `webhooks` uses for a list its service does not paginate.
   //
-  // `total` is the number of rows RETURNED, which is all this request can
-  // honestly claim: the fan-out is capped per collection and across
-  // collections, so more outstanding work may exist than was counted. That is
-  // exactly what `hasNext` reports here — not "there is another page to
-  // request", but "this answer is known to be incomplete" — and it is why
-  // `skippedCollections` is carried in the row set's own metadata rather than
-  // left for the caller to infer from a number.
+  // `total` is what the fan-out FOUND, before the slice, so a caller can see
+  // that the rows on screen are not all of them: fifty-one outstanding
+  // documents return fifty rows and a total of fifty-one, and the screen can
+  // say so. Reporting `rows.length` there instead would present a truncated
+  // backlog as a complete one — the same lie as an unconsulted collection,
+  // one level down.
+  //
+  // It is still a floor rather than a census: each collection is asked for at
+  // most `limit`, so a site far past that has more outstanding work than any
+  // single request can count. Naming a floor is honest; naming it as a total
+  // would not be, which is why the field the screen reads for completeness is
+  // `notConsulted` rather than this number.
   return respondList(
     rows,
     {
-      total: rows.length,
+      total: merged.length,
       page: 1,
       limit,
       totalPages: 1,
-      hasNext: rows.length === limit || skippedCollections.length > 0,
+      // FALSE, always. This endpoint takes no `page` and always returns the
+      // same first slice, so a consumer following `hasNext` would request a
+      // second page and receive the same rows forever. Incompleteness is a
+      // different fact from pagination and travels in `notConsulted`, which is
+      // why that field exists.
+      hasNext: false,
       hasPrev: false,
-      // Named, so the screen can say WHICH. Omitted entirely when the fan-out
-      // reached everything, so the field's presence is itself the signal.
-      ...(skippedCollections.length === 0
-        ? {}
-        : { notConsulted: skippedCollections }),
+      // Named, so the screen can say WHICH. Omitted entirely when the answer
+      // covered everything, so the field's presence is itself the signal.
+      ...(notConsulted.length === 0 ? {} : { notConsulted }),
     },
     { headers: PRIVATE_NO_STORE_HEADERS }
   );

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -18,10 +18,15 @@
 
 import { container } from "../di";
 import type { CollectionRegistryService } from "../domains/collections/services/collection-registry-service";
-import type { UserContext } from "../domains/collections/services/collection-types";
-import type { TranslationFilterState } from "../domains/i18n/companion-join";
+import {
+  TRANSLATION_FILTER_STATES,
+  type TranslationFilterState,
+} from "../domains/i18n/companion-join";
+import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
+import { isValidLocale } from "../domains/i18n/resolve-locale";
 import {
   byMostRecentlyUpdated,
+  eligibleCollections,
   planWorklistFanOut,
   translatedFilter,
   worklistId,
@@ -33,9 +38,14 @@ import {
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import type { CollectionsHandler } from "../services/collections-handler";
+import {
+  isSuperAdmin,
+  listEffectivePermissions,
+} from "../services/lib/permissions";
 
 import {
   authenticatedRead,
+  readCaller,
   PRIVATE_NO_STORE_HEADERS,
 } from "./authenticated-read";
 import { respondData } from "./response-shapes";
@@ -44,33 +54,19 @@ import { withErrorHandler } from "./with-error-handler";
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 
-/**
- * The states a worklist may be asked for.
- *
- * The SAME four the entry table's language filter already offers, read from the
- * one place that defines them. A worklist with a vocabulary of its own would
- * describe the same document differently depending on which screen asked.
- */
-const WORKLIST_STATES: readonly TranslationFilterState[] = [
-  "missing",
-  "translated",
-  "draft",
-  "published",
-];
-
 function parseState(raw: string | null): TranslationFilterState {
   // Defaulted rather than required: "what is missing" is the question the
   // worklist exists for, and asking a translator to name a state before they
   // can see any work is a form to fill in before a list.
   if (raw === null || raw === "") return "missing";
-  const match = WORKLIST_STATES.find(s => s === raw);
+  const match = TRANSLATION_FILTER_STATES.find(s => s === raw);
   if (match === undefined) {
     throw NextlyError.validation({
       errors: [
         {
           path: "state",
           code: "invalid_state",
-          message: `Unknown translation state "${raw}". Expected one of: ${WORKLIST_STATES.join(", ")}.`,
+          message: `Unknown translation state "${raw}". Expected one of: ${TRANSLATION_FILTER_STATES.join(", ")}.`,
         },
       ],
     });
@@ -86,22 +82,79 @@ function parseLimit(raw: string | null): number {
 }
 
 /**
- * The caller, in the shape the access rules read.
+ * Which collections this caller may read at all, or `undefined` for a
+ * super-admin (meaning "no filter").
  *
- * `roles` carries through because a role-based read rule matches on it. It is
- * the difference between a worklist that is short because the work is done and
- * one that is short because nothing matched.
+ * Coarse on purpose. It decides which collections are worth QUERYING; the
+ * per-row rules inside `listEntries` still decide which documents come back.
+ * Both are needed — this one keeps unreadable collections from consuming the
+ * cap, and the per-row one keeps another author's titles out of the answer.
  */
-function worklistUser(auth: { userId: string; roles?: string[] }): UserContext {
-  return {
-    id: auth.userId,
-    ...(auth.roles === undefined ? {} : { roles: auth.roles }),
-  };
+async function readableCollections(
+  userId: string
+): Promise<Set<string> | undefined> {
+  if (await isSuperAdmin(userId)) return undefined;
+  const pairs = await listEffectivePermissions(userId);
+  return new Set(
+    pairs.filter(p => p.endsWith(":read")).map(p => p.split(":")[0] ?? "")
+  );
+}
+
+/**
+ * The app's configured languages, or `undefined` where localization is off.
+ *
+ * Read from the registered service config the same way the entity guards read
+ * it, so "which languages exist" has one answer.
+ */
+function configuredLocalization(): SanitizedLocalizationConfig | undefined {
+  if (!container.has("config")) return undefined;
+  return container.get<{ localization?: SanitizedLocalizationConfig }>("config")
+    .localization;
+}
+
+/**
+ * Refuse a language the app does not have.
+ *
+ * Not pedantry: an unconfigured code has no rows in any companion table, so the
+ * `NOT EXISTS` predicate matches EVERYTHING. `locale=esp` would report every
+ * document on the site as untranslated — a typo rendered as a full backlog,
+ * which is both alarming and completely wrong, and nothing in the response
+ * would hint that the language was the problem.
+ */
+function assertConfiguredLocale(locale: string): void {
+  const localization = configuredLocalization();
+  if (localization === undefined) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "locale",
+          code: "localization_not_configured",
+          message: "This app has no localization configured.",
+        },
+      ],
+    });
+  }
+  if (!isValidLocale(localization, locale)) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "locale",
+          code: "unknown_locale",
+          message: `Unknown locale "${locale}". Configured: ${localization.locales
+            .map(l => l.code)
+            .join(", ")}.`,
+        },
+      ],
+    });
+  }
 }
 
 /** Every collection that HAS a language dimension, with what the list needs to name it. */
 async function localizedCollections(): Promise<
-  (LocalizedCollectionRef & { useAsTitle: string | undefined })[]
+  (LocalizedCollectionRef & {
+    useAsTitle: string | undefined;
+    hasStatus: boolean;
+  })[]
 > {
   const registry = container.get<CollectionRegistryService>(
     "collectionRegistryService"
@@ -113,6 +166,7 @@ async function localizedCollections(): Promise<
       slug: c.slug,
       label: c.labels?.plural ?? c.slug,
       useAsTitle: c.admin?.useAsTitle,
+      hasStatus: c.status === true,
     }));
 }
 
@@ -125,8 +179,7 @@ async function localizedCollections(): Promise<
  *   - limit:  1..200 (default: 50)
  */
 export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
-  const auth = await authenticatedRead(req);
-  const { searchParams } = auth;
+  const { auth, searchParams } = await authenticatedRead(req);
   const locale = searchParams.get("locale");
   // Required, and refused rather than defaulted to the site default: a worklist
   // for a language nobody asked about is a list of work that is not theirs.
@@ -146,10 +199,29 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   const limit = parseLimit(searchParams.get("limit"));
 
   await getCachedNextly();
+  assertConfiguredLocale(locale);
   const handler = container.get<CollectionsHandler>("collectionsHandler");
-  const collections = await localizedCollections();
-  const { queried, skippedCollections } = planWorklistFanOut(collections);
-  const bySlug = new Map(collections.map(c => [c.slug, c]));
+  const caller = await readCaller(auth);
+
+  // Narrowed BEFORE the cap, in two steps, and the order is the point.
+  //
+  // A lifecycle state is a question a statusless collection cannot answer:
+  // `buildTranslationStatusCondition` deliberately produces no condition there,
+  // so the query returns every document and the worklist presents all of them
+  // as being in the state that was asked for.
+  //
+  // And capping the raw registry list lets collections the caller cannot read
+  // consume the alphabetically-first slots, pushing a readable collection into
+  // `skippedCollections` — where its work is never queried AND its slug is
+  // named back to someone with no right to know it exists.
+  const readable = await readableCollections(auth.userId);
+  const eligible = eligibleCollections(
+    await localizedCollections(),
+    state,
+    readable
+  );
+  const { queried, skippedCollections } = planWorklistFanOut(eligible);
+  const bySlug = new Map(eligible.map(c => [c.slug, c]));
 
   const perCollection = await Promise.all(
     queried.map(async coll => {
@@ -161,7 +233,10 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
         // "fully translated" — a silent, reassuring lie rather than an error.
         // Filtering by collection alone (the dashboard's model) would go the
         // other way and list every author's titles to a self-scoped role.
-        user: worklistUser(auth),
+        user: caller.user,
+        ...(caller.authenticatedScope === undefined
+          ? {}
+          : { authenticatedScope: caller.authenticatedScope }),
         // The reserved key is not part of `WhereFilter`'s published shape — the
         // list extractor pulls it off the top level before the clause is typed —
         // so the cast is at the ONE call site that knows that, not in the helper.

--- a/packages/nextly/src/dispatcher/types.ts
+++ b/packages/nextly/src/dispatcher/types.ts
@@ -28,6 +28,7 @@ export type ServiceType =
   | "previewUrl"
   | "imageSizes"
   | "dashboard"
+  | "translations"
   | "email"
   | "schema";
 

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -102,6 +102,7 @@ import {
   buildCompanionExists,
   buildLocalizedOrderExpr,
   buildTranslationStatusCondition,
+  TRANSLATION_FILTER_STATES,
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
   populateTranslationStatus,
@@ -499,12 +500,7 @@ export class CollectionQueryService extends BaseService {
     const cleanedWhere =
       Object.keys(rest).length > 0 ? (rest as WhereFilter) : undefined;
     const f = _translated as { locale?: unknown; state?: unknown };
-    const states: TranslationFilterState[] = [
-      "missing",
-      "translated",
-      "draft",
-      "published",
-    ];
+    const states: readonly TranslationFilterState[] = TRANSLATION_FILTER_STATES;
     if (
       typeof f?.locale !== "string" ||
       typeof f?.state !== "string" ||

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -442,11 +442,25 @@ export function buildCompanionExists(args: {
 }
 
 /** The translation states the list "language filter" can filter on (i18n M7). */
-export type TranslationFilterState =
-  | "missing"
-  | "translated"
-  | "draft"
-  | "published";
+/**
+ * Every translation state a filter may name, and the source the type is built
+ * from.
+ *
+ * A tuple rather than a union so there is something to READ at runtime. The
+ * query service and the worklist endpoint both have to decide whether an
+ * incoming string is a state, and while the union existed they each declared
+ * their own list of the same four words — so adding or renaming one could make
+ * the endpoint accept a value the query layer silently drops, or refuse one it
+ * supports.
+ */
+export const TRANSLATION_FILTER_STATES = [
+  "missing",
+  "translated",
+  "draft",
+  "published",
+] as const;
+
+export type TranslationFilterState = (typeof TRANSLATION_FILTER_STATES)[number];
 
 export interface TranslationStatusFilter {
   /** Target locale code. */

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -4,6 +4,7 @@ import {
   AUTHORIZATION_CONCURRENCY,
   MAX_WORKLIST_COLLECTIONS,
   authorizationGroups,
+  countIsTrustworthy,
   byMostRecentlyUpdated,
   eligibleCollections,
   hasTranslatableFields,
@@ -378,5 +379,82 @@ describe("worklistTotalPages", () => {
     // guard costs nothing while its branch never runs, and `Math.ceil(n / 0)`
     // is Infinity — a number that would serialize into the envelope.
     expect(worklistTotalPages(10, 0)).toBe(1);
+  });
+});
+
+describe("countIsTrustworthy", () => {
+  it("disbelieves a zero count reported beside rows that exist", () => {
+    // The case that costs something. `listEntries` returns success with
+    // `totalDocs: 0` when the ROWS arrived and the paired COUNT failed, so
+    // taking the zero hides that collection's whole backlog behind however many
+    // rows happened to fit — and nothing in the response says so.
+    expect(countIsTrustworthy(0, 50)).toBe(false);
+  });
+
+  it("disbelieves any count smaller than the rows it came with", () => {
+    // A count is the number of rows MATCHING, so it cannot be smaller than the
+    // rows returned. Impossible for a count that ran; certain for one that did
+    // not.
+    expect(countIsTrustworthy(12, 13)).toBe(false);
+  });
+
+  it("believes a count that is larger than the page it accompanies", () => {
+    // The control, and the whole point of summing counts: 100 matches behind a
+    // page of 50 is the ordinary, correct case and must not be discarded as
+    // untrustworthy.
+    expect(countIsTrustworthy(100, 50)).toBe(true);
+  });
+
+  it("believes an exact count", () => {
+    expect(countIsTrustworthy(50, 50)).toBe(true);
+  });
+
+  it("believes zero against no rows", () => {
+    // An empty collection. A failed count here is undetectable and harmless —
+    // there is no backlog for it to hide.
+    expect(countIsTrustworthy(0, 0)).toBe(true);
+  });
+
+  it("disbelieves a count that is not a number at all", () => {
+    expect(countIsTrustworthy(undefined, 0)).toBe(false);
+  });
+
+  it("disbelieves a count that only LOOKS like a number", () => {
+    // The reason the type check is there rather than relying on `>=` alone:
+    // `"100" >= 50` coerces and is true, so a stringified count would be
+    // trusted and summed into a total as a string.
+    expect(countIsTrustworthy("100", 50)).toBe(false);
+  });
+});
+
+describe("authorizationGroups — a step that cannot advance", () => {
+  it("refuses a concurrency of zero rather than looping forever", () => {
+    // `i += 0` never reaches `rest.length`. Unreachable today, which is what
+    // makes the guard cheap rather than what makes it unnecessary.
+    expect(() => authorizationGroups(["a", "b"], 0)).toThrow(
+      expect.objectContaining({ code: "INTERNAL_ERROR" })
+    );
+  });
+
+  it("refuses a negative concurrency, which walks the index backwards", () => {
+    expect(() => authorizationGroups(["a", "b"], -1)).toThrow(
+      expect.objectContaining({ code: "INTERNAL_ERROR" })
+    );
+  });
+
+  it("refuses a fractional concurrency", () => {
+    expect(() => authorizationGroups(["a", "b"], 1.5)).toThrow(
+      expect.objectContaining({ code: "INTERNAL_ERROR" })
+    );
+  });
+
+  it("still accepts the smallest useful step", () => {
+    // The control: the guard must reject the values that cannot work, not the
+    // edge of the ones that can.
+    expect(authorizationGroups(["a", "b", "c"], 1)).toEqual([
+      ["a"],
+      ["b"],
+      ["c"],
+    ]);
   });
 });

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -13,6 +13,7 @@ import {
   worklistId,
   worklistTitle,
   worklistTotal,
+  worklistTotalPages,
   worklistUpdatedAt,
   type TranslationWorkRow,
 } from "./translation-worklist-service";
@@ -345,5 +346,37 @@ describe("worklistTotal", () => {
 
   it("is zero for an empty worklist", () => {
     expect(worklistTotal([], 0)).toBe(0);
+  });
+});
+
+describe("worklistTotalPages", () => {
+  it("does not claim a backlog larger than the page fits on one page", () => {
+    // `total: 100` beside `totalPages: 1` at `limit: 50` asserts that a hundred
+    // documents fit in fifty — so a reader who believes the pair concludes the
+    // fifty rows in hand ARE the hundred. That is the truncation-as-census
+    // failure the summed total exists to end, moved one field along.
+    expect(worklistTotalPages(100, 50)).toBe(2);
+  });
+
+  it("rounds a partial page up", () => {
+    expect(worklistTotalPages(51, 50)).toBe(2);
+  });
+
+  it("is one page when the backlog fits", () => {
+    // The control: deriving must not inflate an answer that was already whole.
+    expect(worklistTotalPages(50, 50)).toBe(1);
+  });
+
+  it("is one empty page for an empty worklist, never zero", () => {
+    // Zero pages is not a thing a list can have, and a consumer dividing by it
+    // or rendering "page 1 of 0" is the reason to say so here.
+    expect(worklistTotalPages(0, 50)).toBe(1);
+  });
+
+  it("survives a limit of zero rather than answering Infinity", () => {
+    // `limit` is clamped upstream, which is exactly why this is cheap: the
+    // guard costs nothing while its branch never runs, and `Math.ceil(n / 0)`
+    // is Infinity — a number that would serialize into the envelope.
+    expect(worklistTotalPages(10, 0)).toBe(1);
   });
 });

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  AUTHORIZATION_CONCURRENCY,
   MAX_WORKLIST_COLLECTIONS,
+  authorizationGroups,
   byMostRecentlyUpdated,
   eligibleCollections,
+  hasTranslatableFields,
   notConsultedSources,
   planWorklistFanOut,
   translatedFilter,
   worklistId,
   worklistTitle,
+  worklistTotal,
   worklistUpdatedAt,
   type TranslationWorkRow,
 } from "./translation-worklist-service";
@@ -236,5 +240,110 @@ describe("translatedFilter", () => {
     expect(translatedFilter("es", "missing")).toEqual({
       _translated: { locale: "es", state: "missing" },
     });
+  });
+});
+
+describe("authorizationGroups", () => {
+  it("resolves ONE decision before any others are started", () => {
+    // The warm-up, and the reason the first group is a single slug rather than
+    // a rounding artefact. `canReadEntity` resolves a session caller through
+    // `isSuperAdmin`, a per-user TTL cache: fired all at once from cold, every
+    // call misses before the first populates it, so one question becomes N
+    // simultaneous permission reads. Letting one finish converts the rest into
+    // cache hits.
+    const groups = authorizationGroups(["a", "b", "c", "d"], 2);
+    expect(groups[0]).toEqual(["a"]);
+  });
+
+  it("never puts more than `concurrency` decisions in flight together", () => {
+    const groups = authorizationGroups(
+      Array.from({ length: 50 }, (_, i) => `c${i}`),
+      8
+    );
+    expect(groups.slice(1).every(g => g.length <= 8)).toBe(true);
+  });
+
+  it("decides EVERY candidate, because a collection with no verdict is unusable", () => {
+    // Bounding the COUNT rather than the concurrency would leave collections
+    // undecided, and there is nothing safe to do with one: naming it as
+    // unconsulted discloses a collection the caller may not read, and dropping
+    // it silently is the "nothing to do there" lie the endpoint exists to
+    // prevent. Every slug in, every slug out, once.
+    const slugs = Array.from({ length: 137 }, (_, i) => `c${i}`);
+    expect(authorizationGroups(slugs).flat()).toEqual(slugs);
+  });
+
+  it("has no group at all for no candidates", () => {
+    // A lone empty group would fire one authorization round-trip for a site
+    // with nothing to authorize.
+    expect(authorizationGroups([])).toEqual([]);
+  });
+
+  it("is one group for one candidate", () => {
+    expect(authorizationGroups(["only"])).toEqual([["only"]]);
+  });
+
+  it("bounds concurrency below the query cap it precedes", () => {
+    // These bound different resources — queries and permission reads — but a
+    // concurrency wider than the fan-out itself would bound nothing in the
+    // common case.
+    expect(AUTHORIZATION_CONCURRENCY).toBeLessThan(MAX_WORKLIST_COLLECTIONS);
+  });
+});
+
+describe("hasTranslatableFields", () => {
+  it("refuses a collection whose fields cannot be translated", () => {
+    // `localized: true` with nothing localizable generates NO companion table,
+    // so the `_translated` predicate produces no condition, so the query
+    // narrows nothing and every document is reported as outstanding work.
+    expect(hasTranslatableFields([{ type: "number", name: "count" }])).toBe(
+      false
+    );
+  });
+
+  it("refuses a collection whose text fields all opted OUT", () => {
+    expect(
+      hasTranslatableFields([
+        { type: "text", name: "sku", localized: false },
+        { type: "text", name: "code", localized: false },
+      ])
+    ).toBe(false);
+  });
+
+  it("accepts a collection with one translatable field", () => {
+    expect(
+      hasTranslatableFields([
+        { type: "number", name: "count" },
+        { type: "text", name: "title" },
+      ])
+    ).toBe(true);
+  });
+
+  it("refuses a collection with no fields at all", () => {
+    expect(hasTranslatableFields([])).toBe(false);
+  });
+});
+
+describe("worklistTotal", () => {
+  it("counts the backlog, not the page it could carry", () => {
+    // The failure this exists to prevent: one collection with 51 outstanding
+    // documents is asked for 50, and reporting what came back presents a
+    // truncated backlog as a complete census.
+    expect(worklistTotal([51], 50)).toBe(51);
+  });
+
+  it("sums across collections rather than reporting the largest", () => {
+    expect(worklistTotal([7, 11, 2], 20)).toBe(20);
+    expect(worklistTotal([7, 11, 2], 5)).toBe(20);
+  });
+
+  it("never reports fewer than the rows sitting beside it on screen", () => {
+    // A count query that fails falls back to zero inside the query service. A
+    // total below the visible rows is the one answer a reader cannot interpret.
+    expect(worklistTotal([0, 0], 12)).toBe(12);
+  });
+
+  it("is zero for an empty worklist", () => {
+    expect(worklistTotal([], 0)).toBe(0);
   });
 });

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   MAX_WORKLIST_COLLECTIONS,
   byMostRecentlyUpdated,
+  eligibleCollections,
   planWorklistFanOut,
   translatedFilter,
   worklistId,
@@ -98,10 +99,78 @@ describe("byMostRecentlyUpdated", () => {
   });
 });
 
+describe("eligibleCollections", () => {
+  const coll = (slug: string, hasStatus = true) => ({
+    slug,
+    label: slug,
+    hasStatus,
+  });
+
+  it("drops collections the caller cannot read", () => {
+    const out = eligibleCollections(
+      [coll("posts"), coll("secrets"), coll("pages")],
+      "missing",
+      new Set(["posts", "pages"])
+    );
+    expect(out.map(c => c.slug)).toEqual(["posts", "pages"]);
+  });
+
+  it("treats an absent readable set as super-admin, not as nothing readable", () => {
+    const out = eligibleCollections([coll("posts")], "missing", undefined);
+    expect(out.map(c => c.slug)).toEqual(["posts"]);
+  });
+
+  it("excludes a statusless collection from a LIFECYCLE state", () => {
+    // The companion condition is deliberately absent for a collection with no
+    // status, so the query returns EVERY document — and the worklist would
+    // present all of them as being in the state that was asked for.
+    for (const state of ["draft", "published"] as const) {
+      const out = eligibleCollections(
+        [coll("posts", true), coll("tags", false)],
+        state,
+        undefined
+      );
+      expect(out.map(c => c.slug)).toEqual(["posts"]);
+    }
+  });
+
+  it("keeps a statusless collection for states that do not need status", () => {
+    // "missing" and "translated" are answerable without a lifecycle, and
+    // excluding those collections would hide real outstanding work.
+    for (const state of ["missing", "translated"] as const) {
+      const out = eligibleCollections(
+        [coll("posts", true), coll("tags", false)],
+        state,
+        undefined
+      );
+      expect(out.map(c => c.slug)).toEqual(["posts", "tags"]);
+    }
+  });
+
+  it("narrows BEFORE the cap, so an unreadable collection cannot consume a slot", () => {
+    // The ordering property, stated as one test. `a`-prefixed unreadable
+    // collections would otherwise fill every slot alphabetically and push the
+    // readable one into `skippedCollections` — where its work is never queried
+    // and its slug is named to someone with no right to know it exists.
+    const all = [
+      ...Array.from({ length: MAX_WORKLIST_COLLECTIONS }, (_, i) =>
+        coll(`a${String(i).padStart(3, "0")}`)
+      ),
+      coll("zebra"),
+    ];
+    const plan = planWorklistFanOut(
+      eligibleCollections(all, "missing", new Set(["zebra"]))
+    );
+    expect(plan.queried.map(c => c.slug)).toEqual(["zebra"]);
+    expect(plan.skippedCollections).toEqual([]);
+  });
+});
+
 describe("planWorklistFanOut", () => {
   const many = Array.from({ length: MAX_WORKLIST_COLLECTIONS + 3 }, (_, i) => ({
     slug: `c${String(i).padStart(3, "0")}`,
     label: `C${i}`,
+    hasStatus: true,
   }));
 
   it("names what the cap excluded rather than dropping it", () => {

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  MAX_WORKLIST_COLLECTIONS,
+  byMostRecentlyUpdated,
+  planWorklistFanOut,
+  translatedFilter,
+  worklistId,
+  worklistTitle,
+  worklistUpdatedAt,
+  type TranslationWorkRow,
+} from "./translation-worklist-service";
+
+const row = (over: Partial<TranslationWorkRow>): TranslationWorkRow => ({
+  collection: "posts",
+  collectionLabel: "Posts",
+  id: "1",
+  title: "t",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+  ...over,
+});
+
+describe("worklistId", () => {
+  it("reads a string or numeric id", () => {
+    expect(worklistId({ id: "abc" })).toBe("abc");
+    expect(worklistId({ id: 42 })).toBe("42");
+  });
+
+  it("answers an id that is neither with an empty string", () => {
+    // `String({})` is "[object Object]" — a plausible-looking URL segment that
+    // addresses no document. An empty id is visibly wrong instead.
+    expect(worklistId({ id: { nested: true } })).toBe("");
+    expect(worklistId({})).toBe("");
+  });
+});
+
+describe("worklistTitle", () => {
+  it("prefers the collection's own useAsTitle", () => {
+    expect(
+      worklistTitle({ id: "1", headline: "H", title: "T" }, "headline")
+    ).toBe("H");
+  });
+
+  it("falls back the same way the dashboard does, so one document has one name", () => {
+    expect(worklistTitle({ id: "1", title: "T", name: "N" }, undefined)).toBe(
+      "T"
+    );
+    expect(worklistTitle({ id: "1", name: "N" }, undefined)).toBe("N");
+  });
+
+  it("skips a blank useAsTitle rather than rendering an unnamed row", () => {
+    // A row titled "" is unclickable in practice: there is nothing to aim at.
+    expect(
+      worklistTitle({ id: "7", headline: "   ", title: "T" }, "headline")
+    ).toBe("T");
+  });
+
+  it("keeps a numeric title instead of falling through it", () => {
+    // `0` and `2026` are legitimate titles. A truthiness test drops both.
+    expect(worklistTitle({ id: "1", year: 0 }, "year")).toBe("0");
+  });
+
+  it("ends at the id, which always addresses the row", () => {
+    expect(worklistTitle({ id: "abc" }, "nope")).toBe("abc");
+  });
+});
+
+describe("worklistUpdatedAt", () => {
+  it("normalises a Date to ISO 8601", () => {
+    expect(worklistUpdatedAt(new Date("2026-03-04T05:06:07Z"))).toBe(
+      "2026-03-04T05:06:07.000Z"
+    );
+  });
+
+  it("answers an unusable value with an empty string, not a fabricated date", () => {
+    expect(worklistUpdatedAt(null)).toBe("");
+    expect(worklistUpdatedAt(undefined)).toBe("");
+  });
+});
+
+describe("byMostRecentlyUpdated", () => {
+  it("puts the most recently touched document first", () => {
+    const rows = [
+      row({ id: "old", updatedAt: "2026-01-01T00:00:00.000Z" }),
+      row({ id: "new", updatedAt: "2026-06-01T00:00:00.000Z" }),
+    ].sort(byMostRecentlyUpdated);
+    expect(rows.map(r => r.id)).toEqual(["new", "old"]);
+  });
+
+  it("sorts an unknown date LAST, never first", () => {
+    // An unknown date is not a fresh one. Sorting it first would let one
+    // collection with broken timestamps occupy every page of the list.
+    const rows = [
+      row({ id: "unknown", updatedAt: "" }),
+      row({ id: "dated", updatedAt: "2020-01-01T00:00:00.000Z" }),
+    ].sort(byMostRecentlyUpdated);
+    expect(rows.map(r => r.id)).toEqual(["dated", "unknown"]);
+  });
+});
+
+describe("planWorklistFanOut", () => {
+  const many = Array.from({ length: MAX_WORKLIST_COLLECTIONS + 3 }, (_, i) => ({
+    slug: `c${String(i).padStart(3, "0")}`,
+    label: `C${i}`,
+  }));
+
+  it("names what the cap excluded rather than dropping it", () => {
+    // A worklist that silently omits a collection reads as "nothing to do
+    // there" — indistinguishable from the truth at a glance.
+    const plan = planWorklistFanOut(many);
+    expect(plan.queried).toHaveLength(MAX_WORKLIST_COLLECTIONS);
+    expect(plan.skippedCollections).toEqual(["c020", "c021", "c022"]);
+  });
+
+  it("skips nothing when the site is under the cap", () => {
+    const plan = planWorklistFanOut(many.slice(0, 3));
+    expect(plan.queried).toHaveLength(3);
+    expect(plan.skippedCollections).toEqual([]);
+  });
+
+  it("gives the same answer for the same site whatever order it arrives in", () => {
+    // Otherwise two identical requests disagree about which collections were
+    // skipped, and the omission looks like a change in the content.
+    const forward = planWorklistFanOut(many, 5);
+    const shuffled = planWorklistFanOut([...many].reverse(), 5);
+    expect(shuffled.queried.map(c => c.slug)).toEqual(
+      forward.queried.map(c => c.slug)
+    );
+    expect(shuffled.skippedCollections).toEqual(forward.skippedCollections);
+  });
+});
+
+describe("translatedFilter", () => {
+  it("puts `_translated` at the TOP level, where the extractor reads it", () => {
+    // Nested inside `and` it is silently ignored, the query returns every
+    // entry, and the worklist reads as "nothing outstanding".
+    expect(translatedFilter("es", "missing")).toEqual({
+      _translated: { locale: "es", state: "missing" },
+    });
+  });
+});

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -4,6 +4,7 @@ import {
   MAX_WORKLIST_COLLECTIONS,
   byMostRecentlyUpdated,
   eligibleCollections,
+  notConsultedSources,
   planWorklistFanOut,
   translatedFilter,
   worklistId,
@@ -196,6 +197,35 @@ describe("planWorklistFanOut", () => {
       forward.queried.map(c => c.slug)
     );
     expect(shuffled.skippedCollections).toEqual(forward.skippedCollections);
+  });
+});
+
+describe("notConsultedSources", () => {
+  it("gathers every reason a collection went uncovered into one list", () => {
+    // A collection the cap never reached and one whose read FAILED make the
+    // same statement to a reader: this answer did not cover that collection.
+    expect(notConsultedSources(["pages"], ["posts"])).toEqual([
+      "pages",
+      "posts",
+    ]);
+  });
+
+  it("names a collection once even when both reasons apply", () => {
+    expect(notConsultedSources(["posts"], ["posts"])).toEqual(["posts"]);
+  });
+
+  it("describes the same site the same way whatever order it arrives in", () => {
+    // An order that varies between two identical requests reads as the content
+    // having changed.
+    expect(notConsultedSources(["zebra"], ["alpha"])).toEqual(
+      notConsultedSources(["alpha"], ["zebra"])
+    );
+  });
+
+  it("is empty when the answer covered everything", () => {
+    // The field's PRESENCE is the signal, so it must not appear as an empty
+    // list on a complete answer.
+    expect(notConsultedSources([], [])).toEqual([]);
   });
 });
 

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -200,6 +200,24 @@ export function planWorklistFanOut(
 }
 
 /**
+ * Everything this answer did not cover, named once and in one order.
+ *
+ * Two different reasons land here — a collection the fan-out cap never reached,
+ * and one whose read FAILED — and the screen makes the same statement about
+ * both: this answer did not cover that collection. Keeping them apart in the
+ * response would invite a caller to handle one and not the other, and the
+ * caller cannot act differently on them anyway.
+ *
+ * Sorted and de-duplicated so two identical requests describe the same site the
+ * same way; an order that varies reads as the content having changed.
+ */
+export function notConsultedSources(
+  ...groups: readonly (readonly string[])[]
+): string[] {
+  return [...new Set(groups.flat())].sort();
+}
+
+/**
  * The reserved filter the collection list already understands.
  *
  * Built here so the worklist and the entry table cannot come to disagree about

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -39,6 +39,7 @@
  * @module domains/i18n/services/translation-worklist-service
  */
 
+import { NextlyError } from "../../../errors/nextly-error";
 import { resolveLocalizedFieldNames } from "../classify-fields";
 import type { TranslationFilterState } from "../companion-join";
 
@@ -100,6 +101,33 @@ export function worklistTotal(
 }
 
 /**
+ * Whether a collection's reported count can be believed.
+ *
+ * `listEntries` runs the rows and the count as two queries and returns SUCCESS
+ * when the rows arrive, falling back to `totalDocs: 0` if the count failed. So
+ * a transient error on the count arm alone is indistinguishable from an empty
+ * collection by the flag — and taking the zero at face value hides the whole of
+ * that collection's backlog behind the handful of rows that did come back, with
+ * nothing in the response saying anything was missing. That is the
+ * truncation-as-census failure once more, arriving through the one path that
+ * still had a silent fallback.
+ *
+ * The contradiction is what gives it away, and it needs no new plumbing: a
+ * count is the number of rows MATCHING, so it can never be smaller than the
+ * rows returned. `totalDocs < docs.length` is therefore impossible for a count
+ * that ran, and certain for one that did not — whenever there were rows to
+ * contradict it, which is exactly the case where believing it would cost
+ * something. A failed count on a genuinely empty collection reports zero
+ * against zero rows and is both undetectable and harmless.
+ */
+export function countIsTrustworthy(
+  totalDocs: unknown,
+  rowCount: number
+): boolean {
+  return typeof totalDocs === "number" && totalDocs >= rowCount;
+}
+
+/**
  * How many pages the backlog would take, at this page size.
  *
  * Derived from `total` rather than stated beside it, because the two are one
@@ -156,6 +184,27 @@ export function authorizationGroups(
   slugs: readonly string[],
   concurrency: number = AUTHORIZATION_CONCURRENCY
 ): string[][] {
+  // A non-positive step never advances `i`, and a negative one walks it
+  // backwards: either spins forever on a non-empty list. Unreachable today —
+  // the only caller takes the default — which is precisely what makes the guard
+  // cheap: it reads two values already in hand and its branch never runs.
+  //
+  // It THROWS where `worklistTotalPages` returns a safe value for the same
+  // shape of bad input, and the difference is where the value comes from.
+  // `limit` is a request parameter, clamped upstream, so a caller can put a
+  // zero in front of it and refusing there would be a 500 for a request the
+  // system chose to accept. `concurrency` is a module constant no request can
+  // reach, so a bad one is a programming error — `INTERNAL_ERROR` is the honest
+  // classification, and the value travels in `logContext` where an operator can
+  // see it without it reaching the response.
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw NextlyError.internal({
+      logContext: {
+        concurrency,
+        reason: "authorization concurrency must be a positive integer",
+      },
+    });
+  }
   if (slugs.length === 0) return [];
   const groups: string[][] = [[slugs[0]]];
   const rest = slugs.slice(1);

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -1,0 +1,183 @@
+/**
+ * The translation worklist — one language's outstanding work, across every
+ * collection that has one.
+ *
+ * Everything below this already existed. A collection's list query accepts a
+ * reserved `_translated` filter and turns it into a companion `EXISTS` /
+ * `NOT EXISTS` condition (see `buildTranslationStatusCondition`), and the admin
+ * already offers that filter on a single collection's table. What nobody could
+ * ask is the question a translator actually has — *what needs me, anywhere?* —
+ * because every surface answers for one collection at a time.
+ *
+ * So this adds the fan-out and nothing else. The filter, the SQL, the state
+ * vocabulary and the access rules are the ones already in use; a second
+ * implementation of any of them would answer the same question differently
+ * depending on which screen asked it, which is the failure the whole R-11 lane
+ * exists to undo.
+ *
+ * ## Why the fan-out is here and not in the browser
+ *
+ * Each localized collection has its own table and its own companion table, so
+ * "one SQL query" is not available without a union over tables that are created
+ * at runtime. The fan-out is real either way; putting it on the server buys the
+ * three things that matter: one round-trip, a merge that happens before the
+ * slice (so the list can be ordered globally rather than per collection), and
+ * one place where access is decided.
+ *
+ * `getRecentEntries` on the dashboard established this shape, including the cap.
+ * This differs from it in one respect deliberately — see below.
+ *
+ * ## Access
+ *
+ * Rows come from `listEntries` with the caller's `user`, so the collection's
+ * stored read rules run per row. The dashboard filters at COLLECTION level
+ * instead, which is coarser than it looks: a role that may read a collection but
+ * only its own entries would have every other author's titles listed back to it.
+ * A worklist is a list of titles, so that distinction is the whole of its
+ * safety.
+ *
+ * @module domains/i18n/services/translation-worklist-service
+ */
+
+import type { TranslationFilterState } from "../companion-join";
+
+/**
+ * How many collections the fan-out will query.
+ *
+ * Matches the dashboard's cap, for the same reason: a site with a hundred
+ * collections would otherwise issue a hundred queries to draw one screen.
+ */
+export const MAX_WORKLIST_COLLECTIONS = 20;
+
+/** One document's outstanding work in one language. */
+export interface TranslationWorkRow {
+  /** The collection's slug, which is also how the row is opened. */
+  collection: string;
+  /** Its plural label, because the row is read by a person, not a route. */
+  collectionLabel: string;
+  id: string;
+  /** The document's title in the DEFAULT language — the thing being translated. */
+  title: string;
+  /** ISO 8601. The merge orders on this, so it is required rather than optional. */
+  updatedAt: string;
+}
+
+export interface TranslationWorklistResult {
+  rows: TranslationWorkRow[];
+  /**
+   * Collections the cap kept out of this answer, named rather than dropped.
+   *
+   * A worklist that silently omits a collection reads as "nothing to do there",
+   * which is the most reassuring possible way to be wrong — and indistinguishable
+   * from the truth at a glance. The caller is expected to say so on screen.
+   */
+  skippedCollections: string[];
+}
+
+/** What the fan-out needs to know about one collection to query it. */
+export interface LocalizedCollectionRef {
+  slug: string;
+  label: string;
+}
+
+/**
+ * A row's id as a string, or `""` when it is neither a string nor a number.
+ *
+ * Narrowed rather than `String(row.id)`: an id that arrived as an object would
+ * stringify to "[object Object]", which is a plausible-looking URL segment that
+ * addresses nothing. Empty is the honest answer, and the caller can see it.
+ */
+export function worklistId(row: Record<string, unknown>): string {
+  const id = row.id;
+  if (typeof id === "string") return id;
+  if (typeof id === "number") return String(id);
+  return "";
+}
+
+/**
+ * Read one document's title without inventing a rule for it.
+ *
+ * `useAsTitle` is the collection's own answer and is preferred wherever it is
+ * declared. The rest is the fallback the dashboard already uses, kept identical
+ * so one document cannot be called two different things on two screens. The id
+ * is the last resort and is never blank, so a row is always addressable even
+ * when nothing names it.
+ */
+export function worklistTitle(
+  row: Record<string, unknown>,
+  useAsTitle: string | undefined
+): string {
+  const candidates = [
+    useAsTitle === undefined ? undefined : row[useAsTitle],
+    row.title,
+    row.name,
+  ];
+  for (const value of candidates) {
+    if (typeof value === "string" && value.trim() !== "") return value;
+    if (typeof value === "number") return String(value);
+  }
+  return worklistId(row);
+}
+
+/** Normalise whatever the adapter returned for a timestamp into ISO 8601. */
+export function worklistUpdatedAt(value: unknown): string {
+  if (value instanceof Date) return value.toISOString();
+  if (typeof value === "string" && value.trim() !== "") return value;
+  return "";
+}
+
+/**
+ * Order the merged rows: most recently touched first.
+ *
+ * Sorted AFTER the merge rather than relying on each collection's own order,
+ * which is the point of doing the fan-out server-side. A row with no usable
+ * timestamp sorts last rather than first — an unknown date is not a fresh one,
+ * and putting it at the top would let a collection with broken timestamps
+ * dominate every page of the list.
+ */
+export function byMostRecentlyUpdated(
+  a: TranslationWorkRow,
+  b: TranslationWorkRow
+): number {
+  const at = Date.parse(a.updatedAt);
+  const bt = Date.parse(b.updatedAt);
+  const aOk = Number.isFinite(at);
+  const bOk = Number.isFinite(bt);
+  if (!aOk && !bOk) return 0;
+  if (!aOk) return 1;
+  if (!bOk) return -1;
+  return bt - at;
+}
+
+/**
+ * Which collections the fan-out will touch, and which the cap excluded.
+ *
+ * Ordered by slug before the cap applies, so the same site always yields the
+ * same answer. Taking whatever order the registry happened to return would make
+ * "which collections were skipped" vary between two identical requests.
+ */
+export function planWorklistFanOut(
+  localized: readonly LocalizedCollectionRef[],
+  max: number = MAX_WORKLIST_COLLECTIONS
+): { queried: LocalizedCollectionRef[]; skippedCollections: string[] } {
+  const ordered = [...localized].sort((a, b) => a.slug.localeCompare(b.slug));
+  return {
+    queried: ordered.slice(0, max),
+    skippedCollections: ordered.slice(max).map(c => c.slug),
+  };
+}
+
+/**
+ * The reserved filter the collection list already understands.
+ *
+ * Built here so the worklist and the entry table cannot come to disagree about
+ * its shape: the extractor reads `_translated` at the TOP level only, never
+ * nested inside `and`, and a filter written the other way is silently ignored
+ * — it would return every entry and read as "nothing outstanding".
+ */
+export function translatedFilter(
+  locale: string,
+  state: TranslationFilterState
+): Record<string, unknown> {
+  return { _translated: { locale, state } };
+}

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -39,6 +39,7 @@
  * @module domains/i18n/services/translation-worklist-service
  */
 
+import { resolveLocalizedFieldNames } from "../classify-fields";
 import type { TranslationFilterState } from "../companion-join";
 
 /**
@@ -48,6 +49,97 @@ import type { TranslationFilterState } from "../companion-join";
  * collections would otherwise issue a hundred queries to draw one screen.
  */
 export const MAX_WORKLIST_COLLECTIONS = 20;
+
+/**
+ * Whether a collection can actually answer a translation question.
+ *
+ * `localized: true` is the master switch, not the answer. A collection may hold
+ * it while every field on it is non-localizable — numbers only, or every text
+ * field explicitly `localized: false` — and no companion table is generated for
+ * such a collection.
+ *
+ * That matters because the reserved `_translated` filter then produces NO SQL
+ * condition (the companion is absent, so the builder returns `undefined`), and
+ * a filter that narrows nothing returns everything. Every document in the
+ * collection would be reported as outstanding work.
+ *
+ * The test is deliberately the SAME expression `buildCompanionSchema` evaluates
+ * before returning `null` — `resolveLocalizedFieldNames(...).length === 0`. Two
+ * rules that merely agree today would drift; one expression cannot.
+ */
+export function hasTranslatableFields(fields: readonly unknown[]): boolean {
+  return (
+    resolveLocalizedFieldNames(
+      fields as Parameters<typeof resolveLocalizedFieldNames>[0],
+      true
+    ).length > 0
+  );
+}
+
+/**
+ * How much outstanding work the fan-out FOUND, which is not how much it returned.
+ *
+ * Each collection is asked for at most `limit` rows, so counting the rows in
+ * hand caps the total at `limit` by construction: one collection holding
+ * fifty-one outstanding documents hands back fifty and would report fifty — a
+ * truncated backlog presented as a finished census, which is precisely the
+ * reassuring lie this endpoint exists to remove. The per-collection counts come
+ * from the same query's count arm, which applies the same `_translated`
+ * predicate as the rows, so they describe the real backlog.
+ *
+ * Floored at the number of rows returned. A count that fails falls back to zero
+ * inside the query service, and a total lower than the rows visible beside it is
+ * the one answer a reader cannot make sense of.
+ */
+export function worklistTotal(
+  perCollectionTotals: readonly number[],
+  rowCount: number
+): number {
+  const counted = perCollectionTotals.reduce((sum, n) => sum + n, 0);
+  return Math.max(counted, rowCount);
+}
+
+/**
+ * How many authorization decisions may be in flight at once.
+ *
+ * The cap above bounds QUERIES; this bounds the far cheaper decision that
+ * precedes them, and it exists for a different resource. `canReadEntity`
+ * resolves a session caller through `isSuperAdmin`, which is a per-user TTL
+ * cache: fired concurrently from a cold cache, every call misses before the
+ * first one populates it, so a site with a hundred localized collections opens
+ * a hundred simultaneous permission reads to answer one question a hundred
+ * times. Grouping them keeps the pool intact and lets the cache do its job.
+ */
+export const AUTHORIZATION_CONCURRENCY = 8;
+
+/**
+ * The order authorization decisions are taken in: one, then bounded groups.
+ *
+ * The lone first group is not a rounding artefact — it is the warm-up. The
+ * shared per-user caches (`isSuperAdmin`, and the role/permission reads behind
+ * it) are populated by whichever call resolves first, so letting one finish
+ * before the rest fan out converts N cold misses into one miss and N-1 hits.
+ * Fanning out immediately is what makes a cold cache expensive.
+ *
+ * Deliberately NOT a cap on how many collections are authorized. Every
+ * candidate still gets a decision, because a collection that is skipped without
+ * one cannot be safely named as unconsulted (naming it discloses that it
+ * exists) nor safely omitted (that is the silent "nothing to do there" this
+ * endpoint exists to prevent). What is bounded here is concurrency, which is
+ * the resource that actually breaks.
+ */
+export function authorizationGroups(
+  slugs: readonly string[],
+  concurrency: number = AUTHORIZATION_CONCURRENCY
+): string[][] {
+  if (slugs.length === 0) return [];
+  const groups: string[][] = [[slugs[0]]];
+  const rest = slugs.slice(1);
+  for (let i = 0; i < rest.length; i += concurrency) {
+    groups.push(rest.slice(i, i + concurrency));
+  }
+  return groups;
+}
 
 /** One document's outstanding work in one language. */
 export interface TranslationWorkRow {

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -100,6 +100,30 @@ export function worklistTotal(
 }
 
 /**
+ * How many pages the backlog would take, at this page size.
+ *
+ * Derived from `total` rather than stated beside it, because the two are one
+ * fact and a consumer checks them against each other. Saying `total: 100` next
+ * to `totalPages: 1` at `limit: 50` asserts that a hundred documents fit on one
+ * page of fifty — so a reader who believes the pair concludes the fifty rows in
+ * hand ARE the hundred, which is the truncation-as-census failure that summing
+ * the counts was meant to end, moved one field along.
+ *
+ * This endpoint still serves only the first page: it takes no `page`, and
+ * `hasNext` stays false so nothing requests a second and receives the first
+ * again. The pair is deliberate and says what is true — the backlog needs two
+ * pages, and this is page one of them, and there is no second page to ask for
+ * here. "More exists" and "here is how to get it" are different claims, and
+ * only the first one is ours to make.
+ *
+ * At least 1: a list with nothing in it is one empty page, not zero pages.
+ */
+export function worklistTotalPages(total: number, limit: number): number {
+  if (limit <= 0) return 1;
+  return Math.max(1, Math.ceil(total / limit));
+}
+
+/**
  * How many authorization decisions may be in flight at once.
  *
  * The cap above bounds QUERIES; this bounds the far cheaper decision that

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -78,6 +78,8 @@ export interface TranslationWorklistResult {
 export interface LocalizedCollectionRef {
   slug: string;
   label: string;
+  /** Whether it has the draft/published lifecycle at all. */
+  hasStatus: boolean;
 }
 
 /**
@@ -147,6 +149,36 @@ export function byMostRecentlyUpdated(
   if (!aOk) return 1;
   if (!bOk) return -1;
   return bt - at;
+}
+
+/**
+ * Which collections can honestly answer this question, before the cap sees them.
+ *
+ * Two exclusions, and both must happen BEFORE `planWorklistFanOut` rather than
+ * after.
+ *
+ * A collection the caller cannot read must not consume one of the capped slots.
+ * If it does, a readable collection further down the alphabet is pushed into
+ * `skippedCollections` — where its outstanding work is never queried, and where
+ * its slug is reported back to someone with no right to know it exists.
+ *
+ * And a lifecycle state is a question a statusless collection cannot answer:
+ * the companion condition is deliberately absent there, so the query returns
+ * EVERY document and the worklist presents all of them as being in the state
+ * that was asked for. Contributing nothing is the truthful answer; contributing
+ * everything is the worst available one.
+ */
+export function eligibleCollections<T extends LocalizedCollectionRef>(
+  localized: readonly T[],
+  state: TranslationFilterState,
+  readable: ReadonlySet<string> | undefined
+): T[] {
+  const wantsLifecycle = state === "draft" || state === "published";
+  return localized.filter(
+    c =>
+      (readable === undefined || readable.has(c.slug)) &&
+      (!wantsLifecycle || c.hasStatus)
+  );
 }
 
 /**

--- a/packages/nextly/src/route-handler/__tests__/route-parser.translations.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.translations.test.ts
@@ -1,0 +1,41 @@
+/**
+ * The translation worklist route.
+ *
+ * The language is a QUERY parameter rather than a path segment, so the route is
+ * bare. That is the thing worth pinning: an unmatched sub-path must not fall
+ * through to the list, or `/api/translations/es` would quietly serve the whole
+ * worklist while looking like it asked for one language — the same failure the
+ * webhook reveal-secret route guards against.
+ */
+import { describe, it, expect } from "vitest";
+
+import { parseRestRoute } from "../route-parser";
+
+describe("translation worklist route", () => {
+  it("parses the worklist read", () => {
+    expect(parseRestRoute(["translations"], "GET")).toMatchObject({
+      service: "translations",
+      operation: "list",
+      method: "getTranslationWorklist",
+    });
+  });
+
+  it("does not serve the worklist from a sub-path", () => {
+    // `/api/translations/es` reads as "the Spanish worklist" and is not a route
+    // this endpoint offers. Falling through would answer a question nobody
+    // asked, for every language.
+    expect(parseRestRoute(["translations", "es"], "GET")).not.toMatchObject({
+      method: "getTranslationWorklist",
+    });
+  });
+
+  it("is read-only", () => {
+    // Nothing here writes. A POST that parsed would reach a handler with no
+    // mutation behind it and answer 400 from the wrong layer.
+    for (const method of ["POST", "PATCH", "PUT", "DELETE"]) {
+      expect(parseRestRoute(["translations"], method)).not.toMatchObject({
+        method: "getTranslationWorklist",
+      });
+    }
+  });
+});

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2221,6 +2221,33 @@ function parseWebhookRoutes(
 // ============================================================================
 
 /**
+ * Parse the translation worklist route.
+ *
+ *   GET /api/translations → getTranslationWorklist
+ *
+ * GET-only and authenticated; the handler owns its own auth, and which rows come
+ * back is decided per row by each collection's read rules.
+ *
+ * Bare rather than nested under a language (`/translations/es`): the language is
+ * a filter over one list, not a different resource, and it travels as a query
+ * parameter beside the state and the limit it belongs with.
+ */
+function parseTranslationRoutes(
+  id: string | undefined,
+  httpMethod: string,
+  routeParams: Record<string, string>
+): ParsedRoute | null {
+  if (httpMethod !== "GET") return null;
+  if (id !== undefined) return null;
+  return {
+    service: "translations",
+    operation: "list",
+    method: "getTranslationWorklist",
+    routeParams,
+  };
+}
+
+/**
  * Parse dashboard-related routes.
  *
  *   GET /api/dashboard/stats          → getDashboardStats
@@ -2569,6 +2596,12 @@ export function parseRestRoute(
       httpMethod,
       routeParams
     );
+    if (result) return result;
+  }
+
+  // Handle the translation worklist
+  if (resource === "translations") {
+    const result = parseTranslationRoutes(id, httpMethod, routeParams);
     if (result) return result;
   }
 

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -346,6 +346,7 @@ const DIRECT_DISPATCH_SERVICES = new Set<string>([
   "previewUrl",
   "imageSizes",
   "dashboard",
+  "translations",
   "schema",
   "email",
 ]);

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -65,6 +65,7 @@ import {
   respondMutation,
 } from "./api/response-shapes";
 import { getSchemaJournal } from "./api/schema-journal";
+import { getTranslationWorklist } from "./api/translations";
 import {
   listWebhooks,
   getWebhookById,
@@ -477,6 +478,32 @@ async function handleDashboardRequest(
     default:
       return new Response(
         JSON.stringify({ error: "Unknown dashboard operation" }),
+        { status: 400, headers: { "Content-Type": "application/json" } }
+      );
+  }
+}
+
+// ============================================================================
+// Translations Direct Dispatch
+// ============================================================================
+
+/**
+ * Delegate a translation-worklist request to its handler.
+ *
+ * One method today. Kept as a switch rather than a direct call so a second
+ * read (a per-language count, say) lands beside it instead of growing another
+ * dispatch branch above.
+ */
+async function handleTranslationsRequest(
+  req: Request,
+  method: string
+): Promise<Response> {
+  switch (method) {
+    case "getTranslationWorklist":
+      return getTranslationWorklist(req);
+    default:
+      return new Response(
+        JSON.stringify({ error: "Unknown translations operation" }),
         { status: 400, headers: { "Content-Type": "application/json" } }
       );
   }
@@ -1040,6 +1067,14 @@ async function handleServiceRequest(
   // endpoints — no body to consume, but keeping consistent dispatch pattern.
   if (service === "dashboard") {
     return handleDashboardRequest(req, method);
+  }
+
+  // ==================== TRANSLATIONS DIRECT DISPATCH ====================
+  // Owns its auth (requireAuthentication) and is read-only, so it intercepts
+  // here for the same reason dashboard does: before `req.text()`, which a GET
+  // has no body for.
+  if (service === "translations") {
+    return handleTranslationsRequest(req, method);
   }
 
   // ==================== SCHEMA DIRECT DISPATCH (F10 PR 4) ====================


### PR DESCRIPTION
R-11 Direction **B1** — the translation worklist. Founder-approved design: [plans/2026-08-26-R-11-translation-workspace-design.md](../blob/main/plans/2026-08-26-R-11-translation-workspace-design.md).

This is the **server half only**. The admin route that consumes it follows separately.

## The gap

A translator's question is *"what needs me, anywhere, in my language?"* Every surface in the admin answers *"what is the state of **this** document?"* — `LanguagePanel`, `TranslationMode`, `TranslationProgress`, `LanguageDots`, all per-document. Five collections × forty entries × three languages is **six hundred openings** to locate a morning's work.

## Most of this already existed — and that changed the shape of the PR

Before building anything I went looking, because R-11's founding lesson is that the feature usually exists already. It does:

- `collection-query-service` has long accepted a reserved **`_translated`** filter and turns it into a companion `EXISTS` / `NOT EXISTS` via `buildTranslationStatusCondition`.
- The entry table **already offers that filter with a UI control** (`EntryTable.tsx:428`, missing/translated).

So "which Posts are missing Spanish?" is answerable today — one collection at a time. **The only thing missing was the fan-out.** This PR adds that and nothing else: the filter, the SQL and the four states are the ones already in use, because a worklist with a vocabulary of its own would describe the same document differently depending on which screen asked.

```
GET /api/translations?locale=es&state=missing&limit=50
```

## Access is the part worth reviewing hardest

Rows come from `listEntries` with the caller's own user, **roles included**, so each collection's stored read rules run per row. Both halves matter, and they fail in opposite directions:

- **Collection-level filtering only** — which is what `DashboardService.getRecentEntries` does, building raw SQL — would list every author's titles back to a role scoped to its own entries. A worklist *is* a list of titles, so that distinction is the whole of its safety.
- **Passing the id without the roles** fails the other way: `UserContext` carries `role`/`roles`, a role-based read rule matches on them, and an id-only context makes such a collection match nothing and **report itself fully translated**. Fail-closed, but silently, and reassuringly.

`requireAuthentication` already returns `roles`; `authenticatedRead` carries them through.

## No silent caps

The fan-out is capped at twenty collections — the dashboard's precedent — but the ones it left out are **named in the response body** rather than only `logger.warn`ed. A worklist that silently omits a collection reads as "nothing to do there", indistinguishable from the truth at a glance. The UI is expected to say so.

Ordering is likewise deliberate: the merge happens **before** the slice, which is the whole reason this runs on the server rather than the browser — the list is ordered across collections, not within each one. A row whose timestamp cannot be parsed sorts **last**, since an unknown date is not a fresh one and one collection with broken timestamps would otherwise occupy every page.

## `authenticatedRead`

Extracts the preamble every read endpoint repeats. The order in it carries a rule — the refusal is thrown *before* anything reads the request, so a handler cannot act on parameters it has not earned the right to see — and a copy that drifts by one line loses that while still looking right. `api/dashboard` predates it and keeps its own two copies; left alone rather than swept into a change about something else.

## Verification

**Break-verified each test individually** against the defect it guards, not the suite:

| break | fails |
| --- | --- |
| truthiness drops a `0`/numeric title | 1 |
| a blank `useAsTitle` wins over the key | 1 |
| unknown date sorts first | 1 |
| the cap drops the excluded silently | 1 |
| fan-out order not stabilised | 1 |
| `_translated` nested under `and` | 1 |
| `String()` the id (`"[object Object]"`) | 1 |
| sub-path falls through to the list | 1 |
| route not GET-only | 1 |

Each fails exactly its own test and nothing else.

**Controls run, not assumed:**
- *Test files silently not loading* — 36 non-integration test files on disk in the touched trees, **36 collected**. A green summary is a claim about what ran, not about what exists.
- *Pre-existing failures* — the 4 in `field-group-route-delegates.test.ts` were re-run on a clean `main` checkout and fail identically there. Not from this change.
- *fallow duplication* — first run reported `duplication_introduced: 1`. Reverting `routeHandler.ts` to `main` and re-auditing showed it persisted, which located it correctly: `translations.ts` against `dashboard.ts`, i.e. genuinely mine. Fixed by extracting `authenticatedRead` rather than suppressing.

Gates, exit codes read directly rather than through a pipe: build, check-types, lint, lint:design, comment-convention, changeset status all `0`; fallow **`verdict: pass`, 0 introduced** in every category.

## Sequencing

Coordinated with the jobs lane: their R-2 Task 8 will add a `jobs` arm to the same three shared files (`routeHandler.ts`, `route-parser.ts`, `dispatcher/types.ts`). All edits here are **additive arms** beside the existing `dashboard` one — nothing moved or renamed — and they will add theirs beside mine once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated translation worklist at `GET /api/translations`.
  * Supports locale, status, pagination, and result-limit filters.
  * Applies access permissions and collection visibility rules.
  * Combines and sorts translation entries by recent updates.
  * Reports collections that were not consulted in pagination metadata.
  * Added translation worklist support to REST routing.

* **Bug Fixes**
  * Standardized supported translation status filters.

* **Tests**
  * Added coverage for filtering, sorting, access rules, limits, routing, and data normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->