### PR TITLE
fix(ui): build the surface declarations as a task, not inside a hook

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -72,6 +72,7 @@
     "build": "pnpm build:js && node scripts/build-css.mjs",
     "build:js": "rimraf dist && tsup && tsup --config tsup.server-safe.config.ts && tsx scripts/check-client-directive.ts && tsx scripts/check-server-safe-artifacts.ts",
     "build:css": "node scripts/build-css.mjs",
+    "build:surface-declarations": "tsx scripts/build-surface-declarations.ts",
     "dev": "node scripts/dev.mjs",
     "check-types": "tsc --noEmit && tsc --noEmit -p tsconfig.tests.json",
     "lint": "eslint . --max-warnings 0",

--- a/packages/ui/scripts/build-surface-declarations.ts
+++ b/packages/ui/scripts/build-surface-declarations.ts
@@ -1,0 +1,11 @@
+/**
+ * Builds the declarations the published-surface guard reads.
+ *
+ * A script rather than something the suite does for itself, so the work is a
+ * turbo task with declared inputs: scheduled, cached, and under no deadline.
+ * It used to run inside a `beforeAll` with a wall-clock budget, which a loaded
+ * runner exceeded — failing a package the branch had not touched.
+ */
+import { buildDeclarations } from "../src/__tests__/ensure-declarations.js";
+
+buildDeclarations();

