### PR TITLE
fix(admin): keep the language when choosing another version to compare

### DIFF
--- a/.changeset/comparison-keeps-its-locale.md
+++ b/.changeset/comparison-keeps-its-locale.md
@@ -1,0 +1,30 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Keep the content language when choosing another version to compare, so the
+comparison stays named in the language of the versions it is showing.

--- a/packages/admin/src/components/features/versions/VersionComparePage.tsx
+++ b/packages/admin/src/components/features/versions/VersionComparePage.tsx
@@ -188,14 +188,26 @@ export function VersionComparePage({
       // reinstate exactly that — these two numbers are what `resolvePair`
       // reads, so they are what "the same comparison" means.
       if (previous.versionNo === from && versionNo === to) return;
+      // Built through the same `versionsHref` the history sheet uses, so one
+      // place decides what a comparison's address looks like. Hand-building it
+      // here is how the locale came to be dropped: the address was assembled
+      // from the two numbers this callback happens to hold, and a language is
+      // not one of them.
+      //
+      // The locale is taken from the SELECTED version rather than carried from
+      // the current address, so choosing a row in another language moves the
+      // page to that language instead of keeping the previous one. The rail
+      // interleaves locales, so the row a reader clicks is routinely not in the
+      // language now on screen.
       navigateTo(
-        withQuery(window.location.pathname, {
-          from: previous.versionNo,
-          to: versionNo,
-        })
+        versionsHref(
+          scope,
+          { from: previous.versionNo, to: versionNo },
+          versions.find(v => v.versionNo === versionNo)?.locale
+        )
       );
     },
-    [versions, list.hasNextPage, from, to]
+    [versions, list.hasNextPage, from, to, scope]
   );
 
   return (

--- a/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionComparePage.test.tsx
@@ -458,3 +458,59 @@ describe("versionsHref — the address carries the language", () => {
     expect(versionsHref(scope, undefined, "fr")).toContain("locale=fr");
   });
 });
+
+describe("VersionComparePage — selecting a row keeps the language", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canMock.mockReturnValue(true);
+  });
+
+  /**
+   * The address is what the page is named from, so a navigation that drops the
+   * locale sends the reader to a comparison headed in another language. The
+   * rail interleaves locales, so the row clicked is routinely not in the
+   * language currently on screen — which is why the SELECTED version's locale
+   * decides, rather than the one the current address happens to carry.
+   */
+  it("writes the selected version's locale into the address", async () => {
+    useVersionsMock.mockReturnValue(
+      listing([row(9, "fr"), row(8, "fr"), row(7, "fr")])
+    );
+    const user = (await import("@testing-library/user-event")).default.setup();
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Version 8/ }));
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0]?.[0]).toContain("locale=fr");
+  });
+
+  /**
+   * The control. A document with no locale must produce no parameter — an
+   * empty one reads as a language that failed to resolve rather than one never
+   * asked for, and without this the assertion above would pass on a page that
+   * always appended something.
+   */
+  it("writes no locale for a document that has none", async () => {
+    useVersionsMock.mockReturnValue(listing([row(9), row(8), row(7)]));
+    const user = (await import("@testing-library/user-event")).default.setup();
+
+    render(
+      <VersionComparePage
+        scope={collection("e1")}
+        documentHref="/admin/collections/posts/e1"
+        readOnlyHref="/admin/collections/posts"
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /Version 8/ }));
+    expect(navigateMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock.mock.calls[0]?.[0]).not.toContain("locale");
+  });
+});


### PR DESCRIPTION
Follow-up to #1321, which merged with this finding open.

## What was wrong

#1321 carried the content language into the comparison page, but the page dropped it again on the next click. `selectPair` rebuilt the address from the two version numbers it happened to hold, and a language is not one of them — so choosing another row refetched and renamed the page in the default language while still showing the same versions.

The reviewer's framing is the right one: the address should be built by the **canonical builder**, not assembled by hand at each site. Hand-assembly is exactly how the locale came to be dropped.

## The fix

`selectPair` now goes through the same `versionsHref` the history sheet uses, so one place decides what a comparison's address looks like.

The language comes from the **selected version**, not from the current address. That is deliberate and it is the more correct of the two: the rail interleaves locales, so the row a reader clicks is routinely *not* in the language now on screen. Carrying the old locale forward would name the new comparison wrongly in the other direction — the versions would be French and the heading English, which is the same defect this fixes, mirrored.

## Verification

Two tests, and the control decides the shape:

| case | asserts |
|---|---|
| a French history, another row chosen | the pushed address contains `locale=fr` |
| **control:** a document with no locale | the pushed address contains **no** `locale` at all |

Without the control, the first would pass on a page that always appended something — and an empty `locale=` reads as a language that failed to resolve rather than one never asked for.

Break-verified: replacing the selected version's locale with `undefined` fails the first test and leaves the control passing.

`check-types` pass · `lint` pass · `fallow` pass (0 introduced) · admin versions suite green · full pre-push gate run and passing.