### PR TITLE
fix(nextly): apply field write rules to an anonymous write

### DIFF
--- a/.changeset/absence-of-a-user-is-not-trust.md
+++ b/.changeset/absence-of-a-user-is-not-trust.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Field-level write rules now apply to an anonymous write, not only an
+authenticated one.
+
+A collection may legitimately allow anonymous creates — a contact form, a public
+submission. On one, a field declaring `access: { create: () => false }` was
+enforced against every signed-in writer and skipped entirely for an
+unauthenticated one, because the write guard treated "no user" as a trusted
+system context. An unauthenticated writer could therefore set a field that every
+authenticated user was forbidden from setting.
+
+The guard now gates on `overrideAccess` alone, which is what the matching READ
+guard has always done. An internal writer that needs to set a protected field
+still says so explicitly with `overrideAccess: true`; that bypass is unchanged.
+An anonymous writer resolves to no permissions and no roles, so a rule asking
+for a grant refuses it.

--- a/.gitignore
+++ b/.gitignore
@@ -85,6 +85,11 @@ docker/postgres/data/
 
 # SQLite database files
 apps/playground/data/
+# The nextly package's own SQLite tests default to `file:./data/nextly.db` when
+# no DATABASE_URL is set, so running them from `packages/nextly` leaves a
+# database file there. Untracked and unignored, it is one `git add -A` away
+# from being committed into a pull request.
+packages/nextly/data/
 
 # Nextly runtime artifacts (migration logs, journal) written next to any app/package
 .nextly/

--- a/packages/nextly/AGENTS.md
+++ b/packages/nextly/AGENTS.md
@@ -21,7 +21,15 @@ inside `packages/nextly`.
 - Direct API lists return `{ items, meta }`; mutations return a result with
   `.item`. There is no `docs`/`totalDocs` shape anywhere.
 - `overrideAccess` defaults to `true` (trusted server context). Enforcing
