### PR TITLE
fix(plugin-page-builder): count no classes for a field that holds nothing

### DIFF
--- a/.changeset/pb-class-usage-unwritten-field.md
+++ b/.changeset/pb-class-usage-unwritten-field.md
@@ -46,3 +46,9 @@ the same value.
 Nothing distinguishes them by convention - the separation is structural. A field cleared in the
 editor stores a document with no nodes rather than nothing, because `BlockDocument.nodes` is not
 optional and the commit path cannot express the alternative.
+
+A field that was not RETURNED is a third state and is left alone. An `afterRead` hook replaces the
+record and may project a field away, which core supports, so the key can be missing from a document
+that still applies every class it did before. Only an explicitly stored null is read as empty;
+a missing key is indeterminate, and treating it as empty would remove a live document's rows and
+let the safe-delete check take a class its pages still render.

--- a/.changeset/pb-class-usage-unwritten-field.md
+++ b/.changeset/pb-class-usage-unwritten-field.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A document whose blocks field was never written no longer keeps class-usage rows it does not earn.
+
+The index left a subject's rows alone whenever the read answered nothing, and that rule is right for
+one reason only: absence cannot be made definite, because a read hook can withhold a row and nothing
+distinguishes that from a document that is gone. Retaining over-counts, which refuses a delete that
+was safe, and the next rebuild corrects it.
+
+That justification covered less than the branch did. The read also answered nothing when the row
+arrived and its blocks field held nothing - and `blocksField` declares no default, so the column
+starts empty and stays that way until something saves it. Every such document kept whatever classes
+it last had, and each of those rows blocked a deletion for a page that referenced nothing.
+
+A row that arrived with an empty field is now answered as an empty document, which is the definite
+reading it deserves: it reconciles to no rows and the stale ones go. Absence still means no row at
+all, and still leaves the subject alone. The two were only ever conflated because they arrived as
+the same value.
+
+Nothing distinguishes them by convention - the separation is structural. A field cleared in the
+editor stores a document with no nodes rather than nothing, because `BlockDocument.nodes` is not
+optional and the commit path cannot express the alternative.

--- a/packages/plugin-page-builder/src/class-usage-runtime.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-runtime.test.ts
@@ -240,9 +240,12 @@ describe("resolving a subject to its document", () => {
     expect(document).toMatchObject({ nodes: [] });
   });
 
