### PR TITLE
refactor(plugin-form-builder): let the schema generator read the rule set the editor reads

### DIFF
--- a/.changeset/derive-enforced-validation.md
+++ b/.changeset/derive-enforced-validation.md
@@ -29,3 +29,9 @@
 Make the form schema generator read the same per-type rule set the field
 editor reads, so a validation rule cannot be offered by one and ignored by
 the other.
+
+That now includes the custom error message, which the generator applied
+whatever the rule set said, and the pattern override on a phone field: a
+stored pattern used to stand the phone's own format check down even where
+the rule set did not enforce patterns, leaving the field accepting any
+text at all.

--- a/.changeset/derive-enforced-validation.md
+++ b/.changeset/derive-enforced-validation.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Make the form schema generator read the same per-type rule set the field
+editor reads, so a validation rule cannot be offered by one and ignored by
+the other.

--- a/packages/plugin-form-builder/src/utils/enforced-validation-rules.test.ts
+++ b/packages/plugin-form-builder/src/utils/enforced-validation-rules.test.ts
@@ -213,3 +213,63 @@ describe("the message rule", () => {
     }
   });
 });
+
+describe("the table is what the generator reads", () => {
+  /**
+   * Every assertion above derives BOTH sides from `ENFORCED_VALIDATION_RULES`:
+   * it asks the table what to expect and then checks the generator against it.
+   * That cannot see the generator ignoring the table — remove a rule and the
+   * suite simply stops checking it, and passes either way.
+   *
+   * These expectations are written out instead. They are the anchor the
+   * derived assertions hang from: if the two ever disagree, one of them is
+   * wrong and the pair says so, where a single self-referential check would
+   * stay quiet.
+   *
+   * Kept deliberately small. This is not a second copy of the table — it is a
+   * handful of cases whose answers were established by running the generator,
+   * chosen because each is a rule some OTHER type deliberately omits.
+   */
+  const ANCHORED: ReadonlyArray<{
+    type: FormFieldType;
+    rule: string;
+    enforced: boolean;
+  }> = [
+    // `pattern` bites on text, and is deliberately absent from textarea.
+    { type: "text", rule: "pattern", enforced: true },
+    { type: "textarea", rule: "pattern", enforced: false },
+    // Length bounds bite on textarea, and email reads neither.
+    { type: "textarea", rule: "minLength", enforced: true },
+    { type: "email", rule: "minLength", enforced: false },
+    // Numeric bounds bite on number; a date reads its bounds from the field
+    // itself, not from `validation`.
+    { type: "number", rule: "min", enforced: true },
+    { type: "date", rule: "min", enforced: false },
+  ];
+
+  for (const { type, rule, enforced } of ANCHORED) {
+    it(`${type}: ${rule} is ${enforced ? "enforced" : "ignored"}`, () => {
+      const bound = REJECTING_BOUND[rule];
+      expect(bound, `no probe defined for ${rule}`).toBeDefined();
+      // The control on the probe itself: unbounded, this value passes.
+      expect(accepts(field(type), ACCEPTED[type])).toBe(true);
+      expect(accepts(field(type, bound), ACCEPTED[type])).toBe(!enforced);
+    });
+  }
+
+  /**
+   * And the anchor agrees with the table, so the two cannot drift apart
+   * silently: a rule listed for a type must be one the anchor calls enforced,
+   * and vice versa, for every case the anchor covers.
+   */
+  it("agrees with the table it anchors", () => {
+    for (const { type, rule, enforced } of ANCHORED) {
+      expect(
+        ENFORCED_VALIDATION_RULES[type].includes(
+          rule as (typeof ENFORCED_VALIDATION_RULES)[typeof type][number]
+        ),
+        `${type}/${rule}: the table and the anchor disagree`
+      ).toBe(enforced);
+    }
+  });
+});

--- a/packages/plugin-form-builder/src/utils/enforced-validation-rules.test.ts
+++ b/packages/plugin-form-builder/src/utils/enforced-validation-rules.test.ts
@@ -19,7 +19,7 @@
  */
 import type { FieldValidationRule } from "nextly/field-catalog";
 import { validationRulesForFieldType } from "nextly/field-catalog";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { FormField, FormFieldType } from "../types";
 import { BUILT_IN_FORM_FIELD_TYPES } from "../types";
@@ -271,5 +271,103 @@ describe("the table is what the generator reads", () => {
         `${type}/${rule}: the table and the anchor disagree`
       ).toBe(enforced);
     }
