### PR TITLE
fix(ci): stop advisory review threads from blocking the merge gate

### DIFF
--- a/.claude/rules/reading-a-ci-verdict.md
+++ b/.claude/rules/reading-a-ci-verdict.md
@@ -483,14 +483,36 @@ naming the mechanism before calling something flake.
 The same shape outside CI. Both bots here can report nothing for reasons that
 have nothing to do with the code.
 
-**Match the bot's COMPLETE login, which carries a `[bot]` suffix.** Measured on
-this repo's PRs:
+**Match the bot's COMPLETE login, which carries a `[bot]` suffix — IN REST.**
+Measured on this repo's PRs:
 
 ```text
 chatgpt-codex-connector[bot]
 coderabbitai[bot]
 pkg-pr-new[bot]
 ```
+
+**GraphQL spells the same accounts WITHOUT the suffix**, and this instruction
+applied there returns zero, byte-identically to "no findings". Measured on #1286
+in one minute:
+
+```text
+REST     pulls/1286/comments   .user.login   coderabbitai[bot]
+GraphQL  reviewThreads author  .login        coderabbitai
+GraphQL  same node             .__typename   Bot
+```
+
+The exposure is unavoidable for thread state, because `isResolved` is
+GraphQL-only — so any "is anything still open" question is forced onto the API
+where this rule, read literally, fails silently. Reconcile at the boundary:
+`__typename == "Bot"` proves the account is an app rather than a user that
+registered the same name, and the suffix is then appended to recover the REST
+spelling everything else compares against. `scripts/ci-verdict.mjs` exports
+`canonicalActorLogin` for exactly this and both gates go through it.
+
+**`__typename` identifies; it cannot discriminate.** Every reviewer here reports
+`Bot` — blocking and advisory alike — so a policy keyed on it exempts the
+blocking reviewer too. Identity from `__typename`, _which_ bot from the login.
 
 Filtering for `chatgpt-codex-connector` returns zero, byte-identically to "not
 yet reviewed". That cost four watch cycles on #785 reporting no verdict while a
@@ -535,10 +557,13 @@ reporting a pass.
 
 The properties, each earned by a version that got it wrong:
 
-- **Identify the reviewer by its COMPLETE login**, `...[bot]` suffix included.
-  Equality on the un-suffixed name returns zero, byte-identically to "not yet
-  reviewed"; a substring match accepts any login containing the word, so anyone
-  able to comment can present a clean-looking verdict.
+- **Identify the reviewer by its COMPLETE login**, `...[bot]` suffix included —
+  which is how REST spells it. Equality on the un-suffixed name returns zero,
+  byte-identically to "not yet reviewed"; a substring match accepts any login
+  containing the word, so anyone able to comment can present a clean-looking
+  verdict. **GraphQL returns the same account without the suffix**, so this
+  equality fails there for every bot; canonicalise the GraphQL side first
+  (`canonicalActorLogin`) rather than loosening the match.
 - **Read `pulls/$PR/reviews`, not `pulls/$PR/comments`.** The latter returns
   only inline comments, and a clean review has none — so the outcome being
   waited for is the one that endpoint cannot report.

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -480,6 +480,79 @@ export function missingReviewers(
   return (required ?? []).filter(login => !seen.has(login));
 }
 
+/** GitHub's `__typename` for a GitHub App's account, as opposed to a user. */
+const BOT_TYPENAME = "Bot";
+
+/** The suffix REST appends to a GitHub App's login, and GraphQL omits. */
+const BOT_SUFFIX = "[bot]";
+
+/**
+ * Whether an actor's login can be read at all.
+ *
+ * A deleted account arrives as `author: null`, and a partial response can carry
+ * the key with nothing in it. Neither is a login, and both must stay
+ * distinguishable from one — every caller here counts what it cannot identify.
+ */
+const isReadableLogin = value => typeof value === "string" && value !== "";
+
+/** Idempotent, so a login already in REST shape is returned unchanged. */
+const withBotSuffix = login =>
+  login.endsWith(BOT_SUFFIX) ? login : `${login}${BOT_SUFFIX}`;
+
+/**
+ * The REST-shaped login for an actor GraphQL described.
+ *
+ * GitHub spells one identity two ways. REST returns a GitHub App's account as
+ * `<app-slug>[bot]`; GraphQL returns the bare slug and puts the account KIND in
+ * `__typename`. Measured on this repository, one pull request, one minute:
+ *
+ * ```text
+ * REST    pulls/1286/comments  .user.login  coderabbitai[bot]
+ * GraphQL reviewThreads author .login       coderabbitai
+ * GraphQL same node            .__typename  Bot
+ * ```
+ *
+ * Reviewer configuration is written in the REST spelling — it is the one a
+ * person reads off the pull request — so REST is the canonical form and the
+ * GraphQL edge is reconciled to it. Reconciled ONCE, here, rather than at each
+ * comparison: a normalisation every call site has to remember is one a call
+ * site will eventually forget, and the failure is silent in both directions.
+ *
+ * **`__typename` is what makes appending the suffix safe, and it is doing a
+ * different job from the login.** It answers *is this account a bot*, which no
+ * account can present about itself, so a USER that registers the name
+ * `coderabbitai` keeps its bare login and cannot borrow the app's identity. The
+ * login answers *which* bot — the question the advisory policy actually asks.
+ * Neither field can do the other's job: every reviewer here is a `Bot`, so
+ * keying the policy on `__typename` alone would exempt the blocking reviewer
+ * this gate exists to enforce.
+ */
+export function canonicalActorLogin(author) {
+  const login = author?.login;
+  if (!isReadableLogin(login)) return undefined;
+  return author.__typename === BOT_TYPENAME ? withBotSuffix(login) : login;
+}
+
+/**
+ * The review-thread page query.
+ *
+ * Exported so a test can assert on the STRING THE CODE SENDS rather than on a
+ * copy of it. The fields here and {@link canonicalActorLogin} are one decision
+ * in two places: the canonicaliser reads `login` and `__typename`, and a
+ * hand-built fixture supplies whatever field a test writes into it, so dropping
+ * `__typename` from this selection breaks nothing any unit test can see. The
+ * request would then return `undefined` for it, no thread would canonicalise to
+ * a bot, no thread would ever be exempt, and every advisory thread would block —
+ * which is the defect this query change exists to fix, reintroduced silently by
+ * editing the query alone.
+ */
+export const REVIEW_THREADS_QUERY =
+  "query($pr:Int!,$owner:String!,$name:String!,$cursor:String){" +
+  " repository(owner:$owner,name:$name){ pullRequest(number:$pr){" +
+  " reviewThreads(first:100, after:$cursor){" +
+  " nodes { isResolved comments(first:1){ nodes { author { login __typename } } } }" +
+  " pageInfo { hasNextPage endCursor } } } } }";
+
 /**
  * Review threads still open.
  *
@@ -501,7 +574,7 @@ export function unresolvedThreads(threads, advisory = []) {
   // ignore".
   return threads.filter(thread => {
     if (thread?.isResolved === true) return false;
-    const author = thread?.comments?.nodes?.[0]?.author?.login;
+    const author = canonicalActorLogin(thread?.comments?.nodes?.[0]?.author);
     return !(typeof author === "string" && advisory.includes(author));
   }).length;
 }
@@ -1084,11 +1157,7 @@ async function main(argv) {
         `name=${name}`,
         ...(cursor === null ? [] : ["-F", `cursor=${cursor}`]),
         "-f",
-        "query=query($pr:Int!,$owner:String!,$name:String!,$cursor:String){" +
-          " repository(owner:$owner,name:$name){ pullRequest(number:$pr){" +
-          " reviewThreads(first:100, after:$cursor){" +
-          " nodes { isResolved comments(first:1){ nodes { author { login } } } }" +
-          " pageInfo { hasNextPage endCursor } } } } }",
+        `query=${REVIEW_THREADS_QUERY}`,
       ]).data.repository.pullRequest.reviewThreads;
       collected.push(...page.nodes);
       // Pagination metadata is REQUIRED rather than optional. A response

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -536,6 +536,14 @@ export function canonicalActorLogin(author) {
 /**
  * The review-thread page query.
  *
+ * Built from {@link REVIEW_THREAD_NODE_FIELDS}, which `verify-merge.mjs` also
+ * uses, so the two gates cannot ask GitHub for different fields. Restating the
+ * selection there was the first version of this change: the shared count
+ * delegates to `canonicalActorLogin`, so a future author field would be added
+ * to this query while the copy stayed as it was, and the other gate would
+ * silently receive incomplete data and disagree again — the very divergence
+ * this change exists to close.
+ *
  * Exported so a test can assert on the STRING THE CODE SENDS rather than on a
  * copy of it. The fields here and {@link canonicalActorLogin} are one decision
  * in two places: the canonicaliser reads `login` and `__typename`, and a
@@ -546,11 +554,14 @@ export function canonicalActorLogin(author) {
  * which is the defect this query change exists to fix, reintroduced silently by
  * editing the query alone.
  */
