### PR TITLE
feat(builder): a right-click menu over the block verbs

### DIFF
--- a/.changeset/canvas-right-click-menu.md
+++ b/.changeset/canvas-right-click-menu.md
@@ -32,4 +32,4 @@ Nothing happened before: the editor had no context menu anywhere, so an author l
 
 Right-clicking a block also selects it first, so the menu always acts on the block under the pointer. Right-clicking one of several selected blocks keeps that selection instead of replacing it.
 
-It is reached by pointer only for now. Every verb in it is already reachable without a pointer through the keystrokes, the block toolbar and the command palette, so this adds a route rather than becoming the only one.
+A touch long press opens it too, on the block under the finger. The platform's context-menu key reaches it from any block that draws a focusable control, since that sends the same event a right-click does; a block that draws none cannot open it, and neither can the canvas background. Every verb in it stays reachable without a pointer regardless, through the keystrokes, the block toolbar and the command palette, so this adds a route rather than becoming the only one.

--- a/.changeset/canvas-right-click-menu.md
+++ b/.changeset/canvas-right-click-menu.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Right-clicking a block on the canvas opens a menu.
+
+Nothing happened before: the editor had no context menu anywhere, so an author looking for the block's actions where every comparable builder puts them found nothing. The menu offers the same verbs the floating toolbar offers, in the same order, with the same availability and the same reasons — it is another way to reach them rather than a second list that can disagree. A verb that is unavailable stays visible and says why, because a menu that silently drops Delete answers "why can I not delete this" with nothing at all.
+
+Right-clicking a block also selects it first, so the menu always acts on the block under the pointer. Right-clicking one of several selected blocks keeps that selection instead of replacing it.
+
+It is reached by pointer only for now. Every verb in it is already reachable without a pointer through the keystrokes, the block toolbar and the command palette, so this adds a route rather than becoming the only one.

--- a/packages/builder/src/block-context-menu.test.tsx
+++ b/packages/builder/src/block-context-menu.test.tsx
@@ -210,6 +210,63 @@ describe("the canvas's right-click menu", () => {
     expect(screen.queryByRole("menu")).toBeNull();
   });
 
