### PR TITLE
fix(blocks): one decision about authored text, and links that survive a move

### DIFF
--- a/.changeset/one-authored-text-decision.md
+++ b/.changeset/one-authored-text-decision.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Keep a link on the words that follow a button inside a heading.
+
+A heading may hold only phrasing content, so a button an author put inside one moves out to sit after it — and any words the author wrote after that button move with it, to stay in the order they were written. Those words were being re-wrapped in a single copy of the link around them, together with the button. A link may not contain another interactive element, so the renderer drops such a wrapper, and the trailing words silently lost the link the author had applied to them. The same passage with an image in place of the button kept its link, so one document rendered by two rules. Each run the wrapper may legally hold now keeps its own copy, in the author's order.
+
+A page description also reads a button label stored as a number the same way the page draws it.
+
+A label of `0` — from an import, a migration, or an older row — is drawn as the character "0" on the page, because a stored number is text a reader recognises. The projection that flattens a passage for search indexing and the crawler description accepted only strings, so it described the page without a label the page displays. Both now read through one decision about what counts as authored text.

--- a/packages/blocks-engine/src/authored-text.ts
+++ b/packages/blocks-engine/src/authored-text.ts
@@ -1,0 +1,39 @@
+/**
+ * Whether a stored value is text an author actually put there.
+ *
+ * A prop schema describes what an EDITOR offers, not what a document holds. A
+ * stored node can carry a number where a string was declared — a legacy row, a
+ * migration, an import — so every reader of authored text has to decide what a
+ * non-string means, and they have to decide it the SAME way. Here rather than
+ * in each reader because the two that exist disagreed: the renderer drew a
+ * stored `0` as the word "0" while the plain-text projection skipped it, so a
+ * page's description omitted a label the page itself displayed.
+ *
+ * A number is text a person would recognise, and a stored `0` or `2024` is
+ * almost always a value someone typed. Booleans, objects and null are not:
+ * `false` and `[object Object]` are artefacts of the conversion rather than
+ * anything an author wrote.
+ *
+ * Separate from {@link authoredText} because a few readers need to tell a
+ * MISSING value from an empty one, and `authoredText` maps both to `""`. An
+ * image's `alt` is the case that matters: absent means "nobody said", while an
+ * explicit `""` is the documented way to mark an image decorative, and those
+ * call for opposite behaviour.
+ */
+export function isAuthoredText(value: unknown): boolean {
+  return (
+    typeof value === "string" ||
+    (typeof value === "number" && Number.isFinite(value))
+  );
+}
+
+/**
+ * A stored value as the text a reader will show, or the fallback.
+ *
+ * The projection every surface shares, so what a page DRAWS and what a
+ * description SAYS about that page are derived from one decision rather than
+ * two that agree until one of them is edited.
+ */
+export function authoredText(value: unknown, fallback = ""): string {
+  return isAuthoredText(value) ? String(value) : fallback;
+}

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -149,6 +149,14 @@ export { isNodeType, isNodeVersion } from "./validation";
  * gets a different answer for exactly the values that survive JSON badly.
  */
 export { isPlainRecord } from "./plain-record";
