### PR TITLE
fix(nextly): read an empty rich-text document as an absence in the diff

### DIFF
--- a/.changeset/rich-text-empty-is-absent.md
+++ b/.changeset/rich-text-empty-is-absent.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Read an empty rich-text document as an absence in the version diff, so a
+field moving between `null` and Lexical's canonical empty document no longer
+reports as added or removed, and no longer renders a blank added block.

--- a/packages/nextly/src/domains/versions/diff/__tests__/rich-text-node.test.ts
+++ b/packages/nextly/src/domains/versions/diff/__tests__/rich-text-node.test.ts
@@ -51,6 +51,47 @@ function doc(paragraphs: string[]) {
 
 const meta = { name: "content", label: "Content", type: "richText" };
 
+/** Lexical's canonical empty document: a root with no children at all. */
+function emptyDoc() {
+  return {
+    root: {
+      type: "root",
+      version: 1,
+      format: "",
+      indent: 0,
+      direction: "ltr",
+      children: [],
+    },
+  };
+}
+
+/**
+ * The OTHER canonical empty document — what Lexical actually emits once an
+ * author deletes the last content, which is a single paragraph with nothing
+ * in it rather than a bare root.
+ */
+function emptyParagraphDoc() {
+  return {
+    root: {
+      type: "root",
+      version: 1,
+      format: "",
+      indent: 0,
+      direction: "ltr",
+      children: [
+        {
+          type: "paragraph",
+          version: 1,
+          format: "",
+          indent: 0,
+          direction: "ltr",
+          children: [],
+        },
+      ],
+    },
+  };
+}
+
 describe("richTextNode — structure", () => {
   it("reports an added paragraph as one added block, leaving the rest alone", () => {
     const node = richTextNode(meta, doc(["A"]), doc(["A", "B"]));
@@ -442,5 +483,71 @@ describe("richTextNode — blocks that read alike", () => {
   it("IDEMPOTENCE: three blocks that read alike compare equal to themselves", () => {
     const same = links(["/a", "/b", "/c"]);
     expect(richTextNode(meta, same, same).status).toBe("unchanged");
+  });
+});
+
+describe("richTextNode — an empty document is an absence, not content", () => {
+  /**
+   * An optional rich-text field has two ways of holding nothing. It stores
+   * `null` when it was never filled in, and it stores one of Lexical's
+   * canonical empty documents once an author has typed and then deleted
+   * everything. Both mean "there is nothing here", and only the first used to
+   * be read that way — so moving between them reported a field ADDED or
+   * REMOVED, and rendered an added blank block, for an edit that changed
+   * nothing a reader can see.
+   *
+   * Asserted in both directions, because presence is asymmetric: the bug
+   * produces `added` one way and `removed` the other, and a test fixing only
+   * one leaves the mirror image live.
+   */
+  for (const [label, empty] of [
+    ["a root with no children", emptyDoc],
+    ["a single empty paragraph", emptyParagraphDoc],
+  ] as const) {
+    it(`treats ${label} and null as the same absence`, () => {
+      const filled = richTextNode(meta, null, empty());
+      const emptied = richTextNode(meta, empty(), null);
+      expect(filled.status).toBe("unchanged");
+      expect(emptied.status).toBe("unchanged");
+      // The other half of the defect. A status of `unchanged` with a blank
+      // block still in the list renders an empty added row, so the field
+      // reports no change while showing one.
+      expect(filled.blocks).toEqual([]);
+      expect(emptied.blocks).toEqual([]);
+    });
+
+    it(`reports filling ${label} as added, not changed`, () => {
+      const node = richTextNode(meta, empty(), doc(["First"]));
+      expect(node.status).toBe("added");
+    });
+
+    it(`reports emptying a field to ${label} as removed, not changed`, () => {
+      const node = richTextNode(meta, doc(["First"]), empty());
+      expect(node.status).toBe("removed");
+    });
+  }
+
+  /**
+   * The control, and the reason the emptiness test is defined over PARSED
+   * blocks rather than over the raw JSON. `isRichTextEmpty` in the admin
+   * package treats any object without a `root` as empty, which is right for a
+   * required-field gate and wrong here: a present but malformed document is
+   * not an absence, it is something this diff cannot read, and collapsing the
+   * two would take the refusal off the screen.
+   */
+  it("still refuses a malformed document rather than calling it absent", () => {
+    const node = richTextNode(meta, { not: "a document" }, doc(["First"]));
+    expect(node.status).toBe("changed");
+    expect(node.blocks.some(b => b.status === "unsupported")).toBe(true);
+  });
+
+  /**
+   * The other control. A paragraph that holds even one character is content,
+   * so the emptiness test must not swallow it — otherwise a real edit between
+   * two short documents would report as unchanged and vanish from the view.
+   */
+  it("does not treat a paragraph with text as empty", () => {
+    expect(richTextNode(meta, null, doc(["x"])).status).toBe("added");
+    expect(richTextNode(meta, doc(["x"]), doc(["y"])).status).toBe("changed");
   });
 });

--- a/packages/nextly/src/domains/versions/diff/__tests__/rich-text-node.test.ts
+++ b/packages/nextly/src/domains/versions/diff/__tests__/rich-text-node.test.ts
@@ -519,11 +519,18 @@ describe("richTextNode — an empty document is an absence, not content", () => 
     it(`reports filling ${label} as added, not changed`, () => {
       const node = richTextNode(meta, empty(), doc(["First"]));
       expect(node.status).toBe("added");
+      // The BLOCKS have to agree with the field. An absent side that still
+      // contributes its empty paragraph pairs it against the new text, so the
+      // block reports `changed` with incidental attribute differences while
+      // the field reports `added` — and the view renders the block status, so
+      // the reader is shown a Changed row on a field that was just filled.
+      expect(node.blocks.map(b => b.status)).toEqual(["added"]);
     });
 
     it(`reports emptying a field to ${label} as removed, not changed`, () => {
       const node = richTextNode(meta, doc(["First"]), empty());
       expect(node.status).toBe("removed");
+      expect(node.blocks.map(b => b.status)).toEqual(["removed"]);
     });
   }
 

--- a/packages/nextly/src/domains/versions/diff/rich-text-node.ts
+++ b/packages/nextly/src/domains/versions/diff/rich-text-node.ts
@@ -298,16 +298,17 @@ export function richTextNode(
     return refuse(meta, presenceStatus(beforeAbsent, afterAbsent, "changed"));
   }
 
-  // Both sides hold nothing, so there is nothing to show and nothing changed.
-  // Returned before the block comparison rather than after, because comparing
-  // `[]` against Lexical's empty paragraph yields one ADDED block — a blank
-  // row rendered into the diff for an edit that changed nothing a reader can
-  // see, which is the other half of reading an empty document as content.
-  if (beforeAbsent && afterAbsent) {
-    return { ...meta, kind: "richText", status: "unchanged", blocks: [] };
-  }
+  // An absent side contributes NO blocks, whichever spelling it arrived in.
+  // Both views then derive from one absence decision: the field status and the
+  // block statuses cannot contradict each other. Left as its parsed blocks, an
+  // empty paragraph pairs against the other side's content and reports the
+  // block `changed` — with incidental attribute differences — while the field
+  // reports `added`, and the view renders the block. It is also what keeps a
+  // blank row out of the diff when both sides are absent.
+  const beforeCompared = beforeAbsent ? [] : beforeBlocks;
+  const afterCompared = afterAbsent ? [] : afterBlocks;
 
-  const blocks = compareBlocks(beforeBlocks, afterBlocks);
+  const blocks = compareBlocks(beforeCompared, afterCompared);
   // Too large to align. Unlike the case above this says nothing about presence
   // either, since both sides were readable documents.
   if (blocks === null) return refuse(meta, "changed");

--- a/packages/nextly/src/domains/versions/diff/rich-text-node.ts
+++ b/packages/nextly/src/domains/versions/diff/rich-text-node.ts
@@ -226,23 +226,85 @@ function compareBlocks(
   });
 }
 
+/**
+ * Whether a parsed document carries anything a reader would see.
+ *
+ * The two shapes Lexical calls empty: a root with no children, and the single
+ * childless paragraph it leaves behind when the last content is deleted. A
+ * paragraph is only empty when it holds no text, no attributes and nothing
+ * unsupported — anything richer is content, and treating it as an absence
+ * would make a real edit report unchanged and drop it from the view.
+ */
+function carriesNoContent(value: unknown, blocks: ComparableBlock[]): boolean {
+  if (blocks.length === 0) return true;
+  if (blocks.length > 1) return false;
+  return isSingleEmptyParagraph(value);
+}
+
+/**
+ * The document Lexical leaves behind when the last content is deleted.
+ *
+ * Read from the document rather than from the walked block, and the difference
+ * matters. Every paragraph walks to the same structural attributes — `.type`,
+ * `.format`, `.indent` — so "no attributes" is never true, and the looser test
+ * that remains, an empty `text`, is also true of a paragraph holding only an
+ * image. That would report a real edit as unchanged and drop it from the view.
+ * Emptiness here is the absence of CHILDREN, which is the same shape the
+ * admin package's `isRichTextEmpty` recognises.
+ */
+function isSingleEmptyParagraph(value: unknown): boolean {
+  const root = (value as { root?: { children?: unknown[] } } | null | undefined)
+    ?.root;
+  const children = root?.children;
+  if (!Array.isArray(children) || children.length !== 1) return false;
+  const only = children[0] as
+    | { type?: string; children?: unknown[] }
+    | null
+    | undefined;
+  return (
+    only?.type === "paragraph" &&
+    Array.isArray(only.children) &&
+    only.children.length === 0
+  );
+}
+
 export function richTextNode(
   meta: NodeMeta,
   before: unknown,
   after: unknown
 ): RichTextFieldDiff {
-  // A field never filled in stores null. That is an absence with a known
-  // meaning rather than something unreadable, so it projects as an empty
-  // document and the other side reads as an addition or a removal.
-  const beforeAbsent = before == null;
-  const afterAbsent = after == null;
-  const beforeBlocks = beforeAbsent ? [] : toComparableBlocks(before);
-  const afterBlocks = afterAbsent ? [] : toComparableBlocks(after);
+  // A field holding nothing has two spellings. It stores null when it was
+  // never filled in, and one of Lexical's canonical empty documents once an
+  // author has typed and then deleted everything. Both are absences, and
+  // reading only the first that way reported a field added or removed — and
+  // rendered an added blank block — for an edit a reader cannot see.
+  const beforeBlocks = before == null ? [] : toComparableBlocks(before);
+  const afterBlocks = after == null ? [] : toComparableBlocks(after);
+  // Asked of the PARSED blocks rather than the raw value, which is what keeps
+  // a malformed document out of it. `toComparableBlocks` answers null for
+  // anything it cannot read, and null is not absent: the field is present and
+  // holds something this diff cannot project, which the refusal below states.
+  // The admin package's `isRichTextEmpty` treats any object without a `root`
+  // as empty — correct for a required-field gate, wrong here, because it
+  // would take the refusal off the screen.
+  const beforeAbsent =
+    beforeBlocks !== null && carriesNoContent(before, beforeBlocks);
+  const afterAbsent =
+    afterBlocks !== null && carriesNoContent(after, afterBlocks);
 
   // A side that is PRESENT but not a rich-text document at all. Its content
   // cannot be projected, but which sides held anything still can be.
   if (beforeBlocks === null || afterBlocks === null) {
     return refuse(meta, presenceStatus(beforeAbsent, afterAbsent, "changed"));
+  }
+
+  // Both sides hold nothing, so there is nothing to show and nothing changed.
+  // Returned before the block comparison rather than after, because comparing
+  // `[]` against Lexical's empty paragraph yields one ADDED block — a blank
+  // row rendered into the diff for an edit that changed nothing a reader can
+  // see, which is the other half of reading an empty document as content.
+  if (beforeAbsent && afterAbsent) {
+    return { ...meta, kind: "richText", status: "unchanged", blocks: [] };
   }
 
   const blocks = compareBlocks(beforeBlocks, afterBlocks);


### PR DESCRIPTION
Closes a **P1** from Codex on #1242 (merged), found by widening the watcher to this lane's merged PRs — a merged PR reads as finished, so nobody re-reads it.

## What was wrong

An optional rich-text field has **two** ways of holding nothing:

- `null` — never filled in
- one of Lexical's canonical empty documents — a root with no children, or the single childless paragraph left behind once an author deletes the last content

Only `null` was read as an absence. So moving between the two reported the field **added** or **removed**, and rendered a **blank added block**: a visible change in the diff for an edit a reader cannot see.

## The fix, and the two things that shaped it

**Presence is asked of the PARSED blocks, not the raw value.** `toComparableBlocks` answers `null` for anything it cannot read, and `null` is not an absence — the field is present and holds something the diff cannot project, which the existing refusal states. The admin package's `isRichTextEmpty` treats *any object without a `root`* as empty: right for a required-field gate, wrong here, because it would take that refusal off the screen. Two pre-existing tests catch that break.

**The empty paragraph is recognised by its lack of CHILDREN, not by its walked block.** My first attempt tested the block and was wrong, which measuring showed:

```
{"blockType":"paragraph","text":"","attrs":{".type":"paragraph",".format":"",".indent":0},"unsupported":false}
```

Every paragraph carries those structural attrs, so "no attributes" is never true. And the looser test that remains — an empty `text` — is **also true of a paragraph holding only an image**, which would report a real edit as unchanged and drop it from the view.

**Where both sides are absent the comparison is skipped entirely**, because comparing `[]` against the empty paragraph yields one `added` block — the blank row this fixes.

## Verification

Both directions, because presence is asymmetric: the bug produces `added` one way and `removed` the other, and a test fixing only one leaves the mirror image live.

Break-verified:

| break | caught by |
|---|---|
| revert absence to `null`-only | the four null-vs-empty cases |
| treat a malformed document as absent | *still refuses a malformed document*, **plus two pre-existing tests** |

Controls that must keep passing: a malformed document still refuses, and a paragraph with one character is still content.

`check-types` pass · `lint` pass · `fallow` pass (0 introduced) · 152/152 in the diff suite · changeset validated by the repo's own gate.

## Disclosure: pushed with `--no-verify`, with the founder's per-case authorisation

The pre-push gate runs `turbo test --filter=nextly`, which **fails on `main` independently of this change**. Measured rather than assumed — the same command on this commit and on its base, comparing the failing FILE SETS, not just counts:

```
with this change: 32 failed | 739 passed
base (HEAD~1):    32 failed | 739 passed
files failing only with my change:  none
files failing only on base:         none
```

Root cause is older and wider than this PR: ~98 files under `packages/nextly/src` import `@nextly/*`, a package scope renamed to `@nextlyhq/*` long ago. It is in no `package.json` and no lockfile entry, and `require.resolve` fails on it. Independently reproduced by two other lanes; `live-preview` measured the same wall and is blocked by it.

`pb-editor` is landing the proper repair — one shared list of not-yet-green packages read by **both** `ci.yml` and `gate-scope.mjs`, with any skip **named in the report** rather than silently passing. That is the right fix and it is theirs; this PR does not touch it.