### PR TITLE
feat(builder): let an author choose how large the canvas draws

### DIFF
--- a/.changeset/canvas-zoom-control.md
+++ b/.changeset/canvas-zoom-control.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The canvas says how large it is drawing, and lets you choose.
+
+The editor has always scaled the page to fit whatever room the panels left, so opening a panel shrank it — from 89% to 59.5% — with nothing on screen naming either number and no way to set one. An author judging type or spacing was doing it at a size they had not chosen and could not read.
+
+The percentage is now always shown, including while fitting, because that is the state the editor spends most of its time in. Choosing a size instead makes it stay put: the page stops resizing when panels open, and the canvas scrolls rather than shrinking. Fit is still the default, sits in the same menu as the sizes, and is how you get back.
+
+Magnification is new. The old scale could only ever shrink, so there was no way to look closely at anything.
+
+The choice is remembered per browser, like the other editor preferences, and a stored value that is not a usable size is ignored rather than painting the canvas somewhere the control cannot be reached.

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -1568,3 +1568,74 @@ describe("F6 from a focused drag handle", () => {
     ).toBeTruthy();
   });
 });
+
+describe("telling the host which zoom the shell is holding", () => {
+  /**
+   * A stored preference set carrying a NON-DEFAULT zoom.
+   *
+   * The value has to differ from the default for any assertion here to mean
+   * something: a host told `fit` cannot tell the shell from a host that
+   * assumed, so a case built on the default passes against a shell that
+   * reports nothing at all. Stored in its PERSISTED form — a number, which is
+   * what `writeZoom` emits — because a record carrying the runtime object is
+   * rejected on read and restores the default, which is the value the case is
+   * built to exclude.
+   */
+  const STORED = JSON.stringify({ ...DEFAULT_PREFERENCES, zoom: 1.5 });
+
+  it("reports the stored zoom to a host that wires its handler LATE", () => {
+    /*
+     * A host can resolve `onZoomChange` from its own state, so the prop moves
+     * from `undefined` to a function after the shell has already loaded its
+     * preferences. Keyed on the value alone the effect does not re-run at that
+     * moment, and the host draws its canvas at the default while the shell's
+     * control reads 150%.
+     */
+    stubContainerFits(true);
+    const store = memoryStore(STORED);
+    const onZoomChange = vi.fn();
+    const view = render(<BuilderShell onExit={vi.fn()} store={store} />);
+
+    view.rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        onZoomChange={onZoomChange}
+      />
+    );
+
+    expect(onZoomChange).toHaveBeenCalledWith({ kind: "fixed", scale: 1.5 });
+  });
+
+  it("does not report again when only the handler's IDENTITY changed", () => {
+    // The control. Reporting on identity would satisfy the case above while
+    // closing a render loop around any host that writes its handler inline.
+    stubContainerFits(true);
+    const store = memoryStore(STORED);
+    const reports: unknown[] = [];
+    const view = render(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        onZoomChange={zoom => reports.push(zoom)}
+      />
+    );
+
+    // The stored value, not the default: the shell reads its store in an
+    // effect, so the mount report carries the default and the restore that
+    // follows carries this. Asserting the LAST one keeps the case about the
+    // value the shell settled on rather than about how many passes it took.
+    const settled = reports.length;
+    expect(reports.at(-1)).toEqual({ kind: "fixed", scale: 1.5 });
+
+    view.rerender(
+      <BuilderShell
+        onExit={vi.fn()}
+        store={store}
+        onZoomChange={zoom => reports.push(zoom)}
+      />
+    );
+
+    expect(reports).toHaveLength(settled);
+  });
+});

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -1286,14 +1286,25 @@ export function BuilderShell({
     [onZoomChange, update]
   );
 
-  // The zoom, held and reported the same way and for the same reasons.
+  /*
+   * The zoom, held and reported the same way and for the same reasons, plus
+   * one the value above does not have: whether a listener EXISTS is itself a
+   * dependency.
+   *
+   * A host can resolve `onZoomChange` from its own state, so the prop moves
+   * from `undefined` to a callback after the first render. Keyed on the value
+   * alone, the effect would not re-run at that moment and the host would carry
+   * the default zoom until the author happened to pick another — its canvas
+   * drawn at a scale the control does not claim.
+   */
   const onZoomChangeRef = React.useRef(onZoomChange);
   React.useEffect(() => {
     onZoomChangeRef.current = onZoomChange;
   });
+  const reportingZoom = onZoomChange !== undefined;
   React.useEffect(() => {
     onZoomChangeRef.current?.(preferences.zoom);
-  }, [preferences.zoom]);
+  }, [reportingZoom, preferences.zoom]);
 
   /*
    * Where overlays inside this shell portal to. State rather than a ref,

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -750,7 +750,8 @@ function useSeparatorRegionEscape(
 }
 
 function ShellRegions({
-  appliedScale,
+  appliedScale = 1,
+  onZoomPick,
   renderPanel,
   availablePanels,
   children,
@@ -765,6 +766,8 @@ function ShellRegions({
   active,
   loadCount,
 }: Omit<BuilderShellProps, "store"> & {
+  /** The zoom picker, or absent where the host wired none. */
+  onZoomPick: ((next: CanvasZoom) => void) | undefined;
   preferences: ShellPreferences;
   update: (change: (current: ShellPreferences) => ShellPreferences) => void;
   /**
@@ -913,11 +916,18 @@ function ShellRegions({
           shell owns preferences and this control edits one. A host drawing its
           own would hold the value in a second place, and the two would correct
           each other on every open.
+
+          Only where the host has WIRED it, though. The canvas belongs to the
+          host, so without `onZoomChange` there is nothing to apply a choice to:
+          the control would store a preference, report a percentage the canvas
+          does not honour, and read 100% whatever was picked. A shell that
+          predates this — the README example and the playground harness among
+          them — should gain no control rather than a dead one.
         */}
         <CanvasZoomControl
           zoom={preferences.zoom}
-          appliedScale={appliedScale ?? 1}
-          onChange={next => update(current => ({ ...current, zoom: next }))}
+          appliedScale={appliedScale}
+          onChange={onZoomPick}
         />
       </header>
 
