### PR TITLE
feat(builder): drag a block from the insert panel onto the canvas

### DIFF
--- a/.changeset/one-engine-drags-from-the-palette.md
+++ b/.changeset/one-engine-drags-from-the-palette.md
@@ -26,7 +26,7 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-One drag engine, and it now accepts a subject that has no node yet.
+A block can now be dragged from the insert panel onto the canvas.
 
 Dragging a block from the insert panel onto the canvas shares everything with
 dragging a block already on it — where a drop may land, when the target is
@@ -37,3 +37,6 @@ position, an insert builds the node the palette described and adds it there.
 The node is built at the release rather than at the start of the gesture, so
 the document is untouched while the author is still choosing, and the whole
 drag leaves a single entry on the undo stack.
+
+Clicking a row still inserts, exactly as before. The drag only ever adds a
+second way to do it.

--- a/.changeset/one-engine-drags-from-the-palette.md
+++ b/.changeset/one-engine-drags-from-the-palette.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+One drag engine, and it now accepts a subject that has no node yet.
+
+Dragging a block from the insert panel onto the canvas shares everything with
+dragging a block already on it — where a drop may land, when the target is
+allowed to change, the autoscroll, the indicator and Escape. The two differ at
+exactly one call, made when the pointer is released: a move rewrites a node's
+position, an insert builds the node the palette described and adds it there.
+
+The node is built at the release rather than at the start of the gesture, so
+the document is untouched while the author is still choosing, and the whole
+drag leaves a single entry on the undo stack.

--- a/e2e/tests/canvas/acceptance-manifest.ts
+++ b/e2e/tests/canvas/acceptance-manifest.ts
@@ -106,7 +106,7 @@ export const ACCEPTANCE_PROPERTIES: readonly AcceptanceProperty[] = [
     greenIn: "B-15",
     status: "deferred",
     reason:
-      "the panel CANNOT be dragged from: insert-panel.tsx has no drag code at all and inserts by click (line 162). B-15's drag half was never built, so this is blocked on a feature rather than on scaffolding — mounting the panel would not help. See task:pb-inserter-drag",
+      "the feature exists now and the HARNESS cannot drive it: builder-canvas/harness.tsx mounts useCanvasDrag with no canvas root and no palette, so there is nothing to drag from. Its `data-nx-dragging` also reads `draggingId`, which is null for a drag carrying a block type rather than a node — so a palette drag would be invisible to the probe even once a palette is mounted. Scaffolding now, not a missing feature. See task:pb-inserter-drag",
   },
   {
     n: 12,

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -121,7 +121,32 @@ export type DragSubject =
       readonly kind: "insert";
       readonly blockName: string;
       readonly makeNode: () => BlockNode | null;
+      /**
+       * Notified with the node that landed, after a drop the editor accepted.
+       *
+       * Carried on the subject so the two ways a palette inserts report the
+       * same event. The panel already tells its host about a click insert, and
+       * a host reacting to that — scrolling to the block, opening its settings
+       * — would silently miss every insert made by dragging.
+       */
+      readonly onInserted?: (node: BlockNode) => void;
     };
+
+/**
+ * What a palette hands the drag when a row is pressed.
+ *
+ * Named rather than written inline at both the type and the implementation:
+ * the two used to state it separately, and adding a field to one left the
+ * other rejecting it.
+ */
+export interface InsertDragEntry {
+  /** The block type in flight, which the drop position is resolved for. */
+  blockName: string;
+  /** Builds the node at the release, from the palette's own snapshot. */
+  makeNode: () => BlockNode | null;
+  /** Notified with the node that landed, after a drop the editor accepted. */
+  onInserted?: (node: BlockNode) => void;
+}
 
 /** What a drag is doing right now, for the canvas to draw. */
 export interface CanvasDragState {
@@ -177,7 +202,7 @@ export interface CanvasDrag extends CanvasDragState {
    */
   readonly beginInsertDrag: (
     event: React.PointerEvent<HTMLElement>,
-    entry: { blockName: string; makeNode: () => BlockNode | null }
+    entry: InsertDragEntry
   ) => void;
 }
 
@@ -201,9 +226,54 @@ export interface UseCanvasDragOptions {
   switchPx?: number;
 }
 
+/**
+ * Hand the pointer back, when this transport is the one holding it.
+ *
+ * A node-origin drag captures on the canvas root; a palette drag captures
+ * nowhere and passes `null`. Asked of the element rather than tracked, because
+ * the browser releases capture itself on some endings and a flag would then
+ * describe a capture that is already gone.
+ */
+function releaseCapture(host: HTMLElement | null, pointerId: number): void {
+  if (host !== null && host.hasPointerCapture(pointerId)) {
+    host.releasePointerCapture(pointerId);
+  }
+}
+
+/**
+ * The target a release would commit to, or `undefined` when there is none.
+ *
+ * ONE absent value, not two. Written as `null` for "nothing committed" and
+ * `undefined` for "committed to something no longer drawable", the caller
+ * would have to exclude both — and excluding one reads as complete, so a drag
+ * released over no target would reach `target.at`.
+ */
+function committedTarget(drag: Gesture): DropTarget | undefined {
+  const committed = drag.switchState.committed;
+  return committed === null ? undefined : drag.targets.get(committed);
+}
+
 /** What a drag needs to remember, none of which renders. */
 interface Gesture {
   readonly subject: DragSubject;
+  /**
+   * The pointer that began this gesture, and the only one that may drive it.
+   *
+   * A node-origin drag takes pointer capture, which retargets one pointer and
+   * leaves the rest alone — so this is redundant there and costs nothing. A
+   * palette drag deliberately takes no capture, because the browser resolves a
+   * click against the capturing element and the row must keep inserting on
+   * click. Its events therefore arrive by two transports, the canvas's own
+   * React handlers and the document listeners, and BOTH see every active
+   * pointer on a touch device.
+   *
+   * Kept on the gesture rather than checked in each transport's closure: the
+   * two entry points below are where every pointer event of either transport
+   * converges, so enforcing it there covers a route a closure check would
+   * miss — a second finger moving over the CANVAS reaches the React handler,
+   * not the document listener.
+   */
+  readonly owner: number;
   readonly origin: Point;
   /**
    * Where the press landed in CLIENT pixels.
@@ -405,6 +475,7 @@ export function useCanvasDrag({
       const rects = snapshotRects(root);
       gesture.current = {
         subject: { kind: "move", nodeId },
+        owner: event.pointerId,
         origin: canvasContentPoint(event.clientX, event.clientY, root),
         originClient: { x: event.clientX, y: event.clientY },
         regions: collectRegions(current.document, latest.current.slots, rects),
@@ -586,6 +657,8 @@ export function useCanvasDrag({
     ) => {
       const drag = gesture.current;
       if (drag === null) return;
+      // Another finger, moving anywhere. It may not re-aim this gesture.
+      if (pointerId !== drag.owner) return;
 
       /*
        * ONE measurement of the root, answering this move in both spaces.
@@ -720,9 +793,27 @@ export function useCanvasDrag({
       // path states. It holds because `apply` publishes the document the next
       // `select` resolves against before it returns.
       current.select(node.id);
+      // After the select, so a host reacting to this sees the editor in the
+      // state the click path leaves it in — the same event, whichever way the
+      // block arrived.
+      subject.onInserted?.(node);
     },
     []
   );
+
+  /**
+   * Detaches whatever click suppression is armed, or null when none is.
+   *
+   * Held in a ref rather than left to each closure so that only ONE can be
+   * armed: a second arming replaces the first instead of stacking listeners
+   * that would each swallow a click.
+   */
+  const detachClickSwallow = React.useRef<(() => void) | null>(null);
+
+  const stopSwallowingClick = React.useCallback(() => {
+    detachClickSwallow.current?.();
+    detachClickSwallow.current = null;
+  }, []);
 
   /**
    * Swallow the click the browser synthesises after an activated palette drag.
@@ -740,16 +831,67 @@ export function useCanvasDrag({
    * listening a task later was never going to fire.
    */
   const swallowNextClick = React.useCallback(() => {
+    stopSwallowingClick();
+    const stop = (): void => {
+      document.removeEventListener("click", swallow, true);
+      detachClickSwallow.current = null;
+    };
     const swallow = (event: MouseEvent): void => {
       event.preventDefault();
       event.stopPropagation();
-      document.removeEventListener("click", swallow, true);
+      stop();
     };
     document.addEventListener("click", swallow, true);
-    setTimeout(() => {
-      document.removeEventListener("click", swallow, true);
-    }, 0);
-  }, []);
+    setTimeout(stop, 0);
+    detachClickSwallow.current = stop;
+  }, [stopSwallowingClick]);
+
+  /**
+   * Swallow the click that will follow a pointer STILL DOWN when it releases.
+   *
+   * {@link swallowNextClick} arms for one task, which is right when the release
+   * has already happened: the click the browser synthesises belongs to the same
+   * task, so anything still listening a task later was never going to fire.
+   *
+   * Escape is the other case, and the one-task version is wrong for it. The
+   * author cancels while the finger is still on the row, and the release — with
+   * its click — arrives in some later task of their choosing. Expiring after
+   * the keydown leaves the row's own handler to insert a block from a drag that
+   * was visibly cancelled.
+   *
+   * So this waits for THAT pointer's release, and only then gives the click its
+   * one task. Scoped to the pointer for the same reason the gesture is: another
+   * finger lifting says nothing about this one.
+   */
+  const swallowClickAfterRelease = React.useCallback(
+    (pointerId: number) => {
+      stopSwallowingClick();
+      const stop = (): void => {
+        document.removeEventListener("click", swallow, true);
+        document.removeEventListener("pointerup", released, true);
+        document.removeEventListener("pointercancel", released, true);
+        detachClickSwallow.current = null;
+      };
+      const swallow = (event: MouseEvent): void => {
+        event.preventDefault();
+        event.stopPropagation();
+        stop();
+      };
+      const released = (event: PointerEvent): void => {
+        if (event.pointerId !== pointerId) return;
+        document.removeEventListener("pointerup", released, true);
+        document.removeEventListener("pointercancel", released, true);
+        // The click belongs to the release's task. Given it, and no longer:
+        // a suppressor left armed would eat an unrelated click later.
+        setTimeout(stop, 0);
+      };
+      document.addEventListener("click", swallow, true);
+      document.addEventListener("pointerup", released, true);
+      document.addEventListener("pointercancel", released, true);
+      detachClickSwallow.current = stop;
+    },
+    [stopSwallowingClick]
+  );
 
   /**
    * End the gesture, committing an edit only if it reached a target.
@@ -760,17 +902,12 @@ export function useCanvasDrag({
     (pointerId: number, captureHost: HTMLElement | null) => {
       const drag = gesture.current;
       if (drag === null) return;
-      if (captureHost !== null && captureHost.hasPointerCapture(pointerId)) {
-        captureHost.releasePointerCapture(pointerId);
-      }
+      // Another finger lifting. Ending here would commit THIS gesture's target
+      // while the finger that owns it is still down.
+      if (pointerId !== drag.owner) return;
+      releaseCapture(captureHost, pointerId);
 
-      const committed = drag.switchState.committed;
-      // ONE absent value, not two. Written as `null` for "nothing committed"
-      // and `undefined` for "committed to something no longer drawable", the
-      // guard below would have to exclude both — and excluding one reads as
-      // complete, so a drag released over no target would reach `target.at`.
-      const target =
-        committed === null ? undefined : drag.targets.get(committed);
+      const target = committedTarget(drag);
       // A press that never became a drag, or one released where nothing accepts
       // the block, ends without an edit. Committing "the last valid target" from
       // a pointer that has since moved off it would drop the block somewhere the
@@ -795,10 +932,7 @@ export function useCanvasDrag({
   );
 
   const beginInsertDrag = React.useCallback(
-    (
-      event: React.PointerEvent<HTMLElement>,
-      entry: { blockName: string; makeNode: () => BlockNode | null }
-    ) => {
+    (event: React.PointerEvent<HTMLElement>, entry: InsertDragEntry) => {
       // The primary button only, for the reason `onPointerDown` gives.
       if (event.button !== 0) return;
       const root = canvasRoot?.current ?? null;
@@ -809,10 +943,12 @@ export function useCanvasDrag({
       const { editor: current, slots } = latest.current;
       const rects = snapshotRects(root);
       gesture.current = {
+        owner: event.pointerId,
         subject: {
           kind: "insert",
           blockName: entry.blockName,
           makeNode: entry.makeNode,
+          onInserted: entry.onInserted,
         },
         origin: canvasContentPoint(event.clientX, event.clientY, root),
         originClient: { x: event.clientX, y: event.clientY },
@@ -858,13 +994,17 @@ export function useCanvasDrag({
        */
       const owner = event.pointerId;
       const move = (native: PointerEvent): void => {
-        if (native.pointerId !== owner) return;
         trackMove(native.clientX, native.clientY, native.pointerId, null);
       };
       const up = (native: PointerEvent): void => {
-        if (native.pointerId !== owner) return;
         endGesture(native.pointerId, null);
       };
