### PR TITLE
fix(builder): discard a creation whose block moved, and clear a stale failure

### DIFF
--- a/.changeset/discard-a-class-creation-whose-block-moved.md
+++ b/.changeset/discard-a-class-creation-whose-block-moved.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Creating a class while the selection moves to another block no longer writes
+one block's classes through the other's. The class is created and simply not
+applied: putting it on a block the author never asked about is worse than not
+applying it at all.
+
+A refusal that no longer describes the selected block is now cleared rather
+than hidden, so a class list the block held before cannot bring the message
+back.

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -79,7 +79,7 @@ export interface ClassManagerPanelProps {
    * The classes something ELSE supplies, which the stored library layers over.
    *
    * Needed because these two are not equally editable, exactly as the tokens
-   * studio found for tokens. `resolveSiteStyle` merges the site'"'"'s configured
+   * studio found for tokens. `resolveSiteStyle` merges the site's configured
    * classes back over the stored tier BY ID, so absence from storage means "no
    * override" rather than "deleted" — a supplied class reappears on the next
    * read while the delete callback has already stripped it from every document

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -684,6 +684,117 @@ describe("a refusal raised by a creation that landed after an edit", () => {
   });
 });
 
+describe("a failure that must be invalidated, not merely hidden", () => {
+  it("stays gone when the node returns to a class list it held before", () => {
+    /*
+     * Hiding leaves the refusal stored, so a list the node held before can
+     * bring it back — an external edit adding a class and an undo removing it
+     * is enough. The alert would then describe an operation that did not just
+     * fail. A test that stops after the first rerender cannot tell hiding from
+     * invalidating, which is exactly what mine did.
+     */
+    const refuse = vi.fn(() => "refused" as const);
+    const at = (ids: readonly string[]) => (
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={ids}
+        onNodeClassesChange={refuse}
+        onCreateClass={createsClass()}
+      />
+    );
+    const view = render(at([]));
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    view.rerender(at(["id-card"]));
+    expect(screen.queryByRole("alert")).toBeNull();
+
+    // Back to the list the refusal was recorded against.
+    view.rerender(at([]));
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});
+
+describe("a creation resolving after the selection moved to another block", () => {
+  it("does not write one node's classes through another node's callback", async () => {
+    /*
+     * The handler captures the node and the write callback from the render
+     * that began the request, and reads the class list live. Unkeyed, a
+     * consumer can rerender to a different block mid-flight — and applying
+     * then puts the new block's classes through the old block's writer.
+     */
+    let resolve: (v: { ok: true; classId: string }) => void = () => {};
+    const create = vi.fn(
+      () =>
+        new Promise<{ ok: true; classId: string }>(r => {
+          resolve = r;
+        })
+    );
+    const writeA = vi.fn(() => "applied" as const);
+    const writeB = vi.fn(() => "applied" as const);
+
+    const view = render(
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={["id-hero"]}
+        onNodeClassesChange={writeA}
+        onCreateClass={create}
+      />
+    );
+    type("brand-new");
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    view.rerender(
+      <ClassSelector
+        nodeId="node-b"
+        library={LIBRARY}
+        nodeClassIds={["id-card"]}
+        onNodeClassesChange={writeB}
+        onCreateClass={create}
+      />
+    );
+
+    await React.act(async () => {
+      resolve({ ok: true, classId: "id-made" });
+    });
+
+    expect(writeA).not.toHaveBeenCalled();
+    expect(writeB).not.toHaveBeenCalled();
+  });
+
+  it("still applies when the selection has NOT moved", async () => {
+    // The control: discarding on a node change must not discard every creation.
+    let resolve: (v: { ok: true; classId: string }) => void = () => {};
+    const create = vi.fn(
+      () =>
+        new Promise<{ ok: true; classId: string }>(r => {
+          resolve = r;
+        })
+    );
+    const write = vi.fn(() => "applied" as const);
+    render(
+      <ClassSelector
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={["id-hero"]}
+        onNodeClassesChange={write}
+        onCreateClass={create}
+      />
+    );
+    type("brand-new");
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    await React.act(async () => {
+      resolve({ ok: true, classId: "id-made" });
+    });
+
+    expect(write).toHaveBeenCalledWith(["id-hero", "id-made"]);
+  });
+});
+
 describe("two blocks that look identical from the class list alone", () => {
   it("drops a refusal when the node changes but its class list does not", () => {
     /*

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -765,6 +765,58 @@ describe("a creation resolving after the selection moved to another block", () =
     expect(writeB).not.toHaveBeenCalled();
   });
 
+  it("applies to the block that asked when the parent keys by node", async () => {
+    /*
+     * The keyed mount is what the style inspector renders, and it does not
+     * reach the discard above: a new key unmounts the instance rather than
+     * updating it, so the node the handler captured is still the node its ref
+     * reports. The write that follows is self-consistent — the originating
+     * block's own class list through its own callback — which is why the
+     * mixing this file guards against cannot occur here. Asserted so the two
+     * mounts are covered separately rather than one standing in for both.
+     */
+    let resolve: (v: { ok: true; classId: string }) => void = () => {};
+    const create = vi.fn(
+      () =>
+        new Promise<{ ok: true; classId: string }>(r => {
+          resolve = r;
+        })
+    );
+    const writeA = vi.fn(() => "applied" as const);
+    const writeB = vi.fn(() => "applied" as const);
+
+    const view = render(
+      <ClassSelector
+        key="node-a"
+        nodeId="node-a"
+        library={LIBRARY}
+        nodeClassIds={["id-hero"]}
+        onNodeClassesChange={writeA}
+        onCreateClass={create}
+      />
+    );
+    type("brand-new");
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    view.rerender(
+      <ClassSelector
+        key="node-b"
+        nodeId="node-b"
+        library={LIBRARY}
+        nodeClassIds={["id-card"]}
+        onNodeClassesChange={writeB}
+        onCreateClass={create}
+      />
+    );
+
+    await React.act(async () => {
+      resolve({ ok: true, classId: "id-made" });
+    });
+
+    expect(writeA.mock.calls).toEqual([[["id-hero", "id-made"]]]);
+    expect(writeB).not.toHaveBeenCalled();
+  });
+
   it("still applies when the selection has NOT moved", async () => {
     // The control: discarding on a node change must not discard every creation.
     let resolve: (v: { ok: true; classId: string }) => void = () => {};

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -690,8 +690,8 @@ describe("a failure that must be invalidated, not merely hidden", () => {
      * Hiding leaves the refusal stored, so a list the node held before can
      * bring it back — an external edit adding a class and an undo removing it
      * is enough. The alert would then describe an operation that did not just
-     * fail. A test that stops after the first rerender cannot tell hiding from
-     * invalidating, which is exactly what mine did.
+     * fail. A test that stops after the first rerender cannot distinguish
+     * hiding from invalidating.
      */
     const refuse = vi.fn(() => "refused" as const);
     const at = (ids: readonly string[]) => (

--- a/packages/builder/src/class-selector.test.tsx
+++ b/packages/builder/src/class-selector.test.tsx
@@ -765,6 +765,46 @@ describe("a creation resolving after the selection moved to another block", () =
     expect(writeB).not.toHaveBeenCalled();
   });
 
+  it("clears a stale refusal even while the library is away", async () => {
+    /*
+     * The library going absent must not suspend the invalidation. A refusal is
+     * cleared by the render that observes the node has left the state it was
+     * raised against, so a render that returns early for a missing library
+     * skips that observation — and a list that changes and comes back while
+     * the library is away arrives back matching, reviving an alert about an
+     * operation that did not just fail.
+     */
+    const refuse = vi.fn(() => "refused" as const);
+    const at = (
+      ids: readonly string[],
+      library: readonly NamedClass[] | undefined
+    ) => (
+      <ClassSelector
+        nodeId="node-a"
+        library={library}
+        libraryAbsence="pending"
+        nodeClassIds={ids}
+        onNodeClassesChange={refuse}
+        onCreateClass={createsClass()}
+      />
+    );
+
+    const view = render(at([], LIBRARY));
+    type("hero");
+    fireEvent.keyDown(field(), { key: "Enter" });
+    expect(screen.getByRole("alert")).toBeTruthy();
+
+    // The library goes away, and the node leaves the list the refusal names.
+    view.rerender(at([], undefined));
+    view.rerender(at(["id-card"], undefined));
+    // Back to that same list, still with no library to draw.
+    view.rerender(at([], undefined));
+    // The library returns.
+    view.rerender(at([], LIBRARY));
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+
   it("applies to the block that asked when the parent keys by node", async () => {
     /*
      * The keyed mount is what the style inspector renders, and it does not

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -96,9 +96,14 @@ function liveFailure(
 /**
  * Whether two class lists are the same list, by CONTENT.
  *
- * A caller with no stored classes hands over a fresh `[]` on every render —
- * `?? []` in the style inspector does exactly that — so comparing by reference
- * would discard a failure on the next render, which is every render.
+ * By value rather than by reference because a caller with no stored classes
+ * hands over a fresh `[]` on every render — `?? []` in the style inspector
+ * does exactly that — so a reference comparison would discard a failure on the
+ * next render, which is every render.
+ *
+ * Half of the scoping, beside the block'"'"'s own identity. This half catches what
+ * identity cannot: the same block whose classes have since changed, where the
+ * refusal describes a state it has left.
  */
 function sameClassIds(a: readonly string[], b: readonly string[]): boolean {
   return a.length === b.length && a.every((id, index) => id === b[index]);
@@ -150,12 +155,17 @@ export interface ClassSelectorProps {
   /**
    * Which block this is editing.
    *
-   * Required, and used only to scope a failure to the element it is about.
-   * Comparing the class ids instead was a proxy for identity and it fails on
-   * the commonest case: two blocks with no classes both present an empty list,
-   * so a refusal raised against one goes on being shown against the other.
-   * Keyed mounting protects a caller that remembers to key; a prop cannot be
-   * forgotten.
+   * Required, and read for two things: scoping a failure to the element it is
+   * about, and telling a creation still in flight whether the block it was
+   * started for is the one still selected.
+   *
+   * It does not replace the class-list comparison — {@link liveFailure} uses
+   * both, and neither settles it alone. This one catches what content cannot:
+   * two blocks with no classes present the same empty list, so a refusal
+   * raised against one would go on being shown against the other.
+   *
+   * A prop rather than a documented requirement to mount this keyed. Keying
+   * protects a caller who remembers; a prop cannot be forgotten.
    */
   nodeId: string;
   library: readonly NamedClass[] | undefined;

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -272,6 +272,23 @@ export function ClassSelector({
   const currentQuery = React.useRef(query);
   currentQuery.current = query;
 
+  /*
+   * Cleared, not merely hidden. Hiding leaves the refusal stored, so a node
+   * returning to a class list it held before — an external edit and an undo
+   * would do it — revives an alert about an operation that did not just fail.
+   * This is React's documented adjust-state-during-render: the condition stops
+   * being true once the state is null, so it converges on the next pass.
+   *
+   * Above the library-absence return because a refusal outlives the
+   * library: a render that draws no list still observes the node leaving
+   * the state the refusal was raised against, and skipping that lets a
+   * list which changes and comes back while the library is away arrive
+   * back matching.
+   */
+  if (failure !== null && liveFailure(failure, nodeId, nodeClassIds) === null) {
+    setFailure(null);
+  }
+
   if (library === undefined) {
     return (
       <div className="nx-classes">
@@ -293,16 +310,6 @@ export function ClassSelector({
    * node may have gained room since, through a removal, an undo, or the host
    * selecting a smaller element.
    */
-  /*
-   * Cleared, not merely hidden. Hiding leaves the refusal stored, so a node
-   * returning to a class list it held before — an external edit and an undo
-   * would do it — revives an alert about an operation that did not just fail.
-   * This is React's documented adjust-state-during-render: the condition stops
-   * being true once the state is null, so it converges on the next pass.
-   */
-  if (failure !== null && liveFailure(failure, nodeId, nodeClassIds) === null) {
-    setFailure(null);
-  }
   const shown = liveFailure(failure, nodeId, nodeClassIds);
   // Clamped rather than reset on every keystroke, so narrowing the list keeps a
   // highlight instead of silently sending Enter back to the first row.

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -242,6 +242,18 @@ export function ClassSelector({
   const currentIds = React.useRef(nodeClassIds);
   currentIds.current = nodeClassIds;
   /*
+   * Which node is selected NOW, so a pending creation can tell whether it is
+   * still about the element it was started for.
+   *
+   * The success handler captures `nodeId` and the write callback from the
+   * render that began the request, while reading the class list live. Mixing
+   * the two lets a resolution write one node's classes through another node's
+   * callback — the built-in parent keys by node and never sees it, a direct
+   * consumer that does not key would.
+   */
+  const currentNodeId = React.useRef(nodeId);
+  currentNodeId.current = nodeId;
+  /*
    * What is typed RIGHT NOW, for the same reason. The field stays editable
    * while a creation is in flight, so an author can begin the next class name
    * before the first one lands — and clearing on success would take away what
@@ -271,6 +283,16 @@ export function ClassSelector({
    * node may have gained room since, through a removal, an undo, or the host
    * selecting a smaller element.
    */
+  /*
+   * Cleared, not merely hidden. Hiding leaves the refusal stored, so a node
+   * returning to a class list it held before — an external edit and an undo
+   * would do it — revives an alert about an operation that did not just fail.
+   * This is React'"'"'s documented adjust-state-during-render: the condition stops
+   * being true once the state is null, so it converges on the next pass.
+   */
+  if (failure !== null && liveFailure(failure, nodeId, nodeClassIds) === null) {
+    setFailure(null);
+  }
   const shown = liveFailure(failure, nodeId, nodeClassIds);
   // Clamped rather than reset on every keystroke, so narrowing the list keeps a
   // highlight instead of silently sending Enter back to the first row.
@@ -300,9 +322,17 @@ export function ClassSelector({
        * knew whether it had landed.
        */
       const submitted = query;
+      const startedOn = nodeId;
       setSaving(true);
       void onCreateClass(option.slug)
         .then(created => {
+          /*
+           * The element moved on. The class was created and is in the library,
+           * but applying it now would put it on a node the author did not ask
+           * about — the request'"'"'s own node is no longer selected, and there is
+           * nothing here that could write to it safely.
+           */
+          if (currentNodeId.current !== startedOn) return;
           if (!created.ok) {
             setFailure({
               about: nodeId,

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -101,7 +101,7 @@ function liveFailure(
  * does exactly that — so a reference comparison would discard a failure on the
  * next render, which is every render.
  *
- * Half of the scoping, beside the block'"'"'s own identity. This half catches what
+ * Half of the scoping, beside the block's own identity. This half catches what
  * identity cannot: the same block whose classes have since changed, where the
  * refusal describes a state it has left.
  */
@@ -297,7 +297,7 @@ export function ClassSelector({
    * Cleared, not merely hidden. Hiding leaves the refusal stored, so a node
    * returning to a class list it held before — an external edit and an undo
    * would do it — revives an alert about an operation that did not just fail.
-   * This is React'"'"'s documented adjust-state-during-render: the condition stops
+   * This is React's documented adjust-state-during-render: the condition stops
    * being true once the state is null, so it converges on the next pass.
    */
   if (failure !== null && liveFailure(failure, nodeId, nodeClassIds) === null) {
@@ -339,7 +339,7 @@ export function ClassSelector({
           /*
            * The element moved on. The class was created and is in the library,
            * but applying it now would put it on a node the author did not ask
-           * about — the request'"'"'s own node is no longer selected, and there is
+           * about — the request's own node is no longer selected, and there is
            * nothing here that could write to it safely.
            */
           if (currentNodeId.current !== startedOn) return;

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -141,18 +141,6 @@ export type ClassCreation =
 
 export interface ClassSelectorProps {
   /**
-   * The site's class library, or `undefined` when there is none to show.
-   *
-   * A real third state rather than an empty library: a site that has stored
-   * nothing legitimately has no classes, and drawing the two the same way would
-   * invite an author to create a class into a library about to be replaced by
-   * the one still loading.
-   *
-   * `undefined` covers two causes — a read in flight and a read that failed —
-   * and {@link ClassSelectorProps.libraryAbsence} says which. They need
-   * different words: one will finish and the other will not.
-   */
-  /**
    * Which block this is editing.
    *
    * Required, and read for two things: scoping a failure to the element it is
@@ -168,6 +156,18 @@ export interface ClassSelectorProps {
    * protects a caller who remembers; a prop cannot be forgotten.
    */
   nodeId: string;
+  /**
+   * The site's class library, or `undefined` when there is none to show.
+   *
+   * A real third state rather than an empty library: a site that has stored
+   * nothing legitimately has no classes, and drawing the two the same way would
+   * invite an author to create a class into a library about to be replaced by
+   * the one still loading.
+   *
+   * `undefined` covers two causes — a read in flight and a read that failed —
+   * and {@link ClassSelectorProps.libraryAbsence} says which. They need
+   * different words: one will finish and the other will not.
+   */
   library: readonly NamedClass[] | undefined;
   /**
    * Why there is no library, when there is none.


### PR DESCRIPTION
**Recovering work stranded by #1320's merge — the second time in a row, and the same shape.**

#1320's head at merge was `c51f9f515`. The merge took `118a528bd` instead and dropped the two commits after it. Measured by symbol on main:

```
sameClassIds     2   <- 118a528bd landed
clearQuery       2   <- landed
nodeId: string;  1   <- landed
currentNodeId    0   <- 4f9d702d3 did NOT land
startedOn        0   <- did NOT land
```

Cherry-picked onto current main and re-gated there rather than trusting the run from the original base.

## What was lost, and why it matters

**A creation resolving after the selection moved could write across blocks.** The success handler captured the block and the write callback from the render that began the request while reading the class list live — so a consumer rerendering to another block mid-flight could write the new block's classes through the old block's writer. It now records which block the request was for and does nothing when that block is no longer selected: the class is in the library, and putting it on a block the author never asked about is worse than not applying it.

**A stale failure was hidden rather than cleared**, so a class list the block held before revived it — an external edit plus an undo is enough. Codex also observed that the existing test rerendered once and therefore could not distinguish hiding from invalidating; the new one returns to the original list, which is the only sequence the two differ on.

Also carried: a comment-only commit fixing two adjacent docblocks in `class-selector.tsx` that had come to answer one question in opposite directions across three rounds. The code was right in both places; only the prose disagreed with itself.

## Both merges had zero check-runs

`c51f9f515` had **no check-runs created** at merge time — not queued, none. So did `c85cfafed`, whose merge stranded the previous commit. Two stranded merges, both with no CI record of the head that merged.

## Gates

Build, vitest (**2388 passed**), check-types, package lint with max-warnings 0, root eslint, comment convention, and check-changesets as CI runs it — all exit 0 **against current main**. Fallow: every introduced counter at 0.

Breaks verified on the original PR, each failing only its named test: applying despite a moved selection, and hiding the failure instead of clearing it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale class-creation errors reappearing when returning to a previously selected class list.
  * Prevented delayed class creation results from being applied to the wrong block after changing selections.
  * Ensured class creation continues to apply correctly when the original block remains selected.

* **Tests**
  * Added coverage for selection changes, failure invalidation, and delayed class-creation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->