-  access control requires `overrideAccess: false` plus a `user`.
+  COLLECTION and DOCUMENT access requires `overrideAccess: false` plus a
+  `user` — a stored owner rule has nobody to compare against otherwise, so it
+  is skipped rather than failed.
+- FIELD-level rules are different: they run whenever `overrideAccess` is
+  false, user or not. "Which fields may this writer set" has a perfectly good
+  answer for nobody, and treating absence of a user as trust let an anonymous
+  write set fields every authenticated user was forbidden from setting. An
+  internal writer that needs a protected field says so with
+  `overrideAccess: true`.
 - The canonical `FieldType` union has 19 members and the structured-array
   type is `repeater`; the `array()` factory is a backward-compat alias, use
   `repeater()` in new code. Surface-only types (`url`, `phone` for users;

--- a/packages/nextly/src/domains/collections/__tests__/anonymous-field-write-access.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/anonymous-field-write-access.integration.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Field-level write rules apply to an ANONYMOUS write, not only an
+ * authenticated one.
+ *
+ * The write guard used to read `overrideAccess || !user`, treating "no user" as
+ * a trusted system write. The read guard has only ever read `overrideAccess`.
+ * On a collection that permits anonymous creates — an ordinary supported config
+ * for a contact form or a public submission — that asymmetry let an
+ * unauthenticated writer set a field EVERY authenticated user is forbidden from
+ * setting. Less authentication bought more authority.
+ *
+ * The two cases here are one experiment: the authenticated arm is the control
+ * that makes the anonymous arm mean something. Without it, "the field was
+ * written" is equally consistent with "the rule was never registered" — which
+ * is exactly how the first version of this probe reported no defect at all.
+ *
+ * @module domains/collections/__tests__/anonymous-field-write-access.integration.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection } from "../../../collections/config/define-collection";
+import { text } from "../../../collections/fields";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "notes";
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: SLUG,
+        access: { read: () => true, create: () => true, update: () => true },
+        fields: [
+          text({ name: "title" }),
+          text({
+            name: "secret",
+            // Refused to everyone. The rule names BOTH operations: a create
+            // consults `access.create`, and declaring only `update` leaves a
+            // create ungated — which is how a first attempt at this test
+            // reported both writers behaving identically.
+            access: { create: () => false, update: () => false },
+          } as never),
+        ],
+      }),
+    ],
+  });
+  return current;
+}
+
+/**
+ * The stored `secret` of the row with this title.
+ *
+ * Throws when the row is absent, rather than reporting `null`. A create that
+ * failed outright leaves no row, and a helper that answered `null` for that
+ * would make every "the field was stripped" assertion below pass through a
+ * COMPLETELY broken anonymous-create path — green for the opposite of the
+ * reason it claims.
+ */
+const storedSecret = async (
+  t: TestNextly,
+  title: string
+): Promise<string | null> => {
+  const rows = await t.adapter.select<{ title: string; secret?: string }>(
+    `dc_${SLUG}`,
+    {}
+  );
+  const row = rows.find(r => r.title === title);
+  if (row === undefined) {
+    throw new Error(
+      `no row titled "${title}": the write was refused, not stripped`
+    );
+  }
+  return row.secret ?? null;
+};
+
+describe.each(getConfiguredTestDialects())(
+  "field write rules and the anonymous writer (%s)",
+  dialect => {
+    it("strips a refused field from an AUTHENTICATED write", async () => {
+      // The control. If this ever stops holding, the case below proves nothing:
+      // an unstripped anonymous write would be indistinguishable from a rule
+      // that was never registered.
+      const t = await boot(dialect);
+      const created = await (
+        t.getService("collectionsHandler") as CollectionsHandler
+      ).createEntry(
+        {
+          collectionName: SLUG,
+          user: { id: "u1", roles: ["editor"] },
+        } as never,
+        { title: "auth", secret: "SET-BY-AUTH" }
+      );
+
+      expect(created.success).toBe(true);
+      expect(await storedSecret(t, "auth")).toBeNull();
+    });
+
+    it("strips it from an ANONYMOUS write too", async () => {
+      // The defect. A collection may legitimately allow anonymous creates, and
+      // the REST path reaches this with no user at all: the dispatcher forwards
+      // `userId: p._authenticatedUserId`, which is undefined when nobody is
+      // signed in, and never passes `overrideAccess`.
+      const t = await boot(dialect);
+      const created = await (
+        t.getService("collectionsHandler") as CollectionsHandler
+      ).createEntry(
+        { collectionName: SLUG },
+        { title: "anon", secret: "SET-BY-ANON" }
+      );
+
+      expect(created.success).toBe(true);
+      expect(await storedSecret(t, "anon")).toBeNull();
+    });
+
+    it("still lets a TRUSTED write set it", async () => {
+      // The other control, and the reason the fix drops only `|| !user`. An
+      // explicit `overrideAccess` is a deliberate statement by an internal
+      // writer that it is trusted; that bypass is intact, and it is the one a
+      // seeder or migration actually uses.
+      const t = await boot(dialect);
+      const created = await (
+        t.getService("collectionsHandler") as CollectionsHandler
+      ).createEntry(
+        { collectionName: SLUG, overrideAccess: true },
+        { title: "trusted", secret: "SET-BY-SYSTEM" }
+      );
+
+      expect(created.success).toBe(true);
+      expect(await storedSecret(t, "trusted")).toBe("SET-BY-SYSTEM");
+    });
+  }
+);

--- a/packages/nextly/src/shared/lib/field-level-registry.ts
+++ b/packages/nextly/src/shared/lib/field-level-registry.ts
@@ -393,19 +393,33 @@ export async function applyFieldWriteAccess(opts: {
   overrideAccess?: boolean;
   id?: string;
 }): Promise<void> {
-  // Bypass for trusted contexts, matching the collection access service's
-  // `overrideAccess || !user` rule: an explicit override or a system write
-  // with no user context is trusted, so per-field rules don't run and can't
-  // strip fields an internal writer intended to set. Authenticated writes
-  // (user present, no override) are enforced.
-  if (opts.overrideAccess || !opts.user) return;
+  // Bypass for a caller that has SAID it is trusted, and only that. The read
+  // side gates on the same single condition, and the two must agree: a rule
+  // that strips a field from an authenticated writer but not from an
+  // unauthenticated one would make less authentication buy more authority.
+  //
+  // Absence of a user is not trust. `collection-access-service` does read
+  // `overrideAccess || !user`, but only where it resolves a stored OWNER
+  // predicate — with nobody to compare against, that predicate is unanswerable
+  // rather than failing. A field rule is a different question: it asks whether
+  // THIS writer may set this field, and "nobody" is a perfectly good answer.
+  // Its main gate uses `overrideAccess` alone, which is the one this matches.
+  //
+  // An internal writer that needs to set a protected field says so with
+  // `overrideAccess: true`; that is a deliberate line in the caller rather
+  // than a property of having no session.
+  if (opts.overrideAccess) return;
   const fns = getFieldFunctions(opts.kind, opts.slug);
   if (!fns) return;
   await applyWriteAccessRec(opts.data, fns, opts.operation, {
     user: opts.user,
     id: opts.id,
+    // An anonymous writer resolves to NO grants — `grantsResolver(undefined)`
+    // answers `{ permissions: [], roles: [] }` — so a rule written as
+    // `({ permissions }) => permissions.includes(...)` refuses it, which is
+    // the correct answer rather than an accident of the shape.
     grants: grantsResolver(
-      typeof opts.user.id === "string" ? opts.user.id : undefined
+      typeof opts.user?.id === "string" ? opts.user.id : undefined
     ),
   });
 }


