### PR TITLE
fix(builder): refuse an empty container the browser has skipped

### DIFF
--- a/.changeset/appender-refuses-a-skipped-container.md
+++ b/.changeset/appender-refuses-a-skipped-container.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An empty container inside a closed accordion section no longer offers an Add control on the page-builder canvas.
+
+A browser lays out a closed section's contents as though the section were open, while drawing none of it, so the control was placed on a rectangle nothing occupies — over the NEXT section's title. Pressing there added the block to a section you had not chosen, with nothing on screen to explain it. Open the section and the control is there.

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -53,6 +53,7 @@ import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { CANVAS_ROOT_CLASS, Canvas } from "./canvas";
+import { EMPTY_CONTAINER_SELECTOR } from "./empty-slot";
 import { BUILDER_CHROME_CLASS } from "./shell-state";
 import {
   centeredControlRect,
@@ -68,6 +69,10 @@ afterEach(() => {
   cleanup();
   clearBlocks();
   vi.unstubAllGlobals();
+  // `withCheckVisibility` writes to a prototype rather than to a global, which
+  // `vi.unstubAllGlobals` does not reach — and leaving it installed would make
+  // its own absence assertion fail for the next case that asks for it.
+  Reflect.deleteProperty(Element.prototype, "checkVisibility");
 });
 
 // Two container TYPES, not just two nodes of one type — `core/card` exists so
@@ -510,6 +515,73 @@ describe("the rectangle the control is drawn at", () => {
  */
 const DETAILS_CONTAINER = "acme/empty-container-appender-details";
 
+/**
+ * The `<details>` rendering that decides whether a descendant is skipped.
+ *
+ * `Element.checkVisibility` is absent from jsdom, and so is the box an engine
+ * generates for a closed disclosure's contents — `getComputedStyle` refuses a
+ * pseudo-element argument outright — so neither the method nor the state it
+ * reports can be reached here without being supplied.
+ *
+ * This is the RULE the method applies, taken from the CSSOM View algorithm and
+ * driven entirely by the fixture's own DOM: walking outwards, a descendant is
+ * skipped when it passes through an ancestor with `content-visibility: hidden`,
+ * or through a closed `<details>` by any route other than its `<summary>` —
+ * which is rendered while the disclosure is closed and is the reason a check
+ * for a closed-`<details>` ANCESTOR is not the same question. `node` is always
+ * the child the walk entered `parent` through, which is what distinguishes
+ * those two routes.
+ *
+ * Only the ancestor step is modelled. The algorithm's first step — an element
+ * with no box at all — is answered by {@link laidOut}, which `layout` already
+ * applies to the same elements' fragment counts and which `measure` asks about
+ * through `layoutFragments` BEFORE it reaches this question at all.
+ *
+ * `=== "hidden"` rather than a list of the values that do not skip: an element
+ * no rule reaches computes to the empty string here, so an allow-list would
+ * report every ordinary container as skipped.
+ */
+function skipsContents(element: Element): boolean {
+  for (
+    let node: Element = element;
+    node.parentElement !== null;
+    node = node.parentElement
+  ) {
+    const parent = node.parentElement;
+    if (getComputedStyle(parent).contentVisibility === "hidden") return true;
+    if (
+      parent instanceof HTMLDetailsElement &&
+      !parent.open &&
+      node.tagName !== "SUMMARY"
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Give this document the `checkVisibility` jsdom does not implement.
+ *
+ * Asserted absent rather than assumed so, because the assertion is what keeps
+ * this a stand-in: a jsdom that gained its own implementation would have this
+ * silently shadow it, and every case below would then be exercising this
+ * function instead of one the fixture could have driven for real.
+ *
+ * Installed on the prototype rather than on the elements a case names, so the
+ * component reaches it through the ordinary call on whichever element it
+ * measures — the same reason `layout` stubs every element in the canvas rather
+ * than the ones a case is about.
+ */
+function withCheckVisibility(): void {
+  expect(
+    Object.getOwnPropertyDescriptor(Element.prototype, "checkVisibility")
+  ).toBeUndefined();
+  Element.prototype.checkVisibility = function (this: Element): boolean {
+    return !skipsContents(this);
+  };
+}
+
 /** The canvas root's own rectangle, and the one every wrapper reports. */
 const CANVAS_BOX = { x: 0, y: 0, width: 800, height: 600 };
 
@@ -667,10 +739,19 @@ describe("which containers it actually draws a control on", () => {
           description: "A container whose root also renders a summary.",
           example: { props: {} },
           slots: { children: {} },
-          render: ({ className, renderSlot }: BlockRenderArgs<object>) =>
+          // `open` comes from the node's own props, exactly as
+          // `core/accordion-item` takes it, so one registered block covers
+          // both states of a disclosure rather than a second block that
+          // differs from this one by an attribute. A node that stores no
+          // `open` renders closed, which is that block's own default.
+          render: ({
+            props,
+            className,
+            renderSlot,
+          }: BlockRenderArgs<{ open?: boolean }>) =>
             React.createElement(
               "details",
-              { className },
+              { className, open: props.open === true },
               React.createElement("summary", null, "Section"),
               renderSlot("children")
             ),
@@ -794,6 +875,76 @@ describe("which containers it actually draws a control on", () => {
       },
     ],
   };
+
+  /**
+   * The same empty container inside a CLOSED disclosure and inside an OPEN one.
+   *
+   * The shape an author reaches by selecting a `core/accordion-item` in the
+   * Layers panel and inserting a `core/box`: the section's `children` slot
+   * carries no restriction, so any container may sit in it, and the section's
+   * own defaults leave it closed. Neither `<details>` is an empty container
+   * itself — each holds the box — so the two controls under test are the boxes'
+   * own.
+   *
+   * The pair is the test. An engine that skips a closed disclosure's contents
+   * still reports a full-size rectangle for the box inside one, positioned as
+   * though the section were open, so every question `measure` asks before the
+   * skip accepts it. Asserting only that the closed one draws nothing would be
+   * satisfied by a component that drew nothing anywhere, and asserting it
+   * WITHOUT the open one would be satisfied by a refusal that declined every
+   * container inside any `<details>` at all.
+   */
+  const DISCLOSED: BlockDocument = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      {
+        id: "closed-section",
+        type: DETAILS_CONTAINER,
+        version: 1,
+        props: {},
+        name: "Closed section",
+        slots: {
+          children: [
+            {
+              id: "in-closed",
+              type: "acme/empty-container-appender-box",
+              version: 1,
+              props: {},
+              name: "Box in a closed section",
+            },
+          ],
+        },
+      },
+      {
+        id: "open-section",
+        type: DETAILS_CONTAINER,
+        version: 1,
+        props: { open: true },
+        name: "Open section",
+        slots: {
+          children: [
+            {
+              id: "in-open",
+              type: "acme/empty-container-appender-box",
+              version: 1,
+              props: {},
+              name: "Box in an open section",
+            },
+          ],
+        },
+      },
+    ],
+  };
+
+  /** The rendered `<details>` a node id addresses, for asking its state. */
+  function disclosureIn(container: HTMLElement, id: string): HTMLElement {
+    const element = canvasRootIn(container).querySelector<HTMLElement>(
+      `[${NODE_ID_ATTRIBUTE}="${id}"]`
+    );
+    if (element === null) throw new Error(`no element for ${id}`);
+    return element;
+  }
 
   /**
    * A document the overlay knows about and the canvas does not render.
@@ -1045,6 +1196,106 @@ describe("which containers it actually draws a control on", () => {
         name: "Add a block to Box in a hidden wrapper",
       })
     ).toBeNull();
+  });
+
+  it("draws NO control on a container inside a CLOSED disclosure, and one inside an open one", () => {
+    /*
+     * The SKIPPED refusal, and the one no other branch here can stand in for.
+     * Both boxes are asserted to pass every question `measure` asks before it:
+     * each has an element, each matches the stylesheet's whole rule, and each
+     * reports exactly ONE layout fragment — the reading an engine gives a
+     * closed disclosure's contents once they are skipped rather than removed
+     * from the rendering, and the reason the no-box refusal above lets this one
+     * through. The two boxes are stubbed the SAME size for the same reason, so
+     * the refusal cannot be coming from a container that measured differently.
+     *
+     * The open section is the positive control, in the same render and the same
+     * measurement pass, and it is a stronger one than a bare container would
+     * be: it is the identical block inside the identical `<details>`, differing
+     * only in the attribute the refusal is about. An absence assertion beside a
+     * plain box would also be satisfied by a refusal that declined everything
+     * inside any disclosure at all.
+     *
+     * Each `<details>`'s own state is asserted before anything is read into the
+     * controls, so this is known to be about a section that really is closed
+     * rather than about a fixture whose `open` prop never reached the render.
+     */
+    withCheckVisibility();
+    const container = measuredCanvas(DISCLOSED, {
+      "in-closed": { x: 0, y: 0, width: 400, height: 200 },
+      "in-open": { x: 0, y: 400, width: 400, height: 200 },
+    });
+
+    expect(disclosureIn(container, "closed-section").matches("details")).toBe(
+      true
+    );
+    expect(disclosureIn(container, "closed-section").hasAttribute("open")).toBe(
+      false
+    );
+    expect(disclosureIn(container, "open-section").hasAttribute("open")).toBe(
+      true
+    );
+    for (const id of ["in-closed", "in-open"]) {
+      const box = disclosureIn(container, id);
+      expect(box.matches(EMPTY_CONTAINER_SELECTOR)).toBe(true);
+      expect(box.getClientRects().length).toBe(1);
+    }
+
+    expect(drawnAt("Box in an open section")).toEqual([
+      "178px",
+      "478px",
+      "44px",
+      "44px",
+    ]);
+    expect(
+      screen.queryByRole("button", {
+        name: "Add a block to Box in a closed section",
+      })
+    ).toBeNull();
+  });
+
+  it("draws the control as soon as the disclosure is opened", async () => {
+    /*
+     * The refusal is re-decided rather than permanent, and this is the case
+     * that says WHAT hears the change. Opening a disclosure is a press on the
+     * canvas rather than an edit: `document` does not change, no React render
+     * follows, nothing resizes, nothing scrolls and no transition finishes, so
+     * every subscription except one stays silent. What the browser does do is
+     * write the `open` attribute onto the `<details>`, which is an attribute
+     * record inside the canvas root and outside this overlay's own layer — the
+     * `MutationObserver` in `watchCanvasFor` is the only thing that reports it.
+     *
+     * The attribute is written directly, which is exactly what a press on the
+     * summary produces; driving it through a synthetic click would additionally
+     * be asserting that jsdom implements the disclosure's own activation
+     * behaviour, which is a claim about jsdom rather than about this component.
+     *
+     * The rectangle is unchanged across the two measurements, so the control
+     * appearing is the refusal being lifted rather than a container that moved.
+     */
+    withCheckVisibility();
+    const container = measuredCanvas(DISCLOSED, {
+      "in-closed": { x: 0, y: 0, width: 400, height: 200 },
+      "in-open": { x: 0, y: 400, width: 400, height: 200 },
+    });
+    expect(
+      screen.queryByRole("button", {
+        name: "Add a block to Box in a closed section",
+      })
+    ).toBeNull();
+
+    const section = disclosureIn(container, "closed-section");
+    await act(async () => {
+      section.setAttribute("open", "");
+      await flushObservers();
+    });
+
+    expect(drawnAt("Box in a closed section")).toEqual([
+      "178px",
+      "78px",
+      "44px",
+      "44px",
+    ]);
   });
 
   it("draws NO control on a container the render does not produce", () => {

--- a/packages/builder/src/empty-container-appender.test.tsx
+++ b/packages/builder/src/empty-container-appender.test.tsx
@@ -61,6 +61,22 @@ import {
 } from "./empty-container-appender";
 import { registrySlotSource } from "./inserter";
 
+/**
+ * The `checkVisibility` the RUNTIME brought, read before any case can replace
+ * it, so the teardown below restores rather than assumes.
+ *
+ * `Element.prototype` is where the method is defined when it exists — an own,
+ * writable, enumerable, configurable data property, per the CSSOM View
+ * `partial interface Element` — so a teardown that deleted unconditionally
+ * would reach the real one and not merely {@link withCheckVisibility}'s
+ * stand-in. jsdom implements none today, which makes this `undefined` and the
+ * restore a deletion.
+ */
+const RUNTIME_CHECK_VISIBILITY = Object.getOwnPropertyDescriptor(
+  Element.prototype,
+  "checkVisibility"
+);
+
 // This suite queries by role against the whole document (`screen`), so a tree
 // left mounted by one test is still there for the next `getByRole` to trip
 // over — matching why `block-toolbar.test.tsx` and `spacing-overlay.test.tsx`
@@ -70,9 +86,20 @@ afterEach(() => {
   clearBlocks();
   vi.unstubAllGlobals();
   // `withCheckVisibility` writes to a prototype rather than to a global, which
-  // `vi.unstubAllGlobals` does not reach — and leaving it installed would make
-  // its own absence assertion fail for the next case that asks for it.
-  Reflect.deleteProperty(Element.prototype, "checkVisibility");
+  // `vi.unstubAllGlobals` does not reach. Both runtimes are covered by putting
+  // the captured descriptor back: where there was none the property goes away
+  // again, and where there was one the runtime's own method returns — which is
+  // what keeps `withCheckVisibility`'s absence check a question about the
+  // RUNTIME rather than about what the previous case cleaned up.
+  if (RUNTIME_CHECK_VISIBILITY === undefined) {
+    Reflect.deleteProperty(Element.prototype, "checkVisibility");
+  } else {
+    Object.defineProperty(
+      Element.prototype,
+      "checkVisibility",
+      RUNTIME_CHECK_VISIBILITY
+    );
+  }
 });
 
 // Two container TYPES, not just two nodes of one type — `core/card` exists so

--- a/packages/builder/src/empty-container-appender.tsx
+++ b/packages/builder/src/empty-container-appender.tsx
@@ -135,15 +135,19 @@
  * and it has three answers rather than two:
  *
  * - MEASURED — the pass found the element, accepted it, and holds a rectangle.
- * - DECLINED — the pass reached this container and refused it, for one of
- *   five reasons: the render produced no element for it at all; the
- *   stylesheet drew no box for the element it did produce (see the section
- *   above); the render laid out no box for that element, because something
- *   between it and the root generates none; the author positioned it against
- *   the VIEWPORT rather than against the page; or an authored ancestor clips
- *   it. `measure` states each one where it is asked. All five are re-decided
- *   on every pass, so each is a refusal for as long as the render keeps this
- *   shape rather than a permanent one.
+ * - DECLINED — the pass reached this container and refused it. The reasons are
+ *   listed rather than counted, because a total kept by hand beside the list
+ *   goes stale the moment one is inserted: the render produced no element for
+ *   it at all; the stylesheet drew no box for the element it did produce (see
+ *   the section above); the render laid out no box for that element, because
+ *   something between it and the root generates none; the render SKIPPED that
+ *   element, so the rectangle it still reports describes no place on the page;
+ *   the author positioned it against the VIEWPORT rather than against the page;
+ *   or an authored ancestor clips it. Each states its own case where it is
+ *   asked — the first in `measure`, which is the only one with no element to
+ *   ask anything of, and the rest in {@link declines}. Every one of them is
+ *   re-decided on every pass, so each is a refusal for as long as the render
+ *   keeps this shape rather than a permanent one.
  * - UNMEASURED — no pass has run at all, because there is no canvas root to
  *   run one against. Nothing has been asked about any container yet.
  *
@@ -205,6 +209,7 @@ import {
   canvasRootFrom,
   clippedByAncestorRect,
   layoutFragments,
+  renderSkips,
   viewportPositioned,
 } from "./geometry-dom";
 import type { SlotSource } from "./inserter";
@@ -401,6 +406,187 @@ export function centeredControlRect(rect: Rect, size: number): Rect {
   };
 }
 
+/**
+ * Whether this pass refuses to place a control on this element.
+ *
+ * The refusals that have an ELEMENT to ask about, gathered into one named
+ * question rather than left as conditions inside the measuring loop, so that
+ * loop reads as find, decide, record and each refusal keeps its own reason
+ * beside its own condition. The one refusal `measure` keeps is the one with no
+ * element at all — a container the render does not produce — which this
+ * function's signature cannot express and which is stated there instead. Every
+ * refusal here is re-decided on each pass: none is a permanent property of a
+ * container, only of the render as it currently stands.
+ *
+ * The ORDER is not arbitrary in one place. Whether the element generates a box
+ * and whether the render skips it are the same question answered differently by
+ * different engines, so the fragment count is asked first and the skip beside it
+ * states what it adds. Everything else here is independent, and asking it in
+ * another order would give the same answer.
+ *
+ * Takes the canvas root because one refusal is about the walk between this
+ * element and it, and reading it from the element again would be a second
+ * answer to a question `measure` has already settled for this pass.
+ */
+function declines(target: Element, root: HTMLElement): boolean {
+  /*
+   * The stylesheet's own condition, WHOLE, asked of the element the
+   * stylesheet would ask it of — not a second condition computed here.
+   *
+   * `emptySlotOf` decided WHICH containers this component knows about,
+   * from the document. That is a different population from the one
+   * `builder-chrome.css` draws its 44px box for, and the module docblock
+   * above depends on them being the same: a container the stylesheet
+   * declined has no box, so a control centred in its measured rectangle is
+   * centred in whatever that block happens to render instead. Both halves
+   * of the rule produce that, and both are reachable:
+   *
+   * - the ELEMENT does not qualify. A closed `core/accordion-item` is the
+   *   first-party case — an empty `children` slot inside a root that also
+   *   renders a `<summary>`, so the root is not `:empty` and measures the
+   *   summary's own height.
+   * - the ANCESTORS do not qualify. `Canvas` and this component are both
+   *   exported, so a host can compose them with no builder shell around them,
+   *   and the rule's `.nx-builder-chrome` scope then never applies to any
+   *   container in that canvas — every one of them sizeless, and every control
+   *   drawn on one a focusable button with no area.
+   *
+   * `Element.matches` evaluates the ancestor combinators as well as the
+   * compound, so one call covers the rule rather than the part of it that
+   * happens to be about this element.
+   */
+  if (!target.matches(EMPTY_CONTAINER_SELECTOR)) {
+    return true;
+  }
+  /*
+   * The render lays out no box for this element, so there is nothing on
+   * the canvas for a control to be anchored to.
+   *
+   * `getBoundingClientRect` still answers for such an element — with the
+   * zero rectangle — so measuring on would centre a square of no area at
+   * the canvas origin. That is the same focusable, named, invisible button
+   * the refusals around this one exist to prevent, arriving through an
+   * element the render kept and never laid out.
+   *
+   * An ANCESTOR is what puts a container here. Its own `display` cannot:
+   * `builder-chrome.css` gives the very selector matched above
+   * `display: block` at five compound units of specificity, outranking the
+   * three of the per-node rule an author's `display: none` or
+   * `display: contents` compiles into — measured in Chromium, a container
+   * carrying either still computed to `block` and generated its box. A
+   * node BETWEEN this one and the root is under no such rule, because a
+   * node holding a child is not `:empty`, so an author who hides a wrapper
+   * leaves every empty container inside it rendered, matching, and
+   * generating nothing. Where that rule is not in force at all the
+   * element's own keyword reaches this too, and the answer is the same.
+   *
+   * `layoutFragments` rather than a rectangle's area judged here. Whether
+   * an element generates a box is `geometry-dom.ts`'s question and
+   * `SpacingOverlay` already refuses on the same answer; the area is a
+   * consequence of it rather than a second reading, since the rule matched
+   * above draws a dashed border and a 2.75rem minimum height, so an
+   * element that generates a box measures more than nothing.
+   *
+   * Re-decided on the next pass like every refusal beside it: an edit that
+   * un-hides the wrapper changes `document`, and a recompiled sheet that
+   * does the same reaches the `MutationObserver` in `watchCanvasFor`, so
+   * either way something re-measures and the control comes back.
+   */
+  if (layoutFragments(target) === 0) {
+    return true;
+  }
+  /*
+   * The render SKIPPED this element, and the rectangle it reports for it
+   * anyway is not a place on the page.
+   *
+   * The sibling of the refusal above, for the engines that answer that one
+   * differently. A container inside a CLOSED `core/accordion-item` is the
+   * first-party case, and its `children` slot accepts any block, so an
+   * author reaches it by selecting a section in the Layers panel and
+   * inserting a `core/box`. Where the engine removes a closed disclosure's
+   * contents from the rendering, that box generates no fragment and the
+   * check above has already declined it. Where the engine gives the
+   * contents `content-visibility: hidden` instead — the rendering the HTML
+   * specification now describes — it generates ONE, full width and sized as
+   * though the section were open, sitting over the NEXT section's title.
+   * Every question asked before this one passes it: the element exists, it
+   * carries the slots marker, it is `:empty` inside a shell and a canvas, it
+   * is `static`, no ancestor clips it, and it has a fragment. A 44px control
+   * centred in that rectangle lands on a title belonging to another
+   * container, and pressing it reports an id the author did not point at.
+   *
+   * `renderSkips` rather than a computed value read here, because the
+   * element cannot see this about itself: the skip belongs to a box above
+   * it, so the container's own `content-visibility` computes to `visible`
+   * under both renderings. See `geometry-dom.ts` for what the question
+   * covers, which options it deliberately does not pass, and why an engine
+   * that cannot answer it declines nothing.
+   *
+   * Re-decided on the next pass like every refusal beside it, and the
+   * disclosure is the case worth naming: opening it is a user press on the
+   * canvas rather than an edit, so `document` does not change and nothing
+   * re-renders. What hears it is the `MutationObserver` in `watchCanvasFor`
+   * — the browser writes the `open` attribute onto the `<details>`, which is
+   * an attribute record inside the canvas root and outside this overlay's
+   * own layer — and the control appears as soon as that pass runs.
+   */
+  if (renderSkips(target)) {
+    return true;
+  }
+  /*
+   * Positioned against the VIEWPORT rather than against the page this
+   * overlay draws in, which is a container no control can be anchored to.
+   *
+   * `position` is a catalog keyword, so `fixed` and `sticky` are values an
+   * author stores like any other. Both hold the container still while the
+   * canvas content under it travels, so the square measured here slides off
+   * the container on the first scroll and comes to rest over unrelated
+   * content — taking the presses meant for that content with it, since this
+   * button is one of the two pieces of chrome that accept pointer events.
+   *
+   * Nothing corrects the drift, which is why it is refused instead of
+   * re-measured: the shell scrolls a section ABOVE the canvas root and a
+   * scroll event does not bubble, so `watchCanvasFor`'s capture-phase
+   * listener on the root reaches a scroller nested INSIDE the canvas and
+   * never hears that one.
+   *
+   * The same predicate `SpacingOverlay` refuses on, asked here rather than
+   * `position` being read a second time — see `viewportPositioned` in
+   * `geometry-dom.ts` for why that question belongs to the coordinate space
+   * rather than to either overlay.
+   */
+  if (viewportPositioned(target)) {
+    return true;
+  }
+  /*
+   * Excluded outright rather than measured. `clippedByAncestorRect`
+   * answers "is this element's own rectangle cut by an authored ancestor
+   * between it and the root" — a clipped container's DOM is cut where
+   * this overlay is not, so a control measured from its un-clipped
+   * rectangle would be drawn over whatever the page actually shows at
+   * that position.
+   *
+   * The RECT question rather than `clippedByAncestor`'s corner-aware one.
+   * That refinement exists for a caller drawing chrome flush against a
+   * block's edges — a spacing band runs the full length of one and does
+   * reach the corners — and this control does not: it is a fixed square
+   * anchored to the container's CENTRE, nowhere near a corner unless the
+   * container itself is barely larger than the control. Measured against
+   * an ordinary full-width child sitting flush inside a rounded, clipping
+   * parent — `core/box` directly inside `core/card`, ordinary enough that
+   * `card.tsx` names it the commonest composition in the library — the
+   * two curves genuinely disagree by a few pixels at each corner, which
+   * `clippedByAncestor` correctly reports and which is irrelevant to
+   * anything drawn away from the corners. Asking the corner-aware
+   * question here would decline the control for exactly the composition
+   * an author reaches for most.
+   */
+  if (clippedByAncestorRect(target, root)) {
+    return true;
+  }
+  return false;
+}
+
 export interface EmptyContainerAppendersProps {
   /** The document to scan for containers with nothing in them. */
   document: BlockDocument;
@@ -490,133 +676,16 @@ export function EmptyContainerAppenders({
        * which is the `root === null` return above and the one case where a
        * control genuinely is waiting to be placed.
        *
-       * Re-decided on the next pass exactly like the three refusals below: a
-       * container that starts rendering — a condition that begins to hold, an
-       * edit that gives the node markup — gets its control back as soon as
+       * Re-decided on the next pass exactly like every refusal in `declines`:
+       * a container that starts rendering — a condition that begins to hold,
+       * an edit that gives the node markup — gets its control back as soon as
        * anything re-measures.
        */
       if (target === null) {
         next.set(container.id, DECLINED);
         continue;
       }
-      /*
-       * The stylesheet's own condition, WHOLE, asked of the element the
-       * stylesheet would ask it of — not a second condition computed here.
-       *
-       * `emptySlotOf` decided WHICH containers this component knows about,
-       * from the document. That is a different population from the one
-       * `builder-chrome.css` draws its 44px box for, and the module docblock
-       * above depends on them being the same: a container the stylesheet
-       * declined has no box, so a control centred in its measured rectangle is
-       * centred in whatever that block happens to render instead. Both halves
-       * of the rule produce that, and both are reachable:
-       *
-       * - the ELEMENT does not qualify. A closed `core/accordion-item` is the
-       *   first-party case — an empty `children` slot inside a root that also
-       *   renders a `<summary>`, so the root is not `:empty` and measures the
-       *   summary's own height.
-       * - the ANCESTORS do not qualify. `Canvas` and this component are both
-       *   exported, so a host can compose them with no builder shell around
-       *   them, and the rule's `.nx-builder-chrome` scope then never applies to
-       *   any container in that canvas — every one of them sizeless, and every
-       *   control drawn on one a focusable button with no area.
-       *
-       * `Element.matches` evaluates the ancestor combinators as well as the
-       * compound, so one call covers the rule rather than the part of it that
-       * happens to be about this element.
-       */
-      if (!target.matches(EMPTY_CONTAINER_SELECTOR)) {
-        next.set(container.id, DECLINED);
-        continue;
-      }
-      /*
-       * The render lays out no box for this element, so there is nothing on
-       * the canvas for a control to be anchored to.
-       *
-       * `getBoundingClientRect` still answers for such an element — with the
-       * zero rectangle — so measuring on would centre a square of no area at
-       * the canvas origin. That is the same focusable, named, invisible button
-       * the refusals around this one exist to prevent, arriving through an
-       * element the render kept and never laid out.
-       *
-       * An ANCESTOR is what puts a container here. Its own `display` cannot:
-       * `builder-chrome.css` gives the very selector matched above
-       * `display: block` at five compound units of specificity, outranking the
-       * three of the per-node rule an author's `display: none` or
-       * `display: contents` compiles into — measured in Chromium, a container
-       * carrying either still computed to `block` and generated its box. A
-       * node BETWEEN this one and the root is under no such rule, because a
-       * node holding a child is not `:empty`, so an author who hides a wrapper
-       * leaves every empty container inside it rendered, matching, and
-       * generating nothing. Where that rule is not in force at all the
-       * element's own keyword reaches this too, and the answer is the same.
-       *
-       * `layoutFragments` rather than a rectangle's area judged here. Whether
-       * an element generates a box is `geometry-dom.ts`'s question and
-       * `SpacingOverlay` already refuses on the same answer; the area is a
-       * consequence of it rather than a second reading, since the rule matched
-       * above draws a dashed border and a 2.75rem minimum height, so an
-       * element that generates a box measures more than nothing.
-       *
-       * Re-decided on the next pass like every refusal beside it: an edit that
-       * un-hides the wrapper changes `document`, and a recompiled sheet that
-       * does the same reaches the `MutationObserver` in `watchCanvasFor`, so
-       * either way something re-measures and the control comes back.
-       */
-      if (layoutFragments(target) === 0) {
-        next.set(container.id, DECLINED);
-        continue;
-      }
-      /*
-       * Positioned against the VIEWPORT rather than against the page this
-       * overlay draws in, which is a container no control can be anchored to.
-       *
-       * `position` is a catalog keyword, so `fixed` and `sticky` are values an
-       * author stores like any other. Both hold the container still while the
-       * canvas content under it travels, so the square measured here slides off
-       * the container on the first scroll and comes to rest over unrelated
-       * content — taking the presses meant for that content with it, since this
-       * button is one of the two pieces of chrome that accept pointer events.
-       *
-       * Nothing corrects the drift, which is why it is refused instead of
-       * re-measured: the shell scrolls a section ABOVE the canvas root and a
-       * scroll event does not bubble, so `watchCanvasFor`'s capture-phase
-       * listener on the root reaches a scroller nested INSIDE the canvas and
-       * never hears that one.
-       *
-       * The same predicate `SpacingOverlay` refuses on, asked here rather than
-       * `position` being read a second time — see `viewportPositioned` in
-       * `geometry-dom.ts` for why that question belongs to the coordinate space
-       * rather than to either overlay.
-       */
-      if (viewportPositioned(target)) {
-        next.set(container.id, DECLINED);
-        continue;
-      }
-      /*
-       * Excluded outright rather than measured. `clippedByAncestorRect`
-       * answers "is this element's own rectangle cut by an authored ancestor
-       * between it and the root" — a clipped container's DOM is cut where
-       * this overlay is not, so a control measured from its un-clipped
-       * rectangle would be drawn over whatever the page actually shows at
-       * that position.
-       *
-       * The RECT question rather than `clippedByAncestor`'s corner-aware one.
-       * That refinement exists for a caller drawing chrome flush against a
-       * block's edges — a spacing band runs the full length of one and does
-       * reach the corners — and this control does not: it is a fixed square
-       * anchored to the container's CENTRE, nowhere near a corner unless the
-       * container itself is barely larger than the control. Measured against
-       * an ordinary full-width child sitting flush inside a rounded, clipping
-       * parent — `core/box` directly inside `core/card`, ordinary enough that
-       * `card.tsx` names it the commonest composition in the library — the
-       * two curves genuinely disagree by a few pixels at each corner, which
-       * `clippedByAncestor` correctly reports and which is irrelevant to
-       * anything drawn away from the corners. Asking the corner-aware
-       * question here would decline the control for exactly the composition
-       * an author reaches for most.
-       */
-      if (clippedByAncestorRect(target, root)) {
+      if (declines(target, root)) {
         next.set(container.id, DECLINED);
         continue;
       }

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -964,22 +964,52 @@ describe("an ancestor that does not clip at all", () => {
 
 describe("whether the render skips an element", () => {
   /**
-   * A `checkVisibility` of a chosen answer, and its absence afterwards.
+   * The `checkVisibility` the RUNTIME brought, read before any case replaces it.
    *
-   * jsdom implements none, which is asserted rather than assumed: this
-   * function's whole contract is what it does when the method is missing, and a
-   * runtime that had one would leave the absent case below untestable while
-   * still reporting green.
+   * `Element.prototype` is where the method is defined when it exists — an own,
+   * writable, enumerable, configurable data property, per the CSSOM View
+   * `partial interface Element` — so the teardown below has to put a real one
+   * back rather than delete. jsdom implements none today, which makes this
+   * `undefined` and the restore a deletion.
    */
-  function answering(visible: boolean): void {
-    expect(
-      Object.getOwnPropertyDescriptor(Element.prototype, "checkVisibility")
-    ).toBeUndefined();
+  const RUNTIME_CHECK_VISIBILITY = Object.getOwnPropertyDescriptor(
+    Element.prototype,
+    "checkVisibility"
+  );
+
+  /**
+   * What `checkVisibility` answers for every element in a case — or, as
+   * `undefined`, that there is no such method to ask.
+   *
+   * All three inputs to {@link renderSkips} are SUPPLIED rather than inherited
+   * from whatever the test runtime happens to implement, and the absent one is
+   * the reason: it is the behaviour on an engine older than Chrome 105, Firefox
+   * 106 or Safari 17.4, it does not stop being reachable when the runtime grows
+   * an implementation of its own, and a case that reached it by merely
+   * installing nothing would be satisfied just as well by a runtime whose
+   * method answers `true` — which is the case two below.
+   */
+  function runtimeAnswering(visible: boolean | undefined): void {
+    if (visible === undefined) {
+      Reflect.deleteProperty(Element.prototype, "checkVisibility");
+      return;
+    }
     Element.prototype.checkVisibility = () => visible;
   }
 
+  // Whatever a case supplied is dropped and the runtime's own method put back:
+  // the captured descriptor where there was one, and its absence where there
+  // was not.
   afterEach(() => {
-    Reflect.deleteProperty(Element.prototype, "checkVisibility");
+    if (RUNTIME_CHECK_VISIBILITY === undefined) {
+      Reflect.deleteProperty(Element.prototype, "checkVisibility");
+    } else {
+      Object.defineProperty(
+        Element.prototype,
+        "checkVisibility",
+        RUNTIME_CHECK_VISIBILITY
+      );
+    }
   });
 
   it("reports NOT skipped where the runtime cannot answer", () => {
@@ -993,16 +1023,17 @@ describe("whether the render skips an element", () => {
      * The two cases below are what make this a statement about the ABSENCE
      * rather than about a function that answers `false` unconditionally.
      */
+    runtimeAnswering(undefined);
     expect(renderSkips(document.createElement("div"))).toBe(false);
   });
 
   it("reports skipped when the runtime says the element is not visible", () => {
-    answering(false);
+    runtimeAnswering(false);
     expect(renderSkips(document.createElement("div"))).toBe(true);
   });
 
   it("reports NOT skipped when the runtime says the element is visible", () => {
-    answering(true);
+    runtimeAnswering(true);
     expect(renderSkips(document.createElement("div"))).toBe(false);
   });
 });

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -27,6 +27,7 @@ import {
   canvasRootFrom,
   hasScrollbarGutter,
   overflowApplies,
+  renderSkips,
   viewportPositioned,
 } from "./geometry-dom";
 
@@ -958,5 +959,50 @@ describe("an ancestor that does not clip at all", () => {
 
     expect(clippedByAncestorRect(child, root)).toBe(false);
     expect(clippedByAncestor(child, root, SQUARE_CORNERS)).toBe(false);
+  });
+});
+
+describe("whether the render skips an element", () => {
+  /**
+   * A `checkVisibility` of a chosen answer, and its absence afterwards.
+   *
+   * jsdom implements none, which is asserted rather than assumed: this
+   * function's whole contract is what it does when the method is missing, and a
+   * runtime that had one would leave the absent case below untestable while
+   * still reporting green.
+   */
+  function answering(visible: boolean): void {
+    expect(
+      Object.getOwnPropertyDescriptor(Element.prototype, "checkVisibility")
+    ).toBeUndefined();
+    Element.prototype.checkVisibility = () => visible;
+  }
+
+  afterEach(() => {
+    Reflect.deleteProperty(Element.prototype, "checkVisibility");
+  });
+
+  it("reports NOT skipped where the runtime cannot answer", () => {
+    /*
+     * The availability posture, stated as a test rather than left to a
+     * docblock. `checkVisibility` is absent before Chrome 105, Firefox 106 and
+     * Safari 17.4, and the answer there is the one that changes nothing: a
+     * caller that refused on absence would delete an affordance from every
+     * element on such a runtime, on no evidence about any of them.
+     *
+     * The two cases below are what make this a statement about the ABSENCE
+     * rather than about a function that answers `false` unconditionally.
+     */
+    expect(renderSkips(document.createElement("div"))).toBe(false);
+  });
+
+  it("reports skipped when the runtime says the element is not visible", () => {
+    answering(false);
+    expect(renderSkips(document.createElement("div"))).toBe(true);
+  });
+
+  it("reports NOT skipped when the runtime says the element is visible", () => {
+    answering(true);
+    expect(renderSkips(document.createElement("div"))).toBe(false);
   });
 });

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -296,6 +296,65 @@ export function layoutFragments(element: Element): number {
 }
 
 /**
+ * Whether the render SKIPS this element, so a rectangle read from it describes
+ * nothing that is on the page.
+ *
+ * `getBoundingClientRect` and `getClientRects` answer for a skipped element as
+ * readily as for a drawn one, and what they answer is not always the zero
+ * rectangle {@link layoutFragments} refuses on. A closed `<details>` is the
+ * case that makes the difference visible: an engine that removes the contents
+ * from the rendering reports NO fragments for a descendant, while one that
+ * gives the contents `content-visibility: hidden` — which is what the HTML
+ * rendering section now describes — reports ONE, sized and positioned as though
+ * the disclosure were open. That rectangle overlaps whatever the page actually
+ * draws at those coordinates, so chrome anchored to it is chrome placed on
+ * somebody else's content.
+ *
+ * The element cannot answer this about itself. The skip is a property of a box
+ * ABOVE it — for a disclosure, the `::details-content` box the engine generates
+ * for the parent — so the element's own computed `content-visibility` reads
+ * `visible` throughout, and no property read from the element separates the two
+ * renderings.
+ *
+ * `checkVisibility()` is the standard question and it is asked with NO options,
+ * which is a narrowing rather than a default. Un-optioned it refuses exactly
+ * two things: an element with no box at all, and an element under an ancestor
+ * with `content-visibility: hidden`. Each option would widen it to "is this
+ * PAINTED", which is a different question and the wrong one here:
+ *
+ * - `contentVisibilityAuto` refuses a subtree the engine is skipping only
+ *   because it is off-screen. The box is real, reserved in flow and correctly
+ *   placed; the skip ends when it is scrolled to. Nothing between the canvas
+ *   root and the window reports that scroll, so a refusal taken on it would not
+ *   be re-decided when it stopped being true.
+ * - `opacityProperty` (and its historical alias `checkOpacity`) refuses a
+ *   transparent element. A transparent element still lays out where it says it
+ *   does and still takes pointer events, so chrome anchored to it is anchored
+ *   correctly.
+ * - `visibilityProperty` (`checkVisibilityCSS`) refuses `visibility: hidden`,
+ *   which likewise reserves its box in flow at the position it reports.
+ *
+ * An ancestor walk for a closed disclosure — `closest("details:not([open])")` —
+ * needs no new API and is rejected on two counts. It identifies the case by one
+ * element's spelling rather than by the property that makes it wrong, so it
+ * says nothing about `content-visibility: hidden` arriving any other way; and
+ * it over-refuses, because a `<summary>` and its descendants are rendered while
+ * the disclosure is closed and are inside that same `<details>`.
+ *
+ * An engine with no `checkVisibility` reports NOT SKIPPED, so it behaves as it
+ * did before this question existed. That is a deliberate posture rather than a
+ * fallback: the method predates the author-visible `::details-content` in every
+ * engine that ships it, and an engine old enough to lack the method removes a
+ * closed disclosure's contents from the rendering instead, where the fragment
+ * count already answers. Refusing on absence would instead delete an affordance
+ * from every container on such an engine, on no evidence at all.
+ */
+export function renderSkips(element: Element): boolean {
+  if (typeof element.checkVisibility !== "function") return false;
+  return !element.checkVisibility();
+}
+
+/**
  * The cumulative transform between an element and the canvas root, reduced to
  * the two things axis-aligned chrome can use.
  *


### PR DESCRIPTION
## What and why

An empty container inside a **closed** `core/accordion-item` was offered an add-control that the author could not see and that intercepted clicks on the **next** section's title.

`accordion-item` renders `<details><summary>{title}</summary>{renderSlot("children")}</details>` and its own `defaultProps` are `{ open: false }`. Its `children` slot has no `allow` restriction, so any container may sit inside it — an author selects the item in the Layers panel, inserts a `core/box`, and the box is empty inside a closed disclosure.

Chrome 131+ ships `::details-content { content-visibility: hidden }`, so the browser **skips** that subtree while still reporting a box for it. Measured on the real admin route (HeadlessChrome/152):

```
box-inside  matches(EMPTY_CONTAINER_SELECTOR)          true
            getClientRects().length                    1        <- layoutFragments() passes
            rect                                       {48, 72, 911, 44}
            position static, no clipping ancestor      <- every other refusal passes
            getComputedStyle(box).contentVisibility     "visible"
            checkVisibility()                          false
            elementFromPoint(centre)                -> SUMMARY "Second section"
item-1      computed ::details-content contentVisibility "hidden"
```

Every refusal the appender had accepted that box. A 44×44 control centred in that rectangle sits on the next item's title, so clicking that title fires `onAppend` for the wrong container — the author's block lands in a section they did not choose, with nothing visible to explain it.

**Two properties make this worse than it reads, and both are in the code comment:**

- **The element cannot see its own state.** `getComputedStyle(box).contentVisibility` reads `"visible"` — the skip lives on the *parent's* `::details-content` pseudo-element, so a computed-style check on the target is blind to it.
- **It is engine- and version-dependent.** The older `display: none` behaviour yields **zero** client rects, where the existing `layoutFragments` refusal already fires correctly. So this works in one engine and hijacks clicks in another, which is worse than failing everywhere.

## How

`renderSkips(element)` in `geometry-dom.ts` wraps `Element.checkVisibility()` — **with no options, deliberately.** The spec's unconditional step 2 is the `content-visibility: hidden` ancestor, which is exactly this case. Every flag widens the question to "is it painted", which is the wrong one: `contentVisibilityAuto` would refuse an off-screen subtree whose box is real and correctly placed, and `opacityProperty`/`visibilityProperty` would refuse elements that reserve their box in flow at the position they report — and the control paints in the overlay layer, so a container's own opacity never hides it.

**Where the method is absent, the answer is "do not refuse" — draw, as today.** This matches the existing `ResizeObserver` posture, and it is safe by construction rather than by hope: `checkVisibility` predates `::details-content` in all three engines (Chrome 105 vs 131, Firefox 106 vs 143, Safari 17.4 vs 18.4), so an engine old enough to lack the method removes a closed disclosure's contents from the rendering entirely and `layoutFragments === 0` already answers there. Refusing on absence would delete the affordance from every container on such an engine on no evidence. **This posture is a test, not a docblock claim.**

## The alternative was rejected on a measurement, not on style

`closest("details:not([open])")` is deterministic and needs no new API, so it deserved a real comparison. It is wrong: a `<span>` appended into the `<summary>` of a closed item reports `checkVisibility() === true` and one client rect — a summary is rendered *while* its disclosure is closed — yet the ancestor walk returns the item and would refuse it. **It refuses an element the browser is drawing.** That plus its blindness to `content-visibility: hidden` from any other source settles it. Filed as `finding:ancestor-walk-over-refuses-a-summary`.

## Re-decidability, measured rather than assumed

Opening the disclosure must bring the control back, and something must hear it. It does: the browser writes the `open` attribute onto the `<details>`, which is an `attributes` record inside the canvas root and outside the overlay's own layer, so `watchCanvasFor`'s `MutationObserver` fires. Break-verified — setting `attributes: false` fails **only** the re-decidability test.

## Test plan

`packages/builder` **2139 → 2144** (+2 appender, +3 geometry-dom). Root `check-types`, root `lint`, `changeset status`, and `fallow audit` (`pass`, zero introduced in all four categories) all exit 0.

Each behaviour break-verified, every substitution asserting exactly one occurrence first and restoring byte-for-byte:

| break | fails |
|---|---|
| delete the `renderSkips` guard | the 2 new appender tests, nothing else |
| `renderSkips` → `true` | the open-section control, and the runtime-says-visible test |
| absent-API branch → `true` | `reports NOT skipped where the runtime cannot answer` |
| `attributes: false` in the observer | only `draws the control as soon as the disclosure is opened` |
| leave the test stub installed | the harness's own absence assertion |

**Verified in a real browser on the real admin route**, because jsdom provably cannot see this — it reports zero client rects for *every* element, laid out or not, so it cannot discriminate. A page was seeded through the API as `core/accordion` > two closed `core/accordion-item`s with an empty `core/box` in the first, plus a loose empty `core/box` as a positive control. While closed, the only control drawn was the loose box's. A **real mouse click** on the first summary flipped `checkVisibility()` to `true` and the control appeared, with no React render behind it; clicking again removed it. Console clean. Page deleted, browser closed, port freed.

## Structure

Adding a seventh sequential guard to `measure` tipped it to `cyclomatic: 10` and **failed `fallow audit` on introduced complexity**. The offered remedy is an inline complexity suppression, which `AGENTS.md` forbids for the same reason it forbids `eslint-disable`. The five element-level refusals are extracted into `declines(target, root)` instead, comments carried verbatim. The `target === null` refusal stays in `measure` — it has no element, so the extracted signature cannot express it — and both docblocks say so. That extraction is why the appender diff is larger than the fix.

The module docblock's hand-maintained "five reasons" count is replaced by the list itself rather than incremented to six.

## Not verified

The exact Chrome/Safari version at which the internal slot switched to `content-visibility: hidden`, independently of exposing `::details-content`, could not be sourced; only Firefox is dated (bug 1724299, FF 139). If Chrome switched internally before 105, a residual gap exists that this instrument cannot close. Stated rather than assumed away.

## Changeset

Added: yes (`patch`, all published packages).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved builder behavior for content inside closed disclosures and other hidden elements.
  * Controls are now omitted when content is not rendered, preventing inaccurate placement or measurement.
  * Controls appear correctly when a disclosure is opened, including dynamically opened disclosures.
  * Improved handling of elements that cannot be measured due to layout, viewport, or clipping conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->