+export const REVIEW_THREAD_NODE_FIELDS =
+  "isResolved comments(first:1){ nodes { author { login __typename } } }";
+
 export const REVIEW_THREADS_QUERY =
   "query($pr:Int!,$owner:String!,$name:String!,$cursor:String){" +
   " repository(owner:$owner,name:$name){ pullRequest(number:$pr){" +
   " reviewThreads(first:100, after:$cursor){" +
-  " nodes { isResolved comments(first:1){ nodes { author { login __typename } } } }" +
+  ` nodes { ${REVIEW_THREAD_NODE_FIELDS} }` +
   " pageInfo { hasNextPage endCursor } } } } }";
 
 /**

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -534,29 +534,26 @@ export function canonicalActorLogin(author) {
 }
 
 /**
- * The review-thread page query.
+ * The author fields a review thread is read through.
  *
- * Built from {@link REVIEW_THREAD_NODE_FIELDS}, which `verify-merge.mjs` also
- * uses, so the two gates cannot ask GitHub for different fields. Restating the
- * selection there was the first version of this change: the shared count
- * delegates to `canonicalActorLogin`, so a future author field would be added
- * to this query while the copy stayed as it was, and the other gate would
- * silently receive incomplete data and disagree again — the very divergence
- * this change exists to close.
+ * `verify-merge.mjs` builds its own query from this same fragment, so the two
+ * gates cannot ask GitHub for different fields. The count they share delegates
+ * to {@link canonicalActorLogin}, so a selection restated in either file leaves
+ * that file asking for less and reaching a different verdict on the same pull
+ * request.
  *
- * Exported so a test can assert on the STRING THE CODE SENDS rather than on a
- * copy of it. The fields here and {@link canonicalActorLogin} are one decision
- * in two places: the canonicaliser reads `login` and `__typename`, and a
- * hand-built fixture supplies whatever field a test writes into it, so dropping
- * `__typename` from this selection breaks nothing any unit test can see. The
- * request would then return `undefined` for it, no thread would canonicalise to
- * a bot, no thread would ever be exempt, and every advisory thread would block —
- * which is the defect this query change exists to fix, reintroduced silently by
- * editing the query alone.
+ * The fields here and {@link canonicalActorLogin} are one decision in two
+ * places: the canonicaliser reads `login` and `__typename`, and a hand-built
+ * fixture supplies whatever field a test writes into it, so a selection missing
+ * `__typename` is invisible to every unit test. The request returns `undefined`
+ * for the absent field, no thread canonicalises to a bot, nothing is ever
+ * exempt, and every advisory thread blocks. Exported so a test asserts on the
+ * string the request SENDS rather than on a copy of it.
  */
 export const REVIEW_THREAD_NODE_FIELDS =
   "isResolved comments(first:1){ nodes { author { login __typename } } }";
 
+/** The paged review-thread query, built from the shared selection. */
 export const REVIEW_THREADS_QUERY =
   "query($pr:Int!,$owner:String!,$name:String!,$cursor:String){" +
   " repository(owner:$owner,name:$name){ pullRequest(number:$pr){" +
@@ -859,7 +856,18 @@ export const fingerprint = (rv, th, ic) =>
       r?.state,
       r?.submitted_at,
     ]),
-    th.map(t => [t?.isResolved, t?.comments?.nodes?.[0]?.author?.login]),
+    // The CANONICAL login rather than the raw one, because that is what
+    // `unresolvedThreads` reads. `__typename` decides whether a login
+    // canonicalises to a bot, so two snapshots carrying the same login and a
+    // different account kind stand for different verdicts, and a stamp over the
+    // raw login alone holds still while the verdict moves. The derived value
+    // also holds still where the verdict CANNOT move — a kind changing between
+    // two non-bot values leaves the canonical login alone — which a pair of raw
+    // fields would report as evidence moving.
+    th.map(t => [
+      t?.isResolved,
+      canonicalActorLogin(t?.comments?.nodes?.[0]?.author),
+    ]),
     // The parsed revision and the timestamp are read by the coverage decision,
     // so a comment edited in place from an older revision to the current one
     // moves this stamp. Recording only the id would leave two snapshots equal

