### PR TITLE
feat(builder): the layers panel says how to reorder a block

### DIFF
--- a/.changeset/layers-says-how-to-reorder.md
+++ b/.changeset/layers-says-how-to-reorder.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The layers panel says how to reorder a block.
+
+Moving and nesting a block with the keyboard already worked while the layers panel had focus, but nothing said so, and a capability nobody can find reads exactly like a missing one. The panel now shows the keystrokes under the tree, and screen readers hear them on entering the tree rather than only if they reach the text below it.
+
+The keystrokes are spelled for the keyboard in front of the author — Option on a Mac, Alt elsewhere — and they are read from the bindings the editor actually registers, so a rebound key changes the hint with it instead of leaving a label that teaches a keystroke which does nothing.

--- a/packages/builder/src/block-toolbar.tsx
+++ b/packages/builder/src/block-toolbar.tsx
@@ -327,15 +327,18 @@ export function BlockToolbar({
              * alone never reaches a keyboard author, who is exactly the person
              * the reason is for.
              *
-             * No keystroke hint, deliberately. Every binding here is spelled
-             * `mod`, which the shortcut manager resolves to Command on Apple
-             * platforms and Control everywhere else — so any fixed string is
-             * wrong on one of them, and "Ctrl+D" on a Mac teaches a keystroke
-             * that does nothing. The manager's own `detectApplePlatform` is the
-             * one rule that answers this, and it is not on `@nextlyhq/ui`'s
-             * public entry; spelling the platform a second time here would let
-             * a tooltip disagree with the binding it describes. The hint
-             * returns when that export does.
+             * No keystroke hint here yet. A binding spelled `mod` resolves to
+             * Command on Apple platforms and Control everywhere else, so any
+             * fixed string is wrong on one of them and "Ctrl+D" on a Mac
+             * teaches a keystroke that does nothing.
+             *
+             * That is answerable now — `detectApplePlatform` is on
+             * `@nextlyhq/ui`'s public entry, and `key-hint.ts` spells a binding
+             * for the platform in hand. What is missing is the other half: the
+             * bar knows an action id, and the id alone does not say which
+             * binding runs it. The moves come from one table and the rest from
+             * the keystroke registrations, so a hint here needs those joined
+             * without writing a third list that can disagree with both.
              */
             title={action.reason ?? action.label}
             tabIndex={index === activeIndex ? 0 : -1}

--- a/packages/builder/src/key-hint.test.ts
+++ b/packages/builder/src/key-hint.test.ts
@@ -1,0 +1,58 @@
+/**
+ * The hint's spelling, which is the half `keyboard-actions` cannot check.
+ *
+ * That module decides WHICH keystroke moves a block. What is only true here is
+ * that the sentence shown to an author names the key their keyboard actually
+ * carries, and that a spec this cannot read produces nothing rather than a
+ * plausible wrong answer.
+ *
+ * @module key-hint.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { keyHint } from "./key-hint";
+
+describe("a binding spelled for a person", () => {
+  it("names the key the platform carries, not the one the spec does", () => {
+    // The same physical key, two labels. A fixed string is wrong on one of the
+    // two platforms, which is the reason the toolbar showed no hint at all.
+    expect(keyHint("alt+ArrowUp", false)).toBe("Alt+↑");
+    expect(keyHint("alt+ArrowUp", true)).toBe("⌥↑");
+  });
+
+  it("resolves `mod` to the modifier that platform actually uses", () => {
+    /*
+     * `mod` is the spelling the whole editor uses, and it is the case where a
+     * retyped hint does real harm: "Ctrl+D" on a Mac teaches a keystroke that
+     * does nothing at all.
+     */
+    expect(keyHint("mod+d", false)).toBe("Ctrl+D");
+    expect(keyHint("mod+d", true)).toBe("⌘D");
+  });
+
+  it("draws an arrow as an arrow and leaves a named key its name", () => {
+    // A key whose name is written on it reads better as that name; only the
+    // arrows are glyphs on the keyboard and words in the spec.
+    expect(keyHint("ArrowLeft", false)).toBe("←");
+    expect(keyHint("Enter", false)).toBe("Enter");
+  });
+
+  it("shows nothing for a spec it cannot read", () => {
+    /*
+     * A hint is a promise that pressing something does something. A spec this
+     * cannot parse is one whose keystroke it does not know, so the honest
+     * answer is silence — the same judgement the toolbar made.
+     */
+    expect(keyHint("", false)).toBeNull();
+    expect(keyHint("alt+", false)).toBeNull();
+  });
+
+  it("keeps a `+` that is a KEY rather than a separator", () => {
+    /*
+     * The grammar's own edge, and the reason this parses rather than splits:
+     * `mod++` is the zoom-in chord — a modifier, a separator, and the plus key
+     * — while a naive split leaves a chord carrying modifiers and no key.
+     */
+    expect(keyHint("mod++", false)).toBe("Ctrl++");
+  });
+});

--- a/packages/builder/src/key-hint.test.ts
+++ b/packages/builder/src/key-hint.test.ts
@@ -37,6 +37,18 @@ describe("a binding spelled for a person", () => {
     expect(keyHint("Enter", false)).toBe("Enter");
   });
 
