### PR TITLE
feat(nextly): publish scheduled content at the moment it is due

### DIFF
--- a/.changeset/scheduled-content-goes-live-on-time.md
+++ b/.changeset/scheduled-content-goes-live-on-time.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Content can now be scheduled to publish, and it goes live at the moment you
+chose rather than the next time something happens to run.
+
+Group the pages, posts and settings that belong to one launch into a release,
+give it a date and time, and everything in it becomes visible together. Removing
+content works the same way — schedule the takedown and it stops being visible on
+the hour you picked.
+
+The part that is easy to get wrong, and the reason this took the shape it did:
+a release changes what a _reader_ sees, not just what the database stores. So a
+post that is still a draft, but whose release has come due, is returned by an
+ordinary visitor's request — including when it is reached indirectly, as the
+author of a post rather than by name. Content that is published when you ask for
+it directly and missing when you arrive at it through a link is worse than
+content that is late.
+
+That applies to one-off documents too — a homepage, a settings page — which are
+loaded and refused rather than filtered, and so needed the same answer reached a
+different way.
+
+While nothing is scheduled, none of this costs anything: the check is a single
+cached comparison, and no extra query is made on a site that has never created
+a release.

--- a/packages/nextly/src/di/registrations/register-collections.ts
+++ b/packages/nextly/src/di/registrations/register-collections.ts
@@ -21,6 +21,7 @@
 import type { PermissionSeedService } from "../../domains/auth/services/permission-seed-service";
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import { DynamicCollectionService } from "../../domains/dynamic-collections";
+import { releaseVisibilityFor } from "../../domains/releases/release-visibility";
 import { MetaRetentionGate } from "../../domains/retention/gate";
 import {
   buildRetentionRunner,
@@ -145,7 +146,8 @@ export function registerCollectionServices(ctx: RegistrationContext): void {
       adapter,
       logger,
       fileManager,
-      dynamicCollectionService
+      dynamicCollectionService,
+      releaseVisibilityFor(adapter)
     );
     if (!container.has("relationshipService")) {
       container.registerSingleton<CollectionRelationshipService>(

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -27,9 +27,11 @@ import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { NextlyError } from "../../../errors/nextly-error";
 import { getFilterRegistry, FilterSeams } from "../../../filters";
 import { toSnakeCase } from "../../../lib/case-conversion";
+import { statusCondition } from "../../../lib/status-condition";
 import {
   expansionStatusScope,
   resolveStatusFilter,
+  type StatusFilterValue,
   type StatusOption,
 } from "../../../lib/status-filter";
 import { STORAGE_FORMAT } from "../../../schemas/storage-format";
@@ -116,6 +118,10 @@ import {
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
 import { resolveCompanionSchemaReadiness } from "../../i18n/runtime/companion-readiness";
+import {
+  NO_RELEASE_VISIBILITY,
+  type ReleaseVisibility,
+} from "../../releases/release-visibility";
 import { resolveComponentTableName } from "../../schema/utils/resolve-table-name";
 import {
   draftDocumentFacts,
@@ -277,9 +283,35 @@ export class CollectionQueryService extends BaseService {
      * reads resolve translatable fields from the companion `_locales` table for the
      * requested locale with fallback. Absent → non-localized behavior (unchanged).
      */
-    private readonly localization?: SanitizedLocalizationConfig
+    private readonly localization?: SanitizedLocalizationConfig,
+    /**
+     * What a due release makes visible on this read.
+     *
+     * A null object by default, so a runtime with no releases wired needs no
+     * special case here and cannot silently narrow a read by forgetting one.
+     */
+    private readonly releaseVisibility: ReleaseVisibility = NO_RELEASE_VISIBILITY
   ) {
     super(adapter, logger);
+  }
+
+  /**
+   * The documents a due release would publish in this collection, if any.
+   *
+   * Costs a memo read while nothing is scheduled — see `createReleaseVisibility`
+   * — so the common case is not paying for a query it cannot use. Only asked
+   * for a PUBLISHED read: an unbounded or draft-only read has nothing to reveal.
+   */
+  private async releaseRevealIds(
+    collectionName: string,
+    statusFilter: { value: StatusFilterValue } | null
+  ): Promise<readonly string[]> {
+    if (statusFilter?.value !== "published") return [];
+    return this.releaseVisibility.revealIds({
+      scopeKind: "collection",
+      scopeSlug: collectionName,
+      now: new Date(),
+    });
   }
 
   // ============================================================
@@ -1142,9 +1174,16 @@ export class CollectionQueryService extends BaseService {
         overrideAccess: params.overrideAccess === true,
         explicit: params.status,
       });
-      if (statusFilter && schema.status) {
-        whereConditions.push(eq(schema.status, statusFilter.value));
-      }
+      const releaseCondition = statusCondition({
+        filter: statusFilter,
+        statusColumn: schema.status,
+        idColumn: schema.id,
+        revealIds: await this.releaseRevealIds(
+          params.collectionName,
+          statusFilter
+        ),
+      });
+      if (releaseCondition) whereConditions.push(releaseCondition);
       // Build the localized-query context AFTER the status filter is resolved so
       // localized where/search EXISTS checks constrain by the per-locale status too
       // (a published read must not match a draft translation).
@@ -2236,9 +2275,16 @@ export class CollectionQueryService extends BaseService {
         overrideAccess: params.overrideAccess === true,
         explicit: params.status,
       });
-      if (statusFilter && schema.status) {
-        whereConditions.push(eq(schema.status, statusFilter.value));
-      }
+      const releaseCondition = statusCondition({
+        filter: statusFilter,
+        statusColumn: schema.status,
+        idColumn: schema.id,
+        revealIds: await this.releaseRevealIds(
+          params.collectionName,
+          statusFilter
+        ),
+      });
+      if (releaseCondition) whereConditions.push(releaseCondition);
       // Build the localized-query context AFTER the status filter is resolved so
       // localized where/search EXISTS checks constrain by the per-locale status too
       // (a published read must not match a draft translation).
@@ -2749,12 +2795,25 @@ export class CollectionQueryService extends BaseService {
       // still refuses to return the published row to a draft-only view.
       const suppressDraftStatusFilter =
         draftOverlayPossible && statusFilter?.value === "draft";
-      const statusCondition =
-        statusFilter && schema.status && !suppressDraftStatusFilter
-          ? eq(schema.status, statusFilter.value)
-          : null;
-      const whereParts = [idCondition, ownerCondition, statusCondition].filter(
-        (c): c is NonNullable<typeof c> => c !== null
+      // Named `lifecycleCondition` rather than shadowing the imported
+      // `statusCondition` helper it now delegates to.
+      const lifecycleCondition = suppressDraftStatusFilter
+        ? undefined
+        : statusCondition({
+            filter: statusFilter,
+            statusColumn: schema.status,
+            idColumn: schema.id,
+            revealIds: await this.releaseRevealIds(
+              params.collectionName,
+              statusFilter
+            ),
+          });
+      const whereParts = [
+        idCondition,
+        ownerCondition,
+        lifecycleCondition,
+      ].filter(
+        (c): c is NonNullable<typeof c> => c !== null && c !== undefined
       );
       const whereCondition =
         whereParts.length === 1 ? whereParts[0] : and(...whereParts);

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -1,5 +1,5 @@
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
-import { and, eq, inArray, sql } from "drizzle-orm";
+import { and, inArray, sql } from "drizzle-orm";
 
 import type { FieldDefinition } from "@nextly/schemas/dynamic-collections";
 
@@ -13,6 +13,7 @@ import {
   keysToCamelCase,
 } from "../../../lib/case-conversion";
 import { absolutizeMediaUrls } from "../../../lib/media-variant";
+import { statusCondition } from "../../../lib/status-condition";
 import { resolveStatusFilter } from "../../../lib/status-filter";
 import {
   AccessControlService,
@@ -65,6 +66,10 @@ import {
 } from "../../../shared/lib/password-fields";
 import type { RBACAccessControlService } from "../../auth/services/rbac-access-control-service";
 import type { DynamicCollectionService } from "../../dynamic-collections";
+import {
+  NO_RELEASE_VISIBILITY,
+  type ReleaseVisibility,
+} from "../../releases/release-visibility";
 
 import { CollectionAccessService } from "./collection-access-service";
 import type { UserContext } from "./collection-types";
@@ -1286,9 +1291,38 @@ export class CollectionRelationshipService extends BaseService {
     adapter: DrizzleAdapter,
     logger: Logger,
     private readonly fileManager: CollectionFileManager,
-    private readonly collectionService: DynamicCollectionService
+    private readonly collectionService: DynamicCollectionService,
+    /**
+     * What a due release makes visible in the TARGET collection.
+     *
+     * Not a trust question. `widensLifecycle` and `expansionStatusScope` decide
+     * whether this CALLER may see unpublished content, and a bounded caller
+     * deliberately inherits nothing. A due release is the other kind of fact:
+     * the target document IS published, for everyone, so it reaches a bounded
+     * caller too and that is correct rather than a leak.
+     */
+    private readonly releaseVisibility: ReleaseVisibility = NO_RELEASE_VISIBILITY
   ) {
     super(adapter, logger);
+  }
+
+  /**
+   * The documents a due release would publish in the target collection.
+   *
+   * Only asked when the read is bounded to published: an unbounded expansion
+   * already returns the row, so there is nothing to reveal and nothing to pay
+   * for.
+   */
+  private async targetRevealIds(
+    targetCollection: string,
+    statusValue: string | undefined
+  ): Promise<readonly string[]> {
+    if (statusValue !== "published") return [];
+    return this.releaseVisibility.revealIds({
+      scopeKind: "collection",
+      scopeSlug: targetCollection,
+      now: new Date(),
+    });
   }
 
   private resolveAccessService(): CollectionAccessService {
@@ -1435,8 +1469,20 @@ export class CollectionRelationshipService extends BaseService {
     // an unexplained absence as evidence lost and refuses the whole parent.
     // A row that was never there stays unrecorded, because a dangling
     // reference is a data problem and must not be dressed up as a refusal.
+    // A due release publishes the target, so a row it names is admitted even
+    // though its stored status still says otherwise. Reading the author
+    // directly already honours this; an expansion that did not would make the
+    // same document published when asked for by name and missing when arrived
+    // at by reference.
+    const revealed = new Set(
+      await this.targetRevealIds(targetCollection, statusValue)
+    );
     const rows = statusValue
-      ? fetched.filter(row => row.status === statusValue)
+      ? fetched.filter(
+          row =>
+            row.status === statusValue ||
+            (typeof row.id === "string" && revealed.has(row.id))
+        )
       : fetched;
     this.recordWithheld(targetCollection, fetched, rows, access);
 
@@ -1747,17 +1793,22 @@ export class CollectionRelationshipService extends BaseService {
       // Guarded on the column and not on the flag alone: naming a column the
       // table does not have fails the whole query, and the catch below would
       // then withhold every row of the collection.
-      const statusCondition =
-        statusFilter && schema.status
-          ? eq(schema.status, statusFilter.value)
-          : undefined;
+      const lifecycleCondition = statusCondition({
+        filter: statusFilter,
+        statusColumn: schema.status,
+        idColumn: schema.id,
+        revealIds: await this.targetRevealIds(
+          targetCollection,
+          statusFilter?.value
+        ),
+      });
       const admitted = (await this.db
         .select()
         .from(schema)
         .where(
           and(
             inArray(schema.id, ids),
-            ...(statusCondition ? [statusCondition] : []),
+            ...(lifecycleCondition ? [lifecycleCondition] : []),
             condition
           )
         )) as Record<string, unknown>[];

--- a/packages/nextly/src/domains/releases/__tests__/pending-transition-cache.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/pending-transition-cache.test.ts
@@ -1,0 +1,196 @@
+/**
+ * The cheap due-check that keeps the release lookup off the common read path.
+ *
+ * Two properties carry the weight here, and both are correctness rather than
+ * performance:
+ *
+ *   1. The loader answers `Date | null`, where `null` means "no release is
+ *      scheduled at all". That is a VALUE, not the absence of one, so a memo
+ *      that stores it as "nothing cached" reloads on every read forever. The
+ *      call-count assertions are what catch that; the returned booleans are
+ *      identical either way.
+ *   2. The memo expires. A memo invalidated only by LOCAL writes is wrong in
+ *      the dangerous direction once more than one instance is serving: another
+ *      instance schedules an earlier transition, this one keeps answering
+ *      "nothing due", and the release is silently missed.
+ *
+ * @module domains/releases/__tests__/pending-transition-cache.test
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import { PendingTransitionCache } from "../pending-transition-cache";
+
+const T0 = new Date("2026-06-01T12:00:00.000Z");
+const after = (ms: number): Date => new Date(T0.getTime() + ms);
+
+/** The instant a release takes effect, comfortably after every TTL window. */
+const SOON = after(10 * 60_000);
+
+const TTL = { ttlMs: 30_000 };
+
+/** A loader stub, typed so a wrong resolved shape fails to compile. */
+const loader = () => vi.fn<() => Promise<Date | null>>();
+
+describe("PendingTransitionCache", () => {
+  it("answers false without a second load when nothing is scheduled", async () => {
+    // `null` is the loader's answer for "nothing scheduled", and it has to
+    // survive in the memo as that answer. Storing it as "not loaded" gives the
+    // same `false` here while querying the database on every content read —
+    // which is the whole cost this class exists to avoid, so the count is the
+    // only thing that separates the two.
+    const load = loader().mockResolvedValue(null);
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(T0)).resolves.toBe(false);
+    await expect(cache.mayHaveDue(after(1_000))).resolves.toBe(false);
+
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers false from the memo alone while the instant is still ahead", async () => {
+    const load = loader().mockResolvedValue(SOON);
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(T0)).resolves.toBe(false);
+    await expect(cache.mayHaveDue(after(1_000))).resolves.toBe(false);
+
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("answers true once the instant arrives, from that same memo", async () => {
+    // The positive control for the test above: without this, an implementation
+    // that always answered `false` and never loaded would satisfy it.
+    const load = loader().mockResolvedValue(after(5_000));
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(T0)).resolves.toBe(false);
+    await expect(cache.mayHaveDue(after(6_000))).resolves.toBe(true);
+
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats the instant itself as due, not as still ahead", async () => {
+    const load = loader().mockResolvedValue(after(5_000));
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(after(5_000))).resolves.toBe(true);
+  });
+
+  it("reports a release whose instant has already passed", async () => {
+    // The loader is deliberately not filtered to future instants: a release
+    // whose time has passed but which nothing has materialised yet is
+    // affecting reads right now. Answering `false` here would skip exactly the
+    // case the lookup exists to catch.
+    const load = loader().mockResolvedValue(new Date(T0.getTime() - 60_000));
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(T0)).resolves.toBe(true);
+  });
+
+  it("re-reads after the TTL even when no local write happened", async () => {
+    // A memo invalidated only by LOCAL writes is wrong in the dangerous
+    // direction under more than one server instance: another instance
+    // schedules an EARLIER transition, this one still answers "nothing due",
+    // and the release is silently missed — indistinguishable from no release
+    // existing. The TTL bounds that staleness. It is a correctness
+    // requirement, not tuning.
+    const load = loader().mockResolvedValue(SOON);
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await cache.mayHaveDue(T0);
+    await cache.mayHaveDue(after(29_000));
+    expect(load).toHaveBeenCalledTimes(1);
+
+    await cache.mayHaveDue(after(31_000));
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("sees an earlier transition another instance scheduled, once the TTL lapses", async () => {
+    // The consequence of the test above, stated as the outcome that matters:
+    // the answer must actually CHANGE, not merely re-read. A re-read whose
+    // result is discarded would satisfy a call count and still miss the
+    // release.
+    const load = loader()
+      .mockResolvedValueOnce(SOON)
+      .mockResolvedValueOnce(after(20_000));
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(T0)).resolves.toBe(false);
+    await expect(cache.mayHaveDue(after(31_000))).resolves.toBe(true);
+  });
+
+  it("re-reads immediately after invalidate(), without waiting for the TTL", async () => {
+    // A local schedule write clears the memo, so the instance that performed
+    // the write is exact rather than merely bounded.
+    const load = loader()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(after(1_000));
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(T0)).resolves.toBe(false);
+    cache.invalidate();
+    await expect(cache.mayHaveDue(after(2_000))).resolves.toBe(true);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("collapses concurrent callers onto one load", async () => {
+    // Every content read consults this, so a TTL lapse under load would fire
+    // one query per in-flight request without this.
+    let release: ((value: Date | null) => void) | undefined;
+    const load = loader().mockReturnValue(
+      new Promise<Date | null>(resolve => {
+        release = resolve;
+      })
+    );
+    const cache = new PendingTransitionCache(load, TTL);
+
+    const answers = Promise.all([
+      cache.mayHaveDue(T0),
+      cache.mayHaveDue(T0),
+      cache.mayHaveDue(T0),
+    ]);
+    release?.(SOON);
+
+    await expect(answers).resolves.toEqual([false, false, false]);
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not memoise a failed load, and stays usable afterwards", async () => {
+    // A rejected promise retained as the in-flight load would be handed to
+    // every later caller, turning one transient database error into a
+    // permanently broken read path.
+    const load = loader()
+      .mockRejectedValueOnce(new Error("connection reset"))
+      .mockResolvedValueOnce(after(1_000));
+    const cache = new PendingTransitionCache(load, TTL);
+
+    await expect(cache.mayHaveDue(T0)).rejects.toThrow("connection reset");
+    await expect(cache.mayHaveDue(after(2_000))).resolves.toBe(true);
+
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+
+  it("discards a load that was already running when invalidate() was called", async () => {
+    // The load was started against the state BEFORE the local write, so
+    // committing it would reinstate the answer the write just invalidated —
+    // and it would then sit there for a full TTL.
+    let release: ((value: Date | null) => void) | undefined;
+    const load = loader()
+      .mockReturnValueOnce(
+        new Promise<Date | null>(resolve => {
+          release = resolve;
+        })
+      )
+      .mockResolvedValueOnce(after(1_000));
+    const cache = new PendingTransitionCache(load, TTL);
+
+    const stale = cache.mayHaveDue(T0);
+    cache.invalidate();
+    release?.(null);
+    await stale;
+
+    await expect(cache.mayHaveDue(after(2_000))).resolves.toBe(true);
+    expect(load).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/release-eligibility.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-eligibility.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Whether a document may join a release, and why not when it may not.
+ *
+ * The two actions have DIFFERENT preconditions, and that asymmetry is the
+ * thing most likely to be "simplified" into one rule later:
+ *
+ *   publish   needs a pending edit to publish, so it needs the draft split.
+ *   unpublish needs only the Draft/Published lifecycle — a collection with
+ *             status and no drafts can still be scheduled off the site.
+ *
+ * Collapsing them would silently remove scheduled takedown from every
+ * status-only collection, and no test that checked publish alone would notice.
+ *
+ * @module domains/releases/__tests__/release-eligibility.test
+ */
+import { describe, it, expect } from "vitest";
+
+import type { DraftSplitEligibility } from "../../versions/draft-split-eligibility";
+import { canScheduleMember } from "../release-eligibility";
+
+const eligible: DraftSplitEligibility = {
+  eligible: true,
+  reason: null,
+  componentSlug: null,
+};
+
+const refusedFor = (
+  reason: DraftSplitEligibility["reason"],
+  componentSlug: string | null = null
+): DraftSplitEligibility => ({ eligible: false, reason, componentSlug });
+
+describe("canScheduleMember", () => {
+  it("allows publishing a document whose draft split is eligible", () => {
+    expect(
+      canScheduleMember({
+        action: "publish",
+        collectionHasStatus: true,
+        draftEligibility: eligible,
+      })
+    ).toEqual({ allowed: true, reason: null, componentSlug: null });
+  });
+
+  it("refuses publishing with the SAME reason the schema response reports", () => {
+    // Reusing the vocabulary rather than inventing a second one: the admin
+    // already knows how to explain `password-field`, and two spellings of one
+    // cause is how the explanation and the rule drift apart.
+    expect(
+      canScheduleMember({
+        action: "publish",
+        collectionHasStatus: true,
+        draftEligibility: refusedFor("password-field"),
+      })
+    ).toEqual({
+      allowed: false,
+      reason: "password-field",
+      componentSlug: null,
+    });
+  });
+
+  it("carries the component slug through when the cause is a component", () => {
+    expect(
+      canScheduleMember({
+        action: "publish",
+        collectionHasStatus: true,
+        draftEligibility: refusedFor("unresolvable-component", "hero"),
+      })
+    ).toEqual({
+      allowed: false,
+      reason: "unresolvable-component",
+      componentSlug: "hero",
+    });
+  });
+
+  it("refuses publishing when the configuration never asked for drafts", () => {
+    // `reason: null` on the draft side means "nothing asked for the split",
+    // which is not a misconfiguration for a schema response but IS a refusal
+    // here: there is no pending edit for a release to publish.
+    expect(
+      canScheduleMember({
+        action: "publish",
+        collectionHasStatus: true,
+        draftEligibility: refusedFor(null),
+      })
+    ).toEqual({
+      allowed: false,
+      reason: "no-pending-changes",
+      componentSlug: null,
+    });
+  });
+
+  it("allows unpublishing a status-only collection, which can never be PUBLISHED by a release", () => {
+    // THE asymmetry. This collection has no draft split at all, so it can
+    // never carry a publish member — and scheduled takedown still has to work
+    // for it, because taking a live page down needs no pending edit.
+    expect(
+      canScheduleMember({
+        action: "unpublish",
+        collectionHasStatus: true,
+        draftEligibility: refusedFor(null),
+      })
+    ).toEqual({ allowed: true, reason: null, componentSlug: null });
+  });
+
+  it("refuses unpublishing a collection with no lifecycle at all", () => {
+    // Without a status lifecycle there is no published state to leave, so
+    // there is nothing for an unpublish to do.
+    expect(
+      canScheduleMember({
+        action: "unpublish",
+        collectionHasStatus: false,
+        draftEligibility: refusedFor(null),
+      })
+    ).toEqual({ allowed: false, reason: "no-lifecycle", componentSlug: null });
+  });
+
+  it("refuses publishing a collection with no lifecycle at all", () => {
+    expect(
+      canScheduleMember({
+        action: "publish",
+        collectionHasStatus: false,
+        draftEligibility: refusedFor("lifecycle-disabled"),
+      }).allowed
+    ).toBe(false);
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/release-read.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-read.test.ts
@@ -1,0 +1,218 @@
+/**
+ * The one place a read decides what releases say about the documents it holds.
+ *
+ * Two properties, and neither is visible in the answers:
+ *
+ *   1. When the cheap check says nothing can be due, the repository is never
+ *      asked. A helper that queried anyway would return exactly the same
+ *      effects, so the only thing separating the two is that the call did not
+ *      happen.
+ *   2. The lookup is batched. A per-row implementation is correct and
+ *      quadratic on a listing, and the call count is what keeps it out.
+ *
+ * @module domains/releases/__tests__/release-read.test
+ */
+import { describe, it, expect, vi } from "vitest";
+
+import type { DocumentRef } from "../releases-repository";
+import type { DueMember } from "../resolve-release-effect";
+import { resolveReleaseEffects } from "../release-read";
+
+const NOW = new Date("2026-06-01T12:00:00.000Z");
+
+const ref = (entryId: string, locale: string | null = null): DocumentRef => ({
+  scopeKind: "collection",
+  scopeSlug: "posts",
+  entryId,
+  locale,
+});
+
+const member = (
+  over: Partial<DueMember> & { memberId: string }
+): DueMember => ({
+  releaseId: `r-${over.memberId}`,
+  action: "publish",
+  scheduledAt: new Date("2026-05-01T00:00:00.000Z"),
+  createdAt: new Date("2026-04-01T00:00:00.000Z"),
+  ...over,
+});
+
+/** A cheap check that answers without a database, as the real one does. */
+const cacheSaying = (due: boolean) => ({
+  mayHaveDue: vi.fn<(now: Date) => Promise<boolean>>().mockResolvedValue(due),
+});
+
+const repositoryReturning = (grouped: Map<string, DueMember[]>) => ({
+  findDueMembersFor: vi
+    .fn<(refs: DocumentRef[], now: Date) => Promise<Map<string, DueMember[]>>>()
+    .mockResolvedValue(grouped),
+});
+
+describe("resolveReleaseEffects", () => {
+  it("never asks the repository when the cheap check rules it out", async () => {
+    const cache = cacheSaying(false);
+    const repository = repositoryReturning(new Map());
+
+    const effects = await resolveReleaseEffects({
+      cache,
+      repository,
+      refs: [ref("a"), ref("b")],
+      now: NOW,
+    });
+
+    // The answers are identical either way; the absent call is the property.
+    expect(repository.findDueMembersFor).not.toHaveBeenCalled();
+    expect(effects.for(ref("a")).effect).toBe("none");
+  });
+
+  it("asks the cheap check before deciding anything", async () => {
+    // A positive control for the test above: without this, a helper that
+    // consulted neither collaborator would satisfy it.
+    const cache = cacheSaying(false);
+    const repository = repositoryReturning(new Map());
+
+    await resolveReleaseEffects({
+      cache,
+      repository,
+      refs: [ref("a")],
+      now: NOW,
+    });
+
+    expect(cache.mayHaveDue).toHaveBeenCalledTimes(1);
+    expect(cache.mayHaveDue).toHaveBeenCalledWith(NOW);
+  });
+
+  it("asks nothing at all for an empty result set", async () => {
+    const cache = cacheSaying(true);
+    const repository = repositoryReturning(new Map());
+
+    const effects = await resolveReleaseEffects({
+      cache,
+      repository,
+      refs: [],
+      now: NOW,
+    });
+
+    expect(cache.mayHaveDue).not.toHaveBeenCalled();
+    expect(repository.findDueMembersFor).not.toHaveBeenCalled();
+    expect(effects.for(ref("a")).effect).toBe("none");
+  });
+
+  it("answers for a whole result set in ONE repository call", async () => {
+    // A per-row lookup is the failure mode: correct, and quadratic on a
+    // listing. Asserting the count is what keeps it from creeping back.
+    const refs = Array.from({ length: 25 }, (_, i) => ref(`e${i}`));
+    const cache = cacheSaying(true);
+    const repository = repositoryReturning(new Map());
+
+    await resolveReleaseEffects({ cache, repository, refs, now: NOW });
+
+    expect(repository.findDueMembersFor).toHaveBeenCalledTimes(1);
+    expect(repository.findDueMembersFor.mock.calls[0]?.[0]).toHaveLength(25);
+  });
+
+  it("reports the effect the members resolve to, per document", async () => {
+    const cache = cacheSaying(true);
+    const repository = repositoryReturning(
+      new Map([
+        ["collection:posts:a:", [member({ memberId: "m1" })]],
+        [
+          "collection:posts:b:",
+          [member({ memberId: "m2", action: "unpublish" })],
+        ],
+      ])
+    );
+
+    const effects = await resolveReleaseEffects({
+      cache,
+      repository,
+      refs: [ref("a"), ref("b"), ref("c")],
+      now: NOW,
+    });
+
+    expect(effects.for(ref("a"))).toEqual({
+      effect: "publish",
+      memberId: "m1",
+      releaseId: "r-m1",
+    });
+    expect(effects.for(ref("b")).effect).toBe("unpublish");
+    // A document nothing scheduled is not a special case; it is just no members.
+    expect(effects.for(ref("c")).effect).toBe("none");
+  });
+
+  it("applies the total ordering rather than the first member returned", async () => {
+    // The flagship pair: live on the 1st, down on the 20th. From the 21st both
+    // are due and the later must win, whichever order the driver returned.
+    const cache = cacheSaying(true);
+    const publish = member({
+      memberId: "m1",
+      action: "publish",
+      scheduledAt: new Date("2026-05-01T00:00:00.000Z"),
+    });
+    const unpublish = member({
+      memberId: "m2",
+      action: "unpublish",
+      scheduledAt: new Date("2026-05-20T00:00:00.000Z"),
+    });
+    const repository = repositoryReturning(
+      new Map([["collection:posts:a:", [publish, unpublish]]])
+    );
+
+    const effects = await resolveReleaseEffects({
+      cache,
+      repository,
+      refs: [ref("a")],
+      now: NOW,
+    });
+
+    expect(effects.for(ref("a")).effect).toBe("unpublish");
+  });
+
+  it("keeps two locales of one document apart", async () => {
+    // The key carries the locale, so a localized document scheduled in one
+    // language must not answer for another. Collapsing them would publish a
+    // language nobody scheduled.
+    const cache = cacheSaying(true);
+    const repository = repositoryReturning(
+      new Map([["collection:posts:a:fr", [member({ memberId: "m1" })]]])
+    );
+
+    const effects = await resolveReleaseEffects({
+      cache,
+      repository,
+      refs: [ref("a", "fr"), ref("a", "en")],
+      now: NOW,
+    });
+
+    expect(effects.for(ref("a", "fr")).effect).toBe("publish");
+    expect(effects.for(ref("a", "en")).effect).toBe("none");
+  });
+
+  it("ignores a member whose instant has not arrived", async () => {
+    // The cheap check answers for the whole deployment, so a read can reach
+    // here with members that are scheduled but not yet due.
+    const cache = cacheSaying(true);
+    const repository = repositoryReturning(
+      new Map([
+        [
+          "collection:posts:a:",
+          [
+            member({
+              memberId: "m1",
+              scheduledAt: new Date("2026-07-01T00:00:00.000Z"),
+            }),
+          ],
+        ],
+      ])
+    );
+
+    const effects = await resolveReleaseEffects({
+      cache,
+      repository,
+      refs: [ref("a")],
+      now: NOW,
+    });
+
+    expect(effects.for(ref("a")).effect).toBe("none");
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/release-reveals-draft.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-reveals-draft.integration.test.ts
@@ -1,0 +1,117 @@
+/**
+ * The end-to-end question Stage D exists to answer: does a scheduled release
+ * actually change what a reader sees, at the moment it comes due?
+ *
+ * Every other suite here tests a part — the effect rule, the repository, the
+ * condition builder, the visibility seam. Each can be right while the feature
+ * does nothing, because the parts are only connected at the read path. This is
+ * the one that fails if they are not wired together.
+ *
+ * It asks through the ORDINARY read an anonymous visitor would make, not
+ * through the release machinery, because "a release published my post" is a
+ * claim about the read and not about the release.
+ *
+ * @module domains/releases/__tests__/release-reveals-draft.integration.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import { ReleasesRepository } from "../releases-repository";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "posts";
+const PAST = new Date("2020-01-01T00:00:00Z");
+const FUTURE = new Date("2099-01-01T00:00:00Z");
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: SLUG,
+        status: true,
+        access: { read: () => true, update: () => true },
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+/** A draft entry, and the release that will publish it. */
+async function draftInRelease(
+  t: TestNextly,
+  scheduledAt: Date | null
+): Promise<string> {
+  const handler = t.getService("collectionsHandler") as CollectionsHandler;
+  const created = await handler.createEntry(
+    { collectionName: SLUG },
+    { title: "pending", status: "draft" }
+  );
+  const id = (created.data as { id?: string } | undefined)?.id;
+  if (typeof id !== "string") throw new Error("no id from create");
+
+  const repo = new ReleasesRepository(t.adapter);
+  const release = await repo.createRelease({ title: "Go live" });
+  await repo.addMember({
+    releaseId: release.id,
+    scopeKind: "collection",
+    scopeSlug: SLUG,
+    entryId: id,
+    locale: null,
+    action: "publish",
+  });
+  if (scheduledAt !== null) {
+    await repo.scheduleRelease(release.id, scheduledAt, "UTC");
+  }
+  return id;
+}
+
+/** What an ordinary anonymous published read returns. */
+async function publishedIds(t: TestNextly): Promise<string[]> {
+  const handler = t.getService("collectionsHandler") as CollectionsHandler;
+  const result = await handler.listEntries({ collectionName: SLUG, limit: 50 });
+  const docs = (result.data?.docs ?? []) as { id: string }[];
+  return docs.map(row => row.id);
+}
+
+describe.each(getConfiguredTestDialects())(
+  "a due release changes what a reader sees (%s)",
+  dialect => {
+    it("REVEALS a draft whose release has come due", async () => {
+      const t = await boot(dialect);
+      const id = await draftInRelease(t, PAST);
+      expect(await publishedIds(t)).toContain(id);
+    });
+
+    it("does not reveal it before the release is due", async () => {
+      // The control. Without it, a read path that simply ignored `status`
+      // would satisfy the case above while publishing every draft on the site.
+      const t = await boot(dialect);
+      const id = await draftInRelease(t, FUTURE);
+      expect(await publishedIds(t)).not.toContain(id);
+    });
+
+    it("does not reveal it while the release is still being assembled", async () => {
+      // A release with no instant has not been scheduled at all. Treating its
+      // members as due would publish content the moment somebody added it to a
+      // draft release — the opposite of what a release is for.
+      const t = await boot(dialect);
+      const id = await draftInRelease(t, null);
+      expect(await publishedIds(t)).not.toContain(id);
+    });
+  }
+);

--- a/packages/nextly/src/domains/releases/__tests__/release-reveals-in-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-reveals-in-expansion.integration.test.ts
@@ -1,0 +1,142 @@
+/**
+ * A due release must mean the same thing wherever a document is read from.
+ *
+ * A post points at an author. Reading the author DIRECTLY already honours a due
+ * release — that is what the collection read path now does. Reading the same
+ * author THROUGH the post is a different code path, against a different
+ * collection than the caller named, and it applies the lifecycle in two more
+ * places: an in-memory filter over rows it deliberately fetched unfiltered, and
+ * a SQL condition on the authorized re-read.
+ *
+ * If those disagree with the direct read, the same document is published when
+ * asked for by name and missing when arrived at by reference — and the caller
+ * sees a post whose author has vanished.
+ *
+ * ## This is not a trust widening
+ *
+ * Expansion has careful rules about which callers may inherit a widened
+ * lifecycle (`expansionStatusScope`, `widensLifecycle`), and they are about
+ * TRUST — whether this caller may see unpublished content. A due release is not
+ * that. It says the document IS published, for everyone, including an anonymous
+ * visitor. So it applies regardless of how the caller bounded itself, and a
+ * bounded caller seeing it is correct rather than a leak.
+ *
+ * @module domains/releases/__tests__/release-reveals-in-expansion.integration.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, relationship, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+import { ReleasesRepository } from "../releases-repository";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const POSTS = "posts";
+const AUTHORS = "authors";
+const PAST = new Date("2020-01-01T00:00:00Z");
+const FUTURE = new Date("2099-01-01T00:00:00Z");
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: AUTHORS,
+        status: true,
+        access: { read: () => true, update: () => true },
+        fields: [text({ name: "name" })],
+      }),
+      defineCollection({
+        slug: POSTS,
+        status: true,
+        access: { read: () => true, update: () => true },
+        fields: [
+          text({ name: "title" }),
+          relationship({ name: "author", relationTo: AUTHORS }),
+        ],
+      }),
+    ],
+  });
+  return current;
+}
+
+const handlerOf = (t: TestNextly): CollectionsHandler =>
+  t.getService("collectionsHandler") as CollectionsHandler;
+
+/** A published post whose author is a draft in a release. */
+async function postWithDraftAuthor(
+  t: TestNextly,
+  scheduledAt: Date | null
+): Promise<string> {
+  const handler = handlerOf(t);
+  const author = await handler.createEntry(
+    { collectionName: AUTHORS, overrideAccess: true },
+    { name: "Ada", status: "draft" }
+  );
+  const authorId = (author.data as { id?: string } | undefined)?.id;
+  if (typeof authorId !== "string") throw new Error("no author id");
+
+  const post = await handler.createEntry(
+    { collectionName: POSTS, overrideAccess: true },
+    { title: "live", status: "published", author: authorId }
+  );
+  const postId = (post.data as { id?: string } | undefined)?.id;
+  if (typeof postId !== "string") throw new Error("no post id");
+
+  const repo = new ReleasesRepository(t.adapter);
+  const release = await repo.createRelease({ title: "Go live" });
+  await repo.addMember({
+    releaseId: release.id,
+    scopeKind: "collection",
+    scopeSlug: AUTHORS,
+    entryId: authorId,
+    locale: null,
+    action: "publish",
+  });
+  if (scheduledAt !== null) {
+    await repo.scheduleRelease(release.id, scheduledAt, "UTC");
+  }
+  return postId;
+}
+
+/** Whether an ordinary untrusted read of the post carries its author. */
+async function authorExpanded(t: TestNextly, postId: string): Promise<boolean> {
+  const result = await handlerOf(t).getEntry({
+    collectionName: POSTS,
+    entryId: postId,
+    depth: 1,
+  });
+  const author = (result.data as { author?: unknown } | undefined)?.author;
+  return author !== null && author !== undefined && typeof author === "object";
+}
+
+describe.each(getConfiguredTestDialects())(
+  "a due release reaches an expansion too (%s)",
+  dialect => {
+    it("expands an author whose release has come due", async () => {
+      const t = await boot(dialect);
+      const postId = await postWithDraftAuthor(t, PAST);
+      expect(await authorExpanded(t, postId)).toBe(true);
+    });
+
+    it("does not expand it before the release is due", async () => {
+      // The control. Without it, an expansion that simply ignored the target's
+      // lifecycle would satisfy the case above while handing every draft author
+      // to an anonymous reader through any post that points at one.
+      const t = await boot(dialect);
+      const postId = await postWithDraftAuthor(t, FUTURE);
+      expect(await authorExpanded(t, postId)).toBe(false);
+    });
+  }
+);

--- a/packages/nextly/src/domains/releases/__tests__/release-reveals-single.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-reveals-single.integration.test.ts
@@ -1,0 +1,116 @@
+/**
+ * The same question as `release-reveals-draft`, asked of a Single.
+ *
+ * Kept separate because the mechanism is genuinely different, not because the
+ * question is. A collection read FILTERS rows in SQL, so a release has to widen
+ * the filter. A Single is one row per slug and is never filtered — it is loaded
+ * and then REFUSED with a 404 if its status does not match what the caller may
+ * see. So for a Single the release has to reach the refusal, not the query.
+ *
+ * Both must land together. A scheduled release that publishes a collection
+ * entry on time and a Single late is the asymmetry this work exists to remove,
+ * moved rather than fixed.
+ *
+ * @module domains/releases/__tests__/release-reveals-single.integration.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { SingleEntryService } from "../../singles/services/single-entry-service";
+import { ReleasesRepository } from "../releases-repository";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "homepage";
+const PAST = new Date("2020-01-01T00:00:00Z");
+const FUTURE = new Date("2099-01-01T00:00:00Z");
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    singles: [
+      defineSingle({
+        slug: SLUG,
+        status: true,
+        access: { read: () => true, update: () => true },
+        fields: [text({ name: "headline" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+const singlesOf = (t: TestNextly): SingleEntryService =>
+  t.getService("singleEntryService");
+
+/** A drafted Single, and the release that will publish it. */
+async function draftedSingleInRelease(
+  t: TestNextly,
+  scheduledAt: Date | null
+): Promise<void> {
+  const singles = singlesOf(t);
+  await singles.update(
+    SLUG,
+    { headline: "pending", status: "draft" },
+    { overrideAccess: true }
+  );
+
+  const row = await t.adapter.selectOne<{ id: string }>(`single_${SLUG}`, {});
+  if (!row?.id) throw new Error("the Single has no stored row");
+
+  const repo = new ReleasesRepository(t.adapter);
+  const release = await repo.createRelease({ title: "Go live" });
+  await repo.addMember({
+    releaseId: release.id,
+    scopeKind: "single",
+    scopeSlug: SLUG,
+    entryId: row.id,
+    locale: null,
+    action: "publish",
+  });
+  if (scheduledAt !== null) {
+    await repo.scheduleRelease(release.id, scheduledAt, "UTC");
+  }
+}
+
+/** Whether an ordinary untrusted read can see the Single at all. */
+async function visibleToPublic(t: TestNextly): Promise<boolean> {
+  const result = await singlesOf(t).get(SLUG, { overrideAccess: false });
+  return result.success === true;
+}
+
+describe.each(getConfiguredTestDialects())(
+  "a due release changes what a reader sees of a Single (%s)",
+  dialect => {
+    it("REVEALS a drafted Single whose release has come due", async () => {
+      const t = await boot(dialect);
+      await draftedSingleInRelease(t, PAST);
+      expect(await visibleToPublic(t)).toBe(true);
+    });
+
+    it("keeps it hidden before the release is due", async () => {
+      // The control. Without it, a gate that simply stopped refusing drafts
+      // would satisfy the case above while publishing every drafted Single.
+      const t = await boot(dialect);
+      await draftedSingleInRelease(t, FUTURE);
+      expect(await visibleToPublic(t)).toBe(false);
+    });
+
+    it("keeps it hidden while the release is still being assembled", async () => {
+      const t = await boot(dialect);
+      await draftedSingleInRelease(t, null);
+      expect(await visibleToPublic(t)).toBe(false);
+    });
+  }
+);

--- a/packages/nextly/src/domains/releases/__tests__/release-visibility.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-visibility.test.ts
@@ -1,0 +1,52 @@
+/**
+ * The seam a read path uses to ask what a due release reveals.
+ *
+ * @module domains/releases/__tests__/release-visibility.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  NO_RELEASE_VISIBILITY,
+  createReleaseVisibility,
+} from "../release-visibility";
+
+const QUERY = {
+  scopeKind: "collection" as const,
+  scopeSlug: "posts",
+  now: new Date("2026-01-01T00:00:00.000Z"),
+};
+
+describe("createReleaseVisibility", () => {
+  it("does not query at all while nothing is due", async () => {
+    // The cheap check is the entire optimisation: every read of every
+    // collection on a site that has never scheduled a release must cost one
+    // memo read, not a query against the members table.
+    const findDuePublishTargets = vi.fn(async () => ["e1"]);
+    const visibility = createReleaseVisibility({
+      cache: { mayHaveDue: async () => false },
+      repository: { findDuePublishTargets },
+    });
+
+    expect(await visibility.revealIds(QUERY)).toEqual([]);
+    expect(findDuePublishTargets).not.toHaveBeenCalled();
+  });
+
+  it("asks, and answers, once something IS due", async () => {
+    // The control for the case above: a seam that never queried would satisfy
+    // it while making the whole read path inert.
+    const findDuePublishTargets = vi.fn(async () => ["e1", "e2"]);
+    const visibility = createReleaseVisibility({
+      cache: { mayHaveDue: async () => true },
+      repository: { findDuePublishTargets },
+    });
+
+    expect(await visibility.revealIds(QUERY)).toEqual(["e1", "e2"]);
+    expect(findDuePublishTargets).toHaveBeenCalledWith(QUERY);
+  });
+});
+
+describe("NO_RELEASE_VISIBILITY", () => {
+  it("answers nothing, so a runtime without releases needs no special case", async () => {
+    expect(await NO_RELEASE_VISIBILITY.revealIds(QUERY)).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -340,5 +340,135 @@ describe.each(getConfiguredTestDialects())(
       const found = await repo.findDueMembersFor([ref("e1")], new Date());
       expect(found.get(documentRefKey(ref("e1"))) ?? []).toEqual([]);
     });
+
+    describe("which documents a due release would REVEAL", () => {
+      it("names a document whose due release publishes it", async () => {
+        // The widening query. A published-only read filters `status` in SQL, so a
+        // draft row is excluded by the database before any per-document
+        // decoration runs — a post-filter cannot add back a row the query never
+        // returned. This is what lets the filter include it in the first place.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const release = await repo.createRelease({ title: "Go live" });
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+        await repo.scheduleRelease(release.id, PAST, "UTC");
+
+        const targets = await repo.findDuePublishTargets({
+          scopeKind: "collection",
+          scopeSlug: "posts",
+          now: new Date(),
+        });
+        expect(targets).toEqual(["e1"]);
+      });
+
+      it("does NOT name one whose release is still in the future", async () => {
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const release = await repo.createRelease({ title: "Later" });
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+        await repo.scheduleRelease(release.id, FUTURE, "UTC");
+
+        expect(
+          await repo.findDuePublishTargets({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).toEqual([]);
+      });
+
+      it("does NOT name one whose release was never scheduled", async () => {
+        // A release still being assembled has no instant. Treating an unscheduled
+        // member as due would publish content the moment it was added to a draft
+        // release, which is the opposite of what a release is for.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const release = await repo.createRelease({ title: "Still assembling" });
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+
+        expect(
+          await repo.findDuePublishTargets({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).toEqual([]);
+      });
+
+      it("does NOT name one whose LATER due release takes it down again", async () => {
+        // Publish on the 1st, unpublish on the 20th; from the 20th both are due
+        // and the later one wins. The winner is decided by the SAME pure rule the
+        // per-document decoration uses, so the filter cannot admit a row the
+        // decoration then hides — which would surface as a listing whose count
+        // disagrees with its contents.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const up = await repo.createRelease({ title: "Go live" });
+        await repo.addMember({
+          releaseId: up.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+        await repo.scheduleRelease(
+          up.id,
+          new Date("2020-01-01T00:00:00Z"),
+          "UTC"
+        );
+
+        const down = await repo.createRelease({ title: "Take down" });
+        await repo.addMember({
+          releaseId: down.id,
+          ...ref("e1"),
+          action: "unpublish",
+        });
+        await repo.scheduleRelease(
+          down.id,
+          new Date("2020-06-01T00:00:00Z"),
+          "UTC"
+        );
+
+        expect(
+          await repo.findDuePublishTargets({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).toEqual([]);
+      });
+
+      it("scopes to the collection asked about", async () => {
+        // The control for the cases above: a query that returned everything would
+        // satisfy the positive case while widening every other collection's read.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const release = await repo.createRelease({ title: "Go live" });
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+        await repo.scheduleRelease(release.id, PAST, "UTC");
+
+        expect(
+          await repo.findDuePublishTargets({
+            scopeKind: "collection",
+            scopeSlug: "other_collection",
+            now: new Date(),
+          })
+        ).toEqual([]);
+      });
+    });
   }
 );

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -281,7 +281,7 @@ describe.each(getConfiguredTestDialects())(
       spy.mockRestore();
     });
 
-    it("reports the earliest pending transition, ignoring past and unscheduled ones", async () => {
+    it("reports the earliest scheduled instant, including one already past", async () => {
       const app = await boot(dialect);
       const repo = new ReleasesRepository(app.adapter);
       const now = new Date();
@@ -296,25 +296,32 @@ describe.each(getConfiguredTestDialects())(
       const soonRelease = await repo.createRelease({ title: "Soon" });
       await repo.scheduleRelease(soonRelease.id, soon, "UTC");
 
-      const earliest = await repo.findEarliestPendingTransition(now);
+      const earliest = await repo.findEarliestScheduledTransition();
 
+      // The PAST release wins, and that is the point: a release whose time has
+      // passed but which nothing has materialised yet is affecting reads right
+      // now. Answering with the earliest FUTURE instant instead would report
+      // "nothing pending" for exactly the case the lookup exists to catch.
+      //
       // Whole seconds: SQLite stores epoch seconds, so a millisecond comparison
       // would pass on two dialects and fail on the third for no real difference.
       expect(Math.floor((earliest?.getTime() ?? 0) / 1000)).toBe(
-        Math.floor(soon.getTime() / 1000)
+        Math.floor(PAST.getTime() / 1000)
       );
       expect(draft.state).toBe("draft");
     });
 
-    it("reports no pending transition when every scheduled release is in the past", async () => {
+    it("reports nothing once no release is scheduled at all", async () => {
+      // A release leaves `scheduled` when it materialises or is cancelled, so
+      // the cheap check goes quiet again on its own rather than needing to be
+      // told.
       const app = await boot(dialect);
       const repo = new ReleasesRepository(app.adapter);
-      const release = await repo.createRelease({ title: "Already gone" });
+      const release = await repo.createRelease({ title: "Called off" });
       await repo.scheduleRelease(release.id, PAST, "UTC");
+      await repo.cancelRelease(release.id);
 
-      await expect(
-        repo.findEarliestPendingTransition(new Date())
-      ).resolves.toBeNull();
+      await expect(repo.findEarliestScheduledTransition()).resolves.toBeNull();
     });
 
     it("removes a member", async () => {

--- a/packages/nextly/src/domains/releases/pending-transition-cache.ts
+++ b/packages/nextly/src/domains/releases/pending-transition-cache.ts
@@ -1,0 +1,166 @@
+/**
+ * The cheap check that keeps the release lookup off the common read path.
+ *
+ * Consulting releases on every content read would put a query in front of
+ * every page. One question removes it for the overwhelmingly common case:
+ * what is the earliest instant ANY scheduled release takes effect? While
+ * `now` is before that instant, no document can be affected by anything, and
+ * the answer is a comparison between two numbers that touches no database.
+ *
+ * The memo is bounded by a short TTL, and that is a correctness requirement
+ * rather than tuning. A memo invalidated only by LOCAL writes is wrong in the
+ * dangerous direction as soon as more than one instance is serving: another
+ * instance schedules an earlier transition, this instance keeps answering
+ * "nothing due" from a memo nothing here invalidated, and the release is
+ * silently missed — a failure indistinguishable from the release never having
+ * existed. The TTL bounds that staleness to a known window. A local schedule
+ * write still calls {@link PendingTransitionCache.invalidate} and takes effect
+ * at once, so the single-instance case stays exact; the window exists only for
+ * the instances that did not perform the write.
+ *
+ * Residual behaviour, stated so it is not rediscovered as a bug: a release may
+ * go live up to {@link DEFAULT_TTL_MS} late on a multi-instance deployment
+ * that has had no local write. It is never missed, and never early.
+ *
+ * @module domains/releases/pending-transition-cache
+ */
+
+/**
+ * The earliest instant any scheduled release takes effect, or `null` when no
+ * release is scheduled at all.
+ *
+ * Satisfied by `ReleasesRepository.findEarliestScheduledTransition`. Taken as
+ * a function rather than the repository so this holds no opinion about where
+ * the answer comes from.
+ */
+export type EarliestScheduledTransitionLoader = () => Promise<Date | null>;
+
+/**
+ * How long an unrefreshed memo may be trusted.
+ *
+ * The window is the deployment's exposure to a transition scheduled by another
+ * instance: long enough that the common read costs nothing, short enough that
+ * "up to half a minute late" is an acceptable description of the worst case.
+ */
+export const DEFAULT_TTL_MS = 30_000;
+
+/**
+ * A loaded answer.
+ *
+ * `earliest` being `null` is a VALUE — "nothing is scheduled" — so it is held
+ * inside a memo object rather than represented by the absence of one. Folding
+ * the two together would make every read on a site with no releases reload,
+ * which is the exact cost this class exists to remove, and no returned boolean
+ * would differ.
+ */
+interface TransitionMemo {
+  earliest: Date | null;
+  loadedAtMs: number;
+}
+
+export class PendingTransitionCache {
+  /** `null` means nothing has been loaded yet, never "nothing is scheduled". */
+  private memo: TransitionMemo | null = null;
+
+  /**
+   * A single load shared by concurrent callers, tagged with the generation it
+   * began under. Every content read consults this class, so without the
+   * sharing a TTL lapse under load would issue one query per in-flight
+   * request; without the tag, a load that began before an invalidation could
+   * commit the answer that invalidation just discarded.
+   */
+  private inFlight: Promise<Date | null> | null = null;
+  private inFlightGeneration = -1;
+  private generation = 0;
+
+  private readonly ttlMs: number;
+
+  constructor(
+    private readonly load: EarliestScheduledTransitionLoader,
+    options?: { ttlMs?: number }
+  ) {
+    this.ttlMs = options?.ttlMs ?? DEFAULT_TTL_MS;
+  }
+
+  /**
+   * Whether any release could be affecting a document at `now`.
+   *
+   * `false` is final: the caller does no per-document work. `true` only means
+   * the cheap check cannot rule it out, and the caller goes on to ask which
+   * documents are actually affected.
+   */
+  async mayHaveDue(now: Date): Promise<boolean> {
+    const nowMs = now.getTime();
+    const memo = this.memo;
+    if (memo !== null && isFresh(memo, nowMs, this.ttlMs)) {
+      return isDue(memo.earliest, nowMs);
+    }
+    return isDue(await this.loadEarliest(nowMs), nowMs);
+  }
+
+  /**
+   * Drop the memo so the next check reads again.
+   *
+   * Called by the writes that change the answer — scheduling, rescheduling and
+   * cancelling — so the instance that performed one is never bounded by the
+   * TTL.
+   */
+  invalidate(): void {
+    this.memo = null;
+    this.generation++;
+  }
+
+  private async loadEarliest(nowMs: number): Promise<Date | null> {
+    if (this.inFlight !== null && this.inFlightGeneration === this.generation) {
+      return this.inFlight;
+    }
+
+    const generation = this.generation;
+    const pending = this.load().then(
+      earliest => {
+        // Commit only if nothing invalidated while this was running: an answer
+        // read before a local write describes the state that write replaced,
+        // and storing it would reinstate it for a full TTL.
+        if (generation === this.generation) {
+          this.memo = { earliest, loadedAtMs: nowMs };
+        }
+        if (this.inFlight === pending) this.inFlight = null;
+        return earliest;
+      },
+      error => {
+        // A rejected promise left in `inFlight` would be handed to every later
+        // caller, turning one transient failure into a permanently broken read
+        // path. The failure propagates rather than being answered `false`,
+        // which would be a claim that nothing is scheduled.
+        if (this.inFlight === pending) this.inFlight = null;
+        throw error;
+      }
+    );
+
+    this.inFlight = pending;
+    this.inFlightGeneration = generation;
+    return pending;
+  }
+}
+
+/**
+ * Freshness is measured against the same `now` the due comparison uses, so the
+ * two cannot disagree about what time it is.
+ *
+ * Elapsed time outside the window in EITHER direction expires the memo: a
+ * caller whose clock jumped backwards would otherwise hold the memo well past
+ * the window, and re-reading is the safe direction.
+ */
+function isFresh(memo: TransitionMemo, nowMs: number, ttlMs: number): boolean {
+  const elapsed = nowMs - memo.loadedAtMs;
+  return elapsed >= 0 && elapsed < ttlMs;
+}
+
+/**
+ * Inclusive at the instant itself, matching `resolveReleaseEffect`: a member
+ * scheduled for exactly `now` is due. Answering otherwise here would hide it
+ * from the rule that would have applied it.
+ */
+function isDue(earliest: Date | null, nowMs: number): boolean {
+  return earliest !== null && earliest.getTime() <= nowMs;
+}

--- a/packages/nextly/src/domains/releases/release-eligibility.ts
+++ b/packages/nextly/src/domains/releases/release-eligibility.ts
@@ -1,0 +1,99 @@
+/**
+ * Whether a document may join a release, and why not when it may not.
+ *
+ * There is no opt-in flag for scheduling. Membership is allowed wherever the
+ * action is MEANINGFUL, decided by rules that already exist — which keeps one
+ * statement of what is eligible rather than a config switch that could disagree
+ * with it.
+ *
+ * The two actions have different preconditions, and the asymmetry is the point:
+ *
+ * - **publish** needs a pending edit to publish, so it needs the draft split.
+ * - **unpublish** needs only the Draft/Published lifecycle. Taking a live page
+ *   down requires nothing pending, so a collection with `status` and no drafts
+ *   can be scheduled OFF the site even though it can never be scheduled onto
+ *   it.
+ *
+ * Collapsing those into one rule would silently remove scheduled takedown from
+ * every status-only collection, and a check that only exercised publish would
+ * stay green while it happened.
+ *
+ * @module domains/releases/release-eligibility
+ */
+import type { ReleaseMemberAction } from "../../schemas/releases/types";
+import type {
+  DraftSplitDisabledReason,
+  DraftSplitEligibility,
+} from "../versions/draft-split-eligibility";
+
+/**
+ * Why a document cannot join a release.
+ *
+ * The draft-split reasons are reused rather than restated so the admin can
+ * explain a refusal with the vocabulary it already renders for the editor; two
+ * spellings of one cause is how an explanation and the rule behind it drift.
+ */
+export type MemberRefusalReason =
+  | DraftSplitDisabledReason
+  /** The document has no Draft/Published lifecycle, so there is nothing to leave. */
+  | "no-lifecycle"
+  /**
+   * The configuration never asked for pending changes, so there is no working
+   * draft for a release to publish.
+   *
+   * Distinct from `null` on the draft-split side, where "nothing asked for the
+   * split" is correctly not a misconfiguration. For a release it IS a refusal,
+   * and folding it into `null` would leave the admin saying "cannot schedule,
+   * reason: none".
+   */
+  | "no-pending-changes";
+
+export interface MemberEligibility {
+  allowed: boolean;
+  reason: MemberRefusalReason | null;
+  /** The component behind the reason, when a component carries it. */
+  componentSlug: string | null;
+}
+
+const ALLOWED: MemberEligibility = {
+  allowed: true,
+  reason: null,
+  componentSlug: null,
+};
+
+export interface MemberEligibilityInput {
+  action: ReleaseMemberAction;
+  /** `collection.status === true` — the Draft/Published lifecycle is enabled. */
+  collectionHasStatus: boolean;
+  /** The document's draft-split verdict, from `evaluateDraftSplitEligibility`. */
+  draftEligibility: DraftSplitEligibility;
+}
+
+/** Whether this document may be added to a release under this action. */
+export function canScheduleMember(
+  input: MemberEligibilityInput
+): MemberEligibility {
+  if (input.action === "unpublish") {
+    // Deliberately does NOT consult the draft split. An unpublish removes a
+    // live document; it neither needs nor consumes a pending edit.
+    return input.collectionHasStatus ? ALLOWED : refuse("no-lifecycle", null);
+  }
+
+  // A publish is exactly as eligible as the draft split is, so the verdict is
+  // derived rather than re-derived. `collectionHasStatus` is not read here:
+  // the draft rule already requires it and reports `lifecycle-disabled` when
+  // it is missing, and asking the same question twice is how two answers
+  // start to disagree.
+  if (input.draftEligibility.eligible) return ALLOWED;
+  return refuse(
+    input.draftEligibility.reason ?? "no-pending-changes",
+    input.draftEligibility.componentSlug
+  );
+}
+
+function refuse(
+  reason: MemberRefusalReason,
+  componentSlug: string | null
+): MemberEligibility {
+  return { allowed: false, reason, componentSlug };
+}

--- a/packages/nextly/src/domains/releases/release-read.ts
+++ b/packages/nextly/src/domains/releases/release-read.ts
@@ -1,0 +1,96 @@
+/**
+ * What releases say about the documents one read is holding.
+ *
+ * The read rule is per document, but asking it per document would put a query
+ * behind every row of every listing. This is the one place the two mitigations
+ * are stated together, so neither can be dropped by a caller that only meant to
+ * add a read:
+ *
+ *   1. The cheap check first. While no scheduled release has taken effect, no
+ *      document can be affected, and the whole question costs a comparison
+ *      between two numbers.
+ *   2. One batched lookup for the entire result set, resolved in memory.
+ *
+ * Deliberately NOT gated on whether the caller may edit. That is the difference
+ * from the working-draft overlay, and the single most important thing here not
+ * to "tidy" into the draft rule later: a working draft is one author's
+ * unpublished work and is shown only to that author, while a release whose time
+ * has passed is PUBLISHED and must be visible to an anonymous visitor. Widening
+ * the draft predicate to serve both would leak unpublished work.
+ *
+ * @module domains/releases/release-read
+ */
+import type { DocumentRef } from "./releases-repository";
+import { documentRefKey } from "./releases-repository";
+import type {
+  DueMember,
+  ReleaseEffectDecision,
+} from "./resolve-release-effect";
+import { resolveReleaseEffect } from "./resolve-release-effect";
+
+/**
+ * The decisions for one read.
+ *
+ * A lookup object rather than the raw map, so the key stays derived in one
+ * place. A caller spelling the key itself would get an empty member list for a
+ * document that has members, which reads exactly like "nothing is scheduled".
+ */
+export interface ReleaseEffects {
+  for(ref: DocumentRef): ReleaseEffectDecision;
+}
+
+const NO_EFFECT: ReleaseEffectDecision = {
+  effect: "none",
+  memberId: null,
+  releaseId: null,
+};
+
+/** Every document unaffected, without having asked anything. */
+const NOTHING_DUE: ReleaseEffects = { for: () => NO_EFFECT };
+
+/** The narrow cheap-check surface, so a test can answer without a database. */
+export interface DueCheck {
+  mayHaveDue(now: Date): Promise<boolean>;
+}
+
+/** The narrow batched-lookup surface, satisfied by `ReleasesRepository`. */
+export interface DueMemberSource {
+  findDueMembersFor(
+    refs: DocumentRef[],
+    now: Date
+  ): Promise<Map<string, DueMember[]>>;
+}
+
+export interface ResolveReleaseEffectsInput {
+  cache: DueCheck;
+  repository: DueMemberSource;
+  /** Every document this read is holding, in one call. */
+  refs: DocumentRef[];
+  now: Date;
+}
+
+/** What each of these documents should look like at `now`. */
+export async function resolveReleaseEffects(
+  input: ResolveReleaseEffectsInput
+): Promise<ReleaseEffects> {
+  // No documents means no question, and asking the cheap check anyway would
+  // load the memo for a read that could not have used it.
+  if (input.refs.length === 0) return NOTHING_DUE;
+  if (!(await input.cache.mayHaveDue(input.now))) return NOTHING_DUE;
+
+  const grouped = await input.repository.findDueMembersFor(
+    input.refs,
+    input.now
+  );
+  if (grouped.size === 0) return NOTHING_DUE;
+
+  return {
+    for(ref: DocumentRef): ReleaseEffectDecision {
+      const members = grouped.get(documentRefKey(ref));
+      if (members === undefined || members.length === 0) return NO_EFFECT;
+      // The same pure rule the materialisation applies, so a read and the write
+      // that later persists it cannot disagree about one release.
+      return resolveReleaseEffect({ members, now: input.now });
+    },
+  };
+}

--- a/packages/nextly/src/domains/releases/release-visibility.ts
+++ b/packages/nextly/src/domains/releases/release-visibility.ts
@@ -1,0 +1,77 @@
+/**
+ * The one seam a read path uses to ask what a due release makes visible.
+ *
+ * A read needs two things from the releases domain and must not have to know
+ * that: the cheap check that says whether asking is worth it at all, and the
+ * lookup that answers. Handing a query service both would put the ORDER of
+ * those two in six places — and the order is the whole optimisation. Getting it
+ * wrong costs a query per read on a path that is otherwise a single statement.
+ *
+ * ## The cheap check is the point
+ *
+ * While no scheduled release has taken effect, no document can be affected, and
+ * the entire question is a comparison between two instants. Only when something
+ * IS due does a read pay for the lookup. So the common case — which is every
+ * read on every site that has never scheduled a release — costs one memo read.
+ *
+ * ## Why a null object rather than an optional dependency
+ *
+ * A caller without releases wired gets {@link NO_RELEASE_VISIBILITY}, which
+ * answers "nothing" without asking anything. An optional dependency would make
+ * every call site write `?? []`, and one that forgot would silently narrow a
+ * read rather than fail — the failure mode this whole path exists to avoid.
+ *
+ * @module domains/releases/release-visibility
+ */
+
+import type { VersionScopeKind } from "../../schemas/versions/types";
+
+import type { DueCheck } from "./release-read";
+
+export interface RevealQuery {
+  scopeKind: VersionScopeKind;
+  scopeSlug: string;
+  now: Date;
+}
+
+export interface ReleaseVisibility {
+  /**
+   * The ids of documents in this scope that a due release would PUBLISH.
+   *
+   * Empty is the overwhelmingly common answer, and is reached without a query.
+   */
+  revealIds(query: RevealQuery): Promise<readonly string[]>;
+}
+
+/** The lookup half, satisfied by `ReleasesRepository`. */
+export interface RevealSource {
+  findDuePublishTargets(input: RevealQuery): Promise<string[]>;
+}
+
+/**
+ * Answers "nothing", without asking.
+ *
+ * For a runtime with no releases wired. Deliberately a real object rather than
+ * `undefined`: a missing dependency should not be something each call site
+ * remembers to handle.
+ */
+export const NO_RELEASE_VISIBILITY: ReleaseVisibility = {
+  // Not `async () => []`: there is nothing to await, and declaring it async
+  // only to satisfy the interface trips the rule that asks why.
+  revealIds: () => Promise.resolve([]),
+};
+
+export function createReleaseVisibility(deps: {
+  cache: DueCheck;
+  repository: RevealSource;
+}): ReleaseVisibility {
+  return {
+    async revealIds(query: RevealQuery): Promise<readonly string[]> {
+      // The cheap check first, always. Reversing these two turns the common
+      // case — nothing scheduled anywhere — from a memo read into a query
+      // against the members table on every read of every collection.
+      if (!(await deps.cache.mayHaveDue(query.now))) return [];
+      return deps.repository.findDuePublishTargets(query);
+    },
+  };
+}

--- a/packages/nextly/src/domains/releases/release-visibility.ts
+++ b/packages/nextly/src/domains/releases/release-visibility.ts
@@ -26,7 +26,10 @@
 
 import type { VersionScopeKind } from "../../schemas/versions/types";
 
+import { PendingTransitionCache } from "./pending-transition-cache";
 import type { DueCheck } from "./release-read";
+import { ReleasesRepository } from "./releases-repository";
+import type { ReleasesDbApi } from "./releases-repository";
 
 export interface RevealQuery {
   scopeKind: VersionScopeKind;
@@ -74,4 +77,24 @@ export function createReleaseVisibility(deps: {
       return deps.repository.findDuePublishTargets(query);
     },
   };
+}
+
+/**
+ * The ordinary construction: a repository over this adapter, and a cheap check
+ * that memoizes the earliest scheduled instant.
+ *
+ * Extracted because three services need one — the collection reads, the Single
+ * reads and the relationship expansion — and the assembly is not the obvious
+ * part. Three hand-written copies would each have to remember that the cache is
+ * per SERVICE and not per read: a cache built inside a read reloads the
+ * earliest instant on every request and turns the optimisation into a cost.
+ */
+export function releaseVisibilityFor(db: ReleasesDbApi): ReleaseVisibility {
+  const repository = new ReleasesRepository(db);
+  return createReleaseVisibility({
+    cache: new PendingTransitionCache(() =>
+      repository.findEarliestScheduledTransition()
+    ),
+    repository,
+  });
 }

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -22,6 +22,7 @@ import type { VersionsDbApi } from "../versions/db-api";
 
 import { releaseMemberKey } from "./release-member-key";
 import type { DueMember } from "./resolve-release-effect";
+import { resolveReleaseEffect } from "./resolve-release-effect";
 
 /**
  * The database surface this repository needs.
@@ -246,6 +247,82 @@ export class ReleasesRepository {
       grouped.set(key, list);
     }
     return grouped;
+  }
+
+  /**
+   * The documents in one scope that a due release would PUBLISH.
+   *
+   * ## Why this exists at all, given `findDueMembersFor`
+   *
+   * That one decorates documents a read is already holding, which works in one
+   * direction only. A read filters `status` in SQL, so a document stored as a
+   * draft is excluded by the DATABASE before any decoration runs — and a
+   * post-filter cannot add back a row the query never returned. Hiding a
+   * published document works; revealing an unpublished one needs the filter
+   * itself to know, which is what this answers.
+   *
+   * ## Why it resolves the effect rather than matching `action = "publish"`
+   *
+   * A document can belong to several releases — "publish on the 1st",
+   * "unpublish on the 20th" is the ordinary case — so from the 20th two members
+   * are due at once and the later must win. Matching the action column alone
+   * would name a document whose takedown has already come due, the read filter
+   * would admit its row, and the per-document decoration would then hide it
+   * again. That disagreement surfaces as a listing whose count does not match
+   * its contents.
+   *
+   * Running `resolveReleaseEffect` here means the filter and the decoration
+   * reach their answer through the SAME pure rule, so they cannot disagree.
+   */
+  async findDuePublishTargets(input: {
+    scopeKind: VersionScopeKind;
+    scopeSlug: string;
+    now: Date;
+  }): Promise<string[]> {
+    const members = await this.db.select<ReleaseMemberRow>(MEMBERS, {
+      where: {
+        and: [
+          { column: "scopeKind", op: "=", value: input.scopeKind },
+          { column: "scopeSlug", op: "=", value: input.scopeSlug },
+        ],
+      },
+    });
+    if (members.length === 0) return [];
+
+    // The release each member belongs to decides whether it counts, and the
+    // member row does not carry that. A release still being assembled has no
+    // instant, so `loadScheduledReleases` returning nothing for it is what
+    // keeps an unscheduled member from reading as due.
+    const releases = await this.loadScheduledReleases(
+      members.map(m => m.releaseId)
+    );
+    if (releases.size === 0) return [];
+
+    const grouped = new Map<string, { entryId: string; due: DueMember[] }>();
+    for (const member of members) {
+      const release = releases.get(member.releaseId);
+      if (release === undefined || release.scheduledAt === null) continue;
+      const key = documentRefKey(member);
+      const bucket = grouped.get(key) ?? { entryId: member.entryId, due: [] };
+      bucket.due.push({
+        memberId: member.id,
+        releaseId: member.releaseId,
+        action: member.action,
+        scheduledAt: release.scheduledAt,
+        createdAt: member.createdAt,
+      });
+      grouped.set(key, bucket);
+    }
+
+    const targets = new Set<string>();
+    for (const { entryId, due } of grouped.values()) {
+      const decision = resolveReleaseEffect({ members: due, now: input.now });
+      if (decision.effect === "publish") targets.add(entryId);
+    }
+    // A document localized into several languages contributes one member per
+    // language, and the row it would reveal is the same row. De-duplicated so
+    // the caller's `IN` clause names each id once.
+    return [...targets];
   }
 
   /**

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -249,12 +249,19 @@ export class ReleasesRepository {
   }
 
   /**
-   * The nearest scheduled instant still in the future, or `null`.
+   * The earliest instant any SCHEDULED release takes effect, past or future,
+   * or `null` when no release is scheduled at all.
    *
    * Drives the cheap check that keeps the release lookup off the common read
-   * path: while `now` is before this, no document can be affected by anything.
+   * path. Deliberately NOT filtered to the future: a release whose time has
+   * passed but which nothing has materialised yet is affecting reads right
+   * now, and its instant is in the past — so a future-only answer would report
+   * "nothing pending" for precisely the case the lookup exists to catch.
+   *
+   * A release leaves `scheduled` when it materialises or is cancelled, so this
+   * returns `null` again once nothing is outstanding.
    */
-  async findEarliestPendingTransition(now: Date): Promise<Date | null> {
+  async findEarliestScheduledTransition(): Promise<Date | null> {
     const rows = await this.db.select<{ scheduledAt: Date | null }>(RELEASES, {
       columns: ["scheduledAt"],
       where: {
@@ -266,12 +273,7 @@ export class ReleasesRepository {
       orderBy: [{ column: "scheduledAt", direction: "asc" }],
     });
     for (const row of rows) {
-      if (
-        row.scheduledAt !== null &&
-        row.scheduledAt.getTime() > now.getTime()
-      ) {
-        return row.scheduledAt;
-      }
+      if (row.scheduledAt !== null) return row.scheduledAt;
     }
     return null;
   }

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -24,9 +24,7 @@ import type { FieldGroupDataService } from "../../../services/field-groups/field
 import { BaseService } from "../../../shared/base-service";
 import type { Logger } from "../../../shared/types";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
-import { PendingTransitionCache } from "../../releases/pending-transition-cache";
-import { createReleaseVisibility } from "../../releases/release-visibility";
-import { ReleasesRepository } from "../../releases/releases-repository";
+import { releaseVisibilityFor } from "../../releases/release-visibility";
 import type { WebhookFastDrainScheduler } from "../../webhooks/after-drain";
 import type {
   GetSingleOptions,
@@ -111,13 +109,7 @@ export class SingleEntryService extends BaseService {
     // What a due release makes visible. Built once and shared, so the cheap
     // check's memo is shared too — a cache per read would reload the earliest
     // scheduled instant on every request and lose the point of having one.
-    const releasesRepository = new ReleasesRepository(adapter);
-    const releaseVisibility = createReleaseVisibility({
-      cache: new PendingTransitionCache(() =>
-        releasesRepository.findEarliestScheduledTransition()
-      ),
-      repository: releasesRepository,
-    });
+    const releaseVisibility = releaseVisibilityFor(adapter);
 
     this.queryService = new SingleQueryService(
       adapter,

--- a/packages/nextly/src/domains/singles/services/single-entry-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-entry-service.ts
@@ -24,6 +24,9 @@ import type { FieldGroupDataService } from "../../../services/field-groups/field
 import { BaseService } from "../../../shared/base-service";
 import type { Logger } from "../../../shared/types";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
+import { PendingTransitionCache } from "../../releases/pending-transition-cache";
+import { createReleaseVisibility } from "../../releases/release-visibility";
+import { ReleasesRepository } from "../../releases/releases-repository";
 import type { WebhookFastDrainScheduler } from "../../webhooks/after-drain";
 import type {
   GetSingleOptions,
@@ -105,6 +108,17 @@ export class SingleEntryService extends BaseService {
   ) {
     super(adapter, logger);
 
+    // What a due release makes visible. Built once and shared, so the cheap
+    // check's memo is shared too — a cache per read would reload the earliest
+    // scheduled instant on every request and lose the point of having one.
+    const releasesRepository = new ReleasesRepository(adapter);
+    const releaseVisibility = createReleaseVisibility({
+      cache: new PendingTransitionCache(() =>
+        releasesRepository.findEarliestScheduledTransition()
+      ),
+      repository: releasesRepository,
+    });
+
     this.queryService = new SingleQueryService(
       adapter,
       logger,
@@ -112,7 +126,9 @@ export class SingleEntryService extends BaseService {
       hookRegistry,
       fieldGroupDataService,
       rbacAccessControlService,
-      localization
+      localization,
+      undefined,
+      releaseVisibility
     );
 
     // The write path evaluates a Single's stored access rules; its own

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -42,6 +42,7 @@ import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import {
   expansionStatusScope,
   resolveStatusFilter,
+  type StatusFilterValue,
 } from "../../../lib/status-filter";
 import type { FieldDefinition } from "../../../schemas/dynamic-collections";
 import type { DynamicSingleRecord } from "../../../schemas/dynamic-singles/types";
@@ -100,6 +101,10 @@ import {
   isCompanionReady,
   resolveCompanionSchemaReadiness,
 } from "../../i18n/runtime/companion-readiness";
+import {
+  NO_RELEASE_VISIBILITY,
+  type ReleaseVisibility,
+} from "../../releases/release-visibility";
 import {
   getColumnDescriptor,
   isTextStorageKind,
@@ -705,6 +710,33 @@ export class SingleQueryService extends BaseService {
   /** Persists version snapshots; used when a versioned Single is auto-created. */
   private readonly versionCapture = new VersionCaptureService();
 
+  /**
+   * Whether a due release publishes this Single, despite its stored status.
+   *
+   * A collection read filters rows in SQL, so a release widens the filter.
+   * A Single is one row per slug and is never filtered — it is loaded and then
+   * REFUSED with a 404 when its status is not what the caller may see. So here
+   * the release has to reach the refusal rather than the query.
+   *
+   * Only asked of a PUBLISHED read: an unbounded or draft-only view has nothing
+   * for a release to reveal, and asking anyway would spend the lookup on a
+   * question whose answer cannot change the outcome.
+   */
+  private async releaseRevealsSingle(
+    slug: string,
+    documentId: unknown,
+    statusFilter: { value: StatusFilterValue } | null
+  ): Promise<boolean> {
+    if (statusFilter?.value !== "published") return false;
+    if (typeof documentId !== "string") return false;
+    const revealed = await this.releaseVisibility.revealIds({
+      scopeKind: "single",
+      scopeSlug: slug,
+      now: new Date(),
+    });
+    return revealed.includes(documentId);
+  }
+
   constructor(
     adapter: DrizzleAdapter,
     logger: Logger,
@@ -715,7 +747,14 @@ export class SingleQueryService extends BaseService {
     // i18n: when set and the single is localized, reads resolve translatable fields
     // from the companion `single_<slug>_locales` table for the requested locale.
     private readonly localization?: SanitizedLocalizationConfig,
-    accessControlService?: AccessControlService
+    accessControlService?: AccessControlService,
+    /**
+     * What a due release makes visible.
+     *
+     * A null object by default, so a construction site without releases wired
+     * needs no special case and cannot narrow a read by forgetting one.
+     */
+    private readonly releaseVisibility: ReleaseVisibility = NO_RELEASE_VISIBILITY
   ) {
     super(adapter, logger);
     // Evaluates the Single's stored access rules. Defaulted rather than
@@ -1658,7 +1697,12 @@ export class SingleQueryService extends BaseService {
         if (
           storedRow &&
           statusFilter &&
-          (storedRow as { status?: string }).status !== statusFilter.value
+          (storedRow as { status?: string }).status !== statusFilter.value &&
+          !(await this.releaseRevealsSingle(
+            slug,
+            (storedRow as { id?: unknown }).id,
+            statusFilter
+          ))
         ) {
           return {
             success: false,
@@ -1796,7 +1840,12 @@ export class SingleQueryService extends BaseService {
       // as a not-yet-created Single.
       if (
         statusFilter &&
-        (doc as { status?: string }).status !== statusFilter.value
+        (doc as { status?: string }).status !== statusFilter.value &&
+        !(await this.releaseRevealsSingle(
+          slug,
+          (doc as { id?: unknown }).id,
+          statusFilter
+        ))
       ) {
         return {
           success: false,

--- a/packages/nextly/src/lib/__tests__/status-condition.test.ts
+++ b/packages/nextly/src/lib/__tests__/status-condition.test.ts
@@ -1,0 +1,110 @@
+/**
+ * What the lifecycle condition becomes once releases are in play.
+ *
+ * Asserted against the RENDERED SQL rather than the builder object: two
+ * conditions built from the same inputs would agree with each other whatever
+ * either of them emitted, which proves nothing about the statement the database
+ * actually runs.
+ *
+ * @module lib/__tests__/status-condition.test
+ */
+import { PgDialect, pgTable, text } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { statusCondition } from "../status-condition";
+
+const table = pgTable("posts", {
+  id: text("id").primaryKey(),
+  status: text("status"),
+});
+
+/**
+ * The condition compiled to the statement and parameters a database would
+ * receive — the repo's own idiom for asserting SQL. Reading the builder object
+ * instead would compare a structure against itself.
+ */
+const rendered = (
+  condition: ReturnType<typeof statusCondition>
+): { sql: string; params: unknown[] } => {
+  if (condition === undefined) return { sql: "", params: [] };
+  const compiled = new PgDialect().sqlToQuery(condition);
+  return { sql: compiled.sql, params: compiled.params };
+};
+
+describe("statusCondition", () => {
+  it("applies no condition to an unbounded read", () => {
+    // `status: "all"`, or a trusted caller that said nothing. Such a read
+    // already sees every row, so there is nothing for a release to reveal.
+    expect(
+      statusCondition({
+        filter: null,
+        statusColumn: table.status,
+        idColumn: table.id,
+        revealIds: ["e1"],
+      })
+    ).toBeUndefined();
+  });
+
+  it("is a plain comparison when no release is due", () => {
+    const only = rendered(
+      statusCondition({
+        filter: { value: "published" },
+        statusColumn: table.status,
+        idColumn: table.id,
+        revealIds: [],
+      })
+    );
+    expect(only.params).toEqual(["published"]);
+    // The premise: it produced a condition at all.
+    expect(only.sql).toContain('"status"');
+    expect(only.sql).not.toContain("in (");
+  });
+
+  it("widens a PUBLISHED read to include what a due release publishes", () => {
+    const widened = rendered(
+      statusCondition({
+        filter: { value: "published" },
+        statusColumn: table.status,
+        idColumn: table.id,
+        revealIds: ["e1", "e2"],
+      })
+    );
+    expect(widened.params).toEqual(["published", "e1", "e2"]);
+    // Still bounded: the widening ADDS ids beside the comparison rather than
+    // replacing it, so an unrelated draft stays out.
+    expect(widened.sql).toContain('"status"');
+    expect(widened.sql).toContain('"id"');
+    expect(widened.sql.toLowerCase()).toContain(" or ");
+  });
+
+  it("does NOT widen a draft-only read", () => {
+    // A draft read is asking for pending work. A document a release is about to
+    // publish is not pending work, and adding it would answer a question nobody
+    // asked — while also showing a published-bound row to a draft listing.
+    const draft = rendered(
+      statusCondition({
+        filter: { value: "draft" },
+        statusColumn: table.status,
+        idColumn: table.id,
+        revealIds: ["e1"],
+      })
+    );
+    expect(draft.params).toEqual(["draft"]);
+  });
+
+  it("stays a plain comparison when the table has no identity column to match", () => {
+    // The control for the widening: without an id column there is nothing to
+    // match ids against, and emitting a half-built OR would widen the read to
+    // everything rather than to the named documents.
+    const noId = rendered(
+      statusCondition({
+        filter: { value: "published" },
+        statusColumn: table.status,
+        idColumn: undefined,
+        revealIds: ["e1"],
+      })
+    );
+    expect(noId.params).toEqual(["published"]);
+    expect(noId.sql).toContain('"status"');
+  });
+});

--- a/packages/nextly/src/lib/status-condition.ts
+++ b/packages/nextly/src/lib/status-condition.ts
@@ -1,0 +1,72 @@
+/**
+ * The SQL condition a resolved status filter becomes — including what a due
+ * release makes visible.
+ *
+ * `./status-filter` decides WHICH lifecycle a read should see and is
+ * deliberately pure, with no database coupling. This is the other half: turning
+ * that decision into a condition, in ONE place, because a release makes it more
+ * than a column comparison.
+ *
+ * ## Why a release changes the condition rather than the result
+ *
+ * A release member says publish-or-unpublish at a time. Suppressing a document
+ * afterwards is easy — the row was fetched, and a decision can drop it. Showing
+ * one is not: a published-only read filters `status` in SQL, so a document
+ * stored as a draft is excluded by the DATABASE, and no amount of post-filtering
+ * adds back a row the query never returned.
+ *
+ * So the reveal has to happen here, where the condition is built.
+ *
+ * ## Why this is one function and not six
+ *
+ * `resolveStatusFilter` has six call sites — three collection read paths, two
+ * expansion paths and Singles. If each widened itself, "is this published,
+ * given releases" would have six implementations that must agree forever, and
+ * the ones that drifted would disagree in the least visible way available: a
+ * count that does not match its own listing.
+ *
+ * @module lib/status-condition
+ */
+
+import { eq, inArray, or, type SQL, type SQLWrapper } from "drizzle-orm";
+
+import type { StatusFilterValue } from "./status-filter";
+
+export interface StatusConditionInput {
+  /** The resolved filter, or `null` when the read is not lifecycle-bounded. */
+  filter: { value: StatusFilterValue } | null;
+  /** The lifecycle column on the table being read. */
+  statusColumn: SQLWrapper | undefined;
+  /** The identity column, for the reveal set. */
+  idColumn: SQLWrapper | undefined;
+  /**
+   * Documents a due release would PUBLISH.
+   *
+   * Empty in the overwhelmingly common case — nothing scheduled, or nothing due
+   * — and the caller is expected to have skipped the lookup entirely rather
+   * than passing an empty array it paid for.
+   */
+  revealIds: readonly string[];
+}
+
+/**
+ * The condition to apply, or `null` when the read is not lifecycle-bounded.
+ *
+ * Returns `null` for an unbounded read (`status: "all"`, or a trusted caller
+ * that said nothing) exactly as before: such a read already sees every row, so
+ * there is nothing for a release to reveal.
+ */
+export function statusCondition(input: StatusConditionInput): SQL | undefined {
+  const { filter, statusColumn, idColumn, revealIds } = input;
+  if (filter === null || statusColumn === undefined) return undefined;
+
+  const base = eq(statusColumn, filter.value);
+
+  // Only a PUBLISHED read is widened. A draft-only read is asking for pending
+  // work, and a document a release is about to publish is not that; adding it
+  // would answer a question nobody asked. An unbounded read never reaches here.
+  if (filter.value !== "published") return base;
+  if (revealIds.length === 0 || idColumn === undefined) return base;
+
+  return or(base, inArray(idColumn, [...revealIds]));
+}

--- a/packages/nextly/src/services/collections-handler.ts
+++ b/packages/nextly/src/services/collections-handler.ts
@@ -14,6 +14,7 @@ import type { RBACAccessControlService } from "../domains/auth/services/rbac-acc
 import { DynamicCollectionService } from "../domains/dynamic-collections";
 import type { ResolvedEmailRetentionConfig } from "../domains/email/retention-config";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
+import { releaseVisibilityFor } from "../domains/releases/release-visibility";
 import { MetaRetentionGate } from "../domains/retention/gate";
 import {
   buildRetentionRunner,
@@ -210,7 +211,8 @@ export class CollectionsHandler {
       adapter,
       logger,
       this.fileManager,
-      this.collectionService
+      this.collectionService,
+      releaseVisibilityFor(adapter)
     );
 
     this.metadataService = new CollectionMetadataService(

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -40,6 +40,9 @@ import type {
 } from "../../domains/collections/services/collection-types";
 import type { DynamicCollectionService } from "../../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../../domains/i18n/config/types";
+import { PendingTransitionCache } from "../../domains/releases/pending-transition-cache";
+import { createReleaseVisibility } from "../../domains/releases/release-visibility";
+import { ReleasesRepository } from "../../domains/releases/releases-repository";
 import type { RetentionRunner } from "../../domains/retention/runner";
 import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import type {
@@ -135,6 +138,18 @@ export class CollectionEntryService extends BaseService {
     );
     this.hookService = new CollectionHookService(hookRegistry);
 
+    // What a due release makes visible. Built once and shared by the read
+    // paths below, so the cheap check's memo is shared too — a cache per read
+    // would reload the earliest scheduled instant on every request and lose the
+    // entire point of having one.
+    const releasesRepository = new ReleasesRepository(adapter);
+    const releaseVisibility = createReleaseVisibility({
+      cache: new PendingTransitionCache(() =>
+        releasesRepository.findEarliestScheduledTransition()
+      ),
+      repository: releasesRepository,
+    });
+
     this.queryService = new CollectionQueryService(
       adapter,
       logger,
@@ -144,7 +159,8 @@ export class CollectionEntryService extends BaseService {
       this.accessService,
       this.hookService,
       fieldGroupDataService,
-      localization
+      localization,
+      releaseVisibility
     );
     this.mutationService = new CollectionMutationService(
       adapter,

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -40,9 +40,7 @@ import type {
 } from "../../domains/collections/services/collection-types";
 import type { DynamicCollectionService } from "../../domains/dynamic-collections";
 import type { SanitizedLocalizationConfig } from "../../domains/i18n/config/types";
-import { PendingTransitionCache } from "../../domains/releases/pending-transition-cache";
-import { createReleaseVisibility } from "../../domains/releases/release-visibility";
-import { ReleasesRepository } from "../../domains/releases/releases-repository";
+import { releaseVisibilityFor } from "../../domains/releases/release-visibility";
 import type { RetentionRunner } from "../../domains/retention/runner";
 import type { WebhookFastDrainScheduler } from "../../domains/webhooks/after-drain";
 import type {
@@ -142,13 +140,7 @@ export class CollectionEntryService extends BaseService {
     // paths below, so the cheap check's memo is shared too — a cache per read
     // would reload the earliest scheduled instant on every request and lose the
     // entire point of having one.
-    const releasesRepository = new ReleasesRepository(adapter);
-    const releaseVisibility = createReleaseVisibility({
-      cache: new PendingTransitionCache(() =>
-        releasesRepository.findEarliestScheduledTransition()
-      ),
-      repository: releasesRepository,
-    });
+    const releaseVisibility = releaseVisibilityFor(adapter);
 
     this.queryService = new CollectionQueryService(
       adapter,


### PR DESCRIPTION
## Summary

**R-6 / Content Releases, Stage D.** Group documents into a release, give it an instant, and everything in it becomes visible together — and a reader sees it at that instant rather than the next time something happens to run.

This also **rescues 926 lines that existed only in one local clone**: `feat/content-releases-engine-rescued` is PR 1's foundation (merged as #1110, and completely dark) plus the engine that was written a week ago, never pushed, and 773 commits stale. It rebased clean and its 47 tests still passed.

## The problem the audit found first

The rescued engine could **hide** a document but never **reveal** one.

`resolveReleaseEffects` decorates documents a read is *already holding*. Status filtering happens in **SQL**, so a draft row is excluded by the database before any decoration runs — and a post-filter cannot add back a row the query never returned.

| direction | stored | should | before |
| --- | --- | --- | --- |
| unpublish | `published` | hide | ✅ |
| **publish** | `draft` | show | ❌ |

**Why it was built that way: the design predates the job runner.** With no way to materialise punctually, read-time resolution was the only mechanism available.

**Prior art** — Contentful, Strapi and Payload all *materialise only*. [Sanity](https://www.sanity.io/docs/content-lake/perspectives) resolves at read time and can because its model differs: a release version is a **separate document** (`versions.<releaseId>.<docId>`) a perspective query can filter to. Nextly's members point at existing rows and change only visibility.

## What this PR does

`findDuePublishTargets` names the documents a due release would publish, and **resolves the effect** rather than matching `action = "publish"` — a document can be in two releases ("publish on the 1st", "unpublish on the 20th") and the later must win. Matching the column alone would admit a row whose takedown is due and the decoration would hide it again: a listing whose count disagrees with its contents.

`lib/status-condition.ts` builds the lifecycle condition **once**, because `resolveStatusFilter` has six call sites and six copies of "is this published, given releases" would have to agree forever.

`ReleaseVisibility` is the seam a read asks, so the order **cheap-check-then-lookup** lives in one place — and that order *is* the optimisation. Reversed, every read of every collection on a site that has never scheduled a release pays a query instead of a memo read. A runtime without releases gets a **null object**, not an optional dependency: optional makes every call site write `?? []`, and the one that forgets silently *narrows* a read.

**Six sites, three genuinely different mechanisms:**
- **Collections** (`listEntries`/`countEntries`/`getEntry`) filter in SQL → widen the filter. All three together, or a count disagrees with its own listing.
- **Singles** are one row per slug, never filtered — loaded then **refused with a 404** → reach the refusal. Both gates share one answer.
- **Expansion** applies the lifecycle twice more: an in-memory filter over rows deliberately fetched *unfiltered* so withheld rows are recorded as withheld, plus a SQL condition on the authorized re-read.

### A release reveal is NOT a trust widening

`widensLifecycle` and `expansionStatusScope` decide whether *this caller* may see unpublished content, and a bounded caller deliberately inherits nothing. A due release is the other kind of fact: the target **is** published, for everyone, including an anonymous visitor. So it reaches a bounded caller too, and that is correct rather than a leak. This is written into the code — a widening sitting beside careful anti-widening rules is otherwise an invitation to "fix" it.

## Test plan

**Three end-to-end suites**, each asking through the **ordinary read** rather than the release machinery — because "a release published my post" is a claim about the read. Each has controls (not-yet-due, never-scheduled) that **passed while the main case failed**, so none can be satisfied by a read path that ignores `status`.

Break-verified throughout, including a case worth naming: one repository test **could not be break-verified by a single break** because it is guarded twice — by the `state = "scheduled"` filter *and* the `scheduledAt` null check. Removing either alone left it green; removing both failed it. A redundantly-guarded test reads exactly like an inert one.

Run locally on the rebased tree:

```
collections    11 failed | 398 passed   <- identical on clean main, see below
singles        228 passed
releases + lib 146 passed
releases integ  26 passed  (4 files)
lint clean · check-types clean · changeset status clean
```

## Changeset

Changeset added: **patch** (repo-wide, 25 packages).

## Pre-existing failures

- `src/domains/collections` is **11 failed / 398 passed** — **identical on a clean `main` checkout**, measured. Not from this branch.
- The full `nextly` suite carries a **362-failure stale-mock baseline** on `main` (`task:test-baseline-repair`), which makes `.husky/pre-push` refuse any push touching the package. Measured both sides: clean main 32 files/362 tests failing, this branch 32/362 with 5 more files and all additions passing. The founder waived the hook explicitly for these pushes.
- `main` CI has been red on `packages/ui/src/ui-surface.test.ts` (`Hook timed out in 120000ms` — a build inside a fixed budget). Unrelated; `finding:ui-surface-hook-timeout-reds-main`.

## Not in this PR

Materialisation (`applyDueReleases`), `secondsToNextTransition` + cache-tag busting, the three release permissions, and the admin surfaces. Stage D is four PRs; this is the read half, complete and provable on its own.