+/**
+ * Exported because the renderer and every plain-text projection of a document
+ * must agree on what counts as authored text. They did not: a stored number was
+ * drawn as text on the page and skipped in the description derived from it.
+ * A caller writing its own `typeof x === "string"` reintroduces exactly that
+ * split, so the decision is published rather than restated.
+ */
+export { authoredText, isAuthoredText } from "./authored-text";
 export { declaresNoMarkup, isConditionGated } from "./visibility";
 export type { NoMarkupDefinitionSource } from "./visibility";
 export type {
@@ -493,8 +501,19 @@ export { BREAKPOINT_AXES } from "./style/breakpoint-axes";
  */
 export { authoredBreakpoints, inCascadeOrder } from "./style/breakpoint-set";
 
-// The remote-host policy: which hosts a compiled page may fetch from. Exported
-// so the React renderer applies the SAME matcher the style compiler does.
+// Two policies about stored URLs, exported for the same reason: every surface
+// that draws or describes a document must reach the same verdict about one
+// stored string.
+//
+// The remote-host policy — `isAllowedRemoteUrl`, `isFetchableUrl`,
+// `isRemoteUrl` — is about which hosts a compiled page may FETCH from, so the
+// React renderer applies the same matcher the style compiler does.
+//
+// `isLinkableUrl` is a separate, format-level question: whether this format can
+// express the destination at all. It governs whether a link is DRAWN, so a
+// consumer restating it as its own scheme check makes a renderer that shows
+// nothing and a projection that still reports the label describe different
+// pages.
 export {
   isAllowedRemoteUrl,
   isFetchableUrl,

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -282,7 +282,7 @@ describe("richTextToPlainText around a block-like leaf", () => {
             type: "paragraph",
             children: [
               { type: "text", text: "Before" },
-              { type: "button-link", text: "Buy now" },
+              { type: "button-link", url: "/buy", text: "Buy now" },
               { type: "text", text: "After" },
             ],
           },
@@ -390,6 +390,41 @@ describe("richTextToPlainText around a block-like leaf", () => {
     ).toBe("Pick 0 2024 one");
   });
 
+  it("reports a STANDALONE button's numeric label too", () => {
+    /*
+     * The same defect one layer up. A lone `button-link` is drawn by the same
+     * row the group items are drawn by, so its label obeys the same rule — but
+     * the walk read `node.text` directly for it and saw only strings.
+     */
+    expect(
+      richTextToPlainText(
+        value([
+          { type: "paragraph", children: [{ type: "text", text: "Before" }] },
+          { type: "button-link", url: "/zero", text: 0 },
+          { type: "paragraph", children: [{ type: "text", text: "After" }] },
+        ] as unknown as RichTextValue["root"]["children"])
+      )
+    ).toBe("Before 0 After");
+  });
+
+  it("omits a STANDALONE button the renderer would not draw", () => {
+    /*
+     * The other half of routing it through `labelOf`, and the one a numeric
+     * fixture alone would not catch: the row filters an item whose URL this
+     * format cannot express, so reporting its label describes the page by a
+     * word that never appears on it.
+     */
+    expect(
+      richTextToPlainText(
+        value([
+          { type: "paragraph", children: [{ type: "text", text: "Before" }] },
+          { type: "button-link", url: "javascript:alert(1)", text: "Danger" },
+          { type: "paragraph", children: [{ type: "text", text: "After" }] },
+        ])
+      )
+    ).toBe("Before After");
+  });
+
   it("still omits a stored value no reader would draw as text", () => {
     /*
      * The control on the other side. Accepting every non-string would report
@@ -449,7 +484,7 @@ describe("richTextToPlainText around a block-like leaf", () => {
       richTextToPlainText(
         value([
           { type: "paragraph", children: [{ type: "text", text: "Before" }] },
-          { type: "button-link", text: "Buy now" },
+          { type: "button-link", url: "/buy", text: "Buy now" },
           { type: "paragraph", children: [{ type: "text", text: "After" }] },
         ])
       )

--- a/packages/blocks-engine/src/rich-text.test.ts
+++ b/packages/blocks-engine/src/rich-text.test.ts
@@ -357,6 +357,71 @@ describe("richTextToPlainText around a block-like leaf", () => {
     ).toBe("Only Real this");
   });
 
+  it("reports a numeric label the renderer draws as text", () => {
+    /*
+     * The renderer treats a finite NUMBER as authored text, so a stored
+     * `text: 0` — a legacy row, an import, a migration — draws the character
+     * "0" on the page. A string-only check here described that page by a label
+     * it does carry, which is the same disagreement between two readers of one
+     * document that the URL check above exists to prevent.
+     *
+     * `0` specifically, because it is the value a truthiness test also drops:
+     * a fix written as `text ? text : null` passes for `2024` and fails here.
+     */
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "Pick" },
+              {
+                type: "button-group",
+                buttons: [
+                  { url: "/zero", text: 0 },
+                  { url: "/year", text: 2024 },
+                ],
+              },
+              { type: "text", text: "one" },
+            ],
+          },
+        ])
+      )
+    ).toBe("Pick 0 2024 one");
+  });
+
+  it("still omits a stored value no reader would draw as text", () => {
+    /*
+     * The control on the other side. Accepting every non-string would report
+     * `true` and `[object Object]` — artefacts of the conversion rather than
+     * anything an author wrote — so a rule of "stringify whatever is there"
+     * passes the test above and describes the page by words nobody typed.
+     */
+    expect(
+      richTextToPlainText(
+        value([
+          {
+            type: "paragraph",
+            children: [
+              { type: "text", text: "Only" },
+              {
+                type: "button-group",
+                buttons: [
+                  { url: "/a", text: true },
+                  { url: "/b", text: { label: "nested" } },
+                  { url: "/c", text: ["x"] },
+                  { url: "/d", text: Number.NaN },
+                  { url: "/e", text: "Real" },
+                ],
+              },
+              { type: "text", text: "this" },
+            ],
+          },
+        ])
+      )
+    ).toBe("Only Real this");
+  });
+
   it("skips a button group carrying no labels rather than inventing a gap", () => {
     // The control: a group with nothing readable must not contribute, and must
     // not throw on shapes storage can hold.

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -49,6 +49,7 @@
  * mismatch is silent in the worst possible way — the editor treats a tree as
  * text, reads no text out of it, and commits an empty string over the passage.
  */
+import { authoredText } from "./authored-text";
 import { isLinkableUrl } from "./url-policy";
 
 export const RICH_TEXT_PROP_TYPE = "richText";
@@ -327,8 +328,12 @@ function labelOf(item: unknown): string | null {
   // by a word that never appears on it — the mirror of the defect that made
   // these labels worth reading in the first place.
   if (!isLinkableUrl(fields.url)) return null;
-  const text = fields.text;
-  return typeof text === "string" && text.length > 0 ? text : null;
+  // Through the SAME projection the renderer draws with, not a `typeof` test of
+  // its own. A stored number is authored text there, so a button whose label is
+  // `0` shows the character "0" on the page; a string-only check here described
+  // that page by a label it does not carry.
+  const text = authoredText(fields.text);
+  return text.length > 0 ? text : null;
 }
 
 function leafText(node: RichTextNode): string | null {

--- a/packages/blocks-engine/src/rich-text.ts
+++ b/packages/blocks-engine/src/rich-text.ts
@@ -337,6 +337,18 @@ function labelOf(item: unknown): string | null {
 }
 
 function leafText(node: RichTextNode): string | null {
+  /*
+   * A block-level leaf carries a LABEL, not text, even though it stores it
+   * under the same key — so it is asked first and asked through `labelOf`.
+   *
+   * Reading `node.text` for it instead gets two things wrong at once, and both
+   * disagree with what the reader draws. A label stored as a number is drawn
+   * and would be skipped here; and a button whose URL this format cannot
+   * express is NOT drawn, yet its label would be reported. `labelOf` is the
+   * decision the group items already go through, and a standalone button is
+   * the same button with nothing beside it.
+   */
+  if (BLOCK_LEVEL_LEAVES.has(node.type)) return labelOf(node);
   if (typeof node.text === "string") return node.text;
   if (node.type === "linebreak") return " ";
   return listedLabels(node);

--- a/packages/blocks-engine/src/style/css-value.ts
+++ b/packages/blocks-engine/src/style/css-value.ts
@@ -26,6 +26,11 @@
 import type { CssNode } from "css-tree";
 import parse from "css-tree/parser";
 
+// Shared with the URL policy rather than spelled again here. A control
+// character is refused for one reason in both places — it survives no round
+// trip through a stylesheet or an attribute intact — and two copies of that
+// character set would drift into a value one layer accepts and the next
+// rejects.
 import { hasControlCharacter } from "../url-policy";
 
 /** Why a value was refused. Each maps to a stable validation issue code. */

--- a/packages/blocks-react/src/blocks/props.ts
+++ b/packages/blocks-react/src/blocks/props.ts
@@ -10,30 +10,34 @@
  *
  * @module blocks/props
  */
-import { isFetchableUrl, isLinkableUrl } from "@nextlyhq/blocks-engine";
+import {
+  authoredText,
+  isAuthoredText,
+  isFetchableUrl,
+  isLinkableUrl,
+} from "@nextlyhq/blocks-engine";
 import type { RemotePatternInput } from "@nextlyhq/blocks-engine";
 
-/** A string prop, or the fallback when the stored value is not usable text. */
 /**
  * Whether a stored value is text an author actually put there.
+ *
+ * Re-exported from the engine rather than declared here, because link
+ * eligibility is not the only decision this renderer shares with the plain-text
+ * projections taken from the same document: what a page DRAWS and what a
+ * description SAYS about it have to answer this identically, and a copy here
+ * agreed on the day it was written and then drifted.
  *
  * Separate from {@link text} because a few props need to tell a MISSING value
  * from an empty one, and `text()` maps both to `""`. An image's `alt` is the
  * case that matters: absent means "nobody said", while an explicit `""` is the
  * documented way to mark an image decorative, and those call for opposite
- * behaviour. Sharing this predicate keeps the two from drifting apart.
+ * behaviour.
  */
-export function isAuthoredText(value: unknown): boolean {
-  // A number is text a person would recognise, and a stored `0` or `2024` is
-  // almost always a value someone typed. Booleans, objects and null are not.
-  return (
-    typeof value === "string" ||
-    (typeof value === "number" && Number.isFinite(value))
-  );
-}
+export { isAuthoredText };
 
+/** A string prop, or the fallback when the stored value is not usable text. */
 export function text(value: unknown, fallback = ""): string {
-  return isAuthoredText(value) ? String(value) : fallback;
+  return authoredText(value, fallback);
 }
 
 /** A stored value constrained to one of a fixed set, or the fallback. */

--- a/packages/blocks-react/src/rich-text.test.tsx
+++ b/packages/blocks-react/src/rich-text.test.tsx
@@ -1696,6 +1696,72 @@ describe("rich-text phrasing-only containers keep their label", () => {
     expect(html).not.toContain("<h2></h2>");
   });
 
+  it("keeps the trailing link when the moved run holds a button", () => {
+    /*
+     * The case the image fixtures cannot reach, and the reason they cannot:
+     * an image is not interactive, so ONE wrapper copy around the moved run
+     * renders fine. A button IS interactive, and an `<a>` may not contain
+     * another, so {@link LinkView} drops a wrapper holding one — taking the
+     * link off `After` as well, which the author linked and which nothing
+     * objects to on its own.
+     *
+     * Asserted as the anchor around `After` rather than as "the html contains
+     * a link", which every one of these fixtures satisfies through `Before`.
+     */
+    const value = doc([
+      {
+        type: "heading",
+        tag: "h2",
+        children: [
+          linked([
+            { type: "text", text: "Before" },
+            { type: "button-link", url: "https://example.com/go", text: "Go" },
+            { type: "text", text: "After" },
+          ]),
+        ],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+    const html = renderToStaticMarkup(<RichText value={value} />);
+    expect(html).toContain('<a href="https://example.com">After</a>');
+    // The heading keeps its own words linked, and the button is NOT re-wrapped
+    // in the anchor that would have been taken apart around it.
+    expect(html).toContain('<h2><a href="https://example.com">Before</a></h2>');
+    expect(html).not.toContain('<a href="https://example.com"><p');
+    // The author's order survives the split: a segment is emitted where the
+    // node it follows was, not gathered to one end.
+    expect(html.indexOf("Before")).toBeLessThan(html.indexOf("Go"));
+    expect(html.indexOf("Go")).toBeLessThan(html.indexOf("After"));
+  });
+
+  it("keeps a non-interactive moved run in ONE wrapper", () => {
+    /*
+     * The control on the other side. Segmenting unconditionally would emit a
+     * separate anchor per node and fragment a run the wrapper may legally hold,
+     * so the image case must still render as a single link around both.
+     */
+    const value = doc([
+      {
+        type: "heading",
+        tag: "h2",
+        children: [
+          linked([
+            { type: "text", text: "Before" },
+            IMAGE,
+            { type: "text", text: "After" },
+          ]),
+        ],
+      },
+    ] as unknown as RichTextValue["root"]["children"]);
+
+    const html = renderToStaticMarkup(<RichText value={value} />);
+    // One anchor holding the figure AND the words that followed it.
+    expect(html).toContain('<a href="https://example.com"><figure');
+    expect(html).toContain("After</a>");
+    // Two anchors in total: the heading's, and the moved run's single copy.
+    expect(html.split('<a href="https://example.com"').length - 1).toBe(2);
+  });
+
   it("splits the same wrapper inside a disclosure label", () => {
     // The sibling container. A rule applied to headings alone leaves the
     // disclosure with an empty label by the identical route.

--- a/packages/blocks-react/src/rich-text.tsx
+++ b/packages/blocks-react/src/rich-text.tsx
@@ -470,8 +470,57 @@ function partitionChild(
   const inner = partitionPhrasing(kidsOf(child), permits, depth + 1);
   return {
     keeps: inner.keeps.length > 0 ? [{ ...child, children: inner.keeps }] : [],
-    moves: inner.moves.length > 0 ? [{ ...child, children: inner.moves }] : [],
+    moves: rewrapMoved(child, inner.moves),
   };
+}
+
+/**
+ * A moved run back inside its inline wrapper, split where the wrapper cannot
+ * hold what it would contain.
+ *
+ * ONE copy around the whole run is the obvious shape and it silently drops the
+ * author's link. A link may not contain another interactive element, so
+ * {@link LinkView} renders such a wrapper as its children alone — and a single
+ * button in the middle of the run therefore unwraps the phrasing AFTER it too,
+ * which the author had linked and which nothing else in the run objects to. The
+ * same passage with an image in place of the button keeps its trailing link,
+ * so the two spellings of one document disagreed.
+ *
+ * Segmenting instead: each run of nodes the wrapper may legally hold gets its
+ * OWN copy, and a node it may not hold is emitted beside them, unwrapped. Order
+ * is preserved throughout, which is the property the move exists to protect.
+ *
+ * Only an interactive wrapper is at risk. Any other inline wrapper — a format
+ * span, a mark — has no such rule against its contents and is copied whole,
+ * because splitting it would fragment a run for no gain.
+ */
+function rewrapMoved(
+  wrapper: RichTextNode,
+  moved: readonly RichTextNode[]
+): RichTextNode[] {
+  if (moved.length === 0) return [];
+  if (!INTERACTIVE_NODES.has(wrapper.type))
+    return [{ ...wrapper, children: [...moved] }];
+
+  const out: RichTextNode[] = [];
+  let run: RichTextNode[] = [];
+  const closeRun = () => {
+    if (run.length === 0) return;
+    out.push({ ...wrapper, children: run });
+    run = [];
+  };
+  for (const node of moved) {
+    // The node itself as well as its descendants: the wrapper is taken apart by
+    // an interactive element at any depth inside it, not only a direct child.
+    if (holdsInteractive([node])) {
+      closeRun();
+      out.push(node);
+      continue;
+    }
+    run.push(node);
+  }
+  closeRun();
+  return out;
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1279 and #1299. Both carried a Codex P2 that arrived shortly before or after the merge, so neither could be answered on its own PR.

## 1. A link is lost on the words that follow a button in a heading

`packages/blocks-react/src/rich-text.tsx`, `partitionChild`. Reported on merged #1279.

A heading holds only phrasing content, so a button inside one moves out to follow it, and words written after that button move with it to preserve the author's order. The whole moved run was re-wrapped in **one** copy of the link around it. A link may not contain another interactive element, so `LinkView` drops such a wrapper — and the trailing words lose the link the author applied.

Measured on `main`, the same passage with an image instead of a button:

| moved run holds | renders as |
|---|---|
| a button | `<h2><a>Before</a></h2>` … button … `After` — **link gone** |
| an image | `<h2><a>Before</a></h2><a href><figure/>After</a>` — link kept |

So one document rendered by two rules, and the image case shows what the button case was meant to do. Each run the wrapper may legally hold now takes its own copy, in order; a node it may not hold is emitted beside them, unwrapped.

**One correction to the finding as written.** It describes this as trailing phrasing *losing* a link. Measured against a plain paragraph — where no partition happens at all — `LinkView` strips that whole anchor too, so `After` was never linked before this code existed either. It is not a regression against the old renderer; it is the move failing to deliver the link it does deliver when the run holds an image.

## 2. A numeric button label is drawn but not described

`packages/blocks-engine/src/rich-text.ts`, `labelOf`. Reported on merged #1299.

`props.text()` in the renderer treats a finite **number** as authored text, so a stored `text: 0` draws the character `0` on the page. `labelOf` accepted only strings, so the plain-text projection used for search indexing and the crawler description omitted a label the page displays.

The decision moves down into the engine as `authoredText` / `isAuthoredText` — the same shape as `isLinkableUrl` in #1299 — and both readers derive from it instead of each spelling `typeof` for itself. The renderer's `props.ts` now delegates rather than keeping its own copy.

## 3. Two boundaries that were not written down

From CodeRabbit on #1299 (posted 28s after the merge). Its claim held at two of the four sites it named:

- `blocks-engine/src/index.ts` — the export comment described only the remote-host policy, while the block also exports `isLinkableUrl`, which is a different, format-level question.
- `blocks-engine/src/style/css-value.ts` — the shared `hasControlCharacter` import had no note saying why it is shared.

The other two sites it named are import lines whose **use** sites already carry the explanation (`props.ts:135-139` and `labelOf`), so those are unchanged.

## Verification

Each of the four new tests was break-verified individually, with the mutation being removal of the behaviour the test's *name* promises — not something adjacent:

| mutation | fails |
|---|---|
| `labelOf` back to string-only | `reports a numeric label the renderer draws as text` |
| `authoredText` accepts any non-null | `still omits a stored value no reader would draw as text` |
| one wrapper around the whole moved run | `keeps the trailing link when the moved run holds a button` |
| segment unconditionally | `keeps a non-interactive moved run in ONE wrapper` |

Each failed exactly one test, and only that one. The last two are opposite mutations, so the pair pins the behaviour from both sides.

The numeric fixture uses `0` specifically: a fix written as `text ? text : null` passes for `2024` and fails on `0`.

Green: `blocks-engine` 1589, `blocks-react` 958, `plugin-page-builder` 500; typecheck and lint clean on all three. Changeset validated by passing its path to `check-changesets.mjs`, with a deliberately broken copy confirming the checker rejects.