+  });
+});
+
+describe("the generator follows the table, rather than agreeing with it", () => {
+  /**
+   * Whether the generator's answers MOVE with the table — which nothing above
+   * can see.
+   *
+   * Every other assertion in this file states what the generator accepts. A
+   * generator that decided each type in a hand-written branch accepts exactly
+   * the same values, so all of them hold against an implementation that never
+   * reads the table at all — the anchored block included, since its six
+   * outcomes are outcomes either implementation produces. Agreement is not
+   * derivation.
+   *
+   * What separates the two is the dependency between the answers, not any one
+   * of them. So these substitute a table differing in exactly one row, and
+   * read the generator's answer for that row back.
+   *
+   * Both directions are asserted and neither alone would do: dropping a rule
+   * and watching it stop biting also passes for a generator that applies
+   * nothing, and adding one also passes for a generator that applies
+   * everything.
+   */
+
+  /** `generateZodSchema`, built against a table that says this instead. */
+  async function generatorReading(
+    table: Record<FormFieldType, readonly FieldValidationRule[]>
+  ) {
+    vi.resetModules();
+    vi.doMock("./enforced-validation", async importOriginal => ({
+      ...(await importOriginal<typeof import("./enforced-validation")>()),
+      ENFORCED_VALIDATION_RULES: table,
+    }));
+    const { generateZodSchema: generate } = await import("./generate-schema");
+    return (f: FormField, value: unknown) =>
+      generate([f]).safeParse({ [f.name]: value }).success;
+  }
+
+  afterEach(() => {
+    vi.doUnmock("./enforced-validation");
+    vi.resetModules();
+  });
+
+  it("stops applying a rule its type's row stops listing", async () => {
+    const substituted = await generatorReading({
+      ...ENFORCED_VALIDATION_RULES,
+      text: ["minLength", "maxLength", "message"],
+    });
+
+    // The control, and this direction needs one. A substitution that never
+    // reached the generator would leave it reading no rules for the type, and
+    // "the dropped rule stopped biting" would be true for the wrong reason.
+    // A rule the row KEEPS must still bite, which distinguishes a table that
+    // arrived and changed from one that did not arrive.
+    expect(substituted(field("text", { minLength: 50 }), ACCEPTED.text)).toBe(
+      false
+    );
+    // The observation: the row no longer lists `pattern`, so the bound the
+    // field still carries is no longer read.
+    expect(
+      substituted(field("text", { pattern: "^ZZZ$" }), ACCEPTED.text)
+    ).toBe(true);
+  });
+
+  it("starts applying a rule its type's row starts listing", async () => {
+    // `textarea` is the type to grow a rule, because its schema body is
+    // `text`'s exactly: the real table's row is the only reason `pattern` is
+    // inert there, so a generator ignoring the table cannot follow this.
+    const substituted = await generatorReading({
+      ...ENFORCED_VALIDATION_RULES,
+      textarea: ["minLength", "maxLength", "pattern", "message"],
+    });
+
+    // Self-controlling, unlike the direction above: every way the substitution
+    // could fail to arrive — the real table, or none — leaves `pattern` inert
+    // and yields the opposite answer here.
+    expect(
+      substituted(field("textarea", { pattern: "^ZZZ$" }), ACCEPTED.textarea)
+    ).toBe(false);
+  });
+
+  it("follows the table where numeric bounds are read, too", async () => {
+    // A second and separate read of the table. Numeric bounds go through their
+    // own applier map, so a hand-written number branch — reinstated alone —
+    // would satisfy both probes above while ignoring the row that governs it.
+    const substituted = await generatorReading({
+      ...ENFORCED_VALIDATION_RULES,
+      number: ["max", "message"],
+    });
+
+    // The kept rule, controlling the arrival of the table as before.
+    expect(substituted(field("number", { max: -100 }), ACCEPTED.number)).toBe(
+      false
+    );
+    expect(substituted(field("number", { min: 100 }), ACCEPTED.number)).toBe(
+      true
+    );
   });
 });

