### PR TITLE
fix(nextly): make the job content client enforce the identity it advertises

### DIFF
--- a/.changeset/a-job-client-enforces-the-identity-it-advertises.md
+++ b/.changeset/a-job-client-enforces-the-identity-it-advertises.md
@@ -1,0 +1,55 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The content client a background job receives now enforces the identity it
+advertises, and a transient database error during a job's lease check no longer
+stops the whole queue.
+
+The client removed only `overrideAccess` and `user` from a handler's arguments.
+Five other authorization-bearing options travelled through untouched, and one of
+them was decisive: `actor` carries an API-key scope whose `permissions` array is
+read as authoritative rather than being checked against the queued user's
+grants, so a handler could hand itself any permission it named. `trusted`,
+`enforceFieldAccess`, `fieldAccessUser` and `frameworkFilter` each disabled a
+different guard. All seven are now stripped from the call rather than overridden,
+and a compile-time check fails the build if a future option is added to the
+Direct API without being classified as either owned or safe to forward.
+
+That check immediately found four options nobody had classified.
+
+A job's `ctx.content` also types correctly in a project with generated types.
+The client's signatures were derived by mapping over the Direct API, which
+collapsed each generic to its constraint: `find({ collection: "posts" })` came
+back typed as the union of every collection's row, and `findSingles()` lost its
+optional argument.
+
+Finally, the lease re-check a job performs before running its handler could
+throw. It sat outside both failure boundaries, so a transient adapter error
+aborted the entire drain — leaving that job leased and skipping every other job
+due in the same pass. It is now charged as an ordinary attempt, and the job
+retries on its own backoff.

