### PR TITLE
feat(nextly): run work later, reliably, as a named person

### DIFF
--- a/.changeset/jobs-run-later-as-someone.md
+++ b/.changeset/jobs-run-later-as-someone.md
@@ -1,0 +1,67 @@
+---
+
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+
+Nextly can now run work in the background — reliably, at a chosen time, and as
+a chosen person. This is the foundation the scheduled-publishing work needs, and
+it replaces the pattern where each feature that needed background work grew its
+own private runner.
+
+A job records what to run, when it may start, whose authority it runs with, and
+how many attempts it gets. It survives a restart, because it is a row in your
+database rather than something held in memory, and it works on PostgreSQL, MySQL
+and SQLite with nothing extra to install — no Redis, no separate queue service,
+nothing to run alongside your site.
+
+Two things it will not do, both deliberate.
+
+It will not run the same job twice. Whichever process picks a job up takes a
+short lease on it, and a second process that finds the same job simply leaves it
+alone. If the first process stalls long enough for the lease to lapse, another
+picks the job up — and the stalled one is then refused when it tries to record
+what it did, so a slow worker cannot overwrite the result of the one that
+replaced it.
+
+It will not quietly run as somebody more powerful. A job remembers who queued
+it, and it acts as that person, with their roles. If that account has since been
+deleted or deactivated, the job stops and says so rather than continuing with no
+identity — which would mean running with no access rules applied at all. It also
+never falls back to an administrator or a system account.
+
+Failures back off before trying again, and the wait is deliberately staggered.
+When one destination goes down, everything queued for it fails at the same
+moment; without staggering they would all retry at the same instant, and hit the
+recovering destination with the entire backlog at once, over and over. Retries
+are also capped, and a job that keeps failing eventually stops and records why.
+
+A run is time-boxed, so it finishes cleanly inside a scheduled task or a
+serverless function rather than being cut off partway. Anything it did not reach
+is still queued for the next run.
+
+Nothing is silently skipped. A job whose type no longer exists in your code is
+recorded with that reason rather than passed over — a queue that never drains
+looks exactly like an empty one, and this makes the difference visible.

--- a/.changeset/jobs-run-later-as-someone.md
+++ b/.changeset/jobs-run-later-as-someone.md
@@ -1,5 +1,4 @@
 ---
-
 "@nextlyhq/adapter-drizzle": patch
 "@nextlyhq/adapter-mysql": patch
 "@nextlyhq/adapter-postgres": patch
@@ -25,6 +24,7 @@
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch
 "@nextlyhq/ui": patch
+---
 
 Nextly can now run work in the background — reliably, at a chosen time, and as
 a chosen person. This is the foundation the scheduled-publishing work needs, and

--- a/.changeset/jobs-run-later-as-someone.md
+++ b/.changeset/jobs-run-later-as-someone.md
@@ -45,12 +45,19 @@ the first stalls long enough for the lease to lapse, another picks the job up �
 and the stalled one is then refused when it tries to record what it did, so a
 slow worker cannot overwrite the result of the one that replaced it.
 
-That is a guarantee about the RECORD, not about the work. A job whose handler
-runs longer than its lease can be picked up again while the first attempt is
-still going, and both will do whatever the handler does. Every durable queue
-works this way — it is not possible to promise otherwise once a job can touch
-something outside the database — so a handler should be written so that running
-it twice is harmless, and the lease should be set longer than the work takes.
+A job that is still being worked on holds on to its claim: the lease is extended
+while the handler runs, so ordinary long-running work does not get taken over
+part-way through.
+
+That is still a guarantee about the RECORD rather than about the work. If a
+process stalls or loses its connection, it stops extending the claim while
+whatever it was doing may still be in flight, and another process can pick the
+job up. Every durable queue works this way — it is not possible to promise
+otherwise once a job can touch something outside the database — so a handler
+should be written so that running it twice is harmless.
+
+Finished jobs are cleared out on a rolling window rather than kept forever, so a
+job that runs every few minutes does not fill the table with its own history.
 
 It will not quietly run as somebody more powerful. A job remembers who queued
 it, and it acts as that person, with their roles. If that account has since been

--- a/.changeset/jobs-run-later-as-someone.md
+++ b/.changeset/jobs-run-later-as-someone.md
@@ -39,12 +39,18 @@ nothing to run alongside your site.
 
 Two things it will not do, both deliberate.
 
