### PR TITLE
fix(admin): make the loading skeleton match the editor that replaces it

### DIFF
--- a/.changeset/the-placeholder-matches-the-editor.md
+++ b/.changeset/the-placeholder-matches-the-editor.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The entry editor no longer shifts its fields when a document finishes loading.
+
+While an entry loads, the placeholder was laid out to a different width than
+the editor that replaces it, so every field moved sideways at the moment the
+content appeared — which reads as the page loading twice rather than as
+content arriving.
+
+The placeholder now matches the editor it stands in for: the same width, and
+the same panel beside it. Creating an entry no longer shows a placeholder for
+a panel it never displays, and the placeholder's panel is the width the real
+one turns out to be, rather than forty pixels wider.

--- a/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
+++ b/packages/admin/src/components/layout/__tests__/content-measure-wiring.test.ts
@@ -27,6 +27,12 @@ import { describe, expect, it } from "vitest";
 const SRC = join(process.cwd(), "src");
 
 /** Every route whose page is a document rather than a settings form. */
+/** Routes whose frame hands the panel to content that bounds itself. */
+const SELF_MEASURING_ROUTES = [
+  "pages/dashboard/entries/[slug]/[id]/index.tsx",
+  "pages/dashboard/entries/[slug]/create.tsx",
+] as const;
+
 /** A `PluginSlot` wrapper and whatever attributes it carries. */
 const SLOT_WRAPPER = /<div\b([^>]*)>\s*<PluginSlot\b/g;
 