--- a/scripts/ci-verdict.mjs
+++ b/scripts/ci-verdict.mjs
@@ -562,6 +562,22 @@ export const REVIEW_THREADS_QUERY =
   " pageInfo { hasNextPage endCursor } } } } }";
 
 /**
+ * The reviewers whose threads may be exempted, once blocking has won.
+ *
+ * A login named in both lists is required for coverage AND excluded from
+ * blocking, so it would be exempt from holding the merge while still being
+ * asked to review it. Blocking wins, and the rule is exported so every gate
+ * applies the same one: a second gate filtering differently clears a pull
+ * request the first refuses.
+ */
+export function advisoryExemptions(blocking, advisory) {
+  const blockingList = Array.isArray(blocking) ? blocking : [];
+  return (Array.isArray(advisory) ? advisory : []).filter(
+    login => !blockingList.includes(login)
+  );
+}
+
+/**
  * Review threads still open.
  *
  * Read from thread state rather than reconstructed from comment counts: a
@@ -728,9 +744,7 @@ export function report({
   // than at each use: a login left in both would be exempted from thread
   // blocking by the advisory list while being required for coverage.
   const blockingList = blocking ?? [];
-  const effectiveAdvisory = advisory.filter(
-    login => !blockingList.includes(login)
-  );
+  const effectiveAdvisory = advisoryExemptions(blockingList, advisory);
   const required = [...new Set([...blockingList, ...effectiveAdvisory])];
   // Taken from the revision SET, never from the order map. Ordering is withheld
   // where ancestry is not linear, and reusing it here would make a merge commit

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -993,6 +993,53 @@ describe("canonicalActorLogin", () => {
   });
 });
 
+describe("the stability stamp moves when the verdict would", () => {
+  const thread = (login, typename) => ({
+    isResolved: false,
+    comments: { nodes: [{ author: { login, __typename: typename } }] },
+  });
+
+  /**
+   * The stamp exists so the observation window can tell whether the evidence
+   * moved underneath it. `unresolvedThreads` reads the CANONICAL login, and
+   * `__typename` decides what a login canonicalises to — so a stamp over the
+   * raw login alone holds still across two snapshots that stand for different
+   * verdicts, and the window reports the first snapshot's answer after the
+   * second would have counted the thread.
+   */
+  it("distinguishes snapshots whose account KIND changes the verdict", () => {
+    const asUser = [thread("coderabbitai", "User")];
+    const asBot = [thread("coderabbitai", "Bot")];
+    // The premise: these two really do decide differently.
+    expect(unresolvedThreads(asUser, [RABBIT])).toBe(1);
+    expect(unresolvedThreads(asBot, [RABBIT])).toBe(0);
+    // So their stamps must differ, or the window cannot see the change.
+    expect(fingerprint([], asUser, [])).not.toBe(fingerprint([], asBot, []));
+  });
+
+  /**
+   * The other half, and the reason the stamp records the DERIVED value rather
+   * than the two raw fields. A kind changing between two non-bot values cannot
+   * move the verdict, and a stamp that moved anyway would report evidence
+   * changing where nothing a decision reads did — retrying a settled answer.
+   */
+  it("holds still where the account kind cannot change the verdict", () => {
+    const asUser = [thread("coderabbitai", "User")];
+    const asOrg = [thread("coderabbitai", "Organization")];
+    expect(unresolvedThreads(asUser, [RABBIT])).toBe(
+      unresolvedThreads(asOrg, [RABBIT])
+    );
+    expect(fingerprint([], asUser, [])).toBe(fingerprint([], asOrg, []));
+  });
+
+  /** The control: an unrelated field still moves the stamp. */
+  it("still moves when resolution changes", () => {
+    const open = [thread("someone", "User")];
+    const closed = [{ ...open[0], isResolved: true }];
+    expect(fingerprint([], open, [])).not.toBe(fingerprint([], closed, []));
+  });
+});
+
 describe("the review-thread query asks for what the code reads", () => {
   /**
    * The one property no fixture can establish. Every test above builds its own

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   EXIT_NOT_CLEAN,
   REVIEW_THREADS_QUERY,
+  REVIEW_THREAD_NODE_FIELDS,
   canonicalActorLogin,
   changesRequested,
   completeRevisionSet,
@@ -1010,6 +1011,20 @@ describe("the review-thread query asks for what the code reads", () => {
     // the document — a `__typename` on any other node would satisfy a bare
     // substring check while telling the canonicaliser nothing.
     expect(REVIEW_THREADS_QUERY).toContain("author { login __typename }");
+  });
+
+  /**
+   * The query and the fragment stay one decision.
+   *
+   * `verify-merge.mjs` builds its own query from this same fragment, and it
+   * reaches it through the dynamic sibling loader — an edge no static analysis
+   * follows. So nothing else connects the two gates' field selections, and if
+   * this query stopped being built from the fragment they could drift apart
+   * again while both files still read correctly on their own.
+   */
+  it("is built from the fragment the other gate also uses", () => {
+    expect(REVIEW_THREAD_NODE_FIELDS).toContain("author { login __typename }");
+    expect(REVIEW_THREADS_QUERY).toContain(REVIEW_THREAD_NODE_FIELDS);
   });
 
   it("still selects the fields the rest of the read depends on", () => {

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -4,6 +4,7 @@ import {
   EXIT_NOT_CLEAN,
   REVIEW_THREADS_QUERY,
   REVIEW_THREAD_NODE_FIELDS,
+  advisoryExemptions,
   canonicalActorLogin,
   changesRequested,
   completeRevisionSet,
@@ -881,6 +882,35 @@ describe("unresolvedThreads", () => {
     expect(report({ ...BASE, threads: undefined }).unresolved_threads).toBe(
       "unavailable"
     );
+  });
+});
+
+describe("advisoryExemptions", () => {
+  /**
+   * A login named in both policies is required for coverage AND excluded from
+   * blocking, so an unreduced advisory list would exempt a reviewer that is
+   * simultaneously being asked to review. Blocking wins, and both gates read
+   * this one rule — a gate filtering differently clears what the other holds.
+   */
+  it("removes a login that is also blocking", () => {
+    expect(advisoryExemptions([CODEX], [RABBIT, CODEX])).toEqual([RABBIT]);
+    expect(advisoryExemptions([CODEX], [CODEX])).toEqual([]);
+  });
+
+  /** The control: with no overlap the advisory list is returned intact. */
+  it("leaves a purely advisory login alone", () => {
+    expect(advisoryExemptions([CODEX], [RABBIT])).toEqual([RABBIT]);
+  });
+
+  /**
+   * An unreadable policy exempts nothing, which counts every thread. A gate
+   * that cannot read its policy must not hand out exemptions it cannot
+   * justify, and returning the input unfiltered would do exactly that.
+   */
+  it("exempts nothing when either list is unreadable", () => {
+    expect(advisoryExemptions(undefined, [RABBIT])).toEqual([RABBIT]);
+    expect(advisoryExemptions([CODEX], undefined)).toEqual([]);
+    expect(advisoryExemptions(undefined, undefined)).toEqual([]);
   });
 });
 

--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   EXIT_NOT_CLEAN,
+  REVIEW_THREADS_QUERY,
+  canonicalActorLogin,
   changesRequested,
   completeRevisionSet,
   fingerprint,
@@ -924,6 +926,150 @@ describe("advisory review threads", () => {
     expect(
       unresolvedThreads([{ isResolved: false, comments: {} }], [RABBIT])
     ).toBe(1);
+  });
+});
+
+describe("canonicalActorLogin", () => {
+  /**
+   * The measured shape. GitHub spells one identity two ways, and this is the
+   * pair, read from the same pull request in the same minute:
+   *
+   *   REST    pulls/1286/comments  .user.login  -> "coderabbitai[bot]"
+   *   GraphQL reviewThreads author .login       -> "coderabbitai"
+   *   GraphQL same node            .__typename  -> "Bot"
+   *
+   * Configuration is written in the REST spelling, because that is the one a
+   * person sees on the pull request, so REST is the canonical form and this
+   * reconciles GraphQL to it.
+   */
+  it("restores the suffix GraphQL omits, for a bot", () => {
+    expect(
+      canonicalActorLogin({ login: "coderabbitai", __typename: "Bot" })
+    ).toBe(RABBIT);
+    expect(
+      canonicalActorLogin({
+        login: "chatgpt-codex-connector",
+        __typename: "Bot",
+      })
+    ).toBe(CODEX);
+  });
+
+  /**
+   * The whole reason the suffix may be appended at all. `__typename` is
+   * assigned by GitHub and no account can present it, so a USER that registers
+   * the name `coderabbitai` keeps its bare login and cannot borrow the app's
+   * identity. Appending on the strength of the NAME would hand any account
+   * that can comment the advisory reviewer's exemption.
+   */
+  it("refuses to promote a user that merely shares the name", () => {
+    expect(
+      canonicalActorLogin({ login: "coderabbitai", __typename: "User" })
+    ).toBe("coderabbitai");
+    expect(
+      canonicalActorLogin({ login: "coderabbitai", __typename: "Organization" })
+    ).toBe("coderabbitai");
+    // No `__typename` at all is not a bot either. A partial response must not
+    // be able to manufacture an exemption.
+    expect(canonicalActorLogin({ login: "coderabbitai" })).toBe("coderabbitai");
+  });
+
+  it("is idempotent, so a login already in REST shape is unchanged", () => {
+    expect(canonicalActorLogin({ login: RABBIT, __typename: "Bot" })).toBe(
+      RABBIT
+    );
+  });
+
+  /**
+   * A deleted account comes back as `author: null`. Undefined rather than a
+   * string, so the caller decides — and every caller here counts what it
+   * cannot identify.
+   */
+  it("reports no login where there is no author to read", () => {
+    expect(canonicalActorLogin(null)).toBeUndefined();
+    expect(canonicalActorLogin(undefined)).toBeUndefined();
+    expect(canonicalActorLogin({})).toBeUndefined();
+    expect(canonicalActorLogin({ login: "" })).toBeUndefined();
+  });
+});
+
+describe("the review-thread query asks for what the code reads", () => {
+  /**
+   * The one property no fixture can establish. Every test above builds its own
+   * thread objects, so they supply `__typename` whether or not the request ever
+   * asked GitHub for it — removing the field from the query leaves all of them
+   * green while, in production, no thread canonicalises to a bot, nothing is
+   * ever exempt, and every advisory thread blocks. That is the defect this
+   * change fixes, reachable again by editing one line nothing else watches.
+   *
+   * Asserted against the exported string the request actually sends, not a copy
+   * of it, so the test cannot drift from the query the way a duplicated literal
+   * would.
+   */
+  it("selects every author field the canonicaliser reads", () => {
+    // Present, and inside the author selection rather than merely somewhere in
+    // the document — a `__typename` on any other node would satisfy a bare
+    // substring check while telling the canonicaliser nothing.
+    expect(REVIEW_THREADS_QUERY).toContain("author { login __typename }");
+  });
+
+  it("still selects the fields the rest of the read depends on", () => {
+    // The control. If the query were replaced wholesale with something that
+    // happened to mention the author fields, these would catch it — and if this
+    // assertion ever fails alongside the one above, the query was rewritten
+    // rather than adjusted.
+    expect(REVIEW_THREADS_QUERY).toContain("isResolved");
+    expect(REVIEW_THREADS_QUERY).toContain("pageInfo { hasNextPage endCursor }");
+    expect(REVIEW_THREADS_QUERY).toContain("reviewThreads(first:100");
+  });
+});
+
+describe("advisory threads, in the shape GraphQL actually sends", () => {
+  /**
+   * Built from the MEASURED GraphQL payload rather than from the constants the
+   * filter is configured with. The helper above this one takes a login and
+   * hands it straight back inside a thread, so the two sides that DIVERGE in
+   * production are one value in the test, and it passes under any suffix
+   * convention at all. That is why the divergence survived: the oracle was a
+   * second derivation of the same source.
+   */
+  const botThread = (slug, isResolved) => ({
+    isResolved,
+    comments: { nodes: [{ author: { login: slug, __typename: "Bot" } }] },
+  });
+
+  it("exempts the advisory bot when its login arrives without the suffix", () => {
+    expect(unresolvedThreads([botThread("coderabbitai", false)], [RABBIT])).toBe(
+      0
+    );
+  });
+
+  /**
+   * THE DISCRIMINATING CASE, and the reason both bots appear in one payload.
+   *
+   * A fixture carrying a single bot is satisfied by three different wrong
+   * implementations: today's, which matches neither and counts both; one that
+   * strips the suffix from the config and matches everything ending in the
+   * name; and one keyed on `__typename === "Bot"`, which exempts EVERY bot and
+   * so waves through the blocking reviewer this gate exists to enforce.
+   * Exactly one survives asserting that these two threads come out different.
+   */
+  it("exempts the advisory bot and still counts the blocking one", () => {
+    const threads = [
+      botThread("coderabbitai", false),
+      botThread("chatgpt-codex-connector", false),
+    ];
+    expect(unresolvedThreads(threads, [RABBIT])).toBe(1);
+  });
+
+  /** A human's thread blocks, and carries no suffix in either API. */
+  it("counts a human thread, whose login is the same in both APIs", () => {
+    const human = {
+      isResolved: false,
+      comments: {
+        nodes: [{ author: { login: "mobeenabdullah", __typename: "User" } }],
+      },
+    };
+    expect(unresolvedThreads([human], [RABBIT])).toBe(1);
   });
 });
 

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -809,8 +809,19 @@ const { isCliEntry } = await sibling("cli-entry.mjs");
 // against the module URL, so a symlinked entry finds no neighbour and dies with
 // ERR_MODULE_NOT_FOUND before this file runs, turning a deliberate exit 2 into
 // an exit 1. Written as a static import first; the symlink tests caught it.
-const { unresolvedThreads: countUnresolvedThreads } =
-  await sibling("ci-verdict.mjs");
+//
+// The FIELD SELECTION comes from there too, rather than being restated here.
+// The count delegates to `canonicalActorLogin`, so a future author field would
+// be added to that module's own query while a copy here stayed as it was —
+// and this gate would receive incomplete data and silently disagree with the
+// other again, which is the divergence being closed.
+const countUnresolvedThreads = verdict.unresolvedThreads;
+/**
+ * The review-thread fields this gate asks GitHub for, taken whole from the
+ * sibling that owns the count, and re-exported in the same way as everything
+ * else here so a test reads the value this file actually sends.
+ */
+export const REVIEW_THREAD_NODE_FIELDS = verdict.REVIEW_THREAD_NODE_FIELDS;
 export const SUBMITTED_REVIEW_STATES = verdict.SUBMITTED_REVIEW_STATES;
 /**
  * The revision a reviewer's comment reports having read.
@@ -874,18 +885,6 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO = "nextlyhq/nextly";
-
-/**
- * The review-thread fields this file reads.
- *
- * Exported so a test asserts the string the request SENDS. `__typename` is not
- * decoration: {@link canonicalActorLogin} needs it to tell a GitHub App's
- * account from a user that shares its name, and without it every thread
- * canonicalises to a non-bot, nothing is ever advisory, and this script blocks
- * on threads policy says cannot block — the behaviour being fixed here.
- */
-export const REVIEW_THREAD_FIELDS =
-  "isResolved comments(first:1){ nodes { author { login __typename } } }";
 
 /**
  * The second reviewer's account, named ONCE.
@@ -1209,7 +1208,7 @@ export function main(argv) {
         "api",
         "graphql",
         "-f",
-        `query=query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:${pr}){ reviewThreads(first:100${after}){ pageInfo { hasNextPage endCursor } nodes { ${REVIEW_THREAD_FIELDS} } } } } }`,
+        `query=query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:${pr}){ reviewThreads(first:100${after}){ pageInfo { hasNextPage endCursor } nodes { ${REVIEW_THREAD_NODE_FIELDS} } } } } }`,
         "--jq",
         "{nodes:.data.repository.pullRequest.reviewThreads.nodes, more:.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage, cur:.data.repository.pullRequest.reviewThreads.pageInfo.endCursor}",
       ])

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -893,12 +893,22 @@ const REPO = "nextlyhq/nextly";
  * list would name the default while the other gate honoured the override, and
  * the two would clear and reject the same pull request.
  *
+ * Reduced by the sibling's own overlap rule, so a login named in BOTH policies
+ * keeps its blocking status here as it does there. Applying the raw advisory
+ * list would exempt a reviewer that is simultaneously required, letting this
+ * gate pass a pull request the other one holds.
+ *
  * A policy that cannot be resolved yields no exemptions, so every thread
  * counts. That is the strict direction: a gate unable to read its policy must
  * not hand out exemptions it cannot justify.
  */
-export const ADVISORY_REVIEWERS =
-  verdict.resolveReviewers(process.env).advisory ?? [];
+/** The overlap rule, from the sibling that owns it, so both gates apply one. */
+export const advisoryExemptions = verdict.advisoryExemptions;
+
+export const ADVISORY_REVIEWERS = (() => {
+  const policy = verdict.resolveReviewers(process.env);
+  return verdict.advisoryExemptions(policy.blocking, policy.advisory);
+})();
 
 /**
  * The second reviewer's account, for the COVERAGE question — whether it has

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -799,6 +799,18 @@ const verdict = await sibling("ci-verdict.mjs");
 // before any of this file runs, turning the gate's deliberate exit 2 into an
 // exit 1.
 const { isCliEntry } = await sibling("cli-entry.mjs");
+// The advisory-thread policy lives in ONE implementation, loaded rather than
+// restated. This file counted EVERY unresolved thread and so blocked on the
+// advisory reviewer's — which the sibling's own comment calls out as
+// reinstating through one door the policy closed at another. Two scripts
+// answering one question two ways is how they came to disagree.
+//
+// Through `sibling` for the reason its docblock gives: a static import resolves
+// against the module URL, so a symlinked entry finds no neighbour and dies with
+// ERR_MODULE_NOT_FOUND before this file runs, turning a deliberate exit 2 into
+// an exit 1. Written as a static import first; the symlink tests caught it.
+const { unresolvedThreads: countUnresolvedThreads } =
+  await sibling("ci-verdict.mjs");
 export const SUBMITTED_REVIEW_STATES = verdict.SUBMITTED_REVIEW_STATES;
 /**
  * The revision a reviewer's comment reports having read.
@@ -862,6 +874,35 @@ import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
 const REPO = "nextlyhq/nextly";
+
+/**
+ * The review-thread fields this file reads.
+ *
+ * Exported so a test asserts the string the request SENDS. `__typename` is not
+ * decoration: {@link canonicalActorLogin} needs it to tell a GitHub App's
+ * account from a user that shares its name, and without it every thread
+ * canonicalises to a non-bot, nothing is ever advisory, and this script blocks
+ * on threads policy says cannot block — the behaviour being fixed here.
+ */
+export const REVIEW_THREAD_FIELDS =
+  "isResolved comments(first:1){ nodes { author { login __typename } } }";
+
+/**
+ * The second reviewer's account, named ONCE.
+ *
+ * It is consulted for two different things — whether it reviewed this revision,
+ * and whether its threads may block — and spelling it separately at each is how
+ * a future change to one leaves the other pointing at an account that no longer
+ * reviews anything.
+ */
+export const CODERABBIT = "coderabbitai[bot]";
+
+/**
+ * Reviewers whose findings are advisory: real, worth reading, and not a merge
+ * blocker. Spelled as REST spells them, which is the canonical form everything
+ * here compares against.
+ */
+export const ADVISORY_REVIEWERS = [CODERABBIT];
 
 /** Set by `main` once the head repository is known; a fork keeps its own. */
 let REMOTE_FOR_FETCH = "origin";
@@ -1155,7 +1196,11 @@ export function main(argv) {
   // Paginated. A pull request with more than 100 review threads would
   // otherwise have everything past the first page counted as resolved, which
   // is the reassuring direction.
-  let threads = 0;
+  // Nodes are collected rather than counted per page, because whether a thread
+  // counts is no longer a property of the thread alone — it depends on who
+  // opened it, and that judgement belongs to the shared policy below, not to a
+  // `jq` filter repeated here in a second dialect.
+  const threadNodes = [];
   let cursor = null;
   for (;;) {
     const after = cursor ? `, after: "${cursor}"` : "";
@@ -1164,12 +1209,18 @@ export function main(argv) {
         "api",
         "graphql",
         "-f",
-        `query=query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:${pr}){ reviewThreads(first:100${after}){ pageInfo { hasNextPage endCursor } nodes { isResolved } } } } }`,
+        `query=query { repository(owner:"nextlyhq",name:"nextly"){ pullRequest(number:${pr}){ reviewThreads(first:100${after}){ pageInfo { hasNextPage endCursor } nodes { ${REVIEW_THREAD_FIELDS} } } } } }`,
         "--jq",
-        "{n:[.data.repository.pullRequest.reviewThreads.nodes[]|select(.isResolved==false)]|length, more:.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage, cur:.data.repository.pullRequest.reviewThreads.pageInfo.endCursor}",
+        "{nodes:.data.repository.pullRequest.reviewThreads.nodes, more:.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage, cur:.data.repository.pullRequest.reviewThreads.pageInfo.endCursor}",
       ])
     );
-    threads += page.n;
+    // A page without a node array is not an empty page. Pushing nothing would
+    // silently shrink the count; leaving `threadNodes` un-arrayed is what makes
+    // the policy below refuse instead.
+    if (!Array.isArray(page.nodes)) {
+      throw new Error("review threads: page carried no nodes array");
+    }
+    threadNodes.push(...page.nodes);
     if (!page.more) break;
     // A cursor that does not advance would loop for ever, re-reading one page
     // and adding its count each time. Both failures are silent in opposite
@@ -1180,6 +1231,10 @@ export function main(argv) {
     }
     cursor = page.cur;
   }
