### PR TITLE
fix(root): typecheck on push, and say when the gates tested a dirty tree

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -33,6 +33,22 @@ unset GIT_DIR GIT_WORK_TREE
 
 set -e
 
+# What is uncommitted RIGHT NOW, recorded before anything below can change it.
+#
+# Every gate in this hook runs against the working tree, and Git then pushes
+# HEAD. Those are different trees whenever anything is uncommitted: an unstaged
+# fix over a broken commit produces a green for a commit that is still broken,
+# and the author has no way to tell from the output.
+#
+# Recorded rather than acted on. Stashing would be a hook rewriting the tree
+# under someone mid-task, and testing a detached HEAD means a second checkout
+# and an install to match it — slow, and a new way to fail. The harm here is
+# the false confidence, not the untested state, so the fix is to say so.
+#
+# `|| true` because a status that cannot be read is not a reason to refuse a
+# push, and this runs under `set -e`.
+DIRTY="$(git status --porcelain 2>/dev/null || true)"
+
 # The two repo-wide lints CI gates on that `turbo lint` does not run. Both
 # finish in well under a second, and neither was reachable from any hook, so
 # knowing they existed was something each person carried privately: an `hsl()`
@@ -45,6 +61,21 @@ pnpm lint:workspace
 pnpm turbo lint --continue \
   --filter='./packages/*'
 pnpm run build
+
+# Types AFTER the build, and over every package rather than the changed ones.
+#
+# The order is load-bearing: `check-types` depends on `^check-types` and never
+# builds, so it reads whatever `dist` survived — on an unbuilt tree it fails for
+# a reason that has nothing to do with the diff. `pnpm run build` above is what
+# makes it answerable.
+#
+# Unfiltered because the breakage a shared package inflicts on its dependents
+# is overwhelmingly an API or type break, and this is the task that catches it.
+# It is also the affordable way to do that: `lint` and `build` above already
+# run repo-wide, so types were the one whole-repo question this hook was not
+# asking. A dependent TEST sweep is the expensive one and stays in CI, where
+# nobody is waiting on it.
+pnpm turbo check-types --continue
 
 # The TESTS of the packages this branch actually changes.
 #
@@ -85,4 +116,12 @@ elif [ "$GATE_STATUS" -ne 0 ]; then
 elif [ -n "$GATE_FILTERS" ]; then
   # shellcheck disable=SC2086 -- one flag per line, intentionally word-split
   pnpm turbo test --continue $GATE_FILTERS
+fi
+
+# Last, so it is the line still on screen when the push proceeds.
+if [ -n "$DIRTY" ]; then
+  echo ""
+  echo "pre-push: NOTE — these gates ran against your working tree, which has"
+  echo "  uncommitted changes. Git is pushing HEAD, which is a different tree."
+  echo "  A green here does not describe the commit being pushed."
 fi