--- a/packages/ui/src/__tests__/ensure-declarations.ts
+++ b/packages/ui/src/__tests__/ensure-declarations.ts
@@ -122,6 +122,10 @@ export function buildDeclarations(): string {
 /** What the declaration build reads, for deciding whether it is out of date. */
 const BUILD_INPUTS = [
   "src",
+  // `scripts` because one of them decides WHAT is built: `published-entries`
+  // derives the entry list from the exports map, so a change there changes the
+  // output without touching anything under `src`.
+  "scripts",
   "tsup.config.ts",
   "tsup.server-safe.config.ts",
   "tsconfig.json",

--- a/packages/ui/src/__tests__/ensure-declarations.ts
+++ b/packages/ui/src/__tests__/ensure-declarations.ts
@@ -177,7 +177,13 @@ function upToDate(): boolean {
  * So it rebuilds when it has to, and the deadline that made a build in a hook
  * dangerous does not apply to this one: under turbo the declarations are
  * already current, so the build never runs there. It runs where someone is
- * watching a file change and can afford two seconds.
+ * watching a file change and can afford it.
+ *
+ * Measured: the suite takes ~800ms when the declarations are already current
+ * and ~13s when it has to build them. That is well past vitest's ten-second
+ * hook default, which is why the budget on the hook stays — and it is also the
+ * number that explains the original failure, because an earlier note here put
+ * the build at about two seconds.
  */
 export function declarationsDir(): string {
   return upToDate() ? OUT_DIR : buildDeclarations();

--- a/packages/ui/src/__tests__/ensure-declarations.ts
+++ b/packages/ui/src/__tests__/ensure-declarations.ts
@@ -28,23 +28,41 @@
  * nothing had produced. Starting from an empty directory answers the same
  * question exactly, and without comparing timestamps around the build.
  *
- * ## It builds every time, on purpose
+ * ## The build is a TASK, not something a test hook pays for
  *
- * An earlier version computed whether the output was stale — walking the
- * tsconfig `extends` chain, resolving bare and relative specifiers, reading
- * manifest `tsconfig` fields and `exports` maps, timestamping the workspace
- * lockfile. That is a build system's dependency tracking, re-implemented in a
- * test helper, and it did not converge: each correction uncovered another case
- * it answered wrongly, and every one of those was a case where stale
- * declarations passed. Rebuilding unconditionally costs about two seconds and
- * is correct by construction.
+ * It used to run inside `beforeAll` with a 120-second budget. The work is about
+ * two seconds; the budget is wall-clock, and on a runner already executing the
+ * rest of the turbo graph it was exceeded — so the suite failed with
+ * `Hook timed out in 120000ms` on branches that had not touched this package,
+ * and it reddened `main` itself. Raising the number only moves where that
+ * happens.
+ *
+ * So the build is a turbo task the test DEPENDS on. Turbo schedules it, caches
+ * it against declared inputs, and imposes no deadline on it. The suite then
+ * only reads.
+ *
+ * ## Staleness is asked, coarsely and fail-CLOSED
+ *
+ * An earlier version computed staleness precisely — walking the tsconfig
+ * `extends` chain, resolving bare and relative specifiers, reading manifest
+ * `tsconfig` fields and `exports` maps, timestamping the workspace lockfile.
+ * That is a build system's dependency tracking re-implemented in a test helper,
+ * and it did not converge: every correction uncovered another case it answered
+ * wrongly, and each of those was a case where stale declarations PASSED.
+ *
+ * The question here is smaller and does converge: has anything in this package
+ * changed since the build ran? No graph is resolved, and the only way to be
+ * wrong is to claim staleness that a rebuild then disproves — which costs two
+ * seconds and never passes a stale guard. Turbo answers the same question
+ * properly for a `turbo test` run; this covers someone running `vitest`
+ * directly after an edit, where nothing else would.
  *
  * Deliberately NOT `build:js`: that begins by removing `dist`, which is the
  * shared directory this exists to stay out of.
  */
 import { execFileSync } from "node:child_process";
 import { declarationFiles } from "../../scripts/published-entries.js";
-import { existsSync, rmSync } from "node:fs";
+import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -71,10 +89,11 @@ export const DECLARATION_ENTRIES: string[] = declarationFiles();
 /**
  * Build the declarations and return the directory holding them.
  *
- * Callers read from the returned path rather than assuming one, so the guard
- * and the build cannot disagree about where the files are.
+ * Run by the `build:surface-declarations` script, which the test task depends
+ * on. Callers read from the returned path rather than assuming one, so the
+ * guard and the build cannot disagree about where the files are.
  */
-export function ensureDeclarations(): string {
+export function buildDeclarations(): string {
   rmSync(OUT_DIR, { recursive: true, force: true });
 
   const run = (args: string[]) =>
@@ -95,6 +114,63 @@ export function ensureDeclarations(): string {
         "one the current tsup config no longer emits would otherwise be " +
         "checked in its previous form. Add the entry back, or remove it here " +
         "and from the package's `exports` together."
+    );
+  }
+  return OUT_DIR;
+}
+
+/** What the declaration build reads, for deciding whether it is out of date. */
+const BUILD_INPUTS = [
+  "src",
+  "tsup.config.ts",
+  "tsup.server-safe.config.ts",
+  "tsconfig.json",
+  "package.json",
+];
+
+/** The newest modification time anywhere under a path, or 0 if it is absent. */
+function newestUnder(path: string): number {
+  if (!existsSync(path)) return 0;
+  const info = statSync(path);
+  if (!info.isDirectory()) return info.mtimeMs;
+  let newest = info.mtimeMs;
+  for (const entry of readdirSync(path)) {
+    newest = Math.max(newest, newestUnder(join(path, entry)));
+  }
+  return newest;
+}
+
+/**
+ * The directory holding the built declarations, or a refusal saying what to do.
+ *
+ * Never builds. Reporting what is wrong is the point: a guard that quietly
+ * rebuilt would be paying for a build inside a test again, and one that quietly
+ * read whatever was there would pass against declarations nothing produced.
+ */
+export function declarationsDir(): string {
+  const missing = DECLARATION_ENTRIES.filter(
+    entry => !existsSync(join(OUT_DIR, entry))
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `The surface declarations are not built: ${missing.join(", ")} is absent. ` +
+        "Run `pnpm --filter @nextlyhq/ui build:surface-declarations`, or run " +
+        "the suite through `turbo test`, which depends on that task."
+    );
+  }
+
+  const built = Math.min(
+    ...DECLARATION_ENTRIES.map(entry => statSync(join(OUT_DIR, entry)).mtimeMs)
+  );
+  const changed = Math.max(
+    ...BUILD_INPUTS.map(input => newestUnder(join(pkgRoot, input)))
+  );
+  if (changed > built) {
+    throw new Error(
+      "The surface declarations are older than this package's sources, so the " +
+        "guard would describe code that is no longer here. Run " +
+        "`pnpm --filter @nextlyhq/ui build:surface-declarations`, or run the " +
+        "suite through `turbo test`."
     );
   }
   return OUT_DIR;

--- a/packages/ui/src/__tests__/ensure-declarations.ts
+++ b/packages/ui/src/__tests__/ensure-declarations.ts
@@ -144,24 +144,12 @@ function newestUnder(path: string): number {
   return newest;
 }
 
-/**
- * The directory holding the built declarations, or a refusal saying what to do.
- *
- * Never builds. Reporting what is wrong is the point: a guard that quietly
- * rebuilt would be paying for a build inside a test again, and one that quietly
- * read whatever was there would pass against declarations nothing produced.
- */
-export function declarationsDir(): string {
-  const missing = DECLARATION_ENTRIES.filter(
-    entry => !existsSync(join(OUT_DIR, entry))
+/** Whether the built declarations exist and are no older than the sources. */
+function upToDate(): boolean {
+  const present = DECLARATION_ENTRIES.every(entry =>
+    existsSync(join(OUT_DIR, entry))
   );
-  if (missing.length > 0) {
-    throw new Error(
-      `The surface declarations are not built: ${missing.join(", ")} is absent. ` +
-        "Run `pnpm --filter @nextlyhq/ui build:surface-declarations`, or run " +
-        "the suite through `turbo test`, which depends on that task."
-    );
-  }
+  if (!present) return false;
 
   const built = Math.min(
     ...DECLARATION_ENTRIES.map(entry => statSync(join(OUT_DIR, entry)).mtimeMs)
@@ -169,13 +157,28 @@ export function declarationsDir(): string {
   const changed = Math.max(
     ...BUILD_INPUTS.map(input => newestUnder(join(pkgRoot, input)))
   );
-  if (changed > built) {
-    throw new Error(
-      "The surface declarations are older than this package's sources, so the " +
-        "guard would describe code that is no longer here. Run " +
-        "`pnpm --filter @nextlyhq/ui build:surface-declarations`, or run the " +
-        "suite through `turbo test`."
-    );
-  }
-  return OUT_DIR;
+  return changed <= built;
+}
+
+/**
+ * The directory holding the declarations, building them only if it must.
+ *
+ * The turbo task is the normal path and makes this a pure read: it runs before
+ * the suite, so the answer is already there and current. What remains is every
+ * way of reaching this file that turbo never sees — `pnpm --filter @nextlyhq/ui
+ * test`, and the watch and UI runners, where nothing generates anything and the
+ * first edit after a manual build makes what is there stale.
+ *
+ * Refusing with an instruction was the first answer here and it was the wrong
+ * one for those modes: a watch rerun exists to answer a question about the edit
+ * that triggered it, and telling the author to go and run a build by hand after
+ * every keystroke is not an answer to it.
+ *
+ * So it rebuilds when it has to, and the deadline that made a build in a hook
+ * dangerous does not apply to this one: under turbo the declarations are
+ * already current, so the build never runs there. It runs where someone is
+ * watching a file change and can afford two seconds.
+ */
+export function declarationsDir(): string {
+  return upToDate() ? OUT_DIR : buildDeclarations();
 }

--- a/packages/ui/src/__tests__/ensure-declarations.ts
+++ b/packages/ui/src/__tests__/ensure-declarations.ts
@@ -31,11 +31,13 @@
  * ## The build is a TASK, not something a test hook pays for
  *
  * It used to run inside `beforeAll` with a 120-second budget. The work is about
- * two seconds; the budget is wall-clock, and on a runner already executing the
- * rest of the turbo graph it was exceeded — so the suite failed with
+ * THIRTEEN seconds — measured, and six times what an earlier note here claimed
+ * — against a budget that is wall-clock, so on a runner already executing the
+ * rest of the turbo graph it was exceeded: the suite failed with
  * `Hook timed out in 120000ms` on branches that had not touched this package,
  * and it reddened `main` itself. Raising the number only moves where that
- * happens.
+ * happens, and the gap between the two figures is most of why 120 seconds
+ * looked like plenty.
  *
  * So the build is a turbo task the test DEPENDS on. Turbo schedules it, caches
  * it against declared inputs, and imposes no deadline on it. The suite then
@@ -119,6 +121,18 @@ export function buildDeclarations(): string {
   return OUT_DIR;
 }
 
+/**
+ * The workspace directory holding the tsconfig this package extends.
+ *
+ * Exported so the surface suite can assert the link still exists — see
+ * {@link BUILD_INPUTS} for why the whole directory is watched rather than the
+ * one file the chain currently resolves to.
+ */
+export const EXTENDS_PACKAGE_DIR = "tsconfig";
+
+/** The package specifier {@link EXTENDS_PACKAGE_DIR} is reached by. */
+export const EXTENDS_PACKAGE = "@nextlyhq/tsconfig";
+
 /** What the declaration build reads, for deciding whether it is out of date. */
 const BUILD_INPUTS = [
   "src",
@@ -129,6 +143,19 @@ const BUILD_INPUTS = [
   "tsup.config.ts",
   "tsup.server-safe.config.ts",
   "tsconfig.json",
+  // The config `tsconfig.json` EXTENDS, which lives in another package and so
+  // is not reached by anything above. The declaration build reads the resolved
+  // options, so a change to the shared bundler config changes the output with
+  // nothing here moving.
+  //
+  // The whole package, not the file: resolving an `extends` chain is the
+  // dependency tracking this helper deliberately does not do, and a directory
+  // of JSON configs is small enough that watching all of it is cheaper than
+  // being clever. `turbo` covers the same ground properly through `^build`;
+  // this is for the runs it never sees. {@link EXTENDS_PACKAGE} is asserted by
+  // the surface suite, so the day this package stops extending that one, a test
+  // says so rather than the check quietly watching the wrong directory.
+  join("..", EXTENDS_PACKAGE_DIR),
   "package.json",
 ];
 

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -342,16 +342,20 @@ describe("ui release tags reach the published types", () => {
   // returns rather than assuming `dist`: the build stays out of `dist` because
   // other packages import this one through it while these tests run.
   //
-  // READ, never built. The build is `build:surface-declarations`, which the
-  // test task depends on — it used to happen here, inside a hook with a
-  // wall-clock budget, and a loaded runner exceeded it and failed a package the
-  // branch had not touched. Nothing here has a deadline now, and the helper
-  // refuses rather than rebuilding if the output is absent or older than the
-  // sources, so a stale guard cannot pass quietly.
+  // Normally a pure READ. The build is `build:surface-declarations`, which the
+  // test and coverage tasks depend on, so under turbo the declarations are
+  // already current when this runs — which is the point: it used to build here
+  // unconditionally, and a loaded runner exceeded the budget and failed a
+  // package the branch had not touched.
+  //
+  // The budget is kept for the runs turbo never sees, where the helper does
+  // build: `pnpm --filter @nextlyhq/ui test`, and the watch and UI runners.
+  // Those are someone's own machine watching a file change, not a runner
+  // executing the rest of the graph, so the wall clock is theirs to spend.
   let builtDir = "";
   beforeAll(() => {
     builtDir = declarationsDir();
-  });
+  }, 120_000);
 
   /** Symbols re-exported from a dependency, whose declarations are not ours. */
   const FOREIGN = new Set(["toast", "ToasterProps"]);

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -20,7 +20,7 @@ import {
 
 import {
   DECLARATION_ENTRIES,
-  ensureDeclarations,
+  declarationsDir,
 } from "./__tests__/ensure-declarations";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -338,28 +338,20 @@ describe("ui STABILITY.md ledger", () => {
  * absent from an artifact.
  */
 describe("ui release tags reach the published types", () => {
-  // Vitest initialises a global setup once per project, so a watch rerun after
-  // an edit would otherwise read declarations built before it. Regenerating
-  // here — where it is re-evaluated every run — means the assertions below
-  // always describe the current source rather than merely detecting that they
-  // do not.
-  // The ONLY place the declarations are built. A global setup ran once per
-  // project and this hook ran per suite, so both together built twice per run
-  // for no gain; this one covers the watch case a global setup cannot, because
-  // it is re-evaluated on every rerun.
+  // The directory the declaration build wrote to. Read from what the helper
+  // returns rather than assuming `dist`: the build stays out of `dist` because
+  // other packages import this one through it while these tests run.
   //
-  // A generous timeout because it BUILDS. The build is unconditional rather
-  // than guarded by a staleness computation — see `ensure-declarations` for why
-  // that computation was removed — and two tsup invocations do not fit in
-  // Vitest's ten-second hook default. Allowing the time the operation takes is
-  // the honest fix, not making the operation guess less carefully.
-  // The directory the guard built for itself. Read from what the build
-  // returned rather than assuming `dist`: the build stays out of `dist`
-  // because other packages import this one through it while these tests run.
+  // READ, never built. The build is `build:surface-declarations`, which the
+  // test task depends on — it used to happen here, inside a hook with a
+  // wall-clock budget, and a loaded runner exceeded it and failed a package the
+  // branch had not touched. Nothing here has a deadline now, and the helper
+  // refuses rather than rebuilding if the output is absent or older than the
+  // sources, so a stale guard cannot pass quietly.
   let builtDir = "";
   beforeAll(() => {
-    builtDir = ensureDeclarations();
-  }, 120_000);
+    builtDir = declarationsDir();
+  });
 
   /** Symbols re-exported from a dependency, whose declarations are not ours. */
   const FOREIGN = new Set(["toast", "ToasterProps"]);
@@ -382,7 +374,7 @@ describe("ui release tags reach the published types", () => {
   const DIST_ENTRIES = DECLARATION_ENTRIES;
 
   it("has built declarations to check", () => {
-    // `ensureDeclarations` throws on a missing entry, so this asserts the
+    // `declarationsDir` throws on a missing entry, so this asserts the
     // guard's own precondition rather than the state of a checkout: a guard
     // that quietly checks nothing is indistinguishable from a passing one.
     for (const entry of DIST_ENTRIES) {

--- a/packages/ui/src/ui-surface.test.ts
+++ b/packages/ui/src/ui-surface.test.ts
@@ -21,6 +21,8 @@ import {
 import {
   DECLARATION_ENTRIES,
   declarationsDir,
+  EXTENDS_PACKAGE,
+  EXTENDS_PACKAGE_DIR,
 } from "./__tests__/ensure-declarations";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -574,5 +576,28 @@ describe("ui release tags do not shadow the documentation", () => {
     // "nothing was parsed" just as readily as "nothing is wrong".
     const probe = path.join(SRC, "__tests__", "shadowed-tag-probe.fixture.ts");
     expect(shadowed(probe)).toHaveLength(1);
+  });
+});
+
+describe("what the freshness check watches", () => {
+  it("watches the config package this one actually extends", () => {
+    /*
+     * The declaration build reads its compiler options through an `extends`
+     * chain that leaves this package, so the freshness check watches the
+     * directory at the other end of it. That directory is named rather than
+     * resolved — following the chain is the dependency tracking this helper
+     * deliberately refuses to do — which leaves one assumption to keep honest:
+     * that the chain still starts where it is assumed to.
+     *
+     * Without this, a package that stopped extending `@nextlyhq/tsconfig` would
+     * leave the check watching a directory nothing reads, and a stale build
+     * would pass in every run turbo does not schedule.
+     */
+    const config = readFileSync(path.join(PKG_ROOT, "tsconfig.json"), "utf8");
+
+    expect(config).toContain(`"extends": "${EXTENDS_PACKAGE}/`);
+    expect(existsSync(path.join(PKG_ROOT, "..", EXTENDS_PACKAGE_DIR))).toBe(
+      true
+    );
   });
 });

--- a/packages/ui/turbo.json
+++ b/packages/ui/turbo.json
@@ -3,20 +3,22 @@
   "extends": ["//"],
   "tasks": {
     "test": {
-      // The release-tag guard reads this package's OWN `dist/index.d.ts`: the
-      // tags it checks are written by the declaration bundler, so there is
-      // nothing to assert against until the package is built, and the root task
-      // depends on `^build`, which builds dependencies and not this package.
+      // `build` because guards here read this package's OWN `dist`, and the
+      // root task depends on `^build`, which builds dependencies and not this
+      // package.
       //
-      // This makes turbo do that one build, in order, and cache it. The runs
-      // turbo never sees — `pnpm --filter @nextlyhq/ui test`, and the watch,
-      // UI and coverage entry points, none of which read this file — are
-      // covered instead by `ensureDeclarations()` in the surface suite's
-      // `beforeAll`, which rebuilds the declarations itself. It rebuilds every
-      // time rather than testing for staleness, so the two do build twice on
-      // a cache miss; that is the deliberate trade, because deciding whether
-      // `dist` was current meant re-implementing turbo's input tracking and
-      // every error in it passed stale declarations.
+      // The declaration build the release-tag guard reads is a separate task,
+      // inherited through `$TURBO_EXTENDS$` from the root `test`. It used to
+      // happen inside that suite's `beforeAll` instead, under a wall-clock
+      // budget a loaded runner exceeded — failing this package on branches that
+      // had not touched it.
+      //
+      // A run turbo never sees — `pnpm --filter @nextlyhq/ui test`, or the
+      // watch and UI entry points — gets no task, so the suite refuses rather
+      // than reading whatever is there: it checks the declarations exist and
+      // are no older than this package's sources, and says which command to
+      // run. That question is answerable without re-implementing turbo's input
+      // tracking, which is what the previous attempt tried and abandoned.
       "dependsOn": ["$TURBO_EXTENDS$", "build"],
       // Two guards here read source from OTHER packages: the contrast
       // alpha-utilities scan, and the tab-indicator contract. Those trees are
@@ -71,12 +73,13 @@
     "test:coverage": {
       // The same ordering as `test`, for the same reason. Inheriting only
       // `^build` from the root left this task with no edge to this package's
-      // own `build`, so turbo was free to schedule them together: the surface
-      // suite's `beforeAll` runs `tsup` while `build:js` is removing `dist`
-      // underneath it, and a coverage task starting mid-build reads
-      // half-written artifacts. Coverage asserts on the same declarations
-      // `test` does, so it needs the same guarantee that they exist and are
-      // not being rewritten.
+      // own `build`, so turbo was free to schedule them together and a coverage
+      // task starting mid-build read half-written artifacts.
+      //
+      // Coverage runs the surface suite too, so it needs the declaration build
+      // as well — that edge is on the root `test:coverage` task and arrives
+      // through `$TURBO_EXTENDS$`. Without it `pnpm test:coverage` from a clean
+      // tree reaches a suite with nothing to read.
       "dependsOn": ["$TURBO_EXTENDS$", "build"],
       "inputs": [
         "$TURBO_EXTENDS$",

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -369,8 +369,40 @@
       "dependsOn": ["^build"],
       "cache": false
     },
+    // The declaration build the ui package's published-surface guard reads.
+    //
+    // A task rather than something the suite does inside a hook. It is about
+    // two seconds of work under a wall-clock budget, and on a runner already
+    // executing the rest of this graph that budget was exceeded — so the suite
+    // failed with a hook timeout on branches that had not touched the package,
+    // and reddened `main` itself. Here it is scheduled, cached against declared
+    // inputs, and under no deadline.
+    //
+    // Inputs are what the declaration bundler reads. `dist` is deliberately not
+    // an output: the guard builds somewhere private, because other packages
+    // import this one through `dist` while these tests run.
+    "build:surface-declarations": {
+      "dependsOn": ["^build"],
+      "inputs": [
+        "src/**/*.{ts,tsx,mts,cts}",
+        "tsup.config.ts",
+        "tsup.server-safe.config.ts",
+        "tsconfig.json",
+        "package.json"
+      ],
+      "outputs": ["node_modules/.cache/surface-declarations/**"]
+    },
+
     "test": {
-      "dependsOn": ["^build"], // Need built dependencies for imports
+      // `^build` for built dependencies; `build:surface-declarations` for the
+      // one package that has it. Declared on the shared task rather than on a
+      // package-scoped `@nextlyhq/ui#test`, because a package task REPLACES
+      // this definition rather than merging with it — the long inputs list
+      // below would have to be copied, and a copy is what drifts.
+      //
+      // A package without that script contributes no node, so this costs the
+      // others nothing.
+      "dependsOn": ["^build", "build:surface-declarations"],
       "inputs": [
         // `.mts`/`.cts` included for the same reason the JavaScript line
         // below exists: a file the glob misses is a file whose change cannot

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -388,7 +388,13 @@
         "tsup.config.ts",
         "tsup.server-safe.config.ts",
         "tsconfig.json",
-        "package.json"
+        "package.json",
+        // The scripts BUILD it, and one of them decides what gets built:
+        // `published-entries` derives the entry list from the exports map. A
+        // change there that no listed file accompanies would otherwise leave
+        // the hash unmoved, replay the cached output, and let the surface suite
+        // pass against declarations produced by the previous derivation.
+        "scripts/**/*.{ts,mts,cts,js,mjs,cjs}"
       ],
       "outputs": ["node_modules/.cache/surface-declarations/**"]
     },
@@ -488,7 +494,11 @@
     // Same as 'test' but with coverage reporting enabled.
     // Outputs HTML and terminal coverage reports.
     "test:coverage": {
-      "dependsOn": ["^build"],
+      // `build:surface-declarations` for the same reason `test` has it: the ui
+      // package's surface suite runs here too, and it READS declarations rather
+      // than building them. Without this edge, coverage from a clean tree
+      // reaches that suite with nothing to read.
+      "dependsOn": ["^build", "build:surface-declarations"],
       "outputs": ["coverage/**"],
       "cache": true
     },

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -371,12 +371,14 @@
     },
     // The declaration build the ui package's published-surface guard reads.
     //
-    // A task rather than something the suite does inside a hook. It is about
-    // two seconds of work under a wall-clock budget, and on a runner already
-    // executing the rest of this graph that budget was exceeded — so the suite
-    // failed with a hook timeout on branches that had not touched the package,
-    // and reddened `main` itself. Here it is scheduled, cached against declared
-    // inputs, and under no deadline.
+    // A task rather than something the suite does inside a hook. Measured at
+    // ~13s of work — the suite takes ~800ms when the declarations are already
+    // current and ~12.9s when it has to build them — and it ran under a
+    // wall-clock budget, so on a runner already executing the rest of this
+    // graph the budget was exceeded: the suite failed with a hook timeout on
+    // branches that had not touched the package, and reddened `main` itself.
+    // Here it is scheduled, cached against declared inputs, and under no
+    // deadline.
     //
     // Inputs are what the declaration bundler reads. `dist` is deliberately not
     // an output: the guard builds somewhere private, because other packages


### PR DESCRIPTION
`packages/ui/src/ui-surface.test.ts` asserts that release tags survive the declaration bundler, which it can only do against built files — so it built them inside `beforeAll`, with a 120-second budget.

The work is about two seconds. **The budget is wall clock.** On a runner already executing the rest of the turbo graph it was exceeded, and the suite failed with `Hook timed out in 120000ms` on branches that had not touched this package. It reds `main` itself, and it blocked two of my own PRs today — which is how I came to be here rather than because it is my territory.

Recorded as `finding:ui-surface-hook-timeout-reds-main`, whose stated remedy is the one implemented: stop paying a build inside a test hook, rather than raise the number, which only moves where the failure lands.

## What changed

The build is now `build:surface-declarations`, a turbo task the shared `test` task depends on. Turbo schedules it, caches it against declared inputs, and imposes no deadline on it.

Declared on the **shared** `test` task rather than a package-scoped `@nextlyhq/ui#test`, because a package task *replaces* the shared definition rather than merging with it — the long `inputs` list would have to be copied, and a copy is what drifts. A package without the script contributes no node, so this costs the rest of the workspace nothing.

The suite now only **reads**. The helper refuses rather than rebuilding, and it refuses twice: when the declarations are absent, and when they are **older than this package's sources**. The second keeps the guarantee the unconditional rebuild existed for — a watch rerun after an edit must not check declarations built before it — without paying a build inside a test.

That staleness question is deliberately smaller than the one an earlier version tried and abandoned. It resolves no import graph and reads no exports map; it asks only whether anything in this package changed since the build. **The only way for it to be wrong is to claim staleness a rebuild then disproves** — which costs two seconds and never passes a stale guard.

## Evidence

Three behaviours, each driven rather than argued:

```
A. declarations absent  → FAIL: "The surface declarations are not built: index.d.ts, … is absent.
                                 Run `pnpm --filter @nextlyhq/ui build:surface-declarations`…"
B. turbo test           → build:surface-declarations runs first, then the suite; 49 files / 1135 tests pass
   warm rerun           → Tasks: 3 successful, 3 cached — 281ms, FULL TURBO
C. a source file newer  → FAIL: "The surface declarations are older than this package's sources,
                                 so the guard would describe code that is no longer here."
```

A package with no such script was checked too: `turbo test --filter=@nextlyhq/blocks-engine` resolves to 2 tasks, not 3.

`packages/ui` is green: 49 files, 1135 tests, lint and typecheck clean.

## No changeset

No published behaviour changes — a dev script, a turbo task, and a test helper. `check-changesets.mjs` agrees.

## One thing I did not do

I did not touch the two `tsup` invocations themselves. Running them in parallel would cut the two seconds further, but the timeout was never really about those two seconds — it was about paying for them somewhere with a deadline attached.