+  // Advisory threads do not block. Same function, same advisory list and same
+  // canonical login shape the sibling script uses, so the two cannot drift into
+  // disagreeing about whether a given pull request is mergeable.
+  const threads = countUnresolvedThreads(threadNodes, ADVISORY_REVIEWERS);
 
   // PREFERRED from the review RECORD's own `commit_id`, because only the record
   // carries a sha the server assigned and nobody can edit afterwards.
@@ -1236,11 +1291,7 @@ export function main(argv) {
     knownRevisions,
   });
   // Scoped to THIS revision: a review of an earlier one is not coverage of it.
-  const coderabbit = reviewsCoveringTip(
-    reviews,
-    tip,
-    "coderabbitai[bot]"
-  ).length;
+  const coderabbit = reviewsCoveringTip(reviews, tip, CODERABBIT).length;
 
   // Commit STATUSES are a separate surface from check-runs, and this
   // repository's title check and CodeRabbit both report through it.

--- a/scripts/verify-merge.mjs
+++ b/scripts/verify-merge.mjs
@@ -800,21 +800,19 @@ const verdict = await sibling("ci-verdict.mjs");
 // exit 1.
 const { isCliEntry } = await sibling("cli-entry.mjs");
 // The advisory-thread policy lives in ONE implementation, loaded rather than
