### PR TITLE
fix(builder): measure the caret before the editor replaces the passage

### DIFF
--- a/.changeset/inline-caret-and-group-labels.md
+++ b/.changeset/inline-caret-and-group-labels.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Place the caret where an author clicked, in a passage the editor restyles.
+
+Opening an inline edit replaces the passage's markup and applies the editor's own theme, so a heading's size, a list's indentation and a table's box can all change the moment editing begins. The click position was being measured after that, against a layout nobody had seen — so in any passage whose appearance changes, the caret could land on an unrelated character or at the end. It is measured now at the last moment the page still shows what the author clicked.
+
+A page description also includes the labels on a button group. Every one is drawn on the page, and each is stored in a place the walk that flattens a passage to plain text never read, so a passage offering "Basic" and "Pro" described the page without them. Read in the shared walk, so search indexing and the crawler description agree.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -498,6 +498,7 @@ export { authoredBreakpoints, inCascadeOrder } from "./style/breakpoint-set";
 export {
   isAllowedRemoteUrl,
   isFetchableUrl,
+  isLinkableUrl,
   isRemoteUrl,
   normalizeUrl,
   type RemotePattern,

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -327,6 +327,36 @@ describe("richTextToPlainText around a block-like leaf", () => {
     ).toBe("Choose Basic Pro today");
   });
 
