### PR TITLE
feat(plugin-page-builder): forget a document's class-usage rows when it is deleted

### DIFF
--- a/.changeset/pb-class-usage-delete-path.md
+++ b/.changeset/pb-class-usage-delete-path.md
@@ -1,0 +1,32 @@
+---
+"@nextlyhq/plugin-page-builder": patch
+---
+
+Deleting a document now removes the class-usage rows it owned.
+
+Until now the index only ever learned about writes. A deleted page's rows stayed behind and kept
+counting towards their classes, so a class that nothing rendered any more could never be deleted -
+the safe-delete check reported usage by a document nobody could open. The rebuild's sweep could
+reach some of those rows but only within one collection, field, locale and variant at a time.
+
+This is the one place in the write path where absence is definite. Everywhere else, whether a
+document is there has to be answered by reading, and a read cannot answer it: a list read applies
+beforeOperation and beforeRead regardless of access override, so a tenant scope or a soft-delete
+filter withholds a live row and the page comes back empty, indistinguishable from a document that
+is gone. That is why an absent document otherwise leaves its rows alone. Here nothing is inferred -
+the hook is the notification that the row was removed, and it runs after the delete committed.
+
+Removal is bound on the document and deliberately not on field, locale or variant. A delete removes
+the document in every language and both lifecycle states at once, so every subject it owned goes
+with it. It also does not consult the collection's configuration first: a blocks field REMOVED from
+a collection after its rows were written would make the collection look untracked, and every row
+that field ever owned would survive the delete with no document left to reconcile it against.
+
+A failure is raised rather than swallowed, for the same reason a failed save is. The deletion is
+already committed and cannot be rolled back, so the throw becomes a warning the caller receives -
+and rows that survive a deleted document name a document that no longer exists, so no later write
+will reconcile them.
+
+Deletes inside a caller-owned transaction are skipped, as writes are: the hook runs before that
+transaction commits and the pooled Direct API cannot join it. Singles and the index's own
+collection are skipped for the reasons they already were.

--- a/.changeset/pb-class-usage-delete-path.md
+++ b/.changeset/pb-class-usage-delete-path.md
@@ -1,5 +1,29 @@
 ---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
 "@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
 ---
 
 Deleting a document now removes the class-usage rows it owned.

--- a/packages/plugin-page-builder/src/class-usage-hook.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-hook.test.ts
@@ -102,7 +102,22 @@ function harness(
       ...over,
     });
 
