### PR TITLE
test(plugin-page-builder): name the rich-text loader in the appender test's admin mock

### DIFF
--- a/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
@@ -128,7 +128,27 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
   };
 });
 
+/*
+ * A closed object literal rather than the real module spread, unlike the shell
+ * mock above — the two modules are not interchangeable here. Importing
+ * `@nextlyhq/plugin-sdk/admin` for real under jsdom throws
+ * `ReferenceError: EventSource is not defined` while the module is still
+ * evaluating: the admin bundle it re-exports opens a dev-mode SSE connection at
+ * module scope behind a `window` guard that jsdom satisfies. So `importOriginal`
+ * here would not fill the gaps in this list, it would take the whole file down
+ * before a single test ran. The shared `scripts/vitest-dom-setup.ts` this
+ * package loads stubs no `EventSource` — `plugin-form-builder`'s own setup file
+ * is where one exists — so until these suites have one, every export the
+ * subject imports has to be named below.
+ */
 vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  /*
+   * Never awaited by these cases: the loader is reached only when an author
+   * double-clicks a passage, and none of them do. Present because the mock
+   * REPLACES the module wholesale, so an export the subject imports and this
+   * omits is a missing-export error rather than an unused stub.
+   */
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
   usePluginClientConfig: () => ({ siteStyle: undefined }),
   useDocumentCheckpoint: () => ({ schedule: () => {} }),
   useEntryFieldsPanel: () => null,


### PR DESCRIPTION
## `main` is red; this makes it green

```
packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
  4 failed
  Error: [vitest] No "loadInlineRichTextEditor" export is defined on the
         "@nextlyhq/plugin-sdk/admin" mock.
```

Measured on `origin/main`, not locally: `BlocksField.tsx` imports it, the test file mocks it zero times, and the test file is present at 239 lines.

## Nothing was skipped, and no CI could have caught it

This reads like a change that forgot its neighbours. **It is not.** `c51aa9c07` **did** update the test files — 7 lines each to `BlocksField.breakpoints.test.tsx` and `BlocksField.policy.test.tsx`, which were the only two that existed at the time. `emptyContainerAppender.test.tsx` (`7c0e47720`) and `inline-outcome.test.tsx` (`26a75492f`) landed the same day on other branches.

**A three-way concurrent collision.** Each branch was green against a `main` that did not yet contain the others, and nothing tests a combination before it exists.

## Why the list is not extended into a spread

The obvious repair — spread the real module with `importOriginal`, as the `builder/shell` mock ten lines above already does — **is impossible here, and measured rather than assumed.** A throwaway probe doing nothing but `{ ...(await importOriginal()) }`:

```
Error: [vitest] There was an error when mocking a module...
Caused by: ReferenceError: EventSource is not defined
```

Exit 1, at import, before any assertion. The admin bundle opens a dev-mode SSE connection at module scope guarded on `window`; under jsdom that guard passes and jsdom has no `EventSource`. `plugin-form-builder` stubs it in its own setup; `plugin-page-builder` loads the shared `scripts/vitest-dom-setup.ts`, which has no `EventSource` in it.

**Note the error's headline blames hoisting and the factory. The real cause is one line down** — worth knowing before someone else tries the same repair.

**So the dichotomy in that directory is explained rather than accidental:** all four `builder/shell` mocks are spreads, all six `plugin-sdk/admin` mocks are closed literals, because the shell can be spread and the admin module cannot. An earlier reading of this — that the file had diagnosed the hazard and left the second mock exposed — is wrong, and the six-file survey refutes it.

## The stub is the established one, not a fourth variant

```ts
loadInlineRichTextEditor: () => new Promise<never>(() => {}),
```

Byte-identical to what `BlocksField.breakpoints.test.tsx:128`, `BlocksField.policy.test.tsx:133` and `BlocksField.inline-outcome.test.tsx:144` already carry. A first draft used a throwing stub and was replaced once the established shape was found — a fourth spelling in a red-fix is a review round for nothing.

Safe because the export only has to **exist**, not work: `inline-editor.ts` has a type-only import, a `JSON.stringify` constant and `let pending = null` at module scope, and every `import("lexical")` is inside `build()`, reached only by calling the loader. These four tests never call it.

## Evidence

Baseline on `a7430c9f2`: exit 1, **496 passed / 4 failed / 500**. After: exit 0, **500 / 500** — same total, so no test went missing.

Three breaks, each asserting exactly one occurrence before substituting:

| break | result |
|---|---|
| remove the loader entry | exit 1, the same 4 names — the entry is what fixes it |
| remove `useSingleDocument` | exit 1, the same 4 names — the literal's entries are genuinely reached |
| shell mock forced to `draggingId: null` | exit 1, **exactly one** failure: `stays hidden during a drag…` |

The third answers the vacuity question: the assertions still discriminate on the named behaviour rather than being satisfied by the mock.

Break 1 was run **twice** — once against the throwing stub and again against the final one — because rewriting a stub changes the experiment.

## Reported, not fixed

Six files carry the closed-literal `plugin-sdk/admin` mock: `registration.test.ts:32`, `site-style-client.test.tsx:56`, `BlocksField.breakpoints.test.tsx:121`, `BlocksField.policy.test.tsx:126`, `BlocksField.inline-outcome.test.tsx:143`, `BlocksField.emptyContainerAppender.test.tsx:144`. **The next export added to that module breaks up to six suites, and each error names the mocking file rather than the change that caused it — so the lane that gets blamed is not the lane that moved.**

The real end state is an `EventSource` stub in `scripts/vitest-dom-setup.ts`, which would make `importOriginal` available to all six. That is another lane's file and the wrong thing to do inside a red-fix. Filed as `finding:plugin-sdk-admin-cannot-be-spread-under-jsdom` and `task:vitest-dom-setup-stubs-eventsource`.

## Gates

`plugin-page-builder` vitest **0** (500/500) · `builder` vitest **0** (2208/2208) · root build **0** · root `check-types` **0** (22/22) · root `lint` **0** (24/24) · `fallow audit` **0**, `verdict: pass`, 1 changed file, zero introduced.

No changeset — test-only, confirmed against the release skill's own rule rather than assumed.
