### PR TITLE
docs(nextly): describe what the staleness groundwork actually ships

### DIFF
--- a/.changeset/a-translation-says-when-its-source-moved.md
+++ b/.changeset/a-translation-says-when-its-source-moved.md
@@ -26,14 +26,14 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Report a translation whose source language changed after it was written, so a
-stale translation stops looking like a finished one. Each language now records
-when it was last written, the translation worklist gains a "Needs review" tab,
-and the language panel marks a translation whose source has moved on -- while
-still reporting it as published, because it is.
+Record when each language of a document was last written, so a later change can
+tell a finished translation from one whose source has moved on since.
 
-Databases created before this keep no history of when each language was
-written, so the column is seeded from version history where that exists and
-left unknown where it does not. Unknown is never reported as up to date: a
-translation the system cannot vouch for is left alone rather than being
-described as current.
+This release is the groundwork only: the timestamp is recorded on every write
+and seeded, where version history allows, for documents that already exist.
+Nothing surfaces it yet.
+
+A database created before this keeps no history of when each language was
+written, so the value is seeded from version history where that exists and left
+unknown where it does not. Unknown is never treated as up to date: a language
+the system cannot vouch for is left alone rather than described as current.

--- a/.changeset/a-translation-says-when-its-source-moved.md
+++ b/.changeset/a-translation-says-when-its-source-moved.md
@@ -29,9 +29,15 @@
 Record when each language of a document was last written, so a later change can
 tell a finished translation from one whose source has moved on since.
 
-This release is the groundwork only: the timestamp is recorded on every write
-and seeded, where version history allows, for documents that already exist.
-Nothing surfaces it yet.
+This release is the groundwork only: the timestamp is recorded on every write,
+for every kind of localized content, and nothing surfaces it yet.
+
+Collections that already exist are seeded from their version history, so their
+languages carry a timestamp from the moment this lands. Singles are not seeded,
+even though they keep history that would allow it: nothing reads the signal for
+a Single today, and seeding one would commit every future reader to whatever
+this release happened to write. Their languages are stamped from their next
+save onward, like any language whose history is unknown.
 
 A database created before this keeps no history of when each language was
 written, so the value is seeded from version history where that exists and left

--- a/packages/admin/src/types/translations/__tests__/worklist.test.ts
+++ b/packages/admin/src/types/translations/__tests__/worklist.test.ts
@@ -90,15 +90,17 @@ describe("WORKLIST_STATES", () => {
     }
   });
 
