### PR TITLE
fix(root): derive the gate scope from pnpm, and stop losing paths Git quotes

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -60,8 +60,29 @@ pnpm run build
 # The scope is DERIVED from the diff rather than listed here, so it cannot go
 # stale as packages are added. Empty means no workspace changed, and the run is
 # skipped rather than becoming a whole-repo test sweep nobody would keep.
+#
+# Three outcomes, not two, and the status says which. A change that redefines
+# the workspace or task graph cannot be narrowed to the packages it happens to
+# sit beside, so it asks for the UNFILTERED run instead. Reporting that as a
+# failure made those files impossible to push: this script runs under `set -e`,
+# so it died before testing anything, and no retry could clear it because
+# running the gates by hand does not change the diff. The only escape was
+# bypassing the hook, which is worse than the narrowing being guarded against.
+#
+# `set +e` around the call only: the status IS the answer here, and letting the
+# shell abort on a non-zero one would discard it.
+set +e
 GATE_FILTERS=$(node scripts/gate-scope.mjs --filters)
-if [ -n "$GATE_FILTERS" ]; then
+GATE_STATUS=$?
+set -e
+
+if [ "$GATE_STATUS" -eq 2 ]; then
+  echo "pre-push: the diff redefines the workspace or task graph — testing every workspace."
+  pnpm turbo test --continue
+elif [ "$GATE_STATUS" -ne 0 ]; then
+  echo "pre-push: gate-scope could not derive a trustworthy scope; refusing." >&2
+  exit "$GATE_STATUS"
+elif [ -n "$GATE_FILTERS" ]; then
   # shellcheck disable=SC2086 -- one flag per line, intentionally word-split
   pnpm turbo test --continue $GATE_FILTERS
 fi

--- a/scripts/gate-scope.mjs
+++ b/scripts/gate-scope.mjs
@@ -62,7 +62,11 @@ export function workspacesFrom(entries, rootDir) {
   const listed = Array.isArray(entries) ? entries : [];
   return listed
     .map(entry => oneWorkspace(entry, rootDir))
-    .filter(w => w.name.length > 0 && w.dir.length > 0)
+    // A directory is enough to be KEPT. An entry whose manifest omits `name`
+    // cannot produce a filter, but dropping it made its paths ownerless and
+    // rootless too, so a change inside it derived an empty scope and the hook
+    // skipped its tests entirely. Kept, it is refused instead.
+    .filter(w => w.dir.length > 0)
     .sort((a, b) => b.dir.length - a.dir.length);
 }
 
