### PR TITLE
fix(nextly): give the job content-client mocks a declared parameter

### DIFF
--- a/.changeset/name-the-parts-of-a-job-attempt.md
+++ b/.changeset/name-the-parts-of-a-job-attempt.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Splits the background-job runner's per-job step into named parts.
+
+`runOne` was one long function that stated the same failure decision three
+times — once for a failed identity lookup, once for a failed lease re-check and
+once for a handler that threw. It states it once now, and the branch for a job
+whose type this instance does not recognise is its own function. Behaviour is
+unchanged.

--- a/packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts
@@ -118,7 +118,13 @@ describe("the options this client OWNS", () => {
     // it sets. `actor` is the sharpest: `apiKeyScopeAllows` reads its
     // `permissions` array as AUTHORITATIVE rather than consulting the bound
     // user's grants, so a caller supplying one grants itself what it names.
-    const find = vi.fn(async () => ({ items: [] }));
+    // The parameter is DECLARED, not inferred. Without it `vi.fn` types
+    // `mock.calls` as an empty tuple, so reading `calls[0][0]` is a type
+    // error — invisible to `vitest` and to a bare `tsc --noEmit`, and
+    // reported only by the second pass `check-types` runs over the tests.
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+    }));
     const client = createJobContentApi({ id: "u1", roles: ["editor"] }, {
       find,
     } as never);
@@ -161,7 +167,9 @@ describe("the options this client OWNS", () => {
     // whose `permissions` array is read as authoritative, behind a wrapper
     // advertising a bound identity. Present-and-undefined is what wins the
     // spread.
-    const find = vi.fn(async () => ({ items: [] }));
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+    }));
     const client = createJobContentApi({ id: "u1", roles: ["editor"] }, {
       find,
     } as never);