@@ -67,19 +73,45 @@ function containersIn(relative: string): string[] {
 
 describe("content routes read the shared measure", () => {
   for (const route of CONTENT_ROUTES) {
-    it(`${route} measures every container from the shared constant`, () => {
+    it(`${route} names no measure of its own`, () => {
       const containers = containersIn(route);
       // The population assertion. Without it, a renamed file or a pattern that
       // stopped matching yields an empty list, and the loop below passes over
       // a route the test never read.
       expect(containers.length).toBeGreaterThan(0);
       for (const attrs of containers) {
-        // Asserted over EVERY container, so dropping the prop fails here
-        // rather than removing the tag from the scan.
-        expect(attrs).toContain("width={CONTENT_PAGE_MEASURE}");
+        // Two legal answers, and no third. `CONTENT_PAGE_MEASURE` is the page
+        // bounding the content; `full` is the content bounding itself. A raw
+        // `"form"` or `"wide"` here is a page deciding a width on its own,
+        // which is what drifts away from the frame beside it.
+        const legal =
+          attrs.includes("width={CONTENT_PAGE_MEASURE}") ||
+          attrs.includes('width="full"');
+        expect(legal, `illegal width in ${route}: ${attrs.trim()}`).toBe(true);
       }
     });
   }
+
+  it("the loading skeleton matches the frame that replaces it", () => {
+    // The property this whole module exists for. The editor bounds its FIELD
+    // column and takes the panel, so a skeleton that bounds the PAGE is
+    // narrower — and every field slides sideways at the moment data arrives,
+    // which reads as the page loading twice.
+    //
+    // Asserted per route rather than centrally: the skeleton and the frame are
+    // in the same file but different branches, and nothing renders both, so
+    // their agreement is not observable at either one.
+    for (const route of SELF_MEASURING_ROUTES) {
+      const source = readFileSync(join(SRC, route), "utf8");
+      const skeleton = source.slice(source.indexOf("PageSkeleton()"));
+      const first = [...skeleton.matchAll(CONTAINER_TAG)][0]?.[1] ?? "";
+      expect(first, `no container found in ${route}'s skeleton`).not.toBe("");
+      expect(
+        first.includes('width="full"'),
+        `${route}: the skeleton bounds the page while its frame does not`
+      ).toBe(true);
+    }
+  });
 
   it("bounds the injection slots that the self-measuring frame renders", () => {
     // The frame gives the panel to the form-and-rail row, so anything else it

--- a/packages/admin/src/components/layout/content-measure.ts
+++ b/packages/admin/src/components/layout/content-measure.ts
@@ -23,6 +23,8 @@
  * @module components/layout/content-measure
  */
 
+import { SHELL_MEASURE } from "@nextlyhq/ui";
+
 import type { PageContainerProps } from "@admin/types/layout/page-container";
 
 /**
@@ -30,23 +32,22 @@ import type { PageContainerProps } from "@admin/types/layout/page-container";
  * is a compile error here rather than a silently ignored attribute at fifteen
  * call sites.
  */
-export const CONTENT_PAGE_MEASURE: keyof typeof CAPPED_MEASURE_TOKEN = "wide";
+export const CONTENT_PAGE_MEASURE: CappedMeasure = "wide";
 
 /**
- * The token each CAPPED measure resolves to.
+ * The widths that CAP the content column, which is every width except `full`.
  *
- * `full` is deliberately absent rather than mapped to null. It is the absence
- * of a cap, so it has no length to convert to, and an entry for it would need a
- * fallback — which is a wrong answer waiting to be returned rather than a
- * missing one. Leaving it out makes `CONTENT_PAGE_MEASURE` below unassignable
- * from `full`, so the case cannot arise instead of being handled badly.
+ * Named as a type rather than a second table of tokens: `SHELL_MEASURE` already
+ * maps each width to its value, and restating those tokens here would be a
+ * second answer to a question the shell owns — one that drifts silently,
+ * because both copies look correct beside their own neighbours.
+ *
+ * `full` is excluded because it is the absence of a cap, so it has no length a
+ * content column could take. Excluding it here makes `CONTENT_PAGE_MEASURE`
+ * unassignable from it, so the case cannot arise rather than being handled with
+ * a fallback that would quietly return the wrong measure.
  */
-const CAPPED_MEASURE_TOKEN = {
-  form: "--nx-measure-form",
-  wide: "--nx-measure-wide",
-} as const satisfies Partial<
-  Record<NonNullable<PageContainerProps["width"]>, string>
->;
+type CappedMeasure = Exclude<NonNullable<PageContainerProps["width"]>, "full">;
 
 /**
  * The content measure as a CSS length, for content that bounds its own column.
@@ -58,4 +59,4 @@ const CAPPED_MEASURE_TOKEN = {
  * the disagreement this module exists to prevent, and writing the token out
  * again by hand is how it would return.
  */
-export const CONTENT_MEASURE_LENGTH = `var(${CAPPED_MEASURE_TOKEN[CONTENT_PAGE_MEASURE]})`;
+export const CONTENT_MEASURE_LENGTH = SHELL_MEASURE[CONTENT_PAGE_MEASURE];

--- a/packages/admin/src/components/layout/page-container/index.test.tsx
+++ b/packages/admin/src/components/layout/page-container/index.test.tsx
@@ -15,6 +15,11 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import {
+  CONTENT_MEASURE_LENGTH,
+  CONTENT_PAGE_MEASURE,
+} from "@admin/components/layout/content-measure";
+
 import { PageContainer } from "./index";
 
 describe("PageContainer", () => {
@@ -66,6 +71,22 @@ describe("PageContainer", () => {
         .getByTestId("page-container")
         .style.getPropertyValue("--nx-shell-measure")
     ).toBe("100%");
+  });
+
+  it("the content length agrees with what the shell actually renders", () => {
+    // The oracle is the RENDER, not the map. `CONTENT_MEASURE_LENGTH` and the
+    // shell both read `SHELL_MEASURE`, so comparing them to each other would
+    // compare two reads of one value and pass however wrong that value was.
+    // Rendering the container at the content measure and reading the property
+    // back off the DOM is a different observation, and it is the one that
+    // catches the field column being bounded to something the page never uses.
+    render(<PageContainer width={CONTENT_PAGE_MEASURE}>content</PageContainer>);
+    const rendered = screen
+      .getByTestId("page-container")
+      .style.getPropertyValue("--nx-shell-measure");
+
+    expect(rendered).not.toBe("");
+    expect(CONTENT_MEASURE_LENGTH).toBe(rendered);
   });
 
   it("keeps the grid for `full`, which is what separates it from no width", () => {

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -91,7 +91,7 @@ function EditEntryBreadcrumbs({
  */
 function EditEntryPageSkeleton() {
   return (
-    <PageContainer width={CONTENT_PAGE_MEASURE}>
+    <PageContainer width="full">
       {/* Accessibility: Announce loading state to screen readers */}
       <div className="sr-only" role="status" aria-live="polite">
         Loading entry...
@@ -105,7 +105,13 @@ function EditEntryPageSkeleton() {
         {/* Main Content */}
         {/* `min-w-0` as the editor that replaces this carries it: without it
             this pane will not shrink and pushes the rail past the column. */}
-        <div className="flex-1 min-w-0 space-y-6 lg:p-8 pt-6">
+        <div
+          className="flex-1 min-w-0 space-y-6 lg:p-8 pt-6 mx-auto w-full"
+          // The editor that replaces this bounds its FIELD column, not the
+          // page, so a skeleton bounded at the page moves every field
+          // sideways the moment data arrives.
+          style={{ maxWidth: CONTENT_MEASURE_LENGTH }}
+        >
           {/* Breadcrumbs skeleton */}
           <div className="mb-6">
             <Skeleton className="h-5 w-64" />
@@ -128,7 +134,7 @@ function EditEntryPageSkeleton() {
         </div>
 
         {/* Sidebar */}
-        <div className="w-full lg:w-[360px] shrink-0  border-t border-border lg:border-t-0 lg:border-l border-border lg:border-border bg-card flex flex-col relative z-10">
+        <div className="w-full lg:w-[320px] shrink-0  border-t border-border lg:border-t-0 lg:border-l border-border lg:border-border bg-card flex flex-col relative z-10">
           <div className="lg:sticky lg:top-0 lg:h-[calc(100vh-4rem)] flex flex-col">
             {/* Sidebar Header/Actions Skeleton */}
             <div className="p-6  border-b border-border space-y-3">

--- a/packages/admin/src/pages/dashboard/entries/[slug]/create.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/create.tsx
@@ -19,7 +19,10 @@ import {
   EntryForm,
   type EntryFormCollection,
 } from "@admin/components/features/entries/EntryForm";
-import { CONTENT_PAGE_MEASURE } from "@admin/components/layout/content-measure";
+import {
+  CONTENT_MEASURE_LENGTH,
+  CONTENT_PAGE_MEASURE,
+} from "@admin/components/layout/content-measure";
 import { MeasuredPageFrame } from "@admin/components/layout/MeasuredPageFrame";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { Breadcrumbs } from "@admin/components/shared";
@@ -81,7 +84,7 @@ function CreateEntryBreadcrumbs({
  */
 function CreateEntryPageSkeleton() {
   return (
-    <PageContainer width={CONTENT_PAGE_MEASURE}>
+    <PageContainer width="full">
       {/* Accessibility: Announce loading state to screen readers */}
       <div className="sr-only" role="status" aria-live="polite">
         Loading collection...
@@ -95,7 +98,13 @@ function CreateEntryPageSkeleton() {
         {/* Main Content */}
         {/* `min-w-0` as the editor that replaces this carries it: without it
             this pane will not shrink and pushes the rail past the column. */}
-        <div className="flex-1 min-w-0 space-y-6 lg:p-8 pt-6">
+        <div
+          className="flex-1 min-w-0 space-y-6 lg:p-8 pt-6 mx-auto w-full"
+          // The form that replaces this bounds its FIELD column, not the
+          // page, so a skeleton bounded at the page moves every field
+          // sideways the moment data arrives.
+          style={{ maxWidth: CONTENT_MEASURE_LENGTH }}
+        >
           {/* Breadcrumbs skeleton */}
           <div className="mb-6">
             <Skeleton className="h-5 w-64" />
@@ -118,39 +127,6 @@ function CreateEntryPageSkeleton() {
         </div>
 
         {/* Sidebar */}
-        <div className="w-full lg:w-[360px] shrink-0  border-t border-border lg:border-t-0 lg:border-l border-border lg:border-border bg-card flex flex-col relative z-10">
-          <div className="lg:sticky lg:top-0 lg:h-[calc(100vh-4rem)] flex flex-col">
-            {/* Sidebar Header/Actions Skeleton */}
-            <div className="p-6  border-b border-border space-y-3">
-              <div className="flex gap-3">
-                <Skeleton className="h-10 flex-1" />
-                <Skeleton className="h-10 flex-1" />
-              </div>
-            </div>
-
-            {/* Sidebar Content Skeleton */}
-            <div className="p-6 space-y-8">
-              {/* Sidebar Fields / SEO */}
-              <div className="space-y-4">
-                <Skeleton className="h-6 w-32" />
-                <div className="space-y-2">
-                  <Skeleton className="h-12 w-full" />
-                  <Skeleton className="h-12 w-full" />
-                </div>
-              </div>
-
-              {/* Document Info Skeleton (Empty in Create mode but placeholder header shown) */}
-              <div className="pt-6  border-t border-border">
-                <div className="bg-primary/5 px-6 py-3 mb-4">
-                  <Skeleton className="h-4 w-32" />
-                </div>
-                <div className="px-6 py-4 text-xs text-muted-foreground italic">
-                  Document info will be available after saving.
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
       </div>
     </PageContainer>
   );

--- a/packages/ui/STABILITY.md
+++ b/packages/ui/STABILITY.md
@@ -86,9 +86,16 @@ Everything else the barrel exports, including: `Accordion`, `Alert`, `AlertDialo
 `Progress`, `ResizablePanelGroup`/`ResizablePanel`/`ResizableHandle`, `Separator`,
 `Skeleton`, `Slider`, `Spinner`, `Table` and its family, `TableSearch`, `TableSkeleton`,
 `TreeView`, the table state components, the layout primitives (`Stack`, `Grid`, `Stat`,
-`PageShell`, `Bleed`, `PageHeader`),
+`PageShell`, `Bleed`, `PageHeader`, `SHELL_MEASURE`),
 `Toaster` and the shortcut manager (`ShortcutProvider`, `ShortcutScope`, `useShortcuts`,
 `useShortcutManager`, `useActiveShortcuts`, `createShortcutManager`, `parseKeys`).
+
+`SHELL_MEASURE` is the width-to-length mapping `PageShell` applies, exported because a
+surface whose CONTENT carries the measure — an editor that seats a rail beside its
+fields, so the page cannot cap the two together — needs the same value as a CSS length.
+The alternative is a second table naming the same tokens, which drifts silently because
+each copy reads correctly beside its own neighbours. Exported so there is one answer
+rather than two that happen to agree.
 
 `Slider` (with `SliderThumbProps`) joins them for the inspector: a bounded numeric property — opacity, blur radius,
 letter spacing, a colour's alpha — is the single most repeated control in an editing surface,

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -180,6 +180,7 @@ exports[`ui public export surface > . surface is unchanged 1`] = `
   "ResizableHandle (value)",
   "ResizablePanel (value)",
   "ResizablePanelGroup (value)",
+  "SHELL_MEASURE (value)",
   "Select (value)",
   "SelectContent (value)",
   "SelectGroup (value)",

--- a/packages/ui/src/components/page-shell.tsx
+++ b/packages/ui/src/components/page-shell.tsx
@@ -97,12 +97,25 @@ function hasDisplayContentsChild(shell: HTMLElement): boolean {
 }
 
 /**
+ * What each named width resolves to, owned here because this is what applies it.
+ *
  * Declared as a lookup rather than branched at the call site so the three arms
  * are one list. A `switch` here would let a fourth width be added to the type
  * and forgotten in the mapping, which the checker cannot see through a
  * `default` arm.
+ *
+ * Exported because a caller whose CONTENT carries the measure needs the same
+ * value as a length, and the alternative is a second table naming the same
+ * tokens — which drifts silently, since both look correct beside their own
+ * neighbours. Reading it here means there is one answer rather than two that
+ * agree today.
+ *
+ * @experimental
  */
-const MEASURE: Record<NonNullable<PageShellProps["width"]>, string> = {
+export const SHELL_MEASURE: Record<
+  NonNullable<PageShellProps["width"]>,
+  string
+> = {
   form: "var(--nx-measure-form)",
   wide: "var(--nx-measure-wide)",
   full: "100%",
@@ -222,7 +235,7 @@ export const PageShell = forwardRef<HTMLDivElement, PageShellProps>(
     // `width` is the supported way to choose it.
     const shellStyle: ShellStyle = {
       ...style,
-      "--nx-shell-measure": MEASURE[width],
+      "--nx-shell-measure": SHELL_MEASURE[width],
     };
 
     return (

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -577,7 +577,7 @@ export type { FormActionsProps } from "./types/form-layout";
  * second inset and a full-bleed child does not have to be rendered outside the
  * measure in order to escape it. No first-party plugin has exercised it yet.
  */
-export { Bleed, PageShell } from "./components/page-shell";
+export { Bleed, PageShell, SHELL_MEASURE } from "./components/page-shell";
 /**
  * @experimental A page's own identity — trail, name, summary and actions — fed
  * entirely by props, so a page declares what it is instead of a foreign file


### PR DESCRIPTION
Two things: a reflow defect I introduced in #1284 and which is **live on main**, and one commit from #1284 that was stranded by the merge.

## 1. The skeleton and the editor disagreed on width

Found by CodeRabbit on #1284, after it had merged. The editor bounds its FIELD column and takes the panel, so the rail sits beside the fields. The skeleton still bounded the PAGE, so it was narrower — and every field slid sideways the moment data arrived.

That is precisely the invariant `content-measure.ts` was written to protect:

> They must agree: a skeleton at one measure followed by a document at another moves every field sideways at the moment the data arrives, which reads as the page loading twice.

Violated by the change that gave the module its reason to exist.

**Two older disagreements in the same markup**, both dating to `554e0f91b` (initial commit) and neither caused by the width change:

| | Skeleton | Reality |
| --- | --- | --- |
| Rail width | `lg:w-[360px]` | `w-[320px]` |
| Rail on **create** | reserved | never rendered — gated on `mode === "edit"` |

So the create placeholder always showed a 360px panel that then vanished.

## 2. Stranded from #1284

`e094f1775` — exporting `SHELL_MEASURE` so the admin stops restating the token table — was pushed after GitHub computed #1284's merge, so it is absent from `main`: `SHELL_MEASURE` returns 0 refs there. Cherry-picked here unchanged.

That answers the reviewer's "derive the CSS length from PageShell's measure definition" finding, which was resolved on #1284 on the strength of a commit that did not land. Verified by content rather than by the PR's state, which read merged and clean throughout.

## The test asserts the property, not the values

A route whose frame hands the panel to its content must have a skeleton that does the same:

```ts
expect(
  first.includes('width="full"'),
  `${route}: the skeleton bounds the page while its frame does not`
).toBe(true);
```

Checked **per route** rather than centrally, because the skeleton and the frame are different branches of one file and nothing renders both — so their agreement is not observable at either of them, which is exactly why this shipped.

The container test now admits two legal answers and no third: `CONTENT_PAGE_MEASURE` (the page bounds the content) or `full` (the content bounds itself). A raw `"form"` or `"wide"` is a page deciding a width on its own, which is what drifts away from the frame beside it.

## Test plan

- **Break-verified**: reverting the create skeleton to bound the page fails `the loading skeleton matches the frame that replaces it`, naming the route and the reason. Restored, 7/7.
- `build` 0 · `check-types` 0 · `lint` 0 · `fallow audit` 0 · **ui 49/49 (1135)** · **admin 319/319 (2994)** · `test:scripts` 627/627.
- Pushed through the full pre-push hook, no bypass.

Changeset added: yes (patch, all 25 lockstep packages).

## Not in this PR

`SingleForm.tsx` renders the same 320px rail and belongs to another lane; its skeleton is not affected by this change. The rail width is still a literal in two components rather than one shared value — worth closing, but it needs that lane's file.