### PR TITLE
feat(plugin-page-builder): give the editor its class library, and create classes

### DIFF
--- a/.changeset/wire-the-class-library-to-the-editor.md
+++ b/.changeset/wire-the-class-library-to-the-editor.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+The page builder now supplies the class library to its inspector, so the class
+selector is reachable in the editor rather than only in isolation.
+
+Creating a class writes the site style's `classes` section and answers with the
+new class's id; putting it on the selected block stays with the inspector,
+which already writes blocks. That keeps one application path, so the limit on
+how many classes a block may carry is enforced in a single place rather than
+once per caller.
+
+A refused save is reported in the author's words instead of clearing the name
+they typed, and a library still being read is told apart from a site that
+genuinely has no classes — only one of those has a field about to fill.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -75,7 +75,19 @@ pnpm run build
 # run repo-wide, so types were the one whole-repo question this hook was not
 # asking. A dependent TEST sweep is the expensive one and stays in CI, where
 # nobody is waiting on it.
+#
+# ADVISORY, not blocking. This is the one gate here whose scope is the whole
+# repository, so it can be red for a package the author never touched — and a
+# hook that refuses a push over someone else's broken package is a hook people
+# learn to pass `--no-verify` to, which costs every gate rather than this one.
+#
+# Reported instead, with the packages named, so an author can see at a glance
+# whether the failure is theirs. CI blocks on the same command; this is the
+# early warning, not the enforcement.
+set +e
 pnpm turbo check-types --continue
+TYPES_STATUS=$?
+set -e
 
 # The TESTS of the packages this branch actually changes.
 #
@@ -116,6 +128,13 @@ elif [ "$GATE_STATUS" -ne 0 ]; then
 elif [ -n "$GATE_FILTERS" ]; then
   # shellcheck disable=SC2086 -- one flag per line, intentionally word-split
   pnpm turbo test --continue $GATE_FILTERS
+fi
+
+if [ "$TYPES_STATUS" -ne 0 ]; then
+  echo ""
+  echo "pre-push: NOTE — the repo-wide typecheck failed. Check whether the"
+  echo "  failing package is one you changed: this gate covers every package,"
+  echo "  so it can be red for someone else's work. CI blocks on it either way."
 fi
 
 # Last, so it is the line still on screen when the push proceeds.

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -395,6 +395,128 @@ describe("a write the document refuses", () => {
   });
 });
 
