### PR TITLE
feat(builder): add blocks straight into an empty container

### DIFF
--- a/.changeset/add-control-for-empty-containers.md
+++ b/.changeset/add-control-for-empty-containers.md
@@ -27,3 +27,5 @@
 ---
 
 An empty container on the page-builder canvas now offers an Add control that puts the new block inside it. Pressing it selects the container and opens the insert panel in one step, so the block you choose next lands inside rather than beside it.
+
+A container you have positioned `fixed` or `sticky` is not offered one, because it stops travelling with the page the control is drawn over and the control would come to rest on unrelated content. Select it and insert as before to fill it.

--- a/.changeset/add-control-for-empty-containers.md
+++ b/.changeset/add-control-for-empty-containers.md
@@ -29,3 +29,5 @@
 An empty container on the page-builder canvas now offers an Add control that puts the new block inside it. Pressing it selects the container and opens the insert panel in one step, so the block you choose next lands inside rather than beside it.
 
 A container you have positioned `fixed` or `sticky` is not offered one, because it stops travelling with the page the control is drawn over and the control would come to rest on unrelated content. Select it and insert as before to fill it.
+
+Nor is a container inside a wrapper you have set to `display: none`, since nothing of it is on the canvas to put a control on. It comes back the moment the wrapper is shown again, and selecting it and inserting fills it either way.

--- a/.changeset/add-control-for-empty-containers.md
+++ b/.changeset/add-control-for-empty-containers.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An empty container on the page-builder canvas now offers an Add control that puts the new block inside it. Pressing it selects the container and opens the insert panel in one step, so the block you choose next lands inside rather than beside it.

--- a/packages/builder/src/builder-chrome-attributes.test.ts
+++ b/packages/builder/src/builder-chrome-attributes.test.ts
@@ -38,6 +38,46 @@ const CHROME = readFileSync(
   "utf8"
 );
 