-  it("keeps `stale` expressible even while no tab offers it", () => {
-    // The TYPE stays wider than the tab list on purpose: the worklist state a
-    // URL can name is `LanguageState | "stale"`, so a saved link naming it
-    // still type-checks and resolves, and the server still answers it honestly
-    // with nothing rather than rejecting it as unknown.
+  it("keeps `stale` askable while refusing to route a URL to it", () => {
+    // Two different facts, and the pairing is the point. `WorklistState` is
+    // what goes on the wire, so it carries every state the server accepts --
+    // `stale` included, which is why a caller holding one can name it.
     const resolved: WorklistState = "stale";
     expect(resolved).toBe("stale");
-    // And it falls back to the question this page exists for, since no tab
-    // matches it today.
+    // But a URL is resolved against the TAB LIST, not against the wire
+    // vocabulary, so a saved link naming `stale` does NOT reach the server as
+    // `stale`: it falls back to the question this page leads with. A page
+    // filtered by a state whose tab is not shown would highlight nothing while
+    // listing a subset the reader cannot account for.
     expect(worklistStateFrom("stale")).toBe("missing");
   });
 

--- a/packages/admin/src/types/translations/worklist.ts
+++ b/packages/admin/src/types/translations/worklist.ts
@@ -61,9 +61,9 @@ const WORKLIST_ORDER = [
  * replacing it.
  *
  * A FILTER, though, is a question rather than a classification, and "which documents need review"
- * is as legitimate a question as "which are drafts". That is why {@link WorklistState} is one
- * member wider than the language-state catalog even though {@link WORKLIST_STATES} currently
- * offers a tab for each of the four states alone.
+ * is as legitimate a question as "which are drafts". So {@link WorklistState} carries a member
+ * the language-state catalog does not, and {@link WORKLIST_STATES} offers a tab for each of the
+ * four states alone.
  */
 
 /** Sentence wording into a button label: "not translated" -> "Not translated". */
@@ -86,18 +86,24 @@ export const WORKLIST_STATES: readonly {
   // tab that is always empty is worse than no tab: it reads as "this site has no stale
   // translations", which is a claim, and the wrong one.
   //
-  // The type stays wider than this array — see `WorklistState` below — so a saved link naming the
-  // state still resolves and the server still answers it honestly rather than rejecting it as
-  // unknown.
+  // The absence reaches the URL as well, and that is deliberate rather than a gap:
+  // `worklistStateFrom` resolves only what this array offers, so a saved link naming `stale`
+  // falls back to the question this page leads with. A page filtered by a state whose tab is not
+  // shown would highlight nothing while listing a subset the reader cannot account for, which is
+  // worse than answering a different question visibly. Offering the tab is an edit to this array
+  // and nothing else.
 ];
 
 /**
- * A state the worklist can show: any language state, plus staleness.
+ * A state the worklist may ASK FOR: any language state, plus staleness.
+ *
+ * This is the value that goes on the wire — `useTranslationWorklist` puts it in
+ * `/translations?state=` — so it mirrors the set the server accepts, which carries `stale`
+ * alongside the four language states. The tab strip offers a subset of it, not the whole of it,
+ * and that is the direction the two differ in.
  *
  * The language half is an ALIAS rather than a restatement, so a state added or removed there is a
- * compile error here rather than a tab that quietly stops matching. The second member is wider
- * than {@link WORKLIST_STATES} deliberately: a FILTER is a question, and "which documents need
- * review" is as legitimate a question as "which are drafts", even while no tab asks it.
+ * compile error here rather than a tab that quietly stops matching.
  */
 export type WorklistState = LanguageState | "stale";
 

--- a/packages/admin/src/types/translations/worklist.ts
+++ b/packages/admin/src/types/translations/worklist.ts
@@ -45,10 +45,10 @@ const WORKLIST_ORDER = [
 ] as const satisfies readonly LanguageState[];
 
 /**
- * The one tab that is NOT a language state (i18n B2 — "changed since translated").
+ * The one worklist state that is NOT a language state: "changed since translated".
  *
- * 🔴 Deliberately not added to `LANGUAGE_STATES`, and this is the load-bearing decision of B2's
- * vocabulary. `languageState()` is a mutually exclusive classifier — missing, then published, then
+ * 🔴 Deliberately not added to `LANGUAGE_STATES`, and this is the load-bearing decision of the
+ * staleness vocabulary. `languageState()` is a mutually exclusive classifier — missing, then published, then
  * draft, then translated, first match wins — and staleness is ORTHOGONAL to every one of them: a
  * stale translation is still translated, and still published if it was published. A fifth member
  * would make the classifier return "stale" INSTEAD of "published", so the entry list's dots and
@@ -61,8 +61,9 @@ const WORKLIST_ORDER = [
  * replacing it.
  *
  * A FILTER, though, is a question rather than a classification, and "which documents need review"
- * is as legitimate a question as "which are drafts". So the worklist's tab list is one entry wider
- * than the state catalog, and that difference is the honest one rather than an oversight.
+ * is as legitimate a question as "which are drafts". That is why {@link WorklistState} is one
+ * member wider than the language-state catalog even though {@link WORKLIST_STATES} currently
+ * offers a tab for each of the four states alone.
  */
 
 /** Sentence wording into a button label: "not translated" -> "Not translated". */
@@ -78,26 +79,24 @@ export const WORKLIST_STATES: readonly {
     value,
     label: asTabLabel(LANGUAGE_STATE_LABEL[value]),
   })),
-  // 🔴 The "Needs review" tab is NOT offered yet, and the entry is kept here rather than deleted
-  // because the vocabulary decision it carries is the durable part.
+  // 🔴 No tab for `stale`, and its absence from this array is the whole statement.
   //
-  // The server currently answers this state with "nothing is known to be stale" — deliberately,
-  // because nothing can yet establish whether a given companion physically carries the timestamp
-  // the answer depends on. A tab that is always empty is worse than no tab: it reads as "this site
-  // has no stale translations", which is a claim, and the wrong one.
+  // The server answers that state with "nothing is known to be stale", because nothing can
+  // establish whether a given companion physically carries the timestamp the answer depends on. A
+  // tab that is always empty is worse than no tab: it reads as "this site has no stale
+  // translations", which is a claim, and the wrong one.
   //
-  // Restored alongside the capability check that lets the server answer it. When it is,
-  // "Needs review" is the label — not "Stale" or "Outdated": the wire value says what the system
-  // measured, the label says what the translator should DO, and a translation whose source moved
-  // may well still be correct.
+  // The type stays wider than this array — see `WorklistState` below — so a saved link naming the
+  // state still resolves and the server still answers it honestly rather than rejecting it as
+  // unknown.
 ];
 
 /**
  * A state the worklist can show: any language state, plus staleness.
  *
  * The language half is an ALIAS rather than a restatement, so a state added or removed there is a
- * compile error here rather than a tab that quietly stops matching. The union's second member is
- * the deliberate widening documented above: a FILTER is a question, and "which documents need
+ * compile error here rather than a tab that quietly stops matching. The second member is wider
+ * than {@link WORKLIST_STATES} deliberately: a FILTER is a question, and "which documents need
  * review" is as legitimate a question as "which are drafts", even while no tab asks it.
  */
 export type WorklistState = LanguageState | "stale";

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -458,19 +458,19 @@ export class CollectionQueryService extends BaseService {
       locales: this.localization.locales.map(l => l.code),
       defaultLocale: this.localization.defaultLocale,
       hasStatus: companion.hasStatus,
-      // 🔴 `staleness` is deliberately NOT supplied yet, so every locale reports its staleness as
-      // UNKNOWN (i18n B2).
+      // 🔴 `staleness` is deliberately NOT supplied, so every locale reports its staleness as
+      // UNKNOWN.
       //
-      // The stamp is written on every companion write and seeded by the migration, so the DATA is
-      // accumulating correctly. What is not ready is the READ: nothing here can yet establish
-      // whether a given companion physically carries `_updated_at`, and a companion created before
-      // the column exists has no upgrade path that adds it. Reporting staleness from a capability
-      // that cannot be checked is the one thing this feature must not do, since a wrong "needs
-      // review" is indistinguishable from a right one to the person reading it.
+      // Nothing here can establish whether a given companion physically carries `_updated_at`.
+      // `hasUpdatedAt` on the schema reports the DECLARED shape and is unconditionally true, which
+      // is a claim about a column nobody checked, and a companion created before the column
+      // existed has no path that adds it. Reporting staleness from a capability that cannot be
+      // checked is the one thing this must not do: a wrong "needs review" is indistinguishable
+      // from a right one to the person reading it.
       //
       // Omission is the mechanism rather than a flag, because it is already the defined answer for
-      // a caller that cannot ask — see `readCompanionStamps`. Supplying it is what turns the badge
-      // on, and that belongs with the capability probe rather than ahead of it.
+      // a caller that cannot ask — see `readCompanionStamps`.
+
       // On a status-scoped read, don't report a draft-only translation as present.
       statusValue:
         companion.hasStatus && statusFilterValue
@@ -585,17 +585,16 @@ export class CollectionQueryService extends BaseService {
       localizedColumns: companion.localizedFields.map(f => f.column),
       hasStatus: companion.hasStatus,
       // 🔴 Left absent, which makes the `stale` filter answer `1=0` — nothing here is KNOWN to be
-      // stale (i18n B2).
+      // stale.
       //
       // `companion.hasUpdatedAt` reports the DECLARED shape and is unconditionally true, which is
       // a claim about a physical column that nothing has checked. A companion created before the
-      // column exists has no upgrade path that adds it, so emitting SQL naming it would fail the
-      // query for that collection — and a filter that cannot be evaluated is worse than one that
-      // returns nothing, because the worklist would present every document as needing review.
+      // column existed has no path that adds it, so emitting SQL naming it would fail the query
+      // for that collection — and a filter that cannot be evaluated is worse than one returning
+      // nothing, because the worklist would present every document as needing review.
       //
       // Absent is already the defined answer for "cannot answer", so this is the designed
-      // conservative path rather than a flag. It is supplied once the capability can be
-      // established from the database instead of from configuration.
+      // conservative path rather than a flag.
       defaultLocale: this.localization.defaultLocale,
       filter,
     });

