### PR TITLE
feat(builder): mount the class selector in the style inspector

### DIFF
--- a/.changeset/mount-the-class-selector.md
+++ b/.changeset/mount-the-class-selector.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The class selector now appears in the style inspector, above the style
+sections, so applying a class happens on the element being styled rather than
+behind a context switch. Until now the surface existed and nothing rendered it.
+
+Applying or removing an existing class is written by the inspector itself,
+because it is an edit to the selected block and the panel already writes those
+— a host only supplies the site's class library and handles creating a new
+class, which needs a site-style write no panel can reach. Removing the last
+class removes the field rather than storing an empty list, so undo restores the
+block as it was.
+
+A host that has not opted in gets no class surface at all, and one that has
+opted in but is still reading its library gets a loading state, so the two are
+never drawn the same way.

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -39,7 +39,10 @@ function draw(overrides: Partial<ClassSelectorProps> = {}): {
   onNodeClassesChange: ReturnType<typeof vi.fn>;
   onCreateClass: ReturnType<typeof vi.fn>;
 } {
-  const onNodeClassesChange = vi.fn();
+  // Answers the contract. A bare `vi.fn()` returns undefined, which is not
+  // "refused" and so reads as success — the fake would then be asserting a
+  // shape the real host cannot use.
+  const onNodeClassesChange = vi.fn(() => "applied" as const);
   const onCreateClass = vi.fn();
   render(
     <ClassSelector
@@ -61,7 +64,7 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
     <ClassSelector
       library={LIBRARY}
       nodeClassIds={initial.nodeClassIds}
-      onNodeClassesChange={vi.fn()}
+      onNodeClassesChange={vi.fn(() => "applied" as const)}
       onCreateClass={vi.fn()}
     />
   );
@@ -71,7 +74,7 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
         <ClassSelector
           library={LIBRARY}
           nodeClassIds={nodeClassIds}
-          onNodeClassesChange={vi.fn()}
+          onNodeClassesChange={vi.fn(() => "applied" as const)}
           onCreateClass={vi.fn()}
         />
       ),
