### PR TITLE
fix(admin): name a comparison in the language it is about, and keep presence when alignment is refused

### DIFF
--- a/.changeset/version-comparison-locale-and-presence.md
+++ b/.changeset/version-comparison-locale-and-presence.md
@@ -1,0 +1,33 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Name a version comparison in the language it is about, so a localized
+document is not headed by another language's title, and keep a code or JSON
+field's presence when its lines are too many to align, so a field that was
+added or removed says so instead of reporting a change to something that was
+not there.

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -267,10 +267,18 @@ export function VersionComparePage({
   );
 }
 
-/** The address of a document's history, with an optional pair already chosen. */
+/**
+ * The address of a document's history, with an optional pair already chosen.
+ *
+ * The locale travels with the pair. A localized document holds different text
+ * per language, so the versions being compared and the name the page gives the
+ * document are both questions the language answers — and a link that omits it
+ * opens the French comparison under the English title.
+ */
 export function versionsHref(
   scope: VersionScope,
-  pair?: { from: number; to: number }
+  pair?: { from: number; to: number },
+  locale?: string | null
 ): string {
   const path =
     scope.kind === "single"
@@ -279,5 +287,12 @@ export function versionsHref(
           slug: scope.slug,
           id: scope.entryId ?? "",
         });
-  return pair ? withQuery(path, { from: pair.from, to: pair.to }) : path;
+  const query = {
+    ...(pair ? { from: pair.from, to: pair.to } : {}),
+    // Omitted rather than sent empty when there is none: a non-localized
+    // document should carry no locale, and `?locale=` reads as one that failed
+    // to resolve rather than one that was never asked for.
+    ...(locale ? { locale } : {}),
+  };
+  return Object.keys(query).length > 0 ? withQuery(path, query) : path;
 }

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -608,10 +608,16 @@ export function VersionHistorySheet({
                 size="sm"
                 onClick={() =>
                   navigateTo(
-                    versionsHref(scope, {
-                      from: previousVersionNo,
-                      to: selected,
-                    })
+                    versionsHref(
+                      scope,
+                      { from: previousVersionNo, to: selected },
+                      // The SELECTED version's language, not the sheet's
+                      // filter: the filter says which rows are listed, while
+                      // this says which text the pair being opened actually
+                      // holds — and that is what the destination must name the
+                      // document in.
+                      versions.find(v => v.versionNo === selected)?.locale
+                    )
                   )
                 }
               >

--- a/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
@@ -61,7 +61,7 @@ vi.mock("@admin/lib/navigation", () => ({
   navigateTo: (...a: unknown[]) => navigateMock(...a),
 }));
 
-import { VersionComparePage } from "../VersionComparePage";
+import { VersionComparePage, versionsHref } from "../VersionComparePage";
 
 const row = (versionNo: number, locale: string | null = null) => ({
   id: `v${versionNo}`,
@@ -423,5 +423,38 @@ describe("VersionComparePage — a failed next page", () => {
     expect(
       screen.queryByRole("button", { name: /Version/ })
     ).not.toBeInTheDocument();
+  });
+});
+
+describe("versionsHref — the address carries the language", () => {
+  const scope = { kind: "collection" as const, slug: "posts", entryId: "e1" };
+
+  /**
+   * The locale travels with the pair. A link shared from a French history has
+   * to open the French comparison, named in French, for a reader whose editor
+   * was last in English — the destination cannot recover the language from
+   * `from` and `to` alone.
+   */
+  it("carries the locale beside the pair", () => {
+    const href = versionsHref(scope, { from: 8, to: 9 }, "fr");
+    expect(href).toContain("from=8");
+    expect(href).toContain("to=9");
+    expect(href).toContain("locale=fr");
+  });
+
+  /**
+   * The control, and it decides the shape: a non-localized document must carry
+   * NO locale rather than an empty one, which would read as a language that
+   * failed to resolve rather than one never asked for.
+   */
+  it("omits the locale entirely when there is none", () => {
+    const href = versionsHref(scope, { from: 8, to: 9 }, null);
+    expect(href).toContain("from=8");
+    expect(href).not.toContain("locale");
+  });
+
+  it("still addresses a history with no pair chosen", () => {
+    expect(versionsHref(scope)).not.toContain("?");
+    expect(versionsHref(scope, undefined, "fr")).toContain("locale=fr");
   });
 });

--- a/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/useVersionDocumentTitle.test.tsx
@@ -135,3 +135,49 @@ describe("useVersionDocumentTitle — a single", () => {
     expect(forEntry().result.current).toBe("An entry");
   });
 });
