### PR TITLE
docs(ci): state what the thread-query tests establish, not their history

### DIFF
--- a/scripts/ci-verdict.test.mjs
+++ b/scripts/ci-verdict.test.mjs
@@ -1076,8 +1076,8 @@ describe("the review-thread query asks for what the code reads", () => {
    * thread objects, so they supply `__typename` whether or not the request ever
    * asked GitHub for it — removing the field from the query leaves all of them
    * green while, in production, no thread canonicalises to a bot, nothing is
-   * ever exempt, and every advisory thread blocks. That is the defect this
-   * change fixes, reachable again by editing one line nothing else watches.
+   * ever exempt, and every advisory thread blocks — reachable by editing one
+   * line nothing else watches.
    *
    * Asserted against the exported string the request actually sends, not a copy
    * of it, so the test cannot drift from the query the way a duplicated literal
@@ -1121,8 +1121,8 @@ describe("advisory threads, in the shape GraphQL actually sends", () => {
    * filter is configured with. The helper above this one takes a login and
    * hands it straight back inside a thread, so the two sides that DIVERGE in
    * production are one value in the test, and it passes under any suffix
-   * convention at all. That is why the divergence survived: the oracle was a
-   * second derivation of the same source.
+   * convention at all — an oracle that is a second derivation of the source it
+   * is checking cannot see the two disagree.
    */
   const botThread = (slug, isResolved) => ({
     isResolved,


### PR DESCRIPTION
Follow-up to #1293, which merged with this finding open. Codex was right and I had missed two docblocks while fixing four others in the same file.

## What was wrong

Two docblocks described the defect they were written against — "the defect this change fixes", "that is why the divergence survived" — rather than the property the test holds. `AGENTS.md` asks that comments describe the code and not tasks, plans or review history, and the reason is practical: a comment that narrates a change stops being true of the code the moment the change is old, while still reading as an explanation.

## What they say now

Both state the invariant, and both keep the facts that make the assertion legible, because those are about the code rather than about its history:

- a hand-built fixture supplies whatever author fields it writes, so a selection missing one is **invisible to every unit test** — which is why the assertion reads the exported query string rather than a fixture
- an oracle built from the source it checks **cannot see that source disagree** with anything — which is why the payload fixture is built from the measured GraphQL shape rather than from the constant the filter is configured with

## Scope

I re-swept all four files this lane touched rather than fixing only the two lines cited:

```
grep -n 'defect this change|this change fixes|this change exists to|
         divergence survived|used to count|first version|caught it'
  scripts/ci-verdict.mjs  scripts/ci-verdict.test.mjs
  scripts/verify-merge.mjs  scripts/verify-merge.test.mjs
  -> none
```

Comments only — no behaviour changes. 667/667 script tests pass, `fallow` clean.

One pre-existing instance elsewhere is deliberately untouched: `scripts/ci-steps-report-independently.test.mjs:39` opens "The first version asked four questions…". It is outside this lane's diff, and narrowing to my own change is the difference between a fix and an unrelated sweep.

## No changeset

`scripts/` ships in no package, so a changeset would bump all 25 lockstep packages for code that ships in none. Verified the repo's own gate passes with none and still rejects a malformed one.