### PR TITLE
fix(root): make the repo-wide typecheck advisory, not a push blocker

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -75,7 +75,19 @@ pnpm run build
 # run repo-wide, so types were the one whole-repo question this hook was not
 # asking. A dependent TEST sweep is the expensive one and stays in CI, where
 # nobody is waiting on it.
+#
+# ADVISORY, not blocking. This is the one gate here whose scope is the whole
+# repository, so it can be red for a package the author never touched — and a
+# hook that refuses a push over someone else's broken package is a hook people
+# learn to pass `--no-verify` to, which costs every gate rather than this one.
+#
+# Reported instead, with the packages named, so an author can see at a glance
+# whether the failure is theirs. CI blocks on the same command; this is the
+# early warning, not the enforcement.
+set +e
 pnpm turbo check-types --continue
+TYPES_STATUS=$?
+set -e
 
 # The TESTS of the packages this branch actually changes.
 #
@@ -116,6 +128,13 @@ elif [ "$GATE_STATUS" -ne 0 ]; then
 elif [ -n "$GATE_FILTERS" ]; then
   # shellcheck disable=SC2086 -- one flag per line, intentionally word-split
   pnpm turbo test --continue $GATE_FILTERS
+fi
+
+if [ "$TYPES_STATUS" -ne 0 ]; then
+  echo ""
+  echo "pre-push: NOTE — the repo-wide typecheck failed. Check whether the"
+  echo "  failing package is one you changed: this gate covers every package,"
+  echo "  so it can be red for someone else's work. CI blocks on it either way."
 fi
 
 # Last, so it is the line still on screen when the push proceeds.

--- a/scripts/husky-hooks.test.mjs
+++ b/scripts/husky-hooks.test.mjs
@@ -117,6 +117,21 @@ describe("the pre-push hook specifically", () => {
     expect(await hook("pre-push")).toMatch(/^#!\/usr\/bin\/env sh\r?\n/);
   });
 
+  it("does not let the repo-wide typecheck refuse the push", async () => {
+    /*
+     * The only gate here whose scope is the whole repository, so it can be red
+     * for a package the author never touched. A hook that refuses over someone
+     * else's breakage is one people pass `--no-verify` to, which costs every
+     * gate rather than this one. CI blocks on the same command.
+     */
+    const source = shellCode(await hook("pre-push"));
+
+    expect(source).toMatch(/^set \+e\n\s*pnpm turbo check-types/m);
+    expect(source).toMatch(/^TYPES_STATUS=\$\?/m);
+    // Reported, so it is not silent either.
+    expect(source).toMatch(/if \[ "\$TYPES_STATUS" -ne 0 \]/);
+  });
+
   it("typechecks the whole repo, which nothing here did before", async () => {
     // `lint` and `build` above already run repo-wide, so types were the one
     // whole-repo question this hook was not asking — and an API or type break


### PR DESCRIPTION
**Urgent — this unblocks every lane's push.** My own change, merged an hour ago in #1315, is what blocked them.

## What happened

#1315 added `pnpm turbo check-types --continue` to the pre-push hook as a blocking step. It covers the whole repository, so it refuses a push whenever **any** package fails to typecheck — including one the author never touched.

That happened within the hour. `2d1868f73` (#1306, merged 05:22Z) landed seven type errors in `packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts`:

```
TS2352  Conversion of type 'undefined' to 'Record<string, unknown>'
TS2493  Tuple type '[]' of length '0' has no element at index '0'
lines 137, 174, 192, 212
```

The expression is `find.mock.calls[0]?.[0] as Record<string, unknown>` — the `vi.fn()` has no call signature, so `calls` types as an empty tuple. **Nobody's diff since is at fault**, and at least two lanes were blocked on it, neither owning that package.

## The change

`check-types` still runs, still on every push, and now **reports instead of refusing**, naming the risk that the failing package may not be the author's.

**A hook that refuses over someone else's breakage is a hook people pass `--no-verify` to** — which costs every gate rather than this one. That is the trade I got wrong. CI blocks on the identical command, so nothing is weaker where enforcement actually lives; this is the early warning it was always worth having.

## What is NOT changed

The dirty-worktree note, the ordering guarantee (`check-types` after `build`, since it never builds and reads `dist`), and the tests asserting both. Only the blocking behaviour moves.

## Note on the underlying red

**`packages/nextly` is still broken on main and this PR does not fix it** — deliberately. It is another lane's territory and one of the failing lines carries the comment *"The key must be PRESENT and undefined. `not.toHaveProperty` would pass on a deleted key"*, so a careless retype would quietly weaken the thing the test exists to check. That belongs to whoever owns it.

## Gates

`pnpm test:scripts` (**673 passed**), `sh -n .husky/pre-push`, comment convention, fallow with every `*_introduced` at 0 — all exit 0. Break-verified: restoring the blocking form fails the new test and only that one.

This branch's own push exercised it — the NOTE printed and the push proceeded.