### PR TITLE
docs(admin): say the builder omits these settings, not that they do not exist

### DIFF
--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/AdvancedTab.tsx
@@ -1,9 +1,12 @@
 // Advanced-tab fields for the BuilderSettingsModal. Like BasicsTab, renders
 // only the fields listed in the per-kind config.
 //
-// Use as Title and Timestamps are deliberately absent: the system title is
-// always the display and timestamps are always emitted, so a control for
-// either would offer a choice that does not exist. The i18n switch is gated on
+// Use as Title and Timestamps are absent from THIS tab, not from the product.
+// Both remain code-first collection options — `admin.useAsTitle` is what the
+// entry table picks its title column from, and `timestamps` defaults to true
+// in `defineCollection`. What the Visual Builder declines to offer is a control
+// for them: a builder-made entity takes the defaults, and a reader who needs to
+// change either edits the collection config. The i18n switch is gated on
 // the app-level
 // `localization` config: enabling it without that config splits the entity's
 // storage into a shape the runtime cannot write to (the server rejects the

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/BasicsTab.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/BasicsTab.tsx
@@ -2,11 +2,13 @@
 // listed in the per-kind config, so the tab is config-driven rather than
 // branching per entity kind.
 //
-// The slug auto-derives from the singular name on each keystroke, and stops as
-// soon as `values.slug` differs from the slug that name would derive. The
-// override is therefore recomputed from the values rather than recorded: there
-// is no flag to keep in step, and editing the slug back to the derived form
-// resumes tracking, which is the behaviour someone correcting a typo expects.
+// The slug auto-derives from the singular name on each keystroke, and stops
+// once a NON-EMPTY `values.slug` differs from the slug that name would derive.
+// Empty counts as automatic, so clearing the field resumes derivation instead
+// of pinning it to the empty string. The override is recomputed from the values
+// rather than recorded — there is no flag to keep in step, and editing the slug
+// back to the derived form resumes tracking too, which is what someone
+// correcting a typo expects.
 // Slug case is per-kind: singles use kebab (the entry-form slug validator is
 // kebab-only); collections and components keep snake to match their backend
 // validators. This is the one place the shared modal needs a per-kind branch

--- a/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/BasicsTab.test.tsx
+++ b/packages/admin/src/components/features/schema-builder/builder-settings-modal/__tests__/BasicsTab.test.tsx
@@ -189,6 +189,10 @@ describe("BasicsTab", () => {
   });
 });
 
+// A kind with no plural name has three basics rather than four, and this group
+// covers what the tab renders for one: singular, slug and icon, each appearing
+// only when the per-kind config lists it. The arrangement is the shared
+// responsive grid, so these assert presence rather than layout classes.
 describe("BasicsTab -- the three basics a kind without a plural renders", () => {
   it("renders singular, slug, and icon when pluralName is omitted from fields", () => {
     render(


### PR DESCRIPTION
Re-lands three comment corrections **stranded** by #1288. They were pushed after GitHub had computed that PR's merge, so the merge took the previous head (`4c8f8ccd1`) and these never reached `main`. The PR reads merged and clean either way — the strand is only visible by content:

```
git merge-base --is-ancestor 79b497355 origin/main   -> NO
git log -1 --format=%P 050ee5e2e | awk "{print \$2}" -> 4c8f8ccd1   (recorded head was 79b497355)
git grep -c "absent from THIS tab" origin/main       -> 0
```

**The comment now on `main` is wrong, and I wrote it.** Removing a change reference from it also removed the qualifier that reference was carrying. The original said a past change dropped Use as Title and Timestamps *"from the UI"*; what replaced it claims a control for either "would offer a choice that does not exist". Both are real code-first collection options — `admin.useAsTitle` is what the entry table picks its title column from ([EntryTableColumns.tsx:181](https://github.com/nextlyhq/nextly/blob/main/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx#L181), pushed into the built-in columns at 191-192), and `timestamps?: boolean` is declared at [define-collection.ts:788](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/collections/config/define-collection.ts#L788) and defaulted to true at 1217. What the Visual Builder declines to offer is a *control* for them.

Worth stating as a general hazard, since removing history from comments is now a recurring task here: **history in a comment can be load-bearing.** Stripping the reference without reading what it qualified turned a true statement about the builder into a false one about the product.

Also re-landed:

- The `BasicsTab` **header** carried the empty-slug error that the commit before it had already fixed three lines further down. Tracking stops once a **non-empty** slug differs from the derived one; an empty slug stays automatic, so clearing the field resumes derivation rather than pinning it to the empty string.
- The renamed test group had no comment saying what it covers.

No behaviour change — comments, and one comment above a `describe`. Schema-builder suite unchanged at 33 files / 250 tests. No changeset: docs-only, per `AGENTS.md:319`, and `check-changesets.mjs` returns 0 with none present.