### PR TITLE
fix(admin): clear the document cache when a Single's identity changes

### DIFF
--- a/.changeset/single-identity-leaves-the-document-cache.md
+++ b/.changeset/single-identity-leaves-the-document-cache.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Clear the Single document cache when a Single is created or deleted, so a
+slug reused by a recreated Single stops serving its predecessor's document
+and the version history keyed on that document's id.

--- a/packages/admin/src/hooks/queries/__tests__/useSingles.identity.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useSingles.identity.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * What a slug refers to, and the cache that remembers the wrong answer.
+ *
+ * `singleKeys` and `singleDocumentKeys` are separate trees — `["singles"]` and
+ * `["single-documents"]` — so invalidating one cannot reach the other. Creating
+ * or removing a Single does not change a document, but it changes WHICH
+ * document a slug names, and a slug reused by a recreated Single kept serving
+ * its predecessor's document, id and all, for the provider's stale window.
+ *
+ * That id is a cache scope elsewhere: the version history and its diffs are
+ * keyed on it, so the comparison page painted a dead incarnation's history
+ * under the recreated Single.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { createMock, deleteMock } = vi.hoisted(() => ({
+  createMock: vi.fn(),
+  deleteMock: vi.fn(),
+}));
+
+vi.mock("@admin/services/singleApi", () => ({
+  singleApi: {
+    create: (...a: unknown[]) => createMock(...a),
+    deleteSingle: (...a: unknown[]) => deleteMock(...a),
+  },
+}));
+
+// The delete path also mirrors the change into ui-schema.json and warns when
+// that fails. Both are stubbed so this test stays about cache invalidation.
+vi.mock("@admin/services/schemaFileApi", () => ({
+  schemaFileApi: { deleteSingle: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("@admin/components/ui", () => ({
+  toast: { success: vi.fn(), error: vi.fn(), warning: vi.fn() },
+}));
+
+import {
+  singleDocumentKeys,
+  singleKeys,
+  useCreateSingle,
+  useDeleteSingle,
+} from "../useSingles";
+
+/** The key trees each `invalidateQueries` call named, as joined strings. */
+function invalidatedTrees(spy: ReturnType<typeof vi.fn>): string[] {
+  return spy.mock.calls.map(([arg]) => {
+    const key = (arg as { queryKey?: readonly unknown[] })?.queryKey ?? [];
+    return key.join("/");
+  });
+}
+
+function harness() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const spy = vi.spyOn(client, "invalidateQueries");
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return { client, spy, wrapper };
+}
+
+describe("a Single's identity leaves the document cache", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createMock.mockResolvedValue({ slug: "homepage" });
+    deleteMock.mockResolvedValue({ success: true });
+  });
+
+  it("clears the document cache when a Single is created", async () => {
+    const { spy, wrapper } = harness();
+    const { result } = renderHook(() => useCreateSingle(), { wrapper });
+
+    result.current.mutate({ slug: "homepage" } as never);
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const trees = invalidatedTrees(spy);
+    // The premise: it does invalidate SOMETHING, so an absent document tree
+    // below is a missing invalidation rather than a mutation that never ran.
+    expect(trees).toContain(singleKeys.all().join("/"));
+    expect(trees).toContain(singleDocumentKeys.all().join("/"));
+  });
+
+  it("clears the document cache when a Single is deleted", async () => {
+    const { spy, wrapper } = harness();
+    const { result } = renderHook(() => useDeleteSingle(), { wrapper });
+
+    result.current.mutate("homepage");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    const trees = invalidatedTrees(spy);
+    expect(trees).toContain(singleKeys.all().join("/"));
+    expect(trees).toContain(singleDocumentKeys.all().join("/"));
+  });
+
+  /**
+   * The control on the key factories themselves. The whole defect is that
+   * these are separate trees; if they ever shared a prefix, invalidating one
+   * WOULD reach the other and the assertions above would pass for a reason
+   * that has nothing to do with the fix.
+   */
+  it("keeps the two caches in genuinely separate trees", () => {
+    expect(singleKeys.all()).toEqual(["singles"]);
+    expect(singleDocumentKeys.all()).toEqual(["single-documents"]);
+    expect(singleDocumentKeys.all()[0]).not.toBe(singleKeys.all()[0]);
+  });
+});

