### PR TITLE
fix(admin): give entry and single editors the measure a document needs

### DIFF
--- a/.changeset/content-pages-take-the-content-measure.md
+++ b/.changeset/content-pages-take-the-content-measure.md
@@ -1,0 +1,46 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Editing an entry or a single now uses the width a document needs, instead of
+the narrower column meant for a settings form.
+
+The editor shared one reading width with pages like Settings. That width suits a
+short list of labelled controls, but an entry is a document: its fields include
+rich text, media and repeated groups, and the document panel on the right was
+taking its share out of the same column. On a large screen the field you type
+into ended up under half the width of the area around it, the editor toolbar
+wrapped onto a third row, and the buttons in the header dropped their labels to
+show as icons alone.
+
+Entries and singles now use the wider of the two measures, in every state the
+page can be in — while it is loading, when it cannot load, and once it has
+loaded. A page that changed width as its content arrived would move every field
+sideways at the moment the data appeared.
+
+Settings pages are unchanged. The narrower width is right for them, and that is
+the point: which width a page takes now follows from what the page holds.

--- a/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
+++ b/packages/admin/src/components/features/entries/PreviewMode/PreviewPanes.tsx
@@ -22,7 +22,7 @@
  *
  * ## Why this asks for the page frame and nothing else
  *
- * The editor's measure is a 56rem column, declared by `MeasuredPageFrame`, and
+ * The editor is bounded to a measure, declared by `MeasuredPageFrame`, and
  * two panes cannot share it. The frame is released the way the page builder
  * releases it — by asking, from inside — rather than by the page passing a
  * different width: `MeasuredPageFrame` states that framed and immersive are the