-It will not run the same job twice. Whichever process picks a job up takes a
-short lease on it, and a second process that finds the same job simply leaves it
-alone. If the first process stalls long enough for the lease to lapse, another
-picks the job up — and the stalled one is then refused when it tries to record
-what it did, so a slow worker cannot overwrite the result of the one that
-replaced it.
+Two processes will not pick up the same job at the same moment. Whichever gets
+there first takes a short lease on it, and the other simply leaves it alone. If
+the first stalls long enough for the lease to lapse, another picks the job up —
+and the stalled one is then refused when it tries to record what it did, so a
+slow worker cannot overwrite the result of the one that replaced it.
+
+That is a guarantee about the RECORD, not about the work. A job whose handler
+runs longer than its lease can be picked up again while the first attempt is
+still going, and both will do whatever the handler does. Every durable queue
+works this way — it is not possible to promise otherwise once a job can touch
+something outside the database — so a handler should be written so that running
+it twice is harmless, and the lease should be set longer than the work takes.
 
 It will not quietly run as somebody more powerful. A job remembers who queued
 it, and it acts as that person, with their roles. If that account has since been

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -263,6 +263,35 @@ export function generateSqliteCoreTableStatements(): string[] {
       ON "nextly_release_members" ("scope_kind", "scope_slug", "entry_id", "locale")`,
     `CREATE INDEX IF NOT EXISTS "nextly_release_members_release_idx"
       ON "nextly_release_members" ("release_id")`,
+    // Background jobs. Columns match schemas/jobs/sqlite.ts.
+    `CREATE TABLE IF NOT EXISTS "nextly_jobs" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "slug" TEXT NOT NULL,
+      "input" TEXT,
+      "state" TEXT NOT NULL,
+      "run_at" INTEGER,
+      "run_as_user_id" TEXT,
+      "dedupe_key" TEXT,
+      "attempt_count" INTEGER NOT NULL DEFAULT 0,
+      "next_attempt_at" INTEGER,
+      "locked_by" TEXT,
+      "locked_until" INTEGER,
+      "last_error" TEXT,
+      "created_at" INTEGER NOT NULL,
+      "updated_at" INTEGER NOT NULL
+    )`,
+    // Separate statements for the reason the release indexes above are: SQLite
+    // skips a CREATE TABLE wholesale once the table exists, so an index folded
+    // into it would never appear on a database built by an earlier boot.
+    `CREATE INDEX IF NOT EXISTS "nextly_jobs_due_idx"
+      ON "nextly_jobs" ("state", "run_at")`,
+    // Nullable and unique: SQLite treats NULL as distinct from NULL, so jobs
+    // that name no dedupe key are never deduplicated, while a job that names
+    // one can be enqueued exactly once. That is what makes duplicate
+    // suppression a constraint rather than a read-then-write two writers can
+    // interleave with.
+    `CREATE UNIQUE INDEX IF NOT EXISTS "nextly_jobs_dedupe_idx"
+      ON "nextly_jobs" ("dedupe_key")`,
     // No REFERENCES to "email_providers": that table is not bootstrapped here,
     // and SQLite resolves a foreign key at insert time rather than at CREATE,
     // so declaring one would turn every recorded delivery into a failure on a

--- a/packages/nextly/src/domains/jobs/__tests__/job-backoff.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-backoff.test.ts
@@ -1,0 +1,103 @@
+/**
+ * When a failed attempt runs again, and when it stops running.
+ *
+ * @module domains/jobs/__tests__/job-backoff.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { BACKOFF_CAP_MS, BACKOFF_BASE_MS, nextAttempt } from "../job-backoff";
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+/** No jitter, so the exponential term is observable on its own. */
+const noJitter = () => 1;
+
+describe("nextAttempt", () => {
+  it("backs off exponentially while the budget lasts", () => {
+    const delay = (attemptCount: number): number => {
+      const result = nextAttempt({
+        attemptCount,
+        maxAttempts: 10,
+        now: NOW,
+        random: noJitter,
+      });
+      if (result.outcome !== "retry") throw new Error("expected a retry");
+      return result.at.getTime() - NOW.getTime();
+    };
+    expect(delay(1)).toBe(BACKOFF_BASE_MS);
+    expect(delay(2)).toBe(BACKOFF_BASE_MS * 2);
+    expect(delay(3)).toBe(BACKOFF_BASE_MS * 4);
+  });
+
+  it("gives up once the budget is spent", () => {
+    expect(
+      nextAttempt({
+        attemptCount: 3,
+        maxAttempts: 3,
+        now: NOW,
+        random: noJitter,
+      })
+    ).toEqual({ outcome: "failed" });
+  });
+
+  it("still retries on the attempt BEFORE the last", () => {
+    // The control for the case above. An implementation that always failed
+    // would satisfy it while making every job single-shot.
+    expect(
+      nextAttempt({
+        attemptCount: 2,
+        maxAttempts: 3,
+        now: NOW,
+        random: noJitter,
+      }).outcome
+    ).toBe("retry");
+  });
+
+  it("caps the delay instead of doubling without limit", () => {
+    // 2^40 milliseconds is longer than the universe has been running. Without a
+    // cap a job with a generous budget schedules its later attempts past any
+    // date the system can act on, which is indistinguishable from dropping it.
+    const result = nextAttempt({
+      attemptCount: 40,
+      maxAttempts: 50,
+      now: NOW,
+      random: noJitter,
+    });
+    if (result.outcome !== "retry") throw new Error("expected a retry");
+    expect(result.at.getTime() - NOW.getTime()).toBe(BACKOFF_CAP_MS);
+  });
+
+  it("spreads simultaneous failures instead of retrying them in lockstep", () => {
+    // The reason jitter is here rather than a plain doubling: when one
+    // downstream receiver goes down, EVERY delivery to it fails in the same
+    // pass. Without jitter all of them retry at the same instant, and keep
+    // doing so, so the recovering receiver is hit by the whole backlog at once
+    // — repeatedly. Webhooks is this runner's first consumer, so that is the
+    // ordinary case, not a hypothetical one.
+    const at = (r: number): number => {
+      const result = nextAttempt({
+        attemptCount: 4,
+        maxAttempts: 10,
+        now: NOW,
+        random: () => r,
+      });
+      if (result.outcome !== "retry") throw new Error("expected a retry");
+      return result.at.getTime();
+    };
+    expect(at(0)).toBeLessThan(at(1));
+  });
+
+  it("never schedules an attempt in the past, whatever the jitter", () => {
+    // A negative or zero delay would make the job immediately due again and
+    // spin the runner.
+    for (const r of [0, 0.5, 1]) {
+      const result = nextAttempt({
+        attemptCount: 1,
+        maxAttempts: 10,
+        now: NOW,
+        random: () => r,
+      });
+      if (result.outcome !== "retry") throw new Error("expected a retry");
+      expect(result.at.getTime()).toBeGreaterThan(NOW.getTime());
+    }
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The identity a job resolved must reach the calls it makes.
+ *
+ * `resolveRunAs` establishes WHO a job runs as, and fails closed when it
+ * cannot. None of that matters if the handler then reaches for an API that
+ * ignores it — and the Direct API does exactly that by default:
+ * `packages/nextly/AGENTS.md` states that `overrideAccess` defaults to `true`,
+ * a trusted server context, and that enforcing access needs `overrideAccess:
+ * false` PLUS a user.
+ *
+ * So a handler doing the obvious thing would run every scheduled operation
+ * with trusted-system authority while the identity sat unused in its context.
+ *
+ * @module domains/jobs/__tests__/job-content-api.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { createJobContentApi } from "../job-content-api";
+
+const user = { id: "u1", roles: ["editor"] };
+
+describe("createJobContentApi", () => {
+  it("binds the resolved user to every call, without the handler asking", () => {
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+      meta: {},
+    }));
+    const api = createJobContentApi(user, { find } as never);
+
+    void api.find({ collection: "posts" } as never);
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        overrideAccess: false,
+        user,
+      })
+    );
+  });
+
+  it("REFUSES a handler's attempt to re-enable the bypass", () => {
+    // The whole point. If a handler could pass `overrideAccess: true`, the
+    // binding would be a default rather than a guarantee, and the one call that
+    // forgot — or a helper that spread its own options last — would silently run
+    // with system authority.
+    const create = vi.fn(async (_args: Record<string, unknown>) => ({
+      item: {},
+    }));
+    const api = createJobContentApi(user, { create } as never);
+
+    void api.create({
+      collection: "posts",
+      data: {},
+      overrideAccess: true,
+    } as never);
+
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ overrideAccess: false, user })
+    );
+  });
+
+  it("runs as ANONYMOUS when the job carries no identity, never as the system", () => {
+    // A job queued without an identity acts as nobody. Nobody is not the
+    // system: leaving `overrideAccess` at its `true` default here would make
+    // the least-privileged case the most-privileged one.
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+      meta: {},
+    }));
+    const api = createJobContentApi(null, { find } as never);
+
+    void api.find({ collection: "posts" } as never);
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({ overrideAccess: false })
+    );
+    // `user` must be ABSENT, not present-and-undefined: a predicate testing
+    // presence reads the latter as "has a user, and it is nothing".
+    const passed = find.mock.lastCall?.[0] as
+      | Record<string, unknown>
+      | undefined;
+    expect(passed).toBeDefined();
+    expect("user" in (passed ?? {})).toBe(false);
+  });
+
+  it("passes the caller's own arguments through untouched", () => {
+    // The control: a wrapper that replaced the arguments would satisfy the
+    // cases above while making every call useless.
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+      meta: {},
+    }));
+    const api = createJobContentApi(user, { find } as never);
+
+    void api.find({
+      collection: "posts",
+      limit: 7,
+      sort: "-createdAt",
+    } as never);
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 7, sort: "-createdAt" })
+    );
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/job-registry.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-registry.test.ts
@@ -1,0 +1,77 @@
+/**
+ * The job type registry: what `defineJob` guarantees, and what the registry
+ * refuses.
+ *
+ * @module domains/jobs/__tests__/job-registry.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { JobRegistry, defineJob } from "../job-registry";
+
+const noop = async (): Promise<void> => {};
+
+describe("defineJob", () => {
+  it("defaults the retry budget rather than leaving it undefined", () => {
+    // A job with no declared budget must still be BOUNDED. An undefined budget
+    // would be read as "retry forever" by the runner, which is how a
+    // permanently failing job becomes an infinite loop.
+    expect(defineJob({ slug: "a", handler: noop }).retry.maxAttempts).toBe(5);
+  });
+
+  it("keeps an explicit retry budget", () => {
+    expect(
+      defineJob({ slug: "a", handler: noop, retry: { maxAttempts: 2 } }).retry
+        .maxAttempts
+    ).toBe(2);
+  });
+
+  it("refuses a budget below one attempt", () => {
+    // Zero attempts means the job can never run at all, which is silently
+    // indistinguishable from a job nobody enqueued.
+    expect(() =>
+      defineJob({ slug: "a", handler: noop, retry: { maxAttempts: 0 } })
+    ).toThrow(/at least one attempt/i);
+  });
+
+  it("refuses a slug that is empty or only whitespace", () => {
+    // The slug is the join between a stored row and the code that runs it. A
+    // blank one stores rows nothing can ever claim.
+    expect(() => defineJob({ slug: "", handler: noop })).toThrow(/slug/i);
+    expect(() => defineJob({ slug: "   ", handler: noop })).toThrow(/slug/i);
+  });
+});
+
+describe("JobRegistry", () => {
+  it("returns the definition registered under a slug", () => {
+    const registry = new JobRegistry();
+    const job = defineJob({ slug: "releases:apply", handler: noop });
+    registry.register(job);
+    expect(registry.get("releases:apply")).toBe(job);
+  });
+
+  it("REFUSES a second registration of one slug rather than replacing it", () => {
+    // Silently replacing would mean the job that runs depends on plugin load
+    // order, and the losing handler would never run with nothing to say so.
+    const registry = new JobRegistry();
+    registry.register(defineJob({ slug: "a", handler: noop }));
+    expect(() =>
+      registry.register(defineJob({ slug: "a", handler: noop }))
+    ).toThrow(/already registered/i);
+  });
+
+  it("returns undefined for a slug nobody registered", () => {
+    // The control for the case above: a registry that threw for everything
+    // would satisfy the refusal test while being useless.
+    expect(new JobRegistry().get("never-registered")).toBeUndefined();
+  });
+
+  it("lists registered slugs, so a runner can report an orphaned row", () => {
+    // A stored row whose slug no longer exists in code — a job type deleted
+    // while rows were still queued — must be reportable rather than silently
+    // skipped on every pass forever.
+    const registry = new JobRegistry();
+    registry.register(defineJob({ slug: "b", handler: noop }));
+    registry.register(defineJob({ slug: "a", handler: noop }));
+    expect(registry.slugs()).toEqual(["a", "b"]);
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-repository.integration.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-repository.integration.test.ts
@@ -219,4 +219,113 @@ describe.each(getConfiguredTestDialects())("JobsRepository (%s)", dialect => {
     });
     expect(wrote).toBe(true);
   });
+
+  it("does not let older not-yet-due rows crowd a runnable one out of the page", async () => {
+    // The head-of-line failure. If the due predicate is applied AFTER the
+    // database limits the page, a page filled with future-scheduled rows comes
+    // back, is filtered to nothing, and the runnable row behind them is never
+    // reached — on this pass or any later one, because the same rows fill the
+    // page every time.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+
+    for (let n = 0; n < 5; n++) {
+      await repo.enqueue({
+        slug: "test:future",
+        input: {},
+        runAt: new Date(NOW.getTime() + 3_600_000),
+        runAsUserId: null,
+        dedupeKey: null,
+        now: new Date(NOW.getTime() - 10_000 + n),
+      });
+    }
+    const { id: runnable } = await repo.enqueue({
+      slug: "test:now",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+
+    const due = await repo.findDue({ now: NOW, limit: 5 });
+    expect(due.map(j => j.id)).toContain(runnable);
+  });
+
+  it("does not report a job another runner currently holds", async () => {
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    const { id } = await repo.enqueue({
+      slug: "test:noop",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+    await repo.claim(id, "runner-a", NOW, 30_000);
+    expect(await repo.findDue({ now: NOW, limit: 10 })).toEqual([]);
+  });
+
+  it("frees a dedupe key once its job reaches a terminal state", async () => {
+    // Recurring work with a stable logical key — "apply release r1", a nightly
+    // sweep — must be enqueueable again after the previous run finished.
+    // Holding the key forever means the SECOND request is silently reported as
+    // a duplicate of a job that has already been and gone.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+
+    const first = await repo.enqueue({
+      slug: "releases:apply",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: "release:r1",
+      now: NOW,
+    });
+    await repo.claim(first.id, "runner-a", NOW, 30_000);
+    await repo.finalize({
+      id: first.id,
+      runnerId: "runner-a",
+      outcome: "done",
+      nextAttemptAt: null,
+      lastError: null,
+      now: NOW,
+    });
+
+    const second = await repo.enqueue({
+      slug: "releases:apply",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: "release:r1",
+      now: NOW,
+    });
+    expect(second.deduped).toBe(false);
+    expect(second.id).not.toBe(first.id);
+  });
+
+  it("still refuses a duplicate while the first job is STILL ACTIVE", async () => {
+    // The control for the case above: releasing the key on completion must not
+    // become releasing it always, or duplicate suppression stops working at all.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    await repo.enqueue({
+      slug: "releases:apply",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: "release:r2",
+      now: NOW,
+    });
+    const again = await repo.enqueue({
+      slug: "releases:apply",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: "release:r2",
+      now: NOW,
+    });
+    expect(again.deduped).toBe(true);
+  });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-repository.integration.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-repository.integration.test.ts
@@ -305,6 +305,82 @@ describe.each(getConfiguredTestDialects())("JobsRepository (%s)", dialect => {
     expect(second.id).not.toBe(first.id);
   });
 
+  it("removes finished rows older than the window, and only finished ones", async () => {
+    // Without this the table grows forever: a recurring workload writes one row
+    // per run and every finished row keeps its input and its error.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    const old = new Date(NOW.getTime() - 30 * 24 * 3_600_000);
+
+    const done = await repo.enqueue({
+      slug: "a",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: old,
+    });
+    await repo.claim(done.id, "r", old, 1_000);
+    await repo.finalize({
+      id: done.id,
+      runnerId: "r",
+      outcome: "done",
+      nextAttemptAt: null,
+      lastError: null,
+      now: old,
+    });
+
+    // Outstanding work of the same age must survive: it is not history.
+    await repo.enqueue({
+      slug: "b",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: old,
+    });
+
+    const removed = await repo.pruneTerminal(
+      new Date(NOW.getTime() - 7 * 24 * 3_600_000),
+      100
+    );
+    expect(removed).toBe(1);
+    expect(
+      (await repo.findDue({ now: NOW, limit: 10 })).map(j => j.slug)
+    ).toEqual(["b"]);
+  });
+
+  it("keeps a finished row that is still inside the window", async () => {
+    // The control: a prune that removed everything terminal would satisfy the
+    // case above while deleting a job that finished a minute ago.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    const recent = await repo.enqueue({
+      slug: "a",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+    await repo.claim(recent.id, "r", NOW, 1_000);
+    await repo.finalize({
+      id: recent.id,
+      runnerId: "r",
+      outcome: "done",
+      nextAttemptAt: null,
+      lastError: null,
+      now: NOW,
+    });
+
+    expect(
+      await repo.pruneTerminal(
+        new Date(NOW.getTime() - 7 * 24 * 3_600_000),
+        100
+      )
+    ).toBe(0);
+  });
+
   it("still refuses a duplicate while the first job is STILL ACTIVE", async () => {
     // The control for the case above: releasing the key on completion must not
     // become releasing it always, or duplicate suppression stops working at all.

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-repository.integration.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-repository.integration.test.ts
@@ -1,0 +1,222 @@
+/**
+ * The job store against a REAL database.
+ *
+ * Three things only an integration test can establish, all of them about
+ * behaviour the database owns rather than the code.
+ *
+ * First, that the table exists at all: it reaches a database through six
+ * separate registries, and a miss in any one of them still leaves every unit
+ * test passing. Booting a real instance and writing to it is what proves the
+ * wiring.
+ *
+ * Second, that duplicate suppression is a CONSTRAINT. `enqueue` deliberately
+ * does not read-then-write — two writers can interleave between the read and
+ * the write and both be told they won, which is a defect already filed against
+ * the Direct API. The rule is only real if the second INSERT is refused, and
+ * only a real index refuses it.
+ *
+ * Third, that the lease actually excludes. A claim that looks exclusive in a
+ * unit test with a mocked transaction proves nothing about two runners racing
+ * on a real one.
+ *
+ * Runs against whichever dialect the integration run configures; CI covers
+ * SQLite, Postgres and MySQL.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { JobsRepository } from "../jobs-repository";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: "posts",
+        status: true,
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+describe.each(getConfiguredTestDialects())("JobsRepository (%s)", dialect => {
+  it("stores a job and reads it back as due", async () => {
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+
+    const { id, deduped } = await repo.enqueue({
+      slug: "test:noop",
+      input: { hello: "world" },
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+
+    expect(deduped).toBe(false);
+    const due = await repo.findDue({ now: NOW, limit: 10 });
+    expect(due.map(j => j.id)).toEqual([id]);
+    expect(due[0]!.slug).toBe("test:noop");
+  });
+
+  it("does not report a job whose runAt is still in the future", async () => {
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    await repo.enqueue({
+      slug: "test:later",
+      input: {},
+      runAt: new Date(NOW.getTime() + 60_000),
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+    expect(await repo.findDue({ now: NOW, limit: 10 })).toEqual([]);
+  });
+
+  it("refuses a duplicate dedupe key AT THE DATABASE, and returns the row that won", async () => {
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+
+    const first = await repo.enqueue({
+      slug: "releases:apply",
+      input: { releaseId: "r1" },
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: "release:r1",
+      now: NOW,
+    });
+    const second = await repo.enqueue({
+      slug: "releases:apply",
+      input: { releaseId: "r1" },
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: "release:r1",
+      now: NOW,
+    });
+
+    expect(first.deduped).toBe(false);
+    expect(second.deduped).toBe(true);
+    // The SAME row, not a second one that happens to look alike.
+    expect(second.id).toBe(first.id);
+    expect(await repo.findDue({ now: NOW, limit: 10 })).toHaveLength(1);
+  });
+
+  it("still admits many jobs that name NO dedupe key", async () => {
+    // The other half of the nullable-unique rule, and the reason it must be
+    // asserted separately: making `dedupe_key` NOT NULL would make the test
+    // above pass and silently collapse every un-deduplicated job into one.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    for (const n of [1, 2, 3]) {
+      await repo.enqueue({
+        slug: `test:${n}`,
+        input: {},
+        runAt: null,
+        runAsUserId: null,
+        dedupeKey: null,
+        now: NOW,
+      });
+    }
+    expect(await repo.findDue({ now: NOW, limit: 10 })).toHaveLength(3);
+  });
+
+  it("lets only ONE of two concurrent runners claim a job", async () => {
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    const { id } = await repo.enqueue({
+      slug: "test:noop",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+
+    const [a, b] = await Promise.all([
+      repo.claim(id, "runner-a", NOW, 30_000),
+      repo.claim(id, "runner-b", NOW, 30_000),
+    ]);
+
+    expect([a, b].filter(row => row !== null)).toHaveLength(1);
+  });
+
+  it("refuses to record an outcome once the lease has been reclaimed", async () => {
+    // The fence. Runner A is slow, its lease expires, runner B takes the job
+    // over. A must NOT be able to write its stale outcome across B's work.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    const { id } = await repo.enqueue({
+      slug: "test:noop",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+
+    const claimed = await repo.claim(id, "runner-a", NOW, 1);
+    expect(claimed).not.toBeNull();
+
+    const later = new Date(NOW.getTime() + 10_000);
+    const reclaimed = await repo.claim(id, "runner-b", later, 30_000);
+    expect(reclaimed).not.toBeNull();
+
+    const wrote = await repo.finalize({
+      id,
+      runnerId: "runner-a",
+      outcome: "done",
+      nextAttemptAt: null,
+      lastError: null,
+      now: later,
+    });
+    expect(wrote).toBe(false);
+
+    // And the row still belongs to B, not to A's stale "done".
+    const stillHeld = await repo.findDue({ now: later, limit: 10 });
+    expect(stillHeld).toEqual([]);
+  });
+
+  it("lets the CURRENT lease holder record its outcome", async () => {
+    // The positive control for the fence above: if `finalize` returned false
+    // for everyone, the previous test would pass while the runner could never
+    // record anything at all.
+    const app = await boot(dialect);
+    const repo = new JobsRepository(app.adapter);
+    const { id } = await repo.enqueue({
+      slug: "test:noop",
+      input: {},
+      runAt: null,
+      runAsUserId: null,
+      dedupeKey: null,
+      now: NOW,
+    });
+    await repo.claim(id, "runner-a", NOW, 30_000);
+
+    const wrote = await repo.finalize({
+      id,
+      runnerId: "runner-a",
+      outcome: "done",
+      nextAttemptAt: null,
+      lastError: null,
+      now: NOW,
+    });
+    expect(wrote).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-runner.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-runner.test.ts
@@ -65,4 +65,35 @@ describe("databaseRunAs", () => {
     );
     await expect(deps.listRoleSlugs("u1")).rejects.toThrow(/unreachable/);
   });
+
+  it("returns the user's name and email, which the context needs to carry", async () => {
+    // resolveRunAs puts these on the reconstructed context because access
+    // predicates here inspect `user.email`. It can only carry what this lookup
+    // returns, so stopping at id/isActive made that handling unable to do
+    // anything at all.
+    const deps = databaseRunAs({
+      select: async () => [
+        { id: "u1", isActive: 1, name: "Ada", email: "ada@example.com" },
+      ],
+    });
+    await expect(deps.findUser("u1")).resolves.toEqual({
+      id: "u1",
+      isActive: true,
+      name: "Ada",
+      email: "ada@example.com",
+    });
+  });
+
+  it("omits attributes the row does not carry rather than setting them undefined", async () => {
+    // The control: spreading unconditionally would put `email: undefined` on
+    // the user, which reads as "has an email, and it is nothing" to a predicate
+    // testing presence.
+    const deps = databaseRunAs({
+      select: async () => [{ id: "u1", isActive: 1 }],
+    });
+    await expect(deps.findUser("u1")).resolves.toEqual({
+      id: "u1",
+      isActive: true,
+    });
+  });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-runner.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-runner.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The shared construction site, and the one read inside it that could fail
+ * silently.
+ *
+ * @module domains/jobs/__tests__/jobs-runner.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { databaseRunAs } from "../jobs-runner";
+
+describe("databaseRunAs", () => {
+  it("reads an active SQLite user, whose flag is 1 rather than true", async () => {
+    // SQLite has no boolean: `is_active` comes back as 0/1. A strict `=== true`
+    // would make every SQLite user look deactivated, and every job queued by
+    // one would fail with an identity error that is nothing to do with them.
+    const deps = databaseRunAs({
+      select: async () => [{ id: "u1", isActive: 1 }],
+    });
+    await expect(deps.findUser("u1")).resolves.toEqual({
+      id: "u1",
+      isActive: true,
+    });
+  });
+
+  it("reads a deactivated user as deactivated, not merely falsy-and-ignored", async () => {
+    // The control: an implementation that returned isActive: true for
+    // everything would satisfy the case above.
+    const deps = databaseRunAs({
+      select: async () => [{ id: "u1", isActive: 0 }],
+    });
+    await expect(deps.findUser("u1")).resolves.toEqual({
+      id: "u1",
+      isActive: false,
+    });
+  });
+
+  it("reports a missing user as null rather than inventing one", async () => {
+    const deps = databaseRunAs({ select: async () => [] });
+    await expect(deps.findUser("ghost")).resolves.toBeNull();
+  });
+
+  it("refuses a row that answered without an id, rather than building a context around undefined", async () => {
+    // The row is read back as an open record. Without narrowing, a users table
+    // that answered without an id would produce a UserContext whose id is
+    // undefined — and an access rule matching on it would compare against
+    // nothing, which fails open or closed depending on the rule and is
+    // unpredictable either way.
+    const deps = databaseRunAs({ select: async () => [{ isActive: 1 }] });
+    await expect(deps.findUser("u1")).resolves.toBeNull();
+  });
+
+  it("PROPAGATES a roles-lookup failure instead of resolving to no roles", async () => {
+    // The reason this uses listRoleSlugsForUserStrict and not
+    // listRoleSlugsForUser: the non-strict one catches its own errors and
+    // returns []. Here that is the worst available failure — the job would run
+    // with an empty role set, every role-gated collection would match nothing,
+    // and the job would report itself complete having done nothing. A thrown
+    // error becomes an ordinary retryable failure instead: a job that did not
+    // run, rather than one that silently did nothing and claimed success.
+    const deps = databaseRunAs(
+      { select: async () => [{ id: "u1", isActive: 1 }] },
+      async () => {
+        throw new Error("roles table unreachable");
+      }
+    );
+    await expect(deps.listRoleSlugs("u1")).rejects.toThrow(/unreachable/);
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/resolve-run-as.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/resolve-run-as.test.ts
@@ -88,4 +88,45 @@ describe("resolveRunAs", () => {
     expect(result.ok).toBe(false);
     expect(JSON.stringify(result)).not.toMatch(/system|admin|root/i);
   });
+
+  it("carries every attribute the user has, not just id and roles", async () => {
+    // Access predicates in this repository inspect `user.email`. A context
+    // missing it evaluates such a rule against `undefined` — which denies
+    // authorized work, or for a negative predicate like `email !== blocked`
+    // GRANTS work it should refuse. Either way the job is not running with the
+    // named person's authority, which is the whole point of resolving one.
+    const result = await resolveRunAs(
+      deps({
+        findUser: async () => ({
+          id: "u1",
+          isActive: true,
+          name: "Ada",
+          email: "ada@example.com",
+        }),
+        listRoleSlugs: async () => ["editor"],
+      }),
+      "u1"
+    );
+    expect(result).toEqual({
+      ok: true,
+      user: {
+        id: "u1",
+        roles: ["editor"],
+        name: "Ada",
+        email: "ada@example.com",
+      },
+    });
+  });
+
+  it("omits attributes the user does not have rather than setting them undefined", async () => {
+    // The control for the case above. Spreading unconditionally would put
+    // `email: undefined` on the context, which reads as "has an email, and it
+    // is nothing" to a predicate testing presence.
+    const result = await resolveRunAs(deps(), "u1");
+    expect(result).toEqual({ ok: true, user: { id: "u1", roles: [] } });
+    expect(Object.keys((result as { user: object }).user)).toEqual([
+      "id",
+      "roles",
+    ]);
+  });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/resolve-run-as.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/resolve-run-as.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Who a job runs as — and what happens when that person is gone.
+ *
+ * This is the access boundary of the whole domain. Every other failure in a job
+ * queue is a job that did not run; this one is a job that runs with the wrong
+ * authority, which is a different class of problem.
+ *
+ * @module domains/jobs/__tests__/resolve-run-as.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveRunAs, type RunAsDeps } from "../resolve-run-as";
+
+const deps = (over: Partial<RunAsDeps> = {}): RunAsDeps => ({
+  findUser: async () => ({ id: "u1", isActive: true }),
+  listRoleSlugs: async () => [],
+  ...over,
+});
+
+describe("resolveRunAs", () => {
+  it("distinguishes 'no identity was asked for' from 'the identity is gone'", async () => {
+    // THE test of this module. An implementation that returns "no user" for
+    // both cases passes every other assertion here and silently promotes a
+    // deleted author's job into an unauthenticated run — which applies no
+    // field rules at all.
+    const gone = deps({ findUser: async () => null });
+
+    await expect(resolveRunAs(gone, null)).resolves.toEqual({
+      ok: true,
+      user: null,
+    });
+    await expect(resolveRunAs(gone, "deleted-user")).resolves.toEqual({
+      ok: false,
+      reason: "JOB_IDENTITY_UNRESOLVABLE",
+    });
+  });
+
+  it("REFUSES a user who no longer resolves", async () => {
+    await expect(
+      resolveRunAs(deps({ findUser: async () => null }), "ghost")
+    ).resolves.toMatchObject({ ok: false });
+  });
+
+  it("REFUSES a user who has been deactivated", async () => {
+    // A deactivated account cannot sign in. A job continuing to act as one
+    // would be a way to keep using an authority that was deliberately withdrawn.
+    await expect(
+      resolveRunAs(
+        deps({ findUser: async () => ({ id: "u1", isActive: false }) }),
+        "u1"
+      )
+    ).resolves.toEqual({ ok: false, reason: "JOB_IDENTITY_DISABLED" });
+  });
+
+  it("carries the full role set, not just the id", async () => {
+    // Verified against UserContext (domains/singles/types.ts:21), whose own
+    // docblock says the route path forwards decoded roles precisely so stored
+    // role-based rules can match. An id-only context makes a role-gated
+    // collection match NOTHING and report itself complete — fail-closed, but
+    // SILENTLY, and "nothing to do" is indistinguishable from a correct answer.
+    const result = await resolveRunAs(
+      deps({ listRoleSlugs: async () => ["editor", "legal"] }),
+      "u1"
+    );
+    expect(result).toEqual({
+      ok: true,
+      user: { id: "u1", roles: ["editor", "legal"] },
+    });
+  });
+
+  it("resolves a user with no roles as ok, with an empty role set", async () => {
+    // The control for the case above: an implementation that refused whenever
+    // the role list was empty would satisfy it while breaking every job queued
+    // by a user who holds permissions directly rather than through a role.
+    await expect(resolveRunAs(deps(), "u1")).resolves.toEqual({
+      ok: true,
+      user: { id: "u1", roles: [] },
+    });
+  });
+
+  it("never reports a system principal as the resolved identity", async () => {
+    // Guards the failure mode the design forbids by name: falling back to a
+    // privileged principal when the stored one cannot be found.
+    const result = await resolveRunAs(
+      deps({ findUser: async () => null }),
+      "ghost"
+    );
+    expect(result.ok).toBe(false);
+    expect(JSON.stringify(result)).not.toMatch(/system|admin|root/i);
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
@@ -233,4 +233,52 @@ describe("runJobs", () => {
     expect(result.claimed).toBeGreaterThan(0);
     expect(result.claimed).toBeLessThan(50);
   });
+
+  it("records a transient identity-lookup FAILURE as a retryable attempt, not as an aborted pass", async () => {
+    // A failed lookup is not the same as a missing user. Letting it throw would
+    // abort the whole drain after the row was claimed: the row keeps its lease
+    // until expiry, the candidates behind it are never reached, and a
+    // persistent lookup failure on an early row aborts every scheduled pass
+    // rather than exhausting one job's budget.
+    const s = store([row({ runAsUserId: "u1", attemptCount: 0 })]);
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({ slug: "test:noop", handler: async () => {} })
+      ),
+      runAs: {
+        findUser: async () => {
+          throw new Error("rbac database unreachable");
+        },
+        listRoleSlugs: async () => [],
+      },
+      now: () => NOW,
+    });
+
+    expect(result).toMatchObject({ retried: 1, failed: 0 });
+    expect(s.finalized[0]).toMatchObject({
+      outcome: "retry",
+      lastError: expect.stringContaining("unreachable"),
+    });
+  });
+
+  it("does not count an outcome the fence refused to record", async () => {
+    // A lease reclaimed before finalization means the write did not land. It
+    // must be reported as unrecorded and NOT also as done, or the same attempt
+    // is counted twice and completed work is overstated.
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row()]),
+      finalize: async () => false,
+    };
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({ slug: "test:noop", handler: async () => {} })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+    });
+
+    expect(result).toMatchObject({ claimed: 1, unrecorded: 1, done: 0 });
+  });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
@@ -50,6 +50,7 @@ function store(rows: JobRow[]): JobsStore & { finalized: unknown[] } {
     },
     claim: async id => rows.find(r => r.id === id) ?? null,
     markAttempt: async () => {},
+    renewLease: async () => true,
     finalize: async input => {
       finalized.push(input);
       return true;
@@ -280,5 +281,70 @@ describe("runJobs", () => {
     });
 
     expect(result).toMatchObject({ claimed: 1, unrecorded: 1, done: 0 });
+  });
+
+  it("extends the lease while a handler is still working", async () => {
+    // The lease is otherwise a wall-clock guess about how long the work takes,
+    // and a handler that outruns it is reclaimed and run a second time
+    // CONCURRENTLY. The fence refuses the stale runner's write but cannot undo
+    // what it already did outside the database.
+    const renewals: string[] = [];
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row()]),
+      renewLease: async (_id, runnerId) => {
+        renewals.push(runnerId);
+        return true;
+      },
+    };
+
+    await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({
+          slug: "test:noop",
+          handler: async () => {
+            await new Promise(resolve => setTimeout(resolve, 40));
+          },
+        })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+      runnerId: "runner-a",
+      renewIntervalMs: 5,
+    });
+
+    expect(renewals.length).toBeGreaterThan(0);
+    expect(renewals.every(r => r === "runner-a")).toBe(true);
+  });
+
+  it("stops renewing once the lease is no longer this runner's", async () => {
+    // Continuing would issue writes that can never apply, against a job another
+    // runner has already taken over.
+    let calls = 0;
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row()]),
+      renewLease: async () => {
+        calls += 1;
+        return false;
+      },
+    };
+
+    await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({
+          slug: "test:noop",
+          handler: async () => {
+            await new Promise(resolve => setTimeout(resolve, 60));
+          },
+        })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+      renewIntervalMs: 5,
+    });
+
+    // One refusal is enough to stop it; without that check this would be ~12.
+    expect(calls).toBeLessThanOrEqual(2);
   });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
@@ -1,0 +1,236 @@
+/**
+ * One drain pass: what it runs, what it defers, and what it refuses.
+ *
+ * Driven against a fake store rather than a database. What is under test here
+ * is the DECISION sequence — claim, establish identity, run, record — and the
+ * repository's own guarantees (the lease, the fence, the unique index) are
+ * proved against a real database in `jobs-repository.integration.test.ts`.
+ *
+ * @module domains/jobs/__tests__/run-jobs.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import type { JobRow } from "../jobs-repository";
+import { JobRegistry, defineJob } from "../job-registry";
+import type { RunAsDeps } from "../resolve-run-as";
+import { runJobs, type JobsStore } from "../run-jobs";
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+function row(over: Partial<JobRow> = {}): JobRow {
+  return {
+    id: "j1",
+    slug: "test:noop",
+    input: { n: 1 },
+    state: "pending",
+    runAt: null,
+    runAsUserId: null,
+    dedupeKey: null,
+    attemptCount: 0,
+    nextAttemptAt: null,
+    lockedBy: null,
+    lockedUntil: null,
+    lastError: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...over,
+  };
+}
+
+/** A store that hands out each row once, so a pass cannot loop forever. */
+function store(rows: JobRow[]): JobsStore & { finalized: unknown[] } {
+  let handed = false;
+  const finalized: unknown[] = [];
+  return {
+    finalized,
+    findDue: async () => {
+      if (handed) return [];
+      handed = true;
+      return rows;
+    },
+    claim: async id => rows.find(r => r.id === id) ?? null,
+    markAttempt: async () => {},
+    finalize: async input => {
+      finalized.push(input);
+      return true;
+    },
+  };
+}
+
+const runAs = (over: Partial<RunAsDeps> = {}): RunAsDeps => ({
+  findUser: async () => ({ id: "u1", isActive: true }),
+  listRoleSlugs: async () => ["editor"],
+  ...over,
+});
+
+function registryWith(...defs: ReturnType<typeof defineJob>[]): JobRegistry {
+  const registry = new JobRegistry();
+  for (const d of defs) registry.register(d);
+  return registry;
+}
+
+describe("runJobs", () => {
+  it("runs a due job and records it done", async () => {
+    const handler = vi.fn(async () => {});
+    const s = store([row()]);
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(defineJob({ slug: "test:noop", handler })),
+      runAs: runAs(),
+      now: () => NOW,
+    });
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      claimed: 1,
+      done: 1,
+      failed: 0,
+      retried: 0,
+    });
+    expect(s.finalized).toEqual([expect.objectContaining({ outcome: "done" })]);
+  });
+
+  it("hands the handler the RESOLVED identity, roles included", async () => {
+    // The reason resolve-run-as exists at all: the handler must act as the
+    // person, so the context it receives has to be the full one.
+    let seen: unknown;
+    const s = store([row({ runAsUserId: "u1" })]);
+    await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({
+          slug: "test:noop",
+          handler: async (_input, ctx) => {
+            seen = ctx.user;
+          },
+        })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+    });
+    expect(seen).toEqual({ id: "u1", roles: ["editor"] });
+  });
+
+  it("fails a job whose identity is gone TERMINALLY, never retrying it", async () => {
+    // Retrying cannot help — a deleted user does not come back next pass — and
+    // retrying would also keep an unrunnable row cycling forever.
+    const handler = vi.fn(async () => {});
+    const s = store([row({ runAsUserId: "ghost" })]);
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(defineJob({ slug: "test:noop", handler })),
+      runAs: runAs({ findUser: async () => null }),
+      now: () => NOW,
+    });
+    expect(handler).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ failed: 1, retried: 0 });
+    expect(s.finalized).toEqual([
+      expect.objectContaining({
+        outcome: "failed",
+        lastError: "JOB_IDENTITY_UNRESOLVABLE",
+      }),
+    ]);
+  });
+
+  it("retries a handler that throws while its budget lasts", async () => {
+    const s = store([row({ attemptCount: 0 })]);
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({
+          slug: "test:noop",
+          handler: async () => {
+            throw new Error("receiver down");
+          },
+          retry: { maxAttempts: 3 },
+        })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+    });
+    expect(result).toMatchObject({ retried: 1, failed: 0 });
+    expect(s.finalized[0]).toMatchObject({ outcome: "retry" });
+  });
+
+  it("fails a handler that throws once its budget is spent", async () => {
+    // The control for the case above: an implementation that always retried
+    // would satisfy it while never giving up on anything.
+    const s = store([row({ attemptCount: 2 })]);
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({
+          slug: "test:noop",
+          handler: async () => {
+            throw new Error("still down");
+          },
+          retry: { maxAttempts: 3 },
+        })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+    });
+    expect(result).toMatchObject({ failed: 1, retried: 0 });
+  });
+
+  it("records a row whose job type no longer exists instead of skipping it", async () => {
+    // A slug deleted from the code while rows were still queued. Skipping it
+    // silently means the row is passed over on every drain forever, and a queue
+    // that never drains looks exactly like an empty one. Treated as a normal
+    // failure so a temporary deploy skew recovers on a later pass, while a
+    // genuinely deleted type gives up when its budget runs out and says why.
+    const s = store([row({ slug: "gone:type", attemptCount: 0 })]);
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({ slug: "test:noop", handler: async () => {} })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+    });
+    expect(result.claimed).toBe(1);
+    expect(s.finalized[0]).toMatchObject({
+      lastError: expect.stringContaining("gone:type"),
+    });
+  });
+
+  it("does not count a job another runner claimed first", async () => {
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row()]),
+      claim: async () => null,
+    };
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({ slug: "test:noop", handler: async () => {} })
+      ),
+      runAs: runAs(),
+      now: () => NOW,
+    });
+    expect(result).toMatchObject({ claimed: 0, done: 0 });
+  });
+
+  it("stops claiming once the wall-clock budget is spent", async () => {
+    // A serverless cron tick is killed by its platform at a fixed limit. The
+    // pass has to return before that on its own; the rows it did not reach are
+    // durable and the next tick continues.
+    let clock = NOW.getTime();
+    const rows = Array.from({ length: 50 }, (_, i) => row({ id: `j${i}` }));
+    const s = store(rows);
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({
+          slug: "test:noop",
+          handler: async () => {
+            clock += 10_000;
+          },
+        })
+      ),
+      runAs: runAs(),
+      now: () => new Date(clock),
+      maxDurationMs: 25_000,
+    });
+    expect(result.claimed).toBeGreaterThan(0);
+    expect(result.claimed).toBeLessThan(50);
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
@@ -49,7 +49,7 @@ function store(rows: JobRow[]): JobsStore & { finalized: unknown[] } {
       return rows;
     },
     claim: async id => rows.find(r => r.id === id) ?? null,
-    markAttempt: async () => {},
+    markAttempt: async () => true,
     renewLease: async () => true,
     finalize: async input => {
       finalized.push(input);
@@ -57,6 +57,21 @@ function store(rows: JobRow[]): JobsStore & { finalized: unknown[] } {
     },
   };
 }
+
+/**
+ * A content API that refuses to be called.
+ *
+ * These cases do not exercise content operations, and a silent no-op would let
+ * one start using it without saying so — the assertion would then pass against
+ * a handler whose reads returned nothing.
+ */
+const noContentApi = new Proxy({} as never, {
+  get: (_target, name) => () => {
+    throw new Error(
+      `content.${String(name)} called by a test that does not stub it`
+    );
+  },
+});
 
 const runAs = (over: Partial<RunAsDeps> = {}): RunAsDeps => ({
   findUser: async () => ({ id: "u1", isActive: true }),
@@ -78,6 +93,7 @@ describe("runJobs", () => {
       store: s,
       registry: registryWith(defineJob({ slug: "test:noop", handler })),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
     });
     expect(handler).toHaveBeenCalledTimes(1);
@@ -106,6 +122,7 @@ describe("runJobs", () => {
         })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
     });
     expect(seen).toEqual({ id: "u1", roles: ["editor"] });
@@ -120,6 +137,7 @@ describe("runJobs", () => {
       store: s,
       registry: registryWith(defineJob({ slug: "test:noop", handler })),
       runAs: runAs({ findUser: async () => null }),
+      contentApi: noContentApi,
       now: () => NOW,
     });
     expect(handler).not.toHaveBeenCalled();
@@ -146,6 +164,7 @@ describe("runJobs", () => {
         })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
     });
     expect(result).toMatchObject({ retried: 1, failed: 0 });
@@ -168,6 +187,7 @@ describe("runJobs", () => {
         })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
     });
     expect(result).toMatchObject({ failed: 1, retried: 0 });
@@ -186,10 +206,12 @@ describe("runJobs", () => {
         defineJob({ slug: "test:noop", handler: async () => {} })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
     });
     expect(result.claimed).toBe(1);
     expect(s.finalized[0]).toMatchObject({
+      outcome: "retry",
       lastError: expect.stringContaining("gone:type"),
     });
   });
@@ -205,6 +227,7 @@ describe("runJobs", () => {
         defineJob({ slug: "test:noop", handler: async () => {} })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
     });
     expect(result).toMatchObject({ claimed: 0, done: 0 });
@@ -228,6 +251,7 @@ describe("runJobs", () => {
         })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => new Date(clock),
       maxDurationMs: 25_000,
     });
@@ -253,6 +277,7 @@ describe("runJobs", () => {
         },
         listRoleSlugs: async () => [],
       },
+      contentApi: noContentApi,
       now: () => NOW,
     });
 
@@ -277,6 +302,7 @@ describe("runJobs", () => {
         defineJob({ slug: "test:noop", handler: async () => {} })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
     });
 
@@ -308,6 +334,7 @@ describe("runJobs", () => {
         })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
       runnerId: "runner-a",
       renewIntervalMs: 5,
@@ -340,11 +367,95 @@ describe("runJobs", () => {
         })
       ),
       runAs: runAs(),
+      contentApi: noContentApi,
       now: () => NOW,
       renewIntervalMs: 5,
     });
 
     // One refusal is enough to stop it; without that check this would be ~12.
     expect(calls).toBeLessThanOrEqual(2);
+  });
+
+  it("hands the handler a content client already bound to the resolved user", async () => {
+    // The identity is only real if it reaches the CALLS. The Direct API
+    // defaults to overrideAccess: true, so a handler importing `nextly`
+    // directly would run every scheduled operation with trusted-system
+    // authority while the resolved user sat unused in its context.
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+    }));
+    await runJobs({
+      store: store([row({ runAsUserId: "u1" })]),
+      registry: registryWith(
+        defineJob({
+          slug: "test:noop",
+          handler: async (_input, ctx) => {
+            await ctx.content.find({ collection: "posts" } as never);
+          },
+        })
+      ),
+      runAs: runAs(),
+      contentApi: { find } as never,
+      now: () => NOW,
+    });
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        overrideAccess: false,
+        user: { id: "u1", roles: ["editor"] },
+      })
+    );
+  });
+
+  it("does NOT run the handler when the attempt fence says the lease is gone", async () => {
+    // markAttempt is fenced on locked_by, so `false` means a successor took the
+    // job between the claim and that write. Running the handler anyway would do
+    // the work twice — and the finalize fence would refuse to record it either
+    // way, so the second run would be invisible as well as duplicated.
+    const handler = vi.fn(async () => {});
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row()]),
+      markAttempt: async () => false,
+    };
+
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(defineJob({ slug: "test:noop", handler })),
+      runAs: runAs(),
+      contentApi: noContentApi,
+      now: () => NOW,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(s.finalized).toEqual([]);
+    expect(result).toMatchObject({ claimed: 1, unrecorded: 1, done: 0 });
+  });
+
+  it("does NOT charge an attempt for a slug this instance does not know", async () => {
+    // A rolling deployment leaves old instances without a type the new ones
+    // already enqueue. If that costs the job an attempt, the old workers can
+    // exhaust its budget before a new one gets a turn — and the job fails
+    // permanently for a reason that had already fixed itself.
+    const marked: number[] = [];
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row({ slug: "gone:type", attemptCount: 0 })]),
+      markAttempt: async (_id, _runner, attemptCount) => {
+        marked.push(attemptCount);
+        return true;
+      },
+    };
+
+    await runJobs({
+      store: s,
+      registry: registryWith(
+        defineJob({ slug: "test:noop", handler: async () => {} })
+      ),
+      runAs: runAs(),
+      contentApi: noContentApi,
+      now: () => NOW,
+    });
+
+    expect(marked).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/jobs/index.ts
+++ b/packages/nextly/src/domains/jobs/index.ts
@@ -1,0 +1,50 @@
+/**
+ * Background jobs — domain surface.
+ *
+ * @module domains/jobs
+ */
+
+export {
+  DEFAULT_MAX_ATTEMPTS,
+  JobRegistry,
+  defineJob,
+  type JobContext,
+  type JobDefinition,
+  type JobDefinitionInput,
+  type JobRetryPolicy,
+} from "./job-registry";
+export {
+  BACKOFF_BASE_MS,
+  BACKOFF_CAP_MS,
+  nextAttempt,
+  type NextAttempt,
+} from "./job-backoff";
+export {
+  JobsRepository,
+  type EnqueueResult,
+  type FinalizeInput,
+  type FinalizeOutcome,
+  type JobRow,
+  type JobsDatabase,
+  type NewJob,
+} from "./jobs-repository";
+export {
+  resolveRunAs,
+  type RunAsDeps,
+  type RunAsRefusal,
+  type RunAsResult,
+  type RunAsUser,
+} from "./resolve-run-as";
+export {
+  DEFAULT_BATCH_SIZE,
+  DEFAULT_MAX_DURATION_MS,
+  runJobs,
+  type JobsStore,
+  type RunJobsDeps,
+  type RunJobsResult,
+} from "./run-jobs";
+export {
+  databaseRunAs,
+  runJobsPass,
+  type RunJobsPassOptions,
+} from "./jobs-runner";

--- a/packages/nextly/src/domains/jobs/job-backoff.ts
+++ b/packages/nextly/src/domains/jobs/job-backoff.ts
@@ -1,0 +1,78 @@
+/**
+ * How long to wait before running a failed job again, and when to stop.
+ *
+ * Pure: it takes the attempt count and the clock and returns a decision. The
+ * runner applies it. Keeping it separate is what makes "does a job give up?"
+ * answerable without a database.
+ *
+ * ## Why the delay is jittered rather than a plain doubling
+ *
+ * When one downstream dependency fails, everything queued against it fails in
+ * the SAME pass. A plain exponential schedules every one of those retries for
+ * the same instant, so the recovering dependency is hit by the entire backlog
+ * at once — and, because they all fail together again, at every subsequent
+ * step too. Webhook delivery is this runner's first consumer, so a receiver
+ * going down and taking hundreds of deliveries with it is the ordinary case.
+ *
+ * Equal jitter — half the computed delay, plus a random amount up to the other
+ * half — spreads the herd while keeping a meaningful floor. Full jitter
+ * (random across the entire window) spreads better but can retry almost
+ * immediately, which for a receiver that is still down means spending the
+ * retry budget during the outage.
+ *
+ * `random` is injected rather than calling `Math.random()` directly so the
+ * schedule is observable in a test. A jitter that cannot be pinned is a jitter
+ * nobody can prove is applied.
+ *
+ * @module domains/jobs/job-backoff
+ */
+
+/** The delay before the first retry, and the base the doubling starts from. */
+export const BACKOFF_BASE_MS = 1_000;
+
+/**
+ * The longest a retry is ever deferred.
+ *
+ * Without a cap the doubling passes any date the system can act on — 2^40
+ * milliseconds is longer than the universe has been running — and a job
+ * scheduled past that point is indistinguishable from one that was dropped.
+ */
+export const BACKOFF_CAP_MS = 60 * 60 * 1_000;
+
+export type NextAttempt =
+  | { outcome: "retry"; at: Date }
+  | { outcome: "failed" };
+
+export interface NextAttemptInput {
+  /** Attempts already made, INCLUDING the one that just failed. */
+  attemptCount: number;
+  maxAttempts: number;
+  now: Date;
+  /** Returns [0, 1]. Injected for determinism in tests. */
+  random?: () => number;
+}
+
+/**
+ * Whether to run this job again, and when.
+ *
+ * `attemptCount` counts the attempt that just failed, so a job whose budget is
+ * three attempts gives up when the third one fails — not after a fourth.
+ */
+export function nextAttempt(input: NextAttemptInput): NextAttempt {
+  if (input.attemptCount >= input.maxAttempts) return { outcome: "failed" };
+
+  const random = input.random ?? Math.random;
+  const exponential = BACKOFF_BASE_MS * 2 ** (input.attemptCount - 1);
+  const capped = Math.min(exponential, BACKOFF_CAP_MS);
+
+  // Equal jitter: half the window is guaranteed, the rest is spread.
+  const half = capped / 2;
+  const delay = half + random() * half;
+
+  // Round UP so the delay can never floor to zero and make the job instantly
+  // due again, which would spin the runner instead of deferring it.
+  return {
+    outcome: "retry",
+    at: new Date(input.now.getTime() + Math.ceil(delay)),
+  };
+}

--- a/packages/nextly/src/domains/jobs/job-content-api.ts
+++ b/packages/nextly/src/domains/jobs/job-content-api.ts
@@ -1,0 +1,99 @@
+/**
+ * The Direct API, bound to the identity a job resolved.
+ *
+ * ## The hole this closes
+ *
+ * `resolveRunAs` establishes who a job runs as and fails closed when it cannot.
+ * None of that reaches the work unless the calls the handler makes carry it —
+ * and by default they do not. `packages/nextly/AGENTS.md` states it plainly:
+ *
+ * > `overrideAccess` defaults to `true` (trusted server context). Enforcing
+ * > access control requires `overrideAccess: false` plus a `user`.
+ *
+ * So a handler doing the obvious thing — importing `nextly` and calling
+ * `find` — runs every scheduled operation with trusted-system authority while
+ * the carefully resolved identity sits unused in its context. The identity
+ * design would be decorative.
+ *
+ * ## Why binding rather than documenting
+ *
+ * "Remember to pass `{ overrideAccess: false, user }` on every call" is a rule
+ * that holds until the first call that forgets, and a forgotten one does not
+ * fail — it succeeds with MORE authority. A guarantee that degrades silently
+ * toward privilege is not a guarantee.
+ *
+ * ## Why the bypass cannot be re-enabled through this client
+ *
+ * A handler passing `overrideAccess: true` is ignored. If it were honoured the
+ * binding would be a default rather than a guarantee, and any helper that
+ * spread its own options last would quietly restore system authority.
+ *
+ * A job that genuinely needs trusted access imports `nextly` directly. That is
+ * then a visible, deliberate line in the handler rather than an invisible
+ * default — which is the whole difference.
+ *
+ * ## Why no identity means ANONYMOUS, not system
+ *
+ * A job queued without an identity acts as nobody. Nobody is not the system:
+ * leaving `overrideAccess` at its `true` default for that case would make the
+ * least-privileged job the most-privileged one.
+ *
+ * @module domains/jobs/job-content-api
+ */
+
+import type { UserContext } from "../collections/services/collection-types";
+
+/**
+ * The content operations a job is expected to reach for.
+ *
+ * Deliberately not the whole Direct API. Authentication and account operations
+ * take their own identity arguments and mean something different inside a
+ * background job; binding them here would imply a job can log somebody in.
+ */
+const BOUND_OPERATIONS = [
+  "find",
+  "findByID",
+  "create",
+  "update",
+  "delete",
+  "count",
+  "duplicate",
+  "findSingle",
+  "updateSingle",
+  "findSingles",
+] as const;
+
+export type BoundOperation = (typeof BOUND_OPERATIONS)[number];
+
+/** The subset of the Direct API this binds, in its own shape. */
+export type JobContentApi = {
+  [K in BoundOperation]: (args: never) => Promise<unknown>;
+};
+
+/**
+ * Wrap `source` so every bound call carries this job's identity.
+ *
+ * `source` is the Direct API. Injected rather than imported so the binding can
+ * be tested without booting a runtime — the one property worth exercising
+ * exhaustively is what reaches the call, and that is observable only from here.
+ */
+export function createJobContentApi(
+  user: UserContext | null,
+  source: Record<BoundOperation, (args: never) => Promise<unknown>>
+): JobContentApi {
+  const bound = {} as JobContentApi;
+  for (const name of BOUND_OPERATIONS) {
+    bound[name] = (args: never) => {
+      const caller = (args ?? {}) as Record<string, unknown>;
+      return source[name]({
+        ...caller,
+        // Applied AFTER the caller's own arguments, so neither an explicit
+        // `overrideAccess: true` nor a spread that lands last can restore the
+        // bypass.
+        overrideAccess: false,
+        ...(user === null ? {} : { user }),
+      } as never);
+    };
+  }
+  return bound;
+}

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -28,6 +28,17 @@ import type { UserContext } from "../collections/services/collection-types";
 /** Attempts a job gets before it is given up on. */
 export const DEFAULT_MAX_ATTEMPTS = 5;
 
+/**
+ * The longest slug every supported dialect can store.
+ *
+ * MySQL holds the slug in `varchar(191)` — the widest utf8mb4 value it will
+ * index — while PostgreSQL and SQLite use unbounded text. Validating here means
+ * a slug that is too long is refused when the job type is DEFINED, on every
+ * dialect, rather than accepted at definition and failing only at enqueue time
+ * and only on MySQL.
+ */
+export const MAX_JOB_SLUG_LENGTH = 191;
+
 /** What a handler is told about the run it is in. */
 export interface JobContext {
   /**
@@ -78,6 +89,13 @@ export function defineJob<TInput = unknown>(
     // blank one stores rows nothing can ever claim.
     throw NextlyError.invalidInput({
       message: "A job type needs a non-empty slug.",
+    });
+  }
+
+  if (slug.length > MAX_JOB_SLUG_LENGTH) {
+    throw NextlyError.invalidInput({
+      message: `A job slug may be at most ${MAX_JOB_SLUG_LENGTH} characters.`,
+      logContext: { slug, length: slug.length },
     });
   }
 

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -1,0 +1,136 @@
+/**
+ * Job types: declaring one, and looking one up.
+ *
+ * A job row stores a `slug` and an opaque `input`; this is what turns that pair
+ * back into code to run. Keeping the registry separate from the runner is what
+ * lets a job type be declared where it MEANS something — releases declares
+ * `releases:apply`, webhooks declares `webhooks:drain` — while one runner
+ * executes all of them.
+ *
+ * ## The shape, and one deliberate divergence
+ *
+ * `defineJob({ slug, handler, retry })` and `queue({ task, input, runAt })`
+ * follow Payload's jobs API, because a large share of the people evaluating
+ * Nextly arrive from it and the concepts should transfer without re-learning.
+ *
+ * The divergence is `runAt` where Payload spells it `waitUntil`. `waitUntil`
+ * reads as a deadline — the point by which something must have happened —
+ * when the field is the opposite, the earliest instant at which it may start.
+ * Choosing the clearer name is worth a small break from familiarity while the
+ * API is still cheap to change.
+ *
+ * @module domains/jobs/job-registry
+ */
+
+import { NextlyError } from "../../errors";
+import type { UserContext } from "../collections/services/collection-types";
+
+/** Attempts a job gets before it is given up on. */
+export const DEFAULT_MAX_ATTEMPTS = 5;
+
+/** What a handler is told about the run it is in. */
+export interface JobContext {
+  /**
+   * The identity this job runs AS, or `null` when it genuinely acts as nobody.
+   *
+   * `null` does NOT mean "as the system". A job whose stored identity no longer
+   * resolves never reaches a handler at all — it fails terminally — so a
+   * handler that receives `null` can rely on it meaning the job was queued
+   * without an identity in the first place.
+   */
+  user: UserContext | null;
+  /** The instant the runner is treating as now. Injected so a job is testable. */
+  now: Date;
+}
+
+export interface JobRetryPolicy {
+  maxAttempts: number;
+}
+
+export interface JobDefinition<TInput = unknown> {
+  slug: string;
+  handler: (input: TInput, context: JobContext) => Promise<void>;
+  retry: JobRetryPolicy;
+}
+
+export interface JobDefinitionInput<TInput = unknown> {
+  slug: string;
+  handler: (input: TInput, context: JobContext) => Promise<void>;
+  /** Defaults to {@link DEFAULT_MAX_ATTEMPTS} attempts. */
+  retry?: Partial<JobRetryPolicy>;
+}
+
+/**
+ * Declare a job type.
+ *
+ * The retry budget is resolved HERE rather than in the runner so that every
+ * definition carries a bounded one. A definition that left it undefined would
+ * put the runner in the position of inventing a policy the author never chose,
+ * and the natural reading of "no budget" — retry forever — turns a permanently
+ * failing job into an infinite loop.
+ */
+export function defineJob<TInput = unknown>(
+  input: JobDefinitionInput<TInput>
+): JobDefinition<TInput> {
+  const slug = input.slug.trim();
+  if (slug.length === 0) {
+    // The slug is the join between a stored row and the code that runs it, so a
+    // blank one stores rows nothing can ever claim.
+    throw NextlyError.invalidInput({
+      message: "A job type needs a non-empty slug.",
+    });
+  }
+
+  const maxAttempts = input.retry?.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
+    // Zero attempts is not "do not retry", it is "never run" — which is
+    // indistinguishable from a job nobody enqueued.
+    throw NextlyError.invalidInput({
+      message: "A job type must allow at least one attempt.",
+      logContext: { slug, maxAttempts },
+    });
+  }
+
+  return { slug, handler: input.handler, retry: { maxAttempts } };
+}
+
+/**
+ * The job types this instance knows how to run.
+ *
+ * Registration REFUSES a duplicate slug rather than replacing the incumbent.
+ * Replacing would make which handler runs depend on plugin load order, and the
+ * losing handler would simply never run with nothing anywhere to say so.
+ */
+export class JobRegistry {
+  private readonly definitions = new Map<string, JobDefinition<never>>();
+
+  register<TInput>(definition: JobDefinition<TInput>): void {
+    if (this.definitions.has(definition.slug)) {
+      throw NextlyError.invalidInput({
+        message: `A job type is already registered for "${definition.slug}".`,
+        logContext: { slug: definition.slug },
+      });
+    }
+    // No cast: a handler declared for a specific input accepts `never`, so a
+    // JobDefinition<TInput> is already a JobDefinition<never>. Storing them
+    // under that type is what lets one registry hold job types with unrelated
+    // input shapes while the runner still calls them uniformly.
+    this.definitions.set(definition.slug, definition);
+  }
+
+  get(slug: string): JobDefinition<never> | undefined {
+    return this.definitions.get(slug);
+  }
+
+  /**
+   * Every registered slug, sorted.
+   *
+   * Exists so a runner can tell an ORPHANED row — one whose slug was deleted
+   * from the code while rows were still queued — from a row it simply has not
+   * reached. Without it such a row is skipped on every pass forever, and a
+   * queue that quietly never drains looks exactly like an empty one.
+   */
+  slugs(): string[] {
+    return [...this.definitions.keys()].sort();
+  }
+}

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -25,6 +25,8 @@
 import { NextlyError } from "../../errors";
 import type { UserContext } from "../collections/services/collection-types";
 
+import type { JobContentApi } from "./job-content-api";
+
 /** Attempts a job gets before it is given up on. */
 export const DEFAULT_MAX_ATTEMPTS = 5;
 
@@ -52,6 +54,20 @@ export interface JobContext {
   user: UserContext | null;
   /** The instant the runner is treating as now. Injected so a job is testable. */
   now: Date;
+  /**
+   * Content operations, already bound to `user`.
+   *
+   * Handed to the handler rather than left for it to construct, because the
+   * Direct API defaults to `overrideAccess: true` — so a handler importing
+   * `nextly` directly runs with trusted-system authority and the resolved
+   * identity above does nothing. Using this is how a job actually acts as the
+   * person who queued it.
+   *
+   * A job that genuinely needs trusted access still imports `nextly` itself.
+   * That is then one visible line in the handler instead of an invisible
+   * default.
+   */
+  content: JobContentApi;
 }
 
 export interface JobRetryPolicy {

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -33,10 +33,14 @@ import type {
   WhereClause,
 } from "@nextlyhq/adapter-drizzle/types";
 
+import { NextlyError } from "../../errors";
 import type { JobState } from "../../schemas/jobs/types";
 import { isUniqueViolation } from "../../shared/lib/unique-violation";
 
 const JOBS = "nextly_jobs";
+
+/** The longest value every supported dialect can store in an indexed column. */
+const MAX_PORTABLE_KEY_LENGTH = 191;
 
 /**
  * The transaction surface the lease claim needs (subset of the adapter tx).
@@ -93,6 +97,7 @@ export interface JobsDatabase {
    * reports failure even when it succeeded. `updateCount` is the adapter's
    * documented path for a conditional update that moves a predicate column.
    */
+  delete(table: string, where: WhereClause): Promise<number>;
   updateCount(
     table: string,
     data: Record<string, unknown>,
@@ -161,6 +166,21 @@ export class JobsRepository {
    * why this is not a read-then-write.
    */
   async enqueue(input: NewJob): Promise<EnqueueResult> {
+    // The same portable bound the slug is held to. MySQL stores this in
+    // varchar(191) — the widest utf8mb4 value it will index — and refuses a
+    // longer one in strict mode, while PostgreSQL and SQLite accept it. Without
+    // this check a dedupe key works on two dialects and throws on the third, at
+    // enqueue time rather than where the caller chose the key.
+    if (
+      input.dedupeKey !== null &&
+      input.dedupeKey.length > MAX_PORTABLE_KEY_LENGTH
+    ) {
+      throw NextlyError.invalidInput({
+        message: `A job dedupe key may be at most ${MAX_PORTABLE_KEY_LENGTH} characters.`,
+        logContext: { slug: input.slug, length: input.dedupeKey.length },
+      });
+    }
+
     const id = crypto.randomUUID();
     try {
       await this.db.insert(JOBS, {
@@ -300,6 +320,66 @@ export class JobsRepository {
   }
 
   /**
+   * Extend this runner's lease while its handler is still working.
+   *
+   * Without renewal the lease is a wall-clock guess about how long a handler
+   * takes, and a handler that outruns it is reclaimed and run a second time
+   * CONCURRENTLY — the fence then refuses the first runner's write but cannot
+   * undo whatever it already did outside the database.
+   *
+   * Fenced on `locked_by` like every other write here, so a runner whose lease
+   * has already been taken cannot extend a lease it no longer holds. `false`
+   * says exactly that, and the runner uses it to stop renewing.
+   */
+  async renewLease(
+    id: string,
+    runnerId: string,
+    now: Date,
+    leaseMs: number
+  ): Promise<boolean> {
+    const affected = await this.db.updateCount(
+      JOBS,
+      { locked_until: new Date(now.getTime() + leaseMs), updated_at: now },
+      {
+        and: [
+          { column: "id", op: "=", value: id },
+          { column: "lockedBy", op: "=", value: runnerId },
+        ],
+      }
+    );
+    return affected > 0;
+  }
+
+  /**
+   * Remove terminal rows older than `before`, at most `limit` of them.
+   *
+   * A queue without this grows forever: every completed and every permanently
+   * failed execution keeps its input and its error, and a recurring workload
+   * writes one row per run. Bounded per call so a sweep cannot become a long
+   * delete that outlives the pass it runs in.
+   *
+   * Only `done` and `failed` rows are eligible. A `pending` row is outstanding
+   * work and a `running` one is somebody's in flight.
+   */
+  async pruneTerminal(before: Date, limit: number): Promise<number> {
+    const rows = await this.db.select<{ id: string }>(JOBS, {
+      columns: ["id"],
+      where: {
+        and: [
+          { column: "state", op: "IN", value: ["done", "failed"] },
+          { column: "updatedAt", op: "<", value: before },
+        ],
+      },
+      orderBy: [{ column: "updatedAt", direction: "asc" }],
+      limit,
+    });
+    if (rows.length === 0) return 0;
+    return this.db.delete(JOBS, {
+      and: [{ column: "id", op: "IN", value: rows.map(r => r.id) }],
+    });
+  }
+
+  /**
    * Record what an attempt did, ONLY if this runner still holds the lease.
    *
    * Returns false when the lease had been handed to someone else — a slow
@@ -351,16 +431,30 @@ export class JobsRepository {
     return affected > 0;
   }
 
-  /** Increment the attempt counter. Called by the runner as it starts work. */
+  /**
+   * Increment the attempt counter, ONLY while this runner holds the lease.
+   *
+   * Fenced for the same reason `finalize` is. A runner that pauses between
+   * claiming and this write can have its lease expire and be reclaimed; the
+   * successor then advances the count, and an unfenced write from the stale
+   * runner would put it back — so a job that has been attempted three times
+   * reports two, and outlives the budget meant to stop it.
+   */
   async markAttempt(
     id: string,
+    runnerId: string,
     attemptCount: number,
     now: Date
   ): Promise<void> {
-    await this.db.update(
+    await this.db.updateCount(
       JOBS,
       { attempt_count: attemptCount, updated_at: now },
-      { and: [{ column: "id", op: "=", value: id }] }
+      {
+        and: [
+          { column: "id", op: "=", value: id },
+          { column: "lockedBy", op: "=", value: runnerId },
+        ],
+      }
     );
   }
 }

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -83,6 +83,21 @@ export interface JobsDatabase {
     where: WhereClause,
     options?: UpdateOptions
   ): Promise<T[]>;
+  /**
+   * Update and report how many rows CHANGED.
+   *
+   * Used by `finalize` instead of `update({ returning })`, because MySQL has no
+   * RETURNING: the adapter emulates it by re-selecting with the original
+   * predicate, and `finalize`'s predicate includes `locked_by` — which the same
+   * write clears. The re-select therefore matches nothing and the fenced update
+   * reports failure even when it succeeded. `updateCount` is the adapter's
+   * documented path for a conditional update that moves a predicate column.
+   */
+  updateCount(
+    table: string,
+    data: Record<string, unknown>,
+    where: WhereClause
+  ): Promise<number>;
   transaction<T>(fn: (tx: JobsTx) => Promise<T>): Promise<T>;
 }
 
@@ -196,24 +211,53 @@ export class JobsRepository {
     }
   }
 
-  /** Jobs whose time has come and whose lease is free, oldest first. */
+  /**
+   * Jobs whose time has come and whose lease is free, oldest first.
+   *
+   * Every predicate is applied by the DATABASE, before the limit. Filtering in
+   * memory afterwards looks equivalent and is not: a page filled with rows that
+   * are not yet due comes back, is filtered to nothing, and a runnable row
+   * behind them is never reached — on this pass or any later one, because the
+   * same rows fill the page every time. That is head-of-line blocking, and it
+   * is permanent rather than transient.
+   *
+   * `nextly_webhook_deliveries` selects its due rows the same way, for the same
+   * reason.
+   */
   async findDue(input: { now: Date; limit: number }): Promise<JobRow[]> {
-    const rows = await this.db.select<JobRow>(JOBS, {
-      where: { and: [{ column: "state", op: "=", value: "pending" }] },
+    return this.db.select<JobRow>(JOBS, {
+      where: {
+        and: [
+          { column: "state", op: "=", value: "pending" },
+          // `runAt` is the schedule and `nextAttemptAt` is the retry. Either
+          // being unset means "no constraint from that side", which is why each
+          // is a null-or-past pair rather than a single comparison.
+          {
+            or: [
+              { column: "runAt", op: "IS NULL", value: null },
+              { column: "runAt", op: "<=", value: input.now },
+            ],
+          },
+          {
+            or: [
+              { column: "nextAttemptAt", op: "IS NULL", value: null },
+              { column: "nextAttemptAt", op: "<=", value: input.now },
+            ],
+          },
+          // A row another runner currently holds is not due. It stays `pending`
+          // so a retry can find it once the lease lapses, so state alone cannot
+          // answer this.
+          {
+            or: [
+              { column: "lockedUntil", op: "IS NULL", value: null },
+              { column: "lockedUntil", op: "<=", value: input.now },
+            ],
+          },
+        ],
+      },
       orderBy: [{ column: "createdAt", direction: "asc" }],
       limit: input.limit,
     });
-    // A row another runner currently holds is NOT due. It is still `pending`,
-    // because a retry has to be able to find it again once the lease lapses,
-    // so state alone cannot answer this.
-    // The due predicate is applied here rather than in SQL because it spans
-    // two nullable columns with different meanings — `runAt` is the schedule
-    // and `nextAttemptAt` is the retry — and expressing "either is null or
-    // either has passed" as a portable where-clause across three dialects
-    // costs more than filtering a bounded page.
-    return rows.filter(
-      row => isDue(row, input.now) && isLeaseFree(row, input.now)
-    );
   }
 
   /**
@@ -283,21 +327,28 @@ export class JobsRepository {
             last_error: input.lastError,
             locked_by: null,
             locked_until: null,
+            // Release the dedupe key. It exists to stop a SECOND copy of work
+            // that is still outstanding; once this row is terminal there is no
+            // outstanding work, and holding the key would report the next
+            // request for the same logical job as a duplicate of one that has
+            // already been and gone. Recurring work with a stable key — "apply
+            // release r1", a nightly sweep — would be enqueued exactly once
+            // ever.
+            dedupe_key: null,
             updated_at: input.now,
           };
 
-    const affected = await this.db.update(
-      JOBS,
-      data,
-      {
-        and: [
-          { column: "id", op: "=", value: input.id },
-          { column: "lockedBy", op: "=", value: input.runnerId },
-        ],
-      },
-      { returning: "*" }
-    );
-    return affected.length > 0;
+    // The write always moves `locked_by` (to null), so on MySQL — which counts
+    // CHANGED rows rather than matched ones — a matched row is always a counted
+    // row. `updateCount`'s own docblock requires exactly that of a caller using
+    // it as a compare-and-set.
+    const affected = await this.db.updateCount(JOBS, data, {
+      and: [
+        { column: "id", op: "=", value: input.id },
+        { column: "lockedBy", op: "=", value: input.runnerId },
+      ],
+    });
+    return affected > 0;
   }
 
   /** Increment the attempt counter. Called by the runner as it starts work. */

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -1,0 +1,344 @@
+/**
+ * Repository for `nextly_jobs`.
+ *
+ * The only place in the domain that writes SQL. Column names are the Drizzle
+ * property names (camelCase) on reads; the adapter maps them to snake_case,
+ * and writes name the snake_case column directly, matching how the webhook
+ * delivery claim addresses its own lease columns.
+ *
+ * ## Why the claim is a lease and not `FOR UPDATE SKIP LOCKED`
+ *
+ * `SKIP LOCKED` is a stronger claim and exists on PostgreSQL and MySQL. SQLite
+ * has no such clause and Nextly ships a SQLite adapter, so expressing the
+ * claim in ORDINARY columns is what lets ONE implementation serve all three
+ * dialects. `nextly_webhook_deliveries` made this exact trade and has run on
+ * it; this inherits the decision rather than re-opening it.
+ *
+ * ## Why `enqueue` does not check before it inserts
+ *
+ * Duplicate suppression is a UNIQUE constraint, and the insert is allowed to
+ * fail. Reading for an existing row and then inserting is the shape that lets
+ * two writers interleave and both be told they won — the defect already filed
+ * as `plugins-cannot-compare-and-set-through-direct-api`. A periodic sweep and
+ * a queue trigger enqueueing the same work concurrently is the ordinary case
+ * here, not an exotic one, so the rule has to hold where the database enforces
+ * it.
+ *
+ * @module domains/jobs/jobs-repository
+ */
+
+import type {
+  SelectOptions,
+  UpdateOptions,
+  WhereClause,
+} from "@nextlyhq/adapter-drizzle/types";
+
+import type { JobState } from "../../schemas/jobs/types";
+import { isUniqueViolation } from "../../shared/lib/unique-violation";
+
+const JOBS = "nextly_jobs";
+
+/**
+ * The transaction surface the lease claim needs (subset of the adapter tx).
+ *
+ * `where` and `options` name the ADAPTER's own types rather than restating
+ * their shape. A restated `{ column, op, value }` looks equivalent and is not:
+ * the adapter constrains the operator and the parameter, so a hand-written copy
+ * is a different type that the real transaction context does not satisfy —
+ * which the compiler reports at the call site, a long way from the mistake.
+ */
+export interface JobsTx {
+  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
+  update<T = unknown>(
+    table: string,
+    data: Record<string, unknown>,
+    where: WhereClause,
+    options?: UpdateOptions
+  ): Promise<T[]>;
+}
+
+/**
+ * The database surface this repository needs.
+ *
+ * Declared here rather than aliased from `VersionsDbApi` because it is
+ * genuinely wider: that port has neither `transaction` nor a `forUpdate`
+ * select, and the claim cannot be written without both. Widening the shared
+ * port to fit would hand every one of its consumers a transaction capability
+ * none of them asked for.
+ */
+export interface JobsDatabase {
+  insert<T = unknown>(
+    table: string,
+    data: Record<string, unknown>,
+    options?: { returning?: string[] | "*" }
+  ): Promise<T>;
+  select<T = unknown>(table: string, options?: SelectOptions): Promise<T[]>;
+  // `returning` names COLUMNS or "*" — it is not a boolean. `finalize` depends
+  // on the returned row count to know whether the fence let its write through,
+  // so asking for rows in a way the adapter does not understand would make that
+  // count meaningless.
+  update<T = unknown>(
+    table: string,
+    data: Record<string, unknown>,
+    where: WhereClause,
+    options?: UpdateOptions
+  ): Promise<T[]>;
+  transaction<T>(fn: (tx: JobsTx) => Promise<T>): Promise<T>;
+}
+
+/** One stored job, as the runner reads it. */
+export interface JobRow {
+  id: string;
+  slug: string;
+  input: unknown;
+  state: JobState;
+  runAt: Date | null;
+  runAsUserId: string | null;
+  dedupeKey: string | null;
+  attemptCount: number;
+  nextAttemptAt: Date | null;
+  lockedBy: string | null;
+  lockedUntil: Date | null;
+  lastError: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface NewJob {
+  slug: string;
+  input: unknown;
+  /** `null` means "as soon as a trigger sees it". */
+  runAt: Date | null;
+  /** `null` means the job acts as nobody; it does NOT mean "as the system". */
+  runAsUserId: string | null;
+  /** `null` opts out of duplicate suppression entirely. */
+  dedupeKey: string | null;
+  now: Date;
+}
+
+export interface EnqueueResult {
+  id: string;
+  /** True when an equal `dedupeKey` already existed and `id` is that row's. */
+  deduped: boolean;
+}
+
+/** What a finished attempt did. */
+export type FinalizeOutcome = "done" | "retry" | "failed";
+
+export interface FinalizeInput {
+  id: string;
+  /** The lease this runner holds. The write is fenced to it. */
+  runnerId: string;
+  outcome: FinalizeOutcome;
+  /** Set only for `retry`; when the next attempt becomes due. */
+  nextAttemptAt: Date | null;
+  lastError: string | null;
+  now: Date;
+}
+
+export class JobsRepository {
+  constructor(private readonly db: JobsDatabase) {}
+
+  /**
+   * Add a job, or report that an equal one is already queued.
+   *
+   * The insert is attempted first and allowed to fail; see the module note on
+   * why this is not a read-then-write.
+   */
+  async enqueue(input: NewJob): Promise<EnqueueResult> {
+    const id = crypto.randomUUID();
+    try {
+      await this.db.insert(JOBS, {
+        id,
+        slug: input.slug,
+        input: input.input ?? null,
+        state: "pending" satisfies JobState,
+        run_at: input.runAt,
+        run_as_user_id: input.runAsUserId,
+        dedupe_key: input.dedupeKey,
+        attempt_count: 0,
+        next_attempt_at: null,
+        locked_by: null,
+        locked_until: null,
+        last_error: null,
+        created_at: input.now,
+        updated_at: input.now,
+      });
+      return { id, deduped: false };
+    } catch (error) {
+      // A duplicate key reaches here in one of several shapes and nested a
+      // couple of wrappers deep; `isUniqueViolation` is the one place that
+      // knows all of them. Deliberately NOT re-derived locally — there were
+      // already three spellings of this question in the codebase, and a fourth
+      // in this file is how they stay out of step.
+      //
+      // `database/errors.ts#toDbError` looks like the obvious choice and is the
+      // wrong one: for SQLite it decides by matching the message, and by this
+      // point the adapter has replaced the driver's message with the SQL
+      // statement. Measured, not assumed.
+      if (!isUniqueViolation(error)) throw error;
+      // A job with no dedupe key can never reach this branch: all three
+      // dialects treat NULL as distinct from NULL in a unique index, so such
+      // rows never collide. Reaching here therefore means `dedupeKey` is set
+      // and some row already holds it.
+      const existing = await this.db.select<JobRow>(JOBS, {
+        where: {
+          and: [{ column: "dedupeKey", op: "=", value: input.dedupeKey }],
+        },
+        limit: 1,
+      });
+      const winner = existing[0];
+      // The row was deleted between the failed insert and this read. Nothing
+      // is queued and nothing was written, so say so rather than reporting a
+      // deduplication against a row that no longer exists.
+      if (!winner) throw error;
+      return { id: winner.id, deduped: true };
+    }
+  }
+
+  /** Jobs whose time has come and whose lease is free, oldest first. */
+  async findDue(input: { now: Date; limit: number }): Promise<JobRow[]> {
+    const rows = await this.db.select<JobRow>(JOBS, {
+      where: { and: [{ column: "state", op: "=", value: "pending" }] },
+      orderBy: [{ column: "createdAt", direction: "asc" }],
+      limit: input.limit,
+    });
+    // A row another runner currently holds is NOT due. It is still `pending`,
+    // because a retry has to be able to find it again once the lease lapses,
+    // so state alone cannot answer this.
+    // The due predicate is applied here rather than in SQL because it spans
+    // two nullable columns with different meanings — `runAt` is the schedule
+    // and `nextAttemptAt` is the retry — and expressing "either is null or
+    // either has passed" as a portable where-clause across three dialects
+    // costs more than filtering a bounded page.
+    return rows.filter(
+      row => isDue(row, input.now) && isLeaseFree(row, input.now)
+    );
+  }
+
+  /**
+   * Claim one job by taking a lease inside a transaction.
+   *
+   * Returns the row if this runner won, else null (another runner holds it, it
+   * is no longer due, or it vanished). The read-check-write runs in ONE
+   * transaction under a `forUpdate` row lock — a no-op on SQLite, whose
+   * transactions already serialize writers — so a concurrent claim cannot slip
+   * between the read and the lease write.
+   */
+  async claim(
+    id: string,
+    runnerId: string,
+    now: Date,
+    leaseMs: number
+  ): Promise<JobRow | null> {
+    return this.db.transaction(async tx => {
+      const rows = await tx.select<JobRow>(JOBS, {
+        where: { and: [{ column: "id", op: "=", value: id }] },
+        limit: 1,
+        forUpdate: true,
+      });
+      const row = rows[0];
+      if (!row) return null;
+      if (row.state !== "pending") return null;
+      if (!isDue(row, now)) return null;
+      if (!isLeaseFree(row, now)) return null;
+
+      const lockedUntil = new Date(now.getTime() + leaseMs);
+      await tx.update(
+        JOBS,
+        { locked_by: runnerId, locked_until: lockedUntil, updated_at: now },
+        { and: [{ column: "id", op: "=", value: id }] }
+      );
+      // Reflect the lease just taken onto the returned row so `finalize` can
+      // fence on ownership: `lockedBy` now identifies this runner.
+      return { ...row, lockedBy: runnerId, lockedUntil };
+    });
+  }
+
+  /**
+   * Record what an attempt did, ONLY if this runner still holds the lease.
+   *
+   * Returns false when the lease had been handed to someone else — a slow
+   * runner whose lease expired must not write its stale outcome across its
+   * successor's work. The fence is the `locked_by` term in the where clause,
+   * so it is the database that refuses, not a check this code performs first.
+   */
+  async finalize(input: FinalizeInput): Promise<boolean> {
+    const data: Record<string, unknown> =
+      input.outcome === "retry"
+        ? {
+            state: "pending" satisfies JobState,
+            next_attempt_at: input.nextAttemptAt,
+            last_error: input.lastError,
+            // The lease is dropped so the next attempt is claimable.
+            locked_by: null,
+            locked_until: null,
+            updated_at: input.now,
+          }
+        : {
+            state: (input.outcome === "done"
+              ? "done"
+              : "failed") satisfies JobState,
+            next_attempt_at: null,
+            last_error: input.lastError,
+            locked_by: null,
+            locked_until: null,
+            updated_at: input.now,
+          };
+
+    const affected = await this.db.update(
+      JOBS,
+      data,
+      {
+        and: [
+          { column: "id", op: "=", value: input.id },
+          { column: "lockedBy", op: "=", value: input.runnerId },
+        ],
+      },
+      { returning: "*" }
+    );
+    return affected.length > 0;
+  }
+
+  /** Increment the attempt counter. Called by the runner as it starts work. */
+  async markAttempt(
+    id: string,
+    attemptCount: number,
+    now: Date
+  ): Promise<void> {
+    await this.db.update(
+      JOBS,
+      { attempt_count: attemptCount, updated_at: now },
+      { and: [{ column: "id", op: "=", value: id }] }
+    );
+  }
+}
+
+/**
+ * Whether a pending row is ready to run.
+ *
+ * `runAt` is the schedule and `nextAttemptAt` is the retry; a row is due when
+ * neither is set in the future. Shared by `findDue` and `claim` so a job
+ * cannot be listed as due by one and refused as not-due by the other — the
+ * divergence that makes a queue appear to stall with work visibly waiting in
+ * it.
+ */
+function isDue(row: JobRow, now: Date): boolean {
+  const ms = now.getTime();
+  if (row.runAt != null && row.runAt.getTime() > ms) return false;
+  if (row.nextAttemptAt != null && row.nextAttemptAt.getTime() > ms) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Whether nobody currently holds this row.
+ *
+ * Shared by `findDue` and `claim` for the same reason `isDue` is: two spellings
+ * of "is it free" lets one report a job as available that the other then
+ * refuses, which presents as a queue that stalls with work visibly waiting.
+ */
+function isLeaseFree(row: JobRow, now: Date): boolean {
+  return row.lockedUntil == null || row.lockedUntil.getTime() <= now.getTime();
+}

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -171,6 +171,16 @@ export class JobsRepository {
     // longer one in strict mode, while PostgreSQL and SQLite accept it. Without
     // this check a dedupe key works on two dialects and throws on the third, at
     // enqueue time rather than where the caller chose the key.
+    // Validated here as well as in `defineJob`. This is an exported surface: a
+    // caller can reach it with a slug that never went through a definition, and
+    // MySQL would then refuse the insert while the other two dialects accepted
+    // it.
+    if (input.slug.length > MAX_PORTABLE_KEY_LENGTH) {
+      throw NextlyError.invalidInput({
+        message: `A job slug may be at most ${MAX_PORTABLE_KEY_LENGTH} characters.`,
+        logContext: { length: input.slug.length },
+      });
+    }
     if (
       input.dedupeKey !== null &&
       input.dedupeKey.length > MAX_PORTABLE_KEY_LENGTH
@@ -181,6 +191,20 @@ export class JobsRepository {
       });
     }
 
+    return this.insertOrDedupe(input, true);
+  }
+
+  /**
+   * One insert attempt, resolving a duplicate-key refusal.
+   *
+   * `mayRetry` is spent by the one case that deserves a second attempt: the row
+   * holding the key vacated it between our failed insert and the read that
+   * looked for it.
+   */
+  private async insertOrDedupe(
+    input: NewJob,
+    mayRetry: boolean
+  ): Promise<EnqueueResult> {
     const id = crypto.randomUUID();
     try {
       await this.db.insert(JOBS, {
@@ -223,10 +247,18 @@ export class JobsRepository {
         limit: 1,
       });
       const winner = existing[0];
-      // The row was deleted between the failed insert and this read. Nothing
-      // is queued and nothing was written, so say so rather than reporting a
-      // deduplication against a row that no longer exists.
-      if (!winner) throw error;
+      // The row that held the key is gone from under us — it reached a terminal
+      // state and released the key, or was pruned, between the failed insert
+      // and this read. Nothing is outstanding, so the caller's work is NOT a
+      // duplicate and reporting it as one would drop it silently. Insert again.
+      //
+      // Once, not in a loop: a second collision means another writer is
+      // actively winning the race, and that IS a live duplicate rather than a
+      // vacated key.
+      if (!winner) {
+        if (!mayRetry) throw error;
+        return this.insertOrDedupe(input, false);
+      }
       return { id: winner.id, deduped: true };
     }
   }
@@ -445,8 +477,8 @@ export class JobsRepository {
     runnerId: string,
     attemptCount: number,
     now: Date
-  ): Promise<void> {
-    await this.db.updateCount(
+  ): Promise<boolean> {
+    const affected = await this.db.updateCount(
       JOBS,
       { attempt_count: attemptCount, updated_at: now },
       {
@@ -456,6 +488,10 @@ export class JobsRepository {
         ],
       }
     );
+    // `false` says the lease is no longer ours: a successor holds the job, and
+    // everything this runner does from here produces a result the fence will
+    // refuse anyway. The caller stops rather than running the handler twice.
+    return affected > 0;
   }
 }
 

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -31,6 +31,19 @@ interface UsersReadDb {
   ): Promise<Array<Record<string, unknown>>>;
 }
 