--- a/packages/nextly/src/domains/i18n/runtime/companion-copy.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-copy.ts
@@ -276,12 +276,18 @@ export async function copyDefaultLocaleOntoMain(
 /**
  * Set one locale's `_updated_at` to NULL, tolerating a companion that has no such column.
  *
- * Raw SQL because the column is deliberately not declared on the companion's Drizzle table — see
- * `readCompanionStamps` for why — so `.set()` cannot name it.
+ * The column is deliberately not declared on the companion's own Drizzle table — see
+ * `readCompanionStamps` for why — so this drives a narrow handle built for the three columns it
+ * needs, `buildCompanionStampTable`, rather than the companion's table. `.set()` can then name
+ * the column, and the value is encoded by the same dialect mapping every other Drizzle write
+ * uses; a hand-built statement would bind a `Date` straight to the driver and write the local
+ * wall clock into a column that records no zone.
  *
  * A companion that predates the column is not an error here: it simply has no stamp to clear, and
- * every locale on it already reads as UNKNOWN. Anything else rethrows, so a permission fault is
- * not quietly absorbed into "there was nothing to do".
+ * every locale on it already reads as UNKNOWN. Recognising that case takes a predicate that walks
+ * the CAUSE chain, because Drizzle wraps the driver error and the wording this must match is on
+ * the cause rather than on the error a caller catches. Anything else rethrows, so a permission
+ * fault is not quietly absorbed into "there was nothing to do".
  *
  * The guard is part of the statement rather than a check before it. This clears the stamp on
  * EVERY row of the locale, and the caller passes the SOURCE locale — one half of every comparison


### PR DESCRIPTION
Three accuracy defects that shipped with the localization staleness groundwork. No behaviour changes: every changed line under `packages/` is a comment.

    git diff origin/main...HEAD -- 'packages/**'
      total changed lines:        68
      non-comment changed lines:   0

### The changeset advertised a feature that does not ship

The merged changeset told users that "the translation worklist gains a 'Needs review' tab, and the language panel marks a translation whose source has moved on". Neither ships: the read path is withheld until the physical column can be established from the database rather than from configuration, so the tab is not offered and the stamps that produce the marker are not supplied.

The changeset is already on `main`, so the generated release notes would have promised behaviour unavailable in the version that carries them. It now describes the groundwork alone — the timestamp is recorded on every companion write and seeded from version history where that exists, and nothing surfaces it yet. The 25-package lockstep frontmatter is unchanged; `changeset status` parses it.

### Two comments narrated work that had not happened

`collection-query-service.ts` carried the plan label `(i18n B2)` twice, plus sentences about what a future capability probe would do. `AGENTS.md` limits comments to the code's behaviour and rationale and prohibits task or plan references. The explanation of *why* the inputs are omitted is retained in full — it is the load-bearing part — and the narration about when they will be supplied is gone.

### One comment described the array incorrectly

`worklist.ts` claimed "the worklist's tab list is one entry wider than the state catalog" and that the stale entry "is kept here rather than deleted". Both were false after the entry was removed: `WORKLIST_STATES` offers a tab for each of the four language states and nothing more. Only the `WorklistState` TYPE is wider, deliberately, so a saved link naming the state still resolves and the server answers it honestly rather than rejecting it as unknown. The comments now say that.

### Verification

    cd packages/nextly && pnpm run check-types    -> 0
    cd packages/admin  && pnpm run check-types    -> 0   (control: an injected type error exits 2)
    cd packages/nextly && pnpm run lint           -> 0
    cd packages/admin  && pnpm run lint           -> 0
    node scripts/check-comment-convention.mjs     -> 0
    pnpm exec changeset status                    -> 0
    pre-push gate: admin 3124/3124, nextly 9786 passed | 42 skipped

No changeset of its own: this edits an existing one and changes no behaviour.

### Not fixed here

`i18n B2` appears 34 more times across the same feature. `scripts/check-comment-convention.mjs` cannot see them — its task/plan pattern requires the `Task 17:` or `(plan D4)` form, and its own comment states the bare-label gap as an accepted cost. Left out deliberately: a mass comment edit across ~15 files can flip `fallow`'s attribution to `introduced` and block the hygiene gate, so it wants a pull request with nothing else in it. Filed as `task:strip-plan-labels-from-i18n-comments`.
