### PR TITLE
feat(blocks-engine): let a slot declare the children it starts with

### DIFF
--- a/.changeset/a-slot-declares-what-it-starts-with.md
+++ b/.changeset/a-slot-declares-what-it-starts-with.md
@@ -1,0 +1,61 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A Columns block now arrives with two columns instead of being empty.
+
+Inserting Columns used to place a container with nothing in it, so an author
+got an empty box and had to build both columns by hand before the block was
+worth anything. An accordion had the same problem for the same reason: its
+slot accepts only accordion sections, and a section cannot be placed anywhere
+else, so an empty accordion offered no way forward. Both now arrive ready to
+use — a row with two columns, an accordion with one section.
+
+A block declares this for itself, so plugin containers can do the same. Each
+slot may name the children it starts with:
+
+    slots: {
+      children: {
+        defaultBlock: [{ type: "acme/cell" }, { type: "acme/cell" }],
+      },
+    }
+
+Each entry is one child, and each carries its own props, so a row whose columns
+have different widths is expressed by writing two different entries rather than
+by repeating a count. The children are created fresh every time the block is
+placed, so two rows on one page never share an id.
+
+Card, Gallery, Box, Section and the accordion's own sections deliberately do
+NOT declare a default: their slots accept any block, or accept one that is
+placeable on its own, so there is no starting child that would be righter than
+none.
+
+BREAKING for block authors: `SlotSpec.template` is REMOVED. It held a list of
+stored nodes carrying literal ids, so two containers expanded from one template
+would have collided on `duplicate-node-id` — nothing in the codebase ever
+expanded it, and no released behaviour depended on it. Replace a `template`
+with a `defaultBlock` naming the child TYPES; ids are then minted per instance.

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -51,8 +51,27 @@ export interface SlotSpec {
    * (`"core/*"`). Omitted means any block is allowed.
    */
   allow?: string[];
-  /** Children inserted when the block is first placed. */
-  template?: BlockNode[];
+  /**
+   * What this slot starts with when its block is first placed.
+   *
+   * Each entry declares one starting child by TYPE, and a type cannot carry an
+   * id. That is the whole point: an expander mints a fresh id per entry per
+   * instance, so two parents built from one declaration cannot collide on
+   * `duplicate-node-id`. A stored list of NODES has the opposite property —
+   * its ids are literal, so the second expansion repeats the first's — which is
+   * why this names types rather than holding nodes.
+   *
+   * A LIST of per-item declarations rather than a type and a count, because the
+   * entries must be allowed to differ: an unequal split declares a different
+   * width per column, and one shared `props` cannot express that. The uniform
+   * case repeats an entry, which costs a few characters and keeps one shape.
+   *
+   * Order is the order the children are created in. An entry naming a type the
+   * expander cannot resolve contributes no child, so an unknown type yields a
+   * shorter slot rather than a node the renderer would replace with a
+   * placeholder.
+   */
+  defaultBlock?: readonly { type: string; props?: Record<string, unknown> }[];
   /**
    * Editing restriction for this slot, inherited by its children:
    * `"all"` locks everything, `"insert"` forbids adding/removing children,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -198,6 +198,7 @@ export {
   registerSupport,
   getBlock,
   isBlockName,
+  isUsableSlotName,
   hasBlock,
   allBlocks,
   getBlockSource,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -81,6 +81,7 @@ export type { DocumentSurvey, SurveyLimits } from "./measure-bytes";
 export {
   newId,
   makeNode,
+  expandSlotDefaults,
   walkNodes,
   findNode,
   locateNode,
@@ -91,7 +92,7 @@ export {
   duplicateNode,
   updateNode,
 } from "./tree";
-export type { NodeLocation, TreePosition } from "./tree";
+export type { NodeLocation, SlotDefaultSource, TreePosition } from "./tree";
 
 // The node selection every reader of a stored document shares. Public because
 // the page-builder plugin's class-usage record has to stop exactly where the

--- a/packages/blocks-engine/src/registry.parent-validation.test.ts
+++ b/packages/blocks-engine/src/registry.parent-validation.test.ts
@@ -120,4 +120,64 @@ describe("slot allow-list validation at registration", () => {
       })
     ).toThrow(/must be a plain object/);
   });
+
+  it("refuses a defaultBlock that is not an array", () => {
+    // The shape that reaches the expansion's `for...of` as
+    // `TypeError: declared is not iterable` — at the author's CLICK on the
+    // block rather than at the declaration, naming neither the plugin nor the
+    // block that caused it.
+    expect(() =>
+      registerBlocks(
+        [withSlots({ default: { defaultBlock: "core/column" } })] as never,
+        { source: "acme" }
+      )
+    ).toThrow(/defaultBlock must be an array/);
+  });
+
+  it("refuses a defaultBlock entry that is not an object", () => {
+    expect(() =>
+      registerBlocks(
+        [withSlots({ default: { defaultBlock: ["core/column"] } })] as never,
+        { source: "acme" }
+      )
+    ).toThrow(/defaultBlock must be an array/);
+  });
+
+  it("refuses a defaultBlock entry whose type is not a block name", () => {
+    expect(() =>
+      registerBlocks(
+        [
+          withSlots({ default: { defaultBlock: [{ type: "column" }] } }),
+        ] as never,
+        { source: "acme" }
+      )
+    ).toThrow(/defaultBlock must be an array/);
+  });
+
+  it("refuses a defaultBlock entry whose props are not a plain object", () => {
+    expect(() =>
+      registerBlocks(
+        [
+          withSlots({
+            default: { defaultBlock: [{ type: "core/column", props: 7 }] },
+          }),
+        ] as never,
+        { source: "acme" }
+      )
+    ).toThrow(/defaultBlock must be an array/);
+  });
+
+  it("accepts a defaultBlock entry that names only a type", () => {
+    // `props` is optional and the child's own defaults stand underneath it, so
+    // an entry naming just a type is the ordinary case. A validator that
+    // required `props` would refuse every first-party declaration.
+    expect(() =>
+      registerBlocks(
+        [
+          withSlots({ default: { defaultBlock: [{ type: "core/column" }] } }),
+        ] as never,
+        { source: "acme" }
+      )
+    ).not.toThrow();
+  });
 });

--- a/packages/blocks-engine/src/registry.parent-validation.test.ts
+++ b/packages/blocks-engine/src/registry.parent-validation.test.ts
@@ -121,6 +121,40 @@ describe("slot allow-list validation at registration", () => {
     ).toThrow(/must be a plain object/);
   });
 
+  it("refuses a slot named for a member Object.prototype owns", () => {
+    // The op layer refuses any node carrying such a slot, so a block declaring
+    // one offers a palette row whose insert is always refused. With declared
+    // starting children that refusal is SILENT — the row is clicked and
+    // nothing appears — which is why this is caught at the declaration.
+    expect(() =>
+      registerBlocks([withSlots({ constructor: {} })] as never, {
+        source: "acme",
+      })
+    ).toThrow(/Object\.prototype owns/);
+  });
+
+  it("refuses a __proto__ slot, which fails on the write rather than the read", () => {
+    // Built through `JSON.parse` rather than an object literal. A literal
+    // `{ __proto__: {} }` invokes the legacy prototype SETTER and creates no
+    // own key, so the fixture would carry no slot at all and the assertion
+    // would pass without the check ever running — the shape this refuses
+    // reaches the engine from stored JSON, where it IS an own key.
+    const slots: unknown = JSON.parse('{"__proto__":{}}');
+    expect(Object.keys(slots as object)).toEqual(["__proto__"]);
+
+    expect(() =>
+      registerBlocks([withSlots(slots as never)] as never, { source: "acme" })
+    ).toThrow(/Object\.prototype owns/);
+  });
+
+  it("accepts an ordinary slot name", () => {
+    // The control. A predicate that refused every name would satisfy both
+    // assertions above while making the engine unusable.
+    expect(() =>
+      registerBlocks([withSlots({ children: {} })] as never, { source: "acme" })
+    ).not.toThrow();
+  });
+
   it("refuses a defaultBlock that is not an array", () => {
     // The shape that reaches the expansion's `for...of` as
     // `TypeError: declared is not iterable` — at the author's CLICK on the

--- a/packages/blocks-engine/src/registry.parent-validation.test.ts
+++ b/packages/blocks-engine/src/registry.parent-validation.test.ts
@@ -169,6 +169,9 @@ describe("slot allow-list validation at registration", () => {
   });
 
   it("refuses a defaultBlock entry that is not an object", () => {
+    // A bare string is iterable, so a reader spreading it produces
+    // one-character values rather than failing — the entry has to be a record
+    // before anything reads `type` off it.
     expect(() =>
       registerBlocks(
         [withSlots({ default: { defaultBlock: ["core/column"] } })] as never,
@@ -178,6 +181,9 @@ describe("slot allow-list validation at registration", () => {
   });
 
   it("refuses a defaultBlock entry whose type is not a block name", () => {
+    // Expansion resolves the entry BY type. A name the grammar rejects can
+    // never resolve, so the child is silently dropped and the container
+    // arrives empty with nothing reported.
     expect(() =>
       registerBlocks(
         [
@@ -189,11 +195,32 @@ describe("slot allow-list validation at registration", () => {
   });
 
   it("refuses a defaultBlock entry whose props are not a plain object", () => {
+    // Props are spread into the child. A non-record spreads to nothing, so the
+    // declaration registers and the child arrives without the values it names.
     expect(() =>
       registerBlocks(
         [
           withSlots({
             default: { defaultBlock: [{ type: "core/column", props: 7 }] },
+          }),
+        ] as never,
+        { source: "acme" }
+      )
+    ).toThrow(/defaultBlock must be an array/);
+  });
+
+  it("refuses defaultBlock props that are an exotic object", () => {
+    // A `Date`, `Map` or class instance is an object and not an array, so a
+    // predicate testing only those two accepts it. Expansion then spreads it
+    // into `{}` and the child arrives with NONE of the declared props, having
+    // registered without complaint. The prototype is what separates them.
+    expect(() =>
+      registerBlocks(
+        [
+          withSlots({
+            default: {
+              defaultBlock: [{ type: "core/column", props: new Date() }],
+            },
           }),
         ] as never,
         { source: "acme" }

--- a/packages/blocks-engine/src/registry.parent-validation.test.ts
+++ b/packages/blocks-engine/src/registry.parent-validation.test.ts
@@ -228,6 +228,22 @@ describe("slot allow-list validation at registration", () => {
     ).toThrow(/defaultBlock must be an array/);
   });
 
+  it("refuses a sparse defaultBlock array", () => {
+    // `Array.prototype.every` SKIPS a hole, so a predicate written with it
+    // reports `Array(1)` as well-formed; `for...of` visits the hole and yields
+    // `undefined`, which the expansion then reads `type` off. The two disagree
+    // about the same array, and only an index check sees it.
+    const sparse = Array(1) as unknown[];
+    expect(Object.hasOwn(sparse, 0)).toBe(false);
+
+    expect(() =>
+      registerBlocks(
+        [withSlots({ default: { defaultBlock: sparse } })] as never,
+        { source: "acme" }
+      )
+    ).toThrow(/defaultBlock must be an array/);
+  });
+
   it("accepts a defaultBlock entry that names only a type", () => {
     // `props` is optional and the child's own defaults stand underneath it, so
     // an entry naming just a type is the ordinary case. A validator that

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -207,25 +207,56 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
         );
       }
       const allow = (spec as { allow?: unknown }).allow;
-      if (allow === undefined) continue;
-      // A namespace wildcard is permitted here and is not a block NAME, so this cannot reuse
-      // `isBlockName`: `core/*` names a set rather than a block.
-      const wellFormed =
-        Array.isArray(allow) &&
-        allow.every(entry => {
-          if (typeof entry !== "string") return false;
-          // A wildcard is checked by substituting a placeholder segment, so the name grammar is
-          // asked ONCE. Testing both forms as alternatives narrows the value to `never` on the
-          // second branch, because the predicate is a type guard.
-          const asName = entry.endsWith("/*")
-            ? `${entry.slice(0, -2)}/x`
-            : entry;
-          return isBlockName(asName);
+      // Each field is validated on its own rather than behind the other's
+      // presence: a slot may declare `defaultBlock` and no `allow` at all,
+      // which is the ordinary case, and a `continue` here would carry the
+      // defaultBlock check past every one of them.
+      if (allow !== undefined) {
+        // A namespace wildcard is permitted here and is not a block NAME, so this cannot reuse
+        // `isBlockName`: `core/*` names a set rather than a block.
+        const wellFormed =
+          Array.isArray(allow) &&
+          allow.every(entry => {
+            if (typeof entry !== "string") return false;
+            // A wildcard is checked by substituting a placeholder segment, so the name grammar is
+            // asked ONCE. Testing both forms as alternatives narrows the value to `never` on the
+            // second branch, because the predicate is a type guard.
+            const asName = entry.endsWith("/*")
+              ? `${entry.slice(0, -2)}/x`
+              : entry;
+            return isBlockName(asName);
+          });
+        if (!wellFormed) {
+          fail(
+            "NEXTLY_BLOCK_INVALID",
+            `block "${def.name}" slot "${slotName}" allow must be an array of block names like "core/heading" or namespaces like "core/*".`
+          );
+        }
+      }
+      // `defaultBlock` is read when an author INSERTS this block, which is the
+      // worst place for a definition error to surface: a non-array is iterated
+      // by the expansion and throws `TypeError: declared is not iterable` at
+      // the click, naming neither the plugin nor the block that declared it.
+      // Checked here for exactly the reason `allow` above is — the type rejects
+      // it at the authoring site, and definitions also arrive from JavaScript
+      // plugins and from JSON, where it does not.
+      const defaultBlock = (spec as { defaultBlock?: unknown }).defaultBlock;
+      if (defaultBlock === undefined) continue;
+      const entriesWellFormed =
+        Array.isArray(defaultBlock) &&
+        defaultBlock.every(entry => {
+          if (!isPlainRecord(entry)) return false;
+          // Only `type` is required. `props` is optional and the child's own
+          // defaults stand underneath it, so an entry naming just a type is the
+          // ordinary case rather than an incomplete one.
+          if (!isBlockName((entry as { type?: unknown }).type)) return false;
+          const props = (entry as { props?: unknown }).props;
+          return props === undefined || isPlainRecord(props);
         });
-      if (!wellFormed) {
+      if (!entriesWellFormed) {
         fail(
           "NEXTLY_BLOCK_INVALID",
-          `block "${def.name}" slot "${slotName}" allow must be an array of block names like "core/heading" or namespaces like "core/*".`
+          `block "${def.name}" slot "${slotName}" defaultBlock must be an array of entries like { type: "core/column" }, each with an optional plain-object props.`
         );
       }
     }

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -94,6 +94,23 @@ export function isBlockName(value: unknown): value is string {
 }
 
 /**
+ * Whether every index of an array is an OWN element rather than a hole.
+ *
+ * An explicit index loop, because every callback-based array method skips
+ * holes — `every`, `some`, `filter` and `forEach` alike — so a predicate
+ * written with one cannot observe the thing it is being asked about. That is
+ * not a detail of this check: it is the reason a sparse array survives
+ * validation and then reaches a `for...of`, which does NOT skip, and yields
+ * `undefined`.
+ */
+function hasNoHoles(values: readonly unknown[]): boolean {
+  for (let index = 0; index < values.length; index += 1) {
+    if (!Object.hasOwn(values, index)) return false;
+  }
+  return true;
+}
+
+/**
  * Whether a slot name can be stored and read back as its own key.
  *
  * The rejected names are the ones `Object.prototype` OWNS. Reading
@@ -269,8 +286,13 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
       // plugins and from JSON, where it does not.
       const defaultBlock = (spec as { defaultBlock?: unknown }).defaultBlock;
       if (defaultBlock === undefined) continue;
+      // A HOLE is not a missing element to `Array.prototype.every`, which skips
+      // it, while `for...of` visits it and yields `undefined` — so a sparse
+      // array validated by the first is read by the second. Checked by index
+      // because no callback-based method can see what it does not visit.
+      const dense = Array.isArray(defaultBlock) && hasNoHoles(defaultBlock);
       const entriesWellFormed =
-        Array.isArray(defaultBlock) &&
+        dense &&
         defaultBlock.every(entry => {
           if (!isPlainRecord(entry)) return false;
           // Only `type` is required. `props` is optional and the child's own

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -93,6 +93,26 @@ export function isBlockName(value: unknown): value is string {
 }
 
 /**
+ * Whether a slot name can be stored and read back as its own key.
+ *
+ * The rejected names are the ones `Object.prototype` OWNS. Reading
+ * `slots[name]` for one of those answers with an inherited member instead of
+ * `undefined`, and assigning it — which a slot-map rebuild does — sets the
+ * prototype rather than creating an own property, dropping that whole child
+ * list. Asked of `Object.prototype` rather than matched against a written
+ * list, because the list everyone writes is `__proto__` and `constructor`
+ * while `toString` behaves identically.
+ *
+ * Exported for the same reason {@link isBlockName} is: a slot name is judged
+ * at a block's DECLARATION and again on every op that carries one, and those
+ * two gates answering differently is how a name a position could not use gets
+ * in through a subtree.
+ */
+export function isUsableSlotName(name: string): boolean {
+  return !Object.prototype.hasOwnProperty.call(Object.prototype, name);
+}
+
+/**
  * The highest version a block may declare. Migration chains a bounded number of
  * steps, so a version above this could never carry its oldest stored nodes
  * forward — registration refuses it rather than promise an upgrade path that
@@ -204,6 +224,17 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
         fail(
           "NEXTLY_BLOCK_INVALID",
           `block "${def.name}" slot "${slotName}" must be a plain object.`
+        );
+      }
+      // A slot whose NAME cannot hold children is not a slot. The op layer
+      // refuses any node carrying one, so a block declaring it offers a
+      // palette row whose insert is always refused — and, where the slot
+      // declares starting children, that refusal is silent: the row is
+      // clicked and nothing appears.
+      if (!isUsableSlotName(slotName)) {
+        fail(
+          "NEXTLY_BLOCK_INVALID",
+          `block "${def.name}" slot "${slotName}" is a name Object.prototype owns, so it cannot be stored and read back. Rename the slot.`
         );
       }
       const allow = (spec as { allow?: unknown }).allow;

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -14,6 +14,7 @@ import { COMPONENT_INSTANCE_TYPE, isBlockType } from "./document";
 import type { MigrationSource } from "./migration";
 import { MAX_MIGRATION_STEPS, findMigrationGaps } from "./migration";
 import type { NestingSource } from "./nesting";
+import { isPlainRecord } from "./plain-record";
 import { styleSupportDefinitions } from "./style/supports-map";
 import type { BlockTypeLookup } from "./validation";
 
@@ -131,11 +132,6 @@ const SUPPORT_KEY_RE = /^[a-zA-Z][a-zA-Z0-9]*$/;
 
 function fail(code: string, message: string): never {
   throw new Error(`${code}: ${message}`);
-}
-
-/** A key/value object — not null, not an array, not a function. */
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 /**

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -1555,6 +1555,53 @@ describe("expanding a slot's declared default", () => {
     ).toBeUndefined();
   });
 
+  it("creates nothing from a slots map that is not a record", () => {
+    // `Object.entries(null)` throws, and a supplied definition reaches this
+    // without registration — the enclosing map arrives through the same
+    // unvalidated source its entries do.
+    const nulled = {
+      get: (type: string) =>
+        type === "core/host" ? { version: 1, slots: null } : undefined,
+    };
+
+    expect(() =>
+      expandSlotDefaults("core/host", nulled as never)
+    ).not.toThrow();
+    expect(expandSlotDefaults("core/host", nulled as never)).toBeUndefined();
+  });
+
+  it("judges a seeded child by the caller's nesting rules when given them", () => {
+    // The caller's source restricts the leaf to a parent that is NOT the
+    // container seeding it. Deriving nesting from the definitions instead would
+    // find no restriction at all and create the child, so the palette would be
+    // filtered by one rule set and the insert populated by another.
+    const definitions = {
+      get: (type: string) =>
+        type === "acme/container"
+          ? {
+              version: 1,
+              slots: { children: { defaultBlock: [{ type: "acme/leaf" }] } },
+            }
+          : type === "acme/leaf"
+            ? { version: 1 }
+            : undefined,
+    };
+    const callerRules = {
+      parentsOf: (type: string) =>
+        type === "acme/leaf" ? ["acme/other"] : undefined,
+    };
+
+    // Without the caller's source the child IS created — that is the control,
+    // and it is what makes the refusal below mean something.
+    expect(
+      expandSlotDefaults("acme/container", definitions)?.children
+    ).toHaveLength(1);
+
+    expect(
+      expandSlotDefaults("acme/container", definitions, callerRules)
+    ).toBeUndefined();
+  });
+
   it("stops creating nodes once the document's node cap is spent", () => {
     // Ten children at each of eight levels is a legal set of declarations and
     // about a hundred million nodes. The DEPTH bound does not reach this: it
@@ -1589,11 +1636,14 @@ describe("expanding a slot's declared default", () => {
     };
     count(slots?.children);
 
-    // Bounded by the DOCUMENT's cap, because a subtree bigger than that could
-    // not be inserted into any document and so must not be built. Asserting
-    // merely "finite" would pass on a bound of any size, including one large
-    // enough to exhaust memory.
-    expect(created).toBeLessThanOrEqual(5000);
+    // Bounded, and bounded so the WHOLE subtree fits rather than just the
+    // children. The node these hang from is created by the caller and is not
+    // charged here, so spending the full cap on children alone yields 5001
+    // nodes — a bound that is satisfied while the thing it bounds does not
+    // fit. Asserting merely "finite" would pass on a bound of any size,
+    // including one large enough to exhaust memory.
+    const parentTheCallerCreates = 1;
+    expect(created + parentTheCallerCreates).toBeLessThanOrEqual(5000);
     // And it did real work rather than refusing everything, which a budget of
     // zero would also satisfy.
     expect(created).toBeGreaterThan(100);

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -1274,4 +1274,224 @@ describe("expanding a slot's declared default", () => {
     expect(slots?.children?.[0]?.props).toEqual({ width: "wide" });
     expect(slots?.children?.[0]?.props).not.toBe(declared);
   });
+
+  /**
+   * A resolver whose children carry the parts a real definition has and the
+   * fixture above omits: prop defaults, a parent restriction, and slots of
+   * their own. The fixture above is deliberately minimal, which is why every
+   * assertion below needs its own.
+   */
+  const rich = {
+    get: (type: string) =>
+      ({
+        "core/columns": {
+          version: 1,
+          slots: {
+            children: {
+              allow: ["core/column"],
+              defaultBlock: [{ type: "core/column" }],
+            },
+          },
+        },
+        // Declares a child its slot does not admit, which is the shape a
+        // plugin produces by renaming a block and updating one of the two
+        // places that name it.
+        "core/mismatched": {
+          version: 1,
+          slots: {
+            children: {
+              allow: ["core/column"],
+              defaultBlock: [{ type: "core/heading" }],
+            },
+          },
+        },
+        // Declares a child that refuses this parent — the other half of the
+        // rule, which the slot's own allow-list cannot see.
+        "core/wrong-parent": {
+          version: 1,
+          slots: { children: { defaultBlock: [{ type: "core/column" }] } },
+        },
+        "core/column": {
+          version: 7,
+          defaultProps: { as: "div", contained: false },
+          parent: ["core/columns", "core/nested"],
+        },
+        "core/heading": { version: 2, defaultProps: { level: 2 } },
+        // A container whose own declaration seeds another container.
+        "core/nested": {
+          version: 1,
+          parent: ["core/columns"],
+          slots: { children: { defaultBlock: [{ type: "core/column" }] } },
+        },
+      })[type],
+  };
+
+  it("starts a seeded child on its own prop defaults", () => {
+    const slots = expandSlotDefaults("core/columns", rich);
+
+    // The separating property is the DEFAULTS being present. An implementation
+    // that passes the entry's props straight through yields `{}` here, and a
+    // child created that way differs from the same block inserted from the
+    // palette — one block with two starting states, decided by how the author
+    // happened to create it.
+    expect(slots?.children?.[0]?.props).toEqual({
+      as: "div",
+      contained: false,
+    });
+  });
+
+  it("lets a declaration override only the props it names", () => {
+    const overriding = {
+      get: (type: string) =>
+        type === "core/columns"
+          ? {
+              version: 1,
+              slots: {
+                children: {
+                  allow: ["core/column"],
+                  defaultBlock: [
+                    { type: "core/column", props: { contained: true } },
+                  ],
+                },
+              },
+            }
+          : rich.get(type),
+    };
+
+    const slots = expandSlotDefaults("core/columns", overriding);
+
+    // `as` survives from the defaults and `contained` is the declaration's.
+    // Asserting only the overridden key would pass on an implementation that
+    // DISCARDS the defaults, which is the case this pairs with above.
+    expect(slots?.children?.[0]?.props).toEqual({
+      as: "div",
+      contained: true,
+    });
+  });
+
+  it("refuses a declared child the slot does not admit", () => {
+    const slots = expandSlotDefaults("core/mismatched", rich);
+
+    // Seeding it would build a document the editor's own validation then
+    // reports as `not-allowed-in-slot` — a block illegal to drag in, arriving
+    // by being declared.
+    expect(slots).toBeUndefined();
+  });
+
+  it("refuses a declared child that does not admit this parent", () => {
+    const slots = expandSlotDefaults("core/wrong-parent", rich);
+
+    // `core/column` names `core/columns` and `core/nested` as its parents, and
+    // this is neither. The slot here declares no `allow`, so ONLY the child's
+    // own restriction can refuse it — which is why this is a separate case
+    // from the slot mismatch above rather than a second example of it.
+    expect(slots).toBeUndefined();
+  });
+
+  it("expands a declared child's own declared children", () => {
+    const slots = expandSlotDefaults("core/columns", {
+      get: (type: string) =>
+        type === "core/columns"
+          ? {
+              version: 1,
+              slots: {
+                children: {
+                  allow: ["core/nested"],
+                  defaultBlock: [{ type: "core/nested" }],
+                },
+              },
+            }
+          : rich.get(type),
+    });
+
+    const nested = slots?.children?.[0];
+    expect(nested?.type).toBe("core/nested");
+    // The grandchild is the assertion. Without recursion the nested container
+    // arrives with no `slots` key at all, so the same block declares different
+    // starting children depending on whether an author inserted it or a parent
+    // seeded it.
+    expect(nested?.slots?.children).toHaveLength(1);
+    expect(nested?.slots?.children?.[0]?.type).toBe("core/column");
+  });
+
+  it("stops a declaration that seeds its own type", () => {
+    const cyclic = {
+      get: (type: string) =>
+        type === "core/a"
+          ? {
+              version: 1,
+              slots: { children: { defaultBlock: [{ type: "core/b" }] } },
+            }
+          : type === "core/b"
+            ? {
+                version: 1,
+                slots: { children: { defaultBlock: [{ type: "core/a" }] } },
+              }
+            : undefined,
+    };
+
+    // Terminating at all is the property. Without the ancestor set this
+    // recurses until the stack gives out, so the assertion below is only
+    // reachable when the cycle is cut.
+    const slots = expandSlotDefaults("core/a", cyclic);
+
+    const b = slots?.children?.[0];
+    expect(b?.type).toBe("core/b");
+    // Cut at the repeat rather than one level later: `core/a` is already being
+    // expanded, so `core/b` fills no slot and carries no `slots` key.
+    expect(b?.slots).toBeUndefined();
+  });
+
+  it("lets two sibling slots seed the same child type", () => {
+    const twoSlots = {
+      get: (type: string) =>
+        type === "core/pair"
+          ? {
+              version: 1,
+              slots: {
+                left: { defaultBlock: [{ type: "core/leaf" }] },
+                right: { defaultBlock: [{ type: "core/leaf" }] },
+              },
+            }
+          : type === "core/leaf"
+            ? { version: 1 }
+            : undefined,
+    };
+
+    const slots = expandSlotDefaults("core/pair", twoSlots);
+
+    // The cycle guard tracks the types on ONE path, not every type seen. A set
+    // shared across siblings would fill `left` and leave `right` empty, which
+    // is a shape an author would reasonably draw being silently refused.
+    expect(slots?.left).toHaveLength(1);
+    expect(slots?.right).toHaveLength(1);
+  });
+
+  it("stops expanding a chain of distinct types at the depth bound", () => {
+    // Each type seeds the next, so no type repeats and the cycle set never
+    // fires — the depth bound is the only thing that ends this.
+    const chain = {
+      get: (type: string) => {
+        const match = /^core\/d(\d+)$/.exec(type);
+        if (match === null) return undefined;
+        const next = Number(match[1]) + 1;
+        return {
+          version: 1,
+          slots: { children: { defaultBlock: [{ type: `core/d${next}` }] } },
+        };
+      },
+    };
+
+    let node = expandSlotDefaults("core/d0", chain)?.children?.[0];
+    let depth = 1;
+    while (node?.slots?.children?.[0] !== undefined) {
+      node = node.slots.children[0];
+      depth += 1;
+    }
+
+    // Bounded, and bounded where the constant says. An unbounded expansion
+    // never reaches this line, and asserting merely "finite" would pass on a
+    // bound of any size.
+    expect(depth).toBe(8);
+  });
 });

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -1467,6 +1467,50 @@ describe("expanding a slot's declared default", () => {
     expect(slots?.right).toHaveLength(1);
   });
 
