### PR TITLE
test(admin): repair the four suites blocking every admin push

### DIFF
--- a/packages/admin/src/components/features/dashboard/StatsCard.test.tsx
+++ b/packages/admin/src/components/features/dashboard/StatsCard.test.tsx
@@ -5,6 +5,20 @@ import { Users } from "@admin/components/icons";
 
 import { StatsCard } from "./StatsCard";
 
+/**
+ * The element carrying the trend colour: the badge wrapping the icon and the
+ * percentage, not the span holding the text.
+ *
+ * Throws rather than returning null when it cannot be found, so a future markup
+ * change surfaces as "the badge is gone" instead of an assertion quietly
+ * passing against an element that does not exist.
+ */
+function trendBadge(text: string): HTMLElement {
+  const badge = screen.getByText(text).closest("div");
+  if (badge === null) throw new Error(`no trend badge around "${text}"`);
+  return badge;
+}
+
 describe("StatsCard", () => {
   it("renders with basic props", () => {
     render(<StatsCard title="Total Users" value={1247} />);
@@ -20,9 +34,19 @@ describe("StatsCard", () => {
     );
 
     expect(screen.getByText("+12.5%")).toBeInTheDocument();
-    // Check for emerald color classes for Antigravity aesthetic
-    const trendElement = screen.getByText("+12.5%");
-    expect(trendElement).toHaveClass("text-success-500");
+    // The colour is on the BADGE, not on the span holding the text — the text
+    // sits in a bare child, so the old assertion read an element with no class
+    // at all and could never have passed.
+    //
+    // Asserted by FAMILY rather than by ramp step: `text-success-700` is the
+    // current value and a legitimate token change would move it, while the
+    // property worth locking is that an up trend is coloured with the success
+    // family and never the destructive one. Both halves are needed — a class
+    // list carrying both would satisfy either check alone, and swapping the two
+    // branches is exactly the regression this guards.
+    const badge = trendBadge("+12.5%");
+    expect(badge.className).toMatch(/\btext-success-\d+\b/);
+    expect(badge.className).not.toMatch(/\btext-destructive-\d+\b/);
   });
 
   it("renders with negative trend indicator", () => {
@@ -31,9 +55,9 @@ describe("StatsCard", () => {
     );
 
     expect(screen.getByText("-5.2%")).toBeInTheDocument();
-    // Check for rose/red color classes for Antigravity aesthetic
-    const trendElement = screen.getByText("-5.2%");
-    expect(trendElement).toHaveClass("text-destructive-500");
+    const badge = trendBadge("-5.2%");
+    expect(badge.className).toMatch(/\btext-destructive-\d+\b/);
+    expect(badge.className).not.toMatch(/\btext-success-\d+\b/);
   });
 
   it("does not render trend when change is undefined", () => {

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/BasicsTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/BasicsTab.test.tsx
@@ -101,8 +101,11 @@ describe("BasicsTab", () => {
       />
     );
 
-    // Override the slug via the SlugInput edit affordance.
-    await user.click(screen.getByRole("button", { name: /edit/i }));
+    // Typed straight into the field. The slug used to sit behind a pencil
+    // button, and `7cdc8d8ee` replaced that arrangement with a plain input —
+    // so clicking "Edit" first found no such button and this test failed
+    // before reaching the behaviour it is named for. The sibling plural test
+    // below has always typed directly; this one now matches it.
     const slugInput = screen.getByRole("textbox", { name: /slug/i });
     await user.clear(slugInput);
     await user.type(slugInput, "post");

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/SlugInput.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/SlugInput.test.tsx
@@ -1,16 +1,19 @@
-// Why: SlugInput shows the auto-derived slug with a dim "Slug:" label, the
-// value bold next to it, and a Lucide pencil icon button to enter edit
-// mode (PR B redesign). Once in edit mode, onChange propagates each
-// keystroke so the parent form sees the override immediately. These tests
-// lock the read/edit modes and the onChange contract so a refactor can't
-// silently break the auto-derive UX.
+// SlugInput is a controlled text input for an entity's slug, read-only once the
+// entity exists.
 //
-// Note: SlugInput is a controlled component, so tests use a stateful wrapper
-// (`<Controlled>`) that feeds onChange back into value — same pattern any
-// real consumer (BasicsTab + react-hook-form) would use.
+// It previously had read and edit modes — a bold value, a pencil button, a
+// "Done" — and four tests locked that UX. `7cdc8d8ee` ("stop offering an
+// entity's slug for editing after creation") replaced the whole arrangement
+// with a single `Input`, so those tests described a component that no longer
+// exists and asserted against markup nothing rendered. They are replaced here
+// rather than deleted: the component still has a contract, and leaving it
+// uncovered would trade four failing tests for none at all.
+//
+// SlugInput is controlled, so these use a stateful wrapper — the same shape any
+// real consumer (BasicsTab with react-hook-form) provides.
+import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
-import userEvent from "@testing-library/user-event";
 
 import { render, screen } from "@admin/__tests__/utils";
 
@@ -19,6 +22,7 @@ import { SlugInput } from "../SlugInput";
 function Controlled(props: {
   initial: string;
   singular?: string;
+  readOnly?: boolean;
   onChange?: (next: string) => void;
 }) {
   const [value, setValue] = useState(props.initial);
@@ -26,6 +30,7 @@ function Controlled(props: {
     <SlugInput
       singular={props.singular ?? "Blog Post"}
       value={value}
+      readOnly={props.readOnly ?? false}
       onChange={next => {
         setValue(next);
         props.onChange?.(next);
@@ -35,40 +40,43 @@ function Controlled(props: {
 }
 
 describe("SlugInput", () => {
-  it("renders the slug value with a dim 'Slug:' label in read mode", () => {
+  it("shows the slug as the input's value", () => {
     render(<Controlled initial="blog_post" />);
-    expect(screen.getByText("blog_post")).toBeInTheDocument();
-    // Why: PR G dropped the redundant "Slug:" prefix per feedback 2.
-    // The Label above already says "Slug" so the prefix was duplicate.
-    expect(screen.queryByText(/^Slug:/)).toBeNull();
-  });
-
-  it("renders a pencil icon edit button (no 'AUTO' badge, no 'Edit' text)", () => {
-    render(<Controlled initial="blog_post" />);
-    expect(screen.queryByText("AUTO")).not.toBeInTheDocument();
-    const button = screen.getByRole("button", { name: /edit slug/i });
-    // The button should contain an SVG (the pencil), not text 'Edit'.
-    expect(button.querySelector("svg")).not.toBeNull();
-    expect(button).not.toHaveTextContent(/^Edit$/);
-  });
-
-  it("reveals an input pre-filled with current value when Edit is clicked", async () => {
-    const user = userEvent.setup();
-    render(<Controlled initial="blog_post" />);
-    await user.click(screen.getByRole("button", { name: /edit slug/i }));
     expect(screen.getByRole("textbox", { name: /slug/i })).toHaveValue(
       "blog_post"
     );
   });
 
-  it("emits each keystroke as an onChange call when overriding", async () => {
-    const user = userEvent.setup();
+  it("names itself for a screen reader, since the field carries no visible label of its own", () => {
+    render(<Controlled initial="blog_post" />);
+    expect(screen.getByLabelText("Slug")).toBeInTheDocument();
+  });
+
+  it("emits each keystroke, so the parent form sees an override immediately", () => {
     const onChange = vi.fn();
-    render(<Controlled initial="blog_post" onChange={onChange} />);
-    await user.click(screen.getByRole("button", { name: /edit slug/i }));
+    render(<Controlled initial="" onChange={onChange} />);
     const input = screen.getByRole("textbox", { name: /slug/i });
-    await user.clear(input);
-    await user.type(input, "post");
-    expect(onChange).toHaveBeenLastCalledWith("post");
+    return userEvent.type(input, "post").then(() => {
+      expect(onChange).toHaveBeenLastCalledWith("post");
+    });
+  });
+
+  it("refuses edits when read-only but keeps the value reachable", async () => {
+    // `readOnly` rather than `disabled`, which is the component's own stated
+    // decision and the separating property between them: a disabled input
+    // leaves the tab order, so an existing entity's slug would stop being
+    // selectable, copyable and reachable by a screen reader. Asserting only
+    // "typing does nothing" would pass for `disabled` too.
+    const onChange = vi.fn();
+    render(<Controlled initial="blog_post" readOnly onChange={onChange} />);
+    const input = screen.getByRole("textbox", { name: /slug/i });
+
+    await userEvent.type(input, "x");
+    expect(onChange).not.toHaveBeenCalled();
+    expect(input).toHaveValue("blog_post");
+
+    expect(input).not.toBeDisabled();
+    input.focus();
+    expect(input).toHaveFocus();
   });
 });

--- a/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/DefaultValueField.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/field-editor-sheet/__tests__/DefaultValueField.test.tsx
@@ -99,11 +99,16 @@ describe("DefaultValueField", () => {
   // entirely (locked decision: brainstorm 2026-05-04 Option B). The old
   // Switch-based test moved into this describe block.
   describe("tri-state boolean default (PR E3)", () => {
+    // `checkbox` is the FIELD type; `boolean` is the COLUMN type it maps to
+    // (`catalog.ts`: `checkbox: "boolean"`). This described the column, so
+    // `SUPPORTED_TYPES` did not recognise it, the component returned null, and
+    // eight assertions failed against an empty body — a test that could only
+    // ever have failed, on a component that works.
     const makeBoolField = (defaultValue?: boolean | null): BuilderField =>
       baseField({
         name: "isPublished",
         label: "Is Published",
-        type: "boolean",
+        type: "checkbox",
         ...(defaultValue !== undefined ? { defaultValue } : {}),
       });
 


### PR DESCRIPTION
`main`'s admin suite has **15 failing tests across 4 files**, and since `#1266` added the gate-scoped `pnpm turbo test` to the pre-push hook, **any branch touching `packages/admin` is refused for failures it did not cause**. Nothing in the output says the cause is pre-existing.

```
before:  Test Files  4 failed | 315 passed (319)     Tests  15 failed | 2973 passed (2988)
after:   Test Files          319 passed (319)        Tests          2988 passed (2988)
```

Verified by pushing this branch through the real hook: the gate selected `--filter=@nextlyhq/admin`, ran it, and the push was accepted. No `--no-verify`.

## None of the four was reporting a real defect

**`DefaultValueField` — 8 failures.** The test passed `type: "boolean"`, which is the **column** type `checkbox` maps to (`catalog.ts`: `checkbox: "boolean"`), not a field type. `SUPPORTED_TYPES` therefore did not recognise it, the component returned `null`, and eight assertions ran against `<body><div /></body>`. A test that could never have passed, on a component that works correctly.

**`SlugInput` — 4 failures.** These described a read mode, a pencil button and a "Done" button that `7cdc8d8ee` ("stop offering an entity's slug for editing after creation") removed. **Replaced rather than deleted** — the component still has a contract, and trading four failing tests for none is not an improvement. The replacements cover what it does now, including *why* it uses `readOnly` rather than `disabled`: a disabled input leaves the tab order, so an existing slug would stop being selectable, copyable and reachable by a screen reader. Asserting only "typing does nothing" would pass for `disabled` too, so the test asserts focusability as well — that is the separating property.

**`BasicsTab` — 1 failure.** It clicked that same removed pencil before typing, so it failed before reaching the auto-derive behaviour it is named for. It now types straight into the field, as its sibling plural test always has.

**`StatsCard` — 2 failures.** It read the class off the `<span>` holding the percentage while the colour is on the badge around it, so the assertion ran against an element with **no class at all** (`Received:` was empty). It now reads the badge, and asserts by colour **family** rather than ramp step — a token change may legitimately move `text-success-700`, while the property worth locking is that an up trend never carries the destructive family. Both directions are asserted, since a class list carrying both would satisfy either check alone.

## Verification

Each repair break-verified against the regression it guards:

| break | fails |
| --- | --- |
| swap the up/down trend colours | 2 (StatsCard) |
| remove the auto-derive override guard | 1 (BasicsTab) |
| `readOnly` → `disabled` | 1 (SlugInput) |

**Collection control:** 319 collected against 319 on disk — and my first control said 318, which was *my control* being wrong, not the run. I had omitted the config's third include pattern (`scripts/**/*.test.mjs`). Worth stating because a control that disagrees with the run is exactly the moment to check the control.

No changeset: test-only.

## Why this is worth landing quickly

The blocker is wider than the lanes hitting it today. Branches cut before `#1266` carry a copy of `.husky/pre-push` with no gate block at all (`grep -c GATE_FILTERS` returns 0 there), so those lanes are unblocked only until their next rebase. Every admin-touching branch meets this eventually.