--- a/packages/admin/src/hooks/queries/__tests__/useSingles.identity.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useSingles.identity.test.tsx
@@ -21,15 +21,21 @@ import { renderHook, waitFor, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { createMock, deleteMock } = vi.hoisted(() => ({
-  createMock: vi.fn(),
-  deleteMock: vi.fn(),
-}));
+const { createMock, deleteMock, getDocumentMock, getSchemaMock } = vi.hoisted(
+  () => ({
+    createMock: vi.fn(),
+    deleteMock: vi.fn(),
+    getDocumentMock: vi.fn(),
+    getSchemaMock: vi.fn(),
+  })
+);
 
 vi.mock("@admin/services/singleApi", () => ({
   singleApi: {
     create: (...a: unknown[]) => createMock(...a),
     deleteSingle: (...a: unknown[]) => deleteMock(...a),
+    getDocument: (...a: unknown[]) => getDocumentMock(...a),
+    getSchema: (...a: unknown[]) => getSchemaMock(...a),
   },
 }));
 
@@ -49,28 +55,58 @@ import {
   useBulkDeleteSingles,
   useCreateSingle,
   useDeleteSingle,
+  useSingleDocument,
 } from "../useSingles";
 
 /** The document a slug pointed at before the Single was replaced. */
 const PREDECESSOR = { id: "old-incarnation", title: "Homepage" };
+/** The fields the builder would apply on a save if it read them. */
+const PREDECESSOR_SCHEMA = { slug: "homepage", fields: [{ name: "oldField" }] };
 
 function harness() {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    defaultOptions: {
+      // The provider's stale window, which is the condition this whole module
+      // is about: without it a seeded entry refetches on mount and no reader
+      // ever holds the predecessor long enough for the defect to appear.
+      queries: { retry: false, staleTime: 5 * 60 * 1000 },
+      mutations: { retry: false },
+    },
   });
   // The cache as it is when an editor has already read the Single: this is the
   // payload that must not survive the slug being reused.
-  client.setQueryData(singleDocumentKeys.detail("homepage"), PREDECESSOR);
+  client.setQueryData(documentKey("homepage"), PREDECESSOR);
   client.setQueryData(singleKeys.detail("homepage"), { slug: "homepage" });
+  client.setQueryData(singleKeys.schema("homepage"), PREDECESSOR_SCHEMA);
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
   return { client, wrapper };
 }
 
+/**
+ * The key `useSingleDocument` actually reads.
+ *
+ * `singleDocumentKeys.detail(slug)` is only its PREFIX — the hook appends the
+ * locale, fallback, translation-status and draft options, because each changes
+ * what the document contains. Seeding or reading the bare prefix would address
+ * an entry no consumer ever looks at, so a test written against it would pass
+ * whatever production did. The clearing helper matches by prefix, which is why
+ * it reaches this key while the assertion has to name it in full.
+ */
+const documentKey = (slug: string) => [
+  ...singleDocumentKeys.detail(slug),
+  {
+    locale: null,
+    fallbackLocale: null,
+    translationStatus: false,
+    draft: false,
+  },
+];
+
 /** What a consumer mounting now would be handed, synchronously. */
 const documentInCache = (client: QueryClient) =>