+  it("stops creating nodes once the document's node cap is spent", () => {
+    // Ten children at each of eight levels is a legal set of declarations and
+    // about a hundred million nodes. The DEPTH bound does not reach this: it
+    // limits how deep a declaration goes and says nothing about how wide, so
+    // without a node budget this test does not finish.
+    const wide = {
+      get: (type: string) => {
+        const match = /^core\/w(\d+)$/.exec(type);
+        if (match === null) return undefined;
+        const next = Number(match[1]) + 1;
+        return {
+          version: 1,
+          slots: {
+            children: {
+              defaultBlock: Array.from({ length: 10 }, () => ({
+                type: `core/w${next}`,
+              })),
+            },
+          },
+        };
+      },
+    };
+
+    const slots = expandSlotDefaults("core/w0", wide);
+
+    let created = 0;
+    const count = (nodes: readonly BlockNode[] | undefined): void => {
+      for (const node of nodes ?? []) {
+        created += 1;
+        for (const list of Object.values(node.slots ?? {})) count(list);
+      }
+    };
+    count(slots?.children);
+
+    // Bounded by the DOCUMENT's cap, because a subtree bigger than that could
+    // not be inserted into any document and so must not be built. Asserting
+    // merely "finite" would pass on a bound of any size, including one large
+    // enough to exhaust memory.
+    expect(created).toBeLessThanOrEqual(5000);
+    // And it did real work rather than refusing everything, which a budget of
+    // zero would also satisfy.
+    expect(created).toBeGreaterThan(100);
+  });
+
   it("stops expanding a chain of distinct types at the depth bound", () => {
     // Each type seeds the next, so no type repeats and the cycle set never
     // fires — the depth bound is the only thing that ends this.

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -5,6 +5,7 @@ import { countNodes, treeDepth } from "./limits";
 import { measureBytes } from "./measure-bytes";
 import {
   duplicateNode,
+  expandSlotDefaults,
   findNode,
   insertNode,
   locateNode,
@@ -1097,5 +1098,180 @@ describe("a record keyed by a stored `__proto__`", () => {
     expect(Object.keys(next[0]!.slots!)).toContain("__proto__");
     expect(Object.getPrototypeOf(next[0]!.slots!)).toBe(Object.prototype);
     expect(next[0]!.slots!.__proto__).toHaveLength(1);
+  });
+});
+
+describe("expanding a slot's declared default", () => {
+  /**
+   * A resolver over three types: a container declaring two identical starting
+   * children, one declaring two DIFFERENT ones, and a leaf declaring none.
+   *
+   * `core/quote` is deliberately absent, so a declaration naming it exercises
+   * the unresolvable-entry branch.
+   */
+  const definitions = {
+    get: (type: string) =>
+      ({
+        "core/columns": {
+          version: 1,
+          slots: {
+            children: {
+              defaultBlock: [{ type: "core/column" }, { type: "core/column" }],
+            },
+          },
+        },
+        "core/split": {
+          version: 3,
+          slots: {
+            children: {
+              defaultBlock: [
+                { type: "core/column", props: { width: "wide" } },
+                { type: "core/column", props: { width: "narrow" } },
+              ],
+            },
+          },
+        },
+        "core/column": { version: 7 },
+      })[type],
+  };
+
+  it("mints a fresh id for every expanded child", () => {
+    const slots = expandSlotDefaults("core/columns", definitions);
+    const ids = slots?.children?.map(node => node.id) ?? [];
+
+    expect(ids).toHaveLength(2);
+    // DISTINCT, not merely present. Two children sharing an id is exactly the
+    // failure a stored node list produces, and the whole reason this layer
+    // exists — `toHaveLength` alone passes on an implementation that expands
+    // one node and repeats the reference.
+    expect(new Set(ids).size).toBe(2);
+  });
+
+  it("gives two parents built from one declaration no id in common", () => {
+    // The collision this design makes unreachable is ACROSS instances, and one
+    // parent cannot produce it: an implementation that mints per child but
+    // caches the finished slot record per type passes the test above and fails
+    // here. Both parents are expanded from the same declaration, which is the
+    // situation two rows on one page are in.
+    const first = expandSlotDefaults("core/columns", definitions);
+    const second = expandSlotDefaults("core/columns", definitions);
+
+    const firstIds = (first?.children ?? []).map(node => node.id);
+    const secondIds = (second?.children ?? []).map(node => node.id);
+
+    expect(firstIds).toHaveLength(2);
+    expect(secondIds).toHaveLength(2);
+    expect(new Set([...firstIds, ...secondIds]).size).toBe(4);
+  });
+
+  it("carries each entry's own props, so the children may differ", () => {
+    // What a count with one shared props object cannot express, and the reason
+    // the declaration is a list.
+    const slots = expandSlotDefaults("core/split", definitions);
+
+    expect(slots?.children?.map(node => node.props)).toEqual([
+      { width: "wide" },
+      { width: "narrow" },
+    ]);
+  });
+
+  it("stamps each child with ITS OWN type's version, not the parent's", () => {
+    // `core/split` is version 3 and `core/column` version 7. Reading the
+    // version from the parent would produce nodes the migration runner treats
+    // as older or newer than they are.
+    const slots = expandSlotDefaults("core/split", definitions);
+
+    expect(slots?.children?.map(node => node.version)).toEqual([7, 7]);
+  });
+
+  it("keeps the declared order", () => {
+    const slots = expandSlotDefaults("core/split", definitions);
+
+    expect(slots?.children?.map(node => node.props.width)).toEqual([
+      "wide",
+      "narrow",
+    ]);
+  });
+
+  it("skips an entry naming a type the resolver does not know", () => {
+    // A node of an unregistered type renders as a placeholder, which is worse
+    // than a shorter slot: the author gets a block they did not ask for and
+    // cannot fix. `core/quote` is not in the fixture.
+    const unknownEntry = {
+      get: (type: string) =>
+        type === "core/box"
+          ? {
+              version: 1,
+              slots: {
+                children: {
+                  defaultBlock: [
+                    { type: "core/quote" },
+                    { type: "core/column" },
+                  ],
+                },
+              },
+            }
+          : type === "core/column"
+            ? { version: 7 }
+            : undefined,
+    };
+
+    const slots = expandSlotDefaults("core/box", unknownEntry);
+
+    expect(slots?.children?.map(node => node.type)).toEqual(["core/column"]);
+  });
+
+  it("answers undefined when no slot declares a default", () => {
+    // Distinct from an empty record: `makeNode` writes a `slots` key only when
+    // one is supplied, so a container with no declared default must arrive
+    // carrying no `slots` at all.
+    expect(expandSlotDefaults("core/column", definitions)).toBeUndefined();
+  });
+
+  it("answers undefined for a type the resolver does not know", () => {
+    expect(expandSlotDefaults("core/nonexistent", definitions)).toBeUndefined();
+  });
+
+  it("omits a slot whose every entry was unresolvable", () => {
+    // The empty-slot case must not become `{ children: [] }`, which would make
+    // a container claim children it does not have.
+    const allUnknown = {
+      get: (type: string) =>
+        type === "core/box"
+          ? {
+              version: 1,
+              slots: { children: { defaultBlock: [{ type: "core/quote" }] } },
+            }
+          : undefined,
+    };
+
+    expect(expandSlotDefaults("core/box", allUnknown)).toBeUndefined();
+  });
+
+  it("does not let a declaration's props object reach the built node", () => {
+    // The declaration outlives every expansion made from it. Handing out its
+    // own object would let an edit to one inserted block reach the block
+    // definition, and through it every block expanded from it afterwards.
+    const declared = { width: "wide" };
+    const shared = {
+      get: (type: string) =>
+        type === "core/box"
+          ? {
+              version: 1,
+              slots: {
+                children: {
+                  defaultBlock: [{ type: "core/column", props: declared }],
+                },
+              },
+            }
+          : type === "core/column"
+            ? { version: 7 }
+            : undefined,
+    };
+
+    const slots = expandSlotDefaults("core/box", shared);
+
+    expect(slots?.children?.[0]?.props).toEqual({ width: "wide" });
+    expect(slots?.children?.[0]?.props).not.toBe(declared);
   });
 });

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -1467,6 +1467,94 @@ describe("expanding a slot's declared default", () => {
     expect(slots?.right).toHaveLength(1);
   });
 
+  it("refuses a malformed declaration that never passed registration", () => {
+    // A supplied definition reaches the expansion WITHOUT `registerBlocks`,
+    // because `blockSourceFor` deliberately admits one the registry does not
+    // hold. Registration is therefore not the only shape boundary, and a
+    // non-array here reaches `for...of` as `TypeError: declared is not
+    // iterable` at the author's click.
+    // A NUMBER rather than a string, deliberately. A string is iterable, so
+    // `for...of` walks its characters and each one is refused by the entry
+    // check further down — the declaration is malformed and the array guard is
+    // never what catches it. A non-iterable is the value that actually reaches
+    // `TypeError: declared is not iterable`.
+    const malformed = {
+      get: (type: string) =>
+        type === "core/host"
+          ? { version: 1, slots: { children: { defaultBlock: 42 } } }
+          : type === "core/column"
+            ? { version: 1 }
+            : undefined,
+    };
+
+    expect(() =>
+      expandSlotDefaults("core/host", malformed as never)
+    ).not.toThrow();
+    expect(expandSlotDefaults("core/host", malformed as never)).toBeUndefined();
+  });
+
+  it("creates no children from a declaration that is a bare string", () => {
+    // The other half of the shape above, and a different mechanism: a string
+    // IS iterable, so the loop yields one-character values rather than
+    // throwing. Each is refused as an entry, so the container arrives empty
+    // instead of holding a child per letter.
+    const stringy = {
+      get: (type: string) =>
+        type === "core/host"
+          ? { version: 1, slots: { children: { defaultBlock: "core/column" } } }
+          : type === "core/column"
+            ? { version: 1 }
+            : undefined,
+    };
+
+    expect(expandSlotDefaults("core/host", stringy as never)).toBeUndefined();
+  });
+
+  it("refuses a declared entry that is a hole in a sparse array", () => {
+    const sparse = Array(1) as unknown[];
+    const holed = {
+      get: (type: string) =>
+        type === "core/host"
+          ? { version: 1, slots: { children: { defaultBlock: sparse } } }
+          : undefined,
+    };
+
+    // The hole arrives as `undefined`, and reading `type` off it throws.
+    expect(() => expandSlotDefaults("core/host", holed as never)).not.toThrow();
+    expect(expandSlotDefaults("core/host", holed as never)).toBeUndefined();
+  });
+
+  it("drops a child whose declared props cannot be cloned", () => {
+    // A prototype check says this is a plain object; `structuredClone` refuses
+    // its contents with a DataCloneError. Uncaught, the insert throws.
+    const uncloneable = {
+      get: (type: string) =>
+        type === "core/host"
+          ? {
+              version: 1,
+              slots: {
+                children: {
+                  defaultBlock: [
+                    { type: "core/leaf", props: { onClick: () => undefined } },
+                  ],
+                },
+              },
+            }
+          : type === "core/leaf"
+            ? { version: 1 }
+            : undefined,
+    };
+
+    expect(() =>
+      expandSlotDefaults("core/host", uncloneable as never)
+    ).not.toThrow();
+    // Dropped rather than created empty: a child carrying none of its declared
+    // props is not the block the declaration named.
+    expect(
+      expandSlotDefaults("core/host", uncloneable as never)
+    ).toBeUndefined();
+  });
+
   it("stops creating nodes once the document's node cap is spent", () => {
     // Ten children at each of eight levels is a legal set of declarations and
     // about a hundred million nodes. The DEPTH bound does not reach this: it

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -66,11 +66,13 @@
  * own.
  */
 import type { SlotSpec } from "./block";
+import { isBlockType } from "./document";
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
 import { MAX_NODES } from "./limits";
 import { canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
+import { isPlainRecord } from "./plain-record";
 import { defineEntry, ownEntry } from "./safe-record";
 
 /** Stable unique node id. `crypto.randomUUID` exists in Node ≥ 20 and browsers. */
@@ -116,6 +118,9 @@ export interface SlotDefaultSource {
       }
     | undefined;
 }
+
+/** What {@link SlotDefaultSource} answers with for a type it knows. */
+type ResolvedDefinition = NonNullable<ReturnType<SlotDefaultSource["get"]>>;
 
 /**
  * How deep a chain of declared defaults may go.
@@ -282,7 +287,13 @@ function childrenForSlot(
     readonly budget: { remaining: number };
   }
 ): BlockNode[] {
-  if (declared === undefined) return [];
+  // The SHAPE is checked here and not only at registration, because
+  // registration is no longer the only way a definition reaches this function.
+  // `blockSourceFor` deliberately admits a caller-supplied definition the
+  // registry does not hold, so a host or fixture declaration never passes
+  // `registerBlocks` at all — and a non-array reaching the loop below throws
+  // `TypeError: declared is not iterable` at the author's click.
+  if (!Array.isArray(declared)) return [];
   const children: BlockNode[] = [];
   for (const entry of declared) {
     const child = childForEntry(entry, context);
@@ -299,24 +310,42 @@ function childrenForSlot(
  * become a child at all. Each `null` below is a distinct refusal, and keeping
  * them together is what lets the loop above read as the shape it builds.
  */
-function childForEntry(
-  entry: { readonly type: string; readonly props?: Record<string, unknown> },
-  context: {
-    readonly type: string;
-    readonly slotName: string;
-    readonly definitions: SlotDefaultSource;
-    readonly nesting: NestingSource;
-    readonly ancestors: ReadonlySet<string>;
-    readonly depth: number;
-    readonly budget: { remaining: number };
-  }
-): BlockNode | null {
-  const { definitions, nesting, ancestors, depth, budget } = context;
+type EntryContext = {
+  readonly type: string;
+  readonly slotName: string;
+  readonly definitions: SlotDefaultSource;
+  readonly nesting: NestingSource;
+  readonly ancestors: ReadonlySet<string>;
+  readonly depth: number;
+  readonly budget: { remaining: number };
+};
+
+/**
+ * The entry's resolved type and definition, or `null` for any reason it must
+ * not become a child.
+ *
+ * Every refusal lives here and none of them in the construction below, so the
+ * two questions stay apart: whether this declaration MAY become a child, and
+ * what that child is. Each `null` is a distinct reason, and the comments name
+ * the failure each one prevents rather than restating the condition.
+ */
+function resolvedEntry(
+  entry: unknown,
+  context: EntryContext
+): { type: string; definition: ResolvedDefinition } | null {
+  const { definitions, nesting, ancestors, budget } = context;
   // Checked before the definition is even resolved: once the budget is spent
   // nothing further can be built, so the cheapest possible refusal is the right
   // one.
   if (budget.remaining <= 0) return null;
-  const definition = definitions.get(entry.type);
+  // An entry is not trusted to BE an entry. A sparse array yields `undefined`
+  // here — `Array.prototype.every` skips a hole while `for...of` visits it, so
+  // a declaration validated by the first is read by the second — and an
+  // unregistered supplied definition never passed any shape check at all.
+  if (!isPlainRecord(entry)) return null;
+  const type = entry.type;
+  if (!isBlockType(type)) return null;
+  const definition = definitions.get(type);
   // A node of an unregistered type renders as a placeholder the author did not
   // ask for and cannot repair.
   if (definition === undefined) return null;
@@ -324,14 +353,24 @@ function childForEntry(
   // neither implies the other: the child says where it belongs, the slot says
   // what it holds, and a seed has to satisfy both to be a placement the author
   // could have made themselves.
-  if (!canNest(entry.type, context.type, nesting).allowed) return null;
-  if (
-    !canNestInSlot(entry.type, context.type, context.slotName, nesting).allowed
-  )
+  if (!canNest(type, context.type, nesting).allowed) return null;
+  if (!canNestInSlot(type, context.type, context.slotName, nesting).allowed) {
     return null;
+  }
   // Already being expanded on this path, so creating it again would not
   // terminate.
-  if (ancestors.has(entry.type)) return null;
+  if (ancestors.has(type)) return null;
+  return { type, definition };
+}
+
+function childForEntry(
+  entry: unknown,
+  context: EntryContext
+): BlockNode | null {
+  const { definitions, nesting, ancestors, depth, budget } = context;
+  const resolved = resolvedEntry(entry, context);
+  if (resolved === null) return null;
+  const { type, definition } = resolved;
 
   // The child's own defaults UNDERNEATH the entry's values, so a seeded child
   // starts where a directly inserted one starts and the declaration overrides
@@ -342,26 +381,40 @@ function childForEntry(
   // one inserted block reach back into the definition, and through it every
   // block expanded from it afterwards. A shallow copy is not enough, because a
   // declared value may be an array or a nested object.
-  const props = structuredClone({
-    ...(definition.defaultProps ?? {}),
-    ...(entry.props ?? {}),
-  });
+  // `isPlainRecord` judges the prototype, not the contents, so a declared prop
+  // holding a function or a symbol is a plain object that `structuredClone`
+  // refuses with a `DataCloneError`. Uncaught, that throws at the author's
+  // click rather than anywhere a plugin author would see it. The child is
+  // dropped instead, which is what every other unusable entry here does — a
+  // container arriving without one declared child is a state the editor
+  // already renders, and a thrown insert is not.
+  let props: Record<string, unknown>;
+  try {
+    props = structuredClone({
+      ...(definition.defaultProps ?? {}),
+      ...(isPlainRecord(entry) && isPlainRecord(entry.props)
+        ? entry.props
+        : {}),
+    });
+  } catch {
+    return null;
+  }
 
   // Spent BEFORE recursing, so a child's own declared children are drawn from
   // what remains after it rather than from the budget its parent saw.
   budget.remaining -= 1;
   return makeNode(
-    entry.type,
+    type,
     // The CHILD's own schema version, never the parent's: a node stamped with
     // its parent's version is read by the migration runner as older or newer
     // than it is, and gets upgrade steps meant for a different block.
     definition.version,
     props,
     expandFrom(
-      entry.type,
+      type,
       definitions,
       nesting,
-      new Set([...ancestors, entry.type]),
+      new Set([...ancestors, type]),
       depth + 1,
       budget
     )

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -68,6 +68,7 @@
 import type { SlotSpec } from "./block";
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
+import { MAX_NODES } from "./limits";
 import { canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
 import { defineEntry, ownEntry } from "./safe-record";
@@ -126,6 +127,23 @@ export interface SlotDefaultSource {
  * rather than a starting point.
  */
 const MAX_SLOT_DEFAULT_DEPTH = 8;
+
+/**
+ * How many nodes one expansion may create, and why a depth bound is not enough.
+ *
+ * The depth bound limits how DEEP a declaration reaches; it says nothing about
+ * how WIDE. Ten children at each of eight levels is a legal set of declarations
+ * and about a hundred million nodes, every one of them minting a UUID, long
+ * before anything asks whether the result could be inserted. A flat declaration
+ * larger than the document cap has the same shape more cheaply: fully built,
+ * then refused.
+ *
+ * `MAX_NODES` is the document's own cap rather than a number chosen here, so
+ * the budget answers the question that actually decides the insert — a subtree
+ * this expansion cannot fit into any document is one it must not spend time
+ * building.
+ */
+const MAX_SLOT_DEFAULT_NODES = MAX_NODES;
 
 /**
  * The nesting rules as they read from a block-definition source.
@@ -199,7 +217,8 @@ export function expandSlotDefaults(
     definitions,
     nestingFrom(definitions),
     new Set([type]),
-    0
+    0,
+    { remaining: MAX_SLOT_DEFAULT_NODES }
   );
 }
 
@@ -216,7 +235,8 @@ function expandFrom(
   definitions: SlotDefaultSource,
   nesting: NestingSource,
   ancestors: ReadonlySet<string>,
-  depth: number
+  depth: number,
+  budget: { remaining: number }
 ): Record<string, BlockNode[]> | undefined {
   if (depth >= MAX_SLOT_DEFAULT_DEPTH) return undefined;
   const declaredSlots = definitions.get(type)?.slots;
@@ -233,6 +253,7 @@ function expandFrom(
       nesting,
       ancestors,
       depth,
+      budget,
     });
     // A slot whose declaration produced nothing is omitted entirely, so a
     // container never claims a slot it did not fill.
@@ -258,6 +279,7 @@ function childrenForSlot(
     readonly nesting: NestingSource;
     readonly ancestors: ReadonlySet<string>;
     readonly depth: number;
+    readonly budget: { remaining: number };
   }
 ): BlockNode[] {
   if (declared === undefined) return [];
@@ -286,9 +308,14 @@ function childForEntry(
     readonly nesting: NestingSource;
     readonly ancestors: ReadonlySet<string>;
     readonly depth: number;
+    readonly budget: { remaining: number };
   }
 ): BlockNode | null {
-  const { definitions, nesting, ancestors, depth } = context;
+  const { definitions, nesting, ancestors, depth, budget } = context;
+  // Checked before the definition is even resolved: once the budget is spent
+  // nothing further can be built, so the cheapest possible refusal is the right
+  // one.
+  if (budget.remaining <= 0) return null;
   const definition = definitions.get(entry.type);
   // A node of an unregistered type renders as a placeholder the author did not
   // ask for and cannot repair.
@@ -320,6 +347,9 @@ function childForEntry(
     ...(entry.props ?? {}),
   });
 
+  // Spent BEFORE recursing, so a child's own declared children are drawn from
+  // what remains after it rather than from the budget its parent saw.
+  budget.remaining -= 1;
   return makeNode(
     entry.type,
     // The CHILD's own schema version, never the parent's: a node stamped with
@@ -332,7 +362,8 @@ function childForEntry(
       definitions,
       nesting,
       new Set([...ancestors, entry.type]),
-      depth + 1
+      depth + 1,
+      budget
     )
   );
 }

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -68,6 +68,8 @@
 import type { SlotSpec } from "./block";
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
+import { canNest, canNestInSlot } from "./nesting";
+import type { NestingSource } from "./nesting";
 import { defineEntry, ownEntry } from "./safe-record";
 
 /** Stable unique node id. `crypto.randomUUID` exists in Node ≥ 20 and browsers. */
@@ -96,9 +98,53 @@ export function makeNode(
  * the result is the same either way.
  */
 export interface SlotDefaultSource {
-  get(
-    type: string
-  ): { version: number; slots?: Record<string, SlotSpec> } | undefined;
+  get(type: string):
+    | {
+        version: number;
+        slots?: Record<string, SlotSpec>;
+        /**
+         * The child's own prop defaults, which a seeded child starts with just
+         * as a directly inserted one does. Without it a block reached through a
+         * parent's declaration arrives with `{}` while the same block chosen
+         * from the palette arrives with its defaults — one block with two
+         * starting states, decided by how the author happened to create it.
+         */
+        defaultProps?: object;
+        /** The child's own parent restriction, read to refuse an illegal seed. */
+        parent?: readonly string[];
+      }
+    | undefined;
+}
+
+/**
+ * How deep a chain of declared defaults may go.
+ *
+ * A bound rather than a promise: the cycle set below already stops a block from
+ * seeding itself at any remove, so this catches only a chain of DISTINCT types
+ * long enough to be a mistake — eight containers deep is past any layout an
+ * author would draw, and a declaration that wants more is describing a document
+ * rather than a starting point.
+ */
+const MAX_SLOT_DEFAULT_DEPTH = 8;
+
+/**
+ * The nesting rules as they read from a block-definition source.
+ *
+ * DERIVED from the one source this function already holds rather than taken as
+ * a second parameter, for the reason `registrySlotSource` is derived from
+ * `registryBlockSource`: two readings of one set of definitions agree only
+ * until one of them changes. The RULE stays in `nesting.ts` — this supplies it
+ * the same declarations the expansion is reading, so a seed is judged by
+ * exactly the predicate that judges an author's own drag.
+ */
+function nestingFrom(definitions: SlotDefaultSource): NestingSource {
+  return {
+    parentsOf: type => definitions.get(type)?.parent,
+    slotAllowOf: (parentType, slot) => {
+      const slots = definitions.get(parentType)?.slots;
+      return slots === undefined ? undefined : ownEntry(slots, slot)?.allow;
+    },
+  };
 }
 
 /**
@@ -117,19 +163,62 @@ export interface SlotDefaultSource {
  * leaves a container carrying no `slots` at all — which is what an empty
  * container is, and what the editor's own emptiness check reads.
  *
- * Two things are deliberately skipped rather than refused, because a block
+ * A declared child is expanded RECURSIVELY, so a container that declares its
+ * own starting children arrives with them whether an author inserted it from
+ * the palette or a parent's declaration seeded it. The alternative makes a
+ * block's declaration depend on how it was reached, which is the one thing a
+ * declaration should not do.
+ *
+ * Four things are deliberately skipped rather than refused, because a block
  * definition is code this package does not own and a bad entry in one must not
  * make the block unplaceable:
  * - an entry whose type the source cannot resolve contributes no child, since
  *   a node of an unregistered type renders as a placeholder the author did not
  *   ask for and cannot repair;
- * - a slot left with no children that way is omitted entirely, so a container
- *   never claims a slot it did not fill.
+ * - an entry the nesting rules refuse contributes no child, because seeding it
+ *   would build a document that the editor's own validation then reports as
+ *   invalid — a block that is illegal to drag in must not arrive by being
+ *   declared;
+ * - an entry naming a type already being expanded contributes no child, which
+ *   is what stops a declaration that cycles from recurring forever;
+ * - a slot left with no children by any of those is omitted entirely, so a
+ *   container never claims a slot it did not fill.
+ *
+ * The SHAPE of `defaultBlock` is not re-checked here. `registry.ts` refuses a
+ * malformed one at registration with an actionable message, for the same reason
+ * and in the same place it refuses a malformed `allow`: a reader that guards
+ * every field it touches turns a boot-time error a plugin author can fix into a
+ * silent difference in behaviour they cannot.
  */
 export function expandSlotDefaults(
   type: string,
   definitions: SlotDefaultSource
 ): Record<string, BlockNode[]> | undefined {
+  return expandFrom(
+    type,
+    definitions,
+    nestingFrom(definitions),
+    new Set([type]),
+    0
+  );
+}
+
+/**
+ * One level of {@link expandSlotDefaults}, carrying what recursion needs.
+ *
+ * `ancestors` holds the types already being expanded on this path rather than
+ * every type seen anywhere, so two sibling slots may each seed the same child —
+ * which is a shape an author would draw — while a type that reaches itself may
+ * not.
+ */
+function expandFrom(
+  type: string,
+  definitions: SlotDefaultSource,
+  nesting: NestingSource,
+  ancestors: ReadonlySet<string>,
+  depth: number
+): Record<string, BlockNode[]> | undefined {
+  if (depth >= MAX_SLOT_DEFAULT_DEPTH) return undefined;
   const declaredSlots = definitions.get(type)?.slots;
   if (declaredSlots === undefined) return undefined;
 
@@ -137,26 +226,16 @@ export function expandSlotDefaults(
   let filledAnySlot = false;
 
   for (const [slotName, spec] of Object.entries(declaredSlots)) {
-    const declared = spec?.defaultBlock;
-    if (declared === undefined) continue;
-
-    const children: BlockNode[] = [];
-    for (const entry of declared) {
-      // The CHILD's own schema version, never the parent's: a node stamped with
-      // its parent's version is read by the migration runner as older or newer
-      // than it is, and gets upgrade steps meant for a different block.
-      const childVersion = definitions.get(entry.type)?.version;
-      if (childVersion === undefined) continue;
-      // Props are deep-copied. The declaration outlives every block expanded
-      // from it, so handing out its own object would let an edit to one
-      // inserted block reach the block definition — and through it every block
-      // expanded from it afterwards. A shallow copy is not enough, because a
-      // declared value may be an array or a nested object.
-      children.push(
-        makeNode(entry.type, childVersion, structuredClone(entry.props ?? {}))
-      );
-    }
-
+    const children = childrenForSlot(spec?.defaultBlock, {
+      type,
+      slotName,
+      definitions,
+      nesting,
+      ancestors,
+      depth,
+    });
+    // A slot whose declaration produced nothing is omitted entirely, so a
+    // container never claims a slot it did not fill.
     if (children.length === 0) continue;
     // `defineEntry` rather than assignment: a slot name is chosen by whichever
     // package defined the block, so it is not a string this package controls,
@@ -167,6 +246,95 @@ export function expandSlotDefaults(
   }
 
   return filledAnySlot ? expanded : undefined;
+}
+
+/** What one slot's declaration expands to, with every refused entry dropped. */
+function childrenForSlot(
+  declared: SlotSpec["defaultBlock"],
+  context: {
+    readonly type: string;
+    readonly slotName: string;
+    readonly definitions: SlotDefaultSource;
+    readonly nesting: NestingSource;
+    readonly ancestors: ReadonlySet<string>;
+    readonly depth: number;
+  }
+): BlockNode[] {
+  if (declared === undefined) return [];
+  const children: BlockNode[] = [];
+  for (const entry of declared) {
+    const child = childForEntry(entry, context);
+    if (child !== null) children.push(child);
+  }
+  return children;
+}
+
+/**
+ * One declared entry as a node, or `null` where it must not be created.
+ *
+ * Separate from the slot loop because it answers a different question: the loop
+ * decides which slots get filled, this decides whether one declaration may
+ * become a child at all. Each `null` below is a distinct refusal, and keeping
+ * them together is what lets the loop above read as the shape it builds.
+ */
+function childForEntry(
+  entry: { readonly type: string; readonly props?: Record<string, unknown> },
+  context: {
+    readonly type: string;
+    readonly slotName: string;
+    readonly definitions: SlotDefaultSource;
+    readonly nesting: NestingSource;
+    readonly ancestors: ReadonlySet<string>;
+    readonly depth: number;
+  }
+): BlockNode | null {
+  const { definitions, nesting, ancestors, depth } = context;
+  const definition = definitions.get(entry.type);
+  // A node of an unregistered type renders as a placeholder the author did not
+  // ask for and cannot repair.
+  if (definition === undefined) return null;
+  // Both halves of the nesting rule, because `block.ts` is explicit that
+  // neither implies the other: the child says where it belongs, the slot says
+  // what it holds, and a seed has to satisfy both to be a placement the author
+  // could have made themselves.
+  if (!canNest(entry.type, context.type, nesting).allowed) return null;
+  if (
+    !canNestInSlot(entry.type, context.type, context.slotName, nesting).allowed
+  )
+    return null;
+  // Already being expanded on this path, so creating it again would not
+  // terminate.
+  if (ancestors.has(entry.type)) return null;
+
+  // The child's own defaults UNDERNEATH the entry's values, so a seeded child
+  // starts where a directly inserted one starts and the declaration overrides
+  // only what it actually names.
+  //
+  // Deep-copied, because the declaration and the definition both outlive every
+  // block expanded from them: handing out either object would let an edit to
+  // one inserted block reach back into the definition, and through it every
+  // block expanded from it afterwards. A shallow copy is not enough, because a
+  // declared value may be an array or a nested object.
+  const props = structuredClone({
+    ...(definition.defaultProps ?? {}),
+    ...(entry.props ?? {}),
+  });
+
+  return makeNode(
+    entry.type,
+    // The CHILD's own schema version, never the parent's: a node stamped with
+    // its parent's version is read by the migration runner as older or newer
+    // than it is, and gets upgrade steps meant for a different block.
+    definition.version,
+    props,
+    expandFrom(
+      entry.type,
+      definitions,
+      nesting,
+      new Set([...ancestors, entry.type]),
+      depth + 1
+    )
+  );
 }
 
 /** Where an insert or move lands: a parent's slot, or the top level when `parentId` is absent. */

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -40,6 +40,19 @@
  * preserve — each reasoned correctly from its own case, and the fourth case had
  * nothing to derive an answer from.
  *
+ * **Where the line falls, because the two cases look alike from a diff.** A
+ * primitive here handles what breaks ITSELF and does not police what breaks a
+ * later stage. `expandSlotDefaults` catching a `structuredClone` that THROWS is
+ * the first kind: without it the function cannot complete and the call site
+ * gets an exception instead of a node. Refusing a value that clones perfectly
+ * and is merely unstorable — a nested `Date`, a `BigInt` — would be the second,
+ * and is the fourth answer this rule exists to prevent.
+ *
+ * Stated here rather than only where it was decided, because it reads as an
+ * omission from any one call site: a reviewer looking at a clone guard and a
+ * missing storability check sees two spellings of one question. It is two
+ * questions, and only this module says so.
+ *
  * What they DO refuse is an ARGUMENT that would break id-addressing: a subtree
  * carrying a duplicate id, or an id already in the destination. That is a
  * different question. It is about an invariant these primitives depend on to

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -65,6 +65,7 @@
  * primitive was ALREADY going to rebuild, and never as a repair pass of its
  * own.
  */
+import type { SlotSpec } from "./block";
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
 import { defineEntry, ownEntry } from "./safe-record";
@@ -84,6 +85,88 @@ export function makeNode(
   const node: BlockNode = { id: newId(), type, version, props };
   if (slots) node.slots = slots;
   return node;
+}
+
+/**
+ * How `expandSlotDefaults` resolves a block type to what it needs to know.
+ *
+ * A one-method source rather than the registry, matching how the rest of this
+ * package takes its inputs: resolving a type differs per caller — the editor
+ * asks the global registry, a test supplies a fixture — and the rule applied to
+ * the result is the same either way.
+ */
+export interface SlotDefaultSource {
+  get(
+    type: string
+  ): { version: number; slots?: Record<string, SlotSpec> } | undefined;
+}
+
+/**
+ * The children a freshly placed block of `type` starts with, ready for
+ * `makeNode`'s `slots` argument.
+ *
+ * This is the layer that makes a declared default safe. A block declares its
+ * starting children by TYPE (`SlotSpec.defaultBlock`), and every node is minted
+ * here through `makeNode` — so each call produces ids that have never existed,
+ * and two parents expanded from one declaration cannot repeat each other's.
+ * Holding the children as stored nodes instead would make that collision the
+ * default behaviour rather than an unreachable one.
+ *
+ * Answers `undefined`, not an empty record, when nothing is to be created.
+ * `makeNode` writes a `slots` key only when one is supplied, so `undefined`
+ * leaves a container carrying no `slots` at all — which is what an empty
+ * container is, and what the editor's own emptiness check reads.
+ *
+ * Two things are deliberately skipped rather than refused, because a block
+ * definition is code this package does not own and a bad entry in one must not
+ * make the block unplaceable:
+ * - an entry whose type the source cannot resolve contributes no child, since
+ *   a node of an unregistered type renders as a placeholder the author did not
+ *   ask for and cannot repair;
+ * - a slot left with no children that way is omitted entirely, so a container
+ *   never claims a slot it did not fill.
+ */
+export function expandSlotDefaults(
+  type: string,
+  definitions: SlotDefaultSource
+): Record<string, BlockNode[]> | undefined {
+  const declaredSlots = definitions.get(type)?.slots;
+  if (declaredSlots === undefined) return undefined;
+
+  const expanded: Record<string, BlockNode[]> = {};
+  let filledAnySlot = false;
+
+  for (const [slotName, spec] of Object.entries(declaredSlots)) {
+    const declared = spec?.defaultBlock;
+    if (declared === undefined) continue;
+
+    const children: BlockNode[] = [];
+    for (const entry of declared) {
+      // The CHILD's own schema version, never the parent's: a node stamped with
+      // its parent's version is read by the migration runner as older or newer
+      // than it is, and gets upgrade steps meant for a different block.
+      const childVersion = definitions.get(entry.type)?.version;
+      if (childVersion === undefined) continue;
+      // Props are deep-copied. The declaration outlives every block expanded
+      // from it, so handing out its own object would let an edit to one
+      // inserted block reach the block definition — and through it every block
+      // expanded from it afterwards. A shallow copy is not enough, because a
+      // declared value may be an array or a nested object.
+      children.push(
+        makeNode(entry.type, childVersion, structuredClone(entry.props ?? {}))
+      );
+    }
+
+    if (children.length === 0) continue;
+    // `defineEntry` rather than assignment: a slot name is chosen by whichever
+    // package defined the block, so it is not a string this package controls,
+    // and assigning to `__proto__` would create no key while replacing the
+    // record's prototype.
+    defineEntry(expanded, slotName, children);
+    filledAnySlot = true;
+  }
+
+  return filledAnySlot ? expanded : undefined;
 }
 
 /** Where an insert or move lands: a parent's slot, or the top level when `parentId` is absent. */

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -138,17 +138,23 @@ const MAX_SLOT_DEFAULT_DEPTH = 8;
  *
  * The depth bound limits how DEEP a declaration reaches; it says nothing about
  * how WIDE. Ten children at each of eight levels is a legal set of declarations
- * and about a hundred million nodes, every one of them minting a UUID, long
- * before anything asks whether the result could be inserted. A flat declaration
- * larger than the document cap has the same shape more cheaply: fully built,
- * then refused.
+ * and about a hundred million nodes, every one of them minting a UUID — enough
+ * to exhaust the heap before anything downstream is asked a question.
  *
- * `MAX_NODES` is the document's own cap rather than a number chosen here, so
- * the budget answers the question that actually decides the insert — a subtree
- * this expansion cannot fit into any document is one it must not spend time
- * building.
+ * **This bounds THIS function's own allocation; it does not enforce a document
+ * limit.** The distinction is the one stated at the top of this module: these
+ * primitives make no claim about whether their result can be saved, and one
+ * place decides that at the point of writing. A host running a lower cap gets
+ * a subtree its op layer refuses, which is what happens to any oversized insert
+ * and is not this function's question.
+ *
+ * `MAX_NODES` supplies the ceiling because it is the natural one and inventing
+ * a second number would give the same question two answers. Less ONE, because
+ * the node these children hang from is created by the caller and is not charged
+ * here — spending the whole cap on children alone yields a subtree of
+ * `MAX_NODES + 1` that could never fit whatever the caller does.
  */
-const MAX_SLOT_DEFAULT_NODES = MAX_NODES;
+const MAX_SLOT_DEFAULT_NODES = MAX_NODES - 1;
 
 /**
  * The nesting rules as they read from a block-definition source.
@@ -215,12 +221,17 @@ function nestingFrom(definitions: SlotDefaultSource): NestingSource {
  */
 export function expandSlotDefaults(
   type: string,
-  definitions: SlotDefaultSource
+  definitions: SlotDefaultSource,
+  nesting?: NestingSource
 ): Record<string, BlockNode[]> | undefined {
   return expandFrom(
     type,
     definitions,
-    nestingFrom(definitions),
+    // The CALLER's rules when it has any, so a seeded child is judged by the
+    // same source that decided what the palette would offer. A caller holding
+    // its own nesting source and getting the registry's here would filter the
+    // palette by one rule set and populate the insert by another.
+    nesting ?? nestingFrom(definitions),
     new Set([type]),
     0,
     { remaining: MAX_SLOT_DEFAULT_NODES }
@@ -244,8 +255,12 @@ function expandFrom(
   budget: { remaining: number }
 ): Record<string, BlockNode[]> | undefined {
   if (depth >= MAX_SLOT_DEFAULT_DEPTH) return undefined;
+  // A plain record, not merely "not undefined". `slots: null` reaches
+  // `Object.entries(null)` as a TypeError, and a supplied definition never
+  // passed registration — the same reason the entries below are checked. The
+  // enclosing map arrives through exactly the source its contents do.
   const declaredSlots = definitions.get(type)?.slots;
-  if (declaredSlots === undefined) return undefined;
+  if (!isPlainRecord(declaredSlots)) return undefined;
 
   const expanded: Record<string, BlockNode[]> = {};
   let filledAnySlot = false;

--- a/packages/blocks-react/src/blocks/accordion-item.tsx
+++ b/packages/blocks-react/src/blocks/accordion-item.tsx
@@ -23,8 +23,10 @@
  * and not the accordion's. Three ways to supply it were considered and each
  * costs more than the behaviour is worth:
  *
- * - seeding a group id through `SlotSpec.template` — the templates are empty by
- *   a ratchet test, because literal ids collide across instances;
+ * - seeding a group id through the accordion's `SlotSpec.defaultBlock` — that
+ *   declares each starting child by TYPE and props, and the group's name would
+ *   have to be the PARENT's id, which no declaration written before the parent
+ *   exists can name;
  * - passing it through the slot context — `renderSlot(name, ctx)` REPLACES the
  *   subtree's context, and `PageContext` says in as many words that widening it
  *   is "a deliberate act rather than a side effect of a new block";
@@ -147,10 +149,11 @@ export const accordionItem = defineBlock<AccordionItemProps, PageContext>({
   // `accordion.tsx`; `block.ts` is explicit that neither implies the other.
   parent: [ACCORDION_BLOCK],
   slots: {
-    // Empty for the same reason every slot template in this library is: a
-    // literal template carries literal ids, and two sections expanded from one
-    // template collide on `duplicate-node-id`. Nothing reads templates yet.
-    children: { template: [] },
+    // No declared starting children. Unlike the accordion that holds it, this
+    // slot carries no allow-list — a section holds whatever a section holds,
+    // which is the substance of the port described above — so there is no child
+    // type it exists to hold and no starting block righter than none.
+    children: {},
   },
   supports: ACCORDION_ITEM_SUPPORTS,
   render: renderAccordionItem,

--- a/packages/blocks-react/src/blocks/accordion-item.tsx
+++ b/packages/blocks-react/src/blocks/accordion-item.tsx
@@ -150,9 +150,9 @@ export const accordionItem = defineBlock<AccordionItemProps, PageContext>({
   parent: [ACCORDION_BLOCK],
   slots: {
     // No declared starting children. Unlike the accordion that holds it, this
-    // slot carries no allow-list — a section holds whatever a section holds,
-    // which is the substance of the port described above — so there is no child
-    // type it exists to hold and no starting block righter than none.
+    // slot carries no allow-list: a section holds whatever a section holds, so
+    // there is no child type it exists to hold and no starting block righter
+    // than none.
     children: {},
   },
   supports: ACCORDION_ITEM_SUPPORTS,

--- a/packages/blocks-react/src/blocks/accordion.test.tsx
+++ b/packages/blocks-react/src/blocks/accordion.test.tsx
@@ -38,6 +38,38 @@ describe("the accordion pair", () => {
     expect(accordionItem.parent).toEqual([ACCORDION_BLOCK]);
   });
 
+  describe("what a fresh accordion starts with", () => {
+    it("declares ONE section, by type rather than as a stored node", () => {
+      // The same rule the columns pair follows: this slot admits only
+      // `core/accordion-item`, and that block names this one as its only
+      // parent, so an empty accordion is a container whose single legal child
+      // can be placed nowhere else on the page.
+      //
+      // The declaration names a TYPE and carries no id, which is what lets two
+      // accordions on one page expand from it without colliding.
+      expect(accordion.slots?.children?.defaultBlock).toEqual([
+        { type: ACCORDION_ITEM_BLOCK },
+      ]);
+    });
+
+    it("starts with one where a row starts with two", () => {
+      // A row of one is a box and `core/box` exists, so one column would be a
+      // degenerate spelling of a block already available. An accordion of one
+      // is not a spelling of anything: a lone section cannot stand on a page,
+      // which the parent rule above states, so one section is a finished
+      // document rather than half of one.
+      expect(accordion.slots?.children?.defaultBlock).toHaveLength(1);
+      expect(accordionItem.parent).toEqual([ACCORDION_BLOCK]);
+    });
+
+    it("gives the SECTION no default of its own", () => {
+      // The child half is unrestricted — a section holds whatever a section
+      // holds — so nothing about it says what it should start with.
+      expect(accordionItem.slots?.children?.defaultBlock).toBeUndefined();
+      expect(accordionItem.slots?.children?.allow).toBeUndefined();
+    });
+  });
+
   it("is registered, parent before child", () => {
     // A resolver built by iterating `coreBlocks` should meet the group first,
     // which is the ordering the columns pair records and this one follows.

--- a/packages/blocks-react/src/blocks/accordion.tsx
+++ b/packages/blocks-react/src/blocks/accordion.tsx
@@ -121,10 +121,18 @@ export const accordion = defineBlock<ContainerProps, PageContext>({
   slots: {
     children: {
       allow: [ACCORDION_ITEM_BLOCK],
-      // Empty, as everywhere in this library: a literal template carries
-      // literal ids and two groups expanded from one collide on
-      // `duplicate-node-id`. Nothing reads `SlotSpec.template` yet.
-      template: [],
+      // One section to start, because an empty accordion is unusable in the
+      // precise sense a row is: this slot admits only `core/accordion-item`,
+      // and that block names this one as its only parent, so the single block
+      // that may go here can be placed nowhere else on the page.
+      //
+      // ONE rather than the row's two, and the difference is the same rule read
+      // the other way. A row of one is a box, and `core/box` already exists, so
+      // one column is a degenerate spelling of a block the author could have
+      // reached for instead. An accordion of one is not a spelling of anything:
+      // a lone `core/accordion-item` cannot stand on a page at all, so a single
+      // disclosure REQUIRES this wrapper and is a finished document.
+      defaultBlock: [{ type: ACCORDION_ITEM_BLOCK }],
     },
   },
   baseStyles: ACCORDION_BASE_STYLES,

--- a/packages/blocks-react/src/blocks/box.tsx
+++ b/packages/blocks-react/src/blocks/box.tsx
@@ -46,7 +46,10 @@ export const box = defineBlock<ContainerProps, PageContext>({
   defaultProps: { as: "div", contained: false },
   example: { props: { as: "div" } },
   slots: {
-    children: { template: [] },
+    // No declared starting children: a box is a general-purpose container with
+    // no allow-list, so there is no child type it exists to hold and nothing to
+    // default to that would be righter than empty.
+    children: {},
   },
   supports: CONTAINER_SUPPORTS,
   render: renderContainer,

--- a/packages/blocks-react/src/blocks/card.test.tsx
+++ b/packages/blocks-react/src/blocks/card.test.tsx
@@ -65,17 +65,15 @@ describe("core/card", () => {
     });
   });
 
-  describe("the template", () => {
-    it("is EMPTY, because nothing can mint per-instance ids yet", () => {
-      // A seeded template needs its ids minted per INSTANCE: two cards expanded
-      // from one literal template carry the same node ids, and the engine
-      // reports `duplicate-node-id` on the second. Nothing reads
-      // `SlotSpec.template`, so no expansion path exists to do that minting.
-      //
-      // A RATCHET: whoever adds an expander fails here and has to seed the card
-      // deliberately rather than inheriting literal ids that were only ever
-      // safe because nothing read them.
-      expect(card.slots?.children.template).toEqual([]);
+  describe("what a fresh card starts with", () => {
+    it("declares no starting children, unlike a row", () => {
+      // A row declares two columns because its slot admits only `core/column`,
+      // and that block names the row as its only parent — so an empty row is a
+      // container whose one legal child can be placed nowhere else. A card's
+      // slot admits every block, so no starting child is more correct than
+      // none, and seeding one would put a block on the page to be deleted.
+      expect(card.slots?.children.defaultBlock).toBeUndefined();
+      expect(card.slots?.children.allow).toBeUndefined();
     });
   });
 

--- a/packages/blocks-react/src/blocks/card.tsx
+++ b/packages/blocks-react/src/blocks/card.tsx
@@ -130,10 +130,12 @@ export const card = defineBlock<ContainerProps, PageContext>({
       // be the `core/columns` arrangement, and a row restricts its slot because
       // a column is meaningless elsewhere — nothing about a card's contents is.
       //
-      // EMPTY template, for the reason `columns.tsx` records at length: nothing
-      // in the repository expands `SlotSpec.template`, and literal node ids
-      // would collide (`duplicate-node-id`) the moment something does.
-      template: [],
+      // And no `defaultBlock`, which follows from the same fact. A row declares
+      // one because `core/column` names `core/columns` as its only parent, so
+      // an empty row is a container whose only legal child exists nowhere else.
+      // A card's slot admits every block, so no starting child is more correct
+      // than none, and guessing one would put a block on the page the author
+      // has to delete.
     },
   },
   baseStyles: CARD_BASE_STYLES,

--- a/packages/blocks-react/src/blocks/collection-loop.tsx
+++ b/packages/blocks-react/src/blocks/collection-loop.tsx
@@ -162,12 +162,16 @@ export const collectionLoop = defineBlock<CollectionLoopProps, PageContext>({
   slots: {
     // The template repeated per entry, structurally editable.
     //
-    // It starts empty, and `contentOnly` forbids exactly the edits that would
-    // fill it: an author could never insert the blocks that make up the
-    // template, so the loop could never show an entry. Locking a template is
-    // worth having once there is a way to lock a FINISHED one; locking an empty
-    // one only prevents it from being written.
-    children: { template: [] },
+    // It declares no starting children, and `contentOnly` would forbid exactly
+    // the edits that fill it: an author could never insert the blocks the loop
+    // repeats, so the loop could never show an entry. Locking is worth having
+    // once there is a way to lock a FINISHED body; locking an empty one only
+    // prevents it from being written.
+    //
+    // Nor could a default supply that body. What one entry should look like is
+    // a property of the collection being looped, which this block cannot see
+    // from its own declaration.
+    children: {},
   },
   supports: {
     spacing: true,

--- a/packages/blocks-react/src/blocks/column.tsx
+++ b/packages/blocks-react/src/blocks/column.tsx
@@ -110,7 +110,10 @@ export const column = defineBlock<ContainerProps, PageContext>({
   // An unrestricted slot: a column holds anything a page holds. The row
   // restricts what may be a COLUMN; it says nothing about what a column holds.
   slots: {
-    children: { template: [] },
+    // No declared starting children, for the same reason the slot is
+    // unrestricted: a column holds anything, so no starting block is more
+    // correct than none.
+    children: {},
   },
   baseStyles: COLUMN_BASE_STYLES,
   supports: CONTAINER_SUPPORTS,

--- a/packages/blocks-react/src/blocks/columns.test.tsx
+++ b/packages/blocks-react/src/blocks/columns.test.tsx
@@ -14,7 +14,7 @@ import type { BlockResolver } from "../resolver";
 import { resolvePageStyles } from "../styles";
 
 import { column, COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
-import { columns, INITIAL_COLUMNS } from "./columns";
+import { columns } from "./columns";
 import { box } from "./box";
 import { coreBlocks } from "./index";
 import { section } from "./section";
@@ -43,27 +43,24 @@ describe("the columns pair", () => {
     });
   });
 
-  describe("the template", () => {
-    it("is EMPTY, because nothing can mint per-instance ids yet", () => {
-      // A seeded template needs its ids minted per INSTANCE: two rows expanded
-      // from one literal template carry the same node ids, and the engine
-      // reports `duplicate-node-id` on the second. Nothing reads
-      // `SlotSpec.template`, so no expansion path exists to do that minting.
-      //
-      // Naming the ids "placeholders" was the first attempt and changed no
-      // behaviour — the collision is a property of the nodes, not of what they
-      // are called. Empty makes it unreachable.
-      //
-      // A RATCHET: whoever adds an expander fails this test and has to seed
-      // the row deliberately, with per-instance ids, rather than inheriting
-      // literal ones that were only ever safe because nothing read them.
-      expect(columns.slots?.children.template).toEqual([]);
+  describe("what a fresh row starts with", () => {
+    it("declares two columns, by TYPE rather than as stored nodes", () => {
+      // The declaration names a type and carries no id, which is what makes it
+      // safe to expand more than once: `expandSlotDefaults` mints a fresh id
+      // per child per instance, so two rows on a page cannot repeat each
+      // other's ids. A stored node list would carry literal ids and collide on
+      // `duplicate-node-id` the second time it was used.
+      expect(columns.slots?.children.defaultBlock).toEqual([
+        { type: COLUMN_BLOCK },
+        { type: COLUMN_BLOCK },
+      ]);
     });
 
-    it("still records how many columns a fresh row wants", () => {
-      // The default did not stop being true; it moved to the layer that can
-      // implement it. Losing the number would make the expander re-derive it.
-      expect(INITIAL_COLUMNS).toBe(2);
+    it("starts with two, because a row of one is a box", () => {
+      // The count lives in the declaration above and nowhere else — it was
+      // previously also spelled as an `INITIAL_COLUMNS` constant, which was a
+      // second answer to one question. Read it from the list.
+      expect(columns.slots?.children.defaultBlock).toHaveLength(2);
     });
   });
 

--- a/packages/blocks-react/src/blocks/columns.tsx
+++ b/packages/blocks-react/src/blocks/columns.tsx
@@ -61,15 +61,6 @@ import type { ContainerProps } from "./container";
 export { COLUMN_BLOCK, COLUMNS_BLOCK } from "./column";
 
 /**
- * How many columns a freshly placed row starts with.
- *
- * Two rather than one, because a row of one is a box and an author who wanted
- * a box would have reached for one; and rather than three, because removing a
- * column is a click and adding one is a decision.
- */
-export const INITIAL_COLUMNS = 2;
-
-/**
  * The row's default layout, in properties the compiler actually accepts.
  *
  * `auto-fit` collapses empty tracks and `minmax(240px, 1fr)` makes every
@@ -120,25 +111,23 @@ export const columns = defineBlock<ContainerProps, PageContext>({
     children: {
       allow: [COLUMN_BLOCK],
       /**
-       * EMPTY, deliberately, until something expands templates.
+       * The two columns a freshly placed row starts with.
        *
-       * A seeded template needs its ids minted per INSTANCE: two rows
-       * expanded from one literal template carry the same node ids, and the
-       * engine reports `duplicate-node-id` on the second. Nothing in the
-       * repository reads `SlotSpec.template`, so there is no expansion path
-       * to do that minting — and shipping nodes whose ids are correct only if
-       * a future reader remembers to replace them is a trap rather than a
-       * default.
+       * A row must start with children at all, because this slot admits only
+       * `core/column` and that block names this one as its only parent — so an
+       * empty row is a container whose single legal child can be placed nowhere
+       * else on the page, and the author has to build both halves by hand.
        *
-       * Naming the ids "placeholders" was the first attempt and it changed no
-       * behaviour: the collision is a property of the nodes, not of what they
-       * are called. An empty template makes it unreachable instead.
+       * Two rather than one, because a row of one is a box and an author who
+       * wanted a box would have reached for one; and rather than three, because
+       * removing a column is a click and adding one is a decision.
        *
-       * The two-column default belongs with the expander, which is the layer
-       * that can mint ids. `INITIAL_COLUMNS` records the intended number so
-       * that work does not have to re-derive it.
+       * The entries are written out rather than repeated from a count. Each
+       * declares one child, so an unequal split — a different width per column —
+       * is a change to an entry rather than a change of shape, and this list is
+       * the only place the number lives.
        */
-      template: [],
+      defaultBlock: [{ type: COLUMN_BLOCK }, { type: COLUMN_BLOCK }],
     },
   },
   baseStyles: COLUMNS_BASE_STYLES,

--- a/packages/blocks-react/src/blocks/gallery.test.tsx
+++ b/packages/blocks-react/src/blocks/gallery.test.tsx
@@ -31,6 +31,17 @@ describe("core/gallery", () => {
     expect(image.parent).toBeUndefined();
   });
 
+  it("declares no starting children, which follows from that asymmetry", () => {
+    // A row and an accordion declare a default because their allowed child
+    // names them back as its only parent, so the container is unusable until it
+    // holds one. `core/image` declares no parent — the test above is that same
+    // fact — so nothing about a gallery makes an image hard to reach, and a
+    // seeded image with no source would be a placeholder to replace rather
+    // than a container to fill.
+    expect(gallery.slots?.children?.defaultBlock).toBeUndefined();
+    expect(image.parent).toBeUndefined();
+  });
+
   it("is registered after the block its slot allows", () => {
     const names = coreBlocks.map(block => block.name);
     expect(names).toContain(gallery.name);

--- a/packages/blocks-react/src/blocks/gallery.tsx
+++ b/packages/blocks-react/src/blocks/gallery.tsx
@@ -123,10 +123,17 @@ export const gallery = defineBlock<ContainerProps, PageContext>({
   slots: {
     children: {
       allow: [GALLERY_ITEM_BLOCK],
-      // Empty, as everywhere in this library: a literal template carries
-      // literal ids, and two galleries expanded from one collide on
-      // `duplicate-node-id`. Nothing reads `SlotSpec.template` yet.
-      template: [],
+      // No `defaultBlock`, and the asymmetry noted above is why. A row and an
+      // accordion declare one because their allowed child names them back as
+      // its only parent, so the container is unusable until it holds one. A
+      // gallery's child is `core/image`, which deliberately declares no parent
+      // and is placeable anywhere — so nothing about a gallery makes an image
+      // hard to reach.
+      //
+      // A default would also have to guess a count that nothing here knows: a
+      // gallery holds as many images as the author has. And an image with no
+      // source is a placeholder awaiting an upload, so seeding two would put
+      // two things on the page that must be replaced rather than filled.
     },
   },
   baseStyles: GALLERY_BASE_STYLES,

--- a/packages/blocks-react/src/blocks/library.test.tsx
+++ b/packages/blocks-react/src/blocks/library.test.tsx
@@ -308,13 +308,17 @@ describe("core/collection-loop", () => {
     expect(children.map(child => child.key)).toEqual(["7", "8"]);
   });
 
-  it("leaves its empty template structurally editable", () => {
-    // The template starts empty, and a content-only lock forbids exactly the
-    // edits that would fill it, so an author could never insert the blocks the
-    // loop repeats. Locking a finished template is worth having; locking an
-    // empty one only stops it being written.
+  it("leaves its empty body structurally editable", () => {
+    // The body starts empty, and a content-only lock forbids exactly the edits
+    // that would fill it, so an author could never insert the blocks the loop
+    // repeats. Locking a finished body is worth having; locking an empty one
+    // only stops it being written.
+    //
+    // Nor is a declared default the answer: what one entry should look like is
+    // a property of the collection being looped, which the block cannot see
+    // from its own declaration.
     expect(collectionLoop.slots?.children.lock).toBeUndefined();
-    expect(collectionLoop.slots?.children.template).toEqual([]);
+    expect(collectionLoop.slots?.children.defaultBlock).toBeUndefined();
   });
 
   it("treats a cleared collection name as no collection", () => {

--- a/packages/blocks-react/src/blocks/section.tsx
+++ b/packages/blocks-react/src/blocks/section.tsx
@@ -40,9 +40,11 @@ export const section = defineBlock<ContainerProps, PageContext>({
   example: { props: { as: "section", contained: true } },
   slots: {
     // Named children with no allow-list: a page region holds whatever a page
-    // holds. Plasmic's guidance is to always give a slot default contents, so
-    // an empty section is never an invisible one.
-    children: { template: [] },
+    // holds, so no starting block is more correct than none. A section that
+    // arrives empty is not therefore an invisible one — the editor draws a box
+    // for any container whose slot is empty, which covers every unrestricted
+    // container rather than only the ones that thought to declare a default.
+    children: {},
   },
   supports: CONTAINER_SUPPORTS,
   render: renderContainer,

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -201,6 +201,7 @@ export {
 } from "./drop-targets";
 export {
   blockAllowedAt,
+  registryBlockSource,
   registrySlotSource,
   type InsertTarget,
   type SlotSource,

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -112,6 +112,75 @@ describe("InsertPanel", () => {
     expect(onInsert).toHaveBeenCalledWith(op.node);
   });
 
+  it("judges a supplied block's declared children by the supplied rules", () => {
+    /*
+     * The palette is handed definitions the REGISTRY does not hold, and no
+     * nesting source. The container declares a starting child that its own
+     * slot's `allow` excludes, so the child must not be seeded.
+     *
+     * What makes this discriminate: the registry cannot see either type, and
+     * an unknown type reports as unrestricted rather than as forbidden — so a
+     * panel that defaults its nesting source to the registry before handing it
+     * on gets "allowed" for a placement the supplied declarations forbid, and
+     * seeds it. Only the definitions themselves carry the rule.
+     */
+    const supplied = [
+      {
+        ...base,
+        name: "acme/row",
+        editor: { label: "Row" },
+        slots: {
+          children: {
+            allow: ["acme/cell"],
+            defaultBlock: [{ type: "acme/stray" }],
+          },
+        },
+      },
+      { ...base, name: "acme/stray", editor: { label: "Stray" } },
+    ] as never;
+
+    const editor = editorSpy(documentOf());
+    render(<InsertPanel editor={editor} definitions={supplied} />);
+
+    fireEvent.click(screen.getByText("Row"));
+
+    const op = editor.apply.mock.calls[0][0];
+    expect(op.node.type).toBe("acme/row");
+    // The row itself still inserts; only the illegal child is refused, and a
+    // slot left with no children carries no `slots` key at all.
+    expect(op.node.slots).toBeUndefined();
+  });
+
+  it("seeds a supplied block's declared child when the supplied rules permit it", () => {
+    // The control on the assertion above. Without it, an implementation that
+    // seeded NOTHING from a supplied definition would satisfy the refusal and
+    // look correct.
+    const supplied = [
+      {
+        ...base,
+        name: "acme/row",
+        editor: { label: "Row" },
+        slots: {
+          children: {
+            allow: ["acme/cell"],
+            defaultBlock: [{ type: "acme/cell" }],
+          },
+        },
+      },
+      { ...base, name: "acme/cell", editor: { label: "Cell" } },
+    ] as never;
+
+    const editor = editorSpy(documentOf());
+    render(<InsertPanel editor={editor} definitions={supplied} />);
+
+    fireEvent.click(screen.getByText("Row"));
+
+    const op = editor.apply.mock.calls[0][0];
+    expect(
+      op.node.slots?.children?.map((c: { type: string }) => c.type)
+    ).toEqual(["acme/cell"]);
+  });
+
   it("draws a mark on every row, so the rows are distinguishable at a glance", () => {
     /*
      * The palette is scanned rather than read: an author looking for a layout

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -51,6 +51,7 @@ import {
   groupByCategory,
   insertionPointFor,
   nodeForEntry,
+  registryBlockSource,
   registrySlotSource,
   type InsertionPoint,
   type InsertEntry,
@@ -130,6 +131,13 @@ export function InsertPanel({
   // changing — a memo keyed on the selection alone would keep a position whose
   // index no longer names the same place.
   const slotSource = React.useMemo(registrySlotSource, []);
+
+  // The definitions an inserted node's declared starting children are expanded
+  // from. Separate from `definitions` above, which is the palette's catalog and
+  // may be a caller-supplied subset: a block's default names child TYPES, and
+  // those must resolve against everything registered rather than against
+  // whatever the palette was told to offer.
+  const blockSource = React.useMemo(registryBlockSource, []);
   const point = insertionPointFor(
     editor.document,
     editor.selectedId,
@@ -155,7 +163,7 @@ export function InsertPanel({
 
   const insert = (entry: InsertEntry) => {
     if (point === null) return;
-    const node = nodeForEntry(entry);
+    const node = nodeForEntry(entry, blockSource);
     // `apply` is the only path a document changes by, so undo covers this
     // insert for free. It answers null when the op is refused, and a refusal
     // must not be reported as an insert — the panel offers only placements the

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -46,12 +46,12 @@ import { BlockIconMark } from "./block-icon";
 import type { EditorState } from "./editor-state";
 import {
   allowedEntries,
+  blockSourceFor,
   catalogFrom,
   filterEntries,
   groupByCategory,
   insertionPointFor,
   nodeForEntry,
-  registryBlockSource,
   registrySlotSource,
   type InsertionPoint,
   type InsertEntry,
@@ -133,11 +133,17 @@ export function InsertPanel({
   const slotSource = React.useMemo(registrySlotSource, []);
 
   // The definitions an inserted node's declared starting children are expanded
-  // from. Separate from `definitions` above, which is the palette's catalog and
-  // may be a caller-supplied subset: a block's default names child TYPES, and
-  // those must resolve against everything registered rather than against
-  // whatever the palette was told to offer.
-  const blockSource = React.useMemo(registryBlockSource, []);
+  // from: the palette's own catalog first, then everything registered. The
+  // catalog above may be a caller-supplied subset holding a definition the
+  // registry does not, and the block being inserted is the one whose
+  // declaration is being read — so resolving only against the registry would
+  // offer that block and then insert it without the children it declares.
+  // Referenced child TYPES still resolve against the registry through the
+  // fallback, which is where a supplied list has no reason to hold them.
+  const blockSource = React.useMemo(
+    () => blockSourceFor(definitions),
+    [definitions]
+  );
   const point = insertionPointFor(
     editor.document,
     editor.selectedId,

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -116,10 +116,17 @@ export function InsertPanel({
 }: InsertPanelProps): React.JSX.Element {
   const [query, setQuery] = React.useState("");
 
-  const catalog = React.useMemo(
-    () => catalogFrom(definitions ?? allBlocks()),
+  // ONE snapshot, taken per mount, that both the catalog and the default
+  // expansion below read. The panel documents its palette as read once per
+  // mount rather than subscribed to, and a second reading of the registry
+  // taken later is a different list: a plugin registering while the panel is
+  // open would leave a row offering one definition's version and props while
+  // its children came from another.
+  const palette = React.useMemo(
+    () => definitions ?? allBlocks(),
     [definitions]
   );
+  const catalog = React.useMemo(() => catalogFrom(palette), [palette]);
   const source = React.useMemo(
     () => nesting ?? registryNestingSource(),
     [nesting]
@@ -132,18 +139,13 @@ export function InsertPanel({
   // index no longer names the same place.
   const slotSource = React.useMemo(registrySlotSource, []);
 
-  // The definitions an inserted node's declared starting children are expanded
-  // from: the palette's own catalog first, then everything registered. The
-  // catalog above may be a caller-supplied subset holding a definition the
+  // Derived from the SAME snapshot the catalog is, so the row an author sees
+  // and the subtree an insert builds cannot come from two different readings.
+  // The palette may be a caller-supplied subset holding a definition the
   // registry does not, and the block being inserted is the one whose
-  // declaration is being read — so resolving only against the registry would
-  // offer that block and then insert it without the children it declares.
-  // Referenced child TYPES still resolve against the registry through the
-  // fallback, which is where a supplied list has no reason to hold them.
-  const blockSource = React.useMemo(
-    () => blockSourceFor(definitions),
-    [definitions]
-  );
+  // declaration is read — so resolving only against the registry would offer
+  // that block and then insert it without the children it declares.
+  const blockSource = React.useMemo(() => blockSourceFor(palette), [palette]);
   const point = insertionPointFor(
     editor.document,
     editor.selectedId,

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -171,7 +171,14 @@ export function InsertPanel({
 
   const insert = (entry: InsertEntry) => {
     if (point === null) return;
-    const node = nodeForEntry(entry, blockSource, source);
+    // `nesting` rather than `source`. They differ exactly when the caller
+    // supplied no rules: `source` has already defaulted to the REGISTRY, which
+    // knows nothing about a supplied definition and so reports every one of its
+    // types as unrestricted. Passing it defeats the fallback in
+    // `expandSlotDefaults`, which derives the rules from these same
+    // definitions — the only source that can see a supplied block's `parent`
+    // and its slots' `allow`.
+    const node = nodeForEntry(entry, blockSource, nesting);
     // `apply` is the only path a document changes by, so undo covers this
     // insert for free. It answers null when the op is refused, and a refusal
     // must not be reported as an insert — the panel offers only placements the

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -171,7 +171,7 @@ export function InsertPanel({
 
   const insert = (entry: InsertEntry) => {
     if (point === null) return;
-    const node = nodeForEntry(entry, blockSource);
+    const node = nodeForEntry(entry, blockSource, source);
     // `apply` is the only path a document changes by, so undo covers this
     // insert for free. It answers null when the op is refused, and a refusal
     // must not be reported as an insert — the panel offers only placements the

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -16,6 +16,7 @@ import {
   clearBlocks,
   registerBlocks,
   registryNestingSource,
+  type AnyBlockDefinition,
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
 
@@ -23,6 +24,7 @@ import {
   UNCATEGORISED,
   type SlotSource,
   allowedEntries,
+  blockSourceFor,
   catalogFrom,
   entryAllowedAt,
   filterEntries,
@@ -864,6 +866,88 @@ describe("nodeForEntry", () => {
       );
 
       expect(nodeForEntry(plain, rowDefinitions).slots).toBeUndefined();
+    });
+  });
+
+  describe("choosing the definitions an insert expands from", () => {
+    /**
+     * A container and its child that are NEVER registered.
+     *
+     * `catalogFrom` rather than the `catalog` helper above, because that helper
+     * REGISTERS what it is handed — which would erase the very condition under
+     * test. The palette offers whatever a caller supplies, so these are blocks
+     * an author can see and choose while the registry knows nothing about them.
+     */
+    const suppliedRow = {
+      ...base,
+      name: "acme/supplied-row",
+      slots: { children: { defaultBlock: [{ type: "acme/supplied-cell" }] } },
+    };
+    const suppliedCell = { ...base, name: "acme/supplied-cell", version: 4 };
+
+    /** Supplied, but naming a child only the registry holds. */
+    const mixedRow = {
+      ...base,
+      name: "acme/mixed-row",
+      slots: { children: { defaultBlock: [{ type: "acme/registered-cell" }] } },
+    };
+    // Version 1: registration refuses a higher version with no migration
+    // chain, so the registered fixtures cannot carry a distinguishing version
+    // the way the supplied ones do. The child's PRESENCE is the proof of
+    // resolution anyway — an unresolvable type contributes no child at all.
+    const registeredCell = { ...base, name: "acme/registered-cell" };
+
+    it("expands a supplied definition the registry does not hold", () => {
+      const source = blockSourceFor([
+        suppliedRow,
+        suppliedCell,
+      ] as unknown as readonly AnyBlockDefinition[]);
+      const node = nodeForEntry(
+        entry(catalogFrom([suppliedRow] as never), "acme/supplied-row"),
+        source
+      );
+
+      // The separating property is the CHILD being there. Resolving only
+      // through the registry finds no declaration for a supplied block, and an
+      // absent declaration is indistinguishable from a declared emptiness — so
+      // the block is offered and then inserted stripped of what it declares,
+      // with nothing reported.
+      expect(node.slots?.children?.map(child => child.type)).toEqual([
+        "acme/supplied-cell",
+      ]);
+      // The child's own version, which proves the CHILD resolved through the
+      // supplied list too rather than the parent alone.
+      expect(node.slots?.children?.[0]?.version).toBe(4);
+    });
+
+    it("falls back to the registry for a type the supplied list omits", () => {
+      registerBlocks([registeredCell] as never, { source: "acme" });
+      const source = blockSourceFor([
+        mixedRow,
+      ] as unknown as readonly AnyBlockDefinition[]);
+      const node = nodeForEntry(
+        entry(catalogFrom([mixedRow] as never), "acme/mixed-row"),
+        source
+      );
+
+      // A declaration names child TYPES the supplied list has no reason to
+      // carry. Consulting the supplied list FIRST must not stop the registry
+      // answering for the rest, or the fix for the case above would break
+      // every ordinary insert.
+      expect(node.slots?.children?.map(child => child.type)).toEqual([
+        "acme/registered-cell",
+      ]);
+    });
+
+    it("uses the registry when no definitions are supplied", () => {
+      const node = nodeForEntry(
+        entry(catalog([mixedRow, registeredCell]), "acme/mixed-row"),
+        blockSourceFor(undefined)
+      );
+
+      expect(node.slots?.children?.map(child => child.type)).toEqual([
+        "acme/registered-cell",
+      ]);
     });
   });
 });

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -939,6 +939,26 @@ describe("nodeForEntry", () => {
       ]);
     });
 
+    it("expands from the snapshot it was built with, not the live registry", () => {
+      // The row is registered BEFORE the source is built; the child it names is
+      // registered AFTER. A source that resolved live would find the child and
+      // seed it.
+      registerBlocks([mixedRow] as never, { source: "acme" });
+      const source = blockSourceFor(undefined);
+      registerBlocks([registeredCell] as never, { source: "acme" });
+
+      const node = nodeForEntry(
+        entry(catalogFrom([mixedRow] as never), "acme/mixed-row"),
+        source
+      );
+
+      // The panel documents its palette as read once per mount, and the row an
+      // author sees must be the row an insert builds. A live source would let a
+      // plugin registering while the panel is open change what a stale row
+      // inserts — same version and props, different children.
+      expect(node.slots).toBeUndefined();
+    });
+
     it("uses the registry when no definitions are supplied", () => {
       const node = nodeForEntry(
         entry(catalog([mixedRow, registeredCell]), "acme/mixed-row"),

--- a/packages/builder/src/inserter.test.ts
+++ b/packages/builder/src/inserter.test.ts
@@ -701,6 +701,15 @@ describe("insertionPointFor", () => {
   });
 });
 
+/**
+ * A definition source resolving nothing, for the cases about props and ids.
+ *
+ * Those blocks declare no starting children, so expansion has nothing to do and
+ * an empty source says exactly that. It also keeps them off the global
+ * registry, which no test here registers into.
+ */
+const noDefaults = { get: () => undefined };
+
 describe("nodeForEntry", () => {
   it("stamps the type and the version the entry carries", () => {
     // Version 3 with its migration steps, rather than the default 1: a stamp
@@ -716,7 +725,7 @@ describe("nodeForEntry", () => {
         },
       },
     ]);
-    const node = nodeForEntry(entry(entries, "acme/text"));
+    const node = nodeForEntry(entry(entries, "acme/text"), noDefaults);
 
     expect(node.type).toBe("acme/text");
     expect(node.version).toBe(3);
@@ -737,7 +746,7 @@ describe("nodeForEntry", () => {
       },
     ]);
 
-    const node = nodeForEntry(entry(entries, "acme/card#loud"));
+    const node = nodeForEntry(entry(entries, "acme/card#loud"), noDefaults);
 
     expect(node.type).toBe("acme/card");
     expect(node.props).toEqual({ tone: "shout" });
@@ -757,8 +766,8 @@ describe("nodeForEntry", () => {
     ]);
     const source = entry(entries, "acme/list");
 
-    const first = nodeForEntry(source);
-    const second = nodeForEntry(source);
+    const first = nodeForEntry(source, noDefaults);
+    const second = nodeForEntry(source, noDefaults);
     (first.props.items as string[]).push("two");
     (first.props.meta as { deep: boolean }).deep = false;
 
@@ -771,6 +780,90 @@ describe("nodeForEntry", () => {
     const entries = catalog([{ ...base, name: "acme/text" }]);
     const source = entry(entries, "acme/text");
 
-    expect(nodeForEntry(source).id).not.toBe(nodeForEntry(source).id);
+    expect(nodeForEntry(source, noDefaults).id).not.toBe(
+      nodeForEntry(source, noDefaults).id
+    );
+  });
+
+  describe("a block that declares what its slot starts with", () => {
+    /**
+     * A row declaring two columns, and the column it names.
+     *
+     * Mirrors `core/columns` without depending on it: the property under test
+     * is that the inserter EXPANDS a declaration, which must hold for a plugin
+     * container nobody here wrote.
+     */
+    const rowDefinitions = {
+      get: (type: string) =>
+        type === "acme/row"
+          ? {
+              version: 1,
+              slots: {
+                children: {
+                  defaultBlock: [{ type: "acme/cell" }, { type: "acme/cell" }],
+                },
+              },
+            }
+          : type === "acme/cell"
+            ? { version: 2 }
+            : undefined,
+    };
+
+    const rowEntry = () =>
+      entry(catalog([{ ...base, name: "acme/row" }]), "acme/row");
+
+    it("arrives carrying the children the block declares", () => {
+      const node = nodeForEntry(rowEntry(), rowDefinitions);
+
+      expect(node.slots?.children?.map(child => child.type)).toEqual([
+        "acme/cell",
+        "acme/cell",
+      ]);
+      // The child's own version, not the row's.
+      expect(node.slots?.children?.map(child => child.version)).toEqual([2, 2]);
+    });
+
+    it("gives the two children of ONE insert distinct ids", () => {
+      const node = nodeForEntry(rowEntry(), rowDefinitions);
+      const ids = (node.slots?.children ?? []).map(child => child.id);
+
+      // Length alone passes on an implementation that expands one child and
+      // repeats the reference, which is the collision this design removes.
+      expect(ids).toHaveLength(2);
+      expect(new Set(ids).size).toBe(2);
+    });
+
+    it("gives TWO inserted rows no id in common, parents included", () => {
+      // The collision that matters is across instances, and one parent cannot
+      // produce it: an implementation caching the expanded children per type
+      // passes the test above and fails here. Two rows dropped on one page are
+      // exactly this situation, and `duplicate-node-id` is what the document
+      // validator answers if it is got wrong.
+      const source = rowEntry();
+      const first = nodeForEntry(source, rowDefinitions);
+      const second = nodeForEntry(source, rowDefinitions);
+
+      const everyId = [
+        first.id,
+        second.id,
+        ...(first.slots?.children ?? []).map(child => child.id),
+        ...(second.slots?.children ?? []).map(child => child.id),
+      ];
+
+      expect(everyId).toHaveLength(6);
+      expect(new Set(everyId).size).toBe(6);
+    });
+
+    it("leaves a block declaring no default with no slots key at all", () => {
+      // Not an empty record: the editor's empty-container check reads the
+      // absence of `slots`, so a container claiming an empty slot it never
+      // filled would be a different state to it.
+      const plain = entry(
+        catalog([{ ...base, name: "acme/text" }]),
+        "acme/text"
+      );
+
+      expect(nodeForEntry(plain, rowDefinitions).slots).toBeUndefined();
+    });
   });
 });

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -25,6 +25,7 @@
  */
 
 import {
+  allBlocks,
   canBeRoot,
   canNest,
   canNestInSlot,
@@ -567,11 +568,18 @@ export function registryBlockSource(): SlotDefaultSource {
 export function blockSourceFor(
   definitions: readonly AnyBlockDefinition[] | undefined
 ): SlotDefaultSource {
-  if (definitions === undefined) return registryBlockSource();
-  const supplied = new Map(
-    definitions.map(definition => [definition.name, definition])
-  );
-  return { get: type => supplied.get(type) ?? getBlock(type) };
+  // Both readings are taken ONCE, here, rather than on each lookup. A source
+  // that consulted the live registry per call would answer from a different
+  // set of definitions than the catalog its caller built alongside it, so a
+  // row offered from one reading could be inserted with children from another.
+  const byName = new Map<string, AnyBlockDefinition>();
+  for (const definition of allBlocks()) byName.set(definition.name, definition);
+  // Supplied definitions are written second, so they WIN for a name in both:
+  // the palette offered that definition, so the insert must build that block.
+  for (const definition of definitions ?? []) {
+    byName.set(definition.name, definition);
+  }
+  return { get: type => byName.get(type) };
 }
 
 /**

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -547,6 +547,34 @@ export function registryBlockSource(): SlotDefaultSource {
 }
 
 /**
+ * The definitions an insert expands declared starting children from, given the
+ * palette's own catalog.
+ *
+ * Supplied definitions are consulted FIRST and the registry second, which is
+ * what keeps the offer and the insert reading one declaration. A caller may
+ * hand the palette a definition the registry does not hold — a host block, a
+ * fixture — and the catalog then offers it; resolving only against the registry
+ * would find no declaration for that block and insert it stripped of the
+ * children it declares, silently, because an absent declaration and a declared
+ * emptiness are the same answer.
+ *
+ * The fallback is the other half and not a leftover: an entry names child TYPES
+ * the supplied list has no reason to contain, so those still resolve against
+ * everything registered. Consulting the supplied list first changes which
+ * declaration wins for a name in both, and that is the intended order — the
+ * palette offered THAT definition, so the insert must build THAT block.
+ */
+export function blockSourceFor(
+  definitions: readonly AnyBlockDefinition[] | undefined
+): SlotDefaultSource {
+  if (definitions === undefined) return registryBlockSource();
+  const supplied = new Map(
+    definitions.map(definition => [definition.name, definition])
+  );
+  return { get: type => supplied.get(type) ?? getBlock(type) };
+}
+
+/**
  * The registry as a slot source.
  *
  * DERIVED from `registryBlockSource` rather than reading the registry again:

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -526,13 +526,19 @@ export function insertionPointFor(
  */
 export function nodeForEntry(
   entry: InsertEntry,
-  definitions: SlotDefaultSource
+  definitions: SlotDefaultSource,
+  nesting?: NestingSource
 ): BlockNode {
   return makeNode(
     entry.blockName,
     entry.version,
     structuredClone(entry.props),
-    expandSlotDefaults(entry.blockName, definitions)
+    // The nesting source travels with the definitions rather than being
+    // rederived inside the engine. A caller that supplies its own rules uses
+    // them to decide what may be OFFERED, and a seeded child that skipped them
+    // would be a placement the caller's own rules forbid, arriving by being
+    // declared rather than chosen.
+    expandSlotDefaults(entry.blockName, definitions, nesting)
   );
 }
 

--- a/packages/builder/src/inserter.ts
+++ b/packages/builder/src/inserter.ts
@@ -28,6 +28,7 @@ import {
   canBeRoot,
   canNest,
   canNestInSlot,
+  expandSlotDefaults,
   findNode,
   getBlock,
   locateNode,
@@ -37,6 +38,7 @@ import {
   type BlockNode,
   type NestingSource,
   type NestingVerdict,
+  type SlotDefaultSource,
 } from "@nextlyhq/blocks-engine";
 
 import { emptySlotOf } from "./empty-slot";
@@ -505,24 +507,51 @@ export function insertionPointFor(
 }
 
 /**
- * The node an entry inserts.
+ * The node an entry inserts, carrying whatever children its block declares it
+ * starts with.
  *
  * Props are deep-copied. The entry outlives every insert made from it, so
  * handing out its own object would let an edit to one inserted block reach the
  * catalog — and through it every block inserted from that entry afterwards.
  * A shallow copy is not enough, because a default value may be an array or a
  * nested object and those would still be shared.
+ *
+ * The children come from `expandSlotDefaults` rather than from anything written
+ * here, so "what does this slot start with" is answered in one place: the block
+ * declares it, the engine expands it with ids minted per instance, and a
+ * container that declares nothing still arrives with no `slots` key at all.
+ * Building the children here instead would put a second answer beside the
+ * declaration, and the two would agree only until one of them changed.
  */
-export function nodeForEntry(entry: InsertEntry): BlockNode {
-  return makeNode(entry.blockName, entry.version, structuredClone(entry.props));
+export function nodeForEntry(
+  entry: InsertEntry,
+  definitions: SlotDefaultSource
+): BlockNode {
+  return makeNode(
+    entry.blockName,
+    entry.version,
+    structuredClone(entry.props),
+    expandSlotDefaults(entry.blockName, definitions)
+  );
+}
+
+/**
+ * The registry as a block-definition source.
+ *
+ * Reads the DEFINITION rather than the node, because a container inserted from
+ * the palette has no `slots` key until something is put in it — which is
+ * precisely the container that needs filling.
+ */
+export function registryBlockSource(): SlotDefaultSource {
+  return { get: type => getBlock(type) };
 }
 
 /**
  * The registry as a slot source.
  *
- * Reads the DEFINITION's declared slots rather than the node's, because a
- * container inserted from the palette has no `slots` key until something is put
- * in it — which is precisely the container that needs filling.
+ * DERIVED from `registryBlockSource` rather than reading the registry again:
+ * the names of a block's slots are a narrower view of its declaration, and two
+ * readings of one registry would agree until one of them learned to filter.
  *
  * Here rather than beside either caller. The palette asks it where an insert
  * would land and the canvas asks it which regions a drag can aim at, and those
@@ -530,9 +559,10 @@ export function nodeForEntry(entry: InsertEntry): BlockNode {
  * is a block that behaves differently depending on how an author reached it.
  */
 export function registrySlotSource(): SlotSource {
+  const definitions = registryBlockSource();
   return {
     slotsOf: type => {
-      const declared = getBlock(type)?.slots;
+      const declared = definitions.get(type)?.slots;
       return declared === undefined ? undefined : Object.keys(declared);
     },
   };

--- a/packages/builder/src/ops.ts
+++ b/packages/builder/src/ops.ts
@@ -32,6 +32,7 @@ import {
   isNodeType,
   isNodeVersion,
   isPlainRecord,
+  isUsableSlotName,
   treeDepth,
   walkNodes,
   insertNode,
@@ -175,26 +176,6 @@ type PatchField = keyof typeof PATCH_FIELDS;
 type RemovableField = {
   [K in PatchField]: IsOptional<BlockNode, K> extends true ? K : never;
 }[PatchField];
-
-/**
- * Whether a slot name can be stored and read back as its own key.
- *
- * ONE policy, asked wherever a slot name appears — a destination position and a
- * slot carried inside an inserted subtree are the same question, and answering
- * it in only one place is what let a subtree smuggle in the name a position
- * could not.
- *
- * The rejected names are the ones `Object.prototype` owns. Reading
- * `slots[name]` for one of those answers with an inherited member instead of
- * `undefined`, and ASSIGNING it — which the engine does when it rebuilds a slot
- * map — sets the prototype rather than creating an own property, dropping that
- * whole child list. Asked of `Object.prototype` rather than matched against a
- * written list, because the list everyone writes is `__proto__` and
- * `constructor` while `toString` behaves identically.
- */
-function isUsableSlotName(name: string): boolean {
-  return !Object.prototype.hasOwnProperty.call(Object.prototype, name);
-}
 
 function isPatchField(key: string): key is PatchField {
   return Object.hasOwn(PATCH_FIELDS, key);

--- a/packages/builder/src/ops.ts
+++ b/packages/builder/src/ops.ts
@@ -32,6 +32,10 @@ import {
   isNodeType,
   isNodeVersion,
   isPlainRecord,
+  // The engine's predicate rather than a local one, so a slot name is judged
+  // the same way at a block's declaration and on every op that carries one.
+  // Two gates answering differently is how a name a position could not use
+  // gets in through a subtree.
   isUsableSlotName,
   treeDepth,
   walkNodes,


### PR DESCRIPTION
## What and why

Insert a `core/columns` today and it arrives **empty** — the author gets a container with nothing in it and has to build both columns by hand. After this it arrives with two columns ready, and `core/accordion` with one section.

Completes R-9 (Tasks 9-11) after [#1257](https://github.com/nextlyhq/nextly/pull/1257), [#1280](https://github.com/nextlyhq/nextly/pull/1280) and [#1296](https://github.com/nextlyhq/nextly/pull/1296).

## The shape, and why not the obvious one

```ts
defaultBlock?: readonly { type: string; props?: Record<string, unknown> }[];
```

**A list of per-item declarations, not a type plus a count** — founder's ruling. Every system with years of real defaults converged on a list, because unequal columns need *different props per column* and one shared `props` cannot express that; Gutenberg's own column variations require it. The middle option — ship the count now, widen later — was explicitly declined, because it puts two shapes behind one question, which is the rule `template` is being deleted under.

**`SlotSpec.template` is deleted.** Not deprecated. It is a list of NODES carrying literal ids, so two parents expanded from one collide on `duplicate-node-id` — which is why nine block files declared `template: []` and five documented it as deliberately empty.

**Do not cite a Gutenberg deprecation as the reason, and this PR does not.** An earlier version of this reasoning claimed Gutenberg deprecated `template` in favour of `defaultBlock`. **That is false**, verified against source: Gutenberg deprecated the `<InnerBlocks template={}>` *prop* in favour of declaring `template` in block-type settings — the same mechanism, relocated. `defaultBlock`/`directInsert` is a separate, still-current API. Ours goes because our shape carries ids and theirs does not: `TemplateItem` is `[name, attributes, innerBlocks]` with no id, and `createBlock()` mints a fresh uuid on every expansion.

## Which blocks get a default, decided structurally

The property is already in the code: **a slot needs a default exactly when its `allow`ed child declares `parent` back at it.** Then the only legal child is placeable nowhere else, so an empty container is a dead end.

| block | verdict | reason |
|---|---|---|
| `columns` | **two columns** | `column` declares `parent: [COLUMNS_BLOCK]` — mutual |
| `accordion` | **one section** | `accordion-item` declares `parent: [ACCORDION_BLOCK]` — mutual |
| `gallery` | comment only | its item *is* `core/image`, which deliberately declares no parent |
| `card` | comment only | no `allow` — holds whatever a box holds |
| `accordion-item` | comment only | no `allow` — a section holds whatever a section holds |

**Accordion gets one, not two.** A row of one column is a degenerate spelling of `core/box`, which exists. An accordion of one is a spelling of nothing — a lone `core/accordion-item` cannot stand on a page, so a single disclosure genuinely requires its wrapper and is a finished document. Shipping one also avoids the two-stacked-empty-items geometry that produced a defect in #1296.

## How

`expandSlotDefaults(type, definitions)` in `blocks-engine/src/tree.ts`, beside `makeNode` — one node per entry, in order, each with its own deep-copied props, each stamped with **its own type's version** rather than the parent's, ids minted through `makeNode`. An unresolvable entry expands to no child; a slot left empty that way is omitted; nothing expanded returns `undefined`, so `makeNode` writes no `slots` key at all. `builder/src/inserter.ts` calls it from `nodeForEntry`.

**One consolidation beyond the brief:** `registrySlotSource` is now derived from `registryBlockSource` rather than reading the registry a second time, and `INITIAL_COLUMNS` is deleted — with a list, the count is `defaultBlock.length`, so the constant was a second answer to one question.

## The test that decides whether this works

**DISTINCTNESS, not count.** `toHaveLength(2)` passes against an implementation that hands back the same object twice — which is exactly the `duplicate-node-id` failure this design exists to make unreachable. And it must be proved across **two parents**, because one parent cannot produce the collision.

The two load-bearing breaks both **keep per-child minting** and cache the finished expansion per type, so the single-parent test still passes and only the two-parent test fails:

| break | failing test |
|---|---|
| cache the finished record per type (engine) | `gives two parents built from one declaration no id in common` — `expected 2 to be 4` |
| expand once per block name and reuse (builder) | `gives TWO inserted rows no id in common, parents included` — `expected 4 to be 6` |

14 new tests, every one with a break that fails **it**; no survivors.

## Two corrections to the plan, both filed

- **`finding:slotspec-template-had-three-test-readers`** — the plan's "0 non-comment readers" was measured over product code only. There were **three**, each a deliberate ratchet (*"whoever adds an expander fails here"*): `card.test.tsx:78`, `columns.test.tsx:60`, `library.test.tsx:317`. They were aimed at exactly this change and worked as designed — but deletion is a compile break, not a no-op. Nine files declared `template: []`, not five.
- **`finding:entry-surface-pins-values-not-type-members`** — `entry-surface.test.ts` needed **no edit**. Its own header says *"Values only. Types are erased before this runs and cannot be enumerated"*; `SlotSpec` is a type, so changing its members is invisible to it.

## Public surface

`INITIAL_COLUMNS` was removed and reached **no** package entry — `blocks-react` exports only `.`, `./next` and `./blocks`, and `blocks/index.ts` re-exports `columns` alone — so it was never public API. `blocks-engine`'s index gained `expandSlotDefaults` and `type SlotDefaultSource`; `builder`'s gained `registryBlockSource`.

## Gates, on the rebased tree

blocks-engine **1594** · blocks-react **960** · builder **2212** · plugin-page-builder **500/500** — all exit 0. Root `check-types` **0**, root `lint` **0**, `fallow audit` **pass** with zero introduced in every category, `changeset status` **0**.

Rebased onto current `main` before opening; `main` had touched none of these files.

## Not done

**The composed browser gesture is unverified** — insert Columns, see two columns, drop a block into one. Tests cover the mechanism; a real click has not. Worth doing before merge rather than claimed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Blocks can now automatically create declared default child blocks when inserted.
  * Default children support custom properties, nesting rules, recursive expansion, and unique identities.
  * Accordions now start with one section; columns start with two columns.
  * Added validation for slot names and default-child declarations.

* **Updates**
  * Replaced empty slot templates with clearer default-child configurations.
  * Cards, galleries, sections, columns, and similar blocks continue to start empty where appropriate.
  * Inserted blocks now consistently reflect the available block definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->