+  it("names the space bar rather than printing one", () => {
+    /*
+     * The parser canonicalises `Space` to the character the browser reports,
+     * `" "`, because a spec split on whitespace cannot carry it any other way.
+     * Passing that straight through prints a hint with a gap where the key
+     * should be — the one key whose name disappears precisely because its value
+     * is what a keyboard event carries.
+     */
+    expect(keyHint("Space", false)).toBe("Space");
+    expect(keyHint("mod+Space", false)).toBe("Ctrl+Space");
+  });
+
   it("shows nothing for a spec it cannot read", () => {
     /*
      * A hint is a promise that pressing something does something. A spec this

--- a/packages/builder/src/key-hint.ts
+++ b/packages/builder/src/key-hint.ts
@@ -1,0 +1,95 @@
+/**
+ * A binding, spelled the way this keyboard spells it.
+ *
+ * The editor stores its shortcuts as specs — `alt+ArrowUp` — because that is
+ * what the shortcut manager matches against. A person reads none of that: the
+ * key on their keyboard says Option or Alt depending on the machine, and the
+ * arrow is a glyph rather than a word.
+ *
+ * ## Why this is not a fixed string
+ *
+ * The block toolbar records the reason it shows no hint at all: a binding
+ * spelled `mod` is Command on Apple platforms and Control everywhere else, so
+ * any fixed string is wrong on one of them, and teaching "Ctrl+D" to a Mac
+ * author teaches a keystroke that does nothing. `alt` has the same problem
+ * more quietly — the same physical key is labelled Alt on one platform and
+ * Option on another.
+ *
+ * `@nextlyhq/ui` owns that decision in `detectApplePlatform`, and it is on the
+ * public entry, so the hint can be resolved rather than guessed.
+ *
+ * ## Why it parses rather than splits
+ *
+ * The spec grammar is not "split on `+`" — a lone `+` is a key, and a trailing
+ * one is too, so `mod++` is the zoom shortcut rather than a malformed chord.
+ * `parseKeys` is the one implementation of that grammar, and re-deriving it
+ * here would produce a hint that disagrees with the binding it describes for
+ * exactly the specs that are hardest to read.
+ *
+ * @module key-hint
+ */
+
+import { detectApplePlatform, parseKeys } from "@nextlyhq/ui";
+
+/**
+ * Glyphs for keys whose NAME is not what a keyboard shows.
+ *
+ * Arrows only. A named key like `Enter` or `Escape` is written on the key in
+ * words, so a symbol would be the less recognisable of the two.
+ */
+const KEY_GLYPHS: Readonly<Record<string, string>> = {
+  arrowup: "↑",
+  arrowdown: "↓",
+  arrowleft: "←",
+  arrowright: "→",
+};
+
+/** The modifier labels, in the order a keyboard shortcut is conventionally written. */
+function modifierLabels(
+  chord: ReturnType<typeof parseKeys>[number],
+  apple: boolean
+): string[] {
+  const labels: string[] = [];
+  // `mod` first, because it is the outermost modifier in every convention that
+  // writes more than one.
+  if (chord.mod) labels.push(apple ? "⌘" : "Ctrl");
+  if (chord.ctrl) labels.push(apple ? "⌃" : "Ctrl");
+  if (chord.alt) labels.push(apple ? "⌥" : "Alt");
+  if (chord.shift) labels.push(apple ? "⇧" : "Shift");
+  if (chord.meta) labels.push(apple ? "⌘" : "Meta");
+  return labels;
+}
+
+/**
+ * One binding as a person would read it, or `null` when the spec cannot be read.
+ *
+ * `null` rather than a best guess: a hint is a promise that pressing something
+ * does something, and a spec this cannot parse is one whose keystroke it does
+ * not know. Showing a wrong one is worse than showing none, which is the same
+ * judgement the toolbar made when it showed none at all.
+ */
+export function keyHint(
+  spec: string,
+  apple = detectApplePlatform()
+): string | null {
+  let chords;
+  try {
+    chords = parseKeys(spec);
+  } catch {
+    return null;
+  }
+  return chords
+    .map(chord => {
+      const key = KEY_GLYPHS[chord.key.toLowerCase()] ?? capitalize(chord.key);
+      return [...modifierLabels(chord, apple), key].join(apple ? "" : "+");
+    })
+    .join(" ");
+}
+
+/**
+ * A single character is shown upper case; a named key keeps the spelling the
+ * spec used, because that is already the name written on the key.
+ */
+function capitalize(key: string): string {
+  return key.length === 1 ? key.toUpperCase() : key;
+}

--- a/packages/builder/src/key-hint.ts
+++ b/packages/builder/src/key-hint.ts
@@ -42,6 +42,13 @@ const KEY_GLYPHS: Readonly<Record<string, string>> = {
   arrowdown: "↓",
   arrowleft: "←",
   arrowright: "→",
+  /*
+   * The space bar, which the parser canonicalises to the character it produces
+   * rather than to the word a spec spells it with. Passing that through would
+   * print a hint with a blank where the key should be — the one key whose name
+   * is unreadable precisely because the value IS readable to the browser.
+   */
+  " ": "Space",
 };
 
 /** The modifier labels, in the order a keyboard shortcut is conventionally written. */

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -52,6 +52,17 @@ import {
  * commonest structural edit in the editor is undiscoverable and awkward on a
  * laptop, and the two letters carry no relationship to the direction they move.
  */
+/**
+ * The layer these bindings register under.
+ *
+ * Named rather than spelled at the registration alone, because a surface that
+ * TELLS an author about a keystroke has to ask the shortcut manager whether
+ * that keystroke is live — and it can only ask about a layer it can name.
+ * Matching on a retyped string would let the question and the registration
+ * drift into a hint for bindings nothing holds.
+ */
+export const BLOCK_ACTIONS_LAYER = "builder-block-actions";
+
 export const MOVE_KEYS: ReadonlyArray<{
   keys: string;
   direction: MoveDirection;
@@ -172,33 +183,6 @@ const BlockActionsContext = React.createContext<BlockActions | null>(null);
  * like a missing wrapper — and it would reach a person before it reached a
  * developer.
  */
-/**
- * Whether the block keystrokes are actually bound right now.
- *
- * Separate from {@link BlockActionsContext} because the two answer different
- * questions and a surface can need the second without the first. The verbs are
- * reachable from anything under the provider; whether PRESSING a key runs them
- * depends on `enabled`, which a host turns off when something modal is over the
- * canvas.
- *
- * Defaults to `false` with no provider above, so a surface that advertises a
- * keystroke cannot advertise one nothing is listening for — an unmounted
- * provider and a disabled one are the same fact to anyone reading a hint.
- */
-const BlockKeysEnabledContext = React.createContext(false);
-
-/**
- * Whether the block keystrokes are live, for a surface that TELLS an author
- * about them.
- *
- * A hint is a claim that pressing something does something, so it has to be
- * derived from whether that is true rather than from the shortcut existing in
- * a table somewhere.
- */
-export function useBlockKeysEnabled(): boolean {
-  return React.useContext(BlockKeysEnabledContext);
-}
-
 export function useBlockActionsContext(): BlockActions {
   const actions = React.useContext(BlockActionsContext);
   if (actions === null) {
@@ -621,7 +605,7 @@ export function useBlockKeyboardActions({
   );
 
   useShortcuts([...bindings, ...editing, ...inlineEditing], {
-    name: "builder-block-actions",
+    name: BLOCK_ACTIONS_LAYER,
     enabled,
   });
 
@@ -725,16 +709,10 @@ export function BlockKeyboardActions({
   // has nothing it was already watching.
   return (
     <BlockActionsContext.Provider value={actions}>
-      {/*
-        The same default the bindings themselves take, so what a hint claims and
-        what a keypress does cannot disagree.
-      */}
-      <BlockKeysEnabledContext.Provider value={enabled ?? true}>
-        <p aria-live="polite" role="status" className="nx-sr-only">
-          {announcement}
-        </p>
-        {children}
-      </BlockKeysEnabledContext.Provider>
+      <p aria-live="polite" role="status" className="nx-sr-only">
+        {announcement}
+      </p>
+      {children}
     </BlockActionsContext.Provider>
   );
 }

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -52,17 +52,6 @@ import {
  * commonest structural edit in the editor is undiscoverable and awkward on a
  * laptop, and the two letters carry no relationship to the direction they move.
  */
-/**
- * The layer these bindings register under.
- *
- * Named rather than spelled at the registration alone, because a surface that
- * TELLS an author about a keystroke has to ask the shortcut manager whether
- * that keystroke is live — and it can only ask about a layer it can name.
- * Matching on a retyped string would let the question and the registration
- * drift into a hint for bindings nothing holds.
- */
-export const BLOCK_ACTIONS_LAYER = "builder-block-actions";
-
 export const MOVE_KEYS: ReadonlyArray<{
   keys: string;
   direction: MoveDirection;
@@ -605,7 +594,7 @@ export function useBlockKeyboardActions({
   );
 
   useShortcuts([...bindings, ...editing, ...inlineEditing], {
-    name: BLOCK_ACTIONS_LAYER,
+    name: "builder-block-actions",
     enabled,
   });
 

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -172,6 +172,33 @@ const BlockActionsContext = React.createContext<BlockActions | null>(null);
  * like a missing wrapper — and it would reach a person before it reached a
  * developer.
  */
+/**
+ * Whether the block keystrokes are actually bound right now.
+ *
+ * Separate from {@link BlockActionsContext} because the two answer different
+ * questions and a surface can need the second without the first. The verbs are
+ * reachable from anything under the provider; whether PRESSING a key runs them
+ * depends on `enabled`, which a host turns off when something modal is over the
+ * canvas.
+ *
+ * Defaults to `false` with no provider above, so a surface that advertises a
+ * keystroke cannot advertise one nothing is listening for — an unmounted
+ * provider and a disabled one are the same fact to anyone reading a hint.
+ */
+const BlockKeysEnabledContext = React.createContext(false);
+
+/**
+ * Whether the block keystrokes are live, for a surface that TELLS an author
+ * about them.
+ *
+ * A hint is a claim that pressing something does something, so it has to be
+ * derived from whether that is true rather than from the shortcut existing in
+ * a table somewhere.
+ */
+export function useBlockKeysEnabled(): boolean {
+  return React.useContext(BlockKeysEnabledContext);
+}
+
 export function useBlockActionsContext(): BlockActions {
   const actions = React.useContext(BlockActionsContext);
   if (actions === null) {
@@ -698,10 +725,16 @@ export function BlockKeyboardActions({
   // has nothing it was already watching.
   return (
     <BlockActionsContext.Provider value={actions}>
-      <p aria-live="polite" role="status" className="nx-sr-only">
-        {announcement}
-      </p>
-      {children}
+      {/*
+        The same default the bindings themselves take, so what a hint claims and
+        what a keypress does cannot disagree.
+      */}
+      <BlockKeysEnabledContext.Provider value={enabled ?? true}>
+        <p aria-live="polite" role="status" className="nx-sr-only">
+          {announcement}
+        </p>
+        {children}
+      </BlockKeysEnabledContext.Provider>
     </BlockActionsContext.Provider>
   );
 }

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -52,7 +52,7 @@ import {
  * commonest structural edit in the editor is undiscoverable and awkward on a
  * laptop, and the two letters carry no relationship to the direction they move.
  */
-const MOVE_KEYS: ReadonlyArray<{
+export const MOVE_KEYS: ReadonlyArray<{
   keys: string;
   direction: MoveDirection;
   description: string;

--- a/packages/builder/src/layers-panel.test.tsx
+++ b/packages/builder/src/layers-panel.test.tsx
@@ -26,6 +26,8 @@ import {
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
 
+import { keyHint } from "./key-hint";
+import { MOVE_KEYS } from "./keyboard-actions";
 import { LayersPanel } from "./layers-panel";
 import { useEditorState, type EditorState } from "./editor-state";
 
@@ -133,6 +135,55 @@ function rows(): string[] {
 }
 
 describe("LayersPanel", () => {
+  it("says how to reorder, in the keys this platform carries", () => {
+    /*
+     * The bindings already work while this panel holds focus — the tree takes
+     * the keystroke and the editor acts on the selection — so what was missing
+     * was never the capability, only any way to find it.
+     */
+    renderPanel();
+
+    const hint = window.document.getElementById("nx-layers-move-hint");
+    expect(hint).not.toBeNull();
+    // The DESCRIPTION every binding already carries, not a second wording.
+    expect(hint?.textContent).toContain("Move the selected block up");
+    expect(hint?.textContent).toContain("Move the selected block out of its");
+  });
+
+  it("derives the hint from the bindings rather than restating them", () => {
+    /*
+     * The property that matters, and the one a fixed string cannot have: every
+     * binding the editor registers is named here, and nothing else is. A
+     * retyped legend passes an assertion about its own text on the day it is
+     * written and teaches a dead keystroke the day someone rebinds one.
+     */
+    renderPanel();
+
+    const hint = window.document.getElementById("nx-layers-move-hint");
+    for (const { keys, description } of MOVE_KEYS) {
+      const shown = keyHint(keys, false);
+      expect(shown).not.toBeNull();
+      expect(hint?.textContent).toContain(description);
+    }
+    // As many keystrokes drawn as there are bindings, so a binding added to the
+    // table cannot quietly go unmentioned here.
+    expect(hint?.querySelectorAll(".nx-layers-panel__hint-key").length).toBe(
+      MOVE_KEYS.length
+    );
+  });
+
+  it("makes the hint the tree's own description", () => {
+    /*
+     * Text near the tree is read by whoever can see it. As the tree's
+     * description it is announced on entering the tree, which is the moment an
+     * author asks the question it answers.
+     */
+    renderPanel();
+
+    const tree = screen.getByRole("tree");
+    expect(tree.getAttribute("aria-describedby")).toBe("nx-layers-move-hint");
+  });
+
   it("shows the top level, and hides what is inside a collapsed block", () => {
     // The precondition for everything below. An assertion that a nested row is
     // ABSENT is satisfied by a panel that renders nothing at all, so the rows

--- a/packages/builder/src/layers-panel.test.tsx
+++ b/packages/builder/src/layers-panel.test.tsx
@@ -14,6 +14,8 @@
  *
  * @module layers-panel.test
  */
+import { ShortcutProvider } from "@nextlyhq/ui";
+import { renderToStaticMarkup } from "react-dom/server";
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import * as React from "react";
@@ -28,6 +30,7 @@ import {
 
 import { keyHint } from "./key-hint";
 import { MOVE_KEYS } from "./keyboard-actions";
+import { BlockKeyboardActions } from "./keyboard-actions";
 import { LayersPanel } from "./layers-panel";
 import { useEditorState, type EditorState } from "./editor-state";
 
@@ -116,15 +119,40 @@ function nestedDocument(): BlockDocument {
 
 let editorRef: EditorState | null = null;
 
-function Host({ document }: { document: BlockDocument }): React.JSX.Element {
+function Host({
+  document,
+  keys = "bound",
+}: {
+  document: BlockDocument;
+  keys?: "bound" | "disabled" | "absent";
+}): React.JSX.Element {
   const editor = useEditorState({ initialDocument: document });
   editorRef = editor;
-  return <LayersPanel editor={editor} />;
+  const panel = <LayersPanel editor={editor} />;
+  /*
+   * The bindings are part of the composition under test, not scenery.
+   *
+   * The panel now says which keystrokes reorder a block, and that sentence is
+   * only true while something is listening for them. A harness that rendered
+   * the panel alone could not tell a hint that is honest from one advertising
+   * keys nothing is bound to — it would assert the words and never the claim.
+   */
+  if (keys === "absent") return panel;
+  return (
+    <ShortcutProvider>
+      <BlockKeyboardActions editor={editor} enabled={keys === "bound"}>
+        {panel}
+      </BlockKeyboardActions>
+    </ShortcutProvider>
+  );
 }
 
-function renderPanel(document: BlockDocument = nestedDocument()) {
+function renderPanel(
+  document: BlockDocument = nestedDocument(),
+  keys: "bound" | "disabled" | "absent" = "bound"
+) {
   register();
-  return render(<Host document={document} />);
+  return render(<Host document={document} keys={keys} />);
 }
 
 /** The rows currently on screen, by their accessible name. */
@@ -170,6 +198,56 @@ describe("LayersPanel", () => {
     expect(hint?.querySelectorAll(".nx-layers-panel__hint-key").length).toBe(
       MOVE_KEYS.length
     );
+  });
+
+  it("emits no keystroke at all in a SERVER render", () => {
+    /*
+     * The hydration case, and the only place it is observable.
+     *
+     * `detectApplePlatform` reads `navigator`, which a server does not have, so
+     * it answers false there — a server would emit `Alt` and the first browser
+     * render `⌥`, React would find markup it did not produce, and it would
+     * throw the subtree away.
+     *
+     * No test in this file can see that: jsdom always HAS a `navigator`, so
+     * resolving the platform during render gives the same answer as resolving
+     * it after mounting, and every case above passes either way. Rendering to
+     * a string is what removes the browser from the question — effects do not
+     * run there, which is exactly the condition the server is in.
+     */
+    register();
+    const html = renderToStaticMarkup(<Host document={nestedDocument()} />);
+
+    expect(html).not.toContain("Move up");
+    expect(html).not.toContain("Alt");
+    expect(html).not.toContain("\u2325");
+  });
+
+  it("says nothing about keys nothing is listening for", () => {
+    /*
+     * A host may mount this panel with no bindings above it at all. Advertising
+     * the keystrokes there is not a cosmetic slip — it is the editor telling an
+     * author to press something that does nothing, which is worse than the
+     * silence this replaced, because silence at least does not mislead.
+     */
+    renderPanel(nestedDocument(), "absent");
+
+    expect(window.document.getElementById("nx-layers-move-hint")).toBeNull();
+    expect(
+      screen.getByRole("tree").getAttribute("aria-describedby")
+    ).toBeNull();
+  });
+
+  it("says nothing while the bindings are turned off", () => {
+    /*
+     * The other way the same claim goes false, and the one a presence check
+     * alone would miss: the provider IS above this, and a host has disabled it
+     * because something modal is over the canvas. The keystrokes reach nothing
+     * until it closes.
+     */
+    renderPanel(nestedDocument(), "disabled");
+
+    expect(window.document.getElementById("nx-layers-move-hint")).toBeNull();
   });
 
   it("makes the hint the tree's own description", () => {

--- a/packages/builder/src/layers-panel.test.tsx
+++ b/packages/builder/src/layers-panel.test.tsx
@@ -130,18 +130,24 @@ function Host({
   editorRef = editor;
   const panel = <LayersPanel editor={editor} />;
   /*
-   * The bindings are part of the composition under test, not scenery.
+   * The bindings are part of the composition under test, not scenery — and the
+   * SHAPE of that composition is load-bearing.
    *
-   * The panel now says which keystrokes reorder a block, and that sentence is
-   * only true while something is listening for them. A harness that rendered
-   * the panel alone could not tell a hint that is honest from one advertising
-   * keys nothing is bound to — it would assert the words and never the claim.
+   * The product does not wrap this panel in the bindings. `BlocksField` draws
+   * it through the shell's panel region while `BlockKeyboardActions` wraps the
+   * shell's children, so the two are SIBLING subtrees. A harness that wrapped
+   * the panel directly proved the hint appears in an arrangement the product
+   * never builds, and would have stayed green while the legend was invisible
+   * to every real author.
+   *
+   * So the panel is rendered beside the bindings here, never inside them.
    */
-  if (keys === "absent") return panel;
+  if (keys === "absent") return <ShortcutProvider>{panel}</ShortcutProvider>;
   return (
     <ShortcutProvider>
+      {panel}
       <BlockKeyboardActions editor={editor} enabled={keys === "bound"}>
-        {panel}
+        <span />
       </BlockKeyboardActions>
     </ShortcutProvider>
   );
@@ -153,6 +159,19 @@ function renderPanel(
 ) {
   register();
   return render(<Host document={document} keys={keys} />);
+}
+
+/**
+ * The legend, found the way assistive technology finds it.
+ *
+ * Through the tree's own `aria-describedby` rather than by a known id: the id
+ * is per instance now, so a fixed one would be a second answer to which element
+ * describes this tree — and looking it up by that fixed name is exactly what
+ * would keep passing if the wiring broke.
+ */
+function hintFor(tree: HTMLElement): HTMLElement | null {
+  const id = tree.getAttribute("aria-describedby");
+  return id === null ? null : window.document.getElementById(id);
 }
 
 /** The rows currently on screen, by their accessible name. */
@@ -171,7 +190,7 @@ describe("LayersPanel", () => {
      */
     renderPanel();
 
-    const hint = window.document.getElementById("nx-layers-move-hint");
+    const hint = hintFor(screen.getByRole("tree"));
     expect(hint).not.toBeNull();
     // The DESCRIPTION every binding already carries, not a second wording.
     expect(hint?.textContent).toContain("Move the selected block up");
@@ -187,7 +206,7 @@ describe("LayersPanel", () => {
      */
     renderPanel();
 
-    const hint = window.document.getElementById("nx-layers-move-hint");
+    const hint = hintFor(screen.getByRole("tree"));
     for (const { keys, description } of MOVE_KEYS) {
       const shown = keyHint(keys, false);
       expect(shown).not.toBeNull();
@@ -221,6 +240,42 @@ describe("LayersPanel", () => {
     expect(html).not.toContain("Move up");
     expect(html).not.toContain("Alt");
     expect(html).not.toContain("\u2325");
+  });
+
+  it("gives each panel its own description to point at", () => {
+    /*
+     * A host can mount two editors on one page. With a fixed id both trees
+     * point at the same element and the lookup is ambiguous, so assistive
+     * technology can read one panel's tree the OTHER panel's description —
+     * which is worse than no description, because it is confidently wrong.
+     *
+     * Two panels is the whole of the case: one panel with a fixed id behaves
+     * perfectly, which is why a single-panel fixture cannot see this.
+     */
+    register();
+    render(
+      <ShortcutProvider>
+        <Host document={nestedDocument()} keys="absent" />
+        <Host document={nestedDocument()} keys="bound" />
+      </ShortcutProvider>
+    );
+
+    const [first, second] = screen.getAllByRole("tree");
+    if (first === undefined || second === undefined) {
+      throw new Error("expected two trees");
+    }
+    const firstId = first.getAttribute("aria-describedby");
+    const secondId = second.getAttribute("aria-describedby");
+    expect(firstId).not.toBe(secondId);
+    // And each id resolves to a legend that is inside ITS OWN panel, which is
+    // the property a mere difference of strings does not establish.
+    for (const tree of [first, second]) {
+      const hint = hintFor(tree);
+      if (hint === null) continue;
+      expect(hint.closest(".nx-layers-panel")).toBe(
+        tree.closest(".nx-layers-panel")
+      );
+    }
   });
 
   it("says nothing about keys nothing is listening for", () => {
@@ -259,7 +314,13 @@ describe("LayersPanel", () => {
     renderPanel();
 
     const tree = screen.getByRole("tree");
-    expect(tree.getAttribute("aria-describedby")).toBe("nx-layers-move-hint");
+    const id = tree.getAttribute("aria-describedby");
+    expect(id).not.toBeNull();
+    // It points at an element that EXISTS and is the legend, which a bare
+    // string comparison against a known id never established.
+    expect(
+      hintFor(tree)?.querySelectorAll(".nx-layers-panel__hint-row").length
+    ).toBe(MOVE_KEYS.length);
   });
 
   it("shows the top level, and hides what is inside a collapsed block", () => {

--- a/packages/builder/src/layers-panel.test.tsx
+++ b/packages/builder/src/layers-panel.test.tsx
@@ -128,12 +128,11 @@ function Host({
   const editor = useEditorState({ initialDocument: document });
   editorRef = editor;
   /*
-   * Rendered with NO provider around it in the default case, deliberately.
+   * No shortcut provider around it, deliberately.
    *
-   * This component is exported, and a host may mount it on its own. An earlier
-   * revision read the shortcut manager from here, which made a `ShortcutProvider`
-   * mandatory for a panel that had never needed one — a crash for direct
-   * consumers, and a harness that always supplied one could not have seen it.
+   * This component is exported and a host may mount it on its own, so it must
+   * render without one. A harness that always supplied a provider could not
+   * tell that apart from a panel that requires one.
    */
   return <LayersPanel editor={editor} moveHints={keys === "bound"} />;
 }
@@ -192,11 +191,25 @@ describe("LayersPanel", () => {
     renderPanel();
 
     const hint = hintFor(screen.getByRole("tree"));
-    for (const { keys, description } of MOVE_KEYS) {
+    const rendered = Array.from(
+      hint?.querySelectorAll(".nx-layers-panel__hint-row") ?? []
+    );
+    expect(rendered).toHaveLength(MOVE_KEYS.length);
+    MOVE_KEYS.forEach(({ keys, description }, index) => {
       const shown = keyHint(keys, false);
       expect(shown).not.toBeNull();
-      expect(hint?.textContent).toContain(description);
-    }
+      const row = rendered[index];
+      /*
+       * The KEY as drawn, beside its own description. Asserting only that the
+       * descriptions appear leaves the keystrokes unchecked, so a legend that
+       * iterated these bindings and printed fixed labels beside them would
+       * pass — which is the exact implementation this claims not to be.
+       */
+      expect(
+        row?.querySelector(".nx-layers-panel__hint-key")?.textContent
+      ).toBe(shown);
+      expect(row?.textContent).toContain(description);
+    });
     // As many keystrokes drawn as there are bindings, so a binding added to the
     // table cannot quietly go unmentioned here.
     expect(hint?.querySelectorAll(".nx-layers-panel__hint-key").length).toBe(
@@ -238,11 +251,16 @@ describe("LayersPanel", () => {
      * perfectly, which is why a single-panel fixture cannot see this.
      */
     register();
+    /*
+     * BOTH bound. With one panel unbound its description is absent, so the
+     * comparison is against a `null` that differs from anything — green with a
+     * shared constant id, which is the regression this is for.
+     */
     render(
-      <ShortcutProvider>
-        <Host document={nestedDocument()} keys="absent" />
+      <>
         <Host document={nestedDocument()} keys="bound" />
-      </ShortcutProvider>
+        <Host document={nestedDocument()} keys="bound" />
+      </>
     );
 
     const [first, second] = screen.getAllByRole("tree");
@@ -251,13 +269,15 @@ describe("LayersPanel", () => {
     }
     const firstId = first.getAttribute("aria-describedby");
     const secondId = second.getAttribute("aria-describedby");
+    expect(firstId).not.toBeNull();
+    expect(secondId).not.toBeNull();
     expect(firstId).not.toBe(secondId);
-    // And each id resolves to a legend that is inside ITS OWN panel, which is
-    // the property a mere difference of strings does not establish.
+    // And each id resolves to a legend inside ITS OWN panel — two different
+    // strings alone do not establish that either points at the right element.
     for (const tree of [first, second]) {
       const hint = hintFor(tree);
-      if (hint === null) continue;
-      expect(hint.closest(".nx-layers-panel")).toBe(
+      expect(hint).not.toBeNull();
+      expect(hint?.closest(".nx-layers-panel")).toBe(
         tree.closest(".nx-layers-panel")
       );
     }

--- a/packages/builder/src/layers-panel.test.tsx
+++ b/packages/builder/src/layers-panel.test.tsx
@@ -30,7 +30,6 @@ import {
 
 import { keyHint } from "./key-hint";
 import { MOVE_KEYS } from "./keyboard-actions";
-import { BlockKeyboardActions } from "./keyboard-actions";
 import { LayersPanel } from "./layers-panel";
 import { useEditorState, type EditorState } from "./editor-state";
 
@@ -128,29 +127,15 @@ function Host({
 }): React.JSX.Element {
   const editor = useEditorState({ initialDocument: document });
   editorRef = editor;
-  const panel = <LayersPanel editor={editor} />;
   /*
-   * The bindings are part of the composition under test, not scenery — and the
-   * SHAPE of that composition is load-bearing.
+   * Rendered with NO provider around it in the default case, deliberately.
    *
-   * The product does not wrap this panel in the bindings. `BlocksField` draws
-   * it through the shell's panel region while `BlockKeyboardActions` wraps the
-   * shell's children, so the two are SIBLING subtrees. A harness that wrapped
-   * the panel directly proved the hint appears in an arrangement the product
-   * never builds, and would have stayed green while the legend was invisible
-   * to every real author.
-   *
-   * So the panel is rendered beside the bindings here, never inside them.
+   * This component is exported, and a host may mount it on its own. An earlier
+   * revision read the shortcut manager from here, which made a `ShortcutProvider`
+   * mandatory for a panel that had never needed one — a crash for direct
+   * consumers, and a harness that always supplied one could not have seen it.
    */
-  if (keys === "absent") return <ShortcutProvider>{panel}</ShortcutProvider>;
-  return (
-    <ShortcutProvider>
-      {panel}
-      <BlockKeyboardActions editor={editor} enabled={keys === "bound"}>
-        <span />
-      </BlockKeyboardActions>
-    </ShortcutProvider>
-  );
+  return <LayersPanel editor={editor} moveHints={keys === "bound"} />;
 }
 
 function renderPanel(
@@ -287,7 +272,7 @@ describe("LayersPanel", () => {
      */
     renderPanel(nestedDocument(), "absent");
 
-    expect(window.document.getElementById("nx-layers-move-hint")).toBeNull();
+    expect(hintFor(screen.getByRole("tree"))).toBeNull();
     expect(
       screen.getByRole("tree").getAttribute("aria-describedby")
     ).toBeNull();
@@ -302,7 +287,7 @@ describe("LayersPanel", () => {
      */
     renderPanel(nestedDocument(), "disabled");
 
-    expect(window.document.getElementById("nx-layers-move-hint")).toBeNull();
+    expect(hintFor(screen.getByRole("tree"))).toBeNull();
   });
 
   it("makes the hint the tree's own description", () => {

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -32,6 +32,24 @@
  * clearing it returns the tree to what the author had open. Only the author's
  * set is stored.
  *
+ * ## The panel says how to reorder, because nothing else does
+ *
+ * The bindings that move a block already work here — the tree holds focus and
+ * the editor's own keystrokes act on the selection, so an author standing in
+ * this panel can already reorder and nest without touching the canvas. Nothing
+ * told them so, and a capability nobody can find reads exactly like a missing
+ * one.
+ *
+ * The hint is DERIVED from the bindings rather than written beside them. A
+ * retyped "Alt+Up" is correct until someone rebinds the keystroke, and then it
+ * is a label that teaches a key which does nothing — with no test that can
+ * fail, because the two are only related by having been typed by the same
+ * person on the same day.
+ *
+ * It is also the tree's accessible description, not merely text near it. A
+ * sighted author reads it because it sits under the tree; a screen-reader user
+ * hears it on entering the tree, which is the moment the question arises.
+ *
  * @module layers-panel
  */
 
@@ -42,6 +60,9 @@ import * as React from "react";
 
 import { BlockIconMark } from "./block-icon";
 import type { EditorState } from "./editor-state";
+import { keyHint } from "./key-hint";
+import { MOVE_KEYS } from "./keyboard-actions";
+import type { MoveDirection } from "./keyboard-move";
 import { ancestorIds, filterLayers, layersOf, type LayerNode } from "./layers";
 
 export interface LayersPanelProps {
@@ -123,6 +144,33 @@ function rowOf(
   };
 }
 
+/** One id, so the tree's description and the hint cannot drift apart. */
+const MOVE_HINT_ID = "nx-layers-move-hint";
+
+/**
+ * The short label each direction gets in the legend.
+ *
+ * The binding's own `description` is a SENTENCE — "Move the selected block into
+ * the container above it" — because it is written to be announced after the
+ * move happens, where the subject has to be named. Four of those stacked under
+ * a tree is a paragraph rather than a legend, and it reads as prose to be
+ * waded through rather than a key to be scanned.
+ *
+ * So the legend names the DIRECTION, which the binding table already carries as
+ * an enum. That keeps this a projection of something the editor decided rather
+ * than a second wording of it: total over `MoveDirection`, so a direction added
+ * to the move rule fails to compile here instead of silently drawing nothing.
+ *
+ * One verb across all four, matching the arrow that runs them, so the pairs
+ * read as opposites rather than as four unrelated commands.
+ */
+const DIRECTION_LABEL: Readonly<Record<MoveDirection, string>> = {
+  up: "Move up",
+  down: "Move down",
+  indent: "Move in",
+  outdent: "Move out",
+};
+
 export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
   const [query, setQuery] = React.useState("");
   const [opened, setOpened] = React.useState<readonly string[]>([]);
@@ -179,6 +227,22 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
     [search.roots, icons]
   );
 
+  /*
+   * Built from the binding table, so a rebound keystroke moves the hint with
+   * it. A binding this cannot spell is dropped rather than guessed at — see
+   * `keyHint` for why a wrong hint is worse than no hint.
+   */
+  const hints = React.useMemo(
+    () =>
+      MOVE_KEYS.flatMap(({ keys, direction, description }) => {
+        const shown = keyHint(keys);
+        return shown === null
+          ? []
+          : [{ keys, shown, label: DIRECTION_LABEL[direction], description }];
+      }),
+    []
+  );
+
   return (
     <div className="nx-layers-panel">
       <div className="nx-layers-panel__search">
@@ -219,7 +283,39 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
           onExpandedChange={next =>
             setOpened(next.filter(id => !search.expand.includes(id)))
           }
+          // The hint is the tree's DESCRIPTION, so it is announced on entering
+          // the tree rather than only readable by someone who can see it below.
+          aria-describedby={hints.length === 0 ? undefined : MOVE_HINT_ID}
         />
+      )}
+
+      {/*
+        Outside the empty and no-match branches deliberately: the bindings are
+        what an author reaches for once there ARE layers to move, and a page
+        with none has nothing to say this about.
+      */}
+      {tree.length === 0 || nodes.length === 0 || hints.length === 0 ? null : (
+        <ul className="nx-layers-panel__hint" id={MOVE_HINT_ID}>
+          {hints.map(({ keys, shown, label, description }) => (
+            <li className="nx-layers-panel__hint-row" key={keys}>
+              <span className="nx-layers-panel__hint-key" aria-hidden="true">
+                {shown}
+              </span>
+              {/*
+                The short label is what is DRAWN; the binding's own sentence is
+                what is read out, because a description announced without its
+                subject — "Move in" — says less than the sentence the shortcut
+                manager already carries for exactly this.
+              */}
+              <span className="nx-layers-panel__hint-label" aria-hidden="true">
+                {label}
+              </span>
+              <span className="nx-sr-only">
+                {shown}: {description}
+              </span>
+            </li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -54,14 +54,19 @@
  */
 
 import { allBlocks } from "@nextlyhq/blocks-engine";
-import { Input, TreeView, type TreeNode } from "@nextlyhq/ui";
+import {
+  Input,
+  TreeView,
+  detectApplePlatform,
+  type TreeNode,
+} from "@nextlyhq/ui";
 import { EyeOff, Lock, SlidersHorizontal } from "lucide-react";
 import * as React from "react";
 
 import { BlockIconMark } from "./block-icon";
 import type { EditorState } from "./editor-state";
 import { keyHint } from "./key-hint";
-import { MOVE_KEYS } from "./keyboard-actions";
+import { MOVE_KEYS, useBlockKeysEnabled } from "./keyboard-actions";
 import type { MoveDirection } from "./keyboard-move";
 import { ancestorIds, filterLayers, layersOf, type LayerNode } from "./layers";
 
@@ -228,19 +233,48 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
   );
 
   /*
+   * Which keyboard is in front of the author, resolved AFTER mounting.
+   *
+   * `detectApplePlatform` reads `navigator`, which a server render does not
+   * have — it answers false there, so a server would emit `Alt` and the first
+   * browser render `⌥`, and React would find markup it did not produce and
+   * throw the subtree away. Held as `null` until it is known, so the legend is
+   * absent rather than briefly wrong: this module's whole rule is that a hint
+   * naming the wrong key is worse than no hint at all.
+   */
+  const [apple, setApple] = React.useState<boolean | null>(null);
+  React.useEffect(() => {
+    setApple(detectApplePlatform());
+  }, []);
+
+  /* Whether pressing these keys does anything, which is what makes it honest to
+   * say so. A host can mount this panel with no bindings above it, or with them
+   * turned off while something modal is over the canvas. */
+  const keysLive = useBlockKeysEnabled();
+
+  /*
    * Built from the binding table, so a rebound keystroke moves the hint with
    * it. A binding this cannot spell is dropped rather than guessed at — see
    * `keyHint` for why a wrong hint is worse than no hint.
    */
   const hints = React.useMemo(
     () =>
-      MOVE_KEYS.flatMap(({ keys, direction, description }) => {
-        const shown = keyHint(keys);
-        return shown === null
-          ? []
-          : [{ keys, shown, label: DIRECTION_LABEL[direction], description }];
-      }),
-    []
+      apple === null || !keysLive
+        ? []
+        : MOVE_KEYS.flatMap(({ keys, direction, description }) => {
+            const shown = keyHint(keys, apple);
+            return shown === null
+              ? []
+              : [
+                  {
+                    keys,
+                    shown,
+                    label: DIRECTION_LABEL[direction],
+                    description,
+                  },
+                ];
+          }),
+    [apple, keysLive]
   );
 
   return (

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -58,7 +58,6 @@ import {
   Input,
   TreeView,
   detectApplePlatform,
-  useActiveShortcuts,
   type TreeNode,
 } from "@nextlyhq/ui";
 import { EyeOff, Lock, SlidersHorizontal } from "lucide-react";
@@ -67,13 +66,31 @@ import * as React from "react";
 import { BlockIconMark } from "./block-icon";
 import type { EditorState } from "./editor-state";
 import { keyHint } from "./key-hint";
-import { BLOCK_ACTIONS_LAYER, MOVE_KEYS } from "./keyboard-actions";
+import { MOVE_KEYS } from "./keyboard-actions";
 import type { MoveDirection } from "./keyboard-move";
 import { ancestorIds, filterLayers, layersOf, type LayerNode } from "./layers";
 
 export interface LayersPanelProps {
   /** The editor whose document this shows and whose selection it drives. */
   editor: EditorState;
+  /**
+   * Whether the block-move keystrokes are bound for THIS editor.
+   *
+   * Asked of the host rather than worked out here, and that is the third answer
+   * to this question — the first two were wrong in instructive ways. A React
+   * context said no in the product, because `BlocksField` draws this panel
+   * through the shell's panel region while the bindings wrap the shell's
+   * children, and those are sibling subtrees. Asking the shortcut manager fixed
+   * that and broke two other things: it made a `ShortcutProvider` mandatory for
+   * a panel that never needed one, and it cannot tell one editor's bindings
+   * from another's, so a second editor's enabled keys advertised themselves in
+   * a panel whose own were off.
+   *
+   * The host is the only place that knows, because the host is what mounts both
+   * halves. Defaults to `false`: a panel told nothing says nothing, which is
+   * the safe direction for a claim that pressing something does something.
+   */
+  moveHints?: boolean;
 }
 
 /** One badge: an icon nobody has to see, and a word every reader gets. */
@@ -174,7 +191,10 @@ const DIRECTION_LABEL: Readonly<Record<MoveDirection, string>> = {
   outdent: "Move out",
 };
 
-export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
+export function LayersPanel({
+  editor,
+  moveHints = false,
+}: LayersPanelProps): React.JSX.Element {
   const [query, setQuery] = React.useState("");
   const [opened, setOpened] = React.useState<readonly string[]>([]);
 
@@ -253,44 +273,15 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
   }, []);
 
   /*
-   * The keystrokes the manager is actually holding right now.
-   *
-   * Asked of the SHORTCUT MANAGER rather than of a React context, because the
-   * question is not "is a provider above me" — this panel is drawn through the
-   * shell's own panel region, which is a sibling of the subtree the bindings
-   * are registered in, so a context would answer no while the keys worked
-   * perfectly. The manager is shell-wide and knows what is registered wherever
-   * it was registered from.
-   *
-   * It also answers the harder half for free: a disabled layer is dropped from
-   * this list, so a host that turns the bindings off while something modal is
-   * over the canvas stops being advertised at the same moment it stops working.
-   */
-  const activeShortcuts = useActiveShortcuts();
-  const liveKeys = React.useMemo(
-    () =>
-      new Set(
-        activeShortcuts
-          .filter(shortcut => shortcut.layer === BLOCK_ACTIONS_LAYER)
-          .map(shortcut => shortcut.keys)
-      ),
-    [activeShortcuts]
-  );
-
-  /*
    * Built from the binding table, so a rebound keystroke moves the hint with
    * it. A binding this cannot spell is dropped rather than guessed at — see
    * `keyHint` for why a wrong hint is worse than no hint.
    */
   const hints = React.useMemo(
     () =>
-      apple === null
+      apple === null || !moveHints
         ? []
         : MOVE_KEYS.flatMap(({ keys, direction, description }) => {
-            // Named by the move table, HELD by the manager. Either alone is a
-            // claim about something else: the table says what the editor
-            // intends, and the manager says what is bound at this moment.
-            if (!liveKeys.has(keys)) return [];
             const shown = keyHint(keys, apple);
             return shown === null
               ? []
@@ -303,7 +294,7 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
                   },
                 ];
           }),
-    [apple, liveKeys]
+    [apple, moveHints]
   );
 
   return (

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -76,19 +76,16 @@ export interface LayersPanelProps {
   /**
    * Whether the block-move keystrokes are bound for THIS editor.
    *
-   * Asked of the host rather than worked out here, and that is the third answer
-   * to this question — the first two were wrong in instructive ways. A React
-   * context said no in the product, because `BlocksField` draws this panel
-   * through the shell's panel region while the bindings wrap the shell's
-   * children, and those are sibling subtrees. Asking the shortcut manager fixed
-   * that and broke two other things: it made a `ShortcutProvider` mandatory for
-   * a panel that never needed one, and it cannot tell one editor's bindings
-   * from another's, so a second editor's enabled keys advertised themselves in
-   * a panel whose own were off.
+   * Owned by the host, which is the only place that can answer it. This panel
+   * is drawn in the shell's panel region while the keystrokes are registered by
+   * a component wrapping the shell's children, and those are sibling subtrees —
+   * so nothing readable from where this sits describes the bindings beside it.
+   * A host with two editors on one page has two answers, and only it knows
+   * which belongs to which.
    *
-   * The host is the only place that knows, because the host is what mounts both
-   * halves. Defaults to `false`: a panel told nothing says nothing, which is
-   * the safe direction for a claim that pressing something does something.
+   * Defaults to `false`, so a panel told nothing says nothing: the legend is a
+   * claim that pressing something does something, and silence is the safe
+   * direction for a claim that cannot be checked from here.
    */
   moveHints?: boolean;
 }

--- a/packages/builder/src/layers-panel.tsx
+++ b/packages/builder/src/layers-panel.tsx
@@ -58,6 +58,7 @@ import {
   Input,
   TreeView,
   detectApplePlatform,
+  useActiveShortcuts,
   type TreeNode,
 } from "@nextlyhq/ui";
 import { EyeOff, Lock, SlidersHorizontal } from "lucide-react";
@@ -66,7 +67,7 @@ import * as React from "react";
 import { BlockIconMark } from "./block-icon";
 import type { EditorState } from "./editor-state";
 import { keyHint } from "./key-hint";
-import { MOVE_KEYS, useBlockKeysEnabled } from "./keyboard-actions";
+import { BLOCK_ACTIONS_LAYER, MOVE_KEYS } from "./keyboard-actions";
 import type { MoveDirection } from "./keyboard-move";
 import { ancestorIds, filterLayers, layersOf, type LayerNode } from "./layers";
 
@@ -148,9 +149,6 @@ function rowOf(
     children: node.children.map(child => rowOf(child, icons)),
   };
 }
-
-/** One id, so the tree's description and the hint cannot drift apart. */
-const MOVE_HINT_ID = "nx-layers-move-hint";
 
 /**
  * The short label each direction gets in the legend.
@@ -242,15 +240,42 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
    * absent rather than briefly wrong: this module's whole rule is that a hint
    * naming the wrong key is worse than no hint at all.
    */
+  /*
+   * Per INSTANCE, not a module constant. A host may mount two editors on one
+   * page, and a fixed id would have both trees pointing at the same element —
+   * an ambiguous lookup, where assistive technology can read one panel's tree
+   * the other panel's description.
+   */
+  const hintId = React.useId();
   const [apple, setApple] = React.useState<boolean | null>(null);
   React.useEffect(() => {
     setApple(detectApplePlatform());
   }, []);
 
-  /* Whether pressing these keys does anything, which is what makes it honest to
-   * say so. A host can mount this panel with no bindings above it, or with them
-   * turned off while something modal is over the canvas. */
-  const keysLive = useBlockKeysEnabled();
+  /*
+   * The keystrokes the manager is actually holding right now.
+   *
+   * Asked of the SHORTCUT MANAGER rather than of a React context, because the
+   * question is not "is a provider above me" — this panel is drawn through the
+   * shell's own panel region, which is a sibling of the subtree the bindings
+   * are registered in, so a context would answer no while the keys worked
+   * perfectly. The manager is shell-wide and knows what is registered wherever
+   * it was registered from.
+   *
+   * It also answers the harder half for free: a disabled layer is dropped from
+   * this list, so a host that turns the bindings off while something modal is
+   * over the canvas stops being advertised at the same moment it stops working.
+   */
+  const activeShortcuts = useActiveShortcuts();
+  const liveKeys = React.useMemo(
+    () =>
+      new Set(
+        activeShortcuts
+          .filter(shortcut => shortcut.layer === BLOCK_ACTIONS_LAYER)
+          .map(shortcut => shortcut.keys)
+      ),
+    [activeShortcuts]
+  );
 
   /*
    * Built from the binding table, so a rebound keystroke moves the hint with
@@ -259,9 +284,13 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
    */
   const hints = React.useMemo(
     () =>
-      apple === null || !keysLive
+      apple === null
         ? []
         : MOVE_KEYS.flatMap(({ keys, direction, description }) => {
+            // Named by the move table, HELD by the manager. Either alone is a
+            // claim about something else: the table says what the editor
+            // intends, and the manager says what is bound at this moment.
+            if (!liveKeys.has(keys)) return [];
             const shown = keyHint(keys, apple);
             return shown === null
               ? []
@@ -274,7 +303,7 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
                   },
                 ];
           }),
-    [apple, keysLive]
+    [apple, liveKeys]
   );
 
   return (
@@ -319,7 +348,7 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
           }
           // The hint is the tree's DESCRIPTION, so it is announced on entering
           // the tree rather than only readable by someone who can see it below.
-          aria-describedby={hints.length === 0 ? undefined : MOVE_HINT_ID}
+          aria-describedby={hints.length === 0 ? undefined : hintId}
         />
       )}
 
@@ -329,7 +358,7 @@ export function LayersPanel({ editor }: LayersPanelProps): React.JSX.Element {
         with none has nothing to say this about.
       */}
       {tree.length === 0 || nodes.length === 0 || hints.length === 0 ? null : (
-        <ul className="nx-layers-panel__hint" id={MOVE_HINT_ID}>
+        <ul className="nx-layers-panel__hint" id={hintId}>
           {hints.map(({ keys, shown, label, description }) => (
             <li className="nx-layers-panel__hint-row" key={keys}>
               <span className="nx-layers-panel__hint-key" aria-hidden="true">

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -2026,3 +2026,57 @@
 .nx-canvas [contenteditable="false"] {
   -webkit-touch-callout: none;
 }
+
+/*
+ * The reordering hint under the layers tree.
+ *
+ * Quiet by construction: it is a standing legend rather than a message, so it
+ * has to be readable without competing with the tree it describes. Kept at the
+ * panel's own text size floor rather than smaller, because a hint nobody can
+ * read is the same as the missing hint it replaced.
+ */
+.nx-layers-panel__hint {
+  margin: 0;
+  padding: 0.5rem 0.625rem;
+  border-top: 1px solid var(--nx-border);
+  color: var(--nx-muted-foreground);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  list-style: none;
+}
+
+/*
+ * One binding per row, with the keystroke in a column of its own.
+ *
+ * A run of them separated inline wraps mid-binding at this width — the key and
+ * the words it belongs to end up on different lines — which turns a legend
+ * meant to be scanned into a paragraph to be read.
+ */
+.nx-layers-panel__hint-row {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+}
+
+/* Wide enough that the four labels start on one line rather than four. */
+.nx-layers-panel__hint-row .nx-layers-panel__hint-key {
+  flex: none;
+  min-width: 2.5rem;
+  text-align: center;
+}
+
+/*
+ * The keystroke reads as a key, so it is set apart from the words around it.
+ * `inline-block` rather than a bare span: the glyphs are narrow and the label
+ * beside them is not, and without a box the two run together at small sizes.
+ */
+.nx-layers-panel__hint-key {
+  display: inline-block;
+  padding: 0 0.25rem;
+  border: 1px solid var(--nx-border);
+  border-radius: 0.25rem;
+  background: var(--nx-muted);
+  color: var(--nx-foreground);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  white-space: nowrap;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -39,7 +39,13 @@ const seen: {
   inspector: Record<string, unknown> | undefined;
   canvas: Record<string, unknown> | undefined;
   switcher: Record<string, unknown> | undefined;
-} = { inspector: undefined, canvas: undefined, switcher: undefined };
+  layers: Record<string, unknown> | undefined;
+} = {
+  inspector: undefined,
+  canvas: undefined,
+  switcher: undefined,
+  layers: undefined,
+};
 
 /** What `usePluginClientConfig` answers with for the test in hand. */
 let clientConfig: Record<string, unknown> | undefined;
@@ -54,7 +60,7 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
    */
   const real = await importOriginal<Record<string, unknown>>();
   const record =
-    (key: "inspector" | "canvas" | "switcher") =>
+    (key: "inspector" | "canvas" | "switcher" | "layers") =>
     (props: Record<string, unknown>): React.JSX.Element => {
       seen[key] = props;
       return <div data-recorder={key} />;
@@ -71,14 +77,23 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
       inspector,
       topBar,
       children,
+      renderPanel,
     }: {
       inspector: React.ReactNode;
       topBar?: React.ReactNode;
       children?: React.ReactNode;
+      renderPanel?: (panel: string) => React.ReactNode;
     }): React.JSX.Element => (
       <div>
         {topBar}
         {inspector}
+        {/*
+          The panel region, drawn as a SIBLING of the children — which is what
+          the real shell does, and the whole reason a panel cannot read what the
+          children provide. A mock that dropped `renderPanel` could not see a
+          panel wired wrongly, or wired not at all.
+        */}
+        {renderPanel?.("layers")}
         {children}
       </div>
     ),
@@ -98,7 +113,7 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     EditorCommandPalette: nothing,
     DropIndicator: nothing,
     InsertPanel: nothing,
-    LayersPanel: nothing,
+    LayersPanel: record("layers"),
     OnboardingChecklist: nothing,
     SelectionBreadcrumb: nothing,
     SpacingOverlay: nothing,
@@ -231,6 +246,25 @@ afterEach(() => {
 });
 
 describe("the container the canvas is compiled against", () => {
+  it("tells the layers panel that the move keystrokes are bound", () => {
+    /*
+     * The panel cannot work this out where it sits. It is drawn in the shell's
+     * panel region while `BlockKeyboardActions` wraps the shell's CHILDREN, and
+     * the real shell renders those as siblings — so anything the panel reads
+     * from its own position answers about the wrong subtree.
+     *
+     * This file is where that is observable, because it is the only place the
+     * two halves are composed the way the product composes them. A case living
+     * beside the panel can assert what the panel does with the fact and never
+     * whether it is given one, which is how the legend came to be invisible to
+     * every real author while its own tests passed.
+     */
+    openEditor();
+
+    expect(seen.layers).toBeDefined();
+    expect(seen.layers?.moveHints).toBe(true);
+  });
+
   it("tells the inspector about the SAME one it compiled with", () => {
     /*
      * The panel decides whether the window may answer for which tiers are live.

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -1591,7 +1591,16 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
               <InsertPanel editor={editor} categoryOrder={CORE_CATEGORIES} />
             );
           }
-          if (panel === "layers") return <LayersPanel editor={editor} />;
+          if (panel === "layers") {
+            /*
+              The panel cannot work this out for itself. It is drawn here, in
+              the shell's panel region, while `BlockKeyboardActions` below wraps
+              the shell's CHILDREN — sibling subtrees, so nothing the panel can
+              read from where it sits reports what this file knows by writing
+              both. Passed as a fact rather than inferred.
+            */
+            return <LayersPanel editor={editor} moveHints />;
+          }
           if (panel === "tokens") {
             return (
               <TokensStudio


### PR DESCRIPTION
Closes the discoverability half of `finding:pb-layers-cannot-reorder`, and corrects what that finding said.

## The report was "reordering not working in layers". It works.

Verified in a real browser before writing anything. With a layer row focused:

| gesture | result |
|---|---|
| `Alt+←` on a Section nested in a Box | Section moved to root — DOM went `nested` → `root` |
| `Alt+↑` on that Section | moved above its sibling — document order flipped, and the tree redrew to match |

So the capability exists, is wired correctly, and reaches the editor's own verbs. What was missing is that **nothing told anyone**, and a capability nobody can find reads exactly like a missing one.

What genuinely does not exist is dragging, and that is deliberately not this PR — the layers tree is `@nextlyhq/ui`'s `TreeView`, which is shared, **virtualized**, and has zero drag support. Its own docblock warns against re-answering questions the design system has already answered, and says the accessibility half is the half that rots when you do. Drag belongs in that component, with research, not bolted on from the builder.

## What this adds

A legend under the tree:

```
⌥↑   Move up
⌥↓   Move down
⌥→   Move in
⌥←   Move out
```

**Derived twice over, rather than written.**

- The **bindings** come from `MOVE_KEYS`, the table the shortcut manager actually registers. A retyped "Alt+Up" is correct until someone rebinds the key, and then it teaches a keystroke that does nothing — with no test that can fail, because the two are related only by having been typed by the same person on the same day.
- The **spelling** comes from `key-hint`, which reads `@nextlyhq/ui`'s own `detectApplePlatform`. Option and Alt are the same physical key with two names, so a fixed string is wrong on one platform.

`key-hint` **parses rather than splits on `+`**, using `parseKeys`. A lone `+` is a key and a trailing one is too, so `mod++` is the zoom chord rather than a malformed one — a second implementation of that grammar would disagree with the binding it describes for exactly the specs hardest to read. There is a test for that case.

A spec it cannot read produces `null` and is dropped rather than guessed at. A hint is a promise that pressing something does something.

## Accessibility

It is the tree's `aria-describedby`, not merely text near it, so it is announced **on entering the tree** — the moment the question arises. `TreeView` already forwards that attribute.

What is *drawn* is a short label per direction; what is *announced* is the binding's own sentence ("Move the selected block into the container above it"). Those sentences exist to be spoken after a move, where the subject must be named — four of them stacked under a tree is a paragraph rather than a legend. I built it that way first, looked at it in a browser, and it wrapped over six lines; the screenshot is why it changed.

The short labels come from the `direction` enum the binding table already carries, so they are a projection of something the editor decided rather than a second wording. The map is total over `MoveDirection`, so a new direction fails to compile here instead of silently drawing nothing.

## Also corrected

`block-toolbar.tsx` carried "The hint returns when that export does", about `detectApplePlatform` not being on `@nextlyhq/ui`'s public entry. **It is on the public entry** — the comment described a blocker that no longer exists. It now says what the toolbar actually still lacks: a way to say which binding runs a given action id, since the moves come from one table and the rest from the keystroke registrations, and joining them without writing a third list is the real work.

## Verification

Every case break-verified, each mutation killing exactly the tests whose names promise that behaviour:

| mutation | fails |
|---|---|
| render no hint | `says how to reorder…`, `derives the hint from the bindings…` |
| drop `aria-describedby` | `makes the hint the tree's own description` |
| show only the first binding | `derives the hint…`, `says how to reorder…` |
| ignore the platform (fixed string) | `names the key the platform carries…` |

Browser-verified on the built branch: 4 rows, `aria-describedby="nx-layers-move-hint"`, glyphs rendered as `⌥↑`, and the screen-reader span confirmed genuinely hidden (`position: absolute`, `clip-path: inset(50%)`, 1×1px) rather than merely assumed.

Green: `builder` 2393, typecheck, lint, and `fallow audit --base origin/main` reports no new findings. Changeset validated.