-  return { registered, fire, api, errors };
+  /**
+   * Fire the handler registered for the DELETE phase.
+   *
+   * Addressed by the phase it was registered under rather than by position, so
+   * that adding a phase cannot silently point this at the wrong handler — which
+   * would make a delete test exercise reconciliation and still pass.
+   */
+  const fireDelete = (over: Record<string, unknown> = {}) =>
+    handlers[registered.indexOf("afterDelete:*")]?.({
+      collection: "pages",
+      data: { id: "p1" },
+      req: { nextly: api },
+      ...over,
+    });
+
+  return { registered, fire, fireDelete, api, errors };
 }
 
 describe("what maintenance is registered on", () => {
@@ -113,7 +128,137 @@ describe("what maintenance is registered on", () => {
     // collections that were added after it.
     const { registered } = harness();
 
-    expect(registered).toEqual(["afterCreate:*", "afterUpdate:*"]);
+    expect(registered).toEqual([
+      "afterCreate:*",
+      "afterUpdate:*",
+      "afterDelete:*",
+    ]);
+  });
+});
+
+describe("a document that was deleted", () => {
+  it("removes its rows, bound on the DOCUMENT and not on a subject", async () => {
+    // A delete removes the document in every language and both lifecycle
+    // states at once, so every subject it owned goes with it. Binding field,
+    // locale or variant would leave the rows that did not match behind, with
+    // no document left to reconcile them against.
+    const { fireDelete, api } = harness();
+    api.find.mockImplementation(async (a: { collection?: string }) =>
+      a.collection === INDEX
+        ? {
+            items: [
+              {
+                id: "r1",
+                scope: "collection",
+                entity: "pages",
+                entityKey: "p1",
+                field: "content",
+                locale: "",
+                variant: "published",
+                classId: "hero",
+              },
+            ],
+            meta: { hasNext: false },
+          }
+        : { items: [], meta: { hasNext: false } }
+    );
+
+    await fireDelete();
+
+    expect(api.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: INDEX,
+        where: {
+          scope: { equals: "collection" },
+          entity: { equals: "pages" },
+          entityKey: { equals: "p1" },
+        },
+      })
+    );
+    expect(api.delete).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: INDEX, id: "r1" })
+    );
+  });
+
+  it("does NOT read the collection's configuration", async () => {
+    // Maintenance asks which blocks fields a collection has because it derives
+    // a row per field. A delete has nothing to derive. Asking anyway would be
+    // actively wrong: a blocks field REMOVED from the collection after its rows
+    // were written makes the collection look untracked, and every row that
+    // field owned would survive the delete for ever.
+    const getCollection = vi.fn(async () => ({
+      fields: [{ type: "blocks", name: "content" }],
+    }));
+    const { fireDelete, fire, api } = harness({ getCollection });
+
+    await fireDelete();
+
+    expect(getCollection).not.toHaveBeenCalled();
+    // Controls, both on this harness: the delete DID run, and a SAVE on the
+    // same context does read the configuration. Without them this would hold
+    // for a delete handler that never ran and for a stubbed-out reader.
+    expect(api.find).toHaveBeenCalled();
+    await fire();
+    expect(getCollection).toHaveBeenCalled();
+  });
+
+  it("SKIPS a delete inside a caller-owned transaction", async () => {
+    // The hook runs before that transaction commits, and the pooled Direct API
+    // cannot join it. The rebuild is what repairs a subject a write bypassed.
+    const { fireDelete, api } = harness();
+
+    // Control first, on the SAME harness: an ordinary delete does reach the
+    // index. Without it this assertion would hold just as well for a handler
+    // that was never registered, or one that does nothing at all.
+    await fireDelete();
+    expect(api.find).toHaveBeenCalled();
+    api.find.mockClear();
+    api.delete.mockClear();
+
+    await fireDelete({ executor: {} });
+
+    expect(api.find).not.toHaveBeenCalled();
+    expect(api.delete).not.toHaveBeenCalled();
+  });
+
+  it("SKIPS its own index collection, whose rows this deletes", async () => {
+    // Every row removed here is itself a delete on the index collection, which
+    // fires this same handler again.
+    const { fireDelete, api } = harness();
+
+    await fireDelete();
+    expect(api.find).toHaveBeenCalled();
+    api.find.mockClear();
+
+    await fireDelete({ collection: INDEX });
+
+    expect(api.find).not.toHaveBeenCalled();
+  });
+
+  it("SKIPS a Single, which a wildcard registration also receives", async () => {
+    // Core namespaces a Single's hooks as `single:<slug>`. The index models
+    // Single subjects but a plugin has no supported way to read one, so none
+    // are written and there are none to forget.
+    const { fireDelete, api } = harness();
+
+    await fireDelete();
+    expect(api.find).toHaveBeenCalled();
+    api.find.mockClear();
+
+    await fireDelete({ collection: "single:site-style" });
+
+    expect(api.find).not.toHaveBeenCalled();
+  });
+
+  it("RAISES when the rows cannot be removed, so the caller is told", async () => {
+    // The delete itself is already committed and cannot be rolled back. A
+    // swallowed failure would report a clean deletion while the rows stay
+    // behind counting towards their classes — and they name a document that no
+    // longer exists, so no later write reconciles them.
+    const { fireDelete, api } = harness();
+    api.find.mockRejectedValue(new Error("index unreachable"));
+
+    await expect(fireDelete()).rejects.toThrow(/could not forget/);
   });
 });
 

--- a/packages/plugin-page-builder/src/class-usage-hook.ts
+++ b/packages/plugin-page-builder/src/class-usage-hook.ts
@@ -32,6 +32,7 @@ import type { DocumentLimits } from "@nextlyhq/blocks-engine";
 import type { HookContext } from "nextly";
 
 import { blocksFieldsOf } from "./class-usage-blocks-fields";
