### PR TITLE
fix(builder): keep one drag in flight at a time

### DIFF
--- a/.changeset/one-palette-drag-at-a-time.md
+++ b/.changeset/one-palette-drag-at-a-time.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Keep one drag in flight at a time on the block canvas.
+
+A second finger pressing a palette row, or a block, while a drag was already
+running replaced that drag with no ending of its own. The first drag's release
+then went unheard and its click was never suppressed, so the row it started
+from inserted a block the author never dropped — while the second drag carried
+on. A stray touch now leaves the drag in progress alone.

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -934,6 +934,26 @@ export function useCanvasDrag({
     [commitDrop, reset, swallowNextClick]
   );
 
+  /**
+   * Abandon the gesture, but only for the pointer that owns it.
+   *
+   * A cancel is the browser withdrawing a contact — captured by something else,
+   * or the touch became a scroll. That is a fact about ONE pointer, so a second
+   * finger being withdrawn says nothing about the drag a first finger is still
+   * performing. Resetting unconditionally would undo the gesture the press
+   * guard exists to protect: a stray touch on a block, cancelled by the browser
+   * a moment later, would end a palette drag the author is mid-way through.
+   */
+  const cancelGesture = React.useCallback(
+    (pointerId: number) => {
+      const drag = gesture.current;
+      if (drag === null) return;
+      if (pointerId !== drag.owner) return;
+      reset();
+    },
+    [reset]
+  );
+
   const onPointerUp = React.useCallback(
     (event: React.PointerEvent<HTMLElement>) => {
       endGesture(event.pointerId, event.currentTarget);
@@ -1004,30 +1024,23 @@ export function useCanvasDrag({
        * listening here rather than on the canvas.
        */
       /*
-       * Only the pointer that began this gesture drives it.
+       * These three forward the pointer id and decide nothing.
        *
-       * The node-origin path gets this from pointer capture, which retargets
-       * one pointer and ignores the rest. A palette drag deliberately takes no
-       * capture, so its document listeners see EVERY active pointer: on a
-       * touch device, lifting a second finger would otherwise commit the first
-       * finger's target, and a second finger's movement would aim the drag.
+       * Ownership is enforced inside `trackMove`, `endGesture` and
+       * `cancelGesture`, which is where BOTH transports converge — the canvas's
+       * React handlers for a pointer over the canvas, and these listeners for
+       * one anywhere else. Checking here as well would state the same rule in
+       * two places, and the copy that mattered would be the one somebody forgot
+       * when a third transport arrived.
        */
-      const owner = event.pointerId;
       const move = (native: PointerEvent): void => {
         trackMove(native.clientX, native.clientY, native.pointerId, null);
       };
       const up = (native: PointerEvent): void => {
         endGesture(native.pointerId, null);
       };
-      // `cancel` alone checks the pointer here, because it is the one ending
-      // that does not pass through `trackMove` or `endGesture` — the two both
-      // transports converge on, and where ownership is enforced for everything
-      // else. Repeating that check in these closures would put the same rule
-      // in two places, and the copy that mattered would be the one someone
-      // forgot when a third transport arrived.
       const cancel = (native: PointerEvent): void => {
-        if (native.pointerId !== owner) return;
-        reset();
+        cancelGesture(native.pointerId);
       };
       document.addEventListener("pointermove", move, true);
       document.addEventListener("pointerup", up, true);
@@ -1038,7 +1051,7 @@ export function useCanvasDrag({
         document.removeEventListener("pointercancel", cancel, true);
       };
     },
-    [canvasRoot, endGesture, reset, trackMove]
+    [canvasRoot, cancelGesture, endGesture, trackMove]
   );
 
   // Every ordinary ending funnels through `reset`. This covers the one that
@@ -1106,10 +1119,9 @@ export function useCanvasDrag({
       onPointerDown,
       onPointerMove,
       onPointerUp,
-      // A cancel is the browser withdrawing the gesture — the pointer was
-      // captured by something else, or the touch became a scroll. Dropping
-      // there would commit a move the author never released.
-      onPointerCancel: reset,
+      // Routed through the same ownership check every other ending uses, so a
+      // second contact being withdrawn cannot end a drag it does not own.
+      onPointerCancel: event => cancelGesture(event.pointerId),
     },
   };
 }

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -253,6 +253,42 @@ function committedTarget(drag: Gesture): DropTarget | undefined {
   return committed === null ? undefined : drag.targets.get(committed);
 }
 
+/**
+ * The gesture this pointer owns, or `null` when it owns none.
+ *
+ * The one answer to "may this event drive the drag", asked by every transport:
+ * the canvas's React handlers for a pointer over the canvas, and the document
+ * listeners for one anywhere else. Written once because it was written three
+ * times — move, release and cancel each compared the id themselves, and a
+ * change to what ownership means would have had to find all three.
+ */
+function gestureOwnedBy(
+  current: Gesture | null,
+  pointerId: number
+): Gesture | null {
+  if (current === null) return null;
+  return current.owner === pointerId ? current : null;
+}
+
+/**
+ * Whether a press may begin a gesture.
+ *
+ * A drag ALREADY IN FLIGHT keeps the pointer that started it: a second finger
+ * must not take it over, or the first gesture is left with no ending of its own
+ * — its release unheard, its click never suppressed.
+ *
+ * An INACTIVE gesture is a different thing and must not block anything. It is a
+ * press that has not yet travelled far enough to mean a drag, and one can be
+ * stranded: a press beginning within the activation threshold of the canvas
+ * edge takes no capture, so if the pointer leaves the root its move and release
+ * are delivered somewhere these handlers never see. Refusing later presses
+ * because of it would lock dragging until the host unmounted, and there is
+ * nothing to protect — no drag was in progress.
+ */
+function admitsPress(current: Gesture | null): boolean {
+  return current === null || !current.active;
+}
+
 /** What a drag needs to remember, none of which renders. */
 interface Gesture {
   readonly subject: DragSubject;
@@ -453,16 +489,11 @@ export function useCanvasDrag({
       // middle-click scrolls, and starting a drag from either takes a gesture
       // the browser has already given a meaning.
       if (event.button !== 0) return;
-      // ONE gesture at a time. A second finger pressing while another owns the
-      // drag must not take it over: the first gesture would be replaced with
-      // no ending of its own, so its release goes unheard, its click is never
-      // suppressed, and the row it started from inserts through the ordinary
-      // click path — a block the author never dropped.
-      //
-      // Ignored rather than cancelled, so the drag already in flight survives
-      // the stray touch. The pressed row keeps its own click, because nothing
-      // here consumed the press.
-      if (gesture.current !== null) return;
+      // One drag at a time, asked through the shared rule. Ignored rather than
+      // cancelled, so the drag already in flight survives a stray touch, and
+      // the pressed element keeps its own click because nothing here consumed
+      // the press.
+      if (!admitsPress(gesture.current)) return;
 
       const root = event.currentTarget;
       const nodeId = nodeIdFromEvent(event.target);
@@ -665,10 +696,10 @@ export function useCanvasDrag({
       pointerId: number,
       captureHost: HTMLElement | null
     ) => {
-      const drag = gesture.current;
+      const drag = gestureOwnedBy(gesture.current, pointerId);
+      // Null for no gesture at all, and for another finger moving anywhere:
+      // neither may re-aim this one.
       if (drag === null) return;
-      // Another finger, moving anywhere. It may not re-aim this gesture.
-      if (pointerId !== drag.owner) return;
 
       /*
        * ONE measurement of the root, answering this move in both spaces.
@@ -910,11 +941,10 @@ export function useCanvasDrag({
    */
   const endGesture = React.useCallback(
     (pointerId: number, captureHost: HTMLElement | null) => {
-      const drag = gesture.current;
+      // Null for another finger lifting, too: ending here would commit THIS
+      // gesture's target while the finger that owns it is still down.
+      const drag = gestureOwnedBy(gesture.current, pointerId);
       if (drag === null) return;
-      // Another finger lifting. Ending here would commit THIS gesture's target
-      // while the finger that owns it is still down.
-      if (pointerId !== drag.owner) return;
       releaseCapture(captureHost, pointerId);
 
       const target = committedTarget(drag);
@@ -946,9 +976,7 @@ export function useCanvasDrag({
    */
   const cancelGesture = React.useCallback(
     (pointerId: number) => {
-      const drag = gesture.current;
-      if (drag === null) return;
-      if (pointerId !== drag.owner) return;
+      if (gestureOwnedBy(gesture.current, pointerId) === null) return;
       reset();
     },
     [reset]
@@ -965,16 +993,11 @@ export function useCanvasDrag({
     (event: React.PointerEvent<HTMLElement>, entry: InsertDragEntry) => {
       // The primary button only, for the reason `onPointerDown` gives.
       if (event.button !== 0) return;
-      // ONE gesture at a time. A second finger pressing while another owns the
-      // drag must not take it over: the first gesture would be replaced with
-      // no ending of its own, so its release goes unheard, its click is never
-      // suppressed, and the row it started from inserts through the ordinary
-      // click path — a block the author never dropped.
-      //
-      // Ignored rather than cancelled, so the drag already in flight survives
-      // the stray touch. The pressed row keeps its own click, because nothing
-      // here consumed the press.
-      if (gesture.current !== null) return;
+      // One drag at a time, asked through the shared rule. Ignored rather than
+      // cancelled, so the drag already in flight survives a stray touch, and
+      // the pressed element keeps its own click because nothing here consumed
+      // the press.
+      if (!admitsPress(gesture.current)) return;
       const root = canvasRoot?.current ?? null;
       // Nothing to drop onto. The press is left entirely alone rather than
       // half-started, so the row's click still inserts by the ordinary path.

--- a/packages/builder/src/canvas-drag.tsx
+++ b/packages/builder/src/canvas-drag.tsx
@@ -453,6 +453,16 @@ export function useCanvasDrag({
       // middle-click scrolls, and starting a drag from either takes a gesture
       // the browser has already given a meaning.
       if (event.button !== 0) return;
+      // ONE gesture at a time. A second finger pressing while another owns the
+      // drag must not take it over: the first gesture would be replaced with
+      // no ending of its own, so its release goes unheard, its click is never
+      // suppressed, and the row it started from inserts through the ordinary
+      // click path — a block the author never dropped.
+      //
+      // Ignored rather than cancelled, so the drag already in flight survives
+      // the stray touch. The pressed row keeps its own click, because nothing
+      // here consumed the press.
+      if (gesture.current !== null) return;
 
       const root = event.currentTarget;
       const nodeId = nodeIdFromEvent(event.target);
@@ -935,6 +945,16 @@ export function useCanvasDrag({
     (event: React.PointerEvent<HTMLElement>, entry: InsertDragEntry) => {
       // The primary button only, for the reason `onPointerDown` gives.
       if (event.button !== 0) return;
+      // ONE gesture at a time. A second finger pressing while another owns the
+      // drag must not take it over: the first gesture would be replaced with
+      // no ending of its own, so its release goes unheard, its click is never
+      // suppressed, and the row it started from inserts through the ordinary
+      // click path — a block the author never dropped.
+      //
+      // Ignored rather than cancelled, so the drag already in flight survives
+      // the stray touch. The pressed row keeps its own click, because nothing
+      // here consumed the press.
+      if (gesture.current !== null) return;
       const root = canvasRoot?.current ?? null;
       // Nothing to drop onto. The press is left entirely alone rather than
       // half-started, so the row's click still inserts by the ordinary path.
@@ -1009,15 +1029,6 @@ export function useCanvasDrag({
         if (native.pointerId !== owner) return;
         reset();
       };
-      // Before registering, never after: overwriting the detach closure below
-      // while an earlier palette gesture is still live would strand its three
-      // listeners with nothing able to remove them, and they would go on
-      // calling into a gesture they no longer own for the life of the page.
-      //
-      // The ordinary sequence cannot reach that — a release arrives first and
-      // resets — so this holds the invariant locally instead of resting it on
-      // an ordering that a lost release or a second pointer breaks.
-      stopTrackingDocument();
       document.addEventListener("pointermove", move, true);
       document.addEventListener("pointerup", up, true);
       document.addEventListener("pointercancel", cancel, true);
@@ -1027,7 +1038,7 @@ export function useCanvasDrag({
         document.removeEventListener("pointercancel", cancel, true);
       };
     },
-    [canvasRoot, endGesture, reset, stopTrackingDocument, trackMove]
+    [canvasRoot, endGesture, reset, trackMove]
   );
 
   // Every ordinary ending funnels through `reset`. This covers the one that

--- a/packages/builder/src/insert-drag.test.tsx
+++ b/packages/builder/src/insert-drag.test.tsx
@@ -229,10 +229,10 @@ function canvasRootOf(container: HTMLElement): HTMLElement {
   return root;
 }
 
-function pressRow(row: HTMLElement, x: number, y: number): void {
+function pressRow(row: HTMLElement, x: number, y: number, pointerId = 7): void {
   fireEvent.pointerDown(row, {
     button: 0,
-    pointerId: 7,
+    pointerId,
     clientX: x,
     clientY: y,
   });
@@ -735,21 +735,78 @@ describe("dragging a block from the palette onto the canvas", () => {
   });
 
   it("still abandons the drag when the OWNING pointer is cancelled", () => {
-    // The must-differ control. A cancel handler that ignored every pointer
-    // would satisfy the case above while breaking what cancel is FOR — the
-    // browser has taken the gesture away, and continuing to draw a drag it
-    // no longer owns leaves an indicator the author cannot dismiss.
-    const { container, row } = renderTwo();
-    pressRow(row, 300, 500);
-    moveTo(200, 154);
+    // The must-differ control, and it drives a NODE-origin drag on purpose.
+    //
+    // A palette drag is followed on the document, and that capture listener
+    // runs BEFORE the canvas's own handler for the same event — so cancelling
+    // a palette drag through the canvas resets it either way, and the case
+    // passes even when `handlers.onPointerCancel` ignores every pointer.
+    // Measured: with that handler emptied, every case in this file still
+    // passed. A control reached by the wrong transport controls nothing.
+    //
+    // A node-origin drag installs no document listeners, so cancelling it is
+    // the only route that exercises the canvas handler.
+    const { container } = renderTwo();
+    const canvas = canvasRootOf(container);
+    const block = container.querySelector<HTMLElement>(
+      `[${NODE_ID_ATTRIBUTE}="a"]`
+    );
+    expect(block, "no rendered node to press").not.toBeNull();
 
-    fireEvent.pointerCancel(canvasRootOf(container), { pointerId: 7 });
+    fireEvent.pointerDown(block!, {
+      button: 0,
+      pointerId: 7,
+      clientX: 200,
+      clientY: 40,
+    });
+    fireEvent.pointerMove(canvas, {
+      pointerId: 7,
+      clientX: 200,
+      clientY: 154,
+    });
+    // Population: the drag has to be in flight, or "it was abandoned" is a
+    // statement about a gesture that never started.
+    expect(dragState.draggingId).toBe("a");
 
-    expect(dragState.draggingBlockName).toBeNull();
-    // And a release afterwards commits nothing, because there is no gesture.
-    release(200, 154);
+    fireEvent.pointerCancel(canvas, { pointerId: 7 });
+
+    expect(dragState.draggingId).toBeNull();
+    // And a release afterwards moves nothing, because there is no gesture.
+    fireEvent.pointerUp(canvas, { pointerId: 7, clientX: 200, clientY: 154 });
     expect(ids()).toEqual(["a", "b"]);
     expect(editorRef?.undoDepth).toBe(0);
+  });
+
+  it("a press that never became a drag does not lock out later presses", () => {
+    // A press beginning within the activation threshold of the canvas edge
+    // takes no capture — capture waits for activation, so an ordinary click
+    // still resolves against the element it landed on. If that pointer then
+    // leaves the root, its move and release are delivered somewhere these
+    // handlers never see, and the inactive gesture is stranded.
+    //
+    // Admission asks whether a drag is IN FLIGHT rather than whether a gesture
+    // object exists, so a stranded press blocks nothing. Gated on existence,
+    // dragging stays locked until the host unmounts.
+    const { container, row } = renderTwo();
+    const block = container.querySelector<HTMLElement>(
+      `[${NODE_ID_ATTRIBUTE}="a"]`
+    );
+    fireEvent.pointerDown(block!, {
+      button: 0,
+      pointerId: 7,
+      clientX: 200,
+      clientY: 40,
+    });
+    // No move, so it never activates; and no release, because the pointer left.
+    expect(dragState.draggingId).toBeNull();
+
+    // A later press must still be able to start a drag.
+    pressRow(row, 300, 500, 9);
+    moveTo(200, 154, 9);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    release(200, 154, 9);
+    expect(ids()).toEqual(["a", "b", INSERTED]);
   });
 
   it("starts no drag at all when the host supplied no canvas", () => {

--- a/packages/builder/src/insert-drag.test.tsx
+++ b/packages/builder/src/insert-drag.test.tsx
@@ -612,19 +612,14 @@ describe("dragging a block from the palette onto the canvas", () => {
     }
   });
 
-  it("detaches a previous palette gesture before starting another", () => {
-    // A palette drag is followed on the document, so its three listeners are
-    // the gesture's only handle on the pointer. Starting a second gesture
-    // overwrites the closure that removes them, and if the first set was not
-    // detached first it survives with nothing able to reach it — calling into
-    // a gesture it no longer owns for the life of the page.
-    //
-    // The ordinary sequence always releases first, so this needs a press with
-    // no release between. Counted rather than observed behaviourally: a leaked
-    // listener does nothing visible once its gesture is gone, which is exactly
-    // why it would go unnoticed.
-    const { container } = renderTwo();
-    const row = container.ownerDocument.body.querySelector("button")!;
+  it("ignores a second palette press while one drag already owns the pointer", () => {
+    // Two fingers, two rows, before the first releases. Taking the drag over
+    // would leave the FIRST gesture with no ending of its own: its release
+    // goes unheard, its click is never suppressed, and the row it started from
+    // inserts through the ordinary click path — a block the author never
+    // dropped, while a second drag is still in flight.
+    const { container, row } = renderTwo();
+    const second = container.ownerDocument.body.querySelectorAll("button")[0]!;
 
     const POINTER = /^pointer(move|up|cancel)$/;
     const added: string[] = [];
@@ -648,21 +643,73 @@ describe("dragging a block from the palette onto the canvas", () => {
       realRemove.call(document, type, fn, opts);
     } as typeof document.removeEventListener;
 
+    /*
+     * The RELEASE is inside the counted window too, deliberately.
+     *
+     * Restoring the real listeners before it would leave the removals
+     * uncounted, and `removed` would read zero for a gesture that detached
+     * perfectly — an assertion no implementation could satisfy.
+     */
     try {
       pressRow(row, 300, 500);
-      pressRow(row, 300, 500);
-      release(200, 90);
+      moveTo(200, 154);
+      // The second finger. A different pointer id, on a palette row.
+      fireEvent.pointerDown(second, {
+        button: 0,
+        pointerId: 9,
+        clientX: 300,
+        clientY: 520,
+      });
+
+      // ONE gesture's worth of listeners. Six would mean the second press
+      // started its own, which is the takeover this guards.
+      expect(added.length).toBe(3);
+      // And the first drag is untouched: still in flight, and still ending
+      // where ITS pointer settled. A takeover would leave this release
+      // unheard, and nothing would be inserted at all.
+      expect(dragState.draggingBlockName).toBe("test/heading");
+
+      release(200, 154);
     } finally {
       document.addEventListener = realAdd;
       document.removeEventListener = realRemove;
     }
 
-    // Two gestures, three listeners each. The control on the instrument: if
-    // this is not 6 the test is counting something other than what it thinks,
-    // and the balance below would be meaningless.
-    expect(added).toHaveLength(6);
-    // Every one of them removed. Without detaching first this is 3.
-    expect(removed).toHaveLength(6);
+    expect(ids()).toEqual(["a", "b", INSERTED]);
+    // Every listener the one gesture took is given back.
+    expect(removed.length).toBe(3);
+  });
+
+  it("ignores a press on the CANVAS while a palette drag owns the gesture", () => {
+    // The same rule at the other entry point. A finger landing on a block
+    // mid-drag would otherwise replace the palette gesture with a move-drag of
+    // that block — so the drag the author is performing vanishes, and a block
+    // they only touched starts moving instead.
+    const { container, row } = renderTwo();
+    pressRow(row, 300, 500);
+    moveTo(200, 154);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    const block = container.querySelector<HTMLElement>(
+      `[${NODE_ID_ATTRIBUTE}="a"]`
+    );
+    expect(block, "no rendered node to press").not.toBeNull();
+    fireEvent.pointerDown(block!, {
+      button: 0,
+      pointerId: 9,
+      clientX: 200,
+      clientY: 40,
+    });
+
+    // Still the palette's gesture, and still reporting no node id — a takeover
+    // would put block "a" in flight and set `draggingId`.
+    expect(dragState.draggingBlockName).toBe("test/heading");
+    expect(dragState.draggingId).toBeNull();
+
+    // And it still ends as its own drag, where its own pointer settled.
+    release(200, 154);
+    expect(ids()).toEqual(["a", "b", INSERTED]);
+    expect(editorRef?.undoDepth).toBe(1);
   });
 
   it("starts no drag at all when the host supplied no canvas", () => {

--- a/packages/builder/src/insert-drag.test.tsx
+++ b/packages/builder/src/insert-drag.test.tsx
@@ -712,6 +712,46 @@ describe("dragging a block from the palette onto the canvas", () => {
     expect(editorRef?.undoDepth).toBe(1);
   });
 
+  it("survives a SECOND pointer being cancelled by the browser", () => {
+    // The press guard stops a second contact taking the gesture over, but the
+    // browser can still withdraw that contact a moment later — recognising a
+    // touch-scroll, say. A cancel is a fact about ONE pointer, so ending the
+    // drag on it undoes the very gesture the guard exists to protect: a stray
+    // finger on a block, cancelled by the browser, would kill a palette drag
+    // the author is mid-way through.
+    const { container, row } = renderTwo();
+    pressRow(row, 300, 500);
+    moveTo(200, 154);
+    expect(dragState.draggingBlockName).toBe("test/heading");
+
+    const canvas = canvasRootOf(container);
+    fireEvent.pointerCancel(canvas, { pointerId: 9 });
+
+    // Still in flight, and still ending where ITS pointer settled.
+    expect(dragState.draggingBlockName).toBe("test/heading");
+    release(200, 154);
+    expect(ids()).toEqual(["a", "b", INSERTED]);
+    expect(editorRef?.undoDepth).toBe(1);
+  });
+
+  it("still abandons the drag when the OWNING pointer is cancelled", () => {
+    // The must-differ control. A cancel handler that ignored every pointer
+    // would satisfy the case above while breaking what cancel is FOR — the
+    // browser has taken the gesture away, and continuing to draw a drag it
+    // no longer owns leaves an indicator the author cannot dismiss.
+    const { container, row } = renderTwo();
+    pressRow(row, 300, 500);
+    moveTo(200, 154);
+
+    fireEvent.pointerCancel(canvasRootOf(container), { pointerId: 7 });
+
+    expect(dragState.draggingBlockName).toBeNull();
+    // And a release afterwards commits nothing, because there is no gesture.
+    release(200, 154);
+    expect(ids()).toEqual(["a", "b"]);
+    expect(editorRef?.undoDepth).toBe(0);
+  });
+
   it("starts no drag at all when the host supplied no canvas", () => {
     // The control on `beginInsertDrag`'s own guard: with no canvas root the
     // press must be left completely alone, so the row's click keeps working.


### PR DESCRIPTION
Follow-up to a P2 Codex raised on #1334 after it had already merged.

## The defect

`beginInsertDrag` assigned `gesture.current` with no check for one already in flight. Two fingers on two palette rows, and the second replaced the first — leaving that first gesture with **no ending of its own**:

- its release is never matched, so nothing commits and nothing resets
- its click suppression is never armed, so the row it started from inserts through the ordinary click path — a block the author never dropped
- meanwhile the second drag carries on, so the editor looks busy while the wrong thing happened

The same hole existed at the other entry point, which Codex did not name and I fixed too: a finger landing on a **block** mid-drag replaced a palette gesture with a move-drag of that block, so the drag being performed vanished and a block that was only touched started moving.

## The choice

Codex offered two remedies — ignore the secondary press, or fully cancel the prior gesture first. I took **ignore**, because it is the one that preserves what the author is doing: the drag in flight survives a stray touch, and the pressed row keeps its own click since nothing consumed the press. Cancelling would let an accidental second finger destroy a deliberate gesture.

## A deletion this makes correct

The guard makes `beginInsertDrag`'s detach-before-register unreachable — the overwrite it protected against can no longer occur. It was added earlier in #1334 at CodeRabbit's request, and keeping both would be two rules for one invariant, with the dead one rotting quietly. Removed; the listener-balance assertion stays, so a leak would still fail.

## Verification

Break-verified per entry point, each against its own case:

| mutation | kills |
|---|---|
| guard removed from the canvas press | *ignores a press on the CANVAS while a palette drag owns the gesture* |
| guard removed from the palette press | *ignores a second palette press while one drag already owns the pointer* |

The first of those two cases exists because the initial run showed the canvas-side guard **surviving** — no test reached it. That is the finding, not a formality.

**A correction on my own instrument, since it cost the most time here.** The new test kept failing with `expected [] to have a length of 3`, and I read it as the `added` counter being empty. It was not — `added` was 3 throughout, confirmed by throwing the value. The failing assertion was the *last* one, on `removed`, which could never pass as written: the release happened after `finally` had restored the real `addEventListener`, so its removals were never counted. An assertion no implementation could satisfy, and I spent four measurements diagnosing the code instead of the probe. The release now sits inside the counted window.

`build`, `check-types`, `lint` and `fallow` pass with 0 introduced findings; builder 2452 tests, plugin-page-builder 486.
