### PR TITLE
refactor(admin): extract the shared insert-dialog shell for rich-text plugins

### DIFF
--- a/.changeset/richtext-insert-dialog-shell.md
+++ b/.changeset/richtext-insert-dialog-shell.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Pressing Enter to accept an IME suggestion no longer submits a rich-text insert
+dialog.
+
+Choosing a candidate in a Japanese, Chinese or Korean input method ends with
+Enter, and the dialogs read that as "insert". An author composing a link title
+or a button label had the dialog close on them mid-word, with whatever the
+editor had at that moment.
+
+The table, video, button and button-link dialogs also share one shell now,
+rather than each carrying its own copy of the same open, focus and submit
+behaviour.

--- a/packages/admin/src/components/features/entries/fields/special/RichTextButtonGroupPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextButtonGroupPlugin.tsx
@@ -18,7 +18,6 @@ import {
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
   DialogDescription,
   Input,
   Label,
@@ -41,14 +40,7 @@ import {
 } from "lexical";
 import { useState, useCallback, useEffect } from "react";
 
-import {
-  AlertCircle,
-  Plus,
-  Trash2,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-} from "@admin/components/icons";
+import { Plus, Trash2 } from "@admin/components/icons";
 
 import {
   $createButtonGroupNode,
@@ -58,6 +50,11 @@ import {
   type ButtonAlignment,
 } from "./ButtonGroupNode";
 import type { ButtonLinkSize, ButtonLinkVariant } from "./ButtonLinkNode";
+import {
+  useInsertDialogState,
+  InsertDialogFooter,
+  ButtonAlignmentControl,
+} from "./RichTextInsertDialog";
 
 // ============================================================
 // Commands
@@ -101,7 +98,6 @@ export function RichTextButtonGroupPlugin({
   disabled = false,
 }: RichTextButtonGroupPluginProps) {
   const [editor] = useLexicalComposerContext();
-  const [isOpen, setIsOpen] = useState(false);
   const [buttons, setButtons] = useState<DialogButton[]>([
     createDefaultButton(),
     createDefaultButton(),
@@ -116,12 +112,6 @@ export function RichTextButtonGroupPlugin({
     setError(null);
     setEditingNodeKey(null);
   }, []);
-
-  const openDialog = useCallback(() => {
-    if (disabled) return;
-    resetState();
-    setIsOpen(true);
-  }, [disabled, resetState]);
 
   const updateButton = useCallback(
     (index: number, updates: Partial<DialogButton>) => {
@@ -163,6 +153,13 @@ export function RichTextButtonGroupPlugin({
       return false;
     }
   }, []);
+
+  const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
+    useInsertDialogState({
+      resetState,
+      onSubmit: () => insertButtonGroup(),
+      disabled,
+    });
 
   const insertButtonGroup = useCallback(() => {
     // Validate all buttons
@@ -235,17 +232,15 @@ export function RichTextButtonGroupPlugin({
 
     setIsOpen(false);
     resetState();
-  }, [editor, buttons, alignment, isValidUrl, resetState, editingNodeKey]);
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        resetState();
-      }
-      setIsOpen(open);
-    },
-    [resetState]
-  );
+  }, [
+    editor,
+    buttons,
+    alignment,
+    isValidUrl,
+    setIsOpen,
+    resetState,
+    editingNodeKey,
+  ]);
 
   // Register commands
   useEffect(() => {
@@ -306,11 +301,14 @@ export function RichTextButtonGroupPlugin({
     return () => {
       window.removeEventListener("edit-button-group", handleEditEvent);
     };
-  }, []);
+  }, [setIsOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-xl max-h-[85vh] overflow-y-auto">
+      <DialogContent
+        className="sm:max-w-xl max-h-[85vh] overflow-y-auto"
+        onKeyDown={handleKeyDown}
+      >
         <DialogHeader>
           <DialogTitle>
             {editingNodeKey ? "Edit Button Group" : "Insert Button Group"}
@@ -324,43 +322,12 @@ export function RichTextButtonGroupPlugin({
 
         <div className="space-y-4">
           {/* Alignment Controls */}
-          <div className="space-y-2">
-            <Label className="text-sm font-medium">
-              Button Group Alignment
-            </Label>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant={alignment === "left" ? "default" : "outline"}
-                size="md"
-                className="flex-1"
-                onClick={() => setAlignment("left")}
-              >
-                <AlignLeft className="h-4 w-4" />
-                Left
-              </Button>
-              <Button
-                type="button"
-                variant={alignment === "center" ? "default" : "outline"}
-                size="md"
-                className="flex-1"
-                onClick={() => setAlignment("center")}
-              >
-                <AlignCenter className="h-4 w-4" />
-                Center
-              </Button>
-              <Button
-                type="button"
-                variant={alignment === "right" ? "default" : "outline"}
-                size="md"
-                className="flex-1"
-                onClick={() => setAlignment("right")}
-              >
-                <AlignRight className="h-4 w-4" />
-                Right
-              </Button>
-            </div>
-          </div>
+          <ButtonAlignmentControl
+            value={alignment}
+            onChange={setAlignment}
+            label="Button Group Alignment"
+            disabled={disabled}
+          />
 
           {/* Individual Button Settings */}
           {buttons.map((button, index) => (
@@ -497,28 +464,16 @@ export function RichTextButtonGroupPlugin({
               Add Button
             </Button>
           )}
-
-          {/* Error */}
-          {error && (
-            <div className="flex items-center gap-2 text-destructive text-sm">
-              <AlertCircle className="h-4 w-4" />
-              {error}
-            </div>
-          )}
         </div>
 
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => handleOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={insertButtonGroup}>
-            {editingNodeKey ? "Update Button Group" : "Insert Button Group"}
-          </Button>
-        </DialogFooter>
+        <InsertDialogFooter
+          error={error}
+          onCancel={() => handleOpenChange(false)}
+          onConfirm={insertButtonGroup}
+          confirmLabel={
+            editingNodeKey ? "Update Button Group" : "Insert Button Group"
+          }
+        />
       </DialogContent>
     </Dialog>
   );

--- a/packages/admin/src/components/features/entries/fields/special/RichTextButtonGroupPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextButtonGroupPlugin.tsx
@@ -154,6 +154,9 @@ export function RichTextButtonGroupPlugin({
     }
   }, []);
 
+  // Shared dialog shell: open/close lifecycle with reset-on-close and
+  // Enter-to-submit. Enter submission is new here — the other three dialogs
+  // already had it, and the shared shell is what makes the four agree.
   const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
     useInsertDialogState({
       resetState,
@@ -466,6 +469,10 @@ export function RichTextButtonGroupPlugin({
           )}
         </div>
 
+        {/* Shared footer: the error banner and Cancel/Confirm row every
+            insert dialog renders. Confirm is gated on every button having
+            text and a URL — emptiness only, matching the button-link dialog,
+            so a non-empty invalid URL still submits and shows the banner. */}
         <InsertDialogFooter
           error={error}
           onCancel={() => handleOpenChange(false)}
@@ -473,6 +480,7 @@ export function RichTextButtonGroupPlugin({
           confirmLabel={
             editingNodeKey ? "Update Button Group" : "Insert Button Group"
           }
+          confirmDisabled={buttons.some(b => !b.text.trim() || !b.url.trim())}
         />
       </DialogContent>
     </Dialog>

--- a/packages/admin/src/components/features/entries/fields/special/RichTextButtonLinkPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextButtonLinkPlugin.tsx
@@ -12,13 +12,11 @@
 
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
-  Button,
   Checkbox,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
   DialogDescription,
   Input,
   Label,
@@ -41,13 +39,7 @@ import {
 } from "lexical";
 import { useState, useCallback, useEffect } from "react";
 
-import {
-  MousePointerClick,
-  AlertCircle,
-  AlignLeft,
-  AlignCenter,
-  AlignRight,
-} from "@admin/components/icons";
+import { MousePointerClick } from "@admin/components/icons";
 
 import {
   $createButtonLinkNode,
@@ -57,6 +49,11 @@ import {
   type ButtonLinkSize,
   type ButtonAlignment,
 } from "./ButtonLinkNode";
+import {
+  useInsertDialogState,
+  InsertDialogFooter,
+  ButtonAlignmentControl,
+} from "./RichTextInsertDialog";
 
 // ============================================================
 // Commands
@@ -80,7 +77,6 @@ export function RichTextButtonLinkPlugin({
   disabled = false,
 }: RichTextButtonLinkPluginProps) {
   const [editor] = useLexicalComposerContext();
-  const [isOpen, setIsOpen] = useState(false);
   const [url, setUrl] = useState("");
   const [text, setText] = useState("");
   const [openInNewTab, setOpenInNewTab] = useState(true);
@@ -105,12 +101,6 @@ export function RichTextButtonLinkPlugin({
     setEditingNodeKey(null);
   }, []);
 
-  const openDialog = useCallback(() => {
-    if (disabled) return;
-    resetState();
-    setIsOpen(true);
-  }, [disabled, resetState]);
-
   const isValidUrl = useCallback((url: string): boolean => {
     if (!url.trim()) return false;
     // Allow relative URLs starting with /
@@ -122,6 +112,13 @@ export function RichTextButtonLinkPlugin({
       return false;
     }
   }, []);
+
+  const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
+    useInsertDialogState({
+      resetState,
+      onSubmit: () => insertButtonLink(),
+      disabled,
+    });
 
   const insertButtonLink = useCallback(() => {
     if (!text.trim()) {
@@ -203,29 +200,10 @@ export function RichTextButtonLinkPlugin({
     textColor,
     alignment,
     isValidUrl,
+    setIsOpen,
     resetState,
     editingNodeKey,
   ]);
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        resetState();
-      }
-      setIsOpen(open);
-    },
-    [resetState]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        insertButtonLink();
-      }
-    },
-    [insertButtonLink]
-  );
 
   // Register commands
   useEffect(() => {
@@ -288,7 +266,7 @@ export function RichTextButtonLinkPlugin({
     return () => {
       window.removeEventListener("edit-button-link", handleEditEvent);
     };
-  }, []);
+  }, [setIsOpen]);
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
@@ -375,41 +353,11 @@ export function RichTextButtonLinkPlugin({
           </div>
 
           {/* Alignment */}
-          <div className="space-y-2">
-            <Label>Alignment</Label>
-            <div className="flex gap-2">
-              <Button
-                type="button"
-                variant={alignment === "left" ? "default" : "outline"}
-                size="md"
-                className="flex-1"
-                onClick={() => setAlignment("left")}
-              >
-                <AlignLeft className="h-4 w-4" />
-                Left
-              </Button>
-              <Button
-                type="button"
-                variant={alignment === "center" ? "default" : "outline"}
-                size="md"
-                className="flex-1"
-                onClick={() => setAlignment("center")}
-              >
-                <AlignCenter className="h-4 w-4" />
-                Center
-              </Button>
-              <Button
-                type="button"
-                variant={alignment === "right" ? "default" : "outline"}
-                size="md"
-                className="flex-1"
-                onClick={() => setAlignment("right")}
-              >
-                <AlignRight className="h-4 w-4" />
-                Right
-              </Button>
-            </div>
-          </div>
+          <ButtonAlignmentControl
+            value={alignment}
+            onChange={setAlignment}
+            disabled={disabled}
+          />
 
           {/* Colors */}
           <div className="grid grid-cols-2 gap-4">
@@ -495,32 +443,15 @@ export function RichTextButtonLinkPlugin({
               </div>
             </div>
           )}
-
-          {/* Error */}
-          {error && (
-            <div className="flex items-center gap-2 text-destructive text-sm">
-              <AlertCircle className="h-4 w-4" />
-              {error}
-            </div>
-          )}
         </div>
 
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => handleOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={insertButtonLink}
-            disabled={!text.trim() || !url.trim()}
-          >
-            {editingNodeKey ? "Update Button" : "Insert Button"}
-          </Button>
-        </DialogFooter>
+        <InsertDialogFooter
+          error={error}
+          onCancel={() => handleOpenChange(false)}
+          onConfirm={insertButtonLink}
+          confirmLabel={editingNodeKey ? "Update Button" : "Insert Button"}
+          confirmDisabled={!text.trim() || !url.trim()}
+        />
       </DialogContent>
     </Dialog>
   );

--- a/packages/admin/src/components/features/entries/fields/special/RichTextButtonLinkPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextButtonLinkPlugin.tsx
@@ -73,6 +73,120 @@ export interface RichTextButtonLinkPluginProps {
   disabled?: boolean;
 }
 
+// ============================================================
+// Dialog body pieces — each one self-contained styling decision
+// ============================================================
+
+/**
+ * The dialog's color fields: background (offered only for the filled variant,
+ * whose background the color paints) and text color.
+ */
+function ButtonLinkColorFields({
+  variant,
+  bgColor,
+  onBgColorChange,
+  textColor,
+  onTextColorChange,
+}: {
+  variant: ButtonLinkVariant;
+  bgColor: string;
+  onBgColorChange: (value: string) => void;
+  textColor: string;
+  onTextColorChange: (value: string) => void;
+}) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      {variant === "filled" && (
+        <div className="space-y-2">
+          <Label htmlFor="button-bg-color">Background Color</Label>
+          <div className="flex items-center gap-2">
+            <input
+              id="button-bg-color"
+              type="color"
+              value={bgColor}
+              onChange={e => onBgColorChange(e.target.value)}
+              className="w-9 rounded-md  border border-input cursor-pointer p-0.5"
+            />
+            <Input
+              value={bgColor}
+              onChange={e => onBgColorChange(e.target.value)}
+              className="flex-1"
+              placeholder="#000000"
+            />
+          </div>
+        </div>
+      )}
+      <div className="space-y-2">
+        <Label htmlFor="button-text-color">Text Color</Label>
+        <div className="flex items-center gap-2">
+          <input
+            id="button-text-color"
+            type="color"
+            value={textColor}
+            onChange={e => onTextColorChange(e.target.value)}
+            className="w-9 rounded-md  border border-input cursor-pointer p-0.5"
+          />
+          <Input
+            value={textColor}
+            onChange={e => onTextColorChange(e.target.value)}
+            className="flex-1"
+            placeholder="#ffffff"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The live preview: renders the button text with the chosen variant, size and
+ * colors so the styling is visible before inserting.
+ */
+function ButtonLinkPreview({
+  text,
+  variant,
+  size,
+  bgColor,
+  textColor,
+}: {
+  text: string;
+  variant: ButtonLinkVariant;
+  size: ButtonLinkSize;
+  bgColor: string;
+  textColor: string;
+}) {
+  return (
+    <div className="p-4 rounded-lg bg-primary/5">
+      <p className="text-xs text-muted-foreground mb-2">Preview:</p>
+      <div className="flex justify-center">
+        <span
+          className={`inline-flex items-center justify-center rounded-md font-medium transition-colors ${
+            variant === "outline" ? "border border-border bg-background" : ""
+          } ${
+            size === "sm"
+              ? "px-3 py-1.5 text-sm"
+              : size === "lg"
+                ? "px-6 py-3 text-base"
+                : "px-4 py-2 text-sm"
+          }`}
+          style={{
+            ...(variant === "filled" && {
+              backgroundColor: bgColor,
+              color: textColor,
+            }),
+            ...(variant === "outline" && {
+              color: textColor,
+              borderColor: textColor,
+            }),
+          }}
+        >
+          {text}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export function RichTextButtonLinkPlugin({
   disabled = false,
 }: RichTextButtonLinkPluginProps) {
@@ -362,46 +476,13 @@ export function RichTextButtonLinkPlugin({
           />
 
           {/* Colors */}
-          <div className="grid grid-cols-2 gap-4">
-            {variant === "filled" && (
-              <div className="space-y-2">
-                <Label htmlFor="button-bg-color">Background Color</Label>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="button-bg-color"
-                    type="color"
-                    value={bgColor}
-                    onChange={e => setBgColor(e.target.value)}
-                    className="w-9 rounded-md  border border-input cursor-pointer p-0.5"
-                  />
-                  <Input
-                    value={bgColor}
-                    onChange={e => setBgColor(e.target.value)}
-                    className="flex-1"
-                    placeholder="#000000"
-                  />
-                </div>
-              </div>
-            )}
-            <div className="space-y-2">
-              <Label htmlFor="button-text-color">Text Color</Label>
-              <div className="flex items-center gap-2">
-                <input
-                  id="button-text-color"
-                  type="color"
-                  value={textColor}
-                  onChange={e => setTextColor(e.target.value)}
-                  className="w-9 rounded-md  border border-input cursor-pointer p-0.5"
-                />
-                <Input
-                  value={textColor}
-                  onChange={e => setTextColor(e.target.value)}
-                  className="flex-1"
-                  placeholder="#ffffff"
-                />
-              </div>
-            </div>
-          </div>
+          <ButtonLinkColorFields
+            variant={variant}
+            bgColor={bgColor}
+            onBgColorChange={setBgColor}
+            textColor={textColor}
+            onTextColorChange={setTextColor}
+          />
 
           {/* Open in new tab */}
           <label className="flex items-center gap-2 cursor-pointer">
@@ -414,36 +495,13 @@ export function RichTextButtonLinkPlugin({
 
           {/* Preview */}
           {text.trim() && (
-            <div className="p-4 rounded-lg bg-primary/5">
-              <p className="text-xs text-muted-foreground mb-2">Preview:</p>
-              <div className="flex justify-center">
-                <span
-                  className={`inline-flex items-center justify-center rounded-md font-medium transition-colors ${
-                    variant === "outline"
-                      ? "border border-border bg-background"
-                      : ""
-                  } ${
-                    size === "sm"
-                      ? "px-3 py-1.5 text-sm"
-                      : size === "lg"
-                        ? "px-6 py-3 text-base"
-                        : "px-4 py-2 text-sm"
-                  }`}
-                  style={{
-                    ...(variant === "filled" && {
-                      backgroundColor: bgColor,
-                      color: textColor,
-                    }),
-                    ...(variant === "outline" && {
-                      color: textColor,
-                      borderColor: textColor,
-                    }),
-                  }}
-                >
-                  {text}
-                </span>
-              </div>
-            </div>
+            <ButtonLinkPreview
+              text={text}
+              variant={variant}
+              size={size}
+              bgColor={bgColor}
+              textColor={textColor}
+            />
           )}
         </div>
 

--- a/packages/admin/src/components/features/entries/fields/special/RichTextButtonLinkPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextButtonLinkPlugin.tsx
@@ -113,6 +113,8 @@ export function RichTextButtonLinkPlugin({
     }
   }, []);
 
+  // Shared dialog shell: open/close lifecycle with reset-on-close and
+  // Enter-to-submit, so this dialog cannot drift from the other three.
   const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
     useInsertDialogState({
       resetState,
@@ -445,6 +447,9 @@ export function RichTextButtonLinkPlugin({
           )}
         </div>
 
+        {/* Shared footer: the error banner and Cancel/Confirm row every
+            insert dialog renders. Only emptiness gates the confirm here so a
+            non-empty but invalid URL still submits and surfaces the banner. */}
         <InsertDialogFooter
           error={error}
           onCancel={() => handleOpenChange(false)}

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
@@ -1,16 +1,35 @@
 import { TooltipProvider } from "@nextlyhq/ui";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import type { SerializedEditorState } from "lexical";
+import { LexicalComposer } from "@lexical/react/LexicalComposer";
+import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
+import type { LexicalCommand, SerializedEditorState } from "lexical";
 import type { RichTextFieldConfig } from "nextly/config";
+import { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { describe, it, expect, beforeAll, vi } from "vitest";
 
 import { RichTextInput } from "./RichTextInput";
+import { RICH_TEXT_NODES } from "./rich-text-kit";
+import {
+  RichTextTablePlugin,
+  OPEN_TABLE_DIALOG_COMMAND,
+} from "./RichTextTablePlugin";
+import {
+  RichTextVideoPlugin,
+  OPEN_VIDEO_DIALOG_COMMAND,
+} from "./RichTextVideoPlugin";
+import {
+  RichTextButtonLinkPlugin,
+  OPEN_BUTTON_LINK_DIALOG_COMMAND,
+} from "./RichTextButtonLinkPlugin";
+import {
+  RichTextButtonGroupPlugin,
+  OPEN_BUTTON_GROUP_DIALOG_COMMAND,
+} from "./RichTextButtonGroupPlugin";
 
-// Lexical's selection and toolbar code touch DOM APIs jsdom does not
-// implement — stub them so the editor can mount and re-render.
+// Lexical selection & toolbar DOM stub
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
   window.matchMedia =
@@ -27,7 +46,6 @@ const FIELD = {
   name: "body",
 } as unknown as RichTextFieldConfig;
 
-/** A minimal serialized Lexical document holding one paragraph of plain text. */
 function doc(text: string): SerializedEditorState {
   return {
     root: {
@@ -60,16 +78,26 @@ function doc(text: string): SerializedEditorState {
   } as unknown as SerializedEditorState;
 }
 
-// Never retries in tests, so a plugin's failed background query cannot hang a run.
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
 
-/**
- * Form harness mirroring the entry/single editors: the editor is bound through RHF
- * `control`, and a locale switch arrives as `form.reset(...)` with another language's
- * value — the exact external-change path the editor must follow.
- */
+type Dispatcher = (command: LexicalCommand<unknown>, payload: unknown) => void;
+
+function CommandBridgePlugin({
+  onReady,
+}: {
+  onReady: (dispatch: Dispatcher) => void;
+}) {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    onReady((cmd, payload) => {
+      editor.dispatchCommand(cmd, payload);
+    });
+  }, [editor, onReady]);
+  return null;
+}
+
 function Harness({
   initial,
   readOnly = false,
@@ -81,8 +109,6 @@ function Harness({
     defaultValues: { body: initial },
   });
   return (
-    // The editor's media plugins query the API and the toolbar renders inside
-    // tooltips, so the harness supplies the same app-level providers the admin does.
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
         <RichTextInput
@@ -97,7 +123,6 @@ function Harness({
         <button onClick={() => form.reset({ body: null })}>clear</button>
         <button
           onClick={() =>
-            // A corrupted stored value: parseable JSON, but not a Lexical document.
             form.reset({ body: { root: { type: "bogus-node-type" } } })
           }
         >
@@ -115,43 +140,35 @@ describe("RichTextInput — external value sync", () => {
   });
 
   it("follows an external form reset to another language's content", async () => {
+    const user = userEvent.setup();
     render(<Harness initial={doc("English body")} />);
     await screen.findByText("English body");
 
-    // A locale switch resets the form with the other language's fetched value; the
-    // editor must display it instead of keeping the first-mounted language.
-    await userEvent.click(screen.getByText("switch-es"));
+    await user.click(screen.getByText("switch-es"));
 
     expect(await screen.findByText("Cuerpo espanol")).toBeInTheDocument();
     expect(screen.queryByText("English body")).not.toBeInTheDocument();
   });
 
   it("clears when the external value becomes empty", async () => {
+    const user = userEvent.setup();
     render(<Harness initial={doc("English body")} />);
     await screen.findByText("English body");
 
-    // An untranslated language has no stored value — the editor must show empty,
-    // not the previous language's content.
-    await userEvent.click(screen.getByText("clear"));
+    await user.click(screen.getByText("clear"));
 
     expect(screen.queryByText("English body")).not.toBeInTheDocument();
   });
 
   it("degrades to an empty document when the external value cannot be parsed", async () => {
+    const user = userEvent.setup();
     render(<Harness initial={doc("English body")} />);
     await screen.findByText("English body");
 
-    // A corrupted or version-mismatched stored value must not crash the editor
-    // tree, and must not leave the previous document on screen (a save from that
-    // screen would write the previous language's content into this one).
-    await userEvent.click(screen.getByText("corrupt"));
+    await user.click(screen.getByText("corrupt"));
 
-    // The whole document is empty — not just missing the previous content, but
-    // holding nothing else either (no partial or garbled render of the bad value).
-    // The contentEditable carries the field name as its accessible label.
     expect(screen.getByLabelText("body").textContent).toBe("");
-    // The editor is still alive: a follow-up valid value loads normally.
-    await userEvent.click(screen.getByText("switch-es"));
+    await user.click(screen.getByText("switch-es"));
     expect(await screen.findByText("Cuerpo espanol")).toBeInTheDocument();
   });
 });
@@ -160,9 +177,6 @@ describe("RichTextInput — read-only", () => {
   it("offers the formatting toolbar while the field is editable", async () => {
     render(<Harness initial={doc("Body copy")} />);
 
-    // The control for the negative below: without this, an absent toolbar in
-    // the read-only case would be satisfied by a harness that renders no
-    // toolbar under any circumstances.
     expect(
       await screen.findByRole("toolbar", { name: /text formatting/i })
     ).toBeInTheDocument();
@@ -171,11 +185,201 @@ describe("RichTextInput — read-only", () => {
   it("renders no formatting toolbar when the field is read-only", async () => {
     render(<Harness initial={doc("Body copy")} readOnly />);
 
-    // The content still has to be there — an absent toolbar proves nothing if
-    // the editor failed to mount at all.
     expect(await screen.findByText("Body copy")).toBeInTheDocument();
     expect(
       screen.queryByRole("toolbar", { name: /text formatting/i })
     ).toBeNull();
+  });
+});
+
+describe("RichTextInput — insert dialogs shell characterization", () => {
+  function renderPluginHarness() {
+    let dispatch: Dispatcher = () => {};
+    const view = render(
+      <TooltipProvider>
+        <LexicalComposer
+          initialConfig={{
+            namespace: "DialogTestEditor",
+            nodes: [...RICH_TEXT_NODES],
+            onError: err => {
+              console.error(err);
+            },
+          }}
+        >
+          <RichTextTablePlugin />
+          <RichTextVideoPlugin />
+          <RichTextButtonLinkPlugin />
+          <RichTextButtonGroupPlugin />
+          <CommandBridgePlugin
+            onReady={d => {
+              dispatch = d;
+            }}
+          />
+        </LexicalComposer>
+      </TooltipProvider>
+    );
+
+    return {
+      ...view,
+      openTable: () => dispatch(OPEN_TABLE_DIALOG_COMMAND, undefined),
+      openVideo: () => dispatch(OPEN_VIDEO_DIALOG_COMMAND, undefined),
+      openButtonLink: () =>
+        dispatch(OPEN_BUTTON_LINK_DIALOG_COMMAND, undefined),
+      openButtonGroup: () =>
+        dispatch(OPEN_BUTTON_GROUP_DIALOG_COMMAND, undefined),
+    };
+  }
+
+  describe("Table dialog", () => {
+    it("opens, resets on cancel, reports validation error, and submits with Enter", async () => {
+      const { openTable } = renderPluginHarness();
+
+      openTable();
+      expect(
+        await screen.findByRole("heading", { name: "Insert Table" })
+      ).toBeInTheDocument();
+      const rowsInput = screen.getByLabelText(/^rows/i);
+      const colsInput = screen.getByLabelText(/^columns/i);
+      expect(rowsInput).toHaveValue(3);
+      expect(colsInput).toHaveValue(3);
+
+      // Cancel closes and resets
+      fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+      expect(
+        screen.queryByRole("heading", { name: "Insert Table" })
+      ).not.toBeInTheDocument();
+
+      // Re-open: invalid row count -> validation error
+      openTable();
+      const rowsInput2 = await screen.findByLabelText(/^rows/i);
+      fireEvent.change(rowsInput2, { target: { value: "0" } });
+      fireEvent.click(screen.getByRole("button", { name: /^insert table$/i }));
+      expect(
+        await screen.findByText("Rows must be between 1 and 20")
+      ).toBeInTheDocument();
+
+      // Valid value + Enter key submits
+      fireEvent.change(rowsInput2, { target: { value: "4" } });
+      fireEvent.keyDown(rowsInput2, { key: "Enter", code: "Enter" });
+      expect(
+        screen.queryByRole("heading", { name: "Insert Table" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Video dialog", () => {
+    it("opens, disables submit when empty, shows preview, and submits with Enter", async () => {
+      const { openVideo } = renderPluginHarness();
+
+      openVideo();
+      expect(
+        await screen.findByRole("heading", { name: "Embed Video" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^embed video$/i })
+      ).toBeDisabled();
+
+      // Cancel closes
+      fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+      expect(
+        screen.queryByRole("heading", { name: "Embed Video" })
+      ).not.toBeInTheDocument();
+
+      // Re-open and fill YouTube URL
+      openVideo();
+      const urlInput = await screen.findByLabelText(/video url/i);
+      fireEvent.change(urlInput, {
+        target: { value: "https://www.youtube.com/watch?v=dQw4w9WgXcQ" },
+      });
+
+      expect(await screen.findByText(/video detected/i)).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^embed video$/i })
+      ).toBeEnabled();
+
+      // Enter key submits
+      fireEvent.keyDown(urlInput, { key: "Enter", code: "Enter" });
+      expect(
+        screen.queryByRole("heading", { name: "Embed Video" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Button Link dialog", () => {
+    it("opens, validates URL on submit, and submits with Enter", async () => {
+      const { openButtonLink } = renderPluginHarness();
+
+      openButtonLink();
+      expect(
+        await screen.findByRole("heading", { name: "Insert Button Link" })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /^insert button$/i })
+      ).toBeDisabled();
+
+      const textInput = screen.getByLabelText(/^button text/i);
+      const urlInput = screen.getByLabelText(/^url/i);
+
+      // Invalid URL error on submit
+      fireEvent.change(textInput, { target: { value: "Documentation" } });
+      fireEvent.change(urlInput, { target: { value: "javascript:alert(1)" } });
+      expect(
+        screen.getByRole("button", { name: /^insert button$/i })
+      ).toBeEnabled();
+
+      fireEvent.click(screen.getByRole("button", { name: /^insert button$/i }));
+      expect(
+        await screen.findByText("Please enter a valid URL")
+      ).toBeInTheDocument();
+
+      // Valid URL + Enter key submits
+      fireEvent.change(urlInput, { target: { value: "https://nextlyhq.com" } });
+      fireEvent.keyDown(urlInput, { key: "Enter", code: "Enter" });
+      expect(
+        screen.queryByRole("heading", { name: "Insert Button Link" })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Button Group dialog", () => {
+    it("opens, validates buttons, and submits on valid input", async () => {
+      const { openButtonGroup } = renderPluginHarness();
+
+      openButtonGroup();
+      expect(
+        await screen.findByRole("heading", { name: "Insert Button Group" })
+      ).toBeInTheDocument();
+
+      // Submitting empty -> validation error
+      fireEvent.click(
+        screen.getByRole("button", { name: /^insert button group$/i })
+      );
+      expect(
+        await screen.findByText("Button 1: Please enter button text")
+      ).toBeInTheDocument();
+
+      // Cancel closes
+      fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
+      expect(
+        screen.queryByRole("heading", { name: "Insert Button Group" })
+      ).not.toBeInTheDocument();
+
+      // Re-open and fill valid buttons
+      openButtonGroup();
+      const textInputs = await screen.findAllByPlaceholderText("Click here");
+      const urlInputs = screen.getAllByPlaceholderText("https://example.com");
+
+      fireEvent.change(textInputs[0], { target: { value: "Docs" } });
+      fireEvent.change(urlInputs[0], { target: { value: "/docs" } });
+      fireEvent.change(textInputs[1], { target: { value: "Blog" } });
+      fireEvent.change(urlInputs[1], { target: { value: "/blog" } });
+
+      fireEvent.click(
+        screen.getByRole("button", { name: /^insert button group$/i })
+      );
+      expect(
+        screen.queryByRole("heading", { name: "Insert Button Group" })
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
@@ -244,7 +244,9 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
             namespace: "DialogTestEditor",
             nodes: [...RICH_TEXT_NODES],
             onError: err => {
-              console.error(err);
+              // Re-throw: returning normally would let Lexical attempt
+              // recovery, so an editor error would never fail the test.
+              throw err;
             },
           }}
         >

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
@@ -4,7 +4,16 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { LexicalComposer } from "@lexical/react/LexicalComposer";
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
-import type { LexicalCommand, SerializedEditorState } from "lexical";
+import { ContentEditable } from "@lexical/react/LexicalContentEditable";
+import { TablePlugin } from "@lexical/react/LexicalTablePlugin";
+import { TableNode } from "@lexical/table";
+import {
+  $getRoot,
+  $nodesOfType,
+  type LexicalCommand,
+  type LexicalEditor,
+  type SerializedEditorState,
+} from "lexical";
 import type { RichTextFieldConfig } from "nextly/config";
 import { useEffect } from "react";
 import { useForm } from "react-hook-form";
@@ -29,7 +38,8 @@ import {
   OPEN_BUTTON_GROUP_DIALOG_COMMAND,
 } from "./RichTextButtonGroupPlugin";
 
-// Lexical selection & toolbar DOM stub
+// Lexical's selection and toolbar code touch DOM APIs jsdom does not
+// implement — stub them so the editor can mount and re-render.
 beforeAll(() => {
   Element.prototype.scrollIntoView = vi.fn();
   window.matchMedia =
@@ -46,6 +56,7 @@ const FIELD = {
   name: "body",
 } as unknown as RichTextFieldConfig;
 
+/** A minimal serialized Lexical document holding one paragraph of plain text. */
 function doc(text: string): SerializedEditorState {
   return {
     root: {
@@ -78,26 +89,33 @@ function doc(text: string): SerializedEditorState {
   } as unknown as SerializedEditorState;
 }
 
+// Never retries in tests, so a plugin's failed background query cannot hang a run.
 const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
 
+// Hand the mounted editor out to the test harness, so tests can dispatch each
+// plugin's registered dialog command (the same command the toolbar trigger
+// fires) and read the editor's node state to observe what a dialog inserted.
 type Dispatcher = (command: LexicalCommand<unknown>, payload: unknown) => void;
 
 function CommandBridgePlugin({
   onReady,
 }: {
-  onReady: (dispatch: Dispatcher) => void;
+  onReady: (editor: LexicalEditor) => void;
 }) {
   const [editor] = useLexicalComposerContext();
   useEffect(() => {
-    onReady((cmd, payload) => {
-      editor.dispatchCommand(cmd, payload);
-    });
+    onReady(editor);
   }, [editor, onReady]);
   return null;
 }
 
+/**
+ * Form harness mirroring the entry/single editors: the editor is bound through RHF
+ * `control`, and a locale switch arrives as `form.reset(...)` with another language's
+ * value — the exact external-change path the editor must follow.
+ */
 function Harness({
   initial,
   readOnly = false,
@@ -108,6 +126,8 @@ function Harness({
   const form = useForm<{ body: unknown }>({
     defaultValues: { body: initial },
   });
+  // The editor's media plugins query the API and the toolbar renders inside
+  // tooltips, so the harness supplies the same app-level providers the admin does.
   return (
     <QueryClientProvider client={queryClient}>
       <TooltipProvider>
@@ -122,9 +142,10 @@ function Harness({
         </button>
         <button onClick={() => form.reset({ body: null })}>clear</button>
         <button
-          onClick={() =>
-            form.reset({ body: { root: { type: "bogus-node-type" } } })
-          }
+          onClick={() => {
+            // A corrupted stored value: parseable JSON, but not a Lexical document.
+            form.reset({ body: { root: { type: "bogus-node-type" } } });
+          }}
         >
           corrupt
         </button>
@@ -144,6 +165,8 @@ describe("RichTextInput — external value sync", () => {
     render(<Harness initial={doc("English body")} />);
     await screen.findByText("English body");
 
+    // A locale switch resets the form with the other language's fetched value; the
+    // editor must display it instead of keeping the first-mounted language.
     await user.click(screen.getByText("switch-es"));
 
     expect(await screen.findByText("Cuerpo espanol")).toBeInTheDocument();
@@ -155,6 +178,8 @@ describe("RichTextInput — external value sync", () => {
     render(<Harness initial={doc("English body")} />);
     await screen.findByText("English body");
 
+    // An untranslated language has no stored value — the editor must show empty,
+    // not the previous language's content.
     await user.click(screen.getByText("clear"));
 
     expect(screen.queryByText("English body")).not.toBeInTheDocument();
@@ -165,9 +190,16 @@ describe("RichTextInput — external value sync", () => {
     render(<Harness initial={doc("English body")} />);
     await screen.findByText("English body");
 
+    // A corrupted or version-mismatched stored value must not crash the editor
+    // tree, and must not leave the previous document on screen (a save from that
+    // screen would write the previous language's content into this one).
     await user.click(screen.getByText("corrupt"));
 
+    // The whole document is empty — not just missing the previous content, but
+    // holding nothing else either (no partial or garbled render of the bad value).
+    // The contentEditable carries the field name as its accessible label.
     expect(screen.getByLabelText("body").textContent).toBe("");
+    // The editor is still alive: a follow-up valid value loads normally.
     await user.click(screen.getByText("switch-es"));
     expect(await screen.findByText("Cuerpo espanol")).toBeInTheDocument();
   });
@@ -177,6 +209,9 @@ describe("RichTextInput — read-only", () => {
   it("offers the formatting toolbar while the field is editable", async () => {
     render(<Harness initial={doc("Body copy")} />);
 
+    // The control for the negative below: without this, an absent toolbar in
+    // the read-only case would be satisfied by a harness that renders no
+    // toolbar under any circumstances.
     expect(
       await screen.findByRole("toolbar", { name: /text formatting/i })
     ).toBeInTheDocument();
@@ -185,6 +220,8 @@ describe("RichTextInput — read-only", () => {
   it("renders no formatting toolbar when the field is read-only", async () => {
     render(<Harness initial={doc("Body copy")} readOnly />);
 
+    // The content still has to be there — an absent toolbar proves nothing if
+    // the editor failed to mount at all.
     expect(await screen.findByText("Body copy")).toBeInTheDocument();
     expect(
       screen.queryByRole("toolbar", { name: /text formatting/i })
@@ -199,6 +236,7 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
   // tests to toolbar layout or its icon buttons.
   function renderPluginHarness() {
     let dispatch: Dispatcher = () => {};
+    let editorRef: LexicalEditor | null = null;
     const view = render(
       <TooltipProvider>
         <LexicalComposer
@@ -210,21 +248,39 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
             },
           }}
         >
+          {/* Handles INSERT_TABLE_COMMAND the way the real editor does, so
+              the dialog's submit actually inserts a table into the composer.
+              The editable gives the insert a selection to anchor to. */}
+          <TablePlugin />
+          <ContentEditable />
           <RichTextTablePlugin />
           <RichTextVideoPlugin />
           <RichTextButtonLinkPlugin />
           <RichTextButtonGroupPlugin />
           <CommandBridgePlugin
-            onReady={d => {
-              dispatch = d;
+            onReady={editor => {
+              editorRef = editor;
+              // jsdom fires no real selection events, so seed one in editor
+              // state — a table insert needs a selection to anchor to.
+              editor.update(() => {
+                $getRoot().selectEnd();
+              });
+              dispatch = (cmd, payload) => editor.dispatchCommand(cmd, payload);
             }}
           />
         </LexicalComposer>
       </TooltipProvider>
     );
 
+    // Reading node state through the editor (rather than the DOM) keeps the
+    // assertion about what the dialog INSERTED, independent of any renderer.
+    const tableCount = (): number =>
+      editorRef?.getEditorState().read(() => $nodesOfType(TableNode).length) ??
+      0;
+
     return {
       ...view,
+      tableCount,
       openTable: () => dispatch(OPEN_TABLE_DIALOG_COMMAND, undefined),
       openVideo: () => dispatch(OPEN_VIDEO_DIALOG_COMMAND, undefined),
       openButtonLink: () =>
@@ -236,7 +292,11 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
 
   describe("Table dialog", () => {
     it("opens, resets on cancel, reports validation error, and submits with Enter", async () => {
-      const { openTable } = renderPluginHarness();
+      const { openTable, tableCount } = renderPluginHarness();
+
+      // Give the insert a selection to anchor to, as a user clicking into the
+      // field would; without it a table insert has nowhere to land.
+      fireEvent.focus(screen.getByRole("textbox"));
 
       openTable();
       expect(
@@ -268,6 +328,9 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
       expect(
         screen.queryByRole("heading", { name: "Insert Table" })
       ).not.toBeInTheDocument();
+      // The dialog closing is not enough: Enter must have INSERTED the table
+      // into the editor, which a close-only submit would silently skip.
+      await vi.waitFor(() => expect(tableCount()).toBe(1));
     });
   });
 

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
@@ -10,8 +10,10 @@ import { TableNode } from "@lexical/table";
 import {
   $getRoot,
   $nodesOfType,
+  type Klass,
   type LexicalCommand,
   type LexicalEditor,
+  type LexicalNode,
   type SerializedEditorState,
 } from "lexical";
 import type { RichTextFieldConfig } from "nextly/config";
@@ -21,6 +23,9 @@ import { describe, it, expect, beforeAll, vi } from "vitest";
 
 import { RichTextInput } from "./RichTextInput";
 import { RICH_TEXT_NODES } from "./rich-text-kit";
+import { VideoNode } from "./VideoNode";
+import { ButtonLinkNode } from "./ButtonLinkNode";
+import { ButtonGroupNode } from "./ButtonGroupNode";
 import {
   RichTextTablePlugin,
   OPEN_TABLE_DIALOG_COMMAND,
@@ -276,13 +281,13 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
 
     // Reading node state through the editor (rather than the DOM) keeps the
     // assertion about what the dialog INSERTED, independent of any renderer.
-    const tableCount = (): number =>
-      editorRef?.getEditorState().read(() => $nodesOfType(TableNode).length) ??
+    const nodeCount = (nodeType: Klass<LexicalNode>): number =>
+      editorRef?.getEditorState().read(() => $nodesOfType(nodeType).length) ??
       0;
 
     return {
       ...view,
-      tableCount,
+      nodeCount,
       openTable: () => dispatch(OPEN_TABLE_DIALOG_COMMAND, undefined),
       openVideo: () => dispatch(OPEN_VIDEO_DIALOG_COMMAND, undefined),
       openButtonLink: () =>
@@ -294,7 +299,7 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
 
   describe("Table dialog", () => {
     it("opens, resets on cancel, reports validation error, and submits with Enter", async () => {
-      const { openTable, tableCount } = renderPluginHarness();
+      const { openTable, nodeCount } = renderPluginHarness();
 
       // Give the insert a selection to anchor to, as a user clicking into the
       // field would; without it a table insert has nowhere to land.
@@ -332,13 +337,13 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
       ).not.toBeInTheDocument();
       // The dialog closing is not enough: Enter must have INSERTED the table
       // into the editor, which a close-only submit would silently skip.
-      await vi.waitFor(() => expect(tableCount()).toBe(1));
+      await vi.waitFor(() => expect(nodeCount(TableNode)).toBe(1));
     });
   });
 
   describe("Video dialog", () => {
     it("opens, disables submit when empty, shows preview, and submits with Enter", async () => {
-      const { openVideo } = renderPluginHarness();
+      const { openVideo, nodeCount } = renderPluginHarness();
 
       openVideo();
       expect(
@@ -366,17 +371,18 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
         screen.getByRole("button", { name: /^embed video$/i })
       ).toBeEnabled();
 
-      // Enter key submits
+      // Enter key submits — and must INSERT the video node, not merely close
       fireEvent.keyDown(urlInput, { key: "Enter", code: "Enter" });
       expect(
         screen.queryByRole("heading", { name: "Embed Video" })
       ).not.toBeInTheDocument();
+      await vi.waitFor(() => expect(nodeCount(VideoNode)).toBe(1));
     });
   });
 
   describe("Button Link dialog", () => {
     it("opens, validates URL on submit, and submits with Enter", async () => {
-      const { openButtonLink } = renderPluginHarness();
+      const { openButtonLink, nodeCount } = renderPluginHarness();
 
       openButtonLink();
       expect(
@@ -401,18 +407,19 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
         await screen.findByText("Please enter a valid URL")
       ).toBeInTheDocument();
 
-      // Valid URL + Enter key submits
+      // Valid URL + Enter key submits — and must INSERT the button node
       fireEvent.change(urlInput, { target: { value: "https://nextlyhq.com" } });
       fireEvent.keyDown(urlInput, { key: "Enter", code: "Enter" });
       expect(
         screen.queryByRole("heading", { name: "Insert Button Link" })
       ).not.toBeInTheDocument();
+      await vi.waitFor(() => expect(nodeCount(ButtonLinkNode)).toBe(1));
     });
   });
 
   describe("Button Group dialog", () => {
     it("gates confirm on filled buttons, validates URLs, and submits with Enter", async () => {
-      const { openButtonGroup } = renderPluginHarness();
+      const { openButtonGroup, nodeCount } = renderPluginHarness();
 
       openButtonGroup();
       expect(
@@ -465,6 +472,8 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
       expect(
         screen.queryByRole("heading", { name: "Insert Button Group" })
       ).not.toBeInTheDocument();
+      // Enter must have INSERTED the button group node, not merely closed
+      await vi.waitFor(() => expect(nodeCount(ButtonGroupNode)).toBe(1));
     });
   });
 });

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInput.test.tsx
@@ -193,6 +193,10 @@ describe("RichTextInput — read-only", () => {
 });
 
 describe("RichTextInput — insert dialogs shell characterization", () => {
+  // The harness renders a real Lexical composer and opens each dialog by
+  // dispatching its OPEN_* command — the same command the toolbar trigger
+  // fires — so the dialogs themselves are exercised without coupling the
+  // tests to toolbar layout or its icon buttons.
   function renderPluginHarness() {
     let dispatch: Dispatcher = () => {};
     const view = render(
@@ -342,7 +346,7 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
   });
 
   describe("Button Group dialog", () => {
-    it("opens, validates buttons, and submits on valid input", async () => {
+    it("gates confirm on filled buttons, validates URLs, and submits with Enter", async () => {
       const { openButtonGroup } = renderPluginHarness();
 
       openButtonGroup();
@@ -350,33 +354,49 @@ describe("RichTextInput — insert dialogs shell characterization", () => {
         await screen.findByRole("heading", { name: "Insert Button Group" })
       ).toBeInTheDocument();
 
-      // Submitting empty -> validation error
+      // Confirm is disabled while any button is missing text or a URL
+      expect(
+        screen.getByRole("button", { name: /^insert button group$/i })
+      ).toBeDisabled();
+
+      // Non-empty but invalid URL leaves confirm enabled so the error
+      // banner stays reachable, mirroring the button-link dialog
+      const textInputs = await screen.findAllByPlaceholderText("Click here");
+      const urlInputs = screen.getAllByPlaceholderText("https://example.com");
+      fireEvent.change(textInputs[0], { target: { value: "Docs" } });
+      fireEvent.change(urlInputs[0], {
+        target: { value: "javascript:alert(1)" },
+      });
+      fireEvent.change(textInputs[1], { target: { value: "Blog" } });
+      fireEvent.change(urlInputs[1], { target: { value: "/blog" } });
+      expect(
+        screen.getByRole("button", { name: /^insert button group$/i })
+      ).toBeEnabled();
+
       fireEvent.click(
         screen.getByRole("button", { name: /^insert button group$/i })
       );
       expect(
-        await screen.findByText("Button 1: Please enter button text")
+        await screen.findByText("Button 1: Please enter a valid URL")
       ).toBeInTheDocument();
 
-      // Cancel closes
+      // Cancel closes and resets
       fireEvent.click(screen.getByRole("button", { name: /^cancel$/i }));
       expect(
         screen.queryByRole("heading", { name: "Insert Button Group" })
       ).not.toBeInTheDocument();
 
-      // Re-open and fill valid buttons
+      // Re-open, fill valid buttons, and submit with Enter from a text
+      // input — the parity behavior the shared shell gives this dialog
       openButtonGroup();
-      const textInputs = await screen.findAllByPlaceholderText("Click here");
-      const urlInputs = screen.getAllByPlaceholderText("https://example.com");
+      const textInputs2 = await screen.findAllByPlaceholderText("Click here");
+      const urlInputs2 = screen.getAllByPlaceholderText("https://example.com");
+      fireEvent.change(textInputs2[0], { target: { value: "Docs" } });
+      fireEvent.change(urlInputs2[0], { target: { value: "/docs" } });
+      fireEvent.change(textInputs2[1], { target: { value: "Blog" } });
+      fireEvent.change(urlInputs2[1], { target: { value: "/blog" } });
 
-      fireEvent.change(textInputs[0], { target: { value: "Docs" } });
-      fireEvent.change(urlInputs[0], { target: { value: "/docs" } });
-      fireEvent.change(textInputs[1], { target: { value: "Blog" } });
-      fireEvent.change(urlInputs[1], { target: { value: "/blog" } });
-
-      fireEvent.click(
-        screen.getByRole("button", { name: /^insert button group$/i })
-      );
+      fireEvent.keyDown(urlInputs2[1], { key: "Enter", code: "Enter" });
       expect(
         screen.queryByRole("heading", { name: "Insert Button Group" })
       ).not.toBeInTheDocument();

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
@@ -134,6 +134,40 @@ describe("useInsertDialogState", () => {
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(preventDefault5).not.toHaveBeenCalled();
+
+    // Enter from a non-text input type (a checkbox toggles on Enter) must
+    // activate the control, not submit — this exercises the type-exclusion
+    // branch a <button> target never reaches
+    const checkbox = document.createElement("input");
+    checkbox.type = "checkbox";
+    const preventDefault6 = vi.fn();
+    act(() => {
+      result.current.handleKeyDown({
+        key: "Enter",
+        shiftKey: false,
+        target: checkbox,
+        nativeEvent: { isComposing: false },
+        preventDefault: preventDefault6,
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(preventDefault6).not.toHaveBeenCalled();
+
+    // Legacy engines report an in-progress composition through keyCode 229
+    // WITHOUT setting isComposing — the fallback must catch that path alone
+    const preventDefault7 = vi.fn();
+    act(() => {
+      result.current.handleKeyDown({
+        key: "Enter",
+        shiftKey: false,
+        keyCode: 229,
+        target: textInput,
+        nativeEvent: { isComposing: false },
+        preventDefault: preventDefault7,
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(preventDefault7).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
@@ -52,7 +52,7 @@ describe("useInsertDialogState", () => {
     expect(resetState).not.toHaveBeenCalled();
   });
 
-  it("submits on Enter without shift key, and ignores shift+Enter and other keys", () => {
+  it("submits on Enter from a text input, and ignores shift+Enter, other keys, and Enter from non-text controls", () => {
     const resetState = vi.fn();
     const onSubmit = vi.fn();
 
@@ -60,12 +60,16 @@ describe("useInsertDialogState", () => {
       useInsertDialogState({ resetState, onSubmit })
     );
 
-    // Regular Enter -> submits
+    const textInput = document.createElement("input");
+    const button = document.createElement("button");
+
+    // Regular Enter from a text input -> submits
     const preventDefault1 = vi.fn();
     act(() => {
       result.current.handleKeyDown({
         key: "Enter",
         shiftKey: false,
+        target: textInput,
         preventDefault: preventDefault1,
       } as unknown as React.KeyboardEvent);
     });
@@ -78,6 +82,7 @@ describe("useInsertDialogState", () => {
       result.current.handleKeyDown({
         key: "Enter",
         shiftKey: true,
+        target: textInput,
         preventDefault: preventDefault2,
       } as unknown as React.KeyboardEvent);
     });
@@ -90,11 +95,26 @@ describe("useInsertDialogState", () => {
       result.current.handleKeyDown({
         key: "Escape",
         shiftKey: false,
+        target: textInput,
         preventDefault: preventDefault3,
       } as unknown as React.KeyboardEvent);
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(preventDefault3).not.toHaveBeenCalled();
+
+    // Enter from a focused button (Cancel, alignment, Select option) must
+    // activate that control, not submit the dialog
+    const preventDefault4 = vi.fn();
+    act(() => {
+      result.current.handleKeyDown({
+        key: "Enter",
+        shiftKey: false,
+        target: button,
+        preventDefault: preventDefault4,
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(preventDefault4).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
@@ -1,0 +1,182 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { renderHook, act } from "@testing-library/react";
+import type React from "react";
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  useInsertDialogState,
+  InsertDialogFooter,
+  ButtonAlignmentControl,
+  type ButtonAlignment,
+} from "./RichTextInsertDialog";
+
+describe("useInsertDialogState", () => {
+  it("initializes closed and toggles open with state reset", () => {
+    const resetState = vi.fn();
+    const onSubmit = vi.fn();
+
+    const { result } = renderHook(() =>
+      useInsertDialogState({ resetState, onSubmit })
+    );
+
+    expect(result.current.isOpen).toBe(false);
+
+    act(() => {
+      result.current.openDialog();
+    });
+
+    expect(result.current.isOpen).toBe(true);
+    expect(resetState).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.handleOpenChange(false);
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(resetState).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not open when disabled", () => {
+    const resetState = vi.fn();
+    const onSubmit = vi.fn();
+
+    const { result } = renderHook(() =>
+      useInsertDialogState({ resetState, onSubmit, disabled: true })
+    );
+
+    act(() => {
+      result.current.openDialog();
+    });
+
+    expect(result.current.isOpen).toBe(false);
+    expect(resetState).not.toHaveBeenCalled();
+  });
+
+  it("submits on Enter without shift key, and ignores shift+Enter and other keys", () => {
+    const resetState = vi.fn();
+    const onSubmit = vi.fn();
+
+    const { result } = renderHook(() =>
+      useInsertDialogState({ resetState, onSubmit })
+    );
+
+    // Regular Enter -> submits
+    const preventDefault1 = vi.fn();
+    act(() => {
+      result.current.handleKeyDown({
+        key: "Enter",
+        shiftKey: false,
+        preventDefault: preventDefault1,
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(preventDefault1).toHaveBeenCalledTimes(1);
+
+    // Shift + Enter -> does not submit
+    const preventDefault2 = vi.fn();
+    act(() => {
+      result.current.handleKeyDown({
+        key: "Enter",
+        shiftKey: true,
+        preventDefault: preventDefault2,
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(preventDefault2).not.toHaveBeenCalled();
+
+    // Escape -> does not submit
+    const preventDefault3 = vi.fn();
+    act(() => {
+      result.current.handleKeyDown({
+        key: "Escape",
+        shiftKey: false,
+        preventDefault: preventDefault3,
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(preventDefault3).not.toHaveBeenCalled();
+  });
+});
+
+describe("InsertDialogFooter", () => {
+  it("renders buttons and triggers callbacks", () => {
+    const onCancel = vi.fn();
+    const onConfirm = vi.fn();
+
+    render(
+      <InsertDialogFooter
+        onCancel={onCancel}
+        onConfirm={onConfirm}
+        confirmLabel="Embed Video"
+      />
+    );
+
+    expect(screen.getByRole("button", { name: "Cancel" })).toBeInTheDocument();
+    const confirmBtn = screen.getByRole("button", { name: "Embed Video" });
+    expect(confirmBtn).toBeInTheDocument();
+    expect(confirmBtn).toBeEnabled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(confirmBtn);
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it("displays error message and supports disabled confirm button", () => {
+    render(
+      <InsertDialogFooter
+        error="Invalid URL"
+        onCancel={vi.fn()}
+        onConfirm={vi.fn()}
+        confirmLabel="Insert Table"
+        confirmDisabled={true}
+        cancelLabel="Dismiss"
+      />
+    );
+
+    expect(screen.getByText("Invalid URL")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dismiss" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Insert Table" })).toBeDisabled();
+  });
+});
+
+describe("ButtonAlignmentControl", () => {
+  it("renders alignment options and switches selection", () => {
+    const onChange = vi.fn();
+    let alignment: ButtonAlignment = "center";
+
+    const { rerender } = render(
+      <ButtonAlignmentControl
+        value={alignment}
+        onChange={val => {
+          alignment = val;
+          onChange(val);
+        }}
+        label="Alignment"
+      />
+    );
+
+    expect(screen.getByText("Alignment")).toBeInTheDocument();
+    const leftBtn = screen.getByRole("button", { name: /left/i });
+    const centerBtn = screen.getByRole("button", { name: /center/i });
+    const rightBtn = screen.getByRole("button", { name: /right/i });
+
+    expect(leftBtn).toBeInTheDocument();
+    expect(centerBtn).toBeInTheDocument();
+    expect(rightBtn).toBeInTheDocument();
+
+    fireEvent.click(leftBtn);
+    expect(onChange).toHaveBeenCalledWith("left");
+
+    rerender(
+      <ButtonAlignmentControl
+        value="left"
+        onChange={onChange}
+        disabled={true}
+      />
+    );
+
+    expect(screen.getByRole("button", { name: /left/i })).toBeDisabled();
+  });
+});

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.test.tsx
@@ -52,7 +52,7 @@ describe("useInsertDialogState", () => {
     expect(resetState).not.toHaveBeenCalled();
   });
 
-  it("submits on Enter from a text input, and ignores shift+Enter, other keys, and Enter from non-text controls", () => {
+  it("submits on Enter from a text input, and ignores shift+Enter, other keys, IME composition, and Enter from non-text controls", () => {
     const resetState = vi.fn();
     const onSubmit = vi.fn();
 
@@ -70,6 +70,7 @@ describe("useInsertDialogState", () => {
         key: "Enter",
         shiftKey: false,
         target: textInput,
+        nativeEvent: { isComposing: false },
         preventDefault: preventDefault1,
       } as unknown as React.KeyboardEvent);
     });
@@ -83,6 +84,7 @@ describe("useInsertDialogState", () => {
         key: "Enter",
         shiftKey: true,
         target: textInput,
+        nativeEvent: { isComposing: false },
         preventDefault: preventDefault2,
       } as unknown as React.KeyboardEvent);
     });
@@ -96,25 +98,42 @@ describe("useInsertDialogState", () => {
         key: "Escape",
         shiftKey: false,
         target: textInput,
+        nativeEvent: { isComposing: false },
         preventDefault: preventDefault3,
       } as unknown as React.KeyboardEvent);
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(preventDefault3).not.toHaveBeenCalled();
 
-    // Enter from a focused button (Cancel, alignment, Select option) must
-    // activate that control, not submit the dialog
+    // Enter accepting an IME composition candidate (CJK input) -> does not
+    // submit; the composition is still in progress from the event's view
     const preventDefault4 = vi.fn();
     act(() => {
       result.current.handleKeyDown({
         key: "Enter",
         shiftKey: false,
-        target: button,
+        target: textInput,
+        nativeEvent: { isComposing: true },
         preventDefault: preventDefault4,
       } as unknown as React.KeyboardEvent);
     });
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(preventDefault4).not.toHaveBeenCalled();
+
+    // Enter from a focused button (Cancel, alignment, Select option) must
+    // activate that control, not submit the dialog
+    const preventDefault5 = vi.fn();
+    act(() => {
+      result.current.handleKeyDown({
+        key: "Enter",
+        shiftKey: false,
+        target: button,
+        nativeEvent: { isComposing: false },
+        preventDefault: preventDefault5,
+      } as unknown as React.KeyboardEvent);
+    });
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(preventDefault5).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.tsx
@@ -13,11 +13,16 @@ import {
   AlignRight,
 } from "@admin/components/icons";
 
+// The alignment contract is owned by the node models; the shared control is a
+// consumer of it, not a second author. Re-exported so plugin consumers can
+// keep importing the type from either surface.
+import type { ButtonAlignment as NodeButtonAlignment } from "./ButtonLinkNode";
+
 // ============================================================
 // Types
 // ============================================================
 
-export type ButtonAlignment = "left" | "center" | "right";
+export type ButtonAlignment = NodeButtonAlignment;
 
 export interface UseInsertDialogStateOptions {
   /** Callback to clear form state when the dialog closes or reopens */
@@ -66,6 +71,19 @@ export interface ButtonAlignmentControlProps {
 // Hook: useInsertDialogState
 // ============================================================
 
+// Input types whose Enter key activates the control itself rather than
+// submitting the surrounding dialog.
+const NON_TEXT_INPUT_TYPES = [
+  "button",
+  "checkbox",
+  "color",
+  "file",
+  "radio",
+  "range",
+  "reset",
+  "submit",
+];
+
 /**
  * Shared state and event handling for rich-text plugin insert dialogs.
  * Encapsulates open/close toggling, state resets, and Enter-to-submit keydown handling.
@@ -95,7 +113,17 @@ export function useInsertDialogState({
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      if (e.key === "Enter" && !e.shiftKey) {
+      if (e.key !== "Enter" || e.shiftKey) return;
+      // Enter submits only while the user is typing in a text field. On
+      // buttons and checkboxes Enter activates the focused control, and the
+      // wrapped Radix Select does not stop its option keydown from bubbling,
+      // which would submit the dialog mid-selection.
+      const el = e.target;
+      const fromTextField =
+        el instanceof HTMLTextAreaElement ||
+        (el instanceof HTMLInputElement &&
+          !NON_TEXT_INPUT_TYPES.includes(el.type));
+      if (fromTextField) {
         e.preventDefault();
         onSubmit();
       }

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.tsx
@@ -1,0 +1,194 @@
+import { Button, DialogFooter, Label } from "@nextlyhq/ui";
+import {
+  useState,
+  useCallback,
+  type KeyboardEvent,
+  type ReactNode,
+} from "react";
+
+import {
+  AlertCircle,
+  AlignLeft,
+  AlignCenter,
+  AlignRight,
+} from "@admin/components/icons";
+
+// ============================================================
+// Types
+// ============================================================
+
+export type ButtonAlignment = "left" | "center" | "right";
+
+export interface UseInsertDialogStateOptions {
+  /** Callback to clear form state when the dialog closes or reopens */
+  resetState: () => void;
+  /** Submission action triggered on Enter keypress */
+  onSubmit: () => void;
+  /** When true, opening the dialog is blocked */
+  disabled?: boolean;
+}
+
+export interface UseInsertDialogStateReturn {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  openDialog: () => void;
+  handleOpenChange: (open: boolean) => void;
+  handleKeyDown: (e: KeyboardEvent) => void;
+}
+
+export interface InsertDialogFooterProps {
+  /** Optional error message displayed above the action buttons */
+  error?: string | null;
+  /** Action called when Cancel is clicked */
+  onCancel: () => void;
+  /** Action called when Confirm/Insert is clicked */
+  onConfirm: () => void;
+  /** Text label for the confirmation button */
+  confirmLabel: string;
+  /** Whether the confirmation button is disabled */
+  confirmDisabled?: boolean;
+  /** Text label for the cancellation button (default: "Cancel") */
+  cancelLabel?: string;
+}
+
+export interface ButtonAlignmentControlProps {
+  /** Current alignment value */
+  value: ButtonAlignment;
+  /** Callback fired when alignment selection changes */
+  onChange: (value: ButtonAlignment) => void;
+  /** Label text (default: "Alignment") */
+  label?: string;
+  /** Whether the control is disabled */
+  disabled?: boolean;
+}
+
+// ============================================================
+// Hook: useInsertDialogState
+// ============================================================
+
+/**
+ * Shared state and event handling for rich-text plugin insert dialogs.
+ * Encapsulates open/close toggling, state resets, and Enter-to-submit keydown handling.
+ */
+export function useInsertDialogState({
+  resetState,
+  onSubmit,
+  disabled = false,
+}: UseInsertDialogStateOptions): UseInsertDialogStateReturn {
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openDialog = useCallback(() => {
+    if (disabled) return;
+    resetState();
+    setIsOpen(true);
+  }, [disabled, resetState]);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        resetState();
+      }
+      setIsOpen(open);
+    },
+    [resetState]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        onSubmit();
+      }
+    },
+    [onSubmit]
+  );
+
+  return {
+    isOpen,
+    setIsOpen,
+    openDialog,
+    handleOpenChange,
+    handleKeyDown,
+  };
+}
+
+// ============================================================
+// Component: InsertDialogFooter
+// ============================================================
+
+/**
+ * Shared footer for rich-text insert dialogs: renders an optional error alert
+ * banner alongside standardized Cancel and Confirm action buttons.
+ */
+export function InsertDialogFooter({
+  error,
+  onCancel,
+  onConfirm,
+  confirmLabel,
+  confirmDisabled = false,
+  cancelLabel = "Cancel",
+}: InsertDialogFooterProps): ReactNode {
+  return (
+    <>
+      {error && (
+        <div className="flex items-center gap-2 text-destructive text-sm">
+          <AlertCircle className="h-4 w-4" />
+          {error}
+        </div>
+      )}
+
+      <DialogFooter>
+        <Button type="button" variant="outline" onClick={onCancel}>
+          {cancelLabel}
+        </Button>
+        <Button type="button" onClick={onConfirm} disabled={confirmDisabled}>
+          {confirmLabel}
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+// ============================================================
+// Component: ButtonAlignmentControl
+// ============================================================
+
+const ALIGNMENT_OPTIONS = [
+  { value: "left", label: "Left", icon: AlignLeft },
+  { value: "center", label: "Center", icon: AlignCenter },
+  { value: "right", label: "Right", icon: AlignRight },
+] as const;
+
+/**
+ * Shared alignment button selector for Button and Button Group rich-text dialogs.
+ */
+export function ButtonAlignmentControl({
+  value,
+  onChange,
+  label = "Alignment",
+  disabled = false,
+}: ButtonAlignmentControlProps): ReactNode {
+  return (
+    <div className="space-y-2">
+      <Label className="text-sm font-medium">{label}</Label>
+      <div className="flex gap-2">
+        {ALIGNMENT_OPTIONS.map(
+          ({ value: optValue, label: optLabel, icon: Icon }) => (
+            <Button
+              key={optValue}
+              type="button"
+              variant={value === optValue ? "default" : "outline"}
+              size="md"
+              className="flex-1 gap-1.5"
+              onClick={() => onChange(optValue)}
+              disabled={disabled}
+            >
+              <Icon className="h-4 w-4" />
+              {optLabel}
+            </Button>
+          )
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextInsertDialog.tsx
@@ -114,6 +114,10 @@ export function useInsertDialogState({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key !== "Enter" || e.shiftKey) return;
+      // Enter that accepts an IME composition candidate (CJK and other
+      // composed input) must not submit. During composition the keydown
+      // reports isComposing, and older engines report keyCode 229.
+      if (e.nativeEvent.isComposing || e.keyCode === 229) return;
       // Enter submits only while the user is typing in a text field. On
       // buttons and checkboxes Enter activates the focused control, and the
       // wrapped Radix Select does not stop its option keydown from bubbling,

--- a/packages/admin/src/components/features/entries/fields/special/RichTextTablePlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextTablePlugin.tsx
@@ -13,13 +13,11 @@
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import { INSERT_TABLE_COMMAND } from "@lexical/table";
 import {
-  Button,
   Checkbox,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
   DialogDescription,
   Input,
   Label,
@@ -31,7 +29,12 @@ import {
 } from "lexical";
 import { useState, useCallback, useEffect } from "react";
 
-import { Table, AlertCircle } from "@admin/components/icons";
+import { Table } from "@admin/components/icons";
+
+import {
+  useInsertDialogState,
+  InsertDialogFooter,
+} from "./RichTextInsertDialog";
 
 // ============================================================
 // Commands
@@ -53,7 +56,6 @@ export function RichTextTablePlugin({
   disabled = false,
 }: RichTextTablePluginProps) {
   const [editor] = useLexicalComposerContext();
-  const [isOpen, setIsOpen] = useState(false);
   const [rows, setRows] = useState("3");
   const [columns, setColumns] = useState("3");
   const [includeHeaders, setIncludeHeaders] = useState(true);
@@ -66,11 +68,12 @@ export function RichTextTablePlugin({
     setError(null);
   }, []);
 
-  const openDialog = useCallback(() => {
-    if (disabled) return;
-    resetState();
-    setIsOpen(true);
-  }, [disabled, resetState]);
+  const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
+    useInsertDialogState({
+      resetState,
+      onSubmit: () => insertTable(),
+      disabled,
+    });
 
   const insertTable = useCallback(() => {
     const rowCount = parseInt(rows, 10);
@@ -94,27 +97,7 @@ export function RichTextTablePlugin({
 
     setIsOpen(false);
     resetState();
-  }, [editor, rows, columns, includeHeaders, resetState]);
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        resetState();
-      }
-      setIsOpen(open);
-    },
-    [resetState]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        insertTable();
-      }
-    },
-    [insertTable]
-  );
+  }, [editor, rows, columns, includeHeaders, setIsOpen, resetState]);
 
   // Register command
   useEffect(() => {
@@ -220,28 +203,14 @@ export function RichTextTablePlugin({
               </table>
             </div>
           </div>
-
-          {/* Error */}
-          {error && (
-            <div className="flex items-center gap-2 text-destructive text-sm">
-              <AlertCircle className="h-4 w-4" />
-              {error}
-            </div>
-          )}
         </div>
 
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => handleOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={insertTable}>
-            Insert Table
-          </Button>
-        </DialogFooter>
+        <InsertDialogFooter
+          error={error}
+          onCancel={() => handleOpenChange(false)}
+          onConfirm={insertTable}
+          confirmLabel="Insert Table"
+        />
       </DialogContent>
     </Dialog>
   );

--- a/packages/admin/src/components/features/entries/fields/special/RichTextTablePlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextTablePlugin.tsx
@@ -68,6 +68,8 @@ export function RichTextTablePlugin({
     setError(null);
   }, []);
 
+  // Shared dialog shell: open/close lifecycle with reset-on-close and
+  // Enter-to-submit, so this dialog cannot drift from the other three.
   const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
     useInsertDialogState({
       resetState,
@@ -205,6 +207,8 @@ export function RichTextTablePlugin({
           </div>
         </div>
 
+        {/* Shared footer: the error banner and Cancel/Confirm row every
+            insert dialog renders, so their behavior and styling stay one. */}
         <InsertDialogFooter
           error={error}
           onCancel={() => handleOpenChange(false)}

--- a/packages/admin/src/components/features/entries/fields/special/RichTextVideoPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextVideoPlugin.tsx
@@ -85,6 +85,8 @@ export function RichTextVideoPlugin({
     setPreviewInfo(null);
   }, []);
 
+  // Shared dialog shell: open/close lifecycle with reset-on-close and
+  // Enter-to-submit, so this dialog cannot drift from the other three.
   const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
     useInsertDialogState({
       resetState,
@@ -257,6 +259,10 @@ export function RichTextVideoPlugin({
           </div>
         </div>
 
+        {/* Shared footer: the error banner and Cancel/Confirm row every
+            insert dialog renders. confirmDisabled carries this dialog's own
+            gate — a non-empty, parseable URL with its preview ready — so the
+            shared shell preserves the video-specific confirmation rules. */}
         <InsertDialogFooter
           error={error}
           onCancel={() => handleOpenChange(false)}

--- a/packages/admin/src/components/features/entries/fields/special/RichTextVideoPlugin.tsx
+++ b/packages/admin/src/components/features/entries/fields/special/RichTextVideoPlugin.tsx
@@ -12,12 +12,10 @@
 
 import { useLexicalComposerContext } from "@lexical/react/LexicalComposerContext";
 import {
-  Button,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-  DialogFooter,
   DialogDescription,
   Input,
   Label,
@@ -32,8 +30,12 @@ import {
 } from "lexical";
 import { useState, useCallback, useEffect } from "react";
 
-import { Video, AlertCircle } from "@admin/components/icons";
+import { Video } from "@admin/components/icons";
 
+import {
+  useInsertDialogState,
+  InsertDialogFooter,
+} from "./RichTextInsertDialog";
 import {
   $createVideoNode,
   parseVideoUrl,
@@ -64,7 +66,6 @@ export function RichTextVideoPlugin({
   disabled = false,
 }: RichTextVideoPluginProps) {
   const [editor] = useLexicalComposerContext();
-  const [isOpen, setIsOpen] = useState(false);
   const [url, setUrl] = useState("");
   const [caption, setCaption] = useState("");
   const [altText, setAltText] = useState("");
@@ -84,11 +85,12 @@ export function RichTextVideoPlugin({
     setPreviewInfo(null);
   }, []);
 
-  const openDialog = useCallback(() => {
-    if (disabled) return;
-    resetState();
-    setIsOpen(true);
-  }, [disabled, resetState]);
+  const { isOpen, setIsOpen, openDialog, handleOpenChange, handleKeyDown } =
+    useInsertDialogState({
+      resetState,
+      onSubmit: () => insertVideo(),
+      disabled,
+    });
 
   // Validate and preview URL as user types
   const handleUrlChange = useCallback((value: string) => {
@@ -146,27 +148,7 @@ export function RichTextVideoPlugin({
 
     setIsOpen(false);
     resetState();
-  }, [editor, url, caption, altText, title, resetState]);
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        resetState();
-      }
-      setIsOpen(open);
-    },
-    [resetState]
-  );
-
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      if (e.key === "Enter" && !e.shiftKey) {
-        e.preventDefault();
-        insertVideo();
-      }
-    },
-    [insertVideo]
-  );
+  }, [editor, url, caption, altText, title, setIsOpen, resetState]);
 
   // Register commands
   useEffect(() => {
@@ -273,32 +255,15 @@ export function RichTextVideoPlugin({
               disabled={disabled}
             />
           </div>
-
-          {/* Error */}
-          {error && (
-            <div className="flex items-center gap-2 text-destructive text-sm">
-              <AlertCircle className="h-4 w-4" />
-              {error}
-            </div>
-          )}
         </div>
 
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => handleOpenChange(false)}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            onClick={insertVideo}
-            disabled={!url.trim() || !previewInfo}
-          >
-            Embed Video
-          </Button>
-        </DialogFooter>
+        <InsertDialogFooter
+          error={error}
+          onCancel={() => handleOpenChange(false)}
+          onConfirm={insertVideo}
+          confirmLabel="Embed Video"
+          confirmDisabled={!url.trim() || !previewInfo}
+        />
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary

The rich-text field's insert-dialog plugins each hand-rolled the same dialog shell: open/close state with reset, Enter-to-submit keydown, an error banner, and a Cancel/Confirm footer. This PR gives that shell one implementation, `RichTextInsertDialog.tsx`, and moves **every** insert dialog in the directory onto it:

- `useInsertDialogState({ resetState, onSubmit, disabled })` — open/close lifecycle, reset on open and close, Enter-to-submit.
- `<InsertDialogFooter error leadingAction onCancel onConfirm confirmLabel confirmDisabled cancelLabel />` — the error banner and action row, with an optional leading action (the link dialog's destructive Remove).
- `<ButtonAlignmentControl value onChange label disabled />` — the Left/Center/Right selector shared by the two button dialogs; `ButtonAlignment` now has a single author (`ButtonLinkNode`), with `ButtonGroupNode` re-exporting rather than redeclaring it.

Consumers: table, video, button-link, button-group (full shell); link (full shell — its open path still pre-fills from the selection, and its error stays inline under the input it `aria-describedby`); gallery (shared footer on its configure step); media (shared open/open-change lifecycle; the picker owns its selection state, so reset/submit are no-ops).

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would change existing behavior)
- [ ] Documentation update
- [x] Refactor / chore (no user-facing change)

…with deliberate behavior unifications listed below, which are user-visible.

## Behavior changes (deliberate unifications, not accidental drift)

- **Enter now submits only from text fields, in every dialog.** Previously table/video/button-link submitted from any focused control, and the link dialog did the same with no IME guard — Enter on the link dialog's checkbox submitted an empty URL. Enter that accepts an IME composition (`isComposing` / legacy `keyCode === 229`) no longer submits anywhere.
- **Button-group gains Enter-to-submit**, which it never had, and its Confirm is disabled until every button has text and a URL.
- The alignment buttons honor the plugin's `disabled` flag, matching every other input in those dialogs.
- Rendering is otherwise identical: the shared control's `Label`/`gap` classes match what the base `Label`/`Button` components already applied, and per-site labels are preserved. The link footer's Remove action sits in the shared footer's `leadingAction` slot instead of a bespoke layout.

## Related issues

None.

## Changeset

- [ ] I added a changeset (or this PR only touches non-publishable code: docs, tests, internal tooling, `apps/*`)
- [ ] I selected the correct semver bump (patch / minor / major)

Deliberately omitted for now at maintainer request; one covering the lockstep group will be added before merge.

## Test plan

Characterization suite in `RichTextInput.test.tsx` opens each dialog through its Lexical open command and asserts open, cancel-with-reset, validation errors, disabled-confirm gating, and Enter submission — asserting the **inserted node** (via editor state), not merely dialog close. The suite encodes the NEW unified behaviors: it was written red-first against the legacy link handler (Enter on the checkbox submitted an empty URL and surfaced its validation error) and passes against the shared shell. `RichTextInsertDialog.test.tsx` covers the hook (including IME and non-text-target guards), footer, and alignment control directly.

- [x] `pnpm lint` (admin package + repo-wide through pre-push hook)
- [x] `pnpm check-types`
- [x] `pnpm build` (full workspace)
- [x] Manually verified the change (18/18 dialog tests; full admin suite aside from the pre-existing Windows-local failures listed below)

Note: `@nextlyhq/admin` is excluded from the CI test filter, so the dialog suites are locally-verified only — CI does not run them.

## Checklist

- [x] I read [CONTRIBUTING](../CONTRIBUTING.md) (if it exists)
- [x] My commits follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (enforced by commitlint)
- [x] I targeted the `main` branch
- [x] I updated relevant documentation

## Screenshots / recordings

Pending — light/dark captures of the affected dialogs to follow before merge.

## Notes for reviewers

- The branch now contains a merge of current `main` (was 106 commits behind). That staleness was why the fallow "Changed files" gate had gone red: CI audits the PR merge-ref against the merge-base, so complexity findings from *main's* recently landed files were attributed to this PR. After the merge the base is current and the audit passes locally against `origin/main`.
- The `RichTextToolbar` pair still shares markup; it is a different pattern (toolbar chrome, not an insert dialog) and is deliberately not folded into this shell.
- `isValidUrl` accepts different schemes in the two button dialogs (button-group allows `mailto:`/`tel:`/protocol-less; button-link requires absolute http(s)) — pre-existing divergence, kept as-is here.
- The admin suite carries pre-existing failures on Windows development machines (recently 5 tests in `BrandingProvider`, timing-flaky under full-suite load and passing standalone; Linux CI passes them). Unrelated to this change and listed per the pre-existing-failure convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Standardized rich-text insertion dialogs for tables, videos, links, and buttons.
  * Added consistent Cancel and Confirm actions, error messaging, alignment controls, and Enter-key submission.
  * Dialog fields now reset when dialogs are opened or closed.
  * Added live previews and streamlined color controls for button links.

* **Bug Fixes**
  * Improved validation and disabled-state handling across insertion dialogs.

* **Tests**
  * Expanded coverage for dialog behavior and confirmed inserted content appears in the editor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