--- a/packages/plugin-form-builder/src/utils/enforced-validation-rules.test.ts
+++ b/packages/plugin-form-builder/src/utils/enforced-validation-rules.test.ts
@@ -296,8 +296,8 @@ describe("the generator follows the table, rather than agreeing with it", () => 
    * everything.
    */
 
-  /** `generateZodSchema`, built against a table that says this instead. */
-  async function generatorReading(
+  /** The generator, rebuilt against a table that says this instead. */
+  async function loadGenerator(
     table: Record<FormFieldType, readonly FieldValidationRule[]>
   ) {
     vi.resetModules();
@@ -306,8 +306,33 @@ describe("the generator follows the table, rather than agreeing with it", () => 
       ENFORCED_VALIDATION_RULES: table,
     }));
     const { generateZodSchema: generate } = await import("./generate-schema");
+    return generate;
+  }
+
+  /** `generateZodSchema`, built against a table that says this instead. */
+  async function generatorReading(
+    table: Record<FormFieldType, readonly FieldValidationRule[]>
+  ) {
+    const generate = await loadGenerator(table);
     return (f: FormField, value: unknown) =>
       generate([f]).safeParse({ [f.name]: value }).success;
+  }
+
+  /**
+   * The wording a rejection carries, for the rule whose whole job is wording.
+   *
+   * `message` cannot be probed by acceptance the way every other rule is: it
+   * does not decide whether a value passes, so a table that stopped enforcing
+   * it changes nothing an `accepts` probe can see.
+   */
+  async function issuesFrom(
+    table: Record<FormFieldType, readonly FieldValidationRule[]>,
+    f: FormField,
+    value: unknown
+  ): Promise<string[]> {
+    const generate = await loadGenerator(table);
+    const result = generate([f]).safeParse({ [f.name]: value });
+    return result.success ? [] : result.error.issues.map(i => i.message);
   }
 
   afterEach(() => {
@@ -351,6 +376,58 @@ describe("the generator follows the table, rather than agreeing with it", () => 
     expect(
       substituted(field("textarea", { pattern: "^ZZZ$" }), ACCEPTED.textarea)
     ).toBe(false);
+  });
+
+  it("stops honouring the author's wording when the row drops `message`", async () => {
+    const CUSTOM = "Say it this way instead";
+    const bounded = field("text", { minLength: 50, errorMessage: CUSTOM });
+
+    // The control, and it is what makes the assertion below mean anything: with
+    // the real table the author's wording IS what comes back, so the probe can
+    // tell the two answers apart.
+    expect(
+      await issuesFrom(ENFORCED_VALIDATION_RULES, bounded, ACCEPTED.text)
+    ).toContain(CUSTOM);
+
+    const without = await issuesFrom(
+      {
+        ...ENFORCED_VALIDATION_RULES,
+        text: ["minLength", "maxLength", "pattern"],
+      },
+      bounded,
+      ACCEPTED.text
+    );
+
+    // The row no longer lists `message`, so the editor would not offer the box
+    // — and the wording stored behind it is no longer applied.
+    expect(without).not.toContain(CUSTOM);
+    // The BOUND still bites, though. Only the wording was governed by the row,
+    // and a probe that merely saw a rejection could not tell the difference.
+    expect(without.length).toBeGreaterThan(0);
+  });
+
+  it("keeps a type's intrinsic shape when the row does not enforce `pattern`", async () => {
+    // A phone carrying a pattern its row no longer enables. The danger is not
+    // that the custom pattern is ignored — it should be — but that storing it
+    // stands the type's OWN check down on the way to being ignored, leaving the
+    // field accepting anything at all.
+    const stored = field("phone", { pattern: "^ZZZ$" });
+
+    // The control: under the real table the row DOES enforce `pattern`, so the
+    // override applies and a real number is refused by it.
+    const real = await generatorReading(ENFORCED_VALIDATION_RULES);
+    expect(real(stored, ACCEPTED.phone)).toBe(false);
+
+    const substituted = await generatorReading({
+      ...ENFORCED_VALIDATION_RULES,
+      phone: ["message"],
+    });
+
+    // The override is not applied, so a real number passes again.
+    expect(substituted(stored, ACCEPTED.phone)).toBe(true);
+    // And the type's intrinsic shape is still in force, which is the half that
+    // was lost: letters are not a phone number under any row.
+    expect(substituted(stored, "not a phone at all")).toBe(false);
   });
 
   it("follows the table where numeric bounds are read, too", async () => {

--- a/packages/plugin-form-builder/src/utils/generate-schema.ts
+++ b/packages/plugin-form-builder/src/utils/generate-schema.ts
@@ -141,6 +141,40 @@ function generateFieldSchema(field: FormField): z.ZodTypeAny | null {
  * Generate schema for text field.
  */
 /**
+ * The author's own wording for a failure, or `undefined` when this field's type
+ * does not enforce `message`.
+ *
+ * Asked of the row rather than read off `validation` directly, for the reason
+ * the table exists at all: the editor decides whether to OFFER the control from
+ * that row, so a generator honouring a stored message regardless would enforce
+ * a value the author was never shown a box for — and, worse, the table would
+ * describe a rule it did not govern.
+ *
+ * `message` was the one rule that stayed outside this. It agreed with the table
+ * only because every row happens to list it, which is agreement by coincidence:
+ * drop `message` from a row and the control disappears while the wording went
+ * on being applied.
+ */
+function customMessage(field: FormField): string | undefined {
+  const enforced = ENFORCED_VALIDATION_RULES[field.type] ?? [];
+  if (!enforced.includes("message")) return undefined;
+  return field.validation?.errorMessage;
+}
+
+/**
+ * A field's stored bounds, with the custom message already resolved by the row.
+ *
+ * Handed to the appliers so they cannot read an ungated message: they take a
+ * validation object, and giving them one whose `errorMessage` has been through
+ * {@link customMessage} makes the rule hold for every applier without each of
+ * them having to remember it.
+ */
+function enforcedValidation(field: FormField): AnyFieldValidation {
+  const stored = (field.validation ?? {}) as AnyFieldValidation;
+  return { ...stored, errorMessage: customMessage(field) };
+}
+
+/**
  * Which rules a type's schema applies, and how each one constrains a string.
  *
  * The WHICH comes from {@link ENFORCED_VALIDATION_RULES}, which the field
@@ -213,6 +247,21 @@ const NUMBER_RULE_APPLIERS: Partial<
 };
 
 /**
+ * Whether an author-supplied pattern actually replaces a type's intrinsic one.
+ *
+ * Two conditions, and both are load-bearing: a pattern must be stored, AND the
+ * type's row must enforce `pattern`. A type that keeps its own shape check —
+ * a phone, a URL — stands it down only for an override that will really be
+ * applied, because standing down for one that will not leaves nothing behind.
+ */
+function overridesPattern(field: FormField): boolean {
+  const enforced = ENFORCED_VALIDATION_RULES[field.type] ?? [];
+  if (!enforced.includes("pattern")) return false;
+  const validation = (field.validation ?? {}) as AnyFieldValidation;
+  return Boolean(validation.pattern);
+}
+
+/**
  * Constrain a string schema by the rules this field's TYPE enforces.
  *
  * A rule the type does not list is not applied even when the field carries a
@@ -229,7 +278,7 @@ function applyStringRules(
   field: FormField,
   patternMessage: string
 ): z.ZodString {
-  const validation = (field.validation ?? {}) as AnyFieldValidation;
+  const validation = enforcedValidation(field);
   let constrained = schema;
   for (const rule of ENFORCED_VALIDATION_RULES[field.type] ?? []) {
     const apply = STRING_RULE_APPLIERS[rule];
@@ -240,7 +289,7 @@ function applyStringRules(
 
 function generateTextSchema(field: TextFormField): z.ZodTypeAny {
   const schema = applyStringRules(z.string(), field, "Invalid format");
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 /**
@@ -250,12 +299,12 @@ function generateEmailSchema(field: EmailFormField): z.ZodTypeAny {
   // The format check is the type's own, not a validation rule: an email field
   // is an email field whether or not its author bounded it further.
   const schema = applyStringRules(
-    z.string().email(field.validation?.errorMessage || "Invalid email address"),
+    z.string().email(customMessage(field) || "Invalid email address"),
     field,
     "Invalid email format"
   );
 
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 /**
@@ -268,12 +317,12 @@ function generateNumberSchema(field: NumberFormField): z.ZodTypeAny {
   let schema = z.number({
     error: issue =>
       issue.input === undefined
-        ? field.validation?.errorMessage || "This field is required"
+        ? customMessage(field) || "This field is required"
         : "Must be a number",
   });
 
   // The same rule set the editor reads decides which bounds apply here.
-  const validation = (field.validation ?? {}) as AnyFieldValidation;
+  const validation = enforcedValidation(field);
   for (const rule of ENFORCED_VALIDATION_RULES[field.type] ?? []) {
     const apply = NUMBER_RULE_APPLIERS[rule];
     if (apply) schema = apply(schema, validation);
@@ -293,18 +342,24 @@ function generatePhoneSchema(field: PhoneFormField): z.ZodTypeAny {
   // The default pattern is part of what a phone field IS, so it belongs to the
   // base rather than to the rule set: it applies when the author supplied none,
   // and the author's own pattern replaces it through the rule below.
-  const base = field.validation?.pattern
+  //
+  // Whether the author CAN replace it is the row's decision, not the stored
+  // value's. Standing the base down because a pattern happens to be stored,
+  // while `applyStringRules` then declines to apply it because the row does not
+  // list `pattern`, would leave the field with no check at all — every string
+  // accepted, on the one type whose whole purpose is a shape.
+  const base = overridesPattern(field)
     ? z.string()
     : z
         .string()
         .regex(
           /^[\d\s\-+()]+$/,
-          field.validation?.errorMessage || "Invalid phone number"
+          customMessage(field) || "Invalid phone number"
         );
 
   const schema = applyStringRules(base, field, "Invalid phone number format");
 
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 /**
@@ -312,12 +367,12 @@ function generatePhoneSchema(field: PhoneFormField): z.ZodTypeAny {
  */
 function generateUrlSchema(field: UrlFormField): z.ZodTypeAny {
   const schema = applyStringRules(
-    z.string().url(field.validation?.errorMessage || "Invalid URL"),
+    z.string().url(customMessage(field) || "Invalid URL"),
     field,
     "Invalid URL format"
   );
 
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 /**
@@ -325,7 +380,7 @@ function generateUrlSchema(field: UrlFormField): z.ZodTypeAny {
  */
 function generateTextareaSchema(field: TextareaFormField): z.ZodTypeAny {
   const schema = applyStringRules(z.string(), field, "Invalid format");
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 /**
@@ -341,7 +396,7 @@ function generateSelectSchema(field: SelectFormField): z.ZodTypeAny {
     if (field.required) {
       return schema.min(
         1,
-        field.validation?.errorMessage || "Please select at least one option"
+        customMessage(field) || "Please select at least one option"
       );
     }
 
@@ -350,8 +405,7 @@ function generateSelectSchema(field: SelectFormField): z.ZodTypeAny {
 
   // Single select
   const schema = z.enum(validValues as [string, ...string[]], {
-    error: () =>
-      field.validation?.errorMessage || "Please select a valid option",
+    error: () => customMessage(field) || "Please select a valid option",
   });
 
   if (field.required) {
@@ -370,7 +424,7 @@ function generateCheckboxSchema(field: CheckboxFormField): z.ZodTypeAny {
   if (field.required) {
     // For required checkbox, value must be true
     return schema.refine(val => val === true, {
-      message: field.validation?.errorMessage || "This field is required",
+      message: customMessage(field) || "This field is required",
     });
   }
 
@@ -384,7 +438,7 @@ function generateRadioSchema(field: RadioFormField): z.ZodTypeAny {
   const validValues = field.options.map(opt => opt.value);
 
   const schema = z.enum(validValues as [string, ...string[]], {
-    error: () => field.validation?.errorMessage || "Please select an option",
+    error: () => customMessage(field) || "Please select an option",
   });
 
   if (field.required) {
@@ -407,7 +461,7 @@ function generateFileSchema(field: FileFormField): z.ZodTypeAny {
     if (field.required) {
       return schema.min(
         1,
-        field.validation?.errorMessage || "Please upload at least one file"
+        customMessage(field) || "Please upload at least one file"
       );
     }
 
@@ -416,7 +470,7 @@ function generateFileSchema(field: FileFormField): z.ZodTypeAny {
 
   // Single file
   const schema = z.string();
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 /**
@@ -433,7 +487,7 @@ function generateDateSchema(field: DateFormField): z.ZodTypeAny {
       const date = new Date(val);
       return !isNaN(date.getTime());
     },
-    { message: field.validation?.errorMessage || "Invalid date" }
+    { message: customMessage(field) || "Invalid date" }
   );
 
   // Min/max date validation
@@ -448,7 +502,7 @@ function generateDateSchema(field: DateFormField): z.ZodTypeAny {
       },
       {
         message:
-          field.validation?.errorMessage ||
+          customMessage(field) ||
           `Date must be between ${field.min || "any"} and ${field.max || "any"}`,
       }
     );
@@ -459,7 +513,7 @@ function generateDateSchema(field: DateFormField): z.ZodTypeAny {
     // Add non-empty check for required fields
     return schema.refine(
       (val: unknown) => val !== undefined && val !== null && val !== "",
-      { message: field.validation?.errorMessage || "This field is required" }
+      { message: customMessage(field) || "This field is required" }
     );
   }
 
@@ -474,10 +528,10 @@ function generateTimeSchema(field: TimeFormField): z.ZodTypeAny {
     .string()
     .regex(
       /^([0-1]?[0-9]|2[0-3]):[0-5][0-9]$/,
-      field.validation?.errorMessage || "Invalid time format (HH:mm)"
+      customMessage(field) || "Invalid time format (HH:mm)"
     );
 
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 /**
@@ -485,7 +539,7 @@ function generateTimeSchema(field: TimeFormField): z.ZodTypeAny {
  */
 function generateHiddenSchema(field: HiddenFormField): z.ZodTypeAny {
   const schema = z.string();
-  return applyRequired(schema, field.required, field.validation?.errorMessage);
+  return applyRequired(schema, field.required, customMessage(field));
 }
 
 // ============================================================

--- a/packages/plugin-form-builder/src/utils/generate-schema.ts
+++ b/packages/plugin-form-builder/src/utils/generate-schema.ts
@@ -8,10 +8,12 @@
  * @since 0.1.0
  */
 
+import type { FieldValidationRule } from "nextly/field-catalog";
 import { z } from "zod";
 
 import { isKnownFormField } from "../types";
 import type {
+  AnyFieldValidation,
   AnyFormField,
   FormField,
   TextFormField,
@@ -28,6 +30,8 @@ import type {
   TimeFormField,
   HiddenFormField,
 } from "../types";
+
+import { ENFORCED_VALIDATION_RULES } from "./enforced-validation";
 
 // ============================================================
 // Main Schema Generator
@@ -136,33 +140,106 @@ function generateFieldSchema(field: FormField): z.ZodTypeAny | null {
 /**
  * Generate schema for text field.
  */
+/**
+ * Which rules a type's schema applies, and how each one constrains a string.
+ *
+ * The WHICH comes from {@link ENFORCED_VALIDATION_RULES}, which the field
+ * editor also reads to decide what to offer. One definition answers both
+ * questions, so a rule cannot be offered by the editor and ignored here, or
+ * honoured here and hidden there — the two used to state the same thing
+ * separately and could only agree by being edited together.
+ *
+ * The HOW stays here, because it is about zod and the table is deliberately
+ * free of it: the editor imports the table, and pulling the schema builder in
+ * behind it would ship this file and its validation library to every admin
+ * client before anyone opened a field.
+ */
+const STRING_RULE_APPLIERS: Partial<
+  Record<
+    FieldValidationRule,
+    (
+      schema: z.ZodString,
+      validation: AnyFieldValidation,
+      fallback: string
+    ) => z.ZodString
+  >
+> = {
+  minLength: (schema, validation) =>
+    validation.minLength === undefined
+      ? schema
+      : schema.min(
+          validation.minLength,
+          validation.errorMessage ||
+            `Minimum ${validation.minLength} characters required`
+        ),
+  maxLength: (schema, validation) =>
+    validation.maxLength === undefined
+      ? schema
+      : schema.max(
+          validation.maxLength,
+          validation.errorMessage ||
+            `Maximum ${validation.maxLength} characters allowed`
+        ),
+  pattern: (schema, validation, fallback) =>
+    validation.pattern
+      ? schema.regex(
+          new RegExp(validation.pattern),
+          validation.errorMessage || fallback
+        )
+      : schema,
+};
+
+/** The same, for the bounds a number carries. */
+const NUMBER_RULE_APPLIERS: Partial<
+  Record<
+    FieldValidationRule,
+    (schema: z.ZodNumber, validation: AnyFieldValidation) => z.ZodNumber
+  >
+> = {
+  min: (schema, validation) =>
+    validation.min === undefined
+      ? schema
+      : schema.min(
+          validation.min,
+          validation.errorMessage || `Minimum value is ${validation.min}`
+        ),
+  max: (schema, validation) =>
+    validation.max === undefined
+      ? schema
+      : schema.max(
+          validation.max,
+          validation.errorMessage || `Maximum value is ${validation.max}`
+        ),
+};
+
+/**
+ * Constrain a string schema by the rules this field's TYPE enforces.
+ *
+ * A rule the type does not list is not applied even when the field carries a
+ * value for it, which is the point: a `pattern` stored on a textarea is a bound
+ * the editor never offered, and honouring it here would enforce a restriction
+ * its author could not see.
+ *
+ * `patternMessage` is the type's own wording for a failed pattern — "Invalid
+ * URL format" reads differently from "Invalid format" — so the rule set decides
+ * WHICH constraints apply while each type keeps its own voice.
+ */
+function applyStringRules(
+  schema: z.ZodString,
+  field: FormField,
+  patternMessage: string
+): z.ZodString {
+  const validation = (field.validation ?? {}) as AnyFieldValidation;
+  let constrained = schema;
+  for (const rule of ENFORCED_VALIDATION_RULES[field.type] ?? []) {
+    const apply = STRING_RULE_APPLIERS[rule];
+    if (apply) constrained = apply(constrained, validation, patternMessage);
+  }
+  return constrained;
+}
+
 function generateTextSchema(field: TextFormField): z.ZodTypeAny {
-  let schema = z.string();
-
-  // Apply validation rules
-  if (field.validation?.minLength !== undefined) {
-    schema = schema.min(
-      field.validation.minLength,
-      field.validation.errorMessage ||
-        `Minimum ${field.validation.minLength} characters required`
-    );
-  }
-
-  if (field.validation?.maxLength !== undefined) {
-    schema = schema.max(
-      field.validation.maxLength,
-      field.validation.errorMessage ||
-        `Maximum ${field.validation.maxLength} characters allowed`
-    );
-  }
-
-  if (field.validation?.pattern) {
-    schema = schema.regex(
-      new RegExp(field.validation.pattern),
-      field.validation.errorMessage || "Invalid format"
-    );
-  }
-
+  const schema = applyStringRules(z.string(), field, "Invalid format");
   return applyRequired(schema, field.required, field.validation?.errorMessage);
 }
 
@@ -170,16 +247,13 @@ function generateTextSchema(field: TextFormField): z.ZodTypeAny {
  * Generate schema for email field.
  */
 function generateEmailSchema(field: EmailFormField): z.ZodTypeAny {
-  let schema = z
-    .string()
-    .email(field.validation?.errorMessage || "Invalid email address");
-
-  if (field.validation?.pattern) {
-    schema = schema.regex(
-      new RegExp(field.validation.pattern),
-      field.validation.errorMessage || "Invalid email format"
-    );
-  }
+  // The format check is the type's own, not a validation rule: an email field
+  // is an email field whether or not its author bounded it further.
+  const schema = applyStringRules(
+    z.string().email(field.validation?.errorMessage || "Invalid email address"),
+    field,
+    "Invalid email format"
+  );
 
   return applyRequired(schema, field.required, field.validation?.errorMessage);
 }
@@ -198,20 +272,11 @@ function generateNumberSchema(field: NumberFormField): z.ZodTypeAny {
         : "Must be a number",
   });
 
-  if (field.validation?.min !== undefined) {
-    schema = schema.min(
-      field.validation.min,
-      field.validation.errorMessage ||
-        `Minimum value is ${field.validation.min}`
-    );
-  }
-
-  if (field.validation?.max !== undefined) {
-    schema = schema.max(
-      field.validation.max,
-      field.validation.errorMessage ||
-        `Maximum value is ${field.validation.max}`
-    );
+  // The same rule set the editor reads decides which bounds apply here.
+  const validation = (field.validation ?? {}) as AnyFieldValidation;
+  for (const rule of ENFORCED_VALIDATION_RULES[field.type] ?? []) {
+    const apply = NUMBER_RULE_APPLIERS[rule];
+    if (apply) schema = apply(schema, validation);
   }
 
   if (field.required) {
@@ -225,20 +290,19 @@ function generateNumberSchema(field: NumberFormField): z.ZodTypeAny {
  * Generate schema for phone field.
  */
 function generatePhoneSchema(field: PhoneFormField): z.ZodTypeAny {
-  let schema = z.string();
+  // The default pattern is part of what a phone field IS, so it belongs to the
+  // base rather than to the rule set: it applies when the author supplied none,
+  // and the author's own pattern replaces it through the rule below.
+  const base = field.validation?.pattern
+    ? z.string()
+    : z
+        .string()
+        .regex(
+          /^[\d\s\-+()]+$/,
+          field.validation?.errorMessage || "Invalid phone number"
+        );
 
-  if (field.validation?.pattern) {
-    schema = schema.regex(
-      new RegExp(field.validation.pattern),
-      field.validation.errorMessage || "Invalid phone number format"
-    );
-  } else {
-    // Default phone pattern - allows common formats
-    schema = schema.regex(
-      /^[\d\s\-+()]+$/,
-      field.validation?.errorMessage || "Invalid phone number"
-    );
-  }
+  const schema = applyStringRules(base, field, "Invalid phone number format");
 
   return applyRequired(schema, field.required, field.validation?.errorMessage);
 }
@@ -247,14 +311,11 @@ function generatePhoneSchema(field: PhoneFormField): z.ZodTypeAny {
  * Generate schema for URL field.
  */
 function generateUrlSchema(field: UrlFormField): z.ZodTypeAny {
-  let schema = z.string().url(field.validation?.errorMessage || "Invalid URL");
-
-  if (field.validation?.pattern) {
-    schema = schema.regex(
-      new RegExp(field.validation.pattern),
-      field.validation.errorMessage || "Invalid URL format"
-    );
-  }
+  const schema = applyStringRules(
+    z.string().url(field.validation?.errorMessage || "Invalid URL"),
+    field,
+    "Invalid URL format"
+  );
 
   return applyRequired(schema, field.required, field.validation?.errorMessage);
 }
@@ -263,24 +324,7 @@ function generateUrlSchema(field: UrlFormField): z.ZodTypeAny {
  * Generate schema for textarea field.
  */
 function generateTextareaSchema(field: TextareaFormField): z.ZodTypeAny {
-  let schema = z.string();
-
-  if (field.validation?.minLength !== undefined) {
-    schema = schema.min(
-      field.validation.minLength,
-      field.validation.errorMessage ||
-        `Minimum ${field.validation.minLength} characters required`
-    );
-  }
-
-  if (field.validation?.maxLength !== undefined) {
-    schema = schema.max(
-      field.validation.maxLength,
-      field.validation.errorMessage ||
-        `Maximum ${field.validation.maxLength} characters allowed`
-    );
-  }
-
+  const schema = applyStringRules(z.string(), field, "Invalid format");
   return applyRequired(schema, field.required, field.validation?.errorMessage);
 }
 


### PR DESCRIPTION
Closes the finding left open on #1281 (merged): *"`ENFORCED_VALIDATION_RULES` independently restates the behavior implemented by the per-type branches in `generate-schema.ts`… The parity tests can detect some divergence, but they do not make the table a derived view. Make the generator and editor consume one shared per-type definition."*

## What was wrong

Two statements of one fact. The table said which rules a type enforces; the generator decided it again in fourteen hand-written branches. Adding or removing a constraint meant editing both, and **either edit failing is silent, in opposite directions**:

- a rule the editor offers and the schema ignores stores a bound nothing reads — the author believes the form is guarded
- a rule the schema applies and the editor hides enforces a restriction its author cannot see

## What changed

The generator now applies the rules the table lists for the field's type. **The table is unchanged**, and still free of `zod` — the editor imports it, and pulling the schema builder in behind it would ship this file and its validation library to every admin client before anyone opened a field. The dependency runs one way: generator reads table, never the reverse.

The split is along what each half actually owns:

| | lives where | why |
|---|---|---|
| which rules a TYPE enforces | the table | both consumers ask this |
| what a rule DOES to a schema | the generator | it is about zod |
| a type's base and its wording | the generator | an email field checks its format and a phone field carries a default pattern whether or not an author bounded it further — those are what the type IS, not rules it opts into. "Invalid URL format" is not "Invalid format" |

## The proof, and why the existing tests could not give it

Editing **only** the table changes what the generator enforces:

```
text: [minLength, maxLength, pattern, message]   ->  pattern-enforced=true
text: [minLength, maxLength, message]            ->  pattern-enforced=false
```

That is the property the finding asked for and the one the parity tests cannot establish — **they ask the table what to expect and check the generator against it**, so removing a rule stops them checking it and they pass either way. I confirmed that: the first break I ran edited the table alone and the whole suite stayed green.

So a small set of **anchored** expectations is written out beside them, each case chosen because it is a rule some other type deliberately omits:

```
text     pattern    enforced        textarea  pattern    ignored
textarea minLength  enforced        email     minLength  ignored
number   min        enforced        date      min        ignored
```

plus an assertion that the anchor and the table agree, so the two cannot drift apart quietly. Every anchored case first asserts the control — unbounded, the probe value passes — so a rule cannot appear to bite because the type rejected the value for some unrelated reason.

**The two halves now cover each other**, break-verified separately:

| break | caught by |
|---|---|
| remove a rule from the table alone | the anchor — 2 failures, where before this the suite passed |
| generator hardcodes its rules again | the parity tests — 5 failures |

`check-types` pass · `lint` pass · `fallow` pass (0 introduced) · plugin-form-builder 364/364 · full pre-push gate run and passing.