+  it("selects the pressed block before a touch long-press can open", () => {
+    /*
+     * Radix opens a long-press from its OWN 700ms pointerdown timer and never
+     * dispatches a `contextmenu` event, so the canvas's filtering — which runs
+     * on that event — never sees this route. Without moving the selection
+     * here, a long press on an unselected block opens the previous selection's
+     * verbs, and Delete among them acts on a block the author is not looking
+     * at. That is why the selection is asserted, not the menu: the menu here
+     * is Radix's to open, and the SUBJECT is what this must get right.
+     */
+    register();
+    const editor = editorSpy(pair(), "b");
+    const { container } = mount(editor);
+
+    fireEvent.pointerDown(blockElement(container), { pointerType: "touch" });
+
+    expect(editor.select).toHaveBeenCalledWith("a", "replace");
+  });
+
+  it("leaves a mouse press to the context event that follows it", () => {
+    // The control on the other side. A rule that selected on every pointer
+    // press would move the selection on the way to a plain left click, which
+    // the canvas already handles on its own event.
+    register();
+    const editor = editorSpy(pair(), "b");
+    const { container } = mount(editor);
+
+    fireEvent.pointerDown(blockElement(container), { pointerType: "mouse" });
+
+    expect(editor.select).not.toHaveBeenCalled();
+  });
+
+  it("stops a touch long-press that is not aimed at a block", () => {
+    /*
+     * Preventing the default is the mechanism, not a formality: Radix composes
+     * its pointer handler BEHIND this one and skips its own when the default
+     * has been prevented, so this is what keeps the timer from opening a menu
+     * over chrome or over text being edited.
+     *
+     * `fireEvent` returns false when a handler prevented the default, which is
+     * the only observable of that decision from here.
+     */
+    register();
+    const editor = editorSpy(pair(), "a");
+    const { container } = mount(editor);
+    const chrome = window.document.createElement("button");
+    chrome.setAttribute("data-nx-chrome", "");
+    blockElement(container).appendChild(chrome);
+
+    const notPrevented = fireEvent.pointerDown(chrome, {
+      pointerType: "touch",
+    });
+
+    expect(notPrevented).toBe(false);
+    expect(editor.select).not.toHaveBeenCalled();
+  });
+
   it("keeps an unavailable verb, carrying the reason it is unavailable", () => {
     /*
      * A lock is the one reason `toolbarActions` reports, because it is the one

--- a/packages/builder/src/block-context-menu.test.tsx
+++ b/packages/builder/src/block-context-menu.test.tsx
@@ -323,6 +323,34 @@ describe("the canvas's right-click menu", () => {
     expect(editor.select).not.toHaveBeenCalledWith("a", "replace");
   });
 
+  it("refuses a block that belongs to a canvas nested inside this one", () => {
+    /*
+     * A canvas rendered inside a block of another canvas sends its events up
+     * through the outer one. Answering for them opens the OUTER menu while the
+     * outer selection stays where it was, so its verbs act on a block nobody is
+     * pointing at — and Delete is among them.
+     *
+     * The inner canvas is built directly rather than by mounting a second
+     * editor: what is being asserted is the hit test's answer about ownership,
+     * and the markup is the whole of what it reads.
+     */
+    register();
+    const editor = editorSpy(pair(), "a");
+    const { container } = mount(editor);
+
+    const inner = window.document.createElement("div");
+    inner.className = "nx-canvas";
+    const innerBlock = window.document.createElement("div");
+    innerBlock.setAttribute(NODE_ID_ATTRIBUTE, "inner-block");
+    inner.appendChild(innerBlock);
+    blockElement(container).appendChild(inner);
+
+    fireEvent.contextMenu(innerBlock);
+
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(editor.select).not.toHaveBeenCalledWith("inner-block", "replace");
+  });
+
   it("keeps an unavailable verb, carrying the reason it is unavailable", () => {
     /*
      * A lock is the one reason `toolbarActions` reports, because it is the one

--- a/packages/builder/src/block-context-menu.test.tsx
+++ b/packages/builder/src/block-context-menu.test.tsx
@@ -23,7 +23,13 @@ import {
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
 import { ShortcutProvider } from "@nextlyhq/ui";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -210,60 +216,84 @@ describe("the canvas's right-click menu", () => {
     expect(screen.queryByRole("menu")).toBeNull();
   });
 
-  it("selects the pressed block before a touch long-press can open", () => {
+  it("acts on the pressed block when a long press opens the menu", () => {
     /*
-     * Radix opens a long-press from its OWN 700ms pointerdown timer and never
+     * Radix opens a long press from its OWN 700ms pointerdown timer and never
      * dispatches a `contextmenu` event, so the canvas's filtering — which runs
-     * on that event — never sees this route. Without moving the selection
-     * here, a long press on an unselected block opens the previous selection's
-     * verbs, and Delete among them acts on a block the author is not looking
-     * at. That is why the selection is asserted, not the menu: the menu here
-     * is Radix's to open, and the SUBJECT is what this must get right.
+     * on that event — never sees this route. Without carrying the pressed
+     * block across, the menu opens on the PREVIOUS selection, and Delete among
+     * its verbs acts on a block the author is not looking at.
+     *
+     * Driven as press-then-open rather than by waiting out the timer: the
+     * timer is Radix's, and what this component has to get right is the
+     * SUBJECT the menu opens on.
+     */
+    register();
+    const editor = editorSpy(pair(), "b");
+    const { container } = mount(editor);
+
+    vi.useFakeTimers();
+    try {
+      fireEvent.pointerDown(blockElement(container), {
+        pointerType: "touch",
+        clientX: 10,
+        clientY: 10,
+      });
+      // Nothing yet: this is a contact, not yet a gesture.
+      expect(editor.select).not.toHaveBeenCalled();
+
+      // Radix's own timer, run out. The menu opening is what carries the
+      // subject across, so the wait is the mechanism rather than a delay.
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+
+    expect(screen.getByRole("menu")).toBeTruthy();
+    expect(editor.select).toHaveBeenCalledWith("a", "replace");
+  });
+
+  it("does not move the selection on a press that never opens anything", () => {
+    /*
+     * The case that makes deferring necessary. Every touch contact begins as a
+     * pointerdown, and most become a scroll rather than a long press — Radix
+     * cancels its own timer on pointermove, but a selection made on contact
+     * would already have retargeted the inspector and the toolbar, and nothing
+     * puts it back.
      */
     register();
     const editor = editorSpy(pair(), "b");
     const { container } = mount(editor);
 
     fireEvent.pointerDown(blockElement(container), { pointerType: "touch" });
-
-    expect(editor.select).toHaveBeenCalledWith("a", "replace");
-  });
-
-  it("leaves a mouse press to the context event that follows it", () => {
-    // The control on the other side. A rule that selected on every pointer
-    // press would move the selection on the way to a plain left click, which
-    // the canvas already handles on its own event.
-    register();
-    const editor = editorSpy(pair(), "b");
-    const { container } = mount(editor);
-
-    fireEvent.pointerDown(blockElement(container), { pointerType: "mouse" });
+    fireEvent.pointerMove(blockElement(container), { pointerType: "touch" });
 
     expect(editor.select).not.toHaveBeenCalled();
   });
 
-  it("stops a touch long-press that is not aimed at a block", () => {
+  it("leaves the caret's own behaviour to the browser", () => {
     /*
-     * Preventing the default is the mechanism, not a formality: Radix composes
-     * its pointer handler BEHIND this one and skips its own when the default
-     * has been prevented, so this is what keeps the timer from opening a menu
-     * over chrome or over text being edited.
-     *
-     * `fireEvent` returns false when a handler prevented the default, which is
-     * the only observable of that decision from here.
+     * The press must not be cancelled. It fires at the start of every contact,
+     * long before anything knows whether it will become a long press, so
+     * preventing the default there takes caret placement and text selection
+     * away from an author who was only tapping into a sentence. Rejection is
+     * done by withholding the event from above instead — asserted here as the
+     * default surviving, which is the observable of that choice.
      */
     register();
     const editor = editorSpy(pair(), "a");
     const { container } = mount(editor);
-    const chrome = window.document.createElement("button");
-    chrome.setAttribute("data-nx-chrome", "");
-    blockElement(container).appendChild(chrome);
+    const editable = window.document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    blockElement(container).appendChild(editable);
 
-    const notPrevented = fireEvent.pointerDown(chrome, {
+    const notPrevented = fireEvent.pointerDown(editable, {
       pointerType: "touch",
     });
 
-    expect(notPrevented).toBe(false);
+    expect(notPrevented).toBe(true);
     expect(editor.select).not.toHaveBeenCalled();
   });
 

--- a/packages/builder/src/block-context-menu.test.tsx
+++ b/packages/builder/src/block-context-menu.test.tsx
@@ -297,6 +297,32 @@ describe("the canvas's right-click menu", () => {
     expect(editor.select).not.toHaveBeenCalled();
   });
 
+  it("opens on the block the gesture named, not the one pressed before it", () => {
+    /*
+     * A rendered block can be focusable on its own — `core/button` draws a real
+     * `button` — so a menu key reaches this as a context event with NO press
+     * before it. A target remembered from an earlier press would still be
+     * sitting there, and the menu would open on that block instead: Delete and
+     * Duplicate then act on something the author is not looking at, which is
+     * the same defect as the touch case arriving by the opposite route.
+     */
+    register();
+    const editor = editorSpy(pair(), "b");
+    const { container } = mount(editor);
+    const first = blockElement(container);
+    const second = container.querySelector(`[${NODE_ID_ATTRIBUTE}="b"]`);
+    if (second === null) throw new Error("expected the second block");
+
+    // A press on one block, which opens nothing.
+    fireEvent.pointerDown(first, { pointerType: "touch" });
+    // Then the gesture that DOES open, aimed somewhere else.
+    fireEvent.contextMenu(second);
+
+    // Never "a", which is what the stale press was pointing at. `b` is already
+    // the selection, so the correct behaviour is to leave it alone entirely.
+    expect(editor.select).not.toHaveBeenCalledWith("a", "replace");
+  });
+
   it("keeps an unavailable verb, carrying the reason it is unavailable", () => {
     /*
      * A lock is the one reason `toolbarActions` reports, because it is the one

--- a/packages/builder/src/block-context-menu.test.tsx
+++ b/packages/builder/src/block-context-menu.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+
+/**
+ * The menu's wiring, which is the half `toolbar-actions.test.ts` cannot see.
+ *
+ * That file already decides which verbs appear and whether each is available.
+ * What is only true HERE is that the menu opens on the gesture at all, that it
+ * offers the SAME verbs the bar offers rather than a second list, and that
+ * choosing one reaches the same verb a keystroke reaches.
+ *
+ * Rendered around a real `Canvas`, for the reason `block-toolbar.test` gives:
+ * the menu's trigger is an ancestor of the canvas and its whole job is to
+ * receive an event the canvas decided to let through, so a stub canvas could
+ * not exhibit the case that matters.
+ *
+ * @module block-context-menu.test
+ */
+import {
+  clearBlocks,
+  hasBlock,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+import { ShortcutProvider } from "@nextlyhq/ui";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BlockContextMenu } from "./block-context-menu";
+import { Canvas } from "./canvas";
+import type { EditorState } from "./editor-state";
+import { BlockKeyboardActions } from "./keyboard-actions";
+import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+});
+
+function register() {
+  if (hasBlock("acme/leaf")) return;
+  registerBlocks(
+    [
+      {
+        name: "acme/leaf",
+        version: 1,
+        description: "A leaf.",
+        example: { props: {} },
+        editor: { label: "Leaf" },
+        render: () => React.createElement("p", null, "leaf"),
+      },
+    ] as never,
+    { source: "block-context-menu-test" }
+  );
+}
+
+/** Two blocks, so `up` and `down` each have a case that is available. */
+function pair(extra: Partial<BlockNode> = {}): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      { id: "a", type: "acme/leaf", version: 1, props: {}, ...extra },
+      { id: "b", type: "acme/leaf", version: 1, props: {} },
+    ],
+  } as BlockDocument;
+}
+
+function editorSpy(doc: BlockDocument, selectedId: string | null): EditorState {
+  return {
+    document: doc,
+    selectedId,
+    selection: {
+      ids: selectedId === null ? [] : [selectedId],
+      primary: selectedId,
+    },
+    select: vi.fn(),
+    apply: vi.fn(() => doc),
+    applyAll: vi.fn(() => doc),
+    undo: vi.fn(),
+    redo: vi.fn(),
+    canUndo: false,
+    canRedo: false,
+    undoDepth: 0,
+  } as unknown as EditorState;
+}
+
+function mount(editor: EditorState) {
+  return render(
+    <ShortcutProvider>
+      <BlockKeyboardActions editor={editor}>
+        <BlockContextMenu editor={editor}>
+          <Canvas
+            document={editor.document}
+            siteStyles={{ css: "", classes: {} } as never}
+            selectedId={editor.selectedId}
+            onSelect={editor.select}
+          />
+        </BlockContextMenu>
+      </BlockKeyboardActions>
+    </ShortcutProvider>
+  );
+}
+
+/** The rendered block, which is what a secondary click is aimed at. */
+function blockElement(container: HTMLElement): Element {
+  const element = container.querySelector(`[${NODE_ID_ATTRIBUTE}="a"]`);
+  if (element === null) throw new Error("expected a rendered block");
+  return element;
+}
+
+describe("the canvas's right-click menu", () => {
+  it("opens on a secondary click over a block", () => {
+    register();
+    const { container } = mount(editorSpy(pair(), "a"));
+    expect(screen.queryByRole("menu")).toBeNull();
+
+    fireEvent.contextMenu(blockElement(container));
+
+    expect(screen.getByRole("menu")).toBeTruthy();
+  });
+
+  it("offers the verbs the toolbar offers, in the toolbar's words", () => {
+    /*
+     * The palette deliberately says "Duplicate block", because a palette row is
+     * read in a list with no context. This menu is drawn AT the block, like the
+     * bar, so it takes the bar's shorter wording — and taking the LIST from the
+     * same call is what keeps a verb from appearing here and not there.
+     */
+    register();
+    const { container } = mount(editorSpy(pair(), "a"));
+    fireEvent.contextMenu(blockElement(container));
+
+    const labels = screen
+      .getAllByRole("menuitem")
+      .map(item => item.textContent);
+    expect(labels).toEqual([
+      "Select parent",
+      "Move up",
+      "Move down",
+      "Duplicate",
+      "Delete",
+    ]);
+  });
+
+  it("runs the verb the keystrokes run", () => {
+    /*
+     * Committed on `pointerup`, which is Radix's own path and the only one that
+     * works here. Its item synthesises the click on pointer-up ONLY when it saw
+     * no pointer-down, because a real browser would deliver the click itself —
+     * and jsdom delivers neither. So a full down-then-up sequence selects
+     * nothing, and a bare `fireEvent.click` reaches none of it either. Both
+     * leave the menu open and the verb unrun, which is a menu that works
+     * perfectly well for a real author and fails its own test.
+     */
+    register();
+    const editor = editorSpy(pair(), "a");
+    const { container } = mount(editor);
+    fireEvent.contextMenu(blockElement(container));
+
+    const duplicate = screen.getByRole("menuitem", { name: "Duplicate" });
+    fireEvent.pointerUp(duplicate, { pointerType: "mouse", button: 0 });
+
+    // Through the editor's own `applyAll`, which is the op path the duplicate
+    // verb takes for the keystroke and the bar alike. Asserting a spy passed to
+    // the menu would prove only that the menu called what the test handed it.
+    expect(editor.applyAll).toHaveBeenCalled();
+  });
+
+  it("keeps an unavailable verb, carrying the reason it is unavailable", () => {
+    /*
+     * A lock is the one reason `toolbarActions` reports, because it is the one
+     * an author can act on and nothing on the canvas explains it. Removing the
+     * item instead answers "why can I not delete this" with nothing at all.
+     */
+    register();
+    const locked = pair({ locked: true } as Partial<BlockNode>);
+    const { container } = mount(editorSpy(locked, "a"));
+    fireEvent.contextMenu(blockElement(container));
+
+    const remove = screen.getByRole("menuitem", { name: "Delete" });
+    expect(remove.getAttribute("data-disabled")).not.toBeNull();
+    expect(remove.getAttribute("title")).not.toBe("Delete");
+  });
+});

--- a/packages/builder/src/block-context-menu.test.tsx
+++ b/packages/builder/src/block-context-menu.test.tsx
@@ -168,6 +168,48 @@ describe("the canvas's right-click menu", () => {
     expect(editor.applyAll).toHaveBeenCalled();
   });
 
+  it("leaves editor chrome to the browser's own menu", () => {
+    /*
+     * The toolbar and the appenders are drawn inside the canvas root, so they
+     * sit inside this menu's trigger — and an appender for an empty container
+     * is drawn inside the container's own element. Merely declining to select
+     * there is not enough: the gesture would still reach the trigger and offer
+     * the block's verbs for a press aimed at a button that is not a block.
+     */
+    register();
+    const { container } = mount(editorSpy(pair(), "a"));
+    // INSIDE the block, which is the case that discriminates. Chrome drawn on
+    // the canvas background resolves to no node anyway, so a fixture there
+    // passes whether or not this rule exists — the appender drawn inside an
+    // empty container is the shape that would otherwise reach the trigger with
+    // a block id already resolved.
+    const chrome = window.document.createElement("button");
+    chrome.setAttribute("data-nx-chrome", "");
+    blockElement(container).appendChild(chrome);
+
+    fireEvent.contextMenu(chrome);
+
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("leaves text being edited to the browser's own menu", () => {
+    /*
+     * Spelling, selection and clipboard for a caret have no replacement here,
+     * so replacing the native menu with "Move up" mid-sentence is a straight
+     * loss. The inline editor stops pointer and click but not this one.
+     */
+    register();
+    const { container } = mount(editorSpy(pair(), "a"));
+    const block = blockElement(container);
+    const editable = window.document.createElement("div");
+    editable.setAttribute("contenteditable", "true");
+    block.appendChild(editable);
+
+    fireEvent.contextMenu(editable);
+
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
   it("keeps an unavailable verb, carrying the reason it is unavailable", () => {
     /*
      * A lock is the one reason `toolbarActions` reports, because it is the one
@@ -179,8 +221,15 @@ describe("the canvas's right-click menu", () => {
     const { container } = mount(editorSpy(locked, "a"));
     fireEvent.contextMenu(blockElement(container));
 
-    const remove = screen.getByRole("menuitem", { name: "Delete" });
+    const remove = screen
+      .getAllByRole("menuitem")
+      .find(item => item.textContent?.startsWith("Delete"));
+    if (remove === undefined) throw new Error("expected a Delete item");
     expect(remove.getAttribute("data-disabled")).not.toBeNull();
-    expect(remove.getAttribute("title")).not.toBe("Delete");
+    // VISIBLE, not a `title`. A disabled item has `pointer-events-none` and is
+    // skipped by keyboard navigation, so a tooltip on it is unreachable by
+    // either input — the reason has to be in the item's own content.
+    expect(remove.textContent).toContain("This block is locked.");
+    expect(remove.getAttribute("title")).toBeNull();
   });
 });

--- a/packages/builder/src/block-context-menu.tsx
+++ b/packages/builder/src/block-context-menu.tsx
@@ -32,7 +32,14 @@
  * the toolbar, so it takes the toolbar's shorter "Duplicate" for the same
  * reason the toolbar does.
  *
- * ## A disabled verb stays, and says why
+ * ## A disabled verb stays, and says why IN THE MENU
+ *
+ * The reason is VISIBLE text inside the item, not a `title`. The toolbar can
+ * use a tooltip because its buttons stay hoverable; a disabled menu item does
+ * not, since the shared item style sets `data-[disabled]:pointer-events-none`
+ * — and Radix skips disabled items in keyboard navigation, so there is no
+ * route to a tooltip by either input. A `title` there is an explanation that
+ * exists in the markup and reaches nobody.
  *
  * `toolbarActions` sets `reason` only for a cause an author can act on — a lock
  * — and leaves self-evident ones unsaid. So an unavailable verb is drawn
@@ -143,18 +150,25 @@ export function BlockContextMenu({
               {DESTRUCTIVE.has(action.id) ? <ContextMenuSeparator /> : null}
               <ContextMenuItem
                 disabled={!action.enabled}
-                // The reason a lock gives, spelled exactly as the toolbar
-                // spells it. Carrying it to a screen reader as well is not
-                // solved here: `aria-description` has uneven support, and a
-                // description on a DISABLED item is inconsistently announced,
-                // so this matches the toolbar rather than inventing a second
-                // behaviour that has not been measured.
-                title={action.reason ?? action.label}
+                // Stacked once there is a reason, so the explanation sits under
+                // the verb rather than running on from it.
+                className={
+                  action.reason === undefined
+                    ? undefined
+                    : "flex-col items-start gap-0.5"
+                }
                 onSelect={() => {
                   run[action.id]();
                 }}
               >
-                {action.label}
+                <span>{action.label}</span>
+                {action.reason === undefined ? null : (
+                  // Part of the item's own content, so it is both on screen and
+                  // in the name the item is announced by. Nothing here stays
+                  // hoverable or focusable once disabled, so an explanation
+                  // carried outside the content would reach nobody.
+                  <span className="text-xs opacity-80">{action.reason}</span>
+                )}
               </ContextMenuItem>
             </React.Fragment>
           ))}

--- a/packages/builder/src/block-context-menu.tsx
+++ b/packages/builder/src/block-context-menu.tsx
@@ -62,6 +62,20 @@
  * touch long-press, and the canvas root already carries a full set for
  * dragging; on one element the two would overwrite each other.
  *
+ * ## Touch and pen open it by a different route, filtered the same way
+ *
+ * Radix opens a long-press from its own 700ms `pointerdown` timer and never
+ * dispatches a `contextmenu` event, so the canvas's own filtering — which runs
+ * on that event — does not see it at all. Left alone, a long press on a block
+ * that was not selected would open the PREVIOUS selection's verbs, and Delete
+ * among them acts on a block the author is not looking at.
+ *
+ * So the pointer-down below asks {@link contextMenuTargetOf}, the same
+ * question the canvas asks, and does one of two things: moves the selection to
+ * the pressed block, or prevents the default — which is what stops Radix's
+ * timer, since it composes its handler behind this one and skips its own when
+ * the default has been prevented.
+ *
  * ## This menu is reached by POINTER only, and that is a limitation
  *
  * Measured in a real browser: a right-click opens it correctly, at the pointer,
@@ -91,6 +105,7 @@ import {
 import * as React from "react";
 
 import { blockActionRunners } from "./builder-commands";
+import { contextMenuTargetOf } from "./canvas";
 import type { EditorState } from "./editor-state";
 import { useBlockActionsContext } from "./keyboard-actions";
 import { toolbarActions } from "./toolbar-actions";
@@ -132,10 +147,36 @@ export function BlockContextMenu({
   );
   const run = React.useMemo(() => blockActionRunners(verbs), [verbs]);
 
+  /*
+   * The touch and pen route into this menu, which arrives as a pointer press
+   * rather than as a context event. Mouse presses are left alone: they open
+   * through `contextmenu`, which the canvas has already filtered and selected
+   * for by the time Radix sees it.
+   */
+  const select = editor.select;
+  const pressed = React.useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (event.pointerType === "mouse") return;
+      const id = contextMenuTargetOf(event.target);
+      if (id === null) {
+        // Nothing to act on. Preventing the default is what keeps Radix's
+        // long-press timer from opening a menu over chrome or over text.
+        event.preventDefault();
+        return;
+      }
+      // Already chosen means already correct, and replacing would drop the
+      // rest of a multiple selection the press was meant to act on.
+      if (!selectedIds.includes(id)) select(id, "replace");
+    },
+    [select, selectedIds]
+  );
+
   return (
     <ContextMenu>
       <ContextMenuTrigger asChild>
-        <div style={TRANSPARENT_WRAPPER}>{children}</div>
+        <div style={TRANSPARENT_WRAPPER} onPointerDown={pressed}>
+          {children}
+        </div>
       </ContextMenuTrigger>
       {/*
         Nothing to act on means nothing to draw. The canvas stops the event

--- a/packages/builder/src/block-context-menu.tsx
+++ b/packages/builder/src/block-context-menu.tsx
@@ -164,20 +164,25 @@ export function BlockContextMenu({
    * update here would rerender the canvas on every contact.
    */
   const pressedTarget = React.useRef<string | null>(null);
-  const notePress = React.useCallback(
-    (event: React.PointerEvent<HTMLDivElement>) => {
+  const noteTarget = React.useCallback(
+    (event: React.SyntheticEvent<HTMLDivElement>) => {
       pressedTarget.current = contextMenuTargetOf(event.target);
     },
     []
   );
   const opened = React.useCallback(
     (open: boolean) => {
-      if (!open) return;
+      // CONSUMED, whether or not this is an opening. A value left behind is a
+      // value some later opening can read: a keyboard menu key arrives as a
+      // context event with no press before it, and would otherwise be answered
+      // with whatever the last press happened to be pointing at.
       const id = pressedTarget.current;
-      // Already chosen means already correct — the mouse route selected on the
-      // context event — and replacing would drop the rest of a multiple
+      pressedTarget.current = null;
+      if (!open || id === null) return;
+      // Already chosen means already correct — every route selects through the
+      // canvas first — and replacing would drop the rest of a multiple
       // selection the gesture was meant to act on.
-      if (id === null || selectedIds.includes(id)) return;
+      if (selectedIds.includes(id)) return;
       select(id, "replace");
     },
     [select, selectedIds]
@@ -186,7 +191,11 @@ export function BlockContextMenu({
   return (
     <ContextMenu onOpenChange={opened}>
       <ContextMenuTrigger asChild>
-        <div style={TRANSPARENT_WRAPPER} onPointerDown={notePress}>
+        <div
+          style={TRANSPARENT_WRAPPER}
+          onPointerDown={noteTarget}
+          onContextMenu={noteTarget}
+        >
           {children}
         </div>
       </ContextMenuTrigger>

--- a/packages/builder/src/block-context-menu.tsx
+++ b/packages/builder/src/block-context-menu.tsx
@@ -84,21 +84,30 @@
  * this one's, and it does it by withholding the event — see its pointer-down
  * rule for why `preventDefault` here would be the wrong instrument.
  *
- * ## This menu is reached by POINTER only, and that is a limitation
+ * ## What opens it, and what is known about the keyboard
  *
- * Measured in a real browser: a right-click opens it correctly, at the pointer,
- * both at scale 1 and under the canvas's CSS `zoom`. Shift+F10 with the canvas
- * focused does NOT open it, and the structure says why — the focusable canvas
- * region is an ANCESTOR of this trigger, so a keyboard-invoked context event
- * originating there bubbles away from it rather than into it.
+ * Measured in a real browser: a right-click opens it at the pointer, both at
+ * scale 1 and under the canvas's CSS `zoom`, and a touch long-press opens it
+ * through Radix's own timer.
  *
- * It is shipped anyway because it takes nothing away. Every verb here is
- * already reachable without a pointer, through the keystrokes, the block
- * toolbar's roving tab stop, and the command palette — this is a fourth route
- * to them, not the only one. The fix is not to move this trigger up, which
- * would open a block menu over chrome that is not a block; it is to make the
- * blocks themselves focusable — a block is what a context-menu key should be
- * aimed at anyway, and a focusable one would carry this trigger with it.
+ * The platform's context-menu key sends a `contextmenu` event from whatever
+ * holds focus, so it reaches this by the same path a right-click does —
+ * PROVIDED focus is on something inside a block. A block that renders a
+ * focusable control is: `core/button` draws an anchor carrying the node marker
+ * itself. Focus on the canvas REGION is not, and cannot be: that region is an
+ * ancestor of this trigger, so an event from it travels away rather than into
+ * it, and there is no block under it to act on either way.
+ *
+ * That keyboard path is reasoned, not measured. The automation available here
+ * cannot generate the event — a synthesised `Shift+F10` produces no
+ * `contextmenu` event at all, measured with a capture listener, so it can
+ * neither confirm nor refute the behaviour and no claim is made from it.
+ *
+ * What does not depend on any of it: every verb here is reachable without a
+ * pointer regardless, through the keystrokes, the block toolbar's roving tab
+ * stop, and the command palette. This is one more route to them, never the
+ * only one — which is why blocks that carry no focusable control cost nothing
+ * by being unable to open it.
  *
  * @module block-context-menu
  */
@@ -113,7 +122,7 @@ import {
 import * as React from "react";
 
 import { blockActionRunners } from "./builder-commands";
-import { contextMenuTargetOf } from "./canvas";
+import { CANVAS_ROOT_CLASS, contextMenuTargetOf } from "./canvas";
 import type { EditorState } from "./editor-state";
 import { useBlockActionsContext } from "./keyboard-actions";
 import { toolbarActions } from "./toolbar-actions";
@@ -166,7 +175,15 @@ export function BlockContextMenu({
   const pressedTarget = React.useRef<string | null>(null);
   const noteTarget = React.useCallback(
     (event: React.SyntheticEvent<HTMLDivElement>) => {
-      pressedTarget.current = contextMenuTargetOf(event.target);
+      /*
+       * This wrapper's OWN canvas, which is the outermost one beneath it. A
+       * canvas nested inside a block of that canvas is deeper, so it is not
+       * what `querySelector` returns — and a block belonging to it is refused
+       * here rather than answered for by this menu.
+       */
+      const root = event.currentTarget.querySelector(`.${CANVAS_ROOT_CLASS}`);
+      pressedTarget.current =
+        root === null ? null : contextMenuTargetOf(event.target, root);
     },
     []
   );

--- a/packages/builder/src/block-context-menu.tsx
+++ b/packages/builder/src/block-context-menu.tsx
@@ -62,19 +62,27 @@
  * touch long-press, and the canvas root already carries a full set for
  * dragging; on one element the two would overwrite each other.
  *
- * ## Touch and pen open it by a different route, filtered the same way
+ * ## Touch and pen open it by a different route, and act on the same subject
  *
  * Radix opens a long-press from its own 700ms `pointerdown` timer and never
- * dispatches a `contextmenu` event, so the canvas's own filtering — which runs
- * on that event — does not see it at all. Left alone, a long press on a block
- * that was not selected would open the PREVIOUS selection's verbs, and Delete
- * among them acts on a block the author is not looking at.
+ * dispatches a `contextmenu` event, so the canvas's filtering — which runs on
+ * that event — does not see it at all. Left alone, a long press on a block that
+ * was not selected opens the PREVIOUS selection's verbs, and Delete among them
+ * acts on a block the author is not looking at.
  *
- * So the pointer-down below asks {@link contextMenuTargetOf}, the same
- * question the canvas asks, and does one of two things: moves the selection to
- * the pressed block, or prevents the default — which is what stops Radix's
- * timer, since it composes its handler behind this one and skips its own when
- * the default has been prevented.
+ * The press is therefore NOTED and nothing more. Acting on it would be acting
+ * on a contact that has not yet become anything: a press becomes a long press
+ * only after 700ms, and most never do — selecting there retargets the
+ * inspector and the toolbar every time the author scrolls the canvas with a
+ * finger, and Radix's own cancellation on `pointermove` would not put it back.
+ *
+ * The selection moves when the menu actually OPENS, which is the first moment
+ * a long press is known to be one. For a mouse the canvas has already selected
+ * by then, on the context event, and the check below makes that a no-op.
+ *
+ * Rejecting a press aimed at chrome or at text is the canvas's job rather than
+ * this one's, and it does it by withholding the event — see its pointer-down
+ * rule for why `preventDefault` here would be the wrong instrument.
  *
  * ## This menu is reached by POINTER only, and that is a limitation
  *
@@ -147,34 +155,38 @@ export function BlockContextMenu({
   );
   const run = React.useMemo(() => blockActionRunners(verbs), [verbs]);
 
-  /*
-   * The touch and pen route into this menu, which arrives as a pointer press
-   * rather than as a context event. Mouse presses are left alone: they open
-   * through `contextmenu`, which the canvas has already filtered and selected
-   * for by the time Radix sees it.
-   */
   const select = editor.select;
-  const pressed = React.useCallback(
+  /*
+   * What the last press was aimed at, remembered rather than acted on.
+   *
+   * A ref because nothing renders from it and because the value has to survive
+   * from the press to the open without causing a render in between — a state
+   * update here would rerender the canvas on every contact.
+   */
+  const pressedTarget = React.useRef<string | null>(null);
+  const notePress = React.useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      if (event.pointerType === "mouse") return;
-      const id = contextMenuTargetOf(event.target);
-      if (id === null) {
-        // Nothing to act on. Preventing the default is what keeps Radix's
-        // long-press timer from opening a menu over chrome or over text.
-        event.preventDefault();
-        return;
-      }
-      // Already chosen means already correct, and replacing would drop the
-      // rest of a multiple selection the press was meant to act on.
-      if (!selectedIds.includes(id)) select(id, "replace");
+      pressedTarget.current = contextMenuTargetOf(event.target);
+    },
+    []
+  );
+  const opened = React.useCallback(
+    (open: boolean) => {
+      if (!open) return;
+      const id = pressedTarget.current;
+      // Already chosen means already correct — the mouse route selected on the
+      // context event — and replacing would drop the rest of a multiple
+      // selection the gesture was meant to act on.
+      if (id === null || selectedIds.includes(id)) return;
+      select(id, "replace");
     },
     [select, selectedIds]
   );
 
   return (
-    <ContextMenu>
+    <ContextMenu onOpenChange={opened}>
       <ContextMenuTrigger asChild>
-        <div style={TRANSPARENT_WRAPPER} onPointerDown={pressed}>
+        <div style={TRANSPARENT_WRAPPER} onPointerDown={notePress}>
           {children}
         </div>
       </ContextMenuTrigger>

--- a/packages/builder/src/block-context-menu.tsx
+++ b/packages/builder/src/block-context-menu.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+/**
+ * The right-click menu over the canvas, and the fourth surface over the block
+ * verbs.
+ *
+ * The keystrokes, the floating toolbar and the command palette were the first
+ * three. This one exists because it is where an author looks first — Webflow,
+ * Framer, Figma and Gutenberg all put the block verbs on a secondary click, so
+ * an editor without one reads as broken rather than as minimal.
+ *
+ * ## It derives; it does not decide
+ *
+ * Every question this menu could ask is already answered somewhere:
+ *
+ * - WHICH verbs, and whether each is available, comes from `toolbarActions` —
+ *   the same call the floating bar makes, with the same order and the same
+ *   reasons. `builder-commands` states the rule for the palette and it is the
+ *   same one here: asking a second time is how a menu comes to offer a verb the
+ *   button beside it shows as unavailable.
+ * - WHAT each one runs comes from `blockActionRunners`, shared with the palette
+ *   so the two cannot bind the same label to different verbs.
+ * - WHICH block it acts on is the canvas's selection, which the canvas itself
+ *   moves to the block under the pointer before this ever opens.
+ *
+ * What is left is presentation, which is this module's whole job.
+ *
+ * ## Labels come from the toolbar, not the palette
+ *
+ * The palette deliberately says "Duplicate block", because a palette row is
+ * read in a list with no context. A context menu is drawn AT the block, like
+ * the toolbar, so it takes the toolbar's shorter "Duplicate" for the same
+ * reason the toolbar does.
+ *
+ * ## A disabled verb stays, and says why
+ *
+ * `toolbarActions` sets `reason` only for a cause an author can act on — a lock
+ * — and leaves self-evident ones unsaid. So an unavailable verb is drawn
+ * disabled with its reason rather than removed: a menu that silently omits
+ * Delete answers "why can I not delete this" with nothing at all, and the
+ * remedy for the one reason it does report is one field away.
+ *
+ * ## Why the trigger generates no box
+ *
+ * Radix's trigger renders a `span`, and a span wrapped around the canvas is an
+ * inline box holding a block one — it would change the layout of the thing it
+ * is meant to be transparent over. `display: contents` makes the wrapper
+ * generate no box at all while leaving it in the DOM, which is all this needs:
+ * events bubble along the tree rather than along the layout, and Radix anchors
+ * a context menu to the pointer's own coordinates rather than to the trigger's
+ * rect.
+ *
+ * Keeping it ABOVE the canvas root, rather than on it, is also what keeps the
+ * canvas's drag handlers intact. Radix binds its own pointer handlers for the
+ * touch long-press, and the canvas root already carries a full set for
+ * dragging; on one element the two would overwrite each other.
+ *
+ * ## This menu is reached by POINTER only, and that is a limitation
+ *
+ * Measured in a real browser: a right-click opens it correctly, at the pointer,
+ * both at scale 1 and under the canvas's CSS `zoom`. Shift+F10 with the canvas
+ * focused does NOT open it, and the structure says why — the focusable canvas
+ * region is an ANCESTOR of this trigger, so a keyboard-invoked context event
+ * originating there bubbles away from it rather than into it.
+ *
+ * It is shipped anyway because it takes nothing away. Every verb here is
+ * already reachable without a pointer, through the keystrokes, the block
+ * toolbar's roving tab stop, and the command palette — this is a fourth route
+ * to them, not the only one. The fix is not to move this trigger up, which
+ * would open a block menu over chrome that is not a block; it is to make the
+ * blocks themselves focusable, which is a separate defect already filed and is
+ * what a keyboard context-menu key should be aimed at anyway.
+ *
+ * @module block-context-menu
+ */
+
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSeparator,
+  ContextMenuTrigger,
+} from "@nextlyhq/ui";
+import * as React from "react";
+
+import { blockActionRunners } from "./builder-commands";
+import type { EditorState } from "./editor-state";
+import { useBlockActionsContext } from "./keyboard-actions";
+import { toolbarActions } from "./toolbar-actions";
+
+/**
+ * The wrapper's style, hoisted so it is one object rather than one per render.
+ *
+ * A fresh literal here would give the wrapper a new `style` prop on every
+ * render of the canvas, which React writes back to the DOM each time.
+ */
+const TRANSPARENT_WRAPPER: React.CSSProperties = { display: "contents" };
+
+/** Where the menu's own verbs end and the editor-wide ones would begin. */
+const DESTRUCTIVE: ReadonlySet<string> = new Set(["delete"]);
+
+export interface BlockContextMenuProps {
+  /** The editor whose selection the verbs act on. */
+  editor: EditorState;
+  /** The canvas this menu opens over. */
+  children: React.ReactNode;
+}
+
+export function BlockContextMenu({
+  editor,
+  children,
+}: BlockContextMenuProps): React.JSX.Element {
+  const verbs = useBlockActionsContext();
+  const { document, selectedId } = editor;
+  const selectedIds = editor.selection.ids;
+
+  /*
+   * Rebuilt on what could change WHICH verbs are offered, for the reason
+   * `EditorCommandPalette` gives: `editor` itself is a fresh object every
+   * render, so depending on it would rebuild this on every frame of a drag.
+   */
+  const actions = React.useMemo(
+    () => toolbarActions(document, selectedId, selectedIds),
+    [document, selectedId, selectedIds]
+  );
+  const run = React.useMemo(() => blockActionRunners(verbs), [verbs]);
+
+  return (
+    <ContextMenu>
+      <ContextMenuTrigger asChild>
+        <div style={TRANSPARENT_WRAPPER}>{children}</div>
+      </ContextMenuTrigger>
+      {/*
+        Nothing to act on means nothing to draw. The canvas stops the event
+        before it reaches the trigger when the pointer was over the background,
+        so this is the other route to the same state: a selection that was
+        cleared while the menu's own markup still existed.
+      */}
+      {selectedId === null ? null : (
+        <ContextMenuContent aria-label="Block actions">
+          {actions.map(action => (
+            <React.Fragment key={action.id}>
+              {DESTRUCTIVE.has(action.id) ? <ContextMenuSeparator /> : null}
+              <ContextMenuItem
+                disabled={!action.enabled}
+                // The reason a lock gives, spelled exactly as the toolbar
+                // spells it. Carrying it to a screen reader as well is not
+                // solved here: `aria-description` has uneven support, and a
+                // description on a DISABLED item is inconsistently announced,
+                // so this matches the toolbar rather than inventing a second
+                // behaviour that has not been measured.
+                title={action.reason ?? action.label}
+                onSelect={() => {
+                  run[action.id]();
+                }}
+              >
+                {action.label}
+              </ContextMenuItem>
+            </React.Fragment>
+          ))}
+        </ContextMenuContent>
+      )}
+    </ContextMenu>
+  );
+}

--- a/packages/builder/src/block-context-menu.tsx
+++ b/packages/builder/src/block-context-menu.tsx
@@ -97,8 +97,8 @@
  * toolbar's roving tab stop, and the command palette — this is a fourth route
  * to them, not the only one. The fix is not to move this trigger up, which
  * would open a block menu over chrome that is not a block; it is to make the
- * blocks themselves focusable, which is a separate defect already filed and is
- * what a keyboard context-menu key should be aimed at anyway.
+ * blocks themselves focusable — a block is what a context-menu key should be
+ * aimed at anyway, and a focusable one would carry this trigger with it.
  *
  * @module block-context-menu
  */

--- a/packages/builder/src/builder-chrome-attributes.test.ts
+++ b/packages/builder/src/builder-chrome-attributes.test.ts
@@ -136,10 +136,18 @@ describe("the canvas keeps the platform's own callout for text", () => {
      * The stylesheet is the only place the override exists, so the stylesheet
      * is where it has to be checked.
      */
-    const rule = CHROME.match(
-      /\.nx-canvas \[contenteditable\]:not\(\[contenteditable="false"\]\)\s*\{[^}]*\}/
+    const restored = CHROME.match(
+      /\.nx-canvas \[contenteditable\]\s*\{[^}]*\}/
     );
-    expect(rule).not.toBeNull();
-    expect(rule?.[0]).toContain("-webkit-touch-callout: default");
+    expect(restored).not.toBeNull();
+    expect(restored?.[0]).toContain("-webkit-touch-callout: default");
+
+    // And still suppressed where the editor has marked a region uneditable
+    // inside an editable one, which is a block again rather than text.
+    const suppressed = CHROME.match(
+      /\.nx-canvas \[contenteditable="false"\]\s*\{[^}]*\}/
+    );
+    expect(suppressed).not.toBeNull();
+    expect(suppressed?.[0]).toContain("-webkit-touch-callout: none");
   });
 });

--- a/packages/builder/src/builder-chrome-attributes.test.ts
+++ b/packages/builder/src/builder-chrome-attributes.test.ts
@@ -120,3 +120,26 @@ describe("the empty-container affordance is keyed off the exported constants", (
     expect(CHROME).not.toContain("[data-nx-nonexistent-marker]");
   });
 });
+
+describe("the canvas keeps the platform's own callout for text", () => {
+  it("restores the touch callout the menu trigger suppresses", () => {
+    /*
+     * The context menu's trigger wraps the canvas, and Radix sets
+     * `-webkit-touch-callout: none` on it. That property INHERITS, so it
+     * reaches the `contenteditable` inside a block — and the canvas withholds
+     * the press there, so a long press on text opens neither the platform's
+     * spelling and clipboard callout nor the block menu.
+     *
+     * Asserted here because no test that renders the editor can see it: jsdom
+     * computes no inherited `-webkit-` property, and the suppression comes
+     * from a library's inline style rather than from anything in this package.
+     * The stylesheet is the only place the override exists, so the stylesheet
+     * is where it has to be checked.
+     */
+    const rule = CHROME.match(
+      /\.nx-canvas \[contenteditable\]:not\(\[contenteditable="false"\]\)\s*\{[^}]*\}/
+    );
+    expect(rule).not.toBeNull();
+    expect(rule?.[0]).toContain("-webkit-touch-callout: default");
+  });
+});

--- a/packages/builder/src/builder-commands.ts
+++ b/packages/builder/src/builder-commands.ts
@@ -93,15 +93,6 @@ export const HISTORY_GROUP = "History";
 export const EDITOR_GROUP = "Editor";
 
 /**
- * The palette's commands for the current state.
- *
- * Unavailable commands are OMITTED rather than listed and disabled, which is
- * the opposite of what the toolbar does — and deliberately. A toolbar keeps one
- * shape so the control an author is aiming at does not move; a palette is
- * searched rather than aimed at, and a row that matches the search and then
- * refuses to run is worse there than one that was never offered.
- */
-/**
  * What each toolbar action id actually RUNS.
  *
  * Published rather than kept inside the palette because the palette is no
@@ -126,6 +117,15 @@ export function blockActionRunners(
   };
 }
 
+/**
+ * The palette's commands for the current state.
+ *
+ * Unavailable commands are OMITTED rather than listed and disabled, which is
+ * the opposite of what the toolbar does — and deliberately. A toolbar keeps one
+ * shape so the control an author is aiming at does not move; a palette is
+ * searched rather than aimed at, and a row that matches the search and then
+ * refuses to run is worse there than one that was never offered.
+ */
 export function builderCommands({
   document,
   selectedId,

--- a/packages/builder/src/builder-commands.ts
+++ b/packages/builder/src/builder-commands.ts
@@ -101,6 +101,31 @@ export const EDITOR_GROUP = "Editor";
  * searched rather than aimed at, and a row that matches the search and then
  * refuses to run is worse there than one that was never offered.
  */
+/**
+ * What each toolbar action id actually RUNS.
+ *
+ * Published rather than kept inside the palette because the palette is no
+ * longer the only surface over these verbs: the right-click menu offers the
+ * same list, and a second copy of this map is how one surface comes to move a
+ * block while another duplicates it. The AVAILABILITY of an action is
+ * `toolbarActions`'s answer and the LABEL is the surface's own; this is the
+ * third and last thing a surface needs, and the only one they can all share.
+ *
+ * Total over {@link ToolbarActionId}, so a verb added to the bar cannot reach a
+ * surface with nothing bound to it — the compiler names the omission here.
+ */
+export function blockActionRunners(
+  verbs: CommandVerbs
+): Record<ToolbarActionId, () => void> {
+  return {
+    "select-parent": verbs.selectParent,
+    "move-up": () => verbs.move("up"),
+    "move-down": () => verbs.move("down"),
+    duplicate: verbs.duplicate,
+    delete: verbs.delete,
+  };
+}
+
 export function builderCommands({
   document,
   selectedId,
@@ -111,13 +136,7 @@ export function builderCommands({
   canRedo,
   onExit,
 }: BuilderCommandsInput): BuilderCommand[] {
-  const run: Record<ToolbarActionId, () => void> = {
-    "select-parent": verbs.selectParent,
-    "move-up": () => verbs.move("up"),
-    "move-down": () => verbs.move("down"),
-    duplicate: verbs.duplicate,
-    delete: verbs.delete,
-  };
+  const run = blockActionRunners(verbs);
 
   const blockCommands = toolbarActions(document, selectedId)
     .filter(action => action.enabled)

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -424,6 +424,110 @@ describe("the gesture a click's modifiers meant", () => {
     );
   }
 
+  it("selects the block under a secondary click before any menu opens", () => {
+    /*
+     * A menu opened over one block while the selection sits on another acts on
+     * the other one, and the author is looking at the block they aimed at — so
+     * a destructive verb would be aimed somewhere off screen. The selection has
+     * to move on the contextmenu event itself, which is the only thing that
+     * happens before a menu above this can open.
+     */
+    const onSelect = vi.fn();
+    const { container } = clickable(onSelect);
+    const block = container.querySelector(`[${NODE_ID_ATTRIBUTE}]`);
+    if (block === null) throw new Error("expected a rendered block");
+
+    fireEvent.contextMenu(block);
+    expect(onSelect).toHaveBeenCalledWith("a", "replace");
+  });
+
+  it("keeps a selection that already holds the block", () => {
+    /*
+     * Right-clicking one of several chosen blocks to act on all of them is what
+     * every comparable editor does. Re-selecting would drop the rest of the
+     * author's selection at the exact moment they went looking for a verb.
+     */
+    const onSelect = vi.fn();
+    const { container } = render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedIds={["a", "other"]}
+        onSelect={onSelect as never}
+      />
+    );
+    const block = container.querySelector(`[${NODE_ID_ATTRIBUTE}]`);
+    if (block === null) throw new Error("expected a rendered block");
+
+    fireEvent.contextMenu(block);
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it("withholds the event from above when no block is under it", () => {
+    /*
+     * A menu of block verbs over the canvas background would have no subject.
+     * Stopping the event here rather than opening an empty menu keeps that
+     * decision beside the hit test that establishes it — and an ancestor
+     * listening for the gesture is exactly how the menu is mounted.
+     */
+    const onSelect = vi.fn();
+    const above = vi.fn();
+    const { container } = render(
+      <div onContextMenu={above}>
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={{ css: "", classes: {} } as never}
+          onSelect={onSelect as never}
+        />
+      </div>
+    );
+    // The page wrapper: inside the canvas, carrying no node id of its own.
+    const background = container.querySelector(".nx-pb-page");
+    if (background === null) throw new Error("expected the page wrapper");
+
+    fireEvent.contextMenu(background);
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(above).not.toHaveBeenCalled();
+  });
+
+  it("lets the event reach above when a block IS under it", () => {
+    // The control on the other side: a rule that stopped every contextmenu
+    // event would pass the test above while no menu could ever open.
+    const above = vi.fn();
+    const { container } = render(
+      <div onContextMenu={above}>
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={{ css: "", classes: {} } as never}
+          onSelect={vi.fn() as never}
+        />
+      </div>
+    );
+    const block = container.querySelector(`[${NODE_ID_ATTRIBUTE}]`);
+    if (block === null) throw new Error("expected a rendered block");
+
+    fireEvent.contextMenu(block);
+    expect(above).toHaveBeenCalledTimes(1);
+  });
+
   it("reports the mode alongside the id", () => {
     // The mode travels with the id because only the event knows it: a caller
     // reading modifiers off a later render's event would read a different

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -90,6 +90,26 @@ export const CHROME_ATTRIBUTE = "data-nx-chrome";
 
 /** Whether an event started inside editor chrome rather than inside the page. */
 /**
+ * The block a context gesture is aimed at, or `null` when it is aimed at
+ * nothing a block menu could act on.
+ *
+ * Published because a context menu can be opened TWO ways and they arrive by
+ * different events. A secondary click arrives as `contextmenu`, which the
+ * canvas sees; a touch or pen long-press is opened by Radix from its own timer
+ * on `pointerdown`, and never produces a `contextmenu` event at all. A menu
+ * that filtered one path and not the other would offer a block's verbs for a
+ * press aimed at chrome, or — worse — offer the PREVIOUS selection's verbs,
+ * with Delete among them, for a press on a block that was never selected.
+ *
+ * So the decision lives here once and both callers ask it, rather than each
+ * spelling out three rejections and drifting.
+ */
+export function contextMenuTargetOf(target: EventTarget | null): string | null {
+  if (isEditableTarget(target) || isChrome(target)) return null;
+  return nodeIdFromEvent(target);
+}
+
+/**
  * Whether the gesture landed in text the author is editing.
  *
  * Asked apart from {@link isChrome} because the answer is the same and the
@@ -586,16 +606,12 @@ function useCanvasPointer(
        * `preventDefault` is deliberately not called, so the browser's own menu
        * still appears wherever this one does not.
        */
-      if (
-        isEditableTarget(event.target) ||
-        isChrome(event.target) ||
-        nodeIdFromEvent(event.target) === null
-      ) {
+      const id = contextMenuTargetOf(event.target);
+      if (id === null) {
         event.stopPropagation();
         return;
       }
-      const id = nodeIdFromEvent(event.target);
-      if (id === null || onSelect === undefined || marked.includes(id)) return;
+      if (onSelect === undefined || marked.includes(id)) return;
       onSelect(id, "replace");
     },
     [marked, onSelect]

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -507,10 +507,14 @@ function markedIds(
  */
 function useCanvasPointer(
   onSelect: ((id: string | null, mode: SelectionMode) => void) | undefined,
-  onDoubleClick: ((event: React.MouseEvent<HTMLDivElement>) => void) | undefined
+  onDoubleClick:
+    | ((event: React.MouseEvent<HTMLDivElement>) => void)
+    | undefined,
+  marked: readonly string[]
 ): {
   onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   onDoubleClick: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onContextMenu: (event: React.MouseEvent<HTMLDivElement>) => void;
 } {
   const click = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -529,7 +533,43 @@ function useCanvasPointer(
     },
     [onDoubleClick]
   );
-  return { onClick: click, onDoubleClick: doubleClick };
+  /*
+   * The secondary button selects, and says whether anything above this has a
+   * block to act on.
+   *
+   * Selecting FIRST is the whole point. A menu opened over one block while the
+   * selection sits on another acts on the other one, and the author is looking
+   * at the block they aimed at — so the destructive verbs on it would be aimed
+   * somewhere they cannot see.
+   *
+   * A block already in the selection is left alone rather than replacing it.
+   * Right-clicking one of several chosen blocks to act on all of them is what
+   * every comparable editor does, and re-selecting would silently drop the rest
+   * of the author's selection at the moment they went looking for a verb.
+   *
+   * Over the canvas BACKGROUND the event is stopped instead. There is no node,
+   * so a menu of block verbs would have no subject; stopping it here rather
+   * than opening an empty one keeps that decision next to the hit test that
+   * establishes it.
+   */
+  const contextMenu = useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (isChrome(event.target)) return;
+      const id = nodeIdFromEvent(event.target);
+      if (id === null) {
+        event.stopPropagation();
+        return;
+      }
+      if (onSelect === undefined || marked.includes(id)) return;
+      onSelect(id, "replace");
+    },
+    [marked, onSelect]
+  );
+  return {
+    onClick: click,
+    onDoubleClick: doubleClick,
+    onContextMenu: contextMenu,
+  };
 }
 
 /**
@@ -896,7 +936,7 @@ export function Canvas({
     () => markedIds(selectedIds, selectedId),
     [selectedIds, selectedId]
   );
-  const pointer = useCanvasPointer(onSelect, onDoubleClick);
+  const pointer = useCanvasPointer(onSelect, onDoubleClick, marked);
 
   // Keyed on the document identity so a re-render for an unrelated reason —
   // a selection change, a hover — does not rebuild the rendered tree.
@@ -945,6 +985,7 @@ export function Canvas({
       data-nx-selected-id={selectedId ?? undefined}
       onClick={pointer.onClick}
       onDoubleClick={pointer.onDoubleClick}
+      onContextMenu={pointer.onContextMenu}
       // Spread rather than merged with a handler of this component's own: the
       // canvas has no pointer behaviour of its own apart from the drag, so
       // there is nothing to combine, and merging would create a second place

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -556,6 +556,7 @@ function useCanvasPointer(
   onClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   onDoubleClick: (event: React.MouseEvent<HTMLDivElement>) => void;
   onContextMenu: (event: React.MouseEvent<HTMLDivElement>) => void;
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void;
 } {
   const click = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
@@ -616,10 +617,32 @@ function useCanvasPointer(
     },
     [marked, onSelect]
   );
+  /*
+   * The same withholding, for the gesture that carries no context event.
+   *
+   * A menu mounted above the canvas can open a touch or pen LONG PRESS from a
+   * timer of its own, started on this event — no `contextmenu` is ever
+   * dispatched, so the rule above never runs and every rejection it makes is
+   * skipped. Withholding the press from anything above keeps one decision
+   * governing both ways in.
+   *
+   * `stopPropagation` and NOT `preventDefault`, which is the whole point of
+   * doing it here. This fires at the start of every contact, long before
+   * anything knows whether it will become a long press, and cancelling the
+   * default that early takes caret placement and text selection away from an
+   * author who was only tapping into a sentence.
+   */
+  const pointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      if (contextMenuTargetOf(event.target) === null) event.stopPropagation();
+    },
+    []
+  );
   return {
     onClick: click,
     onDoubleClick: doubleClick,
     onContextMenu: contextMenu,
+    onPointerDown: pointerDown,
   };
 }
 
@@ -988,6 +1011,15 @@ export function Canvas({
     [selectedIds, selectedId]
   );
   const pointer = useCanvasPointer(onSelect, onDoubleClick, marked);
+  const dragPointerDown = dragHandlers?.onPointerDown;
+  const canvasPointerDown = pointer.onPointerDown;
+  const pointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      dragPointerDown?.(event);
+      canvasPointerDown(event);
+    },
+    [canvasPointerDown, dragPointerDown]
+  );
 
   // Keyed on the document identity so a re-render for an unrelated reason —
   // a selection change, a hover — does not rebuild the rendered tree.
@@ -1037,11 +1069,11 @@ export function Canvas({
       onClick={pointer.onClick}
       onDoubleClick={pointer.onDoubleClick}
       onContextMenu={pointer.onContextMenu}
-      // Spread rather than merged with a handler of this component's own: the
-      // canvas has no pointer behaviour of its own apart from the drag, so
-      // there is nothing to combine, and merging would create a second place
-      // where the two could be ordered wrongly.
+      // Spread whole, because the set cannot be partially applied — then the
+      // one member this component also has something to say about is composed
+      // over the top, drag first so its behaviour is exactly what it was.
       {...dragHandlers}
+      onPointerDown={pointerDown}
     >
       {page}
       {overlay}

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -89,6 +89,27 @@ export const SELECTED_ATTRIBUTE = "data-nx-selected";
 export const CHROME_ATTRIBUTE = "data-nx-chrome";
 
 /** Whether an event started inside editor chrome rather than inside the page. */
+/**
+ * Whether the gesture landed in text the author is editing.
+ *
+ * Asked apart from {@link isChrome} because the answer is the same and the
+ * reason is not: chrome is not the page, while this IS the page and is being
+ * typed into. The browser's own menu carries spelling, selection and clipboard
+ * for a caret, and none of that has a replacement here — taking it away mid
+ * sentence to offer "Move up" is a straight loss.
+ *
+ * `contenteditable="false"` is excluded explicitly: it marks a region the
+ * editor has deliberately made uneditable INSIDE an editable one, which is a
+ * block again rather than text.
+ */
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  const editable = target.closest("[contenteditable]");
+  return (
+    editable !== null && editable.getAttribute("contenteditable") !== "false"
+  );
+}
+
 function isChrome(target: EventTarget | null): boolean {
   return (
     target instanceof Element &&
@@ -554,13 +575,27 @@ function useCanvasPointer(
    */
   const contextMenu = useCallback(
     (event: React.MouseEvent<HTMLDivElement>) => {
-      if (isChrome(event.target)) return;
-      const id = nodeIdFromEvent(event.target);
-      if (id === null) {
+      /*
+       * Three ways to have no block to act on, stopped the same way and for
+       * separate reasons — see each predicate. Stopping rather than merely
+       * returning is what matters: a menu mounted ABOVE the canvas sees
+       * whatever this lets past, and the chrome and the appenders are drawn
+       * INSIDE the canvas root, so a bare return offers the selected block's
+       * verbs for a gesture aimed at a button that is not a block.
+       *
+       * `preventDefault` is deliberately not called, so the browser's own menu
+       * still appears wherever this one does not.
+       */
+      if (
+        isEditableTarget(event.target) ||
+        isChrome(event.target) ||
+        nodeIdFromEvent(event.target) === null
+      ) {
         event.stopPropagation();
         return;
       }
-      if (onSelect === undefined || marked.includes(id)) return;
+      const id = nodeIdFromEvent(event.target);
+      if (id === null || onSelect === undefined || marked.includes(id)) return;
       onSelect(id, "replace");
     },
     [marked, onSelect]

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -104,9 +104,27 @@ export const CHROME_ATTRIBUTE = "data-nx-chrome";
  * So the decision lives here once and both callers ask it, rather than each
  * spelling out three rejections and drifting.
  */
-export function contextMenuTargetOf(target: EventTarget | null): string | null {
+export function contextMenuTargetOf(
+  target: EventTarget | null,
+  root: Element
+): string | null {
   if (isEditableTarget(target) || isChrome(target)) return null;
-  return nodeIdFromEvent(target);
+  if (!(target instanceof Element)) return null;
+  const owner = target.closest(`[${NODE_ID_ATTRIBUTE}]`);
+  if (owner === null) return null;
+  /*
+   * Owned by THIS canvas, not merely by A canvas.
+   *
+   * `nodeIdFromEvent` asks the weaker question — its own comment claims this
+   * one, and it checks only that some canvas is an ancestor. That is enough
+   * for selection, where a foreign id is ignored and nothing happens. It is
+   * not enough here: a canvas rendered inside a block of another canvas sends
+   * its events up through the outer one, which would then let a menu open
+   * while the outer selection stayed where it was — and its verbs would act on
+   * a block nobody was pointing at.
+   */
+  if (owner.closest(`.${CANVAS_ROOT_CLASS}`) !== root) return null;
+  return owner.getAttribute(NODE_ID_ATTRIBUTE);
 }
 
 /**
@@ -607,7 +625,7 @@ function useCanvasPointer(
        * `preventDefault` is deliberately not called, so the browser's own menu
        * still appears wherever this one does not.
        */
-      const id = contextMenuTargetOf(event.target);
+      const id = contextMenuTargetOf(event.target, event.currentTarget);
       if (id === null) {
         event.stopPropagation();
         return;
@@ -634,7 +652,8 @@ function useCanvasPointer(
    */
   const pointerDown = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
-      if (contextMenuTargetOf(event.target) === null) event.stopPropagation();
+      if (contextMenuTargetOf(event.target, event.currentTarget) === null)
+        event.stopPropagation();
     },
     []
   );

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -337,20 +337,6 @@ export {
 } from "./builder-commands";
 
 /**
- * @experimental The right-click menu over the canvas.
- *
- * Assembled here rather than by the host for the reason `EditorCommandPalette`
- * is: mounting it means reaching into the verbs context, deriving the list from
- * `toolbarActions` on the right renders, and knowing it must sit inside
- * `BlockKeyboardActions`. A host given the pieces would get all three right
- * differently.
- */
-export {
-  BlockContextMenu,
-  type BlockContextMenuProps,
-} from "./block-context-menu";
-
-/**
  * @experimental Who owns Escape while the editor is on screen.
  *
  * From this entry because the rule is a plain function over the DOM and a

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -330,10 +330,25 @@ export {
   BLOCK_GROUP,
   EDITOR_GROUP,
   HISTORY_GROUP,
+  blockActionRunners,
   builderCommands,
   type BuilderCommandsInput,
   type CommandVerbs,
 } from "./builder-commands";
+
+/**
+ * @experimental The right-click menu over the canvas.
+ *
+ * Assembled here rather than by the host for the reason `EditorCommandPalette`
+ * is: mounting it means reaching into the verbs context, deriving the list from
+ * `toolbarActions` on the right renders, and knowing it must sit inside
+ * `BlockKeyboardActions`. A host given the pieces would get all three right
+ * differently.
+ */
+export {
+  BlockContextMenu,
+  type BlockContextMenuProps,
+} from "./block-context-menu";
 
 /**
  * @experimental Who owns Escape while the editor is on screen.

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -195,6 +195,16 @@ export type {
 export { EditorCommandPalette } from "./editor-command-palette";
 export type { EditorCommandPaletteProps } from "./editor-command-palette";
 
+/**
+ * The right-click menu over the canvas.
+ *
+ * Beside the palette because the two are the same kind of thing: a surface the
+ * editor assembles from the verbs context so a host does not have to know the
+ * three separate facts that mounting one correctly requires.
+ */
+export { BlockContextMenu } from "./block-context-menu";
+export type { BlockContextMenuProps } from "./block-context-menu";
+
 export { BlockToolbar } from "./block-toolbar";
 export type { BlockToolbarProps } from "./block-toolbar";
 

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1995,3 +1995,23 @@
   border: 1px solid var(--nx-destructive);
   border-radius: 0.375rem;
 }
+
+/*
+ * Text being edited keeps the platform's own long-press callout.
+ *
+ * The context menu's trigger wraps the canvas, and Radix sets
+ * `-webkit-touch-callout: none` on it so a long press opens the block menu
+ * rather than the browser's. That property INHERITS, so it reaches the
+ * `contenteditable` inside a block as well — and the canvas withholds the
+ * press there, so a long press on text would open neither menu: the platform's
+ * spelling, selection and clipboard callout suppressed, and nothing put in its
+ * place. Restored on the editable subtree only, so the block menu keeps the
+ * whole of the canvas that is not text.
+ *
+ * `[contenteditable="false"]` is excluded for the reason the canvas excludes
+ * it: it marks a region deliberately made uneditable inside an editable one,
+ * which is a block again rather than text.
+ */
+.nx-canvas [contenteditable]:not([contenteditable="false"]) {
+  -webkit-touch-callout: default;
+}

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -2012,6 +2012,17 @@
  * it: it marks a region deliberately made uneditable inside an editable one,
  * which is a block again rather than text.
  */
-.nx-canvas [contenteditable]:not([contenteditable="false"]) {
+.nx-canvas [contenteditable] {
   -webkit-touch-callout: default;
+}
+
+/*
+ * ...except a region the editor has deliberately made uneditable inside an
+ * editable one. That is a block again rather than text, so the block menu is
+ * the right menu there and the suppression stands. Written as its own rule
+ * rather than as a `:not()` on the one above: two plain selectors say the same
+ * thing, and the negated form was complex enough to be flagged.
+ */
+.nx-canvas [contenteditable="false"] {
+  -webkit-touch-callout: none;
 }

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -87,6 +87,13 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     InspectorPanel: record("inspector"),
     Canvas: record("canvas"),
     BlockKeyboardActions: passthrough,
+    /*
+     * Passed THROUGH, not stubbed to nothing: the canvas renders inside it, so
+     * a stub would take the recorder below out of the tree along with it. The
+     * real one reads the verbs context, which the passthrough above does not
+     * provide.
+     */
+    BlockContextMenu: passthrough,
     BlockToolbar: nothing,
     EditorCommandPalette: nothing,
     DropIndicator: nothing,

--- a/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
@@ -74,6 +74,13 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     BreakpointSwitcher: nothing,
     Canvas: nothing,
     BlockKeyboardActions: passthrough,
+    /*
+     * Passed THROUGH, not stubbed to nothing: the canvas renders inside it, so
+     * a stub would take the recorder below out of the tree along with it. The
+     * real one reads the verbs context, which the passthrough above does not
+     * provide.
+     */
+    BlockContextMenu: passthrough,
     BlockToolbar: nothing,
     EditorCommandPalette: nothing,
     DropIndicator: nothing,

--- a/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
@@ -97,6 +97,13 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     DropIndicator: nothing,
     SpacingOverlay: nothing,
     BlockKeyboardActions: passthrough,
+    /*
+     * Passed THROUGH, not stubbed to nothing: the canvas renders inside it, so
+     * a stub would take the recorder below out of the tree along with it. The
+     * real one reads the verbs context, which the passthrough above does not
+     * provide.
+     */
+    BlockContextMenu: passthrough,
     EditorCommandPalette: nothing,
     BreakpointManager: nothing,
     BreakpointSwitcher: nothing,

--- a/packages/plugin-page-builder/src/admin/BlocksField.inline-outcome.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.inline-outcome.test.tsx
@@ -82,6 +82,13 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     InspectorPanel: nothing,
     Canvas: nothing,
     BlockKeyboardActions: passthrough,
+    /*
+     * Passed THROUGH, not stubbed to nothing: the canvas renders inside it, so
+     * a stub would take the recorder below out of the tree along with it. The
+     * real one reads the verbs context, which the passthrough above does not
+     * provide.
+     */
+    BlockContextMenu: passthrough,
     BlockToolbar: nothing,
     EditorCommandPalette: nothing,
     DropIndicator: nothing,

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -92,6 +92,13 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     InspectorPanel: record("inspector"),
     Canvas: record("canvas"),
     BlockKeyboardActions: passthrough,
+    /*
+     * Passed THROUGH, not stubbed to nothing: the canvas renders inside it, so
+     * a stub would take the recorder below out of the tree along with it. The
+     * real one reads the verbs context, which the passthrough above does not
+     * provide.
+     */
+    BlockContextMenu: passthrough,
     BlockToolbar: nothing,
     EditorCommandPalette: nothing,
     DropIndicator: nothing,

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -60,6 +60,7 @@ import {
   offeredTiers,
   selectableTiers,
   widthForBreakpoint,
+  BlockContextMenu,
   EditorCommandPalette,
   BuilderShell,
   Canvas,
@@ -1668,50 +1669,57 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                 : "This site\u2019s styles could not be loaded, so the canvas would not match the published page. Reload to try again."}
             </p>
           ) : (
-            <Canvas
-              document={editor.document}
-              siteStyles={siteSheet(canvasSiteStyle)}
-              selectedId={editor.selectedId}
-              selectedIds={editor.selection.ids}
-              onSelect={editor.select}
-              // The style context and the host policy, derived above so both are
-              // one object with one identity rather than rebuilt per render.
-              render={canvasRender}
-              // The box the tiers are compiled against, the width it is asked
-              // to take, and the reporter that closes the loop: the request is
-              // a ceiling, and everything downstream is derived from what the
-              // box actually got rather than from what it was offered.
-              preview={canvasPreview}
-              dragHandlers={drag.handlers}
-              // The pointer route into typing a block's text. Its keyboard
-              // counterpart is the Enter binding above, registered in the same
-              // place so a surface cannot gain one without the other.
-              onDoubleClick={inline.onDoubleClick}
-              // Both pieces of chrome go through the canvas rather than beside it,
-              // because both are positioned in the canvas's own content
-              // coordinates and the canvas root is what establishes them.
-              overlay={
-                <>
-                  <DropIndicator target={drag.target} />
-                  {/*
+            /*
+              Wrapped rather than passed in, because the menu opens over the
+              WHOLE canvas and reads which block from the selection the canvas
+              has already moved. The wrapper generates no box, so the canvas
+              lays out exactly as it did.
+            */
+            <BlockContextMenu editor={editor}>
+              <Canvas
+                document={editor.document}
+                siteStyles={siteSheet(canvasSiteStyle)}
+                selectedId={editor.selectedId}
+                selectedIds={editor.selection.ids}
+                onSelect={editor.select}
+                // The style context and the host policy, derived above so both are
+                // one object with one identity rather than rebuilt per render.
+                render={canvasRender}
+                // The box the tiers are compiled against, the width it is asked
+                // to take, and the reporter that closes the loop: the request is
+                // a ceiling, and everything downstream is derived from what the
+                // box actually got rather than from what it was offered.
+                preview={canvasPreview}
+                dragHandlers={drag.handlers}
+                // The pointer route into typing a block's text. Its keyboard
+                // counterpart is the Enter binding above, registered in the same
+                // place so a surface cannot gain one without the other.
+                onDoubleClick={inline.onDoubleClick}
+                // Both pieces of chrome go through the canvas rather than beside it,
+                // because both are positioned in the canvas's own content
+                // coordinates and the canvas root is what establishes them.
+                overlay={
+                  <>
+                    <DropIndicator target={drag.target} />
+                    {/*
                   Suppressed for the duration of a drag. The bar would otherwise
                   sit over the canvas the author is aiming at, naming a block
                   that is in the middle of moving.
                 */}
-                  <BlockToolbar
-                    editor={editor}
-                    hidden={drag.draggingId !== null}
-                  />
-                  {/*
+                    <BlockToolbar
+                      editor={editor}
+                      hidden={drag.draggingId !== null}
+                    />
+                    {/*
                   Suppressed for the same reason and by the same signal. The
                   bands report a layout that is mid-change during a drag, so
                   every value on them is about to be wrong.
                 */}
-                  <SpacingOverlay
-                    editor={editor}
-                    hidden={drag.draggingId !== null}
-                  />
-                  {/*
+                    <SpacingOverlay
+                      editor={editor}
+                      hidden={drag.draggingId !== null}
+                    />
+                    {/*
                   Suppressed during a drag for the same reason the toolbar and
                   the bands are: the document is mid-change, so a control
                   offering to fill a container names a shape that is about to
@@ -1723,26 +1731,27 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                   left floating over nothing after that would make the
                   preference lie about what a visitor sees.
                 */}
-                  <EmptyContainerAppenders
-                    document={editor.document}
-                    slots={slots}
-                    blocks={blocks}
-                    hidden={emptyContainerAppenderHidden(
-                      drag.draggingId,
-                      showEmptyElements
-                    )}
-                    onAppend={nodeId => {
-                      // Select first, then open. The inserter derives its
-                      // target from the selection, so selecting the container
-                      // is what makes the next insert land inside it — there
-                      // is no second targeting path to keep in step.
-                      editor.select(nodeId);
-                      openInsertPanel();
-                    }}
-                  />
-                </>
-              }
-            />
+                    <EmptyContainerAppenders
+                      document={editor.document}
+                      slots={slots}
+                      blocks={blocks}
+                      hidden={emptyContainerAppenderHidden(
+                        drag.draggingId,
+                        showEmptyElements
+                      )}
+                      onAppend={nodeId => {
+                        // Select first, then open. The inserter derives its
+                        // target from the selection, so selecting the container
+                        // is what makes the next insert land inside it — there
+                        // is no second targeting path to keep in step.
+                        editor.select(nodeId);
+                        openInsertPanel();
+                      }}
+                    />
+                  </>
+                }
+              />
+            </BlockContextMenu>
           )}
         </BlockKeyboardActions>
       </BuilderShell>


### PR DESCRIPTION
Closes `finding:pb-canvas-has-no-context-menu` — founder-reported, and the first of the four canvas items in the order they chose (context menu → layers reordering → zoom → insert grid).

Right-clicking a block did nothing. Verified two ways before building: zero `onContextMenu` anywhere in `packages/*/src` (control: 9 `onDoubleClick` in the builder, so the search works), and in a browser, a real secondary click left `defaultPrevented` false with no `[role=menu]` in the DOM. A missing feature, not a broken one.

## What made this small

`@nextlyhq/ui` **already ships a `ContextMenu`**, built on `@radix-ui/react-context-menu` and exported from its index — ARIA roles, arrow-key navigation, typeahead, Escape, focus return, portalling. `packages/builder` already depends on it. Nothing here re-implements a menu.

## It derives; it does not decide

- **Which verbs, and whether each is available** — `toolbarActions`, the same call the floating bar makes. `builder-commands` already states the rule for the palette: asking a second time "is how a palette ends up offering a command that the button beside it shows as unavailable."
- **What each one runs** — `blockActionRunners`, lifted out of `builder-commands` and published, so the palette and this menu cannot bind the same label to different verbs. It is total over `ToolbarActionId`, so a verb added to the bar cannot reach a surface with nothing bound to it.
- **Labels** — the toolbar's, not the palette's. The palette deliberately says "Duplicate block" because a row is read in a list with no context; this menu is drawn *at* the block, like the bar.

An unavailable verb stays and carries its reason rather than disappearing — a menu that silently drops Delete answers "why can I not delete this" with nothing.

## Selection

The canvas moves the selection to the block under the pointer **on the contextmenu event itself**, before anything can open. A menu opened over one block while the selection sits on another aims its destructive verbs somewhere the author cannot see. A block already in the selection keeps it, so right-clicking one of several does not drop the rest. Over the background the canvas stops the event — a menu of block verbs there has no subject.

## Why the trigger generates no box

Radix's trigger renders a `span`; wrapped around the canvas that is an inline box holding a block one. `display: contents` leaves it in the DOM generating no box — events bubble along the tree, and Radix anchors to the pointer, not the trigger's rect. Keeping it *above* the canvas root also keeps the canvas's drag handlers from colliding with the pointer handlers Radix binds for touch long-press.

## Verified in a real browser

Playground, real CDP right-clicks (not synthetic dispatch — a dispatched `contextmenu` does **not** open it, which is its own reminder that programmatic events prove nothing here):

| case | result |
|---|---|
| right-click a block | menu opens at the pointer (offset dx=2, dy=0), block selected |
| items | `Select parent`, `Move up`, `Move down` (disabled — lone top-level block), `Duplicate`, `Delete` |
| **under canvas CSS `zoom` 0.6** | **identical offset dx=2, dy=0** |
| right-click the background | no menu |

The zoom row settles a question the research flagged and did not assert: the canvas scales with CSS `zoom`, where `clientWidth` reads 1017 logical while the rect reads 610 post-zoom. Radix anchors from the native event's viewport coordinates, so no mapping is needed.

## One limitation, measured and stated

**This menu is reachable by pointer only.** Shift+F10 with the canvas focused does not open it, and the structure says why: the focusable canvas region is an *ancestor* of the trigger (verified `section.contains(.nx-canvas) === true`), so a keyboard-invoked context event bubbles away from it.

It ships anyway because it takes nothing away — every verb in it is already reachable without a pointer through the keystrokes, the toolbar's roving tab stop and the command palette. The fix is not to raise the trigger, which would open a block menu over chrome that is not a block; it is to make blocks themselves focusable, which is `finding:pb-canvas-blocks-invisible-to-assistive-tech` and is the correct target for a context-menu key. The research node's recommendation of keyboard parity "from the canvas region" is recorded in the ledger as measured false.

## Tests

Eight new, each break-verified individually with the mutation being removal of the behaviour the test's *name* promises:

| mutation | fails |
|---|---|
| remove the canvas `onContextMenu` wiring | `selects the block under a secondary click…`, `withholds the event from above…` |
| always replace the selection | `keeps a selection that already holds the block` |
| stop *every* contextmenu event | `lets the event reach above when a block IS under it` |
| never render the menu content | all four menu cases |
| restate the list with palette wording | `offers the verbs the toolbar offers…` |
| bind every item to the wrong verb | `runs the verb the keystrokes run` |
| drop unavailable verbs instead of disabling | `keeps an unavailable verb…` |

No mutation kills `opens on a secondary click` alone, because every other case requires the menu to be open — a property of the dependency structure, not a gap.

The selection test drives Radix on `pointerup` with no preceding `pointerdown`: its item synthesises the click on pointer-up only when it saw no pointer-down, because a real browser delivers the click itself and jsdom delivers neither. A full down-then-up selects nothing, and so does `fireEvent.click`.

Four `BlocksField` test mocks gained `BlockContextMenu: passthrough` — their `BlockKeyboardActions` stub provides no verbs context, and the canvas renders inside this component, so a `nothing` stub would take the recorder out of the tree with it.

Green: `builder` 2336, `plugin-page-builder` 500, typecheck and lint clean. Changeset validated by path, with a deliberately broken copy confirming the checker rejects.