### PR TITLE
refactor(builder): build the hint's modifiers from a table

### DIFF
--- a/.changeset/key-hint-modifier-table.md
+++ b/.changeset/key-hint-modifier-table.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Internal: the keystroke hint builds its modifier list from a table.
+
+No change to what any hint says. The order modifiers are written in is a convention, and a list makes that order the thing being read rather than something recoverable only by following five branches in sequence.

--- a/packages/builder/src/key-hint.ts
+++ b/packages/builder/src/key-hint.ts
@@ -29,7 +29,7 @@
  * @module key-hint
  */
 
-import { detectApplePlatform, parseKeys } from "@nextlyhq/ui";
+import { detectApplePlatform, parseKeys, type KeyChord } from "@nextlyhq/ui";
 
 /**
  * Glyphs for keys whose NAME is not what a keyboard shows.
@@ -51,20 +51,31 @@ const KEY_GLYPHS: Readonly<Record<string, string>> = {
   " ": "Space",
 };
 
-/** The modifier labels, in the order a keyboard shortcut is conventionally written. */
-function modifierLabels(
-  chord: ReturnType<typeof parseKeys>[number],
-  apple: boolean
-): string[] {
-  const labels: string[] = [];
-  // `mod` first, because it is the outermost modifier in every convention that
-  // writes more than one.
-  if (chord.mod) labels.push(apple ? "⌘" : "Ctrl");
-  if (chord.ctrl) labels.push(apple ? "⌃" : "Ctrl");
-  if (chord.alt) labels.push(apple ? "⌥" : "Alt");
-  if (chord.shift) labels.push(apple ? "⇧" : "Shift");
-  if (chord.meta) labels.push(apple ? "⌘" : "Meta");
-  return labels;
+/**
+ * The modifiers, in the order a keyboard shortcut is conventionally written.
+ *
+ * A table rather than a run of conditions: the order IS the convention, and a
+ * list makes it the thing being read rather than something recoverable only by
+ * following five branches in sequence. `mod` leads because it is the outermost
+ * modifier wherever more than one is written.
+ */
+const MODIFIERS: ReadonlyArray<{
+  readonly held: (chord: KeyChord) => boolean;
+  readonly apple: string;
+  readonly other: string;
+}> = [
+  { held: chord => chord.mod, apple: "⌘", other: "Ctrl" },
+  { held: chord => chord.ctrl, apple: "⌃", other: "Ctrl" },
+  { held: chord => chord.alt, apple: "⌥", other: "Alt" },
+  { held: chord => chord.shift, apple: "⇧", other: "Shift" },
+  { held: chord => chord.meta, apple: "⌘", other: "Meta" },
+];
+
+/** The modifier labels this chord carries, in that order. */
+function modifierLabels(chord: KeyChord, apple: boolean): string[] {
+  return MODIFIERS.filter(modifier => modifier.held(chord)).map(modifier =>
+    apple ? modifier.apple : modifier.other
+  );
 }
 
 /**


### PR DESCRIPTION
Follow-up to #1328. The fix was written before that merged and did not make it in, so it is recovered here rather than lost.

A `fallow` warning on the merged branch: `modifierLabels` scored CRAP 37.1 against a threshold of 30, cyclomatic 11.

The shape was the reason. Five conditions, each carrying its own platform ternary, encode a convention — the ORDER modifiers are written in — as something you can only recover by reading all five in sequence. A table states it directly.

**No hint changes.** The 6 `key-hint` cases and the 17 `layers-panel` cases are untouched and green, including the platform pair (`Alt+↑` / `⌥↑`), the `mod` resolution (`Ctrl+D` / `⌘D`), and the two `Space` cases added in #1328.

Verified the warning is actually gone: `npx fallow audit --base origin/main` reports no CRAP finding on this branch, where it reported one before.