+/**
+ * One selector, whatever a formatter did to its whitespace.
+ *
+ * A descendant selector is a run of compounds separated by whitespace, and
+ * which whitespace is a formatter's choice: Prettier breaks this rule's
+ * selector across three indented lines, while the constant it is being held to
+ * is a single string with single spaces. Comparing them raw would fail on the
+ * newlines and read as the stylesheet having diverged.
+ *
+ * Applied to BOTH sides from one function, so the needle and the haystack are
+ * normalised identically — a second spelling of "collapse whitespace" is the
+ * drift this file exists to prevent, one level up.
+ */
+function collapsed(css: string): string {
+  return css.replace(/\s+/g, " ");
+}
+
+/**
+ * A whole rule head, matching this selector and NOTHING WIDER.
+ *
+ * `toContain` is one-directional and the wrong direction is the live one here.
+ * A stylesheet that narrowed its rule fails a containment check, which is what
+ * that check is for — but a CONSTANT that narrowed while the stylesheet kept
+ * its ancestor scopes still reads as contained, since the shorter selector is
+ * a suffix of the longer one. That is precisely the divergence this pair had:
+ * the rule asked three conditions and the constant asked one, so the appender
+ * drew controls where the box was never drawn.
+ *
+ * Anchoring the front closes it. A selector may only begin where the previous
+ * rule or comment ended, so requiring a closing brace, a comment terminator or
+ * the start of the file immediately before it means the constant has to account
+ * for every compound in the rule rather than merely its tail. The trailing
+ * brace is the other end of the same idea, and it is what keeps the selector's
+ * own appearance in a comment further down the file from satisfying this.
+ */
+function ruleFor(selector: string): RegExp {
+  const literal = collapsed(selector).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(?:^|\\}|\\*/)\\s*${literal}\\s*\\{`);
+}
+
 describe("the empty-container affordance is keyed off the exported constants", () => {
   it("matches the slots marker by the constant, not a retyped copy", () => {
     expect(CHROME).toContain(`[${SLOTS_ATTRIBUTE}]`);
@@ -58,8 +98,12 @@ describe("the empty-container affordance is keyed off the exported constants", (
      * comment further down the file, so a bare `toContain` stays green after
      * the rule itself has been changed to key off something else — the
      * comment alone would satisfy it.
+     *
+     * All three of the rule's conditions ride in the constant, so a stylesheet
+     * that dropped or added an ancestor scope fails here rather than leaving
+     * the appender answering a narrower question than the box it stands in for.
      */
-    expect(CHROME).toContain(`${EMPTY_CONTAINER_SELECTOR} {`);
+    expect(collapsed(CHROME)).toMatch(ruleFor(EMPTY_CONTAINER_SELECTOR));
   });
 
   it("guards the affordance behind the hide-preference's attribute and value, by the constant", () => {

--- a/packages/builder/src/builder-chrome-attributes.test.ts
+++ b/packages/builder/src/builder-chrome-attributes.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { SLOTS_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import { describe, expect, it } from "vitest";
 
+import { EMPTY_CONTAINER_SELECTOR } from "./empty-slot";
 import { EMPTY_ELEMENTS_ATTRIBUTE } from "./shell-state";
 
 /**
@@ -40,6 +41,25 @@ const CHROME = readFileSync(
 describe("the empty-container affordance is keyed off the exported constants", () => {
   it("matches the slots marker by the constant, not a retyped copy", () => {
     expect(CHROME).toContain(`[${SLOTS_ATTRIBUTE}]`);
+  });
+
+  it("draws its box for exactly the elements the appender draws a control on", () => {
+    /*
+     * The stylesheet and `EmptyContainerAppenders` cover ONE population, not
+     * two that happen to agree. The appender asks `Element.matches` with this
+     * constant; the stylesheet, having no module system, spells it out — so
+     * this is where the copy is held to it. Without this, a stylesheet that
+     * narrowed or widened its selector would leave the appender drawing
+     * controls on containers carrying no box, or declining containers that
+     * have one, with nothing failing either way.
+     *
+     * The opening brace is part of the needle, and it is what makes this an
+     * assertion about a RULE. The selector is also written in prose in a
+     * comment further down the file, so a bare `toContain` stays green after
+     * the rule itself has been changed to key off something else — the
+     * comment alone would satisfy it.
+     */
+    expect(CHROME).toContain(`${EMPTY_CONTAINER_SELECTOR} {`);
   });
 
   it("guards the affordance behind the hide-preference's attribute and value, by the constant", () => {

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -427,6 +427,85 @@ describe("opening the insert panel from outside the shell", () => {
     expect(screen.getByText("insert panel")).toBeTruthy();
   });
 
+  it("keeps every stored preference when a token is already set at mount", () => {
+    /*
+     * The store is READ in an effect, so on the mount pass the restored record
+     * has only been scheduled: the newest preferences this shell has seen are
+     * still the defaults. A token applied there computes its write from those
+     * defaults and persists them, so the author's panel widths and their
+     * `showEmptyElements` are gone — from the store and from the state — while
+     * the panel they asked for opens and everything on screen looks right.
+     *
+     * Every stored field is asserted, plus the panel: a test asserting only
+     * that the panel opened passes against exactly that loss, and one
+     * asserting only the record passes against a token that never applies at
+     * all. `showEmptyElements` is additionally read off the chrome attribute,
+     * because the store and the state are two separate casualties and the
+     * record alone cannot tell them apart.
+     */
+    stubContainerFits(true);
+    const layouts = { "canvas,panel": { canvas: 3, panel: 1 } };
+    const store = memoryStore(
+      JSON.stringify({
+        ...DEFAULT_PREFERENCES,
+        leftPinned: false,
+        showEmptyElements: false,
+        layouts,
+      })
+    );
+
+    render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
+
+    expect(screen.getByText("insert panel")).toBeTruthy();
+    // Queried rather than assumed present: a selector that matched nothing
+    // would make the attribute assertion pass on `undefined`.
+    const chrome = document.querySelector(".nx-builder-chrome");
+    expect(chrome).not.toBeNull();
+    expect(chrome?.getAttribute(EMPTY_ELEMENTS_ATTRIBUTE)).toBe("hidden");
+    expect(JSON.parse(store.value as string)).toMatchObject({
+      leftPanel: "insert",
+      leftPinned: false,
+      showEmptyElements: false,
+      layouts,
+    });
+  });
+
+  it("still applies a mount-time token when the shell falls back to its own store", () => {
+    /*
+     * Waiting for a store read raises one question: can a token WAIT FOREVER?
+     * It cannot, and the case with no `store` prop at all is where that would
+     * show — the shell builds its own fallback, and the read that releases the
+     * token runs for it exactly as for a supplied one. Reading cannot fail
+     * either: unreadable or malformed storage answers with the defaults rather
+     * than throwing, so there is no path where the count stays where it was.
+     *
+     * `localStorage` is cleared on both sides because this is the only case in
+     * the file that reaches the fallback store: before, so the mount starts
+     * from a known-empty one, and after, so nothing it wrote is still there
+     * for another mount to restore.
+     */
+    stubContainerFits(true);
+    window.localStorage.clear();
+
+    render(
+      <BuilderShell
+        onExit={vi.fn()}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
+
+    expect(screen.getByText("insert panel")).toBeTruthy();
+    window.localStorage.clear();
+  });
+
   it("does not reopen a manually closed panel when the SAME token survives an unrelated effect re-run", () => {
     // `update`'s identity follows the `store` prop (documented on `store`
     // above: a host swapping stores is expected to hand over a new object),

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -506,6 +506,88 @@ describe("opening the insert panel from outside the shell", () => {
     window.localStorage.clear();
   });
 
+  it("keeps the INCOMING store's record when a swap and a new token arrive together", () => {
+    /*
+     * The store swap a host makes when the backing user or workspace changes —
+     * signing into a second workspace, promoting a memory store to a persisted
+     * one — with a press of the canvas appender landing in the same render.
+     *
+     * Reading a store is an effect, so in the commit the new store first
+     * arrives in, the newest preferences this shell has seen are still the
+     * OUTGOING store's. A token applied there computes its write from those and
+     * persists them through the new store, so one workspace's saved layout and
+     * `showEmptyElements` replace another's. A count of reads cannot see this:
+     * it is already nonzero from the first store and a swap only takes it
+     * higher, so the window is exactly where the count looks safest.
+     *
+     * The two records differ in every field, so a write of EITHER wrong record
+     * is visible: `first` is non-default throughout, and `second` differs from
+     * `first` on all three and from the defaults on `layouts`. Asserting the
+     * panel opened as well, because a guard that simply never releases the
+     * token would leave the record intact and the feature dead.
+     */
+    stubContainerFits(true);
+    const firstLayouts = { "canvas,panel": { canvas: 3, panel: 1 } };
+    const secondLayouts = { "canvas,panel": { canvas: 1, panel: 4 } };
+    const first = memoryStore(
+      JSON.stringify({
+        ...DEFAULT_PREFERENCES,
+        leftPinned: false,
+        showEmptyElements: false,
+        layouts: firstLayouts,
+      })
+    );
+    const second = memoryStore(
+      JSON.stringify({
+        ...DEFAULT_PREFERENCES,
+        leftPinned: true,
+        showEmptyElements: true,
+        layouts: secondLayouts,
+      })
+    );
+
+    const { rerender } = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={first}
+        renderPanel={panel => <p>{panel} panel</p>}
+      />
+    );
+    // The first store's read has landed before the swap, which is what makes
+    // this a test about the SECOND store rather than about a cold mount.
+    expect(document.querySelector(".nx-builder-chrome")).not.toBeNull();
+    expect(
+      document
+        .querySelector(".nx-builder-chrome")
+        ?.getAttribute(EMPTY_ELEMENTS_ATTRIBUTE)
+    ).toBe("hidden");
+
+    rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={second}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
+
+    expect(screen.getByText("insert panel")).toBeTruthy();
+    expect(JSON.parse(second.value as string)).toMatchObject({
+      leftPanel: "insert",
+      leftPinned: true,
+      showEmptyElements: true,
+      layouts: secondLayouts,
+    });
+    // The state the author sees, not only the bytes: the attribute is absent
+    // when empty containers are shown, so the outgoing store's `false` reaching
+    // this render would put it back.
+    expect(
+      document
+        .querySelector(".nx-builder-chrome")
+        ?.getAttribute(EMPTY_ELEMENTS_ATTRIBUTE)
+    ).toBeNull();
+  });
+
   it("does not reopen a manually closed panel when the SAME token survives an unrelated effect re-run", () => {
     // `update`'s identity follows the `store` prop (documented on `store`
     // above: a host swapping stores is expected to hand over a new object),

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -360,15 +360,41 @@ describe("opening the insert panel from outside the shell", () => {
     expect(screen.getByText("insert panel")).toBeTruthy();
   });
 
-  it("does not close an already-open insert panel on the same token", () => {
+  it("does not close an already-open insert panel when the effect first applies its token", () => {
     // The rail's own click handler TOGGLES: a second press on the same item
     // closes the panel. Forcing the panel open must not inherit that —
     // pressing the canvas control again for the same container must never
     // read as "hide it".
-    renderShell({
-      renderPanel: panel => <p>{panel} panel</p>,
-      openInsertPanelToken: 1,
-    });
+    //
+    // The panel is opened by a RAIL CLICK here, deliberately not by an
+    // earlier token — from `leftPanel: null`, a correct force-set and a
+    // buggy `panelAfterRailClick(current, "insert")` both land on
+    // `"insert"`, so a fixture starting closed cannot tell them apart. Only
+    // starting from ALREADY OPEN separates them: the toggle would close it,
+    // the force-set leaves it exactly as it was.
+    stubContainerFits(true);
+    const store = memoryStore();
+    const { rerender } = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+    expect(screen.getByText("insert panel")).toBeTruthy();
+
+    // The token's FIRST value, applied against a panel already open by the
+    // rail rather than by a previous token — so the once-per-token guard is
+    // not what is standing between this render and the effect running.
+    rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
 
     expect(screen.getByText("insert panel")).toBeTruthy();
   });

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -594,6 +594,47 @@ describe("preferences", () => {
       showEmptyElements: false,
     });
   });
+
+  it("does not re-invoke onShowEmptyElementsChange when only the host's callback identity changes", () => {
+    // A host wires this the conventional way — an inline callback recreated
+    // on every one of ITS OWN renders — and if the effect reporting this
+    // preference depended on that identity, a rerender with nothing else
+    // changed would call the new callback anyway. Chained with a host whose
+    // own state update is itself a fresh render (`setState(c => ({ ...c }))`
+    // always produces a new object), that is a render loop; this asserts the
+    // narrower, safely-testable half of it: identity churn alone must not
+    // re-invoke the callback.
+    const store = memoryStore();
+    stubContainerFits(true);
+    const first = vi.fn();
+    const { rerender } = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        onShowEmptyElementsChange={first}
+      />
+    );
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(first).toHaveBeenCalledWith(true);
+
+    const second = vi.fn();
+    rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        onShowEmptyElementsChange={second}
+      />
+    );
+    expect(second).not.toHaveBeenCalled();
+
+    // Toggling the preference must still reach the LATEST callback, proving
+    // the ref is read fresh rather than pinned to the first render's closure.
+    fireEvent.click(
+      screen.getByRole("switch", { name: "Show empty containers" })
+    );
+    expect(second).toHaveBeenCalledWith(false);
+    expect(first).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe("where overlays inside the shell portal to", () => {

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -329,6 +329,127 @@ describe("the rail", () => {
   });
 });
 
+describe("opening the insert panel from outside the shell", () => {
+  // `rerender` rather than `renderShell` throughout: these assert what
+  // happens BETWEEN two renders holding the same store, and `renderShell`
+  // builds a fresh store each call, which would additionally exercise the
+  // reload-on-swapped-store behaviour covered elsewhere and confuse which
+  // effect produced the result.
+
+  it("opens it once the token changes from undefined", () => {
+    stubContainerFits(true);
+    const store = memoryStore();
+    const { rerender } = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+      />
+    );
+    expect(screen.queryByText("insert panel")).toBeNull();
+
+    rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
+
+    expect(screen.getByText("insert panel")).toBeTruthy();
+  });
+
+  it("does not close an already-open insert panel on the same token", () => {
+    // The rail's own click handler TOGGLES: a second press on the same item
+    // closes the panel. Forcing the panel open must not inherit that —
+    // pressing the canvas control again for the same container must never
+    // read as "hide it".
+    renderShell({
+      renderPanel: panel => <p>{panel} panel</p>,
+      openInsertPanelToken: 1,
+    });
+
+    expect(screen.getByText("insert panel")).toBeTruthy();
+  });
+
+  it("reopens on a NEW token after the author closed the panel by hand", () => {
+    stubContainerFits(true);
+    const store = memoryStore();
+    const { rerender } = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
+    expect(screen.getByText("insert panel")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+    expect(screen.queryByText("insert panel")).toBeNull();
+
+    rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={2}
+      />
+    );
+
+    expect(screen.getByText("insert panel")).toBeTruthy();
+  });
+
+  it("does not reopen a manually closed panel when the SAME token survives an unrelated effect re-run", () => {
+    // `update`'s identity follows the `store` prop (documented on `store`
+    // above: a host swapping stores is expected to hand over a new object),
+    // so a re-render that swaps stores re-runs this effect even though the
+    // TOKEN did not change. The regression this guards: without the
+    // once-per-token guard, that re-run would reapply "insert" over a manual
+    // close it had nothing to do with.
+    //
+    // A `className` change was tried here first and did not exercise this at
+    // all — neither `openInsertPanelToken` nor `update` depends on it, so the
+    // effect never re-runs and the guard is never reached. Only a dependency
+    // the effect actually reads can demonstrate the guard is doing anything.
+    stubContainerFits(true);
+    const backing: { value: string | null } = { value: null };
+    const storeOverBacking = (): PreferenceStore => ({
+      read: () => backing.value,
+      write: value => {
+        backing.value = value;
+      },
+    });
+
+    const { rerender } = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={storeOverBacking()}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
+    expect(screen.getByText("insert panel")).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Insert" }));
+    expect(screen.queryByText("insert panel")).toBeNull();
+
+    // A DIFFERENT store object reading the same backing value — `update`
+    // changes identity, `openInsertPanelToken` does not.
+    rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={storeOverBacking()}
+        renderPanel={panel => <p>{panel} panel</p>}
+        openInsertPanelToken={1}
+      />
+    );
+
+    expect(screen.queryByText("insert panel")).toBeNull();
+  });
+});
+
 describe("preferences", () => {
   it("writes the open panel through the store, not to localStorage", () => {
     // The port is what lets these become durable server-side prefs later. A

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -1118,9 +1118,23 @@ export function BuilderShell({
    * inert, not incorrect — where applying the SAME token twice would have
    * been a second unwanted forced-open.
    */
+  // Held in a ref rather than read straight from the prop. A host passing the
+  // conventional inline callback — `value => setState(c => ({ ...c, value }))`
+  // — hands this a NEW function identity on every one of its own renders, and
+  // that identity was a dependency here: the effect re-ran even though
+  // `showEmptyElements` had not changed, called the callback again, and a host
+  // whose state update itself triggers a re-render — an ordinary spread
+  // creates a new object every time, whether or not any field actually
+  // differs — closes that into a render loop. The ref always holds the latest
+  // callback without needing to be a dependency, so the effect below runs only
+  // when the PREFERENCE changes.
+  const onShowEmptyElementsChangeRef = React.useRef(onShowEmptyElementsChange);
   React.useEffect(() => {
-    onShowEmptyElementsChange?.(preferences.showEmptyElements);
-  }, [preferences.showEmptyElements, onShowEmptyElementsChange]);
+    onShowEmptyElementsChangeRef.current = onShowEmptyElementsChange;
+  });
+  React.useEffect(() => {
+    onShowEmptyElementsChangeRef.current?.(preferences.showEmptyElements);
+  }, [preferences.showEmptyElements]);
   /*
    * Where overlays inside this shell portal to. State rather than a ref,
    * because `PortalProvider` has to RE-RENDER once the node exists; a ref

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -134,6 +134,24 @@ export interface BuilderShellProps {
    * such control gets by default.
    */
   openInsertPanelToken?: number;
+  /**
+   * Reports `showEmptyElements` to a host that needs to know whether the
+   * canvas's empty-container chrome should be showing right now.
+   *
+   * The preference lives entirely inside this shell — see `store` below —
+   * and a caller drawing a SEPARATE overlay over the same canvas (the
+   * empty-container appender, mounted through `Canvas`'s own `overlay` prop
+   * rather than through this component's internals) has no way to reach it.
+   * This is the read half of that gap; `openInsertPanelToken` above is the
+   * write half of a different one.
+   *
+   * Called for every value the preference takes, including the very first
+   * one: a host that waited for a change would have no answer at all until
+   * the author touched the control, and would have to guess the default in
+   * the meantime — a guess that silently goes stale the day the default
+   * changes here and not at every call site that duplicated it.
+   */
+  onShowEmptyElementsChange?: (showEmptyElements: boolean) => void;
   /** The canvas. The shell never looks inside it. */
   children?: React.ReactNode;
   /** The inspector's contents. */
@@ -1049,6 +1067,7 @@ function ShellRegions({
 export function BuilderShell({
   store,
   openInsertPanelToken,
+  onShowEmptyElementsChange,
   ...props
 }: BuilderShellProps) {
   // The browser store is built once: rebuilt each render it would change
@@ -1087,6 +1106,21 @@ export function BuilderShell({
     handledInsertPanelToken.current = openInsertPanelToken;
     update(current => ({ ...current, leftPanel: "insert" }));
   }, [openInsertPanelToken, update]);
+
+  /*
+   * The read half of the same gap: told on every value `showEmptyElements`
+   * takes, including the first, so a host answers "should my own overlay be
+   * showing" honestly from the start rather than assuming the default and
+   * drifting from it the day that default changes here.
+   *
+   * No once-per-value guard here, unlike the token above. Reporting the same
+   * value twice is calling the host back with information it already has —
+   * inert, not incorrect — where applying the SAME token twice would have
+   * been a second unwanted forced-open.
+   */
+  React.useEffect(() => {
+    onShowEmptyElementsChange?.(preferences.showEmptyElements);
+  }, [preferences.showEmptyElements, onShowEmptyElementsChange]);
   /*
    * Where overlays inside this shell portal to. State rather than a ref,
    * because `PortalProvider` has to RE-RENDER once the node exists; a ref

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -1102,10 +1102,32 @@ export function BuilderShell({
   const handledInsertPanelToken = React.useRef<number | undefined>(undefined);
   React.useEffect(() => {
     if (openInsertPanelToken === undefined) return;
+    /*
+     * Nothing is applied until a store read has LANDED, and that ordering is
+     * the whole of this guard.
+     *
+     * `update` takes the newest preferences this hook has seen and writes the
+     * result straight back through the store. Reading the store is itself an
+     * effect, so on the mount pass it has only SCHEDULED the restored record —
+     * what `update` would spread here is still `DEFAULT_PREFERENCES`. A token
+     * defined at mount would therefore persist the defaults over the author's
+     * own record, taking their panel widths and their `showEmptyElements` with
+     * it, while the panel it was asked for opens and looks entirely correct.
+     *
+     * `loadCount` is the arrival this needs: it counts reads that have reached
+     * state rather than reads that have been started, so a nonzero value means
+     * `preferences` describes the store. It advances on EVERY store — a read
+     * cannot fail (`readPreferences` answers with the defaults for unreadable
+     * or malformed storage) and one that remembers nothing still answers — so
+     * this delays a mount-time token by a single render and can never hold one
+     * indefinitely. A token arriving any later meets a count already past zero
+     * and applies in the same flush it arrived in.
+     */
+    if (loadCount === 0) return;
     if (handledInsertPanelToken.current === openInsertPanelToken) return;
     handledInsertPanelToken.current = openInsertPanelToken;
     update(current => ({ ...current, leftPanel: "insert" }));
-  }, [openInsertPanelToken, update]);
+  }, [openInsertPanelToken, update, loadCount]);
 
   /*
    * The read half of the same gap: told on every value `showEmptyElements`

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -113,6 +113,27 @@ export interface BuilderShellProps {
    * the panel body.
    */
   availablePanels?: readonly LeftPanel[];
+  /**
+   * Opens the insert panel from OUTSIDE the shell, once per distinct value.
+   *
+   * The rail is normally the only way to change which panel is open, and its
+   * own click handler is a TOGGLE — pressing an already-open panel's item
+   * closes it. A control drawn on the canvas itself (the empty-container
+   * appender) needs the opposite contract: pressing it must show the insert
+   * panel whether or not it is already open, and pressing it again for a
+   * DIFFERENT empty container must show it again even if the author closed it
+   * by hand in between.
+   *
+   * A plain boolean or a bare panel name cannot express "again" — the second
+   * press would carry the same value as the first, and an effect keyed on it
+   * would never re-run. A counter the caller bumps on every press is the same
+   * shape `usePreferences` already uses for `loadCount` below: not the state
+   * itself, but a count of how many times the caller asked for it.
+   *
+   * Left `undefined` this does nothing, which is what every host that has no
+   * such control gets by default.
+   */
+  openInsertPanelToken?: number;
   /** The canvas. The shell never looks inside it. */
   children?: React.ReactNode;
   /** The inspector's contents. */
@@ -1025,7 +1046,11 @@ function ShellRegions({
  *
  * @experimental
  */
-export function BuilderShell({ store, ...props }: BuilderShellProps) {
+export function BuilderShell({
+  store,
+  openInsertPanelToken,
+  ...props
+}: BuilderShellProps) {
   // The browser store is built once: rebuilt each render it would change
   // `usePreferences`' callback identity every render, and the write effect with
   // it. Only the FALLBACK needs that treatment though. Capturing the caller's
@@ -1037,6 +1062,31 @@ export function BuilderShell({ store, ...props }: BuilderShellProps) {
   const resolvedStore = store ?? fallbackStore.current;
   const [preferences, update, loadCount] = usePreferences(resolvedStore);
   const [measureShell, shellFits] = useFitsFullShell();
+
+  /*
+   * Applies an `openInsertPanelToken` change AT MOST ONCE, the same
+   * once-per-value guard `usePreferences` uses `loadCount` for above — a ref
+   * rather than state, because recording that a token was handled is not
+   * itself something a re-render should follow from.
+   *
+   * FORCES `leftPanel` to `"insert"` rather than routing through
+   * `panelAfterRailClick`: that helper TOGGLES, and toggling is exactly wrong
+   * for a control whose contract is "show the panel this fills" — never
+   * "close it if it happens to already be open", which is what a second rail
+   * click on the same item means.
+   *
+   * No availability check against `availablePanels` here: `ShellRegions`
+   * below already normalises `preferences.leftPanel` against it when deriving
+   * the panel it actually renders, so a request naming a panel the host
+   * cannot fill is absorbed there rather than needing a second check here.
+   */
+  const handledInsertPanelToken = React.useRef<number | undefined>(undefined);
+  React.useEffect(() => {
+    if (openInsertPanelToken === undefined) return;
+    if (handledInsertPanelToken.current === openInsertPanelToken) return;
+    handledInsertPanelToken.current = openInsertPanelToken;
+    update(current => ({ ...current, leftPanel: "insert" }));
+  }, [openInsertPanelToken, update]);
   /*
    * Where overlays inside this shell portal to. State rather than a ref,
    * because `PortalProvider` has to RE-RENDER once the node exists; a ref

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -28,6 +28,7 @@ import * as React from "react";
 
 import { devWarnOnce } from "./dev-warn";
 import {
+  BUILDER_CHROME_CLASS,
   DEFAULT_PREFERENCES,
   EMPTY_ELEMENTS_ATTRIBUTE,
   browserStore,
@@ -127,8 +128,8 @@ export interface BuilderShellProps {
    * A plain boolean or a bare panel name cannot express "again" — the second
    * press would carry the same value as the first, and an effect keyed on it
    * would never re-run. A counter the caller bumps on every press is the same
-   * shape `usePreferences` already uses for `loadCount` below: not the state
-   * itself, but a count of how many times the caller asked for it.
+   * shape {@link PreferencesLoad.count} below has: not the state itself, but a
+   * count of how many times the thing behind it happened.
    *
    * Left `undefined` this does nothing, which is what every host that has no
    * such control gets by default.
@@ -317,6 +318,40 @@ export function useShellIsActive(): boolean {
 }
 
 /**
+ * What the newest completed read of a preference store left behind.
+ *
+ * TWO fields because there are two different questions downstream, and one
+ * value cannot answer both:
+ *
+ * - `count` answers "has a NEW record arrived", which is what a remount is
+ *   keyed on. Any read qualifies: the panel group has to re-register against
+ *   whatever layout landed, whoever it belongs to.
+ * - `store` answers "whose record is `preferences` holding right now", which is
+ *   what any guard protecting a WRITE needs. The count cannot answer it — it is
+ *   monotonic, so it is already nonzero for the previous store the moment a host
+ *   swaps in a new one, and a write let through in that window spreads the old
+ *   store's record and persists it into the new store, replacing the layout and
+ *   the `showEmptyElements` of whichever user or workspace the new store belongs
+ *   to.
+ *
+ * `store` is the store OBJECT rather than a name or an index, for the reason
+ * the identity is already the read's dependency: it is the thing itself, and no
+ * two live stores can compare equal without being the same store.
+ *
+ * `null` is the state before any read has completed, and it is deliberately not
+ * a fourth thing to test for: every caller compares this against the store it
+ * is about to act on, and `null` is not any store, so "no read yet" and "a
+ * different store's read" answer alike without either being spelled out.
+ */
+interface PreferencesLoad {
+  readonly count: number;
+  readonly store: PreferenceStore | null;
+}
+
+/** Before any read has reached state. */
+const NO_LOAD: PreferencesLoad = { count: 0, store: null };
+
+/**
  * Preferences, restored AFTER mount and written back whenever they change.
  *
  * Reading storage in the initializer is the obvious shape and it is wrong here.
@@ -334,29 +369,7 @@ export function useShellIsActive(): boolean {
 function usePreferences(store: PreferenceStore) {
   const [preferences, setPreferences] =
     React.useState<ShellPreferences>(DEFAULT_PREFERENCES);
-  /**
-   * How many times a store has been READ into this hook.
-   *
-   * Downstream, restoring a layout is a once-per-load act, and "once" has to be
-   * counted against something. Counted against the component's lifetime it is
-   * wrong as soon as the host swaps stores — signing into a second workspace
-   * loads that user's preferences, and a guard that already fired leaves the
-   * previous user's widths on screen.
-   *
-   * A counter rather than the store's identity because it is what the guard
-   * downstream compares against, and it says WHICH load was applied rather than
-   * merely that one was.
-   *
-   * It does NOT detect a host mutating the data behind a store it keeps
-   * handing us: the read below is keyed on the store's identity, so an
-   * unchanged object means no read happens at all and this never advances.
-   * That is the documented contract on `store` — a new backing user or
-   * workspace is a new store object — rather than a gap. Detecting it instead
-   * would mean a subscription or a revision token on the port, which is a
-   * third method every host implementing it would have to get right, for a
-   * case a caller can satisfy by passing a new object.
-   */
-  const [loadCount, setLoadCount] = React.useState(0);
+  const [load, setLoad] = React.useState<PreferencesLoad>(NO_LOAD);
 
   React.useEffect(() => {
     const restored = readPreferences(store);
@@ -365,7 +378,11 @@ function usePreferences(store: PreferenceStore) {
     setPreferences(current =>
       shallowEqualPreferences(current, restored) ? current : restored
     );
-    setLoadCount(count => count + 1);
+    // Set in the SAME effect as the preferences it describes, which is what
+    // makes `store` below an honest account of whose record `preferences`
+    // holds: React applies both updates in one commit, so no render can see
+    // one without the other.
+    setLoad(current => ({ count: current.count + 1, store }));
   }, [store]);
 
   // The newest preferences, reachable from a callback that must not go stale.
@@ -396,7 +413,15 @@ function usePreferences(store: PreferenceStore) {
     [store]
   );
 
-  return [preferences, update, loadCount] as const;
+  /*
+   * The store-specific answer is derived HERE rather than handed out for a
+   * caller to work out, because the comparison is only sound against the same
+   * store the read was keyed on — and that is this argument. Returning
+   * `load.store` instead would leave every caller re-deriving it, and a caller
+   * holding a different store variable (the shell resolves a fallback of its
+   * own) would compare the wrong pair while looking correct.
+   */
+  return [preferences, update, load.count, load.store === store] as const;
 }
 
 /**
@@ -722,6 +747,13 @@ function ShellRegions({
    * Restoring a layout happens once per load, and this is what "once" is
    * counted against: the group is remounted per load so the library
    * re-reads the restored layout at panel registration.
+   *
+   * ANY load, deliberately — unlike the write guard on the token effect, which
+   * has to know WHOSE record arrived. A remount is a response to a new layout
+   * being on screen, and the panels have to re-register against it whichever
+   * store produced it: the swap that makes a count useless for deciding a write
+   * is exactly a case that must remount. So the count and the identity are two
+   * separate answers rather than one this could share.
    */
   loadCount: number;
 }) {
@@ -785,7 +817,8 @@ function ShellRegions({
       ref={chromeRef}
       onKeyDownCapture={onKeyDownCapture}
       className={cn(
-        "nx-builder-chrome flex h-full w-full flex-col overflow-hidden",
+        BUILDER_CHROME_CLASS,
+        "flex h-full w-full flex-col overflow-hidden",
         className
       )}
       // Absent when empty containers are shown, which is the default. A state
@@ -1079,14 +1112,18 @@ export function BuilderShell({
   const fallbackStore = React.useRef<PreferenceStore | null>(null);
   fallbackStore.current ??= browserStore(STORAGE_KEY);
   const resolvedStore = store ?? fallbackStore.current;
-  const [preferences, update, loadCount] = usePreferences(resolvedStore);
+  const [preferences, update, loadCount, loadedFromCurrentStore] =
+    usePreferences(resolvedStore);
   const [measureShell, shellFits] = useFitsFullShell();
 
   /*
-   * Applies an `openInsertPanelToken` change AT MOST ONCE, the same
-   * once-per-value guard `usePreferences` uses `loadCount` for above — a ref
-   * rather than state, because recording that a token was handled is not
-   * itself something a re-render should follow from.
+   * Applies an `openInsertPanelToken` change AT MOST ONCE — a ref rather than
+   * state, because recording that a token was handled is not itself something a
+   * re-render should follow from.
+   *
+   * The ref deliberately survives a store swap. A token already applied belongs
+   * to the session the author pressed the control in, so re-applying it to the
+   * store that replaced it would open a panel nobody asked this store for.
    *
    * FORCES `leftPanel` to `"insert"` rather than routing through
    * `panelAfterRailClick`: that helper TOGGLES, and toggling is exactly wrong
@@ -1103,31 +1140,42 @@ export function BuilderShell({
   React.useEffect(() => {
     if (openInsertPanelToken === undefined) return;
     /*
-     * Nothing is applied until a store read has LANDED, and that ordering is
-     * the whole of this guard.
+     * Nothing is applied until THIS store's read has landed, and that ordering
+     * is the whole of this guard.
      *
      * `update` takes the newest preferences this hook has seen and writes the
-     * result straight back through the store. Reading the store is itself an
-     * effect, so on the mount pass it has only SCHEDULED the restored record —
-     * what `update` would spread here is still `DEFAULT_PREFERENCES`. A token
-     * defined at mount would therefore persist the defaults over the author's
-     * own record, taking their panel widths and their `showEmptyElements` with
-     * it, while the panel it was asked for opens and looks entirely correct.
+     * result straight back through the store it currently holds. Reading a
+     * store is itself an effect, so in the commit a store first arrives in it
+     * has only SCHEDULED that store's record — what `update` would spread here
+     * is still whatever `preferences` held before. Both ways that happens end
+     * in a write of the wrong record:
      *
-     * `loadCount` is the arrival this needs: it counts reads that have reached
-     * state rather than reads that have been started, so a nonzero value means
-     * `preferences` describes the store. It advances on EVERY store — a read
+     * - at MOUNT, `preferences` is `DEFAULT_PREFERENCES`, so a token defined on
+     *   the first render persists the defaults over the author's own panel
+     *   widths and `showEmptyElements`.
+     * - after a store SWAP — signing into a second workspace, promoting a
+     *   memory store to a persisted one — `preferences` is the PREVIOUS store's
+     *   record, so a token arriving in the same render writes one user's or
+     *   workspace's saved layout into another's.
+     *
+     * Either way the panel the token asked for opens and looks entirely
+     * correct, which is what makes the write invisible until the next load.
+     *
+     * So the arrival this waits on is store-specific rather than "some read has
+     * happened": a COUNT of reads is already nonzero for the outgoing store at
+     * the moment of a swap, which is precisely the window the second case sits
+     * in. Once it is true, it stays true for as long as the store does — a read
      * cannot fail (`readPreferences` answers with the defaults for unreadable
      * or malformed storage) and one that remembers nothing still answers — so
-     * this delays a mount-time token by a single render and can never hold one
-     * indefinitely. A token arriving any later meets a count already past zero
-     * and applies in the same flush it arrived in.
+     * this delays a token by a single render and can never hold one
+     * indefinitely. A token arriving any later than that render applies in the
+     * same flush it arrived in.
      */
-    if (loadCount === 0) return;
+    if (!loadedFromCurrentStore) return;
     if (handledInsertPanelToken.current === openInsertPanelToken) return;
     handledInsertPanelToken.current = openInsertPanelToken;
     update(current => ({ ...current, leftPanel: "insert" }));
-  }, [openInsertPanelToken, update, loadCount]);
+  }, [openInsertPanelToken, update, loadedFromCurrentStore]);
 
   /*
    * The read half of the same gap: told on every value `showEmptyElements`
@@ -1199,7 +1247,8 @@ export function BuilderShell({
               // positioning now, and repeating it would apply a grid area or a
               // border twice.
               className={cn(
-                "nx-builder-chrome flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center"
+                BUILDER_CHROME_CLASS,
+                "flex h-full w-full flex-col items-center justify-center gap-3 p-6 text-center"
               )}
             >
               {/*

--- a/packages/builder/src/canvas-geometry-watch.ts
+++ b/packages/builder/src/canvas-geometry-watch.ts
@@ -21,16 +21,61 @@
  * the author scrolled a container — while the file looked like a complete copy
  * of the one beside it. A caller that asks this question asks all of it.
  *
- * What is deliberately NOT here: a `MutationObserver`. It answers a different
- * question — the DOM CHANGED, which includes changes an overlay makes by
- * drawing itself — so a caller adopting it needs its own rule for which
- * mutations are its own, and that rule cannot be shared. `spacing-overlay.tsx`
- * keeps one beside this call for exactly that reason.
+ * A `MutationObserver` answers a THIRD question — the DOM changed, which alters
+ * computed style without necessarily altering any size. It needs something the
+ * other two do not, because the subtree it observes CONTAINS the overlay's own
+ * output: where that output is, which only the overlay knows.
+ *
+ * {@link watchCanvasFor} is therefore the entry point and all three are behind
+ * it, taking the one thing a caller has to supply. Offering the mechanisms
+ * separately would put "did I remember to take all of them" back on each
+ * overlay, which is the failure this module was extracted to remove and which
+ * happened again the moment there were two subscriptions to remember instead of
+ * one — an overlay took the geometry half, left the mutation half out, and its
+ * controls stayed where a recompiled site sheet had moved the blocks from.
  *
  * @module canvas-geometry-watch
  */
 
 import { nodeElements } from "./canvas";
+import { canvasRootFrom } from "./geometry-dom";
+import { CANVAS_ROOT_CLASS } from "./shell-state";
+
+/**
+ * Everything an overlay drawn over this canvas has to re-measure for.
+ *
+ * ONE call rather than a list a caller assembles: which changes can move a
+ * rectangle is a single question, and an overlay that answers part of it looks
+ * exactly like one that answers all of it — the file reads as complete and the
+ * controls are simply stale under whichever mechanism was left out.
+ *
+ * The canvas root is resolved FROM the layer rather than passed in, so a caller
+ * cannot subscribe against one root while drawing into another; `undefined`
+ * comes back when there is none, which is an overlay mounted outside a canvas
+ * and has nothing to watch.
+ *
+ * @param ownLayer - reads the caller's own layer element, and is read rather
+ *   than passed because the layer does not exist until after the first render;
+ *   it locates the canvas AND says which mutations are the caller's own
+ * @param moved - re-measure; called once per change, never per frame
+ * @returns unsubscribes everything this installed, or `undefined` when there
+ *   was no canvas root to install anything on
+ */
+export function watchCanvasFor(
+  ownLayer: () => HTMLElement | null,
+  moved: () => void
+): (() => void) | undefined {
+  const element = ownLayer();
+  const root =
+    element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
+  if (root === null) return undefined;
+  const geometry = watchCanvasGeometry(root, moved);
+  const styles = watchCanvasStyleMutations(root, ownLayer, moved);
+  return () => {
+    geometry();
+    styles();
+  };
+}
 
 /**
  * Call `moved` whenever the canvas's laid-out geometry may have changed.
@@ -39,10 +84,7 @@ import { nodeElements } from "./canvas";
  * @param moved - re-measure; called once per change, never per frame
  * @returns unsubscribes everything this installed
  */
-export function watchCanvasGeometry(
-  root: HTMLElement,
-  moved: () => void
-): () => void {
+function watchCanvasGeometry(root: HTMLElement, moved: () => void): () => void {
   /*
    * EVERY rendered node is observed, not only the ones a caller draws over:
    * what moves a node is often a SIBLING changing size rather than the node
@@ -97,4 +139,75 @@ export function watchCanvasGeometry(
     root.removeEventListener("transitioncancel", settled);
     root.removeEventListener("scroll", settled, true);
   };
+}
+
+/**
+ * Call `moved` when a mutation OUTSIDE the caller's own output lands in the
+ * canvas.
+ *
+ * The change this reaches and {@link watchCanvasGeometry} cannot: a recompiled
+ * site sheet. `PageRenderer` emits the sheet as a `<style>` inside the page
+ * root, so a save mutates this subtree — and a class-driven margin, position or
+ * transform then moves blocks while resizing nothing, scrolling nothing and
+ * finishing no transition. Every subscription in the function above stays
+ * silent, and an overlay drawn over one of those blocks keeps the coordinates
+ * the old rule gave it until something else re-measures.
+ *
+ * SEPARATE from that function rather than folded into it, and this is the part
+ * a caller has to supply. An overlay draws INTO the subtree being observed, so
+ * every measurement mutates it — a control appearing or leaving is a
+ * `childList` record, a new rectangle rewrites a `style` attribute — and an
+ * observer that reacted to those would have each measurement schedule the next.
+ * Which mutations are the caller's own is therefore not answerable here, which
+ * is why it is an argument rather than a rule written into this module.
+ *
+ * The test applied to that answer IS shared, because both overlays give the
+ * same one: a full-bleed layer of their own, so containment within it decides
+ * ownership exactly. An overlay that drew into the page itself — inline
+ * chrome attached to a block rather than a layer above it — could not be
+ * answered by containment and should not use this.
+ *
+ * @param root - the canvas root whose subtree is watched
+ * @param ownOutput - the caller's own layer, read at delivery time because it
+ *   does not exist when the subscription is taken
+ * @param moved - re-measure; called once per batch of foreign mutations
+ * @returns unsubscribes
+ */
+function watchCanvasStyleMutations(
+  root: HTMLElement,
+  ownOutput: () => HTMLElement | null,
+  moved: () => void
+): () => void {
+  // Absent in jsdom unless a test supplies one, and absent in older browsers.
+  // A missing observer costs a re-measure rather than correctness: every caller
+  // measures on render as well.
+  if (typeof MutationObserver === "undefined") return () => {};
+  const styles = new MutationObserver(records => {
+    const own = ownOutput();
+    /*
+     * `own === null` counts as OUTSIDE rather than as the caller's own. The
+     * layer is null only once the caller has unmounted, and an unmounted
+     * overlay owns nothing in this subtree; treating it as own-output would
+     * silently drop a real site-style change in any window where the reference
+     * were momentarily unset.
+     */
+    const outside = records.some(
+      record => own === null || !own.contains(record.target)
+    );
+    if (outside) moved();
+  });
+  /*
+   * Every kind of record, because every kind can carry a new rule: a sheet
+   * being replaced is `childList`, a sheet's bytes changing in place is
+   * `characterData`, and a class or inline style moving on a block is
+   * `attributes`. `subtree` because the sheet sits inside the page root rather
+   * than beside it.
+   */
+  styles.observe(root, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    characterData: true,
+  });
+  return () => styles.disconnect();
 }

--- a/packages/builder/src/canvas-geometry-watch.ts
+++ b/packages/builder/src/canvas-geometry-watch.ts
@@ -1,0 +1,100 @@
+/**
+ * The one subscription that answers "a node's rectangle may have moved".
+ *
+ * Every overlay drawn in the canvas's content coordinates — the spacing bands,
+ * the empty-container appenders — measures the nodes it draws over and has to
+ * re-measure whenever the layout underneath it changes. React reports the
+ * changes that come from a render; nothing reports the rest, and the rest is
+ * several different mechanisms that no single browser API covers:
+ *
+ * - a SIZE change with no render behind it: a container query resolving at a
+ *   new canvas width, a rail panel opening, a webfont swapping in, an image
+ *   finishing its load. `ResizeObserver` is the only thing that sees these.
+ * - a MOVE with no size change at all: a scroller between a node and the root,
+ *   or a transition finishing on a neighbour. No observer reports either,
+ *   because nothing resized, nothing mutated and no element the overlay knows
+ *   about changed at all.
+ *
+ * Held here rather than written out per overlay because the drift is otherwise
+ * silent and has already happened: one overlay subscribed to resizes and not
+ * to scrolls, and its controls stayed at the coordinates the layout had before
+ * the author scrolled a container — while the file looked like a complete copy
+ * of the one beside it. A caller that asks this question asks all of it.
+ *
+ * What is deliberately NOT here: a `MutationObserver`. It answers a different
+ * question — the DOM CHANGED, which includes changes an overlay makes by
+ * drawing itself — so a caller adopting it needs its own rule for which
+ * mutations are its own, and that rule cannot be shared. `spacing-overlay.tsx`
+ * keeps one beside this call for exactly that reason.
+ *
+ * @module canvas-geometry-watch
+ */
+
+import { nodeElements } from "./canvas";
+
+/**
+ * Call `moved` whenever the canvas's laid-out geometry may have changed.
+ *
+ * @param root - the canvas root every node is measured against
+ * @param moved - re-measure; called once per change, never per frame
+ * @returns unsubscribes everything this installed
+ */
+export function watchCanvasGeometry(
+  root: HTMLElement,
+  moved: () => void
+): () => void {
+  /*
+   * EVERY rendered node is observed, not only the ones a caller draws over:
+   * what moves a node is often a SIBLING changing size rather than the node
+   * itself. An image finishing its load resizes that sibling and nothing else
+   * — not the node laid out after it, and not the root, which is
+   * `min-height: 100%` and can absorb the change while reporting nothing.
+   *
+   * The root is observed too, for the resize the nodes cannot report: the
+   * panels around the canvas moving, which changes the frame without changing
+   * any node.
+   *
+   * Absent in jsdom unless a test supplies one, and absent in older browsers.
+   * Guarded on its own rather than gating the listeners below, because the two
+   * answer different questions: a runtime missing the observer must still hear
+   * a scroll. A missing observer costs a re-measure, not correctness — every
+   * caller measures on render as well.
+   */
+  const sizes =
+    typeof ResizeObserver === "undefined"
+      ? null
+      : new ResizeObserver(() => moved());
+  if (sizes !== null) {
+    sizes.observe(root);
+    for (const node of nodeElements(root)) sizes.observe(node);
+  }
+
+  /*
+   * `overflow: auto` and `overflow: scroll` are catalog values, so a block can
+   * sit inside a container the author scrolls. Scrolling it moves the block
+   * relative to the canvas while resizing nothing, mutating nothing and
+   * finishing no transition — none of the observers above hear it.
+   *
+   * CAPTURE, because a scroll event does not bubble: listening on the root in
+   * the capture phase is what reaches a scroller nested anywhere inside it.
+   *
+   * `transition` is a catalog property too, and a transform or margin
+   * animating past its first frame moves a block while resizing nothing. The
+   * completion events are what the browser offers, and they DO bubble, so one
+   * listener each on the root covers every block. This corrects the FINAL
+   * geometry rather than following the animation: tracking the frames between
+   * would mean measuring on every one, which costs more than an overlay being
+   * briefly behind a transition the author is watching.
+   */
+  const settled = (): void => moved();
+  root.addEventListener("transitionend", settled);
+  root.addEventListener("transitioncancel", settled);
+  root.addEventListener("scroll", settled, true);
+
+  return () => {
+    sizes?.disconnect();
+    root.removeEventListener("transitionend", settled);
+    root.removeEventListener("transitioncancel", settled);
+    root.removeEventListener("scroll", settled, true);
+  };
+}

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -47,16 +47,17 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CanvasDragHandlers } from "./canvas-drag";
 import { offeredTiers } from "./canvas-width";
 import { selectionModeFor, type SelectionMode } from "./selection";
+import { CANVAS_ROOT_CLASS } from "./shell-state";
 
 /**
  * The class marking the canvas root, and the boundary the hit-test stops at.
  *
- * The walk needs an upper bound for the reason given in
- * {@link nodeIdFromEvent}, and that bound has to be identifiable from a DOM
- * node rather than from React state, because the walk starts at an event
- * target and climbs.
+ * Declared in `shell-state.ts` beside the other markers `builder-chrome.css`
+ * spells out literally, and re-exported here because this is where a reader
+ * looks for the canvas's own marker. See {@link nodeIdFromEvent} for the walk
+ * that needs it as an upper bound.
  */
-export const CANVAS_ROOT_CLASS = "nx-canvas";
+export { CANVAS_ROOT_CLASS };
 
 /**
  * Marks the selected block's own element.

--- a/packages/builder/src/editor-state.test.ts
+++ b/packages/builder/src/editor-state.test.ts
@@ -583,3 +583,27 @@ describe("two ops applied in one tick", () => {
     expect(byId.get("b")?.cssId).toBe("y");
   });
 });
+
+describe("selecting what was just inserted", () => {
+  it("lands in the same tick as the insert", () => {
+    // `select` resolves the id against the document, so it can only work if
+    // the insert is visible to it immediately rather than at the next render.
+    // A mocked editor cannot observe this: it records the call and says
+    // nothing about whether the selection took.
+    const { result } = renderHook(() =>
+      useEditorState({ initialDocument: doc([node("a")]) })
+    );
+
+    const fresh = node("brand-new");
+
+    act(() => {
+      result.current.apply({ kind: "insert", node: fresh, at: { index: 1 } });
+      result.current.select(fresh.id);
+    });
+
+    // The insert landing is the control: without it this test would be
+    // measuring a selection that was refused for the right reason.
+    expect(ids(result.current.document)).toEqual(["a", "brand-new"]);
+    expect(result.current.selectedId).toBe("brand-new");
+  });
+});

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -886,9 +886,11 @@ describe("which containers it actually draws a control on", () => {
 
   it("draws NO control on a container an authored ancestor clips", () => {
     /*
-     * The second permanent refusal, which has to be covered on its own: the
-     * two guards are separate branches, and a fix applied to one leaves the
-     * other returning whatever it returned before.
+     * The CLIP refusal, which has to be covered on its own: each refusal in
+     * `measure` is its own branch, and a fix applied to one leaves the others
+     * returning whatever they returned before. Named rather than numbered — an
+     * ordinal here is a count of the branches kept by hand beside them, and it
+     * goes stale the moment one is inserted between two others.
      *
      * `layout` gives every unnamed element the canvas's own 800x600 box, so
      * the wrapper reports that and the nested container is stubbed a thousand
@@ -909,8 +911,8 @@ describe("which containers it actually draws a control on", () => {
 
   it("draws NO control on a container the render does not produce", () => {
     /*
-     * The third refusal, and the only one with no element to ask anything of.
-     * `ghost` is in the overlay's document and in no element's id, which is
+     * The UNRENDERED refusal, and the only one with no element to ask anything
+     * of. `ghost` is in the overlay's document and in no element's id, which is
      * where a node `PageRenderer` drops stays: one carrying
      * `visibility.conditions`, or one whose props make it draw nothing. A pass
      * that HAS a canvas root and cannot find the element has decided about
@@ -939,6 +941,108 @@ describe("which containers it actually draws a control on", () => {
     ).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Add a block to Closed section" })
+    ).toBeNull();
+  });
+
+  /**
+   * Three containers of one type, told apart by where their `position` puts
+   * them.
+   *
+   * The two refused ones carry an authored `styles` envelope, which is the same
+   * route the inspector writes: `PageRenderer` compiles it into the page's own
+   * `<style>` and the element's COMPUTED `position` is what the component then
+   * reads. Nothing here assigns the value onto the element, so the fixture
+   * exercises the production path from stored document to computed style rather
+   * than standing in for it — and the assertions below check that the value
+   * arrived before reading anything into the control's absence.
+   */
+  const PINNED: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "anchored",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Anchored box",
+      },
+      {
+        id: "pinned-to-viewport",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Fixed box",
+        styles: { base: { base: { position: { type: "fixed" } } } },
+      },
+      {
+        id: "pinned-to-scrollport",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Sticky box",
+        styles: { base: { base: { position: { type: "sticky" } } } },
+      },
+    ],
+  };
+
+  /** The computed `position` of one node's rendered element. */
+  function computedPositionOf(container: HTMLElement, id: string): string {
+    const element = canvasRootIn(container).querySelector(
+      `[${NODE_ID_ATTRIBUTE}="${id}"]`
+    );
+    if (element === null) throw new Error(`no element for ${id}`);
+    return getComputedStyle(element).position;
+  }
+
+  it("draws NO control on a container the author pinned to the viewport", () => {
+    /*
+     * `position` is a catalog keyword, so `fixed` is a value an author stores.
+     * A fixed container stops travelling with the canvas content this overlay
+     * measures in, and nothing re-measures when it stops: the shell scrolls a
+     * section ABOVE the canvas root, and a scroll event does not bubble, so the
+     * capture-phase listener `watchCanvasFor` puts on the root never hears it.
+     * The square would come to rest over unrelated content and take the presses
+     * meant for it.
+     *
+     * `Anchored box` is the positive control, in the same render and the same
+     * measurement pass: without it the absence below is satisfied by a
+     * component that drew nothing anywhere. The computed value is asserted
+     * first so the refusal is known to be about a container that really is
+     * fixed rather than about a fixture whose styles never compiled.
+     */
+    const container = measuredCanvas(PINNED, {
+      anchored: { x: 0, y: 0, width: 400, height: 200 },
+      "pinned-to-viewport": { x: 0, y: 400, width: 400, height: 200 },
+    });
+
+    expect(computedPositionOf(container, "pinned-to-viewport")).toBe("fixed");
+    expect(drawnAt("Anchored box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(
+      screen.queryByRole("button", { name: "Add a block to Fixed box" })
+    ).toBeNull();
+  });
+
+  it("draws NO control on a container the author pinned to a scrollport", () => {
+    /*
+     * Asserted apart from the fixed case rather than assumed to follow it. The
+     * two are one branch today, and a refusal narrowed to a single value passes
+     * the case above while leaving this one drawn — so the pair is what says
+     * the branch covers both keywords rather than the one that was written
+     * first. A sticky container additionally moves WITHIN its scrollport, which
+     * is the same drift arriving without the container leaving the page at all.
+     */
+    const container = measuredCanvas(PINNED, {
+      anchored: { x: 0, y: 0, width: 400, height: 200 },
+      "pinned-to-scrollport": { x: 0, y: 400, width: 400, height: 200 },
+    });
+
+    expect(computedPositionOf(container, "pinned-to-scrollport")).toBe(
+      "sticky"
+    );
+    expect(drawnAt("Anchored box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(
+      screen.queryByRole("button", { name: "Add a block to Sticky box" })
     ).toBeNull();
   });
 

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -3,9 +3,20 @@
 /**
  * The affordance drawn over a container with nothing in it.
  *
- * Geometry is NOT asserted here: jsdom reports every element as zero-sized, so
- * a position assertion would pass against any implementation. Placement is
- * verified in a real browser in Task 8.
+ * jsdom lays nothing out, so an element MEASURED here reports a zero-sized
+ * rectangle and a position assertion taken from one would pass against any
+ * implementation. That is a limit on measurement and nothing else, and this
+ * file draws the line in the two places it actually falls:
+ *
+ * - `centeredControlRect` is arithmetic over two rectangles with no DOM in it,
+ *   and is asserted directly.
+ * - the cases that need a rendered canvas STUB each element's rectangle first
+ *   — the same thing `canvas-drag.test.tsx` does — and then drive the resize
+ *   the component already subscribes to, so what is measured is a real
+ *   rectangle rather than jsdom's zero.
+ *
+ * The cases that assert only which controls EXIST mount no canvas at all, and
+ * deliberately: which containers get a control comes from the document alone.
  *
  * `fireEvent` rather than `@testing-library/user-event`: this package does not
  * depend on that library and no other suite here does either, and the control
@@ -28,12 +39,21 @@ import {
   type BlockRenderArgs,
   type SiteSheetInput,
 } from "@nextlyhq/blocks-react";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CANVAS_ROOT_CLASS, Canvas } from "./canvas";
-import { EmptyContainerAppenders } from "./empty-container-appender";
+import {
+  centeredControlRect,
+  EmptyContainerAppenders,
+} from "./empty-container-appender";
 import { registrySlotSource } from "./inserter";
 
 // This suite queries by role against the whole document (`screen`), so a tree
@@ -302,7 +322,9 @@ class FakeResizeObserver {
   static instances: FakeResizeObserver[] = [];
   readonly observed: Element[] = [];
   disconnected = false;
-  constructor(_callback: ResizeObserverCallback) {
+  private readonly callback: ResizeObserverCallback;
+  constructor(callback: ResizeObserverCallback) {
+    this.callback = callback;
     FakeResizeObserver.instances.push(this);
   }
   observe(target: Element): void {
@@ -311,6 +333,16 @@ class FakeResizeObserver {
   unobserve(): void {}
   disconnect(): void {
     this.disconnected = true;
+  }
+  /**
+   * Report a resize, which is the only way to make the component measure a
+   * canvas whose rectangles were stubbed AFTER it mounted.
+   *
+   * No entries: the component's own callback ignores them and re-measures
+   * everything, which is what a caller here wants to happen.
+   */
+  fire(): void {
+    this.callback([], this);
   }
 }
 
@@ -414,5 +446,244 @@ describe("what it stays subscribed to", () => {
     expect(observer?.observed).toContain(
       container.querySelector(`.${CANVAS_ROOT_CLASS}`)
     );
+  });
+});
+
+describe("the rectangle the control is drawn at", () => {
+  /*
+   * Asserted directly, because `centeredControlRect` is arithmetic over two
+   * rectangles with no DOM in it. The suite header's reason for not asserting
+   * geometry — jsdom lays nothing out — is about MEASURING an element, and it
+   * does not reach a pure function that is handed a rectangle.
+   */
+  it("centres the control in a container larger than it", () => {
+    expect(
+      centeredControlRect({ x: 10, y: 20, width: 200, height: 100 }, 44)
+    ).toEqual({ x: 88, y: 48, width: 44, height: 44 });
+  });
+
+  it("never grows taller than the container it sits in", () => {
+    // A container shorter than the control. Unclamped, the height stays 44 and
+    // the top is (19 - 44) / 2 = -12.5 ABOVE the container — over whatever is
+    // laid out before it, which is where a press meant for that neighbour then
+    // lands.
+    const container = { x: 0, y: 200, width: 400, height: 19 };
+    const control = centeredControlRect(container, 44);
+
+    // Full 44 on the axis with room for it: the clamp is per axis, so a short
+    // container loses no width.
+    expect(control).toEqual({ x: 178, y: 200, width: 44, height: 19 });
+    expect(control.y).toBeGreaterThanOrEqual(container.y);
+    expect(control.y + control.height).toBeLessThanOrEqual(
+      container.y + container.height
+    );
+  });
+
+  it("never grows wider than the container it sits in", () => {
+    // The axis with no guarantee behind it: `[data-nx-slots]:empty` sets a
+    // `min-height` and no `min-width`, so a narrow empty column is a perfectly
+    // ordinary container that is narrower than the control.
+    const container = { x: 100, y: 0, width: 20, height: 300 };
+    const control = centeredControlRect(container, 44);
+
+    expect(control).toEqual({ x: 100, y: 128, width: 20, height: 44 });
+    expect(control.x).toBeGreaterThanOrEqual(container.x);
+    expect(control.x + control.width).toBeLessThanOrEqual(
+      container.x + container.width
+    );
+  });
+});
+
+/**
+ * A container whose ROOT carries content of its own beside its slot.
+ *
+ * The shape `core/accordion-item` has: a `<details>` holding a `<summary>` and
+ * the slot's output, so an instance with an empty `children` slot renders a
+ * root that is NOT `:empty` and measures the summary's own height. That is the
+ * separating property between the two questions this component used to ask
+ * separately — the document says the slot is empty, the render says the
+ * element carries no affordance.
+ */
+const DETAILS_CONTAINER = "acme/empty-container-appender-details";
+
+/** The canvas root's own rectangle, and the one every wrapper reports. */
+const CANVAS_BOX = { x: 0, y: 0, width: 800, height: 600 };
+
+interface Box {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Give a rendered canvas the rectangles jsdom never lays out.
+ *
+ * Every element reports the canvas's own box first, so no wrapper between a
+ * node and the root reads as clipping it — jsdom's computed `overflow` is the
+ * empty string rather than `visible`, so an ancestor left unstubbed would
+ * report a zero-sized clip rectangle and cut every node inside it. The named
+ * nodes are then overridden with the boxes the case is about.
+ */
+function layout(container: HTMLElement, boxes: Record<string, Box>): void {
+  const root = container.querySelector<HTMLElement>(`.${CANVAS_ROOT_CLASS}`);
+  if (root === null) throw new Error("no canvas root rendered");
+  const stub = (element: Element, box: Box): void => {
+    element.getBoundingClientRect = () =>
+      new DOMRect(box.x, box.y, box.width, box.height);
+  };
+  stub(root, CANVAS_BOX);
+  // `forEach` rather than `for...of`: this package's `lib` predicates
+  // `NodeListOf` having an iterator on a DOM iterable declaration it does not
+  // include, so the loop form does not compile here.
+  root.querySelectorAll("*").forEach(element => stub(element, CANVAS_BOX));
+  for (const [id, box] of Object.entries(boxes)) {
+    const element = root.querySelector(`[${NODE_ID_ATTRIBUTE}="${id}"]`);
+    if (element === null) throw new Error(`no element for ${id}`);
+    stub(element, box);
+  }
+}
+
+/** The inline rectangle a control was drawn at, in the order left/top/w/h. */
+function drawnAt(name: string): [string, string, string, string] {
+  const button = screen.getByRole("button", { name: `Add a block to ${name}` });
+  if (!(button instanceof HTMLElement)) throw new Error(`${name}: no element`);
+  return [
+    button.style.left,
+    button.style.top,
+    button.style.width,
+    button.style.height,
+  ];
+}
+
+describe("which containers it actually draws a control on", () => {
+  function registerShapes() {
+    if (hasBlock(DETAILS_CONTAINER)) return;
+    registerBlocks(
+      [
+        {
+          name: "acme/empty-container-appender-box",
+          version: 1,
+          description: "A container whose root holds nothing but its slot.",
+          example: { props: {} },
+          slots: { children: {} },
+          render: ({ className, renderSlot }: BlockRenderArgs<object>) =>
+            React.createElement("div", { className }, renderSlot("children")),
+        },
+        {
+          name: DETAILS_CONTAINER,
+          version: 1,
+          description: "A container whose root also renders a summary.",
+          example: { props: {} },
+          slots: { children: {} },
+          render: ({ className, renderSlot }: BlockRenderArgs<object>) =>
+            React.createElement(
+              "details",
+              { className },
+              React.createElement("summary", null, "Section"),
+              renderSlot("children")
+            ),
+        },
+      ],
+      { source: "empty-container-appender-shapes" }
+    );
+  }
+
+  const SHAPES: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "wide",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Wide box",
+      },
+      {
+        id: "narrow",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Narrow column",
+      },
+      {
+        id: "summary-bearing",
+        type: DETAILS_CONTAINER,
+        version: 1,
+        props: {},
+        name: "Closed section",
+      },
+    ],
+  };
+
+  /**
+   * Mount the canvas, give it a layout, and let the component re-measure.
+   *
+   * The stubs cannot be in place before mount — the elements do not exist yet
+   * — so the resize the component already subscribes to is what drives the
+   * second measurement, exactly as a breakpoint or a webfont swap would.
+   */
+  function measuredCanvas(boxes: Record<string, Box>): void {
+    registerShapes();
+    withFakeResizeObserver();
+
+    const { container } = render(
+      <Canvas
+        document={SHAPES}
+        siteStyles={SITE_STYLES}
+        overlay={
+          <EmptyContainerAppenders
+            document={SHAPES}
+            slots={registrySlotSource()}
+            blocks={{ get: () => undefined }}
+            onAppend={() => undefined}
+          />
+        }
+      />
+    );
+
+    layout(container, boxes);
+    const observer = FakeResizeObserver.instances.at(-1);
+    if (observer === undefined) throw new Error("no observer subscribed");
+    act(() => observer.fire());
+  }
+
+  it("declines a container whose root is not the one the stylesheet styles", () => {
+    /*
+     * `builder-chrome.css` gives its 44px box to `[data-nx-slots]:empty`, and
+     * a closed `<details>` is not `:empty` — it holds its summary. So there is
+     * no box under this container, its rectangle is the summary's own 19px,
+     * and a 44px control centred in it would start 12.5px ABOVE the container
+     * and paint over the node laid out before it.
+     *
+     * The wide box is the must-be-found control: it is measured in the same
+     * pass, so a zero rectangle on the details container means the container
+     * was declined rather than that nothing was measured at all.
+     */
+    measuredCanvas({
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      "summary-bearing": { x: 0, y: 400, width: 400, height: 19 },
+    });
+
+    expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(drawnAt("Closed section")).toEqual(["0px", "0px", "0px", "0px"]);
+  });
+
+  it("keeps the control inside a container narrower than it", () => {
+    /*
+     * A legitimately narrow empty container: `[data-nx-slots]:empty` promises
+     * a `min-height` and no `min-width`, so this one really is 20px wide and
+     * really does carry the dashed box. Unclamped, a 44px control centred in
+     * it starts at x = -12 and reaches 12px past its right edge, over both
+     * neighbours.
+     */
+    measuredCanvas({
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      narrow: { x: 0, y: 200, width: 20, height: 200 },
+    });
+
+    expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(drawnAt("Narrow column")).toEqual(["0px", "278px", "20px", "44px"]);
   });
 });

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -13,7 +13,9 @@
  * - the cases that need a rendered canvas STUB each element's rectangle first
  *   — the same thing `canvas-drag.test.tsx` does — and then drive the resize
  *   the component already subscribes to, so what is measured is a real
- *   rectangle rather than jsdom's zero.
+ *   rectangle rather than jsdom's zero. Whether an element generates a box at
+ *   all is stubbed there too and separately, since jsdom reports none for
+ *   every element — see `layout` and `laidOut`.
  *
  * The cases that assert only which controls EXIST mount no canvas at all, and
  * deliberately: which containers get a control comes from the document alone.
@@ -536,6 +538,47 @@ function canvasRootIn(container: HTMLElement, which = 0): HTMLElement {
 }
 
 /**
+ * Whether the render lays a box out for this element at all.
+ *
+ * jsdom performs no layout, so `getClientRects` answers with nothing for every
+ * element and the component's no-box refusal would decline every container in
+ * this file. What jsdom DOES resolve is the cascade: a `display` stored on a
+ * node compiles into the page's own `<style>` and reaches `getComputedStyle`,
+ * so the fixture's own value is what decides the answer here rather than a
+ * per-case flag.
+ *
+ * The rule applied is the one measured in Chromium: an element inside a
+ * subtree whose root computes `display: none` generates no box, and neither
+ * does that root. So the walk climbs, and it climbs past the canvas root
+ * because a hidden ancestor anywhere above has the same effect.
+ */
+function laidOut(element: Element): boolean {
+  for (
+    let node: Element | null = element;
+    node !== null;
+    node = node.parentElement
+  ) {
+    if (getComputedStyle(node).display === "none") return false;
+  }
+  return true;
+}
+
+/**
+ * The layout boxes an element generates, in the shape `getClientRects`
+ * returns them.
+ *
+ * An array carrying `item` rather than a cast: `DOMRectList` is a numeric
+ * index, a `length` and that method, and an array already supplies the first
+ * two — so the composed value satisfies the interface as it stands.
+ */
+function rectsOf(rects: readonly DOMRect[]): DOMRectList {
+  const list = [...rects];
+  return Object.assign(list, {
+    item: (index: number): DOMRect | null => list[index] ?? null,
+  });
+}
+
+/**
  * Give a rendered canvas the rectangles jsdom never lays out.
  *
  * Every element reports the canvas's own box first, so no wrapper between a
@@ -543,6 +586,13 @@ function canvasRootIn(container: HTMLElement, which = 0): HTMLElement {
  * empty string rather than `visible`, so an ancestor left unstubbed would
  * report a zero-sized clip rectangle and cut every node inside it. The named
  * nodes are then overridden with the boxes the case is about.
+ *
+ * The FRAGMENT count is stubbed beside the rectangle, and separately from it:
+ * an element that generates a box reports exactly one whatever rectangle it
+ * was given, and an element inside a hidden subtree reports none however large
+ * a rectangle it was given. Keeping the two apart is what lets a case assert
+ * that a container is refused for generating no box rather than for measuring
+ * nothing.
  */
 function layout(
   container: HTMLElement,
@@ -553,6 +603,12 @@ function layout(
   const stub = (element: Element, box: Box): void => {
     element.getBoundingClientRect = () =>
       new DOMRect(box.x, box.y, box.width, box.height);
+    element.getClientRects = () =>
+      rectsOf(
+        laidOut(element)
+          ? [new DOMRect(box.x, box.y, box.width, box.height)]
+          : []
+      );
   };
   stub(root, CANVAS_BOX);
   // `forEach` rather than `for...of`: this package's `lib` predicates
@@ -687,6 +743,51 @@ describe("which containers it actually draws a control on", () => {
               version: 1,
               props: {},
               name: "Clipped box",
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  /**
+   * An empty container inside a wrapper the author has hidden.
+   *
+   * `display` is a catalog keyword, so `none` is a value an author stores, and
+   * the wrapper is where it can still take effect: it holds a child, so it is
+   * not `:empty` and `builder-chrome.css`'s rule — which outranks the compiled
+   * per-node one — never reaches it. The container inside is untouched by that
+   * choice as far as every other question goes. It renders, it carries the
+   * slots marker, it is `:empty`, its own `display` computes to whatever the
+   * page gives it, it is `static`, and no ancestor clips it. It simply has no
+   * box.
+   */
+  const NESTED_IN_HIDDEN: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "wide",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Wide box",
+      },
+      {
+        id: "hidden-wrapper",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Hidden wrapper",
+        styles: { base: { base: { display: "none" } } },
+        slots: {
+          children: [
+            {
+              id: "inside-hidden",
+              type: "acme/empty-container-appender-box",
+              version: 1,
+              props: {},
+              name: "Box in a hidden wrapper",
             },
           ],
         },
@@ -909,6 +1010,43 @@ describe("which containers it actually draws a control on", () => {
     ).toBeNull();
   });
 
+  it("draws NO control on a container the render lays out no box for", () => {
+    /*
+     * The NO-BOX refusal, which no other branch here stands in for. The
+     * container's element exists, matches the stylesheet's whole rule, is
+     * `static` and is clipped by nothing — so every other refusal accepts it,
+     * and what is left is that a hidden wrapper above it means the render lays
+     * out no box for it. `getBoundingClientRect` still answers, with the zero
+     * rectangle, so a pass that measured on would draw a button of no area
+     * that a keyboard still reaches.
+     *
+     * Stubbed with a 400x200 rectangle DELIBERATELY, the same size as the
+     * positive control's. The refusal cannot then be coming from a container
+     * that measured nothing: the fragment count is what differs, which is the
+     * question the component asks.
+     *
+     * The wrapper's computed `display` is asserted first, so the absence below
+     * is known to be about a container that really is inside a hidden subtree
+     * rather than about a fixture whose styles never compiled — an element no
+     * rule reaches computes to jsdom's own default, not to `none`. `Wide box`
+     * is the positive control, in the same render and the same measurement
+     * pass, because an absence assertion alone is satisfied by a component
+     * that drew nothing anywhere.
+     */
+    const container = measuredCanvas(NESTED_IN_HIDDEN, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      "inside-hidden": { x: 0, y: 400, width: 400, height: 200 },
+    });
+
+    expect(computedStyleOf(container, "hidden-wrapper").display).toBe("none");
+    expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(
+      screen.queryByRole("button", {
+        name: "Add a block to Box in a hidden wrapper",
+      })
+    ).toBeNull();
+  });
+
   it("draws NO control on a container the render does not produce", () => {
     /*
      * The UNRENDERED refusal, and the only one with no element to ask anything
@@ -986,13 +1124,22 @@ describe("which containers it actually draws a control on", () => {
     ],
   };
 
-  /** The computed `position` of one node's rendered element. */
-  function computedPositionOf(container: HTMLElement, id: string): string {
+  /**
+   * The computed style of one node's rendered element.
+   *
+   * One entry point returning the whole declaration rather than a reader per
+   * property: each case asks about the value its own fixture stores, and the
+   * varying part is which property that is.
+   */
+  function computedStyleOf(
+    container: HTMLElement,
+    id: string
+  ): CSSStyleDeclaration {
     const element = canvasRootIn(container).querySelector(
       `[${NODE_ID_ATTRIBUTE}="${id}"]`
     );
     if (element === null) throw new Error(`no element for ${id}`);
-    return getComputedStyle(element).position;
+    return getComputedStyle(element);
   }
 
   it("draws NO control on a container the author pinned to the viewport", () => {
@@ -1016,7 +1163,9 @@ describe("which containers it actually draws a control on", () => {
       "pinned-to-viewport": { x: 0, y: 400, width: 400, height: 200 },
     });
 
-    expect(computedPositionOf(container, "pinned-to-viewport")).toBe("fixed");
+    expect(computedStyleOf(container, "pinned-to-viewport").position).toBe(
+      "fixed"
+    );
     expect(drawnAt("Anchored box")).toEqual(["178px", "78px", "44px", "44px"]);
     expect(
       screen.queryByRole("button", { name: "Add a block to Fixed box" })
@@ -1037,7 +1186,7 @@ describe("which containers it actually draws a control on", () => {
       "pinned-to-scrollport": { x: 0, y: 400, width: 400, height: 200 },
     });
 
-    expect(computedPositionOf(container, "pinned-to-scrollport")).toBe(
+    expect(computedStyleOf(container, "pinned-to-scrollport").position).toBe(
       "sticky"
     );
     expect(drawnAt("Anchored box")).toEqual(["178px", "78px", "44px", "44px"]);

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+
+/**
+ * The affordance drawn over a container with nothing in it.
+ *
+ * Geometry is NOT asserted here: jsdom reports every element as zero-sized, so
+ * a position assertion would pass against any implementation. Placement is
+ * verified in a real browser in Task 8.
+ *
+ * `fireEvent` rather than `@testing-library/user-event`: this package does not
+ * depend on that library and no other suite here does either, and the control
+ * under test responds to a plain `onClick`, so one synthetic click exercises it
+ * exactly as a full pointer-event sequence would.
+ *
+ * No jest-dom matcher is used, for the same reason `inspector-panel.test.tsx`
+ * gives: this package does not register jest-dom, so a matcher like
+ * `toBeEmptyDOMElement` is not available and every assertion below reaches for
+ * a plain vitest one instead.
+ */
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { EmptyContainerAppenders } from "./empty-container-appender";
+
+// This suite queries by role against the whole document (`screen`), so a tree
+// left mounted by one test is still there for the next `getByRole` to trip
+// over — matching why `block-toolbar.test.tsx` and `spacing-overlay.test.tsx`
+// both call this between cases.
+afterEach(() => {
+  cleanup();
+});
+
+const slots = {
+  slotsOf: (type: string) =>
+    type === "core/box" ? (["children"] as const) : undefined,
+};
+
+const blocks = {
+  get: (type: string) =>
+    type === "core/box" ? ({ editor: { label: "Box" } } as never) : undefined,
+};
+
+function doc(nodes: BlockDocument["nodes"]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes };
+}
+
+const emptyBox = { id: "box-1", type: "core/box", version: 1, props: {} };
+const filledBox = {
+  id: "box-2",
+  type: "core/box",
+  version: 1,
+  props: {},
+  slots: {
+    children: [{ id: "h", type: "core/heading", version: 1, props: {} }],
+  },
+};
+
+describe("the empty-container appender", () => {
+  it("offers one control per empty container, naming the block", () => {
+    render(
+      <EmptyContainerAppenders
+        document={doc([emptyBox])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={() => undefined}
+      />
+    );
+    expect(screen.getByRole("button", { name: /Box/ })).toBeTruthy();
+  });
+
+  it("offers nothing for a container that already has a child", () => {
+    render(
+      <EmptyContainerAppenders
+        document={doc([filledBox])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={() => undefined}
+      />
+    );
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  it("reports the container's id when pressed", () => {
+    const onAppend = vi.fn();
+    render(
+      <EmptyContainerAppenders
+        document={doc([emptyBox])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={onAppend}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Box/ }));
+    expect(onAppend).toHaveBeenCalledWith("box-1");
+  });
+
+  it("marks itself as chrome so a press does not clear the selection", () => {
+    const { container } = render(
+      <EmptyContainerAppenders
+        document={doc([emptyBox])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={() => undefined}
+      />
+    );
+    expect(container.querySelector("[data-nx-chrome]")).not.toBeNull();
+  });
+
+  it("renders nothing at all while hidden", () => {
+    // Matching `BlockToolbar`: a control that is merely invisible would still
+    // take a press, and a mid-drag press here would run an insert against a
+    // container that is about to be somewhere else.
+    const { container } = render(
+      <EmptyContainerAppenders
+        document={doc([emptyBox])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={() => undefined}
+        hidden
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -216,6 +216,63 @@ describe("the empty-container appender", () => {
   });
 });
 
+describe("the accessible name it announces", () => {
+  it("prefers the author's own instance name over the block's label", () => {
+    // Two containers of the SAME type, one the author has named. A label
+    // taken from the type alone would give both the identical name, which is
+    // exactly what makes them impossible to tell apart by ear.
+    const namedBox = {
+      id: "box-named",
+      type: "core/box",
+      version: 1,
+      props: {},
+      name: "Header slot",
+    };
+    render(
+      <EmptyContainerAppenders
+        document={doc([namedBox, emptyBox])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={() => undefined}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add a block to Header slot" })
+    ).toBeTruthy();
+    // The un-named sibling still falls back to the block's own label, proving
+    // the precedence runs one way: a name wins when given, and its absence
+    // does not disturb the existing fallback.
+    expect(
+      screen.getByRole("button", { name: "Add a block to Box" })
+    ).toBeTruthy();
+  });
+
+  it("ignores a name of only whitespace, the same way the Layers panel does", () => {
+    // `authoredName` trims and treats a blank result as absent; a control
+    // announcing "Add a block to    " would be no name at all.
+    const blankName = {
+      id: "box-blank",
+      type: "core/box",
+      version: 1,
+      props: {},
+      name: "   ",
+    };
+    render(
+      <EmptyContainerAppenders
+        document={doc([blankName])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={() => undefined}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Add a block to Box" })
+    ).toBeTruthy();
+  });
+});
+
 /**
  * A stand-in for `ResizeObserver`, which jsdom does not implement.
  *

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -660,12 +660,14 @@ describe("which containers it actually draws a control on", () => {
   };
 
   /**
-   * A document the overlay knows about and the canvas has not rendered.
+   * A document the overlay knows about and the canvas does not render.
    *
    * `ghost` is a perfectly ordinary empty container that no element in the DOM
-   * carries the id of, which is the state every container is in for the frame
-   * before the canvas mounts. The measurement pass finds no element for it and
-   * records nothing — leaving it UNMEASURED rather than declined.
+   * carries the id of — the state a node `PageRenderer` drops stays in for as
+   * long as it is dropped, whether for a `visibility.conditions` gate or for
+   * props that make it draw nothing. A pass with a canvas root under it has
+   * searched that root and found nothing, so the refusal is a decision rather
+   * than a wait.
    */
   const SHAPES_PLUS_UNRENDERED: BlockDocument = {
     ...SHAPES,
@@ -691,12 +693,15 @@ describe("which containers it actually draws a control on", () => {
    * `overlayDocument` defaults to the canvas's own, which is the ordinary
    * case; a caller passes a different one to model a container the document
    * holds and the render does not.
+   *
+   * Returns the rendered container, for a case that has to re-stub a
+   * rectangle and drive a second measurement of its own.
    */
   function measuredCanvas(
     canvasDocument: BlockDocument,
     boxes: Record<string, Box>,
     overlayDocument: BlockDocument = canvasDocument
-  ): void {
+  ): HTMLElement {
     registerShapes();
     withFakeResizeObserver();
 
@@ -719,6 +724,7 @@ describe("which containers it actually draws a control on", () => {
     const observer = FakeResizeObserver.instances.at(-1);
     if (observer === undefined) throw new Error("no observer subscribed");
     act(() => observer.fire());
+    return container;
   }
 
   it("draws NO control on a container whose root the stylesheet declines", () => {
@@ -769,16 +775,22 @@ describe("which containers it actually draws a control on", () => {
     ).toBeNull();
   });
 
-  it("tells a DECLINED container apart from one no pass has reached", () => {
+  it("draws NO control on a container the render does not produce", () => {
     /*
-     * The separating property between the two states, in one render: `ghost`
-     * is UNMEASURED — in the overlay's document, in no element's id — and
-     * `summary-bearing` is DECLINED. They must come out differently.
+     * The third refusal, and the only one with no element to ask anything of.
+     * `ghost` is in the overlay's document and in no element's id, which is
+     * where a node `PageRenderer` drops stays: one carrying
+     * `visibility.conditions`, or one whose props make it draw nothing. A pass
+     * that HAS a canvas root and cannot find the element has decided about
+     * that container, so treating it as not-yet-measured would leave a
+     * zero-sized button in the tab order, announced by name, for content the
+     * canvas does not show.
      *
-     * A single representation for both gives them the SAME outcome whichever
-     * way it is spelled: hide the unmeasured one and neither button exists;
-     * draw the declined one at the zero rectangle and both do. Only two
-     * distinct states pass this pair of assertions.
+     * Two controls in the same render and the same pass, because an absence
+     * assertion alone is satisfied by a component that drew nothing at all:
+     * `Wide box` proves the query finds a button here, and `Closed section`
+     * proves the OTHER refusal still refuses — so this is a statement about
+     * `ghost` rather than about the render as a whole.
      */
     measuredCanvas(
       SHAPES,
@@ -789,10 +801,85 @@ describe("which containers it actually draws a control on", () => {
       SHAPES_PLUS_UNRENDERED
     );
 
-    expect(drawnAt("Ghost box")).toEqual(["0px", "0px", "0px", "0px"]);
+    expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(
+      screen.queryByRole("button", { name: "Add a block to Ghost box" })
+    ).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Add a block to Closed section" })
     ).toBeNull();
+  });
+
+  it("re-measures when a scroller between a container and the root scrolls", () => {
+    /*
+     * `overflow: auto` and `overflow: scroll` are catalog values, so an empty
+     * container can sit inside a scroller the author made. Scrolling it moves
+     * the container relative to the canvas while resizing nothing, mutating
+     * nothing and finishing no transition — so the resize observer this
+     * component already had has nothing to report, and the control stays at
+     * the coordinates the layout used to give it, over whatever is there now.
+     *
+     * The scroll is dispatched on the NESTED element rather than on the root,
+     * and with the default `bubbles: false` a scroll event really has: only a
+     * listener in the CAPTURE phase on the root hears one from a scroller
+     * inside it, so a bubbling listener would see nothing here. That is what
+     * makes this discriminate rather than merely pass.
+     *
+     * The rectangle is re-stubbed and the control's new position asserted, so
+     * what is checked is a completed re-measurement rather than the presence
+     * of a subscription.
+     */
+    const container = measuredCanvas(NESTED, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 0, width: 400, height: 200 },
+    });
+    expect(drawnAt("Clipped box")).toEqual(["178px", "78px", "44px", "44px"]);
+
+    // The same container, 100px further down its scroller, and nothing
+    // resized: `clipper` still reports the canvas's own box.
+    layout(container, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 100, width: 400, height: 200 },
+    });
+    const scroller = container.querySelector(
+      `[${NODE_ID_ATTRIBUTE}="clipper"]`
+    );
+    if (scroller === null) throw new Error("no element for clipper");
+    act(() => {
+      scroller.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(drawnAt("Clipped box")).toEqual(["178px", "178px", "44px", "44px"]);
+  });
+
+  it("re-measures when a transition finishes inside the canvas", () => {
+    /*
+     * The second change that moves a control while resizing nothing:
+     * `transition` is a catalog property, so a neighbour animating a margin or
+     * a transform past the first frame moves an empty container without
+     * changing any observed box. The completion event bubbles, so the one
+     * listener on the root hears it wherever inside the canvas it is raised —
+     * dispatched here on the wrapper rather than on the root to say so.
+     */
+    const container = measuredCanvas(NESTED, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 0, width: 400, height: 200 },
+    });
+    expect(drawnAt("Clipped box")).toEqual(["178px", "78px", "44px", "44px"]);
+
+    layout(container, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 100, width: 400, height: 200 },
+    });
+    const animated = container.querySelector(
+      `[${NODE_ID_ATTRIBUTE}="clipper"]`
+    );
+    if (animated === null) throw new Error("no element for clipper");
+    act(() => {
+      animated.dispatchEvent(new Event("transitionend", { bubbles: true }));
+    });
+
+    expect(drawnAt("Clipped box")).toEqual(["178px", "178px", "44px", "44px"]);
   });
 
   it("keeps the control inside a container narrower than it", () => {
@@ -822,6 +909,13 @@ describe("a container no measurement pass has reached", () => {
      * container — and the control is still in the accessibility tree, where a
      * screen reader can reach it, because a control that has not been placed
      * yet is not a control that has been refused.
+     *
+     * This is one half of what separates UNMEASURED from DECLINED, and the
+     * halves cannot share a render: whether a pass has run at all is a
+     * property of the MOUNT rather than of a container. The other half is
+     * "draws NO control on a container the render does not produce" above,
+     * where the same missing element under a canvas root draws nothing.
+     * Conflate the two states in either direction and one of the pair fails.
      */
     render(
       <EmptyContainerAppenders

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -23,7 +23,11 @@ import {
   registerBlocks,
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
-import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
+import {
+  NODE_ID_ATTRIBUTE,
+  type BlockRenderArgs,
+  type SiteSheetInput,
+} from "@nextlyhq/blocks-react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -65,6 +69,20 @@ const blocks = {
 function doc(nodes: BlockDocument["nodes"]): BlockDocument {
   return { formatVersion: 1, kind: "page", nodes };
 }
+
+/**
+ * The site sheet `Canvas` requires, declared rather than cast past the checker.
+ *
+ * `SiteSheetInput` requires `breakpoints` and has no `css` field at all, so the
+ * `{ css: "", classes: {} }` shape this file used to hand `Canvas` was not a
+ * site sheet under any reading — the cast was hiding a wrong value, not a
+ * verbose one. Both axes are empty because nothing here previews a tier: a
+ * canvas with no viewport breakpoint renders through the published path, which
+ * is the path every case below is about.
+ */
+const SITE_STYLES: SiteSheetInput = {
+  breakpoints: { viewport: [], container: [] },
+};
 
 const emptyBox = { id: "box-1", type: "core/box", version: 1, props: {} };
 const filledBox = {
@@ -320,18 +338,12 @@ describe("what it stays subscribed to", () => {
           description: "A container with one slot.",
           example: { props: {} },
           slots: { children: {} },
-          // Typed with the one shape this fixture reads, rather than the
-          // full `BlockRenderArgs` — matching how `EmptyContainerAppenders`
-          // itself narrows to `BlockLookup` above, and how it is discarded
-          // anyway by `as never` below; the annotation only exists so `tsc`
-          // can check the destructure rather than reporting an implicit `any`.
-          render: ({
-            className,
-            renderSlot,
-          }: {
-            className: string;
-            renderSlot: (name: string) => React.ReactNode;
-          }) =>
+          // Annotated with the renderer's OWN argument type rather than cast:
+          // the engine types `renderSlot` as returning `unknown`, since it
+          // carries no React types, and `@nextlyhq/blocks-react` is the package
+          // that names the React answer. Every first-party block is written
+          // against exactly this type.
+          render: ({ className, renderSlot }: BlockRenderArgs<object>) =>
             React.createElement("div", { className }, renderSlot("children")),
         },
         {
@@ -341,12 +353,12 @@ describe("what it stays subscribed to", () => {
           example: { props: {} },
           render: () => React.createElement("p", null, "leaf"),
         },
-      ] as never,
+      ],
       { source: "empty-container-appender-test" }
     );
   }
 
-  const CANVAS_DOCUMENT = {
+  const CANVAS_DOCUMENT: BlockDocument = {
     formatVersion: 1,
     kind: "page",
     nodes: [
@@ -363,7 +375,7 @@ describe("what it stays subscribed to", () => {
         props: {},
       },
     ],
-  } as unknown as BlockDocument;
+  };
 
   it("watches EVERY rendered node, not only the container it draws a control for", () => {
     // The separating property for this fix: a populated sibling resizing —
@@ -377,7 +389,7 @@ describe("what it stays subscribed to", () => {
     const { container } = render(
       <Canvas
         document={CANVAS_DOCUMENT}
-        siteStyles={{ css: "", classes: {} } as never}
+        siteStyles={SITE_STYLES}
         overlay={
           <EmptyContainerAppenders
             document={CANVAS_DOCUMENT}

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -618,23 +618,95 @@ describe("which containers it actually draws a control on", () => {
   };
 
   /**
+   * A container nested inside another, so that the walk between a node's root
+   * and the canvas root has an ancestor to ask about.
+   *
+   * Every node in {@link SHAPES} is a direct child of the canvas root, and
+   * `clippedByAncestorRect` stops strictly BELOW the root — so no arrangement
+   * of those three rectangles can reach the clip refusal at all. `clipper`
+   * holds a child, so it is not an empty container itself and offers no
+   * control of its own.
+   */
+  const NESTED: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "wide",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Wide box",
+      },
+      {
+        id: "clipper",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Clipping wrapper",
+        slots: {
+          children: [
+            {
+              id: "clipped",
+              type: "acme/empty-container-appender-box",
+              version: 1,
+              props: {},
+              name: "Clipped box",
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  /**
+   * A document the overlay knows about and the canvas has not rendered.
+   *
+   * `ghost` is a perfectly ordinary empty container that no element in the DOM
+   * carries the id of, which is the state every container is in for the frame
+   * before the canvas mounts. The measurement pass finds no element for it and
+   * records nothing — leaving it UNMEASURED rather than declined.
+   */
+  const SHAPES_PLUS_UNRENDERED: BlockDocument = {
+    ...SHAPES,
+    nodes: [
+      ...SHAPES.nodes,
+      {
+        id: "ghost",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+        name: "Ghost box",
+      },
+    ],
+  };
+
+  /**
    * Mount the canvas, give it a layout, and let the component re-measure.
    *
    * The stubs cannot be in place before mount — the elements do not exist yet
    * — so the resize the component already subscribes to is what drives the
    * second measurement, exactly as a breakpoint or a webfont swap would.
+   *
+   * `overlayDocument` defaults to the canvas's own, which is the ordinary
+   * case; a caller passes a different one to model a container the document
+   * holds and the render does not.
    */
-  function measuredCanvas(boxes: Record<string, Box>): void {
+  function measuredCanvas(
+    canvasDocument: BlockDocument,
+    boxes: Record<string, Box>,
+    overlayDocument: BlockDocument = canvasDocument
+  ): void {
     registerShapes();
     withFakeResizeObserver();
 
     const { container } = render(
       <Canvas
-        document={SHAPES}
+        document={canvasDocument}
         siteStyles={SITE_STYLES}
         overlay={
           <EmptyContainerAppenders
-            document={SHAPES}
+            document={overlayDocument}
             slots={registrySlotSource()}
             blocks={{ get: () => undefined }}
             onAppend={() => undefined}
@@ -649,7 +721,7 @@ describe("which containers it actually draws a control on", () => {
     act(() => observer.fire());
   }
 
-  it("declines a container whose root is not the one the stylesheet styles", () => {
+  it("draws NO control on a container whose root the stylesheet declines", () => {
     /*
      * `builder-chrome.css` gives its 44px box to `[data-nx-slots]:empty`, and
      * a closed `<details>` is not `:empty` — it holds its summary. So there is
@@ -657,17 +729,70 @@ describe("which containers it actually draws a control on", () => {
      * and a 44px control centred in it would start 12.5px ABOVE the container
      * and paint over the node laid out before it.
      *
-     * The wide box is the must-be-found control: it is measured in the same
-     * pass, so a zero rectangle on the details container means the container
-     * was declined rather than that nothing was measured at all.
+     * The wide box is the positive control, in the same render and measured in
+     * the same pass. Without it the absence below is satisfied by a component
+     * that rendered nothing at all; with it, the query is known to find a
+     * button here, so finding none for the details container is a statement
+     * about THAT container.
      */
-    measuredCanvas({
+    measuredCanvas(SHAPES, {
       wide: { x: 0, y: 0, width: 400, height: 200 },
       "summary-bearing": { x: 0, y: 400, width: 400, height: 19 },
     });
 
     expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
-    expect(drawnAt("Closed section")).toEqual(["0px", "0px", "0px", "0px"]);
+    expect(
+      screen.queryByRole("button", { name: "Add a block to Closed section" })
+    ).toBeNull();
+  });
+
+  it("draws NO control on a container an authored ancestor clips", () => {
+    /*
+     * The second permanent refusal, which has to be covered on its own: the
+     * two guards are separate branches, and a fix applied to one leaves the
+     * other returning whatever it returned before.
+     *
+     * `layout` gives every unnamed element the canvas's own 800x600 box, so
+     * the wrapper reports that and the nested container is stubbed a thousand
+     * pixels below it — outside the wrapper's rectangle on both vertical
+     * edges, which is a straight-edge cut no corner refinement is involved in.
+     * Same positive control as above, for the same reason.
+     */
+    measuredCanvas(NESTED, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 1000, width: 400, height: 200 },
+    });
+
+    expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(
+      screen.queryByRole("button", { name: "Add a block to Clipped box" })
+    ).toBeNull();
+  });
+
+  it("tells a DECLINED container apart from one no pass has reached", () => {
+    /*
+     * The separating property between the two states, in one render: `ghost`
+     * is UNMEASURED — in the overlay's document, in no element's id — and
+     * `summary-bearing` is DECLINED. They must come out differently.
+     *
+     * A single representation for both gives them the SAME outcome whichever
+     * way it is spelled: hide the unmeasured one and neither button exists;
+     * draw the declined one at the zero rectangle and both do. Only two
+     * distinct states pass this pair of assertions.
+     */
+    measuredCanvas(
+      SHAPES,
+      {
+        wide: { x: 0, y: 0, width: 400, height: 200 },
+        "summary-bearing": { x: 0, y: 400, width: 400, height: 19 },
+      },
+      SHAPES_PLUS_UNRENDERED
+    );
+
+    expect(drawnAt("Ghost box")).toEqual(["0px", "0px", "0px", "0px"]);
+    expect(
+      screen.queryByRole("button", { name: "Add a block to Closed section" })
+    ).toBeNull();
   });
 
   it("keeps the control inside a container narrower than it", () => {
@@ -678,12 +803,35 @@ describe("which containers it actually draws a control on", () => {
      * it starts at x = -12 and reaches 12px past its right edge, over both
      * neighbours.
      */
-    measuredCanvas({
+    measuredCanvas(SHAPES, {
       wide: { x: 0, y: 0, width: 400, height: 200 },
       narrow: { x: 0, y: 200, width: 20, height: 200 },
     });
 
     expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
     expect(drawnAt("Narrow column")).toEqual(["0px", "278px", "20px", "44px"]);
+  });
+});
+
+describe("a container no measurement pass has reached", () => {
+  it("renders its control anyway, at the zero rectangle", () => {
+    /*
+     * The property the module docblock's UNMEASURED state exists for, said
+     * outright rather than left to emerge from the bare-mount cases above.
+     * There is no canvas root here, so `measure` records nothing about any
+     * container — and the control is still in the accessibility tree, where a
+     * screen reader can reach it, because a control that has not been placed
+     * yet is not a control that has been refused.
+     */
+    render(
+      <EmptyContainerAppenders
+        document={doc([emptyBox])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={() => undefined}
+      />
+    );
+
+    expect(drawnAt("Box")).toEqual(["0px", "0px", "0px", "0px"]);
   });
 });

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -36,6 +36,7 @@ import {
 } from "@nextlyhq/blocks-engine";
 import {
   NODE_ID_ATTRIBUTE,
+  SLOTS_ATTRIBUTE,
   type BlockRenderArgs,
   type SiteSheetInput,
 } from "@nextlyhq/blocks-react";
@@ -50,6 +51,7 @@ import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CANVAS_ROOT_CLASS, Canvas } from "./canvas";
+import { BUILDER_CHROME_CLASS } from "./shell-state";
 import {
   centeredControlRect,
   EmptyContainerAppenders,
@@ -517,6 +519,23 @@ interface Box {
 }
 
 /**
+ * The nth canvas root inside a render, throwing rather than answering `null`.
+ *
+ * Indexed because one case mounts TWO canvases in a single render to compare
+ * them; every other caller takes the only one there is. A missing root is a
+ * broken fixture rather than a result, so it raises instead of letting a later
+ * query report an absence that means nothing.
+ */
+function canvasRootIn(container: HTMLElement, which = 0): HTMLElement {
+  const roots = container.querySelectorAll<HTMLElement>(
+    `.${CANVAS_ROOT_CLASS}`
+  );
+  const root = roots[which];
+  if (root === undefined) throw new Error(`no canvas root at index ${which}`);
+  return root;
+}
+
+/**
  * Give a rendered canvas the rectangles jsdom never lays out.
  *
  * Every element reports the canvas's own box first, so no wrapper between a
@@ -525,9 +544,12 @@ interface Box {
  * report a zero-sized clip rectangle and cut every node inside it. The named
  * nodes are then overridden with the boxes the case is about.
  */
-function layout(container: HTMLElement, boxes: Record<string, Box>): void {
-  const root = container.querySelector<HTMLElement>(`.${CANVAS_ROOT_CLASS}`);
-  if (root === null) throw new Error("no canvas root rendered");
+function layout(
+  container: HTMLElement,
+  boxes: Record<string, Box>,
+  which = 0
+): void {
+  const root = canvasRootIn(container, which);
   const stub = (element: Element, box: Box): void => {
     element.getBoundingClientRect = () =>
       new DOMRect(box.x, box.y, box.width, box.height);
@@ -542,6 +564,19 @@ function layout(container: HTMLElement, boxes: Record<string, Box>): void {
     if (element === null) throw new Error(`no element for ${id}`);
     stub(element, box);
   }
+}
+
+/**
+ * Let queued mutation records reach the observer that asked for them.
+ *
+ * `MutationObserver` delivers its records in a microtask rather than at the
+ * moment of the write, so an assertion taken straight after a DOM change runs
+ * before the callback has been entered at all — which reads exactly like a
+ * subscription that never fired. A macrotask turn drains the microtask queue,
+ * so waiting one is enough for delivery however many turns it takes.
+ */
+async function flushObservers(): Promise<void> {
+  await new Promise(resolve => setTimeout(resolve, 0));
 }
 
 /** The inline rectangle a control was drawn at, in the order left/top/w/h. */
@@ -696,6 +731,14 @@ describe("which containers it actually draws a control on", () => {
    *
    * Returns the rendered container, for a case that has to re-stub a
    * rectangle and drive a second measurement of its own.
+   *
+   * Mounted inside a shell root, because that is the composition the affordance
+   * exists in: `builder-chrome.css` scopes its box to `.nx-builder-chrome`, so a
+   * canvas with no shell around it is drawn no box and gets no control. A plain
+   * element carrying the class rather than `BuilderShell` itself — the class is
+   * the whole of what the selector asks for, and mounting the real shell would
+   * bring a rail, panels and a resize-driven layout into a file about which
+   * rectangles are measured.
    */
   function measuredCanvas(
     canvasDocument: BlockDocument,
@@ -706,18 +749,20 @@ describe("which containers it actually draws a control on", () => {
     withFakeResizeObserver();
 
     const { container } = render(
-      <Canvas
-        document={canvasDocument}
-        siteStyles={SITE_STYLES}
-        overlay={
-          <EmptyContainerAppenders
-            document={overlayDocument}
-            slots={registrySlotSource()}
-            blocks={{ get: () => undefined }}
-            onAppend={() => undefined}
-          />
-        }
-      />
+      <div className={BUILDER_CHROME_CLASS}>
+        <Canvas
+          document={canvasDocument}
+          siteStyles={SITE_STYLES}
+          overlay={
+            <EmptyContainerAppenders
+              document={overlayDocument}
+              slots={registrySlotSource()}
+              blocks={{ get: () => undefined }}
+              onAppend={() => undefined}
+            />
+          }
+        />
+      </div>
     );
 
     layout(container, boxes);
@@ -749,6 +794,93 @@ describe("which containers it actually draws a control on", () => {
     expect(drawnAt("Wide box")).toEqual(["178px", "78px", "44px", "44px"]);
     expect(
       screen.queryByRole("button", { name: "Add a block to Closed section" })
+    ).toBeNull();
+  });
+
+  it("draws NO control on a canvas with no builder shell around it", () => {
+    /*
+     * The third ancestor condition of the stylesheet's rule, and the only one
+     * nothing else answers. `EmptyContainerAppenders` and `Canvas` are both
+     * exported, so a host can compose them with no shell at all — the product
+     * path does not, since `BlocksField` mounts the canvas inside
+     * `BuilderShell`, but nothing prevents it. `builder-chrome.css` scopes its
+     * 44px box to `.nx-builder-chrome`, so in that composition the container
+     * keeps its natural size of nothing and a control drawn on the element-level
+     * match alone is a zero-area button: focusable, announced by name, and
+     * invisible.
+     *
+     * TWO canvases in one render, because an absence assertion on its own is
+     * satisfied by a component that drew nothing anywhere. The shelled one holds
+     * the identical container type and IS drawn, in the same render and the same
+     * measurement pass, so the query is known to find a button here.
+     *
+     * The bare container is additionally checked to satisfy the element-level
+     * half of the rule — it exists, it carries the slots marker, it is `:empty`
+     * — so what is being read below is the ancestor condition refusing rather
+     * than a node that never rendered.
+     */
+    registerShapes();
+    withFakeResizeObserver();
+
+    const container = (id: string, name: string): BlockDocument => ({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id,
+          type: "acme/empty-container-appender-box",
+          version: 1,
+          props: {},
+          name,
+        },
+      ],
+    });
+    const shelled = container("shelled", "Shelled box");
+    const bare = container("bare", "Bare box");
+    const appenders = (document: BlockDocument) => (
+      <EmptyContainerAppenders
+        document={document}
+        slots={registrySlotSource()}
+        blocks={{ get: () => undefined }}
+        onAppend={() => undefined}
+      />
+    );
+
+    const { container: rendered } = render(
+      <>
+        <div className={BUILDER_CHROME_CLASS}>
+          <Canvas
+            document={shelled}
+            siteStyles={SITE_STYLES}
+            overlay={appenders(shelled)}
+          />
+        </div>
+        <Canvas
+          document={bare}
+          siteStyles={SITE_STYLES}
+          overlay={appenders(bare)}
+        />
+      </>
+    );
+
+    layout(rendered, { shelled: { x: 0, y: 0, width: 400, height: 200 } }, 0);
+    layout(rendered, { bare: { x: 0, y: 0, width: 400, height: 200 } }, 1);
+    // Every overlay in the render, not the newest: each canvas subscribes its
+    // own observer, and firing one leaves the other never measured — which would
+    // make the absence below a statement about a pass that did not happen.
+    for (const observer of FakeResizeObserver.instances) {
+      act(() => observer.fire());
+    }
+
+    const bareElement = canvasRootIn(rendered, 1).querySelector(
+      `[${NODE_ID_ATTRIBUTE}="bare"]`
+    );
+    expect(bareElement).not.toBeNull();
+    expect(bareElement?.matches(`[${SLOTS_ATTRIBUTE}]:empty`)).toBe(true);
+
+    expect(drawnAt("Shelled box")).toEqual(["178px", "78px", "44px", "44px"]);
+    expect(
+      screen.queryByRole("button", { name: "Add a block to Bare box" })
     ).toBeNull();
   });
 
@@ -880,6 +1012,92 @@ describe("which containers it actually draws a control on", () => {
     });
 
     expect(drawnAt("Clipped box")).toEqual(["178px", "178px", "44px", "44px"]);
+  });
+
+  it("re-measures when a site style recompiles inside the canvas", async () => {
+    /*
+     * The change no other subscription can see: a recompiled site sheet arrives
+     * as a `<style>` inside the page root, and a class-driven margin or position
+     * moves an empty container while resizing nothing, scrolling nothing and
+     * finishing no transition. Only a mutation record reports it.
+     *
+     * The sheet is REPLACED rather than added, because that is what a save
+     * does, and the record it produces has the `<style>` element's text node as
+     * its target — a `characterData` record from deep inside the page, which is
+     * the shape the observer's options have to cover.
+     *
+     * The rectangle is re-stubbed and the new position asserted, so what is
+     * checked is a completed re-measurement rather than the presence of a
+     * subscription.
+     */
+    const container = measuredCanvas(NESTED, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 0, width: 400, height: 200 },
+    });
+    expect(drawnAt("Clipped box")).toEqual(["178px", "78px", "44px", "44px"]);
+
+    const root = canvasRootIn(container);
+    const sheet = document.createElement("style");
+    sheet.textContent = ".nx-pb-a { margin-top: 0 }";
+    await act(async () => {
+      root.append(sheet);
+      await flushObservers();
+    });
+
+    // The class rule now pushes the container 100px down. Nothing resized:
+    // `clipper` still reports the canvas's own box.
+    layout(container, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 100, width: 400, height: 200 },
+    });
+    await act(async () => {
+      sheet.textContent = ".nx-pb-a { margin-top: 100px }";
+      await flushObservers();
+    });
+
+    expect(drawnAt("Clipped box")).toEqual(["178px", "178px", "44px", "44px"]);
+  });
+
+  it("does NOT re-measure for a mutation of its own output", async () => {
+    /*
+     * The other half of the same subscription, and it needs its own case: the
+     * overlay draws INSIDE the subtree it observes, so an observer with no
+     * exclusion has every measurement schedule the next one off the DOM writes
+     * that measurement just made.
+     *
+     * Driven the same way as the case above and asserted the opposite way
+     * round: the rectangle is re-stubbed so a re-measure WOULD move the control,
+     * and then a mutation is made inside the overlay's own layer. The control
+     * staying where it was is the exclusion working — and the previous test is
+     * what proves this fixture can move it at all, since an assertion that
+     * nothing happened is satisfied by an observer that never fires for
+     * anything.
+     *
+     * The mutation is the shape the overlay's own render produces — the `style`
+     * attribute of a drawn button being written — and it is written back with
+     * the value it already carries, so the mutation record is the only thing
+     * that can move this assertion. A write that changed the position would be
+     * asserting its own edit rather than whether a measurement ran.
+     */
+    const container = measuredCanvas(NESTED, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 0, width: 400, height: 200 },
+    });
+    expect(drawnAt("Clipped box")).toEqual(["178px", "78px", "44px", "44px"]);
+
+    layout(container, {
+      wide: { x: 0, y: 0, width: 400, height: 200 },
+      clipped: { x: 0, y: 100, width: 400, height: 200 },
+    });
+    const drawn = screen.getByRole("button", {
+      name: "Add a block to Clipped box",
+    });
+    await act(async () => {
+      drawn.setAttribute("style", drawn.getAttribute("style") ?? "");
+      await flushObservers();
+    });
+
+    expect(drawnAt("Clipped box")).toEqual(["178px", "78px", "44px", "44px"]);
   });
 
   it("keeps the control inside a container narrower than it", () => {

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -17,11 +17,20 @@
  * `toBeEmptyDOMElement` is not available and every assertion below reaches for
  * a plain vitest one instead.
  */
-import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { CANVAS_ROOT_CLASS, Canvas } from "./canvas";
 import { EmptyContainerAppenders } from "./empty-container-appender";
+import { registrySlotSource } from "./inserter";
 
 // This suite queries by role against the whole document (`screen`), so a tree
 // left mounted by one test is still there for the next `getByRole` to trip
@@ -29,6 +38,8 @@ import { EmptyContainerAppenders } from "./empty-container-appender";
 // both call this between cases.
 afterEach(() => {
   cleanup();
+  clearBlocks();
+  vi.unstubAllGlobals();
 });
 
 // Two container TYPES, not just two nodes of one type — `core/card` exists so
@@ -202,5 +213,137 @@ describe("the empty-container appender", () => {
     expect(screen.getAllByRole("button")).toHaveLength(1);
     fireEvent.click(screen.getByRole("button", { name: /Card/ }));
     expect(onAppend).toHaveBeenCalledWith("card-2");
+  });
+});
+
+/**
+ * A stand-in for `ResizeObserver`, which jsdom does not implement.
+ *
+ * Mirrors `spacing-overlay.test.tsx`'s own fake for the same reason: these
+ * tests assert the SUBSCRIPTION rather than the redraw, since jsdom never
+ * reflows and so can never produce the resize the real observer would report.
+ */
+class FakeResizeObserver {
+  static instances: FakeResizeObserver[] = [];
+  readonly observed: Element[] = [];
+  disconnected = false;
+  constructor(_callback: ResizeObserverCallback) {
+    FakeResizeObserver.instances.push(this);
+  }
+  observe(target: Element): void {
+    this.observed.push(target);
+  }
+  unobserve(): void {}
+  disconnect(): void {
+    this.disconnected = true;
+  }
+}
+
+function withFakeResizeObserver() {
+  FakeResizeObserver.instances = [];
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+}
+
+describe("what it stays subscribed to", () => {
+  /**
+   * A real container and a real leaf, registered so `Canvas` renders an
+   * actual tree with `NODE_ID_ATTRIBUTE` markers this suite's own `doc`/
+   * `blocks` fixtures never produce — the bare-render tests above assert this
+   * component's OWN behaviour and deliberately mount no canvas at all, but
+   * "which elements a resize is watched on" is a question only a rendered
+   * canvas root can answer.
+   */
+  function registerCanvasBlocks() {
+    if (hasBlock("acme/empty-container-appender-box")) return;
+    registerBlocks(
+      [
+        {
+          name: "acme/empty-container-appender-box",
+          version: 1,
+          description: "A container with one slot.",
+          example: { props: {} },
+          slots: { children: {} },
+          // Typed with the one shape this fixture reads, rather than the
+          // full `BlockRenderArgs` — matching how `EmptyContainerAppenders`
+          // itself narrows to `BlockLookup` above, and how it is discarded
+          // anyway by `as never` below; the annotation only exists so `tsc`
+          // can check the destructure rather than reporting an implicit `any`.
+          render: ({
+            className,
+            renderSlot,
+          }: {
+            className: string;
+            renderSlot: (name: string) => React.ReactNode;
+          }) =>
+            React.createElement("div", { className }, renderSlot("children")),
+        },
+        {
+          name: "acme/empty-container-appender-leaf",
+          version: 1,
+          description: "A leaf with nothing to fill.",
+          example: { props: {} },
+          render: () => React.createElement("p", null, "leaf"),
+        },
+      ] as never,
+      { source: "empty-container-appender-test" }
+    );
+  }
+
+  const CANVAS_DOCUMENT = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "empty-container",
+        type: "acme/empty-container-appender-box",
+        version: 1,
+        props: {},
+      },
+      {
+        id: "sibling-leaf",
+        type: "acme/empty-container-appender-leaf",
+        version: 1,
+        props: {},
+      },
+    ],
+  } as unknown as BlockDocument;
+
+  it("watches EVERY rendered node, not only the container it draws a control for", () => {
+    // The separating property for this fix: a populated sibling resizing —
+    // an image finishing its load — moves nothing this component drew a
+    // control for and nothing the canvas root itself reports, so an observer
+    // scoped to only the empty containers never fires. `sibling-leaf` is
+    // never empty and gets no button, and it must still be observed.
+    registerCanvasBlocks();
+    withFakeResizeObserver();
+
+    const { container } = render(
+      <Canvas
+        document={CANVAS_DOCUMENT}
+        siteStyles={{ css: "", classes: {} } as never}
+        overlay={
+          <EmptyContainerAppenders
+            document={CANVAS_DOCUMENT}
+            slots={registrySlotSource()}
+            // The accessible name is not what this test asks about; a lookup
+            // that resolves nothing still exercises which nodes get a
+            // control, since that decision comes from `slots` alone.
+            blocks={{ get: () => undefined }}
+            onAppend={() => undefined}
+          />
+        }
+      />
+    );
+
+    const observer = FakeResizeObserver.instances.at(-1);
+    expect(observer?.observed).toContain(
+      container.querySelector(`[${NODE_ID_ATTRIBUTE}="empty-container"]`)
+    );
+    expect(observer?.observed).toContain(
+      container.querySelector(`[${NODE_ID_ATTRIBUTE}="sibling-leaf"]`)
+    );
+    expect(observer?.observed).toContain(
+      container.querySelector(`.${CANVAS_ROOT_CLASS}`)
+    );
   });
 });

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -31,14 +31,24 @@ afterEach(() => {
   cleanup();
 });
 
+// Two container TYPES, not just two nodes of one type — `core/card` exists so
+// the cardinality tests below can name each control by a distinct accessible
+// name rather than by an assumption about array or DOM order.
 const slots = {
   slotsOf: (type: string) =>
-    type === "core/box" ? (["children"] as const) : undefined,
+    type === "core/box" || type === "core/card"
+      ? (["children"] as const)
+      : undefined,
 };
 
+// No cast: `LabelledBlock` asks for nothing beyond `editor?.label`, so this
+// honest, minimal fixture satisfies `BlockLookup` on its own.
 const blocks = {
-  get: (type: string) =>
-    type === "core/box" ? ({ editor: { label: "Box" } } as never) : undefined,
+  get: (type: string) => {
+    if (type === "core/box") return { editor: { label: "Box" } };
+    if (type === "core/card") return { editor: { label: "Card" } };
+    return undefined;
+  },
 };
 
 function doc(nodes: BlockDocument["nodes"]): BlockDocument {
@@ -121,5 +131,76 @@ describe("the empty-container appender", () => {
       />
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  it("gives two sibling empty containers their own control, reporting its own id", () => {
+    // Cardinality, not just presence: a filled container sits BETWEEN the two
+    // empty ones, so an implementation that stopped at the first match would
+    // still show a control here — just one short of the right count. Asserting
+    // the count alone would also pass an implementation offering two controls
+    // for the SAME node, which is why each press is checked against its own id
+    // below rather than trusting the count on its own.
+    const emptyCard = {
+      id: "card-1",
+      type: "core/card",
+      version: 1,
+      props: {},
+    };
+    const onAppend = vi.fn();
+    render(
+      <EmptyContainerAppenders
+        document={doc([emptyBox, filledBox, emptyCard])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={onAppend}
+      />
+    );
+
+    expect(screen.getAllByRole("button")).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole("button", { name: /Box/ }));
+    expect(onAppend).toHaveBeenLastCalledWith("box-1");
+    fireEvent.click(screen.getByRole("button", { name: /Card/ }));
+    expect(onAppend).toHaveBeenLastCalledWith("card-1");
+  });
+
+  it("finds a container nested inside another container's populated slot", () => {
+    // The specific claim `emptyContainersIn`'s use of `walkNodes` is for: it
+    // descends into every slot of every node regardless of whether that node
+    // itself offers a control, so a still-empty container sitting AFTER a
+    // filled sibling, inside another container's own slot, is still found.
+    const nestedEmptyCard = {
+      id: "card-2",
+      type: "core/card",
+      version: 1,
+      props: {},
+    };
+    const outerBoxWithPopulatedSlot = {
+      id: "box-3",
+      type: "core/box",
+      version: 1,
+      props: {},
+      slots: {
+        children: [
+          { id: "h2", type: "core/heading", version: 1, props: {} },
+          nestedEmptyCard,
+        ],
+      },
+    };
+    const onAppend = vi.fn();
+    render(
+      <EmptyContainerAppenders
+        document={doc([outerBoxWithPopulatedSlot])}
+        slots={slots}
+        blocks={blocks}
+        onAppend={onAppend}
+      />
+    );
+
+    // The outer box already has children, so IT offers nothing; only the
+    // nested card, which has none of its own, does — one control, not zero.
+    expect(screen.getAllByRole("button")).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: /Card/ }));
+    expect(onAppend).toHaveBeenCalledWith("card-2");
   });
 });

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -127,13 +127,14 @@
  * and it has three answers rather than two:
  *
  * - MEASURED — the pass found the element, accepted it, and holds a rectangle.
- * - DECLINED — the pass found the element and refused it: the stylesheet drew
- *   no box for it (see the section above), or an authored ancestor clips it
- *   (see `measure`). Both are re-decided on every pass, so this is a refusal
- *   for as long as the render keeps this shape, not a permanent one.
- * - UNMEASURED — no pass has reached this container. The canvas root has not
- *   mounted, a resize has not settled, or the element was not in the DOM when
- *   the pass ran.
+ * - DECLINED — the pass reached this container and refused it, for one of
+ *   three reasons: the render produced no element for it at all, the
+ *   stylesheet drew no box for the element it did produce (see the section
+ *   above), or an authored ancestor clips it (see `measure`). All three are
+ *   re-decided on every pass, so each is a refusal for as long as the render
+ *   keeps this shape rather than a permanent one.
+ * - UNMEASURED — no pass has run at all, because there is no canvas root to
+ *   run one against. Nothing has been asked about any container yet.
  *
  * An UNMEASURED control RENDERS, at `{ x: 0, y: 0, width: 0, height: 0 }`,
  * which is the property this section exists to protect: a control an author
@@ -152,7 +153,10 @@
  * and invisible. `.nx-empty-container-appenders__button` is `display: flex`
  * and `pointer-events: auto`, and its `:focus-visible` rule would draw an
  * outline on a box with no area. A `core/accordion-item` whose `children` slot
- * is empty reaches that state from its own `defaultProps`.
+ * is empty reaches that state from its own `defaultProps`, and so does any
+ * node `PageRenderer` leaves out of the tree it draws — one carrying
+ * `visibility.conditions`, or one whose props make it draw nothing — which the
+ * document goes on listing for as long as the author keeps it.
  *
  * The two used to share one representation — no entry in the measurement map —
  * so "not yet" and "never" were the same value and the second inherited the
@@ -181,12 +185,8 @@ import {
   type ReactElement,
 } from "react";
 
-import {
-  CANVAS_ROOT_CLASS,
-  CHROME_ATTRIBUTE,
-  nodeElement,
-  nodeElements,
-} from "./canvas";
+import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE, nodeElement } from "./canvas";
+import { watchCanvasGeometry } from "./canvas-geometry-watch";
 import { EMPTY_CONTAINER_SELECTOR, emptySlotOf } from "./empty-slot";
 import type { Rect } from "./geometry";
 import {
@@ -306,8 +306,9 @@ const UNMEASURED_RECT: Rect = { x: 0, y: 0, width: 0, height: 0 };
  *
  * A refusal is a value here rather than the absence of one, because absence
  * already means something else — see the module docblock's three states. Both
- * members are recorded by `measure`, and a container it never got to is left
- * out of the map entirely.
+ * members are recorded by `measure`, which records one for EVERY container it
+ * is handed once it has a root: the map is empty only where there was no root
+ * to run a pass against.
  */
 type RecordedPlacement =
   | { readonly kind: "measured"; readonly rect: Rect }
@@ -462,12 +463,29 @@ export function EmptyContainerAppenders({
     for (const container of containers) {
       const target = nodeElement(root, container.id);
       /*
-       * Left out of the map rather than declined. A container the document
-       * has and the canvas has not rendered yet is UNMEASURED — nothing has
-       * been decided about it — and its control still renders at the zero
-       * rectangle, which is the state the module docblock protects.
+       * DECLINED rather than left out. This pass HAS a canvas root and has
+       * just searched it, so an id with no element is a container the render
+       * does not produce — not one it has not produced yet. `PageRenderer`
+       * drops whole subtrees before drawing anything: a node carrying
+       * `visibility.conditions` is omitted from output, and so is one whose
+       * props make it draw nothing. Neither ever reaches the DOM, however long
+       * this waits, so recording nothing would leave a zero-sized button in
+       * the tab order — announced by name, focusable, and pointing at content
+       * that is not on the canvas.
+       *
+       * That leaves absence from the map meaning only "no pass has run",
+       * which is the `root === null` return above and the one case where a
+       * control genuinely is waiting to be placed.
+       *
+       * Re-decided on the next pass exactly like the two refusals below: a
+       * container that starts rendering — a condition that begins to hold, an
+       * edit that gives the node markup — gets its control back as soon as
+       * anything re-measures.
        */
-      if (target === null) continue;
+      if (target === null) {
+        next.set(container.id, DECLINED);
+        continue;
+      }
       /*
        * The stylesheet's own condition, asked of the element the stylesheet
        * would ask it of — not a second condition computed here.
@@ -536,18 +554,23 @@ export function EmptyContainerAppenders({
   }, [measure, hidden, document]);
 
   /*
-   * Re-measure for a resize no render reports: a breakpoint driven by the
-   * canvas's own width, a rail panel opening, a webfont swapping in.
+   * Re-measure for the changes no render reports, all of them: a resize with
+   * no render behind it (a breakpoint driven by the canvas's own width, a rail
+   * panel opening, a webfont swapping in) and a move with no resize at all (a
+   * scroller between the container and the root, a transition finishing on a
+   * neighbour). Both move a control off the container it names, and the second
+   * kind is invisible to every observer.
    *
-   * EVERY rendered node is observed, not only the containers this overlay
-   * draws a control for — matching `SpacingOverlay`, which observes the same
-   * way for the same reason: what moves a container is often a SIBLING
-   * changing size rather than the container itself. An image finishing its
-   * load resizes that sibling and nothing else — not the empty container
-   * beside it, and not the root, which is `min-height: 100%` and can absorb
-   * the change while reporting nothing. An observer scoped to only the found
-   * containers never fires for that resize, and the control is left drawn
-   * over the coordinates the layout had before it.
+   * `watchCanvasGeometry` owns the whole list rather than this file
+   * subscribing to the part it happened to think of. The one subscription this
+   * overlay does NOT want is a `MutationObserver`, and that is what keeps it
+   * out of the shared helper: drawing a control is itself a mutation of the
+   * observed subtree, so adopting one means owning a rule for which mutations
+   * are this overlay's own. `SpacingOverlay` keeps such a rule beside its own
+   * call. The cost of leaving it out is stated rather than hidden: a
+   * recompiled site sheet moves blocks through changed class rules, and a
+   * control over one stays where it was until the next resize, scroll,
+   * transition or edit.
    */
   useEffect(() => {
     if (hidden || containers.length === 0) return;
@@ -555,14 +578,7 @@ export function EmptyContainerAppenders({
     const root =
       element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
     if (root === null) return;
-    // Absent in jsdom unless a test supplies one, and absent in older
-    // browsers. A missing observer costs a re-measure, not correctness —
-    // every render path above still measures.
-    if (typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => measure());
-    observer.observe(root);
-    for (const node of nodeElements(root)) observer.observe(node);
-    return () => observer.disconnect();
+    return watchCanvasGeometry(root, measure);
   }, [measure, hidden, containers, document]);
 
   // `hidden` renders NOTHING, matching how `BlockToolbar` is suppressed during

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -136,11 +136,12 @@
  *
  * - MEASURED — the pass found the element, accepted it, and holds a rectangle.
  * - DECLINED — the pass reached this container and refused it, for one of
- *   three reasons: the render produced no element for it at all, the
+ *   four reasons: the render produced no element for it at all, the
  *   stylesheet drew no box for the element it did produce (see the section
- *   above), or an authored ancestor clips it (see `measure`). All three are
- *   re-decided on every pass, so each is a refusal for as long as the render
- *   keeps this shape rather than a permanent one.
+ *   above), the author positioned it against the VIEWPORT rather than against
+ *   the page, or an authored ancestor clips it (the last two: see `measure`).
+ *   All four are re-decided on every pass, so each is a refusal for as long as
+ *   the render keeps this shape rather than a permanent one.
  * - UNMEASURED — no pass has run at all, because there is no canvas root to
  *   run one against. Nothing has been asked about any container yet.
  *
@@ -201,6 +202,7 @@ import {
   canvasContentRect,
   canvasRootFrom,
   clippedByAncestorRect,
+  viewportPositioned,
 } from "./geometry-dom";
 import type { SlotSource } from "./inserter";
 import { authoredName } from "./layers";
@@ -485,7 +487,7 @@ export function EmptyContainerAppenders({
        * which is the `root === null` return above and the one case where a
        * control genuinely is waiting to be placed.
        *
-       * Re-decided on the next pass exactly like the two refusals below: a
+       * Re-decided on the next pass exactly like the three refusals below: a
        * container that starts rendering — a condition that begins to hold, an
        * edit that gives the node markup — gets its control back as soon as
        * anything re-measures.
@@ -521,6 +523,32 @@ export function EmptyContainerAppenders({
        * happens to be about this element.
        */
       if (!target.matches(EMPTY_CONTAINER_SELECTOR)) {
+        next.set(container.id, DECLINED);
+        continue;
+      }
+      /*
+       * Positioned against the VIEWPORT rather than against the page this
+       * overlay draws in, which is a container no control can be anchored to.
+       *
+       * `position` is a catalog keyword, so `fixed` and `sticky` are values an
+       * author stores like any other. Both hold the container still while the
+       * canvas content under it travels, so the square measured here slides off
+       * the container on the first scroll and comes to rest over unrelated
+       * content — taking the presses meant for that content with it, since this
+       * button is one of the two pieces of chrome that accept pointer events.
+       *
+       * Nothing corrects the drift, which is why it is refused instead of
+       * re-measured: the shell scrolls a section ABOVE the canvas root and a
+       * scroll event does not bubble, so `watchCanvasFor`'s capture-phase
+       * listener on the root reaches a scroller nested INSIDE the canvas and
+       * never hears that one.
+       *
+       * The same predicate `SpacingOverlay` refuses on, asked here rather than
+       * `position` being read a second time — see `viewportPositioned` in
+       * `geometry-dom.ts` for why that question belongs to the coordinate space
+       * rather than to either overlay.
+       */
+      if (viewportPositioned(target)) {
         next.set(container.id, DECLINED);
         continue;
       }

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -64,11 +64,7 @@
  * @module empty-container-appender
  */
 
-import {
-  walkNodes,
-  type AnyBlockDefinition,
-  type BlockDocument,
-} from "@nextlyhq/blocks-engine";
+import { walkNodes, type BlockDocument } from "@nextlyhq/blocks-engine";
 import { Plus } from "lucide-react";
 import {
   useCallback,
@@ -87,15 +83,34 @@ import { canvasContentRect, canvasRootFrom } from "./geometry-dom";
 import type { SlotSource } from "./inserter";
 
 /**
- * Resolves a block type to its definition.
+ * The one property this component ever reads off a block's definition.
  *
- * Named apart from `AnyBlockDefinition` because it is the SHAPE this component
- * needs, not the registry's own interface: a caller may hand it the live
+ * A block's full definition (`AnyBlockDefinition` in `@nextlyhq/blocks-engine`)
+ * requires `name`, `version`, `description`, `example`, `render` and more —
+ * none of which `nameOf` below touches. Narrowed to just the field actually
+ * read, so a fixture standing in for one is an honest, minimal object rather
+ * than a full definition wearing a cast to get past the compiler.
+ *
+ * Still satisfied by the real thing with no adapter: `AnyBlockDefinition`'s
+ * own `editor` field is `BlockEditorMeta`, which carries more than this needs
+ * but remains structurally assignable to it, so the live registry's
+ * `getBlock` — returning `AnyBlockDefinition | undefined` — is a valid
+ * `BlockLookup["get"]` as it stands.
+ */
+interface LabelledBlock {
+  readonly editor?: { readonly label?: string };
+}
+
+/**
+ * Resolves a block type to (at most) the one property this component reads.
+ *
+ * Named apart from `AnyBlockDefinition` — the registry's own interface — for
+ * the same reason `LabelledBlock` is narrowed: a caller may hand this the live
  * registry (`{ get: getBlock }`) or a plain fixture with nothing registered,
- * and both satisfy this with no adapter in between.
+ * and both satisfy it with no adapter in between.
  */
 interface BlockLookup {
-  get(type: string): AnyBlockDefinition | undefined;
+  get(type: string): LabelledBlock | undefined;
 }
 
 /** One container this component offers a control for, and its accessible name. */

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -76,11 +76,47 @@
  * need of `clippedByAncestor`'s corner-aware refinement — see `measure` for
  * why asking that stricter question here would cost more than it protects.
  *
- * For the ordinary case — a block declaring one slot, empty — this changes
- * nothing an author can see: `builder-chrome.css`'s `[data-nx-slots]:empty`
- * rule already gives such a container a 44px box, so centring a 44px square
- * inside its own measured rectangle places the control exactly where that box
- * already is.
+ * For the ordinary case this changes nothing an author can see: the container
+ * the control is drawn on is one `builder-chrome.css` has already given a 44px
+ * box, so centring a 44px square inside its measured rectangle places the
+ * control exactly where that box already is. That sentence is only true
+ * because of the condition below, which is what makes the box's presence a
+ * guarantee rather than an assumption.
+ *
+ * ## Which containers get a control is the STYLESHEET's question
+ *
+ * `emptySlotOf` decides which containers this component knows about, and that
+ * is a question about the stored document. Whether an affordance is drawn is a
+ * question about the RENDER, and `builder-chrome.css` already asks it:
+ * {@link EMPTY_CONTAINER_SELECTOR}. `measure` asks the same one of the same
+ * element rather than trusting the two to describe the same containers.
+ *
+ * They do not. A node can have an empty slot inside a root that renders
+ * content of its own — `core/accordion-item` puts a `<summary>` beside its
+ * slot, so a closed one has an empty `children` slot and a root that is not
+ * `:empty`. The stylesheet declined such a container, this component did not,
+ * and the fixed-size control was then centred in a rectangle sized by the
+ * summary rather than by a box that was never drawn. A node rendering several
+ * slots is the same shape: its root is not `:empty` while a later slot holds
+ * anything, which is precisely when a control over its centre would sit on a
+ * populated region.
+ *
+ * The consequence is that a container carrying no visual affordance gets no
+ * control either, which is the point rather than a shortfall — it is still
+ * fillable, because selecting it and inserting routes through `emptySlotOf`
+ * in `insertionPointFor` exactly as before.
+ *
+ * ## Never outside its own container
+ *
+ * The control is additionally CLAMPED to the measured rectangle, because the
+ * stylesheet guarantees a minimum height and not a minimum width. An empty
+ * container narrower than the control is legitimate — a narrow column — and an
+ * unclamped square centred in it hangs over both edges, onto whatever sits
+ * beside it. Since the overlay paints in document order, a control that
+ * escapes its own container lands on top of an earlier sibling and takes the
+ * press meant for it. The full-bleed button this replaced could not do that;
+ * containment is the property that had to be kept when the size stopped
+ * matching the container.
  *
  * ## Identity is independent of geometry, and has to stay that way
  *
@@ -122,7 +158,7 @@ import {
   nodeElement,
   nodeElements,
 } from "./canvas";
-import { emptySlotOf } from "./empty-slot";
+import { EMPTY_CONTAINER_SELECTOR, emptySlotOf } from "./empty-slot";
 import type { Rect } from "./geometry";
 import {
   canvasContentRect,
@@ -249,17 +285,29 @@ const NO_RECTS: ReadonlyMap<string, Rect> = new Map();
 const APPENDER_SIZE_PX = 44;
 
 /**
- * A fixed {@link APPENDER_SIZE_PX} square, centred inside a larger rectangle.
+ * A {@link APPENDER_SIZE_PX} square centred inside a rectangle, never larger
+ * than the rectangle itself.
  *
  * See the module docblock ("A fixed, centred square") for why the button is
- * never sized to the measured rectangle itself.
+ * not sized to the measured rectangle, and ("Never outside its own container")
+ * for why it is clamped to it. Exported for its own tests: it is arithmetic on
+ * two rectangles with no DOM in it, so it is the one part of this file's
+ * geometry that can be asserted directly.
+ *
+ * The clamp is per axis because the guarantee is per axis. The stylesheet's
+ * `min-height` makes the ordinary container at least as tall as the control,
+ * so `Math.min` returns `size` and the result is byte-identical to an
+ * unclamped one; there is no `min-width`, so a legitimately narrow empty
+ * container — a column a few pixels wide — is the case that needs it.
  */
-function centeredControlRect(rect: Rect, size: number): Rect {
+export function centeredControlRect(rect: Rect, size: number): Rect {
+  const width = Math.min(size, rect.width);
+  const height = Math.min(size, rect.height);
   return {
-    x: rect.x + (rect.width - size) / 2,
-    y: rect.y + (rect.height - size) / 2,
-    width: size,
-    height: size,
+    x: rect.x + (rect.width - width) / 2,
+    y: rect.y + (rect.height - height) / 2,
+    width,
+    height,
   };
 }
 
@@ -360,6 +408,21 @@ export function EmptyContainerAppenders({
        * question here would decline the control for exactly the composition
        * an author reaches for most.
        */
+      /*
+       * The stylesheet's own condition, asked of the element the stylesheet
+       * would ask it of — not a second condition computed here.
+       *
+       * `emptySlotOf` decided WHICH containers this component knows about,
+       * from the document. That is a different population from the one
+       * `builder-chrome.css` draws its 44px box for, and the module docblock
+       * above depends on them being the same: a container the stylesheet
+       * declined has no box, so a control centred in its measured rectangle is
+       * centred in whatever that block happens to render instead. A closed
+       * `core/accordion-item` is the first-party case — an empty `children`
+       * slot inside a root that also renders a `<summary>`, so the root is not
+       * `:empty` and measures the summary's own height.
+       */
+      if (!target.matches(EMPTY_CONTAINER_SELECTOR)) continue;
       if (clippedByAncestorRect(target, root)) continue;
       const measured = canvasContentRect(target, root);
       next.set(container.id, centeredControlRect(measured, APPENDER_SIZE_PX));

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -136,12 +136,14 @@
  *
  * - MEASURED — the pass found the element, accepted it, and holds a rectangle.
  * - DECLINED — the pass reached this container and refused it, for one of
- *   four reasons: the render produced no element for it at all, the
+ *   five reasons: the render produced no element for it at all; the
  *   stylesheet drew no box for the element it did produce (see the section
- *   above), the author positioned it against the VIEWPORT rather than against
- *   the page, or an authored ancestor clips it (the last two: see `measure`).
- *   All four are re-decided on every pass, so each is a refusal for as long as
- *   the render keeps this shape rather than a permanent one.
+ *   above); the render laid out no box for that element, because something
+ *   between it and the root generates none; the author positioned it against
+ *   the VIEWPORT rather than against the page; or an authored ancestor clips
+ *   it. `measure` states each one where it is asked. All five are re-decided
+ *   on every pass, so each is a refusal for as long as the render keeps this
+ *   shape rather than a permanent one.
  * - UNMEASURED — no pass has run at all, because there is no canvas root to
  *   run one against. Nothing has been asked about any container yet.
  *
@@ -202,6 +204,7 @@ import {
   canvasContentRect,
   canvasRootFrom,
   clippedByAncestorRect,
+  layoutFragments,
   viewportPositioned,
 } from "./geometry-dom";
 import type { SlotSource } from "./inserter";
@@ -523,6 +526,44 @@ export function EmptyContainerAppenders({
        * happens to be about this element.
        */
       if (!target.matches(EMPTY_CONTAINER_SELECTOR)) {
+        next.set(container.id, DECLINED);
+        continue;
+      }
+      /*
+       * The render lays out no box for this element, so there is nothing on
+       * the canvas for a control to be anchored to.
+       *
+       * `getBoundingClientRect` still answers for such an element — with the
+       * zero rectangle — so measuring on would centre a square of no area at
+       * the canvas origin. That is the same focusable, named, invisible button
+       * the refusals around this one exist to prevent, arriving through an
+       * element the render kept and never laid out.
+       *
+       * An ANCESTOR is what puts a container here. Its own `display` cannot:
+       * `builder-chrome.css` gives the very selector matched above
+       * `display: block` at five compound units of specificity, outranking the
+       * three of the per-node rule an author's `display: none` or
+       * `display: contents` compiles into — measured in Chromium, a container
+       * carrying either still computed to `block` and generated its box. A
+       * node BETWEEN this one and the root is under no such rule, because a
+       * node holding a child is not `:empty`, so an author who hides a wrapper
+       * leaves every empty container inside it rendered, matching, and
+       * generating nothing. Where that rule is not in force at all the
+       * element's own keyword reaches this too, and the answer is the same.
+       *
+       * `layoutFragments` rather than a rectangle's area judged here. Whether
+       * an element generates a box is `geometry-dom.ts`'s question and
+       * `SpacingOverlay` already refuses on the same answer; the area is a
+       * consequence of it rather than a second reading, since the rule matched
+       * above draws a dashed border and a 2.75rem minimum height, so an
+       * element that generates a box measures more than nothing.
+       *
+       * Re-decided on the next pass like every refusal beside it: an edit that
+       * un-hides the wrapper changes `document`, and a recompiled sheet that
+       * does the same reaches the `MutationObserver` in `watchCanvasFor`, so
+       * either way something re-measures and the control comes back.
+       */
+      if (layoutFragments(target) === 0) {
         next.set(container.id, DECLINED);
         continue;
       }

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -100,7 +100,11 @@
  * @module empty-container-appender
  */
 
-import { walkNodes, type BlockDocument } from "@nextlyhq/blocks-engine";
+import {
+  walkNodes,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
 import { Plus } from "lucide-react";
 import {
   useCallback,
@@ -126,6 +130,7 @@ import {
   clippedByAncestorRect,
 } from "./geometry-dom";
 import type { SlotSource } from "./inserter";
+import { authoredName } from "./layers";
 
 /**
  * The one property this component ever reads off a block's definition.
@@ -167,19 +172,32 @@ interface EmptyContainer {
 /**
  * The name this control announces for the block it would fill.
  *
- * `editor.label` when the block declares one. Otherwise the block's raw TYPE —
- * not a humanised guess — because this is an accessible NAME rather than a
- * palette entry: a control an author cannot name is one they cannot find, and
- * the type string names the missing block truthfully even when no definition
- * is registered to describe it at all.
+ * The AUTHORED instance name wins when the node has one — via
+ * `authoredName`, the same precedence `layerLabel` gives the Layers panel, so
+ * two empty containers of the same type an author has told apart by name are
+ * told apart here too rather than announcing as one indistinguishable
+ * control. Without one, `editor.label` when the block declares it. Otherwise
+ * the block's raw TYPE — not a humanised guess — because this is an
+ * accessible NAME rather than a palette entry: a control an author cannot
+ * name is one they cannot find, and the type string names the missing block
+ * truthfully even when no definition is registered to describe it at all.
+ *
+ * `layerLabel` itself is not called directly: it resolves the type-level
+ * fallback through the GLOBAL registry (`blockLabel`), where this component
+ * takes an injected {@link BlockLookup} so its tests need not register
+ * anything there. `authoredName` is the part of `layerLabel` that does not
+ * depend on the registry, and it is exported from `layers.ts` for exactly
+ * this reuse.
  *
  * An empty string is treated the same as an absent label: a block declaring
  * `editor: { label: "" }` has not actually named itself, and announcing an
  * empty string would leave the control with no accessible name at all.
  */
-function nameOf(type: string, blocks: BlockLookup): string {
-  const declared = blocks.get(type)?.editor?.label;
-  return declared !== undefined && declared !== "" ? declared : type;
+function nameOf(node: BlockNode, blocks: BlockLookup): string {
+  const named = authoredName(node);
+  if (named !== undefined) return named;
+  const declared = blocks.get(node.type)?.editor?.label;
+  return declared !== undefined && declared !== "" ? declared : node.type;
 }
 
 /**
@@ -201,7 +219,7 @@ function emptyContainersIn(
   const found: EmptyContainer[] = [];
   walkNodes(document.nodes, node => {
     if (emptySlotOf(node, slots) !== null) {
-      found.push({ id: node.id, label: nameOf(node.type, blocks) });
+      found.push({ id: node.id, label: nameOf(node, blocks) });
     }
   });
   return found;

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -46,6 +46,42 @@
  * against: unscaled, it is wrong by `(1 - scale) * inset`, exactly zero at
  * 100% and invisible in precisely the configuration most testing happens in.
  *
+ * ## A fixed, centred square rather than a rectangle sized to the container
+ *
+ * The button does not stretch to the measured rectangle's own width and
+ * height. It is a fixed {@link APPENDER_SIZE_PX} square centred inside it,
+ * and that is a correction rather than a style choice.
+ *
+ * `emptySlotOf` names which SLOT is empty, but there is no DOM address for
+ * "slot X of node Y" to measure — `NODE_ID_ATTRIBUTE` marks a node's whole
+ * root element, and a node with several declared slots renders all of them
+ * inside that one root. So the only rectangle measurable here is the node's
+ * entire root, whether or not every slot inside it is empty. A button sized
+ * to that rectangle sits over a POPULATED later slot exactly as much as over
+ * the empty first one, stealing the pointer clicks the populated slot's own
+ * content should get. A fixed small square anchored to the root's centre
+ * cannot do that: the worst it can overlap is a small area near the middle,
+ * never the slot's whole content.
+ *
+ * The same fix answers a second problem for free. `canvasContentRect` reports
+ * a node's rectangle whether or not an authored ancestor clips it, because
+ * clipping happens in the DOM and this overlay draws in the root's flat
+ * coordinate space above it — so a full-bleed button drawn there paints over
+ * whatever unrelated content happens to sit at the un-clipped position. A
+ * clipped container is excluded outright below (see `measure`, and
+ * `clippedByAncestorRect` in `geometry-dom.ts`), and the fixed size is what
+ * makes that exclusion cheap to reason about: declining a single small square
+ * costs far less than declining a rectangle that might have spanned most of
+ * the canvas, and a control that never reaches a container's corners has no
+ * need of `clippedByAncestor`'s corner-aware refinement — see `measure` for
+ * why asking that stricter question here would cost more than it protects.
+ *
+ * For the ordinary case — a block declaring one slot, empty — this changes
+ * nothing an author can see: `builder-chrome.css`'s `[data-nx-slots]:empty`
+ * rule already gives such a container a 44px box, so centring a 44px square
+ * inside its own measured rectangle places the control exactly where that box
+ * already is.
+ *
  * ## Identity is independent of geometry, and has to stay that way
  *
  * Which containers get a control comes from the DOCUMENT alone. Position is a
@@ -76,10 +112,19 @@ import {
   type ReactElement,
 } from "react";
 
-import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE, nodeElement } from "./canvas";
+import {
+  CANVAS_ROOT_CLASS,
+  CHROME_ATTRIBUTE,
+  nodeElement,
+  nodeElements,
+} from "./canvas";
 import { emptySlotOf } from "./empty-slot";
 import type { Rect } from "./geometry";
-import { canvasContentRect, canvasRootFrom } from "./geometry-dom";
+import {
+  canvasContentRect,
+  canvasRootFrom,
+  clippedByAncestorRect,
+} from "./geometry-dom";
 import type { SlotSource } from "./inserter";
 
 /**
@@ -174,6 +219,32 @@ const UNMEASURED_RECT: Rect = { x: 0, y: 0, width: 0, height: 0 };
 /** No controls: the identity returned before the first measurement runs. */
 const NO_RECTS: ReadonlyMap<string, Rect> = new Map();
 
+/**
+ * The control's fixed side length, in the canvas's content pixels.
+ *
+ * Matches `builder-chrome.css`'s `[data-nx-slots]:empty` rule, whose
+ * `min-height: 2.75rem` (44px) is that stylesheet's own answer to "how small
+ * can a pointer target be and still be comfortable". Reusing the number
+ * rather than picking a second one keeps the control's footprint no larger
+ * than the placeholder box it already draws attention to.
+ */
+const APPENDER_SIZE_PX = 44;
+
+/**
+ * A fixed {@link APPENDER_SIZE_PX} square, centred inside a larger rectangle.
+ *
+ * See the module docblock ("A fixed, centred square") for why the button is
+ * never sized to the measured rectangle itself.
+ */
+function centeredControlRect(rect: Rect, size: number): Rect {
+  return {
+    x: rect.x + (rect.width - size) / 2,
+    y: rect.y + (rect.height - size) / 2,
+    width: size,
+    height: size,
+  };
+}
+
 export interface EmptyContainerAppendersProps {
   /** The document to scan for containers with nothing in them. */
   document: BlockDocument;
@@ -247,9 +318,33 @@ export function EmptyContainerAppenders({
     const next = new Map<string, Rect>();
     for (const container of containers) {
       const target = nodeElement(root, container.id);
-      if (target !== null) {
-        next.set(container.id, canvasContentRect(target, root));
-      }
+      if (target === null) continue;
+      /*
+       * Excluded outright rather than measured. `clippedByAncestorRect`
+       * answers "is this element's own rectangle cut by an authored ancestor
+       * between it and the root" — a clipped container's DOM is cut where
+       * this overlay is not, so a control measured from its un-clipped
+       * rectangle would be drawn over whatever the page actually shows at
+       * that position.
+       *
+       * The RECT question rather than `clippedByAncestor`'s corner-aware one.
+       * That refinement exists for a caller drawing chrome flush against a
+       * block's edges — a spacing band runs the full length of one and does
+       * reach the corners — and this control does not: it is a fixed square
+       * anchored to the container's CENTRE, nowhere near a corner unless the
+       * container itself is barely larger than the control. Measured against
+       * an ordinary full-width child sitting flush inside a rounded, clipping
+       * parent — `core/box` directly inside `core/card`, ordinary enough that
+       * `card.tsx` names it the commonest composition in the library — the
+       * two curves genuinely disagree by a few pixels at each corner, which
+       * `clippedByAncestor` correctly reports and which is irrelevant to
+       * anything drawn away from the corners. Asking the corner-aware
+       * question here would decline the control for exactly the composition
+       * an author reaches for most.
+       */
+      if (clippedByAncestorRect(target, root)) continue;
+      const measured = canvasContentRect(target, root);
+      next.set(container.id, centeredControlRect(measured, APPENDER_SIZE_PX));
     }
     setRects(next);
   }, [containers]);
@@ -269,10 +364,17 @@ export function EmptyContainerAppenders({
 
   /*
    * Re-measure for a resize no render reports: a breakpoint driven by the
-   * canvas's own width, a rail panel opening, a webfont swapping in. Every
-   * found container is watched, not only the canvas root, because what moves
-   * a container is often a SIBLING changing size rather than the container
-   * itself.
+   * canvas's own width, a rail panel opening, a webfont swapping in.
+   *
+   * EVERY rendered node is observed, not only the containers this overlay
+   * draws a control for — matching `SpacingOverlay`, which observes the same
+   * way for the same reason: what moves a container is often a SIBLING
+   * changing size rather than the container itself. An image finishing its
+   * load resizes that sibling and nothing else — not the empty container
+   * beside it, and not the root, which is `min-height: 100%` and can absorb
+   * the change while reporting nothing. An observer scoped to only the found
+   * containers never fires for that resize, and the control is left drawn
+   * over the coordinates the layout had before it.
    */
   useEffect(() => {
     if (hidden || containers.length === 0) return;
@@ -286,10 +388,7 @@ export function EmptyContainerAppenders({
     if (typeof ResizeObserver === "undefined") return;
     const observer = new ResizeObserver(() => measure());
     observer.observe(root);
-    for (const container of containers) {
-      const target = nodeElement(root, container.id);
-      if (target !== null) observer.observe(target);
-    }
+    for (const node of nodeElements(root)) observer.observe(node);
     return () => observer.disconnect();
   }, [measure, hidden, containers, document]);
 

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -120,18 +120,47 @@
  *
  * ## Identity is independent of geometry, and has to stay that way
  *
- * Which containers get a control comes from the DOCUMENT alone. Position is a
- * later, separate refinement of WHERE to draw something that already exists:
- * a control an author cannot yet see on screen — because the canvas root has
- * not mounted, or a resize has not settled — is still a control a screen
- * reader can reach, and a test asserting it exists must not depend on a
- * browser having laid anything out. So an unmeasured control here keeps its
- * geometry at `{ x: 0, y: 0, width: 0, height: 0 }` rather than being hidden:
- * hiding it would remove it from the accessibility tree, which is exactly the
- * state every test in `empty-container-appender.test.tsx` renders in — a
- * bare component with no canvas root at all — so a hidden-until-measured
- * design would make every one of those tests fail to find a control that,
- * mounted for real, is there all along.
+ * Which containers get a control comes from the DOCUMENT alone, and
+ * {@link emptyContainersIn} has to stay that way — it reads no DOM, so a
+ * component with no canvas root still knows its whole set. What a measurement
+ * pass concludes about one of those containers is a LATER, separate question,
+ * and it has three answers rather than two:
+ *
+ * - MEASURED — the pass found the element, accepted it, and holds a rectangle.
+ * - DECLINED — the pass found the element and refused it: the stylesheet drew
+ *   no box for it (see the section above), or an authored ancestor clips it
+ *   (see `measure`). Both are re-decided on every pass, so this is a refusal
+ *   for as long as the render keeps this shape, not a permanent one.
+ * - UNMEASURED — no pass has reached this container. The canvas root has not
+ *   mounted, a resize has not settled, or the element was not in the DOM when
+ *   the pass ran.
+ *
+ * An UNMEASURED control RENDERS, at `{ x: 0, y: 0, width: 0, height: 0 }`,
+ * which is the property this section exists to protect: a control an author
+ * cannot yet see on screen is still a control a screen reader can reach, and a
+ * test asserting it exists must not depend on a browser having laid anything
+ * out. Hiding it would remove it from the accessibility tree, which is exactly
+ * the state the bare-mount cases in `empty-container-appender.test.tsx` render
+ * in — a component with no canvas root at all — so a hidden-until-measured
+ * design would make every one of those fail to find a control that, mounted
+ * for real, is there all along.
+ *
+ * A DECLINED control renders NOTHING, which is the same argument read the
+ * other way. It is not a control waiting to be placed; it is one this
+ * component has decided not to offer, so keeping it in the accessibility tree
+ * leaves a zero-sized button in the tab order — reachable, announced by name,
+ * and invisible. `.nx-empty-container-appenders__button` is `display: flex`
+ * and `pointer-events: auto`, and its `:focus-visible` rule would draw an
+ * outline on a box with no area. A `core/accordion-item` whose `children` slot
+ * is empty reaches that state from its own `defaultProps`.
+ *
+ * The two used to share one representation — no entry in the measurement map —
+ * so "not yet" and "never" were the same value and the second inherited the
+ * first's behaviour. A pass therefore records a {@link RecordedPlacement} for
+ * every container it REACHED, a rectangle or a refusal, which leaves absence
+ * meaning the one thing it can still mean. {@link controlRectFor} is the only
+ * place those three become the two things a render can do, switched
+ * exhaustively so a fourth state cannot fall through a `default` arm.
  *
  * @module empty-container-appender
  */
@@ -266,12 +295,59 @@ function emptyContainersIn(
  *
  * Zero-sized rather than absent, so an unmeasured control still occupies a
  * point in the canvas's coordinate space instead of carrying no position at
- * all — see the module docblock for why it must render regardless.
+ * all — see the module docblock for why it must render regardless. It belongs
+ * to the UNMEASURED state alone: a declined container draws nothing, so it
+ * never reaches a rectangle at all.
  */
 const UNMEASURED_RECT: Rect = { x: 0, y: 0, width: 0, height: 0 };
 
-/** No controls: the identity returned before the first measurement runs. */
-const NO_RECTS: ReadonlyMap<string, Rect> = new Map();
+/**
+ * What one measurement pass concluded about a container it REACHED.
+ *
+ * A refusal is a value here rather than the absence of one, because absence
+ * already means something else — see the module docblock's three states. Both
+ * members are recorded by `measure`, and a container it never got to is left
+ * out of the map entirely.
+ */
+type RecordedPlacement =
+  | { readonly kind: "measured"; readonly rect: Rect }
+  | { readonly kind: "declined" };
+
+/** A container's state, including the one a pass records by omission. */
+type Placement = RecordedPlacement | { readonly kind: "unmeasured" };
+
+/** The refusal, shared rather than allocated once per declined container. */
+const DECLINED: RecordedPlacement = { kind: "declined" };
+
+/** What a container absent from a pass's map is in. */
+const UNMEASURED: Placement = { kind: "unmeasured" };
+
+/** No container reached: the identity returned before any pass runs. */
+const NO_PLACEMENTS: ReadonlyMap<string, RecordedPlacement> = new Map();
+
+/**
+ * Where to draw a container's control, or `null` when it gets none.
+ *
+ * The single place a missing entry is given its meaning, so no caller has to
+ * agree with another about what one stands for. `switch` with no `default`: a
+ * fourth state would leave this able to return `undefined`, which the declared
+ * type refuses — the same property `rectCut` in `geometry-dom.ts` relies on,
+ * rather than a `default` arm that would silently absorb it.
+ */
+function controlRectFor(
+  placements: ReadonlyMap<string, RecordedPlacement>,
+  id: string
+): Rect | null {
+  const placement: Placement = placements.get(id) ?? UNMEASURED;
+  switch (placement.kind) {
+    case "measured":
+      return placement.rect;
+    case "declined":
+      return null;
+    case "unmeasured":
+      return UNMEASURED_RECT;
+  }
+}
 
 /**
  * The control's fixed side length, in the canvas's content pixels.
@@ -364,7 +440,8 @@ export function EmptyContainerAppenders({
     [document, slots, blocks]
   );
 
-  const [rects, setRects] = useState<ReadonlyMap<string, Rect>>(NO_RECTS);
+  const [placements, setPlacements] =
+    useState<ReadonlyMap<string, RecordedPlacement>>(NO_PLACEMENTS);
 
   /*
    * WHERE to draw each control, read through the same helper
@@ -378,13 +455,37 @@ export function EmptyContainerAppenders({
     const root =
       element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
     if (root === null) {
-      setRects(current => (current.size === 0 ? current : NO_RECTS));
+      setPlacements(current => (current.size === 0 ? current : NO_PLACEMENTS));
       return;
     }
-    const next = new Map<string, Rect>();
+    const next = new Map<string, RecordedPlacement>();
     for (const container of containers) {
       const target = nodeElement(root, container.id);
+      /*
+       * Left out of the map rather than declined. A container the document
+       * has and the canvas has not rendered yet is UNMEASURED — nothing has
+       * been decided about it — and its control still renders at the zero
+       * rectangle, which is the state the module docblock protects.
+       */
       if (target === null) continue;
+      /*
+       * The stylesheet's own condition, asked of the element the stylesheet
+       * would ask it of — not a second condition computed here.
+       *
+       * `emptySlotOf` decided WHICH containers this component knows about,
+       * from the document. That is a different population from the one
+       * `builder-chrome.css` draws its 44px box for, and the module docblock
+       * above depends on them being the same: a container the stylesheet
+       * declined has no box, so a control centred in its measured rectangle is
+       * centred in whatever that block happens to render instead. A closed
+       * `core/accordion-item` is the first-party case — an empty `children`
+       * slot inside a root that also renders a `<summary>`, so the root is not
+       * `:empty` and measures the summary's own height.
+       */
+      if (!target.matches(EMPTY_CONTAINER_SELECTOR)) {
+        next.set(container.id, DECLINED);
+        continue;
+      }
       /*
        * Excluded outright rather than measured. `clippedByAncestorRect`
        * answers "is this element's own rectangle cut by an authored ancestor
@@ -408,26 +509,17 @@ export function EmptyContainerAppenders({
        * question here would decline the control for exactly the composition
        * an author reaches for most.
        */
-      /*
-       * The stylesheet's own condition, asked of the element the stylesheet
-       * would ask it of — not a second condition computed here.
-       *
-       * `emptySlotOf` decided WHICH containers this component knows about,
-       * from the document. That is a different population from the one
-       * `builder-chrome.css` draws its 44px box for, and the module docblock
-       * above depends on them being the same: a container the stylesheet
-       * declined has no box, so a control centred in its measured rectangle is
-       * centred in whatever that block happens to render instead. A closed
-       * `core/accordion-item` is the first-party case — an empty `children`
-       * slot inside a root that also renders a `<summary>`, so the root is not
-       * `:empty` and measures the summary's own height.
-       */
-      if (!target.matches(EMPTY_CONTAINER_SELECTOR)) continue;
-      if (clippedByAncestorRect(target, root)) continue;
+      if (clippedByAncestorRect(target, root)) {
+        next.set(container.id, DECLINED);
+        continue;
+      }
       const measured = canvasContentRect(target, root);
-      next.set(container.id, centeredControlRect(measured, APPENDER_SIZE_PX));
+      next.set(container.id, {
+        kind: "measured",
+        rect: centeredControlRect(measured, APPENDER_SIZE_PX),
+      });
     }
-    setRects(next);
+    setPlacements(next);
   }, [containers]);
 
   // Measured before paint, matching `BlockToolbar` and `SpacingOverlay`: a
@@ -491,7 +583,11 @@ export function EmptyContainerAppenders({
       {...{ [CHROME_ATTRIBUTE]: "" }}
     >
       {containers.map(container => {
-        const rect = rects.get(container.id) ?? UNMEASURED_RECT;
+        const rect = controlRectFor(placements, container.id);
+        // A DECLINED container gets no button at all. A zero-sized one would
+        // still be reachable by keyboard and announced by name, which is a
+        // control an author can focus and never see — see the module docblock.
+        if (rect === null) return null;
         return (
           <button
             key={container.id}

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -1,0 +1,324 @@
+"use client";
+
+/**
+ * The affordance drawn over a container with nothing in it.
+ *
+ * An empty `core/box`, `core/card`, `core/section` or `core/columns` renders an
+ * element with no children, so a container that exists only to HOLD something
+ * else has no size, no visible boundary and nothing a pointer can land on.
+ * `builder-chrome.css`'s `[data-nx-slots]:empty` rule already gives it a 44px
+ * dashed box so it is not literally invisible, but a box is not a control:
+ * nothing about it says "click here", nothing names what it would hold, and
+ * pressing it only SELECTS the container rather than offering to fill it. That
+ * rule's own docblock names the remedy: "a follow-up that draws a real
+ * positioned element over each empty container, rather than styling the
+ * container itself" — this is that follow-up.
+ *
+ * This draws a labelled "+" over each such container instead. Pressing one
+ * only reports the container's id through
+ * {@link EmptyContainerAppendersProps.onAppend}; it does not select anything
+ * or open an inserter. Once a container IS selected, `insertionPointFor`
+ * already reads {@link emptySlotOf} to decide that a new block goes INSIDE it
+ * rather than beside it — so wiring a press to select-then-open needs no new
+ * targeting path, and this component needs no knowledge of the editor at all.
+ *
+ * ## One question, answered once
+ *
+ * "Which of this node's declared slots is empty" is `emptySlotOf`'s question,
+ * already asked by the inserter to decide where a chosen block lands. A second
+ * copy of that question here would agree with the inserter on the day both were
+ * written and drift afterwards — an author offered a control that the inserter
+ * then fills somewhere else, which is exactly the failure recomputing it would
+ * risk.
+ *
+ * ## Positioning follows `spacing-overlay.tsx`
+ *
+ * Both draw a rectangle over a node found by its `NODE_ID_ATTRIBUTE` address,
+ * and both need the same correction: the canvas is zoomable through CSS
+ * `zoom`, so an element's `offsetWidth` is its LAYOUT size while
+ * `getBoundingClientRect()` is its PAINTED one, and the two agree only at
+ * 100%. `canvasContentRect` (`geometry-dom.ts`) already divides the painted
+ * rectangle back down by the canvas root's own painted scale, so measuring
+ * through it — exactly as `spacing-overlay.tsx` and `block-toolbar.tsx`
+ * already do — inherits correct placement at any zoom without this file doing
+ * any scale arithmetic of its own. Computing an offset directly from a client
+ * rectangle here would be the second implementation `geometry.ts` warns
+ * against: unscaled, it is wrong by `(1 - scale) * inset`, exactly zero at
+ * 100% and invisible in precisely the configuration most testing happens in.
+ *
+ * ## Identity is independent of geometry, and has to stay that way
+ *
+ * Which containers get a control comes from the DOCUMENT alone. Position is a
+ * later, separate refinement of WHERE to draw something that already exists:
+ * a control an author cannot yet see on screen — because the canvas root has
+ * not mounted, or a resize has not settled — is still a control a screen
+ * reader can reach, and a test asserting it exists must not depend on a
+ * browser having laid anything out. So an unmeasured control here keeps its
+ * geometry at `{ x: 0, y: 0, width: 0, height: 0 }` rather than being hidden:
+ * hiding it would remove it from the accessibility tree, which is exactly the
+ * state every test in `empty-container-appender.test.tsx` renders in — a
+ * bare component with no canvas root at all — so a hidden-until-measured
+ * design would make every one of those tests fail to find a control that,
+ * mounted for real, is there all along.
+ *
+ * @module empty-container-appender
+ */
+
+import {
+  walkNodes,
+  type AnyBlockDefinition,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { Plus } from "lucide-react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactElement,
+} from "react";
+
+import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE, nodeElement } from "./canvas";
+import { emptySlotOf } from "./empty-slot";
+import type { Rect } from "./geometry";
+import { canvasContentRect, canvasRootFrom } from "./geometry-dom";
+import type { SlotSource } from "./inserter";
+
+/**
+ * Resolves a block type to its definition.
+ *
+ * Named apart from `AnyBlockDefinition` because it is the SHAPE this component
+ * needs, not the registry's own interface: a caller may hand it the live
+ * registry (`{ get: getBlock }`) or a plain fixture with nothing registered,
+ * and both satisfy this with no adapter in between.
+ */
+interface BlockLookup {
+  get(type: string): AnyBlockDefinition | undefined;
+}
+
+/** One container this component offers a control for, and its accessible name. */
+interface EmptyContainer {
+  readonly id: string;
+  readonly label: string;
+}
+
+/**
+ * The name this control announces for the block it would fill.
+ *
+ * `editor.label` when the block declares one. Otherwise the block's raw TYPE —
+ * not a humanised guess — because this is an accessible NAME rather than a
+ * palette entry: a control an author cannot name is one they cannot find, and
+ * the type string names the missing block truthfully even when no definition
+ * is registered to describe it at all.
+ *
+ * An empty string is treated the same as an absent label: a block declaring
+ * `editor: { label: "" }` has not actually named itself, and announcing an
+ * empty string would leave the control with no accessible name at all.
+ */
+function nameOf(type: string, blocks: BlockLookup): string {
+  const declared = blocks.get(type)?.editor?.label;
+  return declared !== undefined && declared !== "" ? declared : type;
+}
+
+/**
+ * Every container in the document with nothing in its first declared slot.
+ *
+ * `walkNodes` rather than a walk written here: it is cycle-safe and
+ * depth-bounded, and it descends into every slot of every node regardless of
+ * whether that node itself gets a control — so a container nested inside
+ * another empty one is still found. A hand-written recursive walk would lose
+ * that depth guarantee the first time a document was deeper than the call
+ * stack allows, which is exactly the shape a persisted document can arrive in
+ * whether or not anything validated it first.
+ */
+function emptyContainersIn(
+  document: BlockDocument,
+  slots: SlotSource,
+  blocks: BlockLookup
+): EmptyContainer[] {
+  const found: EmptyContainer[] = [];
+  walkNodes(document.nodes, node => {
+    if (emptySlotOf(node, slots) !== null) {
+      found.push({ id: node.id, label: nameOf(node.type, blocks) });
+    }
+  });
+  return found;
+}
+
+/**
+ * A rectangle with no measurement yet.
+ *
+ * Zero-sized rather than absent, so an unmeasured control still occupies a
+ * point in the canvas's coordinate space instead of carrying no position at
+ * all — see the module docblock for why it must render regardless.
+ */
+const UNMEASURED_RECT: Rect = { x: 0, y: 0, width: 0, height: 0 };
+
+/** No controls: the identity returned before the first measurement runs. */
+const NO_RECTS: ReadonlyMap<string, Rect> = new Map();
+
+export interface EmptyContainerAppendersProps {
+  /** The document to scan for containers with nothing in them. */
+  document: BlockDocument;
+  /** What each block type declares as its child regions. */
+  slots: SlotSource;
+  /**
+   * Resolves a block type to its definition, for the control's accessible
+   * name.
+   *
+   * An explicit resolver rather than the global registry: this keeps the
+   * component testable against a fixture that registers nothing, and lets a
+   * production caller hand it the very source the rest of the canvas already
+   * reads from.
+   */
+  blocks: BlockLookup;
+  /**
+   * Raised with the container's node id when its control is pressed.
+   *
+   * This component decides only WHICH containers may be filled and draws the
+   * control; it does not select anything or open an inserter itself. Turning
+   * an id into a selection and an opened inserter is the caller's wiring, kept
+   * out of here so this component's tests do not need a whole editor to exist.
+   */
+  onAppend: (nodeId: string) => void;
+  /**
+   * Suppress every control, for a host that is mid-gesture.
+   *
+   * Matches `BlockToolbar`: a drag is in the middle of changing the layout
+   * these controls are drawn against, and a press during one would run an
+   * insert against a container that is about to be somewhere else.
+   */
+  hidden?: boolean;
+}
+
+/**
+ * One "+" per empty container, positioned over the element it would fill.
+ */
+export function EmptyContainerAppenders({
+  document,
+  slots,
+  blocks,
+  onAppend,
+  hidden = false,
+}: EmptyContainerAppendersProps): ReactElement | null {
+  const layer = useRef<HTMLDivElement | null>(null);
+
+  // WHICH containers get a control, decided from the document alone — see the
+  // module docblock on why this must not wait on geometry to succeed.
+  const containers = useMemo(
+    () => emptyContainersIn(document, slots, blocks),
+    [document, slots, blocks]
+  );
+
+  const [rects, setRects] = useState<ReadonlyMap<string, Rect>>(NO_RECTS);
+
+  /*
+   * WHERE to draw each control, read through the same helper
+   * `spacing-overlay.tsx` measures blocks with. `canvasContentRect` already
+   * divides by the canvas root's own painted scale, so a control positioned
+   * through it lands correctly whether the canvas is zoomed or not — this
+   * file performs no scale arithmetic of its own, which is the point.
+   */
+  const measure = useCallback(() => {
+    const element = layer.current;
+    const root =
+      element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
+    if (root === null) {
+      setRects(current => (current.size === 0 ? current : NO_RECTS));
+      return;
+    }
+    const next = new Map<string, Rect>();
+    for (const container of containers) {
+      const target = nodeElement(root, container.id);
+      if (target !== null) {
+        next.set(container.id, canvasContentRect(target, root));
+      }
+    }
+    setRects(next);
+  }, [containers]);
+
+  // Measured before paint, matching `BlockToolbar` and `SpacingOverlay`: a
+  // control drawn at a stale rectangle for one frame is worse than one that
+  // appears a frame late.
+  useLayoutEffect(() => {
+    if (hidden) return;
+    measure();
+    // `document` is not read directly by `measure`, and is listed anyway: an
+    // edit can resize the container this control sits over without changing
+    // which containers are empty, and a re-measure keyed on the container set
+    // alone would keep describing the layout the container had before the
+    // edit.
+  }, [measure, hidden, document]);
+
+  /*
+   * Re-measure for a resize no render reports: a breakpoint driven by the
+   * canvas's own width, a rail panel opening, a webfont swapping in. Every
+   * found container is watched, not only the canvas root, because what moves
+   * a container is often a SIBLING changing size rather than the container
+   * itself.
+   */
+  useEffect(() => {
+    if (hidden || containers.length === 0) return;
+    const element = layer.current;
+    const root =
+      element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
+    if (root === null) return;
+    // Absent in jsdom unless a test supplies one, and absent in older
+    // browsers. A missing observer costs a re-measure, not correctness —
+    // every render path above still measures.
+    if (typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(root);
+    for (const container of containers) {
+      const target = nodeElement(root, container.id);
+      if (target !== null) observer.observe(target);
+    }
+    return () => observer.disconnect();
+  }, [measure, hidden, containers, document]);
+
+  // `hidden` renders NOTHING, matching how `BlockToolbar` is suppressed during
+  // a drag: a control that were merely invisible would still take a press, and
+  // a press mid-drag would run an insert against a layout that is about to
+  // move. Nothing to offer is the same answer: an empty overlay has no
+  // controls to measure and nothing for a keyboard user to tab into.
+  if (hidden || containers.length === 0) return null;
+
+  return (
+    <div
+      ref={layer}
+      className="nx-empty-container-appenders"
+      // Marked as chrome so a press here resolves to this control rather than
+      // to the canvas background. `canvas.tsx` documents the failure this
+      // prevents: unmarked, a press on this overlay reads as a click on the
+      // page, which CLEARS the selection this very press is about to make.
+      {...{ [CHROME_ATTRIBUTE]: "" }}
+    >
+      {containers.map(container => {
+        const rect = rects.get(container.id) ?? UNMEASURED_RECT;
+        return (
+          <button
+            key={container.id}
+            type="button"
+            className="nx-empty-container-appenders__button"
+            style={{
+              left: rect.x,
+              top: rect.y,
+              width: rect.width,
+              height: rect.height,
+            }}
+            // The block's own name, so a control an author meets is one they
+            // can find by searching for the thing it fills rather than for a
+            // generic "add block" that says nothing about which container.
+            aria-label={`Add a block to ${container.label}`}
+            title={`Add a block to ${container.label}`}
+            onClick={() => onAppend(container.id)}
+          >
+            <Plus size={16} aria-hidden="true" />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -101,6 +101,14 @@
  * anything, which is precisely when a control over its centre would sit on a
  * populated region.
  *
+ * The rule's ANCESTOR conditions are part of that question and not a detail of
+ * how the stylesheet is written. Its box is scoped to a builder shell that has
+ * not been asked to hide empty-element chrome, and `Canvas` and this component
+ * are both exported — so a host composing them with no shell renders containers
+ * the element-level condition accepts and the rule never reaches. Asking the
+ * whole selector is what keeps "there is a box here" a fact rather than an
+ * assumption about how the caller mounted this.
+ *
  * The consequence is that a container carrying no visual affordance gets no
  * control either, which is the point rather than a shortfall — it is still
  * fillable, because selecting it and inserting routes through `emptySlotOf`
@@ -186,7 +194,7 @@ import {
 } from "react";
 
 import { CANVAS_ROOT_CLASS, CHROME_ATTRIBUTE, nodeElement } from "./canvas";
-import { watchCanvasGeometry } from "./canvas-geometry-watch";
+import { watchCanvasFor } from "./canvas-geometry-watch";
 import { EMPTY_CONTAINER_SELECTOR, emptySlotOf } from "./empty-slot";
 import type { Rect } from "./geometry";
 import {
@@ -487,18 +495,30 @@ export function EmptyContainerAppenders({
         continue;
       }
       /*
-       * The stylesheet's own condition, asked of the element the stylesheet
-       * would ask it of — not a second condition computed here.
+       * The stylesheet's own condition, WHOLE, asked of the element the
+       * stylesheet would ask it of — not a second condition computed here.
        *
        * `emptySlotOf` decided WHICH containers this component knows about,
        * from the document. That is a different population from the one
        * `builder-chrome.css` draws its 44px box for, and the module docblock
        * above depends on them being the same: a container the stylesheet
        * declined has no box, so a control centred in its measured rectangle is
-       * centred in whatever that block happens to render instead. A closed
-       * `core/accordion-item` is the first-party case — an empty `children`
-       * slot inside a root that also renders a `<summary>`, so the root is not
-       * `:empty` and measures the summary's own height.
+       * centred in whatever that block happens to render instead. Both halves
+       * of the rule produce that, and both are reachable:
+       *
+       * - the ELEMENT does not qualify. A closed `core/accordion-item` is the
+       *   first-party case — an empty `children` slot inside a root that also
+       *   renders a `<summary>`, so the root is not `:empty` and measures the
+       *   summary's own height.
+       * - the ANCESTORS do not qualify. `Canvas` and this component are both
+       *   exported, so a host can compose them with no builder shell around
+       *   them, and the rule's `.nx-builder-chrome` scope then never applies to
+       *   any container in that canvas — every one of them sizeless, and every
+       *   control drawn on one a focusable button with no area.
+       *
+       * `Element.matches` evaluates the ancestor combinators as well as the
+       * compound, so one call covers the rule rather than the part of it that
+       * happens to be about this element.
        */
       if (!target.matches(EMPTY_CONTAINER_SELECTOR)) {
         next.set(container.id, DECLINED);
@@ -561,24 +581,21 @@ export function EmptyContainerAppenders({
    * neighbour). Both move a control off the container it names, and the second
    * kind is invisible to every observer.
    *
-   * `watchCanvasGeometry` owns the whole list rather than this file
-   * subscribing to the part it happened to think of. The one subscription this
-   * overlay does NOT want is a `MutationObserver`, and that is what keeps it
-   * out of the shared helper: drawing a control is itself a mutation of the
-   * observed subtree, so adopting one means owning a rule for which mutations
-   * are this overlay's own. `SpacingOverlay` keeps such a rule beside its own
-   * call. The cost of leaving it out is stated rather than hidden: a
-   * recompiled site sheet moves blocks through changed class rules, and a
-   * control over one stays where it was until the next resize, scroll,
-   * transition or edit.
+   * A recompiled site sheet is the third kind and needs the same treatment: a
+   * changed class rule moves an empty container while resizing nothing and
+   * scrolling nothing, so only a mutation record reports it.
+   *
+   * `watchCanvasFor` owns the whole list rather than this file subscribing to
+   * the part it happened to think of — which is exactly how the site-sheet case
+   * came to be missing. The layer is handed over as a READ rather than as an
+   * element, because it does not exist yet on the first pass. It is what
+   * locates the canvas root, and it is also what tells a foreign mutation from
+   * this overlay's own: drawing a control mutates the very subtree being
+   * observed, so without it each measurement would schedule the next.
    */
   useEffect(() => {
     if (hidden || containers.length === 0) return;
-    const element = layer.current;
-    const root =
-      element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
-    if (root === null) return;
-    return watchCanvasGeometry(root, measure);
+    return watchCanvasFor(() => layer.current, measure);
   }, [measure, hidden, containers, document]);
 
   // `hidden` renders NOTHING, matching how `BlockToolbar` is suppressed during

--- a/packages/builder/src/empty-slot.test.ts
+++ b/packages/builder/src/empty-slot.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Which of a block's declared regions is empty — the one question both the
+ * inserter and the canvas appender ask.
+ */
+import { describe, expect, it } from "vitest";
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+
+import { emptySlotOf } from "./empty-slot";
+
+const slots = {
+  slotsOf: (type: string) =>
+    type === "core/box" ? (["children"] as const) : undefined,
+};
+
+function box(children?: BlockNode[]): BlockNode {
+  return {
+    id: "b1",
+    type: "core/box",
+    version: 1,
+    props: {},
+    ...(children ? { slots: { children } } : {}),
+  };
+}
+
+const leaf: BlockNode = {
+  id: "h1",
+  type: "core/heading",
+  version: 1,
+  props: {},
+};
+
+describe("emptySlotOf", () => {
+  it("names the slot when a container has no children", () => {
+    expect(emptySlotOf(box(), slots)).toBe("children");
+  });
+
+  it("names the slot when the slot is present but empty", () => {
+    expect(emptySlotOf(box([]), slots)).toBe("children");
+  });
+
+  it("answers null when the container has a child", () => {
+    expect(emptySlotOf(box([leaf]), slots)).toBeNull();
+  });
+
+  it("answers null for a block that declares no slots", () => {
+    expect(emptySlotOf(leaf, slots)).toBeNull();
+  });
+
+  it("answers null when no slot source is supplied", () => {
+    // The inserter's `slots` argument is optional, and without it nothing can
+    // be known about declarations. Guessing would put a block inside an
+    // element that has nowhere to hold it.
+    expect(emptySlotOf(box(), undefined)).toBeNull();
+  });
+});

--- a/packages/builder/src/empty-slot.test.ts
+++ b/packages/builder/src/empty-slot.test.ts
@@ -9,7 +9,11 @@ import { emptySlotOf } from "./empty-slot";
 
 const slots = {
   slotsOf: (type: string) =>
-    type === "core/box" ? (["children"] as const) : undefined,
+    type === "core/box"
+      ? (["children"] as const)
+      : type === "core/pair"
+        ? (["first", "second"] as const)
+        : undefined,
 };
 
 function box(children?: BlockNode[]): BlockNode {
@@ -19,6 +23,20 @@ function box(children?: BlockNode[]): BlockNode {
     version: 1,
     props: {},
     ...(children ? { slots: { children } } : {}),
+  };
+}
+
+/**
+ * A block declaring two ordered slots, so a case can pin WHICH declared slot
+ * counts as "first" rather than only whether some slot is empty.
+ */
+function pair(first: BlockNode[], second: BlockNode[]): BlockNode {
+  return {
+    id: "p1",
+    type: "core/pair",
+    version: 1,
+    props: {},
+    slots: { first, second },
   };
 }
 
@@ -51,5 +69,17 @@ describe("emptySlotOf", () => {
     // be known about declarations. Guessing would put a block inside an
     // element that has nowhere to hold it.
     expect(emptySlotOf(box(), undefined)).toBeNull();
+  });
+
+  it("stays null when the first slot holds a child, though the second is empty", () => {
+    // Only the first declared slot is ever inspected. A rule that checked
+    // every slot, or picked the LAST one, would answer "second" here.
+    expect(emptySlotOf(pair([leaf], []), slots)).toBeNull();
+  });
+
+  it("names the first slot when it is empty, though the second holds a child", () => {
+    // The mirror of the case above. Without both, a rule that answered null
+    // whenever ANY slot held a child would also pass the first one.
+    expect(emptySlotOf(pair([], [leaf]), slots)).toBe("first");
   });
 });

--- a/packages/builder/src/empty-slot.ts
+++ b/packages/builder/src/empty-slot.ts
@@ -1,18 +1,61 @@
 /**
- * Which of a block's declared regions is empty.
+ * What "an empty container" means, in the two places the editor has to ask.
  *
- * Asked by two callers that must agree: the inserter, deciding whether a new
- * block goes INSIDE the selection or beside it, and the canvas appender,
- * deciding where to draw a "+". A second copy of this would agree on the day
- * it was written and drift afterwards, and the drift would be silent because
- * an appender offering to fill a container the inserter then fills elsewhere
- * looks correct from both sides.
+ * {@link emptySlotOf} answers it about a stored NODE: which of a block's
+ * declared regions is empty. Asked by two callers that must agree — the
+ * inserter, deciding whether a new block goes INSIDE the selection or beside
+ * it, and the canvas appender, deciding which containers to offer a "+" for. A
+ * second copy of it would agree on the day it was written and drift afterwards,
+ * and the drift would be silent because an appender offering to fill a
+ * container the inserter then fills elsewhere looks correct from both sides.
+ *
+ * {@link EMPTY_CONTAINER_SELECTOR} answers it about a RENDERED element: which
+ * elements the editor draws an empty-container affordance on. Both the
+ * stylesheet's dashed box and the appender's control read it, for the same
+ * reason the two callers above share `emptySlotOf`.
  *
  * @module empty-slot
  */
 import type { BlockNode } from "@nextlyhq/blocks-engine";
+import { SLOTS_ATTRIBUTE } from "@nextlyhq/blocks-react";
 
 import type { SlotSource } from "./inserter";
+
+/**
+ * The rendered element an empty-container affordance may be drawn on.
+ *
+ * `builder-chrome.css` gives exactly this selector the 44px dashed box that
+ * makes an otherwise sizeless container visible, and the canvas appender draws
+ * its "+" on exactly the elements it matches. ONE spelling, asked by both,
+ * rather than each deciding for itself which containers it covers.
+ *
+ * The two used to differ, and the difference was not visible from either side.
+ * The appender drew for any node whose first declared slot was empty
+ * ({@link emptySlotOf} below), which is a question about the DOCUMENT; the
+ * stylesheet asks a question about the RENDER. A block whose root element
+ * carries content of its own — `core/accordion-item` renders a `<summary>`
+ * beside its slot — has an empty slot and a root that is not `:empty`, so the
+ * stylesheet declined it and the appender did not. The appender was then
+ * placing a fixed-size control on a container that had been given no box to
+ * place it in, and on a root measuring less than the control it centred there.
+ *
+ * The ELEMENT-level half of the stylesheet's selector, deliberately. The rule
+ * is additionally scoped by two ancestor conditions — inside a builder shell
+ * that has not been told to hide empty-element chrome, inside a canvas — and
+ * each of those is already answered elsewhere for the appender rather than
+ * re-asked here: it measures nothing outside a canvas root, and the shell hands
+ * it the same preference through its `hidden` prop. What was NOT answered
+ * anywhere is which elements qualify, which is this.
+ *
+ * A stylesheet cannot import a constant, so `builder-chrome.css` spells this
+ * out and `builder-chrome-attributes.test.ts` is what holds the two in step.
+ *
+ * `:empty` is asked of the element carrying {@link SLOTS_ATTRIBUTE}, which is
+ * the same element that carries `NODE_ID_ATTRIBUTE` — `block-boundary.tsx`
+ * applies both markers to a block's single root — so the element found by node
+ * id is the element this question is about, with no second address to resolve.
+ */
+export const EMPTY_CONTAINER_SELECTOR = `[${SLOTS_ATTRIBUTE}]:empty`;
 
 /**
  * The block's first declared slot, when it holds nothing.

--- a/packages/builder/src/empty-slot.ts
+++ b/packages/builder/src/empty-slot.ts
@@ -20,6 +20,11 @@ import type { BlockNode } from "@nextlyhq/blocks-engine";
 import { SLOTS_ATTRIBUTE } from "@nextlyhq/blocks-react";
 
 import type { SlotSource } from "./inserter";
+import {
+  BUILDER_CHROME_CLASS,
+  CANVAS_ROOT_CLASS,
+  EMPTY_ELEMENTS_ATTRIBUTE,
+} from "./shell-state";
 
 /**
  * The rendered element an empty-container affordance may be drawn on.
@@ -39,13 +44,30 @@ import type { SlotSource } from "./inserter";
  * placing a fixed-size control on a container that had been given no box to
  * place it in, and on a root measuring less than the control it centred there.
  *
- * The ELEMENT-level half of the stylesheet's selector, deliberately. The rule
- * is additionally scoped by two ancestor conditions — inside a builder shell
- * that has not been told to hide empty-element chrome, inside a canvas — and
- * each of those is already answered elsewhere for the appender rather than
- * re-asked here: it measures nothing outside a canvas root, and the shell hands
- * it the same preference through its `hidden` prop. What was NOT answered
- * anywhere is which elements qualify, which is this.
+ * ## The WHOLE rule, not the element-level part of it
+ *
+ * All three conditions are here, because all three decide whether a box is
+ * drawn and the affordance is only correct where one is:
+ *
+ * - inside a builder shell ({@link BUILDER_CHROME_CLASS}). A consumer can
+ *   compose the exported appender with a bare `Canvas` and no shell at all —
+ *   the product path does not, since `BlocksField` mounts the canvas inside
+ *   `BuilderShell`, but nothing stops a host or a harness doing it. The rule
+ *   then never applies, the container keeps its natural size of nothing, and a
+ *   control drawn on the element-level match alone is a focusable button with
+ *   no area: reachable by keyboard, announced by name, and invisible. That is
+ *   the same defect declining an unrendered container removed, arriving through
+ *   a partial condition.
+ * - not asked to hide empty-element chrome ({@link EMPTY_ELEMENTS_ATTRIBUTE}).
+ * - inside a canvas ({@link CANVAS_ROOT_CLASS}).
+ *
+ * The last two are additionally answered elsewhere for the appender — it
+ * measures nothing outside a canvas root, and the shell hands it the same
+ * preference through its `hidden` prop — and they stay in the selector anyway,
+ * because this is the stylesheet's rule rather than a subset of it chosen for
+ * the appender. `Element.matches` evaluates ancestors, so asking it of the
+ * element the stylesheet would ask it of gets the same answer the browser gives
+ * the rule.
  *
  * A stylesheet cannot import a constant, so `builder-chrome.css` spells this
  * out and `builder-chrome-attributes.test.ts` is what holds the two in step.
@@ -55,7 +77,9 @@ import type { SlotSource } from "./inserter";
  * applies both markers to a block's single root — so the element found by node
  * id is the element this question is about, with no second address to resolve.
  */
-export const EMPTY_CONTAINER_SELECTOR = `[${SLOTS_ATTRIBUTE}]:empty`;
+export const EMPTY_CONTAINER_SELECTOR =
+  `.${BUILDER_CHROME_CLASS}:not([${EMPTY_ELEMENTS_ATTRIBUTE}="hidden"]) ` +
+  `.${CANVAS_ROOT_CLASS} [${SLOTS_ATTRIBUTE}]:empty`;
 
 /**
  * The block's first declared slot, when it holds nothing.

--- a/packages/builder/src/empty-slot.ts
+++ b/packages/builder/src/empty-slot.ts
@@ -1,0 +1,36 @@
+/**
+ * Which of a block's declared regions is empty.
+ *
+ * Asked by two callers that must agree: the inserter, deciding whether a new
+ * block goes INSIDE the selection or beside it, and the canvas appender,
+ * deciding where to draw a "+". A second copy of this would agree on the day
+ * it was written and drift afterwards, and the drift would be silent because
+ * an appender offering to fill a container the inserter then fills elsewhere
+ * looks correct from both sides.
+ *
+ * @module empty-slot
+ */
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+
+import type { SlotSource } from "./inserter";
+
+/**
+ * The block's first declared slot, when it holds nothing.
+ *
+ * FIRST rather than any: a block with several regions has an order, and the
+ * one an author means by "inside this" is the one it declares first. Answering
+ * with some other empty region would put content where nobody pointed.
+ *
+ * @param node - the node to inspect
+ * @param slots - what each block type declares; absent means nothing is known
+ * @returns the slot's name, or `null` when this is not an empty container
+ */
+export function emptySlotOf(
+  node: BlockNode,
+  slots: SlotSource | undefined
+): string | null {
+  const declared = slots?.slotsOf(node.type);
+  const first = declared?.[0];
+  if (first === undefined) return null;
+  return (node.slots?.[first]?.length ?? 0) === 0 ? first : null;
+}

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -27,6 +27,7 @@ import {
   canvasRootFrom,
   hasScrollbarGutter,
   overflowApplies,
+  viewportPositioned,
 } from "./geometry-dom";
 
 /**
@@ -363,6 +364,95 @@ describe("finding the canvas root across realms", () => {
     expect(canvasRootFrom(child, "nx-canvas")).toBe(root);
 
     frame.remove();
+  });
+});
+
+describe("which elements have left the canvas's content coordinates", () => {
+  /**
+   * An element whose computed `position` is whatever the caller names.
+   *
+   * Set as an inline declaration rather than through a class rule, because what
+   * this predicate reads is the COMPUTED value and an inline declaration is the
+   * shortest cascade that produces one. `empty-container-appender.test.tsx`
+   * reaches the same computed value the long way round — through an authored
+   * `styles` envelope compiled into the page's own sheet — so the production
+   * route is covered where the component is, and this file stays about the
+   * predicate.
+   */
+  function positioned(position: string | undefined): HTMLElement {
+    const element = document.createElement("div");
+    if (position !== undefined) element.style.position = position;
+    document.body.appendChild(element);
+    return element;
+  }
+
+  it("refuses an element pinned to the viewport", () => {
+    expect(viewportPositioned(positioned("fixed"))).toBe(true);
+  });
+
+  it("refuses an element pinned to a scrollport", () => {
+    /*
+     * Asserted apart from `fixed` rather than assumed to follow it. The two are
+     * one branch today, and a refusal written as an equality against a single
+     * value passes the case above while leaving this one accepted — which is
+     * the shape a narrowing takes when someone simplifies the condition.
+     */
+    expect(viewportPositioned(positioned("sticky"))).toBe(true);
+  });
+
+  it.each(["static", "relative", "absolute"])(
+    "accepts an element positioned %s, which stays in the page",
+    position => {
+      expect(viewportPositioned(positioned(position))).toBe(false);
+    }
+  );
+
+  it("accepts an element nothing has positioned at all", () => {
+    /*
+     * The control that decides the DIRECTION of the test above, and the one
+     * that would be missing from a predicate written as an allow-list. jsdom
+     * computes `position` on an unstyled element to the EMPTY STRING rather
+     * than to `static`, so "is it one of the values that stay in the page"
+     * answers no for every ordinary block in this runtime — refusing the whole
+     * canvas while every case above still passes.
+     */
+    expect(getComputedStyle(positioned(undefined)).position).toBe("");
+    expect(viewportPositioned(positioned(undefined))).toBe(false);
+  });
+
+  it("reads the ELEMENT's own realm rather than this one", () => {
+    /*
+     * A canvas portalled into a same-origin iframe is styled by that document.
+     * Reading through the ambient `window` asks a `getComputedStyle` that
+     * belongs to a different realm, and the control is the same element read
+     * both ways: this realm's function must NOT be what produced the answer.
+     */
+    const frame = document.createElement("iframe");
+    document.body.appendChild(frame);
+    const inner = frame.contentDocument;
+    if (inner === null) throw new Error("the iframe has no document");
+
+    const foreign = inner.createElement("div");
+    foreign.style.position = "sticky";
+    inner.body.appendChild(foreign);
+
+    const ambient = vi.spyOn(window, "getComputedStyle");
+    expect(viewportPositioned(foreign)).toBe(true);
+    expect(ambient).not.toHaveBeenCalled();
+
+    ambient.mockRestore();
+    frame.remove();
+  });
+
+  it("accepts an element with no view, which nothing has positioned", () => {
+    // A detached document has no `defaultView`, so there is no computed style
+    // to read. Nothing has been laid out and nothing has been positioned, and
+    // the callers decline such an element for their own reasons anyway.
+    const detached = document.implementation.createHTMLDocument();
+    expect(detached.defaultView).toBeNull();
+    const orphan = detached.createElement("div");
+    orphan.style.position = "fixed";
+    expect(viewportPositioned(orphan)).toBe(false);
   });
 });
 

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -820,3 +820,53 @@ describe("a clipping ancestor whose transform cannot be described", () => {
     expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(false);
   });
 });
+
+describe("an ancestor that does not clip at all", () => {
+  /*
+   * The third verdict, and it had no fixture. jsdom's computed `overflow` for
+   * an unstyled element is the EMPTY STRING rather than `visible`, and an empty
+   * string is not `visible` — so every plain ancestor in this file reads as
+   * clipping, and inverting the `no-clip` answer changed nothing anywhere. The
+   * only way to reach it here is to declare `visible` outright.
+   *
+   * What it decides is whether the walk CONTINUES. A `no-clip` ancestor must
+   * neither cut the block nor stop the search, or a block genuinely cut by a
+   * container higher up keeps chrome drawn over pixels that container removed.
+   */
+  it("neither cuts the block nor stops the walk at it", () => {
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+
+    const clipping = box({ x: 0, y: 0, width: 400, height: 400 });
+    clipping.setAttribute("style", "overflow-x:hidden;overflow-y:hidden");
+    root.append(clipping);
+
+    const passthrough = box({ x: 0, y: 0, width: 400, height: 400 });
+    passthrough.setAttribute("style", "overflow-x:visible;overflow-y:visible");
+    clipping.append(passthrough);
+
+    // Inside the passthrough ancestor and well outside the clipping one above
+    // it. Only a walk that reads `no-clip` as "keep going" reaches the verdict.
+    const child = box({ x: -300, y: 10, width: 100, height: 100 });
+    passthrough.append(child);
+
+    expect(clippedByAncestorRect(child, root)).toBe(true);
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(true);
+  });
+
+  it("leaves a child it contains alone", () => {
+    /*
+     * The control: the same non-clipping ancestor with nothing above it that
+     * clips. Reading `no-clip` as a CUT would refuse this block, so the pair
+     * separates "continue the walk" from "answer true".
+     */
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+    const passthrough = box({ x: 0, y: 0, width: 400, height: 400 });
+    passthrough.setAttribute("style", "overflow-x:visible;overflow-y:visible");
+    root.append(passthrough);
+    const child = box({ x: -300, y: 10, width: 100, height: 100 });
+    passthrough.append(child);
+
+    expect(clippedByAncestorRect(child, root)).toBe(false);
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(false);
+  });
+});

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -15,13 +15,14 @@
  *
  * @module geometry-dom.test
  */
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SQUARE_CORNERS } from "./border-radii";
 import {
   canvasContentPoint,
   canvasContentRect,
   clippedByAncestor,
+  clippedByAncestorRect,
   frameInsetOf,
   canvasRootFrom,
   hasScrollbarGutter,
@@ -53,6 +54,7 @@ function frameWith({
 
 afterEach(() => {
   document.body.innerHTML = "";
+  vi.unstubAllGlobals();
 });
 
 describe("frameInsetOf", () => {
@@ -612,5 +614,209 @@ describe("a clipping ancestor inside a canvas that is PAINTED smaller", () => {
     ancestor.append(child);
 
     expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(true);
+  });
+});
+
+/**
+ * The two clip questions, and where they must give DIFFERENT answers.
+ *
+ * `clippedByAncestor` refuses a block whose square corner pokes past a more
+ * tightly rounded ancestor's arc; `clippedByAncestorRect` asks about the
+ * straight edges alone. That gap is the whole reason the second exists — the
+ * appender draws a small control at a container's CENTRE, and refusing it for a
+ * clip confined to a corner nothing is drawn near would decline `core/box`
+ * inside `core/card`, which `card.tsx` calls the commonest composition in the
+ * library. Routing the appender back through the corner-aware question would
+ * bring that regression back, and every case below would stay green unless one
+ * of them pins the disagreement itself.
+ */
+describe("the straight-edge clip question, against the corner-aware one", () => {
+  /** An `overflow: hidden` ancestor with a rounded corner, at a painted rectangle. */
+  function roundedClipper(
+    rect: { x: number; y: number; width: number; height: number },
+    radius: number
+  ) {
+    const element = box(rect);
+    /*
+     * LONGHANDS, and per axis. jsdom's computed style does not expand the
+     * `overflow` or `border-radius` shorthands, so a fixture written with them
+     * reports an empty string for every property this reads — and an empty
+     * string is not `visible`, so the ancestor still counts as clipping while
+     * its radii silently read as zero. The corner test would then never fire
+     * and the two functions would agree for the wrong reason.
+     */
+    element.setAttribute(
+      "style",
+      [
+        "overflow-x:hidden",
+        "overflow-y:hidden",
+        "border-style:solid",
+        "border-width:0px",
+        `border-top-left-radius:${radius}px`,
+        `border-top-right-radius:${radius}px`,
+        `border-bottom-right-radius:${radius}px`,
+        `border-bottom-left-radius:${radius}px`,
+      ].join(";")
+    );
+    return element;
+  }
+
+  it("agrees that a child well outside the clip rectangle is cut", () => {
+    // Both questions answer the same way whenever the straight edges already
+    // settle it, which is what makes the disagreement below a property of the
+    // corner refinement rather than of one function being stricter throughout.
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+    const ancestor = roundedClipper(
+      { x: 0, y: 0, width: 400, height: 400 },
+      60
+    );
+    root.append(ancestor);
+    const child = box({ x: -200, y: 10, width: 100, height: 100 });
+    ancestor.append(child);
+
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(true);
+    expect(clippedByAncestorRect(child, root)).toBe(true);
+  });
+
+  it("DIFFERS on a child cut only where the ancestor's corner is rounded", () => {
+    /*
+     * The child sits inside all four padding edges and its own square top-left
+     * corner lies outside the ancestor's 60px arc — the `core/box` in
+     * `core/card` composition. This is the fixture the whole trade rests on, so
+     * its two assertions have to come out opposite: identical answers here
+     * would mean the fixture never reached the corner test and the case would
+     * license nothing.
+     */
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+    const ancestor = roundedClipper(
+      { x: 0, y: 0, width: 400, height: 400 },
+      60
+    );
+    root.append(ancestor);
+    const child = box({ x: 0, y: 0, width: 100, height: 100 });
+    ancestor.append(child);
+
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(true);
+    expect(clippedByAncestorRect(child, root)).toBe(false);
+  });
+});
+
+/**
+ * The parts of `DOMMatrix` `renderedScale` reads, and nothing else.
+ *
+ * jsdom implements no `DOMMatrix` at all, so `renderedScale` takes its
+ * "nothing is laid out" branch and reports the identity — which is
+ * describable. A rotated ancestor therefore cannot be expressed in this
+ * environment without supplying one, and the refusal it triggers is the only
+ * way any ancestor reaches the `cut` verdict, so nothing reaches that verdict
+ * either.
+ *
+ * Only `a`..`f`, `is2D` and `multiply` are ever read, and only a
+ * `matrix(a, b, c, d, e, f)` literal is ever parsed, because that is the form
+ * the fixtures below declare. A stub narrower than the real interface is
+ * honest here for the same reason a narrowed test double is anywhere: it
+ * cannot answer a question the code does not ask.
+ */
+class Matrix2D {
+  readonly a: number;
+  readonly b: number;
+  readonly c: number;
+  readonly d: number;
+  readonly e: number;
+  readonly f: number;
+  readonly is2D = true;
+
+  constructor(source?: string | readonly number[]) {
+    const terms =
+      typeof source === "string"
+        ? source
+            .slice(source.indexOf("(") + 1, source.lastIndexOf(")"))
+            .split(",")
+            .map(Number)
+        : (source ?? [1, 0, 0, 1, 0, 0]);
+    this.a = terms[0] ?? 1;
+    this.b = terms[1] ?? 0;
+    this.c = terms[2] ?? 0;
+    this.d = terms[3] ?? 1;
+    this.e = terms[4] ?? 0;
+    this.f = terms[5] ?? 0;
+  }
+
+  /** `A.multiply(B)` is A·B, the composition the walk accumulates. */
+  multiply(other: Matrix2D): Matrix2D {
+    return new Matrix2D([
+      this.a * other.a + this.c * other.b,
+      this.b * other.a + this.d * other.b,
+      this.a * other.c + this.c * other.d,
+      this.b * other.c + this.d * other.d,
+      this.a * other.e + this.c * other.f + this.e,
+      this.b * other.e + this.d * other.f + this.f,
+    ]);
+  }
+}
+
+describe("a clipping ancestor whose transform cannot be described", () => {
+  /*
+   * `rotate(30deg)` on the ancestor. Neither reading survives it: `a` and `d`
+   * stop being scale factors, and `getBoundingClientRect` answers with an
+   * axis-aligned BOUNDING box whose edges are not the clip edges — the real
+   * clip is a slanted rectangle inside it, so a child genuinely cut by it
+   * still reads as contained on every straight-edge comparison. Both clip
+   * questions refuse such an ancestor outright, and the child below is one
+   * that BOTH would otherwise accept: it sits well inside the bounding box, so
+   * nothing but the refusal itself can produce a `true` here.
+   */
+  function rotatedClipper(rect: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) {
+    const element = box(rect);
+    element.setAttribute(
+      "style",
+      [
+        "overflow-x:hidden",
+        "overflow-y:hidden",
+        // The composed matrix for a 30-degree rotation, written out because
+        // the stub above reads matrix terms rather than parsing a rotation.
+        "transform:matrix(0.8660254, 0.5, -0.5, 0.8660254, 0, 0)",
+      ].join(";")
+    );
+    return element;
+  }
+
+  it("is refused by BOTH clip questions, not measured", () => {
+    vi.stubGlobal("DOMMatrix", Matrix2D);
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+    const ancestor = rotatedClipper({ x: 0, y: 0, width: 400, height: 400 });
+    root.append(ancestor);
+    const child = box({ x: 100, y: 100, width: 100, height: 100 });
+    ancestor.append(child);
+
+    expect(clippedByAncestorRect(child, root)).toBe(true);
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(true);
+  });
+
+  it("accepts the same child once the ancestor is axis-aligned", () => {
+    /*
+     * The control, and it is what makes the case above about the ROTATION
+     * rather than about the fixture. `matrix(1, 0, 0, 1, 0, 0)` is the
+     * identity written in the same form, so the ancestor still declares a
+     * transform and still clips; only the off-diagonal terms change.
+     */
+    vi.stubGlobal("DOMMatrix", Matrix2D);
+    const root = canvasRoot({ x: 0, y: 0, width: 400, height: 400 });
+    const ancestor = box({ x: 0, y: 0, width: 400, height: 400 });
+    ancestor.setAttribute(
+      "style",
+      "overflow-x:hidden;overflow-y:hidden;transform:matrix(1, 0, 0, 1, 0, 0)"
+    );
+    root.append(ancestor);
+    const child = box({ x: 100, y: 100, width: 100, height: 100 });
+    ancestor.append(child);
+
+    expect(clippedByAncestorRect(child, root)).toBe(false);
+    expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(false);
   });
 });

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -867,10 +867,13 @@ function anyAncestorCuts(
  * each corner where the two curves disagree, which is real and irrelevant to
  * anything drawn away from the corners.
  *
- * Shares {@link ancestorClipContext} with {@link clippedByAncestor} rather
- * than reading `overflow`, composing scale or resolving the clip rectangle a
- * second time: the two answer different questions about the same ancestor,
- * and the parts they share have to stay exactly the same reading.
+ * Shares {@link ancestorClipContext} and {@link rectCut} with
+ * {@link clippedByAncestor} rather than reading `overflow`, composing scale,
+ * resolving the clip rectangle or judging the edges a second time: the two
+ * answer different questions about the same ancestor, and the parts they share
+ * have to stay exactly the same reading. What is left after that sharing is
+ * the whole of the difference — this function is `rectCut` alone, and the
+ * corner-aware one is `rectCut` plus {@link cornerCut}.
  */
 export function clippedByAncestorRect(
   element: Element,
@@ -879,14 +882,9 @@ export function clippedByAncestorRect(
   const view = element.ownerDocument.defaultView;
   if (view === null) return false;
   const box = element.getBoundingClientRect();
-  return anyAncestorCuts(element, root, node => {
-    const context = ancestorClipContext(node, view, root);
-    if (context.kind === "cut") return true;
-    return (
-      context.kind === "clips" &&
-      cutByEdges(box, context.clip, context.clipsX, context.clipsY)
-    );
-  });
+  return anyAncestorCuts(element, root, node =>
+    rectCut(ancestorClipContext(node, view, root), box)
+  );
 }
 
 /**
@@ -906,10 +904,54 @@ function cutByAncestor(
   root: Element
 ): boolean {
   const context = ancestorClipContext(node, view, root);
-  if (context.kind === "no-clip") return false;
-  if (context.kind === "cut") return true;
-  if (cutByEdges(box, context.clip, context.clipsX, context.clipsY))
-    return true;
+  return rectCut(context, box) || cornerCut(context, box, radii);
+}
+
+/**
+ * Whether an ancestor cuts the block's RECTANGLE — the whole of
+ * {@link clippedByAncestorRect}'s verdict, and the first half of
+ * {@link cutByAncestor}'s.
+ *
+ * ONE implementation rather than one per caller. The two questions differ by
+ * the corner refinement below and by nothing else, so the straight-edge part
+ * has to be the same reading in both — and it was not: written out twice, the
+ * rect question guarded with `context.kind === "clips" && ...` while the
+ * corner-aware one narrowed the union. A refusal reason added to
+ * {@link AncestorClipContext} would have been gained by one caller and
+ * silently skipped by the other.
+ *
+ * Exhaustive over the union deliberately: with no `default`, a fourth member
+ * leaves this function able to return `undefined`, which its declared `boolean`
+ * refuses. Both callers inherit that, which is the property the duplicate
+ * version could not have.
+ */
+function rectCut(context: AncestorClipContext, box: DOMRect): boolean {
+  switch (context.kind) {
+    case "no-clip":
+      return false;
+    case "cut":
+      return true;
+    case "clips":
+      return cutByEdges(box, context.clip, context.clipsX, context.clipsY);
+  }
+}
+
+/**
+ * Whether a rounded clipping ancestor cuts the block at a CORNER — the
+ * refinement {@link clippedByAncestor} adds and {@link clippedByAncestorRect}
+ * deliberately does not.
+ *
+ * Only a `clips` ancestor has a curve to compare against: `no-clip` and `cut`
+ * are already whole answers that {@link rectCut} gave, and asking a second
+ * question about them would either re-refuse something or refuse something
+ * nothing clips.
+ */
+function cornerCut(
+  context: AncestorClipContext,
+  box: DOMRect,
+  radii: CornerRadii
+): boolean {
+  if (context.kind !== "clips") return false;
   /*
    * The BLOCK's radii are composed here too, and for the same reason the
    * ancestor's geometry is.

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -820,15 +820,73 @@ export function clippedByAncestor(
   const view = element.ownerDocument.defaultView;
   if (view === null) return false;
   const box = element.getBoundingClientRect();
+  return anyAncestorCuts(element, root, node =>
+    cutByAncestor(node, box, radii, view, root)
+  );
+}
 
+/**
+ * Walks the ancestors strictly between `element` and `root`, reporting
+ * whether any one of them satisfies `cut`.
+ *
+ * Shared by {@link clippedByAncestor} and {@link clippedByAncestorRect}
+ * rather than each climbing the chain on its own: the two answer different
+ * questions about the same ancestor and must stop at the same first match for
+ * the same reason `ancestorClipContext` is shared rather than re-derived —
+ * two copies of "which elements to ask" agree on the day both are written and
+ * are free to drift the moment either caller's walk changes.
+ */
+function anyAncestorCuts(
+  element: Element,
+  root: Element,
+  cut: (node: Element) => boolean
+): boolean {
   for (
     let node: Element | null = element.parentElement;
     node !== null && node !== root;
     node = node.parentElement
   ) {
-    if (cutByAncestor(node, box, radii, view, root)) return true;
+    if (cut(node)) return true;
   }
   return false;
+}
+
+/**
+ * Whether an ancestor cuts the block's own RECTANGLE — the straight-edge
+ * question alone, with no opinion about a rounded corner.
+ *
+ * {@link clippedByAncestor} additionally refuses a block whose SQUARE corner
+ * pokes past a more tightly rounded ancestor's arc — correct for a bounding
+ * box a caller draws chrome flush against, like a spacing band that runs the
+ * full length of an edge. A caller drawing something anchored to the block's
+ * CENTRE and never reaching its corners has no use for that refinement: it
+ * would refuse a container for a clip that exists only within a few pixels of
+ * a corner nothing is drawn near, and it is refused for exactly the
+ * containers most likely to have one — an ordinary full-width child sitting
+ * flush inside a rounded, clipping parent is genuinely cut by a few pixels at
+ * each corner where the two curves disagree, which is real and irrelevant to
+ * anything drawn away from the corners.
+ *
+ * Shares {@link ancestorClipContext} with {@link clippedByAncestor} rather
+ * than reading `overflow`, composing scale or resolving the clip rectangle a
+ * second time: the two answer different questions about the same ancestor,
+ * and the parts they share have to stay exactly the same reading.
+ */
+export function clippedByAncestorRect(
+  element: Element,
+  root: Element
+): boolean {
+  const view = element.ownerDocument.defaultView;
+  if (view === null) return false;
+  const box = element.getBoundingClientRect();
+  return anyAncestorCuts(element, root, node => {
+    const context = ancestorClipContext(node, view, root);
+    if (context.kind === "cut") return true;
+    return (
+      context.kind === "clips" &&
+      cutByEdges(box, context.clip, context.clipsX, context.clipsY)
+    );
+  });
 }
 
 /**
@@ -847,6 +905,68 @@ function cutByAncestor(
   view: Window,
   root: Element
 ): boolean {
+  const context = ancestorClipContext(node, view, root);
+  if (context.kind === "no-clip") return false;
+  if (context.kind === "cut") return true;
+  if (cutByEdges(box, context.clip, context.clipsX, context.clipsY))
+    return true;
+  /*
+   * The BLOCK's radii are composed here too, and for the same reason the
+   * ancestor's geometry is.
+   *
+   * The caller scales them by the block's own composition, which stops below
+   * the root — so the outer curve below carries the canvas scale and the inner
+   * one does not. Compared across that difference, an oversized inner curve
+   * reads as fitting inside the outer one, and a block whose visible corner IS
+   * clipped keeps its bands and draws them over clipped pixels.
+   *
+   * Done at the comparison rather than at the call site: this is the only place
+   * that holds both curves, and asking the caller to pre-compose one of them
+   * puts half a decision somewhere that cannot see the other half.
+   */
+  const inner = scaleCornerRadii(radii, context.painted);
+  return cutByCorner(
+    box,
+    inner,
+    context.clip,
+    context.style,
+    context.scale,
+    context.clipsX && context.clipsY,
+    CLIP_SLACK_PX
+  );
+}
+
+/**
+ * What one ancestor's clip means for a descendant, computed ONCE and shared
+ * by {@link clippedByAncestor} (the corner-aware question) and
+ * {@link clippedByAncestorRect} (the straight-edge one) — reading `overflow`,
+ * composing the rendered scale and resolving the clip rectangle are the same
+ * work either caller needs, and a second reading of any of them is a second
+ * chance for the two to disagree about the same ancestor.
+ *
+ * Three outcomes rather than a boolean, because "does not clip at all" and
+ * "clips, but the geometry cannot be described" are different answers a
+ * caller must not conflate: the first lets the walk continue up to the next
+ * ancestor, the second is itself a refusal.
+ */
+type AncestorClipContext =
+  | { readonly kind: "no-clip" }
+  | { readonly kind: "cut" }
+  | {
+      readonly kind: "clips";
+      readonly clipsX: boolean;
+      readonly clipsY: boolean;
+      readonly style: CSSStyleDeclaration;
+      readonly clip: EdgeBounds;
+      readonly scale: RenderedScale;
+      readonly painted: Scale;
+    };
+
+function ancestorClipContext(
+  node: Element,
+  view: Window,
+  root: Element
+): AncestorClipContext {
   const style = view.getComputedStyle(node);
   /*
    * PER AXIS, because the two can differ and the catalog ships the shorthand
@@ -862,7 +982,7 @@ function cutByAncestor(
    */
   const clipsX = style.overflowX !== "visible";
   const clipsY = style.overflowY !== "visible";
-  if (!clipsX && !clipsY) return false;
+  if (!clipsX && !clipsY) return { kind: "no-clip" };
   /*
    * A computed `overflow` is not the same as an overflow that CLIPS. The
    * property does not apply to every generated box, and the computed value says
@@ -870,7 +990,7 @@ function cutByAncestor(
    * span gets the declaration in the computed style and no clip on the page.
    * Reading the first as the second cuts a descendant nothing removes.
    */
-  if (!overflowApplies(style.display)) return false;
+  if (!overflowApplies(style.display)) return { kind: "no-clip" };
   /*
    * Overflow clips at the PADDING edge, and `getBoundingClientRect` reports the
    * BORDER box. On a container with a border the two differ by its width, so a
@@ -957,33 +1077,9 @@ function cutByAncestor(
    * same answer this module already gives for every other shape it cannot
    * describe.
    */
-  if (!scale.describable) return true;
-  /*
-   * The BLOCK's radii are composed here too, and for the same reason the
-   * ancestor's geometry is.
-   *
-   * The caller scales them by the block's own composition, which stops below
-   * the root — so the outer curve below carries the canvas scale and the inner
-   * one does not. Compared across that difference, an oversized inner curve
-   * reads as fitting inside the outer one, and a block whose visible corner IS
-   * clipped keeps its bands and draws them over clipped pixels.
-   *
-   * Done at the comparison rather than at the call site: this is the only place
-   * that holds both curves, and asking the caller to pre-compose one of them
-   * puts half a decision somewhere that cannot see the other half.
-   */
-  const inner = scaleCornerRadii(radii, painted);
+  if (!scale.describable) return { kind: "cut" };
   const clip = clipEdges(outer, style, scale);
-  if (cutByEdges(box, clip, clipsX, clipsY)) return true;
-  return cutByCorner(
-    box,
-    inner,
-    clip,
-    style,
-    scale,
-    clipsX && clipsY,
-    CLIP_SLACK_PX
-  );
+  return { kind: "clips", clipsX, clipsY, style, clip, scale, painted };
 }
 
 /**

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -169,6 +169,53 @@ export function canvasPaintedPoint(
 }
 
 /**
+ * Whether an element is positioned against the VIEWPORT rather than against the
+ * page {@link canvasContentRect} measures in.
+ *
+ * `position` is a catalog keyword — `blocks-engine`'s style catalog offers
+ * `static`, `relative`, `absolute`, `fixed` and `sticky` — so taking a block
+ * out of the canvas's content coordinates is something an author can store.
+ * `fixed` and `sticky` are the two values that do it: both hold the element
+ * still against a viewport or a scrollport while the content around it travels,
+ * so a rectangle read here describes where the element was at the instant of
+ * the read and stops describing it on the very next scroll.
+ *
+ * Nothing corrects that drift, which is what makes it a refusal rather than a
+ * staleness to re-measure away. The canvas root does not scroll — the shell
+ * scrolls a section ABOVE it — and a scroll event does not bubble, so the
+ * capture-phase listener `canvas-geometry-watch.ts` installs on the root
+ * reaches a scroller nested INSIDE the canvas and nothing outside it.
+ *
+ * Asked of the ELEMENT rather than of a computed string handed in, so every
+ * overlay drawn in this space asks one question and gets one answer. A caller
+ * given the string would decide for itself which property carries it and in
+ * which realm to read it, which is two more chances to answer differently about
+ * the same element.
+ *
+ * The element's own view rather than the ambient `window`, for the reason
+ * {@link canvasRootFrom} gives: a canvas portalled into a same-origin iframe is
+ * styled by that document, and reading through this one would answer about
+ * rules that do not apply to it. An element with no view at all is reported as
+ * NOT viewport-positioned — nothing has positioned it, because nothing has laid
+ * it out, and the callers that reach this already decline an element with no
+ * box for their own reasons.
+ *
+ * The two values are NAMED rather than reached by excluding the ones that stay
+ * in this space, and that direction is load-bearing. An element no rule
+ * positions computes to `static` in a browser and to the EMPTY STRING under
+ * jsdom, so an allow-list of the values that are in the space would refuse both
+ * — every ordinary block, in the runtime the tests run in. Anything this does
+ * not recognise is therefore accepted, `static`, `relative` and `absolute`
+ * included.
+ */
+export function viewportPositioned(element: Element): boolean {
+  const view = element.ownerDocument.defaultView;
+  if (view === null) return false;
+  const position = view.getComputedStyle(element).position;
+  return position === "fixed" || position === "sticky";
+}
+
+/**
  * The nearest ancestor that actually scrolls, or `null` when nothing does.
  *
  * The canvas root is NOT it. That element carries the drag handlers and sizes

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -130,8 +130,16 @@ export type { BuilderShellProps } from "./builder-shell";
 /**
  * @experimental The shell's own decisions: which panels the rail offers, the
  * bounds handed to the panel library, and the preference port.
+ *
+ * `DEFAULT_PREFERENCES` travels with them for a host that mirrors ONE
+ * preference outside the shell — `BuilderShellProps.onShowEmptyElementsChange`
+ * reports `showEmptyElements` after the shell has read it, which is later than
+ * such a host's own first render. Reading the default from here rather than
+ * restating `true` is what keeps that first render honest, and keeps it that
+ * way if the default here ever changes.
  */
 export {
+  DEFAULT_PREFERENCES,
   EMPTY_ELEMENTS_ATTRIBUTE,
   LEFT_PANELS,
   MIN_CANVAS_WIDTH,

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -39,6 +39,7 @@ import {
   type NestingVerdict,
 } from "@nextlyhq/blocks-engine";
 
+import { emptySlotOf } from "./empty-slot";
 import { positionOf, type OpPosition } from "./ops";
 
 /**
@@ -464,18 +465,13 @@ export function insertionPointFor(
   // to it is done by selecting the second and inserting after that — so both
   // placements stay available without a second affordance to discover.
   const selected = findNode(document.nodes, selectedId);
-  const declared =
-    selected === undefined ? undefined : slots?.slotsOf(selected.type);
-  const firstSlot = declared?.[0];
-  if (
-    selected !== undefined &&
-    firstSlot !== undefined &&
-    (selected.slots?.[firstSlot]?.length ?? 0) === 0
-  ) {
+  const emptySlot =
+    selected === undefined ? null : emptySlotOf(selected, slots);
+  if (selected !== undefined && emptySlot !== null) {
     return {
       kind: "inside-selection",
-      at: { parentId: selected.id, slot: firstSlot, index: 0 },
-      target: { at: "slot", parentType: selected.type, slot: firstSlot },
+      at: { parentId: selected.id, slot: emptySlot, index: 0 },
+      target: { at: "slot", parentType: selected.type, slot: emptySlot },
     };
   }
 

--- a/packages/builder/src/layers.ts
+++ b/packages/builder/src/layers.ts
@@ -89,15 +89,29 @@ function hasConditions(node: BlockNode): boolean {
 }
 
 /**
+ * The author's own name for a node, when they gave it a non-blank one.
+ *
+ * Trimmed and an empty result treated as absent: a name of spaces would read
+ * as though the author had named the block while giving nothing that
+ * distinguishes it from its neighbours.
+ *
+ * Exported so a second caller needing "does this node carry an authored
+ * name" asks this rather than restating the trim-and-blank check — precisely
+ * the two-implementations risk this module's own header warns about for the
+ * tree it builds from the same field.
+ */
+export function authoredName(node: BlockNode): string | undefined {
+  const named = node.name?.trim();
+  return named !== undefined && named !== "" ? named : undefined;
+}
+
+/**
  * The name an author reads for one block.
  *
- * An instance name wins, because it is the only part an author wrote. It is
- * trimmed and an empty one is ignored: a name of spaces would render a blank
- * row that cannot be typed to and cannot be told from its neighbours.
+ * An instance name wins, because it is the only part an author wrote.
  */
 export function layerLabel(node: BlockNode): string {
-  const named = node.name?.trim();
-  return named !== undefined && named !== "" ? named : blockLabel(node.type);
+  return authoredName(node) ?? blockLabel(node.type);
 }
 
 /** The document as a tree of rows. */

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -168,6 +168,33 @@ export interface ShellPreferences {
 export const EMPTY_ELEMENTS_ATTRIBUTE = "data-nx-empty-elements";
 
 /**
+ * The class marking the editor shell's own root element.
+ *
+ * The scope every piece of editor chrome is drawn inside, and the element
+ * {@link EMPTY_ELEMENTS_ATTRIBUTE} is stamped on. Kept beside that attribute
+ * and away from the component, for the reason its docblock gives: the markers
+ * `builder-chrome.css` has to spell out literally are the ones a rename can
+ * break silently, so each has one exported spelling that the shell writing it,
+ * the code asking about it and the test pinning the stylesheet all take from.
+ */
+export const BUILDER_CHROME_CLASS = "nx-builder-chrome";
+
+/**
+ * The class marking the canvas root, and the boundary the hit-test stops at.
+ *
+ * Here rather than in `canvas.tsx` for the reason above: it is the middle term
+ * of the empty-container affordance's selector, which `empty-slot.ts` composes
+ * — and reaching into the canvas COMPONENT for it would pull a React module
+ * into every consumer of that constant, for one string. `canvas.tsx` re-exports
+ * it, so callers reading it as the canvas's own marker are unaffected.
+ *
+ * The hit-test walk needs an upper bound (see `nodeIdFromEvent`), and that
+ * bound has to be identifiable from a DOM node rather than from React state,
+ * because the walk starts at an event target and climbs.
+ */
+export const CANVAS_ROOT_CLASS = "nx-canvas";
+
+/**
  * The identity of a panel arrangement, from the panels themselves.
  *
  * Sorted and joined rather than taken from `leftPanel`, so it is derived from

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -214,6 +214,19 @@ export { SpacingOverlay } from "./spacing-overlay";
 export type { SpacingOverlayProps } from "./spacing-overlay";
 
 /**
+ * A labelled "+" drawn over every container that has nothing in it.
+ *
+ * A canvas overlay like the two above, and composed the same way — it goes in
+ * `Canvas`'s `overlay`, because it is positioned in the canvas's own content
+ * coordinates and the canvas root is what establishes them. It is a client
+ * component for the same reason `SpacingOverlay` is: it holds React state for
+ * what it has measured, so it belongs behind this entry's banner rather than
+ * the root's.
+ */
+export { EmptyContainerAppenders } from "./empty-container-appender";
+export type { EmptyContainerAppendersProps } from "./empty-container-appender";
+
+/**
  * The editor's document state, published beside the canvas because it is a hook
  * and therefore client-only for the same reason the shell is.
  *

--- a/packages/builder/src/spacing-overlay.test.tsx
+++ b/packages/builder/src/spacing-overlay.test.tsx
@@ -241,6 +241,30 @@ describe("when the overlay draws at all", () => {
     const { container } = mount(editorOf("a"));
     expect(bandSides(container)).toEqual(["margin-top"]);
   });
+
+  it.each(["fixed", "sticky"])(
+    "draws no band for a block positioned %s",
+    position => {
+      /*
+       * A block pinned to the viewport or to a scrollport has left the canvas
+       * content the bands are drawn in, so a band beside it slides away from it
+       * on the first scroll — and the canvas root is not what scrolls, so
+       * nothing re-measures.
+       *
+       * Here rather than only over the predicate in `geometry-dom.test.ts`,
+       * because what this asserts is the WIRING: the refusal is now decided by
+       * a shared function taking the element, and an overlay that passed the
+       * wrong element — or dropped the argument to a boolean parameter that
+       * accepts any of them — would keep drawing while the predicate itself
+       * stayed correct and covered. The fixture is the same one asserted to
+       * produce a band directly above, so the emptiness is this block being
+       * refused rather than a fixture with no spacing in it.
+       */
+      stubComputedStyle({ a: { marginTop: "16px", position } });
+      const { container } = mount(editorOf("a"));
+      expect(bandSides(container)).toEqual([]);
+    }
+  );
 });
 
 describe("which values it reports", () => {

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -40,10 +40,16 @@
  * ## When it re-measures, and the one case it cannot see
  *
  * A re-measure happens when the selection changes, when the document changes,
- * when the selected block resizes, and when the canvas root resizes. Between
- * them those cover an edit, an image or webfont arriving, the panels moving, and
- * a breakpoint changing — a breakpoint is driven by the canvas's own width, so
+ * whenever `watchCanvasGeometry` reports that a rectangle may have moved, and
+ * when a mutation lands outside this overlay's own layer. Between them those
+ * cover an edit, an image or webfont arriving, the panels moving, a scroller
+ * carrying the block, a transition settling, a recompiled site sheet, and a
+ * breakpoint changing — a breakpoint is driven by the canvas's own width, so
  * the root's resize is the event that reports it.
+ *
+ * Which of those the first of the two owns is deliberately not restated here:
+ * that list belongs to `canvas-geometry-watch.ts`, and a copy of it in this
+ * docblock would be a second answer to fall out of step.
  *
  * What is NOT covered is a spacing change driven purely by a CSS STATE: a
  * `:hover` or `:focus-visible` rule altering a margin repaints without mutating
@@ -66,7 +72,8 @@ import {
   usedCornerRadii,
   type CornerRadii,
 } from "./border-radii";
-import { CANVAS_ROOT_CLASS, nodeElement, nodeElements } from "./canvas";
+import { CANVAS_ROOT_CLASS, nodeElement } from "./canvas";
+import { watchCanvasGeometry } from "./canvas-geometry-watch";
 import type { EditorState } from "./editor-state";
 import type { Rect, Scale } from "./geometry";
 import {
@@ -529,23 +536,17 @@ export function SpacingOverlay({
 
   /*
    * Re-measure when the layout moves for a reason no render reports — an image
-   * finishing, a webfont swapping, the panels being resized around the canvas.
+   * finishing, a webfont swapping, the panels being resized around the canvas,
+   * a scroller between a block and the root, a transition settling.
    *
-   * EVERY rendered node is observed, not just the selected one, because what
-   * moves a block is another block changing size. A `ResizeObserver` reports a
-   * size change and never a position one, so the selected block's own entry
-   * stays silent while a sibling above it grows and pushes it down.
+   * That whole list is `watchCanvasGeometry`'s, shared with every other overlay
+   * measuring against this root: which changes can move a rectangle is one
+   * question, and a second copy of the answer drifts from the first silently —
+   * the copy simply never hears one of the mechanisms, and looks complete.
    *
-   * Watching the canvas root does not stand in for this. The root is
-   * `min-height: 100%`, so on a page shorter than the viewport it holds that
-   * height and reports nothing however much the content inside it reflows — the
-   * case where the bands would sit furthest from the block they name. The root
-   * is still observed, for the resize the nodes cannot report: the panels moving
-   * around the canvas, which changes the frame without changing any node.
-   *
-   * The overlay cannot drive its own loop: it is `position: absolute` filling the
-   * root and carries no node marker, so nothing it draws is observed here or
-   * contributes to the root's size.
+   * The overlay cannot drive its own loop through it: it is `position: absolute`
+   * filling the root and carries no node marker, so nothing it draws is observed
+   * there or contributes to the root's size.
    */
   React.useEffect(() => {
     if (hidden || selectedId === null) return;
@@ -553,35 +554,22 @@ export function SpacingOverlay({
     const root =
       element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
     if (root === null) return;
-    /*
-     * Each observer is guarded separately, and that is not tidiness. They answer
-     * different questions — sizes changed, and the DOM changed — so a runtime
-     * missing one must still get the other. Guarding both behind `ResizeObserver`
-     * would silently drop mutation tracking wherever it is absent.
-     *
-     * Absent in jsdom unless a test supplies one, and absent in older browsers.
-     * A missing observer costs a re-measure, not correctness — every render path
-     * above still measures.
-     */
-    const sizes =
-      typeof ResizeObserver === "undefined"
-        ? null
-        : new ResizeObserver(() => measure());
-    if (sizes !== null) {
-      sizes.observe(root);
-      for (const node of nodeElements(root)) sizes.observe(node);
-    }
+    const geometry = watchCanvasGeometry(root, measure);
 
     /*
-     * The other half: a change that alters computed style without altering any
-     * size. A site-style save recompiles the sheet, and `PageRenderer` emits it
-     * as a `<style>` INSIDE the page root — so the bytes changing is a mutation
-     * in this subtree, where a resize observer has nothing to report because a
-     * class-driven margin moves blocks without resizing them.
+     * The one subscription that stays here, because it is the one this overlay
+     * has to answer for itself: a change that alters computed style without
+     * altering any size. A site-style save recompiles the sheet, and
+     * `PageRenderer` emits it as a `<style>` INSIDE the page root — so the
+     * bytes changing is a mutation in this subtree, where a resize observer has
+     * nothing to report because a class-driven margin moves blocks without
+     * resizing them.
      *
-     * Mutations inside the overlay's own layer are ignored. Drawing the bands is
-     * itself a mutation of this subtree, so reacting to it would have the
-     * measurement trigger the next measurement.
+     * Mutations inside the overlay's own layer are ignored, and that rule is
+     * why this cannot be shared. Drawing the bands is itself a mutation of the
+     * observed subtree, so reacting to it would have the measurement trigger
+     * the next measurement — and which mutations are "its own" is a different
+     * answer for every overlay.
      */
     const styles =
       typeof MutationObserver === "undefined"
@@ -600,37 +588,9 @@ export function SpacingOverlay({
       characterData: true,
     });
 
-    /*
-     * A transition moves geometry over time and emits nothing an observer sees:
-     * `transition` is a catalog property, a transform or margin animating past
-     * its first frame resizes nothing, and no DOM mutation accompanies the
-     * frames. The completion events are what the browser does offer, and they
-     * bubble, so one listener on the root covers every block.
-     *
-     * This corrects the FINAL geometry rather than following the animation.
-     * Tracking the frames between would mean measuring on every one, which costs
-     * more than a band being briefly behind a transition the author is watching.
-     */
-    const settled = (): void => measure();
-    root.addEventListener("transitionend", settled);
-    root.addEventListener("transitioncancel", settled);
-    /*
-     * `overflow: auto` and `overflow: scroll` are catalog values, so a block can
-     * sit inside a container the author scrolls. Scrolling it moves the block
-     * relative to the canvas while resizing nothing, mutating nothing and
-     * finishing no transition — none of the subscriptions above hear it.
-     *
-     * CAPTURE, because a scroll event does not bubble: listening on the root in
-     * the capture phase is what reaches a scroller nested anywhere inside it.
-     */
-    root.addEventListener("scroll", settled, true);
-
     return () => {
-      sizes?.disconnect();
+      geometry();
       styles?.disconnect();
-      root.removeEventListener("transitionend", settled);
-      root.removeEventListener("transitioncancel", settled);
-      root.removeEventListener("scroll", settled, true);
     };
     /*
      * `document` re-subscribes, and dropping it strands the observer on a

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -40,14 +40,13 @@
  * ## When it re-measures, and the one case it cannot see
  *
  * A re-measure happens when the selection changes, when the document changes,
- * whenever `watchCanvasGeometry` reports that a rectangle may have moved, and
- * when a mutation lands outside this overlay's own layer. Between them those
- * cover an edit, an image or webfont arriving, the panels moving, a scroller
- * carrying the block, a transition settling, a recompiled site sheet, and a
- * breakpoint changing — a breakpoint is driven by the canvas's own width, so
- * the root's resize is the event that reports it.
+ * and whenever `watchCanvasFor` reports that a rectangle may have moved.
+ * Between them those cover an edit, an image or webfont arriving, the panels
+ * moving, a scroller carrying the block, a transition settling, a recompiled
+ * site sheet, and a breakpoint changing — a breakpoint is driven by the
+ * canvas's own width, so the root's resize is the event that reports it.
  *
- * Which of those the first of the two owns is deliberately not restated here:
+ * Which mechanisms the second of those owns is deliberately not restated here:
  * that list belongs to `canvas-geometry-watch.ts`, and a copy of it in this
  * docblock would be a second answer to fall out of step.
  *
@@ -73,7 +72,7 @@ import {
   type CornerRadii,
 } from "./border-radii";
 import { CANVAS_ROOT_CLASS, nodeElement } from "./canvas";
-import { watchCanvasGeometry } from "./canvas-geometry-watch";
+import { watchCanvasFor } from "./canvas-geometry-watch";
 import type { EditorState } from "./editor-state";
 import type { Rect, Scale } from "./geometry";
 import {
@@ -539,59 +538,20 @@ export function SpacingOverlay({
    * finishing, a webfont swapping, the panels being resized around the canvas,
    * a scroller between a block and the root, a transition settling.
    *
-   * That whole list is `watchCanvasGeometry`'s, shared with every other overlay
+   * That whole list is `watchCanvasFor`'s, shared with every other overlay
    * measuring against this root: which changes can move a rectangle is one
    * question, and a second copy of the answer drifts from the first silently —
    * the copy simply never hears one of the mechanisms, and looks complete.
    *
-   * The overlay cannot drive its own loop through it: it is `position: absolute`
-   * filling the root and carries no node marker, so nothing it draws is observed
-   * there or contributes to the root's size.
+   * The layer is handed over as a READ rather than as an element, because it
+   * does not exist yet on the first pass. It is what locates the canvas root,
+   * and it is also what tells a foreign mutation from the bands' own: drawing
+   * them mutates the very subtree being observed, so without it each
+   * measurement would schedule the next.
    */
   React.useEffect(() => {
     if (hidden || selectedId === null) return;
-    const element = layer.current;
-    const root =
-      element === null ? null : canvasRootFrom(element, CANVAS_ROOT_CLASS);
-    if (root === null) return;
-    const geometry = watchCanvasGeometry(root, measure);
-
-    /*
-     * The one subscription that stays here, because it is the one this overlay
-     * has to answer for itself: a change that alters computed style without
-     * altering any size. A site-style save recompiles the sheet, and
-     * `PageRenderer` emits it as a `<style>` INSIDE the page root — so the
-     * bytes changing is a mutation in this subtree, where a resize observer has
-     * nothing to report because a class-driven margin moves blocks without
-     * resizing them.
-     *
-     * Mutations inside the overlay's own layer are ignored, and that rule is
-     * why this cannot be shared. Drawing the bands is itself a mutation of the
-     * observed subtree, so reacting to it would have the measurement trigger
-     * the next measurement — and which mutations are "its own" is a different
-     * answer for every overlay.
-     */
-    const styles =
-      typeof MutationObserver === "undefined"
-        ? null
-        : new MutationObserver(records => {
-            const own = layer.current;
-            const outside = records.some(
-              record => own === null || !own.contains(record.target)
-            );
-            if (outside) measure();
-          });
-    styles?.observe(root, {
-      childList: true,
-      subtree: true,
-      attributes: true,
-      characterData: true,
-    });
-
-    return () => {
-      geometry();
-      styles?.disconnect();
-    };
+    return watchCanvasFor(() => layer.current, measure);
     /*
      * `document` re-subscribes, and dropping it strands the observer on a
      * DETACHED element. An edit replaces the rendered tree while the selection

--- a/packages/builder/src/spacing-overlay.tsx
+++ b/packages/builder/src/spacing-overlay.tsx
@@ -82,6 +82,7 @@ import {
   hasScrollbarGutter,
   layoutFragments,
   renderedScale,
+  viewportPositioned,
   type RenderedScale,
 } from "./geometry-dom";
 import {
@@ -352,7 +353,7 @@ const NO_BANDS: readonly SpacingBand[] = [];
  */
 function describable(
   fragments: number,
-  position: string,
+  viewportPositioned: boolean,
   gutter: boolean,
   clipped: boolean,
   scale: RenderedScale
@@ -370,8 +371,14 @@ function describable(
    * block stops moving with the canvas content the bands are drawn in, so they
    * slide away from it on the first scroll — and scrolling emits no resize, so
    * nothing re-measures.
+   *
+   * Decided by `viewportPositioned` in `geometry-dom.ts` rather than by reading
+   * `position` here, because it is a property of the coordinate space
+   * `canvasContentRect` measures in and not of bands: every overlay drawn in
+   * that space refuses the same elements, and a second copy of the test would
+   * go on accepting a value the shared one had learned to refuse.
    */
-  if (position === "fixed" || position === "sticky") return false;
+  if (viewportPositioned) return false;
   /*
    * A classic scrollbar takes its width between the padding box and the border,
    * so a padding box derived from the borders alone is too wide by the gutter
@@ -477,7 +484,7 @@ export function SpacingOverlay({
       radii === undefined ||
       !describable(
         layoutFragments(block),
-        style.position,
+        viewportPositioned(block),
         hasScrollbarGutter(block, borders),
         /*
          * The block's own curve goes in with it: a rounded block flush inside an

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1800,6 +1800,13 @@
   pointer-events: none;
 }
 
+/*
+ * The button itself: transparent at rest, so it does not double up on the
+ * dashed `[data-nx-slots]:empty` box already drawn under it, and picking up
+ * colour only on hover and focus — where the two states share a treatment
+ * because both are ways of saying "this is interactive", pointer and keyboard
+ * alike.
+ */
 .nx-empty-container-appenders__button {
   position: absolute;
   display: flex;

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1773,12 +1773,15 @@
 /**
  * The "+" drawn over an empty container.
  *
- * BASE tokens rather than the `--nx-builder-*` set several sections above.
- * Those are declared on `.nx-builder-chrome`, and this control is measured in
- * the same e2e harness `spacing-overlay.tsx` documents as mounting the canvas
- * with no shell around it — a builder token there resolves to nothing exactly
- * where this control would be verified. The drop indicator reaches for
- * `--nx-primary` for the same reason.
+ * BASE tokens rather than the `--nx-builder-*` set several sections above,
+ * matching the drop indicator: this control belongs to the canvas's own
+ * palette, which is the page's rather than the chrome's, so the token it takes
+ * its colour from should be the one every other canvas affordance uses.
+ *
+ * A builder token would in fact resolve here — the empty-container rule above
+ * is scoped to `.nx-builder-chrome`, so a container carrying this control is
+ * always inside the element those tokens are declared on. That is a reason the
+ * choice is safe either way rather than a reason to change it.
  *
  * Positioned exactly like `.nx-spacing-overlay`: a full-bleed layer over the
  * canvas root's own content box, so the pixel numbers the component computes

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1769,3 +1769,58 @@
   font-weight: 400;
   color: var(--nx-muted-foreground);
 }
+
+/**
+ * The "+" drawn over an empty container.
+ *
+ * BASE tokens rather than the `--nx-builder-*` set several sections above.
+ * Those are declared on `.nx-builder-chrome`, and this control is measured in
+ * the same e2e harness `spacing-overlay.tsx` documents as mounting the canvas
+ * with no shell around it — a builder token there resolves to nothing exactly
+ * where this control would be verified. The drop indicator reaches for
+ * `--nx-primary` for the same reason.
+ *
+ * Positioned exactly like `.nx-spacing-overlay`: a full-bleed layer over the
+ * canvas root's own content box, so the pixel numbers the component computes
+ * through `canvasContentRect` land on the containers they were measured from.
+ */
+.nx-empty-container-appenders {
+  position: absolute;
+  inset: 0;
+  /* Above the spacing bands, which only describe what already is; below the
+     floating toolbar, which can be showing for the same selected-but-empty
+     container and should not be covered by this. */
+  z-index: 2;
+  /*
+   * Never a pointer target ITSELF. This layer spans the whole canvas root, and
+   * a hit-test that could land on the empty space between controls would make
+   * every block underneath it unclickable — exactly the failure
+   * `.nx-spacing-overlay` avoids the same way. Each button below opts back in.
+   */
+  pointer-events: none;
+}
+
+.nx-empty-container-appenders__button {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: auto;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--nx-muted-foreground);
+  cursor: pointer;
+}
+
+.nx-empty-container-appenders__button:hover {
+  background: var(--nx-muted);
+  color: var(--nx-foreground);
+}
+
+.nx-empty-container-appenders__button:focus-visible {
+  outline: 2px solid var(--nx-primary);
+  outline-offset: -2px;
+  color: var(--nx-foreground);
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+
+/**
+ * `showEmptyElements` reaching the empty-container appender.
+ *
+ * `empty-container-appender.test.tsx` (in the builder package) asserts the
+ * component's own behaviour given `hidden`. What is only true HERE is the
+ * WIRING: that this field folds the author's "Show empty containers"
+ * preference into that prop at all. The component was mounted with no
+ * awareness of the preference — it reads only `hidden` and the document — so
+ * without this wiring the dashed placeholder box collapses to zero height
+ * when the preference is off (that CSS rule already matches the preference)
+ * while the appender's own "+" keeps floating over nothing, defeating the
+ * preference's whole point: seeing the page as a visitor would.
+ *
+ * The builder shell is replaced with recorders rather than rendered, as
+ * `BlocksField.breakpoints.test` does and for its reason: what is under test
+ * is which props this component passes, and rendering the real shell would
+ * add a tree whose own behaviour belongs to the builder package's tests.
+ *
+ * @module admin/BlocksField.emptyContainerAppender.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/*
+ * Declared here rather than in a setup file, because neither this package nor
+ * the builder configures one. `React.act` refuses to run without it, and the
+ * refusal is a warning rather than a failure — so a version of this file
+ * missing it would drive nothing and still assert against the FIRST render's
+ * props.
+ */
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** ONE document object for the life of the mount — see the sibling test file. */
+const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
+
+/** Props the recorders captured on the most recent render. */
+const seen: {
+  builderShell: Record<string, unknown> | undefined;
+  appender: Record<string, unknown> | undefined;
+} = { builderShell: undefined, appender: undefined };
+
+/**
+ * What `useCanvasDrag` reports for `draggingId`, mutated per test.
+ *
+ * A module-level variable rather than a per-test mock rebuild: the hook is
+ * read once by `BlocksField` at render time, so flipping this and asking for
+ * a re-render is what stands in for a drag actually starting.
+ */
+let draggingId: string | null = null;
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  /*
+   * The real module SPREAD, with only the surfaces this file drives replaced.
+   * A closed object literal here answers `undefined` for every export it does
+   * not list, so adding one to the shell breaks these tests and leaves the
+   * builder's own suite green — a failure that reads as a fault in this file
+   * rather than as a stale list.
+   */
+  const real = await importOriginal<Record<string, unknown>>();
+  const nothing = (): null => null;
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    // Captures the WHOLE props object — `onShowEmptyElementsChange` and
+    // `openInsertPanelToken` are what this file drives, and a narrower
+    // destructure (as the sibling files use for a shell that ignores those)
+    // would silently discard them.
+    BuilderShell: (
+      props: Record<string, unknown> & { children?: React.ReactNode }
+    ): React.JSX.Element => {
+      seen.builderShell = props;
+      return <>{props.children}</>;
+    },
+    // Renders its `overlay`, which is where `EmptyContainerAppenders` is
+    // mounted — a stub dropping it, as the sibling test files' `Canvas` stub
+    // does, would leave this file asserting on absence.
+    Canvas: (props: Record<string, unknown>): React.JSX.Element => (
+      <>{props.overlay as React.ReactNode}</>
+    ),
+    EmptyContainerAppenders: (
+      props: Record<string, unknown>
+    ): React.JSX.Element | null => {
+      seen.appender = props;
+      return null;
+    },
+    BlockToolbar: nothing,
+    DropIndicator: nothing,
+    SpacingOverlay: nothing,
+    BlockKeyboardActions: passthrough,
+    EditorCommandPalette: nothing,
+    BreakpointManager: nothing,
+    BreakpointSwitcher: nothing,
+    InspectorPanel: nothing,
+    InsertPanel: nothing,
+    LayersPanel: nothing,
+    OnboardingChecklist: nothing,
+    SelectionBreadcrumb: nothing,
+    useBuilderChecklist: () => ({
+      visible: false,
+      steps: [],
+      dismiss: () => {},
+    }),
+    useCanvasDrag: () => ({ handlers: {}, target: null, draggingId }),
+    useEditorState: () => ({
+      document: DOCUMENT,
+      selectedId: null,
+      selection: { ids: [], primary: null },
+      apply: () => null,
+      applyAll: () => null,
+      select: () => {},
+      undo: () => {},
+      redo: () => {},
+      canUndo: false,
+      canRedo: false,
+      undoDepth: 0,
+    }),
+    useInlineText: () => ({ onDoubleClick: () => {} }),
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  usePluginClientConfig: () => ({ siteStyle: undefined }),
+  useDocumentCheckpoint: () => ({ schedule: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  // Nothing stored, read successfully — so `siteStylePending` and
+  // `siteStyleError` both resolve to their "ready" values on the first
+  // render, and `BlocksField` renders `Canvas` rather than its loading
+  // paragraph.
+  useSingleDocument: () => ({ data: undefined, isPending: false, error: null }),
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async () => ({ success: true }),
+    isPending: false,
+  }),
+}));
+
+const { BlocksField } = await import("./BlocksField");
+
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+function openEditor(): { rerender: () => void } {
+  const view = render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  return {
+    rerender: () => {
+      React.act(() => {
+        view.rerender(<Host />);
+      });
+    },
+  };
+}
+
+beforeEach(() => {
+  seen.builderShell = undefined;
+  seen.appender = undefined;
+  draggingId = null;
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the empty-container appender and the show-empty-elements preference", () => {
+  it("starts visible, matching the preference's own default of shown", () => {
+    openEditor();
+
+    expect(seen.appender?.hidden).toBe(false);
+  });
+
+  it("hides the appender once the shell reports the preference switched off", () => {
+    const { rerender } = openEditor();
+
+    const report = seen.builderShell?.onShowEmptyElementsChange as
+      | ((value: boolean) => void)
+      | undefined;
+    if (report === undefined) {
+      throw new Error("the shell was given no onShowEmptyElementsChange");
+    }
+    React.act(() => {
+      report(false);
+    });
+    rerender();
+
+    expect(seen.appender?.hidden).toBe(true);
+  });
+
+  it("shows the appender again once the shell reports the preference switched back on", () => {
+    // Asserted at EACH step rather than only at the end: a fold that ORs the
+    // wrong thing, or one that was never wired at all, can still leave the
+    // FINAL value `false` here purely because it never became `true` in
+    // between — which is exactly the shape of a test that would pass whether
+    // or not the fix under test exists. Requiring the intermediate `true` is
+    // what makes "back on" mean something distinct from "was never off".
+    const { rerender } = openEditor();
+
+    const report = seen.builderShell?.onShowEmptyElementsChange as (
+      value: boolean
+    ) => void;
+    React.act(() => {
+      report(false);
+    });
+    rerender();
+    expect(seen.appender?.hidden).toBe(true);
+
+    React.act(() => {
+      report(true);
+    });
+    rerender();
+
+    expect(seen.appender?.hidden).toBe(false);
+  });
+
+  it("stays hidden during a drag even while the preference is on", () => {
+    // The regression this guards: folding the preference into `hidden`
+    // must OR with the drag condition, not replace it — a control that
+    // reappeared mid-drag because the preference happened to be on would be
+    // exactly the failure `hidden` exists to prevent.
+    draggingId = "some-node";
+
+    openEditor();
+
+    expect(seen.appender?.hidden).toBe(true);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -35,6 +35,7 @@
 
 import {
   resolveSiteTokens,
+  getBlock,
   hasBlock,
   registerBlocks,
   registryNestingSource,
@@ -61,6 +62,7 @@ import {
   BuilderShell,
   Canvas,
   DropIndicator,
+  EmptyContainerAppenders,
   InsertPanel,
   InspectorPanel,
   pageStyleTrace,
@@ -627,6 +629,14 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const drag = useCanvasDrag({ editor, slots, nesting });
 
   /*
+   * The empty-container appender's only read of a block's definition: its
+   * accessible label. `{ get: getBlock }` satisfies its `BlockLookup` with no
+   * adapter, because `getBlock` already returns `AnyBlockDefinition | undefined`
+   * and that type carries the one field the appender reads.
+   */
+  const blocks = useMemo(() => ({ get: getBlock }), []);
+
+  /*
    * Typing a block's text on the canvas. The hook owns the caret; which values
    * may be typed into is the block's own declaration, read by the builder.
    */
@@ -1034,6 +1044,24 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   }, [editor.document, onCommit, onClose]);
 
   /*
+   * Opens the insert panel from the canvas itself, for the empty-container
+   * appender: pressing its "+" must select the container AND show the panel
+   * that fills it as one gesture, never two.
+   *
+   * A counter bumped on every press, not a boolean: `BuilderShell` reads this
+   * as "open it AGAIN", including when the author has since closed the panel
+   * by hand, and a value that repeated itself would look unchanged and do
+   * nothing the second time. Starts `undefined` rather than `0` so mounting
+   * the editor is not itself a press.
+   */
+  const [openInsertPanelToken, setOpenInsertPanelToken] = useState<
+    number | undefined
+  >(undefined);
+  const openInsertPanel = useCallback(() => {
+    setOpenInsertPanelToken(current => (current ?? 0) + 1);
+  }, []);
+
+  /*
    * The editor takes the window: the shell draws its own rail, panels, top bar
    * and bottom bar, so admin chrome around it is a second set of the same
    * furniture, and the canvas is the one surface whose purpose is the space it
@@ -1065,6 +1093,10 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             ? AVAILABLE_PANELS
             : AVAILABLE_PANELS_WITH_SETTINGS
         }
+        // Forces the insert panel open from the empty-container appender,
+        // which lives on the canvas below rather than beside the rail that
+        // normally opens a panel.
+        openInsertPanelToken={openInsertPanelToken}
         // Whether the page is live, which the admin's own chrome would have
         // shown had this editor not asked for it to be hidden. `undoDepth` is
         // the editor's OWN dirty signal: the form's is false for as long as the
@@ -1330,6 +1362,26 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                   <SpacingOverlay
                     editor={editor}
                     hidden={drag.draggingId !== null}
+                  />
+                  {/*
+                  Suppressed during a drag for the same reason the toolbar and
+                  the bands are: the document is mid-change, so a control
+                  offering to fill a container names a shape that is about to
+                  be different.
+                */}
+                  <EmptyContainerAppenders
+                    document={editor.document}
+                    slots={slots}
+                    blocks={blocks}
+                    hidden={drag.draggingId !== null}
+                    onAppend={nodeId => {
+                      // Select first, then open. The inserter derives its
+                      // target from the selection, so selecting the container
+                      // is what makes the next insert land inside it — there
+                      // is no second targeting path to keep in step.
+                      editor.select(nodeId);
+                      openInsertPanel();
+                    }}
                   />
                 </>
               }

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -46,7 +46,7 @@ import {
   type BreakpointId,
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
-import { registrySlotSource } from "@nextlyhq/builder";
+import { DEFAULT_PREFERENCES, registrySlotSource } from "@nextlyhq/builder";
 import {
   BlockKeyboardActions,
   authoredBreakpoints,
@@ -195,6 +195,23 @@ const PLUGIN_SOURCE = "@nextlyhq/plugin-page-builder";
 function ensureCoreBlocksRegistered(): void {
   const missing = coreBlocks.filter(block => !hasBlock(block.name));
   if (missing.length > 0) registerBlocks(missing, { source: PLUGIN_SOURCE });
+}
+
+/**
+ * Whether the empty-container appender should be suppressed right now.
+ *
+ * Two independent reasons collapse into one boolean here, named, rather than
+ * inlined at the JSX call site: a drag in progress, where the document is
+ * mid-change, and the author having turned empty-container chrome off, where
+ * the container this control would sit over has collapsed to zero height. A
+ * bare `||` at the call site reads as one condition; naming it is what says
+ * these are two unrelated causes that happen to share an operator.
+ */
+function emptyContainerAppenderHidden(
+  draggingId: string | null,
+  showEmptyElements: boolean
+): boolean {
+  return draggingId !== null || !showEmptyElements;
 }
 
 /**
@@ -1062,6 +1079,21 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   }, []);
 
   /*
+   * Whether the author wants empty-container chrome showing at all, mirrored
+   * from the shell so the appender mounted below can answer the same question
+   * the dashed placeholder box's own CSS rule already answers.
+   *
+   * Starts at the preference's own default rather than an assumed `true`: the
+   * shell reports the real value once it has read it, but that report lands
+   * one render after this component's first — an assumed value would be a
+   * SECOND declaration of the default that goes stale the day the shell's own
+   * changes and this one does not.
+   */
+  const [showEmptyElements, setShowEmptyElements] = useState(
+    DEFAULT_PREFERENCES.showEmptyElements
+  );
+
+  /*
    * The editor takes the window: the shell draws its own rail, panels, top bar
    * and bottom bar, so admin chrome around it is a second set of the same
    * furniture, and the canvas is the one surface whose purpose is the space it
@@ -1097,6 +1129,10 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // which lives on the canvas below rather than beside the rail that
         // normally opens a panel.
         openInsertPanelToken={openInsertPanelToken}
+        // The read half of the same gap: mirrors the shell's own preference
+        // so the appender below can be suppressed by the SAME switch that
+        // already suppresses the placeholder box it sits over.
+        onShowEmptyElementsChange={setShowEmptyElements}
         // Whether the page is live, which the admin's own chrome would have
         // shown had this editor not asked for it to be hidden. `undoDepth` is
         // the editor's OWN dirty signal: the form's is false for as long as the
@@ -1368,12 +1404,21 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                   the bands are: the document is mid-change, so a control
                   offering to fill a container names a shape that is about to
                   be different.
+                  ALSO suppressed while the author has turned empty-container
+                  chrome off: the dashed placeholder box collapses to zero
+                  height under the same preference (`builder-chrome.css`'s
+                  `[data-nx-slots]:empty` rule already matches it), and a "+"
+                  left floating over nothing after that would make the
+                  preference lie about what a visitor sees.
                 */}
                   <EmptyContainerAppenders
                     document={editor.document}
                     slots={slots}
                     blocks={blocks}
-                    hidden={drag.draggingId !== null}
+                    hidden={emptyContainerAppenderHidden(
+                      drag.draggingId,
+                      showEmptyElements
+                    )}
                     onAppend={nodeId => {
                       // Select first, then open. The inserter derives its
                       // target from the selection, so selecting the container


### PR DESCRIPTION
## What and why

Follows [#1257](https://github.com/nextlyhq/nextly/pull/1257), which made empty containers visible and clickable. This adds the affordance: press the **+** inside an empty container and the block lands *inside* it.

The interaction is one gesture rather than two. Pressing the control selects the container **and** opens the insert panel — and because selection is what `insertionPointFor` already reads, the slot is derived rather than passed. There is no second targeting path to keep in step with the first.

## How

- **`emptySlotOf` is the one implementation of "which declared slot is empty."** `insertionPointFor` computed it inline; the appender needed the identical question. Two copies would agree today and drift silently — an appender offering to fill a container the inserter then fills elsewhere looks correct from both sides. `insertionPointFor` is rewired to derive from it, and `inserter.test.ts` passes **unmodified**, which is the evidence that the extraction changed no behaviour.
- **The control is drawn only where the stylesheet drew a box.** `EMPTY_CONTAINER_SELECTOR` (`empty-slot.ts`) is the single spelling of `[data-nx-slots]:empty`, asked of the measured element and held to the stylesheet by `builder-chrome-attributes.test.ts`. Computing "is this container empty" a second time from the document alone produces a *different population* — see **The behaviour change** below.
- **Its rectangle is clamped to the container it belongs to.** A fixed 44px square centred in the measured rectangle, never wider or taller than that rectangle. `[data-nx-slots]:empty` sets `min-height` and **no `min-width`**, so a legitimately empty column can be narrower than the control.
- **The appender positions through the shared canvas geometry helper**, not raw client rectangles. `geometry.ts:165` names the fault it avoids: an unscaled inset misplaces the origin by `(1 - scale) * inset` — exactly zero at 100% and growing as the canvas zooms out, so every default-scale check passes against a broken implementation.
- **It carries `data-nx-chrome`**, which `canvas.tsx` gates on *before* `onSelect` runs. Without it a press resolves to "no node", so the control would run its action and then watch the selection disappear.
- **`showEmptyElements` suppresses the control, not just the box.** The preference is threaded from the shell rather than re-reading the DOM attribute — a third spelling of `data-nx-empty-elements` is exactly the drift the rest of this PR exists to prevent.

## The behaviour change reviewers should look at first

**An empty, closed `core/accordion-item` no longer offers a "+".** It is the only first-party container affected; the other eight keep theirs.

A closed `<details>` renders only its `<summary>`, so its root is not `:empty` and the stylesheet never gave it a 44px box. The appender used to draw there anyway, on a rectangle that was the summary's own ~19px height — and two stacked empty items put one item's control over the *previous* item's title, so a click on item 1 inserted into item 2.

The affordance exists for containers that are invisible and unhittable when empty. An empty accordion item is neither: it renders its title, it has height, clicking it selects it. Inserting into it is unchanged — `insertionPointFor` reads `emptySlotOf`, so selecting the item and inserting still lands the block inside it.

The population was measured against the real render, with both controls: a must-be-found (9 containers in `coreBlocks`, 10 `data-nx-slots` elements in the render, asserted as `containers.length + 1` so a short query fails loudly) and a must-be-absent (`core/spacer` renders and carries no marker).

## Three states, not two

A control that has **not been measured yet** renders at `{0,0,0,0}` on purpose: identity comes from the document, so a screen reader reaches the control before the canvas has laid anything out, and the bare-mount tests depend on it.

A container that is **declined** — clipped by an authored ancestor, or one the stylesheet drew no box for — renders **nothing**. Sharing the unmeasured representation would put a real `<button>` in the tab order at zero size, with `:focus-visible` drawing its outline on a zero-sized box: a keyboard author reaching an invisible control announced as "Add a block to …".

`controlRectFor` is the single exhaustive `switch` turning those three into the two things a render can do, with no `default` arm, so a fourth state cannot fall through.

## Two additions the plan did not anticipate

Both were forced by the code rather than chosen, and both are additive and optional:

- **`openInsertPanelToken` on `BuilderShellProps`.** Nothing outside `BuilderShell` could open a panel — the mechanism simply did not exist. A counter rather than an imperative ref: "open this panel" is a state transition, and `usePreferences` already uses the same count-of-asks shape for `loadCount`. It deliberately bypasses `panelAfterRailClick`, which toggle-*closes* on a repeat value.
- **`onShowEmptyElementsChange`**, so a host can suppress its own overlays with the same switch. It reports through a ref rather than keying on the callback's identity — a host passing a conventional inline callback would otherwise re-trigger the effect on every one of its own renders.

Every existing `BuilderShell` call site omits both and is unaffected.

## Test plan

`packages/builder`: **73 files / 2110 tests**, plus root `check-types` (22/22), root `lint` (24/24), `lint:design`, `fallow audit` (`verdict=pass`, `dead_code_introduced 0`, `duplication_introduced 0`).

**Browser verification is deliberately NOT cited for placement any more, and that is a correction rather than a gap.** The earlier browser sweep measured `Δ(x)+Δ(y)+Δ(width)` between each button rect and its container rect at 0.015–0.09px — it certified *button rect equals container rect*, which is precisely the geometry this PR now removes. That oracle cannot speak to a clamped, centred control, so citing it would be citing evidence for the superseded implementation. Placement is covered by unit tests instead: `centeredControlRect` is a pure `Rect → Rect` function with no DOM dependency, so jsdom's zero-size limitation does not apply to it at all.

What the browser run still stands for, unchanged by the geometry: press selects **and** opens the panel; the placement line reads "Adds inside …"; the block lands inside; the appender disappears once the container is no longer empty; pressing does not clear the selection; absent mid-drag (load-bearing — the appender shares `z-index: 2` with the drop indicator); preference off → no control, on → it returns; both themes; console clean.

Each behaviour below was break-verified — the code broken, the intended test observed failing for the intended reason, and the restore confirmed byte-identical:

- clamp removed → 3 tests fail, named for the property (`never grows taller/wider than the container it sits in`, `keeps the control inside a container narrower than it`). Before this coverage existed the same break left 2095 tests green.
- draw condition removed → the declined container is measured at `44×19` instead of declining.
- declined conflated with unmeasured → 3 fail, covering **both** refusal paths and the test that separates the two states.
- `clippedByAncestorRect` routed back through `clippedByAncestor` → only the must-differ case fails.
- rotated-ancestor refusal inverted → 1 fails. That branch was previously unreachable in tests, because jsdom reports `overflowX` as `""` for an unstyled element, so every plain ancestor read as clipping and `no-clip` never occurred.

## Defects found by verification rather than review

- **A test that passed against the implementation it existed to reject.** `"does not close an already-open insert panel"` never opened the panel first, so a correct force-set and a buggy toggle both produced the same result.
- **The preference left the "+" mounted** over a collapsed node, making the switch a lie.
- **A cast was hiding a wrong value, not a verbose one.** `siteStyles={... as never}` passed `{ css: "", classes: {} }`, but `SiteSheetInput` requires `breakpoints` and has no `css` field — the cast silenced a checker that was right.
- **A stylesheet assertion that prose satisfied.** `[data-nx-slots]:empty` appears twice in `builder-chrome.css`, once as the rule and once in a comment, so a bare `toContain` passed on a stylesheet whose rule no longer used it. The needle now includes the opening brace.

## Changeset

Added: yes (`patch`, all published packages).

## Scope

One follow-up remains and is deliberately out of scope: a new `core/columns` still arrives with zero columns. Deferred, unverified here: a site with no breakpoints, an OS-level pointer drag, and a third viewport tier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added accessible “+” controls to empty containers for adding content directly from the canvas.
  - Controls target the appropriate container and open the insert panel.
  - Added preferences to show or hide empty-container indicators.
  - Controls reposition when the canvas moves, resizes, scrolls, or changes.

- **Bug Fixes**
  - Improved insertion into newly added containers and corrected slot targeting.
  - Prevented duplicate panel openings and preserved preferences during state changes.
  - Suppressed controls for clipped, hidden, fixed, sticky, or non-rendered containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->