### PR TITLE
fix(builder): scope a class failure by content, and keep a query typed since

### DIFF
--- a/.changeset/class-failure-scoped-by-content.md
+++ b/.changeset/class-failure-scoped-by-content.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A failure reported by the class selector is now matched to its element by what
+that element holds rather than by the identity of the list holding it. A block
+with no classes is described by a freshly built list on every redraw, so the
+message was discarded on the next one — which is every one — and an author
+never saw it.
+
+The name being typed also survives a class being created. The field stays
+usable while the save is in flight, so an author can begin the next name before
+the first one lands, and finishing the first no longer clears what they typed
+since.

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -49,6 +49,7 @@ function draw(overrides: Partial<ClassSelectorProps> = {}): {
   }));
   render(
     <ClassSelector
+      nodeId="node-a"
       library={LIBRARY}
       nodeClassIds={[]}
       onNodeClassesChange={onNodeClassesChange}
@@ -65,6 +66,7 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
 } {
   const view = render(
     <ClassSelector
+      nodeId="node-a"
       library={LIBRARY}
       nodeClassIds={initial.nodeClassIds}
       onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -75,6 +77,7 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
     rerender: nodeClassIds =>
       view.rerender(
         <ClassSelector
+          nodeId="node-a"
           library={LIBRARY}
           nodeClassIds={nodeClassIds}
           onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -110,6 +113,7 @@ describe("a library that has not been read yet", () => {
     // two the same way invites a create into a library about to be replaced.
     render(
       <ClassSelector
+        nodeId="node-a"
         library={undefined}
         nodeClassIds={[]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -352,6 +356,7 @@ describe("a write the document refuses", () => {
     const onNodeClassesChange = vi.fn(() => "refused" as const);
     render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={onNodeClassesChange}
@@ -394,6 +399,7 @@ describe("a write the document refuses", () => {
     const onNodeClassesChange = vi.fn(() => "refused" as const);
     render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={["id-hero"]}
         onNodeClassesChange={onNodeClassesChange}
@@ -427,6 +433,7 @@ describe("a failure that must not outlive the node it describes", () => {
      */
     const view = render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={vi.fn(() => "refused" as const)}
@@ -442,6 +449,7 @@ describe("a failure that must not outlive the node it describes", () => {
 
     view.rerender(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={["id-card"]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -457,6 +465,7 @@ describe("a failure that must not outlive the node it describes", () => {
   it("drops a refused CREATION the same way", async () => {
     const view = render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -472,6 +481,7 @@ describe("a failure that must not outlive the node it describes", () => {
 
     view.rerender(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={["id-card"]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -506,6 +516,7 @@ describe("a failure scoped by what the node holds, not by array identity", () =>
     const create = createsClass();
     const view = render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={onNodeClassesChange}
@@ -519,6 +530,7 @@ describe("a failure scoped by what the node holds, not by array identity", () =>
     // Same CONTENT, different array — an ordinary parent re-render.
     view.rerender(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={onNodeClassesChange}
@@ -534,6 +546,7 @@ describe("a failure scoped by what the node holds, not by array identity", () =>
     const create = createsClass();
     const view = render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={onNodeClassesChange}
@@ -546,6 +559,7 @@ describe("a failure scoped by what the node holds, not by array identity", () =>
 
     view.rerender(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={["id-card"]}
         onNodeClassesChange={onNodeClassesChange}
@@ -572,6 +586,7 @@ describe("a query typed while a creation is still in flight", () => {
     );
     render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -600,6 +615,7 @@ describe("a query typed while a creation is still in flight", () => {
     );
     render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -614,6 +630,70 @@ describe("a query typed while a creation is still in flight", () => {
     });
 
     expect((field() as HTMLInputElement).value).toBe("");
+  });
+});
+
+describe("two blocks that look identical from the class list alone", () => {
+  it("drops a refusal when the node changes but its class list does not", () => {
+    /*
+     * The case content comparison cannot see, and the commonest one: two
+     * blocks with no classes both present an empty list. Scoped by content
+     * alone, a refusal raised against the first goes on being shown against
+     * the second — an alert about an element the author is no longer editing.
+     */
+    const onNodeClassesChange = vi.fn(() => "refused" as const);
+    const view = render(
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={createsClass()}
+      />
+    );
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    // A DIFFERENT block, with the same (empty) class list.
+    view.rerender(
+      <ClassSelector
+        nodeId="node-b"
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={createsClass()}
+      />
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
+  it("keeps it when neither the node nor its classes changed", () => {
+    // The control: identity scoping must not discard a failure on an ordinary
+    // re-render, which is what the content check exists to prevent.
+    const onNodeClassesChange = vi.fn(() => "refused" as const);
+    const view = render(
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={createsClass()}
+      />
+    );
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    view.rerender(
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={createsClass()}
+      />
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
   });
 });
 
@@ -636,6 +716,7 @@ describe("a creation that lands after the node has moved on", () => {
 
     const view = render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={["id-hero", "id-card"]}
         onNodeClassesChange={onNodeClassesChange}
@@ -649,6 +730,7 @@ describe("a creation that lands after the node has moved on", () => {
     // The author removes a chip while the save is still out.
     view.rerender(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={["id-card"]}
         onNodeClassesChange={onNodeClassesChange}
@@ -678,6 +760,7 @@ describe("a creation request that rejects rather than answering", () => {
     });
     render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={vi.fn(() => "applied" as const)}
@@ -704,6 +787,7 @@ describe("a creation request that rejects rather than answering", () => {
     const onNodeClassesChange = vi.fn(() => "applied" as const);
     render(
       <ClassSelector
+        nodeId="node-a"
         library={LIBRARY}
         nodeClassIds={[]}
         onNodeClassesChange={onNodeClassesChange}
@@ -727,6 +811,7 @@ describe("why the library is absent", () => {
   it("says a read is loading when it is still in flight", () => {
     render(
       <ClassSelector
+        nodeId="node-a"
         library={undefined}
         libraryAbsence="pending"
         nodeClassIds={[]}
@@ -748,6 +833,7 @@ describe("why the library is absent", () => {
      */
     render(
       <ClassSelector
+        nodeId="node-a"
         library={undefined}
         libraryAbsence="failed"
         nodeClassIds={[]}

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -68,10 +68,7 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
       library={LIBRARY}
       nodeClassIds={initial.nodeClassIds}
       onNodeClassesChange={vi.fn(() => "applied" as const)}
-      onCreateClass={vi.fn(async () => ({
-        ok: true as const,
-        classId: "id-new",
-      }))}
+      onCreateClass={createsClass()}
     />
   );
   return {
@@ -89,6 +86,17 @@ function drawFor(initial: { nodeClassIds: readonly string[] }): {
       ),
   };
 }
+
+/**
+ * A host that creates successfully, answering the shape the selector awaits.
+ *
+ * The selector AWAITS `onCreateClass` and applies the `classId` it answers
+ * with, so a fake returning anything else — `undefined` from a bare `vi.fn()`
+ * most of all — reads as a rejection or throws on `.then`. Declared once so no
+ * call site can quietly model a contract the host cannot honour.
+ */
+const createsClass = (classId = "id-new") =>
+  vi.fn(async () => ({ ok: true as const, classId }));
 
 const field = (): HTMLElement => screen.getByRole("combobox");
 
@@ -495,10 +503,7 @@ describe("a failure scoped by what the node holds, not by array identity", () =>
      * render, so the author would never see it.
      */
     const onNodeClassesChange = vi.fn(() => "refused" as const);
-    const create = vi.fn(async () => ({
-      ok: true as const,
-      classId: "id-new",
-    }));
+    const create = createsClass();
     const view = render(
       <ClassSelector
         library={LIBRARY}
@@ -526,10 +531,7 @@ describe("a failure scoped by what the node holds, not by array identity", () =>
   it("still drops it when the content actually changes", () => {
     // The control: comparing by content must not make the failure permanent.
     const onNodeClassesChange = vi.fn(() => "refused" as const);
-    const create = vi.fn(async () => ({
-      ok: true as const,
-      classId: "id-new",
-    }));
+    const create = createsClass();
     const view = render(
       <ClassSelector
         library={LIBRARY}
@@ -660,6 +662,64 @@ describe("a creation that lands after the node has moved on", () => {
 
     // `id-hero` must NOT come back: it was removed after the request left.
     expect(onNodeClassesChange).toHaveBeenCalledWith(["id-card", "id-made"]);
+  });
+});
+
+describe("a creation request that rejects rather than answering", () => {
+  it("reports a failure instead of falling silent", async () => {
+    /*
+     * The contract is to answer, but a thrown error or a rejected promise
+     * arrives all the same. Unhandled, the in-flight flag never clears — and
+     * `commit` returns early while it is set, so the surface stays inert for
+     * as long as the editor is open, with nothing on screen to say why.
+     */
+    const create = vi.fn(async () => {
+      throw new Error("network");
+    });
+    render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={create}
+      />
+    );
+    type("brand-new");
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    await React.act(async () => {});
+
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /could not be created/i
+    );
+  });
+
+  it("leaves the field usable, rather than guarded forever", async () => {
+    // The half that makes it a stuck state rather than a missing message: the
+    // in-flight guard must clear on the rejected path too.
+    const create = vi
+      .fn<() => Promise<{ ok: true; classId: string }>>()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce({ ok: true, classId: "id-second" });
+    const onNodeClassesChange = vi.fn(() => "applied" as const);
+    render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={create}
+      />
+    );
+    type("first-try");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    await React.act(async () => {});
+
+    type("second-try");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    await React.act(async () => {});
+
+    expect(create).toHaveBeenCalledTimes(2);
+    expect(onNodeClassesChange).toHaveBeenCalledWith(["id-second"]);
   });
 });
 

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -166,14 +166,23 @@ describe("what Enter does", () => {
     expect(onNodeClassesChange).toHaveBeenCalledWith(["id-card"]);
   });
 
-  it("reports a creation as an intent, not as a node write", () => {
-    // The class has no id until the host has stored it, so a node write here
-    // would have to invent one.
+  it("reports a creation as an intent, then applies the id it answers with", async () => {
+    /*
+     * Both halves, and the second is the one that matters. Asserting only that
+     * no node write happened YET is satisfied by the promise not having settled
+     * — it holds just as well for a component that never applies the class at
+     * all. The apply has to be observed after the microtask runs.
+     */
     const { onCreateClass, onNodeClassesChange } = draw();
     type("call-to-action");
     fireEvent.keyDown(field(), { key: "Enter" });
+
     expect(onCreateClass).toHaveBeenCalledWith("call-to-action");
     expect(onNodeClassesChange).not.toHaveBeenCalled();
+
+    await React.act(async () => {});
+
+    expect(onNodeClassesChange).toHaveBeenCalledWith(["id-call-to-action"]);
   });
 
   it("applies an exact match rather than creating beside it", () => {
@@ -474,6 +483,135 @@ describe("a failure that must not outlive the node it describes", () => {
     type("hero");
     fireEvent.keyDown(field(), { key: "Enter" });
     expect(screen.getByRole("alert").textContent).toMatch(/as many classes/i);
+  });
+});
+
+describe("a failure scoped by what the node holds, not by array identity", () => {
+  it("survives an unrelated re-render that reallocates the id list", () => {
+    /*
+     * A caller with no stored classes hands over a fresh `[]` every render —
+     * `?? []` in the style inspector does exactly that. Compared by reference,
+     * the failure would be discarded on the next re-render, which is every
+     * render, so the author would never see it.
+     */
+    const onNodeClassesChange = vi.fn(() => "refused" as const);
+    const create = vi.fn(async () => ({
+      ok: true as const,
+      classId: "id-new",
+    }));
+    const view = render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={create}
+      />
+    );
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    // Same CONTENT, different array — an ordinary parent re-render.
+    view.rerender(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={create}
+      />
+    );
+    expect(screen.getByRole("alert")).toBeTruthy();
+  });
+
+  it("still drops it when the content actually changes", () => {
+    // The control: comparing by content must not make the failure permanent.
+    const onNodeClassesChange = vi.fn(() => "refused" as const);
+    const create = vi.fn(async () => ({
+      ok: true as const,
+      classId: "id-new",
+    }));
+    const view = render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={create}
+      />
+    );
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    view.rerender(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={["id-card"]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={create}
+      />
+    );
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("a query typed while a creation is still in flight", () => {
+  it("is not cleared by the creation landing", async () => {
+    /*
+     * The field stays editable while the save is out, so an author can begin
+     * the next class name. Clearing unconditionally on success takes away what
+     * they typed after pressing Enter.
+     */
+    let resolve: (v: { ok: true; classId: string }) => void = () => {};
+    const create = vi.fn(
+      () =>
+        new Promise<{ ok: true; classId: string }>(r => {
+          resolve = r;
+        })
+    );
+    render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={create}
+      />
+    );
+    type("first-one");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    type("second-one");
+
+    await React.act(async () => {
+      resolve({ ok: true, classId: "id-first" });
+    });
+
+    expect((field() as HTMLInputElement).value).toBe("second-one");
+  });
+
+  it("IS cleared when the author has typed nothing since", async () => {
+    // The control: the clear must still happen in the ordinary case.
+    let resolve: (v: { ok: true; classId: string }) => void = () => {};
+    const create = vi.fn(
+      () =>
+        new Promise<{ ok: true; classId: string }>(r => {
+          resolve = r;
+        })
+    );
+    render(
+      <ClassSelector
+        library={LIBRARY}
+        nodeClassIds={[]}
+        onNodeClassesChange={vi.fn(() => "applied" as const)}
+        onCreateClass={create}
+      />
+    );
+    type("first-one");
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    await React.act(async () => {
+      resolve({ ok: true, classId: "id-first" });
+    });
+
+    expect((field() as HTMLInputElement).value).toBe("");
   });
 });
 

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -633,6 +633,57 @@ describe("a query typed while a creation is still in flight", () => {
   });
 });
 
+describe("a refusal raised by a creation that landed after an edit", () => {
+  it("is shown, rather than discarded for describing a stale list", async () => {
+    /*
+     * The two fixes meet here. The apply runs against the node as it is NOW,
+     * so the failure it raises is about THAT list — scoped to the list the
+     * closure was created with instead, the content check rejects it the
+     * instant it is set and the author is told nothing at all.
+     */
+    let resolve: (v: { ok: true; classId: string }) => void = () => {};
+    const create = vi.fn(
+      () =>
+        new Promise<{ ok: true; classId: string }>(r => {
+          resolve = r;
+        })
+    );
+    const onNodeClassesChange = vi.fn(() => "refused" as const);
+
+    const view = render(
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={["id-hero", "id-card"]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={create}
+      />
+    );
+    type("brand-new");
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    // A chip goes while the save is out — same node, different class list.
+    view.rerender(
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={["id-card"]}
+        onNodeClassesChange={onNodeClassesChange}
+        onCreateClass={create}
+      />
+    );
+
+    await React.act(async () => {
+      resolve({ ok: true, classId: "id-made" });
+    });
+
+    expect(onNodeClassesChange).toHaveBeenCalledWith(["id-card", "id-made"]);
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /could not be applied/i
+    );
+  });
+});
+
 describe("two blocks that look identical from the class list alone", () => {
   it("drops a refusal when the node changes but its class list does not", () => {
     /*

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -129,12 +129,16 @@ export type ClassCreation =
 
 export interface ClassSelectorProps {
   /**
-   * The site's class library, or `undefined` while the host has not read it.
+   * The site's class library, or `undefined` when there is none to show.
    *
    * A real third state rather than an empty library: a site that has stored
    * nothing legitimately has no classes, and drawing the two the same way would
    * invite an author to create a class into a library about to be replaced by
    * the one still loading.
+   *
+   * `undefined` covers two causes — a read in flight and a read that failed —
+   * and {@link ClassSelectorProps.libraryAbsence} says which. They need
+   * different words: one will finish and the other will not.
    */
   library: readonly NamedClass[] | undefined;
   /**
@@ -273,25 +277,45 @@ export function ClassSelector({
        */
       const submitted = query;
       setSaving(true);
-      void onCreateClass(option.slug).then(created => {
-        setSaving(false);
-        if (!created.ok) {
+      void onCreateClass(option.slug)
+        .then(created => {
+          if (!created.ok) {
+            setFailure({
+              about: nodeClassIds,
+              issue: { kind: "not-created", reason: created.reason },
+            });
+            return;
+          }
+          // Applied through the ordinary path, so a node already at its limit
+          // refuses here exactly as it would for an existing class rather than
+          // being special-cased into a second rule — and against the node as
+          // it is NOW, not as it was when the request left.
+          applyExisting(
+            created.classId,
+            currentIds.current,
+            currentQuery.current === submitted
+          );
+        })
+        /*
+         * A REJECTED request is a refusal too. The contract is to answer, but a
+         * thrown error or a rejected promise arrives here all the same — and
+         * without this the in-flight flag never clears, so `commit` returns
+         * early on every later keystroke and the surface is inert for as long
+         * as the editor stays open. Silent, and unrecoverable without a reload.
+         */
+        .catch(() => {
           setFailure({
             about: nodeClassIds,
-            issue: { kind: "not-created", reason: created.reason },
+            issue: {
+              kind: "not-created",
+              reason: "This class could not be created.",
+            },
           });
-          return;
-        }
-        // Applied through the ordinary path, so a node already at its limit
-        // refuses here exactly as it would for an existing class rather than
-        // being special-cased into a second rule — and against the node as it
-        // is NOW, not as it was when the request left.
-        applyExisting(
-          created.classId,
-          currentIds.current,
-          currentQuery.current === submitted
-        );
-      });
+        })
+        // In `finally`, so neither path can leave the field guarded.
+        .finally(() => {
+          setSaving(false);
+        });
       return;
     }
     applyExisting(option.choice.id, nodeClassIds, true);

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -71,12 +71,22 @@ type SelectorFailure =
  * full would then be describing a state it is no longer in.
  */
 function liveFailure(
-  failure: { about: readonly string[]; issue: SelectorFailure } | null,
+  failure: {
+    about: string;
+    whenIds: readonly string[];
+    issue: SelectorFailure;
+  } | null,
+  nodeId: string,
   nodeClassIds: readonly string[]
 ): SelectorFailure | null {
-  if (failure === null || !sameClassIds(failure.about, nodeClassIds)) {
-    return null;
-  }
+  if (failure === null) return null;
+  // BOTH, because neither settles it alone. Identity catches the case content
+  // cannot see — two blocks with no classes present the same empty list, so a
+  // refusal raised against one would go on being shown against the other.
+  // Content catches the case identity cannot — the same block whose classes
+  // have since changed, where the refusal describes a state it has left.
+  if (failure.about !== nodeId) return null;
+  if (!sameClassIds(failure.whenIds, nodeClassIds)) return null;
   if (failure.issue.kind === "node-full" && nodeHasRoom(nodeClassIds)) {
     return null;
   }
@@ -84,14 +94,11 @@ function liveFailure(
 }
 
 /**
- * Whether two class lists are the same list.
+ * Whether two class lists are the same list, by CONTENT.
  *
- * By CONTENT, not by reference. A caller that has no stored classes hands over
- * a fresh `[]` on every render — `?? []` in the style inspector does exactly
- * that — so an identity comparison would discard a failure on the next
- * unrelated re-render, which is every render. Content also gets the intended
- * behaviour for free: removing a chip changes the list, and that is precisely
- * when a stale failure should go.
+ * A caller with no stored classes hands over a fresh `[]` on every render —
+ * `?? []` in the style inspector does exactly that — so comparing by reference
+ * would discard a failure on the next render, which is every render.
  */
 function sameClassIds(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((id, index) => id === b[index]);
@@ -140,6 +147,17 @@ export interface ClassSelectorProps {
    * and {@link ClassSelectorProps.libraryAbsence} says which. They need
    * different words: one will finish and the other will not.
    */
+  /**
+   * Which block this is editing.
+   *
+   * Required, and used only to scope a failure to the element it is about.
+   * Comparing the class ids instead was a proxy for identity and it fails on
+   * the commonest case: two blocks with no classes both present an empty list,
+   * so a refusal raised against one goes on being shown against the other.
+   * Keyed mounting protects a caller that remembers to key; a prop cannot be
+   * forgotten.
+   */
+  nodeId: string;
   library: readonly NamedClass[] | undefined;
   /**
    * Why there is no library, when there is none.
@@ -184,6 +202,7 @@ export interface ClassSelectorProps {
 
 /** The classes on the selected node, with a field for adding another. */
 export function ClassSelector({
+  nodeId,
   library,
   libraryAbsence,
   nodeClassIds,
@@ -203,7 +222,8 @@ export function ClassSelector({
    * remembered.
    */
   const [failure, setFailure] = React.useState<{
-    readonly about: readonly string[];
+    readonly about: string;
+    readonly whenIds: readonly string[];
     readonly issue: SelectorFailure;
   } | null>(null);
   // In flight, so a second Enter cannot queue a duplicate class while the
@@ -251,7 +271,7 @@ export function ClassSelector({
    * node may have gained room since, through a removal, an undo, or the host
    * selecting a smaller element.
    */
-  const shown = liveFailure(failure, nodeClassIds);
+  const shown = liveFailure(failure, nodeId, nodeClassIds);
   // Clamped rather than reset on every keystroke, so narrowing the list keeps a
   // highlight instead of silently sending Enter back to the first row.
   const highlighted = Math.min(active, Math.max(options.length - 1, 0));
@@ -266,7 +286,11 @@ export function ClassSelector({
        * is checked directly rather than left for the host to rediscover.
        */
       if (!nodeHasRoom(nodeClassIds)) {
-        setFailure({ about: nodeClassIds, issue: { kind: "node-full" } });
+        setFailure({
+          about: nodeId,
+          whenIds: nodeClassIds,
+          issue: { kind: "node-full" },
+        });
         return;
       }
       /*
@@ -281,7 +305,8 @@ export function ClassSelector({
         .then(created => {
           if (!created.ok) {
             setFailure({
-              about: nodeClassIds,
+              about: nodeId,
+              whenIds: nodeClassIds,
               issue: { kind: "not-created", reason: created.reason },
             });
             return;
@@ -305,7 +330,8 @@ export function ClassSelector({
          */
         .catch(() => {
           setFailure({
-            about: nodeClassIds,
+            about: nodeId,
+            whenIds: nodeClassIds,
             issue: {
               kind: "not-created",
               reason: "This class could not be created.",
@@ -338,14 +364,22 @@ export function ClassSelector({
     // append would keep working after that place learned to refuse.
     const outcome = withClassApplied(against, classId);
     if (!outcome.ok) {
-      setFailure({ about: against, issue: { kind: "node-full" } });
+      setFailure({
+        about: nodeId,
+        whenIds: nodeClassIds,
+        issue: { kind: "node-full" },
+      });
       return;
     }
     if (onNodeClassesChange(outcome.classIds) === "refused") {
       // The draft survives, deliberately. An author whose write was refused
       // has lost nothing they typed, and the next thing they do is likely to
       // be trying it again.
-      setFailure({ about: against, issue: { kind: "not-written" } });
+      setFailure({
+        about: nodeId,
+        whenIds: nodeClassIds,
+        issue: { kind: "not-written" },
+      });
       return;
     }
     setFailure(null);
@@ -364,7 +398,11 @@ export function ClassSelector({
           );
           setFailure(
             landed === "refused"
-              ? { about: nodeClassIds, issue: { kind: "not-written" } }
+              ? {
+                  about: nodeId,
+                  whenIds: nodeClassIds,
+                  issue: { kind: "not-written" as const },
+                }
               : null
           );
         }}

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -74,11 +74,27 @@ function liveFailure(
   failure: { about: readonly string[]; issue: SelectorFailure } | null,
   nodeClassIds: readonly string[]
 ): SelectorFailure | null {
-  if (failure === null || failure.about !== nodeClassIds) return null;
+  if (failure === null || !sameClassIds(failure.about, nodeClassIds)) {
+    return null;
+  }
   if (failure.issue.kind === "node-full" && nodeHasRoom(nodeClassIds)) {
     return null;
   }
   return failure.issue;
+}
+
+/**
+ * Whether two class lists are the same list.
+ *
+ * By CONTENT, not by reference. A caller that has no stored classes hands over
+ * a fresh `[]` on every render — `?? []` in the style inspector does exactly
+ * that — so an identity comparison would discard a failure on the next
+ * unrelated re-render, which is every render. Content also gets the intended
+ * behaviour for free: removing a chip changes the list, and that is precisely
+ * when a stale failure should go.
+ */
+function sameClassIds(a: readonly string[], b: readonly string[]): boolean {
+  return a.length === b.length && a.every((id, index) => id === b[index]);
 }
 
 /** What the author is told, per cause. */
@@ -201,6 +217,14 @@ export function ClassSelector({
    */
   const currentIds = React.useRef(nodeClassIds);
   currentIds.current = nodeClassIds;
+  /*
+   * What is typed RIGHT NOW, for the same reason. The field stays editable
+   * while a creation is in flight, so an author can begin the next class name
+   * before the first one lands — and clearing on success would take away what
+   * they had typed since.
+   */
+  const currentQuery = React.useRef(query);
+  currentQuery.current = query;
 
   if (library === undefined) {
     return (
@@ -247,6 +271,7 @@ export function ClassSelector({
        * the typed name the moment the author pressed Enter, before anything
        * knew whether it had landed.
        */
+      const submitted = query;
       setSaving(true);
       void onCreateClass(option.slug).then(created => {
         setSaving(false);
@@ -261,11 +286,15 @@ export function ClassSelector({
         // refuses here exactly as it would for an existing class rather than
         // being special-cased into a second rule — and against the node as it
         // is NOW, not as it was when the request left.
-        applyExisting(created.classId, currentIds.current);
+        applyExisting(
+          created.classId,
+          currentIds.current,
+          currentQuery.current === submitted
+        );
       });
       return;
     }
-    applyExisting(option.choice.id, nodeClassIds);
+    applyExisting(option.choice.id, nodeClassIds, true);
   };
 
   /**
@@ -275,7 +304,11 @@ export function ClassSelector({
    * the id the host just minted, so the per-node bound and the store's refusal
    * are enforced in one place rather than once per caller.
    */
-  function applyExisting(classId: string, against: readonly string[]): void {
+  function applyExisting(
+    classId: string,
+    against: readonly string[],
+    clearQuery: boolean
+  ): void {
     // Through the shared helper rather than an append written here. The bound
     // on how many classes a node may carry belongs to one place, and a second
     // append would keep working after that place learned to refuse.
@@ -292,6 +325,7 @@ export function ClassSelector({
       return;
     }
     setFailure(null);
+    if (!clearQuery) return;
     setQuery("");
     setActive(0);
   }

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -359,6 +359,13 @@ export function ClassSelector({
     against: readonly string[],
     clearQuery: boolean
   ): void {
+    /*
+     * Every failure raised here is scoped to `against`, not to the ids this
+     * closure was created with. On the asynchronous path those differ — a chip
+     * removed while a creation was in flight — and scoping to the stale list
+     * makes `liveFailure` discard the alert the moment it is set, so a refused
+     * apply reports nothing at all.
+     */
     // Through the shared helper rather than an append written here. The bound
     // on how many classes a node may carry belongs to one place, and a second
     // append would keep working after that place learned to refuse.
@@ -366,7 +373,7 @@ export function ClassSelector({
     if (!outcome.ok) {
       setFailure({
         about: nodeId,
-        whenIds: nodeClassIds,
+        whenIds: against,
         issue: { kind: "node-full" },
       });
       return;
@@ -377,7 +384,7 @@ export function ClassSelector({
       // be trying it again.
       setFailure({
         about: nodeId,
-        whenIds: nodeClassIds,
+        whenIds: against,
         issue: { kind: "not-written" },
       });
       return;

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -424,9 +424,12 @@ describe("the class selector, mounted above the style sections", () => {
     );
   });
 
-  it("reports a creation to the host rather than writing it", () => {
-    // The class has no id until the host has stored it, so a node write here
-    // would have to invent one.
+  it("reports a creation to the host, then writes the id it answers with", async () => {
+    /*
+     * Asserting only that no write happened YET is satisfied by the promise not
+     * having settled, and would hold for a panel that never applies the class.
+     * The write has to be observed after the microtask runs.
+     */
     const { editor, onCreateClass } = mountWithClasses({ library: LIBRARY });
     fireEvent.change(screen.getByRole("combobox", { name: /add a class/i }), {
       target: { value: "call-to-action" },
@@ -437,6 +440,14 @@ describe("the class selector, mounted above the style sections", () => {
 
     expect(onCreateClass).toHaveBeenCalledWith("call-to-action");
     expect(editor.applyAll).not.toHaveBeenCalled();
+
+    await React.act(async () => {});
+
+    expect(editor.applyAll.mock.calls[0]?.[0]?.[0]).toEqual({
+      kind: "update",
+      id: "a",
+      patch: { classes: ["id-new"] },
+    });
   });
 });
 

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -263,13 +263,15 @@ export interface StyleInspectorPanelProps {
    */
   onJumpToBreakpoint?: (breakpoint: BreakpointId) => void;
   /**
-   * The site's class library, when the host has read it.
+   * The site's class library, when the host has one to give.
    *
-   * `undefined` here means the read is still in flight, NOT that the question
-   * was never asked — {@link StyleInspectorPanelProps.onCreateClass} carries
-   * that. Two meanings on one value is how a host mid-load and a host with no
-   * class surface at all came to be drawn the same way, and only one of them
-   * should see a field that is about to fill.
+   * Two signals, not one. {@link StyleInspectorPanelProps.onCreateClass} says
+   * whether the host has a class surface at all; this says what it holds. So
+   * `undefined` here means the library is absent rather than unasked-for, and
+   * it covers BOTH a read in flight and a read that failed —
+   * {@link StyleInspectorPanelProps.classLibraryAbsence} says which. They need
+   * different words: one will finish and the other will not, and only the
+   * first has a field about to fill.
    */
   classLibrary?: readonly NamedClass[];
   /** Why the library is absent, when it is. Forwarded to the selector. */

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -425,6 +425,7 @@ function SelectedNodeClasses({
   if (onCreateClass === undefined) return null;
   return (
     <ClassSelector
+      nodeId={nodeId}
       /*
        * Keyed by NODE, for the reason the style sections are. The typed query
        * and the highlighted row are state about the node in hand; unkeyed,


### PR DESCRIPTION
**Recovering work stranded by #1317's merge.** Not a new change — this is the last commit of that PR, which the merge did not include.

## The stranding

#1317's head at merge time was `c85cfafed`. The merge commit `63436b4d2` carries the subject of the commit **before** it, and main has none of the symbols the last one introduced:

```
git show origin/main:packages/builder/src/class-selector.tsx | grep -c sameClassIds   -> 0
                                                            | grep -c clearQuery      -> 0
                                                            | grep -c currentQuery    -> 0
```

So `236e40fb3` merged and `c85cfafed` did not. Cherry-picked onto current main and re-gated there, rather than trusting the run from its original base.

## Why it matters — one of these fixes a defect in a fix that DID land

The three Codex findings this commit answered were verified and replied to on #1317. Two of the fixes are on main; the third is not.

**A failure was scoped to its node by array identity.** `SelectedNodeClasses` passes `findNode(...)?.classes ?? []`, so a node with no stored classes hands over a **fresh array on every parent render**. Compared by reference, the failure is discarded on the next render — which is every render — so an author never sees a refusal at all. That is live on main right now.

Now compared by content, which also gets the intended behaviour for free: removing a chip changes the list, and that is exactly when a stale failure should go. Two tests make it a real check — same content with a different array must KEEP it, changed content must DROP it.

**The typed query was cleared by a creation landing.** The field stays editable while a site-style save is in flight so an author can begin the next class name; clearing unconditionally on success took that away. It now clears only when nothing has been typed since the request left, with a control asserting the ordinary clear still happens.

**Two creation tests could not fail for their stated reason.** Asserting that no node write had happened YET is satisfied by the promise not having settled — it held just as well for a component that never applied the created class. Both now observe the write after the microtask, against the id the host answered with.

## Gates

Build, vitest (**2354 passed**), check-types, package lint with max-warnings 0, root eslint, comment convention, and check-changesets as CI runs it — all exit 0 **against current main**. Fallow: every introduced counter at 0.

Breaks verified on the original PR, each failing only its named test: restoring the identity comparison, and clearing the query unconditionally.

## Worth noting about the merge

`c85cfafed` had **zero check-runs** when it merged — not queued, none created. That is the fourth time this session a merge has landed work I then had to verify by content, and the first where content proved something missing.
