### PR TITLE
fix(blocks-engine): apply the slot-name rule where registration cannot

### DIFF
--- a/.changeset/a-supplied-block-obeys-the-same-slot-rules.md
+++ b/.changeset/a-supplied-block-obeys-the-same-slot-rules.md
@@ -1,0 +1,17 @@
+---
+"@nextlyhq/blocks-engine": patch
+---
+
+Refuse to fill a declared slot whose name cannot be stored, and derive the
+expansion depth from the document's own limit.
+
+A block supplied to the inserter rather than registered never passes
+registration, so the slot-name rule enforced there did not reach it: a slot
+named for an `Object.prototype` member was filled, the op layer rejected the
+resulting node, and the author's click did nothing with nothing reported. The
+same predicate now answers on both paths.
+
+The expansion also carried its own depth bound alongside the document model's,
+and the lower of two policies silently wins — a declaration nesting nine
+containers is legal by the document model and was truncated. The bound is now
+derived from `MAX_DEPTH`, less the root the caller creates.

--- a/packages/blocks-engine/src/tree.test.ts
+++ b/packages/blocks-engine/src/tree.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { BlockNode } from "./document";
-import { countNodes, treeDepth } from "./limits";
+import { MAX_DEPTH, countNodes, treeDepth } from "./limits";
 import { measureBytes } from "./measure-bytes";
 import {
   duplicateNode,
@@ -1649,6 +1649,55 @@ describe("expanding a slot's declared default", () => {
     expect(created).toBeGreaterThan(100);
   });
 
+  it("refuses to fill a slot whose name cannot be stored", () => {
+    // Registration rejects such a name, and a SUPPLIED definition never passes
+    // registration — `blockSourceFor` admits one the registry does not hold.
+    // Filling it materialises a key the op layer then rejects, so the insert is
+    // refused and the author's click does nothing with nothing reported.
+    const slots: Record<string, unknown> = {};
+    // `defineProperty` because a literal `{ constructor: ... }` is fine but
+    // `__proto__` written as a literal key sets the prototype instead, and the
+    // two must be built the same way to be compared.
+    Object.defineProperty(slots, "constructor", {
+      value: { defaultBlock: [{ type: "core/leaf" }] },
+      enumerable: true,
+      configurable: true,
+      writable: true,
+    });
+    expect(Object.keys(slots)).toEqual(["constructor"]);
+
+    const supplied = {
+      get: (type: string) =>
+        type === "core/host"
+          ? { version: 1, slots }
+          : type === "core/leaf"
+            ? { version: 1 }
+            : undefined,
+    };
+
+    expect(expandSlotDefaults("core/host", supplied as never)).toBeUndefined();
+  });
+
+  it("fills an ordinary slot name on the same path", () => {
+    // The control. A guard that refused every slot would satisfy the assertion
+    // above while making declared defaults inert for every supplied block.
+    const supplied = {
+      get: (type: string) =>
+        type === "core/host"
+          ? {
+              version: 1,
+              slots: { children: { defaultBlock: [{ type: "core/leaf" }] } },
+            }
+          : type === "core/leaf"
+            ? { version: 1 }
+            : undefined,
+    };
+
+    expect(
+      expandSlotDefaults("core/host", supplied as never)?.children
+    ).toHaveLength(1);
+  });
+
   it("stops expanding a chain of distinct types at the depth bound", () => {
     // Each type seeds the next, so no type repeats and the cycle set never
     // fires — the depth bound is the only thing that ends this.
@@ -1674,6 +1723,9 @@ describe("expanding a slot's declared default", () => {
     // Bounded, and bounded where the constant says. An unbounded expansion
     // never reaches this line, and asserting merely "finite" would pass on a
     // bound of any size.
-    expect(depth).toBe(8);
+    // Derived from the document's own MAX_DEPTH, less the root the caller
+    // creates — not a number chosen here. Asserting the literal would let a
+    // second depth policy be reintroduced without failing anything.
+    expect(depth).toBe(MAX_DEPTH - 1);
   });
 });

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -82,10 +82,11 @@ import type { SlotSpec } from "./block";
 import { isBlockType } from "./document";
 import type { BlockNode } from "./document";
 import { walkForest } from "./forest-walk";
-import { MAX_NODES } from "./limits";
+import { MAX_DEPTH, MAX_NODES } from "./limits";
 import { canNest, canNestInSlot } from "./nesting";
 import type { NestingSource } from "./nesting";
 import { isPlainRecord } from "./plain-record";
+import { isUsableSlotName } from "./registry";
 import { defineEntry, ownEntry } from "./safe-record";
 
 /** Stable unique node id. `crypto.randomUUID` exists in Node ≥ 20 and browsers. */
@@ -138,13 +139,19 @@ type ResolvedDefinition = NonNullable<ReturnType<SlotDefaultSource["get"]>>;
 /**
  * How deep a chain of declared defaults may go.
  *
- * A bound rather than a promise: the cycle set below already stops a block from
- * seeding itself at any remove, so this catches only a chain of DISTINCT types
- * long enough to be a mistake — eight containers deep is past any layout an
- * author would draw, and a declaration that wants more is describing a document
- * rather than a starting point.
+ * DERIVED from the document's own `MAX_DEPTH` rather than chosen here. A second
+ * number would be a second depth policy, and the lower of the two silently
+ * wins: a declaration nesting nine containers is legal by the document model
+ * and was truncated by a bound this module invented, with nothing reported.
+ *
+ * Less ONE, because the node these children hang from is created by the caller
+ * and counts toward the document's depth just as they do — spending the whole
+ * allowance below it yields a tree one level deeper than any document may hold.
+ *
+ * The cycle set is what stops a block seeding itself at any remove, so this
+ * bounds only a chain of DISTINCT types.
  */
-const MAX_SLOT_DEFAULT_DEPTH = 8;
+const MAX_SLOT_DEFAULT_DEPTH = MAX_DEPTH - 1;
 
 /**
  * How many nodes one expansion may create, and why a depth bound is not enough.
@@ -279,6 +286,13 @@ function expandFrom(
   let filledAnySlot = false;
 
   for (const [slotName, spec] of Object.entries(declaredSlots)) {
+    // Registration refuses a slot named for an `Object.prototype` member, and
+    // registration is not the only way a definition reaches here: a supplied
+    // definition the registry does not hold never passed that check. Filling
+    // such a slot materialises a key `assertNodeShape` then rejects, so the op
+    // is refused and the author's click does nothing, silently. The SAME
+    // predicate answers here, so the two paths cannot disagree about a name.
+    if (!isUsableSlotName(slotName)) continue;
     const children = childrenForSlot(spec?.defaultBlock, {
       type,
       slotName,

--- a/packages/blocks-engine/src/tree.ts
+++ b/packages/blocks-engine/src/tree.ts
@@ -139,14 +139,24 @@ type ResolvedDefinition = NonNullable<ReturnType<SlotDefaultSource["get"]>>;
 /**
  * How deep a chain of declared defaults may go.
  *
- * DERIVED from the document's own `MAX_DEPTH` rather than chosen here. A second
- * number would be a second depth policy, and the lower of the two silently
- * wins: a declaration nesting nine containers is legal by the document model
- * and was truncated by a bound this module invented, with nothing reported.
+ * **This bounds THIS function's own recursion; it does not promise the result
+ * fits.** The same distinction the node budget below draws, and for the same
+ * reason stated at the top of this module: these primitives make no claim about
+ * whether what they build can be saved, and one place decides that at the point
+ * of writing. A subtree seeded into an already-deep slot can exceed the
+ * document's depth once placed, and the op layer refuses it — which is what
+ * happens to any oversized insert and is not this function's question. It
+ * cannot be this function's question: the insertion point belongs to the
+ * caller, and a value expanded here may be placed anywhere or nowhere.
+ *
+ * `MAX_DEPTH` supplies the ceiling because it is the natural one and inventing
+ * a second number would give the same question two answers — the failure this
+ * replaced, where a legal nine-deep declaration was truncated by a bound this
+ * module had chosen for itself.
  *
  * Less ONE, because the node these children hang from is created by the caller
- * and counts toward the document's depth just as they do — spending the whole
- * allowance below it yields a tree one level deeper than any document may hold.
+ * and occupies a level of its own. That removes the case that could never fit
+ * WHEREVER it landed; it does not make the remainder fit everywhere.
  *
  * The cycle set is what stops a block seeding itself at any remove, so this
  * bounds only a chain of DISTINCT types.


### PR DESCRIPTION
Follow-up to #1308, from two findings that arrived on it after it merged. Both are one rule answering in two places, and both were introduced by my own earlier fix in that PR.

## A supplied block skipped the slot-name rule

`registerBlocks` refuses a slot named for an `Object.prototype` member — `constructor`, `toString`, `__proto__` — because the op layer rejects every node carrying one.

#1308 also made `blockSourceFor` deliberately admit a definition the registry does **not** hold, so the inserter can offer a caller-supplied block. That is the right behaviour and it moved a boundary: such a definition never passes registration, so the slot-name check never reached it. The slot was filled, `assertNodeShape` rejected the node, `apply` returned null, and `InsertPanel` returned early — **the author clicks and nothing happens, with nothing reported anywhere.**

The expansion now asks the same exported `isUsableSlotName`, so the declaration gate and this path cannot disagree about a name. Not a second copy of the predicate — the one the registry uses.

This is the third time in this series that a fix of mine moved a boundary and left a rule behind it. The first two were caught inside #1308; this is the same shape, and it is worth naming rather than quietly patching.

## The expansion carried its own depth policy

`MAX_SLOT_DEFAULT_DEPTH` was `8`, sitting beside the document model's `MAX_DEPTH` of `12`. Two policies over one question, and the lower silently wins: a declaration nesting nine containers is legal by the document model and was truncated with nothing reported.

It is now `MAX_DEPTH - 1` — less one because the node these children hang from is created by the caller and counts toward the document's depth exactly as they do.

**The test asserts `MAX_DEPTH - 1` rather than the literal**, so reintroducing a second policy fails rather than passing quietly. Asserting `11` would have let the next hardcoded number through.

## Verification

Every new test break-verified individually:

| break | fails |
|---|---|
| remove the slot-name guard | `refuses to fill a slot whose name cannot be stored` |
| re-hardcode the depth to `8` | `stops expanding a chain of distinct types at the depth bound` |
| drop the root allowance (`MAX_DEPTH`) | same test |

The slot-name test carries a **control** — an ordinary slot name on the same path must still be filled — because a guard that refused every slot would satisfy the refusal while making declared defaults inert for every supplied block.

Its fixture builds the key with `Object.defineProperty` and asserts `Object.keys` first. A literal `{ __proto__: … }` invokes the prototype setter and creates no own key, so a fixture written that way passes **without the check ever running** — that exact mistake cost me a green test earlier in this series.

Gates, exit statuses read directly: build 0, `check-types` 0, `lint` 0, comment convention 0, `fallow audit` pass with dead-code / duplication / complexity introduced all 0, `changeset status` 0. Suites: blocks-engine 1628, blocks-react 962, builder 2360, plugin-page-builder 514 — 0 failures each.

## Not included

A third finding on #1308 — `packages/nextly`'s block-manifest codegen validates `allow` but not `defaultBlock`, so a definition the engine now rejects at boot still passes `generate:manifest --check`. Real, and deliberately not here: the honest fix is one shared predicate across both packages rather than a second copy of mine, which is a design change in a package this PR does not touch. Filed separately. Whoever takes it should check the slot-NAME rule for the same parity gap, not only `defaultBlock`.

@codex review