@@ -92,7 +95,7 @@ describe("a library that has not been read yet", () => {
       <ClassSelector
         library={undefined}
         nodeClassIds={[]}
-        onNodeClassesChange={vi.fn()}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
         onCreateClass={vi.fn()}
       />
     );
@@ -307,6 +310,70 @@ describe("a node the page cannot fully apply", () => {
   it("says nothing for a node within the limit", () => {
     draw({ nodeClassIds: ["id-hero"] });
     expect(screen.queryByText(/lists .* more class/i)).toBeNull();
+  });
+});
+
+describe("a write the document refuses", () => {
+  /*
+   * A different failure from the node being full: that one is predictable from
+   * the ids in hand, this one is only knowable by asking the document — a page
+   * at its byte limit rejects an edit whose class was perfectly valid.
+   */
+  function drawRefusing() {
+    const onNodeClassesChange = vi.fn(() => "refused" as const);
+    render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={vi.fn()}
+      />
+    );
+    return { onNodeClassesChange };
+  }
+
+  it("keeps the typed query rather than clearing it as though applied", () => {
+    drawRefusing();
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect((field() as HTMLInputElement).value).toBe("hero");
+  });
+
+  it("says the change did not reach the document", () => {
+    drawRefusing();
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /could not be applied/i
+    );
+  });
+
+  it("clears the query when the write DOES land", () => {
+    // The control: the two outcomes must be distinguishable, or the assertion
+    // above would hold for a selector that never cleared anything.
+    draw();
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect((field() as HTMLInputElement).value).toBe("");
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("reports a refused REMOVAL too, not only a refused apply", () => {
+    const onNodeClassesChange = vi.fn(() => "refused" as const);
+    render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={["id-hero"]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={vi.fn()}
+      />
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /remove hero from this element/i })
+    );
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /could not be applied/i
+    );
   });
 });
 

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -461,12 +461,11 @@ describe("a class whose id collides with the synthetic create row", () => {
 
   it("gives the two rows different REACT keys", () => {
     /*
-     * The only observable consequence, and it took a passing break to find it:
-     * duplicate keys leave both rows rendered, separately clickable and with
-     * distinct DOM ids, so every assertion about the markup holds either way.
-     * React itself is what notices, and the cost — one row's state reused for
-     * the other across a re-render — is exactly what is invisible in a single
-     * render.
+     * React's warning is the only observable consequence. Duplicate keys leave
+     * both rows rendered, separately clickable and with distinct DOM ids —
+     * those are derived from the index — so every assertion about the markup
+     * holds either way. The cost is one row's state being reused for the other
+     * across a re-render, which a single render cannot show.
      */
     const reported: unknown[] = [];
     const spy = vi

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -50,6 +50,9 @@ import {
   type ClassOption,
 } from "./class-library";
 
+/** Whether a write to the selected node's classes reached the document. */
+export type ClassWriteOutcome = "applied" | "refused";
+
 export interface ClassSelectorProps {
   /**
    * The site's class library, or `undefined` while the host has not read it.
@@ -62,8 +65,18 @@ export interface ClassSelectorProps {
   library: readonly NamedClass[] | undefined;
   /** The class ids the selected node carries, as stored. */
   nodeClassIds: readonly string[];
-  /** The node's classes after an apply or a remove. */
-  onNodeClassesChange: (classIds: string[]) => void;
+  /**
+   * The node's classes after an apply or a remove, and whether it landed.
+   *
+   * Returns an outcome rather than nothing, because the store can refuse a
+   * write the rules here cannot anticipate: this module judges the class, while
+   * the document has its own limits and a page at its byte cap rejects an edit
+   * whose value is perfectly valid. Discarding that refusal would clear the
+   * query and reset the highlight as though the class had been applied, leaving
+   * the author with no explanation and no draft — the same failure the style
+   * controls in this package already return an outcome to avoid.
+   */
+  onNodeClassesChange: (classIds: string[]) => ClassWriteOutcome;
   /**
    * Create a class under this slug and put it on the selected node.
    *
@@ -82,6 +95,10 @@ export function ClassSelector({
   const [query, setQuery] = React.useState("");
   const [active, setActive] = React.useState(0);
   const [refused, setRefused] = React.useState(false);
+  // The store's refusal, which is a different failure from the node being full:
+  // that one is predictable from the ids in hand, this one is only knowable by
+  // asking the document. Kept apart so the message can say which happened.
+  const [writeRefused, setWriteRefused] = React.useState(false);
   const listId = React.useId();
 
   if (library === undefined) {
@@ -130,9 +147,16 @@ export function ClassSelector({
         setRefused(true);
         return;
       }
-      onNodeClassesChange(outcome.classIds);
+      if (onNodeClassesChange(outcome.classIds) === "refused") {
+        // The draft survives, deliberately. An author whose write was refused
+        // has lost nothing they typed, and the next thing they do is likely to
+        // be trying it again.
+        setWriteRefused(true);
+        return;
+      }
     }
     setRefused(false);
+    setWriteRefused(false);
     setQuery("");
     setActive(0);
   };
@@ -141,7 +165,12 @@ export function ClassSelector({
     <div className="nx-classes">
       <AppliedChips
         applied={applied}
-        onRemove={id => onNodeClassesChange(withClassRemoved(nodeClassIds, id))}
+        onRemove={id => {
+          const landed = onNodeClassesChange(
+            withClassRemoved(nodeClassIds, id)
+          );
+          setWriteRefused(landed === "refused");
+        }}
       />
       <Input
         className="nx-classes__query"
@@ -177,6 +206,11 @@ export function ClassSelector({
       {hidden > 0 ? (
         <p className="nx-inspector__note">
           {`${hidden} more — keep typing to narrow the list.`}
+        </p>
+      ) : null}
+      {writeRefused ? (
+        <p className="nx-classes__issue" role="alert">
+          This change could not be applied to the document.
         </p>
       ) : null}
       {showRefusal ? (

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -113,6 +113,50 @@ function mount(node: Partial<BlockNode> = {}) {
   return editor;
 }
 
+describe("what InspectorPanel forwards to the style tab", () => {
+  it("carries the class props through, so the selector reaches the editor", () => {
+    /*
+     * The chain is the feature. `StyleInspectorPanel` treats a missing
+     * `onCreateClass` as the host opting out, so a prop dropped ANYWHERE
+     * between the host and it is invisible: the selector renders fine in
+     * isolation, its own tests pass, and every real selection in the shipped
+     * editor shows nothing at all.
+     *
+     * Asserted through the rendered SELECTOR rather than by inspecting props,
+     * because what matters is that it arrives — a forwarding test that checked
+     * the call would pass on a panel that received the prop and ignored it.
+     */
+    register();
+    const editor = editorFor(documentOf({}));
+    render(
+      <InspectorPanel
+        editor={editor}
+        onCreateClass={vi.fn()}
+        classLibrary={[
+          { id: "id-hero", slug: "hero", orderIndex: 0, styles: {} },
+        ]}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(
+      screen.getByRole("combobox", { name: /add a class/i })
+    ).toBeDefined();
+  });
+
+  it("shows no class surface when the host passed nothing", () => {
+    // The control: the assertion above must be about forwarding, not about the
+    // selector rendering unconditionally.
+    register();
+    render(<InspectorPanel editor={editorFor(documentOf({}))} />);
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(screen.queryByRole("combobox", { name: /add a class/i })).toBeNull();
+  });
+});
+
 describe("InspectorPanel identity fields", () => {
   it("shows the block's stored name and lock", () => {
     mount({ name: "Hero title", locked: true });

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -62,10 +62,28 @@ import {
   type LockState,
 } from "./inspector";
 import { selectionLock } from "./selection-ops";
-import { StyleInspectorPanel } from "./style-inspector-panel";
+import {
+  StyleInspectorPanel,
+  type StyleInspectorPanelProps,
+} from "./style-inspector-panel";
 import type { StylePolicy } from "./style-values";
 
 export interface InspectorPanelProps {
+  /**
+   * The site's class library, forwarded to the style tab's class selector.
+   *
+   * Declared here only to CARRY it: this panel has no opinion about classes,
+   * and the meaning of each — including why an absent library is a read in
+   * flight rather than a host opting out — lives on
+   * {@link StyleInspectorPanelProps.classLibrary}.
+   *
+   * Forwarded rather than left out because a prop the chain drops is invisible:
+   * the surface renders in isolation, its tests pass, and every real selection
+   * in the shipped editor shows nothing.
+   */
+  classLibrary?: StyleInspectorPanelProps["classLibrary"];
+  /** Create a class and apply it to the selected block. Opts the surface in. */
+  onCreateClass?: StyleInspectorPanelProps["onCreateClass"];
   /**
    * The editor whose selected block this edits.
    *
@@ -165,6 +183,8 @@ const INSPECTOR_TABS = [
 
 export function InspectorPanel({
   editor,
+  classLibrary,
+  onCreateClass,
   policy,
   styleState,
   breakpoint,
@@ -317,6 +337,8 @@ export function InspectorPanel({
             liveBreakpoints={liveBreakpoints}
             onJumpToBreakpoint={onJumpToBreakpoint}
             tokens={tokens}
+            classLibrary={classLibrary}
+            onCreateClass={onCreateClass}
           />
         </TabsContent>
 

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -312,6 +312,68 @@ describe("the class selector, mounted above the style sections", () => {
     });
   });
 
+  it("appears for a block that offers no style properties at all", () => {
+    /*
+     * Named classes compile independently of a block's own style support, so
+     * such a block can still carry one. Exiting early on an empty section list
+     * left the only surface that can apply a class unreachable for exactly the
+     * blocks whose styling has to come from classes.
+     */
+    register({});
+    const editor = editorFor(documentOf());
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        onCreateClass={vi.fn()}
+        classLibrary={LIBRARY}
+      />
+    );
+
+    expect(
+      screen.getByRole("combobox", { name: /add a class/i })
+    ).toBeDefined();
+    // And it still says the block has no style controls, rather than pretending.
+    expect(screen.getByText(/does not offer style properties/i)).toBeDefined();
+  });
+
+  it("forgets a typed query when the selection moves to another block", () => {
+    /*
+     * The query and the highlighted row are state about the node in hand.
+     * Unkeyed, React reuses the component across a selection change while the
+     * write callback switches to the new node — so Enter applies the PREVIOUS
+     * block's pending choice to the block now selected.
+     */
+    register({ spacing: true });
+    const first = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "acme/box", version: 1, props: {} },
+        { id: "b", type: "acme/box", version: 1, props: {} },
+      ] as BlockNode[],
+    } as BlockDocument;
+
+    const view = render(
+      <StyleInspectorPanel
+        editor={editorFor(first, "a")}
+        onCreateClass={vi.fn()}
+        classLibrary={LIBRARY}
+      />
+    );
+    const field = () => screen.getByRole("combobox", { name: /add a class/i });
+    fireEvent.change(field(), { target: { value: "hero" } });
+    expect((field() as HTMLInputElement).value).toBe("hero");
+
+    view.rerender(
+      <StyleInspectorPanel
+        editor={editorFor(first, "b")}
+        onCreateClass={vi.fn()}
+        classLibrary={LIBRARY}
+      />
+    );
+    expect((field() as HTMLInputElement).value).toBe("");
+  });
+
   it("reports a creation to the host rather than writing it", () => {
     // The class has no id until the host has stored it, so a node write here
     // would have to invent one.

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -187,10 +187,9 @@ describe("the Style tab beside Content", () => {
 describe("when there is nothing to style", () => {
   it("says to select a block, rather than rendering an empty panel", () => {
     /*
-     * The one guard of the four with no direct test until now — the wrapper's
-     * no-selection case covers `InspectorPanel`, not this panel, and the two
-     * say different words. Found by breaking the shared guard and watching
-     * only three of the four fail.
+     * Not covered by the wrapper's own no-selection case: that one renders
+     * `InspectorPanel`, which says "Select a block to edit it." This panel says
+     * "style", and a query matching one does not match the other.
      */
     register({ spacing: true });
     const { container } = render(

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -184,6 +184,150 @@ describe("the Style tab beside Content", () => {
   });
 });
 
+describe("when there is nothing to style", () => {
+  it("says to select a block, rather than rendering an empty panel", () => {
+    /*
+     * The one guard of the four with no direct test until now — the wrapper's
+     * no-selection case covers `InspectorPanel`, not this panel, and the two
+     * say different words. Found by breaking the shared guard and watching
+     * only three of the four fail.
+     */
+    register({ spacing: true });
+    const { container } = render(
+      <StyleInspectorPanel editor={editorFor(documentOf(), null)} />
+    );
+    expect(
+      container.querySelector('[data-empty="no-selection"]')
+    ).not.toBeNull();
+    expect(screen.getByText(/select a block to style it/i)).toBeDefined();
+  });
+});
+
+describe("the class selector, mounted above the style sections", () => {
+  const LIBRARY = [
+    { id: "id-hero", slug: "hero", orderIndex: 0, styles: {} },
+    { id: "id-card", slug: "card", orderIndex: 1, styles: {} },
+  ];
+
+  /** The panel with a node carrying classes, and a host that opted in. */
+  function mountWithClasses(
+    options: {
+      classIds?: string[];
+      library?: typeof LIBRARY | undefined;
+      optIn?: boolean;
+    } = {}
+  ) {
+    register({ spacing: true });
+    const document = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "a",
+          type: "acme/box",
+          version: 1,
+          props: {},
+          ...(options.classIds === undefined
+            ? {}
+            : { classes: options.classIds }),
+        },
+      ] as BlockNode[],
+    } as BlockDocument;
+    const editor = editorFor(document);
+    const onCreateClass = vi.fn();
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        {...(options.optIn === false ? {} : { onCreateClass })}
+        {...(options.library === undefined
+          ? {}
+          : { classLibrary: options.library })}
+      />
+    );
+    return { editor, onCreateClass };
+  }
+
+  it("is absent entirely when the host never opted in", () => {
+    /*
+     * `onCreateClass` is what opts in, NOT the library. A host that cannot
+     * write the site style has no way to create a class, and a selector that
+     * offered to would report an intent nobody acts on.
+     */
+    mountWithClasses({ optIn: false, library: LIBRARY });
+    expect(screen.queryByRole("combobox", { name: /add a class/i })).toBeNull();
+  });
+
+  it("shows the loading state when the host opted in but is still reading", () => {
+    // The distinction that would otherwise collapse: an absent library means
+    // "in flight" only BECAUSE opting in is signalled separately. Drawn the
+    // same way, a host mid-load and a host with no class surface at all would
+    // be indistinguishable, and only one of them has a field about to fill.
+    mountWithClasses({ library: undefined });
+    expect(screen.getByText(/loading classes/i)).toBeDefined();
+  });
+
+  it("shows the classes the selected node carries", () => {
+    mountWithClasses({ classIds: ["id-card"], library: LIBRARY });
+    expect(screen.getByRole("button", { name: /remove card/i })).toBeDefined();
+  });
+
+  it("writes an applied class through the editor, with no host callback", () => {
+    // Applying an EXISTING class is a node edit, which this panel already
+    // knows how to write. Requiring a callback for it would make the host
+    // rebuild an op the panel is holding all the parts of.
+    const { editor, onCreateClass } = mountWithClasses({ library: LIBRARY });
+    fireEvent.change(screen.getByRole("combobox", { name: /add a class/i }), {
+      target: { value: "hero" },
+    });
+    fireEvent.keyDown(screen.getByRole("combobox", { name: /add a class/i }), {
+      key: "Enter",
+    });
+
+    expect(onCreateClass).not.toHaveBeenCalled();
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect(editor.applyAll.mock.calls[0]?.[0]?.[0]).toEqual({
+      kind: "update",
+      id: "a",
+      patch: { classes: ["id-hero"] },
+    });
+  });
+
+  it("UNSETS the field when the last class is removed", () => {
+    /*
+     * Not `classes: []`. The field is optional and the two mean the same to
+     * every reader, so writing the empty array leaves a key that says nothing
+     * — and an inverse built from it would restore that key on undo.
+     */
+    const { editor } = mountWithClasses({
+      classIds: ["id-hero"],
+      library: LIBRARY,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /remove hero/i }));
+
+    expect(editor.applyAll.mock.calls[0]?.[0]?.[0]).toEqual({
+      kind: "update",
+      id: "a",
+      patch: {},
+      unset: ["classes"],
+    });
+  });
+
+  it("reports a creation to the host rather than writing it", () => {
+    // The class has no id until the host has stored it, so a node write here
+    // would have to invent one.
+    const { editor, onCreateClass } = mountWithClasses({ library: LIBRARY });
+    fireEvent.change(screen.getByRole("combobox", { name: /add a class/i }), {
+      target: { value: "call-to-action" },
+    });
+    fireEvent.keyDown(screen.getByRole("combobox", { name: /add a class/i }), {
+      key: "Enter",
+    });
+
+    expect(onCreateClass).toHaveBeenCalledWith("call-to-action");
+    expect(editor.applyAll).not.toHaveBeenCalled();
+  });
+});
+
 describe("sections", () => {
   it("opens one section at a time", () => {
     mount({ spacing: true, effects: true });

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -374,6 +374,42 @@ describe("the class selector, mounted above the style sections", () => {
     expect((field() as HTMLInputElement).value).toBe("");
   });
 
+  it("tells the selector when the document refused the write", () => {
+    /*
+     * `applyAll` answers null when the store refuses — a page at its byte limit
+     * rejects an edit the class rules found valid. Discarded, the selector
+     * clears the query and resets as though the class had been applied, so the
+     * author loses the typed choice and is told nothing.
+     */
+    register({ spacing: true });
+    const document = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "a", type: "acme/box", version: 1, props: {} },
+      ] as BlockNode[],
+    } as BlockDocument;
+    const editor = editorFor(document);
+    editor.applyAll.mockReturnValue(null);
+
+    render(
+      <StyleInspectorPanel
+        editor={editor}
+        onCreateClass={vi.fn()}
+        classLibrary={LIBRARY}
+      />
+    );
+    const field = () => screen.getByRole("combobox", { name: /add a class/i });
+    fireEvent.change(field(), { target: { value: "hero" } });
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
+    expect((field() as HTMLInputElement).value).toBe("hero");
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /could not be applied/i
+    );
+  });
+
   it("reports a creation to the host rather than writing it", () => {
     // The class has no id until the host has stored it, so a node write here
     // would have to invent one.

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -37,6 +37,7 @@ import {
   type BreakpointId,
   type BreakpointSet,
   type ContrastResult,
+  type NamedClass,
   type NodeStyles,
   type SiteTokenSet,
   type TokenMode,
@@ -71,9 +72,11 @@ import * as React from "react";
 
 import { batchStyleClearOps, batchStyleWriteOps } from "./batch-style";
 import { breakpointQueries, matchedBreakpoints } from "./breakpoints";
+import { ClassSelector } from "./class-selector";
 import { commitOnEnter } from "./commit-on-enter";
 import type { EditorState } from "./editor-state";
 import { fieldLabel } from "./inspector";
+import type { BuilderOp } from "./ops";
 import {
   activeTokenMode,
   colourHexOf,
@@ -97,6 +100,7 @@ import {
   inspectStyle,
   type InspectedStyleProperty,
   type StyleSection,
+  type StyleInspection,
 } from "./style-inspector";
 import {
   CSS_NUMBER,
@@ -258,6 +262,175 @@ export interface StyleInspectorPanelProps {
    * than absent.
    */
   onJumpToBreakpoint?: (breakpoint: BreakpointId) => void;
+  /**
+   * The site's class library, when the host has read it.
+   *
+   * `undefined` here means the read is still in flight, NOT that the question
+   * was never asked — {@link StyleInspectorPanelProps.onCreateClass} carries
+   * that. Two meanings on one value is how a host mid-load and a host with no
+   * class surface at all came to be drawn the same way, and only one of them
+   * should see a field that is about to fill.
+   */
+  classLibrary?: readonly NamedClass[];
+  /**
+   * Create a class under this slug and put it on the selected block.
+   *
+   * Supplying it is what OPTS IN to the class surface: a host that cannot
+   * write the site style has no way to create one, and a selector that offered
+   * to would report an intent nobody acts on.
+   *
+   * One callback rather than two, because this surface cannot mint an id — the
+   * class has no identity until the host has stored it, so "create it and
+   * apply it" is a single intent and splitting it would leave the caller
+   * correlating them.
+   *
+   * Applying and removing an EXISTING class needs no callback: those are edits
+   * to the selected node, which this panel already writes through the editor.
+   */
+  onCreateClass?: (slug: string) => void;
+}
+
+/**
+ * The op that stores a node's class ids.
+ *
+ * An empty list REMOVES the field rather than storing `[]`. The two mean the
+ * same thing to every reader, and the field is optional, so writing the empty
+ * array would leave a document carrying a key that says nothing — and an
+ * inverse built from it would restore that key on undo.
+ */
+function nodeClassesOp(nodeId: string, classIds: readonly string[]): BuilderOp {
+  if (classIds.length === 0) {
+    return { kind: "update", id: nodeId, patch: {}, unset: ["classes"] };
+  }
+  return { kind: "update", id: nodeId, patch: { classes: [...classIds] } };
+}
+
+/**
+ * Why this panel has nothing to style, drawn, or `null` when it does.
+ *
+ * All four ask ONE question — can an edit here mean what it appears to mean —
+ * and each is refused for a different reason. Gathered so the panel body holds
+ * one branch instead of four: the reasons are stable and the panel is not, and
+ * a large function that grows a branch per release is how one arrives over the
+ * complexity gate without anyone deciding to.
+ */
+type StyleAvailability =
+  | { readonly available: false; readonly reason: React.JSX.Element }
+  | { readonly available: true; readonly inspection: StyleInspection };
+
+function styleUnavailable(
+  editor: EditorState,
+  inspection: StyleInspection | null
+): StyleAvailability {
+  if (editor.selection.ids.length > 1) {
+    return {
+      available: false,
+      reason: (
+        <div className="nx-style-inspector" data-empty="many-selected">
+          <p className="nx-inspector__note">
+            {editor.selection.ids.length} blocks selected. Select one to style
+            it.
+          </p>
+        </div>
+      ),
+    };
+  }
+
+  /*
+   * A block whose id is not unique cannot be styled, and saying so is the only
+   * honest answer this panel has.
+   *
+   * The compiler already reaches this conclusion for the same reason, and its
+   * words are worth keeping: a class is derived from the id, so two nodes
+   * sharing one share a class, and "writing corrupts a node the author did not
+   * touch". It refuses to emit their rules.
+   *
+   * The editor has to refuse for a second reason the compiler does not face. The
+   * cascade is read from the PREPARED tree, where read-time repair has already
+   * dropped the later duplicate — but gating runs first, so a gated first node
+   * leaves a LATER one owning that id there, while every lookup in the stored
+   * document returns the first. The controls would then show and write one
+   * block while the provenance dots describe another, and typing into a field
+   * would silently change a block that is not on screen.
+   *
+   * Refused rather than reconciled: pointing the controls at the rendered node
+   * would not help, because a write is addressed by id and would still land on
+   * the first. There is no edit here that means what it appears to mean.
+   */
+  if (editor.selectedId !== null && sharesItsId(editor, editor.selectedId)) {
+    return {
+      available: false,
+      reason: (
+        <div className="nx-style-inspector" data-empty="duplicate-id">
+          <p className="nx-inspector__note">
+            Another block on this page has the same id, so styles written here
+            could not be told apart. Give one of them a new id to style either.
+          </p>
+        </div>
+      ),
+    };
+  }
+
+  if (inspection === null) {
+    return {
+      available: false,
+      reason: (
+        <div className="nx-style-inspector" data-empty="no-selection">
+          <p className="nx-inspector__note">Select a block to style it.</p>
+        </div>
+      ),
+    };
+  }
+
+  if (inspection.sections.length === 0) {
+    return {
+      available: false,
+      reason: (
+        <div className="nx-style-inspector" data-empty="no-style-support">
+          <p className="nx-inspector__note">
+            This block does not offer style properties.
+          </p>
+        </div>
+      ),
+    };
+  }
+  return { available: true, inspection };
+}
+
+/**
+ * The class surface for the selected block, or nothing.
+ *
+ * Its own component rather than a conditional in the panel body: the panel is
+ * already near the complexity the gate allows, and a branch plus two inline
+ * callbacks is exactly the kind of growth that pushes a large function over
+ * without anyone deciding to.
+ *
+ * `onCreateClass` is what OPTS IN. `library` being undefined then means the
+ * read is in flight, which the selector draws as such — two signals, so a host
+ * mid-load and a host with no class surface are never the same picture.
+ */
+function SelectedNodeClasses({
+  editor,
+  nodeId,
+  library,
+  onCreateClass,
+}: {
+  editor: EditorState;
+  nodeId: string;
+  library: readonly NamedClass[] | undefined;
+  onCreateClass: ((slug: string) => void) | undefined;
+}): React.JSX.Element | null {
+  if (onCreateClass === undefined) return null;
+  return (
+    <ClassSelector
+      library={library}
+      nodeClassIds={findNode(editor.document.nodes, nodeId)?.classes ?? []}
+      onNodeClassesChange={classIds =>
+        editor.applyAll([nodeClassesOp(nodeId, classIds)])
+      }
+      onCreateClass={onCreateClass}
+    />
+  );
 }
 
 export function StyleInspectorPanel({
@@ -271,6 +444,8 @@ export function StyleInspectorPanel({
   previewContainer,
   liveBreakpoints,
   onJumpToBreakpoint,
+  classLibrary,
+  onCreateClass,
 }: StyleInspectorPanelProps): React.JSX.Element {
   // `null` is "the author has not chosen yet", which is NOT the same as the
   // empty string the accordion sends when they collapse the open section. The
@@ -329,65 +504,15 @@ export function StyleInspectorPanel({
    * and writing to every block — is a different surface with its own rules
    * about what a shared value means, and it does not exist yet.
    */
-  if (editor.selection.ids.length > 1) {
-    return (
-      <div className="nx-style-inspector" data-empty="many-selected">
-        <p className="nx-inspector__note">
-          {editor.selection.ids.length} blocks selected. Select one to style it.
-        </p>
-      </div>
-    );
-  }
-
   /*
-   * A block whose id is not unique cannot be styled, and saying so is the only
-   * honest answer this panel has.
-   *
-   * The compiler already reaches this conclusion for the same reason, and its
-   * words are worth keeping: a class is derived from the id, so two nodes
-   * sharing one share a class, and "writing corrupts a node the author did not
-   * touch". It refuses to emit their rules.
-   *
-   * The editor has to refuse for a second reason the compiler does not face. The
-   * cascade is read from the PREPARED tree, where read-time repair has already
-   * dropped the later duplicate — but gating runs first, so a gated first node
-   * leaves a LATER one owning that id there, while every lookup in the stored
-   * document returns the first. The controls would then show and write one
-   * block while the provenance dots describe another, and typing into a field
-   * would silently change a block that is not on screen.
-   *
-   * Refused rather than reconciled: pointing the controls at the rendered node
-   * would not help, because a write is addressed by id and would still land on
-   * the first. There is no edit here that means what it appears to mean.
+   * One branch here, four inside. Narrowed through the RESULT rather than
+   * re-tested afterwards: a second `inspection === null` check in this body
+   * would put the branch back that the extraction removed, and a non-null
+   * assertion would state as fact what the guard already proved.
    */
-  if (editor.selectedId !== null && sharesItsId(editor, editor.selectedId)) {
-    return (
-      <div className="nx-style-inspector" data-empty="duplicate-id">
-        <p className="nx-inspector__note">
-          Another block on this page has the same id, so styles written here
-          could not be told apart. Give one of them a new id to style either.
-        </p>
-      </div>
-    );
-  }
-
-  if (inspection === null) {
-    return (
-      <div className="nx-style-inspector" data-empty="no-selection">
-        <p className="nx-inspector__note">Select a block to style it.</p>
-      </div>
-    );
-  }
-
-  if (inspection.sections.length === 0) {
-    return (
-      <div className="nx-style-inspector" data-empty="no-style-support">
-        <p className="nx-inspector__note">
-          This block does not offer style properties.
-        </p>
-      </div>
-    );
-  }
+  const availability = styleUnavailable(editor, inspection);
+  if (!availability.available) return availability.reason;
+  const inspected = availability.inspection;
 
   /*
    * ONE subject for the whole panel, and one live-breakpoint set.
@@ -407,23 +532,23 @@ export function StyleInspectorPanel({
    * asking about one node at one address.
    */
   const editing: EditedAddress = {
-    nodeId: inspection.nodeId,
+    nodeId: inspected.nodeId,
     blockType: subject?.blockType,
-    state: inspection.state,
-    breakpoint: inspection.breakpoint,
+    state: inspected.state,
+    breakpoint: inspected.breakpoint,
     labelOf: id => breakpointLabel(breakpoints, id),
   };
   const provenanceOf = provenanceReader({
     cascade,
     subject,
     live,
-    state: inspection.state,
-    breakpoint: inspection.breakpoint,
+    state: inspected.state,
+    breakpoint: inspected.breakpoint,
     breakpoints,
     onJumpToBreakpoint,
   });
 
-  const groups = inspection.sections.map(section => section.group);
+  const groups = inspected.sections.map(section => section.group);
   // Held rather than left to the accordion, so the open section survives a
   // change of selection. Falling back to the first is what keeps it valid when
   // the newly selected block does not offer the section that was open — an
@@ -438,22 +563,33 @@ export function StyleInspectorPanel({
 
   return (
     <div className="nx-style-inspector">
+      {/*
+       * Above the sections, because applying a class is the frequent action and
+       * it decides what the controls below are even editing. Webflow puts its
+       * selector field at the top of the Style panel for the same reason.
+       */}
+      <SelectedNodeClasses
+        editor={editor}
+        nodeId={inspected.nodeId}
+        library={classLibrary}
+        onCreateClass={onCreateClass}
+      />
       <Accordion
         type="single"
         collapsible
         value={open}
         onValueChange={setOpenGroup}
       >
-        {inspection.sections.map(section => (
+        {inspected.sections.map(section => (
           <StyleSectionItem
             // Keyed by node AND group: a bare group would let React reuse one
             // block's inputs for the next block's same-named section, so a field
             // would keep the previous block's uncommitted text.
-            key={`${inspection.nodeId}:${section.group}`}
+            key={`${inspected.nodeId}:${section.group}`}
             section={section}
-            nodeId={inspection.nodeId}
-            state={inspection.state}
-            breakpoint={inspection.breakpoint}
+            nodeId={inspected.nodeId}
+            state={inspected.state}
+            breakpoint={inspected.breakpoint}
             editor={editor}
             policy={policy}
             tokens={tokens}

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -429,7 +429,13 @@ function SelectedNodeClasses({
       library={library}
       nodeClassIds={findNode(editor.document.nodes, nodeId)?.classes ?? []}
       onNodeClassesChange={classIds =>
-        editor.applyAll([nodeClassesOp(nodeId, classIds)])
+        // `applyAll` answers null when the store refuses — a document at its
+        // byte limit rejects an edit the class rules found perfectly valid.
+        // Reported back so the selector keeps the draft rather than clearing
+        // it as though the write had landed.
+        editor.applyAll([nodeClassesOp(nodeId, classIds)]) === null
+          ? "refused"
+          : "applied"
       }
       onCreateClass={onCreateClass}
     />

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -382,18 +382,14 @@ function styleUnavailable(
     };
   }
 
-  if (inspection.sections.length === 0) {
-    return {
-      available: false,
-      reason: (
-        <div className="nx-style-inspector" data-empty="no-style-support">
-          <p className="nx-inspector__note">
-            This block does not offer style properties.
-          </p>
-        </div>
-      ),
-    };
-  }
+  /*
+   * A block offering no style properties is NOT unavailable, and that is the
+   * distinction this function turns on. The three refusals above are about
+   * there being no single node an edit could address — a multi-selection, an
+   * ambiguous id, nothing selected. This one is only about the block's own
+   * controls, and named classes compile independently of them: such a block
+   * can still carry a class, so the class surface has to survive it.
+   */
   return { available: true, inspection };
 }
 
@@ -423,6 +419,13 @@ function SelectedNodeClasses({
   if (onCreateClass === undefined) return null;
   return (
     <ClassSelector
+      /*
+       * Keyed by NODE, for the reason the style sections are. The typed query
+       * and the highlighted row are state about the node in hand; unkeyed,
+       * React reuses this component when the selection changes and Enter can
+       * apply the previous block's pending choice to the new one.
+       */
+      key={nodeId}
       library={library}
       nodeClassIds={findNode(editor.document.nodes, nodeId)?.classes ?? []}
       onNodeClassesChange={classIds =>
@@ -574,6 +577,11 @@ export function StyleInspectorPanel({
         library={classLibrary}
         onCreateClass={onCreateClass}
       />
+      {inspected.sections.length === 0 ? (
+        <p className="nx-inspector__note" data-empty="no-style-support">
+          This block does not offer style properties.
+        </p>
+      ) : null}
       <Accordion
         type="single"
         collapsible


### PR DESCRIPTION
Closes the last open thread on the merged #1298. Both class surfaces shipped and nothing rendered either, so the feature did not exist for an author.

## Where it mounts, and why there

Above the style sections. Applying a class is the frequent action and it decides what the controls below are even editing — Webflow puts its selector field at the top of the Style panel for the same reason, and the C-9 research recorded that as the placement.

## The host wires only what it alone can reach

`classes` is a patchable field on the `update` op, so **applying and removing an existing class is written by the inspector itself**. Requiring a callback would make every host rebuild an op this panel is already holding all the parts of.

Only creation is reported outward, as one intent rather than two — the class has no id until the host has stored it, and the site-style write is not reachable from `packages/builder`.

**Removing the last class unsets the field** rather than storing `[]`. The field is optional and both forms mean the same to every reader, so the empty array leaves a key that says nothing, and an inverse built from it would restore that key on undo.

## Two signals, not one overloaded value

`onCreateClass` is what opts a host in. `classLibrary` being `undefined` then means the read is in flight, which the selector draws as a loading state. Collapsed onto one value, a host mid-load and a host with no class surface at all would be drawn identically — and only one of them has a field about to fill. Both cases are asserted.

## The complexity gate, and what it turned up

Mounting pushed `StyleInspectorPanel` from under the threshold to cognitive **18**. Extracting the mount took it to 16 — still over — so the four reasons the panel has nothing to style are now gathered into one function. It returns a **discriminated result** rather than a nullable element, so the body narrows through it instead of re-testing `inspection === null` (which would put back the branch the extraction removed) or asserting non-null (which would state as fact what the guard just proved). Introduced complexity is now **0**, and the panel has no finding at all.

Break-verifying that guard found **the fourth had never had a test** — the wrapper's no-selection case covers `InspectorPanel`, not this panel, and the two say different words. Breaking the shared guard failed three of four. It now fails all four.

## Gates

Build, vitest (**2335 passed**, 80 files), check-types, package lint `--max-warnings 0`, root eslint, `lint:design`, `lint:workspace`, comment convention, and `check-changesets` run the way CI runs it — all exit 0. Fallow: every `*_introduced` at **0**.

Breaks verified, each failing only its named tests: gating on the library instead of the opt-in callback, storing `[]` instead of unsetting, and disabling the availability guards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added named-class selection to the Style Inspector.
  * Users can apply, remove, and create classes from the inspector.
  * Class changes now provide clear feedback when a write is refused.
  * Class selections remain intact when changes cannot be saved.
  * Style controls remain available with an inline notice when style support is unavailable.

* **Bug Fixes**
  * Improved handling of empty class selections and cleared class values.
  * Ensured class-selector options and creation actions are correctly surfaced through the Inspector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->