### PR TITLE
fix(admin): make the version comparison page say what it is doing

### DIFF
--- a/.changeset/version-rail-locale-and-narrow-viewports.md
+++ b/.changeset/version-rail-locale-and-narrow-viewports.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Name each version's language in the comparison page's history rail, and
+stack the rail above the comparison on narrow viewports instead of leaving
+the comparison a sliver beside it.

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
@@ -18,6 +18,8 @@ import type { NextlyColumn } from "@admin/components/ui/table/data-table";
 import { formatDateWithAdminTimezone } from "@admin/hooks/useAdminDateFormatter";
 import { fieldLabel } from "@admin/lib/field-label";
 
+import { entryTitleField } from "../entry-title";
+
 import { EntryTableCell } from "./EntryTableCell";
 import { LanguageDots } from "./LanguageDots";
 
@@ -314,26 +316,21 @@ export function getEntryTitleField(
 }
 
 /**
- * Which field names an entry, from the author's choice and the field names.
+ * Which COLUMN names an entry.
  *
- * Separated from {@link getEntryTitleField} because the same rule is asked of
- * collections carrying two different field types — the list has schema fields,
- * the comparison page has the shape `useCollection` answers with — and neither
- * is convertible to the other. The rule reads only a setting and a list of
- * names, so it is stated once here and given a typed front door per caller,
- * rather than restated where a second copy would drift into naming an entry
- * differently on two pages.
+ * The preference order comes from `entry-title`, shared with the editor and
+ * comparison headings so a document is not called one thing by its editor and
+ * another by the page beside it. Only the last resort is decided here, because
+ * a column needs a field that exists where a heading needs text.
  */
 export function pickTitleFieldName(
   useAsTitle: string | undefined,
   fieldNames: readonly string[]
 ): string {
-  return (
-    useAsTitle ||
-    ["title", "name", "label"].find(name => fieldNames.includes(name)) ||
-    fieldNames[0] ||
-    "id"
-  );
+  // A column has to name a field that exists, so where nothing is conventional
+  // this falls back to the first field and finally to `id`: a table with an
+  // empty primary column is worse than one showing an unhelpful field.
+  return entryTitleField(useAsTitle, fieldNames) ?? fieldNames[0] ?? "id";
 }
 
 /**

--- a/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
+++ b/packages/admin/src/components/features/entries/EntryList/EntryTableColumns.tsx
@@ -307,12 +307,29 @@ export function getEntryTitleField(
   // Resolve from ACTUAL schema fields. `getAvailableColumns` always injects a
   // synthetic "title" column, so testing it would always win and leave
   // collections without a real title field with an empty primary column.
-  const fieldNames = getAllDataFields(collection.fields).map(
-    field => field.name
+  return pickTitleFieldName(
+    collection.admin?.useAsTitle,
+    getAllDataFields(collection.fields).map(field => field.name)
   );
+}
 
+/**
+ * Which field names an entry, from the author's choice and the field names.
+ *
+ * Separated from {@link getEntryTitleField} because the same rule is asked of
+ * collections carrying two different field types — the list has schema fields,
+ * the comparison page has the shape `useCollection` answers with — and neither
+ * is convertible to the other. The rule reads only a setting and a list of
+ * names, so it is stated once here and given a typed front door per caller,
+ * rather than restated where a second copy would drift into naming an entry
+ * differently on two pages.
+ */
+export function pickTitleFieldName(
+  useAsTitle: string | undefined,
+  fieldNames: readonly string[]
+): string {
   return (
-    collection.admin?.useAsTitle ||
+    useAsTitle ||
     ["title", "name", "label"].find(name => fieldNames.includes(name)) ||
     fieldNames[0] ||
     "id"

--- a/packages/admin/src/components/features/entries/__tests__/entry-title.test.ts
+++ b/packages/admin/src/components/features/entries/__tests__/entry-title.test.ts
@@ -1,0 +1,129 @@
+/**
+ * What an entry is called, asked by three surfaces that must agree.
+ *
+ * The entry list picks a primary COLUMN, the editor heading and the version
+ * comparison heading each need TEXT. Answering with different preference lists
+ * let a document be called one thing by its editor and another by the page
+ * comparing its versions — and a reader cannot tell whether such a difference
+ * means something.
+ */
+import { describe, it, expect } from "vitest";
+
+import {
+  COMMON_TITLE_FIELDS,
+  entryTitleField,
+  entryTitleValue,
+} from "../entry-title";
+
+describe("entryTitleField — which field names an entry", () => {
+  it("takes the author's nomination first", () => {
+    expect(entryTitleField("headline", ["headline", "title"])).toBe("headline");
+  });
+
+  /**
+   * The case that exposed the divergence: a collection whose fields are
+   * `[description, subject]` and which nominates nothing. One rule reached for
+   * the FIRST field, `description`, while the other knew `subject` is
+   * conventionally a title — so the two named the same document differently.
+   */
+  it("prefers a conventional field over merely the first one", () => {
+    expect(entryTitleField(undefined, ["description", "subject"])).toBe(
+      "subject"
+    );
+  });
+
+  it("follows the preference order rather than the field order", () => {
+    // `name` outranks `subject` wherever both exist, whichever comes first in
+    // the schema — otherwise the answer depends on how the author happened to
+    // arrange the collection.
+    expect(entryTitleField(undefined, ["subject", "name"])).toBe("name");
+    expect(entryTitleField(undefined, ["name", "subject"])).toBe("name");
+  });
+
+  /**
+   * `undefined` rather than a guess, so a caller can tell "nothing here is
+   * conventionally a title" from "the title is empty" and answer each in the
+   * way its own surface needs.
+   */
+  it("says nothing when no field is conventional", () => {
+    expect(entryTitleField(undefined, ["description", "body"])).toBeUndefined();
+  });
+
+  it("ignores a nomination that is absent, or is `id`", () => {
+    // A nominated field that is not in the schema cannot be read, and `id` is
+    // what the fallbacks already show — treating it as a title would hide a
+    // real title field behind it.
+    expect(entryTitleField("missing", ["title"])).toBe("title");
+    expect(entryTitleField("id", ["title"])).toBe("title");
+  });
+});
+
+describe("entryTitleValue — what to call this entry", () => {
+  it("takes the nominated field's value", () => {
+    expect(
+      entryTitleValue({ headline: "Ada writes a compiler" }, "headline")
+    ).toBe("Ada writes a compiler");
+  });
+
+  /**
+   * The nominated field being EMPTY is not the end of the search. An entry with
+   * a blank title and a filled `name` has a better name available, and showing
+   * the caller's fallback there would be worse than showing it.
+   */
+  it("keeps looking when the nominated field is blank", () => {
+    expect(entryTitleValue({ headline: "   ", name: "Ada" }, "headline")).toBe(
+      "Ada"
+    );
+  });
+
+  it("follows the same order as the field choice", () => {
+    expect(entryTitleValue({ subject: "Re: hello", name: "Ada" })).toBe("Ada");
+  });
+
+  it("ignores values that are not readable text", () => {
+    // A number or an object stringifies to something no reader recognises as a
+    // name, so it is not one.
+    expect(entryTitleValue({ title: 42, name: "Ada" })).toBe("Ada");
+    expect(entryTitleValue({ title: {}, name: "Ada" })).toBe("Ada");
+    expect(entryTitleValue({ title: "" })).toBeUndefined();
+  });
+
+  it("says nothing for an entry that says nothing about itself", () => {
+    expect(entryTitleValue({ body: "text" })).toBeUndefined();
+    expect(entryTitleValue(undefined, "title")).toBeUndefined();
+  });
+});
+
+describe("the two answers agree", () => {
+  /**
+   * The property the whole module exists for. Whichever field the column
+   * choice lands on, reading that field's value must produce the same title —
+   * otherwise the list and the heading name one document two ways, which is
+   * exactly the divergence this replaced.
+   */
+  it("names the same field the value comes from", () => {
+    const fieldNames = ["description", "subject", "name"];
+    const chosen = entryTitleField(undefined, fieldNames);
+    expect(chosen).toBeDefined();
+
+    const entry = {
+      description: "long text",
+      subject: "Re: hello",
+      name: "Ada",
+    };
+    expect(entryTitleValue(entry, undefined)).toBe(
+      entry[chosen as keyof typeof entry]
+    );
+  });
+
+  /** The order is one list, not two copies that happen to match today. */
+  it("uses one preference order", () => {
+    expect(COMMON_TITLE_FIELDS).toEqual([
+      "title",
+      "name",
+      "label",
+      "subject",
+      "heading",
+    ]);
+  });
+});

--- a/packages/admin/src/components/features/entries/__tests__/entry-title.test.ts
+++ b/packages/admin/src/components/features/entries/__tests__/entry-title.test.ts
@@ -80,11 +80,23 @@ describe("entryTitleValue — what to call this entry", () => {
     expect(entryTitleValue({ subject: "Re: hello", name: "Ada" })).toBe("Ada");
   });
 
-  it("ignores values that are not readable text", () => {
-    // A number or an object stringifies to something no reader recognises as a
-    // name, so it is not one.
-    expect(entryTitleValue({ title: 42, name: "Ada" })).toBe("Ada");
+  /**
+   * A number IS a name where an author chose one. An invoice or issue number
+   * is what such an entry is called, the entry table already shows that
+   * column, and the translation worklist already converts it — so refusing it
+   * here would name one entry three different ways.
+   */
+  it("keeps a numeric title", () => {
+    expect(entryTitleValue({ invoiceNo: 42 }, "invoiceNo")).toBe("42");
+    expect(entryTitleValue({ title: 0, name: "Ada" })).toBe("0");
+  });
+
+  it("refuses values a reader would not recognise as a name", () => {
+    // Objects and arrays stringify to `[object Object]` and to their contents;
+    // neither is a name. `NaN` and `Infinity` are numbers that are not.
     expect(entryTitleValue({ title: {}, name: "Ada" })).toBe("Ada");
+    expect(entryTitleValue({ title: [1, 2], name: "Ada" })).toBe("Ada");
+    expect(entryTitleValue({ title: NaN, name: "Ada" })).toBe("Ada");
     expect(entryTitleValue({ title: "" })).toBeUndefined();
   });
 

--- a/packages/admin/src/components/features/entries/entry-title.ts
+++ b/packages/admin/src/components/features/entries/entry-title.ts
@@ -1,0 +1,84 @@
+/**
+ * What an entry is called.
+ *
+ * Three surfaces ask this — the entry list picks a primary COLUMN, the editor
+ * heading and the version comparison heading each need TEXT — and they were
+ * answering it with two different preference lists. A collection with fields
+ * `[description, subject]` and no `useAsTitle` was named "description" by one
+ * and "subject" by the other, so a document could be called one thing by its
+ * editor and another by the page comparing its versions.
+ *
+ * The preference ORDER lives here, once. The last resort deliberately does not:
+ * a column has to name a field that exists, a heading has to produce text, and
+ * those are different needs that each caller states where it can be read.
+ *
+ * @module components/features/entries/entry-title
+ */
+
+/**
+ * Field names that conventionally hold a title, in preference order.
+ *
+ * `subject` and `heading` are here because a mail-like or article-like
+ * collection names its entries with them, and a reader scanning a list of
+ * either sees nothing useful without them.
+ */
+export const COMMON_TITLE_FIELDS = [
+  "title",
+  "name",
+  "label",
+  "subject",
+  "heading",
+] as const;
+
+/**
+ * The field that names an entry, from the author's choice then convention.
+ *
+ * `undefined` where neither applies, so a caller can tell "no conventional
+ * title field" from "the title field is empty" and answer each in its own way.
+ */
+export function entryTitleField(
+  useAsTitle: string | undefined,
+  fieldNames: readonly string[]
+): string | undefined {
+  // `id` is not a title even when nominated: it is what the fallbacks already
+  // show, and treating it as one would hide a real title field behind it.
+  if (useAsTitle && useAsTitle !== "id" && fieldNames.includes(useAsTitle)) {
+    return useAsTitle;
+  }
+  return COMMON_TITLE_FIELDS.find(name => fieldNames.includes(name));
+}
+
+/** A value counts as a title only if it is text with something in it. */
+function readableText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * What to call this entry, or `undefined` when it says nothing about itself.
+ *
+ * The nominated field is tried first and then the conventional ones IN ORDER,
+ * rather than stopping at the nominated field: an entry whose title field is
+ * still empty has a better name available if another conventional field is
+ * filled, and showing the fallback there would be worse than showing it.
+ */
+export function entryTitleValue(
+  entry: Record<string, unknown> | undefined,
+  useAsTitle?: string
+): string | undefined {
+  if (!entry) return undefined;
+  const nominated =
+    useAsTitle && useAsTitle !== "id"
+      ? readableText(entry[useAsTitle])
+      : undefined;
+  if (nominated !== undefined) return nominated;
+  // No field-name list is consulted: a value lookup that also had to be told
+  // which fields exist could be handed a list that disagrees with the entry,
+  // and reading the entry answers the question directly.
+  for (const name of COMMON_TITLE_FIELDS) {
+    const value = readableText(entry[name]);
+    if (value !== undefined) return value;
+  }
+  return undefined;
+}

--- a/packages/admin/src/components/features/entries/entry-title.ts
+++ b/packages/admin/src/components/features/entries/entry-title.ts
@@ -48,8 +48,19 @@ export function entryTitleField(
   return COMMON_TITLE_FIELDS.find(name => fieldNames.includes(name));
 }
 
-/** A value counts as a title only if it is text with something in it. */
+/**
+ * A value counts as a title if it is a scalar with something in it.
+ *
+ * Numbers included, because an author who nominates an invoice or issue number
+ * as the title means it — and the entry table already shows that column, the
+ * translation worklist already converts it, so rejecting it here would name one
+ * entry three ways. Objects and arrays are refused: they stringify to something
+ * no reader recognises as a name.
+ */
 function readableText(value: unknown): string | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? String(value) : undefined;
+  }
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -197,8 +197,15 @@ export function VersionComparePage({
         </div>
       </header>
 
-      <div className="flex min-h-0 flex-1">
-        <aside className="w-72 shrink-0 overflow-y-auto border-r border-border">
+      {/* Stacked below `lg`, side by side above it. The rail is a fixed 18rem,
+          and at a 375px viewport that leaves the comparison roughly 87px before
+          borders and padding — its pair description, filter and field values
+          all clipped. `DashboardLayout` already switches to a mobile header at
+          the same breakpoint, so the split is what has to give, not the
+          content beside it. Stacked, the rail keeps a bounded height so the
+          comparison is reachable without scrolling past the whole history. */}
+      <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
+        <aside className="max-h-[40vh] shrink-0 overflow-y-auto border-b border-border lg:max-h-none lg:w-72 lg:border-r lg:border-b-0">
           <VersionTimelineRail
             scope={scope}
             versions={versions}

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -150,6 +150,13 @@ export function VersionComparePage({
     [list.data]
   );
   const pair = resolvePair(versions, from, to, list.hasNextPage ?? false);
+  // Derived once and given to BOTH surfaces. An infinite query flips to
+  // `isError` when a LATER page fails while keeping the pages it already holds,
+  // so the aggregate state says "this failed" about a page nobody asked for.
+  // Passed raw, it erases the rail's rows on one surface and unmounts a valid
+  // comparison on the other — two different lies about the same event. Only a
+  // failure that left nothing on screen is a failure of the history itself.
+  const historyUnavailable = list.isError && versions.length === 0;
 
   // Choosing a row compares it against the version before it IN ITS OWN LOCALE,
   // and writes that choice to the URL so the comparison on screen is the one the
@@ -164,22 +171,24 @@ export function VersionComparePage({
         list.hasNextPage ?? false
       );
       if (previous.kind !== "version") return;
-      const target = withQuery(window.location.pathname, {
-        from: previous.versionNo,
-        to: versionNo,
-      });
+      // Compared as the VALUES that decide the comparison, not as URL text.
       // `navigateTo` skips a push only when its argument equals
-      // `window.location.pathname`, which a target carrying a query never does
-      // — so choosing the row already on screen stacked another identical
-      // entry, and Back walked through indistinguishable copies of one
-      // comparison before leaving the page. Compared here against the full
-      // current URL, which is what actually distinguishes two comparisons.
-      if (target === `${window.location.pathname}${window.location.search}`) {
-        return;
-      }
-      navigateTo(target);
+      // `window.location.pathname`, which a target carrying a query never does,
+      // so choosing the row already on screen stacked another identical entry
+      // and Back walked through indistinguishable copies of one comparison.
+      // Comparing serialized text instead would answer differently for
+      // `?to=9&from=8`, or for a link carrying an unrelated parameter, and
+      // reinstate exactly that — these two numbers are what `resolvePair`
+      // reads, so they are what "the same comparison" means.
+      if (previous.versionNo === from && versionNo === to) return;
+      navigateTo(
+        withQuery(window.location.pathname, {
+          from: previous.versionNo,
+          to: versionNo,
+        })
+      );
     },
-    [versions, list.hasNextPage]
+    [versions, list.hasNextPage, from, to]
   );
 
   return (
@@ -220,12 +229,7 @@ export function VersionComparePage({
             selected={pair.kind === "pair" ? pair.to : null}
             onSelect={selectPair}
             isLoading={list.isLoading}
-            // Only a failure that left NOTHING on screen replaces the rail. A
-            // failed next page also flips the query to error while its loaded
-            // pages remain, and passing that through discarded every row a
-            // reader already had, along with the Load more control that would
-            // have retried it. The history sheet draws the same distinction.
-            isError={list.isError && versions.length === 0}
+            isError={historyUnavailable}
             hasNextPage={list.hasNextPage}
             isFetchingNextPage={list.isFetchingNextPage}
             onLoadMore={() => void list.fetchNextPage()}
@@ -242,7 +246,7 @@ export function VersionComparePage({
           <ComparisonPane
             scope={scope}
             pair={pair}
-            isError={list.isError}
+            isError={historyUnavailable}
             isLoading={list.isLoading}
             onRetry={() => void list.refetch()}
           />

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -65,6 +65,13 @@ const NO_PAIR_MESSAGE: Record<
   "no-history": "There is nothing to compare yet.",
   "only-version":
     "There is only one version so far, so there is nothing to compare it with.",
+  // Deliberately different from the line above. Saying "there is only one
+  // version" beside a rail listing several would leave a reader unable to tell
+  // which surface to believe; this says which language is meant, and that
+  // there is somewhere else to look.
+  "only-in-locale":
+    "This is the only version in this language, so there is nothing to compare " +
+    "it with. Versions in other languages have their own history.",
   "not-loaded":
     "The version before this one has not been loaded yet. Choose Load more in the list to fetch it.",
 };

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -233,6 +233,10 @@ export function VersionComparePage({
             hasNextPage={list.hasNextPage}
             isFetchingNextPage={list.isFetchingNextPage}
             onLoadMore={() => void list.fetchNextPage()}
+            // Page-specific, not the aggregate: `historyUnavailable` above
+            // answers whether the history could be read at all, and a later
+            // page failing is a different event with a different remedy.
+            nextPageError={list.isFetchNextPageError ? list.error : null}
           />
         </aside>
 

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -164,12 +164,20 @@ export function VersionComparePage({
         list.hasNextPage ?? false
       );
       if (previous.kind !== "version") return;
-      navigateTo(
-        withQuery(window.location.pathname, {
-          from: previous.versionNo,
-          to: versionNo,
-        })
-      );
+      const target = withQuery(window.location.pathname, {
+        from: previous.versionNo,
+        to: versionNo,
+      });
+      // `navigateTo` skips a push only when its argument equals
+      // `window.location.pathname`, which a target carrying a query never does
+      // — so choosing the row already on screen stacked another identical
+      // entry, and Back walked through indistinguishable copies of one
+      // comparison before leaving the page. Compared here against the full
+      // current URL, which is what actually distinguishes two comparisons.
+      if (target === `${window.location.pathname}${window.location.search}`) {
+        return;
+      }
+      navigateTo(target);
     },
     [versions, list.hasNextPage]
   );
@@ -212,7 +220,12 @@ export function VersionComparePage({
             selected={pair.kind === "pair" ? pair.to : null}
             onSelect={selectPair}
             isLoading={list.isLoading}
-            isError={list.isError}
+            // Only a failure that left NOTHING on screen replaces the rail. A
+            // failed next page also flips the query to error while its loaded
+            // pages remain, and passing that through discarded every row a
+            // reader already had, along with the Load more control that would
+            // have retried it. The history sheet draws the same distinction.
+            isError={list.isError && versions.length === 0}
             hasNextPage={list.hasNextPage}
             isFetchingNextPage={list.isFetchingNextPage}
             onLoadMore={() => void list.fetchNextPage()}

--- a/packages/admin/src/components/features/versions/VersionLocaleBadge.tsx
+++ b/packages/admin/src/components/features/versions/VersionLocaleBadge.tsx
@@ -1,0 +1,60 @@
+/**
+ * Which translation a version holds.
+ *
+ * A localized document captures a version per locale and every history view
+ * interleaves them, so a row identified only by its number leaves an editor
+ * unable to tell whether version 5 is the English or the French one.
+ *
+ * One component, used by every list that shows versions. The rule has three
+ * parts a second copy would drift on — when to show anything, what to show,
+ * and what the label falls back to — and two lists naming a language
+ * differently is worse than either choice, because the reader cannot tell
+ * whether the difference means something.
+ *
+ * The CODE is what shows, with the human label as its tooltip: the code is
+ * short enough to sit in a dense row without truncating, and stays legible
+ * beside a version number and a status.
+ *
+ * @module components/features/versions/VersionLocaleBadge
+ */
+
+import { Badge } from "@admin/components/ui";
+import { useLocalization } from "@admin/hooks/useLocalization";
+
+export interface VersionLocale {
+  /** Whether this version's language should be named at all. */
+  show: boolean;
+  /** The locale code, as stored on the version. */
+  code: string | null;
+  /** Its human label, falling back to the code, for tooltips and aria text. */
+  label: string | null;
+}
+
+/**
+ * The locale facts a version row needs, resolved once.
+ *
+ * Exported beside the component because a row's accessible name has to include
+ * the language as text, and reading it from anywhere else would be the second
+ * copy this module exists to prevent.
+ */
+export function useVersionLocale(locale: string | null): VersionLocale {
+  const { enabled, getLocale } = useLocalization();
+  const label = locale !== null ? (getLocale(locale)?.label ?? locale) : null;
+  return { show: enabled && locale !== null, code: locale, label };
+}
+
+/** Nothing is rendered on a single-language install, or for a version that
+ *  carries no locale — a badge there would carry no information. */
+export function VersionLocaleBadge({ locale }: { locale: string | null }) {
+  const { show, code, label } = useVersionLocale(locale);
+  if (!show) return null;
+  return (
+    <Badge
+      variant="outline"
+      className="shrink-0 uppercase"
+      title={label ?? undefined}
+    >
+      {code}
+    </Badge>
+  );
+}

--- a/packages/admin/src/components/features/versions/VersionRow.tsx
+++ b/packages/admin/src/components/features/versions/VersionRow.tsx
@@ -11,10 +11,11 @@ import { Pencil } from "lucide-react";
 
 import { formatRelativeTime } from "@admin/components/features/notifications/relative-time";
 import { Badge } from "@admin/components/ui";
-import { useLocalization } from "@admin/hooks/useLocalization";
 import { formatDateTime } from "@admin/lib/dates/format";
 import { cn } from "@admin/lib/utils";
 import type { VersionMeta } from "@admin/services/versionApi";
+
+import { VersionLocaleBadge, useVersionLocale } from "./VersionLocaleBadge";
 
 export interface VersionRowProps {
   version: VersionMeta;
@@ -23,6 +24,40 @@ export interface VersionRowProps {
   onSelect: (versionNo: number) => void;
   /** Omitted when the caller cannot rename, which hides the affordance. */
   onRename?: (versionNo: number) => void;
+}
+
+/**
+ * What a screen reader announces for a row.
+ *
+ * Mirrors what the row SHOWS, in the order it shows it: name and ordinal,
+ * status, the language, the restore lineage when there is one, then the author.
+ * Built here rather than inline so the row's own body stays about layout, and
+ * so the order can be read in one place against the markup it describes.
+ */
+function rowAriaLabel({
+  title,
+  ordinal,
+  named,
+  status,
+  locale,
+  restoredFrom,
+  author,
+}: {
+  title: string;
+  ordinal: string;
+  named: boolean;
+  status: string;
+  locale: string | null;
+  restoredFrom: number | null;
+  author: string;
+}): string {
+  const opening = named
+    ? `${title}, ${ordinal}, ${status}`
+    : `${title}, ${status}`;
+  const language = locale !== null ? `, ${locale}` : "";
+  const lineage =
+    restoredFrom !== null ? `, restored from version ${restoredFrom}` : "";
+  return `${opening}${language}${lineage}, by ${author}`;
 }
 
 export function VersionRow({
@@ -38,11 +73,9 @@ export function VersionRow({
   // A localized document captures a version per locale, so each row names the
   // language it holds. Only shown when the app is localized and this version
   // carries a locale; its human label (falling back to the code) is the title.
-  const { enabled: localized, getLocale } = useLocalization();
-  const localeCode = version.locale;
-  const localeLabel =
-    localeCode !== null ? (getLocale(localeCode)?.label ?? localeCode) : null;
-  const showLocale = localized && localeCode !== null;
+  const { show: showLocale, label: localeLabel } = useVersionLocale(
+    version.locale
+  );
 
   // What the row is called. `version.label` is the editor's own name for it;
   // the number is the fallback, and stays visible either way so two versions
@@ -59,15 +92,15 @@ export function VersionRow({
   // lineage. Absent (null) for an ordinary edit, in which case nothing shows.
   const restoredFrom = version.sourceVersionNo;
 
-  // The accessible name mirrors what the row shows: name/ordinal, status, the
-  // language, the restore lineage when present, then the author.
-  const ariaLabel =
-    (named
-      ? `${title}, ${ordinal}, ${version.status}`
-      : `${title}, ${version.status}`) +
-    (showLocale ? `, ${localeLabel}` : "") +
-    (restoredFrom !== null ? `, restored from version ${restoredFrom}` : "") +
-    `, by ${author}`;
+  const ariaLabel = rowAriaLabel({
+    title,
+    ordinal,
+    named,
+    status: version.status,
+    locale: showLocale ? localeLabel : null,
+    restoredFrom,
+    author,
+  });
 
   const canRename = selectable && onRename !== undefined;
 
@@ -113,15 +146,7 @@ export function VersionRow({
           </Badge>
           {/* Language: names which translation this version holds, so an editor
               scanning a mixed-locale history can tell them apart. */}
-          {showLocale && (
-            <Badge
-              variant="outline"
-              className="shrink-0 uppercase"
-              title={localeLabel ?? undefined}
-            >
-              {localeCode}
-            </Badge>
-          )}
+          <VersionLocaleBadge locale={version.locale} />
           {/* Lineage: a restored version names the one it was made from, so an
               editor can see at a glance that this entry came from a rollback. */}
           {restoredFrom !== null && (

--- a/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
+++ b/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
@@ -11,6 +11,7 @@
  */
 
 import { Badge, Button, Skeleton } from "@admin/components/ui";
+import { useLocalization } from "@admin/hooks/useLocalization";
 import { formatDateTime } from "@admin/lib/dates/format";
 import type { VersionMeta, VersionScope } from "@admin/services/versionApi";
 
@@ -55,6 +56,24 @@ function RailSkeleton() {
   );
 }
 
+/**
+ * The language a version holds, on a document that has more than one.
+ *
+ * A localized document captures a version per locale and this list interleaves
+ * them, so a row identified only by its number leaves an editor unable to tell
+ * whether version 5 is the English or the French one. Read from the same hook
+ * `VersionRow` uses, with the locale's human label falling back to its code, so
+ * the two lists name a language the same way.
+ *
+ * Nothing is said on a single-language install, where a badge on every row
+ * would carry no information.
+ */
+function LocaleBadge({ locale }: { locale: string | null }) {
+  const { enabled, getLocale } = useLocalization();
+  if (!enabled || locale === null) return null;
+  return <Badge variant="outline">{getLocale(locale)?.label ?? locale}</Badge>;
+}
+
 /** A row's first line: which version it is, its status, and any name given it. */
 function RowHeading({ version }: { version: VersionMeta }) {
   return (
@@ -64,6 +83,7 @@ function RowHeading({ version }: { version: VersionMeta }) {
           ? "Autosave"
           : `Version ${version.versionNo}`}
       </span>
+      <LocaleBadge locale={version.locale} />
       {version.status ? (
         <Badge variant={version.status === "published" ? "success" : "outline"}>
           {version.status}

--- a/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
+++ b/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
@@ -11,6 +11,7 @@
  */
 
 import { Badge, Button, Skeleton } from "@admin/components/ui";
+import { apiErrorMessage } from "@admin/lib/api/parseApiError";
 import { formatDateTime } from "@admin/lib/dates/format";
 import type { VersionMeta, VersionScope } from "@admin/services/versionApi";
 
@@ -38,6 +39,14 @@ export interface VersionTimelineRailProps {
   hasNextPage?: boolean;
   isFetchingNextPage?: boolean;
   onLoadMore?: () => void;
+  /**
+   * Why the last Load more failed, or null when it did not.
+   *
+   * Separate from `isError`, which asks whether the HISTORY could be read at
+   * all: a page that failed after others loaded leaves every row on screen
+   * valid, so it is reported beside the retry rather than in place of the list.
+   */
+  nextPageError?: unknown;
 }
 
 function RailSkeleton() {
@@ -94,6 +103,49 @@ function unpairableReason(previous: Predecessor): string | null {
   return previous.kind === "first"
     ? "Nothing before this version to compare it against"
     : "Load more history to compare this version";
+}
+
+/**
+ * The control that extends the history, and what happened last time it was used.
+ *
+ * A failed request clears `isFetchingNextPage` and returns the button to its
+ * resting label, so without a message the click appears to have done nothing.
+ * The rows already on screen stay valid, which is why the failure is reported
+ * beside the retry rather than in place of the list.
+ */
+function LoadMoreFooter({
+  isFetchingNextPage,
+  nextPageError,
+  onLoadMore,
+}: {
+  isFetchingNextPage?: boolean;
+  nextPageError: unknown;
+  onLoadMore?: () => void;
+}) {
+  const failed = nextPageError !== null && nextPageError !== undefined;
+  const label = isFetchingNextPage
+    ? "Loading…"
+    : failed
+      ? "Try again"
+      : "Load more";
+  return (
+    <div className="flex flex-col gap-2 p-4">
+      {failed ? (
+        <p role="status" className="text-xs text-destructive">
+          {apiErrorMessage(nextPageError, "Could not load more history.")}
+        </p>
+      ) : null}
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-full"
+        disabled={isFetchingNextPage}
+        onClick={onLoadMore}
+      >
+        {label}
+      </Button>
+    </div>
+  );
 }
 
 /** One version in the rail. */
@@ -173,6 +225,7 @@ export function VersionTimelineRail({
   hasNextPage = false,
   isFetchingNextPage = false,
   onLoadMore,
+  nextPageError = null,
 }: VersionTimelineRailProps) {
   if (isLoading) return <RailSkeleton />;
 
@@ -223,17 +276,11 @@ export function VersionTimelineRail({
       </ul>
 
       {hasNextPage ? (
-        <div className="p-4">
-          <Button
-            variant="outline"
-            size="sm"
-            className="w-full"
-            disabled={isFetchingNextPage}
-            onClick={onLoadMore}
-          >
-            {isFetchingNextPage ? "Loading…" : "Load more"}
-          </Button>
-        </div>
+        <LoadMoreFooter
+          isFetchingNextPage={isFetchingNextPage}
+          nextPageError={nextPageError}
+          onLoadMore={onLoadMore}
+        />
       ) : null}
     </nav>
   );

--- a/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
+++ b/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
@@ -11,11 +11,11 @@
  */
 
 import { Badge, Button, Skeleton } from "@admin/components/ui";
-import { useLocalization } from "@admin/hooks/useLocalization";
 import { formatDateTime } from "@admin/lib/dates/format";
 import type { VersionMeta, VersionScope } from "@admin/services/versionApi";
 
 import { predecessorOf, type Predecessor } from "./version-pairing";
+import { VersionLocaleBadge } from "./VersionLocaleBadge";
 import { VersionSummaryLine } from "./VersionSummaryLine";
 
 /** How many rows fetch their summary. Beyond this a reader has to scroll. */
@@ -56,24 +56,6 @@ function RailSkeleton() {
   );
 }
 
-/**
- * The language a version holds, on a document that has more than one.
- *
- * A localized document captures a version per locale and this list interleaves
- * them, so a row identified only by its number leaves an editor unable to tell
- * whether version 5 is the English or the French one. Read from the same hook
- * `VersionRow` uses, with the locale's human label falling back to its code, so
- * the two lists name a language the same way.
- *
- * Nothing is said on a single-language install, where a badge on every row
- * would carry no information.
- */
-function LocaleBadge({ locale }: { locale: string | null }) {
-  const { enabled, getLocale } = useLocalization();
-  if (!enabled || locale === null) return null;
-  return <Badge variant="outline">{getLocale(locale)?.label ?? locale}</Badge>;
-}
-
 /** A row's first line: which version it is, its status, and any name given it. */
 function RowHeading({ version }: { version: VersionMeta }) {
   return (
@@ -83,7 +65,7 @@ function RowHeading({ version }: { version: VersionMeta }) {
           ? "Autosave"
           : `Version ${version.versionNo}`}
       </span>
-      <LocaleBadge locale={version.locale} />
+      <VersionLocaleBadge locale={version.locale} />
       {version.status ? (
         <Badge variant={version.status === "published" ? "success" : "outline"}>
           {version.status}
@@ -146,7 +128,6 @@ function TimelineRow({
         type="button"
         aria-current={active ? "true" : undefined}
         disabled={versionNo === null || unpairable !== null}
-        title={unpairable ?? undefined}
         onClick={() =>
           versionNo !== null && unpairable === null && onSelect(versionNo)
         }
@@ -156,6 +137,14 @@ function TimelineRow({
       >
         <RowHeading version={version} />
         <span className="mt-0.5 flex flex-col gap-0.5">
+          {/* Rendered as text rather than a `title` tooltip. The button is
+              disabled, so it is not focusable and no tooltip is reachable by
+              keyboard; a touch user has no hover to reveal one either. Left
+              there, the row would say it is unavailable without saying that
+              loading more history makes it available. */}
+          {unpairable === null ? null : (
+            <span className="text-xs text-muted-foreground">{unpairable}</span>
+          )}
           <span className="text-xs text-muted-foreground">
             {version.author?.name ?? "Unknown author"} &middot;{" "}
             {formatDateTime(version.createdAt)}

--- a/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
+++ b/packages/admin/src/components/features/versions/VersionTimelineRail.tsx
@@ -98,6 +98,22 @@ function RowHeading({ version }: { version: VersionMeta }) {
   );
 }
 
+/**
+ * Why a row cannot be compared, or null when it can.
+ *
+ * The two answers are different and a reader needs to tell them apart: the
+ * oldest version has nothing before it and never will, while a version whose
+ * predecessor lies beyond the loaded pages becomes comparable as soon as more
+ * history is fetched. Collapsing them into one disabled state would say the
+ * history ends here, which for the second is untrue.
+ */
+function unpairableReason(previous: Predecessor): string | null {
+  if (previous.kind === "version") return null;
+  return previous.kind === "first"
+    ? "Nothing before this version to compare it against"
+    : "Load more history to compare this version";
+}
+
 /** One version in the rail. */
 function TimelineRow({
   scope,
@@ -118,13 +134,22 @@ function TimelineRow({
   // shown without being selectable rather than hidden — it is still a record of
   // the document having been touched.
   const versionNo = version.versionNo;
+  // Choosing a row compares it against the version before it, so a row with no
+  // predecessor TO compare against cannot be chosen — and says which of the two
+  // reasons applies rather than accepting the click and doing nothing. Left
+  // enabled, the button reported success by changing nothing, which reads as a
+  // page that has stopped responding.
+  const unpairable = versionNo === null ? null : unpairableReason(previous);
   return (
     <li>
       <button
         type="button"
         aria-current={active ? "true" : undefined}
-        disabled={versionNo === null}
-        onClick={() => versionNo !== null && onSelect(versionNo)}
+        disabled={versionNo === null || unpairable !== null}
+        title={unpairable ?? undefined}
+        onClick={() =>
+          versionNo !== null && unpairable === null && onSelect(versionNo)
+        }
         className={`w-full border-b border-border px-4 py-3 text-left transition-colors hover:bg-muted/60 disabled:opacity-60 ${
           active ? "bg-muted" : ""
         }`}

--- a/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
@@ -305,3 +305,123 @@ describe("VersionComparePage — a failed history is not an empty one", () => {
     expect(screen.getByText("No versions yet")).toBeInTheDocument();
   });
 });
+
+describe("VersionComparePage — choosing a row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canMock.mockReturnValue(true);
+    useVersionsMock.mockReturnValue(listing([row(9), row(8)]));
+  });
+
+  /**
+   * `navigateTo` skips a push only when its argument equals
+   * `window.location.pathname`, and a target carrying `?from=&to=` never does.
+   * So choosing the row already on screen pushed another identical entry, and
+   * Back then walked through indistinguishable copies of one comparison
+   * before leaving the page — which reads as a stuck Back button.
+   */
+  it("does not push a second entry for the comparison already shown", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/admin/collections/posts/e1/versions?from=8&to=9"
+    );
+
+    const user = (await import("@testing-library/user-event")).default.setup();
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+        from={8}
+        to={9}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Version 9/ }));
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The control, and it has to be capable of the other answer: a row naming a
+   * DIFFERENT pair still navigates. Without it the assertion above would pass
+   * on a page whose rows no longer do anything at all.
+   */
+  it("still navigates when a different pair is chosen", async () => {
+    window.history.replaceState(
+      null,
+      "",
+      "/admin/collections/posts/e1/versions?from=8&to=9"
+    );
+    useVersionsMock.mockReturnValue(listing([row(9), row(8), row(7)]));
+
+    const user = (await import("@testing-library/user-event")).default.setup();
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+        from={8}
+        to={9}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Version 8/ }));
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("VersionComparePage — a failed next page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canMock.mockReturnValue(true);
+  });
+
+  /**
+   * An infinite query flips to `isError` when a LATER page fails, while
+   * keeping the pages it already has. Passing that aggregate state to the rail
+   * discarded every row the reader already had — and the Load more control
+   * that would have retried it — for a failure that lost nothing.
+   */
+  it("keeps the rows it already has when another page fails to load", () => {
+    useVersionsMock.mockReturnValue(
+      listing([row(9), row(8)], { isError: true, hasNextPage: true })
+    );
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /Version 9/ })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Version 8/ })
+    ).toBeInTheDocument();
+  });
+
+  /**
+   * The control. A failure with NOTHING loaded is a genuine load failure and
+   * must still replace the rail — otherwise the assertion above would be
+   * satisfied by a rail that ignores errors entirely.
+   */
+  it("still reports a failure that left nothing on screen", () => {
+    useVersionsMock.mockReturnValue(listing([], { isError: true }));
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+
+    expect(
+      screen.queryByRole("button", { name: /Version/ })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
@@ -1,0 +1,119 @@
+/**
+ * The rail has to say WHICH version each row is, and on a localized document
+ * that includes which language it holds.
+ *
+ * A localized document captures a version per locale and this list interleaves
+ * them, so a row identified only by its number leaves an editor unable to tell
+ * whether version 5 is the English or the French one — and the comparison pane
+ * beside it names version numbers too, so the ambiguity is not resolved by
+ * looking anywhere else on the page.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import type { VersionMeta, VersionScope } from "@admin/services/versionApi";
+
+import { VersionTimelineRail } from "../VersionTimelineRail";
+
+const useLocalization = vi.hoisted(() => vi.fn());
+vi.mock("@admin/hooks/useLocalization", () => ({ useLocalization }));
+
+/** Mocked so a row's summary does not pull the network into a layout test. */
+vi.mock("../VersionSummaryLine", () => ({
+  VersionSummaryLine: () => null,
+}));
+
+const scope: VersionScope = {
+  kind: "collection",
+  slug: "posts",
+  entryId: "e1",
+};
+
+function version(overrides: Partial<VersionMeta> = {}): VersionMeta {
+  return {
+    id: "v1",
+    versionNo: 5,
+    status: "published",
+    isAutosave: false,
+    label: null,
+    locale: null,
+    sourceVersionNo: null,
+    createdBy: "u1",
+    author: { id: "u1", name: "Ada Lovelace" },
+    createdAt: new Date("2026-01-01T00:00:00Z").toISOString(),
+    updatedAt: new Date("2026-01-01T00:00:00Z").toISOString(),
+    ...overrides,
+  };
+}
+
+function renderRail(versions: VersionMeta[]) {
+  return render(
+    <VersionTimelineRail
+      scope={scope}
+      versions={versions}
+      selected={null}
+      onSelect={vi.fn()}
+    />
+  );
+}
+
+describe("VersionTimelineRail — a row names its language", () => {
+  beforeEach(() => {
+    useLocalization.mockReset();
+  });
+
+  it("shows the locale's human label when the app is localized", () => {
+    useLocalization.mockReturnValue({
+      enabled: true,
+      getLocale: (code: string) =>
+        code === "fr" ? { code, label: "French" } : null,
+    });
+
+    renderRail([version({ locale: "fr" })]);
+
+    // The premise: the row rendered at all, so an absent label below would be
+    // a missing locale rather than a rail that drew nothing.
+    expect(screen.getByText("Version 5")).toBeInTheDocument();
+    expect(screen.getByText("French")).toBeInTheDocument();
+  });
+
+  it("falls back to the locale CODE when it has no label", () => {
+    // An unlabelled locale is still an answer, and a blank space is not.
+    useLocalization.mockReturnValue({
+      enabled: true,
+      getLocale: () => null,
+    });
+
+    renderRail([version({ locale: "de" })]);
+
+    expect(screen.getByText("de")).toBeInTheDocument();
+  });
+
+  it("says nothing about language on a document that is not localized", () => {
+    // The control. Every row would otherwise carry a badge that means nothing
+    // on a single-language install, and the assertions above would pass on a
+    // component that always printed one.
+    useLocalization.mockReturnValue({
+      enabled: false,
+      getLocale: () => ({ code: "fr", label: "French" }),
+    });
+
+    renderRail([version({ locale: "fr" })]);
+
+    expect(screen.getByText("Version 5")).toBeInTheDocument();
+    expect(screen.queryByText("French")).not.toBeInTheDocument();
+  });
+
+  it("says nothing when a localized document's version has no locale", () => {
+    // The other control: enabled is not on its own a reason to print a badge.
+    useLocalization.mockReturnValue({
+      enabled: true,
+      getLocale: () => ({ code: "fr", label: "French" }),
+    });
+
+    renderRail([version({ locale: null })]);
+
+    expect(screen.getByText("Version 5")).toBeInTheDocument();
+    expect(screen.queryByText("French")).not.toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-import { render, screen } from "@admin/__tests__/utils";
+import { render, screen, within } from "@admin/__tests__/utils";
 import type { VersionMeta, VersionScope } from "@admin/services/versionApi";
 
 import { VersionTimelineRail } from "../VersionTimelineRail";
@@ -75,10 +75,14 @@ describe("VersionTimelineRail — a row names its language", () => {
 
     renderRail([version({ locale: "fr" })]);
 
-    // The premise: the row rendered at all, so an absent label below would be
+    // The premise: the row rendered at all, so an absent badge below would be
     // a missing locale rather than a rail that drew nothing.
     expect(screen.getByText("Version 5")).toBeInTheDocument();
-    expect(screen.getByText("French")).toBeInTheDocument();
+    // The CODE shows and the human label is its tooltip — the presentation the
+    // history sheet's rows already use, through the same component.
+    const badge = screen.getByText("fr");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "French");
   });
 
   it("falls back to the locale CODE when it has no label", () => {
@@ -90,7 +94,9 @@ describe("VersionTimelineRail — a row names its language", () => {
 
     renderRail([version({ locale: "de" })]);
 
-    expect(screen.getByText("de")).toBeInTheDocument();
+    const badge = screen.getByText("de");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute("title", "de");
   });
 
   it("says nothing about language on a document that is not localized", () => {
@@ -105,7 +111,7 @@ describe("VersionTimelineRail — a row names its language", () => {
     renderRail([version({ locale: "fr" })]);
 
     expect(screen.getByText("Version 5")).toBeInTheDocument();
-    expect(screen.queryByText("French")).not.toBeInTheDocument();
+    expect(screen.queryByText("fr")).not.toBeInTheDocument();
   });
 
   it("says nothing when a localized document's version has no locale", () => {
@@ -118,7 +124,7 @@ describe("VersionTimelineRail — a row names its language", () => {
     renderRail([version({ locale: null })]);
 
     expect(screen.getByText("Version 5")).toBeInTheDocument();
-    expect(screen.queryByText("French")).not.toBeInTheDocument();
+    expect(screen.queryByText("fr")).not.toBeInTheDocument();
   });
 });
 
@@ -145,10 +151,11 @@ describe("VersionTimelineRail — a row that cannot be compared says so", () => 
     const oldest = rows.find(r => r.textContent?.includes("Version 1"));
     expect(oldest).toBeDefined();
     expect(oldest).toBeDisabled();
-    expect(oldest).toHaveAttribute(
-      "title",
-      "Nothing before this version to compare it against"
-    );
+    // Visible text, not a tooltip: a disabled button is not focusable, so a
+    // keyboard user reaches no tooltip, and a touch user has no hover.
+    expect(
+      screen.getByText("Nothing before this version to compare it against")
+    ).toBeInTheDocument();
   });
 
   /**
@@ -162,10 +169,9 @@ describe("VersionTimelineRail — a row that cannot be compared says so", () => 
 
     const row = screen.getByRole("button", { name: /Version 4/ });
     expect(row).toBeDisabled();
-    expect(row).toHaveAttribute(
-      "title",
-      "Load more history to compare this version"
-    );
+    expect(
+      screen.getByText("Load more history to compare this version")
+    ).toBeInTheDocument();
   });
 
   /**
@@ -180,6 +186,11 @@ describe("VersionTimelineRail — a row that cannot be compared says so", () => 
 
     const row = screen.getByRole("button", { name: /Version 2/ });
     expect(row).toBeEnabled();
-    expect(row).not.toHaveAttribute("title");
+    // Scoped to THIS row: the oldest row in the same rail legitimately carries
+    // a reason, so an unscoped query would find it and report this row as
+    // unavailable when it is not.
+    expect(
+      within(row).queryByText(/Load more history|Nothing before this version/)
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
@@ -48,7 +48,11 @@ function version(overrides: Partial<VersionMeta> = {}): VersionMeta {
 
 function renderRail(
   versions: VersionMeta[],
-  extra: { hasNextPage?: boolean } = {}
+  extra: {
+    hasNextPage?: boolean;
+    nextPageError?: unknown;
+    onLoadMore?: () => void;
+  } = {}
 ) {
   return render(
     <VersionTimelineRail
@@ -57,6 +61,8 @@ function renderRail(
       selected={null}
       onSelect={vi.fn()}
       hasNextPage={extra.hasNextPage}
+      nextPageError={extra.nextPageError}
+      onLoadMore={extra.onLoadMore}
     />
   );
 }
@@ -192,5 +198,60 @@ describe("VersionTimelineRail — a row that cannot be compared says so", () => 
     expect(
       within(row).queryByText(/Load more history|Nothing before this version/)
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("VersionTimelineRail — a failed Load more", () => {
+  beforeEach(() => {
+    useLocalization.mockReset();
+    useLocalization.mockReturnValue({ enabled: false, getLocale: () => null });
+  });
+
+  /**
+   * A failed next page clears `isFetchingNextPage` and returns the button to
+   * its resting label, so without a message the click appears to have done
+   * nothing — the same silence a disabled row gave before it said why.
+   */
+  it("says why the click changed nothing", () => {
+    renderRail([version()], {
+      hasNextPage: true,
+      nextPageError: new Error("Network unreachable"),
+    });
+
+    expect(screen.getByRole("status")).toHaveTextContent("Network unreachable");
+  });
+
+  it("offers the retry as a retry, not as a fresh Load more", () => {
+    renderRail([version()], {
+      hasNextPage: true,
+      nextPageError: new Error("nope"),
+    });
+
+    expect(screen.getByRole("button", { name: "Try again" })).toBeEnabled();
+  });
+
+  /**
+   * The rows already loaded are still valid, so the failure is reported BESIDE
+   * the list rather than in place of it — a page failing is not the history
+   * becoming unreadable.
+   */
+  it("keeps the rows it already has", () => {
+    renderRail([version()], {
+      hasNextPage: true,
+      nextPageError: new Error("nope"),
+    });
+
+    expect(screen.getByText("Version 5")).toBeInTheDocument();
+  });
+
+  /**
+   * The control. Without it every assertion above would pass on a rail that
+   * always showed an error and always said "Try again".
+   */
+  it("says nothing, and offers Load more, when nothing has failed", () => {
+    renderRail([version()], { hasNextPage: true });
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Load more" })).toBeEnabled();
   });
 });

--- a/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionTimelineRail.test.tsx
@@ -46,13 +46,17 @@ function version(overrides: Partial<VersionMeta> = {}): VersionMeta {
   };
 }
 
-function renderRail(versions: VersionMeta[]) {
+function renderRail(
+  versions: VersionMeta[],
+  extra: { hasNextPage?: boolean } = {}
+) {
   return render(
     <VersionTimelineRail
       scope={scope}
       versions={versions}
       selected={null}
       onSelect={vi.fn()}
+      hasNextPage={extra.hasNextPage}
     />
   );
 }
@@ -115,5 +119,67 @@ describe("VersionTimelineRail — a row names its language", () => {
 
     expect(screen.getByText("Version 5")).toBeInTheDocument();
     expect(screen.queryByText("French")).not.toBeInTheDocument();
+  });
+});
+
+describe("VersionTimelineRail — a row that cannot be compared says so", () => {
+  beforeEach(() => {
+    useLocalization.mockReset();
+    useLocalization.mockReturnValue({ enabled: false, getLocale: () => null });
+  });
+
+  /**
+   * Choosing a row compares it against the version before it. A row with no
+   * predecessor to compare against used to stay enabled and silently discard
+   * the click — the button reported success by changing nothing, which reads
+   * as a page that has stopped responding.
+   */
+  it("disables the oldest version, whose predecessor does not exist", () => {
+    // A complete history: nothing before v1, and no further pages.
+    renderRail([
+      version({ id: "v2", versionNo: 2 }),
+      version({ versionNo: 1 }),
+    ]);
+
+    const rows = screen.getAllByRole("button", { name: /Version/ });
+    const oldest = rows.find(r => r.textContent?.includes("Version 1"));
+    expect(oldest).toBeDefined();
+    expect(oldest).toBeDisabled();
+    expect(oldest).toHaveAttribute(
+      "title",
+      "Nothing before this version to compare it against"
+    );
+  });
+
+  /**
+   * The other reason, and it must NOT read the same. A version whose
+   * predecessor lies beyond the loaded pages becomes comparable as soon as
+   * more history is fetched, so telling the reader the history ends here would
+   * be untrue.
+   */
+  it("distinguishes a predecessor that is merely not loaded yet", () => {
+    renderRail([version({ versionNo: 4 })], { hasNextPage: true });
+
+    const row = screen.getByRole("button", { name: /Version 4/ });
+    expect(row).toBeDisabled();
+    expect(row).toHaveAttribute(
+      "title",
+      "Load more history to compare this version"
+    );
+  });
+
+  /**
+   * The control. Every row would otherwise be disabled and the assertions
+   * above would pass on a rail nobody can use at all.
+   */
+  it("leaves a row with a loaded predecessor selectable", () => {
+    renderRail([
+      version({ id: "v2", versionNo: 2 }),
+      version({ versionNo: 1 }),
+    ]);
+
+    const row = screen.getByRole("button", { name: /Version 2/ });
+    expect(row).toBeEnabled();
+    expect(row).not.toHaveAttribute("title");
   });
 });

--- a/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * A comparison page has to say which document it belongs to.
+ *
+ * The URL carries an opaque id and the dashboard header shows no breadcrumbs,
+ * so a page that cannot name its document leaves a reader unable to tell what
+ * the snapshots are of without navigating away.
+ *
+ * The fallback cases matter as much as the happy one: a title that silently
+ * becomes empty is worse than an ugly one, because the heading then reads the
+ * same as a page that failed to load.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+import { renderHook } from "@admin/__tests__/utils";
+
+const { collectionMock, entryMock, singleSchemaMock } = vi.hoisted(() => ({
+  collectionMock: vi.fn(),
+  entryMock: vi.fn(),
+  singleSchemaMock: vi.fn(),
+}));
+
+vi.mock("@admin/hooks/queries/useCollections", () => ({
+  useCollection: (...a: unknown[]) => collectionMock(...a),
+}));
+vi.mock("@admin/hooks/queries/useEntry", () => ({
+  useEntry: (...a: unknown[]) => entryMock(...a),
+}));
+vi.mock("@admin/hooks/queries/useSingles", () => ({
+  useSingleSchema: (...a: unknown[]) => singleSchemaMock(...a),
+}));
+
+import { useVersionDocumentTitle } from "../useVersionDocumentTitle";
+
+const field = (name: string) => ({ name, type: "text" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  collectionMock.mockReturnValue({ data: undefined });
+  entryMock.mockReturnValue({ data: undefined });
+  singleSchemaMock.mockReturnValue({ data: undefined });
+});
+
+const forEntry = () =>
+  renderHook(() =>
+    useVersionDocumentTitle({
+      kind: "collection",
+      slug: "posts",
+      entryId: "e1",
+    })
+  );
+
+describe("useVersionDocumentTitle — a collection entry", () => {
+  it("uses the field the collection nominates as its title", () => {
+    collectionMock.mockReturnValue({
+      data: {
+        admin: { useAsTitle: "headline" },
+        fields: [field("headline"), field("title")],
+      },
+    });
+    entryMock.mockReturnValue({
+      data: { headline: "Ada writes a compiler", title: "ignored" },
+    });
+
+    // `useAsTitle` wins over the conventional `title`, which is the author's
+    // decision and the reason the setting exists.
+    expect(forEntry().result.current).toBe("Ada writes a compiler");
+  });
+
+  it("falls back to a conventional field when none is nominated", () => {
+    collectionMock.mockReturnValue({ data: { fields: [field("title")] } });
+    entryMock.mockReturnValue({ data: { title: "Untitled draft" } });
+
+    expect(forEntry().result.current).toBe("Untitled draft");
+  });
+
+  /**
+   * The heading has to say something. An entry whose title field is blank, or
+   * whose data has not arrived, would otherwise render an empty heading — which
+   * reads as a page that failed rather than one still loading.
+   */
+  it("names the entry by slug and id when its title is empty", () => {
+    collectionMock.mockReturnValue({ data: { fields: [field("title")] } });
+    entryMock.mockReturnValue({ data: { title: "   " } });
+
+    expect(forEntry().result.current).toBe("posts · e1");
+  });
+
+  it("names the entry by slug and id before anything has loaded", () => {
+    expect(forEntry().result.current).toBe("posts · e1");
+  });
+
+  /**
+   * The fallback carries the ID, not the slug alone. Every entry in a
+   * collection shares its slug, so a slug-only heading would name them all the
+   * same and tell a reader nothing about which one is on screen.
+   */
+  it("distinguishes two entries of the same collection", () => {
+    const other = renderHook(() =>
+      useVersionDocumentTitle({
+        kind: "collection",
+        slug: "posts",
+        entryId: "e2",
+      })
+    );
+    expect(forEntry().result.current).not.toBe(other.result.current);
+  });
+});
+
+describe("useVersionDocumentTitle — a single", () => {
+  const forSingle = () =>
+    renderHook(() =>
+      useVersionDocumentTitle({ kind: "single", slug: "site-settings" })
+    );
+
+  it("uses the single's label", () => {
+    singleSchemaMock.mockReturnValue({ data: { label: "Site settings" } });
+    expect(forSingle().result.current).toBe("Site settings");
+  });
+
+  it("falls back to the slug, which is what the URL shows", () => {
+    singleSchemaMock.mockReturnValue({ data: { label: "  " } });
+    expect(forSingle().result.current).toBe("site-settings");
+  });
+
+  /**
+   * The control on scope: a Single must not be asked for through the entry
+   * query, and a collection entry must not be named from a Single's schema.
+   * Without this, a hook that ignored `kind` would satisfy everything above.
+   */
+  it("does not read a single's schema for a collection entry", () => {
+    collectionMock.mockReturnValue({ data: { fields: [field("title")] } });
+    entryMock.mockReturnValue({ data: { title: "An entry" } });
+    singleSchemaMock.mockReturnValue({ data: { label: "A single" } });
+
+    expect(forEntry().result.current).toBe("An entry");
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/version-pairing.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/version-pairing.test.ts
@@ -156,3 +156,53 @@ describe("defaultPair", () => {
     expect(defaultPair(plain(9), true)).toEqual({ kind: "not-loaded" });
   });
 });
+
+describe("defaultPair — a locale's first is not the document's only", () => {
+  /**
+   * `predecessorOf` answers a LOCALE-SCOPED question: `first` means nothing
+   * older exists in this language, not that the document holds one version.
+   * Reported as `only-version`, the pane told a reader "there is only one
+   * version so far" while the rail beside it listed two — and the two surfaces
+   * contradicting each other is worse than either being wrong alone, because
+   * the reader cannot tell which to believe.
+   */
+  it("does not claim one version when another language has its own", () => {
+    // v2 English is newest; v1 French is the whole of the French history.
+    // Nothing older in English, and no further pages.
+    const history = [
+      { versionNo: 2, locale: "en" },
+      { versionNo: 1, locale: "fr" },
+    ];
+
+    expect(defaultPair(history, false)).toEqual({ kind: "only-in-locale" });
+  });
+
+  /**
+   * The control, and it decides the whole distinction: a document that really
+   * does hold one version still says so. Without it the fix could report
+   * `only-in-locale` everywhere and every assertion here would pass.
+   */
+  it("still claims one version when that is the whole history", () => {
+    expect(defaultPair(plain(1), false)).toEqual({ kind: "only-version" });
+    expect(defaultPair([{ versionNo: 1, locale: "en" }], false)).toEqual({
+      kind: "only-version",
+    });
+  });
+
+  /** Unchanged: nothing older LOADED is still distinct from nothing older. */
+  it("still separates an unfetched predecessor from an absent one", () => {
+    expect(defaultPair(plain(9), true)).toEqual({ kind: "not-loaded" });
+  });
+
+  it("still pairs within a locale when there is something to pair with", () => {
+    expect(defaultPair(interleaved, false)).toEqual({
+      kind: "pair",
+      from: 3,
+      to: 5,
+    });
+  });
+
+  it("still reports an empty history as having nothing to compare", () => {
+    expect(defaultPair([], false)).toEqual({ kind: "no-history" });
+  });
+});

--- a/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
+++ b/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
@@ -50,6 +50,11 @@ export function useVersionDocumentTitle(scope: TitleScope): string | undefined {
     collectionSlug: scope.slug,
     entryId: isCollection ? scope.entryId : "",
     enabled: isCollection,
+    // The working draft, where the collection has one. The editor overlays it,
+    // so without this a comparison opened from an editor showing an unpublished
+    // title change is headed by the OLD published title — two surfaces naming
+    // one document by different states of it.
+    draft: collection.data?.draftsEnabled === true,
   });
   const single = useSingleSchema(isCollection ? undefined : scope.slug);
 

--- a/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
+++ b/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
@@ -1,0 +1,86 @@
+/**
+ * The readable name of the document a comparison belongs to.
+ *
+ * A comparison page carries an opaque id in its URL and the dashboard header
+ * shows no breadcrumbs, so without this the page announces itself only as
+ * "Version history" and a reader cannot tell which entry or Single the
+ * snapshots belong to without navigating away.
+ *
+ * One hook rather than a derivation in each wrapper. The collection and Single
+ * routes ask the same question of different schemas, and answering it twice is
+ * how the two pages come to name a document differently.
+ *
+ * @module components/features/versions/useVersionDocumentTitle
+ */
+
+import { pickTitleFieldName } from "@admin/components/features/entries/EntryList/EntryTableColumns";
+import { useCollection } from "@admin/hooks/queries/useCollections";
+import { useEntry } from "@admin/hooks/queries/useEntry";
+import { useSingleSchema } from "@admin/hooks/queries/useSingles";
+/**
+ * What naming a document actually depends on.
+ *
+ * Narrower than `VersionScope` on purpose: a Single's title comes from its
+ * schema, which is reached by slug alone, and the Single route cannot name its
+ * scope until it has read the document's id. Asking for the whole scope would
+ * make this hook uncallable exactly where it is needed, or force a placeholder
+ * id through it.
+ */
+export type TitleScope =
+  | { kind: "collection"; slug: string; entryId: string }
+  | { kind: "single"; slug: string };
+
+/** A value is a usable title only if it is text with something in it. */
+function readableText(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Both queries are asked unconditionally and gated by `enabled`, because a hook
+ * cannot be called on one branch and skipped on the other. The disabled one
+ * fetches nothing.
+ */
+export function useVersionDocumentTitle(scope: TitleScope): string | undefined {
+  const isCollection = scope.kind === "collection";
+
+  const collection = useCollection(isCollection ? scope.slug : undefined);
+  const entry = useEntry<Record<string, unknown>>({
+    collectionSlug: scope.slug,
+    entryId: isCollection ? scope.entryId : "",
+    enabled: isCollection,
+  });
+  const single = useSingleSchema(isCollection ? undefined : scope.slug);
+
+  if (!isCollection) {
+    // A Single's label is its name, and the slug is what a reader sees in the
+    // URL when it has none.
+    return readableText(single.data?.label) ?? scope.slug;
+  }
+
+  // Which field names an entry is the collection's decision, and the entry list
+  // already makes it — through `useAsTitle` where the author set one, and a
+  // conventional field otherwise. Reused rather than restated so a comparison
+  // names an entry the way its list does.
+  // Which field names an entry is the collection's decision, and the entry list
+  // already makes it — `useAsTitle` where the author set one, a conventional
+  // field otherwise. The rule is shared rather than restated, so a comparison
+  // names an entry the way its list does.
+  const fields = collection.data?.fields;
+  const titleField = fields
+    ? pickTitleFieldName(
+        collection.data?.admin?.useAsTitle,
+        fields.map(field => field.name)
+      )
+    : undefined;
+  const fromField = titleField
+    ? readableText(entry.data?.[titleField])
+    : undefined;
+
+  // The id is the fallback rather than the slug alone: a slug names the
+  // collection, and every entry in it would then share one title. It is also
+  // what the URL already shows, so a reader can at least match the two while
+  // the entry loads or when its title field is empty.
+  return fromField ?? `${scope.slug} · ${scope.entryId}`;
+}

--- a/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
+++ b/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
@@ -13,7 +13,7 @@
  * @module components/features/versions/useVersionDocumentTitle
  */
 
-import { pickTitleFieldName } from "@admin/components/features/entries/EntryList/EntryTableColumns";
+import { entryTitleValue } from "@admin/components/features/entries/entry-title";
 import { useCollection } from "@admin/hooks/queries/useCollections";
 import { useEntry } from "@admin/hooks/queries/useEntry";
 import { useSingleSchema } from "@admin/hooks/queries/useSingles";
@@ -59,24 +59,13 @@ export function useVersionDocumentTitle(scope: TitleScope): string | undefined {
     return readableText(single.data?.label) ?? scope.slug;
   }
 
-  // Which field names an entry is the collection's decision, and the entry list
-  // already makes it — through `useAsTitle` where the author set one, and a
-  // conventional field otherwise. Reused rather than restated so a comparison
-  // names an entry the way its list does.
-  // Which field names an entry is the collection's decision, and the entry list
-  // already makes it — `useAsTitle` where the author set one, a conventional
-  // field otherwise. The rule is shared rather than restated, so a comparison
-  // names an entry the way its list does.
-  const fields = collection.data?.fields;
-  const titleField = fields
-    ? pickTitleFieldName(
-        collection.data?.admin?.useAsTitle,
-        fields.map(field => field.name)
-      )
-    : undefined;
-  const fromField = titleField
-    ? readableText(entry.data?.[titleField])
-    : undefined;
+  // What an entry is called is one question with one answer, shared with the
+  // editor's heading: a document named one thing by its editor and another by
+  // the page comparing its versions is worse than either name on its own.
+  const fromField = entryTitleValue(
+    entry.data,
+    collection.data?.admin?.useAsTitle
+  );
 
   // The id is the fallback rather than the slug alone: a slug names the
   // collection, and every entry in it would then share one title. It is also

--- a/packages/admin/src/components/features/versions/version-pairing.ts
+++ b/packages/admin/src/components/features/versions/version-pairing.ts
@@ -96,16 +96,24 @@ export function predecessorOf(
 /**
  * A pair to compare, or the reason there is none.
  *
- * The reasons are kept apart because they are three different situations and a
- * reader acts differently on each: a document with no history at all, one whose
- * history holds a single version, and one whose older versions simply have not
- * been fetched. Collapsing them into a null pair made the pane tell someone
- * with no versions that they had exactly one.
+ * The reasons are kept apart because a reader acts differently on each: a
+ * document with no history at all, one whose history holds a single version,
+ * one where only THIS language holds a single version and another language has
+ * its own, and one whose older versions simply have not been fetched.
+ * Collapsing them into a null pair made the pane tell someone with no versions
+ * that they had exactly one.
  */
 export type PairResolution =
   | { kind: "pair"; from: number; to: number }
   | { kind: "no-history" }
   | { kind: "only-version" }
+  /**
+   * This language holds one version; the document holds more, in others.
+   * Distinct from `only-version` because the remedy is: there is somewhere
+   * else to look, and saying "there is only one version" would contradict a
+   * rail listing several.
+   */
+  | { kind: "only-in-locale" }
   | { kind: "not-loaded" };
 
 /**
@@ -122,9 +130,17 @@ export function defaultPair(
   if (previous.kind === "version") {
     return { kind: "pair", from: previous.versionNo, to: newest.versionNo };
   }
-  // `first` means this document really does hold one version; `unknown` means
-  // its predecessor is beyond the loaded pages and "Load more" would find it.
-  return previous.kind === "first"
+  if (previous.kind !== "first") {
+    // `unknown`: the predecessor is beyond the loaded pages, and Load more
+    // would find it.
+    return { kind: "not-loaded" };
+  }
+  // `first` is a LOCALE-SCOPED answer — `predecessorOf` looks only within one
+  // language — so it means nothing older exists in THIS one. Whether the
+  // document holds one version is a question about the whole history, and it
+  // is asked here rather than inferred from an answer that cannot carry it.
+  const comparable = versions.filter(v => v.versionNo !== null).length;
+  return comparable <= 1
     ? { kind: "only-version" }
-    : { kind: "not-loaded" };
+    : { kind: "only-in-locale" };
 }

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -15,6 +15,7 @@ import { Alert, AlertDescription, Button, Skeleton } from "@nextlyhq/ui";
 import type React from "react";
 import { useMemo } from "react";
 
+import { entryTitleValue } from "@admin/components/features/entries/entry-title";
 import {
   EntryForm,
   type EntryFormCollection,
@@ -196,28 +197,11 @@ function getEntryTitle(
   id: string,
   useAsTitle?: string
 ): string {
-  // 1. Try designated title field
-  if (useAsTitle && useAsTitle !== "id") {
-    const value = entry[useAsTitle];
-    // eslint-disable-next-line @typescript-eslint/no-base-to-string
-    if (value !== undefined && value !== null && String(value).trim()) {
-      // eslint-disable-next-line @typescript-eslint/no-base-to-string
-      return String(value);
-    }
-  }
-
-  // 2. Try common title fields
-  const titleFields = ["title", "name", "label", "subject", "heading"];
-
-  for (const field of titleFields) {
-    const value = entry[field];
-    if (typeof value === "string" && value.trim()) {
-      return value;
-    }
-  }
-
-  // 3. Fallback to shortened ID
-  return `Entry ${id.substring(0, 8)}...`;
+  // The shared order, so this heading and the version comparison's name the
+  // same document the same way. Only the last resort is decided here: a
+  // heading must produce text, and a shortened id is what identifies an entry
+  // that says nothing about itself.
+  return entryTitleValue(entry, useAsTitle) ?? `Entry ${id.substring(0, 8)}...`;
 }
 
 // ============================================================================

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
@@ -10,6 +10,7 @@
  * @module pages/dashboard/entries/[slug]/[id]/versions
  */
 
+import { useVersionDocumentTitle } from "@admin/components/features/versions/useVersionDocumentTitle";
 import { readVersionParam } from "@admin/components/features/versions/version-search-params";
 import { VersionComparePage } from "@admin/components/features/versions/VersionComparePage";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
@@ -18,11 +19,20 @@ import type { PageProps } from "@admin/lib/routing";
 export default function EntryVersionsPage({ params, searchParams }: PageProps) {
   const slug = typeof params?.slug === "string" ? params.slug : "";
   const id = typeof params?.id === "string" ? params.id : "";
+  // Without this the page announces itself only as "Version history", while the
+  // URL carries an opaque id and the dashboard header shows no breadcrumbs — so
+  // a reader cannot tell which entry the snapshots belong to without leaving.
+  const documentTitle = useVersionDocumentTitle({
+    kind: "collection",
+    slug,
+    entryId: id,
+  });
 
   return (
     <VersionComparePage
       scope={{ kind: "collection", slug, entryId: id }}
       documentHref={buildRoute(ROUTES.COLLECTION_ENTRY_EDIT, { slug, id })}
+      documentTitle={documentTitle}
       // Reaching this page needs `read-${slug}`; the editor needs
       // `update-${slug}`. The entry list needs only the former, so it is where a
       // read-only viewer can actually go back to.

--- a/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/versions.tsx
@@ -13,6 +13,7 @@
  * @module pages/dashboard/singles/[slug]/versions
  */
 
+import { useVersionDocumentTitle } from "@admin/components/features/versions/useVersionDocumentTitle";
 import { readVersionParam } from "@admin/components/features/versions/version-search-params";
 import { VersionComparePage } from "@admin/components/features/versions/VersionComparePage";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
@@ -26,6 +27,9 @@ export default function SingleVersionsPage({
   const slug = typeof params?.slug === "string" ? params.slug : "";
   const document = useSingleDocument(slug);
   const documentId = document.data?.id;
+  // Read BEFORE the guard below, because a hook cannot be called after an early
+  // return. It needs only the slug, which is why it asks for less than a scope.
+  const documentTitle = useVersionDocumentTitle({ kind: "single", slug });
 
   // Nothing is rendered until the document's identity is known: a scope built
   // with a placeholder id would key the cache to a document that does not
@@ -46,6 +50,7 @@ export default function SingleVersionsPage({
     <VersionComparePage
       scope={{ kind: "single", slug, documentId: String(documentId) }}
       documentHref={buildRoute(ROUTES.SINGLE_EDIT, { slug })}
+      documentTitle={documentTitle}
       // Reaching this page needs `read-${slug}`; the single's own editor needs
       // `update-${slug}`. `/admin/singles` is NOT the readable alternative it
       // looks like: it redirects straight to the first single the viewer can


### PR DESCRIPTION
Five findings from the review of #1247 (merged), found by widening the watcher to this lane's merged pull requests — a merged PR reads as finished, so nobody re-reads it.

All five are the same question from a reader's side: **what is this page doing, and what am I looking at?**

## Three silent failures

Each accepted an action and changed nothing visible, which reads as software that has stopped responding.

**A row that could not be compared still invited the click.** Choosing a row compares it against the version before it; a row with no predecessor discarded the click while staying enabled. Such a row is now disabled and says *which* of two reasons applies:

| reason | message |
|---|---|
| oldest version, nothing before it | "Nothing before this version to compare it against" |
| predecessor beyond the loaded pages | "Load more history to compare this version" |

Collapsing those into one disabled state would tell the reader the history ends here, which for the second is untrue — it becomes comparable as soon as more is fetched.

**The Back button appeared stuck.** `navigateTo` skips a push only when its argument equals `window.location.pathname`, and a target carrying `?from=&to=` never does. Choosing the row already on screen pushed another identical entry, so Back walked through indistinguishable copies of one comparison before leaving the page. Now compared against the full current URL, which is what actually distinguishes two comparisons.

**A failed next page wiped the history.** An infinite query flips to `isError` when a *later* page fails while keeping the pages it already holds. Passing that aggregate state to the rail discarded every row the reader had — and the Load more control that would have retried — for a failure that lost nothing. Only a failure that left nothing on screen replaces the rail now, the same distinction `VersionHistorySheet` already draws.

## Two ways the page would not say what it showed

**A localized row would not name its language.** A localized document captures a version per locale and the rail interleaves them, so version 5 could be English or French — and the comparison beside it names version numbers too, so nothing on the page resolved it. The row now carries the locale's human label, falling back to its code, read from the same hook the history sheet's rows use so the two lists name a language identically. A single-language install says nothing.

**The rail left the comparison 87 pixels.** It reserved a fixed `w-72` at every width; at a 375px viewport the comparison got roughly 87px before borders, with its pair description, filter and field values clipped. It now stacks above the comparison below `lg` — the breakpoint at which `DashboardLayout` already switches to a mobile header, so the page agrees with the shell rather than choosing its own — with a bounded height so the comparison is reachable without scrolling past the whole history.

## Verification

Every fix has a test that fails without it, and a control **capable of the opposite answer** — the controls are the substance, since each assertion here is about something *not* happening:

| fix | control that must keep passing |
|---|---|
| unpairable rows disabled | a row with a loaded predecessor stays selectable |
| no duplicate push | a *different* pair still navigates |
| partial failure keeps rows | a failure with nothing loaded still reports |
| locale badge shown | no badge on a non-localized install, and none when the version's locale is null |

Break-verified individually: each break fails exactly its own test and leaves the others green.

`check-types` pass · `lint` pass · `fallow` pass (0 introduced) · 262/262 in the versions component suite · pushed with the full pre-push gate running and passing.

## A note on shape

The locale rule is its own component rather than another branch in the row heading — it has two distinct reasons to say nothing, and stating them once where they can be read beats a condition inline. That also brought the row heading back under the complexity gate, which had flagged it; the decomposition is what the gate was asking for rather than a way around it.

## Not in this PR

Three findings remain open on #1247:

- no wrapper passes `documentTitle`, so every comparison announces itself only as "Version history" while the URL carries an opaque entry id — needs the collection's title field and the entry data
- `version-pairing` conflates "first in this locale" with "only version in the document"
- a recreated Single can be read from a stale slug-only cache