--- a/scripts/husky-hooks.test.mjs
+++ b/scripts/husky-hooks.test.mjs
@@ -116,4 +116,66 @@ describe("the pre-push hook specifically", () => {
   it("declares a POSIX shell, so dash and Git Bash both accept it", async () => {
     expect(await hook("pre-push")).toMatch(/^#!\/usr\/bin\/env sh\r?\n/);
   });
+
+  it("typechecks the whole repo, which nothing here did before", async () => {
+    // `lint` and `build` above already run repo-wide, so types were the one
+    // whole-repo question this hook was not asking — and an API or type break
+    // is how a shared package breaks the packages that depend on it.
+    expect(shellCode(await hook("pre-push"))).toMatch(
+      /^\s*pnpm turbo check-types\b/m
+    );
+  });
+
+  it("typechecks AFTER the build, which is what makes it answerable", async () => {
+    /*
+     * `check-types` depends on `^check-types` and never builds, so it reads
+     * whatever `dist` survived. Run before the build it fails on an unbuilt
+     * tree for a reason that has nothing to do with the diff — a red that
+     * teaches the next person to stop reading this hook's output.
+     */
+    const source = shellCode(await hook("pre-push"));
+
+    const buildAt = source.search(/^\s*pnpm run build\b/m);
+    const typesAt = source.search(/^\s*pnpm turbo check-types\b/m);
+
+    expect(buildAt).toBeGreaterThan(-1);
+    expect(typesAt).toBeGreaterThan(-1);
+    expect(buildAt).toBeLessThan(typesAt);
+  });
+
+  it("records what is uncommitted BEFORE the first gate runs", async () => {
+    /*
+     * Every gate here runs against the working tree while Git pushes HEAD, so
+     * a green describes a different tree whenever anything is uncommitted.
+     * Reading the status after the gates would let lint-staged, a formatter or
+     * a build artefact decide the answer.
+     */
+    const source = shellCode(await hook("pre-push"));
+
+    const recordAt = source.search(/^DIRTY=/m);
+    const firstTool = source.search(FIRST_TOOL);
+
+    expect(recordAt).toBeGreaterThan(-1);
+    expect(recordAt).toBeLessThan(firstTool);
+  });
+
+  it("reports it LAST, so it is still on screen when the push proceeds", async () => {
+    const source = shellCode(await hook("pre-push"));
+
+    const recordAt = source.search(/^DIRTY=/m);
+    const reportAt = source.search(/^if \[ -n "\$DIRTY" \]/m);
+
+    expect(reportAt).toBeGreaterThan(-1);
+    expect(reportAt).toBeGreaterThan(recordAt);
+    // Nothing runs after it, which is the whole point of where it sits.
+    expect(source.slice(reportAt)).not.toMatch(FIRST_TOOL);
+  });
+
+  it("does not refuse the push over a status it could not read", async () => {
+    // A hook that cannot answer a question it only WARNS about must not turn
+    // that into a refusal — this runs under `set -e`.
+    expect(shellCode(await hook("pre-push"))).toMatch(
+      /^DIRTY=.*\|\| true\)"?$/m
+    );
+  });
 });


### PR DESCRIPTION
Two of the eight unworked findings on the merged #1266. Both let a green describe something other than what is being pushed.

## What the hook actually ran, which is not what I assumed

I re-read it rather than reasoning from my summary, and the scoping question I had been planning to answer turned out to be already answered:

```
pnpm turbo lint --filter='./packages/*'   <- ALL packages, never diff-scoped
pnpm run build                             <- whole repo
[gate-scope] -> pnpm turbo test $FILTERS   <- the ONLY filtered task
grep -c check-types .husky/pre-push        -> 0
```

So dependents were already covered for `lint` and `build`. **Types were simply never asked.** An API or type break is how a shared package breaks its dependents, and `check-types` is the task that catches it — so that is the change, rather than the dependent-expansion I had originally proposed for three tasks.

**It runs after the build, and the order is load-bearing.** `check-types` depends on `^check-types` and never builds, so on an unbuilt tree it fails for a reason unrelated to anyone's diff — on every push, reading as a broken repository rather than a misordered hook. `ci.yml` records the same constraint. The test asserts the ORDER; one asserting mere presence would pass on the broken arrangement.

Cost measured on two machines: **41s wall / 18-of-22 cached** here, **25s / 8-of-22** on another lane's. Load-dependent, tens of seconds, well under what tempts anyone toward `--no-verify`.

## The dirty-tree note

Every gate runs against the working tree; Git then pushes `HEAD`. An unstaged fix over a broken commit produces a green for a commit that is still broken, and nothing in the output says so.

It **warns** rather than stashing, checking out detached, or refusing. Stashing is a hook rewriting the tree under someone mid-task; a detached checkout needs a second install to match it. The harm is the false confidence, not the untested state. `|| true` on the status read so that an unreadable status cannot turn an advisory into a blocked push under `set -e` — that inversion would cost more than the thing it guards.

## No test sweep over dependents

Deliberately. That is the expensive one — it drags in `nextly` and `e2e`, which is where people reach for `--no-verify` and the whole gate is lost rather than a few minutes. It belongs in CI, where nobody is waiting.

## Verification

Three breaks against `scripts/husky-hooks.test.mjs`, each failing only its named test: removing `check-types`, moving it before the build, and reading the dirty state after the gates.

Those assert on the hook's **text**, which is a derivation and not the behaviour — so the real condition was also run in a real POSIX shell: dirty warns, clean stays silent, and an unreadable status under `set -e` survives with exit 0.

**And this branch's own push exercised it end to end**: `check-types` ran across 27 packages, 22 of 22 tasks succeeded, and the note correctly did not appear because the worktree was clean.

Gates: `pnpm test:scripts` (**672 passed**), `sh -n .husky/pre-push`, comment convention, and fallow with every `*_introduced` at 0. No changeset: nothing here ships in a published package.