### PR TITLE
fix(nextly): give a drafted Single the same date shapes a published one returns

### DIFF
--- a/.changeset/drafted-single-dates-match-published.md
+++ b/.changeset/drafted-single-dates-match-published.md
@@ -1,0 +1,46 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A date field on a single (a settings page, a homepage — any one-off document)
+now comes back the same way whether you are looking at the published version or
+at unpublished changes.
+
+Before, the published version handed your code a real date and the unpublished
+one handed it a piece of text that merely looked like a date. Anything that then
+asked the date a question — what year is this, is it before that — worked on the
+published document and failed on the one with pending edits. The failure only
+appeared once someone had unsaved changes, which is exactly when it is hardest
+to connect to a cause.
+
+The shaping that produces an unpublished document now restores date values the
+same way an ordinary read does, so both come back in the same form.
+
+System timestamps such as "last updated" are deliberately left as they were.
+Singles and collections genuinely present those differently, and making them
+uniform here would have fixed one and broken the other — so which behaviour
+applies is now stated explicitly by each caller rather than assumed.

--- a/packages/nextly/src/domains/singles/__tests__/draft-date-parity.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/draft-date-parity.integration.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Does a DRAFTED Single hand back the same value SHAPES a published one does?
+ *
+ * The collections draft overlay rehydrates system timestamps and every declared
+ * date field to `Date` before the read pipeline runs, and says why
+ * (`collection-query-service.ts:3138`): a live read hands the afterRead hooks
+ * Drizzle-decoded `Date` objects, so a hook that calls date methods "would fail
+ * only for a drafted entry".
+ *
+ * The singles overlay calls neither of those functions. It runs
+ * `deserializeJsonFields` with a timestamp normalizer instead — a different
+ * mechanism, which may or may not reach the same result.
+ *
+ * This suite settles that by MEASUREMENT rather than by reading either
+ * implementation. It compares the drafted read against the published read of
+ * the same document: two renders of the same field, where only the overlay
+ * differs. Comparing an implementation against itself would prove nothing.
+ *
+ * @module domains/singles/__tests__/draft-date-parity.integration.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { date, defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { SingleEntryService } from "../services/single-entry-service";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "release_notes";
+const PUBLISHED_AT = "2026-03-04T10:00:00.000Z";
+const EDITED_AT = "2026-05-06T11:30:00.000Z";
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    singles: [
+      defineSingle({
+        slug: SLUG,
+        status: true,
+        versions: { drafts: true },
+        access: { read: () => true, update: () => true },
+        fields: [text({ name: "headline" }), date({ name: "goesLiveAt" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+const singlesOf = (t: TestNextly): SingleEntryService =>
+  t.getService("singleEntryService");
+
+/** What kind of thing came back, in a form an assertion can compare. */
+const shapeOf = (value: unknown): string =>
+  value instanceof Date ? "Date" : typeof value;
+
+describe.each(getConfiguredTestDialects())(
+  "a drafted Single's value shapes (%s)",
+  dialect => {
+    it("returns a declared date field in the SAME shape as a published read", async () => {
+      const t = await boot(dialect);
+      const singles = singlesOf(t);
+
+      await singles.update(
+        SLUG,
+        { headline: "live", goesLiveAt: PUBLISHED_AT, status: "published" },
+        { overrideAccess: true }
+      );
+
+      const published = await singles.get(SLUG, { overrideAccess: true });
+      const publishedShape = shapeOf(
+        (published.data as { goesLiveAt?: unknown }).goesLiveAt
+      );
+      // The premise: the published read must itself return something, or the
+      // comparison below is satisfied by two absences agreeing.
+      expect(
+        (published.data as { goesLiveAt?: unknown }).goesLiveAt
+      ).toBeDefined();
+
+      await singles.update(
+        SLUG,
+        { headline: "edited", goesLiveAt: EDITED_AT },
+        { overrideAccess: true }
+      );
+
+      const drafted = await singles.get(SLUG, {
+        overrideAccess: true,
+        includeWorkingDraft: true,
+        status: "all",
+      });
+      // The overlay is actually in effect — otherwise this compares the
+      // published document with itself and passes for the wrong reason.
+      expect((drafted.data as { headline?: string }).headline).toBe("edited");
+
+      expect(
+        shapeOf((drafted.data as { goesLiveAt?: unknown }).goesLiveAt)
+      ).toBe(publishedShape);
+    });
+
+    it("returns the system timestamps in the SAME shape as a published read", async () => {
+      const t = await boot(dialect);
+      const singles = singlesOf(t);
+
+      await singles.update(
+        SLUG,
+        { headline: "live", goesLiveAt: PUBLISHED_AT, status: "published" },
+        { overrideAccess: true }
+      );
+      const published = await singles.get(SLUG, { overrideAccess: true });
+      const publishedShape = shapeOf(
+        (published.data as { updatedAt?: unknown }).updatedAt
+      );
+      expect(
+        (published.data as { updatedAt?: unknown }).updatedAt
+      ).toBeDefined();
+
+      await singles.update(
+        SLUG,
+        { headline: "edited" },
+        { overrideAccess: true }
+      );
+      const drafted = await singles.get(SLUG, {
+        overrideAccess: true,
+        includeWorkingDraft: true,
+        status: "all",
+      });
+      expect((drafted.data as { headline?: string }).headline).toBe("edited");
+
+      expect(shapeOf((drafted.data as { updatedAt?: unknown }).updatedAt)).toBe(
+        publishedShape
+      );
+    });
+  }
+);

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -869,6 +869,10 @@ export class SingleQueryService extends BaseService {
       componentSchemas: view.componentSchemas,
       hasSlug: singleMeta.fields.some(f => f.name === "slug"),
       hasTitle: singleMeta.fields.some(f => f.name === "title"),
+      // A Single's live read normalizes its system timestamps to strings, so
+      // rehydrating them here would make a drafted Single disagree with a
+      // published one — the opposite of the parity this shaping exists for.
+      rehydrateSystemTimestampsToDate: false,
     }) as unknown as SingleDocument;
 
     // The snapshot REPLACES the assembled document, so every response-shaping

--- a/packages/nextly/src/domains/versions/__tests__/shape-draft-snapshot.test.ts
+++ b/packages/nextly/src/domains/versions/__tests__/shape-draft-snapshot.test.ts
@@ -20,6 +20,10 @@ const base = {
   componentSchemas: undefined,
   hasSlug: true,
   hasTitle: true,
+  // These cases are about the PRUNE. `false` keeps the stored strings as
+  // strings, so what each assertion below reads is unchanged by the
+  // rehydration that was added alongside this parameter.
+  rehydrateSystemTimestampsToDate: false,
 };
 
 describe("shapeDraftSnapshot", () => {

--- a/packages/nextly/src/domains/versions/shape-draft-snapshot.ts
+++ b/packages/nextly/src/domains/versions/shape-draft-snapshot.ts
@@ -13,6 +13,19 @@
  * columns it deliberately holds back — a restore must not resubmit them, a read
  * carries them — are copied back afterwards.
  *
+ * ## Why the rehydration is part of the question, not a step callers add
+ *
+ * A snapshot stores dates as strings; an ordinary live read hands the afterRead
+ * hooks Drizzle-decoded `Date` objects. A caller that prunes without
+ * rehydrating therefore returns a document whose dates are the wrong TYPE, and
+ * a hook calling date methods fails only for a drafted document — which is
+ * exactly what was measured on Singles before this function did it
+ * (`draft-date-parity.integration.test.ts`).
+ *
+ * Leaving it to callers is what produced that: two of the three call sites
+ * remembered, one did not, and the one that did not was the one reached through
+ * an extracted helper whose name claims it shapes the document whole.
+ *
  * Pure and DI-free so the shaping can be tested directly, which is the half of
  * an overlay that has no database in it.
  *
@@ -20,10 +33,14 @@
  */
 
 import type { FieldConfig } from "../../collections/fields/types";
-import { SYSTEM_TIMESTAMP_KEYS } from "../../shared/lib/case-conversion";
+import {
+  SYSTEM_TIMESTAMP_KEYS,
+  rehydrateSystemTimestamps,
+} from "../../shared/lib/case-conversion";
 
 import { buildRestorePayload } from "./restore-snapshot";
 import type { ComponentSchemas } from "./restore-snapshot";
+import { rehydrateSnapshotDates } from "./tag-component-types";
 
 export interface ShapeDraftSnapshotInput {
   /** The snapshot as stored. */
@@ -37,9 +54,36 @@ export interface ShapeDraftSnapshotInput {
    *
    * A plugin-contributed collection gets no synthesized pair, so claiming they
    * exist would keep an obsolete snapshot key the current schema never declared.
+   *
+   * Deliberately a PARAMETER rather than something derived here: the callers
+   * answer it differently and both are argued. A Single asks whether the field
+   * is declared; a collection treats a non-plugin collection as always having
+   * the pair. Folding either rule in would silently change the other.
    */
   hasSlug: boolean;
   hasTitle: boolean;
+  /**
+   * Whether to restore the SYSTEM timestamps to `Date`.
+   *
+   * Not universal, and measured rather than assumed: a collection's live read
+   * hands back `Date` for `createdAt`/`updatedAt`, and a Single's hands back a
+   * STRING — a Single normalizes them on the way out. So rehydrating
+   * unconditionally fixes the drafted collection and breaks the drafted Single,
+   * which is what `draft-date-parity.integration.test.ts` caught when this was
+   * first written as an unconditional step.
+   *
+   * DECLARED date fields are not affected by this: both document types return
+   * those as `Date`, so they are always rehydrated.
+   */
+  rehydrateSystemTimestampsToDate: boolean;
+  /**
+   * Whether the document carries the lifecycle column.
+   *
+   * Defaults to `true`: reaching this at all normally means the draft/published
+   * split applied. The collection WRITE-response path shapes a draft for a
+   * collection that may not have it, so it passes the answer explicitly.
+   */
+  hasStatus?: boolean;
 }
 
 /**
@@ -49,9 +93,7 @@ export function shapeDraftSnapshot(
   input: ShapeDraftSnapshotInput
 ): Record<string, unknown> {
   const { payload } = buildRestorePayload(input.snapshot, input.fields, {
-    // Reaching this function at all means the draft/published split applied,
-    // which requires the lifecycle column.
-    hasStatus: true,
+    hasStatus: input.hasStatus ?? true,
     hasSlug: input.hasSlug,
     hasTitle: input.hasTitle,
     componentSchemas: input.componentSchemas,
@@ -70,6 +112,13 @@ export function shapeDraftSnapshot(
       payload[key] = input.snapshot[key];
     }
   }
+
+  // Rehydrate, so every caller returns the value shapes ITS OWN live read
+  // returns. See the module note: this is part of the question, not a step a
+  // caller is trusted to remember — but the system-timestamp half differs by
+  // document type, so it is declared rather than assumed.
+  if (input.rehydrateSystemTimestampsToDate) rehydrateSystemTimestamps(payload);
+  rehydrateSnapshotDates(payload, input.fields, input.componentSchemas ?? null);
 
   return payload;
 }


### PR DESCRIPTION
## Summary

A **confirmed, user-facing bug**, found by auditing before writing code — and the audit also showed that the "cleanup" the ledger asked for would have *introduced* a bug rather than removed one.

### The bug

A snapshot stores dates as strings; an ordinary live read hands the afterRead hooks Drizzle-decoded `Date` objects. The **Singles draft overlay pruned the snapshot without restoring them**, so:

```
published read:  goesLiveAt -> Date
drafted read:    goesLiveAt -> string     <- same document, same field
```

A hook calling `.getTime()` on a date field **works on a published Single and throws on one with pending edits** — a failure that only appears once someone has unsaved changes, which is exactly when it is hardest to attribute.

The collections overlay already got this right and says why (`collection-query-service.ts:3138`): *"a hook that calls date methods would fail only for a drafted entry."* Singles simply never did it.

### How it was established

`draft-date-parity.integration.test.ts` compares the **drafted read against the published read of the same document**, so the overlay is the only difference. Comparing an implementation against itself would have proved nothing. It reported `string` where the published read reported `Date`.

### The fix

The rehydration now belongs to `shapeDraftSnapshot` rather than to its callers. Leaving it to callers is what produced the gap: two of the three sites remembered, one did not — and the one that did not was reached through a helper whose *name* claims it shapes the document whole.

### One thing that is deliberately NOT uniform

**System timestamps are a declared parameter, not an unconditional step.** A collection's live read returns `Date` for `createdAt`/`updatedAt`; a Single's returns a **string**. So rehydrating them unconditionally fixes the drafted collection and *breaks* the drafted Single — which is precisely what the second test caught when this was first written that way. Each caller now states which convention it follows.

## Why this corrects the ledger finding it grew out of

`finding:collections-inline-copy-of-shape-draft-snapshot` says there are **two** statements of the draft-shaping question. There are **three**, and they implement different numbers of steps:

| | prune | copy back id+timestamps | rehydrate system ts | rehydrate declared dates |
| --- | :-: | :-: | :-: | :-: |
| `shape-draft-snapshot.ts` (singles) — **before this PR** | ✅ | ✅ | ❌ | ❌ |
| `collection-query-service.ts:3060/:3143` | ✅ | ✅ | ✅ | ✅ |
| `collection-mutation-service.ts#shapeDraftForResponse:2026` | ✅ | ✅ | ✅ | ✅ |

The third was not in the finding at all. **Doing the dedup as filed** — pointing the query service at the two-step helper — **would have dropped both rehydrate steps** and introduced on collections the exact bug this PR fixes on singles.

Full audit: `findings/R-6-draft-shaping-audit.md`.

## Scope: what this PR deliberately does NOT do

It does **not** convert the two collections call sites. In `collection-query-service`, rehydration runs *after* relationship expansion; moving it into the helper reorders it, and I will not make that change without a collections parity test that proves the reorder is safe — including an expanded-relationship case. That is a follow-up, stated rather than quietly skipped.

## Test plan

- New `draft-date-parity.integration.test.ts`, 2 cases, runs on every configured dialect. Each carries a premise assertion (the published read returned *something*; the overlay was actually in effect) so neither can pass by two absences agreeing.
- **Break-verified independently:** removing the declared-date rehydration fails exactly the first test; making system-timestamp rehydration unconditional fails exactly the second. The two are independently discriminating — one catches under-rehydration, the other over-rehydration.

Run locally: versions **492**, singles **228**, `shape-draft-snapshot` unit **5**, lint clean, check-types clean, `changeset status` clean.

## Changeset

Changeset added: **patch** (repo-wide, 25 packages). Frontmatter verified with `pnpm exec changeset status`.

## Pre-existing failures

`pnpm --filter nextly test src/domains/collections` is **11 failed / 398 passed** — and it is **identical on clean `main`** (measured on an unmodified checkout, same counts). Not from this branch.

CI has been unreliable repo-wide; everything above was run **locally**.