### PR TITLE
fix(nextly): detect a missing column through the wrapped cause, and drop the last raw SQL

### DIFF
--- a/.changeset/detect-a-missing-column-through-the-wrapped-cause.md
+++ b/.changeset/detect-a-missing-column-through-the-wrapped-cause.md
@@ -1,0 +1,31 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Detect a missing column through the driver error the ORM wraps, so a translation
+table created before the staleness timestamp existed reports "unknown" instead
+of failing the read.

--- a/packages/nextly/src/domains/i18n/companion-join.test.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.test.ts
@@ -122,6 +122,31 @@ describe("populateTranslationStatus — staleness (i18n B2)", () => {
   }
 
   /**
+   * The error a Drizzle select ACTUALLY throws when the column is absent.
+   *
+   * 🔴 Transcribed from a real SQLite adapter, not invented, because the invented one is what let
+   * this defect ship: the earlier fixture put the driver wording on the top-level message, so the
+   * predicate matched and the test passed while the real path rethrew and the read failed.
+   *
+   * Two properties matter and both are reproduced here. The driver wording is on `cause`, not on
+   * the error a caller catches. And the TOP-level message quotes the SQL, so it CONTAINS the
+   * column name — which is why a predicate must test both conditions at the same level rather
+   * than asking whether any level mentions the column and any level reads as missing.
+   */
+  function drizzleMissingColumnError(): Error {
+    const top = new Error(
+      'Failed query: select "_parent", "_locale", "_updated_at" from "dc_posts_locales" where ...'
+    );
+    top.name = "DrizzleQueryError";
+    const driver = new Error(
+      'no such column: "_updated_at" - should this be a string literal in single-quotes?'
+    );
+    driver.name = "SqliteError";
+    top.cause = driver;
+    return top;
+  }
+
+  /**
    * A db whose FIRST select answers normally and whose SECOND rejects.
    *
    * The stamp read is the second query `populateTranslationStatus` issues, so failing every select
@@ -276,10 +301,7 @@ describe("populateTranslationStatus — staleness (i18n B2)", () => {
     const row: Record<string, unknown> = { id: "doc1" };
     await expect(
       populateTranslationStatus({
-        db: dbFailingOnStampRead(
-          rows,
-          new Error("SqliteError: no such column: _updated_at")
-        ),
+        db: dbFailingOnStampRead(rows, drizzleMissingColumnError()),
         companionTable: { _parent: "p", _locale: "l" },
         localizedFields: [{ name: "title", column: "title" }],
         rows: [row],

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -856,18 +856,53 @@ function toStampDate(raw: unknown): Date | null {
 }
 
 /**
- * Does this driver error say the companion has no `_updated_at` column?
+ * Does this error say the table has no such column?
  *
- * Matched on the COLUMN NAME appearing in a message that also reads as a missing-column error,
- * because the three dialects word it differently and none of them exposes a portable code for it
- * that this layer can see: SQLite says `no such column`, PostgreSQL `column ... does not exist`,
- * MySQL `Unknown column`. Requiring the column name as well as the shape keeps this from
- * swallowing an unrelated missing column and reporting the site as having no staleness data.
+ * 🔴 WALKS THE CAUSE CHAIN, because the driver wording is not on the error a caller catches.
+ * Measured against a real SQLite adapter, a Drizzle select on a missing column throws:
+ *
+ *   DrizzleQueryError  "Failed query: select \"_parent\", \"_locale\", \"_updated_at\" from ..."
+ *     cause: SqliteError  "no such column: \"_updated_at\" - should this be a string literal..."
+ *
+ * so a predicate reading only the top-level message finds no driver wording and rethrows — and
+ * the legacy companion this exists to tolerate fails its read after all.
+ *
+ * 🔴 Both conditions are tested PER LEVEL rather than across the chain, and that is not fussiness:
+ * the top-level message quotes the SQL, so it CONTAINS the column name. Testing "some level
+ * mentions the column" and "some level reads as a missing-column error" separately would match the
+ * name from the statement text and the wording from an unrelated cause, and report any nested
+ * failure on a query that happens to select this column as a missing column.
+ *
+ * Matched on wording because none of the three dialects exposes a portable code for this that
+ * reaches here: SQLite says `no such column`, PostgreSQL `column ... does not exist`, MySQL
+ * `Unknown column`. Requiring the column NAME alongside the shape keeps it from swallowing a
+ * different column's absence and reporting the site as having no staleness data.
  */
 export function isMissingColumnError(error: unknown, column: string): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  if (!message.includes(column)) return false;
-  return /no such column|does not exist|unknown column/i.test(message);
+  const seen = new Set<unknown>();
+  let current: unknown = error;
+  // Bounded by identity rather than by a depth constant: a cause chain that loops would otherwise
+  // spin here, and a legitimate chain is short.
+  while (current !== null && current !== undefined && !seen.has(current)) {
+    seen.add(current);
+    // A cause is `unknown`, and only two shapes carry a readable message. Anything else is
+    // skipped rather than stringified: `String(someObject)` yields "[object Object]", which
+    // matches nothing and would quietly make this level unexaminable.
+    const message =
+      current instanceof Error
+        ? current.message
+        : typeof current === "string"
+          ? current
+          : "";
+    if (
+      message.includes(column) &&
+      /no such column|does not exist|unknown column/i.test(message)
+    ) {
+      return true;
+    }
+    current = current instanceof Error ? current.cause : undefined;
+  }
+  return false;
 }
 
 /**

--- a/packages/nextly/src/domains/i18n/migration/__tests__/enable-disable.integration.test.ts
+++ b/packages/nextly/src/domains/i18n/migration/__tests__/enable-disable.integration.test.ts
@@ -122,8 +122,14 @@ describe("i18n enable/disable migration (real sqlite)", () => {
     await apply();
 
     // add a German translation, then remove the enable file so only disable is pending
+    // Columns named rather than positional, unlike the `dc_pages` seeds above. This table is
+    // created by the migration under test, so its shape belongs to the production DDL and grows
+    // with it -- a structural column added there turns a positional VALUES list into
+    // "N columns but M values were supplied", failing a test that is about neither the column
+    // nor the count.
     sqlite.exec(
-      `INSERT INTO "dc_pages_locales" VALUES ('p1','de','Hallo','Welt')`
+      `INSERT INTO "dc_pages_locales" ("_parent", "_locale", "title", "body") ` +
+        `VALUES ('p1','de','Hallo','Welt')`
     );
     rmSync(join(dir, "20260708_000000_000_enable_localization_pages.sql"));
 

--- a/packages/nextly/src/domains/i18n/runtime/companion-copy.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-copy.ts
@@ -26,9 +26,7 @@ import { COMPANION_DEFAULT_STATUS } from "../migration/generate-up";
 
 import type { CompanionIntrospectAdapter } from "./companion-io";
 import { buildCompanionRuntimeTable } from "./companion-registration";
-
-/** Physical name of the runtime key/value table the transition claim lives in. */
-const META_TABLE = "nextly_meta";
+import { buildCompanionStampTable } from "./companion-stamp-table";
 
 /** Minimal field shape these copies need. */
 export interface CopyableField {
@@ -298,33 +296,26 @@ async function clearLocaleStamp(
     guard?: { key: string; value: string };
   }
 ): Promise<void> {
-  const isPg = adapter.dialect === "postgresql";
-  const q = (id: string) =>
-    adapter.dialect === "mysql" ? `\`${id}\`` : `"${id}"`;
-  const params: unknown[] = [args.locale];
-  const hole = () => (isPg ? `$${params.length}` : "?");
-  const localeHole = hole();
-
-  // The claim condition, in the SAME statement. A separate pre-check would leave exactly the
-  // window the guard exists to close: the claim can be superseded between reading it and issuing
-  // the update.
-  let guardClause = "";
-  if (args.guard) {
-    params.push(args.guard.key);
-    const keyHole = hole();
-    params.push(args.guard.value);
-    const valueHole = hole();
-    guardClause =
-      ` AND EXISTS (SELECT 1 FROM ${q(META_TABLE)} ` +
-      `WHERE ${q("key")} = ${keyHole} AND ${q("value")} = ${valueHole})`;
-  }
+  const stamp = buildCompanionStampTable(
+    args.companionTableName,
+    adapter.dialect
+  );
+  const meta = metaTableFor(adapter.dialect);
+  const thisLocale = eq(stamp.locale as never, args.locale);
 
   try {
-    await adapter.executeQuery(
-      `UPDATE ${q(args.companionTableName)} SET ${q(COMPANION_UPDATED_AT_COLUMN)} = NULL ` +
-        `WHERE ${q("_locale")} = ${localeHole}${guardClause}`,
-      params
-    );
+    await adapter
+      .getDrizzle<UpdatableDb>()
+      .update(stamp.table)
+      .set({ [COMPANION_UPDATED_AT_COLUMN]: null })
+      .where(
+        args.guard
+          ? and(
+              thisLocale,
+              sql`exists (select 1 from ${meta} where ${eq(meta.key, args.guard.key)} and ${eq(meta.value as never, args.guard.value as never)})`
+            )
+          : thisLocale
+      );
   } catch (error) {
     if (isMissingColumnError(error, COMPANION_UPDATED_AT_COLUMN)) return;
     throw error;


### PR DESCRIPTION
## Why this exists

**A commit was stranded when #1332 merged.** The PR was squashed from snapshot `582a74164` while the branch tip was `4416ede52`, so the last commit never reached `main`. Verified by content, not by state:

```
merge b514b8e88, parents=[f8dcdc249]      # squash, one parent
headRefOid (merged snapshot) 582a74164
branch tip                   4416ede52   # absent from the merge
0 history-rewrite events                 # so the range is trustworthy
```

The stranded marker is absent from the merge commit and **present on the branch tip** — the control that proves the search works rather than that it found nothing.

## What it fixes

The missing-column predicate read only the top-level error message. The stamp read goes through Drizzle, whose message does not carry the driver's wording. Measured against a real adapter:

```
DrizzleQueryError  "Failed query: select "_parent", "_locale", "_updated_at" from ..."
  cause: SqliteError  "no such column: "_updated_at" - should this be ..."
```

So the predicate found no driver wording, rethrew, and the companion it exists to tolerate failed its read anyway. It now walks the cause chain.

**Both conditions are tested per level, never across the chain** — the top-level message quotes the SQL, so it *contains* the column name. Asking whether some level mentions the column and some level reads as a missing-column error would match the name from the statement text and the wording from an unrelated cause.

**The test could not have caught this.** It built an error with the driver wording on the top-level message — a shape nothing throws — so the predicate matched and it passed while the real path rethrew. The fixture is now transcribed from a measured error, cause and all.

Also moves the stamp clear off a hand-built `UPDATE` onto the same narrow Drizzle handle the read uses. It is safe to move only now that the predicate survives the wrapping; before, it would have detected nothing.

## Severity

**Latent on `main` today, not live.** The staleness read is withheld (`582a74164` landed), so the predicate is unreachable through that path, and the raw-SQL clear it replaces carried its driver wording where the predicate could still see it. Turning the read on — `task:b2-enable-staleness-read` — is what makes this load-bearing, which is why it should land before that task rather than with it.

## Verification

- `nextly` i18n suite 27 files / 351 passed; `check-types` and `lint` clean against current `main`.
- fallow `pass`, all introduced counters zero.
- The predicate's three behaviours are covered and break-verified: unknown when the caller cannot ask, unknown when the column is absent, and a non-missing-column failure still propagates.