@@ -1147,7 +1157,7 @@ export function BuilderShell({
   openInsertPanelToken,
   onShowEmptyElementsChange,
   onZoomChange,
-  appliedScale,
+  appliedScale = 1,
   ...props
 }: BuilderShellProps) {
   // The browser store is built once: rebuilt each render it would change
@@ -1260,6 +1270,22 @@ export function BuilderShell({
    * write preferences on every render, and every write reports back out, which
    * is a loop rather than a preference.
    */
+  /*
+   * The zoom picker, resolved here rather than where it is drawn.
+   *
+   * `undefined` when the host has wired nothing, which is what makes the
+   * control render nothing — see its own documentation for why a dead one is
+   * worse than none. Deciding it at the render site put the branch inside a
+   * region that is already the largest function in this file.
+   */
+  const onZoomPick = React.useMemo(
+    () =>
+      onZoomChange === undefined
+        ? undefined
+        : (next: CanvasZoom) => update(current => ({ ...current, zoom: next })),
+    [onZoomChange, update]
+  );
+
   // The zoom, held and reported the same way and for the same reasons.
   const onZoomChangeRef = React.useRef(onZoomChange);
   React.useEffect(() => {
@@ -1430,6 +1456,7 @@ export function BuilderShell({
               <PortalProvider container={overlayHost}>
                 <ShellRegions
                   appliedScale={appliedScale}
+                  onZoomPick={onZoomPick}
                   {...props}
                   preferences={preferences}
                   update={update}

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -28,6 +28,7 @@ import {
 import * as React from "react";
 
 import type { CanvasZoom } from "./canvas-zoom";
+import { CanvasZoomControl } from "./canvas-zoom-control";
 import { devWarnOnce } from "./dev-warn";
 import {
   BUILDER_CHROME_CLASS,
@@ -165,6 +166,19 @@ export interface BuilderShellProps {
    * value, so a host never has to assume the default.
    */
   onZoomChange?: (zoom: CanvasZoom) => void;
+  /**
+   * The scale the canvas is actually painting at, for the zoom control.
+   *
+   * Travels UP because only the canvas can know it — while fitting it is
+   * derived from a region the canvas measures — and the canvas is the host's to
+   * render. The zoom itself travels DOWN, because this shell owns preferences
+   * and therefore owns the choice.
+   *
+   * One direction each is the whole design. Holding the zoom on both sides and
+   * syncing them is what produced an oscillating write of `fit, 2, fit, 2` on
+   * every open: two owners, each correcting the other.
+   */
+  appliedScale?: number;
   /** The canvas. The shell never looks inside it. */
   children?: React.ReactNode;
   /** The inspector's contents. */
@@ -450,6 +464,12 @@ function usePreferences(store: PreferenceStore) {
  * builds a fresh object every call, so identity is always false and the restore
  * effect would set state on every mount even when nothing changed.
  */
+/** Whether two zooms mean the same thing, which is not object identity. */
+function sameZoom(a: CanvasZoom, b: CanvasZoom): boolean {
+  if (a.kind !== b.kind) return false;
+  return a.kind === "fixed" && b.kind === "fixed" ? a.scale === b.scale : true;
+}
+
 function shallowEqualPreferences(
   a: ShellPreferences,
   b: ShellPreferences
@@ -458,10 +478,7 @@ function shallowEqualPreferences(
     a.leftPanel !== b.leftPanel ||
     a.leftPinned !== b.leftPinned ||
     a.showEmptyElements !== b.showEmptyElements ||
-    a.zoom.kind !== b.zoom.kind ||
-    (a.zoom.kind === "fixed" &&
-      b.zoom.kind === "fixed" &&
-      a.zoom.scale !== b.zoom.scale)
+    !sameZoom(a.zoom, b.zoom)
   ) {
     return false;
   }
@@ -733,6 +750,7 @@ function useSeparatorRegionEscape(
 }
 
 function ShellRegions({
+  appliedScale,
   renderPanel,
   availablePanels,
   children,
@@ -890,6 +908,17 @@ function ShellRegions({
             }
           />
         </Label>
+        {/*
+          Rendered by the shell, not handed to the host as a slot, because the
+          shell owns preferences and this control edits one. A host drawing its
+          own would hold the value in a second place, and the two would correct
+          each other on every open.
+        */}
+        <CanvasZoomControl
+          zoom={preferences.zoom}
+          appliedScale={appliedScale ?? 1}
+          onChange={next => update(current => ({ ...current, zoom: next }))}
+        />
       </header>
 
       <div className="flex min-h-0 flex-1">
@@ -1118,6 +1147,7 @@ export function BuilderShell({
   openInsertPanelToken,
   onShowEmptyElementsChange,
   onZoomChange,
+  appliedScale,
   ...props
 }: BuilderShellProps) {
   // The browser store is built once: rebuilt each render it would change
@@ -1222,6 +1252,14 @@ export function BuilderShell({
   React.useEffect(() => {
     onShowEmptyElementsChangeRef.current?.(preferences.showEmptyElements);
   }, [preferences.showEmptyElements]);
+  /*
+   * A zoom chosen outside this shell, stored here.
+   *
+   * Compared by VALUE rather than by object identity: a host rebuilding the
+   * object each render — which the conventional inline handler does — would
+   * write preferences on every render, and every write reports back out, which
+   * is a loop rather than a preference.
+   */
   // The zoom, held and reported the same way and for the same reasons.
   const onZoomChangeRef = React.useRef(onZoomChange);
   React.useEffect(() => {
@@ -1230,6 +1268,7 @@ export function BuilderShell({
   React.useEffect(() => {
     onZoomChangeRef.current?.(preferences.zoom);
   }, [preferences.zoom]);
+
   /*
    * Where overlays inside this shell portal to. State rather than a ref,
    * because `PortalProvider` has to RE-RENDER once the node exists; a ref
@@ -1390,6 +1429,7 @@ export function BuilderShell({
                */}
               <PortalProvider container={overlayHost}>
                 <ShellRegions
+                  appliedScale={appliedScale}
                   {...props}
                   preferences={preferences}
                   update={update}

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -27,6 +27,7 @@ import {
 } from "lucide-react";
 import * as React from "react";
 
+import type { CanvasZoom } from "./canvas-zoom";
 import { devWarnOnce } from "./dev-warn";
 import {
   BUILDER_CHROME_CLASS,
@@ -155,6 +156,15 @@ export interface BuilderShellProps {
    * changes here and not at every call site that duplicated it.
    */
   onShowEmptyElementsChange?: (showEmptyElements: boolean) => void;
+  /**
+   * Reports the canvas zoom, and takes the change back.
+   *
+   * The shell owns it because the shell owns preferences, and a host owns what
+   * to DO with it — the canvas is the host's to render, so only it can apply a
+   * scale. Reported the same way `showEmptyElements` is, including on the first
+   * value, so a host never has to assume the default.
+   */
+  onZoomChange?: (zoom: CanvasZoom) => void;
   /** The canvas. The shell never looks inside it. */
   children?: React.ReactNode;
   /** The inspector's contents. */
@@ -447,7 +457,11 @@ function shallowEqualPreferences(
   if (
     a.leftPanel !== b.leftPanel ||
     a.leftPinned !== b.leftPinned ||
-    a.showEmptyElements !== b.showEmptyElements
+    a.showEmptyElements !== b.showEmptyElements ||
+    a.zoom.kind !== b.zoom.kind ||
+    (a.zoom.kind === "fixed" &&
+      b.zoom.kind === "fixed" &&
+      a.zoom.scale !== b.zoom.scale)
   ) {
     return false;
   }
@@ -1103,6 +1117,7 @@ export function BuilderShell({
   store,
   openInsertPanelToken,
   onShowEmptyElementsChange,
+  onZoomChange,
   ...props
 }: BuilderShellProps) {
   // The browser store is built once: rebuilt each render it would change
@@ -1207,6 +1222,14 @@ export function BuilderShell({
   React.useEffect(() => {
     onShowEmptyElementsChangeRef.current?.(preferences.showEmptyElements);
   }, [preferences.showEmptyElements]);
+  // The zoom, held and reported the same way and for the same reasons.
+  const onZoomChangeRef = React.useRef(onZoomChange);
+  React.useEffect(() => {
+    onZoomChangeRef.current = onZoomChange;
+  });
+  React.useEffect(() => {
+    onZoomChangeRef.current?.(preferences.zoom);
+  }, [preferences.zoom]);
   /*
    * Where overlays inside this shell portal to. State rather than a ref,
    * because `PortalProvider` has to RE-RENDER once the node exists; a ref

--- a/packages/builder/src/canvas-zoom-control.test.tsx
+++ b/packages/builder/src/canvas-zoom-control.test.tsx
@@ -66,6 +66,23 @@ describe("the canvas zoom control", () => {
     );
   });
 
+  it("renders nothing where nothing can act on a choice", () => {
+    /*
+     * The canvas belongs to the host, so a shell whose host has not wired this
+     * has nowhere to apply a choice. Rendered anyway it stores a preference,
+     * reports a percentage the canvas does not honour, and goes on reading
+     * 100% whatever was picked — a control that looks operable and is not,
+     * which is worse than its absence.
+     */
+    render(
+      <PortalProvider container={window.document.body}>
+        <CanvasZoomControl zoom={FIT_ZOOM} appliedScale={1} />
+      </PortalProvider>
+    );
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
   it("reports a chosen step rather than applying it itself", () => {
     /*
      * The canvas is the host's to render, so the control cannot scale anything

--- a/packages/builder/src/canvas-zoom-control.test.tsx
+++ b/packages/builder/src/canvas-zoom-control.test.tsx
@@ -92,7 +92,7 @@ describe("the canvas zoom control", () => {
     const { onChange } = mount({ appliedScale: 1 });
 
     fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
-    const item = screen.getByRole("menuitem", { name: "150%" });
+    const item = screen.getByRole("menuitemradio", { name: "150%" });
     fireEvent.pointerUp(item, { pointerType: "mouse" });
 
     expect(onChange).toHaveBeenCalledWith({ kind: "fixed", scale: 1.5 });
@@ -107,10 +107,67 @@ describe("the canvas zoom control", () => {
     const { onChange } = mount({ zoom: { kind: "fixed", scale: 2 } });
 
     fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
-    fireEvent.pointerUp(screen.getByRole("menuitem", { name: "Fit" }), {
+    fireEvent.pointerUp(screen.getByRole("menuitemradio", { name: "Fit" }), {
       pointerType: "mouse",
     });
 
     expect(onChange).toHaveBeenCalledWith(FIT_ZOOM);
+  });
+});
+
+describe("which zoom the open menu says is current", () => {
+  /** Open the menu and return the item with this label. */
+  function itemNamed(name: string): HTMLElement {
+    return screen.getByRole("menuitemradio", { name });
+  }
+
+  function open(): void {
+    fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
+  }
+
+  it("marks FIT rather than the step it happens to resolve to", () => {
+    /*
+     * The case the trigger cannot cover. Fit produces exactly 100% at the
+     * widest tier, which is the state the editor opens in, so the visible
+     * label is the same four characters for a canvas that will resize when a
+     * panel opens and one that will not. Both items are asserted: marking Fit
+     * while also marking 100% would satisfy an assertion on Fit alone, and it
+     * is precisely the ambiguity being removed.
+     */
+    mount({ zoom: FIT_ZOOM, appliedScale: 1 });
+    open();
+
+    expect(itemNamed("Fit").getAttribute("aria-checked")).toBe("true");
+    expect(itemNamed("100%").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("marks the STEP when one was chosen, at the same painted scale", () => {
+    // The other half of the pair, deliberately at the scale that makes the two
+    // states indistinguishable on the trigger.
+    mount({ zoom: { kind: "fixed", scale: 1 }, appliedScale: 1 });
+    open();
+
+    expect(itemNamed("100%").getAttribute("aria-checked")).toBe("true");
+    expect(itemNamed("Fit").getAttribute("aria-checked")).toBe("false");
+  });
+
+  it("marks NOTHING for a fixed scale the menu does not offer", () => {
+    /*
+     * A host can build a zoom directly and a stored value can outlive the step
+     * list, so a scale between the steps is reachable. Marking the nearest one
+     * would tell the author they chose something they did not; an unmarked
+     * menu says truthfully that none of these is what is on screen.
+     */
+    mount({ zoom: { kind: "fixed", scale: 1.23 }, appliedScale: 1.23 });
+    open();
+
+    const marked = screen
+      .getAllByRole("menuitemradio")
+      .filter(item => item.getAttribute("aria-checked") === "true");
+    // Asserted through the count of MARKED items rather than by naming each
+    // one: a case that checks only the steps it thought of passes against an
+    // implementation that marks a step it did not.
+    expect(marked).toHaveLength(0);
+    expect(screen.getAllByRole("menuitemradio").length).toBeGreaterThan(1);
   });
 });

--- a/packages/builder/src/canvas-zoom-control.test.tsx
+++ b/packages/builder/src/canvas-zoom-control.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+/**
+ * The control's wiring, which is the half `canvas-zoom` cannot see.
+ *
+ * That module decides what a zoom IS and how it steps. What is only true here
+ * is that the number on screen is the one the canvas is painting at — including
+ * while fitting, which is the state that caused the confusion — and that
+ * choosing a step reports the choice rather than applying it locally.
+ *
+ * @module canvas-zoom-control.test
+ */
+import { PortalProvider } from "@nextlyhq/ui";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { CanvasZoomControl } from "./canvas-zoom-control";
+import { FIT_ZOOM } from "./canvas-zoom";
+
+afterEach(cleanup);
+
+function mount(props: Partial<React.ComponentProps<typeof CanvasZoomControl>>) {
+  const onChange = vi.fn();
+  render(
+    <PortalProvider container={window.document.body}>
+      <CanvasZoomControl
+        zoom={FIT_ZOOM}
+        appliedScale={1}
+        onChange={onChange}
+        {...props}
+      />
+    </PortalProvider>
+  );
+  return { onChange };
+}
+
+describe("the canvas zoom control", () => {
+  it("names the scale the canvas is PAINTING at while fitting", () => {
+    /*
+     * The state the whole control exists for. A canvas fitting into the region
+     * the panels leave was measured falling from 89% to 59.5% when a panel
+     * opened, with nothing on screen naming either — so a control that showed
+     * only a scale the author had SET would be blank exactly when it matters.
+     */
+    mount({ zoom: FIT_ZOOM, appliedScale: 0.595 });
+
+    expect(screen.getByRole("button").textContent).toBe("60%");
+  });
+
+  it("says whether that number will move on its own", () => {
+    /*
+     * "60%" alone does not say whether it is about to change when a panel
+     * opens, and that is the entire difference between the two states. The
+     * accessible name carries the mode; the visible text stays the number.
+     */
+    mount({ zoom: FIT_ZOOM, appliedScale: 0.6 });
+    expect(screen.getByRole("button").getAttribute("aria-label")).toContain(
+      "fitting"
+    );
+
+    cleanup();
+    mount({ zoom: { kind: "fixed", scale: 0.6 }, appliedScale: 0.6 });
+    expect(screen.getByRole("button").getAttribute("aria-label")).not.toContain(
+      "fitting"
+    );
+  });
+
+  it("reports a chosen step rather than applying it itself", () => {
+    /*
+     * The canvas is the host's to render, so the control cannot scale anything
+     * — it can only say what was asked for. A control that held its own scale
+     * would be a second answer to how large the page is drawn.
+     */
+    const { onChange } = mount({ appliedScale: 1 });
+
+    fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
+    const item = screen.getByRole("menuitem", { name: "150%" });
+    fireEvent.pointerUp(item, { pointerType: "mouse" });
+
+    expect(onChange).toHaveBeenCalledWith({ kind: "fixed", scale: 1.5 });
+  });
+
+  it("offers a way back to fitting", () => {
+    /*
+     * Without it a fixed scale is a one-way door: an author who chose 200% can
+     * step back through the list but never return to the size that follows the
+     * region, which is the editor's own default.
+     */
+    const { onChange } = mount({ zoom: { kind: "fixed", scale: 2 } });
+
+    fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
+    fireEvent.pointerUp(screen.getByRole("menuitem", { name: "Fit" }), {
+      pointerType: "mouse",
+    });
+
+    expect(onChange).toHaveBeenCalledWith(FIT_ZOOM);
+  });
+});

--- a/packages/builder/src/canvas-zoom-control.tsx
+++ b/packages/builder/src/canvas-zoom-control.tsx
@@ -31,13 +31,20 @@
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@nextlyhq/ui";
 import type * as React from "react";
+import { Fragment } from "react";
 
-import { FIT_ZOOM, ZOOM_STEPS, type CanvasZoom } from "./canvas-zoom";
+import {
+  FIT_ZOOM,
+  ZOOM_STEPS,
+  writeZoom,
+  type CanvasZoom,
+} from "./canvas-zoom";
 
 export interface CanvasZoomControlProps {
   /** What the canvas was asked to draw at. */
@@ -69,6 +76,34 @@ function asPercent(scale: number): string {
   return `${Math.round(scale * 100)}%`;
 }
 
+/**
+ * A zoom as the string the menu addresses it by.
+ *
+ * Routed through `writeZoom` rather than spelled here, so the value a checked
+ * item is compared against and the value the preference is stored as are one
+ * decision. Written twice they agree until one of them learns a new kind, and
+ * the failure is a menu with nothing checked rather than an error.
+ */
+function choiceValue(zoom: CanvasZoom): string {
+  return String(writeZoom(zoom));
+}
+
+/**
+ * Every zoom the menu offers, in the order it offers them.
+ *
+ * Built once from the steps rather than parsed back out of the chosen string.
+ * A parse is a second implementation of what this list already knows, and it
+ * has a failure mode the lookup does not: an unrecognised string has to become
+ * SOME zoom, so it silently becomes the wrong one.
+ */
+const CHOICES: readonly { value: string; label: string; zoom: CanvasZoom }[] = [
+  { value: choiceValue(FIT_ZOOM), label: "Fit", zoom: FIT_ZOOM },
+  ...ZOOM_STEPS.map(step => {
+    const zoom: CanvasZoom = { kind: "fixed", scale: step };
+    return { value: choiceValue(zoom), label: asPercent(step), zoom };
+  }),
+];
+
 export function CanvasZoomControl({
   zoom,
   appliedScale,
@@ -94,24 +129,36 @@ export function CanvasZoomControl({
         <span aria-hidden="true">{shown}</span>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start">
-        <DropdownMenuItem
-          onSelect={() => {
-            onChange(FIT_ZOOM);
+        {/* A RADIO group, so the open menu says which mode is active.
+
+            The trigger cannot: Fit resolves to exactly 100% at the widest
+            tier, which is the state an editor opens in, so "100%" is the same
+            two characters for a canvas that will resize when a panel opens and
+            one that will not. The mark is the only place a sighted author can
+            read the difference, and a checked radio is also what tells a
+            screen reader which item is current.
+
+            Nothing is marked when the zoom is a fixed scale the steps do not
+            contain — a host can pass one, and a stored value can outlive the
+            step list. That is honest: the menu genuinely does not hold it, and
+            marking the nearest step would claim the author chose something
+            they did not. */}
+        <DropdownMenuRadioGroup
+          value={choiceValue(zoom)}
+          onValueChange={next => {
+            const choice = CHOICES.find(candidate => candidate.value === next);
+            if (choice !== undefined) onChange(choice.zoom);
           }}
         >
-          Fit
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        {ZOOM_STEPS.map(step => (
-          <DropdownMenuItem
-            key={step}
-            onSelect={() => {
-              onChange({ kind: "fixed", scale: step });
-            }}
-          >
-            {asPercent(step)}
-          </DropdownMenuItem>
-        ))}
+          {CHOICES.map((choice, index) => (
+            <Fragment key={choice.value}>
+              {index === 1 ? <DropdownMenuSeparator /> : null}
+              <DropdownMenuRadioItem value={choice.value}>
+                {choice.label}
+              </DropdownMenuRadioItem>
+            </Fragment>
+          ))}
+        </DropdownMenuRadioGroup>
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/packages/builder/src/canvas-zoom-control.tsx
+++ b/packages/builder/src/canvas-zoom-control.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+/**
+ * The control that says how large the canvas is drawing, and lets an author
+ * change it.
+ *
+ * Both halves matter and the first is the one that was missing. The canvas has
+ * always scaled to fit the region the panels leave, so opening a panel took it
+ * from 89% to 59.5% with nothing on screen naming either number — an author
+ * judging type or spacing was doing it at a size they had not chosen and could
+ * not read.
+ *
+ * ## The percentage is always shown, including while fitting
+ *
+ * A control that only reported a scale the author had SET would be blank in
+ * the state that caused the confusion. Fit is the default and the state an
+ * editor spends most of its time in, so the number it produces is exactly the
+ * one worth naming.
+ *
+ * ## Discrete steps, and Fit as a peer of them
+ *
+ * A menu of steps rather than a slider or a free number: 37% of a page is not
+ * a view of anything, and every comparable editor offers steps for the same
+ * reason. Fit sits in the same menu rather than beside it as a separate
+ * button, because from the author's side it is one question — how big — and
+ * splitting it into a mode switch plus a size makes them answer twice.
+ *
+ * @module canvas-zoom-control
+ */
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@nextlyhq/ui";
+import type * as React from "react";
+
+import { FIT_ZOOM, ZOOM_STEPS, type CanvasZoom } from "./canvas-zoom";
+
+export interface CanvasZoomControlProps {
+  /** What the canvas was asked to draw at. */
+  zoom: CanvasZoom;
+  /**
+   * The scale the canvas is ACTUALLY painting at.
+   *
+   * Passed in rather than recomputed, because while fitting it is derived from
+   * a region only the canvas has measured. A control deriving its own would be
+   * a second answer to what is on screen, and the two would disagree for
+   * exactly the frame after a panel opens — which is the moment this exists to
+   * report.
+   */
+  appliedScale: number;
+  onChange: (zoom: CanvasZoom) => void;
+}
+
+/** A scale as a percentage, rounded to whole points. */
+function asPercent(scale: number): string {
+  return `${Math.round(scale * 100)}%`;
+}
+
+export function CanvasZoomControl({
+  zoom,
+  appliedScale,
+  onChange,
+}: CanvasZoomControlProps): React.JSX.Element {
+  const shown = asPercent(appliedScale);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        className="nx-zoom-control"
+        /*
+         * The accessible name carries the MODE as well as the number, because
+         * "89%" alone does not say whether it will move when a panel opens —
+         * and that is the whole difference between the two states.
+         */
+        aria-label={
+          zoom.kind === "fit"
+            ? `Canvas zoom: fitting, ${shown}`
+            : `Canvas zoom: ${shown}`
+        }
+      >
+        <span aria-hidden="true">{shown}</span>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        <DropdownMenuItem
+          onSelect={() => {
+            onChange(FIT_ZOOM);
+          }}
+        >
+          Fit
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {ZOOM_STEPS.map(step => (
+          <DropdownMenuItem
+            key={step}
+            onSelect={() => {
+              onChange({ kind: "fixed", scale: step });
+            }}
+          >
+            {asPercent(step)}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/builder/src/canvas-zoom-control.tsx
+++ b/packages/builder/src/canvas-zoom-control.tsx
@@ -52,7 +52,16 @@ export interface CanvasZoomControlProps {
    * report.
    */
   appliedScale: number;
-  onChange: (zoom: CanvasZoom) => void;
+  /**
+   * What to do with a chosen zoom, or absent where nothing can act on one.
+   *
+   * Absent renders NOTHING. The canvas belongs to the host, so a shell whose
+   * host has not wired this has nowhere to apply a choice: the control would
+   * store a preference, report a percentage the canvas does not honour, and go
+   * on reading 100% whatever was picked. A surface that predates the wiring
+   * should gain no control rather than a dead one.
+   */
+  onChange?: (zoom: CanvasZoom) => void;
 }
 
 /** A scale as a percentage, rounded to whole points. */
@@ -64,7 +73,8 @@ export function CanvasZoomControl({
   zoom,
   appliedScale,
   onChange,
-}: CanvasZoomControlProps): React.JSX.Element {
+}: CanvasZoomControlProps): React.JSX.Element | null {
+  if (onChange === undefined) return null;
   const shown = asPercent(appliedScale);
   return (
     <DropdownMenu>

--- a/packages/builder/src/canvas-zoom.test.ts
+++ b/packages/builder/src/canvas-zoom.test.ts
@@ -1,0 +1,102 @@
+/**
+ * The zoom model, which is the half the canvas cannot check.
+ *
+ * The canvas decides what a scale DOES to the box. What is only true here is
+ * that a chosen scale survives a round trip through storage, that a value
+ * storage should never have held is refused rather than painted, and that
+ * stepping from Fit starts where the author is looking.
+ *
+ * @module canvas-zoom.test
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  FIT_ZOOM,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  ZOOM_STEPS,
+  readZoom,
+  steppedZoom,
+  writeZoom,
+} from "./canvas-zoom";
+
+describe("a zoom read back from storage", () => {
+  it("round-trips both kinds", () => {
+    // Asserted through the pair rather than against a literal, so a change to
+    // how a zoom is written cannot pass by changing both sides at once.
+    expect(readZoom(writeZoom(FIT_ZOOM))).toEqual(FIT_ZOOM);
+    expect(readZoom(writeZoom({ kind: "fixed", scale: 1.5 }))).toEqual({
+      kind: "fixed",
+      scale: 1.5,
+    });
+  });
+
+  it("refuses a value that would paint the canvas out of reach", () => {
+    /*
+     * A stored value can come from a later version, a hand-edited preference,
+     * or a bug. Below the floor the page is illegible and above the ceiling one
+     * block fills the region, and in both cases the author has no way back
+     * except to find the control they can no longer see.
+     */
+    expect(readZoom(MIN_ZOOM / 2)).toBeNull();
+    expect(readZoom(MAX_ZOOM * 2)).toBeNull();
+    // The bounds themselves are inside, or the guard rejects what it names.
+    expect(readZoom(MIN_ZOOM)).toEqual({ kind: "fixed", scale: MIN_ZOOM });
+    expect(readZoom(MAX_ZOOM)).toEqual({ kind: "fixed", scale: MAX_ZOOM });
+  });
+
+  it("refuses what is not a scale at all", () => {
+    // `null` rather than a quiet fall back to fit: a caller restoring
+    // preferences needs to know it found nothing, and a fixed scale that
+    // silently became fit reads as the editor forgetting the author's choice.
+    for (const value of [undefined, null, "1.5", Number.NaN, Infinity, {}]) {
+      expect(readZoom(value)).toBeNull();
+    }
+  });
+});
+
+describe("stepping the zoom", () => {
+  it("steps off the scale the author is LOOKING at, not off the list", () => {
+    /*
+     * From Fit there is no stored number to step from, and the fit scale is
+     * the only one that describes what is on screen. Stepping from an end of
+     * the list instead would jump the canvas somewhere unrelated on the first
+     * press — the gesture that is supposed to be the smallest possible change.
+     */
+    expect(steppedZoom(FIT_ZOOM, 0.6, "in")).toEqual({
+      kind: "fixed",
+      scale: 0.75,
+    });
+    expect(steppedZoom(FIT_ZOOM, 0.6, "out")).toEqual({
+      kind: "fixed",
+      scale: 0.5,
+    });
+  });
+
+  it("stays put at the ends rather than wrapping", () => {
+    const largest = ZOOM_STEPS[ZOOM_STEPS.length - 1];
+    const smallest = ZOOM_STEPS[0];
+    if (largest === undefined || smallest === undefined) {
+      throw new Error("expected steps");
+    }
+    const top = { kind: "fixed", scale: largest } as const;
+    const bottom = { kind: "fixed", scale: smallest } as const;
+    // Wrapping would take a press meant to magnify and shrink the page to its
+    // smallest, which is the opposite of what was asked for.
+    expect(steppedZoom(top, 1, "in")).toEqual(top);
+    expect(steppedZoom(bottom, 1, "out")).toEqual(bottom);
+  });
+
+  it("does not stall on the step it is already at", () => {
+    // Exact equality against a float is the case a naive `>=` gets wrong: at
+    // 100% a press to magnify must reach 150%, not answer 100% again.
+    expect(steppedZoom({ kind: "fixed", scale: 1 }, 1, "in")).toEqual({
+      kind: "fixed",
+      scale: 1.5,
+    });
+    expect(steppedZoom({ kind: "fixed", scale: 1 }, 1, "out")).toEqual({
+      kind: "fixed",
+      scale: 0.75,
+    });
+  });
+});

--- a/packages/builder/src/canvas-zoom.ts
+++ b/packages/builder/src/canvas-zoom.ts
@@ -61,6 +61,22 @@ export const MIN_ZOOM = 0.25;
 export const MAX_ZOOM = 4;
 
 /**
+ * A fixed scale the canvas can actually paint at, or `null` when it cannot.
+ *
+ * The bounds are not only about what STORAGE may hold. `CanvasZoom` is
+ * exported, so a host can construct `{ kind: "fixed", scale }` directly with
+ * any number the type admits — `NaN`, `Infinity`, zero, or something far
+ * outside these bounds — and none of those reach `readZoom` on the way in.
+ * Interpolated into a `zoom` declaration they produce an invalid rule or a
+ * canvas nobody can see, so the check belongs wherever a scale is USED rather
+ * than only where one is parsed.
+ */
+export function usableScale(scale: number): number | null {
+  if (!Number.isFinite(scale)) return null;
+  return scale < MIN_ZOOM || scale > MAX_ZOOM ? null : scale;
+}
+
+/**
  * A stored value read back as a zoom, or `null` when it is not one.
  *
  * `null` rather than a silent fall back to fit: a caller restoring preferences
@@ -69,9 +85,9 @@ export const MAX_ZOOM = 4;
  */
 export function readZoom(value: unknown): CanvasZoom | null {
   if (value === "fit") return FIT_ZOOM;
-  if (typeof value !== "number" || !Number.isFinite(value)) return null;
-  if (value < MIN_ZOOM || value > MAX_ZOOM) return null;
-  return { kind: "fixed", scale: value };
+  if (typeof value !== "number") return null;
+  const scale = usableScale(value);
+  return scale === null ? null : { kind: "fixed", scale };
 }
 
 /** A zoom as it is stored: the string `"fit"`, or the scale itself. */

--- a/packages/builder/src/canvas-zoom.ts
+++ b/packages/builder/src/canvas-zoom.ts
@@ -1,0 +1,101 @@
+/**
+ * How large the canvas draws the page it is previewing.
+ *
+ * The canvas has always had a scale, and it has never been the author's. It is
+ * derived to make the requested width fit the region left over after the
+ * panels, so opening a panel silently shrinks the page — measured at 89% with
+ * the rail alone and 59.5% with a panel open. Nothing said which of those an
+ * author was looking at, and nothing let them choose.
+ *
+ * ## Fit is a CHOICE, not the absence of one
+ *
+ * Modelled as a discriminated union rather than a nullable number, because
+ * "fit" and "a scale I picked" are different intentions and a caller has to
+ * tell them apart. `null` meaning fit would be the same overloaded absence
+ * that a `number | null` scale invites: is it unset, is it fitting, or did
+ * something fail to measure?
+ *
+ * Fit RE-DERIVES on every layout change, which is what makes it fit; a fixed
+ * scale deliberately does not, so opening a panel narrows what is visible
+ * rather than shrinking the page under the author.
+ *
+ * ## Why a percentage is absolute, and not a multiplier of the fit
+ *
+ * A multiplier is the obvious composition and it makes the number a lie: an
+ * author choosing 100% is asking for actual size, and "fit × 1" is whatever
+ * the panels happen to leave. Every editor that shows a zoom percentage means
+ * the absolute one, so the number here means what it says and Fit is the mode
+ * that computes one.
+ *
+ * @module canvas-zoom
+ */
+
+/** What the canvas was asked to draw at. */
+export type CanvasZoom =
+  | { readonly kind: "fit" }
+  | { readonly kind: "fixed"; readonly scale: number };
+
+/** The default, and what every canvas did before there was a choice. */
+export const FIT_ZOOM: CanvasZoom = { kind: "fit" };
+
+/**
+ * The steps the control offers, as fractions.
+ *
+ * Discrete rather than continuous. A slider or a free number invites values
+ * whose arithmetic is exact and whose result is unreadable — 37% of a page is
+ * not a view of anything — and every comparable editor offers steps for the
+ * same reason. `1` is in the middle of the list because actual size is the
+ * value an author returns to.
+ */
+export const ZOOM_STEPS: readonly number[] = [0.5, 0.75, 1, 1.5, 2];
+
+/**
+ * The bounds a stored or typed scale is held to.
+ *
+ * Wider than the steps, because a value can arrive from storage written by a
+ * later version, and clamping is what keeps that from painting the canvas
+ * somewhere unreachable. Below the floor the page is illegible; above the
+ * ceiling one block fills the region and the author has lost the page.
+ */
+export const MIN_ZOOM = 0.25;
+export const MAX_ZOOM = 4;
+
+/**
+ * A stored value read back as a zoom, or `null` when it is not one.
+ *
+ * `null` rather than a silent fall back to fit: a caller restoring preferences
+ * needs to know it found nothing, and a fixed scale that quietly became fit
+ * would look to an author like the editor forgetting what they chose.
+ */
+export function readZoom(value: unknown): CanvasZoom | null {
+  if (value === "fit") return FIT_ZOOM;
+  if (typeof value !== "number" || !Number.isFinite(value)) return null;
+  if (value < MIN_ZOOM || value > MAX_ZOOM) return null;
+  return { kind: "fixed", scale: value };
+}
+
+/** A zoom as it is stored: the string `"fit"`, or the scale itself. */
+export function writeZoom(zoom: CanvasZoom): "fit" | number {
+  return zoom.kind === "fit" ? "fit" : zoom.scale;
+}
+
+/**
+ * The next step in a direction, or the same zoom when there is none.
+ *
+ * From FIT it steps off the scale the fit produced, so the first press moves
+ * from what the author is looking at rather than jumping to an end of the
+ * list. That needs the fit scale passed in, because only the canvas knows it.
+ */
+export function steppedZoom(
+  zoom: CanvasZoom,
+  fitScale: number,
+  direction: "in" | "out"
+): CanvasZoom {
+  const from = zoom.kind === "fit" ? fitScale : zoom.scale;
+  const candidates =
+    direction === "in"
+      ? ZOOM_STEPS.filter(step => step > from + 1e-9)
+      : [...ZOOM_STEPS].reverse().filter(step => step < from - 1e-9);
+  const next = candidates[0];
+  return next === undefined ? zoom : { kind: "fixed", scale: next };
+}

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -892,10 +892,9 @@ describe("what the canvas reports about the box it got", () => {
       /*
        * The widest tier requests nothing — the box IS the region — and that is
        * the state the editor opens in, so it is where a zoom control is used
-       * most. There is nothing to fit there, and an early return for that case
-       * left the control reporting a number that changed nothing: verified in
-       * a browser, where choosing 150% moved the label and left the canvas at
-       * `zoom: 1`.
+       * most. Nothing has to be fitted there, and a chosen scale still has to
+       * reach the box: the alternative is a control whose label moves while
+       * the canvas stays at `zoom: 1`.
        */
       const { container } = render(
         <Canvas
@@ -1820,5 +1819,109 @@ describe("what the canvas reports about the box it got", () => {
     );
 
     expect(FakeResizeObserver.last).toBeUndefined();
+  });
+});
+
+describe("reporting the scale to a host that keeps changing its mind", () => {
+  /**
+   * The document every case here draws, which is beside the point in all of
+   * them: what varies is the reporter, not what is under it.
+   */
+  const DOCUMENT = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+  } as never;
+
+  it("does not report again when only the reporter's IDENTITY changed", () => {
+    /*
+     * The conventional host writes the reporter inline, so every render of it
+     * hands the canvas a new function. Depended on directly, each report would
+     * update the host, the update would produce a new identity, and the new
+     * identity would report again — a render loop on a host that did nothing
+     * wrong. Two renders with the same scale must produce ONE report.
+     */
+    const reports: number[] = [];
+    const view = render(
+      <Canvas
+        document={DOCUMENT}
+        siteStyles={PREVIEWABLE}
+        zoom={{ kind: "fixed", scale: 1.5 }}
+        onScale={scale => reports.push(scale)}
+      />
+    );
+
+    expect(reports).toEqual([1.5]);
+
+    view.rerender(
+      <Canvas
+        document={DOCUMENT}
+        siteStyles={PREVIEWABLE}
+        zoom={{ kind: "fixed", scale: 1.5 }}
+        onScale={scale => reports.push(scale)}
+      />
+    );
+
+    expect(reports).toEqual([1.5]);
+  });
+
+  it("reports the CURRENT scale to a reporter that arrives late", () => {
+    /*
+     * A host can resolve its reporter from its own state, so the prop moves
+     * from `undefined` to a function after the canvas has already settled on a
+     * scale. Keyed on the scale alone the effect would not re-run at that
+     * moment, and the host would hold its initial guess until the author
+     * happened to pick a different zoom.
+     *
+     * The scale is deliberately NOT 1 here: a reporter told `1` cannot be
+     * distinguished from one told the default, so the case would pass against
+     * an implementation that reports nothing and a host that assumed.
+     */
+    const reports: number[] = [];
+    const view = render(
+      <Canvas
+        document={DOCUMENT}
+        siteStyles={PREVIEWABLE}
+        zoom={{ kind: "fixed", scale: 1.5 }}
+      />
+    );
+
+    view.rerender(
+      <Canvas
+        document={DOCUMENT}
+        siteStyles={PREVIEWABLE}
+        zoom={{ kind: "fixed", scale: 1.5 }}
+        onScale={scale => reports.push(scale)}
+      />
+    );
+
+    expect(reports).toEqual([1.5]);
+  });
+
+  it("reports each scale the canvas actually takes", () => {
+    // The control for both cases above: an implementation that never reported
+    // after the first render would satisfy the identity case, and one that
+    // reported on every render would satisfy the arrival case.
+    const reports: number[] = [];
+    const onScale = (scale: number) => reports.push(scale);
+    const view = render(
+      <Canvas
+        document={DOCUMENT}
+        siteStyles={PREVIEWABLE}
+        zoom={{ kind: "fixed", scale: 1.5 }}
+        onScale={onScale}
+      />
+    );
+
+    view.rerender(
+      <Canvas
+        document={DOCUMENT}
+        siteStyles={PREVIEWABLE}
+        zoom={{ kind: "fixed", scale: 0.75 }}
+        onScale={onScale}
+      />
+    );
+
+    expect(reports).toEqual([1.5, 0.75]);
   });
 });

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -888,6 +888,71 @@ describe("what the canvas reports about the box it got", () => {
       expect(root.style.transform).toBe("");
     });
 
+    it("draws a chosen scale at the tier that asks for no width", () => {
+      /*
+       * The widest tier requests nothing — the box IS the region — and that is
+       * the state the editor opens in, so it is where a zoom control is used
+       * most. There is nothing to fit there, and an early return for that case
+       * left the control reporting a number that changed nothing: verified in
+       * a browser, where choosing 150% moved the label and left the canvas at
+       * `zoom: 1`.
+       */
+      const { container } = render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={PREVIEWABLE}
+          preview={{ container: "nx-preview-viewport" }}
+          zoom={{ kind: "fixed", scale: 1.5 }}
+        />
+      );
+
+      const root = rootOf(container);
+      expect(zoomOf(root)).toBe("1.5");
+      /*
+       * And the width is COMPENSATED, which is the point rather than an
+       * incidental. `zoom` participates in layout and divides the logical width
+       * the container queries resolve against, so a plain full width came out
+       * at region/scale: at 200% a 911px region became 455px and the canvas
+       * started previewing the MOBILE tier. Magnifying showed a different
+       * layout instead of a larger one.
+       *
+       * Multiplying the percentage back restores the width the box had. No
+       * measurement is involved, so nothing here has to observe a region that
+       * the zoom is itself changing.
+       */
+      // Matched on the RATIO rather than the spelling: engines normalise the
+      // expression differently — jsdom reports `calc(150%)` for what is
+      // authored as `calc(100% * 1.5)` — and the ratio is the behaviour.
+      expect(root.style.width.replace(/\s+/g, "")).toMatch(/(100%\*1\.5|150%)/);
+    });
+
+    it("leaves that tier alone while FITTING", () => {
+      // The control on the other side. A rule that zoomed whenever there was no
+      // requested width would scale the default view by whatever the fit
+      // produced, which is the behaviour this replaces rather than repeats.
+      const { container } = render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={PREVIEWABLE}
+          preview={{ container: "nx-preview-viewport" }}
+        />
+      );
+
+      expect(zoomOf(rootOf(container))).toBe("");
+    });
+
     it("draws a CHOSEN scale where fitting would not have", () => {
       /*
        * The case the old shape could not express. A fit that needs no shrinking

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -46,6 +46,7 @@ import {
   canvasScale,
   nodeIdFromEvent,
 } from "./canvas";
+import type { CanvasZoom } from "./canvas-zoom";
 
 // Explicit because this package does not enable vitest globals, and without
 // them testing-library never registers its own cleanup: every render stays
@@ -823,7 +824,7 @@ describe("what the canvas reports about the box it got", () => {
   }
 
   /** A canvas asked for `width`, so it has a region to scale against. */
-  function atWidth(width: number) {
+  function atWidth(width: number, zoom?: CanvasZoom) {
     return render(
       <Canvas
         document={
@@ -835,6 +836,7 @@ describe("what the canvas reports about the box it got", () => {
         }
         siteStyles={PREVIEWABLE}
         preview={{ container: "nx-preview-viewport", width }}
+        {...(zoom === undefined ? {} : { zoom })}
       />
     );
   }
@@ -884,6 +886,40 @@ describe("what the canvas reports about the box it got", () => {
        */
       expect(zoomOf(root)).toBe(`${912 / 1280}`);
       expect(root.style.transform).toBe("");
+    });
+
+    it("draws a CHOSEN scale where fitting would not have", () => {
+      /*
+       * The case the old shape could not express. A fit that needs no shrinking
+       * is left unzoomed and centred, so every scale at or above 1 took the
+       * `maxWidth` path — and no reading of `maxWidth` magnifies. Choosing 150%
+       * has to reach `zoom`, or the control moves a number on screen and
+       * nothing else.
+       */
+      const { container } = atWidth(600, { kind: "fixed", scale: 1.5 });
+      region(912);
+
+      const root = rootOf(container);
+      expect(zoomOf(root)).toBe("1.5");
+      // And NOT the fitting shape, which has no way to magnify.
+      expect(root.style.maxWidth).toBe("");
+    });
+
+    it("holds a chosen scale when the region changes under it", () => {
+      /*
+       * Choosing a scale means it stops moving when the panels do. Re-deriving
+       * it anyway is the defect this replaces: the canvas fell from 89% to
+       * 59.5% because a panel opened, with nothing said and no way back.
+       *
+       * The region is moved to a width that WOULD have produced a different
+       * fit, so a canvas still fitting reports something else here.
+       */
+      const { container } = atWidth(1280, { kind: "fixed", scale: 1 });
+      region(912);
+
+      const root = rootOf(container);
+      expect(zoomOf(root)).toBe("1");
+      expect(root.style.width).toBe("1280px");
     });
 
     it("leaves a tier that FITS unscaled and centred", () => {

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -953,6 +953,71 @@ describe("what the canvas reports about the box it got", () => {
       expect(zoomOf(rootOf(container))).toBe("");
     });
 
+    it("draws a chosen scale on a site that previews no viewport at all", () => {
+      /*
+       * Previewing needs a container name AND a site declaring viewport tiers,
+       * and the default configuration has neither — so there is no preview
+       * object, which is the state most sites are in. Nesting the scale inside
+       * that object left the control moving a number on screen and changing
+       * nothing for exactly those sites.
+       */
+      const { container } = render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={{ css: "", classes: {} } as never}
+          zoom={{ kind: "fixed", scale: 1.5 }}
+        />
+      );
+
+      expect(zoomOf(rootOf(container))).toBe("1.5");
+    });
+
+    it("refuses a scale it cannot paint at", () => {
+      /*
+       * `CanvasZoom` is exported, so a host can build one directly and never
+       * pass through the storage guard. Interpolated into a `zoom` declaration
+       * these produce either a rule the browser drops or a canvas beyond reach
+       * of the control that would undo it, so the check belongs where a scale
+       * is USED rather than only where one is parsed.
+       */
+      /*
+       * WITH a preview, which is the path the validation is load-bearing on.
+       * Without one the box style already declines to apply an unchosen scale,
+       * so a no-preview fixture passes whether or not the scale was checked —
+       * it cannot separate the two guards.
+       */
+      const previewing = atWidth(1280, { kind: "fixed", scale: Number.NaN });
+      region(912);
+      expect(zoomOf(rootOf(previewing.container))).not.toContain("NaN");
+      previewing.unmount();
+
+      for (const scale of [Number.NaN, Infinity, 0, 500]) {
+        const { container, unmount } = render(
+          <Canvas
+            document={
+              {
+                formatVersion: 1,
+                kind: "page",
+                nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+              } as never
+            }
+            siteStyles={{ css: "", classes: {} } as never}
+            zoom={{ kind: "fixed", scale }}
+          />
+        );
+        // Falls back to fitting, which paints nothing rather than painting a
+        // value the browser cannot use.
+        expect(zoomOf(rootOf(container))).toBe("");
+        unmount();
+      }
+    });
+
     it("draws a CHOSEN scale where fitting would not have", () => {
       /*
        * The case the old shape could not express. A fit that needs no shrinking

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -46,6 +46,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { CanvasDragHandlers } from "./canvas-drag";
 import { offeredTiers } from "./canvas-width";
+import { FIT_ZOOM, type CanvasZoom } from "./canvas-zoom";
 import { selectionModeFor, type SelectionMode } from "./selection";
 import { CANVAS_ROOT_CLASS } from "./shell-state";
 
@@ -401,8 +402,16 @@ function useRegionWidth(
  */
 export function canvasScale(
   requested: number | undefined,
-  region: number | undefined
+  region: number | undefined,
+  zoom: CanvasZoom = FIT_ZOOM
 ): number {
+  /*
+   * A chosen scale is not derived from anything, which is the whole of what
+   * choosing means. It is answered before the guards below because those exist
+   * to make a FIT computable — an unmeasured region cannot be fitted to, and a
+   * fixed scale never needed it.
+   */
+  if (zoom.kind === "fixed") return zoom.scale;
   if (requested === undefined || region === undefined) return 1;
   if (!(requested > 0) || !(region > 0)) return 1;
   return Math.min(1, region / requested);
@@ -451,12 +460,22 @@ export function canvasScale(
  */
 function previewBoxStyle(
   preview: CanvasPreview | undefined,
-  scale: number
+  scale: number,
+  chosen: boolean
 ): React.CSSProperties {
   if (preview === undefined) return {};
   const container = previewContainerStyle(preview.container);
   if (preview.width === undefined) return container;
-  if (scale >= 1) {
+  /*
+   * A FIT that needs no shrinking is left unzoomed and centred, which is the
+   * shape a canvas showing a page at its own size has always had.
+   *
+   * A CHOSEN scale is applied whatever its value, including 1 and above. The
+   * two are not the same request: fitting to 1 means "it already fits", while
+   * choosing 1 means "draw it at actual size and let the region clip" — and at
+   * anything above 1 there is no reading of `maxWidth` that magnifies.
+   */
+  if (!chosen && scale >= 1) {
     return {
       ...container,
       maxWidth: `${preview.width}px`,
@@ -480,7 +499,8 @@ function previewBoxStyle(
  */
 function useCanvasSurface(
   root: React.RefObject<HTMLElement | null>,
-  preview: CanvasPreview | undefined
+  preview: CanvasPreview | undefined,
+  zoom: CanvasZoom
 ): React.CSSProperties {
   // What the box GOT, reported outward to whoever asked.
   useReportedInlineWidth(root, preview?.onMeasured);
@@ -489,7 +509,12 @@ function useCanvasSurface(
   // nothing to scale, and an observer that exists to answer a question nobody
   // asked still fires on every pane drag.
   const region = useRegionWidth(root, preview?.width !== undefined);
-  return previewBoxStyle(preview, canvasScale(preview?.width, region));
+  const scale = canvasScale(preview?.width, region, zoom);
+  const onScale = preview?.onScale;
+  useEffect(() => {
+    onScale?.(scale);
+  }, [onScale, scale]);
+  return previewBoxStyle(preview, scale, zoom.kind === "fixed");
 }
 
 /**
@@ -725,6 +750,20 @@ export interface CanvasPreview {
    * tier as live on the strength of a box nobody has looked at.
    */
   onMeasured?: (width: number | undefined) => void;
+  /**
+   * The scale the box is actually painted at, reported as it changes.
+   *
+   * Separate from {@link CanvasPreview.onMeasured} because they answer
+   * different questions: that one is the width the box GOT, this one is how far
+   * it had to shrink to get it. A caller can derive neither from the other
+   * without the region, which only this canvas measures.
+   *
+   * Reported rather than exposed as state for the reason the width is: a
+   * control that computed its own would be a second answer to what is on
+   * screen, and the two would disagree for exactly the frame after a panel
+   * opens — which is the moment worth naming.
+   */
+  onScale?: (scale: number) => void;
 }
 
 /**
@@ -978,6 +1017,14 @@ export interface CanvasProps {
    */
   dragHandlers?: CanvasDragHandlers;
   /**
+   * How large to draw the previewed page.
+   *
+   * Defaults to fitting, which is what this canvas did before the scale could
+   * be chosen — so a host offering no zoom control keeps exactly the behaviour
+   * it had.
+   */
+  zoom?: CanvasZoom;
+  /**
    * Raised when a double-click lands on the page.
    *
    * Separate from `onSelect` because the two gestures mean different things and
@@ -1015,6 +1062,7 @@ export function Canvas({
   render,
   className,
   dragHandlers,
+  zoom = FIT_ZOOM,
   onDoubleClick,
   overlay,
   preview,
@@ -1048,7 +1096,7 @@ export function Canvas({
     preview
   );
 
-  const boxStyle = useCanvasSurface(root, active);
+  const boxStyle = useCanvasSurface(root, active, zoom);
 
   const page = useMemo(
     () => (

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -46,7 +46,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { CanvasDragHandlers } from "./canvas-drag";
 import { offeredTiers } from "./canvas-width";
-import { FIT_ZOOM, type CanvasZoom } from "./canvas-zoom";
+import { FIT_ZOOM, usableScale, type CanvasZoom } from "./canvas-zoom";
 import { selectionModeFor, type SelectionMode } from "./selection";
 import { CANVAS_ROOT_CLASS } from "./shell-state";
 
@@ -411,7 +411,15 @@ export function canvasScale(
    * to make a FIT computable — an unmeasured region cannot be fitted to, and a
    * fixed scale never needed it.
    */
-  if (zoom.kind === "fixed") return zoom.scale;
+  if (zoom.kind === "fixed") {
+    // A host can build this value directly, so it has not necessarily been
+    // through the storage guard. An unusable one falls back to fitting rather
+    // than being painted: an invalid `zoom` declaration is dropped by the
+    // browser and an enormous one puts the page beyond reach of the control
+    // that would undo it.
+    const usable = usableScale(zoom.scale);
+    if (usable !== null) return usable;
+  }
   if (requested === undefined || region === undefined) return 1;
   if (!(requested > 0) || !(region > 0)) return 1;
   return Math.min(1, region / requested);
@@ -463,7 +471,18 @@ function previewBoxStyle(
   scale: number,
   chosen: boolean
 ): React.CSSProperties {
-  if (preview === undefined) return {};
+  /*
+   * A CHOSEN scale applies with no preview at all.
+   *
+   * Previewing needs a container name and a site that declares viewport tiers;
+   * a site with neither — which the default configuration is — has no preview
+   * object, and returning nothing here left the zoom control moving a number
+   * on screen and changing nothing. How large the canvas draws is not a
+   * property of whether a viewport is being simulated.
+   */
+  if (preview === undefined) {
+    return chosen ? { width: `calc(100% * ${scale})`, zoom: scale } : {};
+  }
   const container = previewContainerStyle(preview.container);
   /*
    * No requested width means the box fills the region, which is the widest
@@ -536,7 +555,8 @@ function previewBoxStyle(
 function useCanvasSurface(
   root: React.RefObject<HTMLElement | null>,
   preview: CanvasPreview | undefined,
-  zoom: CanvasZoom
+  zoom: CanvasZoom,
+  onScale: ((scale: number) => void) | undefined
 ): React.CSSProperties {
   // What the box GOT, reported outward to whoever asked.
   useReportedInlineWidth(root, preview?.onMeasured);
@@ -546,11 +566,17 @@ function useCanvasSurface(
   // asked still fires on every pane drag.
   const region = useRegionWidth(root, preview?.width !== undefined);
   const scale = canvasScale(preview?.width, region, zoom);
-  const onScale = preview?.onScale;
   useEffect(() => {
     onScale?.(scale);
   }, [onScale, scale]);
-  return previewBoxStyle(preview, scale, zoom.kind === "fixed");
+  /*
+   * CHOSEN means a scale the author asked for AND this canvas can paint at.
+   * A refused one has already fallen back to fitting above, so treating it as
+   * chosen here would apply the fit's own scale as though it were a choice —
+   * writing `zoom: 1` onto a canvas that should carry no zoom at all.
+   */
+  const chosen = zoom.kind === "fixed" && usableScale(zoom.scale) !== null;
+  return previewBoxStyle(preview, scale, chosen);
 }
 
 /**
@@ -786,20 +812,6 @@ export interface CanvasPreview {
    * tier as live on the strength of a box nobody has looked at.
    */
   onMeasured?: (width: number | undefined) => void;
-  /**
-   * The scale the box is actually painted at, reported as it changes.
-   *
-   * Separate from {@link CanvasPreview.onMeasured} because they answer
-   * different questions: that one is the width the box GOT, this one is how far
-   * it had to shrink to get it. A caller can derive neither from the other
-   * without the region, which only this canvas measures.
-   *
-   * Reported rather than exposed as state for the reason the width is: a
-   * control that computed its own would be a second answer to what is on
-   * screen, and the two would disagree for exactly the frame after a panel
-   * opens — which is the moment worth naming.
-   */
-  onScale?: (scale: number) => void;
 }
 
 /**
@@ -1061,6 +1073,20 @@ export interface CanvasProps {
    */
   zoom?: CanvasZoom;
   /**
+   * The scale the canvas is actually painting at, reported as it changes.
+   *
+   * On the CANVAS rather than on {@link CanvasProps.preview}, because the
+   * scale is not a property of previewing a viewport: a site declaring no
+   * tiers has no preview at all and is still drawn at some size. Nested there,
+   * this went silent in exactly the configuration most sites start in.
+   *
+   * Reported rather than exposed as state for the reason the width is: a
+   * control computing its own would be a second answer to what is on screen,
+   * and the two would disagree for the frame after a panel opens — which is
+   * the moment worth naming.
+   */
+  onScale?: (scale: number) => void;
+  /**
    * Raised when a double-click lands on the page.
    *
    * Separate from `onSelect` because the two gestures mean different things and
@@ -1099,6 +1125,7 @@ export function Canvas({
   className,
   dragHandlers,
   zoom = FIT_ZOOM,
+  onScale,
   onDoubleClick,
   overlay,
   preview,
@@ -1132,7 +1159,7 @@ export function Canvas({
     preview
   );
 
-  const boxStyle = useCanvasSurface(root, active, zoom);
+  const boxStyle = useCanvasSurface(root, active, zoom, onScale);
 
   const page = useMemo(
     () => (

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -465,7 +465,43 @@ function previewBoxStyle(
 ): React.CSSProperties {
   if (preview === undefined) return {};
   const container = previewContainerStyle(preview.container);
-  if (preview.width === undefined) return container;
+  /*
+   * No requested width means the box fills the region, which is the widest
+   * tier and the state the editor opens in. There is nothing to FIT there —
+   * the box is already the region — but a chosen scale still applies: it
+   * magnifies or shrinks what is drawn and the region scrolls, which is the
+   * whole of what an author asked for. Returning early here left the control
+   * reporting a number that changed nothing at the tier it is used at most.
+   */
+  if (preview.width === undefined) {
+    if (!chosen) return container;
+    /*
+     * The width is PINNED before zooming, and that is the whole of this branch.
+     *
+     * `zoom` participates in layout, so it divides the logical width the
+     * container queries resolve against: at 200% a 911px region became 455px
+     * and the canvas silently started previewing the MOBILE tier. An author
+     * magnifying to look closely at something was shown a different layout
+     * instead — measured on screen, where the tier readout changed with the
+     * zoom.
+     *
+     * Fixing the box at the width it had leaves the queries resolving against
+     * that same width whatever the scale, so magnifying magnifies and nothing
+     * else moves. Without a measured region there is nothing to pin, and the
+     * scale is left off rather than applied against a width that would shift.
+     */
+    return {
+      ...container,
+      // `100%` resolves against the containing block in this element's OWN
+      // coordinates, which `zoom` has already divided by the scale — so a
+      // plain full width comes out at `region / scale` logically. Multiplying
+      // it back restores the width the box had, and the scale then paints it
+      // larger without moving what the queries resolve against. No measurement
+      // is involved, so there is no observer to disagree with the layout.
+      width: `calc(100% * ${scale})`,
+      zoom: scale,
+    };
+  }
   /*
    * A FIT that needs no shrinking is left unzoomed and centred, which is the
    * shape a canvas showing a page at its own size has always had.

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -566,9 +566,28 @@ function useCanvasSurface(
   // asked still fires on every pane drag.
   const region = useRegionWidth(root, preview?.width !== undefined);
   const scale = canvasScale(preview?.width, region, zoom);
+  /*
+   * Reported through a ref, keyed on the scale and on whether anyone is
+   * listening — never on the reporter's identity.
+   *
+   * A host writing `onScale={s => setView({ ...view, scale: s })}` inline hands
+   * a new function every render. Depended on directly, each report updates the
+   * host, the update produces a new identity, and the new identity reports
+   * again: a render loop on a host that did nothing wrong.
+   *
+   * Existence is a dependency because it changes the answer. A host that wires
+   * the reporter after its first render — one resolving `onScale` from state,
+   * or a shell whose control mounts late — would otherwise hear nothing until
+   * the scale next moved, and sit on a stale number in the meantime.
+   */
+  const latestScaleReport = useRef(onScale);
   useEffect(() => {
-    onScale?.(scale);
-  }, [onScale, scale]);
+    latestScaleReport.current = onScale;
+  }, [onScale]);
+  const reportingScale = onScale !== undefined;
+  useEffect(() => {
+    latestScaleReport.current?.(scale);
+  }, [reportingScale, scale]);
   /*
    * CHOSEN means a scale the author asked for AND this canvas can paint at.
    * A refused one has already fallen back to fitting above, so treating it as
@@ -1065,20 +1084,18 @@ export interface CanvasProps {
    */
   dragHandlers?: CanvasDragHandlers;
   /**
-   * How large to draw the previewed page.
+   * The layout scale this canvas applies to the page it lays out.
    *
-   * Defaults to fitting, which is what this canvas did before the scale could
-   * be chosen — so a host offering no zoom control keeps exactly the behaviour
-   * it had.
+   * Defaults to fitting, so a host that offers no zoom control never has to
+   * name a scale.
    */
   zoom?: CanvasZoom;
   /**
    * The scale the canvas is actually painting at, reported as it changes.
    *
    * On the CANVAS rather than on {@link CanvasProps.preview}, because the
-   * scale is not a property of previewing a viewport: a site declaring no
-   * tiers has no preview at all and is still drawn at some size. Nested there,
-   * this went silent in exactly the configuration most sites start in.
+   * scale is not a property of previewing a viewport: a site that declares no
+   * tiers has no preview at all and is still laid out at some scale.
    *
    * Reported rather than exposed as state for the reason the width is: a
    * control computing its own would be a second answer to what is on screen,

--- a/packages/builder/src/index.ts
+++ b/packages/builder/src/index.ts
@@ -327,6 +327,23 @@ export {
  * offers, and availability derived from a second reading of the lock and move
  * rules is how the two come to disagree.
  */
+/**
+ * @experimental How large the canvas draws the page.
+ *
+ * Pure, so it stays on this entry: a host reads a stored preference and hands
+ * the result to the canvas, and neither half needs a component to do it.
+ */
+export {
+  FIT_ZOOM,
+  MAX_ZOOM,
+  MIN_ZOOM,
+  ZOOM_STEPS,
+  readZoom,
+  steppedZoom,
+  writeZoom,
+  type CanvasZoom,
+} from "./canvas-zoom";
+
 export {
   BLOCK_GROUP,
   EDITOR_GROUP,

--- a/packages/builder/src/shell-state.test.ts
+++ b/packages/builder/src/shell-state.test.ts
@@ -149,12 +149,30 @@ describe("preferences round-trip", () => {
     // exercises this field rather than passing on the strength of a default
     // that both the write and a no-op read would agree on.
     showEmptyElements: false,
+    // Non-default for the same reason, and FIXED rather than fit: fit is the
+    // default, and it is also what a read falls back to when it cannot make
+    // sense of what was stored — so a round trip carrying fit would pass
+    // whether the value survived or was discarded.
+    zoom: { kind: "fixed", scale: 1.5 },
   };
 
   it("restores what was written", () => {
     const store = memoryStore();
     writePreferences(store, stored);
     expect(readPreferences(store)).toEqual(stored);
+  });
+
+  it("falls back to fitting when the stored zoom is not one", () => {
+    /*
+     * Preferences written before there was a zoom have no such field, and a
+     * hand-edited or later-version file can carry anything. A scale outside the
+     * bounds is the case that matters: it would paint the canvas at a size from
+     * which the control that sets it cannot be reached.
+     */
+    for (const bad of [undefined, "1.5", 0, 99, null]) {
+      const store = memoryStore(JSON.stringify({ ...stored, zoom: bad }));
+      expect(readPreferences(store).zoom).toEqual(DEFAULT_PREFERENCES.zoom);
+    }
   });
 
   it("uses the defaults when nothing was ever stored", () => {
@@ -201,6 +219,7 @@ describe("preferences round-trip", () => {
       // Absent from the stored JSON above, so it falls back the same way
       // `leftPinned` does here rather than surfacing as `undefined`.
       showEmptyElements: DEFAULT_PREFERENCES.showEmptyElements,
+      zoom: DEFAULT_PREFERENCES.zoom,
     });
   });
 

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -14,6 +14,8 @@
  * @module shell-state
  */
 
+import { FIT_ZOOM, readZoom, writeZoom, type CanvasZoom } from "./canvas-zoom";
+
 /**
  * The panels the left rail switches between.
  *
@@ -125,6 +127,14 @@ export interface ShellPreferences {
   leftPanel: LeftPanel | null;
   leftPinned: boolean;
   /**
+   * How large the canvas draws the page, as the author last left it.
+   *
+   * Chrome rather than document state, like everything else here: it describes
+   * how one person is looking at the editor, not what the page IS, so it must
+   * not travel with the document to another author.
+   */
+  zoom: CanvasZoom;
+  /**
    * Layouts, one per PANEL TOPOLOGY.
    *
    * Keyed rather than singular because a layout only means anything alongside
@@ -210,6 +220,7 @@ export function topologyKey(panelIds: readonly string[]): string {
 export const DEFAULT_PREFERENCES: ShellPreferences = {
   leftPanel: null,
   leftPinned: true,
+  zoom: FIT_ZOOM,
   layouts: {},
   showEmptyElements: true,
 };
@@ -324,6 +335,11 @@ export function readPreferences(store: PreferenceStore): ShellPreferences {
       typeof record.leftPinned === "boolean"
         ? record.leftPinned
         : DEFAULT_PREFERENCES.leftPinned,
+    // Fit when the stored value is not a zoom, which includes every preference
+    // written before there was one. `readZoom` refuses a scale outside the
+    // bounds rather than painting the canvas somewhere the control cannot be
+    // reached to undo it.
+    zoom: readZoom(record.zoom) ?? DEFAULT_PREFERENCES.zoom,
     layouts: readLayouts(record.layouts),
     showEmptyElements:
       typeof record.showEmptyElements === "boolean"
@@ -338,7 +354,12 @@ export function writePreferences(
   preferences: ShellPreferences
 ): void {
   try {
-    store.write(JSON.stringify(preferences));
+    // Narrowed on the way out for the reason it is checked on the way in: what
+    // is stored is a value this can read back, not whatever shape the running
+    // editor happens to hold.
+    store.write(
+      JSON.stringify({ ...preferences, zoom: writeZoom(preferences.zoom) })
+    );
   } catch {
     // A quota error or unavailable storage. Losing a panel width is not worth
     // interrupting an edit over, and there is nothing the author could do.

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -146,6 +146,16 @@ export type { BreakpointManagerProps } from "./breakpoint-manager";
  */
 export { BreakpointSwitcher } from "./breakpoint-switcher";
 export type { BreakpointSwitcherProps } from "./breakpoint-switcher";
+
+/**
+ * The canvas zoom, and the control that names it.
+ *
+ * The control is a client component and belongs here; the model beside it is
+ * pure and is exported from the root entry as well, so a host can read a stored
+ * preference without pulling a component into a server render.
+ */
+export { CanvasZoomControl } from "./canvas-zoom-control";
+export type { CanvasZoomControlProps } from "./canvas-zoom-control";
 export {
   breakpointsAtWidth,
   editedBreakpointAtWidth,

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -156,6 +156,9 @@ export type { BreakpointSwitcherProps } from "./breakpoint-switcher";
  */
 export { CanvasZoomControl } from "./canvas-zoom-control";
 export type { CanvasZoomControlProps } from "./canvas-zoom-control";
+// The type alone: a host threading a zoom through this entry should not have
+// to import the model from a second one.
+export type { CanvasZoom } from "./canvas-zoom";
 export {
   breakpointsAtWidth,
   editedBreakpointAtWidth,

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -2080,3 +2080,48 @@
   font-family: var(--font-mono, ui-monospace, monospace);
   white-space: nowrap;
 }
+
+/*
+ * The canvas zoom trigger.
+ *
+ * Styled here because it is a bare Radix trigger: Preflight strips a button's
+ * border and background, so without this the percentage renders as plain text
+ * and reads as a status readout rather than something to press. It sits in the
+ * top bar beside the breakpoint switcher, so it borrows that furniture's
+ * proportions rather than introducing its own.
+ */
+.nx-zoom-control {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 3.5rem;
+  padding: 0.25rem 0.5rem;
+  border: 1px solid var(--nx-border);
+  border-radius: 0.375rem;
+  background: var(--nx-background);
+  color: var(--nx-foreground);
+  font-size: var(--text-xs);
+  /* The digits change as the canvas resizes, and a proportional face makes the
+     control shift width while an author is reading it. */
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+  transition:
+    background-color 120ms ease,
+    border-color 120ms ease;
+}
+
+.nx-zoom-control:hover {
+  background: var(--nx-muted);
+}
+
+/* Open is a STATE, not a hover: the menu can be opened from the keyboard, and
+   a trigger that looks unpressed while its menu is up reads as a stray popup. */
+.nx-zoom-control[data-state="open"] {
+  background: var(--nx-muted);
+  border-color: var(--nx-ring);
+}
+
+.nx-zoom-control:focus-visible {
+  outline: 2px solid var(--nx-ring);
+  outline-offset: 2px;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -246,6 +246,22 @@ afterEach(() => {
 });
 
 describe("the container the canvas is compiled against", () => {
+  it("gives the canvas the reporter the zoom control reads", () => {
+    /*
+     * The scale the canvas paints at is reported back so the control can name
+     * it — including while FITTING, where it is derived from a region only the
+     * canvas measures.
+     *
+     * Asserted on the CANVAS's own props rather than inside `preview`, because
+     * that is exactly where it was wrong: an extra key on an inferred object is
+     * accepted and ignored rather than refused, so the reporter never ran and
+     * the control sat at 100% while the canvas zoomed.
+     */
+    openEditor();
+
+    expect(seen.canvas?.onScale).toBeTypeOf("function");
+  });
+
   it("tells the layers panel that the move keystrokes are bound", () => {
     /*
      * The panel cannot work this out where it sits. It is drawn in the shell's

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -1142,10 +1142,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * Nothing writes it from this side. The shell persists the choice and reports
    * it, including the value restored on load; this holds the last report so the
    * canvas can be scaled by it. Holding it as a second source of truth and
-   * syncing back is what produced an oscillating write of `fit, 2, fit, 2` on
+   * syncing BACK is what produced an oscillating write of `fit, 2, fit, 2` on
    * every open — two owners, each correcting the other.
+   *
+   * Seeded with the same default the shell starts from, so there is no absent
+   * state for the canvas to interpret. That is safe only because this direction
+   * is one-way: with nothing sending a zoom back, a default held here can never
+   * reach the store to overwrite what the author chose.
    */
-  const [zoom, setZoom] = useState<CanvasZoom | undefined>(undefined);
+  const [zoom, setZoom] = useState<CanvasZoom>(DEFAULT_PREFERENCES.zoom);
   const [appliedScale, setAppliedScale] = useState(1);
   const [measuredWidth, setMeasuredWidth] = useState<number | undefined>(
     undefined
@@ -1710,7 +1715,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             */
             <BlockContextMenu editor={editor}>
               <Canvas
-                zoom={zoom ?? DEFAULT_PREFERENCES.zoom}
+                zoom={zoom}
                 document={editor.document}
                 siteStyles={siteSheet(canvasSiteStyle)}
                 selectedId={editor.selectedId}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -55,7 +55,7 @@ import {
   BlockToolbar,
   BreakpointManager,
   BreakpointSwitcher,
-  CanvasZoomControl,
+  type CanvasZoom,
   breakpointsAtWidth,
   editedBreakpointAtWidth,
   offeredTiers,
@@ -1136,7 +1136,16 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * than computed here, where a second derivation would disagree with the
    * screen for exactly the frame after a panel opens.
    */
-  const [zoom, setZoom] = useState(DEFAULT_PREFERENCES.zoom);
+  /*
+   * The zoom the SHELL owns, mirrored here only to draw the canvas with it.
+   *
+   * Nothing writes it from this side. The shell persists the choice and reports
+   * it, including the value restored on load; this holds the last report so the
+   * canvas can be scaled by it. Holding it as a second source of truth and
+   * syncing back is what produced an oscillating write of `fit, 2, fit, 2` on
+   * every open — two owners, each correcting the other.
+   */
+  const [zoom, setZoom] = useState<CanvasZoom | undefined>(undefined);
   const [appliedScale, setAppliedScale] = useState(1);
   const [measuredWidth, setMeasuredWidth] = useState<number | undefined>(
     undefined
@@ -1457,6 +1466,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // already suppresses the placeholder box it sits over.
         onShowEmptyElementsChange={setShowEmptyElements}
         onZoomChange={setZoom}
+        appliedScale={appliedScale}
         // Whether the page is live, which the admin's own chrome would have
         // shown had this editor not asked for it to be hidden. `undoDepth` is
         // the editor's OWN dirty signal: the form's is false for as long as the
@@ -1494,16 +1504,6 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
              * only the measured width it would unselect the option just
              * clicked whenever the region could not honour it.
              */}
-            {/*
-              Beside the tier switcher, because between them they answer one
-              question: which viewport is being simulated, and how large it is
-              drawn. Split across the shell they read as unrelated controls.
-            */}
-            <CanvasZoomControl
-              zoom={zoom}
-              appliedScale={appliedScale}
-              onChange={setZoom}
-            />
             <BreakpointSwitcher
               breakpoints={canvasRender.styleContext.breakpoints}
               width={requestedWidth}
@@ -1710,7 +1710,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             */
             <BlockContextMenu editor={editor}>
               <Canvas
-                zoom={zoom}
+                zoom={zoom ?? DEFAULT_PREFERENCES.zoom}
                 document={editor.document}
                 siteStyles={siteSheet(canvasSiteStyle)}
                 selectedId={editor.selectedId}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -1251,7 +1251,6 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             container: canvasPreviewContainer,
             ...(requestedWidth === undefined ? {} : { width: requestedWidth }),
             onMeasured: setMeasuredWidth,
-            onScale: setAppliedScale,
           },
     [canvasPreviewContainer, requestedWidth]
   );
@@ -1716,6 +1715,13 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             <BlockContextMenu editor={editor}>
               <Canvas
                 zoom={zoom}
+                /*
+                  On the CANVAS, not inside `preview`. The scale is reported
+                  whether or not a viewport is being previewed, and an extra key
+                  on that inferred object is accepted and ignored rather than
+                  refused — so the reporter simply never ran.
+                */
+                onScale={setAppliedScale}
                 document={editor.document}
                 siteStyles={siteSheet(canvasSiteStyle)}
                 selectedId={editor.selectedId}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -55,6 +55,7 @@ import {
   BlockToolbar,
   BreakpointManager,
   BreakpointSwitcher,
+  CanvasZoomControl,
   breakpointsAtWidth,
   editedBreakpointAtWidth,
   offeredTiers,
@@ -1126,6 +1127,17 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const [requestedTier, setRequestedTier] = useState<BreakpointId | undefined>(
     undefined
   );
+  /*
+   * The zoom, and the scale it produces, held apart.
+   *
+   * The first is what the author ASKED for and the shell persists it. The
+   * second is what the canvas is painting at, which while fitting is derived
+   * from a region only the canvas measures — so it is reported back rather
+   * than computed here, where a second derivation would disagree with the
+   * screen for exactly the frame after a panel opens.
+   */
+  const [zoom, setZoom] = useState(DEFAULT_PREFERENCES.zoom);
+  const [appliedScale, setAppliedScale] = useState(1);
   const [measuredWidth, setMeasuredWidth] = useState<number | undefined>(
     undefined
   );
@@ -1225,6 +1237,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             container: canvasPreviewContainer,
             ...(requestedWidth === undefined ? {} : { width: requestedWidth }),
             onMeasured: setMeasuredWidth,
+            onScale: setAppliedScale,
           },
     [canvasPreviewContainer, requestedWidth]
   );
@@ -1443,6 +1456,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // so the appender below can be suppressed by the SAME switch that
         // already suppresses the placeholder box it sits over.
         onShowEmptyElementsChange={setShowEmptyElements}
+        onZoomChange={setZoom}
         // Whether the page is live, which the admin's own chrome would have
         // shown had this editor not asked for it to be hidden. `undoDepth` is
         // the editor's OWN dirty signal: the form's is false for as long as the
@@ -1480,6 +1494,16 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
              * only the measured width it would unselect the option just
              * clicked whenever the region could not honour it.
              */}
+            {/*
+              Beside the tier switcher, because between them they answer one
+              question: which viewport is being simulated, and how large it is
+              drawn. Split across the shell they read as unrelated controls.
+            */}
+            <CanvasZoomControl
+              zoom={zoom}
+              appliedScale={appliedScale}
+              onChange={setZoom}
+            />
             <BreakpointSwitcher
               breakpoints={canvasRender.styleContext.breakpoints}
               width={requestedWidth}
@@ -1686,6 +1710,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             */
             <BlockContextMenu editor={editor}>
               <Canvas
+                zoom={zoom}
                 document={editor.document}
                 siteStyles={siteSheet(canvasSiteStyle)}
                 selectedId={editor.selectedId}


### PR DESCRIPTION
Closes `finding:pb-canvas-has-no-zoom-control` — the third of the four canvas items, in the order you chose.

## The problem

The canvas has always had a scale and it has never been the author's. It is derived to fit whatever room the panels leave, so opening one took the page from **89% to 59.5%** with nothing on screen naming either number and no way to set one. Judging type or spacing meant judging it at a size nobody chose. And the scale could only ever *shrink* — `canvasScale` capped at 1 as an explicit contract — so there was no way to look closely at anything.

## What it does

A percentage in the shell header, always shown **including while fitting**, because fitting is the state the editor spends most of its time in and the one that moved without being announced. Fit sits in the same menu as the sizes rather than beside it as a mode switch: from the author's side it is one question — how big — and splitting it makes them answer twice.

**A chosen percentage is absolute, not a multiplier of the fit.** The research this came from recommended a multiplier; that makes the number a lie, because 100% would mean whatever the panels happened to leave, where an author asking for 100% is asking for actual size. Every editor showing a zoom percentage means the absolute one.

Stored per browser beside the other chrome preferences, and read back through a guard: a scale outside the bounds is refused rather than painting the canvas at a size from which the control that sets it cannot be reached.

## Three defects the tests could not see, and a browser found in a minute

Worth listing, because each was invisible to jsdom and each would have shipped.

**1. The control did nothing at the tier it is used at most.** The widest tier requests no width — the box *is* the region — and the box style returned early for that case. Choosing 150% moved the label and left the canvas at `zoom: 1`. That is the state the editor opens in.

**2. Magnifying changed which breakpoint was previewed.** `zoom` participates in layout, so it divides the logical width container queries resolve against: at 200% a 911px canvas became **455px and started previewing MOBILE**. An author looking closely at something was shown a different layout instead of a larger one.

Fixed by compensating the width by the same factor. `calc(100% * scale)` rather than a measured pin — a percentage already resolves in the element's zoomed coordinates, so nothing has to observe a region that the zoom is itself changing. Verified: tier reads `911px · Tablet` before and after, logical width stays 911, painted width goes to 1822.

**3. The preference erased itself on every open.** The shell owns preferences and the host owned the control, so the value lived in two places and each corrected the other — an oscillating write of `fit, 2, fit, 2` per open, ending in whichever landed last, usually the default over the author's choice.

Fixed by **ownership, not suppression**. I tried suppression first — a load guard, then echo-tracking — and both were patches over a design with two owners. The shell renders the control, because the shell owns what the control edits; the host reports the scale the canvas is painting at, because only the canvas can measure it, and consumes the zoom to draw with. One direction each, so there is nothing to synchronise. Verified: opening with a stored `2` now produces **zero** writes.

## Verification

Every case break-verified, each mutation killing exactly the tests whose names promise that behaviour:

| mutation | fails |
|---|---|
| chosen scale takes the fitting path at ≥1 | `draws a CHOSEN scale where fitting would not have` |
| chosen scale re-derived from the region | same, plus `holds a chosen scale when the region changes under it` |
| return early at the unbounded tier | `draws a chosen scale at the tier that asks for no width` |
| zoom the unbounded tier while fitting | `leaves that tier alone while FITTING` |
| drop the width compensation | `draws a chosen scale at the tier that asks for no width` |
| show the chosen scale instead of the painted one | `names the scale the canvas is PAINTING at while fitting` |
| name stops distinguishing the modes | `says whether that number will move on its own` |
| no way back to fitting | `offers a way back to fitting` |
| `readZoom` accepts anything numeric | `refuses a value that would paint the canvas out of reach` |

The stepping cases use `1` exactly, because a naive `>=` answers 100% again for a press meant to magnify.

The research node's repo claims were re-verified against current main rather than taken on trust — `canvasScale`'s cap, the absence of stored zoom state, `paintedScale` deriving live, and `caretRangeFromPoint` being native. All held; my first search for `paintedScale` was the flawed instrument, not the claim.

Green: `builder` 2418, `plugin-page-builder` 481, typecheck, lint, `fallow` clean. Client boundary checked in the artifact: the control appears in `dist/shell.mjs` and **not** in the bannerless `dist/index.mjs`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added canvas zoom controls with Fit and selectable zoom levels from 25% to 400%.
  * Displays the currently applied canvas scale and supports accessible zoom controls.
  * Zoom preferences are restored and persisted across sessions.
  * Canvas zoom remains consistent as the preview region changes.
  * Added experimental zoom APIs and client-side control exports.

* **Bug Fixes**
  * Invalid or unsupported zoom values now safely fall back to Fit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->