@@ -122,13 +126,13 @@ export function workspaceRootsOf(workspaces) {
  * deleted or renamed — which the author should see rather than have hidden
  * behind a smaller gate.
  */
-export function filtersFor(paths, workspaces) {
+export function filtersFor(paths, workspaces, deleted = new Set()) {
   const roots = workspaceRootsOf(workspaces);
   const names = new Set();
   const unlisted = new Set();
 
   for (const raw of paths) {
-    const verdict = classify(String(raw), workspaces, roots);
+    const verdict = classify(String(raw), workspaces, roots, deleted);
     if (verdict.name !== null) names.add(verdict.name);
     if (verdict.missing !== null) unlisted.add(verdict.missing);
   }
@@ -146,10 +150,17 @@ export function filtersFor(paths, workspaces) {
  * Exactly one of the two can be set. A path a workspace claims is gated and is
  * never also reported missing; a path no workspace claims cannot name a filter.
  */
-function classify(path, workspaces, roots) {
+function classify(path, workspaces, roots, deleted) {
   const owner = ownerOf(path, workspaces);
-  if (owner !== undefined) return { name: owner.name, missing: null };
-  const missing = removedWorkspaceDir(path) ?? missingWorkspaceDir(path, roots);
+  // A workspace with no usable name cannot be gated: a `--filter` built from
+  // an empty string matches nothing, so it would shrink the gate while reading
+  // as coverage. Reported instead, under the directory that does identify it.
+  if (owner !== undefined)
+    return owner.name.length > 0
+      ? { name: owner.name, missing: null }
+      : { name: null, missing: owner.dir };
+  const missing =
+    removedWorkspaceDir(path, deleted) ?? missingWorkspaceDir(path, roots);
   return { name: null, missing };
 }
 
@@ -180,9 +191,14 @@ function ownerOf(path, workspaces) {
  * Consulted only for a path no workspace claims, so a manifest nested inside a
  * live workspace — a fixture, say — is owned before it reaches here.
  */
-function removedWorkspaceDir(path) {
+function removedWorkspaceDir(path, deleted) {
   const suffix = "/package.json";
   if (!path.endsWith(suffix)) return null;
+  // DELETED, not merely present in the diff. A manifest ADDED outside every
+  // workspace — `docs/example/package.json`, a fixture, a scaffold template —
+  // is an ordinary change, and reporting it as a removal refused a push that
+  // was perfectly valid.
+  if (!deleted.has(path)) return null;
   const dir = path.slice(0, -suffix.length);
   return dir.length > 0 ? dir : null;
 }
@@ -200,14 +216,43 @@ function missingWorkspaceDir(path, roots) {
   return end === -1 ? null : path.slice(0, end);
 }
 
+/**
+ * The files that define the workspace or task graph for EVERY package.
+ *
+ * A change to one of these cannot be narrowed to the packages it appears
+ * beside. `pnpm-workspace.yaml` decides what a workspace IS — removing an
+ * entry detaches a directory that still exists, and the only changed path is
+ * the YAML itself, so nothing names the workspace that just lost its gate.
+ * `turbo.jsonc` defines the tasks every workspace runs, so a filtered run
+ * exercises the new definition for one package and none of the others.
+ */
+const ROOT_WIDE_FILES = new Set([
+  "pnpm-workspace.yaml",
+  "turbo.json",
+  "turbo.jsonc",
+]);
+
+/**
+ * The graph-defining files a change touches.
+ *
+ * Reported rather than silently widened, because widening is a decision the
+ * runner makes and this module only derives. A caller that cannot narrow
+ * safely should run the root gates unfiltered.
+ */
+export function rootWideChanges(paths) {
+  const hits = paths.map(String).filter(path => ROOT_WIDE_FILES.has(path));
+  return [...new Set(hits)].sort();
+}
+
 /** Whether a change reaches the root `scripts/` task, which `turbo run test` does not. */
 export function touchesScripts(paths) {
   return paths.some(path => String(path).split("/")[0] === "scripts");
 }
 
 /** The human-readable report. */
-export function report({ filters, unreadable, scripts }) {
+export function report({ filters, unreadable, scripts, rootWide = [] }) {
   const sections = [
+    rootWideSection(rootWide),
     filterSection(filters),
     unreadableSection(unreadable),
     scripts ? SCRIPTS_NOTE : "",
@@ -225,6 +270,14 @@ export function report({ filters, unreadable, scripts }) {
 /** `turbo run test` has its own task list and does not reach `scripts/`. */
 const SCRIPTS_NOTE =
   "Also run `pnpm test:scripts` — `turbo run test` does not reach scripts/.";
+
+function rootWideSection(rootWide) {
+  if (rootWide.length === 0) return "";
+  return [
+    "Root gates only, UNFILTERED — these define the graph for every package:",
+    ...rootWide.map(f => `  ${f}`),
+  ].join("\n");
+}
 
 function filterSection(filters) {
   if (filters.length === 0) return "";
@@ -278,7 +331,15 @@ function git(cwd, args) {
  * demonstrable — the exit status is what a hook acts on, and a hook is not a
  * thing a unit test can observe.
  */
-export function filtersRefusal(unreadable) {
+export function filtersRefusal(unreadable, rootWide = []) {
+  if (rootWide.length > 0) {
+    return (
+      "gate-scope: " +
+      rootWide.join(", ") +
+      " defines the workspace or task graph for every package — refusing to " +
+      "narrow. Run the root gates unfiltered."
+    );
+  }
   if (unreadable.length === 0) return null;
   return (
     "gate-scope: no readable manifest for " +
@@ -298,12 +359,16 @@ function main() {
   const paths = changedPaths(cwd, base);
   const { filters, unreadable } = filtersFor(
     paths,
-    workspacesFrom(pnpmWorkspaces(cwd), cwd)
+    workspacesFrom(pnpmWorkspaces(cwd), cwd),
+    new Set(deletedPaths(cwd, base))
   );
+  const rootWide = rootWideChanges(paths);
 
-  if (args.includes("--filters")) emitFilters(filters, unreadable);
+  if (args.includes("--filters")) emitFilters(filters, unreadable, rootWide);
   else
-    console.log(report({ filters, unreadable, scripts: touchesScripts(paths) }));
+    console.log(
+      report({ filters, unreadable, rootWide, scripts: touchesScripts(paths) })
+    );
 }
 
 /**
@@ -337,6 +402,28 @@ export function changedPaths(cwd, base) {
   ];
 }
 
+/**
+ * The paths this branch DELETED, which is what names a removed workspace.
+ *
+ * Separate from the full list because presence in a diff says nothing about
+ * direction: a manifest ADDED outside every workspace looks identical to one
+ * removed from inside a workspace, and reporting the first as a removal
+ * refused a push that was valid.
+ */
+export function deletedPaths(cwd, base) {
+  const mergeBase = git(cwd, ["merge-base", base, "HEAD"]).trim();
+  return nulPaths(
+    git(cwd, [
+      "diff",
+      "--name-only",
+      "-z",
+      "--no-renames",
+      "--diff-filter=D",
+      mergeBase,
+    ])
+  );
+}
+
 /** Paths from a NUL-delimited Git listing. */
 function nulPaths(out) {
   return out.split("\0").filter(Boolean);
@@ -349,10 +436,10 @@ function nulPaths(out) {
  * into a command, the other is read by a person — and so the refusal is not
  * buried in a branch of a function that mostly formats prose.
  */
-function emitFilters(filters, unreadable) {
+function emitFilters(filters, unreadable, rootWide = []) {
   const line = filterArguments(filters);
   if (line) console.log(line);
-  const refusal = filtersRefusal(unreadable);
+  const refusal = filtersRefusal(unreadable, rootWide);
   if (refusal === null) return;
   console.error(refusal);
   process.exitCode = 1;

--- a/scripts/gate-scope.mjs
+++ b/scripts/gate-scope.mjs
@@ -160,7 +160,8 @@ function classify(path, workspaces, roots, deleted) {
       ? { name: owner.name, missing: null }
       : { name: null, missing: owner.dir };
   const missing =
-    removedWorkspaceDir(path, deleted) ?? missingWorkspaceDir(path, roots);
+    removedWorkspaceDir(path, deleted, roots) ??
+    missingWorkspaceDir(path, roots);
   return { name: null, missing };
 }
 
@@ -191,17 +192,42 @@ function ownerOf(path, workspaces) {
  * Consulted only for a path no workspace claims, so a manifest nested inside a
  * live workspace — a fixture, say — is owned before it reaches here.
  */
-function removedWorkspaceDir(path, deleted) {
-  const suffix = "/package.json";
-  if (!path.endsWith(suffix)) return null;
-  // DELETED, not merely present in the diff. A manifest ADDED outside every
-  // workspace — `docs/example/package.json`, a fixture, a scaffold template —
-  // is an ordinary change, and reporting it as a removal refused a push that
-  // was perfectly valid.
-  if (!deleted.has(path)) return null;
-  const dir = path.slice(0, -suffix.length);
+function removedWorkspaceDir(path, deleted, roots) {
+  if (!deletedManifest(path, deleted)) return null;
+  if (!underDeclaredRoot(path, roots)) return null;
+  const dir = path.slice(0, -MANIFEST.length);
   return dir.length > 0 ? dir : null;
 }
+
+/** The file a workspace is declared by, wherever it sits. */
+const MANIFEST = "/package.json";
+
+/**
+ * Whether a path is a manifest this diff DELETED.
+ *
+ * Presence alone says nothing about direction: a manifest ADDED outside every
+ * workspace — a fixture, a scaffold template — looks identical to one removed
+ * from inside a workspace, and reporting the first as a removal refused a push
+ * that was perfectly valid.
+ */
+function deletedManifest(path, deleted) {
+  return path.endsWith(MANIFEST) && deleted.has(path);
+}
+
+/**
+ * Whether a path sits under a root pnpm STILL declares.
+ *
+ * Deletion does not say the directory was ever a workspace, so
+ * `docs/example/package.json` must not be read as one.
+ *
+ * A bare workspace removed outright is not lost by this. Its entry has to
+ * leave `pnpm-workspace.yaml` too, and that file redefines the graph — so the
+ * unfiltered path claims the diff before scope is narrowed at all.
+ */
+function underDeclaredRoot(path, roots) {
+  return roots.some(root => path.startsWith(`${root}/`));
+}
+
 
 /**
  * The workspace directory a path names but no workspace claims, or null.
@@ -331,15 +357,41 @@ function git(cwd, args) {
  * demonstrable — the exit status is what a hook acts on, and a hook is not a
  * thing a unit test can observe.
  */
-export function filtersRefusal(unreadable, rootWide = []) {
-  if (rootWide.length > 0) {
-    return (
-      "gate-scope: " +
-      rootWide.join(", ") +
-      " defines the workspace or task graph for every package — refusing to " +
-      "narrow. Run the root gates unfiltered."
-    );
-  }
+/**
+ * What `--filters` tells its caller, as an exit status.
+ *
+ * Three outcomes, not two. A caller that can only distinguish "worked" from
+ * "failed" has to treat "this change cannot be narrowed" as a failure, and
+ * that is what made a `pnpm-workspace.yaml` edit unpushable.
+ */
+export const EXIT = {
+  /** Filters on stdout, possibly none. Gate what they name. */
+  filters: 0,
+  /** A workspace could not be named. Do not gate; the scope would be wrong. */
+  refuse: 1,
+  /** The change redefines the graph. Gate everything, unfiltered. */
+  unfiltered: 2,
+};
+
+/** Why a caller should widen rather than narrow. */
+export function unfilteredReason(rootWide) {
+  return (
+    "gate-scope: " +
+    rootWide.join(", ") +
+    " defines the workspace or task graph for every package — run the root " +
+    "gates UNFILTERED rather than narrowing."
+  );
+}
+
+export function noWorkspacesRefusal(workspaces) {
+  if (workspaces.length > 0) return null;
+  return (
+    "gate-scope: pnpm reported no usable workspace — refusing to report an " +
+    "empty scope, which would run no gates at all."
+  );
+}
+
+export function filtersRefusal(unreadable) {
   if (unreadable.length === 0) return null;
   return (
     "gate-scope: no readable manifest for " +
@@ -357,14 +409,16 @@ function main() {
   const base = args.find(arg => !arg.startsWith("--")) ?? "origin/main";
   const cwd = process.cwd();
   const paths = changedPaths(cwd, base);
+  const workspaces = workspacesFrom(pnpmWorkspaces(cwd), cwd);
   const { filters, unreadable } = filtersFor(
     paths,
-    workspacesFrom(pnpmWorkspaces(cwd), cwd),
+    workspaces,
     new Set(deletedPaths(cwd, base))
   );
   const rootWide = rootWideChanges(paths);
 
-  if (args.includes("--filters")) emitFilters(filters, unreadable, rootWide);
+  if (args.includes("--filters"))
+    emitFilters(filters, unreadable, rootWide, workspaces);
   else
     console.log(
       report({ filters, unreadable, rootWide, scripts: touchesScripts(paths) })
@@ -436,14 +490,66 @@ function nulPaths(out) {
  * into a command, the other is read by a person — and so the refusal is not
  * buried in a branch of a function that mostly formats prose.
  */
-function emitFilters(filters, unreadable, rootWide = []) {
-  const line = filterArguments(filters);
-  if (line) console.log(line);
-  const refusal = filtersRefusal(unreadable, rootWide);
-  if (refusal === null) return;
-  console.error(refusal);
-  process.exitCode = 1;
+function emitFilters(filters, unreadable, rootWide, workspaces) {
+  const outcome = filtersOutcome({ filters, unreadable, rootWide, workspaces });
+  if (outcome.stdout) console.log(outcome.stdout);
+  if (outcome.stderr) console.error(outcome.stderr);
+  process.exitCode = outcome.status;
 }
+
+/**
+ * What `--filters` should print and exit with, as a value.
+ *
+ * Separated from printing it so the decision is assertable rather than only
+ * demonstrable: the exit status is what a hook acts on, and a hook is not a
+ * thing a unit test can observe.
+ *
+ * Ordered by how much it overrides. An unusable workspace list makes every
+ * later answer meaningless; a graph-defining change makes any narrowing wrong
+ * whatever the filters say.
+ */
+export function filtersOutcome({ filters, unreadable, rootWide, workspaces }) {
+  return (
+    refuseWithoutWorkspaces(workspaces) ??
+    widenForGraphChange(rootWide) ??
+    narrowToFilters(filters, unreadable)
+  );
+}
+
+/** Nothing later means anything if the workspace list itself is unusable. */
+function refuseWithoutWorkspaces(workspaces) {
+  const reason = noWorkspacesRefusal(workspaces);
+  if (reason === null) return null;
+  return { stdout: "", stderr: reason, status: EXIT.refuse };
+}
+
+/**
+ * A graph-defining change makes any narrowing wrong, whatever the filters say.
+ *
+ * Its own status rather than a refusal. Refusing made these files impossible
+ * to push: the hook runs under `set -e`, so it died before testing anything,
+ * and no retry could clear it because running the root gates by hand does not
+ * change the diff. The only escape was bypassing the hook, which is worse than
+ * the narrowing this guards against.
+ */
+function widenForGraphChange(rootWide) {
+  if (rootWide.length === 0) return null;
+  return {
+    stdout: "",
+    stderr: unfilteredReason(rootWide),
+    status: EXIT.unfiltered,
+  };
+}
+
+/** The ordinary answer: gate what the filters name, unless one cannot be named. */
+function narrowToFilters(filters, unreadable) {
+  const refusal = filtersRefusal(unreadable);
+  if (refusal !== null)
+    return { stdout: "", stderr: refusal, status: EXIT.refuse };
+  return { stdout: filterArguments(filters), stderr: "", status: EXIT.filters };
+}
+
+
 
 /**
  * Whether this module was the thing invoked, rather than imported.

--- a/scripts/gate-scope.mjs
+++ b/scripts/gate-scope.mjs
@@ -128,20 +128,29 @@ export function filtersFor(paths, workspaces) {
   const unlisted = new Set();
 
   for (const raw of paths) {
-    const path = String(raw);
-    const owner = ownerOf(path, workspaces);
-    if (owner !== undefined) names.add(owner.name);
-    else {
-      const missing =
-        removedWorkspaceDir(path) ?? missingWorkspaceDir(path, roots);
-      if (missing !== null) unlisted.add(missing);
-    }
+    const verdict = classify(String(raw), workspaces, roots);
+    if (verdict.name !== null) names.add(verdict.name);
+    if (verdict.missing !== null) unlisted.add(verdict.missing);
   }
 
   return {
     filters: [...names].sort(),
     unreadable: [...unlisted].sort(),
   };
+}
+
+/**
+ * What one path contributes: a workspace to gate, a workspace that is gone, or
+ * neither.
+ *
+ * Exactly one of the two can be set. A path a workspace claims is gated and is
+ * never also reported missing; a path no workspace claims cannot name a filter.
+ */
+function classify(path, workspaces, roots) {
+  const owner = ownerOf(path, workspaces);
+  if (owner !== undefined) return { name: owner.name, missing: null };
+  const missing = removedWorkspaceDir(path) ?? missingWorkspaceDir(path, roots);
+  return { name: null, missing };
 }
 
 /**

--- a/scripts/gate-scope.mjs
+++ b/scripts/gate-scope.mjs
@@ -34,108 +34,136 @@
  * @module scripts/gate-scope
  */
 import { execFileSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import { relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
 
 /**
- * The workspace directory a path belongs to, for each declared root.
+ * Every workspace this repository declares, as `{ name, dir }`.
  *
- * The roots are READ from `pnpm-workspace.yaml` rather than assumed to be
- * `packages/`. This repository declares `apps/*`, `packages/*` and a bare
- * `e2e` — a browser suite that is under neither — so a mapper that knew only
- * `packages/` would drop a change to an app or to that suite in silence, which
- * is the exact failure this module exists to remove.
+ * ASKED of pnpm rather than derived from `pnpm-workspace.yaml`. Deriving it
+ * meant reimplementing a YAML reader, and the hand-rolled one answered wrongly
+ * for a valid document: `- "apps/*" # application workspaces` kept the comment
+ * as part of the glob, after which no app path matched any root and the gate
+ * omitted every app change in silence.
+ *
+ * pnpm resolves that same file to decide what a workspace IS, so asking it is
+ * the only answer that cannot disagree with the tool these filters are handed
+ * to. It also supplies each package's NAME, which is what a filter needs — the
+ * per-directory manifest read this replaces derived the same fact a second
+ * time, and disagreed with itself about where a directory was rooted.
+ *
+ * Sorted LONGEST DIRECTORY FIRST so a nested workspace wins over one that
+ * merely shares its prefix. The repository root is dropped: its directory is a
+ * prefix of every path, so keeping it would match everything and collapse the
+ * scope to a single filter.
  */
-export function workspaceDirsOf(paths, globs) {
-  const dirs = paths.map(path => workspaceDirOf(String(path), globs));
-  return [...new Set(dirs.filter(dir => dir !== null))].sort();
+export function workspacesFrom(entries, rootDir) {
+  const listed = Array.isArray(entries) ? entries : [];
+  return listed
+    .map(entry => oneWorkspace(entry, rootDir))
+    .filter(w => w.name.length > 0 && w.dir.length > 0)
+    .sort((a, b) => b.dir.length - a.dir.length);
 }
 
-/** The one workspace directory a path names, or null. */
-function workspaceDirOf(path, globs) {
-  const segments = path.split("/");
-  for (const glob of globs) {
-    const dir = matchGlob(segments, glob);
-    if (dir !== null) return dir;
+/** One pnpm entry as `{ name, dir }`, with anything unusable emptied. */
+function oneWorkspace(entry, rootDir) {
+  return { name: entryName(entry), dir: entryDir(entry, rootDir) };
+}
+
+/**
+ * An entry's package name, or the empty string.
+ *
+ * Empty rather than absent, because a `--filter` built from an empty name
+ * matches nothing: it would shrink the gate while reading as coverage.
+ */
+function entryName(entry) {
+  const name = entry?.name;
+  return typeof name === "string" ? name : "";
+}
+
+/** An entry's directory relative to the repository root, or the empty string. */
+function entryDir(entry, rootDir) {
+  const path = entry?.path;
+  return typeof path === "string" ? relativeDir(rootDir, path) : "";
+}
+
+/** One workspace's directory, relative to the repository root, with `/` separators. */
+function relativeDir(rootDir, absolute) {
+  const rel = relative(rootDir, absolute).split(sep).join("/");
+  return rel === "." ? "" : rel;
+}
+
+/**
+ * The roots a workspace may live under, derived from the workspaces themselves.
+ *
+ * Needed to tell "a path in no workspace" apart from "a path in a workspace
+ * that is GONE". `scripts/x.mjs` is the first and gates nothing extra;
+ * `packages/deleted/x.ts` is the second and must be refused rather than
+ * dropped, because dropping it shrinks the gate for the very change that
+ * removed a package.
+ *
+ * Derived rather than read back from the globs, so this cannot disagree with
+ * the list above about where workspaces live. A workspace declared as a bare
+ * directory contributes no root and needs none: it matches itself directly.
+ */
+export function workspaceRootsOf(workspaces) {
+  const roots = workspaces
+    .map(w => (w.dir.includes("/") ? w.dir.slice(0, w.dir.lastIndexOf("/")) : null))
+    .filter(root => root !== null);
+  return [...new Set(roots)].sort();
+}
+
+/**
+ * The filter for every workspace a change reaches, plus the ones it cannot name.
+ *
+ * A path under a known root that belongs to no listed workspace is REPORTED
+ * rather than skipped, because the likeliest cause is a package the diff
+ * deleted or renamed — which the author should see rather than have hidden
+ * behind a smaller gate.
+ */
+export function filtersFor(paths, workspaces) {
+  const roots = workspaceRootsOf(workspaces);
+  const names = new Set();
+  const unlisted = new Set();
+
+  for (const raw of paths) {
+    const path = String(raw);
+    const owner = ownerOf(path, workspaces);
+    if (owner !== undefined) names.add(owner.name);
+    else {
+      const missing = missingWorkspaceDir(path, roots);
+      if (missing !== null) unlisted.add(missing);
+    }
   }
-  return null;
-}
 
-/**
- * A path's directory under one workspace glob, or null.
- *
- * Two forms, because those are the two pnpm declares here, and each is its own
- * decision: a wildcard root matches one directory beneath it, and a literal
- * entry matches that directory itself.
- */
-function matchGlob(segments, glob) {
-  return glob.endsWith("/*")
-    ? matchWildcardRoot(segments, glob.slice(0, -2))
-    : matchLiteralDir(segments, glob);
-}
-
-/**
- * `<root>/*` — one directory beneath a root.
- *
- * Requires a segment AFTER that directory, since a path naming the directory
- * alone names no file inside it and so names no manifest to gate.
- */
-function matchWildcardRoot(segments, root) {
-  if (segments[0] !== root) return null;
-  if (segments.length < 3 || !segments[1]) return null;
-  return `${root}/${segments[1]}`;
-}
-
-/** A bare `<dir>` entry — the directory itself, which is its own package. */
-function matchLiteralDir(segments, dir) {
-  if (segments[0] !== dir || segments.length < 2) return null;
-  return dir;
-}
-
-/**
- * Kept as the narrow form for callers that only care about published packages.
- *
- * Expressed through {@link workspaceDirsOf} rather than reimplemented, so the
- * two cannot disagree about what a package directory is.
- */
-export function changedPackageDirs(paths) {
-  return workspaceDirsOf(paths, ["packages/*"]).map(dir => dir.split("/")[1]);
-}
-
-/**
- * The pnpm filter for each directory, read from its own manifest.
- *
- * A directory whose manifest cannot be read is REPORTED rather than skipped.
- * Skipping it would shrink the gate silently, which is the failure this whole
- * module exists to prevent — and the likeliest cause is a package deleted in
- * the diff, which the author should see rather than have hidden.
- */
-export function packageFilters(dirs, readManifest) {
-  const named = dirs.map(dir => ({ dir, name: manifestName(dir, readManifest) }));
   return {
-    filters: named.filter(e => e.name !== null).map(e => e.name),
-    unreadable: named.filter(e => e.name === null).map(e => e.dir),
+    filters: [...names].sort(),
+    unreadable: [...unlisted].sort(),
   };
 }
 
-/** One directory's package name, or null when the manifest cannot answer. */
-function manifestName(dir, readManifest) {
-  try {
-    return usableName(readManifest(dir));
-  } catch {
-    return null;
-  }
+/**
+ * The workspace a path lies inside, or undefined.
+ *
+ * A segment AFTER the directory is required: a path naming the workspace
+ * directory alone names no file inside it, so there is nothing to gate.
+ */
+function ownerOf(path, workspaces) {
+  return workspaces.find(w => path.startsWith(`${w.dir}/`));
 }
 
 /**
- * The name a manifest supplies, or null.
+ * The workspace directory a path names but no workspace claims, or null.
  *
- * An empty name is null rather than the empty string: a `--filter` built from
- * one matches nothing, so it would shrink the gate while reading as coverage.
+ * A second segment is required: `packages/README.md` sits under a root without
+ * naming a workspace directory, so nothing is missing.
  */
-function usableName(manifest) {
-  const name = manifest?.name;
-  return typeof name === "string" && name.length > 0 ? name : null;
+function missingWorkspaceDir(path, roots) {
+  const root = roots.find(r => path.startsWith(`${r}/`));
+  if (root === undefined) return null;
+  const end = path.indexOf("/", root.length + 1);
+  return end === -1 ? null : path.slice(0, end);
 }
 
 /** Whether a change reaches the root `scripts/` task, which `turbo run test` does not. */
@@ -175,23 +203,26 @@ function unreadableSection(unreadable) {
   if (unreadable.length === 0) return "";
   return [
     "Directories with no readable manifest (deleted, or renamed):",
-    ...unreadable.map(d => `  packages/${d}`),
+    // Rendered as derived. Re-rooting it here produced `packages/packages/ui`
+    // and `packages/apps/playground` — nonexistent paths, in the one message
+    // whose whole job is to name the workspace that could not be gated.
+    ...unreadable.map(d => `  ${d}`),
   ].join("\n");
 }
 
-/** The workspace globs pnpm declares, so the roots are read rather than assumed. */
-export function workspaceGlobs(yaml) {
-  return yaml
-    .split("\n")
-    .map(line => line.trim())
-    .filter(line => line.startsWith("- "))
-    .map(line => line.slice(2).trim().replace(/^["']|["']$/g, ""))
-    .filter(Boolean);
-}
-
-/** Read the manifest of one workspace directory. */
-function manifestReader(cwd) {
-  return dir => JSON.parse(readFileSync(`${cwd}/${dir}/package.json`, "utf8"));
+/**
+ * Every workspace pnpm resolves, as it resolves them.
+ *
+ * A subprocess, and worth its cost: it is the only source that cannot disagree
+ * with the runner the derived filters are handed to.
+ */
+function pnpmWorkspaces(cwd) {
+  const out = execFileSync("pnpm", ["list", "-r", "--depth", "-1", "--json"], {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 1024 * 1024 * 32,
+  });
+  return JSON.parse(out);
 }
 
 function git(cwd, args) {
@@ -231,13 +262,14 @@ function main() {
   const base = args.find(arg => !arg.startsWith("--")) ?? "origin/main";
   const cwd = process.cwd();
   const paths = changedPaths(cwd, base);
-  const { filters, unreadable } = packageFilters(
-    workspaceDirsOf(paths, workspaceGlobs(readFileSync(`${cwd}/pnpm-workspace.yaml`, "utf8"))),
-    manifestReader(cwd)
+  const { filters, unreadable } = filtersFor(
+    paths,
+    workspacesFrom(pnpmWorkspaces(cwd), cwd)
   );
 
   if (args.includes("--filters")) emitFilters(filters, unreadable);
-  else console.log(report({ filters, unreadable, scripts: touchesScripts(paths) }));
+  else
+    console.log(report({ filters, unreadable, scripts: touchesScripts(paths) }));
 }
 
 /**
@@ -252,12 +284,28 @@ function main() {
  * `git diff` reports neither an untracked file nor its directory, so a branch
  * that only ADDS files would derive an empty scope and gate nothing.
  */
-function changedPaths(cwd, base) {
+export function changedPaths(cwd, base) {
   const mergeBase = git(cwd, ["merge-base", base, "HEAD"]).trim();
   return [
-    ...git(cwd, ["diff", "--name-only", mergeBase]).split("\n"),
-    ...git(cwd, ["ls-files", "--others", "--exclude-standard"]).split("\n"),
-  ].filter(Boolean);
+    // `-z` because Git QUOTES a path containing non-ASCII or other special
+    // characters under the default `core.quotePath`, and a quoted path starts
+    // with `"` — so it matched no workspace and the only changed package was
+    // dropped in silence. NUL-delimited output is neither quoted nor escaped.
+    //
+    // `--no-renames` because rename detection reports a move as the
+    // DESTINATION alone. A file moved out of a workspace then left that
+    // workspace ungated, having lost the file. Off, Git reports the delete and
+    // the add separately, which is both sides.
+    ...nulPaths(
+      git(cwd, ["diff", "--name-only", "-z", "--no-renames", mergeBase])
+    ),
+    ...nulPaths(git(cwd, ["ls-files", "--others", "--exclude-standard", "-z"])),
+  ];
+}
+
+/** Paths from a NUL-delimited Git listing. */
+function nulPaths(out) {
+  return out.split("\0").filter(Boolean);
 }
 
 /**
@@ -276,4 +324,24 @@ function emitFilters(filters, unreadable) {
   process.exitCode = 1;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) main();
+/**
+ * Whether this module was the thing invoked, rather than imported.
+ *
+ * Compared as REAL paths. Node resolves `import.meta.url` through symlinks
+ * while `process.argv[1]` keeps the link it was called by, so comparing them
+ * directly answered false whenever the script was launched through a symlink —
+ * and a false answer here is silent: `main()` never runs, nothing is printed,
+ * and the exit status is 0, so the hook reads a no-op as an empty scope.
+ */
+function invokedDirectly() {
+  try {
+    return (
+      realpathSync(fileURLToPath(import.meta.url)) ===
+      realpathSync(process.argv[1] ?? "")
+    );
+  } catch {
+    return false;
+  }
+}
+
+if (invokedDirectly()) main();

--- a/scripts/gate-scope.mjs
+++ b/scripts/gate-scope.mjs
@@ -132,7 +132,8 @@ export function filtersFor(paths, workspaces) {
     const owner = ownerOf(path, workspaces);
     if (owner !== undefined) names.add(owner.name);
     else {
-      const missing = missingWorkspaceDir(path, roots);
+      const missing =
+        removedWorkspaceDir(path) ?? missingWorkspaceDir(path, roots);
       if (missing !== null) unlisted.add(missing);
     }
   }
@@ -151,6 +152,30 @@ export function filtersFor(paths, workspaces) {
  */
 function ownerOf(path, workspaces) {
   return workspaces.find(w => path.startsWith(`${w.dir}/`));
+}
+
+/**
+ * The workspace a diff REMOVED, read from the manifest it deleted, or null.
+ *
+ * The root-based check below cannot see this one. Roots are derived from the
+ * workspaces pnpm currently lists, so removing the LAST workspace under a root
+ * — or the bare `e2e` entry, which contributes no root at all — takes the root
+ * away with it. The paths then match nothing, and a workspace-removal diff
+ * passes with neither a filter nor a refusal: precisely the diff the refusal
+ * exists for.
+ *
+ * A manifest survives that, because deleting a workspace deletes its
+ * `package.json` and the diff therefore names it. Rename detection is off, so
+ * a workspace MOVED reports its old manifest as a deletion too.
+ *
+ * Consulted only for a path no workspace claims, so a manifest nested inside a
+ * live workspace — a fixture, say — is owned before it reaches here.
+ */
+function removedWorkspaceDir(path) {
+  const suffix = "/package.json";
+  if (!path.endsWith(suffix)) return null;
+  const dir = path.slice(0, -suffix.length);
+  return dir.length > 0 ? dir : null;
 }
 
 /**

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -150,6 +150,43 @@ describe("a workspace the diff removed", () => {
     expect(unreadable).toEqual(["apps/gone", "packages/deleted-pkg"]);
   });
 
+  it("catches a workspace whose ROOT went with it", () => {
+    // The root-based check cannot see this. Roots are derived from the
+    // workspaces pnpm currently lists, so removing the last workspace under a
+    // root — or the bare `e2e` entry, which contributes no root at all — takes
+    // the root away too. The paths then match nothing and the removal passes
+    // with neither a filter nor a refusal, which is the one diff the refusal
+    // exists for. The deleted manifest is what survives to name it.
+    const survivors = workspacesFrom(
+      [
+        { name: "nextly-project-setup", path: "/repo" },
+        { name: "@nextlyhq/ui", path: "/repo/packages/ui" },
+      ],
+      "/repo"
+    );
+
+    const { filters, unreadable } = filtersFor(
+      [
+        "e2e/tests/a.spec.ts",
+        "e2e/package.json",
+        "apps/playground/app/page.tsx",
+        "apps/playground/package.json",
+      ],
+      survivors
+    );
+
+    expect(filters).toEqual([]);
+    expect(unreadable).toEqual(["apps/playground", "e2e"]);
+  });
+
+  it("does not mistake a manifest INSIDE a live workspace for a removal", () => {
+    // A fixture or a nested example carries its own `package.json`. The
+    // workspace owns the path first, so it never reaches the removal check.
+    expect(
+      filtersFor(["packages/ui/fixtures/package.json"], WS)
+    ).toEqual({ filters: ["@nextlyhq/ui"], unreadable: [] });
+  });
+
   it("does NOT report a root-level path as a missing workspace", () => {
     // `scripts/` and `.github/` are under no workspace root, so there is
     // nothing missing — refusing here would refuse every tooling change.

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -1,100 +1,165 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 import { describe, expect, it } from "vitest";
 
+/** This module's sibling script, resolved from here rather than from the cwd. */
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "gate-scope.mjs");
+
 import {
-  changedPackageDirs,
+  changedPaths,
   filterArguments,
+  filtersFor,
   filtersRefusal,
-  workspaceDirsOf,
-  workspaceGlobs,
-  packageFilters,
   report,
   touchesScripts,
+  workspaceRootsOf,
+  workspacesFrom,
 } from "./gate-scope.mjs";
+
+/** The workspaces pnpm reports for this repository, in pnpm's own shape. */
+const PNPM = [
+  { name: "nextly-project-setup", path: "/repo" },
+  { name: "@nextlyhq/plugin-page-builder", path: "/repo/packages/plugin-page-builder" },
+  { name: "@nextlyhq/plugin-sdk", path: "/repo/packages/plugin-sdk" },
+  { name: "@nextlyhq/ui", path: "/repo/packages/ui" },
+  { name: "playground", path: "/repo/apps/playground" },
+  { name: "@nextlyhq/e2e", path: "/repo/e2e" },
+];
+const WS = workspacesFrom(PNPM, "/repo");
+const filtersOf = paths => filtersFor(paths, WS).filters;
 
 describe("the packages a diff touches", () => {
   it("names each one once, whatever its file count", () => {
     expect(
-      changedPackageDirs([
+      filtersOf([
         "packages/plugin-page-builder/src/a.ts",
         "packages/plugin-page-builder/src/b.ts",
         "packages/plugin-sdk/src/index.ts",
       ])
-    ).toEqual(["plugin-page-builder", "plugin-sdk"]);
+    ).toEqual(["@nextlyhq/plugin-page-builder", "@nextlyhq/plugin-sdk"]);
   });
 
   it("names a package the author did not expect to touch", () => {
     // The case this module exists for. A gate list written from the package
     // the author has in mind cannot report the second one; a derivation does.
     expect(
-      changedPackageDirs([
+      filtersOf([
         "packages/plugin-page-builder/src/blocks-fields.ts",
         "packages/plugin-sdk/src/index.ts",
       ])
-    ).toContain("plugin-sdk");
+    ).toContain("@nextlyhq/plugin-sdk");
   });
 
-  it("drops paths outside packages/ rather than mapping them to a package", () => {
+  it("gates a workspace that is under neither packages/ nor apps/", () => {
+    // `e2e` is declared as a bare directory. A mapper that assumed a wildcard
+    // root would drop it, and the browser suite would never be gated.
+    expect(filtersOf(["e2e/tests/canvas/acceptance.spec.ts"])).toEqual([
+      "@nextlyhq/e2e",
+    ]);
+  });
+
+  it("gates an app, not only a package", () => {
+    expect(filtersOf(["apps/playground/app/page.tsx"])).toEqual(["playground"]);
+  });
+
+  it("attaches a root-level path to NO workspace", () => {
     // A change to `scripts/` or `.github/` belongs to a root task. Attaching it
     // to a nearest package would gate the wrong thing while reporting coverage.
+    // The repository root is itself a workspace pnpm lists, and its directory
+    // is a prefix of every path — so this also asserts the root was dropped.
     expect(
-      changedPackageDirs([
+      filtersOf([
         "scripts/gate-scope.mjs",
         ".github/workflows/ci.yml",
         "README.md",
         "packages/ui/src/x.ts",
       ])
-    ).toEqual(["ui"]);
+    ).toEqual(["@nextlyhq/ui"]);
   });
 
-  it("ignores a bare packages/<dir> entry that names no file", () => {
-    expect(changedPackageDirs(["packages/ui", "packages"])).toEqual([]);
+  it("ignores a bare workspace directory that names no file", () => {
+    expect(filtersOf(["packages/ui", "packages"])).toEqual([]);
   });
 
-  it("returns nothing for a diff that touches no package", () => {
+  it("returns nothing for a diff that touches no workspace", () => {
     // Must come out EMPTY rather than defaulting to every package: a gate list
     // that always names everything is not a derivation and would be ignored.
-    expect(changedPackageDirs(["README.md", "scripts/x.mjs"])).toEqual([]);
+    expect(filtersOf(["README.md", "scripts/x.mjs"])).toEqual([]);
+  });
+
+  it("keeps a path Git would have QUOTED", () => {
+    // Under the default `core.quotePath` a non-ASCII path comes back quoted, so
+    // it began with `"` and matched no workspace — the only changed package was
+    // dropped and the gate ran nothing. The commands ask for NUL-delimited
+    // output now, which is neither quoted nor escaped, so the raw path arrives.
+    expect(filtersOf(["packages/ui/src/é.ts"])).toEqual(["@nextlyhq/ui"]);
   });
 });
 
-describe("turning directories into filters", () => {
-  const manifests = {
-    "plugin-sdk": { name: "@nextlyhq/plugin-sdk" },
-    nextly: { name: "nextly" },
-  };
-
-  it("reads each filter from that package's own manifest", () => {
-    // Derived, not restated: a rename cannot leave a filter pointing at
-    // nothing, because the name comes from the file the rename edits.
-    const { filters } = packageFilters(
-      ["plugin-sdk", "nextly"],
-      dir => manifests[dir]
-    );
-
-    expect(filters).toEqual(["@nextlyhq/plugin-sdk", "nextly"]);
+describe("the workspaces pnpm reports", () => {
+  it("drops the repository root, whose directory prefixes every path", () => {
+    // Keeping it would match everything and collapse the scope to one filter.
+    expect(WS.map(w => w.name)).not.toContain("nextly-project-setup");
   });
 
-  it("REPORTS a directory whose manifest cannot be read", () => {
-    // Skipping it would shrink the gate silently, which is the failure this
-    // module exists to prevent. The likeliest cause is a package deleted in the
-    // diff, and the author should see that rather than have it hidden.
-    const { filters, unreadable } = packageFilters(
-      ["plugin-sdk", "ghost"],
-      dir => {
-        if (dir === "ghost") throw new Error("ENOENT");
-        return manifests[dir];
-      }
+  it("orders them longest directory first, so a nested workspace wins", () => {
+    const nested = workspacesFrom(
+      [
+        { name: "outer", path: "/repo/packages/outer" },
+        { name: "inner", path: "/repo/packages/outer/inner" },
+      ],
+      "/repo"
     );
-
-    expect(filters).toEqual(["@nextlyhq/plugin-sdk"]);
-    expect(unreadable).toEqual(["ghost"]);
+    expect(filtersFor(["packages/outer/inner/x.ts"], nested).filters).toEqual([
+      "inner",
+    ]);
   });
 
-  it("treats a manifest with no name as unreadable rather than as empty", () => {
-    const { filters, unreadable } = packageFilters(["odd"], () => ({}));
+  it("ignores an entry with no usable name", () => {
+    // A filter built from an empty name matches nothing, so it would shrink the
+    // gate while reading as coverage.
+    expect(
+      workspacesFrom([{ name: "", path: "/repo/packages/x" }], "/repo")
+    ).toEqual([]);
+  });
+
+  it("derives the roots from the workspaces themselves", () => {
+    // Read back from the list rather than from the globs, so the two cannot
+    // disagree about where a workspace lives. A bare directory contributes no
+    // root and needs none — it matches itself.
+    expect(workspaceRootsOf(WS)).toEqual(["apps", "packages"]);
+  });
+});
+
+describe("a workspace the diff removed", () => {
+  it("is REPORTED rather than dropped, at the path it actually had", () => {
+    // Dropping it shrinks the gate for the very change that deleted a package.
+    // The path is rendered as derived: re-rooting it produced
+    // `packages/packages/ui` and `packages/apps/playground`, nonexistent paths
+    // in the one message whose job is to name what could not be gated.
+    const { filters, unreadable } = filtersFor(
+      ["packages/deleted-pkg/src/x.ts", "apps/gone/a.ts"],
+      WS
+    );
 
     expect(filters).toEqual([]);
-    expect(unreadable).toEqual(["odd"]);
+    expect(unreadable).toEqual(["apps/gone", "packages/deleted-pkg"]);
+  });
+
+  it("does NOT report a root-level path as a missing workspace", () => {
+    // `scripts/` and `.github/` are under no workspace root, so there is
+    // nothing missing — refusing here would refuse every tooling change.
+    expect(filtersFor(["scripts/x.mjs", ".github/w.yml"], WS).unreadable).toEqual(
+      []
+    );
+  });
+
+  it("does not report a bare root path, which names no workspace directory", () => {
+    expect(filtersFor(["packages/README.md"], WS).unreadable).toEqual([]);
   });
 });
 
@@ -136,65 +201,20 @@ describe("the report", () => {
   });
 
   it("surfaces unreadable directories instead of dropping them", () => {
-    expect(
-      report({ filters: [], unreadable: ["ghost"], scripts: false })
-    ).toContain("packages/ghost");
-  });
-});
+    // Rendered exactly as derived. Prepending a root here turned
+    // `apps/playground` into `packages/apps/playground` — a path that exists
+    // nowhere, in the one message whose job is to name the workspace that
+    // could not be gated.
+    const rendered = report({
+      filters: [],
+      unreadable: ["apps/playground", "packages/ghost"],
+      scripts: false,
+    });
 
-describe("the workspace roots, which are not only packages/", () => {
-  // `pnpm-workspace.yaml` declares `apps/*`, `packages/*` and the bare `e2e`.
-  // A mapper that knows only `packages/` drops a change to an app or to the
-  // browser suite silently — and silence is the failure this module exists to
-  // remove.
-  const GLOBS = ["apps/*", "packages/*", "e2e"];
-
-  it("maps a packages/ path", () => {
-    expect(workspaceDirsOf(["packages/ui/src/x.ts"], GLOBS)).toEqual([
-      "packages/ui",
-    ]);
-  });
-
-  it("maps an apps/ path", () => {
-    expect(workspaceDirsOf(["apps/playground/app/page.tsx"], GLOBS)).toEqual([
-      "apps/playground",
-    ]);
-  });
-
-  it("maps a BARE workspace entry that has no wildcard", () => {
-    expect(workspaceDirsOf(["e2e/tests/a.spec.ts"], GLOBS)).toEqual(["e2e"]);
-  });
-
-  it("drops a path in no workspace root", () => {
-    // The control. A mapper that returned something for every path would
-    // satisfy the three cases above and name a package for `README.md`.
-    expect(workspaceDirsOf(["README.md", "scripts/x.mjs"], GLOBS)).toEqual([]);
-  });
-
-  it("ignores a bare root entry naming no file", () => {
-    expect(workspaceDirsOf(["packages/ui", "packages"], GLOBS)).toEqual([]);
-  });
-});
-
-describe("reading the workspace roots from pnpm-workspace.yaml", () => {
-  it("takes every list entry, quoted or bare", () => {
-    expect(
-      workspaceGlobs(
-        [
-          "packages:",
-          '  - "apps/*"',
-          '  - "packages/*"',
-          "  # a comment, and the bare entry below it",
-          "  - e2e",
-        ].join("\n")
-      )
-    ).toEqual(["apps/*", "packages/*", "e2e"]);
-  });
-
-  it("returns nothing for a file that declares no list", () => {
-    // Must be EMPTY rather than defaulting to `packages/*`: a silent default
-    // is how the mapper came to know one root and drop the other two.
-    expect(workspaceGlobs("packages:\n")).toEqual([]);
+    expect(rendered).toContain("packages/ghost");
+    expect(rendered).toContain("apps/playground");
+    expect(rendered).not.toContain("packages/apps/playground");
+    expect(rendered).not.toContain("packages/packages/ghost");
   });
 });
 
@@ -233,3 +253,71 @@ describe("refusing a scope that would silently omit a workspace", () => {
     expect(filtersRefusal([])).toBeNull();
   });
 });
+
+describe("against a real repository, where Git decides how paths arrive", () => {
+  // The unit cases above hand the derivation raw paths, so they cannot see how
+  // Git was ASKED for them. These build a throwaway repository instead: they
+  // are the only tests that fail if the commands stop requesting NUL-delimited
+  // output or start detecting renames again.
+  const run = (cwd, args) => execFileSync("git", args, { cwd, encoding: "utf8" });
+
+  /** A repository with one workspace, a base commit, and a branch off it. */
+  function repo() {
+    const dir = mkdtempSync(join(tmpdir(), "gate-scope-"));
+    run(dir, ["init", "-q", "-b", "main"]);
+    run(dir, ["config", "user.email", "t@example.com"]);
+    run(dir, ["config", "user.name", "t"]);
+    // Left at its default ON, which is what quotes a non-ASCII path.
+    mkdirSync(join(dir, "packages", "ui", "src"), { recursive: true });
+    writeFileSync(join(dir, "packages", "ui", "package.json"), '{"name":"@nextlyhq/ui"}');
+    writeFileSync(join(dir, "packages", "ui", "src", "a.ts"), "export const a = 1;\n");
+    run(dir, ["add", "-A"]);
+    run(dir, ["commit", "-qm", "base"]);
+    // The work happens on a BRANCH: the derivation diffs the merge base, so a
+    // change committed onto the base itself would compare a commit with itself
+    // and report nothing — an empty result that reads exactly like "clean".
+    run(dir, ["checkout", "-q", "-b", "feature"]);
+    return dir;
+  }
+
+  /** The script's own path collection, run against a real repository. */
+  const changedIn = dir => changedPaths(dir, "main");
+
+  it("sees an ordinary change at all, which the two cases below rely on", () => {
+    // The control. Both cases assert a path is PRESENT, and an empty result
+    // would fail them for the wrong reason — a broken fixture rather than a
+    // lost path. This says the harness reports anything.
+    const dir = repo();
+    writeFileSync(join(dir, "packages", "ui", "src", "b.ts"), "export const b = 1;\n");
+    run(dir, ["add", "-A"]);
+    run(dir, ["commit", "-qm", "ordinary"]);
+
+    expect(changedIn(dir)).toEqual(["packages/ui/src/b.ts"]);
+  });
+
+  it("does not lose a path Git would have quoted", () => {
+    // With `core.quotePath` at its default, `git diff --name-only` returns
+    // "packages/ui/src/\303\251.ts" — starting with a quote, so it matched no
+    // workspace and the only changed package was dropped in silence.
+    const dir = repo();
+    writeFileSync(join(dir, "packages", "ui", "src", "é.ts"), "export const e = 1;\n");
+    run(dir, ["add", "-A"]);
+    run(dir, ["commit", "-qm", "add non-ascii"]);
+
+    expect(changedIn(dir)).toContain("packages/ui/src/é.ts");
+  });
+
+  it("reports BOTH sides when a file moves out of a workspace", () => {
+    // Rename detection reports a move as the destination alone, so a workspace
+    // that LOST a file was not gated — though it is the one whose build could
+    // break. Detection off, Git reports the delete and the add separately.
+    const dir = repo();
+    mkdirSync(join(dir, "docs"), { recursive: true });
+    run(dir, ["mv", "packages/ui/src/a.ts", "docs/a.ts"]);
+    run(dir, ["commit", "-qm", "move out"]);
+
+    const paths = changedIn(dir);
+    expect(paths).toContain("packages/ui/src/a.ts");
+    expect(paths).toContain("docs/a.ts");
+  });
+})

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -12,6 +12,7 @@ const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "gate-scope.mjs");
 import {
   changedPaths,
   filterArguments,
+  rootWideChanges,
   filtersFor,
   filtersRefusal,
   report,
@@ -119,12 +120,20 @@ describe("the workspaces pnpm reports", () => {
     ]);
   });
 
-  it("ignores an entry with no usable name", () => {
-    // A filter built from an empty name matches nothing, so it would shrink the
-    // gate while reading as coverage.
+  it("KEEPS an entry with no usable name, so it can be refused", () => {
+    // A filter built from an empty name matches nothing, so it must never
+    // become one. But dropping the entry was worse: its paths then had no
+    // owner and no derived root, so a change inside it produced an empty scope
+    // and the hook skipped its tests. Kept, it is refused by name below.
     expect(
       workspacesFrom([{ name: "", path: "/repo/packages/x" }], "/repo")
-    ).toEqual([]);
+    ).toEqual([{ name: "", dir: "packages/x" }]);
+  });
+
+  it("still drops an entry with no usable DIRECTORY", () => {
+    // The repository root resolves to the empty string and is dropped by this
+    // same rule; an entry with no path is unusable for the same reason.
+    expect(workspacesFrom([{ name: "x", path: "/repo" }], "/repo")).toEqual([]);
   });
 
   it("derives the roots from the workspaces themselves", () => {
@@ -132,6 +141,49 @@ describe("the workspaces pnpm reports", () => {
     // disagree about where a workspace lives. A bare directory contributes no
     // root and needs none — it matches itself.
     expect(workspaceRootsOf(WS)).toEqual(["apps", "packages"]);
+  });
+});
+
+describe("a change that redefines the graph for every package", () => {
+  it("refuses to narrow a workspace-declaration change", () => {
+    // Removing an entry from `pnpm-workspace.yaml` detaches a directory that
+    // still exists, so no manifest is deleted and no path names the workspace
+    // that just lost its gate — the only changed file is the YAML itself.
+    // Narrowing to whatever package happens to sit beside it in the diff would
+    // skip the detached workspace entirely.
+    const rootWide = rootWideChanges([
+      "pnpm-workspace.yaml",
+      "packages/ui/src/x.ts",
+    ]);
+
+    expect(rootWide).toEqual(["pnpm-workspace.yaml"]);
+    expect(filtersRefusal([], rootWide)).toMatch(/refusing to narrow/);
+  });
+
+  it("refuses for the task graph too, not only the workspace list", () => {
+    // `turbo.jsonc` defines the tasks every workspace runs, so a filtered run
+    // exercises the new definition for one package and none of the others.
+    expect(rootWideChanges(["turbo.jsonc"])).toEqual(["turbo.jsonc"]);
+  });
+
+  it("says so in the report as well as in the refusal", () => {
+    // The two audiences are separate: one is spliced into a command, the other
+    // is read by a person, and a person following the report must not be told
+    // a narrower scope than the machine refused.
+    expect(
+      report({
+        filters: ["@nextlyhq/ui"],
+        unreadable: [],
+        scripts: false,
+        rootWide: ["pnpm-workspace.yaml"],
+      })
+    ).toMatch(/UNFILTERED/);
+  });
+
+  it("stays silent for an ordinary change", () => {
+    // The control: refusing every push would be its own failure.
+    expect(rootWideChanges(["packages/ui/src/x.ts"])).toEqual([]);
+    expect(filtersRefusal([], [])).toBeNull();
   });
 });
 
@@ -172,7 +224,10 @@ describe("a workspace the diff removed", () => {
         "apps/playground/app/page.tsx",
         "apps/playground/package.json",
       ],
-      survivors
+      survivors,
+      // Both manifests were DELETED, which is what makes them removals rather
+      // than ordinary manifests sitting outside every workspace.
+      new Set(["e2e/package.json", "apps/playground/package.json"])
     );
 
     expect(filters).toEqual([]);
@@ -185,6 +240,42 @@ describe("a workspace the diff removed", () => {
     expect(
       filtersFor(["packages/ui/fixtures/package.json"], WS)
     ).toEqual({ filters: ["@nextlyhq/ui"], unreadable: [] });
+  });
+
+  it("reports a removal only when the manifest was actually DELETED", () => {
+    // Presence in a diff says nothing about direction. A manifest ADDED
+    // outside every workspace — a fixture, a scaffold template — looked
+    // identical to one removed from inside a workspace, and reporting the
+    // first as a removal refused a push that was perfectly valid.
+    const added = filtersFor(["docs/example/package.json"], WS, new Set());
+    expect(added).toEqual({ filters: [], unreadable: [] });
+
+    const survivors = workspacesFrom(
+      [{ name: "nextly-project-setup", path: "/repo" }],
+      "/repo"
+    );
+    const removed = filtersFor(
+      ["e2e/package.json"],
+      survivors,
+      new Set(["e2e/package.json"])
+    );
+    expect(removed.unreadable).toEqual(["e2e"]);
+  });
+
+  it("REFUSES a workspace whose manifest omits a name, rather than dropping it", () => {
+    // A `--filter` built from an empty name matches nothing, so it would
+    // shrink the gate while reading as coverage. Dropping the entry was worse
+    // still: its paths then had no owner AND no derived root, so a change
+    // inside it produced an empty scope and the hook skipped its tests.
+    const nameless = workspacesFrom(
+      [{ name: "nextly-project-setup", path: "/repo" }, { path: "/repo/e2e" }],
+      "/repo"
+    );
+
+    expect(filtersFor(["e2e/tests/a.spec.ts"], nameless)).toEqual({
+      filters: [],
+      unreadable: ["e2e"],
+    });
   });
 
   it("does NOT report a root-level path as a missing workspace", () => {

--- a/scripts/gate-scope.test.mjs
+++ b/scripts/gate-scope.test.mjs
@@ -10,10 +10,14 @@ import { describe, expect, it } from "vitest";
 const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), "gate-scope.mjs");
 
 import {
+  EXIT,
   changedPaths,
   filterArguments,
+  noWorkspacesRefusal,
   rootWideChanges,
+  unfilteredReason,
   filtersFor,
+  filtersOutcome,
   filtersRefusal,
   report,
   touchesScripts,
@@ -157,7 +161,12 @@ describe("a change that redefines the graph for every package", () => {
     ]);
 
     expect(rootWide).toEqual(["pnpm-workspace.yaml"]);
-    expect(filtersRefusal([], rootWide)).toMatch(/refusing to narrow/);
+    // NOT a refusal. Refusing made these files impossible to push: the hook
+    // runs under `set -e`, so it died before testing anything, and no retry
+    // could clear it because running the gates by hand does not change the
+    // diff. It asks the caller to WIDEN instead, under its own status.
+    expect(EXIT.unfiltered).not.toBe(EXIT.refuse);
+    expect(unfilteredReason(rootWide)).toMatch(/UNFILTERED/);
   });
 
   it("refuses for the task graph too, not only the workspace list", () => {
@@ -178,6 +187,52 @@ describe("a change that redefines the graph for every package", () => {
         rootWide: ["pnpm-workspace.yaml"],
       })
     ).toMatch(/UNFILTERED/);
+  });
+
+  it("asks the caller to WIDEN, and never to fail, on a graph change", () => {
+    // The decision as a value, because the exit status is what the hook acts
+    // on and a hook is not a thing a unit test can observe.
+    const outcome = filtersOutcome({
+      filters: ["@nextlyhq/ui"],
+      unreadable: [],
+      rootWide: ["pnpm-workspace.yaml"],
+      workspaces: WS,
+    });
+
+    expect(outcome.status).toBe(EXIT.unfiltered);
+    expect(outcome.status).not.toBe(EXIT.refuse);
+    // No filters on stdout: emitting them beside a widen instruction would let
+    // a caller splice a narrower scope than the status just asked for.
+    expect(outcome.stdout).toBe("");
+  });
+
+  it("orders the outcomes so an unusable workspace list wins", () => {
+    // Nothing later means anything if the list itself is empty, so that answer
+    // must not be reachable only when the other two happen not to fire.
+    expect(
+      filtersOutcome({
+        filters: [],
+        unreadable: [],
+        rootWide: ["turbo.jsonc"],
+        workspaces: [],
+      }).status
+    ).toBe(EXIT.refuse);
+  });
+
+  it("keeps the three outcomes distinct, since a caller acts on the status", () => {
+    // Two statuses cannot express this. A caller that can only tell "worked"
+    // from "failed" must treat "cannot be narrowed" as a failure, which is
+    // exactly the bug: widen and refuse are opposite instructions.
+    expect(new Set(Object.values(EXIT)).size).toBe(3);
+    expect(EXIT.filters).toBe(0);
+  });
+
+  it("REFUSES when pnpm reports no usable workspace at all", () => {
+    // An empty list printed nothing and exited 0, which reads as "nothing to
+    // gate" — so a broken or unresolvable workspace response ran no tests and
+    // looked clean.
+    expect(noWorkspacesRefusal([])).toMatch(/refusing/);
+    expect(noWorkspacesRefusal([{ name: "x", dir: "packages/x" }])).toBeNull();
   });
 
   it("stays silent for an ordinary change", () => {
@@ -202,7 +257,7 @@ describe("a workspace the diff removed", () => {
     expect(unreadable).toEqual(["apps/gone", "packages/deleted-pkg"]);
   });
 
-  it("catches a workspace whose ROOT went with it", () => {
+  it("catches a removed workspace while its ROOT survives", () => {
     // The root-based check cannot see this. Roots are derived from the
     // workspaces pnpm currently lists, so removing the last workspace under a
     // root — or the bare `e2e` entry, which contributes no root at all — takes
@@ -218,20 +273,41 @@ describe("a workspace the diff removed", () => {
     );
 
     const { filters, unreadable } = filtersFor(
-      [
-        "e2e/tests/a.spec.ts",
-        "e2e/package.json",
-        "apps/playground/app/page.tsx",
-        "apps/playground/package.json",
-      ],
+      ["packages/gone/src/x.ts", "packages/gone/package.json"],
       survivors,
-      // Both manifests were DELETED, which is what makes them removals rather
-      // than ordinary manifests sitting outside every workspace.
-      new Set(["e2e/package.json", "apps/playground/package.json"])
+      // DELETED, which is what makes it a removal rather than an ordinary
+      // manifest sitting outside every workspace.
+      new Set(["packages/gone/package.json"])
     );
 
     expect(filters).toEqual([]);
-    expect(unreadable).toEqual(["apps/playground", "e2e"]);
+    expect(unreadable).toEqual(["packages/gone"]);
+  });
+
+  it("leaves a removal that took its root with it to the UNFILTERED path", () => {
+    // Removing the bare `e2e` workspace, or the last app, takes its root away
+    // too — so nothing here can recognise the directory as one that used to be
+    // a workspace, and guessing from a deleted manifest alone would refuse
+    // every deleted `docs/example/package.json` as well.
+    //
+    // Not a gap: a bare entry cannot leave without `pnpm-workspace.yaml`
+    // changing, and that file is graph-defining, so the unfiltered path claims
+    // the diff before scope is narrowed at all.
+    const survivors = workspacesFrom(
+      [{ name: "nextly-project-setup", path: "/repo" }],
+      "/repo"
+    );
+
+    expect(
+      filtersFor(
+        ["e2e/package.json", "pnpm-workspace.yaml"],
+        survivors,
+        new Set(["e2e/package.json"])
+      )
+    ).toEqual({ filters: [], unreadable: [] });
+    expect(rootWideChanges(["e2e/package.json", "pnpm-workspace.yaml"])).toEqual([
+      "pnpm-workspace.yaml",
+    ]);
   });
 
   it("does not mistake a manifest INSIDE a live workspace for a removal", () => {
@@ -250,16 +326,26 @@ describe("a workspace the diff removed", () => {
     const added = filtersFor(["docs/example/package.json"], WS, new Set());
     expect(added).toEqual({ filters: [], unreadable: [] });
 
-    const survivors = workspacesFrom(
-      [{ name: "nextly-project-setup", path: "/repo" }],
-      "/repo"
-    );
     const removed = filtersFor(
-      ["e2e/package.json"],
-      survivors,
-      new Set(["e2e/package.json"])
+      ["packages/gone/package.json"],
+      WS,
+      new Set(["packages/gone/package.json"])
     );
-    expect(removed.unreadable).toEqual(["e2e"]);
+    expect(removed.unreadable).toEqual(["packages/gone"]);
+  });
+
+  it("does not report a DELETED manifest that was never a workspace", () => {
+    // Deletion status alone does not say the directory was ever a workspace.
+    // `docs/example/package.json` sits under no declared root, so removing it
+    // is an ordinary change — refusing it blocked a valid push exactly as
+    // reporting an ADDED manifest did.
+    expect(
+      filtersFor(
+        ["docs/example/package.json"],
+        WS,
+        new Set(["docs/example/package.json"])
+      )
+    ).toEqual({ filters: [], unreadable: [] });
   });
 
   it("REFUSES a workspace whose manifest omits a name, rather than dropping it", () => {


### PR DESCRIPTION
Works **5 of the 15 Codex findings that #1266 merged with unresolved.** They were never worked, and I only found them because another lane pointed out that a merged PR reads as finished so nobody re-reads it. The remaining ten are about which *tasks* to recommend and which *commit* the hook tests; both are separate changes and I have not touched them here.

Every fix below is a way the tool could **omit a changed workspace in silence** — the exact failure it exists to prevent.

## The architectural change

The script parsed `pnpm-workspace.yaml` by hand and then read every package's manifest to get its name. Both are derivations of facts pnpm already holds, and both were wrong:

- `- "apps/*" # application workspaces` parsed as `apps/*" # application workspaces`, after which **no app path matched any root**.
- The manifest step re-rooted its own output, so the diagnostic for an ungateable workspace printed `packages/packages/ui` and `packages/apps/playground` — paths that exist nowhere, in the one message whose job is to name what could not be gated.

**pnpm is asked instead** (`pnpm list -r --depth -1 --json`). It resolves that same file to decide what a workspace *is*, so its answer cannot disagree with the runner these filters are handed to, and it supplies the names — so one call replaces both derivations. It costs ~244ms in a hook that then runs a test suite.

The refusal for a workspace the diff **deleted** is kept. Its roots are now derived from the listed workspaces themselves rather than read back from the globs, so the two cannot disagree about where a workspace lives.

## The three silent-omission bugs

| finding | mechanism |
|---|---|
| **NUL-delimited output** | Under the default `core.quotePath`, a non-ASCII path returns quoted, so it began with `"`, matched no workspace, and the only changed package was dropped |
| **Rename detection** | A move reports the **destination alone**, so a workspace that *lost* a file was not gated — though it is the one whose build can break |
| **Symlinked entry point** | Node realpaths `import.meta.url` while `argv[1]` keeps the link, so invoking through a symlink ran nothing, printed nothing, and exited **0** — a no-op indistinguishable from an empty scope |

## Evidence

**28 tests, up from 25**, including three that run against a **real throwaway Git repository** — the only ones that can fail if the commands stop asking for NUL output or start detecting renames again. The unit cases hand the derivation raw paths, so by construction they cannot see how Git was *asked*.

Those three carry a control: `sees an ordinary change at all`. Both real cases assert a path is **present**, so an empty result would fail them for the wrong reason — a broken fixture rather than a lost path. I needed it: my first version committed on the base branch, so `merge-base` compared a commit with itself and returned nothing.

Break-verified, each compiling and failing the test named in advance:

| break | fails |
|---|---|
| drop `-z` | quoted-path case (+ the control, correctly) |
| drop `--no-renames` | move-out case |
| keep the repository root as matchable | root-dropped case |
| re-root the unreadable diagnostic | deleted-workspace case |

Gates: `pnpm test:scripts` 0 (**630 passed**), comment-convention 0, fallow `verdict: pass` with every `*_introduced` at 0. Two complexity findings appeared during the rewrite and were **split rather than suppressed** — `filtersFor` into `ownerOf`/`missingWorkspaceDir`, and the entry mapper into `entryName`/`entryDir`.

No changeset: `scripts/` ships in no published package, and #1266 carried none for the same reason.

## Note for reviewers

This PR's own diff is `scripts/`-only, so the derived scope is **empty** and the pre-push hook runs no tests on it. That is finding 10 of the fifteen (*"Run script tests for scripts-only pushes"*), which is in the next batch. I ran `pnpm test:scripts` by hand.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved change detection across workspaces, including nested, removed, deleted, and unreadable workspaces.
  * Correctly handles renamed files, non-ASCII paths, symlinks, and root-level configuration changes.
  * Ensures relevant root checks run when workspace graph configuration changes.

* **Tests**
  * Expanded coverage for workspace filtering, Git path handling, deletions, renames, and reporting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->