### PR TITLE
fix(changeset): close the frontmatter so a release plan can be built

### DIFF
--- a/.changeset/sqlite-says-what-actually-failed.md
+++ b/.changeset/sqlite-says-what-actually-failed.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 On SQLite, a failed database write is now reported as what actually went wrong,
 instead of occasionally being reported as a timeout.


### PR DESCRIPTION
**`main` currently fails `pnpm exec changeset status`.** Measured on a clean `main` checkout, not on a feature branch:

```
$ git rev-parse --abbrev-ref HEAD   # main, working tree clean
$ pnpm exec changeset status
🦋  error could not parse changeset - missing or invalid frontmatter.
EXIT 1
```

## The fault

`.changeset/sqlite-says-what-actually-failed.md` (from `aa88709fb`, #1267) has **two** structural problems, not one:

```
1: ---
2:            <- blank line where the first package should be
3: "@nextlyhq/adapter-drizzle": patch
   ...
   "@nextlyhq/ui": patch
              <- no closing --- anywhere in the file
   On SQLite, a failed database write is now reported as...
```

`grep -n "^---"` finds the delimiter **once**. The frontmatter is opened and never closed, so the package list runs straight into the prose.

I found the second fault only because removing the blank line **did not fix it** — `changeset status` still exited 1. Worth saying plainly, because "one stray blank line" was my first diagnosis and it was wrong.

## Why this is worth its own PR

- **It blocks releasing, not just merging.** A release plan cannot be built while any changeset is unparseable, so `version-packages` cannot run at all.
- **It fails a required gate on every open PR**, whether or not that PR touches a changeset — the check reads the merge ref, so the whole repository inherits it.
- **CI cannot show it.** It is not a test, so no suite reports it. It is visible only by running the command.

## Nothing semantic changed

| | on `main` | here |
| --- | --- | --- |
| packages named | 25 | 25 |
| release-note prose | — | **byte-identical** (`diff` clean) |

The blank line is removed and the closing `---` added. Both are what make the author's own words reachable; no package was added, removed or re-tiered, and no wording was touched. There is no decision of theirs being ratified here — the file simply cannot be parsed as written.

## Verification

```
before:  pnpm exec changeset status -> EXIT 1
after:   pnpm exec changeset status -> EXIT 0, "Packages to be bumped at patch: ..." (25)
```

Verified in a worktree with dependencies installed. A fresh `git worktree add` has no `node_modules`, and `changeset status` there reports `Command "changeset" not found` — which looks like a validation failure and is not one.

Owner notified: #1267's lane, via two other sessions, before this went up.