--- a/packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts
@@ -74,13 +74,21 @@ describe("createJobContentApi", () => {
     expect(find).toHaveBeenCalledWith(
       expect.objectContaining({ overrideAccess: false })
     );
-    // `user` must be ABSENT, not present-and-undefined: a predicate testing
-    // presence reads the latter as "has a user, and it is nothing".
+    // `user` must be present and UNDEFINED, not absent. Every operation begins
+    // with `mergeConfig(ctx.defaultConfig, args)` — `{ ...defaultConfig,
+    // ...args }` — so an absent key lets a configured default user merge back
+    // in, and the least-privileged job would run as whoever that names.
+    //
+    // Nothing downstream reads these by presence: `directApiActor` and
+    // `callerAccess` reach them as `config.user?.id` and
+    // `config.actor?.actorType`, so present-and-undefined is indistinguishable
+    // from absent to every consumer, and distinguishable only to the merge.
     const passed = find.mock.lastCall?.[0] as
       | Record<string, unknown>
       | undefined;
     expect(passed).toBeDefined();
-    expect("user" in (passed ?? {})).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(passed, "user")).toBe(true);
+    expect(passed?.user).toBeUndefined();
   });
 
   it("passes the caller's own arguments through untouched", () => {
@@ -101,5 +109,110 @@ describe("createJobContentApi", () => {
     expect(find).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 7, sort: "-createdAt" })
     );
+  });
+});
+
+describe("the options this client OWNS", () => {
+  it("strips EVERY authorization-bearing option, not just the two it sets", async () => {
+    // Every authority-bearing option is owned by this client, not just the two
+    // it sets. `actor` is the sharpest: `apiKeyScopeAllows` reads its
+    // `permissions` array as AUTHORITATIVE rather than consulting the bound
+    // user's grants, so a caller supplying one grants itself what it names.
+    const find = vi.fn(async () => ({ items: [] }));
+    const client = createJobContentApi({ id: "u1", roles: ["editor"] }, {
+      find,
+    } as never);
+
+    await (client.find as (args: unknown) => Promise<unknown>)({
+      collection: "posts",
+      actor: { actorType: "apiKey", permissions: ["delete-posts"] },
+      trusted: () => true,
+      enforceFieldAccess: false,
+      fieldAccessUser: { id: "somebody-else", roles: ["admin"] },
+      frameworkFilter: true,
+      overrideAccess: true,
+      user: { id: "somebody-else", roles: ["admin"] },
+    });
+
+    const sent = find.mock.calls[0]?.[0] as Record<string, unknown>;
+    for (const owned of [
+      "actor",
+      "trusted",
+      "enforceFieldAccess",
+      "fieldAccessUser",
+      "frameworkFilter",
+    ]) {
+      // Present and undefined, which is what overrides an instance default in
+      // `mergeConfig`'s spread. Asserting absence here would pass against a
+      // `delete`, and a `delete` leaves the default standing.
+      expect(Object.prototype.hasOwnProperty.call(sent, owned)).toBe(true);
+      expect(sent[owned]).toBeUndefined();
+    }
+    // The two this client DOES set are set to its own values, not the caller's.
+    expect(sent.overrideAccess).toBe(false);
+    expect(sent.user).toEqual({ id: "u1", roles: ["editor"] });
+  });
+
+  it("CLEARS an owned option so an instance default cannot reinstate it", async () => {
+    // Every operation begins with `mergeConfig(ctx.defaultConfig, args)`, which
+    // is `{ ...defaultConfig, ...args }`. A DELETED key is merely absent from
+    // `args`, so the instance default survives into the authorized call — an
+    // instance configured with `actor` would hand the job an API-key scope
+    // whose `permissions` array is read as authoritative, behind a wrapper
+    // advertising a bound identity. Present-and-undefined is what wins the
+    // spread.
+    const find = vi.fn(async () => ({ items: [] }));
+    const client = createJobContentApi({ id: "u1", roles: ["editor"] }, {
+      find,
+    } as never);
+
+    await (client.find as (args: unknown) => Promise<unknown>)({
+      collection: "posts",
+      actor: { actorType: "apiKey", permissions: ["delete-posts"] },
+    });
+
+    const sent = find.mock.calls[0]?.[0] as Record<string, unknown>;
+    // The key must be PRESENT and undefined. `not.toHaveProperty` would pass on
+    // a deleted key, which is the implementation this case exists to reject.
+    expect(Object.prototype.hasOwnProperty.call(sent, "actor")).toBe(true);
+    expect(sent.actor).toBeUndefined();
+  });
+
+  it("clears `user` too, so an anonymous job cannot inherit a configured one", async () => {
+    // A job queued by nobody acts as nobody. With `user` merely deleted, an
+    // instance default would be merged back in and the least-privileged job
+    // would run as whoever that default names.
+    const find = vi.fn(async () => ({ items: [] }));
+    const client = createJobContentApi(null, { find } as never);
+
+    await (client.find as (args: unknown) => Promise<unknown>)({
+      collection: "posts",
+    });
+
+    const sent = find.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(sent, "user")).toBe(true);
+    expect(sent.user).toBeUndefined();
+    expect(sent.overrideAccess).toBe(false);
+  });
+
+  it("still forwards the options that carry no authority", async () => {
+    // The control. Stripping everything would satisfy the case above while
+    // making the client useless: a job could not choose a locale, a depth, or
+    // pass context to its hooks.
+    const find = vi.fn(async () => ({ items: [] }));
+    const client = createJobContentApi(null, { find } as never);
+
+    await (client.find as (args: unknown) => Promise<unknown>)({
+      collection: "posts",
+      locale: "de",
+      depth: 2,
+      context: { from: "a job" },
+    });
+
+    expect(find.mock.calls[0]?.[0]).toMatchObject({
+      locale: "de",
+      depth: 2,
+      context: { from: "a job" },
+    });
   });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/run-jobs.test.ts
@@ -419,6 +419,38 @@ describe("runJobs", () => {
     expect(result).toMatchObject({ claimed: 1, done: 0 });
   });
 
+  it("does not let a THROWN lease fence abort the rest of the drain", async () => {
+    // The fence sits between the two failure boundaries in `runOne`, so a
+    // transient adapter error there escaped `runJobs` entirely: the row stayed
+    // leased and every later candidate in the batch was skipped. One unlucky
+    // write would stop the whole drain.
+    const handler = vi.fn(async () => {});
+    const s: JobsStore & { finalized: unknown[] } = {
+      ...store([row({ id: "j1" }), row({ id: "j2" })]),
+      renewLease: async () => {
+        throw new Error("adapter blew up");
+      },
+    };
+
+    const result = await runJobs({
+      store: s,
+      registry: registryWith(defineJob({ slug: "test:noop", handler })),
+      runAs: runAs(),
+      contentApi: noContentApi,
+      now: () => NOW,
+    });
+
+    // Both rows were claimed and both were RECORDED, rather than the pass
+    // dying on the first one.
+    expect(result.claimed).toBe(2);
+    expect(s.finalized).toHaveLength(2);
+    // Charged as an ordinary attempt, so the job comes back on its own backoff.
+    expect(handler).not.toHaveBeenCalled();
+    expect((s.finalized[0] as { lastError?: string }).lastError).toContain(
+      "adapter blew up"
+    );
+  });
+
   it("hands the handler a content client already bound to the resolved user", async () => {
     // The identity is only real if it reaches the CALLS. The Direct API
     // defaults to overrideAccess: true, so a handler importing `nextly`

--- a/packages/nextly/src/domains/jobs/job-content-api.ts
+++ b/packages/nextly/src/domains/jobs/job-content-api.ts
@@ -41,8 +41,198 @@
  * @module domains/jobs/job-content-api
  */
 
+import type {
+  CollectionSlug,
+  CountArgs,
+  CountResult,
+  CreateArgs,
+  DeleteArgs,
+  DeleteResult,
+  DuplicateArgs,
+  FindArgs,
+  FindByIDArgs,
+  FindSingleArgs,
+  FindSinglesArgs,
+  ListResult,
+  MutationResult,
+  RowFromCollectionSlug,
+  RowFromSingleSlug,
+  SingleListResult,
+  SingleSlug,
+  UpdateArgs,
+  UpdateSingleArgs,
+} from "../../direct-api/types";
 import type { Nextly } from "../../init/nextly-instance";
 import type { UserContext } from "../collections/services/collection-types";
+
+/**
+ * The options this client OWNS, and which a handler therefore cannot pass.
+ *
+ * Every one of them decides authorization, and each is a distinct way to have
+ * the bound identity ignored.
+ *
+ * - `overrideAccess` turns enforcement off outright.
+ * - `user` is the identity itself.
+ * - `actor` is an `AuthenticatedScope`, and `apiKeyScopeAllows` reads its
+ *   `permissions` array as AUTHORITATIVE rather than consulting the bound
+ *   user's grants — so a handler could hand itself `["delete-posts"]`.
+ * - `trusted` widens which collections a populated relationship may reach.
+ * - `enforceFieldAccess` / `fieldAccessUser` decide whether field rules run at
+ *   all, and whose identity they run against.
+ * - `frameworkFilter` exempts a where clause from `assertFilterableFields`,
+ *   whose whole subject is a caller probing a field it may not read.
+ *
+ * They are stripped from the call rather than overridden. Overriding reaches
+ * only the options this client sets, which leaves the rest to arrive from an
+ * ordinary spread; a value that is never set here must be unable to arrive at
+ * all.
+ */
+const JOB_OWNED_ACCESS_OPTIONS = [
+  "overrideAccess",
+  "user",
+  "actor",
+  "trusted",
+  "enforceFieldAccess",
+  "fieldAccessUser",
+  "frameworkFilter",
+] as const;
+
+type JobOwnedAccessOption = (typeof JOB_OWNED_ACCESS_OPTIONS)[number];
+
+/**
+ * The `DirectAPIConfig` options that carry no authority and are forwarded.
+ *
+ * Listed so the guard below can prove the two lists COVER the config. Without
+ * that, a new authorization-bearing option added upstream would be forwarded by
+ * default and nothing here would notice — which is exactly how the five doors
+ * above stayed open.
+ */
+type ForwardedOption =
+  // Shared config.
+  | "req"
+  | "context"
+  | "locale"
+  | "fallbackLocale"
+  | "showHiddenFields"
+  | "disableErrors"
+  | "disableTransaction"
+  // How deep relationships are populated. Shaping, not authority: WHICH
+  // collections a populate may reach is governed by `trusted`, which this
+  // client owns, so a deeper read still cannot cross a boundary the bound
+  // identity may not cross.
+  | "depth"
+  // Output shaping.
+  | "richTextFormat"
+  // Which collections hold form definitions and submissions — namespace
+  // configuration.
+  | "forms"
+  // Document (soft) locks, and not an escalation: it defaults to `true`, so
+  // locks are already ignored. Passing it can only make a job RESPECT a lock it
+  // would otherwise have walked through, which is the safe direction.
+  | "overrideLock"
+  // Which document, and which part of it.
+  | "collection"
+  | "id"
+  | "slug"
+  | "data"
+  | "overrides"
+  | "duplicateFromID"
+  // Query shaping. `where` and `search` choose rows; they do not decide who may
+  // see them, and the filterable-field guard that governs probing through
+  // `where` is reached via `frameworkFilter`, which this client owns.
+  | "where"
+  | "search"
+  | "sort"
+  | "limit"
+  | "page"
+  | "offset"
+  | "pagination"
+  | "select"
+  | "populate"
+  // Lifecycle SELECTION. `status` and `draft` say which lifecycle a read asks
+  // for; whether the caller may HAVE it is decided by `resolveStatusFilter`
+  // from the access options this client owns.
+  | "status"
+  | "draft"
+  // `findSingles` filters.
+  | "source"
+  | "migrationStatus"
+  | "locked"
+  // Side-effect suppression.
+  | "disableRevalidate"
+  | "disableVerificationEmail"
+  | "overwriteExistingFiles";
+
+/**
+ * Every argument key of every bound operation.
+ *
+ * The complete surface this client wraps, not the shared config alone.
+ * `frameworkFilter` is declared on `FindArgs` and `CountArgs` rather than on
+ * `DirectAPIConfig`, so a check over the shared config reports complete while
+ * an operation-specific authorization option passes straight through.
+ */
+type AllBoundArgKeys = {
+  [K in BoundOperation]: keyof NonNullable<Parameters<Nextly[K]>[0]>;
+}[BoundOperation];
+
+/**
+ * Fails to compile when `DirectAPIConfig` gains an option neither list names.
+ *
+ * The error names the offending key, and the fix is a decision: either it
+ * carries authority and belongs in `JOB_OWNED_ACCESS_OPTIONS`, or it does not
+ * and belongs in `ForwardedOption`.
+ */
+type UnclassifiedOption = Exclude<
+  AllBoundArgKeys,
+  JobOwnedAccessOption | ForwardedOption
+>;
+type AssertEveryOptionClassified = [UnclassifiedOption] extends [never]
+  ? true
+  : ["unclassified Direct API option", UnclassifiedOption];
+const _everyOptionClassified: AssertEveryOptionClassified = true;
+void _everyOptionClassified;
+
+/** One operation's arguments, minus what this client owns. */
+type JobArgs<TArgs> = Omit<TArgs, JobOwnedAccessOption>;
+
+/**
+ * The subset of the Direct API this binds.
+ *
+ * Written out per operation rather than mapped over `Nextly`. A mapped type
+ * collapses each generic signature to its constraint, so
+ * `find({ collection: "posts" })` came back typed as the union of EVERY
+ * collection's row in a project with generated types, and `findSingles()` lost
+ * its optional argument. The argument types are still the Direct API's own, so
+ * only the method list is restated here — and that list already exists below.
+ */
+export interface JobContentApi {
+  find: <TSlug extends CollectionSlug>(
+    args: JobArgs<FindArgs<TSlug>>
+  ) => Promise<ListResult<RowFromCollectionSlug<TSlug>>>;
+  findByID: <TSlug extends CollectionSlug>(
+    args: JobArgs<FindByIDArgs<TSlug>>
+  ) => Promise<RowFromCollectionSlug<TSlug> | null>;
+  create: <TSlug extends CollectionSlug>(
+    args: JobArgs<CreateArgs<TSlug>>
+  ) => Promise<MutationResult<RowFromCollectionSlug<TSlug>>>;
+  update: <TSlug extends CollectionSlug>(
+    args: JobArgs<UpdateArgs<TSlug>>
+  ) => Promise<MutationResult<RowFromCollectionSlug<TSlug>>>;
+  delete: <TSlug extends CollectionSlug = CollectionSlug>(
+    args: JobArgs<DeleteArgs<TSlug>>
+  ) => Promise<MutationResult<{ id: string }> | DeleteResult>;
+  count: (args: JobArgs<CountArgs>) => Promise<CountResult>;
+  duplicate: <TSlug extends CollectionSlug>(
+    args: JobArgs<DuplicateArgs<TSlug>>
+  ) => Promise<MutationResult<RowFromCollectionSlug<TSlug>>>;
+  findSingle: <TSlug extends SingleSlug>(
+    args: JobArgs<FindSingleArgs<TSlug>>
+  ) => Promise<RowFromSingleSlug<TSlug>>;
+  updateSingle: <TSlug extends SingleSlug>(
+    args: JobArgs<UpdateSingleArgs<TSlug>>
+  ) => Promise<MutationResult<RowFromSingleSlug<TSlug>>>;
+  findSingles: (args?: JobArgs<FindSinglesArgs>) => Promise<SingleListResult>;
+}
 
 /**
  * The content operations a job is expected to reach for.
@@ -67,42 +257,62 @@ const BOUND_OPERATIONS = [
 export type BoundOperation = (typeof BOUND_OPERATIONS)[number];
 
 /**
- * The two fields this client owns.
+ * The contract each bound operation must still satisfy.
  *
- * Removed from every bound signature rather than accepted and ignored. A
- * handler that could write `overrideAccess: true` and see it silently dropped
- * would read the binding as a default it may override; the compiler saying no
- * is what makes it a guarantee.
+ * The interface above is written out per operation, which is what preserves the
+ * per-slug generics a mapped type collapses. The cost is a second statement of
+ * a shape the Direct API owns, and the runtime object reaches it through an
+ * assertion — so nothing would otherwise compare the two, and a changed
+ * argument or result contract upstream would leave this silently stale.
+ *
+ * Checked at the constraint rather than per slug: instantiating the generic is
+ * what a mapped type cannot do, but a change to the ARGUMENT or RESULT type is
+ * visible without it, and that is the drift worth catching.
  */
-type AccessFields = "overrideAccess" | "user";
+type JobParams<K extends BoundOperation> =
+  Parameters<Nextly[K]> extends [infer TArgs]
+    ? [args: JobArgs<TArgs>]
+    : // The optional-argument case, which `findSingles` is: a required parameter
+      // here would report drift for an operation that correctly keeps its
+      // argument optional, and losing that optionality is one of the defects this
+      // interface exists to fix.
+      [args?: JobArgs<NonNullable<Parameters<Nextly[K]>[0]>>];
 
-/** One bound operation: the Direct API's own signature, minus what this owns. */
-type Bound<TOperation> = TOperation extends (args: infer TArgs) => infer TResult
-  ? (args: Omit<TArgs, AccessFields>) => TResult
-  : never;
+type BoundContract<K extends BoundOperation> = (
+  ...args: JobParams<K>
+) => ReturnType<Nextly[K]>;
 
 /**
- * The subset of the Direct API this binds.
+ * Fails to compile when a bound signature stops matching the Direct API.
  *
- * Derived from `Nextly` so the argument and result types are the Direct API's
- * own — a second hand-written shape would drift from it, and the drift would
- * surface as a job handler that compiles against a signature the runtime no
- * longer has.
+ * Bidirectional: one direction alone would accept an interface that merely
+ * widened its arguments or narrowed its result, which is drift that still
+ * compiles at every call site and only shows up as a wrong shape at runtime.
  */
-export type JobContentApi = {
-  [K in BoundOperation]: Bound<Nextly[K]>;
+type AssertBoundContractsMatch = {
+  [K in BoundOperation]: JobContentApi[K] extends BoundContract<K>
+    ? BoundContract<K> extends JobContentApi[K]
+      ? true
+      : ["bound signature drifted from the Direct API", K]
+    : ["bound signature drifted from the Direct API", K];
 };
+const _boundContractsMatch: AssertBoundContractsMatch = {
+  find: true,
+  findByID: true,
+  create: true,
+  update: true,
+  delete: true,
+  count: true,
+  duplicate: true,
+  findSingle: true,
+  updateSingle: true,
+  findSingles: true,
+};
+void _boundContractsMatch;
 
 /** The Direct API surface this needs, named so the runner can inject a double. */
 export type JobContentSource = Pick<Nextly, BoundOperation>;
 
-/**
- * Wrap `source` so every bound call carries this job's identity.
- *
- * `source` is the Direct API. Injected rather than imported so the binding can
- * be tested without booting a runtime — the one property worth exercising
- * exhaustively is what reaches the call, and that is observable only from here.
- */
 export function createJobContentApi(
   user: UserContext | null,
   source: JobContentSource
@@ -115,16 +325,26 @@ export function createJobContentApi(
     // erasure is confined to these two lines.
     const operation = source[name] as (args: unknown) => unknown;
     bound[name] = (args: unknown) => {
-      const caller = (args ?? {}) as Record<string, unknown>;
+      // CLEARED to `undefined`, not deleted. Every operation begins with
+      // `mergeConfig(ctx.defaultConfig, args)`, which is `{ ...defaultConfig,
+      // ...args }` — so a DELETED key is merely absent from `args` and the
+      // instance default survives into the authorized call. An instance
+      // configured with `actor` would have reinstated an API-key scope whose
+      // `permissions` array is read as authoritative, behind a wrapper
+      // advertising a bound identity; a configured `user` would have been
+      // reinstated for a job that runs as nobody. Present-and-undefined wins
+      // the spread, which is what makes the clearing reach the merge.
+      const caller = { ...((args ?? {}) as Record<string, unknown>) };
+      for (const owned of JOB_OWNED_ACCESS_OPTIONS) caller[owned] = undefined;
       return operation({
         ...caller,
-        // Applied AFTER the caller's own arguments, so neither an explicit
-        // `overrideAccess: true` nor a spread that lands last can restore the
-        // bypass.
+        // Applied AFTER the stripped arguments, so a future edit that stopped
+        // stripping would still not let an explicit `overrideAccess: true`
+        // through.
         overrideAccess: false,
         ...(user === null ? {} : { user }),
       });
     };
   }
-  return bound as JobContentApi;
+  return bound as unknown as JobContentApi;
 }

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -305,12 +305,31 @@ async function runOne(
   // does not begin until `withLeaseRenewal` — so the fence it passed describes
   // a lease it no longer holds. `renewLease` is fenced on `lockedBy`, so one
   // write both extends the lease and answers whether it is still ours.
-  const stillOursAfterIdentity = await deps.store.renewLease(
-    job.id,
-    runnerId,
-    now(),
-    deps.leaseMs ?? DEFAULT_LEASE_MS
-  );
+  let stillOursAfterIdentity: boolean;
+  try {
+    stillOursAfterIdentity = await deps.store.renewLease(
+      job.id,
+      runnerId,
+      now(),
+      deps.leaseMs ?? DEFAULT_LEASE_MS
+    );
+  } catch (error) {
+    // A transient adapter error on the fence is not a verdict about ownership,
+    // and it must not escape: this sits between the two failure boundaries, so
+    // a rejection here would abort `runJobs` outright — leaving this row leased
+    // and skipping every later candidate in the batch. One unlucky write would
+    // stop the whole drain. Charged as an ordinary attempt instead, so the job
+    // retries on its own backoff.
+    return decide(
+      job,
+      attempt,
+      definition.retry.maxAttempts,
+      error instanceof Error ? error.message : String(error),
+      runnerId,
+      now,
+      deps.random
+    );
+  }
   if (!stillOursAfterIdentity) return LEASE_LOST;
 
   try {


### PR DESCRIPTION
Follow-up to #1300 (merged), which left three findings at head. All three were real and all three were mine.

## P1 — the wrapper built to stop bypasses had five of them

`createJobContentApi` removed `overrideAccess` and `user` and let everything else through. `actor` is the decisive one — `apiKeyScopeAllows` is literally:

```ts
if (scope?.actorType !== "apiKey") return null;
return scope.permissions.includes(permissionSlug(operation, resource));
```

It reads the supplied `permissions` array as **authoritative** rather than consulting the bound user's grants. A handler could pass `actor: { actorType: "apiKey", permissions: ["delete-posts"] }` and grant itself the permission. `trusted`, `enforceFieldAccess`, `fieldAccessUser` and `frameworkFilter` each disable a different guard.

All seven are now **stripped** from the call, not overridden. Overriding only the two this client sets left the rest to arrive from an ordinary spread.

### Why I did not just fix the three names in the review

That leaves the same shape — a hand-maintained blocklist nobody re-audits — and the next option added upstream is forwarded silently. So the options are **classified**, and a compile-time check fails the build when `DirectAPIConfig` gains a key in neither list:

```ts
type UnclassifiedOption = Exclude<keyof DirectAPIConfig, JobOwnedAccessOption | ForwardedOption>;
type AssertEveryOptionClassified = [UnclassifiedOption] extends [never] ? true : [...];
```

**It found four options on its first run** — `depth`, `richTextFormat`, `forms`, `overrideLock`. I checked each rather than waving them through: `overrideLock` looked like a bypass but defaults to `true` (locks already ignored), so passing it can only make a job *more* restrictive. None carries authority, and I would not have enumerated any of them by hand.

## P2 — generics were collapsed

Deriving the signatures by mapping over `Nextly` reduces each generic to its constraint, so in a project with generated types `find({ collection: "posts" })` returned the union of **every** collection's row, and `findSingles()` lost its optional argument. Written out per operation now, over the Direct API's own argument types.

The review was also right that my earlier `@ts-expect-error` probe proved only that one call was *accepted* — it confirmed what I already believed instead of testing the generic. That is the failure mode, not the omission.

## P2 — a thrown lease fence aborted the whole drain

The pre-handler `renewLease` sits between the two failure boundaries in `runOne`, so a transient adapter error escaped `runJobs`: the row stayed leased and every later candidate in the batch was skipped. One unlucky write stopped the entire drain. Charged as an ordinary attempt now.

## Verification

- Break-verified each fix individually: not stripping the owned options fails `strips EVERY authorization-bearing option`; stripping the forwarded ones too fails 2 tests (the control — a client that strips everything is useless); letting the fence throw fails `does not let a THROWN lease fence abort the rest of the drain`.
- One break attempt produced a **parse error rather than a behaviour change**, which proves nothing; redone as a `throw error` in the catch.
- The drain test asserts both rows are claimed *and* both finalized, so an implementation that dies after the first fails it.
- 67 jobs/schema tests pass. Typecheck and lint clean.