### PR TITLE
fix(blocks-react): tell the truth about a stated null, and stop spreading it

### DIFF
--- a/.changeset/reconciler-tells-the-truth-about-null.md
+++ b/.changeset/reconciler-tells-the-truth-about-null.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The renderer no longer passes a stored `null` into a compile input declared as a value, and the type it publishes for its reconciled inputs now admits the `null` it can genuinely return. A colour draft also survives a right-click on a Reset, which invokes nothing.

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -256,7 +256,11 @@ const SOURCE_MODULES: ReadonlyArray<{
     // implementation of one pass, which is the drift the pass's own docblock
     // argues against — but it is an internal derivation rather than something a
     // host composes with, so it crosses a module boundary and stops there.
-    internal: ["pruneRenderedPlaceholders", "withoutStatedNulls"],
+    internal: [
+      "pruneRenderedPlaceholders",
+      "statedBreakpoints",
+      "withoutStatedNulls",
+    ],
   },
   {
     name: "prepare-document",

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -241,6 +241,12 @@ const SOURCE_MODULES: ReadonlyArray<{
     // build a compile context: `compileContextFor` remains the only one of
     // those, and this returns a patch of already-reconciled inputs.
     //
+    // `withoutStatedNulls` stays internal for the same reason: it crosses a
+    // module boundary so `page-style-trace` and this module do not each decide
+    // what a stated null means at a compile boundary, and a host composing a
+    // context has no use for it — it exists to DELETE a copy rather than to
+    // offer an API.
+    //
     // `pruneRenderedPlaceholders` is the case that stays internal, and the
     // contrast is the point. It answers "which tree does this page's sheet
     // describe" for the nodes a placeholder replaced, and the editor's cascade
@@ -250,7 +256,7 @@ const SOURCE_MODULES: ReadonlyArray<{
     // implementation of one pass, which is the drift the pass's own docblock
     // argues against — but it is an internal derivation rather than something a
     // host composes with, so it crosses a module boundary and stops there.
-    internal: ["pruneRenderedPlaceholders"],
+    internal: ["pruneRenderedPlaceholders", "withoutStatedNulls"],
   },
   {
     name: "prepare-document",

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -25,7 +25,7 @@ import {
 
 import type { PageContext } from "./context";
 import { createStandaloneContext, defineBlock } from "./context";
-import { PageRenderer } from "./page-renderer";
+import { PageRenderer, withoutStatedNulls } from "./page-renderer";
 import { createBlockResolver } from "./resolver";
 import { resolvePageStyles, type PageStyles } from "./styles";
 
@@ -5938,5 +5938,60 @@ describe("which runtimes the contract warning is willing to speak in", () => {
       vi.unstubAllGlobals();
       warn.mockRestore();
     }
+  });
+});
+
+describe("a stated NULL among the reconciled inputs", () => {
+  /*
+   * `firstStated` keeps a stored `null` because it OUTRANKS a lower tier: a
+   * site stating null for a field is saying it has none, and that has to beat a
+   * route context which has some. So the reconciler's published type admits it,
+   * and every compile boundary has to deal with it — a compile context declares
+   * these slots as values rather than nullable ones, and a null spread into one
+   * was a lie no type was catching.
+   */
+  it("is dropped from the inputs a compile is given", () => {
+    /*
+     * `breakpoints` is deliberately absent from this: for that field alone,
+     * DROPPING is the wrong answer, because a missing set falls through to
+     * whatever the route context carries — which is exactly what a stated null
+     * exists to override. It is normalised to an empty set instead, and the
+     * canvas suite pins that behaviour end to end.
+     */
+    const stripped = withoutStatedNulls({
+      namedClasses: null,
+      blockBases: null,
+      tokenPrefix: null,
+      previewContainer: null,
+    });
+
+    expect(Object.keys(stripped)).toEqual([]);
+  });
+
+  it("KEEPS a value that was actually stated", () => {
+    /*
+     * The control, and it has to come out non-empty or the case above says only
+     * that this returns nothing. A helper that dropped everything would satisfy
+     * it while removing the whole reconciliation from every compile.
+     */
+    const kept = withoutStatedNulls({
+      namedClasses: [],
+      tokenPrefix: "nx",
+      previewContainer: "nx-preview-viewport",
+    });
+
+    expect(kept).toEqual({
+      namedClasses: [],
+      tokenPrefix: "nx",
+      previewContainer: "nx-preview-viewport",
+    });
+  });
+
+  it("does not confuse a stated null with an unstated field", () => {
+    // Both end up absent from a compile, and they are different statements —
+    // the distinction lives in what the reconciler REPORTS, which is why it
+    // keeps the null rather than normalising at source.
+    expect(withoutStatedNulls({ tokenPrefix: null })).toEqual({});
+    expect(withoutStatedNulls({})).toEqual({});
   });
 });

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5965,7 +5965,31 @@ describe("a stated NULL among the reconciled inputs", () => {
       previewContainer: null,
     });
 
-    expect(Object.keys(stripped)).toEqual([]);
+    /*
+     * Present and `undefined`, not absent. This patch is spread OVER a route
+     * context, and an absent key leaves the route's own value standing — so a
+     * site's null would silently fail to override the value it was stated to
+     * beat, which is the whole reason `firstStated` keeps it.
+     */
+    expect(Object.keys(stripped).sort()).toEqual([
+      "blockBases",
+      "namedClasses",
+      "previewContainer",
+      "tokenPrefix",
+    ]);
+    expect(Object.values(stripped).every(v => v === undefined)).toBe(true);
+  });
+
+  it("OVERRIDES a lower tier's value when spread over it", () => {
+    /*
+     * The property the shape above exists for, asserted as the merge rather
+     * than as the patch: a route context supplying a prefix, and a site stating
+     * null, must compile with no prefix at all.
+     */
+    const route = { tokenPrefix: "route" };
+    const merged = { ...route, ...withoutStatedNulls({ tokenPrefix: null }) };
+
+    expect(merged.tokenPrefix).toBeUndefined();
   });
 
   it("KEEPS a value that was actually stated", () => {
@@ -5980,18 +6004,18 @@ describe("a stated NULL among the reconciled inputs", () => {
       previewContainer: "nx-preview-viewport",
     });
 
-    expect(kept).toEqual({
-      namedClasses: [],
-      tokenPrefix: "nx",
-      previewContainer: "nx-preview-viewport",
-    });
+    expect(kept.namedClasses).toEqual([]);
+    expect(kept.tokenPrefix).toBe("nx");
+    expect(kept.previewContainer).toBe("nx-preview-viewport");
   });
 
   it("does not confuse a stated null with an unstated field", () => {
     // Both end up absent from a compile, and they are different statements —
     // the distinction lives in what the reconciler REPORTS, which is why it
     // keeps the null rather than normalising at source.
-    expect(withoutStatedNulls({ tokenPrefix: null })).toEqual({});
-    expect(withoutStatedNulls({})).toEqual({});
+    expect(
+      withoutStatedNulls({ tokenPrefix: null }).tokenPrefix
+    ).toBeUndefined();
+    expect(withoutStatedNulls({}).tokenPrefix).toBeUndefined();
   });
 });

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -249,10 +249,11 @@ type ResolvedShared = {
  * and dereferences a value the renderer explicitly supports.
  *
  * Stated separately from {@link ResolvedShared} rather than by widening it,
- * because that one describes what this module SPREADS into a compile context
- * and those slots are declared non-null. The two differ, and the difference is
- * a real gap rather than a modelling choice — see
- * `finding:renderer-spreads-stated-nulls-into-non-null-slots`.
+ * because the two answer different questions. This one describes what the
+ * reconciler RETURNS, nulls included; that one describes what may be spread
+ * into a compile context, whose slots are declared as values. Everything
+ * between them is {@link withoutStatedNulls}, which is where a stated null
+ * stops being a value and becomes an absence.
  *
  * Named distinctly from the cache stamp's input projection in
  * `shared-style-inputs.ts`, which is a different type for a different job and
@@ -283,28 +284,39 @@ export type ReconciledStyleInputs = Partial<{
  * whatever the route context carries, which is exactly what a stated null
  * exists to override. Its "none" is an empty set rather than an absence.
  */
+/**
+ * The reconciled inputs as a compile patch: every stated NULL turned into an
+ * absence, and every key present.
+ *
+ * `firstStated` keeps a stored `null` because it OUTRANKS a lower tier — a site
+ * stating null for a field is saying it has none, and that has to beat a route
+ * context which has some. That contest is over by the time these reach a
+ * compile; what is left is a value, and "the site has none" is `undefined`.
+ *
+ * EVERY key is returned, set to `undefined` where nothing was stated. That is
+ * what makes the override work: this is spread OVER a route context, and an
+ * absent key would leave the route's own value standing — so a site's null
+ * would silently fail to override the very value it was stated to beat.
+ *
+ * And it is what makes the exhaustiveness real. The return type is not
+ * `Partial`, so omitting a key does not compile: a field added to the
+ * reconciliation and forgotten here fails the build rather than disappearing
+ * from every compile. A `Partial` return accepts any subset, which is a promise
+ * this function cannot keep.
+ *
+ * `breakpoints` is excluded and handled by {@link statedBreakpoints}, because
+ * absent means something different for it: a compile context declares it as a
+ * set rather than an optional, so `undefined` is not a legal value there. Its
+ * "none" is an empty set.
+ */
 export function withoutStatedNulls(
   shared: ReconciledStyleInputs
-): Partial<Omit<ResolvedShared, "breakpoints">> {
-  /*
-   * Written out field by field rather than filtered from `Object.entries`.
-   *
-   * A filter returns a record keyed by string, so handing it back as this type
-   * needs an assertion — and an assertion here would be the one thing that
-   * could hide the very mismatch this function exists to remove. Naming the
-   * fields makes the compiler check each one, and makes a field added to the
-   * reconciliation and forgotten here a build failure rather than a silent
-   * omission from every compile.
-   */
+): Omit<ResolvedShared, "breakpoints"> {
   return {
-    ...(shared.namedClasses == null
-      ? {}
-      : { namedClasses: shared.namedClasses }),
-    ...(shared.blockBases == null ? {} : { blockBases: shared.blockBases }),
-    ...(shared.tokenPrefix == null ? {} : { tokenPrefix: shared.tokenPrefix }),
-    ...(shared.previewContainer == null
-      ? {}
-      : { previewContainer: shared.previewContainer }),
+    namedClasses: shared.namedClasses ?? undefined,
+    blockBases: shared.blockBases ?? undefined,
+    tokenPrefix: shared.tokenPrefix ?? undefined,
+    previewContainer: shared.previewContainer ?? undefined,
   };
 }
 
@@ -322,7 +334,7 @@ export function withoutStatedNulls(
  * page compiles against needs to tell "the site said none" from "nobody said
  * anything", and an empty set collapses those into one.
  */
-function statedBreakpoints(
+export function statedBreakpoints(
   set: BreakpointSet | null | undefined
 ): BreakpointSet | undefined {
   if (set === undefined) return undefined;

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -7,6 +7,7 @@ import {
   type DocumentLimits,
   type SiteSheetInput,
   type StyleCompileContext,
+  type BreakpointSet,
 } from "@nextlyhq/blocks-engine";
 import type { ReactElement, ReactNode } from "react";
 
@@ -239,6 +240,20 @@ type ResolvedShared = {
  * What {@link sharedStyleInputs} RETURNS: the same inputs as a context patch,
  * with unstated keys absent rather than present and undefined.
  *
+ * Each value may be `null`, and that is not a nicety. `firstStated` skips only
+ * `undefined`, so a stored `null` is KEPT and means something: a site stating a
+ * null breakpoint set defines no viewport tiers, and that answer outranks a
+ * route context which has some — `canvas.test.tsx` pins it, because reading it
+ * as absent turns preview on for a canvas left on the unconditional tier.
+ * Published without the null, a consumer is told to check only for `undefined`
+ * and dereferences a value the renderer explicitly supports.
+ *
+ * Stated separately from {@link ResolvedShared} rather than by widening it,
+ * because that one describes what this module SPREADS into a compile context
+ * and those slots are declared non-null. The two differ, and the difference is
+ * a real gap rather than a modelling choice — see
+ * `finding:renderer-spreads-stated-nulls-into-non-null-slots`.
+ *
  * Named distinctly from the cache stamp's input projection in
  * `shared-style-inputs.ts`, which is a different type for a different job and
  * requires `breakpoints`. Under one name a caller writing
@@ -246,17 +261,84 @@ type ResolvedShared = {
  * compile, because the reconciler may legally resolve nothing — a published
  * type unusable with the function published beside it.
  */
-export type ReconciledStyleInputs = Partial<ResolvedShared>;
+export type ReconciledStyleInputs = Partial<{
+  [K in keyof ResolvedShared]: ResolvedShared[K] | null;
+}>;
+
+/**
+ * The reconciled inputs with every stated NULL dropped.
+ *
+ * `firstStated` keeps a stored `null` because it OUTRANKS a lower tier — a site
+ * stating null for a field is saying it has none, and that has to beat a route
+ * context which has some. That is a fact about the reconciliation, and it is
+ * settled by the time these reach a compile: what the compiler needs is the
+ * value, and "the site has none" is the absent key.
+ *
+ * A compile context declares these slots as values rather than nullable ones,
+ * so a null spread into one was a lie no type was catching. Dropping the key
+ * states the same thing in the shape the compiler declares.
+ *
+ * `breakpoints` is excluded and handled by {@link statedBreakpoints}, because
+ * absent means something different for it: a missing set falls through to
+ * whatever the route context carries, which is exactly what a stated null
+ * exists to override. Its "none" is an empty set rather than an absence.
+ */
+export function withoutStatedNulls(
+  shared: ReconciledStyleInputs
+): Partial<Omit<ResolvedShared, "breakpoints">> {
+  /*
+   * Written out field by field rather than filtered from `Object.entries`.
+   *
+   * A filter returns a record keyed by string, so handing it back as this type
+   * needs an assertion — and an assertion here would be the one thing that
+   * could hide the very mismatch this function exists to remove. Naming the
+   * fields makes the compiler check each one, and makes a field added to the
+   * reconciliation and forgotten here a build failure rather than a silent
+   * omission from every compile.
+   */
+  return {
+    ...(shared.namedClasses == null
+      ? {}
+      : { namedClasses: shared.namedClasses }),
+    ...(shared.blockBases == null ? {} : { blockBases: shared.blockBases }),
+    ...(shared.tokenPrefix == null ? {} : { tokenPrefix: shared.tokenPrefix }),
+    ...(shared.previewContainer == null
+      ? {}
+      : { previewContainer: shared.previewContainer }),
+  };
+}
+
+/**
+ * A stated set, or the empty one a stated NULL means.
+ *
+ * `firstStated` keeps a stored `null`, and it is an answer rather than an
+ * absence: the site defines no viewport tiers, and that outranks a route
+ * context which has some. A compile context declares `breakpoints` as a set,
+ * so the null cannot be handed on as it stands — an empty set is the same
+ * statement in the shape the compiler declares, and yields the same contexts.
+ *
+ * Normalised at the COMPILE boundary rather than inside the reconciler, which
+ * has to go on reporting what was stated: a surface asking which breakpoints a
+ * page compiles against needs to tell "the site said none" from "nobody said
+ * anything", and an empty set collapses those into one.
+ */
+function statedBreakpoints(
+  set: BreakpointSet | null | undefined
+): BreakpointSet | undefined {
+  if (set === undefined) return undefined;
+  return set ?? { viewport: [], container: [] };
+}
 
 /**
  * Resolve every shared input once, so the compiles cannot disagree.
  *
- * Exported at MODULE level and deliberately not from the package entry. A third
- * compile exists — the editor asks for the cascade behind the page so its
- * inspector can say where a value came from — and a context assembled
- * independently there is the same defect this function was written to prevent,
- * one caller further out: the trace would carry no named classes and report a
- * value from `.card` as coming from nowhere.
+ * PUBLISHED from the package entry, and it was not always. The reason it was
+ * withheld is the reason it is now out: a third compile exists — the editor
+ * asks for the cascade behind the page so its inspector can say where a value
+ * came from — and a context assembled independently there carries no named
+ * classes, so a value from `.card` reports as coming from nowhere. Withholding
+ * this left that assembly as the only option; publishing it makes asking the
+ * cheaper one.
  *
  * The defect this exists to prevent is not a wrong precedence — it is two
  * computations of one question. Each field therefore keeps the precedence it
@@ -576,14 +658,21 @@ export function PageRenderer({
   // uses to decide whether a site sheet can be built at all. A render that knows
   // them can compile both sheets; one that does not can compile neither, and
   // there the stored artifact is all there is.
+  const pageBreakpoints = statedBreakpoints(pageShared.breakpoints);
   const pageStyleContext: StyleCompileContext | undefined =
     styleContext !== undefined
-      ? { ...styleContext, ...pageShared }
-      : pageShared.breakpoints === undefined
+      ? {
+          ...styleContext,
+          ...withoutStatedNulls(pageShared),
+          // Resolved rather than spread, so the normalised set replaces the
+          // null the reconciler may legitimately have stated.
+          breakpoints: pageBreakpoints ?? styleContext.breakpoints,
+        }
+      : pageBreakpoints === undefined
         ? undefined
         : {
-            ...pageShared,
-            breakpoints: pageShared.breakpoints,
+            ...withoutStatedNulls(pageShared),
+            breakpoints: pageBreakpoints,
             // The site's own fetch predicate, handed to the reconciler rather
             // than reconciled here. `effectiveCompile` derives ONE predicate and
             // gives it to both compiles — but only from what the context it is
@@ -653,7 +742,8 @@ export function PageRenderer({
   // with no sheet. Two answers to "what are this site's breakpoints" is also how
   // the shared sheet and the page sheet come to disagree about which at-rules a
   // tier is emitted under, invisibly, since each sheet is consistent on its own.
-  const siteBreakpoints = siteStyles === false ? undefined : shared.breakpoints;
+  const siteBreakpoints =
+    siteStyles === false ? undefined : statedBreakpoints(shared.breakpoints);
   // A sheet by DEFAULT. Without one a block cannot reference a token at all —
   // a default reading `color.surface` would resolve on a route and resolve to
   // nothing here — which is why `core/card` shipped with no background.
@@ -669,10 +759,10 @@ export function PageRenderer({
           // given. Spreading `siteInput` alone would leave each consumer
           // computing its own answer, which is the defect this closes.
           breakpoints: siteBreakpoints,
-          ...(shared.blockBases === undefined
+          ...(shared.blockBases == null
             ? {}
             : { blockBases: shared.blockBases }),
-          ...(shared.tokenPrefix === undefined
+          ...(shared.tokenPrefix == null
             ? {}
             : { tokenPrefix: shared.tokenPrefix }),
           tokens: resolveSiteTokens(siteInput?.tokens),
@@ -691,7 +781,7 @@ export function PageRenderer({
           // context above was given. A shared tier compiled for the published
           // page beneath node styles compiled for a preview surface puts two
           // answers to one breakpoint in one document.
-          ...(shared.previewContainer === undefined
+          ...(shared.previewContainer == null
             ? {}
             : { previewContainer: shared.previewContainer }),
         });

--- a/packages/blocks-react/src/page-style-trace.ts
+++ b/packages/blocks-react/src/page-style-trace.ts
@@ -28,7 +28,11 @@ import type {
   StyleTraceEntry,
 } from "@nextlyhq/blocks-engine";
 
-import { pruneRenderedPlaceholders, sharedStyleInputs } from "./page-renderer";
+import {
+  pruneRenderedPlaceholders,
+  sharedStyleInputs,
+  withoutStatedNulls,
+} from "./page-renderer";
 import { prepareDocumentReadStages } from "./prepare-document";
 import type { BlockResolver } from "./resolver";
 import { registeredBlocks } from "./resolver";
@@ -100,6 +104,21 @@ export function pageStyleTrace(
 ): PageStyleCascade | undefined {
   const shared = sharedStyleInputs(input.styleContext, input.site);
   /*
+   * A stated NULL is the site saying it defines no viewport tiers, which is an
+   * answer rather than an absence — `firstStated` keeps it, and it outranks a
+   * route context that has some. The compile context declares a set, so the
+   * null cannot be handed on as it stands; an empty set is the same statement
+   * in the shape the compiler declares and yields the same contexts.
+   *
+   * Not normalised inside the reconciler, which has to go on reporting what was
+   * stated: a caller asking which breakpoints a page compiles against needs to
+   * tell "the site said none" from "nobody said anything".
+   */
+  const stated =
+    shared.breakpoints === undefined
+      ? undefined
+      : (shared.breakpoints ?? { viewport: [], container: [] });
+  /*
    * The same construction the renderer uses, and for its reason: a route context
    * takes the shared inputs over the top, while a site tier alone can still
    * compile provided it named the breakpoints — the one field a compile cannot
@@ -107,12 +126,18 @@ export function pageStyleTrace(
    */
   const merged: StyleCompileContext | undefined =
     input.styleContext !== undefined
-      ? { ...input.styleContext, ...shared }
-      : shared.breakpoints === undefined
+      ? {
+          ...input.styleContext,
+          ...withoutStatedNulls(shared),
+          // Spread LAST, so the normalised set replaces the null the spread
+          // above would otherwise carry into a slot declared as a set.
+          breakpoints: stated ?? input.styleContext.breakpoints,
+        }
+      : stated === undefined
         ? undefined
         : {
-            ...shared,
-            breakpoints: shared.breakpoints,
+            ...withoutStatedNulls(shared),
+            breakpoints: stated,
             /*
              * The site's OWN predicate, copied exactly as the renderer's
              * site-only construction copies it. Dropped, a `url(...)` the site

--- a/packages/blocks-react/src/page-style-trace.ts
+++ b/packages/blocks-react/src/page-style-trace.ts
@@ -31,6 +31,7 @@ import type {
 import {
   pruneRenderedPlaceholders,
   sharedStyleInputs,
+  statedBreakpoints,
   withoutStatedNulls,
 } from "./page-renderer";
 import { prepareDocumentReadStages } from "./prepare-document";
@@ -104,20 +105,11 @@ export function pageStyleTrace(
 ): PageStyleCascade | undefined {
   const shared = sharedStyleInputs(input.styleContext, input.site);
   /*
-   * A stated NULL is the site saying it defines no viewport tiers, which is an
-   * answer rather than an absence — `firstStated` keeps it, and it outranks a
-   * route context that has some. The compile context declares a set, so the
-   * null cannot be handed on as it stands; an empty set is the same statement
-   * in the shape the compiler declares and yields the same contexts.
-   *
-   * Not normalised inside the reconciler, which has to go on reporting what was
-   * stated: a caller asking which breakpoints a page compiles against needs to
-   * tell "the site said none" from "nobody said anything".
+   * ASKED of the renderer's own helper rather than computed here. This trace and
+   * the render must agree about what a stated null means, and two computations
+   * of one question agree until the day one of them changes.
    */
-  const stated =
-    shared.breakpoints === undefined
-      ? undefined
-      : (shared.breakpoints ?? { viewport: [], container: [] });
+  const stated = statedBreakpoints(shared.breakpoints);
   /*
    * The same construction the renderer uses, and for its reason: a route context
    * takes the shared inputs over the top, while a site tier alone can still

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -616,12 +616,27 @@ function compiledBreakpoints(
   render: Omit<PageRendererProps, "document" | "siteStyles"> | undefined,
   siteStyles: NonNullable<PageRendererProps["siteStyles"]>
 ): BreakpointSet | undefined {
-  return sharedStyleInputs(
+  const stated = sharedStyleInputs(
     render?.styleContext,
     // `false` is a host serving no site sheet, which states no breakpoints —
     // not a sheet whose breakpoints are absent.
     typeof siteStyles === "object" ? siteStyles : undefined
   ).breakpoints;
+  /*
+   * A stated NULL collapses to `undefined` HERE, and only here.
+   *
+   * It had to survive the reconciliation, which is where it means something: a
+   * site stating null defines no viewport tiers, and that outranks a route
+   * context which has some. By this line that contest is over, and what is left
+   * is a canvas asking whether there are tiers to preview. There are not, which
+   * is what `undefined` says to every reader below.
+   *
+   * Collapsed any EARLIER — inside the reconciler, or with a nullish coalesce
+   * over the two tiers — the null loses to the route's set and the canvas
+   * previews a tier the renderer left on base. That is the defect this
+   * function's own docblock names, and it is why the null reaches this far.
+   */
+  return stated ?? undefined;
 }
 
 /**

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -1137,6 +1137,29 @@ describe("a Reset beside a picker mid-gesture", () => {
     expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
   });
 
+  it("keeps a gesture when the Reset is RIGHT-clicked, which runs nothing", async () => {
+    /*
+     * A secondary press opens a context menu and invokes no handler. Radix
+     * dismisses the popover on any `pointerdown` outside it, so reading that
+     * press as a supersede discards the colour an author was composing on
+     * behalf of a button that never ran — the gesture is gone and nothing
+     * replaced it, which is the worst of the three outcomes available.
+     *
+     * The gesture is therefore committed, exactly as it is when the dismissal
+     * lands anywhere else that writes nothing.
+     */
+    const editor = mountWithResets([{ property: "color" }]);
+    await dragTo("#ff0000");
+    expect(editor.applyAll).not.toHaveBeenCalled();
+
+    // Secondary button: no click follows, and `onReset` never runs.
+    fireEvent.pointerDown(resetFor("Color"), { button: 2 });
+    await settle();
+
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
+  });
+
   it("keeps a gesture ANOTHER control's Reset does not replace", async () => {
     /*
      * The supersede is scoped to the field whose value the press writes. A

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -1160,6 +1160,28 @@ describe("a Reset beside a picker mid-gesture", () => {
     expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
   });
 
+  it("keeps a gesture when the Reset is CONTROL-clicked on a Mac", async () => {
+    /*
+     * Control held with the primary button is a context-menu gesture on macOS,
+     * and the pointer event still reports `button === 0` — so a check on the
+     * button alone lets it through. Radix's own popover classifies the same
+     * pair as a right-click.
+     *
+     * The consequence is the same as a right-click's: the picker closes, the
+     * Reset's handler never runs, and the colour the author was composing is
+     * discarded on behalf of a button that did nothing.
+     */
+    const editor = mountWithResets([{ property: "color" }]);
+    await dragTo("#ff0000");
+    expect(editor.applyAll).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(resetFor("Color"), { button: 0, ctrlKey: true });
+    await settle();
+
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
+  });
+
   it("keeps a gesture ANOTHER control's Reset does not replace", async () => {
     /*
      * The supersede is scoped to the field whose value the press writes. A

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -1160,26 +1160,88 @@ describe("a Reset beside a picker mid-gesture", () => {
     expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
   });
 
-  it("keeps a gesture when the Reset is CONTROL-clicked on a Mac", async () => {
+  /**
+   * Pretend to be a platform, for the duration of one case.
+   *
+   * `navigator.platform` is the only signal that separates a macOS context-menu
+   * gesture from an ordinary Control-click, so a case about that distinction
+   * has to state which platform it is on. Restored afterwards, because a
+   * leaked value would silently decide every later case in the file.
+   */
+  function onPlatform(name: string): () => void {
+    const original = Object.getOwnPropertyDescriptor(
+      window.navigator,
+      "platform"
+    );
+    Object.defineProperty(window.navigator, "platform", {
+      value: name,
+      configurable: true,
+    });
+    return () => {
+      if (original === undefined) return;
+      Object.defineProperty(window.navigator, "platform", original);
+    };
+  }
+
+  it("keeps a gesture when the Reset is CONTROL-clicked on a MAC", async () => {
     /*
      * Control held with the primary button is a context-menu gesture on macOS,
      * and the pointer event still reports `button === 0` — so a check on the
-     * button alone lets it through. Radix's own popover classifies the same
-     * pair as a right-click.
-     *
-     * The consequence is the same as a right-click's: the picker closes, the
-     * Reset's handler never runs, and the colour the author was composing is
-     * discarded on behalf of a button that did nothing.
+     * button alone lets it through. No click follows, so the Reset's handler
+     * never runs and the colour the author was composing would be discarded on
+     * behalf of a button that did nothing.
      */
-    const editor = mountWithResets([{ property: "color" }]);
-    await dragTo("#ff0000");
-    expect(editor.applyAll).not.toHaveBeenCalled();
+    const restore = onPlatform("MacIntel");
+    try {
+      const editor = mountWithResets([{ property: "color" }]);
+      await dragTo("#ff0000");
+      expect(editor.applyAll).not.toHaveBeenCalled();
 
-    fireEvent.pointerDown(resetFor("Color"), { button: 0, ctrlKey: true });
-    await settle();
+      // No click: on this platform the press opens a menu instead.
+      fireEvent.pointerDown(resetFor("Color"), { button: 0, ctrlKey: true });
+      await settle();
 
-    expect(editor.applyAll).toHaveBeenCalledTimes(1);
-    expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain("#ff0000");
+      expect(editor.applyAll).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(editor.applyAll.mock.calls[0])).toContain(
+        "#ff0000"
+      );
+    } finally {
+      restore();
+    }
+  });
+
+  it("writes ONCE for a Control-click anywhere else, where it is an ordinary click", async () => {
+    /*
+     * The control on the case above, and the reason the platform is asked at
+     * all rather than the modifier alone. On Windows and Linux a Control-click
+     * IS an ordinary modified click: the button runs, so treating it as a
+     * context menu commits the picker's draft on dismissal AND lets the Reset
+     * write — one gesture becoming two edits, and the first undo restoring the
+     * colour the author pressed Reset to be rid of.
+     *
+     * The click is dispatched here and deliberately NOT in the case above: a
+     * case that sends only `pointerDown` cannot observe the platform's ensuing
+     * click, so it would pass on both platforms and separate nothing.
+     */
+    const restore = onPlatform("Win32");
+    try {
+      const editor = mountWithResets([{ property: "color" }]);
+      await dragTo("#ff0000");
+
+      const reset = resetFor("Color");
+      fireEvent.pointerDown(reset, { button: 0, ctrlKey: true });
+      fireEvent.click(reset, { ctrlKey: true });
+      await settle();
+
+      // The clear alone. Two calls would be the draft and the reset both
+      // landing, which is the defect the supersede exists to prevent.
+      expect(editor.applyAll).toHaveBeenCalledTimes(1);
+      expect(JSON.stringify(editor.applyAll.mock.calls[0])).not.toContain(
+        "#ff0000"
+      );
+    } finally {
+      restore();
+    }
   });
 
   it("keeps a gesture ANOTHER control's Reset does not replace", async () => {

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -2623,7 +2623,28 @@ function ColourPicker({
          * everywhere else in this panel, the text fields included.
          */
         onPointerDownOutside={event => {
-          superseded.current = supersededBy(event.target);
+          /*
+           * A PRIMARY press, because only that one can run the control.
+           *
+           * A right-click opens a context menu and invokes nothing, so reading
+           * it as a supersede discards the gesture an author was composing on
+           * behalf of a button that never ran — the colour is gone and nothing
+           * replaced it.
+           *
+           * This narrows the gap rather than closing it, and the remainder is
+           * stated rather than left to be discovered: a primary press that then
+           * DRAGS OFF the control and releases elsewhere fires no click either,
+           * and is still read here as a supersede. Closing that needs the write
+           * to confirm the discard instead of the press predicting it, which
+           * means either holding the draft until a later signal — the timer
+           * this module removed, whose cancellation cost a race — or routing
+           * the marked control's write back through this field, which the
+           * declaration exists precisely to avoid. Neither is worth an
+           * ambiguous gesture; a context menu is not ambiguous.
+           */
+          superseded.current =
+            event.detail.originalEvent.button === 0 &&
+            supersededBy(event.target);
         }}
       >
         {unrepresented ? (

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1274,30 +1274,57 @@ function sourceLabel(source: BreakpointSource): string {
  * for everybody rather than for screen-reader users alone.
  */
 /**
+ * Whether Control held with a primary press means a CONTEXT MENU here.
+ *
+ * It does on macOS and nowhere else: there the platform opens a menu and no
+ * click follows, while on Windows and Linux a Control-click is an ordinary
+ * modified click and the button runs exactly as it always does.
+ *
+ * So this cannot be answered without asking the platform, and the platform is
+ * asked by NAME because nothing else decides it. There is no structural probe
+ * for "will a click follow this press" that can be run before the click either
+ * arrives or does not — which is the same reason the whole supersede is
+ * predicted at press time rather than confirmed.
+ *
+ * `userAgentData` first because `platform` is deprecated, and both because the
+ * modern one is Chromium-only. Neither present — a non-browser runtime —
+ * answers `false`, which is the ordinary-click reading and the one that keeps
+ * the two-write defect closed.
+ */
+function contextMenuModifier(): boolean {
+  const agent: { platform?: string } | undefined = (
+    navigator as Navigator & { userAgentData?: { platform?: string } }
+  ).userAgentData;
+  const name = agent?.platform ?? navigator.platform ?? "";
+  return /mac/i.test(name);
+}
+
+/**
  * Whether a press can actually RUN the control it landed on.
  *
  * Only a press that will be followed by a click can, and two gestures report a
- * pointer press while invoking nothing: a secondary press, and — on macOS — a
- * primary press held with Control, which the platform treats as a context menu.
- * Radix's own popover classifies that same pair as a right-click.
+ * pointer press while invoking nothing: a secondary press anywhere, and a
+ * Control-held primary press on macOS.
  *
- * It matters because the picker closes on any outside press. Read as an
- * activation, a gesture that opens a context menu discards the colour an author
- * was composing on behalf of a button that never ran: the value is gone and
- * nothing replaced it, which is the worst of the outcomes available.
+ * Both directions cost something, which is why the platform is asked rather
+ * than the modifier alone. Reading a context menu as an activation discards the
+ * colour an author was composing on behalf of a button that never ran. Reading
+ * an ordinary Control-click as a context menu does the opposite: the picker
+ * commits its draft on dismissal AND the button's click writes, so one gesture
+ * becomes two edits and the first undo restores the colour they pressed Reset
+ * to be rid of — the defect the supersede exists to prevent, reintroduced.
  *
- * This narrows the gap rather than closing it, and the remainder is stated
- * rather than left to be discovered: a primary press that DRAGS OFF the control
- * and releases elsewhere fires no click either, and is still read here as an
- * activation. Closing that needs the write to confirm the discard instead of
- * the press predicting it — either holding the draft for a later signal, which
- * is the timer this module removed and whose cancellation cost a race, or
- * routing the marked control's write back through this field, which the
- * declaration exists to avoid. A context menu is unambiguous; a drag-away is
- * not.
+ * The remainder is stated rather than left to be discovered: a primary press
+ * that DRAGS OFF the control and releases elsewhere fires no click either, and
+ * is still read here as an activation. Closing that needs the write to confirm
+ * the discard instead of the press predicting it — either holding the draft for
+ * a later signal, which is the timer this module removed and whose cancellation
+ * cost a race, or routing the marked control's write back through this field,
+ * which the declaration exists to avoid.
  */
 function activates(event: PointerEvent): boolean {
-  return event.button === 0 && !event.ctrlKey;
+  if (event.button !== 0) return false;
+  return !(event.ctrlKey && contextMenuModifier());
 }
 
 /**

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -1274,6 +1274,33 @@ function sourceLabel(source: BreakpointSource): string {
  * for everybody rather than for screen-reader users alone.
  */
 /**
+ * Whether a press can actually RUN the control it landed on.
+ *
+ * Only a press that will be followed by a click can, and two gestures report a
+ * pointer press while invoking nothing: a secondary press, and — on macOS — a
+ * primary press held with Control, which the platform treats as a context menu.
+ * Radix's own popover classifies that same pair as a right-click.
+ *
+ * It matters because the picker closes on any outside press. Read as an
+ * activation, a gesture that opens a context menu discards the colour an author
+ * was composing on behalf of a button that never ran: the value is gone and
+ * nothing replaced it, which is the worst of the outcomes available.
+ *
+ * This narrows the gap rather than closing it, and the remainder is stated
+ * rather than left to be discovered: a primary press that DRAGS OFF the control
+ * and releases elsewhere fires no click either, and is still read here as an
+ * activation. Closing that needs the write to confirm the discard instead of
+ * the press predicting it — either holding the draft for a later signal, which
+ * is the timer this module removed and whose cancellation cost a race, or
+ * routing the marked control's write back through this field, which the
+ * declaration exists to avoid. A context menu is unambiguous; a drag-away is
+ * not.
+ */
+function activates(event: PointerEvent): boolean {
+  return event.button === 0 && !event.ctrlKey;
+}
+
+/**
  * Which field a control writes the value of, when it is not that field.
  *
  * The colour picker commits its gesture when the popover closes, and pressing
@@ -2623,28 +2650,9 @@ function ColourPicker({
          * everywhere else in this panel, the text fields included.
          */
         onPointerDownOutside={event => {
-          /*
-           * A PRIMARY press, because only that one can run the control.
-           *
-           * A right-click opens a context menu and invokes nothing, so reading
-           * it as a supersede discards the gesture an author was composing on
-           * behalf of a button that never ran — the colour is gone and nothing
-           * replaced it.
-           *
-           * This narrows the gap rather than closing it, and the remainder is
-           * stated rather than left to be discovered: a primary press that then
-           * DRAGS OFF the control and releases elsewhere fires no click either,
-           * and is still read here as a supersede. Closing that needs the write
-           * to confirm the discard instead of the press predicting it, which
-           * means either holding the draft until a later signal — the timer
-           * this module removed, whose cancellation cost a race — or routing
-           * the marked control's write back through this field, which the
-           * declaration exists precisely to avoid. Neither is worth an
-           * ambiguous gesture; a context menu is not ambiguous.
-           */
+          // Only a press that can RUN the control supersedes. See `activates`.
           superseded.current =
-            event.detail.originalEvent.button === 0 &&
-            supersededBy(event.target);
+            activates(event.detail.originalEvent) && supersededBy(event.target);
         }}
       >
         {unrepresented ? (


### PR DESCRIPTION
Three Codex findings that arrived on **#1249 fifteen minutes after it merged**, so they were never worked. Per the standing instruction, they land here rather than on a reopened branch.

## The finding, and what it turned out to be

`sharedStyleInputs` publishes a type saying its values are never `null`. They can be. `firstStated` skips only `undefined`, so a stored `null` is **kept** and means something: a site stating a null breakpoint set defines no viewport tiers, and that answer **outranks** a route context which has some. A consumer following the old type checks for `undefined` alone and dereferences a value the renderer explicitly supports.

Saying so exposed that this package does exactly that to itself. Three call sites, all silent, none caught by a type:

- `page-renderer.tsx` spreads the reconciled inputs into a `StyleCompileContext`, whose slots are declared as values
- `page-style-trace.ts` does the same, and it is itself published
- `canvas.tsx` reads `.breakpoints` and hands it on as a set

## Why "none" is two different shapes

| field | a stated null becomes | why |
|---|---|---|
| `breakpoints` | an **empty set** | *absent* falls through to whatever the route context carries — precisely what the null exists to override |
| everything else | **absent** | for those, the compiler's representation of "the site has none" is the missing key |

That asymmetry is the fix rather than an inconsistency, and `canvas.test.tsx` pins the breakpoints half end to end: read as absent, preview turns on for a canvas the renderer left on the unconditional tier.

The stripping helper is written field by field rather than filtered from `Object.entries`. A filter returns a string-keyed record, so handing it back needs an assertion — and an assertion there is the one thing that could hide the mismatch the helper exists to remove. Named fields make a field added to the reconciliation and forgotten here a **build failure** rather than a silent omission from every compile.

## The other two

The source docblock still said the function was *"deliberately not from the package entry"* while the entry published it — two opposing contracts beside one API.

And a colour draft now survives a **right-click** on a marked Reset. A secondary press opens a context menu and invokes nothing, but Radix dismisses on any outside `pointerdown`, so the gesture was discarded on behalf of a button that never ran.

**Stated in the code rather than left to be discovered:** a primary press that drags off the control before release still supersedes. Closing that needs the write to confirm the discard instead of the press predicting it, which means either holding the draft for a later signal — the timer this module removed, whose cancellation cost a race — or routing the marked control's write back through the field, which the declaration exists to avoid. A context menu is unambiguous; a drag-away is not.

## Verification

Gates from the worktree root: build, `check-types`, lint, `blocks-react` 933, `builder` 2073, `test:scripts` 602, comment convention, changeset, `fallow` with `complexity_introduced: 0` and `dead_code_introduced: 0`.

Break-verified: reverting the null-stripping fails the **build** with `TS2322` naming `readonly NamedClass[] | null | undefined` — the expected diagnostic, so the contract is enforced by the type system rather than by a test. Reverting the primary-press check fails the right-click case and nothing else.

One inherited failure worth noting for whoever reads the first CI run: `test:scripts` was red on my stale base from another lane's changeset frontmatter (`sqlite-says-what-actually-failed.md`). Already fixed on main; merging main cleared it, 602/602.

The entry-surface guard also caught the new cross-module helper and made me classify it internal — the same guard #1249 repaired, now working on its author.