+  it("omits a label the renderer would not draw", () => {
+    /*
+     * A reader draws nothing for a button whose URL this format cannot express
+     * — a missing one, or a scheme outside the allowed set — so reporting its
+     * label would describe the page by a word that never appears on it. That is
+     * the mirror of the defect that made these labels worth reading at all.
+     */
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "Only" },
+              {
+                type: "button-group",
+                buttons: [
+                  { url: "javascript:alert(1)", text: "Danger" },
+                  { text: "No link at all" },
+                  { url: "/real", text: "Real" },
+                ],
+              },
+              { type: "text", text: "this" },
+            ],
+          },
+        ])
+      )
+    ).toBe("Only Real this");
+  });
+
   it("skips a button group carrying no labels rather than inventing a gap", () => {
     // The control: a group with nothing readable must not contribute, and must
     // not throw on shapes storage can hold.

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -306,9 +306,17 @@ describe("richTextToPlainText around a block-like leaf", () => {
               { type: "text", text: "Choose" },
               {
                 type: "button-group",
+                // The REAL serialized shape: a button group's items are not
+                // nodes and carry no `type`. A fixture that invents one gets
+                // past a node-shaped guard and proves nothing about storage.
                 buttons: [
-                  { type: "button", text: "Basic" },
-                  { type: "button", text: "Pro" },
+                  {
+                    url: "/basic",
+                    text: "Basic",
+                    variant: "filled",
+                    size: "md",
+                  },
+                  { url: "/pro", text: "Pro", variant: "outline", size: "md" },
                 ],
               },
               { type: "text", text: "today" },
@@ -330,6 +338,7 @@ describe("richTextToPlainText around a block-like leaf", () => {
             children: [
               { type: "text", text: "Only" },
               { type: "button-group", buttons: [] },
+              { type: "button-group", buttons: [{ url: "/x", text: "" }] },
               { type: "text", text: "this" },
             ],
           },

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -291,6 +291,53 @@ describe("richTextToPlainText around a block-like leaf", () => {
     ).toBe("Before Buy now After");
   });
 
+  it("reads the labels a button group keeps in a list of its own", () => {
+    /*
+     * `button-group` stores each label under `buttons[].text`, and the renderer
+     * draws every one. A walk reading only `text` and `children` sees neither,
+     * so the words on the page are missing from the description of it.
+     */
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "Choose" },
+              {
+                type: "button-group",
+                buttons: [
+                  { type: "button", text: "Basic" },
+                  { type: "button", text: "Pro" },
+                ],
+              },
+              { type: "text", text: "today" },
+            ],
+          },
+        ])
+      )
+    ).toBe("Choose Basic Pro today");
+  });
+
+  it("skips a button group carrying no labels rather than inventing a gap", () => {
+    // The control: a group with nothing readable must not contribute, and must
+    // not throw on shapes storage can hold.
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "Only" },
+              { type: "button-group", buttons: [] },
+              { type: "text", text: "this" },
+            ],
+          },
+        ])
+      )
+    ).toBe("Only this");
+  });
+
   it("separates one between root paragraphs too", () => {
     // The shape a stored document can also hold, kept because the two travel
     // different paths through the walk.

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -297,12 +297,30 @@ function isInline(node: RichTextNode): boolean {
  */
 function listedLabels(node: RichTextNode): string | null {
   if (node.type !== "button-group" || !Array.isArray(node.buttons)) return null;
-  const labels = node.buttons.flatMap(button =>
-    isRichTextNode(button) && typeof button.text === "string" && button.text
-      ? [button.text]
-      : []
-  );
+  const labels = node.buttons.flatMap(button => {
+    const label = labelOf(button);
+    return label === null ? [] : [label];
+  });
   return labels.length > 0 ? labels.join(" ") : null;
+}
+
+/**
+ * The label a serialized list ITEM carries, or `null` if it has none.
+ *
+ * Asked of the shape rather than of a node type, because these items are not
+ * nodes: a button in a group serializes as `{ url, text, variant, size }` with
+ * no `type` at all. A check written against the node guard rejects every real
+ * one, and a fixture that invents a `type` to get past it tests nothing.
+ *
+ * Empty labels are dropped rather than joined, so a button whose text was never
+ * filled in does not open a gap in the middle of a sentence.
+ */
+function labelOf(item: unknown): string | null {
+  if (typeof item !== "object" || item === null || Array.isArray(item)) {
+    return null;
+  }
+  const text = (item as { text?: unknown }).text;
+  return typeof text === "string" && text.length > 0 ? text : null;
 }
 
 function leafText(node: RichTextNode): string | null {

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -283,10 +283,32 @@ function isInline(node: RichTextNode): boolean {
   return INLINE_CONTAINERS.has(node.type);
 }
 
+/**
+ * Labels a node keeps in a LIST of its own rather than in `text`.
+ *
+ * `button-group` stores each button under `buttons[].text`, and the renderer
+ * draws every one of them. A walk that reads only `text` and `children` sees
+ * neither, so a passage of "Choose", a group offering "Basic" and "Pro", then
+ * "today" flattens to "Choose today" — words the page shows, missing from the
+ * description of it.
+ *
+ * Projected here rather than at the consumer, so SEO, search indexing and
+ * anything else reading this walk describe the same page.
+ */
+function listedLabels(node: RichTextNode): string | null {
+  if (node.type !== "button-group" || !Array.isArray(node.buttons)) return null;
+  const labels = node.buttons.flatMap(button =>
+    isRichTextNode(button) && typeof button.text === "string" && button.text
+      ? [button.text]
+      : []
+  );
+  return labels.length > 0 ? labels.join(" ") : null;
+}
+
 function leafText(node: RichTextNode): string | null {
   if (typeof node.text === "string") return node.text;
   if (node.type === "linebreak") return " ";
-  return null;
+  return listedLabels(node);
 }
 
 /**

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -49,6 +49,8 @@
  * mismatch is silent in the worst possible way — the editor treats a tree as
  * text, reads no text out of it, and commits an empty string over the passage.
  */
+import { isLinkableUrl } from "./url-policy";
+
 export const RICH_TEXT_PROP_TYPE = "richText";
 
 /**
@@ -319,7 +321,13 @@ function labelOf(item: unknown): string | null {
   if (typeof item !== "object" || item === null || Array.isArray(item)) {
     return null;
   }
-  const text = (item as { text?: unknown }).text;
+  const fields = item as { text?: unknown; url?: unknown };
+  // Only what a reader would actually SHOW. A button whose URL this format
+  // cannot express is not drawn, so reporting its label would describe a page
+  // by a word that never appears on it — the mirror of the defect that made
+  // these labels worth reading in the first place.
+  if (!isLinkableUrl(fields.url)) return null;
+  const text = fields.text;
   return typeof text === "string" && text.length > 0 ? text : null;
 }
 

--- a/packages/blocks-engine/src/style/css-value.ts
+++ b/packages/blocks-engine/src/style/css-value.ts
@@ -26,6 +26,8 @@
 import type { CssNode } from "css-tree";
 import parse from "css-tree/parser";
 
+import { hasControlCharacter } from "../url-policy";
+
 /** Why a value was refused. Each maps to a stable validation issue code. */
 export type CssValueRejection =
   | "unparsable"
@@ -97,21 +99,6 @@ const UNSAFE_URL_CHARS = /["'()\\<>]/;
  * the boundary is made of.
  */
 const UNSAFE_QUOTED_URL_CHARS = /["'\\<>]/;
-
-/**
- * True when a URL contains a control character. A URL parser strips these
- * before reading the scheme, so `java\tscript:` becomes `javascript:` in the
- * browser while looking like a scheme-less path to a check that does not.
- * Refused outright rather than stripped: a URL carrying a control character is
- * malformed however it was meant.
- */
-function hasControlCharacter(value: string): boolean {
-  for (const character of value) {
-    const code = character.codePointAt(0) ?? 0;
-    if (code <= 0x1f || code === 0x7f) return true;
-  }
-  return false;
-}
 
 /**
  * Keywords every property accepts, whatever its value type.

--- a/packages/blocks-engine/src/url-policy.ts
+++ b/packages/blocks-engine/src/url-policy.ts
@@ -59,6 +59,85 @@ export function normalizeUrl(value: string): string {
 const URL_SCHEME = /^[a-z][a-z0-9+.-]*:/i;
 
 /** Whether a URL reaches anywhere other than the document's own origin. */
+/**
+ * Schemes a stored link may name.
+ *
+ * The format's own rule, not one renderer's. A value carrying any other scheme
+ * is not a link this document can express, so nothing reading the document —
+ * a renderer drawing it, a flattener describing it, an indexer searching it —
+ * should treat it as one.
+ */
+const LINKABLE_SCHEMES: readonly string[] = ["http", "https", "mailto", "tel"];
+
+/**
+ * Any leading `scheme:`, which is what decides whether the list above applies.
+ *
+ * A value with NO scheme is left alone: `/about`, `a.png` and `#top` resolve
+ * against the page's own origin and name no destination of their own. So does
+ * `//host/x`, which carries no scheme and still reaches another host — bounding
+ * WHICH hosts may be reached is a separate question, asked of the host policy
+ * by the blocks that fetch, not of this list.
+ */
+const LINK_SCHEME = /^([a-z][a-z0-9+.-]*):/i;
+
+/**
+ * Whether a string still holds a control character.
+ *
+ * A URL parser strips these before reading the scheme, so `java\tscript:`
+ * becomes `javascript:` in the browser while looking like a scheme-less path to
+ * a check that does not. Refused outright rather than stripped: a URL carrying
+ * one is malformed however it was meant.
+ *
+ * Scanned by code point rather than matched by a regular expression: a pattern
+ * for these needs a lint suppression, and the rule it would suppress is there
+ * because a literal control character in a pattern is invisible to whoever reads
+ * it next. `0x20` is deliberately excluded — a space is not a control character,
+ * and an interior one belongs to the path.
+ *
+ * Exported for `style/css-value`, which asks the same question of a URL inside
+ * a CSS value. Two copies of this is two chances for one of them to start
+ * treating a byte differently, and the byte in question is the one that hides a
+ * scheme.
+ */
+export function hasControlCharacter(value: string): boolean {
+  for (const character of value) {
+    const code = character.codePointAt(0) ?? 0;
+    if (code <= 0x1f || code === 0x7f) return true;
+  }
+  return false;
+}
+
+/**
+ * Whether a stored value names a link this document can express.
+ *
+ * Asked of the FORMAT rather than of a renderer, because more than one reader
+ * has to agree about it: a renderer that draws nothing for an unusable link and
+ * a flattener that still reports its label describe different pages, and the
+ * description is the one nobody looks at until a crawler does.
+ *
+ * The scheme is read as the BROWSER's parser will read it — after normalising
+ * the tab, newline and leading-control tricks that hide one — so a value cannot
+ * pass here and mean something else in an attribute.
+ *
+ * @param value - anything a stored document might hold in a link position
+ * @returns whether a reader should treat it as a link
+ */
+export function isLinkableUrl(value: unknown): boolean {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  if (trimmed === "") return false;
+
+  const normalized = normalizeUrl(trimmed);
+  if (normalized === "") return false;
+  if (hasControlCharacter(normalized)) return false;
+
+  const scheme = LINK_SCHEME.exec(normalized);
+  if (scheme === null) return true;
+  const name = scheme[1];
+  if (name === undefined) return false;
+  return LINKABLE_SCHEMES.includes(name.toLowerCase());
+}
+
 export function isRemoteUrl(value: string): boolean {
   const normalized = normalizeUrl(value);
   if (URL_SCHEME.test(normalized)) return true;

--- a/packages/blocks-react/src/blocks/props.ts
+++ b/packages/blocks-react/src/blocks/props.ts
@@ -10,7 +10,7 @@
  *
  * @module blocks/props
  */
-import { isFetchableUrl, normalizeUrl } from "@nextlyhq/blocks-engine";
+import { isFetchableUrl, isLinkableUrl } from "@nextlyhq/blocks-engine";
 import type { RemotePatternInput } from "@nextlyhq/blocks-engine";
 
 /** A string prop, or the fallback when the stored value is not usable text. */
@@ -84,8 +84,6 @@ export function number(
  * accepts a wider set for what an author may TYPE; that is an input affordance
  * and not the boundary, which is here.
  */
-const ALLOWED_SCHEMES: readonly string[] = ["http", "https", "mailto", "tel"];
-
 /**
  * Any leading `scheme:`, which is what decides whether the list above applies.
  *
@@ -95,8 +93,6 @@ const ALLOWED_SCHEMES: readonly string[] = ["http", "https", "mailto", "tel"];
  * WHICH hosts may be reached is a separate question, asked of the host policy
  * by the blocks that fetch, not of this list.
  */
-const URL_SCHEME = /^([a-z][a-z0-9+.-]*):/i;
-
 /**
  * Whether a string still holds a control character.
  *
@@ -106,14 +102,6 @@ const URL_SCHEME = /^([a-z][a-z0-9+.-]*):/i;
  * it next. `0x20` is deliberately excluded — a space is not a control character,
  * and an interior one belongs to the path.
  */
-function hasControlCharacter(value: string): boolean {
-  for (const character of value) {
-    const code = character.codePointAt(0) ?? 0;
-    if (code <= 0x1f || code === 0x7f) return true;
-  }
-  return false;
-}
-
 /**
  * A URL safe to place in an attribute, or `undefined`.
  *
@@ -139,19 +127,13 @@ function hasControlCharacter(value: string): boolean {
  * a legitimate URL is never silently rewritten.
  */
 export function url(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  if (trimmed === "") return undefined;
-
-  const normalized = normalizeUrl(trimmed);
-  if (normalized === "") return undefined;
-  if (hasControlCharacter(normalized)) return undefined;
-
-  const scheme = URL_SCHEME.exec(normalized);
-  if (scheme === null) return trimmed;
-  const name = scheme[1];
-  if (name === undefined) return undefined;
-  return ALLOWED_SCHEMES.includes(name.toLowerCase()) ? trimmed : undefined;
+  // The DECISION belongs to the engine, which owns what the stored format can
+  // express — otherwise a renderer that draws nothing for an unusable link and
+  // a flattener that still reports its label describe different pages. What
+  // stays here is the return value: the original trimmed string, so a
+  // legitimate URL is never silently rewritten into its normalised form.
+  if (!isLinkableUrl(value)) return undefined;
+  return typeof value === "string" ? value.trim() : undefined;
 }
 
 /**

--- a/packages/builder/src/use-inline-rich-text.ts
+++ b/packages/builder/src/use-inline-rich-text.ts
@@ -580,6 +580,19 @@ export function useInlineRichText(
           setEditing(null);
           return;
         }
+        /*
+         * Measured BEFORE the handover, and that ordering is the whole point.
+         *
+         * Attaching replaces this subtree and applies the editor's own theme —
+         * a heading's size, a list's indentation, a table's box all change — so
+         * hit-testing afterwards asks where a point falls in a layout the
+         * author never saw. It is measured here rather than before the chunk
+         * was requested, because the passage may have been rewritten while it
+         * was in flight: this is the first moment where what is on screen is
+         * also what is about to be edited.
+         */
+        const caret =
+          point === null ? undefined : caretOffsetAt(element, point);
         const attachment = live.attach(element, target.value);
         if (attachment.status === "refused") {
           /*
@@ -600,11 +613,7 @@ export function useInlineRichText(
         }
         const session = attachment.session;
         element.setAttribute(EDITING_ATTRIBUTE, editing.prop);
-        // Measured against the passage now on screen, which is the one being
-        // attached — see where the point was taken.
-        session.focus(
-          point === null ? undefined : caretOffsetAt(element, point)
-        );
+        session.focus(caret);
         mounted.current = {
           session,
           element,


### PR DESCRIPTION
Follow-up to #1279, carrying the two fixes that were pushed while it was being merged and did not land with it. Verified by content rather than by the PR's state: neither `listedLabels` nor the reordered caret measurement is present on `main`.

Both were raised by Codex on #1279 and answered there; this is the code.

## The caret was measured against a layout nobody had seen

`caretOffsetAt` was evaluated inside the `focus` call, which runs **after** `attach`. Attaching replaces the passage's subtree and applies the editor's own theme — a heading's size, a list's indentation, a table's box all change — so hit-testing afterwards asks where the click fell in a layout that appeared only once editing began. The answer is an unrelated character, or nothing, which sends the caret to the end of the passage.

The comment beside it claimed the opposite: that the offset was measured against the passage on screen. It was measured against the passage the editor had just drawn. I wrote that sentence one round earlier while moving the measurement out of its *pre-load* position, and moved it one step too far.

It now sits between revalidating the target and handing the element over — the first moment where what is on screen is also what is about to be edited.

**Not covered by the browser suite, and I am not claiming it is.** That fixture uses a plain paragraph, whose geometry need not change when the editor takes it, so it cannot distinguish the two orderings. Filed as `finding:inline-caret-fixture-cannot-see-reflow`, which wants a heading or list fixture chosen by measuring both renderings rather than assuming they differ.

## A button group's labels were absent from the page description

`ButtonGroupNode.exportJSON()` stores each label under `buttons[].text`, and the renderer draws every one. The walk that flattens a passage to plain text reads `text` and `children`, and a group has neither — so "Choose", a group offering "Basic" and "Pro", then "today" described the page as "Choose today".

Projected in the shared walk rather than at the SEO call site, because that walk's own docblock names search indexing as its other caller — fixing it at one consumer would have left the two describing different pages.

Two cases: the labels appear in order between the group's boundaries, and a group carrying nothing readable contributes nothing and does not throw. `buttons` is stored JSON this package cannot constrain, so the second is not hypothetical.

## Checks

`builder`, `blocks-engine` and `blocks-react` all green on test, lint and typecheck. fallow `new-only` clean. Break-verified: dropping the label projection fails the group case and nothing else.

One changeset, patch, covering the lockstep group — checked by passing it to `scripts/release/check-changesets.mjs`, with a deliberately broken changeset as a control to prove the checker rejects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for including valid button labels when converting rich text to plain text.
  - Added consistent link validation for supported URL schemes and unsafe characters.

- **Bug Fixes**
  - Invalid or unsupported button links are now excluded from plain-text output.
  - Improved caret positioning when handing off inline rich-text editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->