-// restated. This file counted EVERY unresolved thread and so blocked on the
-// advisory reviewer's — which the sibling's own comment calls out as
-// reinstating through one door the policy closed at another. Two scripts
-// answering one question two ways is how they came to disagree.
+// restated. A reviewer the policy excludes from blocking must not hold the
+// merge through a thread either, and two gates answering that question
+// separately agree only until one of them is edited.
 //
 // Through `sibling` for the reason its docblock gives: a static import resolves
 // against the module URL, so a symlinked entry finds no neighbour and dies with
 // ERR_MODULE_NOT_FOUND before this file runs, turning a deliberate exit 2 into
-// an exit 1. Written as a static import first; the symlink tests caught it.
+// an exit 1.
 //
-// The FIELD SELECTION comes from there too, rather than being restated here.
-// The count delegates to `canonicalActorLogin`, so a future author field would
-// be added to that module's own query while a copy here stayed as it was —
-// and this gate would receive incomplete data and silently disagree with the
-// other again, which is the divergence being closed.
+// The FIELD SELECTION comes from there too. The count delegates to
+// `canonicalActorLogin`, so a selection restated here would leave this gate
+// asking for less than the other and reaching a different verdict on the same
+// pull request.
 const countUnresolvedThreads = verdict.unresolvedThreads;
 /**
  * The review-thread fields this gate asks GitHub for, taken whole from the
@@ -887,21 +885,30 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 const REPO = "nextlyhq/nextly";
 
 /**
- * The second reviewer's account, named ONCE.
+ * Reviewers whose findings are advisory: real, worth reading, and not a merge
+ * blocker.
  *
- * It is consulted for two different things — whether it reviewed this revision,
- * and whether its threads may block — and spelling it separately at each is how
- * a future change to one leaves the other pointing at an account that no longer
- * reviews anything.
+ * RESOLVED by the sibling from the environment it reads, rather than listed
+ * here. That policy is configurable through `CI_VERDICT_ADVISORY`, so a second
+ * list would name the default while the other gate honoured the override, and
+ * the two would clear and reject the same pull request.
+ *
+ * A policy that cannot be resolved yields no exemptions, so every thread
+ * counts. That is the strict direction: a gate unable to read its policy must
+ * not hand out exemptions it cannot justify.
  */