-  client.getQueryData(singleDocumentKeys.detail("homepage"));
+  client.getQueryData(documentKey("homepage"));
 
 describe("a Single's identity leaves the document cache", () => {
   beforeEach(() => {
@@ -120,23 +156,69 @@ describe("a Single's identity leaves the document cache", () => {
   });
 
   /**
-   * The schema tree is INVALIDATED rather than removed, and that difference is
-   * deliberate: a slightly stale list costs a reader nothing while it
-   * refetches, and it is the identity that must not survive. Asserting it here
-   * keeps the two from being collapsed into one behaviour later.
+   * The SCHEMA goes too, and it is not a lesser case than the document. The
+   * builder reads `useSingleSchema(slug)`; handed the predecessor's fields it
+   * can apply them to the new Single with one save. `singleKeys.all()` is the
+   * prefix of this key, so clearing the tree as a whole marked it stale and
+   * kept the fields available — which is the shape of the original defect.
    */
-  it("keeps the schema entry, marking it stale rather than evicting it", async () => {
+  it("clears the slug's schema and detail, not only its document", async () => {
     const { client, wrapper } = harness();
+    expect(client.getQueryData(singleKeys.schema("homepage"))).toEqual(
+      PREDECESSOR_SCHEMA
+    );
+
     const { result } = renderHook(() => useDeleteSingle(), { wrapper });
     result.current.mutate("homepage");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(client.getQueryData(singleKeys.detail("homepage"))).toEqual({
-      slug: "homepage",
+    expect(client.getQueryData(singleKeys.schema("homepage"))).toBeUndefined();
+    expect(client.getQueryData(singleKeys.detail("homepage"))).toBeUndefined();
+  });
+
+  /**
+   * A consumer already MOUNTED against the document, which is the case a cache
+   * lookup cannot see. Removal drops the data without telling an existing
+   * observer, so the page goes on presenting the result it last saw — the old
+   * id, and the history keyed on it — until something else makes it render.
+   */
+  it("tells a mounted reader to stop showing the old document", async () => {
+    const { client, wrapper } = harness();
+    getDocumentMock.mockResolvedValue({ id: "new-incarnation" });
+
+    const reader = renderHook(() => useSingleDocument("homepage"), { wrapper });
+    // The premise: the mounted reader really is showing the predecessor.
+    await waitFor(() =>
+      expect(reader.result.current.data).toEqual(PREDECESSOR)
+    );
+
+    const { result } = renderHook(() => useDeleteSingle(), { wrapper });
+    result.current.mutate("homepage");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    await waitFor(() =>
+      expect(reader.result.current.data).not.toEqual(PREDECESSOR)
+    );
+  });
+
+  /**
+   * A bulk delete in which nothing succeeded must leave every cache alone:
+   * those Singles still exist, and discarding their content during the failure
+   * that already cost the reader something makes it worse.
+   */
+  it("leaves the caches alone when every deletion failed", async () => {
+    const { client, wrapper } = harness();
+    deleteMock.mockRejectedValue(new Error("offline"));
+
+    const { result } = renderHook(() => useBulkDeleteSingles(), { wrapper });
+    await act(async () => {
+      await result.current.mutate(["homepage"], undefined);
     });
-    expect(
-      client.getQueryState(singleKeys.detail("homepage"))?.isInvalidated
-    ).toBe(true);
+
+    expect(documentInCache(client)).toEqual(PREDECESSOR);
+    expect(client.getQueryData(singleKeys.schema("homepage"))).toEqual(
+      PREDECESSOR_SCHEMA
+    );
   });
 
   /**

--- a/packages/admin/src/hooks/queries/__tests__/useSingles.identity.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useSingles.identity.test.tsx
@@ -2,17 +2,22 @@
  * What a slug refers to, and the cache that remembers the wrong answer.
  *
  * `singleKeys` and `singleDocumentKeys` are separate trees — `["singles"]` and
- * `["single-documents"]` — so invalidating one cannot reach the other. Creating
- * or removing a Single does not change a document, but it changes WHICH
- * document a slug names, and a slug reused by a recreated Single kept serving
- * its predecessor's document, id and all, for the provider's stale window.
+ * `["single-documents"]` — so clearing one cannot reach the other. Creating or
+ * deleting a Single does not change a document, but it changes WHICH document
+ * a slug names, and a slug reused by a recreated Single otherwise goes on
+ * serving its predecessor's document, id and all.
  *
- * That id is a cache scope elsewhere: the version history and its diffs are
- * keyed on it, so the comparison page painted a dead incarnation's history
- * under the recreated Single.
+ * That id is a cache scope elsewhere: the version list and its diffs are keyed
+ * on it, so a comparison mounted meanwhile belongs to an incarnation that no
+ * longer exists.
+ *
+ * Asserted on the CACHE, not on the calls made to it. A spy on
+ * `invalidateQueries` reports that a request was issued and says nothing about
+ * what survived it — and invalidation keeps its data, so such a test passes
+ * while the predecessor's document is still there to be handed out.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
@@ -29,7 +34,7 @@ vi.mock("@admin/services/singleApi", () => ({
 }));
 
 // The delete path also mirrors the change into ui-schema.json and warns when
-// that fails. Both are stubbed so this test stays about cache invalidation.
+// that fails. Both are stubbed so these tests stay about the cache.
 vi.mock("@admin/services/schemaFileApi", () => ({
   schemaFileApi: { deleteSingle: vi.fn().mockResolvedValue(undefined) },
 }));
@@ -41,28 +46,31 @@ vi.mock("@admin/components/ui", () => ({
 import {
   singleDocumentKeys,
   singleKeys,
+  useBulkDeleteSingles,
   useCreateSingle,
   useDeleteSingle,
 } from "../useSingles";
 
-/** The key trees each `invalidateQueries` call named, as joined strings. */
-function invalidatedTrees(spy: ReturnType<typeof vi.fn>): string[] {
-  return spy.mock.calls.map(([arg]) => {
-    const key = (arg as { queryKey?: readonly unknown[] })?.queryKey ?? [];
-    return key.join("/");
-  });
-}
+/** The document a slug pointed at before the Single was replaced. */
+const PREDECESSOR = { id: "old-incarnation", title: "Homepage" };
 
 function harness() {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  const spy = vi.spyOn(client, "invalidateQueries");
+  // The cache as it is when an editor has already read the Single: this is the
+  // payload that must not survive the slug being reused.
+  client.setQueryData(singleDocumentKeys.detail("homepage"), PREDECESSOR);
+  client.setQueryData(singleKeys.detail("homepage"), { slug: "homepage" });
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
-  return { client, spy, wrapper };
+  return { client, wrapper };
 }
+
+/** What a consumer mounting now would be handed, synchronously. */
+const documentInCache = (client: QueryClient) =>
+  client.getQueryData(singleDocumentKeys.detail("homepage"));
 
 describe("a Single's identity leaves the document cache", () => {
   beforeEach(() => {
@@ -71,41 +79,73 @@ describe("a Single's identity leaves the document cache", () => {
     deleteMock.mockResolvedValue({ success: true });
   });
 
-  it("clears the document cache when a Single is created", async () => {
-    const { spy, wrapper } = harness();
-    const { result } = renderHook(() => useCreateSingle(), { wrapper });
+  it("is gone after a Single is created", async () => {
+    const { client, wrapper } = harness();
+    // The premise: it really is cached before the mutation, so its absence
+    // afterwards is this change and not an empty cache all along.
+    expect(documentInCache(client)).toEqual(PREDECESSOR);
 
+    const { result } = renderHook(() => useCreateSingle(), { wrapper });
     result.current.mutate({ slug: "homepage" } as never);
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const trees = invalidatedTrees(spy);
-    // The premise: it does invalidate SOMETHING, so an absent document tree
-    // below is a missing invalidation rather than a mutation that never ran.
-    expect(trees).toContain(singleKeys.all().join("/"));
-    expect(trees).toContain(singleDocumentKeys.all().join("/"));
+    expect(documentInCache(client)).toBeUndefined();
   });
 
-  it("clears the document cache when a Single is deleted", async () => {
-    const { spy, wrapper } = harness();
-    const { result } = renderHook(() => useDeleteSingle(), { wrapper });
+  it("is gone after a Single is deleted", async () => {
+    const { client, wrapper } = harness();
+    expect(documentInCache(client)).toEqual(PREDECESSOR);
 
+    const { result } = renderHook(() => useDeleteSingle(), { wrapper });
     result.current.mutate("homepage");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    const trees = invalidatedTrees(spy);
-    expect(trees).toContain(singleKeys.all().join("/"));
-    expect(trees).toContain(singleDocumentKeys.all().join("/"));
+    expect(documentInCache(client)).toBeUndefined();
   });
 
   /**
-   * The control on the key factories themselves. The whole defect is that
-   * these are separate trees; if they ever shared a prefix, invalidating one
-   * WOULD reach the other and the assertions above would pass for a reason
-   * that has nothing to do with the fix.
+   * The bulk path had no test at all, which is how one copy of an invariant
+   * drifts from the other two without anything reporting it.
+   */
+  it("is gone after Singles are deleted in bulk", async () => {
+    const { client, wrapper } = harness();
+    expect(documentInCache(client)).toEqual(PREDECESSOR);
+
+    const { result } = renderHook(() => useBulkDeleteSingles(), { wrapper });
+    await act(async () => {
+      await result.current.mutate(["homepage"], undefined);
+    });
+
+    expect(documentInCache(client)).toBeUndefined();
+  });
+
+  /**
+   * The schema tree is INVALIDATED rather than removed, and that difference is
+   * deliberate: a slightly stale list costs a reader nothing while it
+   * refetches, and it is the identity that must not survive. Asserting it here
+   * keeps the two from being collapsed into one behaviour later.
+   */
+  it("keeps the schema entry, marking it stale rather than evicting it", async () => {
+    const { client, wrapper } = harness();
+    const { result } = renderHook(() => useDeleteSingle(), { wrapper });
+    result.current.mutate("homepage");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(client.getQueryData(singleKeys.detail("homepage"))).toEqual({
+      slug: "homepage",
+    });
+    expect(
+      client.getQueryState(singleKeys.detail("homepage"))?.isInvalidated
+    ).toBe(true);
+  });
+
+  /**
+   * The control on the key factories. The whole defect is that these are
+   * separate trees; if they ever shared a prefix, clearing one WOULD reach the
+   * other and every assertion above would pass for an unrelated reason.
    */
   it("keeps the two caches in genuinely separate trees", () => {
     expect(singleKeys.all()).toEqual(["singles"]);
     expect(singleDocumentKeys.all()).toEqual(["single-documents"]);
-    expect(singleDocumentKeys.all()[0]).not.toBe(singleKeys.all()[0]);
   });
 });

--- a/packages/admin/src/hooks/queries/useSingles.ts
+++ b/packages/admin/src/hooks/queries/useSingles.ts
@@ -31,6 +31,7 @@ import {
   useMutation,
   useQuery,
   useQueryClient,
+  type QueryClient,
   type UseQueryOptions,
 } from "@tanstack/react-query";
 
@@ -239,6 +240,35 @@ export function useSingle(
  * }
  * ```
  */
+/**
+ * Forget which document each slug named.
+ *
+ * Creating or deleting a Single does not change a document, but it changes
+ * WHICH document a slug names — and `singleKeys` and `singleDocumentKeys` are
+ * separate trees, so clearing the first cannot reach the second. A slug reused
+ * by a recreated Single otherwise goes on serving its predecessor's document,
+ * id and all. That id is a cache scope elsewhere: the version history and its
+ * diffs are keyed on it, so a comparison mounted meanwhile belongs to an
+ * incarnation that no longer exists.
+ *
+ * The document cache is REMOVED, not invalidated. Invalidation marks a query
+ * stale and KEEPS its data, so the next mount synchronously hands out the
+ * predecessor's document while the refetch runs — and a refetch that fails
+ * leaves it on screen indefinitely. Removal has no such window.
+ *
+ * The schema tree is invalidated rather than removed, because showing a
+ * slightly stale LIST while it refetches costs a reader nothing; it is the
+ * identity that must not survive.
+ *
+ * One helper for all three mutations: three copies of an invariant is three
+ * places a later correction has to reach, and the one that gets missed
+ * restores exactly the stale document this exists to prevent.
+ */
+function clearSingleIdentityCaches(queryClient: QueryClient): void {
+  void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
+  queryClient.removeQueries({ queryKey: singleDocumentKeys.all() });
+}
+
 export function useCreateSingle() {
   const queryClient = useQueryClient();
 
@@ -251,17 +281,7 @@ export function useCreateSingle() {
       return await singleApi.create(singleData);
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
-      // The DOCUMENT cache too, and not because this mutation changed a
-      // document. Creating or removing a Single changes which document a slug
-      // refers to, and `singleDocumentKeys` is a separate tree that
-      // `singleKeys` cannot reach — so a slug reused by a recreated Single
-      // kept serving its predecessor's document, id and all, for the stale
-      // window. Anything keyed on that id, a version history among them, then
-      // belonged to an incarnation that no longer exists.
-      void queryClient.invalidateQueries({
-        queryKey: singleDocumentKeys.all(),
-      });
+      clearSingleIdentityCaches(queryClient);
     },
   });
 }
@@ -353,17 +373,7 @@ export function useDeleteSingle() {
       return result;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
-      // The DOCUMENT cache too, and not because this mutation changed a
-      // document. Creating or removing a Single changes which document a slug
-      // refers to, and `singleDocumentKeys` is a separate tree that
-      // `singleKeys` cannot reach — so a slug reused by a recreated Single
-      // kept serving its predecessor's document, id and all, for the stale
-      // window. Anything keyed on that id, a version history among them, then
-      // belonged to an incarnation that no longer exists.
-      void queryClient.invalidateQueries({
-        queryKey: singleDocumentKeys.all(),
-      });
+      clearSingleIdentityCaches(queryClient);
     },
     // Disable retry for delete operations - if deletion succeeds on first attempt,
     // a retry would fail with 404 (already deleted) and incorrectly show an error
@@ -402,17 +412,7 @@ export function useBulkDeleteSingles() {
     },
     defaultOptions: {
       onComplete: () => {
-        void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
-        // The DOCUMENT cache too, and not because this mutation changed a
-        // document. Creating or removing a Single changes which document a slug
-        // refers to, and `singleDocumentKeys` is a separate tree that
-        // `singleKeys` cannot reach — so a slug reused by a recreated Single
-        // kept serving its predecessor's document, id and all, for the stale
-        // window. Anything keyed on that id, a version history among them, then
-        // belonged to an incarnation that no longer exists.
-        void queryClient.invalidateQueries({
-          queryKey: singleDocumentKeys.all(),
-        });
+        clearSingleIdentityCaches(queryClient);
       },
     },
   });

--- a/packages/admin/src/hooks/queries/useSingles.ts
+++ b/packages/admin/src/hooks/queries/useSingles.ts
@@ -252,6 +252,16 @@ export function useCreateSingle() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
+      // The DOCUMENT cache too, and not because this mutation changed a
+      // document. Creating or removing a Single changes which document a slug
+      // refers to, and `singleDocumentKeys` is a separate tree that
+      // `singleKeys` cannot reach — so a slug reused by a recreated Single
+      // kept serving its predecessor's document, id and all, for the stale
+      // window. Anything keyed on that id, a version history among them, then
+      // belonged to an incarnation that no longer exists.
+      void queryClient.invalidateQueries({
+        queryKey: singleDocumentKeys.all(),
+      });
     },
   });
 }
@@ -344,6 +354,16 @@ export function useDeleteSingle() {
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
+      // The DOCUMENT cache too, and not because this mutation changed a
+      // document. Creating or removing a Single changes which document a slug
+      // refers to, and `singleDocumentKeys` is a separate tree that
+      // `singleKeys` cannot reach — so a slug reused by a recreated Single
+      // kept serving its predecessor's document, id and all, for the stale
+      // window. Anything keyed on that id, a version history among them, then
+      // belonged to an incarnation that no longer exists.
+      void queryClient.invalidateQueries({
+        queryKey: singleDocumentKeys.all(),
+      });
     },
     // Disable retry for delete operations - if deletion succeeds on first attempt,
     // a retry would fail with 404 (already deleted) and incorrectly show an error
@@ -383,6 +403,16 @@ export function useBulkDeleteSingles() {
     defaultOptions: {
       onComplete: () => {
         void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
+        // The DOCUMENT cache too, and not because this mutation changed a
+        // document. Creating or removing a Single changes which document a slug
+        // refers to, and `singleDocumentKeys` is a separate tree that
+        // `singleKeys` cannot reach — so a slug reused by a recreated Single
+        // kept serving its predecessor's document, id and all, for the stale
+        // window. Anything keyed on that id, a version history among them, then
+        // belonged to an incarnation that no longer exists.
+        void queryClient.invalidateQueries({
+          queryKey: singleDocumentKeys.all(),
+        });
       },
     },
   });

--- a/packages/admin/src/hooks/queries/useSingles.ts
+++ b/packages/admin/src/hooks/queries/useSingles.ts
@@ -241,32 +241,45 @@ export function useSingle(
  * ```
  */
 /**
- * Forget which document each slug named.
+ * Forget everything a slug meant, because it now means something else.
  *
  * Creating or deleting a Single does not change a document, but it changes
- * WHICH document a slug names — and `singleKeys` and `singleDocumentKeys` are
- * separate trees, so clearing the first cannot reach the second. A slug reused
- * by a recreated Single otherwise goes on serving its predecessor's document,
- * id and all. That id is a cache scope elsewhere: the version history and its
+ * WHICH document — and which schema — a slug names. A slug reused by a
+ * recreated Single otherwise goes on serving its predecessor's, id and fields
+ * and all. That id is a cache scope elsewhere: the version history and its
  * diffs are keyed on it, so a comparison mounted meanwhile belongs to an
- * incarnation that no longer exists.
+ * incarnation that no longer exists, and the builder reading a stale schema can
+ * apply the old fields to the new Single with one save.
  *
- * The document cache is REMOVED, not invalidated. Invalidation marks a query
- * stale and KEEPS its data, so the next mount synchronously hands out the
- * predecessor's document while the refetch runs — and a refetch that fails
- * leaves it on screen indefinitely. Removal has no such window.
+ * Slug-scoped entries are RESET rather than invalidated or removed, and the
+ * three differ in ways that matter here. Invalidation marks a query stale and
+ * KEEPS its data, so the next read is handed the predecessor while a refetch
+ * runs — and a refetch that fails leaves it indefinitely. Removal drops the
+ * data but does not notify an observer already mounted against that key, which
+ * goes on presenting the result it last saw. Reset does both: the data goes and
+ * anything watching is told to fetch again.
  *
- * The schema tree is invalidated rather than removed, because showing a
- * slightly stale LIST while it refetches costs a reader nothing; it is the
- * identity that must not survive.
+ * The LIST is only invalidated. It carries no identity, and a briefly stale
+ * list refetches behind the reader at no cost.
  *
- * One helper for all three mutations: three copies of an invariant is three
- * places a later correction has to reach, and the one that gets missed
- * restores exactly the stale document this exists to prevent.
+ * Nothing at all happens for an empty slug list, which is what a wholly failed
+ * bulk delete produces: those Singles still exist, and discarding their caches
+ * would lose valid content during the failure that already inconvenienced the
+ * reader.
  */
-function clearSingleIdentityCaches(queryClient: QueryClient): void {
-  void queryClient.invalidateQueries({ queryKey: singleKeys.all() });
-  queryClient.removeQueries({ queryKey: singleDocumentKeys.all() });
+function clearSingleIdentityCaches(
+  queryClient: QueryClient,
+  slugs: readonly string[]
+): void {
+  if (slugs.length === 0) return;
+  void queryClient.invalidateQueries({ queryKey: singleKeys.lists() });
+  for (const slug of slugs) {
+    void queryClient.resetQueries({ queryKey: singleKeys.detail(slug) });
+    void queryClient.resetQueries({ queryKey: singleKeys.schema(slug) });
+    void queryClient.resetQueries({
+      queryKey: singleDocumentKeys.detail(slug),
+    });
+  }
 }
 
 export function useCreateSingle() {
@@ -280,8 +293,12 @@ export function useCreateSingle() {
     mutationFn: async (singleData: UpdateSinglePayload) => {
       return await singleApi.create(singleData);
     },
-    onSuccess: () => {
-      clearSingleIdentityCaches(queryClient);
+    onSuccess: (created, submitted) => {
+      // The slug the server assigned where it reports one, and the submitted
+      // slug otherwise: a create that adjusted the slug must clear the name it
+      // actually took, not the one that was asked for.
+      const slug = created?.data?.slug ?? submitted.slug;
+      clearSingleIdentityCaches(queryClient, slug ? [slug] : []);
     },
   });
 }
@@ -372,8 +389,8 @@ export function useDeleteSingle() {
       }
       return result;
     },
-    onSuccess: () => {
-      clearSingleIdentityCaches(queryClient);
+    onSuccess: (_, slug) => {
+      clearSingleIdentityCaches(queryClient, [slug]);
     },
     // Disable retry for delete operations - if deletion succeeds on first attempt,
     // a retry would fail with 404 (already deleted) and incorrectly show an error
@@ -411,8 +428,11 @@ export function useBulkDeleteSingles() {
       await singleApi.deleteSingle(slug);
     },
     defaultOptions: {
-      onComplete: () => {
-        clearSingleIdentityCaches(queryClient);
+      // `onComplete` runs after every item settles, including when all of them
+      // failed. Clearing then would discard caches for Singles that still
+      // exist, during the very failure that already cost the reader something.
+      onComplete: result => {
+        clearSingleIdentityCaches(queryClient, result.succeededIds);
       },
     },
   });


### PR DESCRIPTION
The last of the eight findings from the review of #1247 (merged). The other seven landed in #1303.

## What was wrong

`singleKeys` and `singleDocumentKeys` are separate cache trees:

```
singleKeys.all()          ->  ["singles"]
singleDocumentKeys.all()  ->  ["single-documents"]
```

so invalidating one cannot reach the other. Measured on `main`, the schema-level mutations cleared only the first:

| mutation | invalidated |
|---|---|
| `useCreateSingle` | `singleKeys.all()` |
| `useDeleteSingle` | `singleKeys.all()` |
| `useBulkDeleteSingles` | `singleKeys.all()` |

That is defensible on its face — creating or deleting a Single does not change a *document*. But it changes **which document a slug names**, and `useSingleDocument` is keyed on slug alone. So a Single deleted and recreated with the same slug in one session went on serving its predecessor's document, **id and all**, for the provider's stale window.

That id is a cache scope elsewhere: the version list and its diffs are keyed on it. A comparison mounted in that window painted a dead incarnation's history under the recreated Single.

## The fix

Invalidate the document tree wherever a Single's identity changes.

Fixed **where the identity changes**, not where the stale id is read. Every consumer of that document is affected, and defending the one call site the finding happened to name would leave the rest reading the same wrong answer — the comparison page is where it was noticed, not where it is caused.

## Verification

Three tests, and both controls earn their place:

- creating a Single clears both trees
- deleting one clears both trees
- **control:** the two key trees are genuinely disjoint — the whole defect is that they are separate, so if they ever shared a prefix, invalidating one *would* reach the other and the assertions above would pass for a reason unrelated to this change

Each mutation test also asserts the **schema** tree was invalidated, so a missing document invalidation is distinguishable from a mutation that never ran.

Break-verified: removing the three invalidations fails exactly the two mutation tests and leaves the control passing.

`check-types` pass · `lint` pass · `fallow` pass (0 introduced) · 335/335 across admin hooks and versions · full pre-push gate run and passing.

## A note on the break-verification

My first attempt to break this asserted it would remove 3 invalidations and found **4** — the pre-existing document-update mutation uses the identical call. The count assertion refused and wrote nothing, so the green run that followed was unmodified code and proved nothing. Re-anchored on the new comment block so only the three added here were removed. Worth stating because the failed break is the interesting part: without the count check I would have deleted a pre-existing invalidation and read the result as verification.