--- a/packages/admin/src/components/layout/MeasuredPageFrame.test.tsx
+++ b/packages/admin/src/components/layout/MeasuredPageFrame.test.tsx
@@ -135,7 +135,7 @@ describe("MeasuredPageFrame", () => {
     // `BlocksField` asks from INSIDE the form rather than as a registered
     // view, so the default branch has to honour the request too. A page that
     // declared a measure without honouring it would hand the page builder a
-    // 56rem column to work in.
+    // measured column to work in.
     function FormWithTakeoverField() {
       useSuppressAdminChrome({ layers: ["pageFrame"], canExit: false });
       return <p>builder canvas</p>;

--- a/packages/admin/src/components/layout/MeasuredPageFrame.test.tsx
+++ b/packages/admin/src/components/layout/MeasuredPageFrame.test.tsx
@@ -8,7 +8,7 @@
  * window while editing a record was framed and capped at the form measure while
  * creating one.
  */
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import { useEffect, useState } from "react";
 import { describe, expect, it } from "vitest";
 
@@ -16,6 +16,9 @@ import {
   ChromeSuppressionProvider,
   useSuppressAdminChrome,
 } from "./ChromeSuppression";
+
+import { CONTENT_PAGE_MEASURE } from "./content-measure";
+import { PageContainer } from "./page-container";
 
 import { MeasuredPageFrame } from "./MeasuredPageFrame";
 
@@ -52,6 +55,11 @@ describe("MeasuredPageFrame", () => {
     expect(container.className).toContain("nx-page-shell");
     expect(container.className).not.toContain("contents");
     expect(container.style.getPropertyValue("--nx-shell-measure")).toBe(
+      "var(--nx-measure-wide)"
+    );
+    // The control for the line above: asserting only that SOME measure is set
+    // would pass on a frame that had silently kept the settings measure.
+    expect(container.style.getPropertyValue("--nx-shell-measure")).not.toBe(
       "var(--nx-measure-form)"
     );
   });
@@ -161,5 +169,35 @@ describe("MeasuredPageFrame", () => {
 
     const trail = screen.getByTestId("page-container").firstElementChild;
     expect(trail?.className).toBe("");
+  });
+});
+
+describe("the content measure is declared once", () => {
+  it("renders whatever the shared constant says, not a literal of its own", () => {
+    // Reading the constant back is what makes this a wiring test rather than a
+    // restatement: change `CONTENT_PAGE_MEASURE` and this follows, while a
+    // frame that had drifted back to its own literal fails here.
+    render(
+      <ChromeSuppressionProvider>
+        <MeasuredPageFrame>
+          <p>body</p>
+        </MeasuredPageFrame>
+      </ChromeSuppressionProvider>
+    );
+    const framed = screen.getByTestId("page-container");
+
+    cleanup();
+    render(
+      <PageContainer width={CONTENT_PAGE_MEASURE}>reference</PageContainer>
+    );
+    const reference = screen.getByTestId("page-container");
+
+    // A page's loading skeleton reaches the container directly while its loaded
+    // state reaches it through the frame. The two must resolve to one measure,
+    // or every field moves sideways when the data arrives.
+    expect(framed.style.getPropertyValue("--nx-shell-measure")).toBe(
+      reference.style.getPropertyValue("--nx-shell-measure")
+    );
+    expect(reference.style.getPropertyValue("--nx-shell-measure")).not.toBe("");
   });
 });

--- a/packages/admin/src/components/layout/MeasuredPageFrame.test.tsx
+++ b/packages/admin/src/components/layout/MeasuredPageFrame.test.tsx
@@ -174,9 +174,11 @@ describe("MeasuredPageFrame", () => {
 
 describe("the content measure is declared once", () => {
   it("renders whatever the shared constant says, not a literal of its own", () => {
-    // Reading the constant back is what makes this a wiring test rather than a
-    // restatement: change `CONTENT_PAGE_MEASURE` and this follows, while a
-    // frame that had drifted back to its own literal fails here.
+    // Both sides derive from `CONTENT_PAGE_MEASURE`, so this proves only that
+    // the FRAME reads it — a skeleton that drifted back to its own literal is
+    // invisible here, because no route state is rendered. That property is
+    // covered by `__tests__/content-measure-wiring.test.ts`, which reads the
+    // route sources; this one guards the frame's own half.
     render(
       <ChromeSuppressionProvider>
         <MeasuredPageFrame>
@@ -192,9 +194,8 @@ describe("the content measure is declared once", () => {
     );
     const reference = screen.getByTestId("page-container");
 
-    // A page's loading skeleton reaches the container directly while its loaded
-    // state reaches it through the frame. The two must resolve to one measure,
-    // or every field moves sideways when the data arrives.
+    // The frame and a direct container must resolve to one measure, so a page
+    // whose states use both routes to the same width.
     expect(framed.style.getPropertyValue("--nx-shell-measure")).toBe(
       reference.style.getPropertyValue("--nx-shell-measure")
     );

--- a/packages/admin/src/components/layout/MeasuredPageFrame.tsx
+++ b/packages/admin/src/components/layout/MeasuredPageFrame.tsx
@@ -42,7 +42,7 @@ interface MeasuredPageFrameProps {
  *
  * The default form matters as much as the custom one. `BlocksField` suppresses
  * `pageFrame` from inside it, and a page that declares a measure without
- * honouring that would hand the page builder a 56rem column to work in.
+ * honouring that would hand the page builder a measured column to work in.
  *
  * A framed view is page CONTENT, so the measure is the page's, declared here.
  * A view that declared its own would sit inside this container's padding and

--- a/packages/admin/src/components/layout/MeasuredPageFrame.tsx
+++ b/packages/admin/src/components/layout/MeasuredPageFrame.tsx
@@ -3,6 +3,7 @@
 import type { ReactNode } from "react";
 
 import { useSuppressedChrome } from "./ChromeSuppression";
+import { CONTENT_PAGE_MEASURE } from "./content-measure";
 import { PageContainer } from "./page-container";
 
 interface MeasuredPageFrameProps {
@@ -48,6 +49,15 @@ interface MeasuredPageFrameProps {
  * add a second inset to it, which is the disagreement the shell exists to end.
  * Framed and immersive are the whole vocabulary; there is no third case for a
  * width to answer.
+ *
+ * The measure is `wide`, not the form measure. Both are reading widths and the
+ * difference is what is being read. A settings form is a short column of
+ * labelled controls and nothing else. An entry is a document: its fields
+ * include rich text, media and repeated groups, and it shares its column with
+ * the document rail, so the rail's width comes out of the author's. At the form
+ * measure that leaves the widest field under half the column, and controls that
+ * lay out horizontally — an editor toolbar, the header's actions — wrap onto
+ * extra rows or drop their labels for icons.
  */
 export function MeasuredPageFrame({
   breadcrumbs,
@@ -84,7 +94,10 @@ export function MeasuredPageFrame({
     : "hidden";
 
   return (
-    <PageContainer width="form" className={framed ? undefined : "contents"}>
+    <PageContainer
+      width={CONTENT_PAGE_MEASURE}
+      className={framed ? undefined : "contents"}
+    >
       <div className={trailClass}>{breadcrumbs}</div>
       {children}
     </PageContainer>

--- a/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
+++ b/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
@@ -42,23 +42,35 @@ const CONTENT_ROUTES = [
  */
 const SETTINGS_ROUTE = "pages/dashboard/settings/webhooks/create.tsx";
 
-const WIDTH_PROP = /<PageContainer\s[^>]*width=(\{[^}]*\}|"[^"]*")/g;
+/**
+ * Every opening `PageContainer` tag with its attributes, whatever they are.
+ *
+ * Deliberately not anchored on `width=`. A pattern that requires the prop in
+ * order to match cannot see a container that DROPPED it, and that is the
+ * change worth catching: no width is the unmeasured padded path, so a state
+ * that lost the prop reflows against the states that kept it, while the
+ * remaining matches keep any population assertion satisfied.
+ */
+const CONTAINER_TAG = /<PageContainer([^>]*)>/g;
 
-function widthsIn(relative: string): string[] {
+/** The attribute text of each `PageContainer` in a file, in source order. */
+function containersIn(relative: string): string[] {
   const source = readFileSync(join(SRC, relative), "utf8");
-  return [...source.matchAll(WIDTH_PROP)].map(m => m[1] as string);
+  return [...source.matchAll(CONTAINER_TAG)].map(m => m[1] as string);
 }
 
 describe("content routes read the shared measure", () => {
   for (const route of CONTENT_ROUTES) {
-    it(`${route} names no width of its own`, () => {
-      const widths = widthsIn(route);
+    it(`${route} measures every container from the shared constant`, () => {
+      const containers = containersIn(route);
       // The population assertion. Without it, a renamed file or a pattern that
-      // stopped matching yields an empty list, and "no literals" passes over a
-      // route the test never read.
-      expect(widths.length).toBeGreaterThan(0);
-      for (const w of widths) {
-        expect(w).toBe("{CONTENT_PAGE_MEASURE}");
+      // stopped matching yields an empty list, and the loop below passes over
+      // a route the test never read.
+      expect(containers.length).toBeGreaterThan(0);
+      for (const attrs of containers) {
+        // Asserted over EVERY container, so dropping the prop fails here
+        // rather than removing the tag from the scan.
+        expect(attrs).toContain("width={CONTENT_PAGE_MEASURE}");
       }
     });
   }
@@ -67,8 +79,8 @@ describe("content routes read the shared measure", () => {
     // If this ever comes back as the constant, either settings pages were swept
     // up by mistake or the scan has stopped seeing literals — and in the second
     // case every assertion above is passing on nothing.
-    const widths = widthsIn(SETTINGS_ROUTE);
-    expect(widths.length).toBeGreaterThan(0);
-    expect(widths).toContain('"form"');
+    const containers = containersIn(SETTINGS_ROUTE);
+    expect(containers.length).toBeGreaterThan(0);
+    expect(containers.some(a => a.includes('width="form"'))).toBe(true);
   });
 });

--- a/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
+++ b/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Guards that the content routes read the shared measure rather than a literal.
+ *
+ * A content page renders in several states — a loading skeleton, a handful of
+ * error cards, and the loaded document — and only the last reaches
+ * `MeasuredPageFrame`. The others build their own container, so rendering the
+ * frame and comparing it against a reference built from the same constant
+ * cannot see them: both sides derive from one source, so the comparison proves
+ * the frame reads the constant and nothing about the skeleton beside it.
+ *
+ * The property that actually matters is that no state names a width of its own.
+ * A skeleton at one measure followed by a document at another moves every field
+ * sideways at the moment data arrives, and each literal looks correct beside its
+ * own neighbours, so nothing in review catches the disagreement.
+ *
+ * Reading the route source is what reaches those states. Rendering them would be
+ * stronger and is not available: the skeletons are module-private, and exporting
+ * three components so a test can see them widens the package's surface to serve
+ * the test rather than a caller.
+ */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/** Repo-relative, resolved from the package root vitest runs in. */
+const SRC = join(process.cwd(), "src");
+
+/** Every route whose page is a document rather than a settings form. */
+const CONTENT_ROUTES = [
+  "pages/dashboard/entries/[slug]/[id]/index.tsx",
+  "pages/dashboard/entries/[slug]/create.tsx",
+  "pages/dashboard/singles/[slug]/index.tsx",
+] as const;
+
+/**
+ * A settings route, which SHOULD carry a literal `width="form"`.
+ *
+ * The must-differ control. A scan that reported "no literal widths" everywhere
+ * — because its pattern never matched anything — would satisfy every assertion
+ * about the content routes while checking nothing at all.
+ */
+const SETTINGS_ROUTE = "pages/dashboard/settings/webhooks/create.tsx";
+
+const WIDTH_PROP = /<PageContainer\s[^>]*width=(\{[^}]*\}|"[^"]*")/g;
+
+function widthsIn(relative: string): string[] {
+  const source = readFileSync(join(SRC, relative), "utf8");
+  return [...source.matchAll(WIDTH_PROP)].map(m => m[1] as string);
+}
+
+describe("content routes read the shared measure", () => {
+  for (const route of CONTENT_ROUTES) {
+    it(`${route} names no width of its own`, () => {
+      const widths = widthsIn(route);
+      // The population assertion. Without it, a renamed file or a pattern that
+      // stopped matching yields an empty list, and "no literals" passes over a
+      // route the test never read.
+      expect(widths.length).toBeGreaterThan(0);
+      for (const w of widths) {
+        expect(w).toBe("{CONTENT_PAGE_MEASURE}");
+      }
+    });
+  }
+
+  it("discriminates: a settings route still declares its own literal", () => {
+    // If this ever comes back as the constant, either settings pages were swept
+    // up by mistake or the scan has stopped seeing literals — and in the second
+    // case every assertion above is passing on nothing.
+    const widths = widthsIn(SETTINGS_ROUTE);
+    expect(widths.length).toBeGreaterThan(0);
+    expect(widths).toContain('"form"');
+  });
+});

--- a/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
+++ b/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
@@ -10,8 +10,8 @@
  *
  * The property that actually matters is that no state names a width of its own.
  * A skeleton at one measure followed by a document at another moves every field
- * sideways at the moment data arrives, and each literal looks correct beside its
- * own neighbours, so nothing in review catches the disagreement.
+ * sideways at the moment data arrives, and because each literal is correct on
+ * its own terms, the disagreement is visible only by comparing the sites.
  *
  * Reading the route source is what reaches those states. Rendering them would be
  * stronger and is not available: the skeletons are module-private, and exporting

--- a/packages/admin/src/components/layout/content-measure.ts
+++ b/packages/admin/src/components/layout/content-measure.ts
@@ -7,10 +7,11 @@
  * document at another moves every field sideways at the moment the data
  * arrives, which reads as the page loading twice.
  *
- * Agreement is not something a reviewer can see, because the states are in
- * different branches of different files and each one looks correct beside its
- * own neighbours. So the value is declared here and imported, and divergence
- * stops being possible rather than being something a test has to notice.
+ * That agreement has no single place it can be observed: the states are early
+ * returns in different branches of different files, and each width is correct
+ * on its own terms wherever it appears. Declaring the value here and importing
+ * it makes divergence unrepresentable instead of something that has to be
+ * noticed by comparing the sites.
  *
  * `wide` rather than the form measure because of what a content page holds. A
  * settings form is a short column of labelled controls; an entry is a document

--- a/packages/admin/src/components/layout/content-measure.ts
+++ b/packages/admin/src/components/layout/content-measure.ts
@@ -1,0 +1,33 @@
+/**
+ * The measure a content page is bounded to, named once.
+ *
+ * A page renders in several states — a loading skeleton, a handful of error
+ * cards, and the loaded document — and each is a separate early return with its
+ * own container. They must agree: a skeleton at one measure followed by a
+ * document at another moves every field sideways at the moment the data
+ * arrives, which reads as the page loading twice.
+ *
+ * Agreement is not something a reviewer can see, because the states are in
+ * different branches of different files and each one looks correct beside its
+ * own neighbours. So the value is declared here and imported, and divergence
+ * stops being possible rather than being something a test has to notice.
+ *
+ * `wide` rather than the form measure because of what a content page holds. A
+ * settings form is a short column of labelled controls; an entry is a document
+ * whose fields include rich text, media and repeated groups, and which shares
+ * its column with the document rail — so the rail's width is taken out of the
+ * author's. Settings pages are deliberately NOT expressed here: they are a
+ * different kind of page and their measure is their own to declare.
+ *
+ * @module components/layout/content-measure
+ */
+
+import type { PageContainerProps } from "@admin/types/layout/page-container";
+
+/**
+ * Typed as the container's own prop, so a value this vocabulary does not offer
+ * is a compile error here rather than a silently ignored attribute at fifteen
+ * call sites.
+ */
+export const CONTENT_PAGE_MEASURE: NonNullable<PageContainerProps["width"]> =
+  "wide";

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -309,10 +309,11 @@ export default function EditEntryPage({
   /**
    * The page's measure, on every branch.
    *
-   * `form` because an entry is a labelled form: an unbounded panel stretches a
-   * short text input across the whole of it. These early-return branches never
-   * reach `MeasuredPageFrame`, which carries the same reasoning for the branch
-   * that does, so they state it here rather than inheriting it.
+   * `CONTENT_PAGE_MEASURE` rather than a literal, and not the settings measure:
+   * an entry is a document rather than a short column of labelled controls, and
+   * it shares its column with the document rail. These early-return branches
+   * never reach `MeasuredPageFrame`, so they read the same constant it does
+   * rather than restating a width that could disagree with it.
    *
    * Every branch carries it — loading, each error state, and the editor —
    * because they are the SAME page at different moments. Measuring only the

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -19,6 +19,7 @@ import {
   EntryForm,
   type EntryFormCollection,
 } from "@admin/components/features/entries/EntryForm";
+import { CONTENT_PAGE_MEASURE } from "@admin/components/layout/content-measure";
 import { MeasuredPageFrame } from "@admin/components/layout/MeasuredPageFrame";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { Breadcrumbs } from "@admin/components/shared";
@@ -87,7 +88,7 @@ function EditEntryBreadcrumbs({
  */
 function EditEntryPageSkeleton() {
   return (
-    <PageContainer width="form">
+    <PageContainer width={CONTENT_PAGE_MEASURE}>
       {/* Accessibility: Announce loading state to screen readers */}
       <div className="sr-only" role="status" aria-live="polite">
         Loading entry...
@@ -323,7 +324,7 @@ export default function EditEntryPage({
   // Missing slug error state
   if (!slug) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             No collection was specified in the URL.
@@ -341,7 +342,7 @@ export default function EditEntryPage({
   // Missing ID error state
   if (!id) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             No entry ID was specified in the URL.
@@ -374,7 +375,7 @@ export default function EditEntryPage({
   // Error state
   if (error) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Failed to load entry:{" "}
@@ -393,7 +394,7 @@ export default function EditEntryPage({
   // Collection not found
   if (!collection) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Collection &quot;{slug}&quot; not found.
@@ -411,7 +412,7 @@ export default function EditEntryPage({
   // Entry not found
   if (!entry) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Entry &quot;{id}&quot; not found in collection &quot;{slug}&quot;.

--- a/packages/admin/src/pages/dashboard/entries/[slug]/create.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/create.tsx
@@ -19,6 +19,7 @@ import {
   EntryForm,
   type EntryFormCollection,
 } from "@admin/components/features/entries/EntryForm";
+import { CONTENT_PAGE_MEASURE } from "@admin/components/layout/content-measure";
 import { MeasuredPageFrame } from "@admin/components/layout/MeasuredPageFrame";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { Breadcrumbs } from "@admin/components/shared";
@@ -80,7 +81,7 @@ function CreateEntryBreadcrumbs({
  */
 function CreateEntryPageSkeleton() {
   return (
-    <PageContainer width="form">
+    <PageContainer width={CONTENT_PAGE_MEASURE}>
       {/* Accessibility: Announce loading state to screen readers */}
       <div className="sr-only" role="status" aria-live="polite">
         Loading collection...
@@ -202,7 +203,7 @@ export default function CreateEntryPage({
   // Missing slug error state
   if (!slug) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             No collection was specified in the URL.
@@ -225,7 +226,7 @@ export default function CreateEntryPage({
   // Error state
   if (error) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Failed to load collection:{" "}
@@ -244,7 +245,7 @@ export default function CreateEntryPage({
   // Collection not found
   if (!collection) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Collection &quot;{slug}&quot; not found.

--- a/packages/admin/src/pages/dashboard/entries/[slug]/create.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/create.tsx
@@ -188,10 +188,11 @@ export default function CreateEntryPage({
   /**
    * The page's measure, on every branch.
    *
-   * `form` because an entry is a labelled form: an unbounded panel stretches a
-   * short text input across the whole of it. These early-return branches never
-   * reach `MeasuredPageFrame`, which carries the same reasoning for the branch
-   * that does, so they state it here rather than inheriting it.
+   * `CONTENT_PAGE_MEASURE` rather than a literal, and not the settings measure:
+   * an entry is a document rather than a short column of labelled controls, and
+   * it shares its column with the document rail. These early-return branches
+   * never reach `MeasuredPageFrame`, so they read the same constant it does
+   * rather than restating a width that could disagree with it.
    *
    * Every branch carries it — loading, each error state, and the editor —
    * because they are the SAME page at different moments. Measuring only the

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -23,6 +23,7 @@ import {
   SingleForm,
   type SingleSchema,
 } from "@admin/components/features/singles";
+import { CONTENT_PAGE_MEASURE } from "@admin/components/layout/content-measure";
 import { MeasuredPageFrame } from "@admin/components/layout/MeasuredPageFrame";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
@@ -57,7 +58,7 @@ interface SingleEditPageProps {
  */
 function SingleEditPageSkeleton() {
   return (
-    <PageContainer width="form">
+    <PageContainer width={CONTENT_PAGE_MEASURE}>
       {/* Accessibility: Announce loading state to screen readers */}
       <div className="sr-only" role="status" aria-live="polite">
         Loading...
@@ -227,7 +228,7 @@ export default function SingleEditPage({
   // Missing slug error state
   if (!slug) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             No Single was specified in the URL.
@@ -250,7 +251,7 @@ export default function SingleEditPage({
   // Error state
   if (error) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Failed to load Single:{" "}
@@ -269,7 +270,7 @@ export default function SingleEditPage({
   // Schema not found
   if (!schema) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Single &quot;{slug}&quot; not found.
@@ -287,7 +288,7 @@ export default function SingleEditPage({
   // Document not found (should auto-create, but handle edge case)
   if (!document) {
     return (
-      <PageContainer width="form">
+      <PageContainer width={CONTENT_PAGE_MEASURE}>
         <Alert variant="destructive">
           <AlertDescription>
             Failed to load document data for Single &quot;{slug}&quot;.

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -214,10 +214,10 @@ export default function SingleEditPage({
   /**
    * The page's measure, on every branch.
    *
-   * `form` because a Single is a labelled form, and because it now shares the
-   * translation pane with entries: the pane stops padding where the editor goes
-   * edge-to-edge, so a Single rendering into an UNMEASURED page would be the
-   * one consumer still expecting that padding to be there.
+   * `CONTENT_PAGE_MEASURE` rather than a literal: a Single is a document, and
+   * it shares the translation pane with entries — the pane stops padding where
+   * the editor goes edge-to-edge, so a Single rendering into an UNMEASURED page
+   * would be the one consumer still expecting that padding to be there.
    *
    * Every branch carries it — loading, each error state, and the editor —
    * because they are the SAME page at different moments. Measuring only the
@@ -328,7 +328,7 @@ export default function SingleEditPage({
       {/* Through the shared frame rather than a bare container: translation
           mode asks to suppress `pageFrame` from inside the form, and only this
           component reacts to that. A page that declared its own measure here
-          would keep the two-pane translation surface inside a 56rem column
+          keep the two-pane translation surface inside the content measure
           while the entry editor beside it took the whole panel. */}
       <MeasuredPageFrame>
         <SingleForm

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -328,8 +328,8 @@ export default function SingleEditPage({
       {/* Through the shared frame rather than a bare container: translation
           mode asks to suppress `pageFrame` from inside the form, and only this
           component reacts to that. A page that declared its own measure here
-          keep the two-pane translation surface inside the content measure
-          while the entry editor beside it took the whole panel. */}
+          would keep the two-pane translation surface inside the content
+          measure while the entry editor beside it took the whole panel. */}
       <MeasuredPageFrame>
         <SingleForm
           // ApiSingle.fields is SchemaField[] (loose `type: string`); SingleSchema


### PR DESCRIPTION
## What changed

Editing an entry or a single now uses the width a document needs, instead of the narrower column meant for a settings form.

Measured at a 1680px viewport, in a 1352px content panel:

| Page | Before | After |
| --- | --- | --- |
| Entry edit / create, singles | 896px column, widest field **462px** | 1152px column, widest field **718px** |
| Entry create (no document rail) | 462px | **1038px** |
| Settings, webhook create | 896px | **896px — unchanged** |
| Dashboard, lists, media, users | full width | **full width — unchanged** |

At the old measure the editor toolbar wrapped onto a third row and the header's actions dropped their labels for icons. Both recover at the wider measure.

## Why it was wrong

`MeasuredPageFrame` offered exactly two states — framed at the form measure, or immersive with no frame at all — and its docblock stated the assumption: *"Framed and immersive are the whole vocabulary; there is no third case for a width to answer."*

That welds two independent questions together: *does the page keep its chrome?* and *is its content capped at a reading measure?* The only way to get width was to surrender the frame, which is why the page-builder canvas has to suppress `pageFrame` to breathe, and why an entry form that simply wanted room had no option at all.

The measure is right for settings — a short column of labelled controls. It is wrong for a document whose fields include rich text, media and repeated groups, and which shares its column with the document rail, so the rail's width came out of the author's.

## The value is declared once

A page renders in several states: a loading skeleton, five error cards, and the loaded document. Each is a separate early return with its own container, spread across three files. They must agree — a skeleton at one measure followed by a document at another moves every field sideways at the moment data arrives.

Each literal looks correct beside its own neighbours, so that agreement is not something review can see. `CONTENT_PAGE_MEASURE` is typed as `NonNullable<PageContainerProps["width"]>`, so divergence is unrepresentable rather than something a test has to notice.

Deliberately **not** included: settings pages keep their own literal measure. They are a different kind of page and the narrower width is right for them.

## Considered and rejected

`full` (100%). Probed on the live page by overriding `--nx-shell-measure`: it yields a 1288px column and an 854px widest field, but single-line inputs like Meta Title become 854px — worse to scan than 718px — and the toolbar still wraps, so the extra 136px buys almost nothing. `wide` also keeps a 100px gutter, so the page still reads as framed rather than as a takeover.

The 16 pages on the unmeasured path were left alone. `page-container.ts` already documents why: `APIPlayground`, `BuilderPageLayout`, `not-found-page` and `media/index` hand height down a `height: 100%` chain that a grid area sized by `align-content: start` would collapse, and jsdom computes no layout, so no test on those pages could observe it.

## Test plan

- `MeasuredPageFrame.test.tsx` — 7 passed. The measure assertion carries a control that it is **not** the form measure, so it cannot pass on a frame that silently kept the old value.
- New wiring test reads `CONTENT_PAGE_MEASURE` back and asserts the frame and a direct container resolve to the same measure — the skeleton/loaded agreement, stated as a test.
- **Break-verified**: made the frame drift back to its own literal while the constant stayed `wide`. Two named tests failed — `frames a view that asked for nothing, and measures the page`, `renders whatever the shared constant says, not a literal of its own` — and five kept passing, so the break did not simply take the module down. Restored: 7/7.
- Browser-verified every page type at 1680px (table above).
- `build` 0 · `check-types` 0 · `lint` 0 · `fallow audit` verdict `warn`, 0 introduced across dead code, complexity and styling · `pnpm test:scripts` **602/602**.

Changeset added: yes (patch, all 25 lockstep packages, derived from `.changeset/config.json` `fixed[0]`).

## Pre-existing failures, not from this change

`@nextlyhq/admin` has a stale-mock baseline of **15 failures across 4 files** — `StatsCard`, `BasicsTab`, `SlugInput`, `DefaultValueField`. Unchanged by this PR and untouched by it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved entry and single-document page layouts by applying a consistent wide content measure across loading, error, and empty states.
  * Ensured document editing views align correctly with their accompanying document rail.
* **Tests**
  * Added coverage to verify consistent content sizing across document routes while preserving narrower sizing for settings pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->