+import { forgetDeletedDocument } from "./class-usage-maintenance";
 import {
   classUsageDocumentReader,
   classUsageIndexStore,
@@ -44,11 +45,20 @@ import { reconcileWrittenDocument } from "./class-usage-write";
  *
  * `afterCreate` and `afterUpdate` only. A publish, a draft save and a restore
  * all arrive as one of those two, so the pair covers every path that changes a
- * document's blocks. Deletion is deliberately absent: removing a document's
- * rows is a different reconciliation — there is no document left to derive
- * from — and it is built separately rather than bolted here.
+ * document's blocks. Deletion is not one of them: there is no document left to
+ * derive rows from, so it is not a reconciliation at all and runs its own
+ * handler below.
  */
 const MAINTAINED_PHASES = ["afterCreate", "afterUpdate"] as const;
+
+/**
+ * The phases that FORGET a document.
+ *
+ * Separate from maintenance because the two share nothing but their guards.
+ * Reconciliation reads a document and computes a difference; this one has no
+ * document to read and removes everything the id owned.
+ */
+const FORGOTTEN_PHASES = ["afterDelete"] as const;
 
 /** How core names a Single's hooks, so a wildcard registration can tell them apart. */
 const SINGLE_HOOK_NAMESPACE = "single:";
@@ -117,6 +127,11 @@ export function registerClassUsageMaintenance(args: {
   for (const phase of MAINTAINED_PHASES) {
     args.ctx.hooks.on(phase, "*", handler);
   }
+
+  const forgetHandler = (context: UnknownRecord) => forget(args, context);
+  for (const phase of FORGOTTEN_PHASES) {
+    args.ctx.hooks.on(phase, "*", forgetHandler);
+  }
 }
 
 /**
@@ -148,6 +163,61 @@ async function maintain(
       `"${work.collection.slug}" ${work.documentId}. The index disagrees with ` +
       `the document until a rebuild runs.`
   );
+}
+
+/**
+ * Drop the rows of a document that has just been deleted.
+ *
+ * Shares every guard a write goes through — `writeTargetOf` answers the
+ * transaction, the Single namespace, this plugin's own index and the missing
+ * Direct API identically here, and a delete is exactly as unable to run on a
+ * pre-commit transactional path as a save is.
+ *
+ * It does NOT consult the collection's configuration, and that is deliberate
+ * rather than an omission. Maintenance asks which blocks fields a collection
+ * has because it must derive rows for each; this has nothing to derive and
+ * removes by id. Asking anyway would be worse than wasteful: a blocks field
+ * REMOVED from a collection after its rows were written would make the
+ * collection look untracked, and every row that field ever owned would survive
+ * the delete with no document left to reconcile it against and no sweep that
+ * visits it. The class it referenced would then be undeletable for ever.
+ *
+ * Skipping the read also means an untracked collection pays one indexed query
+ * per delete instead of a registry read, which is the cheaper of the two.
+ */
+async function forget(
+  args: Parameters<typeof registerClassUsageMaintenance>[0],
+  context: UnknownRecord
+): Promise<void> {
+  const target = writeTargetOf(context, args.indexCollection);
+  if (target === null) return;
+
+  try {
+    await forgetDeletedDocument({
+      store: classUsageIndexStore(target.nextly, args.indexCollection),
+      scope: "collection",
+      entity: target.slug,
+      entityKey: target.documentId,
+    });
+  } catch (failure) {
+    // Raised for the same reason maintenance raises: `after*` is a side-effect
+    // phase whose throw the registry converts into a warning the caller
+    // receives, and the delete itself is already committed. Swallowing would
+    // report a clean deletion while the document's rows stay behind, counting
+    // towards classes nothing renders — and those rows name a document that no
+    // longer exists, so no later write reconciles them.
+    args.ctx.logger?.error?.(
+      "[page-builder] class-usage rows survived a deleted document; " +
+        "they count towards their classes until a rebuild runs",
+      { collection: target.slug, documentId: target.documentId, error: failure }
+    );
+    throw new Error(
+      `[page-builder] class-usage could not forget "${target.slug}" ` +
+        `${target.documentId}. Its rows still count towards their classes ` +
+        `until a rebuild runs.`,
+      { cause: failure }
+    );
+  }
 }
 
 /**

--- a/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
 
 import {
+  forgetDeletedDocument,
   maintainClassUsage,
   type ClassUsageIndexStore,
 } from "./class-usage-maintenance";
@@ -339,5 +340,214 @@ describe("a subject whose rows span several pages", () => {
     // have reported `card` as an insert and never seen `stale` at all.
     expect(report).toEqual({ inserted: 0, removed: 1, undetermined: false });
     expect(deletes).toEqual(["r3"]);
+  });
+});
+
+describe("forgetting a document that was deleted", () => {
+  /**
+   * A store holding rows for ONE document spread across the three columns a
+   * delete must ignore, plus a row belonging to a different document.
+   *
+   * The foreign row is what makes the predicate assertions mean anything: a
+   * query that bound nothing at all would also return every row of the
+   * deleted document, and would pass a test that only counted deletions.
+   */
+  function storeWithRows() {
+    const all = [
+      { id: "r1", field: "content", locale: "", variant: "published" },
+      { id: "r2", field: "content", locale: "", variant: "draft" },
+      { id: "r3", field: "content", locale: "de", variant: "published" },
+      { id: "r4", field: "sidebar", locale: "en", variant: "draft" },
+    ].map(r => ({
+      ...r,
+      scope: "collection",
+      entity: "pages",
+      entityKey: "page-1",
+      classId: "hero",
+    }));
+    const foreign = {
+      id: "r9",
+      scope: "collection",
+      entity: "pages",
+      entityKey: "page-2",
+      field: "content",
+      locale: "",
+      variant: "published",
+      classId: "hero",
+    };
+
+    const calls: string[] = [];
+    const store: ClassUsageIndexStore = {
+      find: async args => {
+        calls.push(`find:${Object.keys(args.where).sort().join(",")}`);
+        // Answered as a real store would: only the rows matching every bound
+        // predicate. A fake returning everything would let a query that
+        // dropped `entityKey` pass while deleting another document's rows.
+        const items = [...all, foreign].filter(row =>
+          Object.entries(args.where).every(
+            ([column, predicate]) =>
+              (row as unknown as Record<string, unknown>)[column] ===
+              predicate.equals
+          )
+        );
+        return { items, meta: { hasNext: false } };
+      },
+      create: async () => ({}),
+      delete: async args => {
+        calls.push(`delete:${args.id}`);
+        return {};
+      },
+    };
+    return { store, calls };
+  }
+
+  it("removes every subject's rows, whatever field, locale or variant they name", async () => {
+    // A delete removes the document in every language and both lifecycle states
+    // at once. Binding any of those three columns would leave the rows that did
+    // not match behind, counting towards their classes with no document left to
+    // reconcile them against and no sweep that visits them.
+    const { store, calls } = storeWithRows();
+
+    const result = await forgetDeletedDocument({
+      store,
+      scope: "collection",
+      entity: "pages",
+      entityKey: "page-1",
+    });
+
+    expect(result).toEqual({ removed: 4 });
+    expect(calls).toEqual([
+      // Bound on the DOCUMENT and on nothing else.
+      "find:entity,entityKey,scope",
+      "delete:r1",
+      "delete:r2",
+      "delete:r3",
+      "delete:r4",
+    ]);
+  });
+
+  it("leaves another document's rows alone", async () => {
+    // The same store holds a row for `page-2`. Deleting `page-1` must not
+    // touch it — an over-broad query here removes usage a live page still has.
+    const { store, calls } = storeWithRows();
+
+    await forgetDeletedDocument({
+      store,
+      scope: "collection",
+      entity: "pages",
+      entityKey: "page-1",
+    });
+
+    expect(calls).not.toContain("delete:r9");
+  });
+
+  it("reads every PAGE before deleting any row", async () => {
+    // These are offset queries, so deleting while paging shifts later rows
+    // behind the cursor and a row is skipped — surviving the document it
+    // belonged to and counting towards its class for ever.
+    //
+    // The fixture spans TWO pages deliberately. On a single page, deleting as
+    // each page arrives produces exactly the same call order as reading
+    // everything first, so a one-page fixture asserts nothing: it passed
+    // against a per-page delete when that was tried as a break.
+    const calls: string[] = [];
+    const rowsByPage: Record<number, string[]> = { 1: ["r1", "r2"], 2: ["r3"] };
+    const store: ClassUsageIndexStore = {
+      find: async args => {
+        calls.push(`find:page=${args.page}`);
+        const ids = rowsByPage[args.page] ?? [];
+        return {
+          items: ids.map(id => ({
+            id,
+            scope: "collection",
+            entity: "pages",
+            entityKey: "page-1",
+            field: "content",
+            locale: "",
+            variant: "published",
+            classId: "hero",
+          })),
+          meta: { hasNext: args.page < 2 },
+        };
+      },
+      create: async () => ({}),
+      delete: async args => {
+        calls.push(`delete:${args.id}`);
+        return {};
+      },
+    };
+
+    const result = await forgetDeletedDocument({
+      store,
+      scope: "collection",
+      entity: "pages",
+      entityKey: "page-1",
+    });
+
+    expect(result).toEqual({ removed: 3 });
+    // Both reads land before the first removal. Interleaving them is the
+    // failure this exists to catch.
+    expect(calls).toEqual([
+      "find:page=1",
+      "find:page=2",
+      "delete:r1",
+      "delete:r2",
+      "delete:r3",
+    ]);
+  });
+
+  it("removes nothing when the document owned no rows", async () => {
+    // A document with no blocks field, or one whose rows were never written.
+    // The absence is not an error and must not be reported as one.
+    const { store, calls } = storeWithRows();
+
+    const result = await forgetDeletedDocument({
+      store,
+      scope: "collection",
+      entity: "pages",
+      entityKey: "never-indexed",
+    });
+
+    expect(result).toEqual({ removed: 0 });
+    expect(calls.filter(c => c.startsWith("delete:"))).toEqual([]);
+  });
+
+  it("REFUSES to delete a row the query did not ask for", async () => {
+    // If a misbound query returns a foreign row, deleting it removes usage
+    // belonging to a document that still exists. The refusal must raise rather
+    // than skip, or a misbound query would quietly do damage on every call.
+    const calls: string[] = [];
+    const store: ClassUsageIndexStore = {
+      find: async () => ({
+        items: [
+          {
+            id: "r9",
+            scope: "collection",
+            entity: "pages",
+            entityKey: "page-2",
+            field: "content",
+            locale: "",
+            variant: "published",
+            classId: "hero",
+          },
+        ],
+        meta: { hasNext: false },
+      }),
+      create: async () => ({}),
+      delete: async args => {
+        calls.push(`delete:${args.id}`);
+        return {};
+      },
+    };
+
+    await expect(
+      forgetDeletedDocument({
+        store,
+        scope: "collection",
+        entity: "pages",
+        entityKey: "page-1",
+      })
+    ).rejects.toThrow(/entityKey/);
+    expect(calls).toEqual([]);
   });
 });

