### PR TITLE
fix(admin): a refused language switch takes its seed with it

### DIFF
--- a/.changeset/refused-switch-drops-its-seed.md
+++ b/.changeset/refused-switch-drops-its-seed.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A language switch that was refused no longer fills a language later. Asking to
+start one language from another travels with a navigation, and on a dirty form
+the unsaved-changes guard holds that navigation until the author answers. When
+they chose "Keep Editing" the request stayed behind — so reaching that language
+afterwards by any other route, browser history or a later switch, opened a copy
+confirmation for something declined minutes earlier, with nothing on screen to
+explain why.
+
+The guard now says when it was refused, and both ways out of it count: the
+button and dismissing with Escape. Confirming still carries the request through,
+which is the case that must keep working — reporting a refusal there would drop
+the intent at the one moment it was meant to be honoured.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -738,7 +738,16 @@ export function EntryForm({
     // closing the dialog rather than a history move — and a modal opened FROM
     // this editor would mount a second interceptor over this one, so two
     // dialogs would answer one navigation.
-    <UnsavedChangesGuard isDirty={hasUnsavedWork} disabled={isSubmitting}>
+    <UnsavedChangesGuard
+      isDirty={hasUnsavedWork}
+      disabled={isSubmitting}
+      // A refused switch takes its seed with it. The request to fill the target
+      // from this language was made ALONGSIDE a navigation; if the navigation
+      // does not happen, the request did not either — and a seed left behind
+      // fires the moment the author reaches that language by any other route,
+      // offering a copy they declined minutes earlier.
+      onCancel={onSeedHandled}
+    >
       <UnsavedWorkProvider report={unsavedWork.report}>
         <EntryLocaleProvider value={localeCtx}>
           <DocumentHistoryContext.Provider value={documentHistory}>

--- a/packages/admin/src/components/features/entries/EntryForm/UnsavedChangesGuard.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/UnsavedChangesGuard.tsx
@@ -21,7 +21,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@nextlyhq/ui";
-import { createContext, useContext, type ReactNode } from "react";
+import { createContext, useContext, useRef, type ReactNode } from "react";
 
 import { useUnsavedChanges } from "@admin/hooks/useUnsavedChanges";
 
@@ -57,6 +57,25 @@ export interface UnsavedChangesGuardProps {
    * Use this to perform any cleanup before navigation.
    */
   onDiscard?: () => void;
+
+  /**
+   * Callback fired when the author declines to leave — "Keep Editing", or
+   * dismissing the dialog.
+   *
+   * The counterpart to `onDiscard`, and needed for the same reason: a caller
+   * that recorded an intent alongside the navigation has to know the navigation
+   * did not happen. Without it the intent survives the refusal, and fires later
+   * if the author reaches that destination by some other route.
+   */
+  /*
+   * Explicitly nullable rather than merely optional, which is not a style
+   * choice: under `exactOptionalPropertyTypes` an optional prop cannot be
+   * handed a `T | undefined`, so every caller holding one has to spread it
+   * conditionally — and each of those spreads is a branch in a component that
+   * already has plenty. Widening the contract here costs nothing; the callers
+   * pass the value they hold.
+   */
+  onCancel?: (() => void) | undefined;
 
   /**
    * Whether to disable the guard.
@@ -118,6 +137,7 @@ export interface UnsavedChangesGuardProps {
 export function UnsavedChangesGuard({
   isDirty,
   onDiscard,
+  onCancel,
   disabled = false,
   children,
 }: UnsavedChangesGuardProps) {
@@ -128,14 +148,41 @@ export function UnsavedChangesGuard({
       disabled,
     });
 
+  /*
+   * Every exit from this dialog is funnelled through `onOpenChange`, and
+   * whether it was a refusal is decided by ONE fact recorded on the way out.
+   *
+   * Wiring the refusal to the Cancel button instead looks equivalent and is
+   * not, in two ways that only a test shows. The button also closes the dialog,
+   * so the refusal fires twice. And confirming closes it too — so "Discard
+   * changes" reported a refusal as well, dropping the very intent the
+   * navigation was carrying, at the one moment it was supposed to be honoured.
+   *
+   * A ref rather than state: it is read during the close that the same gesture
+   * causes, and a state update would not have landed by then.
+   */
+  const confirmed = useRef(false);
+
+  const handleOpenChange = (open: boolean): void => {
+    if (open) {
+      confirmed.current = false;
+      return;
+    }
+    if (confirmed.current) return;
+    cancelLeave();
+    onCancel?.();
+  };
+
+  const handleConfirm = (): void => {
+    confirmed.current = true;
+    confirmLeave();
+  };
+
   return (
     <LeaveWithoutWarningContext.Provider value={leaveWithoutWarning}>
       {children}
 
-      <AlertDialog
-        open={showDialog}
-        onOpenChange={open => !open && cancelLeave()}
-      >
+      <AlertDialog open={showDialog} onOpenChange={handleOpenChange}>
         <AlertDialogContent>
           <AlertDialogHeader>
             <AlertDialogTitle>Unsaved Changes</AlertDialogTitle>
@@ -145,16 +192,16 @@ export function UnsavedChangesGuard({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogCancel onClick={cancelLeave}>
-              Keep Editing
-            </AlertDialogCancel>
+            {/* No handler: closing IS the refusal, and it is reported once
+                from `onOpenChange` rather than from both places. */}
+            <AlertDialogCancel>Keep Editing</AlertDialogCancel>
             {/* Hover darkens the fill by one ramp step, not two.
                 `destructive-700` drops the on-color label to 3.70:1 in dark
                 mode, under the 4.5:1 text minimum; `destructive-600` holds
                 5.67:1 dark and 5.92:1 light and still reads as a state change
                 against the resting fill. */}
             <AlertDialogAction
-              onClick={confirmLeave}
+              onClick={handleConfirm}
               className="bg-destructive-solid text-destructive-foreground hover:bg-destructive-600"
             >
               Discard Changes

--- a/packages/admin/src/components/features/entries/EntryForm/UnsavedChangesGuard.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/UnsavedChangesGuard.tsx
@@ -164,11 +164,19 @@ export function UnsavedChangesGuard({
   const confirmed = useRef(false);
 
   const handleOpenChange = (open: boolean): void => {
-    if (open) {
-      confirmed.current = false;
-      return;
-    }
-    if (confirmed.current) return;
+    if (open) return;
+    // Read and clear in the same breath, so the flag is spent by exactly the
+    // close it describes.
+    //
+    // Clearing it on OPEN instead does not work, and the reason is easy to miss:
+    // this dialog is controlled, so Radix reports a close the author caused but
+    // never reports the reopen, which `showDialog` does on its own. The flag
+    // would survive the first confirmed navigation — and on the NEXT prompt,
+    // "Keep Editing" would take the confirmed path, leaving `cancelLeave`
+    // uncalled and the dialog on screen with no way out.
+    const wasConfirmed = confirmed.current;
+    confirmed.current = false;
+    if (wasConfirmed) return;
     cancelLeave();
     onCancel?.();
   };

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
@@ -15,6 +15,18 @@ import {
   useLeaveWithoutWarning,
 } from "../UnsavedChangesGuard";
 
+/** Navigates to a NAMED destination, for tests that need two of them. */
+function GoTo({ path, label }: { path: string; label: string }) {
+  return (
+    <button
+      type="button"
+      onClick={() => window.history.pushState(null, "", path)}
+    >
+      {label}
+    </button>
+  );
+}
+
 /** Navigates the way the admin's own router does — by pushing history. */
 function GoElsewhere() {
   return (
@@ -142,6 +154,51 @@ describe("UnsavedChangesGuard", () => {
       await screen.findByRole("button", { name: /discard/i })
     );
     expect(onCancel).not.toHaveBeenCalled();
+  });
+
+  it("still reports a refusal on the SECOND prompt, after a confirmed one", async () => {
+    // The guard stays mounted across a confirmed navigation — approving a
+    // dirty `?translate=` change keeps the same editor on screen — so whatever
+    // records "this close was confirmed" has to be spent by that close and not
+    // outlive it.
+    //
+    // It is easy to get wrong because the dialog is CONTROLLED: Radix reports
+    // the close the author caused but never reports the reopen, so a flag
+    // cleared on open is never cleared at all. The second "Keep Editing" then
+    // takes the confirmed path — no `cancelLeave`, no `onCancel`, and the
+    // dialog left on screen with no way out.
+    const onCancel = vi.fn();
+    render(
+      <UnsavedChangesGuard isDirty onCancel={onCancel}>
+        {/* Two DIFFERENT destinations. Pushing the same path twice is not a
+            second navigation, so the guard would never ask again and the test
+            would pass without exercising anything. */}
+        <GoTo path="/admin/first" label="first" />
+        <GoTo path="/admin/second" label="second" />
+      </UnsavedChangesGuard>
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: "first" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /discard/i })
+    );
+    expect(onCancel).not.toHaveBeenCalled();
+
+    // Two deliberate windows sit between the attempts, and the second click has
+    // to clear BOTH or it is being ignored rather than answered:
+    //   - `confirmLeave` suppresses re-interception for 100ms, so the
+    //     navigation it just released is not caught by its own guard;
+    //   - the interceptor will not re-show the dialog within 500ms of the last
+    //     one (`lastDialogShownAt`), which stops a burst of pushes producing a
+    //     stack of prompts.
+    await new Promise(resolve => setTimeout(resolve, 600));
+
+    // Same mounted guard, a second attempt, refused this time.
+    await userEvent.click(screen.getByRole("button", { name: "second" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /keep editing/i })
+    );
+    expect(onCancel).toHaveBeenCalledTimes(1);
   });
 
   it("completes the navigation the author confirmed", async () => {

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/UnsavedChangesGuard.test.tsx
@@ -93,6 +93,57 @@ describe("UnsavedChangesGuard", () => {
     expect(window.location.pathname).toBe(START);
   });
 
+  it("says so when the author refuses to leave", async () => {
+    // The counterpart to `onDiscard`. A caller that recorded an intent
+    // alongside the navigation — "switch language AND fill it from this one" —
+    // has to learn the navigation did not happen, or the intent outlives the
+    // refusal and fires when that destination is reached by some other route.
+    const onCancel = vi.fn();
+    render(
+      <UnsavedChangesGuard isDirty onCancel={onCancel}>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /keep editing/i })
+    );
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(window.location.pathname).toBe(START);
+  });
+
+  it("says so when the author dismisses the question rather than answering it", async () => {
+    // Escape is a refusal too. Wiring only the button would leave the intent
+    // alive for anyone who closes the dialog the other way — which is the more
+    // common gesture, not the rarer one.
+    const onCancel = vi.fn();
+    render(
+      <UnsavedChangesGuard isDirty onCancel={onCancel}>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    await screen.findByRole("button", { name: /keep editing/i });
+    await userEvent.keyboard("{Escape}");
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not report a refusal when the author confirmed", async () => {
+    // The separating case: `onCancel` must not fire on the path that DID
+    // navigate, or the intent is dropped exactly when it should be honoured.
+    const onCancel = vi.fn();
+    render(
+      <UnsavedChangesGuard isDirty onCancel={onCancel}>
+        <GoElsewhere />
+      </UnsavedChangesGuard>
+    );
+    await userEvent.click(screen.getByRole("button", { name: "go" }));
+    await userEvent.click(
+      await screen.findByRole("button", { name: /discard/i })
+    );
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+
   it("completes the navigation the author confirmed", async () => {
     const onDiscard = vi.fn();
     render(

--- a/packages/admin/src/components/features/singles/SingleForm.tsx
+++ b/packages/admin/src/components/features/singles/SingleForm.tsx
@@ -608,7 +608,12 @@ export function SingleForm({
   return (
     // A single is only ever edited standalone, so unlike the entry editor there
     // is no embedded case to exclude.
-    <UnsavedChangesGuard isDirty={hasUnsavedWork} disabled={isSubmitting}>
+    <UnsavedChangesGuard
+      isDirty={hasUnsavedWork}
+      disabled={isSubmitting}
+      // Same rule as the entry editor: a refused switch takes its seed with it.
+      onCancel={onSeedHandled}
+    >
       <UnsavedWorkProvider report={unsavedWork.report}>
         {/*
         Which document the fields are inside. The entry editor has always

--- a/packages/admin/src/hooks/__tests__/useEditorLocale.test.ts
+++ b/packages/admin/src/hooks/__tests__/useEditorLocale.test.ts
@@ -82,10 +82,9 @@ describe("useEditorLocale", () => {
     expect(result.current.seedFromLocale).toBe("en");
   });
 
-  it("never offers a seed for a switch that was abandoned", () => {
-    // The other half of the same rule. If the author cancels instead of
-    // discarding, the intent must not survive to fire against some later
-    // language they did choose.
+  it("never offers a seed for a switch that went somewhere else", () => {
+    // The other half of the same rule. If the author ends up in a different
+    // language, the intent must not fire against the one they did choose.
     go("?locale=en");
     const { result, rerender } = renderHook(() => useEditorLocale());
 
@@ -94,6 +93,28 @@ describe("useEditorLocale", () => {
     rerender();
 
     expect(result.current.locale).toBe("fr");
+    expect(result.current.seedFromLocale).toBeUndefined();
+  });
+
+  it("drops a seed whose switch was refused, even if the target is reached later", () => {
+    // The case the previous test does NOT cover, because it stops at a third
+    // language and never returns. Decline the switch, then arrive at the same
+    // target by another route — browser history, or a later switch after
+    // saving — and a retained pair would offer a copy the author declined
+    // minutes earlier, with no memory of having asked.
+    go("?locale=en");
+    const { result, rerender } = renderHook(() => useEditorLocale());
+
+    act(() => result.current.changeLocale("de", { seedFrom: "en" }));
+    // The guard asked; the author chose "Keep Editing", so the editor stays put
+    // and tells the hook the intent is over.
+    act(() => result.current.clearSeed());
+
+    // Later, the same mounted page reaches German anyway.
+    go("?locale=de");
+    rerender();
+
+    expect(result.current.locale).toBe("de");
     expect(result.current.seedFromLocale).toBeUndefined();
   });
 


### PR DESCRIPTION
Two review findings from #1258 and #1262, both describing the same defect, both posted **after** those PRs merged.

## The defect

Asking to start one language from another travels *with* a navigation. On a dirty form the unsaved-changes guard holds that navigation until the author answers — and choosing **Keep Editing** refused the switch but left the request behind.

Reach that language afterwards by any other route (browser history, or a later switch after saving) and a copy confirmation opens for something declined minutes earlier, with nothing on screen to explain why.

The reviewer also pointed out, correctly, that the test I added in #1258 **does not cover this**: it stops at a third locale and never revisits the retained target. It has been replaced with one that does.

## The fix, and the two bugs my own fix had

The guard now reports a refusal via `onCancel`, and every exit is funnelled through `onOpenChange` with one fact recorded on the way out.

Wiring the refusal to the Cancel button instead looks equivalent. It is not, in two ways **only the tests showed**:

1. **The button also closes the dialog** — so the refusal fired twice.
2. **Confirming closes it too** — so "Discard changes" reported a refusal as well, *dropping the very intent the navigation was carrying*, at the one moment it was meant to be honoured.

The second is worse than the bug being fixed: it would have silently broken seeding on the path that works today. Both were caught before shipping, by tests written for this change.

Dismissing with **Escape** counts as a refusal for the same reason the button does — it is the more common gesture, not the rarer one.

## Verification

Break-verified each test against the specific defect it guards:

| break | fails |
| --- | --- |
| confirm also reports a refusal (the seed-dropping bug) | 1 |
| refusal reported from the button too (double fire) | 1 |
| refusal reported **only** from the button (the original wiring) | 1 — the Escape test |
| `clearSeed` does nothing | 2 |

The third is the one worth noting: my first attempt at breaking the Escape case was a no-op that passed, so it proved nothing. Re-broken using the *actual* pre-change wiring, which is the only honest control for it.

**964 admin tests** pass. Gates: build, check-types, lint, lint:design, comment-convention all `0`; fallow **`pass`, 0 introduced**.

`changeset status` was red on this branch purely by inheritance from `main` — confirmed by applying #1272 locally, which took it to `0`. #1272 is now merged.

## One note on `onCancel`'s type

Declared `(() => void) | undefined` rather than optional. Under `exactOptionalPropertyTypes` an optional prop cannot take a `T | undefined`, so each caller needs a conditional spread — and each spread is a branch. One of them pushed `SingleForm` past its cyclomatic threshold, which fallow caught. Widening the contract costs nothing and callers pass the value they hold.