### PR TITLE
perf(builder): read the canvas root once per pointer move

### DIFF
--- a/.changeset/drag-measures-the-canvas-once.md
+++ b/.changeset/drag-measures-the-canvas-once.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Make dragging a block in the page editor smoother. Every pointer move measured the canvas twice for one pointer position — once to place it among the blocks and once for the threshold that decides when a rival drop target takes over — and each measurement forces the browser to lay the page out there and then. Both answers now come from a single measurement, so a drag has less work to finish between one frame and the next.

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -61,10 +61,11 @@ import type { EditorState } from "./editor-state";
 import type { Point, Rect } from "./geometry";
 import {
   canvasContentPoint,
-  canvasPaintedPoint,
   canvasContentRect,
+  canvasPointerPoints,
   containerEdges,
   scrollableAncestor,
+  type CanvasPointerPoints,
 } from "./geometry-dom";
 import type { SlotSource } from "./inserter";
 import { lockBlockingMove } from "./locking";
@@ -302,16 +303,23 @@ export function useCanvasDrag({
   );
 
   /**
-   * Re-aim the drag at a content point, and draw the result.
+   * Re-aim the drag at a pointer position, and draw the result.
    *
    * Shared by the pointer handler and the autoscroll frame because they ask the
    * same question at different moments: a move changes where the pointer is, and
    * a scroll changes what is under it. Computing the answer twice is how the
    * indicator and the committed target come apart — the frame would draw one
    * thing and the release would apply another.
+   *
+   * Takes the pointer already MAPPED, in both spaces, rather than mapping it
+   * here. Both callers hold a rectangle of the root at the instant they aim —
+   * the move because it has just measured, the frame because it has just
+   * scrolled — and measuring again inside would answer this one drag step from
+   * two rectangles: `resolveDrop` placing the pointer among the snapshotted
+   * blocks by one, and the switch rule measuring travel by the other.
    */
   const aim = React.useCallback(
-    (drag: Gesture, pointer: Point) => {
+    (drag: Gesture, pointer: CanvasPointerPoints) => {
       const resolution = resolveDrop(
         {
           blockName: drag.blockName,
@@ -320,7 +328,9 @@ export function useCanvasDrag({
           rects: drag.rects,
           nesting: latest.current.nesting,
         },
-        pointer
+        // CONTENT coordinates: the rects were snapshotted in that space at drag
+        // start, and a scroll deliberately does not invalidate them.
+        pointer.content
       );
 
       if (resolution.kind === "none") {
@@ -364,11 +374,11 @@ export function useCanvasDrag({
          * hand, and they move with the scroll because the root's own rectangle
          * does.
          *
-         * Read from the GESTURE rather than from an event, because this is
-         * shared with the autoscroll frame, which has no event of its own — and
-         * both callers keep these current before they aim.
+         * The same measurement the content point above came from, so the
+         * position this rule anchors on and the position the drop was resolved
+         * at are one pointer rather than two.
          */
-        canvasPaintedPoint(drag.clientX, drag.clientY, drag.root),
+        pointer.painted,
         switchPx
       );
 
@@ -424,7 +434,10 @@ export function useCanvasDrag({
       // assignment is clamped to what it already was, and re-aiming then costs
       // a full resolve per frame to arrive at the answer already on screen.
       if (scroller.scrollTop !== before) {
-        aim(drag, canvasContentPoint(drag.clientX, drag.clientY, drag.root));
+        // Measured AFTER the assignment above, which is the one thing in this
+        // module that moves the canvas: the root's rectangle has just travelled
+        // and the pointer has to be placed against where it is now.
+        aim(drag, canvasPointerPoints(drag.clientX, drag.clientY, drag.root));
       }
     }
     drag.frame = requestAnimationFrame(pump);
@@ -435,8 +448,30 @@ export function useCanvasDrag({
       const drag = gesture.current;
       if (drag === null) return;
 
-      const root = event.currentTarget;
-      const pointer = canvasContentPoint(event.clientX, event.clientY, root);
+      /*
+       * ONE measurement of the root, answering this move in both spaces.
+       *
+       * Against `drag.root`, not `event.currentTarget`: the rects were
+       * snapshotted against the element the press landed on, and the frame loop
+       * re-aims against it too, so that is the element this pointer has to be
+       * expressed relative to. Capture makes the two the same element for the
+       * whole of a drag, which is why reading either used to work.
+       *
+       * The pair stays true for the rest of this handler because nothing below
+       * moves the canvas: the assignments are bookkeeping, `setPointerCapture`
+       * retargets events rather than laying anything out, `requestAnimationFrame`
+       * only schedules, and `select` and the draw inside `aim` are React state
+       * that flushes after this returns. The one thing that DOES move layout is
+       * `pump`'s scroll, and it runs in a frame callback of its own, so it
+       * cannot land between this read and the aim below. Anything added here
+       * that scrolls, resizes or writes a style invalidates the pair and has to
+       * measure again.
+       */
+      const pointer = canvasPointerPoints(
+        event.clientX,
+        event.clientY,
+        drag.root
+      );
       // Recorded for the frame loop, which runs between moves and has no event
       // of its own to read a position from.
       drag.clientX = event.clientX;

--- a/packages/builder/src/geometry-dom.test.ts
+++ b/packages/builder/src/geometry-dom.test.ts
@@ -21,6 +21,7 @@ import { SQUARE_CORNERS } from "./border-radii";
 import {
   canvasContentPoint,
   canvasContentRect,
+  canvasPointerPoints,
   clippedByAncestor,
   clippedByAncestorRect,
   frameInsetOf,
@@ -283,6 +284,42 @@ describe("a canvas that is PAINTED smaller than it is laid out", () => {
     ).toEqual({ x: rect.x, y: rect.y });
   });
 
+  it("leaves the PAINTED point undivided and unmoved by the scroll", () => {
+    /*
+     * The half that reads as correct while being wrong, because the two spaces
+     * COINCIDE at every default: unscaled, they differ by nothing; unscrolled,
+     * they differ only by the scale. So the separating fixture is a scale that
+     * is not 1 TOGETHER WITH a non-zero scroll, and either one alone leaves a
+     * painted point that had quietly acquired the division, or the scroll, or
+     * both, agreeing with a correct one.
+     *
+     * What each space is for: the painted point is the distance from the
+     * canvas's painted top-left, which is what the HAND moved, so a drag's
+     * hysteresis threshold measured in it stays a threshold about the hand
+     * however far the canvas is zoomed out. The content point is that same
+     * distance in the canvas's own pixels, past everything already scrolled,
+     * which is the space the rectangles a drop is resolved against live in.
+     */
+    const root = scaledRoot(
+      { x: 100, y: 50, width: 912, height: 570 },
+      { width: 1280, height: 800 },
+      { left: 0, top: 250 }
+    );
+
+    const points = canvasPointerPoints(
+      100 + 200 * SCALE,
+      50 + 300 * SCALE,
+      root
+    );
+
+    // The fixture is CAPABLE of telling them apart. Without this the two
+    // assertions below could both hold on an implementation that answered one
+    // point twice, which is exactly the confusion they exist to catch.
+    expect(points.painted).not.toEqual(points.content);
+    expect(points.painted).toEqual({ x: 200 * SCALE, y: 300 * SCALE });
+    expect(points.content).toEqual({ x: 200, y: 550 });
+  });
+
   it("is the IDENTITY when nothing has been laid out", () => {
     /*
      * jsdom lays nothing out, so `offsetWidth` is 0 and a ratio taken from it
@@ -319,6 +356,65 @@ describe("canvasContentPoint", () => {
       x: rect.x,
       y: rect.y,
     });
+  });
+});
+
+describe("what a mapped pointer costs", () => {
+  /**
+   * Count the reads of ONE element's rectangle.
+   *
+   * Wraps the fixture's own stub rather than the prototype, so a read of some
+   * other element cannot satisfy the count — which is the way a second
+   * implementation would hide, since it needs this root and no other.
+   */
+  function countingRoot(scroll: { left: number; top: number }) {
+    const root = canvasRoot({ x: 100, y: 50, width: 400, height: 800 }, scroll);
+    const counter = { reads: 0 };
+    const measured = root.getBoundingClientRect.bind(root);
+    root.getBoundingClientRect = () => {
+      counter.reads += 1;
+      return measured();
+    };
+    return { root, counter };
+  }
+
+  it("reads the root ONCE for both spaces", () => {
+    /*
+     * The reason the two points are returned together rather than fetched one
+     * at a time. `getBoundingClientRect` forces the layout the browser was
+     * deferring, and a drag asks on every pointer move — so a caller that
+     * wanted both spaces and called two mappings paid a second synchronous
+     * reflow per move for an answer it already held.
+     *
+     * Exact rather than a bound, so it fails in both directions: a second read
+     * regresses it, and an implementation that answered without measuring at
+     * all — which would place every overlay at a nonsense coordinate — does not
+     * pass it either.
+     */
+    const { root, counter } = countingRoot({ left: 0, top: 250 });
+
+    canvasPointerPoints(140, 150, root);
+
+    expect(counter.reads).toBe(1);
+  });
+
+  it("costs the same when only the content point is wanted", () => {
+    /*
+     * The projection must not measure a second time on its way to discarding
+     * the painted half. Its own case rather than a second assertion above,
+     * because the two paths regress independently: a read added here fails only
+     * this one.
+     *
+     * What it does NOT see, stated so the green is not read as more than it is:
+     * this function's body replaced by an equivalent mapping with ONE read of
+     * its own costs exactly the same and passes. That is a duplicate rather
+     * than a cost, and no read count can tell the two apart.
+     */
+    const { root, counter } = countingRoot({ left: 0, top: 250 });
+
+    canvasContentPoint(140, 150, root);
+
+    expect(counter.reads).toBe(1);
   });
 });
 

--- a/packages/builder/src/geometry-dom.ts
+++ b/packages/builder/src/geometry-dom.ts
@@ -117,55 +117,100 @@ export function canvasContentRect(element: Element, root: HTMLElement): Rect {
 }
 
 /**
+ * One pointer position, in the two canvas spaces a drag reads it in.
+ *
+ * Both are taken from a SINGLE measurement of the root, and that is the whole
+ * reason they arrive together. They are the same offset expressed twice — the
+ * painted one IS the numerator the content one divides — so a caller that
+ * measured the root once for each would be free to answer the same move from
+ * two rectangles, and a drag would compare its pointer against rectangles the
+ * hysteresis had already stopped agreeing with.
+ */
+export interface CanvasPointerPoints {
+  /**
+   * The point in the canvas's own content coordinates.
+   *
+   * The exact counterpart of {@link canvasContentRect} rather than a second
+   * mapping written to match: a pointer event arrives in viewport coordinates
+   * and has to be compared against rectangles measured there, and the two
+   * disagreeing by a scroll offset is the fault this pairing exists to prevent.
+   */
+  readonly content: Point;
+  /**
+   * The point relative to the canvas's PAINTED top-left corner.
+   *
+   * A third space, and it exists because the other two each lose one of the two
+   * things a drag's hysteresis has to see.
+   *
+   * CLIENT coordinates are hand-scale — 8px of them is 8px of real movement,
+   * whatever the canvas is painted at — but they do not move when the page
+   * scrolls under a stationary pointer, which is exactly what autoscroll does.
+   * Measured there, a rival target's distance from its anchor stays zero
+   * however far the page travels, so the committed target never advances and
+   * the indicator stays on a position that has scrolled off screen.
+   *
+   * CANVAS CONTENT coordinates move with the scroll but are divided by the
+   * canvas scale, so the same threshold asks for less hand movement the further
+   * the canvas is zoomed out.
+   *
+   * This one moves with the scroll — the root's own painted rectangle travels —
+   * and is not divided, so a threshold in it stays a threshold about the hand.
+   * It is NOT interchangeable with {@link canvasContentRect}: nothing may be
+   * drawn from it, because it does not survive a scroll.
+   */
+  readonly painted: Point;
+}
+
+/**
+ * Map a viewport point into the canvas, in both spaces, from one rect read.
+ *
+ * `getBoundingClientRect` is the expensive part — it forces the layout the
+ * browser was hoping to defer — so a pointer handler that wants both spaces
+ * asks once here rather than calling two mappings that each measure.
+ *
+ * The pair describes the root as it was AT THE MOMENT OF THE READ, and it stops
+ * being true the next time anything moves the canvas. Callers that scroll,
+ * resize or restyle between using the two halves must measure again.
+ */
+export function canvasPointerPoints(
+  clientX: number,
+  clientY: number,
+  root: HTMLElement
+): CanvasPointerPoints {
+  const rootBox = root.getBoundingClientRect();
+  const scale = paintedScale(root, rootBox);
+  const painted = { x: clientX - rootBox.x, y: clientY - rootBox.y };
+  return {
+    painted,
+    // DERIVED from the painted offset rather than subtracting the root a second
+    // time: the two spaces differ only by the canvas scale and the root's
+    // scroll, so written apart they would be two subtractions to keep in step.
+    //
+    // The SCROLL is added after the division, exactly as in canvasContentRect.
+    // A scroll offset is already in content pixels — it counts the root's own
+    // laid-out content, which a transform never touches — so dividing it would
+    // shrink a real offset by the zoom.
+    content: {
+      x: painted.x / scale.x + root.scrollLeft,
+      y: painted.y / scale.y + root.scrollTop,
+    },
+  };
+}
+
+/**
  * A viewport point in the canvas's own content coordinates.
  *
- * The exact counterpart of {@link canvasContentRect} rather than a second
- * mapping written to match: a pointer event arrives in viewport coordinates and
- * has to be compared against rectangles measured above, and the two disagreeing
- * by a scroll offset is the fault this pairing exists to prevent.
+ * For the callers that need only that space, and a projection of
+ * {@link canvasPointerPoints} rather than a mapping of its own — a second
+ * subtraction here would be free to disagree with the one a drag reads.
+ * The discarded half costs nothing: the root is measured once either way.
  */
 export function canvasContentPoint(
   clientX: number,
   clientY: number,
   root: HTMLElement
 ): Point {
-  const rootBox = root.getBoundingClientRect();
-  const scale = paintedScale(root, rootBox);
-  return {
-    x: (clientX - rootBox.x) / scale.x + root.scrollLeft,
-    y: (clientY - rootBox.y) / scale.y + root.scrollTop,
-  };
-}
-
-/**
- * A viewport point relative to the canvas's PAINTED top-left corner.
- *
- * A third space, and it exists because the other two each lose one of the two
- * things a drag's hysteresis has to see.
- *
- * CLIENT coordinates are hand-scale — 8px of them is 8px of real movement,
- * whatever the canvas is painted at — but they do not move when the page
- * scrolls under a stationary pointer, which is exactly what autoscroll does.
- * Measured there, a rival target's distance from its anchor stays zero however
- * far the page travels, so the committed target never advances and the
- * indicator stays on a position that has scrolled off screen.
- *
- * CANVAS CONTENT coordinates move with the scroll but are divided by the canvas
- * scale, so the same threshold asks for less hand movement the further the
- * canvas is zoomed out.
- *
- * This one moves with the scroll — the root's own painted rectangle travels —
- * and is not divided, so a threshold in it stays a threshold about the hand.
- * It is NOT interchangeable with {@link canvasContentRect}: nothing may be
- * drawn from it, because it does not survive a scroll.
- */
-export function canvasPaintedPoint(
-  clientX: number,
-  clientY: number,
-  root: HTMLElement
-): Point {
-  const rootBox = root.getBoundingClientRect();
-  return { x: clientX - rootBox.x, y: clientY - rootBox.y };
+  return canvasPointerPoints(clientX, clientY, root).content;
 }
 
 /**


### PR DESCRIPTION
## What and why

`onPointerMove` read the canvas root's rectangle **twice per event, with no layout mutation between**, because the two pointer-space mappings were written side by side rather than derived from one another:

```
geometry-dom.ts:132   canvasContentPoint reads root.getBoundingClientRect()
geometry-dom.ts:167   canvasPaintedPoint reads it AGAIN, returning { clientX - rootBox.x, clientY - rootBox.y }
                      — verbatim the numerator :135-136 divides by paintedScale before adding scroll
canvas-drag.tsx:439   calls the first on event.currentTarget
canvas-drag.tsx:483 -> :371   aim() called the second on drag.root
```

Same element: `drag.root` is assigned at `:293` from the pointerdown's `currentTarget`, and `canvas.tsx:952` spreads **all four** drag handlers onto one `<div>`, so both handlers see the same element regardless of pointer capture.

This is `AGENTS.md`'s one-question-one-implementation rule: *derive the narrower view from the richer one; never compute it alongside.* The second mapping arrived in `582a0086c` on 2026-08-26, six days after `22bb0a43e` wrote the test that measures this.

## How

`canvasPointerPoints(clientX, clientY, root) → { painted, content }` — one `getBoundingClientRect()`, `painted` computed first, `content` **derived from it**. `canvasPaintedPoint` is deleted; `canvasContentPoint` survives as a one-line projection through the pair, so the pointerdown caller and two existing named tests that want that space alone keep working at no cost.

**Alternatives, and why each is worse:**

- **Thread a cached `DOMRect` out to `canvas-drag.tsx`.** `geometry-ownership.test.ts:57,74` permits a rect read in exactly two relative paths and its docblock calls a third *"a decision to be argued in a review, not a name to be chosen."* The caller would hold the read. **Note the reason: it is the ownership rule, not the one-question rule.** An earlier draft of this reasoning cited the ownership *test* as forbidding a duplicate mapping — that is false, and the test says so itself: *"This checks where a rectangle is READ. It does NOT check where the [mapping lives] … A duplicate mapping added alongside this file passes every assertion below."*
- **Keep both exports and add a third returning the pair.** Three implementations of two mappings — the fault being fixed, with an extra layer.
- **Delete `canvasContentPoint`.** The pointerdown origin (`:284`) and two named tests want that space alone, and the projection is free once the root is measured once.

**One deliberate semantic change:** `onPointerMove` now maps against `drag.root` rather than `event.currentTarget`. Picking one was forced — `pump` has no event and must use `drag.root` — and `drag.root` is the element the rectangles were snapshotted against. A no-op in every reachable case, per the `canvas.tsx:952` finding above.

## The staleness window

The shared read is safe across **one `onPointerMove` body**, and that is stated in the code because it is what a future edit could silently violate. Established by walking every statement between the read and the last use:

- `drag.clientX/Y =` assignments, and `Math.hypot` — pure
- `setPointerCapture` — retargets events, no layout. No `gotpointercapture` listener exists in product code
- `requestAnimationFrame(pump)` — schedules only
- `editor.select` — `editor-state.ts:298` is a bare `setSelection(...)`, and there is **no `flushSync` anywhere in `packages/builder` or `packages/plugin-page-builder`** except `command-palette.tsx:409`, which this path never reaches. Batched; flushes after the handler returns
- `aim` → `resolveDrop` (pure, over the snapshot) and `setState`

So `pump`'s `scroller.scrollTop = before + step` is the only layout mutation in play, and it runs in a rAF callback — a different task. **What would violate it:** anything added to that handler that scrolls, resizes, writes a style, or forces a synchronous React flush.

## Measured

`e2e/tests/canvas/acceptance.spec.ts` A9, bound temporarily lowered so the assertion message prints the value, restored after (`git diff -- e2e/` = 0 lines):

| | run 1 | run 2 | run 3 |
|---|---|---|---|
| before (`origin/main`) | **6** | **6** | **6.35** |
| after (dist rebuilt, `.next-e2e` cleared) | **4** | **4.9** | **4** |

**The bound of 6 was already failing on a loaded local run before this change** — the 6.35. The headroom was negative, not thin.

The residual variance is the autoscroll's rAF term, exactly as modelled: the per-event root reads are now a hard 2.0 and the frames contribute the rest. Full canvas acceptance file at the real bound: **13 passed, exit 0**, no test changed.

**The bound is not moved.** Its comment exists to stop that: *"a change past it is a real change somebody should look at rather than a threshold nobody noticed."*

## The break-verification found a coverage hole first

The first break proved nothing, and that is the finding. Corrupting the `painted` local killed two **content** tests — content derives from painted, so of course it did. Restated as a mutation of the returned `painted` field only:

- `painted-only-carries-scale-and-scroll` → **exit 0, zero failures.** The painted half had **no coverage at all**: every canvas-drag fixture runs at scale 1 with `scrollTop` 0, where the two spaces coincide.

Coverage was added first, then re-verified:

| break | fails |
|---|---|
| painted carries the scale and scroll | `leaves the PAINTED point undivided and unmoved by the scroll` (1, the new one) |
| content drops the scale divisor | that, plus `keeps the pointer in the same space as the rectangles` |
| content drops the scroll term | those two, plus `maps a pointer into the same space the rectangles are measured in` |
| the pair measures twice | `reads the root ONCE for both spaces` + `costs the same when only the content point is wanted` |
| only the projection reads again | `costs the same when only the content point is wanted` (1 — the two read tests discriminate independently) |

Each asserted exactly one occurrence before substituting and byte-equality after.

**One break deliberately does not fire, and the test comment says so:** an equivalent mapping written inline *with one read of its own* passes the count test. That is a duplicate, not a cost, and no read count can see it — the duplication gate is the instrument for that (0 introduced clone groups).

## Gates

builder build **0** · root `check-types` **0** (22/22) · root `lint` **0** (24/24) · builder vitest **0** — 77 files, 2205 → **2208** · comment convention **0** · `changeset status` **0** · `fallow audit` **pass**, zero introduced in all four categories · e2e canvas acceptance at the real bound **0**, 13 passed.

## Out of scope, filed rather than fixed

`pump` reads `containerEdges(scroller)` on **every** frame, before the `step !== 0` check — so a drag nowhere near an edge still pays a rect read per rAF frame. That is the whole of the residual 4 → 4.9 variance, and it is a separate cheap fix. Not touched here.

## Changeset

Added: yes (`patch`, all published packages) — user-facing drag responsiveness.