+describe("a failure that must not outlive the node it describes", () => {
+  const full = Array.from(
+    { length: MAX_CLASSES_PER_NODE },
+    (_, index) => `id-filler-${index}`
+  );
+
+  it("drops a refused WRITE when the host hands it another node", () => {
+    /*
+     * Every failure carries the ids it was produced against. Without that, a
+     * refusal outlives the element: the alert goes on describing a node that
+     * is no longer selected, and the author reads it as being about the one
+     * in front of them.
+     */
+    const view = render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={vi.fn(() => "refused" as const)}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
+      />
+    );
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    view.rerender(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={["id-card"]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
+      />
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("drops a refused CREATION the same way", async () => {
+    const view = render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={vi.fn(async () => ({
+          ok: false as const,
+          reason: "The site style refused this.",
+        }))}
+      />
+    );
+    type("brand-new");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    await screen.findByText(/site style refused/i);
+
+    view.rerender(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={["id-card"]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
+      />
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps a failure that IS still about the node in hand", () => {
+    // The control: invalidating on identity must not throw away a failure the
+    // author has not yet had a chance to read.
+    drawFor({ nodeClassIds: full });
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert").textContent).toMatch(/as many classes/i);
+  });
+});
+
+describe("why the library is absent", () => {
+  it("says a read is loading when it is still in flight", () => {
+    render(
+      <ClassSelector
+        library={undefined}
+        libraryAbsence="pending"
+        nodeClassIds={[]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
+      />
+    );
+    expect(screen.getByText(/loading classes/i)).toBeTruthy();
+  });
+
+  it("says a read FAILED, rather than loading forever", () => {
+    /*
+     * A failed read will not finish. A surface that goes on saying "loading"
+     * describes a state the site is not in and gives the author nothing to do
+     * about it — the distinction the tokens studio already draws.
+     */
+    render(
+      <ClassSelector
+        library={undefined}
+        libraryAbsence="failed"
+        nodeClassIds={[]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
+      />
+    );
+    expect(screen.getByText(/could not be read/i)).toBeTruthy();
+    expect(screen.queryByText(/loading classes/i)).toBeNull();
+  });
+});
+
 describe("who owns the tab sequence", () => {
   it("keeps option rows out of it, so Tab leaves the field once", () => {
     /*

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -43,7 +43,10 @@ function draw(overrides: Partial<ClassSelectorProps> = {}): {
   // "refused" and so reads as success — the fake would then be asserting a
   // shape the real host cannot use.
   const onNodeClassesChange = vi.fn(() => "applied" as const);
-  const onCreateClass = vi.fn();
+  const onCreateClass = vi.fn(async (slug: string) => ({
+    ok: true as const,
+    classId: `id-${slug}`,
+  }));
   render(
     <ClassSelector
       library={LIBRARY}
@@ -65,7 +68,10 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
       library={LIBRARY}
       nodeClassIds={initial.nodeClassIds}
       onNodeClassesChange={vi.fn(() => "applied" as const)}
-      onCreateClass={vi.fn()}
+      onCreateClass={vi.fn(async () => ({
+        ok: true as const,
+        classId: "id-new",
+      }))}
     />
   );
   return {
@@ -75,7 +81,10 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
           library={LIBRARY}
           nodeClassIds={nodeClassIds}
           onNodeClassesChange={vi.fn(() => "applied" as const)}
-          onCreateClass={vi.fn()}
+          onCreateClass={vi.fn(async () => ({
+            ok: true as const,
+            classId: "id-new",
+          }))}
         />
       ),
   };
@@ -96,7 +105,10 @@ describe("a library that has not been read yet", () => {
         library={undefined}
         nodeClassIds={[]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
       />
     );
     expect(screen.getByText(/loading classes/i)).toBeTruthy();
@@ -326,7 +338,10 @@ describe("a write the document refuses", () => {
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={onNodeClassesChange}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
       />
     );
     return { onNodeClassesChange };
@@ -365,7 +380,10 @@ describe("a write the document refuses", () => {
         library={LIBRARY}
         nodeClassIds={["id-hero"]}
         onNodeClassesChange={onNodeClassesChange}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
       />
     );
     fireEvent.click(

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -477,6 +477,54 @@ describe("a failure that must not outlive the node it describes", () => {
   });
 });
 
+describe("a creation that lands after the node has moved on", () => {
+  it("applies against the node as it is NOW, not as it was", async () => {
+    /*
+     * A site-style save is asynchronous and an author can remove a chip while
+     * it is in flight. Applying from the render that STARTED the request would
+     * write back the classes as they stood before the removal — undoing it,
+     * from a callback about something else entirely.
+     */
+    let resolve: (v: { ok: true; classId: string }) => void = () => {};
+    const onCreateClass = vi.fn(
+      () =>
+        new Promise<{ ok: true; classId: string }>(r => {
+          resolve = r;
+        })
+    );
+    const onNodeClassesChange = vi.fn(() => "applied" as const);
+
+    const view = render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={["id-hero", "id-card"]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={onCreateClass}
+      />
+    );
+    type("brand-new");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(onCreateClass).toHaveBeenCalled();
+
+    // The author removes a chip while the save is still out.
+    view.rerender(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={["id-card"]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={onCreateClass}
+      />
+    );
+
+    await React.act(async () => {
+      resolve({ ok: true, classId: "id-made" });
+    });
+
+    // `id-hero` must NOT come back: it was removed after the request left.
+    expect(onNodeClassesChange).toHaveBeenCalledWith(["id-card", "id-made"]);
+  });
+});
+
 describe("why the library is absent", () => {
   it("says a read is loading when it is still in flight", () => {
     render(

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -53,6 +53,24 @@ import {
 /** Whether a write to the selected node's classes reached the document. */
 export type ClassWriteOutcome = "applied" | "refused";
 
+/**
+ * What creating a class produced: its new id, or why it could not be created.
+ *
+ * The ID comes back rather than the host applying the class itself. Creating
+ * is a SITE-STYLE write and applying is a NODE write — two documents — and the
+ * host owns only the first. Returning the id lets the application go through
+ * the same path every other apply takes, so the per-node bound and the store's
+ * own refusal are enforced once instead of twice.
+ *
+ * A REASON rather than a bare refusal, because this one has words available:
+ * the site-style save reports per-section issues, where a node write can only
+ * answer null. `breakpoints` in the page-builder admin already returns its
+ * refusal this way.
+ */
+export type ClassCreation =
+  | { readonly ok: true; readonly classId: string }
+  | { readonly ok: false; readonly reason: string };
+
 export interface ClassSelectorProps {
   /**
    * The site's class library, or `undefined` while the host has not read it.
@@ -81,8 +99,17 @@ export interface ClassSelectorProps {
    * Create a class under this slug and put it on the selected node.
    *
    * One intent, for the reason in the module note: the id does not exist yet.
+   *
+   * Asynchronous and answering, because creating a class is a SITE-STYLE write
+   * — a different document from the one the node lives in, saved over the
+   * network and refusable. A void contract would clear the typed name on a
+   * refusal exactly as it does on success, which is the same failure
+   * {@link ClassSelectorProps.onNodeClassesChange} returns an outcome to avoid.
+   *
+   * It creates only. Putting the class ON the node is this component's job,
+   * through the same callback every other application uses.
    */
-  onCreateClass: (slug: string) => void;
+  onCreateClass: (slug: string) => Promise<ClassCreation>;
 }
 
 /** The classes on the selected node, with a field for adding another. */
@@ -99,6 +126,11 @@ export function ClassSelector({
   // that one is predictable from the ids in hand, this one is only knowable by
   // asking the document. Kept apart so the message can say which happened.
   const [writeRefused, setWriteRefused] = React.useState(false);
+  // In flight, so a second Enter cannot queue a duplicate class while the
+  // first save is still on the network.
+  const [saving, setSaving] = React.useState(false);
+  // The site-style save's own words, which a node write cannot produce.
+  const [createIssue, setCreateIssue] = React.useState<string | null>(null);
   const listId = React.useId();
 
   if (library === undefined) {
@@ -125,7 +157,7 @@ export function ClassSelector({
   const highlighted = Math.min(active, Math.max(options.length - 1, 0));
 
   const commit = (option: ClassOption | undefined): void => {
-    if (option === undefined) return;
+    if (option === undefined || saving) return;
     if (option.kind === "create") {
       /*
        * The same node bound the apply path observes, asked before the class
@@ -137,29 +169,59 @@ export function ClassSelector({
         setRefused(true);
         return;
       }
-      onCreateClass(option.slug);
-    } else {
-      // Through the shared helper rather than an append written here. The
-      // bound on how many classes a node may carry belongs to one place, and a
-      // second append would keep working after that place learned to refuse.
-      const outcome = withClassApplied(nodeClassIds, option.choice.id);
-      if (!outcome.ok) {
-        setRefused(true);
-        return;
-      }
-      if (onNodeClassesChange(outcome.classIds) === "refused") {
-        // The draft survives, deliberately. An author whose write was refused
-        // has lost nothing they typed, and the next thing they do is likely to
-        // be trying it again.
-        setWriteRefused(true);
-        return;
-      }
+      /*
+       * Not awaited here, and the query is not cleared until it answers. A
+       * site-style save is a network write: clearing on dispatch would lose
+       * the typed name the moment the author pressed Enter, before anything
+       * knew whether it had landed.
+       */
+      setSaving(true);
+      void onCreateClass(option.slug).then(created => {
+        setSaving(false);
+        if (!created.ok) {
+          setCreateIssue(created.reason);
+          return;
+        }
+        setCreateIssue(null);
+        // Applied through the ordinary path, so a node already at its limit
+        // refuses here exactly as it would for an existing class rather than
+        // being special-cased into a second rule.
+        applyExisting(created.classId);
+      });
+      return;
+    }
+    applyExisting(option.choice.id);
+  };
+
+  /**
+   * Put a class the library already holds onto the node.
+   *
+   * One path for both kinds of apply. A newly created class reaches it with
+   * the id the host just minted, so the per-node bound and the store's refusal
+   * are enforced in one place rather than once per caller.
+   */
+  function applyExisting(classId: string): void {
+    // Through the shared helper rather than an append written here. The bound
+    // on how many classes a node may carry belongs to one place, and a second
+    // append would keep working after that place learned to refuse.
+    const outcome = withClassApplied(nodeClassIds, classId);
+    if (!outcome.ok) {
+      setRefused(true);
+      return;
+    }
+    if (onNodeClassesChange(outcome.classIds) === "refused") {
+      // The draft survives, deliberately. An author whose write was refused
+      // has lost nothing they typed, and the next thing they do is likely to
+      // be trying it again.
+      setWriteRefused(true);
+      return;
     }
     setRefused(false);
     setWriteRefused(false);
+    setCreateIssue(null);
     setQuery("");
     setActive(0);
-  };
+  }
 
   return (
     <div className="nx-classes">
@@ -206,6 +268,11 @@ export function ClassSelector({
       {hidden > 0 ? (
         <p className="nx-inspector__note">
           {`${hidden} more — keep typing to narrow the list.`}
+        </p>
+      ) : null}
+      {createIssue !== null ? (
+        <p className="nx-classes__issue" role="alert">
+          {createIssue}
         </p>
       ) : null}
       {writeRefused ? (

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -50,6 +50,46 @@ import {
   type ClassOption,
 } from "./class-library";
 
+/**
+ * What went wrong on the last attempt, in the terms the author is told.
+ *
+ * Three distinguishable causes rather than one flag: the node being full is
+ * predictable from the ids in hand, a refused node write is only knowable by
+ * asking the document, and a refused creation carries the site style's own
+ * words. Collapsed into one boolean, the message would name the wrong cause.
+ */
+type SelectorFailure =
+  | { readonly kind: "node-full" }
+  | { readonly kind: "not-written" }
+  | { readonly kind: "not-created"; readonly reason: string };
+
+/**
+ * The stored failure, if it still describes the node in hand.
+ *
+ * A capacity refusal is checked against the node as well as matched to it: the
+ * element may have gained room since the attempt, and an alert saying it is
+ * full would then be describing a state it is no longer in.
+ */
+function liveFailure(
+  failure: { about: readonly string[]; issue: SelectorFailure } | null,
+  nodeClassIds: readonly string[]
+): SelectorFailure | null {
+  if (failure === null || failure.about !== nodeClassIds) return null;
+  if (failure.issue.kind === "node-full" && nodeHasRoom(nodeClassIds)) {
+    return null;
+  }
+  return failure.issue;
+}
+
+/** What the author is told, per cause. */
+function failureMessage(failure: SelectorFailure): string {
+  if (failure.kind === "not-created") return failure.reason;
+  if (failure.kind === "not-written") {
+    return "This change could not be applied to the document.";
+  }
+  return "This element already has as many classes as the page can apply.";
+}
+
 /** Whether a write to the selected node's classes reached the document. */
 export type ClassWriteOutcome = "applied" | "refused";
 
@@ -81,6 +121,16 @@ export interface ClassSelectorProps {
    * the one still loading.
    */
   library: readonly NamedClass[] | undefined;
+  /**
+   * Why there is no library, when there is none.
+   *
+   * `undefined` has two causes and they need different words: a read still in
+   * flight will finish, and a refused or failed one will not. Told apart for
+   * the reason the tokens studio tells them apart — a panel saying "reading…"
+   * forever after a 403 describes a state the site is not in, and gives the
+   * author nothing to do about it.
+   */
+  libraryAbsence?: "pending" | "failed";
   /** The class ids the selected node carries, as stored. */
   nodeClassIds: readonly string[];
   /**
@@ -115,28 +165,40 @@ export interface ClassSelectorProps {
 /** The classes on the selected node, with a field for adding another. */
 export function ClassSelector({
   library,
+  libraryAbsence,
   nodeClassIds,
   onNodeClassesChange,
   onCreateClass,
 }: ClassSelectorProps): React.ReactElement {
   const [query, setQuery] = React.useState("");
   const [active, setActive] = React.useState(0);
-  const [refused, setRefused] = React.useState(false);
-  // The store's refusal, which is a different failure from the node being full:
-  // that one is predictable from the ids in hand, this one is only knowable by
-  // asking the document. Kept apart so the message can say which happened.
-  const [writeRefused, setWriteRefused] = React.useState(false);
+  /*
+   * ONE failure at a time, carrying the node it was produced against.
+   *
+   * Separate flags each go stale on their own: a refusal outlived the host
+   * handing this component a different node, so an alert went on describing an
+   * element no longer selected. Storing the ids it is ABOUT and comparing them
+   * on render means a change of node invalidates it with no effect to keep in
+   * step — the same reason the capacity refusal is derived rather than
+   * remembered.
+   */
+  const [failure, setFailure] = React.useState<{
+    readonly about: readonly string[];
+    readonly issue: SelectorFailure;
+  } | null>(null);
   // In flight, so a second Enter cannot queue a duplicate class while the
   // first save is still on the network.
   const [saving, setSaving] = React.useState(false);
-  // The site-style save's own words, which a node write cannot produce.
-  const [createIssue, setCreateIssue] = React.useState<string | null>(null);
   const listId = React.useId();
 
   if (library === undefined) {
     return (
       <div className="nx-classes">
-        <p className="nx-inspector__note">Loading classes…</p>
+        <p className="nx-inspector__note">
+          {libraryAbsence === "failed"
+            ? "This site's classes could not be read."
+            : "Loading classes…"}
+        </p>
       </div>
     );
   }
@@ -145,13 +207,12 @@ export function ClassSelector({
   const { options, hidden } = selectorOptions(library, nodeClassIds, query);
   const unapplied = unappliedNodeClassCount(nodeClassIds);
   /*
-   * DERIVED from the current node rather than read from state alone. A stored
-   * refusal outlives the node it described: removing a chip, an undo, or the
-   * host selecting a different element all give the node room again while the
-   * flag still says it is full. Deriving it cannot drift, where an effect that
-   * cleared the flag would have to be kept in step with every one of those.
+   * The failure to draw, or none. Scoped twice over: it must have been produced
+   * against THIS node, and a capacity refusal must still be true of it — the
+   * node may have gained room since, through a removal, an undo, or the host
+   * selecting a smaller element.
    */
-  const showRefusal = refused && !nodeHasRoom(nodeClassIds);
+  const shown = liveFailure(failure, nodeClassIds);
   // Clamped rather than reset on every keystroke, so narrowing the list keeps a
   // highlight instead of silently sending Enter back to the first row.
   const highlighted = Math.min(active, Math.max(options.length - 1, 0));
@@ -166,7 +227,7 @@ export function ClassSelector({
        * is checked directly rather than left for the host to rediscover.
        */
       if (!nodeHasRoom(nodeClassIds)) {
-        setRefused(true);
+        setFailure({ about: nodeClassIds, issue: { kind: "node-full" } });
         return;
       }
       /*
@@ -179,10 +240,12 @@ export function ClassSelector({
       void onCreateClass(option.slug).then(created => {
         setSaving(false);
         if (!created.ok) {
-          setCreateIssue(created.reason);
+          setFailure({
+            about: nodeClassIds,
+            issue: { kind: "not-created", reason: created.reason },
+          });
           return;
         }
-        setCreateIssue(null);
         // Applied through the ordinary path, so a node already at its limit
         // refuses here exactly as it would for an existing class rather than
         // being special-cased into a second rule.
@@ -206,19 +269,17 @@ export function ClassSelector({
     // append would keep working after that place learned to refuse.
     const outcome = withClassApplied(nodeClassIds, classId);
     if (!outcome.ok) {
-      setRefused(true);
+      setFailure({ about: nodeClassIds, issue: { kind: "node-full" } });
       return;
     }
     if (onNodeClassesChange(outcome.classIds) === "refused") {
       // The draft survives, deliberately. An author whose write was refused
       // has lost nothing they typed, and the next thing they do is likely to
       // be trying it again.
-      setWriteRefused(true);
+      setFailure({ about: nodeClassIds, issue: { kind: "not-written" } });
       return;
     }
-    setRefused(false);
-    setWriteRefused(false);
-    setCreateIssue(null);
+    setFailure(null);
     setQuery("");
     setActive(0);
   }
@@ -231,7 +292,11 @@ export function ClassSelector({
           const landed = onNodeClassesChange(
             withClassRemoved(nodeClassIds, id)
           );
-          setWriteRefused(landed === "refused");
+          setFailure(
+            landed === "refused"
+              ? { about: nodeClassIds, issue: { kind: "not-written" } }
+              : null
+          );
         }}
       />
       <Input
@@ -270,19 +335,9 @@ export function ClassSelector({
           {`${hidden} more — keep typing to narrow the list.`}
         </p>
       ) : null}
-      {createIssue !== null ? (
+      {shown !== null ? (
         <p className="nx-classes__issue" role="alert">
-          {createIssue}
-        </p>
-      ) : null}
-      {writeRefused ? (
-        <p className="nx-classes__issue" role="alert">
-          This change could not be applied to the document.
-        </p>
-      ) : null}
-      {showRefusal ? (
-        <p className="nx-classes__issue" role="alert">
-          This element already has as many classes as the page can apply.
+          {failureMessage(shown)}
         </p>
       ) : null}
       {unapplied > 0 ? (

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -190,6 +190,17 @@ export function ClassSelector({
   // first save is still on the network.
   const [saving, setSaving] = React.useState(false);
   const listId = React.useId();
+  /*
+   * What the node holds RIGHT NOW, for the callback that runs after a save.
+   *
+   * A site-style save is asynchronous, and an author can remove a chip while it
+   * is in flight. The success handler closes over the render that started the
+   * request, so applying from that render's ids would write back the classes as
+   * they stood before the removal — undoing it, from a callback about something
+   * else entirely.
+   */
+  const currentIds = React.useRef(nodeClassIds);
+  currentIds.current = nodeClassIds;
 
   if (library === undefined) {
     return (
@@ -248,12 +259,13 @@ export function ClassSelector({
         }
         // Applied through the ordinary path, so a node already at its limit
         // refuses here exactly as it would for an existing class rather than
-        // being special-cased into a second rule.
-        applyExisting(created.classId);
+        // being special-cased into a second rule — and against the node as it
+        // is NOW, not as it was when the request left.
+        applyExisting(created.classId, currentIds.current);
       });
       return;
     }
-    applyExisting(option.choice.id);
+    applyExisting(option.choice.id, nodeClassIds);
   };
 
   /**
@@ -263,20 +275,20 @@ export function ClassSelector({
    * the id the host just minted, so the per-node bound and the store's refusal
    * are enforced in one place rather than once per caller.
    */
-  function applyExisting(classId: string): void {
+  function applyExisting(classId: string, against: readonly string[]): void {
     // Through the shared helper rather than an append written here. The bound
     // on how many classes a node may carry belongs to one place, and a second
     // append would keep working after that place learned to refuse.
-    const outcome = withClassApplied(nodeClassIds, classId);
+    const outcome = withClassApplied(against, classId);
     if (!outcome.ok) {
-      setFailure({ about: nodeClassIds, issue: { kind: "node-full" } });
+      setFailure({ about: against, issue: { kind: "node-full" } });
       return;
     }
     if (onNodeClassesChange(outcome.classIds) === "refused") {
       // The draft survives, deliberately. An author whose write was refused
       // has lost nothing they typed, and the next thing they do is likely to
       // be trying it again.
-      setFailure({ about: nodeClassIds, issue: { kind: "not-written" } });
+      setFailure({ about: against, issue: { kind: "not-written" } });
       return;
     }
     setFailure(null);

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -131,7 +131,10 @@ describe("what InspectorPanel forwards to the style tab", () => {
     render(
       <InspectorPanel
         editor={editor}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
         classLibrary={[
           { id: "id-hero", slug: "hero", orderIndex: 0, styles: {} },
         ]}

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -82,6 +82,8 @@ export interface InspectorPanelProps {
    * in the shipped editor shows nothing.
    */
   classLibrary?: StyleInspectorPanelProps["classLibrary"];
+  /** Why the library is absent, when it is. Carried, not interpreted. */
+  classLibraryAbsence?: StyleInspectorPanelProps["classLibraryAbsence"];
   /** Create a class and apply it to the selected block. Opts the surface in. */
   onCreateClass?: StyleInspectorPanelProps["onCreateClass"];
   /**
@@ -184,6 +186,7 @@ const INSPECTOR_TABS = [
 export function InspectorPanel({
   editor,
   classLibrary,
+  classLibraryAbsence,
   onCreateClass,
   policy,
   styleState,
@@ -338,6 +341,7 @@ export function InspectorPanel({
             onJumpToBreakpoint={onJumpToBreakpoint}
             tokens={tokens}
             classLibrary={classLibrary}
+            classLibraryAbsence={classLibraryAbsence}
             onCreateClass={onCreateClass}
           />
         </TabsContent>

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -233,7 +233,10 @@ describe("the class selector, mounted above the style sections", () => {
       ] as BlockNode[],
     } as BlockDocument;
     const editor = editorFor(document);
-    const onCreateClass = vi.fn();
+    const onCreateClass = vi.fn(async () => ({
+      ok: true as const,
+      classId: "id-new",
+    }));
     render(
       <StyleInspectorPanel
         editor={editor}
@@ -323,7 +326,10 @@ describe("the class selector, mounted above the style sections", () => {
     render(
       <StyleInspectorPanel
         editor={editor}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
         classLibrary={LIBRARY}
       />
     );
@@ -355,7 +361,10 @@ describe("the class selector, mounted above the style sections", () => {
     const view = render(
       <StyleInspectorPanel
         editor={editorFor(first, "a")}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
         classLibrary={LIBRARY}
       />
     );
@@ -366,7 +375,10 @@ describe("the class selector, mounted above the style sections", () => {
     view.rerender(
       <StyleInspectorPanel
         editor={editorFor(first, "b")}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
         classLibrary={LIBRARY}
       />
     );
@@ -394,7 +406,10 @@ describe("the class selector, mounted above the style sections", () => {
     render(
       <StyleInspectorPanel
         editor={editor}
-        onCreateClass={vi.fn()}
+        onCreateClass={vi.fn(async () => ({
+          ok: true as const,
+          classId: "id-new",
+        }))}
         classLibrary={LIBRARY}
       />
     );

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -72,7 +72,7 @@ import * as React from "react";
 
 import { batchStyleClearOps, batchStyleWriteOps } from "./batch-style";
 import { breakpointQueries, matchedBreakpoints } from "./breakpoints";
-import { ClassSelector } from "./class-selector";
+import { ClassSelector, type ClassSelectorProps } from "./class-selector";
 import { commitOnEnter } from "./commit-on-enter";
 import type { EditorState } from "./editor-state";
 import { fieldLabel } from "./inspector";
@@ -287,7 +287,7 @@ export interface StyleInspectorPanelProps {
    * Applying and removing an EXISTING class needs no callback: those are edits
    * to the selected node, which this panel already writes through the editor.
    */
-  onCreateClass?: (slug: string) => void;
+  onCreateClass?: ClassSelectorProps["onCreateClass"];
 }
 
 /**
@@ -414,7 +414,7 @@ function SelectedNodeClasses({
   editor: EditorState;
   nodeId: string;
   library: readonly NamedClass[] | undefined;
-  onCreateClass: ((slug: string) => void) | undefined;
+  onCreateClass: ClassSelectorProps["onCreateClass"] | undefined;
 }): React.JSX.Element | null {
   if (onCreateClass === undefined) return null;
   return (

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -272,6 +272,8 @@ export interface StyleInspectorPanelProps {
    * should see a field that is about to fill.
    */
   classLibrary?: readonly NamedClass[];
+  /** Why the library is absent, when it is. Forwarded to the selector. */
+  classLibraryAbsence?: ClassSelectorProps["libraryAbsence"];
   /**
    * Create a class under this slug and put it on the selected block.
    *
@@ -409,11 +411,13 @@ function SelectedNodeClasses({
   editor,
   nodeId,
   library,
+  libraryAbsence,
   onCreateClass,
 }: {
   editor: EditorState;
   nodeId: string;
   library: readonly NamedClass[] | undefined;
+  libraryAbsence: ClassSelectorProps["libraryAbsence"];
   onCreateClass: ClassSelectorProps["onCreateClass"] | undefined;
 }): React.JSX.Element | null {
   if (onCreateClass === undefined) return null;
@@ -427,6 +431,7 @@ function SelectedNodeClasses({
        */
       key={nodeId}
       library={library}
+      libraryAbsence={libraryAbsence}
       nodeClassIds={findNode(editor.document.nodes, nodeId)?.classes ?? []}
       onNodeClassesChange={classIds =>
         // `applyAll` answers null when the store refuses — a document at its
@@ -454,6 +459,7 @@ export function StyleInspectorPanel({
   liveBreakpoints,
   onJumpToBreakpoint,
   classLibrary,
+  classLibraryAbsence,
   onCreateClass,
 }: StyleInspectorPanelProps): React.JSX.Element {
   // `null` is "the author has not chosen yet", which is NOT the same as the
@@ -581,6 +587,7 @@ export function StyleInspectorPanel({
         editor={editor}
         nodeId={inspected.nodeId}
         library={classLibrary}
+        libraryAbsence={classLibraryAbsence}
         onCreateClass={onCreateClass}
       />
       {inspected.sections.length === 0 ? (

--- a/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
@@ -1,0 +1,274 @@
+// @vitest-environment jsdom
+
+/**
+ * The site's class library reaching the inspector, and a new class reaching the
+ * site style.
+ *
+ * `class-library.test.ts` in the builder asserts the RULES and
+ * `class-selector.test.tsx` asserts the surface. What is only true HERE is the
+ * wiring: that this component hands the inspector a library at all, that it
+ * tells a read still in flight apart from a library that is genuinely empty,
+ * and that creating a class writes the `classes` section and answers with the
+ * id rather than applying it.
+ *
+ * Every rule can be correct while the props are absent — the selector renders
+ * perfectly in isolation, its own tests pass, and no author ever sees it. That
+ * failure has already happened once on this chain, one component further up.
+ *
+ * The builder shell is replaced with recorders rather than rendered, as
+ * `BlocksField.breakpoints.test` does and for its reason: what is under test is
+ * which props this component passes.
+ *
+ * @module admin/BlocksField.classes.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
+
+/** Props the inspector recorder captured on the most recent render. */
+const seen: { inspector: Record<string, unknown> | undefined } = {
+  inspector: undefined,
+};
+
+/** What `usePluginClientConfig` answers with for the test in hand. */
+let clientConfig: Record<string, unknown> | undefined;
+/** What the stored site-style read reports, so `pending` can be driven. */
+let storedRead: { data: unknown; isPending: boolean; error: unknown };
+/** What a save answers, and what it was handed. */
+let saveResult: { success: boolean } | Error;
+const saved: Array<Record<string, unknown>> = [];
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  const real = await importOriginal<Record<string, unknown>>();
+  const nothing = (): null => null;
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    BuilderShell: ({
+      inspector,
+      topBar,
+      children,
+    }: {
+      inspector: React.ReactNode;
+      topBar?: React.ReactNode;
+      children?: React.ReactNode;
+    }): React.JSX.Element => (
+      <div>
+        {topBar}
+        {inspector}
+        {children}
+      </div>
+    ),
+    InspectorPanel: (props: Record<string, unknown>): React.JSX.Element => {
+      seen.inspector = props;
+      return <div data-recorder="inspector" />;
+    },
+    BreakpointManager: nothing,
+    BreakpointSwitcher: nothing,
+    Canvas: nothing,
+    BlockKeyboardActions: passthrough,
+    BlockToolbar: nothing,
+    EditorCommandPalette: nothing,
+    DropIndicator: nothing,
+    InsertPanel: nothing,
+    LayersPanel: nothing,
+    OnboardingChecklist: nothing,
+    SelectionBreadcrumb: nothing,
+    SpacingOverlay: nothing,
+    useBuilderChecklist: () => ({
+      visible: false,
+      steps: [],
+      dismiss: () => {},
+    }),
+    useCanvasDrag: () => ({ handlers: {}, target: null }),
+    useEditorState: () => ({
+      document: DOCUMENT,
+      selectedId: null,
+      selection: { ids: [], primary: null },
+      apply: () => null,
+      applyAll: () => null,
+      select: () => {},
+      undo: () => {},
+      redo: () => {},
+      canUndo: false,
+      canRedo: false,
+      undoDepth: 0,
+    }),
+    useInlineText: () => ({ onDoubleClick: () => {} }),
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
+  usePluginClientConfig: () => clientConfig,
+  useDocumentCheckpoint: () => ({ schedule: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  /*
+   * Reached only on the refusal path, where `site-style-client` asks it to turn
+   * a rejection into per-field messages. Answering none exercises the branch
+   * that must still refuse when the transport could not describe why.
+   */
+  validationIssues: () => [],
+  useSingleDocument: () => storedRead,
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async (value: Record<string, unknown>) => {
+      saved.push(value);
+      if (saveResult instanceof Error) throw saveResult;
+      return saveResult;
+    },
+    isPending: false,
+  }),
+}));
+
+const { BlocksField } = await import("./BlocksField");
+
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+function openEditor(): void {
+  render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+}
+
+/** What the inspector was handed for the class surface. */
+function classProps(): {
+  classLibrary?: readonly { id: string; slug: string }[];
+  onCreateClass?: (
+    slug: string
+  ) => Promise<{ ok: true; classId: string } | { ok: false; reason: string }>;
+} {
+  return (seen.inspector ?? {}) as never;
+}
+
+beforeEach(() => {
+  seen.inspector = undefined;
+  clientConfig = {};
+  storedRead = { data: undefined, isPending: false, error: null };
+  saveResult = { success: true };
+  saved.length = 0;
+});
+
+afterEach(cleanup);
+
+describe("the library reaching the inspector", () => {
+  it("hands it the classes the site has, so the selector can offer them", () => {
+    clientConfig = {
+      siteStyle: {
+        classes: [{ id: "id-hero", slug: "hero", orderIndex: 0, styles: {} }],
+      },
+    };
+    openEditor();
+
+    expect(classProps().classLibrary?.map(c => c.slug)).toEqual(["hero"]);
+  });
+
+  it("hands it an EMPTY library, not undefined, when the site has none", () => {
+    /*
+     * The two are different answers. `undefined` means the read is still in
+     * flight and the selector says so; an empty list means the site genuinely
+     * has no classes, and the selector must offer to create the first one.
+     */
+    openEditor();
+
+    expect(classProps().classLibrary).toEqual([]);
+  });
+
+  it("hands it undefined while the stored read is still pending", () => {
+    storedRead = { data: undefined, isPending: true, error: null };
+    openEditor();
+
+    expect(classProps().classLibrary).toBeUndefined();
+  });
+
+  it("opts the surface in by supplying the create callback", () => {
+    // Without it the inspector renders no class surface at all, which is how
+    // this chain shipped unreachable once already.
+    openEditor();
+
+    expect(typeof classProps().onCreateClass).toBe("function");
+  });
+});
+
+describe("creating a class", () => {
+  it("writes the classes section and answers with the new id", async () => {
+    clientConfig = {
+      siteStyle: {
+        classes: [{ id: "id-hero", slug: "hero", orderIndex: 0, styles: {} }],
+      },
+    };
+    openEditor();
+
+    const created = await classProps().onCreateClass!("call-to-action");
+
+    expect(created.ok).toBe(true);
+    expect(saved).toHaveLength(1);
+    const written = saved[0]?.classes as { id: string; slug: string }[];
+    expect(written.map(c => c.slug)).toEqual(["hero", "call-to-action"]);
+    // The id it reports is the id it stored, or the caller applies a class the
+    // library does not contain.
+    expect(created.ok && created.classId).toBe(written[1]?.id);
+  });
+
+  it("gives the new class a fresh id rather than seeding it from the slug", () => {
+    // `NamedClass` keeps id and slug apart so a rename cannot orphan the
+    // documents referencing it; an id derived from the name would be a fossil
+    // of whatever the class was called first.
+    openEditor();
+
+    return classProps().onCreateClass!("call-to-action").then(() => {
+      const written = saved[0]?.classes as { id: string; slug: string }[];
+      expect(written[0]?.id).not.toBe("call-to-action");
+      expect(written[0]?.id.length).toBeGreaterThan(10);
+    });
+  });
+
+  it("orders it past every existing class, so applying it wins", async () => {
+    clientConfig = {
+      siteStyle: {
+        classes: [
+          { id: "a", slug: "one", orderIndex: 0, styles: {} },
+          { id: "b", slug: "two", orderIndex: 7, styles: {} },
+        ],
+      },
+    };
+    openEditor();
+
+    await classProps().onCreateClass!("three");
+
+    const written = saved[0]?.classes as { orderIndex: number }[];
+    expect(written[2]?.orderIndex).toBe(8);
+  });
+
+  it("does NOT apply it to a node — that is the inspector's write", async () => {
+    // Two documents. Returning the id keeps the application on the one path
+    // that enforces the per-node bound.
+    openEditor();
+
+    await classProps().onCreateClass!("call-to-action");
+
+    expect(saved).toHaveLength(1);
+    expect(Object.keys(saved[0] ?? {})).toEqual(["classes"]);
+  });
+
+  it("reports a refusal instead of claiming the class exists", async () => {
+    saveResult = new Error("nope");
+    openEditor();
+
+    const created = await classProps().onCreateClass!("call-to-action");
+
+    expect(created.ok).toBe(false);
+    expect(created.ok === false && created.reason.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
@@ -145,6 +145,7 @@ function openEditor(): void {
 /** What the inspector was handed for the class surface. */
 function classProps(): {
   classLibrary?: readonly { id: string; slug: string }[];
+  classLibraryAbsence?: "pending" | "failed";
   onCreateClass?: (
     slug: string
   ) => Promise<{ ok: true; classId: string } | { ok: false; reason: string }>;
@@ -198,6 +199,37 @@ describe("the library reaching the inspector", () => {
     openEditor();
 
     expect(typeof classProps().onCreateClass).toBe("function");
+  });
+});
+
+describe("why the library is absent", () => {
+  it("reports a pending read as pending", () => {
+    storedRead = { data: undefined, isPending: true, error: null };
+    openEditor();
+
+    expect(classProps().classLibrary).toBeUndefined();
+    expect(classProps().classLibraryAbsence).toBe("pending");
+  });
+
+  it("reports a FAILED read as failed, not as still loading", () => {
+    /*
+     * A failed read will not finish. Passed as pending, the selector says
+     * "loading" for as long as the editor is open — a state the site is not in,
+     * with nothing the author can do about it.
+     */
+    storedRead = { data: undefined, isPending: false, error: new Error("403") };
+    openEditor();
+
+    expect(classProps().classLibrary).toBeUndefined();
+    expect(classProps().classLibraryAbsence).toBe("failed");
+  });
+
+  it("reports a successful empty read as a library, not an absence", () => {
+    // The control: a site with no classes has READ them. Treating that as an
+    // absence would hide the surface that creates the first one.
+    openEditor();
+
+    expect(classProps().classLibrary).toEqual([]);
   });
 });
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
@@ -235,10 +235,15 @@ describe("why the library is absent", () => {
 
 describe("creating a class", () => {
   it("writes the classes section and answers with the new id", async () => {
-    clientConfig = {
-      siteStyle: {
+    // STORED rather than config-supplied: a config class is layered under
+    // storage and is deliberately not written back, which is a different test
+    // below. What this one is about is an existing stored library gaining one.
+    storedRead = {
+      data: {
         classes: [{ id: "id-hero", slug: "hero", orderIndex: 0, styles: {} }],
       },
+      isPending: false,
+      error: null,
     };
     openEditor();
 
@@ -267,13 +272,15 @@ describe("creating a class", () => {
   });
 
   it("orders it past every existing class, so applying it wins", async () => {
-    clientConfig = {
-      siteStyle: {
+    storedRead = {
+      data: {
         classes: [
           { id: "a", slug: "one", orderIndex: 0, styles: {} },
           { id: "b", slug: "two", orderIndex: 7, styles: {} },
         ],
       },
+      isPending: false,
+      error: null,
     };
     openEditor();
 
@@ -292,6 +299,44 @@ describe("creating a class", () => {
 
     expect(saved).toHaveLength(1);
     expect(Object.keys(saved[0] ?? {})).toEqual(["classes"]);
+  });
+
+  it("stores only what differs from the site's own config classes", async () => {
+    /*
+     * `canvasSiteStyle` is the MERGED library the canvas compiles. Saving it
+     * whole would copy every config-supplied class into the database on the
+     * first creation and mask the site's code from then on — the argument
+     * `tokenOverrideOf` already makes for tokens.
+     */
+    clientConfig = {
+      siteStyle: {
+        classes: [
+          { id: "id-cfg", slug: "from-config", orderIndex: 0, styles: {} },
+        ],
+      },
+    };
+    openEditor();
+
+    await classProps().onCreateClass!("mine");
+
+    const written = saved[0]?.classes as { id: string; slug: string }[];
+    expect(written.map(c => c.slug)).toEqual(["mine"]);
+    expect(written.map(c => c.id)).not.toContain("id-cfg");
+  });
+
+  it("refuses to create at all when the library could not be read", async () => {
+    /*
+     * A failed read leaves `useSiteStyle` answering with the config defaults
+     * alone. Composing against that would build a library missing everything
+     * stored, and the save would DELETE those classes rather than add one.
+     */
+    storedRead = { data: undefined, isPending: false, error: new Error("403") };
+    openEditor();
+
+    const created = await classProps().onCreateClass!("mine");
+
+    expect(created.ok).toBe(false);
+    expect(saved).toHaveLength(0);
   });
 
   it("reports a refusal instead of claiming the class exists", async () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -40,8 +40,10 @@ import {
   registerBlocks,
   registryNestingSource,
   previewContainerFor,
+  newId,
   type BlockDocument,
   type BreakpointSet,
+  type NamedClass,
   type SiteTokenSet,
   type BreakpointId,
 } from "@nextlyhq/blocks-engine";
@@ -541,6 +543,82 @@ function TokensStudio({
  * three fields of the record are owned by other studios and are not read here in
  * order to write this one.
  */
+/**
+ * Create a named class in the site's library, answering with its new id.
+ *
+ * Two documents are involved and this owns only one. The class lives in the
+ * site style; putting it on a block is a node write the inspector already
+ * performs, so this returns the id rather than applying it — one application
+ * path, and the per-node bound stays enforced in a single place.
+ *
+ * The id is minted with the engine's own `newId`, which is where every other id
+ * in this repository comes from. Deliberately not derived from the slug:
+ * `NamedClass` keeps `id` and `slug` apart precisely so a rename cannot orphan
+ * the documents referencing it, and a slug-seeded id would be a fossil of
+ * whatever the class was called first.
+ *
+ * `orderIndex` is one past the highest in the library, so a class an author has
+ * just created and applied wins over the ones already there rather than being
+ * silently overridden by them.
+ */
+function useClassSurface(
+  siteStyle: { classes?: readonly NamedClass[] } | undefined,
+  pending: boolean
+) {
+  /*
+   * `undefined` while the read is in flight, and the resolved list once it is
+   * not — including an empty one. `useSiteStyle` names `pending` as a real
+   * third state for exactly this reason: the defaults alone are a legitimate
+   * answer, so a surface cannot tell "nothing is stored" from "the read has
+   * not come back" by looking at the value. Decided here rather than in the
+   * markup, so the component that renders the inspector holds no branch.
+   */
+  const library = pending ? undefined : (siteStyle?.classes ?? []);
+  return { library, create: useCreateClass(siteStyle?.classes) };
+}
+
+function useCreateClass(library: readonly NamedClass[] | undefined) {
+  // Its own write handle rather than one passed in. The caller is already the
+  // largest component in this file, and a dependency a hook can obtain for
+  // itself is a statement that does not need to live there.
+  const { save: saveSection } = useSaveSiteStyle();
+  return useCallback(
+    async (slug: string) => {
+      const existing = library ?? [];
+      const classId = newId();
+      const next: NamedClass[] = [
+        ...existing,
+        { id: classId, slug, orderIndex: nextOrderIndex(existing), styles: {} },
+      ];
+      const result = await saveSection("classes", next);
+      if (result.saved) return { ok: true as const, classId };
+      const reasons = Object.values(result.issues);
+      // An empty `issues` is still a refusal — the transport could not describe
+      // it. Reporting it as saved is the one outcome that must never be silent,
+      // which is the rule the breakpoints writer below follows too.
+      return {
+        ok: false as const,
+        reason:
+          reasons.length > 0
+            ? reasons.join(" ")
+            : "This class could not be saved.",
+      };
+    },
+    [library, saveSection]
+  );
+}
+
+/** One past the highest position in the library, or zero for an empty one. */
+function nextOrderIndex(library: readonly NamedClass[]): number {
+  return library.reduce(
+    (highest, entry) =>
+      Number.isFinite(entry.orderIndex)
+        ? Math.max(highest, entry.orderIndex + 1)
+        : highest,
+    0
+  );
+}
+
 function useBreakpointWriter(
   configSiteStyle: SiteStyleData | undefined
 ): (next: BreakpointSet) => Promise<string | undefined> {
@@ -839,6 +917,10 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     pending: siteStylePending,
     error: siteStyleError,
   } = useSiteStyle(configSiteStyle);
+
+  // The site-style half of the class surface. The node half stays with the
+  // inspector, which already writes nodes — see `useClassSurface`.
+  const classes = useClassSurface(canvasSiteStyle, siteStylePending);
 
   /*
    * The hosts this site loads media from, read back from the same client
@@ -1401,6 +1483,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         inspector={
           <InspectorPanel
             editor={editor}
+            classLibrary={classes.library}
+            onCreateClass={classes.create}
             policy={stylePolicy}
             cascade={styleCascade}
             breakpoints={canvasRender.styleContext.breakpoints}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -116,6 +116,7 @@ import {
 import { emptyBlockDocument } from "../fields/blocks-document";
 import { hostFetchPolicy, readRemotePatterns } from "../host-policy";
 import {
+  classOverrideOf,
   tokenOverrideOf,
   tokenSaveOutcome,
   siteBreakpoints,
@@ -564,7 +565,9 @@ function TokensStudio({
 function useClassSurface(
   siteStyle: { classes?: readonly NamedClass[] } | undefined,
   pending: boolean,
-  error: unknown
+  error: unknown,
+  /** The site's own config, whose classes storage layers over. */
+  config: { classes?: readonly NamedClass[] } | undefined
 ) {
   /*
    * `undefined` while the read is in flight, and the resolved list once it is
@@ -584,24 +587,50 @@ function useClassSurface(
      * the site is not in — the distinction the tokens studio already draws.
      */
     absence: failed ? ("failed" as const) : ("pending" as const),
-    create: useCreateClass(siteStyle?.classes),
+    /*
+     * Withheld while the library is unknown. A failed read leaves
+     * `useSiteStyle` answering with the config defaults alone, so creating
+     * against it would compose a library missing everything stored — and the
+     * save would then delete those classes rather than add one.
+     */
+    create: useCreateClass(library, config?.classes),
   };
 }
 
-function useCreateClass(library: readonly NamedClass[] | undefined) {
+function useCreateClass(
+  library: readonly NamedClass[] | undefined,
+  configured: readonly NamedClass[] | undefined
+) {
   // Its own write handle rather than one passed in. The caller is already the
   // largest component in this file, and a dependency a hook can obtain for
   // itself is a statement that does not need to live there.
   const { save: saveSection } = useSaveSiteStyle();
   return useCallback(
     async (slug: string) => {
-      const existing = library ?? [];
+      if (library === undefined) {
+        return {
+          ok: false as const,
+          reason:
+            "This site's classes could not be read, so none can be added.",
+        };
+      }
+      const existing = library;
       const classId = newId();
       const next: NamedClass[] = [
         ...existing,
         { id: classId, slug, orderIndex: nextOrderIndex(existing), styles: {} },
       ];
-      const result = await saveSection("classes", next);
+      /*
+       * Only what DIFFERS from the site's own config classes. `library` is the
+       * MERGED set the canvas compiles, so saving it whole would copy every
+       * config class into the database on the first creation and mask the
+       * site's code from then on — the argument `tokenOverrideOf` already
+       * makes for tokens.
+       */
+      const result = await saveSection(
+        "classes",
+        classOverrideOf(configured, next)
+      );
       if (result.saved) return { ok: true as const, classId };
       const reasons = Object.values(result.issues);
       // An empty `issues` is still a refusal — the transport could not describe
@@ -615,7 +644,7 @@ function useCreateClass(library: readonly NamedClass[] | undefined) {
             : "This class could not be saved.",
       };
     },
-    [library, saveSection]
+    [library, configured, saveSection]
   );
 }
 
@@ -934,7 +963,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const classes = useClassSurface(
     canvasSiteStyle,
     siteStylePending,
-    siteStyleError
+    siteStyleError,
+    configSiteStyle
   );
 
   /*

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -563,7 +563,8 @@ function TokensStudio({
  */
 function useClassSurface(
   siteStyle: { classes?: readonly NamedClass[] } | undefined,
-  pending: boolean
+  pending: boolean,
+  error: unknown
 ) {
   /*
    * `undefined` while the read is in flight, and the resolved list once it is
@@ -573,8 +574,18 @@ function useClassSurface(
    * not come back" by looking at the value. Decided here rather than in the
    * markup, so the component that renders the inspector holds no branch.
    */
-  const library = pending ? undefined : (siteStyle?.classes ?? []);
-  return { library, create: useCreateClass(siteStyle?.classes) };
+  const failed = !pending && error !== null && error !== undefined;
+  const library = pending || failed ? undefined : (siteStyle?.classes ?? []);
+  return {
+    library,
+    /*
+     * Which absence, so the selector can say so. A read that FAILED will not
+     * finish, and a surface that goes on saying "loading" describes a state
+     * the site is not in — the distinction the tokens studio already draws.
+     */
+    absence: failed ? ("failed" as const) : ("pending" as const),
+    create: useCreateClass(siteStyle?.classes),
+  };
 }
 
 function useCreateClass(library: readonly NamedClass[] | undefined) {
@@ -920,7 +931,11 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
 
   // The site-style half of the class surface. The node half stays with the
   // inspector, which already writes nodes — see `useClassSurface`.
-  const classes = useClassSurface(canvasSiteStyle, siteStylePending);
+  const classes = useClassSurface(
+    canvasSiteStyle,
+    siteStylePending,
+    siteStyleError
+  );
 
   /*
    * The hosts this site loads media from, read back from the same client
@@ -1484,6 +1499,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           <InspectorPanel
             editor={editor}
             classLibrary={classes.library}
+            classLibraryAbsence={classes.absence}
             onCreateClass={classes.create}
             policy={stylePolicy}
             cascade={styleCascade}

--- a/packages/plugin-page-builder/src/site-style.ts
+++ b/packages/plugin-page-builder/src/site-style.ts
@@ -110,6 +110,40 @@ export function resolveSiteStyle(
 }
 
 /**
+ * The stored class tier that, merged under the site's config classes, gives
+ * this library.
+ *
+ * The same argument `tokenOverrideOf` makes, for the same reason: what the
+ * canvas holds is the MERGED library, and saving it whole would copy every
+ * config-supplied class into the database on the first creation and mask the
+ * site's own code from then on. Only what differs is stored.
+ *
+ * A class is compared whole rather than by id alone, so an override that
+ * changes a supplied class's name or styles is kept while an untouched copy of
+ * it is dropped.
+ */
+export function classOverrideOf(
+  defaults: readonly NamedClass[] | undefined,
+  edited: readonly NamedClass[]
+): NamedClass[] {
+  const supplied = new Map((defaults ?? []).map(entry => [entry.id, entry]));
+  return edited.filter(entry => {
+    const base = supplied.get(entry.id);
+    return base === undefined || !sameNamedClass(base, entry);
+  });
+}
+
+/** Whether two classes are the same class, to the byte. */
+function sameNamedClass(a: NamedClass, b: NamedClass): boolean {
+  return (
+    a.id === b.id &&
+    a.slug === b.slug &&
+    a.orderIndex === b.orderIndex &&
+    sameJsonValue(a.styles, b.styles)
+  );
+}
+
+/**
  * The stored tier that, merged under the site's config defaults, gives this set.
  *
  * The INVERSE of the token half of {@link resolveSiteStyle}, and the reason a

--- a/scripts/husky-hooks.test.mjs
+++ b/scripts/husky-hooks.test.mjs
@@ -117,6 +117,21 @@ describe("the pre-push hook specifically", () => {
     expect(await hook("pre-push")).toMatch(/^#!\/usr\/bin\/env sh\r?\n/);
   });
 
+  it("does not let the repo-wide typecheck refuse the push", async () => {
+    /*
+     * The only gate here whose scope is the whole repository, so it can be red
+     * for a package the author never touched. A hook that refuses over someone
+     * else's breakage is one people pass `--no-verify` to, which costs every
+     * gate rather than this one. CI blocks on the same command.
+     */
+    const source = shellCode(await hook("pre-push"));
+
+    expect(source).toMatch(/^set \+e\n\s*pnpm turbo check-types/m);
+    expect(source).toMatch(/^TYPES_STATUS=\$\?/m);
+    // Reported, so it is not silent either.
+    expect(source).toMatch(/if \[ "\$TYPES_STATUS" -ne 0 \]/);
+  });
+
   it("typechecks the whole repo, which nothing here did before", async () => {
     // `lint` and `build` above already run repo-wide, so types were the one
     // whole-repo question this hook was not asking — and an API or type break


### PR DESCRIPTION
**Stacked on #1314** — it needs the `classLibrary` / `onCreateClass` props that PR adds. Base is `feat/pb-mount-class-selector`, not `main`; retarget once #1314 lands.

This is the last link. The selector reached the inspector but nothing supplied it, so the surface existed and no author could see it.

## The split: two documents, and this owns one

A class lives in the **site style**; putting it on a block is a **node write**. `onCreateClass` therefore creates and returns the new **id** rather than applying it — the inspector applies, through the same path every other application takes, so the per-block class limit and the store's own refusal stay enforced in one place instead of once per caller.

## The id, which had no precedent I could find at first

I searched `plugin-page-builder` and `builder` and found nothing, then was pointed at `blocks-engine`'s `newId()` — exported from its index, and repo-wide the **only** thing anything mints ids with (65 uses of `crypto.randomUUID`, zero of nanoid/uuid/cuid). So `newId`.

**Deliberately not seeded from the slug.** `NamedClass` keeps `id` and `slug` apart precisely so a rename cannot orphan the documents referencing it; a slug-derived id would be a fossil of whatever the class was first called.

`orderIndex` is one past the highest in the library, so a class an author just created and applied wins rather than being silently overridden by what was already there.

## Two states that must not collapse

`useSiteStyle` documents `pending` as a real third state — *"a surface cannot tell 'nothing is stored' from 'the read has not come back' by looking at the value"*. So `classLibrary` is `undefined` while reading and `[]` when the site genuinely has none. Only one of those has a field about to fill.

A refused save reports the reason in the author's words rather than clearing the name they typed. `onCreateClass` became async and answering for that reason — the same defect Codex found on the node-write path in #1314, fixed here before it was found rather than after.

## The complexity gate, twice

`BlocksEditor` is the largest component in the file and already carries an inherited cognitive 43. My first wiring took it to **46 introduced**, and moving the save handle into the hook only reached 45. Both decisions now live in **one hook** (`useClassSurface`), so the component gains a single statement and **no branch** — the `pending` ternary moved out of the markup. `complexity_introduced` is back to **0** and `BlocksEditor` reports `introduced: false`.

## Gates

Both packages: build, vitest (**2344** builder, **509** plugin-page-builder), check-types, package lint `--max-warnings 0`, root eslint, `lint:design`, `lint:workspace`, comment convention, `check-changesets` as CI runs it — all exit 0. Fallow: every `*_introduced` at **0**.

Four breaks verified, each failing only its named tests: dropping the forwarded props, ignoring `pending`, seeding `orderIndex` at zero, and reporting a refused save as success.

**One thing found by reading the exit status rather than the summary:** making `onCreateClass` async produced three unhandled `Cannot read properties of undefined (reading 'then')` while vitest printed "216 passed". The fakes returned `undefined` from a callback now contracted to return a promise. They answer the contract now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added named-class management to the page builder, including class creation, ordering, persistence, and configuration overrides.
  - Added clear loading and failure states when the class library is unavailable.
  - Improved class application while changes are being saved, preventing duplicate or outdated updates.

- **Bug Fixes**
  - Failure messages now clear when switching nodes.
  - Prevented stale asynchronous class creations from being applied to the wrong node.

- **Chores**
  - Pre-push typecheck failures are now reported as warnings while tests remain blocking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->