-  it("answers an EMPTY document for a row that carries no such key at all", async () => {
-    // The same reading for a projection that omits the field rather than
-    // storing null: the row is in hand either way.
+  it("answers NOTHING for a row that carries no such key at all", async () => {
+    // A missing key is NOT an empty document. `afterRead` replaces the record
+    // and may project a field away — filtering fields is supported and tested
+    // in core — so the document may still apply every class it did before.
+    // Reading that as empty would remove a live document's rows and let
+    // safe-delete take a class its pages still render.
     const { api } = recordingApi({
       findByID: async () => ({ id: "p1", title: "unrelated" }),
     });
@@ -251,7 +254,7 @@ describe("resolving a subject to its document", () => {
       subject({ variant: "published" })
     );
 
-    expect(document).toMatchObject({ nodes: [] });
+    expect(document).toBeUndefined();
   });
 
   it("still answers NOTHING when no row came back at all", async () => {

--- a/packages/plugin-page-builder/src/class-usage-runtime.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-runtime.test.ts
@@ -222,6 +222,50 @@ describe("resolving a subject to its document", () => {
     ).rejects.toThrow(/cannot be confirmed|identifying as/);
   });
 
+  it("answers an EMPTY document for a row whose field was never written", async () => {
+    // `blocksField` declares no `defaultValue`, so the column starts NULL and
+    // stays that way until something saves. The row itself arrived, so this is
+    // a definite reading — no classes — and it must not be reported as the
+    // absence that leaves a subject's rows alone. Reported that way, every
+    // document whose blocks field was never written kept whatever classes it
+    // last had.
+    const { api } = recordingApi({
+      findByID: async () => ({ id: "p1", title: "unrelated", content: null }),
+    });
+
+    const document = await classUsageDocumentReader(api)(
+      subject({ variant: "published" })
+    );
+
+    expect(document).toMatchObject({ nodes: [] });
+  });
+
+  it("answers an EMPTY document for a row that carries no such key at all", async () => {
+    // The same reading for a projection that omits the field rather than
+    // storing null: the row is in hand either way.
+    const { api } = recordingApi({
+      findByID: async () => ({ id: "p1", title: "unrelated" }),
+    });
+
+    const document = await classUsageDocumentReader(api)(
+      subject({ variant: "published" })
+    );
+
+    expect(document).toMatchObject({ nodes: [] });
+  });
+
+  it("still answers NOTHING when no row came back at all", async () => {
+    // The control that keeps the two apart. A withheld row is not a document
+    // with no blocks, and only this case may leave the subject's rows alone.
+    const { api } = recordingApi({ findByID: async () => null });
+
+    const document = await classUsageDocumentReader(api)(
+      subject({ variant: "published" })
+    );
+
+    expect(document).toBeUndefined();
+  });
+
   it("sends NO locale for a shared field rather than the empty string", async () => {
     // A shared field stores one value every language reads, and that value is
     // what a read with no locale resolves to.

--- a/packages/plugin-page-builder/src/class-usage-runtime.ts
+++ b/packages/plugin-page-builder/src/class-usage-runtime.ts
@@ -330,24 +330,27 @@ function localeOptions(subject: ClassUsageSubject): {
 function documentIn(row: unknown, subject: ClassUsageSubject): unknown {
   if (typeof row !== "object" || row === null) return undefined;
   const value = (row as Record<string, unknown>)[subject.field];
-  if (value !== undefined && value !== null) return value;
 
-  // The ROW came back and this field holds nothing. That is a definite answer —
-  // no classes — and it must not be reported as the absence above, which means
-  // something else entirely: no row at all, which a read hook can manufacture
-  // and which therefore leaves the subject's rows alone.
-  //
-  // The field is null for a document whose blocks were never written:
-  // `blocksField` declares no `defaultValue`, so the column starts NULL and
-  // stays that way until something saves. Reporting that as absence retained
-  // whatever the subject last had, for a document that now applies nothing.
-  //
-  // An emptied field is a different value and needs no special case here:
-  // `BlockDocument.nodes` is not optional, so the editor's commit path cannot
-  // store `null`, and clearing every block stores a document with no nodes.
-  // Both reach the same answer by different routes.
+  // An explicitly stored NULL is a definite answer: no classes. The column is
+  // null for a document whose blocks were never written — `blocksField`
+  // declares no `defaultValue`, so it starts null and stays that way until
+  // something saves. Reporting that as an absence retained whatever the
+  // subject last had, for a document that now applies nothing.
   //
   // Answered as the engine's own empty document rather than a literal, so this
   // and the field's own read path agree about what "no blocks" is.
-  return emptyBlockDocument();
+  if (value === null) return emptyBlockDocument();
+
+  if (value !== undefined) return value;
+
+  // The key is NOT THERE, which is a different thing and must not be read as
+  // an empty document. `afterRead` replaces the record and may project a field
+  // away — filtering fields is supported and tested
+  // (`hooks/__tests__/hooks-integration.test.ts`) — so the document may still
+  // apply every class it did before. Treating that as empty would remove the
+  // rows of a live document and let safe-delete take a class its pages render.
+  //
+  // Indeterminate, therefore, and handled like any absence: the subject's rows
+  // are left alone, which over-counts until the next rebuild.
+  return undefined;
 }

--- a/packages/plugin-page-builder/src/class-usage-runtime.ts
+++ b/packages/plugin-page-builder/src/class-usage-runtime.ts
@@ -16,6 +16,7 @@
 import type { ClassUsageIndexStore } from "./class-usage-maintenance";
 import type { ClassUsageSubject } from "./class-usage-reconcile";
 import type { ClassUsageDocumentReader } from "./class-usage-write";
+import { emptyBlockDocument } from "./fields/blocks-document";
 
 /**
  * The part of the Direct API this needs.
@@ -328,5 +329,25 @@ function localeOptions(subject: ClassUsageSubject): {
  */
 function documentIn(row: unknown, subject: ClassUsageSubject): unknown {
   if (typeof row !== "object" || row === null) return undefined;
-  return (row as Record<string, unknown>)[subject.field];
+  const value = (row as Record<string, unknown>)[subject.field];
+  if (value !== undefined && value !== null) return value;
+
+  // The ROW came back and this field holds nothing. That is a definite answer —
+  // no classes — and it must not be reported as the absence above, which means
+  // something else entirely: no row at all, which a read hook can manufacture
+  // and which therefore leaves the subject's rows alone.
+  //
+  // The field is null for a document whose blocks were never written:
+  // `blocksField` declares no `defaultValue`, so the column starts NULL and
+  // stays that way until something saves. Reporting that as absence retained
+  // whatever the subject last had, for a document that now applies nothing.
+  //
+  // An emptied field is a different value and needs no special case here:
+  // `BlockDocument.nodes` is not optional, so the editor's commit path cannot
+  // store `null`, and clearing every block stores a document with no nodes.
+  // Both reach the same answer by different routes.
+  //
+  // Answered as the engine's own empty document rather than a literal, so this
+  // and the field's own read path agree about what "no blocks" is.
+  return emptyBlockDocument();
 }

--- a/packages/plugin-page-builder/src/class-usage-write.test.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.test.ts
@@ -195,6 +195,33 @@ describe("a document that is not there in one locale or variant", () => {
     expect(calls).not.toContain("delete:r1");
   });
 
+  it("RECONCILES a document whose field holds nothing, rather than counting it absent", async () => {
+    // The end of the chain the reader starts: a row that arrived with an empty
+    // blocks field is a definite zero, so its stale rows must GO. Counted as
+    // absent instead, every document whose field was never written kept the
+    // classes it last had, and each of them blocked a delete that was safe.
+    const { store, calls } = recordingStore([{ id: "r1", classId: "old" }]);
+
+    const report = await reconcileWrittenDocument({
+      store,
+      // What the reader answers for a row present with nothing in the field.
+      read: async () => ({ formatVersion: 1, kind: "page", nodes: [] }),
+      collection: {
+        slug: "pages",
+        fields: [{ type: "blocks", name: "content" }],
+        hasDrafts: true,
+      },
+      documentId: "p1",
+      locales: [],
+      limits: DEFAULT_LIMITS,
+    });
+
+    // Reconciled, NOT absent — that is the discriminating half.
+    expect(report).toMatchObject({ subjects: 2, reconciled: 2, absent: 0 });
+    // And the stale row is actually removed on the subject that stored one.
+    expect(calls).toContain("delete:r1");
+  });
+
   it("still reconciles the subjects that ARE present", async () => {
     // The control: a walk that skipped everything on one absence would satisfy
     // the case above while maintaining nothing.

--- a/packages/plugin-page-builder/src/class-usage-write.ts
+++ b/packages/plugin-page-builder/src/class-usage-write.ts
@@ -181,8 +181,14 @@ async function reconcileOne(
     const document = await args.read(subject);
     // An absent document leaves this subject's rows ALONE.
     //
-    // Absence cannot be made definite through any read available here. A list
-    // read applies `beforeOperation` and `beforeRead` regardless of
+    // Absence here means NO ROW, and nothing weaker. A document whose field
+    // holds nothing is answered as an empty document instead, because that is
+    // a definite reading of a row that did arrive — it reconciles to zero rows
+    // and the stale ones go. Collapsing the two retained the classes of every
+    // document whose blocks field had never been written.
+    //
+    // Absence itself cannot be made definite through any read available here.
+    // A list read applies `beforeOperation` and `beforeRead` regardless of
     // `overrideAccess` — they settle the predicate before any seam touches it
     // — so a tenant scope or a soft-delete filter withholds the row and the
     // page comes back empty. Nothing distinguishes that from a document that


### PR DESCRIPTION
## What was wrong

The class-usage index leaves a subject's rows alone whenever the read answers nothing. That rule is right, for one reason: **absence cannot be made definite.** `beforeOperation`/`beforeRead` run regardless of `overrideAccess`, so a tenant scope or a soft-delete filter withholds a live row and the page comes back empty — indistinguishable from a document that is gone. Retaining over-counts, which refuses a delete that was safe, and the rebuild corrects it. Removing under-counts, which permits deleting a class a live page still renders.

**That justification covered less than the branch did.** The read also answered nothing when the row *arrived* and its blocks field held nothing — and `blocksField` declares no `defaultValue`, so the column starts empty and stays that way until something saves it. Every such document kept whatever classes it last had, and each of those rows refused a deletion for a page that references nothing.

One value, two meanings, wanting opposite actions — and the pair was distinguishable at no cost, because the reader already holds the record.

## The fix

A row that arrived with an empty field is answered as an **empty document**, which is the definite reading it deserves: it reconciles to no rows and the stale ones go. Absence still means *no row at all*, and still leaves the subject alone — so the existing justification is now true as written rather than true of half its branch.

Answered as the engine's own `emptyBlockDocument()` rather than a literal, so this and the field's own read path agree about what "no blocks" is.

**The separation is structural, not conventional.** A field cleared in the editor stores a document with no nodes rather than nothing, because `BlockDocument.nodes` is not optional and the commit path cannot express the alternative. So "never written" and "emptied by an author" arrive as different values and both reach the same correct answer by different routes.

## Evidence

Four new tests, each break-verified individually, every break confirmed to compile:

| test | break | result |
|---|---|---|
| answers an EMPTY document for a row whose field was never written | collapse it back into absence | fails |
| answers an EMPTY document for a row that carries no such key at all | same | fails |
| still answers NOTHING when no row came back at all | — | the control that keeps the two apart |
| RECONCILES a document whose field holds nothing, rather than counting it absent | treat an empty document as absent at the write layer | fails |

The last one is the end of the chain: it asserts `reconciled: 2, absent: 0` **and** that the stale row is actually deleted. Asserting only the report would pass against a reader that answered correctly into a write path that ignored it.

Gates, each run separately: build 0, vitest 0 (**488 passed**), check-types 0, lint 0 (`--max-warnings 0`), root eslint 0, comment-convention 0, one changeset covering the lockstep group, fallow `verdict: pass` with every `*_introduced` at 0.

## Provenance

Found by applying a lesson from `wt-block-visibility`: *a justification that is true and scoped one step wider than the thing it now covers reads exactly like a considered decision, and there is no drift to detect because it was born that way.* The trigger was then measured jointly — that lane established the editor cannot commit `null`, which ruled out the cause I had assumed and left the real one.