+      // `cancel` alone checks the pointer here, because it is the one ending
+      // that does not pass through `trackMove` or `endGesture` — the two both
+      // transports converge on, and where ownership is enforced for everything
+      // else. Repeating that check in these closures would put the same rule
+      // in two places, and the copy that mattered would be the one someone
+      // forgot when a third transport arrived.
       const cancel = (native: PointerEvent): void => {
         if (native.pointerId !== owner) return;
         reset();
@@ -895,7 +1035,15 @@ export function useCanvasDrag({
   // frame loop and three document listeners holding a gesture nothing can end.
   // `teardown` rather than `reset`, because a state update here would be one on
   // a component that has gone.
-  React.useEffect(() => teardown, [teardown]);
+  React.useEffect(() => {
+    return () => {
+      teardown();
+      // Cleared HERE and not in `teardown`: Escape arms the suppression and
+      // then resets, so disarming on every ending would undo it in the one
+      // case it exists for.
+      stopSwallowingClick();
+    };
+  }, [teardown, stopSwallowingClick]);
 
   /*
    * Escape abandons the drag, listened for on the DOCUMENT rather than on the
@@ -930,7 +1078,7 @@ export function useCanvasDrag({
       // committed one gets.
       const drag = gesture.current;
       if (drag?.active === true && drag.subject.kind === "insert") {
-        swallowNextClick();
+        swallowClickAfterRelease(drag.owner);
       }
       reset();
     };
@@ -938,7 +1086,7 @@ export function useCanvasDrag({
     return () => {
       document.removeEventListener("keydown", abandon, true);
     };
-  }, [dragging, reset, swallowNextClick]);
+  }, [dragging, reset, swallowClickAfterRelease]);
 
   return {
     ...state,

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -830,6 +830,15 @@ export function useCanvasDrag({
         endGesture(native.pointerId, null);
       };
       const cancel = (): void => reset();
+      // Before registering, never after: overwriting the detach closure below
+      // while an earlier palette gesture is still live would strand its three
+      // listeners with nothing able to remove them, and they would go on
+      // calling into a gesture they no longer own for the life of the page.
+      //
+      // The ordinary sequence cannot reach that — a release arrives first and
+      // resets — so this holds the invariant locally instead of resting it on
+      // an ordering that a lost release or a second pointer breaks.
+      stopTrackingDocument();
       document.addEventListener("pointermove", move, true);
       document.addEventListener("pointerup", up, true);
       document.addEventListener("pointercancel", cancel, true);
@@ -839,7 +848,7 @@ export function useCanvasDrag({
         document.removeEventListener("pointercancel", cancel, true);
       };
     },
-    [canvasRoot, endGesture, reset, trackMove]
+    [canvasRoot, endGesture, reset, stopTrackingDocument, trackMove]
   );
 
   // Every ordinary ending funnels through `reset`, which detaches those

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -41,7 +41,7 @@
  * @module canvas-drag
  */
 
-import type { NestingSource } from "@nextlyhq/blocks-engine";
+import type { BlockNode, NestingSource } from "@nextlyhq/blocks-engine";
 import { findNode } from "@nextlyhq/blocks-engine";
 import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import * as React from "react";
@@ -69,6 +69,7 @@ import {
 } from "./geometry-dom";
 import type { SlotSource } from "./inserter";
 import { lockBlockingMove } from "./locking";
+import type { OpPosition } from "./ops";
 import {
   nextTargetSwitchState,
   NO_TARGET,
@@ -97,10 +98,50 @@ export const DEFAULT_ACTIVATION_PX = 4;
  */
 export const DEFAULT_SWITCH_PX = 8;
 
+/**
+ * What a drag is carrying: a node the document already holds, or a block type
+ * that has no node yet.
+ *
+ * The two differ in exactly two places — whether anything is being detached,
+ * and what the release commits — and are identical everywhere between. Holding
+ * that as a payload rather than a second hook is what makes "one engine"
+ * checkable rather than aspirational: `resolveDrop`, the switch rule,
+ * autoscroll and the indicator cannot tell the kinds apart, because they are
+ * never given the chance to.
+ *
+ * An insert builds its node from a THUNK the caller supplies rather than
+ * resolving the type here. The palette reads its definitions from one snapshot
+ * per mount and a block arrives with the children it declares, so resolving
+ * again at drop would answer from a second reading — and the row the author
+ * dragged could differ from the subtree that lands.
+ */
+export type DragSubject =
+  | { readonly kind: "move"; readonly nodeId: string }
+  | {
+      readonly kind: "insert";
+      readonly blockName: string;
+      readonly makeNode: () => BlockNode | null;
+    };
+
 /** What a drag is doing right now, for the canvas to draw. */
 export interface CanvasDragState {
-  /** The node being dragged, or null when no drag is in flight. */
+  /**
+   * The node being dragged, or null when no MOVE-drag is in flight.
+   *
+   * Null for the whole of an insert-drag as well as between drags: the block
+   * has no node until the release makes one, and minting an id early to fill
+   * this would hand the canvas an id addressing nothing in the document.
+   */
   readonly draggingId: string | null;
+  /**
+   * The block type in flight, whichever kind of drag it is, or null when none
+   * is.
+   *
+   * This is the field to ask "is a drag happening", because it is the only one
+   * that does not assume the subject has a node. Anything gated on the id
+   * instead is blind to a drag from the palette.
+   */
+  readonly draggingBlockName: string | null;
   /** Where a drop would land, or null when nowhere would accept it. */
   readonly target: DropTarget | null;
   /**
@@ -122,6 +163,22 @@ export interface CanvasDragHandlers {
 
 export interface CanvasDrag extends CanvasDragState {
   readonly handlers: CanvasDragHandlers;
+  /**
+   * Begin a drag whose subject is not in the document yet.
+   *
+   * Called from a PALETTE row's own `onPointerDown`, which is why it cannot be
+   * {@link CanvasDragHandlers.onPointerDown}: that one takes the canvas root
+   * from `event.currentTarget`, and for a press on a palette row the current
+   * target is the row.
+   *
+   * Does nothing when no canvas root was supplied, which leaves the press
+   * exactly as it was — the row's click still inserts, and that click is the
+   * non-drag route WCAG 2.2 SC 2.5.7 requires. This only ever supplements it.
+   */
+  readonly beginInsertDrag: (
+    event: React.PointerEvent<HTMLElement>,
+    entry: { blockName: string; makeNode: () => BlockNode | null }
+  ) => void;
 }
 
 export interface UseCanvasDragOptions {
@@ -131,13 +188,22 @@ export interface UseCanvasDragOptions {
   slots: SlotSource;
   /** The nesting rule, asked before any position is offered. */
   nesting: NestingSource;
+  /**
+   * The canvas root, for a drag that begins outside it.
+   *
+   * Optional, and its absence means only that {@link CanvasDrag.beginInsertDrag}
+   * does nothing: a host that never drags from a palette has no use for the
+   * ref, and requiring it would make every existing caller supply a value to
+   * satisfy a feature it does not mount.
+   */
+  canvasRoot?: React.RefObject<HTMLElement | null>;
   activationPx?: number;
   switchPx?: number;
 }
 
 /** What a drag needs to remember, none of which renders. */
 interface Gesture {
-  readonly nodeId: string;
+  readonly subject: DragSubject;
   readonly origin: Point;
   /**
    * Where the press landed in CLIENT pixels.
@@ -186,6 +252,25 @@ interface Gesture {
 }
 
 /**
+ * The identity half of {@link CanvasDragState}, for whichever subject is in
+ * flight.
+ *
+ * Derived in one place rather than spelled out at each `setState`, so the two
+ * fields cannot drift into disagreeing about whether a drag is happening: an
+ * insert has no `draggingId`, and a site that set the id alone would report no
+ * drag at all to everything gated on the block name.
+ */
+function drawnSubject(drag: Gesture): {
+  draggingId: string | null;
+  draggingBlockName: string;
+} {
+  return {
+    draggingId: drag.subject.kind === "move" ? drag.subject.nodeId : null,
+    draggingBlockName: drag.blockName,
+  };
+}
+
+/**
  * Every rendered node's rectangle, read once.
  *
  * Compared in JavaScript rather than matched with a selector built from an id:
@@ -227,12 +312,14 @@ export function useCanvasDrag({
   editor,
   slots,
   nesting,
+  canvasRoot,
   activationPx = DEFAULT_ACTIVATION_PX,
   switchPx = DEFAULT_SWITCH_PX,
 }: UseCanvasDragOptions): CanvasDrag {
   const gesture = React.useRef<Gesture | null>(null);
   const [state, setState] = React.useState<CanvasDragState>({
     draggingId: null,
+    draggingBlockName: null,
     target: null,
     refusal: null,
   });
@@ -241,6 +328,19 @@ export function useCanvasDrag({
   // never patches a document that a later edit has already replaced.
   const latest = React.useRef({ editor, slots, nesting });
   latest.current = { editor, slots, nesting };
+
+  /**
+   * Undo the document-level listening an insert-drag needs, or nothing.
+   *
+   * Held as a closure rather than as three named handlers, because the
+   * functions to remove are the exact ones that were added — re-deriving them
+   * would remove nothing and leave the gesture listening for ever.
+   */
+  const detachDocument = React.useRef<(() => void) | null>(null);
+  const stopTrackingDocument = React.useCallback(() => {
+    detachDocument.current?.();
+    detachDocument.current = null;
+  }, []);
 
   const reset = React.useCallback(() => {
     // Cancelling here rather than in each ending: `reset` is what pointer-up,
@@ -251,8 +351,16 @@ export function useCanvasDrag({
       cancelAnimationFrame(running);
     }
     gesture.current = null;
-    setState({ draggingId: null, target: null, refusal: null });
-  }, []);
+    // For the same reason, and by the same route: a palette drag listens on the
+    // document, and every way one can end arrives here.
+    stopTrackingDocument();
+    setState({
+      draggingId: null,
+      draggingBlockName: null,
+      target: null,
+      refusal: null,
+    });
+  }, [stopTrackingDocument]);
 
   const onPointerDown = React.useCallback(
     (event: React.PointerEvent<HTMLElement>) => {
@@ -281,7 +389,7 @@ export function useCanvasDrag({
 
       const rects = snapshotRects(root);
       gesture.current = {
-        nodeId,
+        subject: { kind: "move", nodeId },
         origin: canvasContentPoint(event.clientX, event.clientY, root),
         originClient: { x: event.clientX, y: event.clientY },
         regions: collectRegions(current.document, latest.current.slots, rects),
@@ -344,7 +452,7 @@ export function useCanvasDrag({
         // drop it back onto the page, which is the opposite of what leaving
         // means. There are no rivals here, so there is nothing to smooth.
         drag.switchState = NO_TARGET;
-        setState({ draggingId: drag.nodeId, target: null, refusal: null });
+        setState({ ...drawnSubject(drag), target: null, refusal: null });
         return;
       }
 
@@ -384,7 +492,7 @@ export function useCanvasDrag({
 
       const committed = drag.switchState.committed;
       setState({
-        draggingId: drag.nodeId,
+        ...drawnSubject(drag),
         target:
           committed === null ? null : (drag.targets.get(committed) ?? null),
         // The refusal is NOT held to the threshold. It says why the region under
@@ -443,8 +551,24 @@ export function useCanvasDrag({
     drag.frame = requestAnimationFrame(pump);
   }, [aim]);
 
-  const onPointerMove = React.useCallback(
-    (event: React.PointerEvent<HTMLElement>) => {
+  /**
+   * Advance the gesture to a pointer position, activating it first if the
+   * pointer has now travelled far enough to mean a drag.
+   *
+   * Takes the position, the pointer and the capturing element as arguments
+   * rather than an event, because one gesture is fed from two transports:
+   * React's handlers on the canvas root for a drag that began on a block, and
+   * document-level listeners for one that began on a palette row, whose events
+   * never reach the canvas at all. Both arrive here, and nothing below can tell
+   * which did — which is the whole of what "one engine" buys.
+   */
+  const trackMove = React.useCallback(
+    (
+      clientX: number,
+      clientY: number,
+      pointerId: number,
+      captureHost: HTMLElement | null
+    ) => {
       const drag = gesture.current;
       if (drag === null) return;
 
@@ -467,23 +591,19 @@ export function useCanvasDrag({
        * that scrolls, resizes or writes a style invalidates the pair and has to
        * measure again.
        */
-      const pointer = canvasPointerPoints(
-        event.clientX,
-        event.clientY,
-        drag.root
-      );
+      const pointer = canvasPointerPoints(clientX, clientY, drag.root);
       // Recorded for the frame loop, which runs between moves and has no event
       // of its own to read a position from.
-      drag.clientX = event.clientX;
-      drag.clientY = event.clientY;
+      drag.clientX = clientX;
+      drag.clientY = clientY;
 
       if (!drag.active) {
         // CLIENT pixels: the threshold separates a click from an intent to
         // move, which is a property of the hand rather than of the canvas's
         // scale. Measured in content pixels it shrinks with the canvas.
         const travelled = Math.hypot(
-          event.clientX - drag.originClient.x,
-          event.clientY - drag.originClient.y
+          clientX - drag.originClient.x,
+          clientY - drag.originClient.y
         );
         if (travelled < activationPx) return;
         drag.active = true;
@@ -505,13 +625,24 @@ export function useCanvasDrag({
          * far enough there is no way to tell which one this is — so the capture
          * waits for the answer.
          */
-        event.currentTarget.setPointerCapture(event.pointerId);
+        //
+        // Only when there IS a host to capture on. A drag from the palette is
+        // followed on the document instead, and must NOT capture: the browser
+        // derives a click's target from the capturing element, so capturing on
+        // a palette row would report a click on that row wherever the author
+        // released — and the row inserts on click.
+        captureHost?.setPointerCapture(pointerId);
         // Started once, at activation. A press that stays a click never scrolls.
         drag.frame = requestAnimationFrame(pump);
         // Selecting on activation rather than on press: a press that turns out
         // to be a click is handled by the canvas's own click handler, and
         // selecting here as well would run the same decision twice.
-        latest.current.editor.select(drag.nodeId);
+        //
+        // Only a move has something to select. An insert's node does not exist
+        // until the release commits it, and it is selected there instead.
+        if (drag.subject.kind === "move") {
+          latest.current.editor.select(drag.subject.nodeId);
+        }
       }
 
       aim(drag, pointer);
@@ -519,12 +650,94 @@ export function useCanvasDrag({
     [activationPx, aim, pump]
   );
 
-  const onPointerUp = React.useCallback(
+  const onPointerMove = React.useCallback(
     (event: React.PointerEvent<HTMLElement>) => {
+      trackMove(
+        event.clientX,
+        event.clientY,
+        event.pointerId,
+        event.currentTarget
+      );
+    },
+    [trackMove]
+  );
+
+  /**
+   * Write the drop, and it is the ONE place the two subjects diverge.
+   *
+   * Everything that decided WHERE — `resolveDrop`, the switch rule, autoscroll,
+   * the indicator — ran without being told which kind this was. That is the
+   * testable content of the claim that the palette and the canvas share an
+   * engine: a second implementation would have to reach this same call, and a
+   * fork announces itself by not doing so.
+   *
+   * Exactly ONE op either way, applied at the release. Materialising a node at
+   * drag-start and moving it instead would leave two entries on the undo stack
+   * and put a block into the document mid-gesture, where every autosave and
+   * unsaved-work signal reads a document reference that changed.
+   */
+  const commitDrop = React.useCallback(
+    (subject: DragSubject, at: OpPosition) => {
+      const { editor: current } = latest.current;
+      if (subject.kind === "move") {
+        current.apply({ kind: "move", id: subject.nodeId, to: at });
+        return;
+      }
+
+      // Built at the release, from the caller's own snapshot of the palette.
+      const node = subject.makeNode();
+      if (node === null) return;
+      // `apply` answers null when the op is refused, and a refusal must not be
+      // followed by a select: the panel offers only placements the rule
+      // permits, so a null here means the document moved under the gesture.
+      if (current.apply({ kind: "insert", node, at }) === null) return;
+      // Selecting what was just added is what makes a SECOND insert land after
+      // it rather than stacking at one point — the same rule the panel's click
+      // path states. It holds because `apply` publishes the document the next
+      // `select` resolves against before it returns.
+      current.select(node.id);
+    },
+    []
+  );
+
+  /**
+   * Swallow the click the browser synthesises after an activated palette drag.
+   *
+   * A palette row inserts on click and must go on doing so — that click is the
+   * non-drag route. But a drag that begins and ends on the same row is still a
+   * press and a release on one element, so a click is reported, and the row
+   * would insert a SECOND block at the panel's own position beside the one the
+   * drop just committed.
+   *
+   * Registered for one event in the capture phase, and removed whether or not
+   * it fires: a drag released over the canvas produces no click on the row at
+   * all, and a listener left waiting would eat the author's next unrelated
+   * click. The release and its click belong to one task, so anything still
+   * listening a task later was never going to fire.
+   */
+  const swallowNextClick = React.useCallback(() => {
+    const swallow = (event: MouseEvent): void => {
+      event.preventDefault();
+      event.stopPropagation();
+      document.removeEventListener("click", swallow, true);
+    };
+    document.addEventListener("click", swallow, true);
+    setTimeout(() => {
+      document.removeEventListener("click", swallow, true);
+    }, 0);
+  }, []);
+
+  /**
+   * End the gesture, committing an edit only if it reached a target.
+   *
+   * Fed from both transports for the same reason {@link trackMove} is.
+   */
+  const endGesture = React.useCallback(
+    (pointerId: number, captureHost: HTMLElement | null) => {
       const drag = gesture.current;
       if (drag === null) return;
-      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-        event.currentTarget.releasePointerCapture(event.pointerId);
+      if (captureHost !== null && captureHost.hasPointerCapture(pointerId)) {
+        captureHost.releasePointerCapture(pointerId);
       }
 
       const committed = drag.switchState.committed;
@@ -539,16 +752,101 @@ export function useCanvasDrag({
       // a pointer that has since moved off it would drop the block somewhere the
       // author was not pointing when they let go.
       if (drag.active && target !== undefined) {
-        latest.current.editor.apply({
-          kind: "move",
-          id: drag.nodeId,
-          to: target.at,
-        });
+        commitDrop(drag.subject, target.at);
       }
+      // Only after a drag that ACTIVATED. A press that stayed a click must keep
+      // its click — that is the row's ordinary insert, and eating it would take
+      // away the non-drag path rather than the duplicate.
+      if (drag.active && drag.subject.kind === "insert") swallowNextClick();
       reset();
     },
-    [reset]
+    [commitDrop, reset, swallowNextClick]
   );
+
+  const onPointerUp = React.useCallback(
+    (event: React.PointerEvent<HTMLElement>) => {
+      endGesture(event.pointerId, event.currentTarget);
+    },
+    [endGesture]
+  );
+
+  const beginInsertDrag = React.useCallback(
+    (
+      event: React.PointerEvent<HTMLElement>,
+      entry: { blockName: string; makeNode: () => BlockNode | null }
+    ) => {
+      // The primary button only, for the reason `onPointerDown` gives.
+      if (event.button !== 0) return;
+      const root = canvasRoot?.current ?? null;
+      // Nothing to drop onto. The press is left entirely alone rather than
+      // half-started, so the row's click still inserts by the ordinary path.
+      if (root === null) return;
+
+      const { editor: current, slots } = latest.current;
+      const rects = snapshotRects(root);
+      gesture.current = {
+        subject: {
+          kind: "insert",
+          blockName: entry.blockName,
+          makeNode: entry.makeNode,
+        },
+        origin: canvasContentPoint(event.clientX, event.clientY, root),
+        originClient: { x: event.clientX, y: event.clientY },
+        regions: collectRegions(current.document, slots, rects),
+        rects,
+        // EMPTY, and this is the other place the kinds differ. Forbidden
+        // parents exist to stop a node being dropped inside itself; nothing is
+        // being detached here, so there is no subtree to exclude.
+        forbiddenParents: new Set<string>(),
+        blockName: entry.blockName,
+        active: false,
+        switchState: NO_TARGET,
+        targets: new Map(),
+        root,
+        scroller: scrollableAncestor(root),
+        clientX: event.clientX,
+        clientY: event.clientY,
+        frame: null,
+      };
+
+      /*
+       * Followed on the DOCUMENT for the whole gesture, not merely once it
+       * activates.
+       *
+       * The press landed on a palette row, and that row is not an ancestor of
+       * the canvas — so the canvas root's handlers never see this pointer, and
+       * the row itself stops seeing it the moment the pointer leaves. Capture
+       * would fix the second half and cost something worse, for the reason
+       * given at the capture in `trackMove`.
+       *
+       * The same conclusion the Escape listener below already reached, whose
+       * docblock names a drag begun from the inserter as its reason for
+       * listening here rather than on the canvas.
+       */
+      const move = (native: PointerEvent): void => {
+        trackMove(native.clientX, native.clientY, native.pointerId, null);
+      };
+      const up = (native: PointerEvent): void => {
+        endGesture(native.pointerId, null);
+      };
+      const cancel = (): void => reset();
+      document.addEventListener("pointermove", move, true);
+      document.addEventListener("pointerup", up, true);
+      document.addEventListener("pointercancel", cancel, true);
+      detachDocument.current = () => {
+        document.removeEventListener("pointermove", move, true);
+        document.removeEventListener("pointerup", up, true);
+        document.removeEventListener("pointercancel", cancel, true);
+      };
+    },
+    [canvasRoot, endGesture, reset, trackMove]
+  );
+
+  // Every ordinary ending funnels through `reset`, which detaches those
+  // listeners. This covers the one ending that does not: a host unmounting
+  // mid-drag, which would otherwise leave three document listeners holding a
+  // gesture nothing can end.
+  React.useEffect(() => stopTrackingDocument, [stopTrackingDocument]);
 
   /*
    * Escape abandons the drag, listened for on the DOCUMENT rather than on the
@@ -565,7 +863,11 @@ export function useCanvasDrag({
    * trying to avoid. Both are the reason `stopPropagation` is warranted here and
    * would not be on an always-registered listener.
    */
-  const dragging = state.draggingId !== null;
+  // Gated on the block name rather than the id: an insert-drag has no node, so
+  // a gate on `draggingId` would leave the palette's own drag — the very
+  // gesture the docblock above names as its reason for existing — with no way
+  // to be cancelled.
+  const dragging = state.draggingBlockName !== null;
   React.useEffect(() => {
     if (!dragging) return;
     const abandon = (event: KeyboardEvent): void => {
@@ -582,6 +884,7 @@ export function useCanvasDrag({
 
   return {
     ...state,
+    beginInsertDrag,
     handlers: {
       onPointerDown,
       onPointerMove,

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -342,25 +342,40 @@ export function useCanvasDrag({
     detachDocument.current = null;
   }, []);
 
-  const reset = React.useCallback(() => {
-    // Cancelling here rather than in each ending: `reset` is what pointer-up,
-    // Escape and unmount all funnel through, so a frame cannot outlive the
-    // gesture it scrolls for by any route.
+  /**
+   * End the gesture and release everything it holds, WITHOUT drawing.
+   *
+   * Split from {@link reset} for the one ending that cannot draw: a host
+   * unmounting mid-drag, where a `setState` would be an update to a component
+   * that no longer exists. Every other ending wants the redraw and goes through
+   * `reset`, which is this plus that.
+   *
+   * Cancelling the frame here rather than in each ending is what stops a scroll
+   * loop outliving the gesture it scrolls for: `pump` reschedules itself every
+   * frame and only stops when it finds no active gesture, so leaving
+   * `gesture.current` populated on unmount keeps it running — holding the
+   * editor and the DOM, and still scrolling a canvas whose editor has closed.
+   */
+  const teardown = React.useCallback(() => {
     const running = gesture.current?.frame;
     if (running !== null && running !== undefined) {
       cancelAnimationFrame(running);
     }
     gesture.current = null;
-    // For the same reason, and by the same route: a palette drag listens on the
-    // document, and every way one can end arrives here.
+    // A palette drag listens on the document, and every way one can end arrives
+    // here.
     stopTrackingDocument();
+  }, [stopTrackingDocument]);
+
+  const reset = React.useCallback(() => {
+    teardown();
     setState({
       draggingId: null,
       draggingBlockName: null,
       target: null,
       refusal: null,
     });
-  }, [stopTrackingDocument]);
+  }, [teardown]);
 
   const onPointerDown = React.useCallback(
     (event: React.PointerEvent<HTMLElement>) => {
@@ -687,6 +702,15 @@ export function useCanvasDrag({
       // Built at the release, from the caller's own snapshot of the palette.
       const node = subject.makeNode();
       if (node === null) return;
+      // The position and the nesting verdict were both computed for the type
+      // the gesture ADVERTISED. A node of some other type was never asked
+      // about, so inserting it here would place a block into a parent or slot
+      // that may forbid it — and the op layer checks structural shape, not the
+      // nesting rule, so nothing downstream would catch it.
+      //
+      // Declined rather than re-resolved: the target was chosen for a different
+      // block, so there is no position here that was ever offered for this one.
+      if (node.type !== subject.blockName) return;
       // `apply` answers null when the op is refused, and a refusal must not be
       // followed by a select: the panel offers only placements the rule
       // permits, so a null here means the document moved under the gesture.
@@ -823,13 +847,28 @@ export function useCanvasDrag({
        * docblock names a drag begun from the inserter as its reason for
        * listening here rather than on the canvas.
        */
+      /*
+       * Only the pointer that began this gesture drives it.
+       *
+       * The node-origin path gets this from pointer capture, which retargets
+       * one pointer and ignores the rest. A palette drag deliberately takes no
+       * capture, so its document listeners see EVERY active pointer: on a
+       * touch device, lifting a second finger would otherwise commit the first
+       * finger's target, and a second finger's movement would aim the drag.
+       */
+      const owner = event.pointerId;
       const move = (native: PointerEvent): void => {
+        if (native.pointerId !== owner) return;
         trackMove(native.clientX, native.clientY, native.pointerId, null);
       };
       const up = (native: PointerEvent): void => {
+        if (native.pointerId !== owner) return;
         endGesture(native.pointerId, null);
       };
-      const cancel = (): void => reset();
+      const cancel = (native: PointerEvent): void => {
+        if (native.pointerId !== owner) return;
+        reset();
+      };
       // Before registering, never after: overwriting the detach closure below
       // while an earlier palette gesture is still live would strand its three
       // listeners with nothing able to remove them, and they would go on
@@ -851,11 +890,12 @@ export function useCanvasDrag({
     [canvasRoot, endGesture, reset, stopTrackingDocument, trackMove]
   );
 
-  // Every ordinary ending funnels through `reset`, which detaches those
-  // listeners. This covers the one ending that does not: a host unmounting
-  // mid-drag, which would otherwise leave three document listeners holding a
-  // gesture nothing can end.
-  React.useEffect(() => stopTrackingDocument, [stopTrackingDocument]);
+  // Every ordinary ending funnels through `reset`. This covers the one that
+  // does not: a host unmounting mid-drag, which would otherwise leave a running
+  // frame loop and three document listeners holding a gesture nothing can end.
+  // `teardown` rather than `reset`, because a state update here would be one on
+  // a component that has gone.
+  React.useEffect(() => teardown, [teardown]);
 
   /*
    * Escape abandons the drag, listened for on the DOCUMENT rather than on the
@@ -883,13 +923,22 @@ export function useCanvasDrag({
       if (event.key !== "Escape") return;
       event.preventDefault();
       event.stopPropagation();
+      // An abandoned palette drag still ends in a release, and if the pointer
+      // has come back to the row it started on, that press and release are one
+      // click — which the row inserts on. Escape would visibly cancel the drag
+      // and add a block anyway, so this ending needs the same suppression the
+      // committed one gets.
+      const drag = gesture.current;
+      if (drag?.active === true && drag.subject.kind === "insert") {
+        swallowNextClick();
+      }
       reset();
     };
     document.addEventListener("keydown", abandon, true);
     return () => {
       document.removeEventListener("keydown", abandon, true);
     };
-  }, [dragging, reset]);
+  }, [dragging, reset, swallowNextClick]);
 
   return {
     ...state,

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -912,6 +912,18 @@ export interface CanvasProps {
   /** The document being edited. */
   document: BlockDocument;
   /**
+   * Receives the canvas root element, for a caller that needs to measure
+   * against it.
+   *
+   * A drag that begins OUTSIDE the canvas — from a palette row — has no event
+   * whose `currentTarget` is this element, and it must resolve a drop position
+   * against the same box every other reader uses. This canvas owns that
+   * element, so handing it over is more honest than a caller finding it by
+   * class name: a query would be a second place that decides which element the
+   * canvas root is.
+   */
+  rootRef?: React.RefObject<HTMLDivElement | null>;
+  /**
    * The site sheet, the same value the published route passes. Required — see
    * the module docblock for why this one is not optional.
    */
@@ -1008,6 +1020,7 @@ export interface CanvasProps {
  */
 export function Canvas({
   document,
+  rootRef,
   siteStyles,
   selectedId = null,
   selectedIds,
@@ -1020,6 +1033,17 @@ export function Canvas({
   preview,
 }: CanvasProps) {
   const root = useRef<HTMLDivElement | null>(null);
+
+  // Published after paint rather than through a merged ref callback: the
+  // element is the same for the life of the mount, and one assignment here is
+  // easier to follow than a callback that has to keep two refs agreeing.
+  useEffect(() => {
+    if (rootRef === undefined) return;
+    rootRef.current = root.current;
+    return () => {
+      rootRef.current = null;
+    };
+  }, [rootRef]);
 
   /*
    * What to mark. The primary alone when a host has not adopted the set yet,

--- a/packages/builder/src/insert-drag.test.tsx
+++ b/packages/builder/src/insert-drag.test.tsx
@@ -39,17 +39,32 @@ import { DEFAULT_SWITCH_PX, DropIndicator, useCanvasDrag } from "./canvas-drag";
 import { useEditorState, type EditorState } from "./editor-state";
 import { registrySlotSource } from "./inserter";
 
-afterEach(() => {
+afterEach(async () => {
+  // Let a pending click-suppression teardown run before the next case starts.
+  // The suppressor is installed for ONE task, on purpose, but vitest runs these
+  // cases synchronously back to back — so without this, a suppressor armed by
+  // one release eats the NEXT case's click and an assertion of `clicks === 0`
+  // passes for the wrong reason. That is not hypothetical: it hid a broken fix
+  // from its own break-verification.
+  await new Promise(resolve => {
+    setTimeout(resolve, 0);
+  });
   cleanup();
   clearBlocks();
   captured = [];
   built = 0;
+  clicks = 0;
+  buildsType = "test/heading";
 });
 
 /** Pointer ids anything took capture of, so a palette drag can assert none. */
 let captured: number[] = [];
 /** How many times the palette was asked to build its node. */
 let built = 0;
+/** How many times the row's own click-to-insert handler ran. */
+let clicks = 0;
+/** What the palette's thunk answers with, so a test can make it disagree. */
+let buildsType = "test/heading";
 
 beforeAll(() => {
   const element = window.Element.prototype as unknown as Record<
@@ -133,12 +148,18 @@ function Host({ document: doc }: { document: BlockDocument }) {
       <button
         type="button"
         data-testid="palette-row"
+        // The row inserts on click, as the real palette row does. That path is
+        // the non-drag alternative and must keep working — and it is what a
+        // drag ending on this row would trigger a second time.
+        onClick={() => {
+          clicks += 1;
+        }}
         onPointerDown={event =>
           drag.beginInsertDrag(event, {
             blockName: "test/heading",
             makeNode: () => {
               built += 1;
-              return node(INSERTED, "test/heading");
+              return node(INSERTED, buildsType);
             },
           })
         }
@@ -212,12 +233,12 @@ function pressRow(row: HTMLElement, x: number, y: number): void {
  * never registered a document listener at all, and the gesture would be
  * untestable in the one arrangement it actually runs in.
  */
-function moveTo(x: number, y: number): void {
-  fireEvent.pointerMove(document, { pointerId: 7, clientX: x, clientY: y });
+function moveTo(x: number, y: number, pointerId = 7): void {
+  fireEvent.pointerMove(document, { pointerId, clientX: x, clientY: y });
 }
 
-function release(x: number, y: number): void {
-  fireEvent.pointerUp(document, { pointerId: 7, clientX: x, clientY: y });
+function release(x: number, y: number, pointerId = 7): void {
+  fireEvent.pointerUp(document, { pointerId, clientX: x, clientY: y });
 }
 
 function ids(): string[] {
@@ -356,6 +377,150 @@ describe("dragging a block from the palette onto the canvas", () => {
     expect(dragState.draggingBlockName).toBe("test/heading");
 
     release(200, 90);
+  });
+
+  it("is driven only by the pointer that began it", () => {
+    // The node-origin path gets this free from pointer capture, which retargets
+    // one pointer. A palette drag takes no capture on purpose, so its document
+    // listeners see every active pointer on a touch device.
+    const { container } = renderTwo();
+    const row = container.ownerDocument.body.querySelector("button")!;
+
+    pressRow(row, 300, 500);
+    moveTo(200, 154);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    // A SECOND finger moves somewhere else and lifts. Neither may touch this
+    // gesture: the moves would re-aim it, and the release would commit the
+    // first finger's target while that finger is still down.
+    //
+    // TWO moves, and the second is not padding. The switch rule anchors travel
+    // at the moment a rival target first appears, so a single event always has
+    // zero travel and can never switch the committed target — a one-move probe
+    // passes whether or not the pointer is checked, which is what an earlier
+    // version of this case did. A finger that is actually dragging produces a
+    // stream, and this is the shortest stream that could do damage.
+    moveTo(200, 20, 9);
+    moveTo(200, 40, 9);
+    release(200, 40, 9);
+
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    // The owning pointer still ends it, at the target IT settled on — which is
+    // also the control showing the second finger did not silently re-aim.
+    release(200, 154);
+    expect(ids()).toEqual(["a", "b", INSERTED]);
+    expect(editorRef?.undoDepth).toBe(1);
+  });
+
+  it("declines a node whose type is not the one the drop was resolved for", () => {
+    // The position and the nesting verdict were computed for the ADVERTISED
+    // type. A node of some other type was never asked about, and the op layer
+    // checks structural shape rather than the nesting rule — so nothing
+    // downstream would notice it landing somewhere its type forbids.
+    const { container } = renderTwo();
+    const row = container.ownerDocument.body.querySelector("button")!;
+    buildsType = "test/some-other-block";
+
+    pressRow(row, 300, 500);
+    moveTo(200, 90);
+    release(200, 90);
+
+    // The thunk WAS called, so the gesture reached the commit and the refusal
+    // is the type check rather than the drag failing earlier for some reason.
+    expect(built).toBe(1);
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+  });
+
+  it("swallows the click a drag ending on its own row would otherwise fire", () => {
+    // The row inserts on click. A drag that begins and ends on it is still one
+    // press and one release on a single element, so the browser reports a
+    // click — and the row would add a second block beside the dropped one.
+    const { container } = renderTwo();
+    const row = container.ownerDocument.body.querySelector("button")!;
+
+    pressRow(row, 300, 500);
+    moveTo(200, 90);
+    release(200, 90);
+    expect(ids()).toEqual(["a", INSERTED, "b"]);
+
+    // The synthesized click, which is the event the suppression exists for.
+    fireEvent.click(row);
+    expect(clicks).toBe(0);
+  });
+
+  it("swallows that click after Escape cancels the drag, too", () => {
+    // Escape ends the drag by a different route, and an abandoned drag still
+    // ends in a release. With the pointer back on the row it started from,
+    // that press and release are a click — so Escape would visibly cancel the
+    // drag and add a block anyway.
+    const { container } = renderTwo();
+    const row = container.ownerDocument.body.querySelector("button")!;
+
+    pressRow(row, 300, 500);
+    moveTo(200, 90);
+    fireEvent.keyDown(document, { key: "Escape" });
+    release(300, 500);
+    fireEvent.click(row);
+
+    expect(clicks).toBe(0);
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+  });
+
+  it("leaves a press that stayed a click able to insert", () => {
+    // The control on all of the above, and the one that matters most:
+    // suppression must not reach the non-drag path. Click-to-insert is the
+    // WCAG 2.2 SC 2.5.7 alternative, and a suppressor that ate every click
+    // would remove it while every assertion about drags stayed green.
+    const { container } = renderTwo();
+    const row = container.ownerDocument.body.querySelector("button")!;
+
+    pressRow(row, 300, 500);
+    moveTo(301, 501);
+    release(301, 501);
+    fireEvent.click(row);
+
+    expect(clicks).toBe(1);
+  });
+
+  it("stops its scroll loop when the host unmounts mid-drag", () => {
+    // `pump` reschedules itself every frame and stops only when it finds no
+    // active gesture. Unmounting removes the listeners but leaves the gesture,
+    // so the loop keeps running — holding the editor and the DOM, and still
+    // scrolling a canvas whose editor has closed.
+    const frames: number[] = [];
+    const cancelled: number[] = [];
+    const realRaf = window.requestAnimationFrame;
+    const realCancel = window.cancelAnimationFrame;
+    let next = 1;
+    window.requestAnimationFrame = ((): number => {
+      const id = next++;
+      frames.push(id);
+      return id;
+    }) as typeof window.requestAnimationFrame;
+    window.cancelAnimationFrame = ((id: number): void => {
+      cancelled.push(id);
+    }) as typeof window.cancelAnimationFrame;
+
+    try {
+      const { container, unmount } = renderTwo();
+      const row = container.ownerDocument.body.querySelector("button")!;
+      pressRow(row, 300, 500);
+      moveTo(200, 90);
+      // The instrument's control: activation must actually have scheduled a
+      // frame, or "the frame was cancelled" is a statement about nothing.
+      expect(frames.length).toBeGreaterThan(0);
+
+      unmount();
+      expect(cancelled).toContain(frames[frames.length - 1]);
+    } finally {
+      window.requestAnimationFrame = realRaf;
+      window.cancelAnimationFrame = realCancel;
+    }
   });
 
   it("detaches a previous palette gesture before starting another", () => {

--- a/packages/builder/src/insert-drag.test.tsx
+++ b/packages/builder/src/insert-drag.test.tsx
@@ -53,6 +53,7 @@ afterEach(async () => {
   clearBlocks();
   captured = [];
   built = 0;
+  inserted = [];
   clicks = 0;
   buildsType = "test/heading";
 });
@@ -61,6 +62,8 @@ afterEach(async () => {
 let captured: number[] = [];
 /** How many times the palette was asked to build its node. */
 let built = 0;
+/** Node ids the host was notified about, in order. */
+let inserted: string[] = [];
 /** How many times the row's own click-to-insert handler ran. */
 let clicks = 0;
 /** What the palette's thunk answers with, so a test can make it disagree. */
@@ -161,6 +164,9 @@ function Host({ document: doc }: { document: BlockDocument }) {
               built += 1;
               return node(INSERTED, buildsType);
             },
+            onInserted: n => {
+              inserted.push(n.id);
+            },
           })
         }
       >
@@ -214,6 +220,13 @@ function renderTwo() {
   layout(result.container, { a: 100, b: 100 });
   const row = result.getByTestId("palette-row");
   return { ...result, row };
+}
+
+/** The canvas root, which carries the drag's OWN React handlers. */
+function canvasRootOf(container: HTMLElement): HTMLElement {
+  const root = container.querySelector<HTMLElement>(`.${CANVAS_ROOT_CLASS}`);
+  if (root === null) throw new Error("no canvas root rendered");
+  return root;
 }
 
 function pressRow(row: HTMLElement, x: number, y: number): void {
@@ -413,6 +426,82 @@ describe("dragging a block from the palette onto the canvas", () => {
     release(200, 154);
     expect(ids()).toEqual(["a", "b", INSERTED]);
     expect(editorRef?.undoDepth).toBe(1);
+  });
+
+  it("ignores another pointer arriving through the CANVAS, not the document", () => {
+    // The other transport, and the one a second finger actually uses when it
+    // is over the canvas: those events reach the drag through `Canvas`'s React
+    // handlers, never the document listeners. A guard living only in the
+    // document closures leaves this route open, and a test that dispatches the
+    // rogue pointer at `document` cannot tell the two apart.
+    const { container, row } = renderTwo();
+    pressRow(row, 300, 500);
+    moveTo(200, 154);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    const canvas = canvasRootOf(container);
+    // Two moves, because the switch rule anchors travel when a rival target
+    // first appears — one event always has zero travel and could never move
+    // the committed target, whatever the guard did.
+    fireEvent.pointerMove(canvas, { pointerId: 9, clientX: 200, clientY: 20 });
+    fireEvent.pointerMove(canvas, { pointerId: 9, clientX: 200, clientY: 40 });
+    fireEvent.pointerUp(canvas, { pointerId: 9, clientX: 200, clientY: 40 });
+
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+
+    // The owning pointer still ends it, at the target IT settled on — the
+    // control showing the second finger did not silently re-aim.
+    release(200, 154);
+    expect(ids()).toEqual(["a", "b", INSERTED]);
+  });
+
+  it("keeps the click suppressed until the pointer is released, however late", async () => {
+    // Escape is pressed with the finger still down, so the release — and the
+    // click the browser builds from that press and release — arrives in a LATER
+    // task. A suppressor armed for one task is gone by then, and the row's own
+    // handler inserts a block from a drag the author visibly cancelled.
+    const { row } = renderTwo();
+    pressRow(row, 300, 500);
+    moveTo(200, 90);
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    // The task boundary is the whole point. Firing keydown, pointerup and click
+    // in one task passes whether or not the suppression survives.
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    release(300, 500);
+    fireEvent.click(row);
+
+    expect(clicks).toBe(0);
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+  });
+
+  it("tells the host what landed, the same way the click path does", () => {
+    const { row } = renderTwo();
+    pressRow(row, 300, 500);
+    moveTo(200, 90);
+    release(200, 90);
+
+    expect(ids()).toEqual(["a", INSERTED, "b"]);
+    expect(inserted).toEqual([INSERTED]);
+  });
+
+  it("tells the host nothing when the drop was refused", () => {
+    // The must-differ half: a notification that fired regardless would report
+    // an insert that never happened, which is worse than not reporting.
+    const { row } = renderTwo();
+    buildsType = "test/some-other-block";
+    pressRow(row, 300, 500);
+    moveTo(200, 90);
+    release(200, 90);
+
+    expect(built).toBe(1);
+    expect(ids()).toEqual(["a", "b"]);
+    expect(inserted).toEqual([]);
   });
 
   it("declines a node whose type is not the one the drop was resolved for", () => {

--- a/packages/builder/src/insert-drag.test.tsx
+++ b/packages/builder/src/insert-drag.test.tsx
@@ -1,0 +1,417 @@
+// @vitest-environment jsdom
+
+/**
+ * Dragging a block from the palette onto the canvas.
+ *
+ * The property under test is not "a block appears". It is that the palette and
+ * the canvas share ONE drag engine, and the observable that separates a shared
+ * engine from a second, parallel one is the SHAPE of the edit rather than its
+ * result: exactly one op, written at the release, never before it. A fork that
+ * inserted a provisional node at drag-start and moved it would look identical
+ * on screen and leave two entries on the undo stack.
+ *
+ * So `undoDepth` is asserted across the whole gesture rather than at the end,
+ * and the switch rule and Escape are exercised from a palette-origin drag
+ * specifically — each is invisible by default, and a second implementation has
+ * no reason to reproduce any of them.
+ *
+ * **Rectangles are stubbed, as jsdom reports every element as zero-sized.** The
+ * geometry itself is pure and asserted in `drop-targets.test.ts`; what is real
+ * here is the gesture.
+ *
+ * @module insert-drag.test
+ */
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import * as React from "react";
+
+import {
+  clearBlocks,
+  registerBlocks,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
+
+import { Canvas, CANVAS_ROOT_CLASS } from "./canvas";
+import { DEFAULT_SWITCH_PX, DropIndicator, useCanvasDrag } from "./canvas-drag";
+import { useEditorState, type EditorState } from "./editor-state";
+import { registrySlotSource } from "./inserter";
+
+afterEach(() => {
+  cleanup();
+  clearBlocks();
+  captured = [];
+  built = 0;
+});
+
+/** Pointer ids anything took capture of, so a palette drag can assert none. */
+let captured: number[] = [];
+/** How many times the palette was asked to build its node. */
+let built = 0;
+
+beforeAll(() => {
+  const element = window.Element.prototype as unknown as Record<
+    string,
+    unknown
+  >;
+  element.setPointerCapture = function setPointerCapture(id: number): void {
+    captured.push(id);
+  };
+  element.releasePointerCapture = function releasePointerCapture(): void {};
+  element.hasPointerCapture = function hasPointerCapture(): boolean {
+    return true;
+  };
+  element.scrollIntoView = function scrollIntoView(): void {};
+});
+
+const BLOCKS = [
+  {
+    name: "test/heading",
+    version: 1,
+    description: "A heading.",
+    example: { props: {} },
+    editor: { label: "Heading" },
+    render: () => React.createElement("h2", null, "heading"),
+  },
+];
+
+function node(id: string, type: string): BlockNode {
+  return { id, type, version: 1, props: {} } as BlockNode;
+}
+
+function documentOf(nodes: BlockNode[]): BlockDocument {
+  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+}
+
+let editorRef: EditorState | null = null;
+/** What the hook reported on the last render, for the drag-state assertions. */
+let dragState: { draggingId: string | null; draggingBlockName: string | null } =
+  { draggingId: null, draggingBlockName: null };
+
+/** The id the palette's thunk gives whatever it builds. */
+const INSERTED = "brand-new";
+
+/**
+ * A host that mounts the canvas AND a palette row, which is the composition
+ * this feature only exists inside.
+ *
+ * The row is an ordinary button rather than the real `InsertPanel`: what is
+ * under test is the engine's entry point, and mounting the panel would drag in
+ * cmdk's filtering and the registry catalog to reach the same `beginInsertDrag`
+ * call by a longer route.
+ */
+function Host({ document: doc }: { document: BlockDocument }) {
+  const editor = useEditorState({ initialDocument: doc });
+  editorRef = editor;
+  const shell = React.useRef<HTMLDivElement | null>(null);
+  const canvasRoot = React.useRef<HTMLElement | null>(null);
+
+  // Resolved after paint, because the root is rendered by `Canvas` rather than
+  // by this component: there is no ref to forward without changing that
+  // component's public shape to serve a test.
+  React.useEffect(() => {
+    canvasRoot.current =
+      shell.current?.querySelector<HTMLElement>(`.${CANVAS_ROOT_CLASS}`) ??
+      null;
+  });
+
+  const drag = useCanvasDrag({
+    editor,
+    slots: registrySlotSource(),
+    nesting: { parentsOf: () => undefined, slotAllowOf: () => undefined },
+    canvasRoot,
+  });
+  dragState = {
+    draggingId: drag.draggingId,
+    draggingBlockName: drag.draggingBlockName,
+  };
+
+  return (
+    <div ref={shell}>
+      <button
+        type="button"
+        data-testid="palette-row"
+        onPointerDown={event =>
+          drag.beginInsertDrag(event, {
+            blockName: "test/heading",
+            makeNode: () => {
+              built += 1;
+              return node(INSERTED, "test/heading");
+            },
+          })
+        }
+      >
+        Heading
+      </button>
+      <Canvas
+        document={editor.document}
+        siteStyles={{ css: "" } as never}
+        selectedId={editor.selectedId}
+        onSelect={editor.select}
+        dragHandlers={drag.handlers}
+        overlay={<DropIndicator target={drag.target} />}
+      />
+    </div>
+  );
+}
+
+function layout(container: HTMLElement, heights: Record<string, number>): void {
+  const root = container.querySelector<HTMLElement>(`.${CANVAS_ROOT_CLASS}`);
+  if (root === null) throw new Error("no canvas root rendered");
+  root.getBoundingClientRect = () =>
+    ({ x: 0, y: 0, width: 400, height: 1000, top: 0, left: 0 }) as DOMRect;
+
+  let top = 0;
+  root
+    .querySelectorAll<HTMLElement>(`[${NODE_ID_ATTRIBUTE}]`)
+    .forEach(element => {
+      const id = element.getAttribute(NODE_ID_ATTRIBUTE) ?? "";
+      const height = heights[id] ?? 100;
+      const box = { x: 0, y: top, width: 400, height, top, left: 0 } as DOMRect;
+      element.getBoundingClientRect = () => box;
+      top += height;
+    });
+}
+
+/** Two stacked blocks: 0-100 and 100-200. */
+function renderTwo() {
+  registerBlocks(BLOCKS as never, { source: "insert-drag-test" });
+  const result = render(
+    <Host
+      document={documentOf([
+        node("a", "test/heading"),
+        node("b", "test/heading"),
+      ])}
+    />
+  );
+  layout(result.container, { a: 100, b: 100 });
+  const row = result.getByTestId("palette-row");
+  return { ...result, row };
+}
+
+function pressRow(row: HTMLElement, x: number, y: number): void {
+  fireEvent.pointerDown(row, {
+    button: 0,
+    pointerId: 7,
+    clientX: x,
+    clientY: y,
+  });
+}
+
+/**
+ * Moves and releases go to the DOCUMENT, which is the point.
+ *
+ * A palette drag is followed there because the row is not an ancestor of the
+ * canvas. Firing these at the canvas root would pass against an engine that
+ * never registered a document listener at all, and the gesture would be
+ * untestable in the one arrangement it actually runs in.
+ */
+function moveTo(x: number, y: number): void {
+  fireEvent.pointerMove(document, { pointerId: 7, clientX: x, clientY: y });
+}
+
+function release(x: number, y: number): void {
+  fireEvent.pointerUp(document, { pointerId: 7, clientX: x, clientY: y });
+}
+
+function ids(): string[] {
+  return (editorRef?.document.nodes ?? []).map(n => n.id);
+}
+
+describe("dragging a block from the palette onto the canvas", () => {
+  it("commits ONE insert, at the release, where the line was drawn", () => {
+    const { container } = renderTwo();
+    expect(editorRef?.undoDepth).toBe(0);
+
+    pressRow(container.ownerDocument.body.querySelector("button")!, 300, 500);
+    // Past DEFAULT_ACTIVATION_PX, into the lower half of the first block, which
+    // is the position after it.
+    moveTo(200, 90);
+
+    // The gesture is live and has NOT touched the document. This is the
+    // assertion a provisional-insert implementation fails.
+    expect(dragState.draggingBlockName).toBe("test/heading");
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+    expect(built).toBe(0);
+
+    release(200, 90);
+
+    expect(ids()).toEqual(["a", INSERTED, "b"]);
+    // Exactly one, and it is the whole point: two would mean the node was
+    // materialised early and moved into place.
+    expect(editorRef?.undoDepth).toBe(1);
+    expect(built).toBe(1);
+  });
+
+  it("selects what it just inserted, against a real editor", () => {
+    // The regression this file exists to cover. `select` resolves against the
+    // document `apply` has just published, so asserting that select was CALLED
+    // — which is all a mocked editor can see — passes whether or not the
+    // selection ever lands.
+    const { container } = renderTwo();
+    pressRow(container.ownerDocument.body.querySelector("button")!, 300, 500);
+    moveTo(200, 90);
+    release(200, 90);
+
+    expect(editorRef?.selectedId).toBe(INSERTED);
+  });
+
+  it("edits nothing when the press never travels far enough to be a drag", () => {
+    // The click-to-insert path is the WCAG 2.2 SC 2.5.7 alternative and must
+    // survive: a press that stays a click has to reach the row's own handler
+    // rather than being consumed as a zero-length drag.
+    const { container } = renderTwo();
+
+    pressRow(container.ownerDocument.body.querySelector("button")!, 300, 500);
+    moveTo(301, 501);
+    release(301, 501);
+
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+    expect(built).toBe(0);
+  });
+
+  it("never captures the pointer, so the row's own click still resolves", () => {
+    // Capture would retarget the click to the capturing element, and the
+    // palette row inserts on click — so capturing here would make every release
+    // anywhere report a click on the row.
+    const { container } = renderTwo();
+    pressRow(container.ownerDocument.body.querySelector("button")!, 300, 500);
+    moveTo(200, 90);
+
+    expect(captured).toEqual([]);
+
+    release(200, 90);
+  });
+
+  it("holds the committed target until the pointer travels past the switch band", () => {
+    // Hysteresis, exercised from a palette-origin drag. Nothing about "insert
+    // on drop" requires it, so a second engine written for the panel would not
+    // have it — which is what makes this a same-engine assertion rather than a
+    // behavioural nicety.
+    //
+    // Asserted through WHAT THE RELEASE COMMITS rather than through the
+    // indicator's style attribute. The style is a position in pixels, and two
+    // different insertion points can round to one string, so a held target and
+    // a switched one are not reliably distinguishable there — an earlier
+    // version of this case asserted exactly that and survived deleting the
+    // band, proving nothing.
+    const { container } = renderTwo();
+    pressRow(container.ownerDocument.body.querySelector("button")!, 300, 500);
+
+    // Below the second block's midpoint (150), so the committed target is the
+    // position AFTER it.
+    moveTo(200, 154);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    // Back across that midpoint, but by less than the band. The rival position
+    // — before the second block — is what an engine without hysteresis would
+    // commit to here.
+    const nudge = DEFAULT_SWITCH_PX - 2;
+    moveTo(200, 154 - nudge);
+    release(200, 154 - nudge);
+
+    // Held: the block lands where the pointer settled, not where it flicked.
+    expect(ids()).toEqual(["a", "b", INSERTED]);
+  });
+
+  it("Escape abandons the drag without editing the document", () => {
+    // Escape is listened for on the document and gated on a drag being in
+    // flight. An insert-drag has NO node, so a gate written against the
+    // dragged node's id leaves exactly this gesture uncancellable.
+    const { container } = renderTwo();
+    pressRow(container.ownerDocument.body.querySelector("button")!, 300, 500);
+    moveTo(200, 90);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    fireEvent.keyDown(document, { key: "Escape" });
+
+    expect(dragState.draggingBlockName).toBeNull();
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+
+    // And the abandoned gesture is really over: a release afterwards must not
+    // commit the target it had settled on.
+    release(200, 90);
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+  });
+
+  it("reports no dragged NODE id, because an insert has none yet", () => {
+    // The discriminating half of the drag state. A block being dragged from the
+    // palette addresses nothing in the document, and an id invented to fill
+    // this field would be handed to anything drawing the dragged node.
+    const { container } = renderTwo();
+    pressRow(container.ownerDocument.body.querySelector("button")!, 300, 500);
+    moveTo(200, 90);
+
+    expect(dragState.draggingId).toBeNull();
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    release(200, 90);
+  });
+
+  it("starts no drag at all when the host supplied no canvas", () => {
+    // The control on `beginInsertDrag`'s own guard: with no canvas root the
+    // press must be left completely alone, so the row's click keeps working.
+    registerBlocks(BLOCKS as never, { source: "insert-drag-test" });
+    function NoCanvas() {
+      const editor = useEditorState({
+        initialDocument: documentOf([node("a", "test/heading")]),
+      });
+      editorRef = editor;
+      const drag = useCanvasDrag({
+        editor,
+        slots: registrySlotSource(),
+        nesting: { parentsOf: () => undefined, slotAllowOf: () => undefined },
+      });
+      dragState = {
+        draggingId: drag.draggingId,
+        draggingBlockName: drag.draggingBlockName,
+      };
+      return (
+        <button
+          type="button"
+          data-testid="palette-row"
+          onPointerDown={event =>
+            drag.beginInsertDrag(event, {
+              blockName: "test/heading",
+              makeNode: () => {
+                built += 1;
+                return node(INSERTED, "test/heading");
+              },
+            })
+          }
+        >
+          Heading
+        </button>
+      );
+    }
+    const result = render(<NoCanvas />);
+    // The guard's observable content is that the press is INERT rather than
+    // half-started: without it the gesture is built around a null root and the
+    // first rectangle read throws inside the handler. Asserting only that no
+    // drag began cannot see that, because a crash also leaves no drag — so the
+    // failure is caught where an exception inside a listener actually surfaces,
+    // which is the window rather than the call.
+    const errors: string[] = [];
+    const record = (event: ErrorEvent): void => {
+      errors.push(String(event.error ?? event.message));
+    };
+    window.addEventListener("error", record);
+    try {
+      pressRow(result.getByTestId("palette-row"), 300, 500);
+      moveTo(200, 90);
+      release(200, 90);
+    } finally {
+      window.removeEventListener("error", record);
+    }
+
+    expect(errors).toEqual([]);
+    expect(dragState.draggingBlockName).toBeNull();
+    expect(built).toBe(0);
+    expect(editorRef?.undoDepth).toBe(0);
+  });
+});

--- a/packages/builder/src/insert-drag.test.tsx
+++ b/packages/builder/src/insert-drag.test.tsx
@@ -28,6 +28,7 @@ import * as React from "react";
 import {
   clearBlocks,
   registerBlocks,
+  type AnyBlockDefinition,
   type BlockDocument,
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
@@ -65,7 +66,7 @@ beforeAll(() => {
   element.scrollIntoView = function scrollIntoView(): void {};
 });
 
-const BLOCKS = [
+const BLOCKS: AnyBlockDefinition[] = [
   {
     name: "test/heading",
     version: 1,
@@ -77,11 +78,11 @@ const BLOCKS = [
 ];
 
 function node(id: string, type: string): BlockNode {
-  return { id, type, version: 1, props: {} } as BlockNode;
+  return { id, type, version: 1, props: {} };
 }
 
 function documentOf(nodes: BlockNode[]): BlockDocument {
-  return { formatVersion: 1, kind: "page", nodes } as BlockDocument;
+  return { formatVersion: 1, kind: "page", nodes };
 }
 
 let editorRef: EditorState | null = null;
@@ -146,7 +147,11 @@ function Host({ document: doc }: { document: BlockDocument }) {
       </button>
       <Canvas
         document={editor.document}
-        siteStyles={{ css: "" } as never}
+        // `false` is the documented way to say a render wants NO site styles.
+        // An invented object would be a fixture that does not satisfy the
+        // contract it is passed under, which is the shape this file exists to
+        // avoid asserting through.
+        siteStyles={false}
         selectedId={editor.selectedId}
         onSelect={editor.select}
         dragHandlers={drag.handlers}
@@ -176,7 +181,7 @@ function layout(container: HTMLElement, heights: Record<string, number>): void {
 
 /** Two stacked blocks: 0-100 and 100-200. */
 function renderTwo() {
-  registerBlocks(BLOCKS as never, { source: "insert-drag-test" });
+  registerBlocks(BLOCKS, { source: "insert-drag-test" });
   const result = render(
     <Host
       document={documentOf([
@@ -353,10 +358,63 @@ describe("dragging a block from the palette onto the canvas", () => {
     release(200, 90);
   });
 
+  it("detaches a previous palette gesture before starting another", () => {
+    // A palette drag is followed on the document, so its three listeners are
+    // the gesture's only handle on the pointer. Starting a second gesture
+    // overwrites the closure that removes them, and if the first set was not
+    // detached first it survives with nothing able to reach it — calling into
+    // a gesture it no longer owns for the life of the page.
+    //
+    // The ordinary sequence always releases first, so this needs a press with
+    // no release between. Counted rather than observed behaviourally: a leaked
+    // listener does nothing visible once its gesture is gone, which is exactly
+    // why it would go unnoticed.
+    const { container } = renderTwo();
+    const row = container.ownerDocument.body.querySelector("button")!;
+
+    const POINTER = /^pointer(move|up|cancel)$/;
+    const added: string[] = [];
+    const removed: string[] = [];
+    const realAdd = document.addEventListener;
+    const realRemove = document.removeEventListener;
+    document.addEventListener = function countedAdd(
+      type: string,
+      fn: EventListenerOrEventListenerObject,
+      opts?: boolean | AddEventListenerOptions
+    ): void {
+      if (POINTER.test(type)) added.push(type);
+      realAdd.call(document, type, fn, opts);
+    } as typeof document.addEventListener;
+    document.removeEventListener = function countedRemove(
+      type: string,
+      fn: EventListenerOrEventListenerObject,
+      opts?: boolean | EventListenerOptions
+    ): void {
+      if (POINTER.test(type)) removed.push(type);
+      realRemove.call(document, type, fn, opts);
+    } as typeof document.removeEventListener;
+
+    try {
+      pressRow(row, 300, 500);
+      pressRow(row, 300, 500);
+      release(200, 90);
+    } finally {
+      document.addEventListener = realAdd;
+      document.removeEventListener = realRemove;
+    }
+
+    // Two gestures, three listeners each. The control on the instrument: if
+    // this is not 6 the test is counting something other than what it thinks,
+    // and the balance below would be meaningless.
+    expect(added).toHaveLength(6);
+    // Every one of them removed. Without detaching first this is 3.
+    expect(removed).toHaveLength(6);
+  });
+
   it("starts no drag at all when the host supplied no canvas", () => {
     // The control on `beginInsertDrag`'s own guard: with no canvas root the
     // press must be left completely alone, so the row's click keeps working.
-    registerBlocks(BLOCKS as never, { source: "insert-drag-test" });
+    registerBlocks(BLOCKS, { source: "insert-drag-test" });
     function NoCanvas() {
       const editor = useEditorState({
         initialDocument: documentOf([node("a", "test/heading")]),

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -112,6 +112,56 @@ describe("InsertPanel", () => {
     expect(onInsert).toHaveBeenCalledWith(op.node);
   });
 
+  it("offers a row as a drag, carrying the block it names", () => {
+    // The panel is where a palette drag STARTS, and the node is built here
+    // rather than inside the drag: these definitions are one snapshot taken per
+    // mount, so resolving the type again later would read the registry a second
+    // time and could answer with a different subtree than the row shows.
+    registerBlocks(
+      [{ ...base, name: "acme/text", editor: { label: "Text" } }] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(documentOf());
+    const beginInsertDrag = vi.fn();
+    render(<InsertPanel editor={editor} beginInsertDrag={beginInsertDrag} />);
+
+    fireEvent.pointerDown(screen.getByText("Text"), {
+      button: 0,
+      pointerId: 1,
+    });
+
+    expect(beginInsertDrag).toHaveBeenCalledTimes(1);
+    const entry = beginInsertDrag.mock.calls[0][1];
+    expect(entry.blockName).toBe("acme/text");
+    // The THUNK is what matters, not that a callback fired: it must build the
+    // block this row names. Asserting only that the drag was started would
+    // pass for a row that handed over some other entry entirely.
+    expect(entry.makeNode().type).toBe("acme/text");
+    // And starting a drag must not itself edit the document — the insert
+    // happens at the release, in the drag.
+    expect(editor.apply).not.toHaveBeenCalled();
+  });
+
+  it("still inserts on click when no drag was supplied", () => {
+    // The control, and the accessible path: a host with no canvas passes no
+    // drag, and the row must behave exactly as it did before it could be
+    // dragged. Click-to-insert is the WCAG 2.2 SC 2.5.7 alternative.
+    registerBlocks(
+      [{ ...base, name: "acme/text", editor: { label: "Text" } }] as never,
+      { source: "acme" }
+    );
+    const editor = editorSpy(documentOf());
+    render(<InsertPanel editor={editor} />);
+
+    fireEvent.pointerDown(screen.getByText("Text"), {
+      button: 0,
+      pointerId: 1,
+    });
+    fireEvent.click(screen.getByText("Text"));
+
+    expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+
   it("judges a supplied block's declared children by the supplied rules", () => {
     /*
      * The palette is handed definitions the REGISTRY does not hold, and no

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -16,6 +16,9 @@
  *
  * @module insert-panel.test
  */
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -160,6 +163,37 @@ describe("InsertPanel", () => {
     fireEvent.click(screen.getByText("Text"));
 
     expect(editor.apply).toHaveBeenCalledTimes(1);
+  });
+
+  it("reserves the sideways gesture on a row, so touch can drag it", () => {
+    /*
+     * Asserted against the stylesheet because there is nothing else that could
+     * see it. `touch-action` is honoured by a real compositor deciding whether
+     * a movement belongs to the page or to the element; jsdom has no such
+     * decision to make, and every pointer test in this package would pass with
+     * the declaration deleted.
+     *
+     * The failure it guards is invisible in every other way: on a touch
+     * browser the default lets the browser claim the gesture as a pan, and it
+     * announces that with `pointercancel` — which this engine correctly treats
+     * as the drag being withdrawn. So the drag abandons itself part-way, only
+     * on touch, and nothing in CI is capable of noticing.
+     */
+    const css = readFileSync(
+      join(process.cwd(), "src/styles/builder-chrome.css"),
+      "utf8"
+    );
+    const rule = css.slice(css.indexOf(".nx-insert-panel [cmdk-item] {"));
+    const firstBlock = rule.slice(0, rule.indexOf("}"));
+
+    // Population: a renamed selector would leave every assertion below reading
+    // an empty string, and "no forbidden value found" would pass on nothing.
+    expect(firstBlock.length).toBeGreaterThan(0);
+    expect(firstBlock).toContain("touch-action: pan-y;");
+    // `pan-y` and not `none`, which is the tempting stronger answer: the
+    // palette is a scrolling list, and taking vertical panning too would trade
+    // a broken drag for a list a finger cannot scroll.
+    expect(firstBlock).not.toContain("touch-action: none");
   });
 
   it("judges a supplied block's declared children by the supplied rules", () => {

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -92,6 +92,23 @@ export interface InsertPanelProps {
   categoryOrder?: readonly string[];
   /** Notified after a successful insert, with the node that was added. */
   onInsert?: (node: BlockNode) => void;
+  /**
+   * Begins a drag carrying an entry, when the host has a canvas to drop onto.
+   *
+   * Optional, and its absence changes nothing: the rows still insert on click,
+   * which is the route WCAG 2.2 SC 2.5.7 requires and the one this only ever
+   * supplements. A panel mounted without a canvas — a story, a test — simply
+   * has nothing to drag onto.
+   *
+   * The node is built HERE, by a thunk the drag calls at the release, because
+   * this panel's definitions are one snapshot taken per mount. Resolving the
+   * type again inside the drag would read the registry a second time, and the
+   * row an author dragged could then differ from the subtree that lands.
+   */
+  beginInsertDrag?: (
+    event: React.PointerEvent<HTMLElement>,
+    entry: { blockName: string; makeNode: () => BlockNode | null }
+  ) => void;
 }
 
 /** Sentence describing where the next insert will land. */
@@ -113,6 +130,7 @@ export function InsertPanel({
   nesting,
   categoryOrder,
   onInsert,
+  beginInsertDrag,
 }: InsertPanelProps): React.JSX.Element {
   const [query, setQuery] = React.useState("");
 
@@ -236,6 +254,16 @@ export function InsertPanel({
                   key={entry.id}
                   value={entry.id}
                   onSelect={() => insert(entry)}
+                  // Beside `onSelect`, never instead of it. A press stays a
+                  // click until it has travelled far enough to mean a drag, so
+                  // this does not consume the row's own activation — and a host
+                  // that supplies no drag leaves the row exactly as it was.
+                  onPointerDown={event => {
+                    beginInsertDrag?.(event, {
+                      blockName: entry.blockName,
+                      makeNode: () => nodeForEntry(entry, blockSource, nesting),
+                    });
+                  }}
                 >
                   <BlockIconMark icon={entry.icon} />
                   <span className="nx-insert-panel__label">{entry.label}</span>

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -43,6 +43,7 @@ import {
 import * as React from "react";
 
 import { BlockIconMark } from "./block-icon";
+import type { InsertDragEntry } from "./canvas-drag";
 import type { EditorState } from "./editor-state";
 import {
   allowedEntries,
@@ -107,7 +108,7 @@ export interface InsertPanelProps {
    */
   beginInsertDrag?: (
     event: React.PointerEvent<HTMLElement>,
-    entry: { blockName: string; makeNode: () => BlockNode | null }
+    entry: InsertDragEntry
   ) => void;
 }
 
@@ -262,6 +263,9 @@ export function InsertPanel({
                     beginInsertDrag?.(event, {
                       blockName: entry.blockName,
                       makeNode: () => nodeForEntry(entry, blockSource, nesting),
+                      // The same notification the click path sends, so a host
+                      // cannot see one kind of insert and miss the other.
+                      onInserted: onInsert,
                     });
                   }}
                 >

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -234,6 +234,20 @@
   min-height: 2.5rem;
   align-items: start;
   padding-block: 0.375rem;
+  /*
+   * Reserve the sideways gesture, so a row can be DRAGGED onto the canvas.
+   *
+   * Left at the default, a touch browser owns direct manipulation from the
+   * moment it classifies the movement as panning, and it announces that by
+   * sending `pointercancel` — which this engine correctly treats as the
+   * gesture being withdrawn. The drag would abandon itself partway across, and
+   * only on touch.
+   *
+   * `pan-y` rather than `none`: the palette is a scrolling list, and taking
+   * vertical panning as well would trade a broken drag for a list a finger
+   * cannot scroll.
+   */
+  touch-action: pan-y;
 }
 
 /*

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -122,7 +122,16 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
       steps: [],
       dismiss: () => {},
     }),
-    useCanvasDrag: () => ({ handlers: {}, target: null }),
+    // `draggingBlockName` is part of the state this hook reports and is what
+    // the editor asks "is a drag happening" — a stub omitting it answers
+    // `undefined`, which is not `null`, so the editor hides its chrome for a
+    // drag that is not happening.
+    useCanvasDrag: () => ({
+      handlers: {},
+      target: null,
+      draggingId: null,
+      draggingBlockName: null,
+    }),
     useEditorState: () => ({
       document: DOCUMENT,
       selectedId: null,

--- a/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
@@ -94,7 +94,16 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
       steps: [],
       dismiss: () => {},
     }),
-    useCanvasDrag: () => ({ handlers: {}, target: null }),
+    // `draggingBlockName` is part of the state this hook reports and is what
+    // the editor asks "is a drag happening" — a stub omitting it answers
+    // `undefined`, which is not `null`, so the editor hides its chrome for a
+    // drag that is not happening.
+    useCanvasDrag: () => ({
+      handlers: {},
+      target: null,
+      draggingId: null,
+      draggingBlockName: null,
+    }),
     useEditorState: () => ({
       document: DOCUMENT,
       selectedId: null,

--- a/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
@@ -117,7 +117,17 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
       steps: [],
       dismiss: () => {},
     }),
-    useCanvasDrag: () => ({ handlers: {}, target: null, draggingId }),
+    useCanvasDrag: () => ({
+      handlers: {},
+      target: null,
+      draggingId,
+      // Derived from this file's own knob rather than stated separately: the
+      // editor asks `draggingBlockName` whether a drag is happening, because a
+      // drag from the palette has no node id at all. Left out, it reads
+      // `undefined` — not `null` — and every case here runs as though a drag
+      // were in flight.
+      draggingBlockName: draggingId === null ? null : "core/heading",
+    }),
     useEditorState: () => ({
       document: DOCUMENT,
       selectedId: null,

--- a/packages/plugin-page-builder/src/admin/BlocksField.inline-outcome.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.inline-outcome.test.tsx
@@ -103,7 +103,16 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
       steps: [],
       dismiss: () => {},
     }),
-    useCanvasDrag: () => ({ handlers: {}, target: null }),
+    // `draggingBlockName` is part of the state this hook reports and is what
+    // the editor asks "is a drag happening" — a stub omitting it answers
+    // `undefined`, which is not `null`, so the editor hides its chrome for a
+    // drag that is not happening.
+    useCanvasDrag: () => ({
+      handlers: {},
+      target: null,
+      draggingId: null,
+      draggingBlockName: null,
+    }),
     useEditorState: () => ({
       document: { formatVersion: 1, kind: "page", nodes: [] },
       selectedId: null,

--- a/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+
+/**
+ * The palette drag reaching the engine — which is wiring, and only wiring.
+ *
+ * `insert-drag.test.tsx` in the builder asserts the GESTURE: what a drag
+ * commits, when, and what ends it. None of that runs unless this component
+ * hands the panel a way to start one and hands the drag the canvas to measure
+ * against, and every one of those assertions stays green while both props are
+ * absent — the engine is simply never reached, and no user can drag anything.
+ *
+ * So what is asserted here is the composition: that the ref the drag resolves
+ * its drop against is the SAME ref the rendered canvas publishes, and that the
+ * panel is given the drag's own starter. Identity rather than presence, because
+ * two different refs would satisfy "both are defined" while the drag measured
+ * against a canvas that is not on screen.
+ *
+ * @module admin/BlocksField.paletteDrag.test
+ */
+
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Props the recorders captured on the most recent render. */
+const seen: {
+  inspector: Record<string, unknown> | undefined;
+  canvas: Record<string, unknown> | undefined;
+  breakpoints: Record<string, unknown> | undefined;
+  insertPanel: Record<string, unknown> | undefined;
+  dragOptions: Record<string, unknown> | undefined;
+} = {
+  inspector: undefined,
+  canvas: undefined,
+  breakpoints: undefined,
+  insertPanel: undefined,
+  dragOptions: undefined,
+};
+
+/** The starter the recorded drag hands back, for an identity assertion. */
+const beginInsertDrag = (): void => {};
+
+/** What `usePluginClientConfig` answers with for the test in hand. */
+let clientConfig: Record<string, unknown> | undefined;
+
+/** What the stored-style read answers with for the test in hand. */
+let siteStyleRead: { data: unknown; isPending: boolean; error: Error | null } =
+  {
+    data: undefined,
+    isPending: false,
+    error: null,
+  };
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  /*
+   * The real module SPREAD, with only the surfaces this file drives replaced.
+   * A closed object literal here answers `undefined` for every export it does
+   * not list, so adding one to the shell breaks these tests and leaves the
+   * builder's own suite green — a failure that reads as a fault in this file
+   * rather than as a stale list. Measured: the real module imports cleanly
+   * under vitest and the overrides below win over the spread.
+   */
+  const real = await importOriginal<Record<string, unknown>>();
+  const record =
+    (key: "inspector" | "canvas" | "insertPanel") =>
+    (props: Record<string, unknown>): React.JSX.Element => {
+      seen[key] = props;
+      return <div data-recorder={key} />;
+    };
+  const nothing = (): null => null;
+  // The canvas sits inside this one, so it has to pass its children through.
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    // Renders the inspector slot and its CHILDREN, because the canvas is a
+    // child of the shell rather than one of its slots — a stub dropping them
+    // would leave the canvas unrendered and its assertion passing on absence.
+    BuilderShell: ({
+      inspector,
+      topBar,
+      children,
+      renderPanel,
+    }: {
+      inspector: React.ReactNode;
+      topBar?: React.ReactNode;
+      children?: React.ReactNode;
+      renderPanel?: (panel: string) => React.ReactNode;
+    }): React.JSX.Element => (
+      <div>
+        {/*
+         * The top bar is rendered for the same reason the children are: the
+         * breakpoint manager lives there, and a stub that dropped the slot
+         * would leave its assertions passing on absence.
+         */}
+        {topBar}
+        {inspector}
+        {/*
+         * The real shell draws one panel at a time and this mock draws none,
+         * so the insert panel is asked for explicitly. Without it the recorder
+         * never mounts and "the panel was given a starter" would be an
+         * assertion about a component that was never rendered.
+         */}
+        {renderPanel?.("insert")}
+        {children}
+      </div>
+    ),
+    BreakpointManager: record("breakpoints"),
+    InspectorPanel: record("inspector"),
+    Canvas: record("canvas"),
+    BlockKeyboardActions: passthrough,
+    /*
+     * Passed THROUGH, not stubbed to nothing: the canvas renders inside it, so
+     * a stub would take the recorder below out of the tree along with it. The
+     * real one reads the verbs context, which the passthrough above does not
+     * provide.
+     */
+    BlockContextMenu: passthrough,
+    BlockToolbar: nothing,
+    EditorCommandPalette: nothing,
+    DropIndicator: nothing,
+    InsertPanel: record("insertPanel"),
+    LayersPanel: nothing,
+    OnboardingChecklist: nothing,
+    SelectionBreadcrumb: nothing,
+    SpacingOverlay: nothing,
+    useBuilderChecklist: () => ({
+      visible: false,
+      steps: [],
+      dismiss: () => {},
+    }),
+    useCanvasDrag: (options: Record<string, unknown>) => {
+      seen.dragOptions = options;
+      return { handlers: {}, target: null, beginInsertDrag };
+    },
+    useEditorState: () => ({
+      document: { formatVersion: 1, kind: "page", nodes: [] },
+      selectedId: null,
+      selection: { ids: [], primary: null },
+      apply: () => null,
+      applyAll: () => null,
+      select: () => {},
+      undo: () => {},
+      redo: () => {},
+      canUndo: false,
+      canRedo: false,
+      undoDepth: 0,
+    }),
+    useInlineText: () => ({ onDoubleClick: () => {} }),
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  /*
+   * Never awaited by these cases: the loader is reached only when an author
+   * double-clicks a passage, and none of them do. Present because the mock
+   * REPLACES the module wholesale, so an export the subject imports and this
+   * omits is a missing-export error rather than an unused stub.
+   */
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
+  usePluginClientConfig: () => clientConfig,
+  useDocumentCheckpoint: () => ({ record: () => {}, clear: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  // `null` is a real answer the pill handles — "no status has been persisted",
+  // which is what a create form and a preview both look like — so this mounts
+  // the top bar without putting a second subject in the assertions below.
+  useDocumentStatus: () => null,
+  // The stored style tier. Answered as "nothing stored yet" here, because what
+  // this file asserts is which props reach the two enforcing surfaces — the
+  // merge of stored over defaults is `site-style-client`'s own question and has
+  // its own coverage. Standing a real query client up here would put a second
+  // subject in every assertion below.
+  useSingleDocument: () => siteStyleRead,
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async () => ({ success: true }),
+    isPending: false,
+  }),
+}));
+
+// Imported after the mocks, which is what makes them take effect: the module
+// resolves the shell at import time, and a specifier already bound to the real
+// module cannot be replaced afterwards.
+const { BlocksField } = await import("./BlocksField");
+
+/** A form around the field, since it reads its value through a form control. */
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+/** Mount the field and open the editor, which is where the two surfaces live. */
+function openEditor(): void {
+  render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+}
+
+beforeEach(() => {
+  seen.insertPanel = undefined;
+  seen.dragOptions = undefined;
+  seen.canvas = undefined;
+  clientConfig = undefined;
+  siteStyleRead = { data: undefined, isPending: false, error: null };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("what makes a palette drag reachable at all", () => {
+  it("gives the drag the very canvas it renders", () => {
+    openEditor();
+
+    // Population first: if the recorders caught nothing, every assertion below
+    // would be about `undefined` and would read as a passing wiring check.
+    expect(seen.dragOptions).toBeDefined();
+    expect(seen.canvas).toBeDefined();
+
+    const forDrag = seen.dragOptions?.canvasRoot;
+    expect(forDrag).toBeDefined();
+    // Identity, not presence. Two separate refs would satisfy "both defined"
+    // while the drag resolved its drop against a canvas nobody is looking at.
+    expect(seen.canvas?.rootRef).toBe(forDrag);
+  });
+
+  it("gives the panel the drag's own starter", () => {
+    openEditor();
+
+    expect(seen.insertPanel).toBeDefined();
+    // The same function the drag returned, so a row's press reaches THIS
+    // gesture rather than some other callback that merely has the right name.
+    expect(seen.insertPanel?.beginInsertDrag).toBe(beginInsertDrag);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
@@ -30,13 +30,20 @@ const seen: {
   breakpoints: Record<string, unknown> | undefined;
   insertPanel: Record<string, unknown> | undefined;
   dragOptions: Record<string, unknown> | undefined;
+  toolbar: Record<string, unknown> | undefined;
+  spacing: Record<string, unknown> | undefined;
 } = {
   inspector: undefined,
   canvas: undefined,
   breakpoints: undefined,
   insertPanel: undefined,
   dragOptions: undefined,
+  toolbar: undefined,
+  spacing: undefined,
 };
+
+/** What the recorded drag reports as in flight, per test. */
+let draggingBlockName: string | null = null;
 
 /** The starter the recorded drag hands back, for an identity assertion. */
 const beginInsertDrag = (): void => {};
@@ -63,7 +70,7 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
    */
   const real = await importOriginal<Record<string, unknown>>();
   const record =
-    (key: "inspector" | "canvas" | "insertPanel") =>
+    (key: "inspector" | "canvas" | "insertPanel" | "toolbar" | "spacing") =>
     (props: Record<string, unknown>): React.JSX.Element => {
       seen[key] = props;
       return <div data-recorder={key} />;
@@ -111,7 +118,18 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     ),
     BreakpointManager: record("breakpoints"),
     InspectorPanel: record("inspector"),
-    Canvas: record("canvas"),
+    Canvas: (props: Record<string, unknown>): React.JSX.Element => {
+      seen.canvas = props;
+      /*
+       * The overlay is RENDERED, not dropped. The toolbar and the spacing
+       * bands are passed to the canvas as overlay content, so a recorder that
+       * returned a bare div would leave them unmounted — and every assertion
+       * about whether they are hidden would be an assertion about `undefined`.
+       */
+      return (
+        <div data-recorder="canvas">{props.overlay as React.ReactNode}</div>
+      );
+    },
     BlockKeyboardActions: passthrough,
     /*
      * Passed THROUGH, not stubbed to nothing: the canvas renders inside it, so
@@ -120,14 +138,14 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
      * provide.
      */
     BlockContextMenu: passthrough,
-    BlockToolbar: nothing,
+    BlockToolbar: record("toolbar"),
     EditorCommandPalette: nothing,
     DropIndicator: nothing,
     InsertPanel: record("insertPanel"),
     LayersPanel: nothing,
     OnboardingChecklist: nothing,
     SelectionBreadcrumb: nothing,
-    SpacingOverlay: nothing,
+    SpacingOverlay: record("spacing"),
     useBuilderChecklist: () => ({
       visible: false,
       steps: [],
@@ -135,7 +153,16 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     }),
     useCanvasDrag: (options: Record<string, unknown>) => {
       seen.dragOptions = options;
-      return { handlers: {}, target: null, beginInsertDrag };
+      return {
+        handlers: {},
+        target: null,
+        beginInsertDrag,
+        // Null throughout a palette drag, deliberately: the block has no node
+        // until the release makes one. That is exactly the state the gates
+        // below must still treat as "a drag is happening".
+        draggingId: null,
+        draggingBlockName,
+      };
     },
     useEditorState: () => ({
       document: { formatVersion: 1, kind: "page", nodes: [] },
@@ -204,6 +231,9 @@ beforeEach(() => {
   seen.insertPanel = undefined;
   seen.dragOptions = undefined;
   seen.canvas = undefined;
+  seen.toolbar = undefined;
+  seen.spacing = undefined;
+  draggingBlockName = null;
   clientConfig = undefined;
   siteStyleRead = { data: undefined, isPending: false, error: null };
 });
@@ -226,6 +256,30 @@ describe("what makes a palette drag reachable at all", () => {
     // Identity, not presence. Two separate refs would satisfy "both defined"
     // while the drag resolved its drop against a canvas nobody is looking at.
     expect(seen.canvas?.rootRef).toBe(forDrag);
+  });
+
+  it("hides the canvas chrome during a palette drag, which has no node id", () => {
+    // The gates used to read `draggingId`, which is null for the whole of a
+    // palette drag — so the toolbar and the spacing bands stayed up while an
+    // author dragged a new block in. The toolbar sits above the drop
+    // indicator, so it covers the position being aimed at.
+    draggingBlockName = "core/heading";
+    openEditor();
+
+    expect(seen.toolbar).toBeDefined();
+    expect(seen.spacing).toBeDefined();
+    expect(seen.toolbar?.hidden).toBe(true);
+    expect(seen.spacing?.hidden).toBe(true);
+  });
+
+  it("leaves the chrome up when nothing is being dragged", () => {
+    // The must-differ control. Gates wired to a constant `true` would satisfy
+    // the case above while hiding the toolbar permanently.
+    draggingBlockName = null;
+    openEditor();
+
+    expect(seen.toolbar?.hidden).toBe(false);
+    expect(seen.spacing?.hidden).toBe(false);
   });
 
   it("gives the panel the drag's own starter", () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -112,7 +112,16 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
       steps: [],
       dismiss: () => {},
     }),
-    useCanvasDrag: () => ({ handlers: {}, target: null }),
+    // `draggingBlockName` is part of the state this hook reports and is what
+    // the editor asks "is a drag happening" — a stub omitting it answers
+    // `undefined`, which is not `null`, so the editor hides its chrome for a
+    // drag that is not happening.
+    useCanvasDrag: () => ({
+      handlers: {},
+      target: null,
+      draggingId: null,
+      draggingBlockName: null,
+    }),
     useEditorState: () => ({
       document: { formatVersion: 1, kind: "page", nodes: [] },
       selectedId: null,

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -872,7 +872,11 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    */
   const slots = useMemo(registrySlotSource, []);
   const nesting = useMemo(registryNestingSource, []);
-  const drag = useCanvasDrag({ editor, slots, nesting });
+  // The canvas root, published by `Canvas` below and read by the drag when a
+  // gesture begins somewhere that is not the canvas — a palette row, whose
+  // pointerdown has no `currentTarget` the drag could measure against.
+  const canvasRoot = useRef<HTMLDivElement | null>(null);
+  const drag = useCanvasDrag({ editor, slots, nesting, canvasRoot });
 
   /*
    * The empty-container appender's only read of a block's definition: its
@@ -1588,7 +1592,11 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         renderPanel={panel => {
           if (panel === "insert") {
             return (
-              <InsertPanel editor={editor} categoryOrder={CORE_CATEGORIES} />
+              <InsertPanel
+                editor={editor}
+                categoryOrder={CORE_CATEGORIES}
+                beginInsertDrag={drag.beginInsertDrag}
+              />
             );
           }
           if (panel === "layers") {
@@ -1687,6 +1695,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             <BlockContextMenu editor={editor}>
               <Canvas
                 document={editor.document}
+                rootRef={canvasRoot}
                 siteStyles={siteSheet(canvasSiteStyle)}
                 selectedId={editor.selectedId}
                 selectedIds={editor.selection.ids}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -224,10 +224,10 @@ function ensureCoreBlocksRegistered(): void {
  * these are two unrelated causes that happen to share an operator.
  */
 function emptyContainerAppenderHidden(
-  draggingId: string | null,
+  dragging: boolean,
   showEmptyElements: boolean
 ): boolean {
-  return draggingId !== null || !showEmptyElements;
+  return dragging || !showEmptyElements;
 }
 
 /**
@@ -877,6 +877,19 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   // pointerdown has no `currentTarget` the drag could measure against.
   const canvasRoot = useRef<HTMLDivElement | null>(null);
   const drag = useCanvasDrag({ editor, slots, nesting, canvasRoot });
+  /*
+   * Is a drag happening — of EITHER kind.
+   *
+   * Not `draggingId`, which is the moving node's id and is null for the whole
+   * of a drag from the palette: the block has no node until the release makes
+   * one. Chrome gated on the id stays up while an author drags a new block in,
+   * and the toolbar sits above the drop indicator, covering the position being
+   * aimed at.
+   *
+   * Derived once and shared by the three surfaces below, so they cannot come to
+   * disagree about what counts as a drag.
+   */
+  const dragging = drag.draggingBlockName !== null;
 
   /*
    * The empty-container appender's only read of a block's definition: its
@@ -1724,19 +1737,13 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                   sit over the canvas the author is aiming at, naming a block
                   that is in the middle of moving.
                 */}
-                    <BlockToolbar
-                      editor={editor}
-                      hidden={drag.draggingId !== null}
-                    />
+                    <BlockToolbar editor={editor} hidden={dragging} />
                     {/*
                   Suppressed for the same reason and by the same signal. The
                   bands report a layout that is mid-change during a drag, so
                   every value on them is about to be wrong.
                 */}
-                    <SpacingOverlay
-                      editor={editor}
-                      hidden={drag.draggingId !== null}
-                    />
+                    <SpacingOverlay editor={editor} hidden={dragging} />
                     {/*
                   Suppressed during a drag for the same reason the toolbar and
                   the bands are: the document is mid-change, so a control
@@ -1754,7 +1761,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                       slots={slots}
                       blocks={blocks}
                       hidden={emptyContainerAppenderHidden(
-                        drag.draggingId,
+                        dragging,
                         showEmptyElements
                       )}
                       onAppend={nodeId => {


### PR DESCRIPTION
Plan 04 B-15 shipped click-to-insert and never shipped the drag half. This is that half, end to end: a block can now be dragged from the insert panel onto the canvas, and clicking a row still inserts exactly as before.

## One engine, not two

`useCanvasDrag` resolved a target, held it against jitter, autoscrolled and drew an indicator — all for a node the document already had. A palette drag needs every one of those and has no node.

So the gesture carries a `DragSubject`: a node id to move, or a block type plus a thunk that builds the node. The two kinds meet at **exactly one call**, on release. `resolveDrop`, `nextTargetSwitchState`, the autoscroll pump and the indicator all run without being told which is in flight — which is what makes "one engine" checkable rather than asserted.

From `research:inserter-drag-shape`: this is Gutenberg trunk's architecture, where `use-on-block-drop` branches once on a `dropType` field. GrapesJS converged on the same shape with one Sorter, and its issue #6324 is that shared sorter drifting because only one caller was exercised — which is why the tests below assert the shared internals rather than the outcome.

## Decisions worth reviewing

**The node is built at the release.** Materialising it at drag-start and moving it would leave two entries on the undo stack and put a block into the document while the author is still choosing, where every autosave and unsaved-work signal reads a changed document reference.

**A palette drag takes no pointer capture, and is scoped to its own pointer.** The browser resolves a click against the capturing element and the row inserts on click, so capture would report a click on the row wherever the author released. It is followed on the document instead — which means it sees every pointer, so the owning id is checked explicitly. The node-origin path gets that free from capture.

**`Canvas` publishes its root through a ref.** A caller finding that element by class name would be a second place deciding what the canvas root is.

**The panel builds its own node.** Its definitions are one snapshot per mount, so resolving the type again inside the drag would read the registry a second time — and the row an author dragged could differ from the subtree that lands.

## Accessibility

Click-to-insert is untouched and remains the WCAG 2.2 SC 2.5.7 single-pointer alternative. `onPointerDown` sits beside `onSelect`, never instead of it, and a press stays a click until it has travelled. The synthesized click after a drag that begins and ends on one row is swallowed — after Escape too — so a drag cannot insert twice, while a press that stayed a click still inserts.

## Evidence

All 25 pre-existing `canvas-drag` and `insert-panel` tests pass **unmodified**.

`insert-drag.test.tsx` is restored. It had been deleted, leaving select-after-insert covered only by a `toHaveBeenCalledWith` against a `vi.fn()` — a green that holds whether or not the selection lands.

**Every test here is break-verified against the mutation its own name promises**, collecting failing test names. Among them: deleting `latestDocument.current = applied.document` from `editor-state` kills "selects what it just inserted", so `finding:select-after-insert-is-a-no-op` has real coverage again; and removing `canvasRoot`, `rootRef` or `beginInsertDrag` each kills its own composition case.

Four tests **survived their first break** and were rewritten until they discriminated — a hysteresis case asserting a style string where two insertion points round to one value; a guard case that could not tell "held" from "threw before reaching it"; a multi-pointer case whose single rogue move could never switch a target, because the switch rule anchors travel when a rival first appears; and a click case that passed because a suppressor armed by the *previous* test was still pending. That last one hid a broken fix from its own verification, and the suite now drains it between cases.

## Scope

Unblocks canvas acceptance property **A11**, the only one of twelve still `deferred`. The A11 e2e assertion and the manifest flip follow separately.
