### PR TITLE
fix(nextly): run a job as the person who queued it, and unbreak the v1 upgrade sim

### DIFF
--- a/.changeset/a-job-runs-as-the-person-who-queued-it.md
+++ b/.changeset/a-job-runs-as-the-person-who-queued-it.md
@@ -1,0 +1,61 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A job now runs with exactly the authority of the person who queued it, and a
+release scheduled far ahead no longer quietly prunes itself.
+
+The identity a job resolves is built by the same constructor every authenticated
+request uses. It previously assembled its own, which dropped the single-role
+alias that rules written as `user.role` read: those rules compared against
+nothing, denying authorized work — and a negative rule such as
+`user.role !== "suspended"` GRANTED work it should have refused.
+
+A job also re-proves it still holds its lease after resolving that identity.
+Resolving it is two database reads, and a lease that expired while they were in
+flight could be taken over by another runner, which then did the work a second
+time.
+
+`retentionMs: null` now does what it documents. It means "keep the history, I
+prune it myself", and it was being read as "unset" — so the seven-day default
+came back and deleted the rows a deployment had asked to keep.
+
+The content client handed to a job handler carries the Direct API's own
+signatures, so `ctx.content.find({ collection: "posts" })` compiles and its
+result is usable without casts. Passing `overrideAccess` or `user` through it is
+now a compile error rather than something silently ignored.
+
+On MySQL, the column recording who a job runs as is as wide as the user id
+column it stores, so a job queued by a user with a longer id is no longer
+refused — or truncated into an id that resolves to nobody, which was reported as
+a deleted account.
+
+Two lint gates were repaired. The v1 upgrade simulation now recognises the jobs
+table as a legitimate post-0.45 addition instead of a phantom diff, and source
+modules under `src/` whose names begin with `run-` are linted again: a pattern
+meant for dev-tooling scripts had been silently excluding three real modules
+from every lint gate.

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-runner.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-runner.test.ts
@@ -6,7 +6,44 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { databaseRunAs } from "../jobs-runner";
+import {
+  DEFAULT_RETENTION_MS,
+  databaseRunAs,
+  resolveRetentionMs,
+} from "../jobs-runner";
+
+describe("resolveRetentionMs", () => {
+  it("takes the default when the option was not set", async () => {
+    expect(resolveRetentionMs(undefined)).toBe(DEFAULT_RETENTION_MS);
+  });
+
+  it("keeps everything when a deployment explicitly passes null", async () => {
+    // The documented opt-out: "retain the history, I prune it myself." A `??`
+    // here cannot tell this from the unset case, so the default came back and
+    // terminal rows older than the default window were deleted anyway — the
+    // option validated, and did nothing.
+    expect(resolveRetentionMs(null)).toBeNull();
+  });
+
+  it("distinguishes null from the default rather than agreeing by accident", async () => {
+    // The control for the case above. If the default were ever null, the
+    // assertion there would pass against an implementation that collapsed the
+    // two states — which is precisely the implementation it exists to reject.
+    expect(DEFAULT_RETENTION_MS).not.toBeNull();
+    expect(resolveRetentionMs(null)).not.toBe(resolveRetentionMs(undefined));
+  });
+
+  it("honours an explicit window", async () => {
+    expect(resolveRetentionMs(1_000)).toBe(1_000);
+  });
+
+  it("honours a zero window rather than reading it as unset", async () => {
+    // Zero is falsy: an implementation reaching for `||` instead of a
+    // three-state check would replace "prune everything terminal immediately"
+    // with the seven-day default.
+    expect(resolveRetentionMs(0)).toBe(0);
+  });
+});
 
 describe("databaseRunAs", () => {
   it("reads an active SQLite user, whose flag is 1 rather than true", async () => {

--- a/packages/nextly/src/domains/jobs/__tests__/resolve-run-as.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/resolve-run-as.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { buildUserContext } from "../../../auth/user-context";
 import { resolveRunAs, type RunAsDeps } from "../resolve-run-as";
 
 const deps = (over: Partial<RunAsDeps> = {}): RunAsDeps => ({
@@ -64,7 +65,12 @@ describe("resolveRunAs", () => {
     );
     expect(result).toEqual({
       ok: true,
-      user: { id: "u1", roles: ["editor", "legal"] },
+      user: buildUserContext({
+        id: "u1",
+        name: undefined,
+        email: undefined,
+        roles: ["editor", "legal"],
+      }),
     });
   });
 
@@ -74,7 +80,12 @@ describe("resolveRunAs", () => {
     // by a user who holds permissions directly rather than through a role.
     await expect(resolveRunAs(deps(), "u1")).resolves.toEqual({
       ok: true,
-      user: { id: "u1", roles: [] },
+      user: buildUserContext({
+        id: "u1",
+        name: undefined,
+        email: undefined,
+        roles: [],
+      }),
     });
   });
 
@@ -109,24 +120,57 @@ describe("resolveRunAs", () => {
     );
     expect(result).toEqual({
       ok: true,
-      user: {
+      user: buildUserContext({
         id: "u1",
-        roles: ["editor"],
         name: "Ada",
         email: "ada@example.com",
-      },
+        roles: ["editor"],
+      }),
     });
   });
 
-  it("omits attributes the user does not have rather than setting them undefined", async () => {
-    // The control for the case above. Spreading unconditionally would put
-    // `email: undefined` on the context, which reads as "has an email, and it
-    // is nothing" to a predicate testing presence.
-    const result = await resolveRunAs(deps(), "u1");
-    expect(result).toEqual({ ok: true, user: { id: "u1", roles: [] } });
-    expect(Object.keys((result as { user: object }).user)).toEqual([
-      "id",
-      "roles",
-    ]);
+  it("derives the single-role alias a rule written against `user.role` reads", async () => {
+    // The specific attribute a hand-built context dropped. `buildUserContext`
+    // sets `role` from `roles[0]` because rules and field-level callbacks
+    // written against a single-role model read it; a job whose context omits
+    // it evaluates `user.role === "editor"` against `undefined` and denies
+    // authorized work, while `user.role !== "suspended"` GRANTS work it should
+    // refuse. Asserted on its own so a change that keeps the object shape but
+    // stops deriving the alias still fails.
+    const result = await resolveRunAs(
+      deps({ listRoleSlugs: async () => ["editor", "legal"] }),
+      "u1"
+    );
+    expect((result as { user: { role?: string } }).user.role).toBe("editor");
+  });
+
+  it("builds the same context an authenticated request would for that person", async () => {
+    // The property the three cases above are each an instance of. A
+    // `UserContext` is an open record an access rule is evaluated against, so
+    // a second builder that merely agrees today authorizes differently the
+    // moment the canonical one gains a field. Comparing against
+    // `buildUserContext` itself is what makes this test notice that, rather
+    // than pinning the shape this module happens to produce.
+    const identity = {
+      id: "u1",
+      isActive: true,
+      name: "Ada",
+      email: "ada@example.com",
+    };
+    const result = await resolveRunAs(
+      deps({
+        findUser: async () => identity,
+        listRoleSlugs: async () => ["editor", "legal"],
+      }),
+      "u1"
+    );
+    expect((result as { user: unknown }).user).toEqual(
+      buildUserContext({
+        id: identity.id,
+        name: identity.name,
+        email: identity.email,
+        roles: ["editor", "legal"],
+      })
+    );
   });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
@@ -10,6 +10,7 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import { buildUserContext } from "../../../auth/user-context";
 import type { JobRow } from "../jobs-repository";
 import { JobRegistry, defineJob } from "../job-registry";
 import type { RunAsDeps } from "../resolve-run-as";
@@ -125,7 +126,14 @@ describe("runJobs", () => {
       contentApi: noContentApi,
       now: () => NOW,
     });
-    expect(seen).toEqual({ id: "u1", roles: ["editor"] });
+    expect(seen).toEqual(
+      buildUserContext({
+        id: "u1",
+        name: undefined,
+        email: undefined,
+        roles: ["editor"],
+      })
+    );
   });
 
   it("fails a job whose identity is gone TERMINALLY, never retrying it", async () => {
@@ -376,6 +384,41 @@ describe("runJobs", () => {
     expect(calls).toBeLessThanOrEqual(2);
   });
 
+  it("refuses to start the handler when the lease lapsed while the identity was resolving", async () => {
+    // `markAttempt` fences the row, but resolving the identity is two database
+    // reads and renewal does not begin until the handler is already running.
+    // A lease that expires in that window is claimed by a successor, and this
+    // runner would otherwise wake up and do the work a second time — the fence
+    // it passed describes a lease it no longer holds.
+    const handler = vi.fn(async () => {});
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row({ runAsUserId: "u1" })]),
+      // Refuse from the first call: the successor took the row during the
+      // identity reads below.
+      renewLease: async () => false,
+    };
+
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(defineJob({ slug: "test:noop", handler })),
+      runAs: runAs({
+        listRoleSlugs: async () => {
+          // Stand in for identity reads slow enough to outlive the lease.
+          await new Promise(resolve => setTimeout(resolve, 5));
+          return ["editor"];
+        },
+      }),
+      contentApi: noContentApi,
+      now: () => NOW,
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+    // Nothing is written either: the row belongs to whoever holds it now, and
+    // a finalize from this runner would overwrite their outcome.
+    expect(s.finalized).toEqual([]);
+    expect(result).toMatchObject({ claimed: 1, done: 0 });
+  });
+
   it("hands the handler a content client already bound to the resolved user", async () => {
     // The identity is only real if it reaches the CALLS. The Direct API
     // defaults to overrideAccess: true, so a handler importing `nextly`
@@ -390,7 +433,9 @@ describe("runJobs", () => {
         defineJob({
           slug: "test:noop",
           handler: async (_input, ctx) => {
-            await ctx.content.find({ collection: "posts" } as never);
+            // No cast: the bound client carries the Direct API's own
+            // signatures, so a handler calls it the way it calls `nextly`.
+            await ctx.content.find({ collection: "posts" });
           },
         })
       ),
@@ -403,7 +448,12 @@ describe("runJobs", () => {
       expect.objectContaining({
         collection: "posts",
         overrideAccess: false,
-        user: { id: "u1", roles: ["editor"] },
+        user: buildUserContext({
+          id: "u1",
+          name: undefined,
+          email: undefined,
+          roles: ["editor"],
+        }),
       })
     );
   });

--- a/packages/nextly/src/domains/jobs/job-content-api.ts
+++ b/packages/nextly/src/domains/jobs/job-content-api.ts
@@ -41,6 +41,7 @@
  * @module domains/jobs/job-content-api
  */
 
+import type { Nextly } from "../../init/nextly-instance";
 import type { UserContext } from "../collections/services/collection-types";
 
 /**
@@ -65,10 +66,35 @@ const BOUND_OPERATIONS = [
 
 export type BoundOperation = (typeof BOUND_OPERATIONS)[number];
 
-/** The subset of the Direct API this binds, in its own shape. */
+/**
+ * The two fields this client owns.
+ *
+ * Removed from every bound signature rather than accepted and ignored. A
+ * handler that could write `overrideAccess: true` and see it silently dropped
+ * would read the binding as a default it may override; the compiler saying no
+ * is what makes it a guarantee.
+ */
+type AccessFields = "overrideAccess" | "user";
+
+/** One bound operation: the Direct API's own signature, minus what this owns. */
+type Bound<TOperation> = TOperation extends (args: infer TArgs) => infer TResult
+  ? (args: Omit<TArgs, AccessFields>) => TResult
+  : never;
+
+/**
+ * The subset of the Direct API this binds.
+ *
+ * Derived from `Nextly` so the argument and result types are the Direct API's
+ * own — a second hand-written shape would drift from it, and the drift would
+ * surface as a job handler that compiles against a signature the runtime no
+ * longer has.
+ */
 export type JobContentApi = {
-  [K in BoundOperation]: (args: never) => Promise<unknown>;
+  [K in BoundOperation]: Bound<Nextly[K]>;
 };
+
+/** The Direct API surface this needs, named so the runner can inject a double. */
+export type JobContentSource = Pick<Nextly, BoundOperation>;
 
 /**
  * Wrap `source` so every bound call carries this job's identity.
@@ -79,21 +105,26 @@ export type JobContentApi = {
  */
 export function createJobContentApi(
   user: UserContext | null,
-  source: Record<BoundOperation, (args: never) => Promise<unknown>>
+  source: JobContentSource
 ): JobContentApi {
-  const bound = {} as JobContentApi;
+  const bound = {} as Record<BoundOperation, unknown>;
   for (const name of BOUND_OPERATIONS) {
-    bound[name] = (args: never) => {
+    // The generic per-slug signatures cannot be preserved through this loop, so
+    // the call is made untyped here and the assembled object is asserted to
+    // `JobContentApi` once. The types callers see are the Direct API's own; the
+    // erasure is confined to these two lines.
+    const operation = source[name] as (args: unknown) => unknown;
+    bound[name] = (args: unknown) => {
       const caller = (args ?? {}) as Record<string, unknown>;
-      return source[name]({
+      return operation({
         ...caller,
         // Applied AFTER the caller's own arguments, so neither an explicit
         // `overrideAccess: true` nor a spread that lands last can restore the
         // bypass.
         overrideAccess: false,
         ...(user === null ? {} : { user }),
-      } as never);
+      });
     };
   }
-  return bound;
+  return bound as JobContentApi;
 }

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -47,6 +47,22 @@ function executorOf(db: UsersReadDb): unknown {
 
 /** How long a finished job row is kept before a pass may remove it. */
 export const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+
+/**
+ * How long finished rows are kept, from the option a deployment passed.
+ *
+ * Three states, not two: `undefined` is "unset, take the default", `null` is
+ * "keep everything, I prune it myself", and a number is a window. Nullish
+ * coalescing collapses the first two, which is what turned the documented
+ * opt-out back into the default and pruned history a deployment had asked to
+ * keep. Named and exported so that distinction is testable rather than one
+ * character inside a longer function.
+ */
+export function resolveRetentionMs(
+  option: number | null | undefined
+): number | null {
+  return option === undefined ? DEFAULT_RETENTION_MS : option;
+}
 /** Rows a single pass may remove, so a sweep cannot become a long delete. */
 export const DEFAULT_PRUNE_LIMIT = 100;
 
@@ -151,7 +167,7 @@ export async function runJobsPass(
   // this grows forever — a recurring workload writes one row per run, and every
   // finished row keeps its input and its error. Bounded per pass so a sweep
   // cannot become a long delete that outlives the tick running it.
-  const retentionMs = options?.retentionMs ?? DEFAULT_RETENTION_MS;
+  const retentionMs = resolveRetentionMs(options?.retentionMs);
   if (retentionMs !== null) {
     const now = options?.now ?? (() => new Date());
     try {

--- a/packages/nextly/src/domains/jobs/resolve-run-as.ts
+++ b/packages/nextly/src/domains/jobs/resolve-run-as.ts
@@ -37,6 +37,7 @@
  * @module domains/jobs/resolve-run-as
  */
 
+import { buildUserContext } from "../../auth/user-context";
 import type { UserContext } from "../collections/services/collection-types";
 
 /** The minimum a user must look like for a job to act as them. */
@@ -88,14 +89,22 @@ export async function resolveRunAs(
   if (!user.isActive) return { ok: false, reason: "JOB_IDENTITY_DISABLED" };
 
   const roles = await deps.listRoleSlugs(user.id);
-  // Every attribute the user carries, not just id and roles. Access predicates
-  // in this repository inspect `user.email`; a context missing it evaluates
-  // such a rule against `undefined`, which denies authorized work — or, for a
-  // negative predicate like `email !== blocked`, GRANTS work it should refuse.
-  // Either way the job is not running with the named person's authority, which
-  // is the one thing this function exists to guarantee.
-  const context: UserContext = { id: user.id, roles };
-  if (user.name !== undefined) context.name = user.name;
-  if (user.email !== undefined) context.email = user.email;
-  return { ok: true, user: context };
+  // The canonical constructor, not a second one that happens to agree. A
+  // `UserContext` is an open record an access rule is evaluated against, so a
+  // path that assembles it differently authorizes differently — which is why
+  // `auth/user-context` states that every path builds it there. Building it by
+  // hand here dropped `role`, the single-role alias `buildUserContext` derives
+  // from `roles[0]`: a rule reading `user.role` then saw `undefined`, denying
+  // authorized work, and a negative one like `user.role !== "suspended"`
+  // GRANTED work it should have refused. The same argument covers `claims`,
+  // which a hand-built context omits entirely.
+  return {
+    ok: true,
+    user: buildUserContext({
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      roles,
+    }),
+  };
 }

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -60,10 +60,10 @@
  * @module domains/jobs/run-jobs
  */
 
-import { DEFAULT_MAX_ATTEMPTS, type JobRegistry } from "./job-registry";
 import { nextAttempt } from "./job-backoff";
-import type { FinalizeInput, FinalizeOutcome, JobRow } from "./jobs-repository";
 import { createJobContentApi } from "./job-content-api";
+import { DEFAULT_MAX_ATTEMPTS, type JobRegistry } from "./job-registry";
+import type { FinalizeInput, FinalizeOutcome, JobRow } from "./jobs-repository";
 import { resolveRunAs, type RunAsDeps } from "./resolve-run-as";
 
 /** Rows claimed and finalized per pass when the caller does not say. */
@@ -297,6 +297,21 @@ async function runOne(
   // Terminal, not retried: a deleted or deactivated user does not come back on
   // the next pass, and retrying would cycle an unrunnable row forever.
   if (!identity.ok) return terminal(identity.reason);
+
+  // Re-prove ownership before starting the handler. `markAttempt` fenced the
+  // row, but resolving the identity above is two database reads, and a lease
+  // that expires while they are in flight lets a successor claim the row. This
+  // runner would then wake up and start the handler anyway, because renewal
+  // does not begin until `withLeaseRenewal` — so the fence it passed describes
+  // a lease it no longer holds. `renewLease` is fenced on `lockedBy`, so one
+  // write both extends the lease and answers whether it is still ours.
+  const stillOursAfterIdentity = await deps.store.renewLease(
+    job.id,
+    runnerId,
+    now(),
+    deps.leaseMs ?? DEFAULT_LEASE_MS
+  );
+  if (!stillOursAfterIdentity) return LEASE_LOST;
 
   try {
     // Renew while the handler works. The lease is otherwise a wall-clock guess

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -119,6 +119,13 @@ const POST_045_TABLES = [
   // touching the child reading as a phantom diff.
   "nextly_releases",
   "nextly_release_members",
+  // The durable job queue, post-0.45 like the tables above: an existing install
+  // gains it on upgrade, so its CREATE TABLE and its indexes are legitimate
+  // rather than phantom. The pass-2 assertion below is what proves the
+  // declaration reaches the dialect bundles as well as the core schema — a
+  // table present in only one of the two is re-proposed on every reconcile
+  // instead of round-tripping to silence.
+  "nextly_jobs",
 ];
 
 // The post-045 names are static identifiers, but escape defensively so the

--- a/packages/nextly/src/schemas/jobs/__tests__/parity.test.ts
+++ b/packages/nextly/src/schemas/jobs/__tests__/parity.test.ts
@@ -10,6 +10,7 @@ import { Column, is, type Table } from "drizzle-orm";
 import { describe, it, expect } from "vitest";
 
 import { CORE_TABLE_NAMES, getCoreSchema } from "../../index";
+import { users as mysqlUsers } from "../../users/mysql";
 import { my, pg, sl } from "../index";
 import { JOB_STATES } from "../types";
 
@@ -73,6 +74,36 @@ describe("the job table is identical across dialects", () => {
     ]) {
       expect(columnNames(table)).toContain("runAsUserId:run_as_user_id");
     }
+  });
+
+  it("stores a run-as id as wide as MySQL stores a user id", () => {
+    // MySQL is the only dialect that bounds these; PostgreSQL and SQLite use
+    // unbounded text. A narrower column here refuses a job queued by a
+    // legitimate user whose id is longer, and truncates it otherwise — and a
+    // truncated id resolves to no user, which `resolveRunAs` reports as a
+    // DELETED ACCOUNT. The job then fails terminally with a reason naming the
+    // wrong cause.
+    //
+    // Compared against the users table rather than a literal, so widening
+    // `users.id` later cannot silently re-open the gap this closes.
+    const columnNamed = (table: object, name: string): Column | undefined =>
+      Object.entries(table).find(
+        (entry): entry is [string, Column] =>
+          is(entry[1], Column) && entry[1].name === name
+      )?.[1];
+
+    const usersId = columnNamed(mysqlUsers, "id");
+    const runAs = columnNamed(my.nextlyJobsMysql, "run_as_user_id");
+    // The control: a lookup that found nothing would make both reads
+    // `undefined` and the comparison below trivially true. An earlier version
+    // of this test compared a property neither column has and passed against a
+    // deliberately narrowed column for exactly that reason.
+    expect(usersId).toBeDefined();
+    expect(runAs).toBeDefined();
+
+    // Compared as the RENDERED type rather than an internal field: that string
+    // is what reaches the database, so it cannot agree while the DDL differs.
+    expect(runAs?.getSQLType()).toBe(usersId?.getSQLType());
   });
 });
 

--- a/packages/nextly/src/schemas/jobs/mysql.ts
+++ b/packages/nextly/src/schemas/jobs/mysql.ts
@@ -40,7 +40,12 @@ export const nextlyJobsMysql = mysqlTable(
 
     runAt: datetime("run_at", { fsp: 3 }),
 
-    runAsUserId: varchar("run_as_user_id", { length: 36 }),
+    // Matched to `users.id`, which MySQL stores as varchar(191). A narrower
+    // column here refuses a job queued by a legitimate user whose id is longer
+    // in strict mode, and truncates it to an id that resolves to nobody
+    // otherwise — and `resolveRunAs` fails a job closed when the id it reads
+    // resolves to no user, so a truncation would look like a deleted account.
+    runAsUserId: varchar("run_as_user_id", { length: 191 }),
 
     // 191 rather than 255: this column carries a unique index, and 191 is the
     // longest utf8mb4 key MySQL will index under the 767-byte prefix limit on


### PR DESCRIPTION
Follow-up to #1273, which merged with two integration jobs red and six review findings outstanding.

## `main` is red — this fixes it first

`Integration (postgres)` and `Integration (mysql)` fail on `upgrade-sim-045`: `nextly_jobs` was never added to the post-0.45 allowlist, so the upgrade's own `CREATE TABLE` reads as a phantom diff.

SQLite passed because its case only checks for **destructive** statements — it never asks the phantom-diff question. That asymmetry is why the gap reached main.

Verified the entry is legitimate rather than a waiver: the table is in the core schema **and** all three dialect bundles, so pass 2 round-trips to silence instead of re-proposing forever (the `nextly_i18n_archive` failure mode the list's own comment records). Offline, the allowlist predicate matches both dialects' exact CI statements, and three controls still miss — including `DROP TABLE "nextly_jobs"`, so the entry does not whitelist a destructive statement.

## Review findings — 7 of 14 were stale re-posts

Measured each against the tree rather than fixing or dismissing blindly. Already fixed in #1273 and confirmed present: barrel export, dedupe-key release on terminal, slug limit at `defineJob` **and** at `enqueue`, dedupe-key limit, retention/prune, and the `overrideAccess` binding. The handler-deadline finding remains deliberately documented, not fixed.

The six that were real:

**P1 — identity was built by a second, divergent constructor.** `auth/user-context` exists so every path builds a `UserContext` the same way; `resolveRunAs` hand-built its own and dropped `role`, the single-role alias derived from `roles[0]`. A rule written `user.role === "editor"` compared against `undefined` and denied authorized work — and `user.role !== "suspended"` **granted** work it should have refused. `claims` was dropped too. Now uses `buildUserContext`, and the tests compare against that function rather than pinning a shape, so the two cannot drift apart again.

**P1 — the lease could lapse between the fence and the handler.** `markAttempt` fences the row, but resolving an identity is two database reads and renewal does not start until the handler is already running. A lease expiring in that window was reclaimed by a successor while this runner went on to do the work a second time. `renewLease` is already fenced on `locked_by`, so one write both extends the lease and answers whether it is still ours.

**P2 — `retentionMs: null` did nothing.** It documents "keep the history, I prune it myself" and `??` read it as unset, so the seven-day default came back and deleted the rows a deployment asked to keep. The three-state decision is now `resolveRetentionMs`, named and tested — including that `0` is honoured rather than treated as unset.

**P2 — the bound content client was unusable.** `(args: never) => Promise<unknown>` meant handlers needed casts; the PR's own test used `as never`. Now derived from the `Nextly` interface, so `ctx.content.find({ collection: "posts" })` compiles and its result is usable. Passing `overrideAccess` or `user` through it is a **compile error** rather than silently ignored — verified with `@ts-expect-error` directives plus a control proving an unused directive is itself reported.

**P2 — MySQL `run_as_user_id` was `varchar(36)`, `users.id` is `varchar(191)`.** A longer id was refused in strict mode, or truncated into an id resolving to nobody — which `resolveRunAs` reports as a *deleted account*, naming the wrong cause. The parity test compares the **rendered** `getSQLType()` of both columns, not a literal.

**warn — `runJobs` cognitive complexity.** Not changed: that rule is the review bot's own; `--print-config` shows no complexity rule configured in this repo.

## Scope note: a lint gate that was not running

`run-jobs.ts` could not be checked for the complexity finding because **eslint never looked at it**. `**/run-*.{ts,js,mjs}` — intended for dev-tooling runners outside a package's tsconfig project — was also excluding three published modules: `run-jobs.ts`, `run-drain.ts` and `run-statement.ts`.

Narrowed to spare `src/`, placed *before* the test globs so those still win (a first attempt put it after and un-ignored `run-jobs.test.ts`). Blast radius measured across every tracked `run-*` file: `run-statement.ts` is clean, `run-jobs.ts` had 2 import-order warnings, `run-drain.ts` (pre-existing, from #751) had 2 unnecessary non-null assertions TypeScript can already prove via aliased-condition narrowing. All fixed. `run-media-folders-migration.ts` genuinely cannot be linted and stays ignored.

This touches shared config, so it is called out rather than buried — happy to split it out if you would rather.

## Verification

- Break-verified each mechanism individually, collecting failing test **names**: removing the lease fence fails exactly 1 test; reverting to the hand-built context fails 6; restoring `??` fails 2; narrowing the MySQL column fails 1.
- The MySQL test **initially failed to break** — it compared `.size`, a property neither column has, so it asserted `undefined === undefined`. Caught by break-verification and rewritten against the rendered SQL type.
- 318 tests pass across `domains/jobs`, `domains/webhooks`, `schemas/jobs`. Typecheck clean.
- `turbo run lint --force` — 24/24, **0 cached**, since a cached lint result would predate the shared-config change.
- `changeset status` parses the changeset.

Postgres and MySQL are unavailable locally (no Docker daemon), so the upgrade-sim fix itself is verified offline against CI's exact statements plus controls — **CI is the only thing that can confirm pass-2 silence.**

Pushed with `--no-verify` per the standing waiver for this lane: `.husky/pre-push` runs the full suite, which carries the inherited ~362-failure stale-mock baseline on `main` (`task:test-baseline-repair`).