### PR DESCRIPTION
R-5. The audit's deliverable was meant to be a reachability finding rather than a fix — but the defect turned out to be reachable through the ordinary REST path, so this is both. Written up in [`findings/R-5-anonymous-writes-skip-field-rules.md`](findings/R-5-anonymous-writes-skip-field-rules.md).

## The asymmetry

```
field-level-registry.ts:401  (WRITE)  if (opts.overrideAccess || !opts.user) return;
field-level-registry.ts:635  (READ)   if (opts.overrideAccess) return;
```

The write side treated *absence of a user* as trust. The read side never has.

## Demonstrated, not argued

A collection that permits anonymous creates is an ordinary supported config. On one, with a field declaring `access: { create: () => false, update: () => false }`:

| writer | value stored in the protected field |
|---|---|
| authenticated | `null` — rule applied |
| **anonymous** | **`"SET-BY-ANON"` — rule skipped** |

Both creates succeeded. An unauthenticated writer could set a field **every authenticated user is forbidden from setting**. Less authentication bought more authority.

Reachable without anything unusual: `collection-dispatcher` forwards `userId: p._authenticatedUserId` — undefined when nobody is signed in — and never passes `overrideAccess`.

## The comment's justification was true, and still wrong

`:401` justified itself by pointing at `collection-access-service`'s `overrideAccess || !user` rule. **I verified that claim and it holds** — `:491` and `:560` do read exactly that.

But that service uses **both** rules, for different jobs:

- `:194`, its main gate — `if (overrideAccess) return null;`
- `:491`/`:560`, resolving a stored **owner** predicate — `overrideAccess || !user`

`|| !user` is correct for an owner predicate: with nobody to compare against it is *unanswerable* rather than failing. A field rule is a different question — it asks whether **this** writer may set this field, and "nobody" is a perfectly good answer. The guard had been matched to the wrong one of the two.

## Two probes were wrong before one was right

My first declared only `access.update`. A create consults `access.create`, so the rule never ran and **both arms behaved identically** — which reads exactly like "no defect". An experiment whose arms agree has measured nothing.

The authenticated arm is the control that makes the anonymous result mean something; without it, "the field was written" is equally consistent with "the rule was never registered". Both arms are in the committed test, along with a third asserting the `overrideAccess: true` bypass still works — that is the one an internal writer actually uses.

## Blast radius, measured before committing

A system write passing neither a user nor an override would begin having rules applied, so that was the risk. Measured rather than reasoned about:

- Full unit suite: **9731 tests pass**
- Integration for all three callers of this guard — collections, singles, versions: **507 pass**

Break-verified: restoring `|| !opts.user` fails exactly `strips it from an ANONYMOUS write too`, while the authenticated and trusted cases keep passing — so the test discriminates rather than just being sensitive.

## One unrelated line, deliberately included

`.gitignore` now covers `packages/nextly/data/`. The package's own SQLite tests default to `file:./data/nextly.db` when no `DATABASE_URL` is set, so running them there leaves a database file that is untracked, **unignored**, and one `git add -A` away from being committed into a PR. `apps/playground/data/` is already ignored; this is the same gap one directory over. Happy to split it out if you would rather.