### PR TITLE
fix(builder): refuse class edits the engine cannot render, and bound the list

### DIFF
--- a/.changeset/class-surfaces-refuse-unrenderable-states.md
+++ b/.changeset/class-surfaces-refuse-unrenderable-states.md
@@ -1,0 +1,45 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The class surfaces now refuse the states the engine cannot render, rather than
+recording them and drawing them as done.
+
+An element that already carries as many classes as a page applies refuses both
+applying and creating, and one that stores more than that says so — those extra
+references style nothing, and removing a class could previously bring one into
+use with no explanation. A name is refused once the library is full, because
+such a class emits no rule and cannot be saved at all.
+
+The list of classes to add is bounded and says how many it withheld, so a long
+library narrows by typing instead of putting thousands of rows in front of an
+author. Its rows leave the keyboard where the ARIA combobox pattern puts it —
+in the field, with the highlighted row named to assistive technology — instead
+of taking every row into the tab order.
+
+Renaming a class to the name it already has no longer reports an edit, so a
+document is not revised into a version that renders identically.

--- a/packages/builder/src/class-library.test.ts
+++ b/packages/builder/src/class-library.test.ts
@@ -31,8 +31,10 @@ import {
   classRows,
   deletionWarning,
   filterClassRows,
+  MAX_SELECTOR_OPTIONS,
   newClassName,
   renamedClassName,
+  unappliedNodeClassCount,
   selectorOptions,
   siteClasses,
   withClassApplied,
@@ -287,7 +289,7 @@ describe("what one keystroke resolves to", () => {
     // Enter has to resolve to exactly one action. Create sitting last is what
     // makes a partially typed name apply the match rather than create a
     // near-duplicate beside it.
-    const options = selectorOptions(LIBRARY, [], "ca");
+    const { options } = selectorOptions(LIBRARY, [], "ca");
     expect(options.map(o => o.kind)).toEqual(["apply", "create"]);
     expect(options[0]).toEqual({
       kind: "apply",
@@ -299,32 +301,77 @@ describe("what one keystroke resolves to", () => {
   it("does not offer to create a name the library already holds", () => {
     // A second class under one slug is dropped by the compiler, so offering it
     // would be offering an entry that styles nothing.
-    const options = selectorOptions(LIBRARY, [], "hero");
+    const { options } = selectorOptions(LIBRARY, [], "hero");
     expect(options.map(o => o.kind)).toEqual(["apply"]);
   });
 
   it("offers nothing for a class the node already carries", () => {
     // Neither action is available: applying is a no-op and creating collides.
-    expect(selectorOptions(LIBRARY, ["id-hero"], "hero")).toEqual([]);
+    expect(selectorOptions(LIBRARY, ["id-hero"], "hero").options).toEqual([]);
   });
 
   it("offers no creation for a name the engine's grammar rejects", () => {
-    const options = selectorOptions(LIBRARY, [], "Not A Slug");
+    const { options } = selectorOptions(LIBRARY, [], "Not A Slug");
     expect(options.every(o => o.kind === "apply")).toBe(true);
   });
 
   it("offers every applicable class and no creation for an empty query", () => {
     // The opened-but-untyped state. An empty name cannot be created, so the
     // list is exactly what the node could still be given.
-    const options = selectorOptions(LIBRARY, ["id-hero"], "");
+    const { options } = selectorOptions(LIBRARY, ["id-hero"], "");
     expect(options.map(o => o.kind)).toEqual(["apply", "apply"]);
   });
 
   it("carries the CREATE slug normalized, not as typed", () => {
-    expect(selectorOptions(LIBRARY, [], "  new-thing ")).toContainEqual({
-      kind: "create",
-      slug: "new-thing",
-    });
+    expect(selectorOptions(LIBRARY, [], "  new-thing ").options).toContainEqual(
+      {
+        kind: "create",
+        slug: "new-thing",
+      }
+    );
+  });
+});
+
+describe("a library too long to put in front of an author", () => {
+  const many = Array.from({ length: MAX_SELECTOR_OPTIONS + 20 }, (_, index) =>
+    cls(`id-many-${index}`, `many-${String(index).padStart(3, "0")}`, index)
+  );
+
+  it("offers at most the cap, and REPORTS what it withheld", () => {
+    // A truncated list that says nothing reads as "these are all of them",
+    // which is the one thing it is not.
+    const { options, hidden } = selectorOptions(many, [], "many");
+    expect(options.filter(o => o.kind === "apply")).toHaveLength(
+      MAX_SELECTOR_OPTIONS
+    );
+    expect(hidden).toBe(20);
+  });
+
+  it("reports nothing hidden when everything fits", () => {
+    // The control: `hidden` must distinguish a capped list from a short one,
+    // or the surface would warn about a list it showed in full.
+    expect(selectorOptions(LIBRARY, [], "").hidden).toBe(0);
+  });
+
+  it("keeps the CREATE row even when the matches are capped", () => {
+    // It is the one row the author's own typing produced; dropping it would
+    // make a full library unable to gain a class through this surface.
+    const { options } = selectorOptions(many, [], "brand-new");
+    expect(options.at(-1)).toEqual({ kind: "create", slug: "brand-new" });
+  });
+});
+
+describe("a node storing more references than the page applies", () => {
+  it("counts the ones that style nothing", () => {
+    const over = Array.from(
+      { length: MAX_CLASSES_PER_NODE + 3 },
+      (_, index) => `id-${index}`
+    );
+    expect(unappliedNodeClassCount(over)).toBe(3);
+  });
+
+  it("counts none for a node within the limit", () => {
+    expect(unappliedNodeClassCount(["a", "b"])).toBe(0);
   });
 });
 

--- a/packages/builder/src/class-library.ts
+++ b/packages/builder/src/class-library.ts
@@ -80,6 +80,17 @@ export function usageSummary(row: Pick<ClassRow, "indexedDocuments">): string {
     : `${row.indexedDocuments} in index`;
 }
 
+/**
+ * How many classes the selector offers at once.
+ *
+ * A library may hold `MAX_NAMED_CLASSES`, and an empty query matches all of
+ * them. Rendering that is neither usable — nobody reads two thousand rows —
+ * nor cheap, and it puts every one of them in front of an author who is
+ * typing to narrow. The remainder is REPORTED rather than dropped quietly:
+ * a list that silently stops is a list an author believes is complete.
+ */
+export const MAX_SELECTOR_OPTIONS = 50;
+
 /** Which classes the manager lists. */
 export type ClassFilter = "all" | "not-in-index" | "on-this-page";
 
@@ -205,7 +216,9 @@ export function filterClassRows(
  * so a node holding more is a node whose tail styles nothing. `styleSubjectFor`
  * bounds its own read the same way; this is the same bound, not a second one.
  */
-function readableNodeClassIds(nodeClassIds: readonly string[]): string[] {
+export function readableNodeClassIds(
+  nodeClassIds: readonly string[]
+): string[] {
   return nodeClassIds.slice(0, MAX_CLASSES_PER_NODE);
 }
 
@@ -267,6 +280,18 @@ export type ClassOption =
   | { readonly kind: "apply"; readonly choice: ClassChoice }
   | { readonly kind: "create"; readonly slug: string };
 
+export interface SelectorOptions {
+  /** The rows to draw, in the order Enter would take them. */
+  readonly options: ClassOption[];
+  /**
+   * Applicable classes NOT offered, because the list is capped.
+   *
+   * Reported so the surface can say so. A truncated list that says nothing
+   * reads as "these are all of them", which is the one thing it is not.
+   */
+  readonly hidden: number;
+}
+
 /**
  * What the selector offers for a query, applying first and creating last.
  *
@@ -279,21 +304,23 @@ export type ClassOption =
  * Create sits LAST so that Enter on a partially typed name applies the match
  * rather than creating a near-duplicate. An author who means to create keeps
  * typing until nothing matches, which is the same gesture that makes the name
- * unambiguous.
+ * unambiguous. It is never dropped by the cap, for the same reason: it is the
+ * one row the author's own typing produced.
  */
 export function selectorOptions(
   library: readonly NamedClass[],
   nodeClassIds: readonly string[],
   query: string
-): ClassOption[] {
-  const options: ClassOption[] = applicableClasses(
-    library,
-    nodeClassIds,
-    query
-  ).map(choice => ({ kind: "apply", choice }));
+): SelectorOptions {
+  const applicable = applicableClasses(library, nodeClassIds, query);
+  const shown = applicable.slice(0, MAX_SELECTOR_OPTIONS);
+  const options: ClassOption[] = shown.map(choice => ({
+    kind: "apply",
+    choice,
+  }));
   const outcome = newClassName(query, library);
   if (outcome.ok) options.push({ kind: "create", slug: outcome.slug });
-  return options;
+  return { options, hidden: applicable.length - shown.length };
 }
 
 /** Why a name cannot become a class. */
@@ -388,6 +415,20 @@ export type ApplyRefusal = "node-full";
  */
 export function nodeHasRoom(nodeClassIds: readonly string[]): boolean {
   return nodeClassIds.length < MAX_CLASSES_PER_NODE;
+}
+
+/**
+ * How many stored references the page does not apply.
+ *
+ * Zero for every node in a valid document. A legacy or hand-edited one can
+ * store more, and those references style nothing while still being on the
+ * node — a state the author has no way to discover from the canvas, and one
+ * that makes a removal look as though it applied a class it never touched.
+ */
+export function unappliedNodeClassCount(
+  nodeClassIds: readonly string[]
+): number {
+  return Math.max(nodeClassIds.length - MAX_CLASSES_PER_NODE, 0);
 }
 
 /** A node's new class ids, or why the class cannot go on it. */

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -190,10 +190,14 @@ describe("renaming in place", () => {
     expect(onRename).not.toHaveBeenCalled();
   });
 
-  it("lets a class keep its own name, which is not a collision", () => {
-    // Typed away and back, because a field set to the value it already holds
-    // fires no change and would leave the draft unset — the test would then
-    // pass on a code path that never consulted the collision rule at all.
+  it("treats a name typed away and back as no rename at all", () => {
+    /*
+     * Two things at once, and both matter. Its own slug is not a COLLISION, so
+     * no refusal is reported — but it is also not a CHANGE, so no rename is
+     * dispatched: a host that persists every reported intent would write a
+     * revision rendering identically to the one before it. The draft still
+     * clears, because the author did finish editing.
+     */
     const { onRename } = draw();
     fireEvent.change(nameField("hero"), { target: { value: "heroic" } });
     fireEvent.change(screen.getByLabelText("Name of hero"), {
@@ -201,7 +205,19 @@ describe("renaming in place", () => {
     });
     expect(screen.queryByRole("alert")).toBeNull();
     fireEvent.keyDown(screen.getByLabelText("Name of hero"), { key: "Enter" });
-    expect(onRename).toHaveBeenCalledWith("id-hero", "hero");
+    expect(onRename).not.toHaveBeenCalled();
+    expect(
+      (screen.getByLabelText("Name of hero") as HTMLInputElement).value
+    ).toBe("hero");
+  });
+
+  it("treats whitespace around the current slug as no rename either", () => {
+    // Normalisation happens before the comparison, so " hero " is the value
+    // the class already has — the same no-op wearing different text.
+    const { onRename } = draw();
+    fireEvent.change(nameField("hero"), { target: { value: "  hero  " } });
+    fireEvent.keyDown(screen.getByLabelText("Name of hero"), { key: "Enter" });
+    expect(onRename).not.toHaveBeenCalled();
   });
 
   it("commits nothing when the field was never edited", () => {

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -270,8 +270,15 @@ function NameField({
 
   const commit = (): void => {
     if (outcome === null) return;
-    if (outcome.ok) onRename(row.id, outcome.slug);
-    else return;
+    if (!outcome.ok) return;
+    /*
+     * A rename to the name the class already has is not a rename. Text typed
+     * away and back, or the same slug with surrounding space, both normalise to
+     * the stored value — and a host that persists every reported intent would
+     * write a revision whose rendered output is identical to the one before it.
+     * The draft still clears, because the author did finish editing.
+     */
+    if (outcome.slug !== row.slug) onRename(row.id, outcome.slug);
     setDraft(null);
   };
 

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -53,6 +53,31 @@ function draw(overrides: Partial<ClassSelectorProps> = {}): {
   return { onNodeClassesChange, onCreateClass };
 }
 
+/** The selector with a host that can hand it a different node. */
+function drawFor(initial: { nodeClassIds: readonly string[] }): {
+  rerender: (nodeClassIds: readonly string[]) => void;
+} {
+  const view = render(
+    <ClassSelector
+      library={LIBRARY}
+      nodeClassIds={initial.nodeClassIds}
+      onNodeClassesChange={vi.fn()}
+      onCreateClass={vi.fn()}
+    />
+  );
+  return {
+    rerender: nodeClassIds =>
+      view.rerender(
+        <ClassSelector
+          library={LIBRARY}
+          nodeClassIds={nodeClassIds}
+          onNodeClassesChange={vi.fn()}
+          onCreateClass={vi.fn()}
+        />
+      ),
+  };
+}
+
 const field = (): HTMLElement => screen.getByRole("combobox");
 
 const type = (value: string): void => {
@@ -243,6 +268,76 @@ describe("what assistive technology is told", () => {
   });
 });
 
+describe("a refusal that must not outlive the node it described", () => {
+  const full = Array.from(
+    { length: MAX_CLASSES_PER_NODE },
+    (_, index) => `id-filler-${index}`
+  );
+
+  it("stops claiming the element is full once it has room", () => {
+    /*
+     * The refusal was stored and cleared only by a later successful commit, so
+     * removing a chip, an undo, or the host selecting a smaller node all left
+     * an alert describing an element that no longer existed. Deriving it from
+     * the CURRENT node is what makes that impossible rather than unlikely.
+     */
+    const { rerender } = drawFor({ nodeClassIds: full });
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert").textContent).toMatch(/as many classes/i);
+
+    rerender(full.slice(0, MAX_CLASSES_PER_NODE - 1));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("a node the page cannot fully apply", () => {
+  it("says how many stored classes style nothing", () => {
+    // Otherwise an author has no way to discover the state from the canvas,
+    // and a removal looks as though it applied a class it never touched.
+    const over = [
+      ...Array.from({ length: MAX_CLASSES_PER_NODE }, () => "id-badge"),
+      "id-hero",
+      "id-card",
+    ];
+    draw({ nodeClassIds: over });
+    expect(screen.getByText(/lists 2 more class/i)).toBeTruthy();
+  });
+
+  it("says nothing for a node within the limit", () => {
+    draw({ nodeClassIds: ["id-hero"] });
+    expect(screen.queryByText(/lists .* more class/i)).toBeNull();
+  });
+});
+
+describe("who owns the tab sequence", () => {
+  it("keeps option rows out of it, so Tab leaves the field once", () => {
+    /*
+     * The APG is explicit: with `aria-activedescendant`, only the composite
+     * container is tabbable. A focusable child in each row put the whole list
+     * into the tab order — an empty query offers up to `MAX_SELECTOR_OPTIONS`
+     * rows — and once focus left the input the arrow handler stopped running,
+     * so the keyboard lost the widget entirely.
+     */
+    draw();
+    type("");
+    const rows = screen.getAllByRole("option");
+    expect(rows.length).toBeGreaterThan(0);
+    for (const row of rows) {
+      expect(row.getAttribute("tabindex")).toBe("-1");
+      expect(row.querySelector("button, a, input, [tabindex='0']")).toBeNull();
+    }
+  });
+
+  it("still commits the row a pointer clicks", () => {
+    // The control: removing the button must not remove the pointer target.
+    const { onNodeClassesChange } = draw();
+    type("badge");
+    fireEvent.click(screen.getByRole("option"));
+    expect(onNodeClassesChange).toHaveBeenCalledWith(["id-badge"]);
+  });
+});
+
 describe("the pointer and the keyboard share one highlight", () => {
   it("moves the highlight to the row the pointer is over", () => {
     /*
@@ -283,7 +378,7 @@ describe("a class whose id collides with the synthetic create row", () => {
     const rows = screen.getAllByRole("option");
     expect(rows).toHaveLength(2);
 
-    fireEvent.click(rows[0]!.querySelector("button")!);
+    fireEvent.click(rows[0]!);
     expect(onNodeClassesChange).toHaveBeenCalledWith(["create"]);
     expect(onCreateClass).not.toHaveBeenCalled();
   });
@@ -380,7 +475,7 @@ describe("the list of options", () => {
   it("applies the row that was clicked", () => {
     const { onNodeClassesChange } = draw();
     type("badge");
-    fireEvent.click(screen.getByRole("option").querySelector("button")!);
+    fireEvent.click(screen.getByRole("option"));
     expect(onNodeClassesChange).toHaveBeenCalledWith(["id-badge"]);
   });
 });

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -43,6 +43,7 @@ import {
   appliedClasses,
   nodeHasRoom,
   selectorOptions,
+  unappliedNodeClassCount,
   withClassApplied,
   withClassRemoved,
   type ClassChoice,
@@ -92,7 +93,16 @@ export function ClassSelector({
   }
 
   const applied = appliedClasses(library, nodeClassIds);
-  const options = selectorOptions(library, nodeClassIds, query);
+  const { options, hidden } = selectorOptions(library, nodeClassIds, query);
+  const unapplied = unappliedNodeClassCount(nodeClassIds);
+  /*
+   * DERIVED from the current node rather than read from state alone. A stored
+   * refusal outlives the node it described: removing a chip, an undo, or the
+   * host selecting a different element all give the node room again while the
+   * flag still says it is full. Deriving it cannot drift, where an effect that
+   * cleared the flag would have to be kept in step with every one of those.
+   */
+  const showRefusal = refused && !nodeHasRoom(nodeClassIds);
   // Clamped rather than reset on every keystroke, so narrowing the list keeps a
   // highlight instead of silently sending Enter back to the first row.
   const highlighted = Math.min(active, Math.max(options.length - 1, 0));
@@ -164,9 +174,19 @@ export function ClassSelector({
         onChoose={commit}
         onHighlight={setActive}
       />
-      {refused ? (
+      {hidden > 0 ? (
+        <p className="nx-inspector__note">
+          {`${hidden} more — keep typing to narrow the list.`}
+        </p>
+      ) : null}
+      {showRefusal ? (
         <p className="nx-classes__issue" role="alert">
           This element already has as many classes as the page can apply.
+        </p>
+      ) : null}
+      {unapplied > 0 ? (
+        <p className="nx-classes__issue" role="status">
+          {`This element lists ${unapplied} more class(es) than the page applies. They style nothing, and removing one here can bring another into use.`}
         </p>
       ) : null}
     </div>
@@ -277,17 +297,21 @@ function OptionList({
           key={optionKey(option)}
           id={optionDomId(id, index)}
           role="option"
+          /*
+           * NOT in the tab sequence. The APG is explicit that with
+           * `aria-activedescendant` only the composite container is tabbable —
+           * DOM focus stays in the input and the arrows move the active
+           * descendant. A nested native button put every row in the tab order,
+           * so one Tab out of the field walked the whole list, and once focus
+           * left the input the arrow handler stopped running at all.
+           */
+          tabIndex={-1}
           aria-selected={index === highlighted}
           className={optionClass(index === highlighted)}
           onMouseEnter={() => onHighlight(index)}
+          onClick={() => onChoose(option)}
         >
-          <button
-            type="button"
-            className="nx-classes__option-button"
-            onClick={() => onChoose(option)}
-          >
-            {optionLabel(option)}
-          </button>
+          {optionLabel(option)}
         </li>
       ))}
     </ul>

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1897,15 +1897,15 @@
   overflow: hidden;
 }
 
-.nx-classes__option-button {
-  display: block;
-  width: 100%;
+/*
+ * The row IS the target. It carries no nested button, because with
+ * `aria-activedescendant` the input owns the tab sequence and a focusable
+ * child would take rows into it.
+ */
+.nx-classes__option {
   padding: 0.25rem 0.5rem;
-  text-align: start;
   font-size: var(--text-xs);
   font-family: var(--font-mono, monospace);
-  background: none;
-  border: 0;
   cursor: pointer;
 }
 


### PR DESCRIPTION
Four Codex findings that arrived as #1298 merged. Each was verified against the code before acting, and each fix is break-verified — the break compiles and fails only the test named in advance.

## The findings

**Removal promoted hidden classes.** `appliedClasses` reads the compiler-readable prefix while removal edited the whole stored array, so removing a visible chip on an over-capacity node shifted the previously hidden 65th class into the rendered set. Rather than silently discarding stored references or silently promoting one, the surface now **reports the state**: `unappliedNodeClassCount` drives a note saying how many stored classes style nothing and that removing one here can bring another into use. Nothing is dropped, and nothing changes without an explanation.

**The capacity refusal outlived its node.** It was stored and cleared only by a later successful commit, so removing a chip, an undo, or the host selecting a smaller element left an alert describing an element that no longer existed. It is now derived from the current node — `refused && !nodeHasRoom(nodeClassIds)` — which cannot drift the way an effect kept in step with three callers would.

**Option rows were in the tab sequence.** Each held a native `<button>`. The [ARIA APG](https://www.w3.org/WAI/ARIA/apg/patterns/combobox/) is explicit that with `aria-activedescendant` *only the composite container* is tabbable; its own listbox example gives options `tabindex="-1"` and binds click and mouseover to the option element. So Tab from the field walked the list instead of leaving it, and once focus left the input the arrow handler stopped running at all. Rows are now the pointer target directly.

**A rename to the current name still dispatched.** Text typed away and back, or whitespace normalising to the stored slug, both reported an intent — and a host persisting each one would write a revision rendering identically to the one before it.

## One thing beyond the findings

The option list was unbounded: a library may hold `MAX_NAMED_CLASSES` (2000) and an empty query matched every one. It is now capped at `MAX_SELECTOR_OPTIONS` and **says how many it withheld** — a list that silently stops is one an author believes is complete. The create row is never dropped by the cap, since it is the row the author's own typing produced.

## Gates

Build, vitest (**2328 passed**, 80 files), check-types, package lint `--max-warnings 0`, root eslint, `lint:design`, `lint:workspace`, comment convention, and `check-changesets` run the way CI runs it — all exit 0. Fallow: every `*_introduced` at **0**.

Five breaks verified, each failing only its named test: dropping the derived refusal, restoring `tabIndex`, restoring the no-op rename dispatch, uncapping the list, and silencing the over-capacity report.