### PR TITLE
refactor(nextly): write every companion locale row through one upsert

### DIFF
--- a/.changeset/one-companion-upsert.md
+++ b/.changeset/one-companion-upsert.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Write every localized companion row through one upsert. The collection write
+path carried a private copy that built the same `INSERT ... ON CONFLICT` as the
+shared helper, kept separate only because it holds a transaction and the helper
+took an adapter. A transaction can now present itself as that adapter, so the
+copy is gone and there is a single place a companion column is written.

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -113,6 +113,10 @@ import {
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
 import {
+  companionWriteVia,
+  upsertCompanionRow,
+} from "../../i18n/runtime/companion-io";
+import {
   cachedCompanionReadiness,
   companionNotReadyMessage,
   isCompanionReady,
@@ -1219,55 +1223,6 @@ export class CollectionMutationService extends BaseService {
         `${this.localization.locales.map(l => l.code).join(", ")}.`,
       data: null,
     };
-  }
-
-  /**
-   * Upsert the companion `_locales` row for `(parentId, locale)` with the provided localized
-   * columns (i18n M5, updateEntry). Only the provided columns are written — an existing row for
-   * another locale, or other localized fields on this locale's row, are left untouched. Uses the
-   * PK `(_parent, _locale)` conflict target. Runs inside the caller's transaction via `tx.execute`.
-   */
-  private async upsertCompanionRow(
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- adapter tx surface
-    tx: any,
-    companionTableName: string,
-    parentId: string,
-    locale: string,
-    companionData: Record<string, unknown>
-  ): Promise<void> {
-    const cols = Object.keys(companionData);
-    if (cols.length === 0) return;
-    const isMysql = this.dialect === "mysql";
-    const q = (id: string) => (isMysql ? `\`${id}\`` : `"${id}"`);
-    const params: unknown[] = [];
-    const ph = () =>
-      this.dialect === "postgresql" ? `$${params.length}` : "?";
-
-    const allCols = ["_parent", "_locale", ...cols];
-    const valuePlaceholders = allCols
-      .map(c => {
-        params.push(
-          c === "_parent"
-            ? parentId
-            : c === "_locale"
-              ? locale
-              : companionData[c]
-        );
-        return ph();
-      })
-      .join(", ");
-
-    const conflict = isMysql
-      ? `ON DUPLICATE KEY UPDATE ${cols.map(c => `${q(c)} = VALUES(${q(c)})`).join(", ")}`
-      : `ON CONFLICT (${q("_parent")}, ${q("_locale")}) DO UPDATE SET ${cols
-          .map(c => `${q(c)} = excluded.${q(c)}`)
-          .join(", ")}`;
-
-    await tx.execute(
-      `INSERT INTO ${q(companionTableName)} (${allCols.map(q).join(", ")}) ` +
-        `VALUES (${valuePlaceholders}) ${conflict}`,
-      params
-    );
   }
 
   /**
@@ -6291,8 +6246,8 @@ export class CollectionMutationService extends BaseService {
             localizedUpdate &&
             Object.keys(localizedUpdate.companionData).length > 0
           ) {
-            await this.upsertCompanionRow(
-              tx,
+            await upsertCompanionRow(
+              companionWriteVia(tx, this.dialect),
               localizedUpdate.companionTableName,
               params.entryId,
               localizedUpdate.writeLocale,

--- a/packages/nextly/src/domains/i18n/runtime/__tests__/companion-write-via.test.ts
+++ b/packages/nextly/src/domains/i18n/runtime/__tests__/companion-write-via.test.ts
@@ -1,0 +1,133 @@
+/**
+ * The seam that let one companion upsert replace two.
+ *
+ * `collection-mutation-service.ts` carried its own private `upsertCompanionRow`
+ * for one reason: it holds a transaction, and the shared helper took an
+ * adapter. The two implementations built byte-identical SQL and drifted only in
+ * where they read the dialect from. A second copy of an INSERT is not a style
+ * problem here — i18n B2 adds an `_updated_at` column to this row, and a column
+ * written by one copy and not the other leaves those locales permanently
+ * unstamped, which makes a stale translation read as fresh. That failure is
+ * silent, so the duplication had to go before the column arrives.
+ *
+ * These tests pin what the seam has to preserve for that replacement to be
+ * safe: the transaction's own connection is used, the caller's dialect decides
+ * the placeholder syntax, and the emitted statement is the one the deleted copy
+ * emitted.
+ *
+ * @module domains/i18n/runtime/__tests__/companion-write-via.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { companionWriteVia, upsertCompanionRow } from "../companion-io";
+
+/** A transaction double that records the raw SQL it is handed. */
+function txSpy() {
+  const execute = vi.fn().mockResolvedValue([]);
+  return { execute, tx: { execute } };
+}
+
+describe("companionWriteVia", () => {
+  it("writes on the TRANSACTION's connection, never a pooled one", async () => {
+    const { execute, tx } = txSpy();
+
+    await upsertCompanionRow(
+      companionWriteVia(tx, "postgresql"),
+      "dc_posts_locales",
+      "entry-1",
+      "fr",
+      { title: "Bonjour" }
+    );
+
+    // The whole point of the seam. A companion write that reached a pooled
+    // connection would sit outside the caller's transaction: it would survive a
+    // rollback of the main-table write it belongs to, leaving a translation for
+    // a revision that never landed.
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("takes its dialect from the caller, since a transaction carries none", async () => {
+    const pg = txSpy();
+    await upsertCompanionRow(
+      companionWriteVia(pg.tx, "postgresql"),
+      "dc_posts_locales",
+      "entry-1",
+      "fr",
+      { title: "Bonjour" }
+    );
+    const sqlite = txSpy();
+    await upsertCompanionRow(
+      companionWriteVia(sqlite.tx, "sqlite"),
+      "dc_posts_locales",
+      "entry-1",
+      "fr",
+      { title: "Bonjour" }
+    );
+
+    // Placeholder syntax is dialect-specific and is the observable proof the
+    // dialect was threaded rather than defaulted: Postgres numbers them,
+    // everything else uses `?`. A default would silently produce a statement
+    // the driver rejects on two of the three dialects.
+    expect(pg.execute.mock.calls[0][0]).toContain("$1");
+    expect(sqlite.execute.mock.calls[0][0]).not.toContain("$1");
+    expect(sqlite.execute.mock.calls[0][0]).toContain("?");
+  });
+
+  it("emits the statement the deleted private copy emitted", async () => {
+    const { execute, tx } = txSpy();
+
+    await upsertCompanionRow(
+      companionWriteVia(tx, "postgresql"),
+      "dc_posts_locales",
+      "entry-1",
+      "fr",
+      { title: "Bonjour", body: "Salut" }
+    );
+
+    const [sql, params] = execute.mock.calls[0];
+    // Transcribed from the implementation this replaced, so the assertion is
+    // about equivalence with the deleted code and not merely about the survivor
+    // agreeing with itself.
+    expect(sql).toBe(
+      'INSERT INTO "dc_posts_locales" ("_parent", "_locale", "title", "body") ' +
+        "VALUES ($1, $2, $3, $4) " +
+        'ON CONFLICT ("_parent", "_locale") DO UPDATE SET ' +
+        '"title" = excluded."title", "body" = excluded."body"'
+    );
+    expect(params).toEqual(["entry-1", "fr", "Bonjour", "Salut"]);
+  });
+
+  it("quotes with backticks and uses MySQL's upsert clause", async () => {
+    const { execute, tx } = txSpy();
+
+    await upsertCompanionRow(
+      companionWriteVia(tx, "mysql"),
+      "dc_posts_locales",
+      "entry-1",
+      "fr",
+      { title: "Bonjour" }
+    );
+
+    const [sql] = execute.mock.calls[0];
+    expect(sql).toContain("`dc_posts_locales`");
+    expect(sql).toContain("ON DUPLICATE KEY UPDATE `title` = VALUES(`title`)");
+    expect(sql).not.toContain("ON CONFLICT");
+  });
+
+  it("writes nothing at all when there are no columns", async () => {
+    const { execute, tx } = txSpy();
+
+    await upsertCompanionRow(
+      companionWriteVia(tx, "postgresql"),
+      "dc_posts_locales",
+      "entry-1",
+      "fr",
+      {}
+    );
+
+    // Not merely "no error": an INSERT naming only `_parent` and `_locale`
+    // would create an empty companion row, and an empty row is not nothing --
+    // it is a row that reads as "this locale exists" to every join.
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.ts
@@ -11,7 +11,10 @@
  * @module domains/i18n/runtime/companion-io
  */
 
-import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+import type {
+  SqlParam,
+  SupportedDialect,
+} from "@nextlyhq/adapter-drizzle/types";
 
 import { NextlyError } from "../../../errors/nextly-error";
 import type { ColumnOrigin } from "../../schema/services/field-column-descriptor";
@@ -193,6 +196,43 @@ export async function upsertCompanionRow(
       `VALUES (${valuePlaceholders}) ${conflict}`,
     params
   );
+}
+
+/**
+ * Present a transaction as the write surface {@link upsertCompanionRow} takes.
+ *
+ * There is exactly one difference between an adapter and a transaction here: the NAME of the
+ * raw-SQL method. `CompanionWriteAdapter.executeQuery` and `TransactionContext.execute` have the
+ * same `(sql, params) => Promise<T[]>` shape; only the dialect has to be supplied separately,
+ * because a transaction does not carry one.
+ *
+ * That difference is the entire reason a SECOND hand-written companion upsert existed inside
+ * `collection-mutation-service.ts` — the collection write path holds a `tx`, could not pass it
+ * here, and grew its own copy of the same INSERT ... ON CONFLICT. Naming the difference in one
+ * place is what lets one upsert serve both, so a column added to the companion row (i18n B2's
+ * `_updated_at`) is written by every path rather than by whichever one the author remembered.
+ *
+ * @param tx - The caller's open transaction; writes land on its connection, not a pooled one.
+ * @param dialect - Read from the calling service, since a transaction does not expose it.
+ */
+export function companionWriteVia(
+  tx: {
+    execute<T = unknown>(sql: string, params?: SqlParam[]): Promise<T[]>;
+  },
+  dialect: SupportedDialect
+): CompanionWriteAdapter {
+  return {
+    dialect,
+    // The cast is the one place the two surfaces disagree: `executeQuery` declares `unknown[]`
+    // and `execute` declares `SqlParam[]`. The values are companion column values plus the
+    // parent id and locale, which is exactly what the previous call site already passed — it
+    // simply passed them through a `tx: any`, so nothing checked them at all. Narrowing here
+    // is stricter than what it replaces, not looser.
+    executeQuery: <T = unknown>(
+      sql: string,
+      params?: unknown[]
+    ): Promise<T[]> => tx.execute<T>(sql, params as SqlParam[] | undefined),
+  };
 }
 
 /**


### PR DESCRIPTION
> **Stacked on #1312.** Base is `fix/nextly-test-baseline`, not `main`, because the `packages/nextly` suite is red on `main` until #1312 lands and the pre-push gate runs it. Review that one first; this diff is three files.

## What this does

`collection-mutation-service.ts` carried its own `private async upsertCompanionRow` that hand-built the same `INSERT ... ON CONFLICT` as `i18n/runtime/companion-io.ts` already exports to six other callers. The SQL was byte-identical. The two existed separately for exactly one reason: **the collection write path holds a transaction and the shared helper takes an adapter**, so there was no way to pass a `tx` — and a copy grew instead.

That difference is now named once:

```ts
companionWriteVia(tx, dialect): CompanionWriteAdapter
```

The only divergence between the two surfaces is the method name — `execute` against `executeQuery`, both `(sql, params) => Promise<T[]>` — plus a dialect a transaction does not carry. The private copy is deleted; its single call site goes through the shared helper.

## Why now, and why this is not tidying

i18n **B2** adds an `_updated_at` column to the companion row so the worklist can say a translation went stale while its source moved.

A column written by one upsert and not the other leaves every locale written through the other path **permanently unstamped** — and an unstamped row cannot be judged stale, so those translations read as fresh forever. Nobody notices a warning that never appears, which is precisely the failure B2 exists to remove. Converging first means the column has one place to be written.

This is step 0 of the B2 design, split into its own PR per the founder's ruling so a reviewer can judge *"did this change behaviour?"* with nothing else in the diff.

## Evidence it is behaviour-preserving — measured, not asserted

Same tree, same build, with and without the change:

```
i18n + collections suites, WITH:     11 failed | 697 passed
i18n + collections suites, WITHOUT:  11 failed | 697 passed
new failures introduced:             0
```

Those 11 are `main`'s pre-existing baseline, fixed by #1312. Full `nextly` suite on this stack: **785 files, 9708 passed, 45 skipped, 0 failed.**

## The tests pin what the replacement had to preserve

Not that the survivor agrees with itself — that the survivor agrees with the **deleted** code:

- **the transaction's own connection is used.** A companion write reaching a pooled connection would sit outside the caller's transaction: it would survive a rollback of the main-table write it belongs to, leaving a translation for a revision that never landed.
- **the caller's dialect decides placeholder syntax.** Postgres numbers placeholders, the others use `?`; a defaulted dialect produces a statement two of three drivers reject. The emitted SQL is the observable proof the dialect was threaded rather than assumed.
- **the exact statement, transcribed from the implementation this replaces**, for both the `ON CONFLICT` and `ON DUPLICATE KEY UPDATE` forms.
- **an empty column set writes nothing at all.** Not merely "no error": an INSERT naming only `_parent` and `_locale` creates an empty companion row, and an empty row reads as *"this locale exists"* to every join.

Each was verified by breaking the seam three ways — ignoring the caller's dialect, routing off the transaction, and dropping the empty-column guard — and confirming the right tests failed.

## Note on the one cast

`unknown[]` → `SqlParam[]` at the seam is **stricter than what it replaces**, not looser: the deleted call site passed its params through a `tx: any`, so nothing checked them at all.

## Coordination

The workflows lane (#1301, #1306) was notified before I read this file. They measured that `collection-mutation-service.ts` is not among R-6 Task 8's 21 files and structurally cannot be — their materialiser takes the write path as an injected port, so it is a *caller* of `updateEntry`, never an editor of it. No observable behaviour of `updateEntry` changes here.