@@ -182,7 +190,9 @@ describe("the options this client OWNS", () => {
     // A job queued by nobody acts as nobody. With `user` merely deleted, an
     // instance default would be merged back in and the least-privileged job
     // would run as whoever that default names.
-    const find = vi.fn(async () => ({ items: [] }));
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+    }));
     const client = createJobContentApi(null, { find } as never);
 
     await (client.find as (args: unknown) => Promise<unknown>)({
@@ -199,7 +209,9 @@ describe("the options this client OWNS", () => {
     // The control. Stripping everything would satisfy the case above while
     // making the client useless: a job could not choose a locale, a depth, or
     // pass context to its hooks.
-    const find = vi.fn(async () => ({ items: [] }));
+    const find = vi.fn(async (_args: Record<string, unknown>) => ({
+      items: [],
+    }));
     const client = createJobContentApi(null, { find } as never);
 
     await (client.find as (args: unknown) => Promise<unknown>)({

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -233,36 +233,30 @@ async function runOne(
   };
 
   const definition = deps.registry.get(job.slug);
-
-  // Deferred BEFORE an attempt is charged.
-  //
-  // During a rolling deployment an instance that has not been replaced yet does
-  // not know a slug the new instances already enqueue. Charging that to the
-  // job's retry budget lets the old workers exhaust it before a new one gets a
-  // turn — the job then fails permanently for a reason that had already fixed
-  // itself.
-  //
-  // The row is still never silently skipped: the reason is recorded, so a type
-  // genuinely deleted while rows were queued shows up in the admin instead of
-  // cycling invisibly. It simply keeps its budget for a runner that can run it.
   if (definition === undefined) {
-    const deferred = nextAttempt({
-      attemptCount: 1,
-      maxAttempts: DEFAULT_MAX_ATTEMPTS,
-      now: now(),
-      random: deps.random,
-    });
-    return {
-      id: job.id,
-      runnerId,
-      outcome: "retry",
-      nextAttemptAt: deferred.outcome === "retry" ? deferred.at : null,
-      lastError: `No job type is registered for "${job.slug}".`,
-      now: now(),
-    };
+    return deferUnregistered(job, runnerId, now, deps.random);
   }
 
   const attempt = job.attemptCount + 1;
+  /**
+   * Record this attempt as failed, and let the backoff policy decide whether
+   * another one follows.
+   *
+   * Every failure below reaches the same decision with the same arguments, and
+   * stating it once is what keeps the three of them from drifting into three
+   * slightly different answers to "what happens when this job errors".
+   */
+  const failed = (error: unknown): FinalizeInput =>
+    decide(
+      job,
+      attempt,
+      definition.retry.maxAttempts,
+      error instanceof Error ? error.message : String(error),
+      runnerId,
+      now,
+      deps.random
+    );
+
   const stillOurs = await deps.store.markAttempt(
     job.id,
     runnerId,
@@ -284,15 +278,7 @@ async function runOne(
   try {
     identity = await resolveRunAs(deps.runAs, job.runAsUserId);
   } catch (error) {
-    return decide(
-      job,
-      attempt,
-      definition.retry.maxAttempts,
-      error instanceof Error ? error.message : String(error),
-      runnerId,
-      now,
-      deps.random
-    );
+    return failed(error);
   }
   // Terminal, not retried: a deleted or deactivated user does not come back on
   // the next pass, and retrying would cycle an unrunnable row forever.
@@ -320,15 +306,7 @@ async function runOne(
     // and skipping every later candidate in the batch. One unlucky write would
     // stop the whole drain. Charged as an ordinary attempt instead, so the job
     // retries on its own backoff.
-    return decide(
-      job,
-      attempt,
-      definition.retry.maxAttempts,
-      error instanceof Error ? error.message : String(error),
-      runnerId,
-      now,
-      deps.random
-    );
+    return failed(error);
   }
   if (!stillOursAfterIdentity) return LEASE_LOST;
 
@@ -346,15 +324,7 @@ async function runOne(
       })
     );
   } catch (error) {
-    return decide(
-      job,
-      attempt,
-      definition.retry.maxAttempts,
-      error instanceof Error ? error.message : String(error),
-      runnerId,
-      now,
-      deps.random
-    );
+    return failed(error);
   }
 
   return {
@@ -363,6 +333,41 @@ async function runOne(
     outcome: "done",
     nextAttemptAt: null,
     lastError: null,
+    now: now(),
+  };
+}
+
+/**
+ * A job whose type this instance does not know, deferred without charging an
+ * attempt.
+ *
+ * During a rolling deployment an instance that has not been replaced yet does
+ * not know a slug the new instances already enqueue. Charging that to the job's
+ * retry budget lets the old workers exhaust it before a new one gets a turn —
+ * the job then fails permanently for a reason that had already fixed itself.
+ *
+ * The row is still never silently skipped: the reason is recorded, so a type
+ * genuinely deleted while rows were queued shows up in the admin instead of
+ * cycling invisibly. It simply keeps its budget for a runner that can run it.
+ */
+function deferUnregistered(
+  job: JobRow,
+  runnerId: string,
+  now: () => Date,
+  random: (() => number) | undefined
+): FinalizeInput {
+  const deferred = nextAttempt({
+    attemptCount: 1,
+    maxAttempts: DEFAULT_MAX_ATTEMPTS,
+    now: now(),
+    random,
+  });
+  return {
+    id: job.id,
+    runnerId,
+    outcome: "retry",
+    nextAttemptAt: deferred.outcome === "retry" ? deferred.at : null,
+    lastError: `No job type is registered for "${job.slug}".`,
     now: now(),
   };
 }


### PR DESCRIPTION
**`main` is red at `check-types`, and it is my file.** Measured on a clean `origin/main` checkout (`da590b026`), after building siblings so the result is not the fresh-worktree "cannot find module" noise:

```
pnpm run check-types  →  7 errors, all in
  packages/nextly/src/domains/jobs/__tests__/job-content-api.test.ts
```

This branch: **0**.

## The bug

`vi.fn(async () => ...)` infers an **empty parameter tuple**, so `find.mock.calls[0]?.[0]` is `TS2493: Tuple type '[]' of length '0' has no element at index '0'`. Naming the parameter gives the tuple an element. Four occurrences.

## Why nothing caught it before it merged

`check-types` is `tsc --noEmit && tsc --noEmit -p tsconfig.tests.json`, and **only the second invocation covers the test tree**. A test-file type error is invisible to a bare `tsc --noEmit` — which is what I was running — and vitest runs the file green regardless. The suite passes with all 7 errors present.

That is the whole trap: every signal in my normal loop was green. I have switched to running the package script rather than the bare command.

It mattered more than untidiness because #1315 added `check-types` to `.husky/pre-push`, so a red `main` rejected any push touching `packages/nextly` in **any** lane. A separate change has since made that advisory, but main should be green regardless.

## Also: `runOne` split up

Fallow scored it **CRAP 49.5** against a threshold of 30 — a 151-line function carrying three identical nine-line failure blocks. The three are now one `failed()` decision stated once, and the unregistered-slug branch is its own function.

Measured locally rather than inferred, and **controlled**: auditing the pre-split function with the file marked changed reproduces `runOne crap=49.5 cyclo=13` exactly; with the split, `complexity_findings=0`.

My first attempt at that control was invalid and I discarded it — stashing the change made the file identical to main, so fallow stopped analysing it entirely and reported no finding. A file the tool is not looking at cannot produce one.

**This is worth fixing beyond this package.** Fallow's `--changed-since` runs against the merge ref, so a complex function landing on `main` is attributed to whichever PR runs next — this one was reddening an unrelated lane's `Changed files` check.

## Verification

- Behaviour unchanged: reverting the shared `failed()` decision to a terminal outcome fails two named tests (`records a transient identity-lookup FAILURE as a retryable attempt...`, `retries a handler that throws while its budget lasts`).
- `check-types` 0 errors, lint clean, prettier clean, 69 jobs/schema tests pass.
- 3 files, 0 deletions, 0 conflicts against `main`.