--- a/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
@@ -557,6 +557,61 @@ describe("forgetting a document that was deleted", () => {
     expect(deleted).toEqual(["legacy"]);
   });
 
+  it("RAISES on this document's row that carries no readable id", async () => {
+    // `afterRead` may reshape a list response and the Direct API applies it
+    // even for a trusted caller, so a host projecting this plugin's own index
+    // collection can drop the column the rows are addressed by. Skipping such a
+    // row reports a clean deletion that did not happen — and because the
+    // document is gone, no reconciliation visits it again and it counts towards
+    // its class for ever.
+    const deleted: string[] = [];
+    const store: ClassUsageIndexStore = {
+      find: async () => ({
+        items: [
+          {
+            // Addressable, and removed.
+            id: "r1",
+            scope: "collection",
+            entity: "pages",
+            entityKey: "page-1",
+            field: "content",
+            locale: "",
+            variant: "published",
+            classId: "hero",
+          },
+          {
+            // This document's row, with the id projected away.
+            scope: "collection",
+            entity: "pages",
+            entityKey: "page-1",
+            field: "content",
+            locale: "",
+            variant: "published",
+            classId: "card",
+          },
+        ],
+        meta: { hasNext: false },
+      }),
+      create: async () => ({}),
+      delete: async args => {
+        deleted.push(args.id);
+        return {};
+      },
+    };
+
+    await expect(
+      forgetDeletedDocument({
+        store,
+        scope: "collection",
+        entity: "pages",
+        entityKey: "page-1",
+      })
+    ).rejects.toThrow(/no readable id/);
+    // Nothing was deleted: the walk reads every page before removing anything,
+    // so the failure is reported before a partial cleanup is begun.
+    expect(deleted).toEqual([]);
+  });
+
   it("REFUSES to delete a row the query did not ask for", async () => {
     // If a misbound query returns a foreign row, deleting it removes usage
     // belonging to a document that still exists. The refusal must raise rather

--- a/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.test.ts
@@ -512,6 +512,51 @@ describe("forgetting a document that was deleted", () => {
     expect(calls.filter(c => c.startsWith("delete:"))).toEqual([]);
   });
 
+  it("removes a LEGACY row whose variant is unreadable", async () => {
+    // A row written before the `variant` column existed, or left NULL by a
+    // restore, is rejected by the reconciler's reader — correctly, because that
+    // walk binds a variant and such a row belongs to no subject it could be
+    // compared against. It is therefore reachable by no reconciliation and by
+    // no sweep, so if the delete spared it too it would outlive its document
+    // and count towards its class for ever with nothing able to remove it.
+    const deleted: string[] = [];
+    const store: ClassUsageIndexStore = {
+      find: async () => ({
+        items: [
+          {
+            id: "legacy",
+            scope: "collection",
+            entity: "pages",
+            entityKey: "page-1",
+            field: "content",
+            // The two columns a legacy row is missing. Neither is bound by this
+            // query, and neither is needed to know the row belongs to a
+            // document that is gone.
+            locale: null,
+            variant: null,
+            classId: "hero",
+          },
+        ],
+        meta: { hasNext: false },
+      }),
+      create: async () => ({}),
+      delete: async args => {
+        deleted.push(args.id);
+        return {};
+      },
+    };
+
+    const result = await forgetDeletedDocument({
+      store,
+      scope: "collection",
+      entity: "pages",
+      entityKey: "page-1",
+    });
+
+    expect(result).toEqual({ removed: 1 });
+    expect(deleted).toEqual(["legacy"]);
+  });
+
   it("REFUSES to delete a row the query did not ask for", async () => {
     // If a misbound query returns a foreign row, deleting it removes usage
     // belonging to a document that still exists. The refusal must raise rather

--- a/packages/plugin-page-builder/src/class-usage-maintenance.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.ts
@@ -246,7 +246,55 @@ async function storedRowsWhere(
   where: Record<string, { equals: string }>,
   describe: string
 ): Promise<StoredClassUsageRow[]> {
-  const rows: StoredClassUsageRow[] = [];
+  return rowsWhere(store, where, describe, readStoredRow);
+}
+
+/**
+ * The identity of a stored row, without decoding the columns it is not keyed by.
+ *
+ * A row whose `variant` is NULL — written before that column existed, or left
+ * that way by a restore — is rejected by `readStoredRow`, which is right for
+ * reconciliation: that walk binds a variant, so a row carrying none belongs to
+ * no subject it could be compared against, and nothing there knows enough to
+ * remove it.
+ *
+ * A document-wide DELETE knows enough. It binds only the document, the document
+ * is gone, and every row keyed to it goes with it whatever else the row says.
+ * Decoding the variant there would silently spare exactly the rows no subject
+ * can reach and no sweep visits — they would outlive their document and count
+ * towards their classes for ever, with nothing able to remove them.
+ */
+interface ClassUsageRowIdentity {
+  id: string;
+  scope: string;
+  entity: string;
+  entityKey: string;
+}
+
+/** Read only the columns a document-wide removal is keyed by. */
+function readRowIdentity(item: unknown): ClassUsageRowIdentity | null {
+  if (!isPlainRecord(item)) return null;
+  const parts = readStrings(item, ["id", "scope", "entity", "entityKey"]);
+  if (parts === null) return null;
+  const [id, scope, entity, entityKey] = parts;
+  return { id, scope, entity, entityKey };
+}
+
+/**
+ * Every row matching a query, decoded by the caller's reader.
+ *
+ * The reader is a parameter because two walks need different amounts of the
+ * row: reconciliation compares whole subjects, while a removal needs only what
+ * it is keyed by. Sharing the paging and the misbinding check keeps them from
+ * drifting apart, which is how one of them would stop refusing foreign rows.
+ */
+async function rowsWhere<T extends { id: string }>(
+  store: ClassUsageIndexStore,
+  where: Record<string, { equals: string }>,
+  describe: string,
+  decode: (item: unknown) => T | null
+): Promise<T[]> {
+  const rows: T[] = [];
   await walkPages({
     maxPages: MAX_PAGES,
     describe,
@@ -263,7 +311,7 @@ async function storedRowsWhere(
       }),
     onPage: items => {
       for (const item of items) {
-        const row = readStoredRow(item);
+        const row = decode(item);
         if (row === null) continue;
         // Validated HERE rather than by each consumer. Every path that reads
         // rows goes on to delete some of them, and a row outside the requested
@@ -289,7 +337,7 @@ async function storedRowsWhere(
  * invisibly on every call and nothing would ever report it.
  */
 function assertRowMatches(
-  row: StoredClassUsageRow,
+  row: { id: string },
   where: Record<string, { equals: string }>,
   describe: string
 ): void {
@@ -415,6 +463,10 @@ export async function maintainClassUsage(args: {
  *
  * Rows are read whole before any is deleted. These are offset queries, so
  * deleting while paging shifts later rows behind the cursor and skips them.
+ *
+ * Only the identity columns are decoded, so a row whose `variant` or `locale`
+ * is unreadable still goes. Those are precisely the rows no subject can name
+ * and no sweep visits, so sparing them here would strand them for ever.
  */
 export async function forgetDeletedDocument(args: {
   store: ClassUsageIndexStore;
@@ -427,10 +479,11 @@ export async function forgetDeletedDocument(args: {
     entity: { equals: args.entity },
     entityKey: { equals: args.entityKey },
   };
-  const rows = await storedRowsWhere(
+  const rows = await rowsWhere(
     args.store,
     where,
-    `${args.scope}:${args.entity}:${args.entityKey}:*`
+    `${args.scope}:${args.entity}:${args.entityKey}:*`,
+    readRowIdentity
   );
 
   let removed = 0;

--- a/packages/plugin-page-builder/src/class-usage-maintenance.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.ts
@@ -271,12 +271,36 @@ interface ClassUsageRowIdentity {
   entityKey: string;
 }
 
-/** Read only the columns a document-wide removal is keyed by. */
+/**
+ * Read only the columns a document-wide removal is keyed by.
+ *
+ * A row that answers the document's predicates but carries no readable `id`
+ * RAISES rather than being skipped. Skipping is right for a row this walk
+ * cannot recognise at all — that row is another query's business — but a row
+ * that IS this document's and cannot be addressed is the one case where
+ * silence strands it: the document is gone, so no reconciliation will visit it
+ * again, and it counts towards its class for ever.
+ *
+ * The id can go missing for a real reason. `afterRead` may reshape a list
+ * response, and the Direct API applies those transformations even for a
+ * trusted caller — so a host that projects this plugin's own index collection
+ * can drop the column the rows are addressed by. Raising reports that; the
+ * alternative reported a clean deletion that had not happened.
+ */
 function readRowIdentity(item: unknown): ClassUsageRowIdentity | null {
   if (!isPlainRecord(item)) return null;
-  const parts = readStrings(item, ["id", "scope", "entity", "entityKey"]);
-  if (parts === null) return null;
-  const [id, scope, entity, entityKey] = parts;
+  const keyed = readStrings(item, ["scope", "entity", "entityKey"]);
+  if (keyed === null) return null;
+  const [scope, entity, entityKey] = keyed;
+
+  const id = item.id;
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error(
+      `Class-usage row for ${scope}:${entity}:${entityKey} has no readable ` +
+        `id, so it cannot be removed with the document it belongs to; it ` +
+        `would count towards its class until a rebuild runs.`
+    );
+  }
   return { id, scope, entity, entityKey };
 }
 

--- a/packages/plugin-page-builder/src/class-usage-maintenance.ts
+++ b/packages/plugin-page-builder/src/class-usage-maintenance.ts
@@ -390,6 +390,58 @@ export async function maintainClassUsage(args: {
 }
 
 /**
+ * Drop every row a deleted document owned.
+ *
+ * This is the one place in the write path where absence is DEFINITE. Every
+ * other question about whether a document is there is asked by reading, and a
+ * read cannot answer it: `listEntries` applies `beforeOperation` and
+ * `beforeRead` regardless of access override, so a tenant scope or a
+ * soft-delete filter withholds a live row and the page comes back empty,
+ * indistinguishable from a document that is gone. That is why an absent
+ * document leaves its rows alone everywhere else.
+ *
+ * Here nothing is inferred. The hook IS the notification that the row was
+ * removed, and it runs after the delete committed — so the rows can be dropped
+ * outright, and the usual asymmetry does not apply because there is no reading
+ * to be wrong about.
+ *
+ * Bound on the document and NOT on field, locale or variant. A delete removes
+ * the document in every language and both lifecycle states at once, so every
+ * subject it owned goes with it. Binding the other three would need the caller
+ * to enumerate subjects from configuration that may since have changed —
+ * and a blocks field REMOVED from a collection after its rows were written
+ * would then be unnameable, leaving those rows behind for ever with no live
+ * document to reconcile them against and no sweep that visits them.
+ *
+ * Rows are read whole before any is deleted. These are offset queries, so
+ * deleting while paging shifts later rows behind the cursor and skips them.
+ */
+export async function forgetDeletedDocument(args: {
+  store: ClassUsageIndexStore;
+  scope: ClassUsageScope;
+  entity: string;
+  entityKey: string;
+}): Promise<{ removed: number }> {
+  const where = {
+    scope: { equals: args.scope },
+    entity: { equals: args.entity },
+    entityKey: { equals: args.entityKey },
+  };
+  const rows = await storedRowsWhere(
+    args.store,
+    where,
+    `${args.scope}:${args.entity}:${args.entityKey}:*`
+  );
+
+  let removed = 0;
+  for (const row of rows) {
+    await args.store.delete({ id: row.id });
+    removed += 1;
+  }
+  return { removed };
+}
+
+/**
  * Drop rows belonging to documents that no longer exist.
  *
  * A walk over live documents can only reconcile the ones it finds. A document


### PR DESCRIPTION
Stacked on #1271. Review that one first; this branch contains its commits.

## What was wrong

The class-usage index only ever learned about **writes**. Nothing removed a document's rows when the document itself went, so they stayed behind and kept counting towards their classes. A class that nothing rendered any more could never be deleted — the safe-delete check reported usage by a document nobody could open, and no later write would ever reconcile rows whose subject names an id that no longer exists.

The rebuild's sweep (`forgetAbsentDocuments`) could reach some of them, but only one collection, field, locale and variant per invocation.

## The one place absence is definite

Everywhere else in this plugin, "is the document still there" has to be answered by reading, and a read **cannot** answer it: `listEntries` applies `beforeOperation` and `beforeRead` regardless of `overrideAccess`, so a tenant scope or a soft-delete filter withholds a live row and the page comes back empty — indistinguishable from a document that is gone. That is why an absent document otherwise leaves its rows alone.

Here nothing is inferred. The hook **is** the notification that the row was removed, and `afterDelete` runs post-commit (`committedWrite = deletedRow` is set before `execute("afterDelete")`, `collection-mutation-service.ts:7431`/`:7471`). So the usual over-count asymmetry does not apply: there is no reading to be wrong about.

## Two deliberate choices worth reviewing

**Bound on the document, not on a subject.** A delete removes the document in every language and both lifecycle states at once, so every subject it owned goes with it. Binding `field`/`locale`/`variant` would leave the rows that did not match behind.

**It does not read the collection's configuration.** Maintenance asks which blocks fields a collection has because it derives a row per field; this has nothing to derive. Asking anyway would be actively wrong — a blocks field *removed* from a collection after its rows were written makes the collection look untracked, and every row that field ever owned would survive the delete for ever. Skipping the read is also the cheaper path for an untracked collection: one indexed query instead of a registry read.

**Failure raises**, as a failed save does. The deletion is already committed and cannot be rolled back, so the throw becomes a side-effect warning the caller receives.

Transactional deletes, Singles and the index's own collection are skipped through the same `writeTargetOf` guards a write uses.

## Evidence

11 new tests. Every one break-verified individually, and every break confirmed to compile.

One break **passed**, which was the finding: `reads every row BEFORE deleting any of them` was vacuous. With a single-page fixture, deleting per page and deleting after reading everything produce identical call order — the property only exists across pages. Rewritten across two pages, the same break now fails it.

The three `SKIPS …` tests assert an absence, so each is paired with a positive control on the same harness. Removing the registration entirely now fails **all seven** delete tests rather than passing three of them vacuously.

Gates, each run separately: build 0, vitest 0 (**480 passed**), check-types 0, lint 0 (`--max-warnings 0`), root eslint 0, comment-convention 0, fallow `verdict: pass` with every `*_introduced` at 0.

## Note on CI

`main` is currently red on `e2e/tests/canvas/acceptance.spec.ts:509` (`expect(perMove).toBeLessThanOrEqual(6)`, received 6.05 then 6.35 on retry), which `ops/merge-policy` blocks on through its `base` clause. Filed as `finding:canvas-a9-geometry-threshold-reds-main`. Not related to this change.