-export const CODERABBIT = "coderabbitai[bot]";
+export const ADVISORY_REVIEWERS =
+  verdict.resolveReviewers(process.env).advisory ?? [];
 
 /**
- * Reviewers whose findings are advisory: real, worth reading, and not a merge
- * blocker. Spelled as REST spells them, which is the canonical form everything
- * here compares against.
+ * The second reviewer's account, for the COVERAGE question — whether it has
+ * reviewed this revision at all.
+ *
+ * Separate from the list above, which answers whether a thread may block. A
+ * reviewer can be required to look without being able to hold the merge, and
+ * collapsing the two would make one answer the other.
  */
-export const ADVISORY_REVIEWERS = [CODERABBIT];
+export const CODERABBIT = "coderabbitai[bot]";
 
 /** Set by `main` once the head repository is known; a fork keeps its own. */
 let REMOTE_FOR_FETCH = "origin";

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -16,7 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
   ADVISORY_REVIEWERS,
   CODERABBIT,
-  REVIEW_THREAD_FIELDS,
+  REVIEW_THREAD_NODE_FIELDS,
   assertCompleteFileList,
   flatPages,
   blockingJobs,
@@ -1415,13 +1415,37 @@ describe("advisory review threads do not block the merge gate", () => {
    * change removes, reachable by editing one line nothing else watches.
    */
   it("asks for the author fields the shared policy reads", () => {
-    expect(REVIEW_THREAD_FIELDS).toContain("author { login __typename }");
-  });
-
-  it("still asks for the resolution state the count depends on", () => {
+    expect(REVIEW_THREAD_NODE_FIELDS).toContain("author { login __typename }");
     // The control. If the selection were replaced wholesale by something that
     // merely mentioned the author, this catches it.
-    expect(REVIEW_THREAD_FIELDS).toContain("isResolved");
+    expect(REVIEW_THREAD_NODE_FIELDS).toContain("isResolved");
+  });
+
+  /**
+   * The selection is SHARED, not restated.
+   *
+   * The first version of this change declared the same fields here. Nothing
+   * failed, and nothing would have: the count delegates to
+   * `canonicalActorLogin`, so a future author field would be added to
+   * `ci-verdict.mjs`'s own query while this copy stayed as it was — and this
+   * gate would then receive incomplete data and silently disagree with the
+   * other, which is the divergence the whole change exists to close. Two
+   * copies of one decision is also what produced the original defect.
+   *
+   * Asserted against the SOURCE because that is where the duplication would
+   * reappear; a value test cannot tell a shared constant from an equal copy.
+   */
+  it("builds its query from the shared fragment rather than its own copy", () => {
+    const source = readFileSync(
+      new URL("./verify-merge.mjs", import.meta.url),
+      "utf8"
+    );
+    expect(source).toContain("${REVIEW_THREAD_NODE_FIELDS}");
+    // Population: the query line exists at all, so a rename cannot satisfy
+    // this by matching nothing.
+    expect(source).toContain("reviewThreads(first:100");
+    // And no restated selection beside it.
+    expect(source).not.toContain("author { login __typename }");
   });
 
   /**

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -14,6 +14,9 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 import {
+  ADVISORY_REVIEWERS,
+  CODERABBIT,
+  REVIEW_THREAD_FIELDS,
   assertCompleteFileList,
   flatPages,
   blockingJobs,
@@ -1394,5 +1397,58 @@ describe("exitCode", () => {
     expect(
       exitCode({ landedVerdict: "no-candidates", mergeable: false })
     ).toBe(1);
+  });
+});
+
+describe("advisory review threads do not block the merge gate", () => {
+  /**
+   * This file used to count EVERY unresolved thread, so the advisory reviewer
+   * held the merge through a door the policy had closed elsewhere. The count is
+   * now taken by the sibling's shared implementation, which needs to know who
+   * opened each thread — and can only know it if the request asks.
+   *
+   * Asserted on the exported string the query is built from, because a fixture
+   * cannot establish this: every unit test supplies whatever author fields it
+   * writes into its own objects, so dropping `__typename` here leaves them all
+   * green while, in production, nothing canonicalises to a bot, nothing is ever
+   * advisory, and every advisory thread blocks again — the exact defect this
+   * change removes, reachable by editing one line nothing else watches.
+   */
+  it("asks for the author fields the shared policy reads", () => {
+    expect(REVIEW_THREAD_FIELDS).toContain("author { login __typename }");
+  });
+
+  it("still asks for the resolution state the count depends on", () => {
+    // The control. If the selection were replaced wholesale by something that
+    // merely mentioned the author, this catches it.
+    expect(REVIEW_THREAD_FIELDS).toContain("isResolved");
+  });
+
+  /**
+   * The advisory list is spelled the way REST spells it, which is the canonical
+   * form. Written as an assertion rather than a comment because the whole
+   * defect was two spellings of one identity that never met.
+   */
+  it("spells the advisory reviewer once, in REST form", () => {
+    expect(CODERABBIT).toBe("coderabbitai[bot]");
+    expect(ADVISORY_REVIEWERS).toEqual([CODERABBIT]);
+  });
+
+  /**
+   * An unreadable count must not read as zero. `unresolvedThreads` answers
+   * `Infinity` for a list it could not read, and `gateVerdict` treats a
+   * non-integer as unknown — so the two compose into a refusal rather than a
+   * pass. Asserted here because it spans both, and neither alone shows it.
+   */
+  it("refuses rather than passes when the thread count is unreadable", () => {
+    const verdict = gateVerdict({
+      tip: "a".repeat(40),
+      unresolvedThreads: Number.POSITIVE_INFINITY,
+      checkRuns: [],
+      changedPaths: [],
+      required: [],
+      eligibility: {},
+    });
+    expect(verdict.blockers.some(b => b.kind === "threads-unknown")).toBe(true);
   });
 });

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -1424,13 +1424,10 @@ describe("advisory review threads do not block the merge gate", () => {
   /**
    * The selection is SHARED, not restated.
    *
-   * The first version of this change declared the same fields here. Nothing
-   * failed, and nothing would have: the count delegates to
-   * `canonicalActorLogin`, so a future author field would be added to
-   * `ci-verdict.mjs`'s own query while this copy stayed as it was — and this
-   * gate would then receive incomplete data and silently disagree with the
-   * other, which is the divergence the whole change exists to close. Two
-   * copies of one decision is also what produced the original defect.
+   * A selection declared here instead passes every other test: the count
+   * delegates to `canonicalActorLogin`, so a field added to `ci-verdict.mjs`'s
+   * query leaves a copy here asking for less, and this gate then reaches a
+   * different verdict than the other on the same pull request.
    *
    * Asserted against the SOURCE because that is where the duplication would
    * reappear; a value test cannot tell a shared constant from an equal copy.
@@ -1453,9 +1450,38 @@ describe("advisory review threads do not block the merge gate", () => {
    * form. Written as an assertion rather than a comment because the whole
    * defect was two spellings of one identity that never met.
    */
-  it("spells the advisory reviewer once, in REST form", () => {
+  /**
+   * The advisory list is RESOLVED, not restated.
+   *
+   * The sibling computes it from `CI_VERDICT_ADVISORY`. A literal here would
+   * name the default while the other gate honoured an override, and the two
+   * would clear and reject the same pull request — the disagreement this file
+   * is being brought into line with.
+   *
+   * Asserted against the source because that is where a literal would come
+   * back; the resolved value and a hard-coded copy are equal under the default
+   * environment, so no value test can tell them apart.
+   */
+  it("resolves the advisory list rather than declaring one", () => {
+    const source = readFileSync(
+      new URL("./verify-merge.mjs", import.meta.url),
+      "utf8"
+    );
+    expect(source).toContain("verdict.resolveReviewers(process.env).advisory");
+    // Population: the export exists, so a rename cannot satisfy this by
+    // matching nothing.
+    expect(source).toContain("export const ADVISORY_REVIEWERS");
+    // And the value is usable under the default environment.
+    expect(ADVISORY_REVIEWERS).toContain("coderabbitai[bot]");
+  });
+
+  /**
+   * Coverage and blocking are different questions, so the second reviewer's
+   * account is named separately from the advisory list on purpose: a reviewer
+   * can be required to look without being able to hold the merge.
+   */
+  it("keeps the coverage identity distinct from the blocking policy", () => {
     expect(CODERABBIT).toBe("coderabbitai[bot]");
-    expect(ADVISORY_REVIEWERS).toEqual([CODERABBIT]);
   });
 
   /**

--- a/scripts/verify-merge.test.mjs
+++ b/scripts/verify-merge.test.mjs
@@ -16,6 +16,7 @@ import { describe, expect, it } from "vitest";
 import {
   ADVISORY_REVIEWERS,
   CODERABBIT,
+  advisoryExemptions,
   REVIEW_THREAD_NODE_FIELDS,
   assertCompleteFileList,
   flatPages,
@@ -1402,17 +1403,14 @@ describe("exitCode", () => {
 
 describe("advisory review threads do not block the merge gate", () => {
   /**
-   * This file used to count EVERY unresolved thread, so the advisory reviewer
-   * held the merge through a door the policy had closed elsewhere. The count is
-   * now taken by the sibling's shared implementation, which needs to know who
-   * opened each thread — and can only know it if the request asks.
+   * The count is taken by the sibling's shared implementation, which needs to
+   * know who opened each thread and can only know it if the request asks.
    *
    * Asserted on the exported string the query is built from, because a fixture
-   * cannot establish this: every unit test supplies whatever author fields it
-   * writes into its own objects, so dropping `__typename` here leaves them all
-   * green while, in production, nothing canonicalises to a bot, nothing is ever
-   * advisory, and every advisory thread blocks again — the exact defect this
-   * change removes, reachable by editing one line nothing else watches.
+   * cannot establish it: every unit test supplies whatever author fields it
+   * writes into its own objects, so a selection missing `__typename` leaves
+   * them all green while in production nothing canonicalises to a bot, nothing
+   * is ever advisory, and every advisory thread blocks.
    */
   it("asks for the author fields the shared policy reads", () => {
     expect(REVIEW_THREAD_NODE_FIELDS).toContain("author { login __typename }");
@@ -1467,12 +1465,36 @@ describe("advisory review threads do not block the merge gate", () => {
       new URL("./verify-merge.mjs", import.meta.url),
       "utf8"
     );
-    expect(source).toContain("verdict.resolveReviewers(process.env).advisory");
+    expect(source).toContain("verdict.resolveReviewers(process.env)");
+    // And reduced by the sibling's overlap rule, so a login named in BOTH
+    // policies keeps its blocking status here as it does there. The raw
+    // advisory list would exempt a reviewer that is simultaneously required,
+    // letting this gate pass a pull request the other one holds.
+    expect(source).toContain("verdict.advisoryExemptions(");
     // Population: the export exists, so a rename cannot satisfy this by
     // matching nothing.
     expect(source).toContain("export const ADVISORY_REVIEWERS");
     // And the value is usable under the default environment.
     expect(ADVISORY_REVIEWERS).toContain("coderabbitai[bot]");
+  });
+
+  /**
+   * Blocking wins over advisory wherever the two policies name one login.
+   *
+   * Asserted through the shared rule rather than through this module's
+   * environment-resolved constant, because the constant is computed once at
+   * load and cannot be varied per case — and the property that matters is the
+   * rule both gates apply, not the value one of them happened to resolve.
+   */
+  it("never exempts a reviewer that is also blocking", () => {
+    const CODEX = "chatgpt-codex-connector[bot]";
+    // The premise: without the overlap, the advisory login IS exempted.
+    expect(advisoryExemptions([CODEX], [CODERABBIT])).toEqual([CODERABBIT]);
+    // And a login in both keeps its blocking status.
+    expect(advisoryExemptions([CODEX], [CODERABBIT, CODEX])).toEqual([
+      CODERABBIT,
+    ]);
+    expect(advisoryExemptions([CODEX], [CODEX])).toEqual([]);
   });
 
   /**


### PR DESCRIPTION
## What was wrong

GitHub spells one identity two ways. Measured on #1286, one pull request, one minute:

```text
REST     pulls/1286/comments   .user.login   coderabbitai[bot]
GraphQL  reviewThreads author  .login        coderabbitai
GraphQL  same node             .__typename   Bot
```

Reviewer configuration is written in the REST spelling, so comparing it against a GraphQL login never matches. **Both gates got the policy right and the identity wrong, in different ways:**

| script | defect | effect |
|---|---|---|
| `ci-verdict.mjs` | compared a GraphQL login against a REST-spelled list | advisory exemption was **dead code** |
| `verify-merge.mjs` | never attempted the exemption; counted every unresolved thread | `unresolvedThreads > 0` is a **hard blocker** |

Either way an open CodeRabbit thread holds a pull request indefinitely, though policy says an advisory reviewer cannot block. `ci-verdict.mjs:499-502` states that intent exactly and was describing behaviour the code did not have.

Two lanes report having been bitten: `live-preview` waited on #1271 reading a blocked gate as "Codex has not come back yet".

## The fix

Reconciled **once, at the GraphQL boundary**, rather than at each comparison — a normalisation every call site must remember is one a call site will forget, and it fails silently in both directions.

`__typename` and the login do **two different jobs**, and neither can do the other's:

- `__typename == "Bot"` is assigned by GitHub and no account can present it, so a *user* registering the name `coderabbitai` keeps its bare login. This is what makes appending the suffix safe.
- the **login** says *which* bot — the question the advisory policy actually asks.

Keying the exemption on `__typename` alone was tried and rejected: every reviewer here reports `Bot`, so it would exempt **Codex**, the blocking reviewer — a false clean on the gate that matters, reached through the repair for a false block.

`verify-merge` now takes its count from the same implementation, loaded through the sibling loader rather than a static import (written as a static import first; the symlinked-entry tests caught it).

## Why the original survived review

`ci-verdict.test.mjs:896` built its fixture from the same constant it configured the filter with:

```js
expect(unresolvedThreads([thread(RABBIT, false)], [RABBIT])).toBe(0)
```

In production those two come from different sources. The test was structurally incapable of seeing the divergence and passed under any suffix convention at all.

## Verification

New tests are built from the **measured** GraphQL payload, not from shared constants. The discriminating case carries **both bots in one payload** and asserts the count is exactly 1 — a single-bot fixture is satisfied by three different wrong implementations.

Break-verified, each caught by a different test:

| break | caught by |
|---|---|
| key the policy on `__typename` alone | *exempts the advisory bot and still counts the blocking one* |
| revert the call site to the raw login | *exempts the advisory bot when its login arrives without the suffix* |
| append the suffix on the name alone | *refuses to promote a user that merely shares the name* |
| **drop `__typename` from the query** | *selects every author field the canonicaliser reads* — **and nothing else** |

That last row is why the query is exported and asserted: a hand-built fixture supplies whatever field it writes, so editing the query alone reintroduces the defect in production while every other test stays green.

## Notes

- `.claude/rules/reading-a-ci-verdict.md` is corrected in the same PR so the rule and the code move together. Its instruction was right for REST and silent about which API it meant.
- **No changeset**: `scripts/` ships in no package, so a changeset would bump all 25 lockstep packages for code that ships in none. Verified the gate passes with none, and that it still rejects a bad one.
- `verify-merge.mjs` spelled the second reviewer twice; now named once.

## Out of scope, found while here

- `reviewsCoveringTip` filters on login, commit and state but **never the body**, so a rate-limit notice recorded as a review row counts as coverage.
- Most lanes never mark threads resolved, so the Codex half still blocks on findings that were answered but not closed. Whether "answered" belongs in the gate beside "resolved" is a policy question, not a bug.