+
+describe("useVersionDocumentTitle — the language it reads in", () => {
+  /**
+   * A localized entry holds a title per language. Read without one, a French
+   * comparison is headed by the English title — while the editor it was opened
+   * from passes its own active locale, so the two surfaces name one document
+   * by different states of it.
+   */
+  it("reads the entry in the language it was given", () => {
+    collectionMock.mockReturnValue({ data: { fields: [field("title")] } });
+    entryMock.mockReturnValue({ data: { title: "Bonjour" } });
+
+    renderHook(() =>
+      useVersionDocumentTitle(
+        { kind: "collection", slug: "posts", entryId: "e1" },
+        "fr"
+      )
+    );
+
+    expect(entryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: "fr" })
+    );
+  });
+
+  /**
+   * The control. Without a locale the query must ask for none rather than
+   * inventing one — the server resolves the default, which is what a
+   * non-localized document needs.
+   */
+  it("asks for no locale when the address names none", () => {
+    collectionMock.mockReturnValue({ data: { fields: [field("title")] } });
+    entryMock.mockReturnValue({ data: { title: "Hello" } });
+
+    renderHook(() =>
+      useVersionDocumentTitle({
+        kind: "collection",
+        slug: "posts",
+        entryId: "e1",
+      })
+    );
+
+    expect(entryMock).toHaveBeenCalledWith(
+      expect.objectContaining({ locale: undefined })
+    );
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
+++ b/packages/admin/src/components/features/versions/__tests__/version-search-params.test.ts
@@ -9,7 +9,11 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { readVersionParam, resolvePair } from "../version-search-params";
+import {
+  readLocaleParam,
+  readVersionParam,
+  resolvePair,
+} from "../version-search-params";
 
 describe("readVersionParam", () => {
   it("reads a version number", () => {
@@ -117,5 +121,37 @@ describe("resolvePair", () => {
     expect(resolvePair(interleaved, undefined, undefined, true)).toEqual({
       kind: "not-loaded",
     });
+  });
+});
+
+describe("readLocaleParam", () => {
+  /**
+   * A version's locale decides which text the document HAS, so it decides what
+   * the document is called. It is carried in the address rather than inferred
+   * because the page is addressable: a link shared from a French history has
+   * to open the French comparison, named in French, for a reader whose editor
+   * was last in English.
+   */
+  it("takes a locale the address names", () => {
+    expect(readLocaleParam("fr")).toBe("fr");
+    expect(readLocaleParam("  fr  ")).toBe("fr");
+  });
+
+  /**
+   * Absent means the default language, which is what the server resolves when
+   * none is asked for — so a non-localized document needs no parameter. An
+   * EMPTY one is not a language either: it reads as a locale that failed to
+   * resolve rather than one never asked for.
+   */
+  it("treats absent and empty alike, as no locale at all", () => {
+    expect(readLocaleParam(undefined)).toBeUndefined();
+    expect(readLocaleParam("")).toBeUndefined();
+    expect(readLocaleParam("   ")).toBeUndefined();
+  });
+
+  /** A repeated parameter is ambiguous, and guessing which one is meant is
+   *  worse than answering with the default. */
+  it("refuses a repeated parameter rather than picking one", () => {
+    expect(readLocaleParam(["fr", "en"])).toBeUndefined();
   });
 });

--- a/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
+++ b/packages/admin/src/components/features/versions/useVersionDocumentTitle.ts
@@ -42,7 +42,10 @@ function readableText(value: unknown): string | undefined {
  * cannot be called on one branch and skipped on the other. The disabled one
  * fetches nothing.
  */
-export function useVersionDocumentTitle(scope: TitleScope): string | undefined {
+export function useVersionDocumentTitle(
+  scope: TitleScope,
+  locale?: string
+): string | undefined {
   const isCollection = scope.kind === "collection";
 
   const collection = useCollection(isCollection ? scope.slug : undefined);
@@ -55,6 +58,11 @@ export function useVersionDocumentTitle(scope: TitleScope): string | undefined {
     // title change is headed by the OLD published title — two surfaces naming
     // one document by different states of it.
     draft: collection.data?.draftsEnabled === true,
+    // The language the comparison is about. A localized entry holds a title
+    // per language, so reading without one names a French comparison by its
+    // English title — the editor's own read passes its active locale, and the
+    // two must agree about which state of the document they describe.
+    locale,
   });
   const single = useSingleSchema(isCollection ? undefined : scope.slug);
 

--- a/packages/admin/src/components/features/versions/version-search-params.ts
+++ b/packages/admin/src/components/features/versions/version-search-params.ts
@@ -47,6 +47,27 @@ export function readVersionParam(
  * this feature exists to support. The request that follows is what decides
  * whether the versions exist.
  */
+/**
+ * The content language a comparison is about, from the address.
+ *
+ * A version's locale decides which text the document HAS, so it decides what
+ * the document is called. Carried in the URL rather than inferred, because the
+ * page is addressable: a link shared from a French history has to open on the
+ * French comparison, named in French, for someone whose editor was last in
+ * English.
+ *
+ * Absent means the default language, which is what the server resolves when no
+ * locale is asked for — so a non-localized document needs no parameter and
+ * gains none.
+ */
+export function readLocaleParam(
+  raw: string | string[] | undefined
+): string | undefined {
+  if (typeof raw !== "string") return undefined;
+  const trimmed = raw.trim();
+  return trimmed === "" ? undefined : trimmed;
+}
+
 export function resolvePair(
   versions: readonly PairableVersion[],
   from: number | undefined,

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/versions.tsx
@@ -11,7 +11,10 @@
  */
 
 import { useVersionDocumentTitle } from "@admin/components/features/versions/useVersionDocumentTitle";
-import { readVersionParam } from "@admin/components/features/versions/version-search-params";
+import {
+  readLocaleParam,
+  readVersionParam,
+} from "@admin/components/features/versions/version-search-params";
 import { VersionComparePage } from "@admin/components/features/versions/VersionComparePage";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
 import type { PageProps } from "@admin/lib/routing";
@@ -22,11 +25,14 @@ export default function EntryVersionsPage({ params, searchParams }: PageProps) {
   // Without this the page announces itself only as "Version history", while the
   // URL carries an opaque id and the dashboard header shows no breadcrumbs — so
   // a reader cannot tell which entry the snapshots belong to without leaving.
-  const documentTitle = useVersionDocumentTitle({
-    kind: "collection",
-    slug,
-    entryId: id,
-  });
+  // The language the address names, so a link shared from a French history
+  // opens the French comparison under the French title regardless of what the
+  // reader's editor was last set to.
+  const locale = readLocaleParam(searchParams?.locale);
+  const documentTitle = useVersionDocumentTitle(
+    { kind: "collection", slug, entryId: id },
+    locale
+  );
 
   return (
     <VersionComparePage

--- a/packages/nextly/src/domains/versions/diff/__tests__/source-node.test.ts
+++ b/packages/nextly/src/domains/versions/diff/__tests__/source-node.test.ts
@@ -272,3 +272,50 @@ describe("sourceNode — what it cannot represent", () => {
     expect(node.status).toBe("added");
   });
 });
+
+describe("sourceNode — presence survives a refusal", () => {
+  /**
+   * A value with more distinct lines than the alignment alphabet holds cannot
+   * be aligned, and the node then reports that it is not comparable. What the
+   * refusal must NOT discard is which sides held anything: whether a field was
+   * added, removed, or edited is still known, and it is the answer a reader
+   * uses to decide whether to restore.
+   *
+   * The sibling branch above — content unreadable on one side — already keeps
+   * presence for exactly this reason. Two refusals in one function answering
+   * the same question differently is the divergence being closed.
+   */
+  const tooManyLines = Array.from({ length: 200_000 }, (_, i) => `l${i}`).join(
+    "\n"
+  );
+
+  it("reports an added field as added, not merely changed", () => {
+    const node = sourceNode(codeMeta, missing, at(tooManyLines), "javascript");
+    // The premise: this really is a refusal, so the assertion below is about
+    // the refusal path and not some ordinary comparison.
+    expect(node.lines.every(l => l.status === "unsupported")).toBe(true);
+    expect(node.status).toBe("added");
+  });
+
+  it("reports a removed field as removed, not merely changed", () => {
+    const node = sourceNode(codeMeta, at(tooManyLines), missing, "javascript");
+    expect(node.lines.every(l => l.status === "unsupported")).toBe(true);
+    expect(node.status).toBe("removed");
+  });
+
+  /**
+   * The control. With both sides present there is no presence answer to keep,
+   * so the refusal still reports `changed` — and if this ever came back as
+   * `added` or `removed`, presence would be being invented rather than
+   * preserved.
+   */
+  it("still reports changed when both sides held a value", () => {
+    const node = sourceNode(
+      codeMeta,
+      at(tooManyLines),
+      at(`${tooManyLines}\nextra`),
+      "javascript"
+    );
+    expect(node.status).toBe("changed");
+  });
+});

--- a/packages/nextly/src/domains/versions/diff/source-node.ts
+++ b/packages/nextly/src/domains/versions/diff/source-node.ts
@@ -209,7 +209,18 @@ export function sourceNode(
   }
 
   const alignment = alignUnits(beforeLines.compare, afterLines.compare);
-  if (!alignment.aligned) return refuse(meta, language, "changed");
+  // Alignment refused, because the value holds more distinct lines than its
+  // alphabet can encode. Presence survives that exactly as it survives
+  // unreadable content above: which sides held anything is still known, and it
+  // is what a reader decides to restore from. Reporting `changed` for a field
+  // that was added describes an edit to something that was not there.
+  if (!alignment.aligned) {
+    return refuse(
+      meta,
+      language,
+      presenceStatus(!before.present, !after.present, "changed")
+    );
+  }
 
   const lines = alignment.pairs.map(pair =>
     toLine(pair, beforeLines, afterLines)


### PR DESCRIPTION
Two findings, both from reviews of merged PRs — the locale one left open on #1303, the presence one on #1242. Kept in one PR because both are the version comparison telling a reader something untrue about what they are looking at.

## The comparison was named in the wrong language

A localized entry holds a title per language. The comparison read the entry **without one**, so a French comparison opened from a French editor was headed by the **English** title — while the editor's own read passes its active locale. Two surfaces naming one document by different states of it, which is the class this page has produced repeatedly.

The locale now travels **in the address**, beside the pair:

```
/admin/collections/posts/e1/versions?from=8&to=9&locale=fr
```

The page is addressable, and that is the reason: a link shared from a French history has to open the French comparison, named in French, for a reader whose editor was last in English. `from` and `to` alone cannot recover which language they name.

**The history sheet sends the SELECTED version's locale, not its own filter.** The filter says which rows are listed; the version says which text the pair being opened actually holds, and that is what the destination must name the document in.

A document with no locale carries **no parameter**. An empty one would read as a language that failed to resolve rather than one never asked for, and the server already resolves the default when none is given.

## A refused alignment discarded presence

A code or JSON value with more distinct lines than the alignment alphabet can encode cannot be aligned, and the node reports it is not comparable. That refusal **discarded which sides held anything**, so a field that had just been added reported as `changed` — describing an edit to something that was not there, and pointing a reader deciding whether to restore in the wrong direction.

The branch directly above it, for content unreadable on one side, already keeps presence for the same reason. Two refusals in one function answered the same question differently; both now go through `presenceStatus`.

## Verification

| assertion | control that must keep passing |
|---|---|
| the href carries `locale=fr` | a document with no locale carries **no** `locale` at all |
| the hook reads the entry in that language | with no locale it asks for **none**, rather than inventing one |
| `readLocaleParam` takes a trimmed value | absent, empty and whitespace are all "no locale"; a repeated parameter is refused rather than guessed |
| an added field says `added` through a refusal | with both sides present it still says `changed`, so presence is preserved rather than invented |

The presence tests assert the **premise** before the conclusion — that every line really did come back `unsupported` — so the status assertion is about the refusal path rather than an ordinary comparison.

Break-verified individually: dropping the locale from the hook fails its two tests, dropping it from the href fails the href test, and restoring the old refusal fails the presence tests.

`check-types` pass · `lint` pass · `fallow` pass (0 introduced) · admin versions 287/287 · nextly versions-diff 155/155 · full pre-push gate run and passing.

## A note on the push

The first push attempt failed and the second succeeded with no change to the tree. Every pre-push step passes when run individually — `lint:design`, `lint:workspace`, `turbo lint`, `turbo check-types`, and the scoped test gate at 787/787 and 326/326. `pb-breakpoint-badges` measured the same thing independently: three nextly files fail only inside the full parallel run and pass alone. That is order dependence in the suite, not a regression here, and it is worth knowing before anyone reads a red pre-push as a real failure.