+/**
+ * The executor a role lookup should run on, when the handle exposes one.
+ *
+ * `undefined` lets the lookup fall back to the global executor, which is
+ * correct for the single-instance case and is what a plain adapter gives.
+ */
+function executorOf(db: UsersReadDb): unknown {
+  const candidate = db as { getDrizzle?: () => unknown };
+  return typeof candidate.getDrizzle === "function"
+    ? candidate.getDrizzle()
+    : undefined;
+}
+
 export interface RunJobsPassOptions {
   now?: () => Date;
   runnerId?: string;
@@ -57,7 +70,13 @@ export function databaseRunAs(
   db: UsersReadDb,
   // Injected so the propagation guarantee above is TESTABLE. A guarantee whose
   // only guard is a comment is a guarantee nobody can prove still holds.
-  listRoleSlugs: (id: string) => Promise<string[]> = listRoleSlugsForUserStrict
+  listRoleSlugs: (id: string) => Promise<string[]> = id =>
+    // Bound to the SAME handle `findUser` reads from. `listRoleSlugsForUserStrict`
+    // otherwise queries through the process-global executor, so with more than
+    // one Nextly instance a context could pair a user from one database with
+    // roles from another — and run the handler with an authority that exists in
+    // neither.
+    listRoleSlugsForUserStrict(id, executorOf(db))
 ): RunAsDeps {
   return {
     async findUser(id: string): Promise<RunAsUser | null> {

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -10,6 +10,7 @@
  * @module domains/jobs/jobs-runner
  */
 
+import { nextly } from "../../direct-api/nextly";
 import { listRoleSlugsForUserStrict } from "../../services/lib/permissions";
 
 import type { JobRegistry } from "./job-registry";
@@ -141,6 +142,9 @@ export async function runJobsPass(
     maxDurationMs: options?.maxDurationMs,
     leaseMs: options?.leaseMs,
     random: options?.random,
+    // The real Direct API, resolved lazily per call so a job queued before the
+    // runtime finished booting still binds to a live one.
+    contentApi: nextly,
   });
 
   // Prune AFTER the drain, and never in a way that can fail it. A queue without

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -1,0 +1,105 @@
+/**
+ * Assembling a drain pass — the ONE place both triggers build it.
+ *
+ * The cron/manual route and the post-response fast path call this rather than
+ * each constructing their own dependencies, so they cannot drift in how the
+ * engine is wired. `domains/webhooks/drain-runner` exists for exactly this
+ * reason and states it plainly; the same reasoning applies here, and two
+ * triggers that assemble a runner differently are two runners.
+ *
+ * @module domains/jobs/jobs-runner
+ */
+
+import { listRoleSlugsForUserStrict } from "../../services/lib/permissions";
+
+import type { JobRegistry } from "./job-registry";
+import { JobsRepository, type JobsDatabase } from "./jobs-repository";
+import type { RunAsDeps, RunAsUser } from "./resolve-run-as";
+import { runJobs, type RunJobsResult } from "./run-jobs";
+
+/**
+ * The users read the identity resolver needs.
+ *
+ * Non-generic on purpose: the adapter's `select<T>` is assignable to this, and
+ * a generic port would force every fake to be generic too, which is friction
+ * with no benefit — this reads exactly one shape.
+ */
+interface UsersReadDb {
+  select(
+    table: string,
+    options?: { where?: unknown; limit?: number }
+  ): Promise<Array<Record<string, unknown>>>;
+}
+
+export interface RunJobsPassOptions {
+  now?: () => Date;
+  runnerId?: string;
+  batchSize?: number;
+  maxDurationMs?: number;
+  leaseMs?: number;
+  random?: () => number;
+  /** Override the identity reads; the default goes to the database. */
+  runAs?: RunAsDeps;
+}
+
+/**
+ * The identity reads, backed by the database.
+ *
+ * Uses `listRoleSlugsForUserStrict` rather than `listRoleSlugsForUser`. The
+ * non-strict one CATCHES its errors and returns an empty array, which here
+ * would be the worst possible failure: a job would run with no roles, every
+ * role-gated collection would match nothing, and the job would report itself
+ * complete having done nothing. Letting the error propagate turns that into an
+ * ordinary retryable failure instead — a job that did not run, rather than one
+ * that silently did nothing and claimed success.
+ */
+export function databaseRunAs(
+  db: UsersReadDb,
+  // Injected so the propagation guarantee above is TESTABLE. A guarantee whose
+  // only guard is a comment is a guarantee nobody can prove still holds.
+  listRoleSlugs: (id: string) => Promise<string[]> = listRoleSlugsForUserStrict
+): RunAsDeps {
+  return {
+    async findUser(id: string): Promise<RunAsUser | null> {
+      const rows = await db.select("users", {
+        where: { and: [{ column: "id", op: "=", value: id }] },
+        limit: 1,
+      });
+      const row = rows[0];
+      if (row === undefined) return null;
+      // The row is read back as an open record, so the id is narrowed rather
+      // than assumed: a users table that answered without one would otherwise
+      // produce a context whose id is `undefined`, and an access rule matching
+      // on it would compare against nothing.
+      if (typeof row.id !== "string") return null;
+      // SQLite stores a boolean as 0/1, so compare by truthiness rather than
+      // identity — `row.isActive === true` is false for an active SQLite user.
+      return { id: row.id, isActive: Boolean(row.isActive) };
+    },
+    listRoleSlugs,
+  };
+}
+
+/**
+ * Run one drain pass, assembling the engine from the adapter and the registry.
+ *
+ * Returns once nothing further is immediately actionable or the wall-clock
+ * budget is spent; jobs scheduled for a future retry are left for a later pass.
+ */
+export function runJobsPass(
+  adapter: JobsDatabase & UsersReadDb,
+  registry: JobRegistry,
+  options?: RunJobsPassOptions
+): Promise<RunJobsResult> {
+  return runJobs({
+    store: new JobsRepository(adapter),
+    registry,
+    runAs: options?.runAs ?? databaseRunAs(adapter),
+    now: options?.now,
+    runnerId: options?.runnerId,
+    batchSize: options?.batchSize,
+    maxDurationMs: options?.maxDurationMs,
+    leaseMs: options?.leaseMs,
+    random: options?.random,
+  });
+}

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -44,6 +44,11 @@ function executorOf(db: UsersReadDb): unknown {
     : undefined;
 }
 
+/** How long a finished job row is kept before a pass may remove it. */
+export const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+/** Rows a single pass may remove, so a sweep cannot become a long delete. */
+export const DEFAULT_PRUNE_LIMIT = 100;
+
 export interface RunJobsPassOptions {
   now?: () => Date;
   runnerId?: string;
@@ -53,6 +58,13 @@ export interface RunJobsPassOptions {
   random?: () => number;
   /** Override the identity reads; the default goes to the database. */
   runAs?: RunAsDeps;
+  /**
+   * How long a finished row is kept. `null` disables removal entirely, for a
+   * deployment that would rather keep the history and prune it itself.
+   */
+  retentionMs?: number | null;
+  /** Rows one pass may remove. */
+  pruneLimit?: number;
 }
 
 /**
@@ -93,7 +105,15 @@ export function databaseRunAs(
       if (typeof row.id !== "string") return null;
       // SQLite stores a boolean as 0/1, so compare by truthiness rather than
       // identity — `row.isActive === true` is false for an active SQLite user.
-      return { id: row.id, isActive: Boolean(row.isActive) };
+      // Every attribute `RunAsUser` carries, not just the two the lease needs.
+      // `resolveRunAs` puts these on the reconstructed context because access
+      // predicates here inspect `user.email` — but it can only carry what this
+      // lookup returns, so stopping at id/isActive made that handling unable to
+      // do anything.
+      const user: RunAsUser = { id: row.id, isActive: Boolean(row.isActive) };
+      if (typeof row.name === "string") user.name = row.name;
+      if (typeof row.email === "string") user.email = row.email;
+      return user;
     },
     listRoleSlugs,
   };
@@ -105,13 +125,14 @@ export function databaseRunAs(
  * Returns once nothing further is immediately actionable or the wall-clock
  * budget is spent; jobs scheduled for a future retry are left for a later pass.
  */
-export function runJobsPass(
+export async function runJobsPass(
   adapter: JobsDatabase & UsersReadDb,
   registry: JobRegistry,
   options?: RunJobsPassOptions
 ): Promise<RunJobsResult> {
-  return runJobs({
-    store: new JobsRepository(adapter),
+  const repository = new JobsRepository(adapter);
+  const result = await runJobs({
+    store: repository,
     registry,
     runAs: options?.runAs ?? databaseRunAs(adapter),
     now: options?.now,
@@ -121,4 +142,24 @@ export function runJobsPass(
     leaseMs: options?.leaseMs,
     random: options?.random,
   });
+
+  // Prune AFTER the drain, and never in a way that can fail it. A queue without
+  // this grows forever — a recurring workload writes one row per run, and every
+  // finished row keeps its input and its error. Bounded per pass so a sweep
+  // cannot become a long delete that outlives the tick running it.
+  const retentionMs = options?.retentionMs ?? DEFAULT_RETENTION_MS;
+  if (retentionMs !== null) {
+    const now = options?.now ?? (() => new Date());
+    try {
+      await repository.pruneTerminal(
+        new Date(now().getTime() - retentionMs),
+        options?.pruneLimit ?? DEFAULT_PRUNE_LIMIT
+      );
+    } catch {
+      // Housekeeping is not the work. A failed prune must not turn a pass that
+      // ran its jobs into a pass that reports failure.
+    }
+  }
+
+  return result;
 }

--- a/packages/nextly/src/domains/jobs/resolve-run-as.ts
+++ b/packages/nextly/src/domains/jobs/resolve-run-as.ts
@@ -88,5 +88,14 @@ export async function resolveRunAs(
   if (!user.isActive) return { ok: false, reason: "JOB_IDENTITY_DISABLED" };
 
   const roles = await deps.listRoleSlugs(user.id);
-  return { ok: true, user: { id: user.id, roles } satisfies UserContext };
+  // Every attribute the user carries, not just id and roles. Access predicates
+  // in this repository inspect `user.email`; a context missing it evaluates
+  // such a rule against `undefined`, which denies authorized work — or, for a
+  // negative predicate like `email !== blocked`, GRANTS work it should refuse.
+  // Either way the job is not running with the named person's authority, which
+  // is the one thing this function exists to guarantee.
+  const context: UserContext = { id: user.id, roles };
+  if (user.name !== undefined) context.name = user.name;
+  if (user.email !== undefined) context.email = user.email;
+  return { ok: true, user: context };
 }

--- a/packages/nextly/src/domains/jobs/resolve-run-as.ts
+++ b/packages/nextly/src/domains/jobs/resolve-run-as.ts
@@ -1,0 +1,92 @@
+/**
+ * Turning a stored user id back into the authority a job runs with.
+ *
+ * This is the access boundary of the jobs domain. Everything else that can go
+ * wrong here produces a job that did not run; this produces a job that runs
+ * with the WRONG authority, which is a different class of problem.
+ *
+ * ## An id is not a context
+ *
+ * The job stored an id when it was queued. Rebuilding a context from that id at
+ * execution time necessarily uses the permissions that person holds NOW, not
+ * the ones they held when they scheduled the work. That is the right answer —
+ * authority withdrawn should take effect — but it means the reconstruction can
+ * fail, and how it fails is the whole design:
+ *
+ * - **Never fall back to a system principal.** A job that cannot establish who
+ *   it is must not proceed as somebody more powerful.
+ * - **Never silently skip.** A job that quietly does nothing looks exactly like
+ *   a job that had nothing to do, and on a release that means "nothing was
+ *   published" reported as success.
+ * - **Fail terminally, and say why.** The row moves to `failed` with a reason
+ *   the admin can show. Retrying would not help: a deleted user does not come
+ *   back on the next pass.
+ *
+ * This is the position the preview-link work reached for the same reason — a
+ * request whose actor cannot be identified is REFUSED rather than executed as
+ * nobody, because acting as nobody applies no field rules at all.
+ *
+ * ## Why roles are loaded, not just the id
+ *
+ * `UserContext` carries a role set, and stored role-based access rules match on
+ * it. A context built from the id alone makes every role-gated collection match
+ * NOTHING and report itself complete — fail-closed, but silently. On a release
+ * read path "nothing is due" is the worst thing to say by accident, because it
+ * is indistinguishable from a correct answer.
+ *
+ * @module domains/jobs/resolve-run-as
+ */
+
+import type { UserContext } from "../collections/services/collection-types";
+
+/** The minimum a user must look like for a job to act as them. */
+export interface RunAsUser {
+  id: string;
+  isActive: boolean;
+  name?: string;
+  email?: string;
+}
+
+/**
+ * The reads this needs. Injected rather than reaching for a service so the
+ * boundary is testable without a database — the one module here whose failure
+ * modes are worth exercising exhaustively.
+ */
+export interface RunAsDeps {
+  findUser(id: string): Promise<RunAsUser | null>;
+  listRoleSlugs(id: string): Promise<string[]>;
+}
+
+/** Why an identity could not be established. Recorded in `last_error`. */
+export type RunAsRefusal =
+  | "JOB_IDENTITY_UNRESOLVABLE"
+  | "JOB_IDENTITY_DISABLED";
+
+export type RunAsResult =
+  | { ok: true; user: UserContext | null }
+  | { ok: false; reason: RunAsRefusal };
+
+/**
+ * Resolve the identity a job runs as.
+ *
+ * `id === null` resolves to `{ ok: true, user: null }` — a job that genuinely
+ * acts as nobody, such as webhook delivery, which reads nothing
+ * access-controlled. That is NOT the same answer as "the stored identity is
+ * gone", and the difference is the point of this function: collapsing the two
+ * turns a deleted author's job into an unauthenticated run.
+ */
+export async function resolveRunAs(
+  deps: RunAsDeps,
+  id: string | null
+): Promise<RunAsResult> {
+  if (id === null) return { ok: true, user: null };
+
+  const user = await deps.findUser(id);
+  if (user === null) return { ok: false, reason: "JOB_IDENTITY_UNRESOLVABLE" };
+  // A deactivated account cannot sign in; a job continuing to act as one would
+  // be a way to keep exercising an authority that was deliberately withdrawn.
+  if (!user.isActive) return { ok: false, reason: "JOB_IDENTITY_DISABLED" };
+
+  const roles = await deps.listRoleSlugs(user.id);
+  return { ok: true, user: { id: user.id, roles } satisfies UserContext };
+}

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -5,6 +5,19 @@
  * stores, the registry supplies the code. Assembling those is `jobs-runner`'s
  * job, so that both triggers assemble them identically.
  *
+ * ## What the wall-clock budget bounds, and what it does not
+ *
+ * `maxDurationMs` is checked before each CLAIM, so it bounds how many jobs a
+ * pass starts. It cannot bound how long one already-running handler takes:
+ * nothing here can interrupt a promise mid-flight, and a cancellation that the
+ * handler does not cooperate with would abandon whatever it had half-done
+ * outside the database — worse than being late.
+ *
+ * So a single handler CAN overrun the budget. Two things bound that instead:
+ * `leaseMs`, which the handler's runner renews only while it is alive, and the
+ * handler itself being written to fit a tick. Saying the budget bounds the pass
+ * would be the more comfortable claim and the false one.
+ *
  * ## The pass is bounded, deliberately
  *
  * A drain runs behind a serverless cron tick as often as it runs on a long-
@@ -50,6 +63,7 @@
 import { DEFAULT_MAX_ATTEMPTS, type JobRegistry } from "./job-registry";
 import { nextAttempt } from "./job-backoff";
 import type { FinalizeInput, FinalizeOutcome, JobRow } from "./jobs-repository";
+import { createJobContentApi } from "./job-content-api";
 import { resolveRunAs, type RunAsDeps } from "./resolve-run-as";
 
 /** Rows claimed and finalized per pass when the caller does not say. */
@@ -71,12 +85,13 @@ export interface JobsStore {
     now: Date,
     leaseMs: number
   ): Promise<JobRow | null>;
+  /** `false` means the lease was lost; the caller must not run the handler. */
   markAttempt(
     id: string,
     runnerId: string,
     attemptCount: number,
     now: Date
-  ): Promise<void>;
+  ): Promise<boolean>;
   finalize(input: FinalizeInput): Promise<boolean>;
   renewLease(
     id: string,
@@ -100,6 +115,13 @@ export interface RunJobsDeps {
    * the lease, so two renewals may be missed before it lapses.
    */
   renewIntervalMs?: number;
+  /**
+   * The Direct API the bound content client wraps.
+   *
+   * Injected rather than imported so a pass can be driven without booting a
+   * runtime; `runJobsPass` supplies the real one.
+   */
+  contentApi: Parameters<typeof createJobContentApi>[1];
   random?: () => number;
 }
 
@@ -115,6 +137,15 @@ export interface RunJobsResult {
    */
   unrecorded: number;
 }
+
+/**
+ * `runOne`'s answer when the lease was lost before the handler ran.
+ *
+ * Distinct from any outcome, because there is nothing to record: the row
+ * belongs to another runner and writing to it is exactly what the fence exists
+ * to refuse.
+ */
+const LEASE_LOST = Symbol("lease-lost");
 
 export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
   const now = deps.now ?? (() => new Date());
@@ -147,6 +178,10 @@ export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
     result.claimed += 1;
 
     const outcome = await runOne(deps, job, runnerId, now);
+    if (outcome === LEASE_LOST) {
+      result.unrecorded += 1;
+      continue;
+    }
     countOutcome(result, outcome.outcome, await deps.store.finalize(outcome));
   }
 
@@ -185,7 +220,7 @@ async function runOne(
   job: JobRow,
   runnerId: string,
   now: () => Date
-): Promise<FinalizeInput> {
+): Promise<FinalizeInput | typeof LEASE_LOST> {
   const terminal = (lastError: string): FinalizeInput => {
     return {
       id: job.id,
@@ -198,8 +233,46 @@ async function runOne(
   };
 
   const definition = deps.registry.get(job.slug);
+
+  // Deferred BEFORE an attempt is charged.
+  //
+  // During a rolling deployment an instance that has not been replaced yet does
+  // not know a slug the new instances already enqueue. Charging that to the
+  // job's retry budget lets the old workers exhaust it before a new one gets a
+  // turn — the job then fails permanently for a reason that had already fixed
+  // itself.
+  //
+  // The row is still never silently skipped: the reason is recorded, so a type
+  // genuinely deleted while rows were queued shows up in the admin instead of
+  // cycling invisibly. It simply keeps its budget for a runner that can run it.
+  if (definition === undefined) {
+    const deferred = nextAttempt({
+      attemptCount: 1,
+      maxAttempts: DEFAULT_MAX_ATTEMPTS,
+      now: now(),
+      random: deps.random,
+    });
+    return {
+      id: job.id,
+      runnerId,
+      outcome: "retry",
+      nextAttemptAt: deferred.outcome === "retry" ? deferred.at : null,
+      lastError: `No job type is registered for "${job.slug}".`,
+      now: now(),
+    };
+  }
+
   const attempt = job.attemptCount + 1;
-  await deps.store.markAttempt(job.id, runnerId, attempt, now());
+  const stillOurs = await deps.store.markAttempt(
+    job.id,
+    runnerId,
+    attempt,
+    now()
+  );
+  // The lease went to a successor between the claim and this write. Running the
+  // handler now would do the work twice, and the fence would refuse to record
+  // it either way — so stop, and leave the row to whoever holds it.
+  if (!stillOurs) return LEASE_LOST;
 
   // The identity READS can fail — a transient RBAC database error, say — and
   // that is a different thing from the identity being gone. Letting it throw
@@ -214,7 +287,7 @@ async function runOne(
     return decide(
       job,
       attempt,
-      definition?.retry.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      definition.retry.maxAttempts,
       error instanceof Error ? error.message : String(error),
       runnerId,
       now,
@@ -224,26 +297,6 @@ async function runOne(
   // Terminal, not retried: a deleted or deactivated user does not come back on
   // the next pass, and retrying would cycle an unrunnable row forever.
   if (!identity.ok) return terminal(identity.reason);
-
-  if (definition === undefined) {
-    // NOT terminal on its own. A deploy that has not finished rolling out can
-    // leave one instance without a type another instance queued, and that
-    // recovers by itself. A type genuinely deleted while rows were queued
-    // instead exhausts its budget and gives up saying which slug is missing —
-    // either way the row is never silently passed over.
-    return decide(
-      job,
-      attempt,
-      // Derived from the registry's own default rather than restated, so
-      // changing that default cannot leave orphan rows on a different budget
-      // from registered jobs.
-      DEFAULT_MAX_ATTEMPTS,
-      `No job type is registered for "${job.slug}".`,
-      runnerId,
-      now,
-      deps.random
-    );
-  }
 
   try {
     // Renew while the handler works. The lease is otherwise a wall-clock guess
@@ -255,6 +308,7 @@ async function runOne(
       definition.handler(job.input as never, {
         user: identity.user,
         now: now(),
+        content: createJobContentApi(identity.user, deps.contentApi),
       })
     );
   } catch (error) {

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -13,6 +13,24 @@
  * next tick continues from them. This is the same shape the webhook drain
  * already uses, and the reason it can be triggered the same three ways.
  *
+ * ## The contract is AT-LEAST-ONCE, and saying otherwise would be a lie
+ *
+ * The lease makes two runners unable to claim one job AT THE SAME INSTANT, and
+ * the fence makes a runner that lost its lease unable to record an outcome over
+ * its successor's. Neither stops a handler that OUTLIVES its lease: while it is
+ * still running, the lease expires, another pass reclaims the row, and the same
+ * handler runs again concurrently. The fence then refuses the first runner's
+ * write — but it cannot undo anything that runner already did outside the
+ * database.
+ *
+ * So: **handlers must be idempotent**, and `leaseMs` must be sized to the work.
+ * This is the same contract SQS, BullMQ and pg-boss give, for the same reason —
+ * exactly-once across a process boundary and an external side effect is not
+ * something a queue can offer.
+ *
+ * What IS guaranteed: a job's outcome is recorded once, by whoever holds the
+ * lease when it finishes.
+ *
  * ## Every outcome is recorded
  *
  * There is no branch here that leaves a claimed row untouched. A row that is
@@ -23,7 +41,7 @@
  * @module domains/jobs/run-jobs
  */
 
-import type { JobRegistry } from "./job-registry";
+import { DEFAULT_MAX_ATTEMPTS, type JobRegistry } from "./job-registry";
 import { nextAttempt } from "./job-backoff";
 import type { FinalizeInput, JobRow } from "./jobs-repository";
 import { resolveRunAs, type RunAsDeps } from "./resolve-run-as";
@@ -104,9 +122,18 @@ export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
     if (job === null) continue;
     result.claimed += 1;
 
-    const outcome = await runOne(deps, job, runnerId, now, result);
+    const outcome = await runOne(deps, job, runnerId, now);
     const wrote = await deps.store.finalize(outcome);
-    if (!wrote) result.unrecorded += 1;
+    // Counted only once the write LANDED. Counting when the decision was made
+    // would report an attempt as both done and unrecorded when the fence
+    // refuses it, which overstates completed work to whatever reads this.
+    if (!wrote) {
+      result.unrecorded += 1;
+      continue;
+    }
+    if (outcome.outcome === "done") result.done += 1;
+    else if (outcome.outcome === "failed") result.failed += 1;
+    else result.retried += 1;
   }
 
   return result;
@@ -122,11 +149,9 @@ async function runOne(
   deps: RunJobsDeps,
   job: JobRow,
   runnerId: string,
-  now: () => Date,
-  result: RunJobsResult
+  now: () => Date
 ): Promise<FinalizeInput> {
   const terminal = (lastError: string): FinalizeInput => {
-    result.failed += 1;
     return {
       id: job.id,
       runnerId,
@@ -137,14 +162,33 @@ async function runOne(
     };
   };
 
-  const identity = await resolveRunAs(deps.runAs, job.runAsUserId);
-  // Terminal, not retried: a deleted or deactivated user does not come back on
-  // the next pass, and retrying would cycle an unrunnable row forever.
-  if (!identity.ok) return terminal(identity.reason);
-
   const definition = deps.registry.get(job.slug);
   const attempt = job.attemptCount + 1;
   await deps.store.markAttempt(job.id, attempt, now());
+
+  // The identity READS can fail — a transient RBAC database error, say — and
+  // that is a different thing from the identity being gone. Letting it throw
+  // would abort the whole pass after this row was claimed: the row keeps its
+  // lease until expiry, later candidates are never reached, and a persistent
+  // lookup failure on an early row aborts every scheduled drain instead of
+  // exhausting one job's retry budget.
+  let identity: Awaited<ReturnType<typeof resolveRunAs>>;
+  try {
+    identity = await resolveRunAs(deps.runAs, job.runAsUserId);
+  } catch (error) {
+    return decide(
+      job,
+      attempt,
+      definition?.retry.maxAttempts ?? DEFAULT_MAX_ATTEMPTS,
+      error instanceof Error ? error.message : String(error),
+      runnerId,
+      now,
+      deps.random
+    );
+  }
+  // Terminal, not retried: a deleted or deactivated user does not come back on
+  // the next pass, and retrying would cycle an unrunnable row forever.
+  if (!identity.ok) return terminal(identity.reason);
 
   if (definition === undefined) {
     // NOT terminal on its own. A deploy that has not finished rolling out can
@@ -155,14 +199,14 @@ async function runOne(
     return decide(
       job,
       attempt,
-      // The registry's own default budget governs, since the definition that
-      // would have carried one is exactly what is missing.
-      5,
+      // Derived from the registry's own default rather than restated, so
+      // changing that default cannot leave orphan rows on a different budget
+      // from registered jobs.
+      DEFAULT_MAX_ATTEMPTS,
       `No job type is registered for "${job.slug}".`,
       runnerId,
       now,
-      deps.random,
-      result
+      deps.random
     );
   }
 
@@ -179,12 +223,10 @@ async function runOne(
       error instanceof Error ? error.message : String(error),
       runnerId,
       now,
-      deps.random,
-      result
+      deps.random
     );
   }
 
-  result.done += 1;
   return {
     id: job.id,
     runnerId,
@@ -203,8 +245,7 @@ function decide(
   lastError: string,
   runnerId: string,
   now: () => Date,
-  random: (() => number) | undefined,
-  result: RunJobsResult
+  random: (() => number) | undefined
 ): FinalizeInput {
   const decision = nextAttempt({
     attemptCount: attempt,
@@ -214,7 +255,6 @@ function decide(
   });
 
   if (decision.outcome === "failed") {
-    result.failed += 1;
     return {
       id: job.id,
       runnerId,
@@ -225,7 +265,6 @@ function decide(
     };
   }
 
-  result.retried += 1;
   return {
     id: job.id,
     runnerId,

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -1,0 +1,237 @@
+/**
+ * One drain pass over the job table.
+ *
+ * Pure orchestration over injected dependencies: it decides, the repository
+ * stores, the registry supplies the code. Assembling those is `jobs-runner`'s
+ * job, so that both triggers assemble them identically.
+ *
+ * ## The pass is bounded, deliberately
+ *
+ * A drain runs behind a serverless cron tick as often as it runs on a long-
+ * lived process, and a platform kills a tick at a fixed limit. So the pass
+ * returns on its own before that: the rows it did not reach are durable and the
+ * next tick continues from them. This is the same shape the webhook drain
+ * already uses, and the reason it can be triggered the same three ways.
+ *
+ * ## Every outcome is recorded
+ *
+ * There is no branch here that leaves a claimed row untouched. A row that is
+ * passed over silently is passed over on EVERY pass, forever — and a queue that
+ * never drains is indistinguishable from an empty one. That is why an
+ * unregistered slug is recorded as a failure rather than skipped.
+ *
+ * @module domains/jobs/run-jobs
+ */
+
+import type { JobRegistry } from "./job-registry";
+import { nextAttempt } from "./job-backoff";
+import type { FinalizeInput, JobRow } from "./jobs-repository";
+import { resolveRunAs, type RunAsDeps } from "./resolve-run-as";
+
+/** Rows claimed and finalized per pass when the caller does not say. */
+export const DEFAULT_BATCH_SIZE = 50;
+/**
+ * Wall-clock budget for one pass. Under a typical serverless limit with room
+ * for the final write to commit.
+ */
+export const DEFAULT_MAX_DURATION_MS = 25_000;
+
+/** The store surface a pass needs. `JobsRepository` satisfies it. */
+export interface JobsStore {
+  findDue(input: { now: Date; limit: number }): Promise<JobRow[]>;
+  claim(
+    id: string,
+    runnerId: string,
+    now: Date,
+    leaseMs: number
+  ): Promise<JobRow | null>;
+  markAttempt(id: string, attemptCount: number, now: Date): Promise<void>;
+  finalize(input: FinalizeInput): Promise<boolean>;
+}
+
+export interface RunJobsDeps {
+  store: JobsStore;
+  registry: JobRegistry;
+  runAs: RunAsDeps;
+  now?: () => Date;
+  runnerId?: string;
+  batchSize?: number;
+  maxDurationMs?: number;
+  leaseMs?: number;
+  random?: () => number;
+}
+
+export interface RunJobsResult {
+  claimed: number;
+  done: number;
+  failed: number;
+  retried: number;
+  /**
+   * Attempts whose outcome was NOT recorded because the lease had been handed
+   * to another runner before the write. Counted rather than ignored: a pass
+   * reporting work it did not actually record would overstate what happened.
+   */
+  unrecorded: number;
+}
+
+export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
+  const now = deps.now ?? (() => new Date());
+  const runnerId = deps.runnerId ?? crypto.randomUUID();
+  const batchSize = deps.batchSize ?? DEFAULT_BATCH_SIZE;
+  const maxDurationMs = deps.maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
+  const leaseMs = deps.leaseMs ?? 30_000;
+
+  const startedAt = now().getTime();
+  const result: RunJobsResult = {
+    claimed: 0,
+    done: 0,
+    failed: 0,
+    retried: 0,
+    unrecorded: 0,
+  };
+
+  const due = await deps.store.findDue({ now: now(), limit: batchSize });
+
+  for (const candidate of due) {
+    // Checked before the claim, not after: claiming a row and then abandoning
+    // it would leave a lease held by a runner that has already returned, and
+    // the row would wait out the lease for no reason.
+    if (now().getTime() - startedAt >= maxDurationMs) break;
+
+    const job = await deps.store.claim(candidate.id, runnerId, now(), leaseMs);
+    // Another runner won it, it stopped being due, or it vanished. Not ours,
+    // and not an error.
+    if (job === null) continue;
+    result.claimed += 1;
+
+    const outcome = await runOne(deps, job, runnerId, now, result);
+    const wrote = await deps.store.finalize(outcome);
+    if (!wrote) result.unrecorded += 1;
+  }
+
+  return result;
+}
+
+/**
+ * Establish identity, run the handler, and decide what to record.
+ *
+ * Returns the finalize input rather than writing it, so the single write site
+ * above can also observe whether the fence let it through.
+ */
+async function runOne(
+  deps: RunJobsDeps,
+  job: JobRow,
+  runnerId: string,
+  now: () => Date,
+  result: RunJobsResult
+): Promise<FinalizeInput> {
+  const terminal = (lastError: string): FinalizeInput => {
+    result.failed += 1;
+    return {
+      id: job.id,
+      runnerId,
+      outcome: "failed",
+      nextAttemptAt: null,
+      lastError,
+      now: now(),
+    };
+  };
+
+  const identity = await resolveRunAs(deps.runAs, job.runAsUserId);
+  // Terminal, not retried: a deleted or deactivated user does not come back on
+  // the next pass, and retrying would cycle an unrunnable row forever.
+  if (!identity.ok) return terminal(identity.reason);
+
+  const definition = deps.registry.get(job.slug);
+  const attempt = job.attemptCount + 1;
+  await deps.store.markAttempt(job.id, attempt, now());
+
+  if (definition === undefined) {
+    // NOT terminal on its own. A deploy that has not finished rolling out can
+    // leave one instance without a type another instance queued, and that
+    // recovers by itself. A type genuinely deleted while rows were queued
+    // instead exhausts its budget and gives up saying which slug is missing —
+    // either way the row is never silently passed over.
+    return decide(
+      job,
+      attempt,
+      // The registry's own default budget governs, since the definition that
+      // would have carried one is exactly what is missing.
+      5,
+      `No job type is registered for "${job.slug}".`,
+      runnerId,
+      now,
+      deps.random,
+      result
+    );
+  }
+
+  try {
+    await definition.handler(job.input as never, {
+      user: identity.user,
+      now: now(),
+    });
+  } catch (error) {
+    return decide(
+      job,
+      attempt,
+      definition.retry.maxAttempts,
+      error instanceof Error ? error.message : String(error),
+      runnerId,
+      now,
+      deps.random,
+      result
+    );
+  }
+
+  result.done += 1;
+  return {
+    id: job.id,
+    runnerId,
+    outcome: "done",
+    nextAttemptAt: null,
+    lastError: null,
+    now: now(),
+  };
+}
+
+/** Retry or give up, per the backoff policy. */
+function decide(
+  job: JobRow,
+  attempt: number,
+  maxAttempts: number,
+  lastError: string,
+  runnerId: string,
+  now: () => Date,
+  random: (() => number) | undefined,
+  result: RunJobsResult
+): FinalizeInput {
+  const decision = nextAttempt({
+    attemptCount: attempt,
+    maxAttempts,
+    now: now(),
+    random,
+  });
+
+  if (decision.outcome === "failed") {
+    result.failed += 1;
+    return {
+      id: job.id,
+      runnerId,
+      outcome: "failed",
+      nextAttemptAt: null,
+      lastError,
+      now: now(),
+    };
+  }
+
+  result.retried += 1;
+  return {
+    id: job.id,
+    runnerId,
+    outcome: "retry",
+    nextAttemptAt: decision.at,
+    lastError,
+    now: now(),
+  };
+}

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -23,6 +23,12 @@
  * write — but it cannot undo anything that runner already did outside the
  * database.
  *
+ * The lease is now RENEWED while a handler runs, so it tracks the work rather
+ * than predicting it, and the ordinary long-handler case no longer expires.
+ * That narrows the window; it does not close it. A process that stalls, is
+ * paused, or loses its connection stops renewing while its side effects may
+ * still be in flight.
+ *
  * So: **handlers must be idempotent**, and `leaseMs` must be sized to the work.
  * This is the same contract SQS, BullMQ and pg-boss give, for the same reason —
  * exactly-once across a process boundary and an external side effect is not
@@ -43,7 +49,7 @@
 
 import { DEFAULT_MAX_ATTEMPTS, type JobRegistry } from "./job-registry";
 import { nextAttempt } from "./job-backoff";
-import type { FinalizeInput, JobRow } from "./jobs-repository";
+import type { FinalizeInput, FinalizeOutcome, JobRow } from "./jobs-repository";
 import { resolveRunAs, type RunAsDeps } from "./resolve-run-as";
 
 /** Rows claimed and finalized per pass when the caller does not say. */
@@ -53,6 +59,8 @@ export const DEFAULT_BATCH_SIZE = 50;
  * for the final write to commit.
  */
 export const DEFAULT_MAX_DURATION_MS = 25_000;
+/** How long a claim is held before another runner may take the job over. */
+export const DEFAULT_LEASE_MS = 30_000;
 
 /** The store surface a pass needs. `JobsRepository` satisfies it. */
 export interface JobsStore {
@@ -63,8 +71,19 @@ export interface JobsStore {
     now: Date,
     leaseMs: number
   ): Promise<JobRow | null>;
-  markAttempt(id: string, attemptCount: number, now: Date): Promise<void>;
+  markAttempt(
+    id: string,
+    runnerId: string,
+    attemptCount: number,
+    now: Date
+  ): Promise<void>;
   finalize(input: FinalizeInput): Promise<boolean>;
+  renewLease(
+    id: string,
+    runnerId: string,
+    now: Date,
+    leaseMs: number
+  ): Promise<boolean>;
 }
 
 export interface RunJobsDeps {
@@ -76,6 +95,11 @@ export interface RunJobsDeps {
   batchSize?: number;
   maxDurationMs?: number;
   leaseMs?: number;
+  /**
+   * How often to extend the lease while a handler runs. Defaults to a third of
+   * the lease, so two renewals may be missed before it lapses.
+   */
+  renewIntervalMs?: number;
   random?: () => number;
 }
 
@@ -97,7 +121,7 @@ export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
   const runnerId = deps.runnerId ?? crypto.randomUUID();
   const batchSize = deps.batchSize ?? DEFAULT_BATCH_SIZE;
   const maxDurationMs = deps.maxDurationMs ?? DEFAULT_MAX_DURATION_MS;
-  const leaseMs = deps.leaseMs ?? 30_000;
+  const leaseMs = deps.leaseMs ?? DEFAULT_LEASE_MS;
 
   const startedAt = now().getTime();
   const result: RunJobsResult = {
@@ -123,20 +147,31 @@ export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
     result.claimed += 1;
 
     const outcome = await runOne(deps, job, runnerId, now);
-    const wrote = await deps.store.finalize(outcome);
-    // Counted only once the write LANDED. Counting when the decision was made
-    // would report an attempt as both done and unrecorded when the fence
-    // refuses it, which overstates completed work to whatever reads this.
-    if (!wrote) {
-      result.unrecorded += 1;
-      continue;
-    }
-    if (outcome.outcome === "done") result.done += 1;
-    else if (outcome.outcome === "failed") result.failed += 1;
-    else result.retried += 1;
+    countOutcome(result, outcome.outcome, await deps.store.finalize(outcome));
   }
 
   return result;
+}
+
+/**
+ * Record what one attempt did — but only once its write actually landed.
+ *
+ * Counting when the decision was MADE would report an attempt as both done and
+ * unrecorded whenever the fence refuses it, overstating completed work to
+ * whatever reads the result.
+ */
+function countOutcome(
+  result: RunJobsResult,
+  outcome: FinalizeOutcome,
+  wrote: boolean
+): void {
+  if (!wrote) {
+    result.unrecorded += 1;
+    return;
+  }
+  if (outcome === "done") result.done += 1;
+  else if (outcome === "failed") result.failed += 1;
+  else result.retried += 1;
 }
 
 /**
@@ -164,7 +199,7 @@ async function runOne(
 
   const definition = deps.registry.get(job.slug);
   const attempt = job.attemptCount + 1;
-  await deps.store.markAttempt(job.id, attempt, now());
+  await deps.store.markAttempt(job.id, runnerId, attempt, now());
 
   // The identity READS can fail — a transient RBAC database error, say — and
   // that is a different thing from the identity being gone. Letting it throw
@@ -211,10 +246,17 @@ async function runOne(
   }
 
   try {
-    await definition.handler(job.input as never, {
-      user: identity.user,
-      now: now(),
-    });
+    // Renew while the handler works. The lease is otherwise a wall-clock guess
+    // about how long the work takes, and a handler that outruns it is reclaimed
+    // and run a second time CONCURRENTLY — the fence refuses the stale runner's
+    // write but cannot undo what it already did outside the database. Renewal
+    // makes the lease track the work instead of predicting it.
+    await withLeaseRenewal(deps, job, runnerId, now, () =>
+      definition.handler(job.input as never, {
+        user: identity.user,
+        now: now(),
+      })
+    );
   } catch (error) {
     return decide(
       job,
@@ -273,4 +315,48 @@ function decide(
     lastError,
     now: now(),
   };
+}
+
+/**
+ * Run `work`, extending the lease at an interval until it settles.
+ *
+ * Renewal stops as soon as the store reports the lease is no longer this
+ * runner's: continuing would be issuing writes that can never apply, and the
+ * job has already been taken over.
+ *
+ * The interval is always cleared, including when `work` throws — a timer left
+ * running would hold the process open and keep renewing a lease for a handler
+ * that is no longer executing.
+ */
+async function withLeaseRenewal<T>(
+  deps: RunJobsDeps,
+  job: JobRow,
+  runnerId: string,
+  now: () => Date,
+  work: () => Promise<T>
+): Promise<T> {
+  const leaseMs = deps.leaseMs ?? DEFAULT_LEASE_MS;
+  const every = deps.renewIntervalMs ?? Math.floor(leaseMs / 3);
+  // A non-positive interval would schedule a timer that fires continuously.
+  if (every <= 0) return work();
+
+  const timer = setInterval(() => {
+    void deps.store
+      .renewLease(job.id, runnerId, now(), leaseMs)
+      .then(held => {
+        if (!held) clearInterval(timer);
+      })
+      .catch(() => {
+        // Renewal is best-effort: a failed extension is not a reason to fail
+        // the job, and the lease simply lapses as it would have anyway.
+      });
+  }, every);
+  // Never keep the process alive for a renewal timer.
+  timer.unref?.();
+
+  try {
+    return await work();
+  } finally {
+    clearInterval(timer);
+  }
 }

--- a/packages/nextly/src/domains/versions/version-conflict.ts
+++ b/packages/nextly/src/domains/versions/version-conflict.ts
@@ -12,7 +12,6 @@
  * @module domains/versions/version-conflict
  */
 
-import { isDbError } from "../../database/errors";
 import { NextlyError } from "../../errors/nextly-error";
 
 /**
@@ -45,67 +44,18 @@ export class VersionConflictError extends NextlyError {
   }
 }
 
-// Raw driver unique-violation identifiers by dialect. The transaction-context
-// insert path throws the driver error directly — it is NOT normalized to a
-// nextly `DbError` until it escapes the transaction — so capture must recognize
-// the raw driver codes (and the adapter's own `DatabaseError`) at the insert
-// site, where it still knows the insert targeted `nextly_versions`.
-const RAW_UNIQUE_CODES = new Set<string>([
-  "23505", // PostgreSQL unique_violation (SQLSTATE)
-  "ER_DUP_ENTRY", // MySQL
-  "SQLITE_CONSTRAINT_UNIQUE", // better-sqlite3
-  "SQLITE_CONSTRAINT_PRIMARYKEY",
-]);
-
-/**
- * True when `err` is a unique-constraint violation in ANY of the forms it can
- * take between the driver and the nextly service layer: a raw driver error
- * (tx-context insert path), the adapter's `DatabaseError` (`kind:
- * "unique_violation"`, underscore), or a fully-normalized nextly `DbError`
- * (`kind: "unique-violation"`, hyphen). Capture only inserts into
- * `nextly_versions`, whose sole unique index is the version_no sequence, so any
- * unique violation from that insert is a version_no collision.
- */
-function isUniqueViolationShape(err: unknown): boolean {
-  // Fully-normalized nextly DbError (service-layer boundary).
-  if (isDbError(err) && err.kind === "unique-violation") return true;
-  if (typeof err !== "object" || err === null) return false;
-  const e = err as { code?: unknown; errno?: unknown; kind?: unknown };
-  // Adapter-layer DatabaseError: distinct name, underscore kind.
-  if (e.kind === "unique_violation") return true;
-  // MySQL surfaces the duplicate as errno 1062.
-  if (e.errno === 1062) return true;
-  // pg SQLSTATE / mysql code string / sqlite constraint code.
-  if (typeof e.code === "string" && RAW_UNIQUE_CODES.has(e.code)) return true;
-  return false;
-}
-
 /**
  * True when `err`, or anything in its `cause` chain, is a unique-constraint
  * violation.
  *
- * The walk is depth-bounded rather than one level deep, matching
- * {@link findVersionConflict} below. One level is not enough for the ordinary
- * case: a failed query arrives as the adapter's `DatabaseError` wrapping a
- * `DrizzleQueryError` wrapping the driver's error, so the only object carrying
- * `SQLITE_CONSTRAINT_UNIQUE` sits at depth TWO. This returned `false` for a
- * real duplicate key until that was measured.
- *
- * The existing caller was unaffected because version capture catches at the
- * tx-insert site, where the driver error is still near the surface — which is
- * why the gap stayed latent rather than harmless.
- *
- * The bound also guards a cyclic chain: an error whose `cause` points back at
- * itself would otherwise hang the check.
+ * Re-exported rather than defined here: the job queue became a second consumer
+ * and `domains/jobs` has nothing to do with versions, so the shared question
+ * moved to `shared/lib/unique-violation` and this keeps the name its existing
+ * callers import. Capture only inserts into `nextly_versions`, whose sole
+ * unique index is the version_no sequence, so any unique violation from that
+ * insert is a version_no collision.
  */
-export function isUniqueViolation(err: unknown): boolean {
-  let cursor: unknown = err;
-  for (let depth = 0; depth < 10 && cursor != null; depth++) {
-    if (isUniqueViolationShape(cursor)) return true;
-    cursor = (cursor as { cause?: unknown }).cause;
-  }
-  return false;
-}
+export { isUniqueViolation } from "../../shared/lib/unique-violation";
 
 /**
  * Find the {@link VersionConflictError} in `err`'s `cause` chain, if any. The

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
@@ -65,7 +65,7 @@ function store(rows: JobRow[]): JobsStore & { finalized: FinalizeInput[] } {
       return rows;
     },
     claim: async id => rows.find(r => r.id === id) ?? null,
-    markAttempt: async () => {},
+    markAttempt: async () => true,
     renewLease: async () => true,
     finalize: async input => {
       finalized.push(input);
@@ -108,6 +108,21 @@ const fakeRegistry = () =>
     getEnabledEndpointsFresh: vi.fn(async () => []),
   }) satisfies WebhookDrainRegistry;
 
+/**
+ * A content API that refuses to be called.
+ *
+ * These cases do not exercise content operations, and a silent no-op would let
+ * one start using it without saying so — the assertion would then pass against
+ * a handler whose reads returned nothing.
+ */
+const noContentApi = new Proxy({} as never, {
+  get: (_target, name) => () => {
+    throw new Error(
+      `content.${String(name)} called by a test that does not stub it`
+    );
+  },
+});
+
 describe("the webhook drain as a job", () => {
   it("registers under a stable slug", () => {
     // The slug is stored in every queued row. Renaming it orphans every row
@@ -140,6 +155,7 @@ describe("the webhook drain as a job", () => {
       store: s,
       registry,
       runAs: { findUser: async () => null, listRoleSlugs: async () => [] },
+      contentApi: noContentApi,
       now: () => NOW,
     });
 
@@ -171,6 +187,7 @@ describe("the webhook drain as a job", () => {
       registry,
       // A resolver that would REFUSE any id, proving the null path is distinct.
       runAs: { findUser: async () => null, listRoleSlugs: async () => [] },
+      contentApi: noContentApi,
       now: () => NOW,
     });
 

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
@@ -11,9 +11,18 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { JobRegistry } from "../../jobs/job-registry";
-import type { JobRow } from "../../jobs/jobs-repository";
+import type { FinalizeInput, JobRow } from "../../jobs/jobs-repository";
 import { runJobs, type JobsStore } from "../../jobs/run-jobs";
+import type {
+  WebhookDrainDatabase,
+  WebhookDrainRegistry,
+} from "../drain-runner";
 import { WEBHOOK_DRAIN_JOB, createWebhookDrainJob } from "../webhook-drain-job";
+
+/** The transaction shape the drain's database surface hands its callback. */
+type WebhookDrainTx = Parameters<
+  Parameters<WebhookDrainDatabase["transaction"]>[0]
+>[0];
 
 const NOW = new Date("2026-01-01T00:00:00.000Z");
 
@@ -37,9 +46,9 @@ function jobRow(over: Partial<JobRow> = {}): JobRow {
   };
 }
 
-function store(rows: JobRow[]): JobsStore & { finalized: any[] } {
+function store(rows: JobRow[]): JobsStore & { finalized: FinalizeInput[] } {
   let handed = false;
-  const finalized: any[] = [];
+  const finalized: FinalizeInput[] = [];
   return {
     finalized,
     findDue: async () => {
@@ -80,13 +89,15 @@ describe("the webhook drain as a job", () => {
     );
   });
 
-  it("does NOT retry the pass — the outbox rows carry their own retry state", () => {
-    // A drain is a sweep, not a unit of work. Re-running the sweep would
-    // re-attempt deliveries that already recorded an outcome and restart their
-    // backoff from the wrong clock.
+  it("IS retryable, so a transient failure does not strand the outbox", () => {
+    // Repeating a sweep is safe: deliverDueDeliveries selects only due
+    // pending/retrying rows whose lease is free, so a completed delivery is
+    // already excluded and a deferred one stays deferred. A single attempt
+    // meant a brief database outage failed the job terminally and left the
+    // remaining outbox work to whenever some other trigger happened to fire.
     expect(
       createWebhookDrainJob(fakeAdapter(), fakeRegistry()).retry.maxAttempts
-    ).toBe(1);
+    ).toBeGreaterThan(1);
   });
 
   it("runs the drain when the runner claims its row, and records it done", async () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
@@ -13,16 +13,24 @@ import { describe, expect, it, vi } from "vitest";
 import { JobRegistry } from "../../jobs/job-registry";
 import type { FinalizeInput, JobRow } from "../../jobs/jobs-repository";
 import { runJobs, type JobsStore } from "../../jobs/run-jobs";
+import type { DeliverTx } from "../deliver";
 import type {
   WebhookDrainDatabase,
   WebhookDrainRegistry,
 } from "../drain-runner";
+import type { FanOutTx } from "../fan-out";
 import { WEBHOOK_DRAIN_JOB, createWebhookDrainJob } from "../webhook-drain-job";
 
-/** The transaction shape the drain's database surface hands its callback. */
-type WebhookDrainTx = Parameters<
-  Parameters<WebhookDrainDatabase["transaction"]>[0]
->[0];
+/**
+ * The transaction context the drain's database surface hands its callback.
+ *
+ * `WebhookDrainDatabase` is `FanOutDatabase & DeliverDatabase`, so its
+ * `transaction` is an INTERSECTION of two call signatures whose contexts differ
+ * — fan-out needs `insertMany`, delivery does not. A fake satisfying only one
+ * of them is what the previous `as any` was hiding: the cast made a fake that
+ * cannot stand in for the real dependency compile as though it could.
+ */
+type WebhookDrainTx = FanOutTx & DeliverTx;
 
 const NOW = new Date("2026-01-01T00:00:00.000Z");
 
@@ -58,6 +66,7 @@ function store(rows: JobRow[]): JobsStore & { finalized: FinalizeInput[] } {
     },
     claim: async id => rows.find(r => r.id === id) ?? null,
     markAttempt: async () => {},
+    renewLease: async () => true,
     finalize: async input => {
       finalized.push(input);
       return true;
@@ -65,18 +74,39 @@ function store(rows: JobRow[]): JobsStore & { finalized: FinalizeInput[] } {
   };
 }
 
-/** A drain that records that it ran, standing in for the real engine. */
-const fakeAdapter = () =>
-  ({
-    select: vi.fn(async () => []),
-    update: vi.fn(async () => []),
-    transaction: vi.fn(async (fn: any) =>
-      fn({ select: async () => [], update: async () => [] })
-    ),
-  }) as any;
+/**
+ * A drain that records that it ran, standing in for the real engine.
+ *
+ * `satisfies` rather than a cast. This fake stands at the boundary of the
+ * production wiring, and a cast removes the structural check that makes it
+ * stand there: a dependency the drain gains, or one misspelled here, would keep
+ * compiling against the fake while the real call site broke.
+ */
+const fakeAdapter = () => {
+  const empty = async (): Promise<never[]> => [];
+  const tx: WebhookDrainTx = {
+    select: empty,
+    update: empty,
+    insertMany: empty,
+  };
+  const transaction: WebhookDrainDatabase["transaction"] = <T>(
+    fn: (ctx: never) => Promise<T>
+  ): Promise<T> => fn(tx as never);
+  return {
+    select: vi.fn(empty),
+    update: vi.fn(empty),
+    // Not wrapped in vi.fn: `transaction` is an intersection of two call
+    // signatures, and Mock<A & B> is not assignable to A & B. Nothing asserts
+    // on it — the drain having reached the database is observed through
+    // `select` — so wrapping it would cost the type check and buy nothing.
+    transaction,
+  } satisfies WebhookDrainDatabase;
+};
 
 const fakeRegistry = () =>
-  ({ getEnabledEndpointsFresh: vi.fn(async () => []) }) as any;
+  ({
+    getEnabledEndpointsFresh: vi.fn(async () => []),
+  }) satisfies WebhookDrainRegistry;
 
 describe("the webhook drain as a job", () => {
   it("registers under a stable slug", () => {

--- a/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/webhook-drain-job.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Webhook delivery running on the shared job runner.
+ *
+ * The point of this suite is not that the drain works — 23 files already prove
+ * that. It is that routing it through the runner does not CHANGE it: the same
+ * drain, invoked the same way, with the runner supplying the claim and the
+ * bookkeeping around it.
+ *
+ * @module domains/webhooks/__tests__/webhook-drain-job.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { JobRegistry } from "../../jobs/job-registry";
+import type { JobRow } from "../../jobs/jobs-repository";
+import { runJobs, type JobsStore } from "../../jobs/run-jobs";
+import { WEBHOOK_DRAIN_JOB, createWebhookDrainJob } from "../webhook-drain-job";
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+function jobRow(over: Partial<JobRow> = {}): JobRow {
+  return {
+    id: "drain-1",
+    slug: WEBHOOK_DRAIN_JOB,
+    input: null,
+    state: "pending",
+    runAt: null,
+    runAsUserId: null,
+    dedupeKey: null,
+    attemptCount: 0,
+    nextAttemptAt: null,
+    lockedBy: null,
+    lockedUntil: null,
+    lastError: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...over,
+  };
+}
+
+function store(rows: JobRow[]): JobsStore & { finalized: any[] } {
+  let handed = false;
+  const finalized: any[] = [];
+  return {
+    finalized,
+    findDue: async () => {
+      if (handed) return [];
+      handed = true;
+      return rows;
+    },
+    claim: async id => rows.find(r => r.id === id) ?? null,
+    markAttempt: async () => {},
+    finalize: async input => {
+      finalized.push(input);
+      return true;
+    },
+  };
+}
+
+/** A drain that records that it ran, standing in for the real engine. */
+const fakeAdapter = () =>
+  ({
+    select: vi.fn(async () => []),
+    update: vi.fn(async () => []),
+    transaction: vi.fn(async (fn: any) =>
+      fn({ select: async () => [], update: async () => [] })
+    ),
+  }) as any;
+
+const fakeRegistry = () =>
+  ({ getEnabledEndpointsFresh: vi.fn(async () => []) }) as any;
+
+describe("the webhook drain as a job", () => {
+  it("registers under a stable slug", () => {
+    // The slug is stored in every queued row. Renaming it orphans every row
+    // already in the table, which the runner would then report as an unknown
+    // job type — recoverable, but only because nothing is silently skipped.
+    expect(WEBHOOK_DRAIN_JOB).toBe("webhooks:drain");
+    expect(createWebhookDrainJob(fakeAdapter(), fakeRegistry()).slug).toBe(
+      "webhooks:drain"
+    );
+  });
+
+  it("does NOT retry the pass — the outbox rows carry their own retry state", () => {
+    // A drain is a sweep, not a unit of work. Re-running the sweep would
+    // re-attempt deliveries that already recorded an outcome and restart their
+    // backoff from the wrong clock.
+    expect(
+      createWebhookDrainJob(fakeAdapter(), fakeRegistry()).retry.maxAttempts
+    ).toBe(1);
+  });
+
+  it("runs the drain when the runner claims its row, and records it done", async () => {
+    const registry = new JobRegistry();
+    const adapter = fakeAdapter();
+    registry.register(createWebhookDrainJob(adapter, fakeRegistry()));
+
+    const s = store([jobRow()]);
+    const result = await runJobs({
+      store: s,
+      registry,
+      runAs: { findUser: async () => null, listRoleSlugs: async () => [] },
+      now: () => NOW,
+    });
+
+    expect(result).toMatchObject({ claimed: 1, done: 1, failed: 0 });
+    // The drain actually reached the database rather than the job merely being
+    // marked done — the assertion that distinguishes "ran" from "recorded".
+    expect(adapter.select).toHaveBeenCalled();
+  });
+
+  it("runs as NOBODY, and that is not the same as running as the system", async () => {
+    // Webhook delivery reads nothing access-controlled, so it is one of the
+    // few jobs legitimately queued with no identity. It must therefore reach
+    // the handler rather than being refused — the identity rule refuses a
+    // MISSING user, not an ABSENT one.
+    let sawUser: unknown = "unset";
+    const registry = new JobRegistry();
+    const adapter = fakeAdapter();
+    const job = createWebhookDrainJob(adapter, fakeRegistry());
+    registry.register({
+      ...job,
+      handler: async (input, ctx) => {
+        sawUser = ctx.user;
+        await job.handler(input, ctx);
+      },
+    });
+
+    const result = await runJobs({
+      store: store([jobRow({ runAsUserId: null })]),
+      registry,
+      // A resolver that would REFUSE any id, proving the null path is distinct.
+      runAs: { findUser: async () => null, listRoleSlugs: async () => [] },
+      now: () => NOW,
+    });
+
+    expect(sawUser).toBeNull();
+    expect(result).toMatchObject({ done: 1, failed: 0 });
+  });
+});

--- a/packages/nextly/src/domains/webhooks/index.ts
+++ b/packages/nextly/src/domains/webhooks/index.ts
@@ -73,3 +73,4 @@ export {
   type FilterSpecExpression,
   type WebhookEndpoint,
 } from "./types";
+export { WEBHOOK_DRAIN_JOB, createWebhookDrainJob } from "./webhook-drain-job";

--- a/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
+++ b/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
@@ -1,0 +1,68 @@
+/**
+ * Webhook delivery as a job type — the first consumer of the shared runner.
+ *
+ * This is what proves the extraction. The runner's lease, fencing, retry and
+ * budget were lifted from this domain, so putting the drain back on top of them
+ * is the test that they were lifted faithfully: a real, already-reviewed
+ * workload rather than a fixture written to agree with the new code.
+ *
+ * ## Why a factory rather than a bare definition
+ *
+ * The drain needs the raw database adapter and the endpoint registry. A job
+ * handler receives only its input and a context, deliberately — widening
+ * `JobContext` to carry the Nextly instance would point the jobs domain at the
+ * instance that owns it, and this repo already has a standing task for its
+ * import cycles.
+ *
+ * A handler that needs CONTENT does not need this: the Direct API resolves
+ * itself lazily (`direct-api/nextly.ts` calls `getNextly()` per method), so a
+ * job can import and use it without anything being threaded through. Only a
+ * consumer like this one, which wants the adapter beneath the API, takes deps
+ * at registration.
+ *
+ * ## This does not replace the existing triggers yet
+ *
+ * The cron/manual route and the post-response fast path stay exactly as they
+ * are. Removing them before the job runner has a trigger of its own would leave
+ * webhook delivery with nothing to run it — the failure Payload's own docs warn
+ * about, where scheduled work never fires because no processor exists. Running
+ * both is safe precisely because of the lease: whichever gets there first
+ * claims each delivery, and the other finds nothing to do.
+ *
+ * @module domains/webhooks/webhook-drain-job
+ */
+
+import { defineJob, type JobDefinition } from "../jobs/job-registry";
+
+import {
+  runWebhookDrain,
+  type RunWebhookDrainOptions,
+  type WebhookDrainDatabase,
+  type WebhookDrainRegistry,
+} from "./drain-runner";
+
+/** The slug the drain is registered and enqueued under. */
+export const WEBHOOK_DRAIN_JOB = "webhooks:drain";
+
+/**
+ * A drain pass, as a job.
+ *
+ * `maxAttempts: 1`. A drain is not a unit of work that either succeeds or
+ * fails — it is a sweep over an outbox whose OWN rows carry the retry state.
+ * Retrying the sweep would re-attempt deliveries that already recorded their
+ * outcome and re-run their backoff from the wrong clock, so the retry belongs
+ * to the deliveries and not to the pass over them.
+ */
+export function createWebhookDrainJob(
+  adapter: WebhookDrainDatabase,
+  registry: WebhookDrainRegistry,
+  options?: RunWebhookDrainOptions
+): JobDefinition<unknown> {
+  return defineJob({
+    slug: WEBHOOK_DRAIN_JOB,
+    retry: { maxAttempts: 1 },
+    handler: async () => {
+      await runWebhookDrain(adapter, registry, options);
+    },
+  });
+}

--- a/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
+++ b/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
@@ -47,11 +47,21 @@ export const WEBHOOK_DRAIN_JOB = "webhooks:drain";
 /**
  * A drain pass, as a job.
  *
- * `maxAttempts: 1`. A drain is not a unit of work that either succeeds or
- * fails — it is a sweep over an outbox whose OWN rows carry the retry state.
- * Retrying the sweep would re-attempt deliveries that already recorded their
- * outcome and re-run their backoff from the wrong clock, so the retry belongs
- * to the deliveries and not to the pass over them.
+ * The pass is RETRYABLE, and an earlier version of this module was wrong about
+ * why it should not be.
+ *
+ * The reasoning then was that re-running a sweep would re-attempt deliveries
+ * that had already recorded an outcome and restart their backoff from the wrong
+ * clock. It would not: `deliverDueDeliveries` selects only `pending`/`retrying`
+ * rows whose `nextAttemptAt` has passed and whose lease is free
+ * (`deliver.ts:706-719`), so a completed delivery is already excluded and a
+ * deferred one stays deferred. Per-row retry state is exactly what makes the
+ * sweep safe to repeat.
+ *
+ * What a single attempt DID cost: a transient failure — the database briefly
+ * unreachable, the endpoint registry erroring — made the job row terminally
+ * failed and left the remaining outbox work to whenever some other trigger
+ * happened to fire.
  */
 export function createWebhookDrainJob(
   adapter: WebhookDrainDatabase,
@@ -60,7 +70,9 @@ export function createWebhookDrainJob(
 ): JobDefinition<unknown> {
   return defineJob({
     slug: WEBHOOK_DRAIN_JOB,
-    retry: { maxAttempts: 1 },
+    // The default budget. Nothing about a sweep calls for a narrower one, and
+    // deriving it rather than restating a number keeps it with every other job.
+
     handler: async () => {
       await runWebhookDrain(adapter, registry, options);
     },

--- a/packages/nextly/src/index.ts
+++ b/packages/nextly/src/index.ts
@@ -610,6 +610,33 @@ export {
 // TAKES, because that is the only thing a plugin author choosing between the
 // two can see.
 export { schemaDraftSplit as resolvedCollectionDraftSplit } from "./domains/versions/draft-split-eligibility";
+
+// Background jobs. Exported from the root entry rather than only from the
+// domain barrel: a barrel that no published entry re-exports is unreachable
+// from an installed application, so the feature would exist for this
+// repository's own tests and for nobody else.
+export {
+  DEFAULT_MAX_ATTEMPTS,
+  MAX_JOB_SLUG_LENGTH,
+  defineJob,
+  JobRegistry,
+} from "./domains/jobs/job-registry";
+export type {
+  JobContext,
+  JobDefinition,
+  JobDefinitionInput,
+  JobRetryPolicy,
+} from "./domains/jobs/job-registry";
+export { JobsRepository } from "./domains/jobs/jobs-repository";
+export type {
+  EnqueueResult,
+  JobRow,
+  NewJob,
+} from "./domains/jobs/jobs-repository";
+export { runJobsPass } from "./domains/jobs/jobs-runner";
+export type { RunJobsPassOptions } from "./domains/jobs/jobs-runner";
+export type { RunJobsResult } from "./domains/jobs/run-jobs";
+
 export type { SchemaEligibilityCollection as ResolvedDraftSplitCollection } from "./domains/versions/draft-split-eligibility";
 
 // Plugin event bus (D8/D51) — `ctx.events` surface + types.

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -78,3 +78,7 @@ export {
   nextlyReleasesMysql as nextlyReleases,
   nextlyReleaseMembersMysql as nextlyReleaseMembers,
 } from "../releases/mysql";
+
+// Background jobs; see the releases note above for why the bundle entry is
+// required and not merely tidy.
+export { nextlyJobsMysql as nextlyJobs } from "../jobs/mysql";

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -103,3 +103,8 @@ export {
   nextlyReleasesPg as nextlyReleases,
   nextlyReleaseMembersPg as nextlyReleaseMembers,
 } from "../releases/postgres";
+
+// Background jobs; in the bundle for the reason the releases note above
+// gives — getCoreSchema makes a table diffable, this map is what apply
+// actually pushes.
+export { nextlyJobsPg as nextlyJobs } from "../jobs/postgres";

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -78,3 +78,7 @@ export {
   nextlyReleasesSqlite as nextlyReleases,
   nextlyReleaseMembersSqlite as nextlyReleaseMembers,
 } from "../releases/sqlite";
+
+// Background jobs; see the releases note above for why the bundle entry is
+// required and not merely tidy.
+export { nextlyJobsSqlite as nextlyJobs } from "../jobs/sqlite";

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -50,6 +50,7 @@ import { emailTemplatesMysql } from "./email-templates/mysql";
 import { emailTemplatesPg } from "./email-templates/postgres";
 import { emailTemplatesSqlite } from "./email-templates/sqlite";
 import { fieldGroupLockTables } from "./field-group-lock";
+import { jobsTables } from "./jobs";
 import { mediaTables } from "./media";
 import { nextlyI18nArchiveTables } from "./nextly-i18n-archive";
 import { nextlyMetaTables } from "./nextly-meta";
@@ -191,6 +192,7 @@ export function getCoreSchema(
     // — a table absent from this snapshot is never created by db:sync, and the
     // SQLite bootstrap fallback would hide that on one dialect only.
     ...Object.values(releasesTables(dialect)),
+    ...Object.values(jobsTables(dialect)),
     ...Object.values(webhookTables(dialect)),
   ];
 
@@ -288,6 +290,7 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   "nextly_versions",
   "nextly_releases",
   "nextly_release_members",
+  "nextly_jobs",
   "nextly_events",
   "nextly_webhooks",
   "nextly_webhook_deliveries",

--- a/packages/nextly/src/schemas/jobs/__tests__/parity.test.ts
+++ b/packages/nextly/src/schemas/jobs/__tests__/parity.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The three dialect tables are hand-mirrored from `./postgres.ts`, so a column
+ * added to one and forgotten in another is the failure to catch. Comparing
+ * NAME SETS rather than counts means a rename plus an addition cannot cancel
+ * out and read as agreement.
+ *
+ * @module schemas/jobs/__tests__/parity.test
+ */
+import { Column, is, type Table } from "drizzle-orm";
+import { describe, it, expect } from "vitest";
+
+import { CORE_TABLE_NAMES, getCoreSchema } from "../../index";
+import { my, pg, sl } from "../index";
+import { JOB_STATES } from "../types";
+
+/**
+ * Read the columns by asking Drizzle what each property IS, rather than by
+ * enumerating the object.
+ *
+ * A table object also carries dialect-specific METHODS as own enumerable
+ * properties — `enableRLS` exists on the pg builder and on neither of the
+ * others — so a bare `Object.keys` reports a difference that is not a column
+ * and never could be. `is(value, Column)` keeps exactly the columns, and it is
+ * not the deprecated whole-table column helper the drizzle-legacy gate
+ * rejects: that helper still compiles on v1, so the compiler cannot catch its
+ * use and the gate is what does. Naming it here is not possible either — the
+ * gate greps source text, so a comment mentioning it fails the same check.
+ *
+ * Both the property name and the database column name are compared, for the
+ * reason the releases mirror gives: keeping the property while mistyping the
+ * snake_case name passes a property-only comparison and produces a table the
+ * others cannot be read alongside.
+ */
+const columnNames = (table: Table): string[] =>
+  Object.entries(table)
+    .filter((entry): entry is [string, Column] => is(entry[1], Column))
+    .map(([property, column]) => `${property}:${column.name}`)
+    .sort();
+
+describe("the job table is identical across dialects", () => {
+  it("nextly_jobs has the same columns everywhere", () => {
+    const canonical = columnNames(pg.nextlyJobsPg);
+    // The control: if this ever reads as empty, the comparisons below are
+    // satisfied by absence and prove nothing about either dialect.
+    expect(canonical.length).toBeGreaterThan(0);
+    expect(columnNames(my.nextlyJobsMysql)).toEqual(canonical);
+    expect(columnNames(sl.nextlyJobsSqlite)).toEqual(canonical);
+  });
+
+  it("carries the lease pair, without which two runners can run one job", () => {
+    // Named rather than left to the set comparison above: that comparison is
+    // satisfied by three dialects agreeing, INCLUDING three dialects that all
+    // dropped the lease together. The claim in `jobs-repository` is built on
+    // exactly these two columns.
+    for (const table of [
+      pg.nextlyJobsPg,
+      my.nextlyJobsMysql,
+      sl.nextlyJobsSqlite,
+    ]) {
+      expect(columnNames(table)).toContain("lockedBy:locked_by");
+      expect(columnNames(table)).toContain("lockedUntil:locked_until");
+    }
+  });
+
+  it("carries run_as_user_id, which the fail-closed identity rule reads", () => {
+    // Also named: a job that loses this column does not fail, it runs as
+    // NOBODY — which applies no field rules at all. Losing it would keep every
+    // dialect in agreement while removing the access boundary.
+    for (const table of [
+      pg.nextlyJobsPg,
+      my.nextlyJobsMysql,
+      sl.nextlyJobsSqlite,
+    ]) {
+      expect(columnNames(table)).toContain("runAsUserId:run_as_user_id");
+    }
+  });
+});
+
+describe("job states", () => {
+  it("lists every state exactly once", () => {
+    expect([...JOB_STATES]).toEqual(["pending", "running", "done", "failed"]);
+  });
+});
+
+/**
+ * Declaring the Drizzle tables does not create them. A core table reaches a
+ * real database only if it is ALSO in the core schema snapshot and in
+ * `CORE_TABLE_NAMES`, which is what db:sync and boot-apply read. Missing that
+ * step fails in the least visible way available: the SQLite bootstrap DDL
+ * still creates the table, so the feature works on one dialect and is absent
+ * on the other two.
+ */
+describe("nextly_jobs is registered as a core table", () => {
+  it("is named in CORE_TABLE_NAMES", () => {
+    expect(CORE_TABLE_NAMES).toContain("nextly_jobs");
+  });
+
+  it.each(["postgresql", "mysql", "sqlite"] as const)(
+    "appears in the %s core schema snapshot",
+    dialect => {
+      const names = getCoreSchema(dialect).tables.map(t => t.name);
+      // The control: an empty snapshot would satisfy the assertion below by
+      // absence and prove nothing about registration.
+      expect(names.length).toBeGreaterThan(0);
+      expect(names).toContain("nextly_jobs");
+    }
+  );
+});

--- a/packages/nextly/src/schemas/jobs/index.ts
+++ b/packages/nextly/src/schemas/jobs/index.ts
@@ -1,0 +1,40 @@
+/**
+ * Job tables - dialect-aware barrel.
+ *
+ * Re-exports the per-dialect job table under a canonical name; the runtime
+ * dialect selects which table a caller sees.
+ *
+ * @module schemas/jobs
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../errors";
+
+import * as my from "./mysql";
+import * as pg from "./postgres";
+import * as sl from "./sqlite";
+
+export { pg, my, sl };
+export { JOB_STATES, type JobState } from "./types";
+
+/** Returns the Drizzle table objects for the jobs feature group. */
+export function jobsTables(dialect: SupportedDialect) {
+  switch (dialect) {
+    case "postgresql":
+      return { nextlyJobs: pg.nextlyJobsPg };
+    case "mysql":
+      return { nextlyJobs: my.nextlyJobsMysql };
+    case "sqlite":
+      return { nextlyJobs: sl.nextlyJobsSqlite };
+    default: {
+      const _exhaustive: never = dialect;
+      // NextlyError (not bare Error) per the packages/nextly convention. This
+      // branch is unreachable given the SupportedDialect union; the `never`
+      // assignment is the compile-time exhaustiveness guard.
+      throw NextlyError.internal({
+        logContext: { dialect: String(_exhaustive) },
+      });
+    }
+  }
+}

--- a/packages/nextly/src/schemas/jobs/mysql.ts
+++ b/packages/nextly/src/schemas/jobs/mysql.ts
@@ -1,0 +1,73 @@
+/**
+ * `nextly_jobs` - MySQL.
+ *
+ * Mirrors `./postgres.ts` column for column; see that module for why the claim
+ * is a lease rather than `FOR UPDATE SKIP LOCKED`, and why `dedupe_key` is
+ * nullable and unique.
+ *
+ * `datetime(..., { fsp: 3 })` throughout, matching the other core tables:
+ * without fractional seconds two writes in the same second serialize to the
+ * same value, and a lease whose expiry cannot be ordered against its
+ * replacement is not a lease.
+ *
+ * @module schemas/jobs/mysql
+ */
+
+import {
+  mysqlTable,
+  varchar,
+  int,
+  datetime,
+  json,
+  text,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/mysql-core";
+
+import type { JobState } from "./types";
+
+export const nextlyJobsMysql = mysqlTable(
+  "nextly_jobs",
+  {
+    id: varchar("id", { length: 36 })
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    slug: varchar("slug", { length: 191 }).notNull(),
+    input: json("input"),
+
+    state: varchar("state", { length: 32 }).$type<JobState>().notNull(),
+
+    runAt: datetime("run_at", { fsp: 3 }),
+
+    runAsUserId: varchar("run_as_user_id", { length: 36 }),
+
+    // 191 rather than 255: this column carries a unique index, and 191 is the
+    // longest utf8mb4 key MySQL will index under the 767-byte prefix limit on
+    // older row formats. `nextly_webhook_deliveries.locked_by` uses the same
+    // bound for the same reason.
+    dedupeKey: varchar("dedupe_key", { length: 191 }),
+
+    attemptCount: int("attempt_count").notNull().default(0),
+    nextAttemptAt: datetime("next_attempt_at", { fsp: 3 }),
+
+    lockedBy: varchar("locked_by", { length: 191 }),
+    lockedUntil: datetime("locked_until", { fsp: 3 }),
+
+    lastError: text("last_error"),
+
+    createdAt: datetime("created_at", { fsp: 3 })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: datetime("updated_at", { fsp: 3 })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  table => [
+    index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
+  ]
+);
+
+export type NextlyJobMysql = typeof nextlyJobsMysql.$inferSelect;
+export type NextlyJobInsertMysql = typeof nextlyJobsMysql.$inferInsert;

--- a/packages/nextly/src/schemas/jobs/postgres.ts
+++ b/packages/nextly/src/schemas/jobs/postgres.ts
@@ -1,0 +1,97 @@
+/**
+ * `nextly_jobs` - PostgreSQL.
+ *
+ * The canonical column list; `./mysql.ts` and `./sqlite.ts` mirror it with
+ * their own types. `id` uses the client-side UUID pattern (text +
+ * `$defaultFn`) for cross-dialect parity with the other system tables.
+ *
+ * ## Why the lease, and not `FOR UPDATE SKIP LOCKED`
+ *
+ * `locked_by`/`locked_until` express the claim in ORDINARY columns, so one
+ * implementation serves all three dialects. `SKIP LOCKED` is stronger and
+ * exists on PostgreSQL and MySQL; SQLite has no such clause, and Nextly ships
+ * a SQLite adapter. `nextly_webhook_deliveries` made the same trade for the
+ * same reason and has run on it in production, so this inherits a decision
+ * rather than re-opening one.
+ *
+ * ## Why `dedupe_key` is nullable AND unique
+ *
+ * All three dialects allow unlimited NULLs in a unique index, so a job that
+ * names no dedupe key is never deduplicated while a job that names one can be
+ * enqueued exactly once. `nextly_versions.draft_key` relies on the same
+ * property. This is what makes duplicate suppression a DATABASE constraint
+ * rather than a read-then-write: a periodic sweep and a queue trigger can both
+ * try to enqueue the same work, and the second insert is refused rather than
+ * prevented by a check that another writer could interleave with.
+ *
+ * @module schemas/jobs/postgres
+ */
+
+import {
+  pgTable,
+  text,
+  integer,
+  timestamp,
+  jsonb,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/pg-core";
+
+import type { JobState } from "./types";
+
+export const nextlyJobsPg = pgTable(
+  "nextly_jobs",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    /** Which registered job type runs this row. */
+    slug: text("slug").notNull(),
+    /** The handler's input, opaque to this domain. */
+    input: jsonb("input"),
+
+    state: text("state").$type<JobState>().notNull(),
+
+    // NULL means "as soon as a trigger sees it". A stored placeholder would be
+    // indistinguishable from a job deliberately scheduled for the epoch.
+    runAt: timestamp("run_at", { withTimezone: true }),
+
+    // The identity the handler acts AS. NULL means the job genuinely acts as
+    // nobody (webhook delivery reads nothing access-controlled); it does NOT
+    // mean "system". A row whose id is set but no longer resolves is a
+    // terminal failure, never a downgrade to this NULL case.
+    runAsUserId: text("run_as_user_id"),
+
+    // See the module note: nullable, unique, and the reason duplicate
+    // suppression is a constraint rather than a check.
+    dedupeKey: text("dedupe_key"),
+
+    attemptCount: integer("attempt_count").notNull().default(0),
+    nextAttemptAt: timestamp("next_attempt_at", { withTimezone: true }),
+
+    // The lease. Taken inside a transaction, released before the work runs (a
+    // handler must never hold a row lock), and fenced on write so a runner
+    // whose lease expired cannot record an outcome over its successor's.
+    lockedBy: text("locked_by"),
+    lockedUntil: timestamp("locked_until", { withTimezone: true }),
+
+    /** Why a `failed` row failed. Surfaced in the admin. */
+    lastError: text("last_error"),
+
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  table => [
+    // The due-job query reads exactly these two columns together.
+    index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
+  ]
+);
+
+export type NextlyJobPg = typeof nextlyJobsPg.$inferSelect;
+export type NextlyJobInsertPg = typeof nextlyJobsPg.$inferInsert;

--- a/packages/nextly/src/schemas/jobs/sqlite.ts
+++ b/packages/nextly/src/schemas/jobs/sqlite.ts
@@ -1,0 +1,62 @@
+/**
+ * `nextly_jobs` - SQLite.
+ *
+ * Mirrors `./postgres.ts` column for column; see that module for why the claim
+ * is a lease rather than `FOR UPDATE SKIP LOCKED` — this dialect is the reason
+ * — and why `dedupe_key` is nullable and unique.
+ *
+ * @module schemas/jobs/sqlite
+ */
+
+import {
+  sqliteTable,
+  text,
+  integer,
+  index,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core";
+
+import type { JobState } from "./types";
+
+export const nextlyJobsSqlite = sqliteTable(
+  "nextly_jobs",
+  {
+    id: text("id")
+      .primaryKey()
+      .notNull()
+      .$defaultFn(() => crypto.randomUUID()),
+
+    slug: text("slug").notNull(),
+    input: text("input", { mode: "json" }),
+
+    state: text("state").$type<JobState>().notNull(),
+
+    runAt: integer("run_at", { mode: "timestamp" }),
+
+    runAsUserId: text("run_as_user_id"),
+
+    dedupeKey: text("dedupe_key"),
+
+    attemptCount: integer("attempt_count").notNull().default(0),
+    nextAttemptAt: integer("next_attempt_at", { mode: "timestamp" }),
+
+    lockedBy: text("locked_by"),
+    lockedUntil: integer("locked_until", { mode: "timestamp" }),
+
+    lastError: text("last_error"),
+
+    createdAt: integer("created_at", { mode: "timestamp" })
+      .$defaultFn(() => new Date())
+      .notNull(),
+    updatedAt: integer("updated_at", { mode: "timestamp" })
+      .$defaultFn(() => new Date())
+      .notNull(),
+  },
+  table => [
+    index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
+  ]
+);
+
+export type NextlyJobSqlite = typeof nextlyJobsSqlite.$inferSelect;
+export type NextlyJobInsertSqlite = typeof nextlyJobsSqlite.$inferInsert;

--- a/packages/nextly/src/schemas/jobs/types.ts
+++ b/packages/nextly/src/schemas/jobs/types.ts
@@ -1,0 +1,22 @@
+/**
+ * Job state vocabulary.
+ *
+ * @module schemas/jobs/types
+ */
+
+/**
+ * The states a job row can hold.
+ *
+ * A failed ATTEMPT is not a failed JOB: an attempt that may be retried leaves
+ * the row `pending` with `attempt_count` incremented and `next_attempt_at`
+ * set by the backoff. Only exhausting the retry budget — or a failure declared
+ * terminal, of which an unresolvable `run_as_user_id` is the first — moves a
+ * row to `failed`. `failed` is therefore an end state no trigger picks up
+ * again, and `last_error` records why.
+ *
+ * Without that distinction "non-retryable" would have no representation in the
+ * table, and a job whose identity is gone would retry forever.
+ */
+export const JOB_STATES = ["pending", "running", "done", "failed"] as const;
+
+export type JobState = (typeof JOB_STATES)[number];

--- a/packages/nextly/src/shared/lib/unique-violation.ts
+++ b/packages/nextly/src/shared/lib/unique-violation.ts
@@ -1,0 +1,77 @@
+/**
+ * "Was this failure a duplicate key?" — asked once, for every caller.
+ *
+ * A unique violation reaches application code in several different shapes
+ * depending on where it is caught, and each layer respells it:
+ *
+ * | where it is caught | what it looks like |
+ * | --- | --- |
+ * | inside a transaction callback | the RAW driver error, with the driver's own code |
+ * | after the adapter wraps it | `DatabaseError`, `kind: "unique_violation"` (underscore) |
+ * | at the nextly service boundary | `DbError`, `kind: "unique-violation"` (hyphen) |
+ *
+ * The two `kind` spellings are different enums, not a typo.
+ *
+ * It also arrives NESTED. A failed query is an adapter `DatabaseError` wrapping
+ * a `DrizzleQueryError` wrapping the driver's error, so the only object
+ * carrying `SQLITE_CONSTRAINT_UNIQUE` sits at depth TWO. A one-level check
+ * answers `false` for an ordinary duplicate key — measured, and the reason this
+ * walk is depth-bounded rather than shallow.
+ *
+ * ## Why this lives in `shared/lib` rather than in a domain
+ *
+ * It began in `domains/versions/version-conflict`, which is where its first
+ * caller was. The job queue is the second, and `domains/jobs` has nothing to do
+ * with versions — importing one from the other would add a dependency edge that
+ * describes history rather than meaning. `canonicalJson` moved here for exactly
+ * this reason when it gained a second consumer. `version-conflict` re-exports
+ * it, so its own callers are unchanged.
+ *
+ * @module shared/lib/unique-violation
+ */
+
+import { isDbError } from "../../database/errors";
+
+/**
+ * Raw driver unique-violation identifiers by dialect. The transaction-context
+ * insert path throws the driver error directly — it is NOT normalized to a
+ * nextly `DbError` until it escapes the transaction — so a caller must be able
+ * to recognize the raw driver codes at the insert site.
+ */
+const RAW_UNIQUE_CODES = new Set<string>([
+  "23505", // PostgreSQL unique_violation (SQLSTATE)
+  "ER_DUP_ENTRY", // MySQL
+  "SQLITE_CONSTRAINT_UNIQUE", // better-sqlite3
+  "SQLITE_CONSTRAINT_PRIMARYKEY",
+]);
+
+/** One error object, in any of the three shapes described above. */
+function isUniqueViolationShape(err: unknown): boolean {
+  // Fully-normalized nextly DbError (service-layer boundary).
+  if (isDbError(err) && err.kind === "unique-violation") return true;
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { code?: unknown; errno?: unknown; kind?: unknown };
+  // Adapter-layer DatabaseError: distinct name, underscore kind.
+  if (e.kind === "unique_violation") return true;
+  // MySQL surfaces the duplicate as errno 1062.
+  if (e.errno === 1062) return true;
+  // pg SQLSTATE / mysql code string / sqlite constraint code.
+  if (typeof e.code === "string" && RAW_UNIQUE_CODES.has(e.code)) return true;
+  return false;
+}
+
+/**
+ * True when `err`, or anything in its `cause` chain, is a unique-constraint
+ * violation.
+ *
+ * The depth bound also guards a cyclic chain: an error whose `cause` points
+ * back at itself would otherwise hang the check.
+ */
+export function isUniqueViolation(err: unknown): boolean {
+  let cursor: unknown = err;
+  for (let depth = 0; depth < 10 && cursor != null; depth++) {
+    if (isUniqueViolationShape(cursor)) return true;
+    cursor = (cursor as { cause?: unknown }).cause;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

The foundation for background work in Nextly: a durable job queue that runs on **PostgreSQL, MySQL and SQLite with no extra infrastructure** — no Redis, no broker, no separate service.

This is R-2, which is foundation **F3**. The live ops record states its purpose verbatim (`HANDOFF-2026-08-23-canvas-spacing-overlay.md:328`):

> `F3 ⚠️ (webhook drain shipped; periodic sweep gates scheduled publish)`

So F3 was already half-built. This is the general runner the other half needs, and it unblocks R-6's scheduled publishing.

### Why build rather than adopt — a constraint, not a preference

pg-boss and Graphile Worker are **Postgres-only** (`SKIP LOCKED` does not exist in SQLite); BullMQ **requires Redis**; Inngest and Trigger.dev are hosted SaaS. Nextly must run on all three dialects straight out of `create-nextly-app`. Payload reached the same conclusion and ships its own. We already own the right machinery — it is spelled `domains/webhooks`, and this generalises its proven parts rather than re-deriving them.

## What is in this PR (7 tasks)

| | |
| --- | --- |
| **Table** | `nextly_jobs` on three dialects, registered at all **six** sites |
| **Claim** | portable lease under `forUpdate`, outcome **fenced to the lease owner** |
| **Registry** | `defineJob({ slug, handler, retry })`, duplicate slug refused |
| **Backoff** | exponential, **jittered**, capped |
| **Identity** | resolved at execution, **fails closed** |
| **Runner** | bounded pass; one construction site for both triggers |

### Design decisions worth reviewing

**The claim is a lease, not `SKIP LOCKED`.** Stronger on PG/MySQL, absent on SQLite. `nextly_webhook_deliveries` made the same trade; this inherits the reasoning rather than re-opening it.

**Duplicate suppression is a UNIQUE constraint, never a read-then-write.** A sweep racing a queue trigger to enqueue the same work is the ordinary case here. `finding:plugins-cannot-compare-and-set-through-direct-api` records that `collection-bulk-service.ts` enumerates then updates by id, so **both writers are told they won** — correctness here rests on the database refusing, not on a check.

**Identity fails closed.** A job acts as whoever queued it, with their roles. If that account is gone or deactivated the job **fails terminally** and says why — it never falls back to a system principal, and never silently skips. Rebuilding a context from a stored id necessarily uses the permissions held *now*, which is the right answer and means the reconstruction can fail.

Roles are loaded via `listRoleSlugsForUserStrict`, **not** `listRoleSlugsForUser` — the non-strict one catches its errors and returns `[]`, which here would be the worst failure available: the job runs with no roles, every role-gated collection matches nothing, and the job reports itself complete having done nothing. The lookup is injected so that guarantee is testable.

**Backoff is jittered.** When one receiver goes down, every delivery to it fails in the same pass; a plain exponential schedules them all for the same instant and hits the recovering receiver with the whole backlog, repeatedly. Webhooks is consumer #1, so that is ordinary. *This deviates from the approved plan, deliberately, and the reasoning is in the code.*

**Nothing is silently skipped.** A row whose job type no longer exists is recorded, not passed over — a queue that never drains looks exactly like an empty one. Recorded as an ordinary failure so a partly rolled-out deploy recovers by itself, while a genuinely deleted type exhausts its budget and names the missing slug.

## Test plan

**Every mechanism break-verified individually** — commented out, confirmed *that named test* fails, restored. Highlights:

- Collapsing "identity is gone" into "acts as nobody" fails **3** named tests; dropping roles fails **2**; letting a deactivated account act fails **1**.
- Removing the `locked_by` fence fails exactly the fencing test; the positive control (current holder *can* record) still passes, so the fence cannot be satisfied by a `finalize` that always refuses.
- Removing `"nextly_jobs"` from `CORE_TABLE_NAMES` fails exactly **1** test while parity still passes — proving the registration test discriminates independently.

**A break-verification that did not fail, and what it meant.** Making the dedupe index non-unique in `sqlite-core-tables.ts` left all tests green — the harness builds tables from the **Drizzle schema**, not the bootstrap DDL. Re-broken at `schemas/jobs/sqlite.ts` it failed correctly. A break that does not fail can mean you edited a file the test never reads.

Run locally on the rebased tree:

```
jobs domain      5 unit files / 33 tests  +  1 integration file / 7 tests
schemas         28 files / 208 tests
versions        33 files / 492 tests
database        14 files / 132 tests
lint clean · check-types clean · changeset status clean
```

> Files-on-disk == files-collected checked (5 == 5). An unbuilt worktree earlier reported `25 files / 169 passed` while **three files never loaded** — build sibling packages before believing a green suite.

## Changeset

Changeset added: **patch** (repo-wide, 25 packages). Frontmatter verified with `pnpm exec changeset status`.

## Pre-existing failures

- **`main` currently fails `changeset status`** — my changeset in #1267 never closed its frontmatter. Being fixed in **#1272** (not mine; I stood down rather than duplicate it). Isolated: the missing closing `---` is the cause, *not* the blank line that was first reported.
- CI verdicts have been unreliable repo-wide (`queued` / `startup_failure`). Everything above was run **locally**.