### PR TITLE
fix(nextly): answer the companion capability probe from the column list

### DIFF
--- a/.changeset/a-probe-that-cannot-tell-absent-from-unreachable.md
+++ b/.changeset/a-probe-that-cannot-tell-absent-from-unreachable.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A translation restored from the archive can no longer be left describing itself as current.
+
+Deciding whether a translations table carries the column that records when each language was
+last written used to be a question the database was asked indirectly: a statement was attempted,
+and any failure at all was read as "the column is not there". A dropped connection, or an
+account permitted to write the table but not to read the catalogue, therefore answered the same
+way a genuinely older table does — and on that answer a restore preserves the timestamp already
+on a language while replacing its content with older archived material, leaving a translation
+that reports itself as up to date when it is not.
+
+The question is now answered from the table's own column list. Absent is absent; anything that
+prevents the question being answered is reported rather than being turned into a claim about the
+schema.

--- a/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
+++ b/packages/nextly/src/dispatcher/handlers/__tests__/collection-dispatcher-shapes.test.ts
@@ -1127,7 +1127,11 @@ describe("dispatchCollections, i18n request flag", () => {
       getDrizzle: vi.fn().mockReturnValue({
         all: vi.fn().mockResolvedValue([]),
         run: vi.fn().mockResolvedValue(undefined),
-        execute: vi.fn().mockResolvedValue([]),
+        // `{ rows }` because this fake is postgres and node-postgres returns a QueryResult, not
+        // an array. The companion capability probe introspects through this handle and reads
+        // `.rows`, so a bare `[]` here is not "no columns" -- it is a shape the reader cannot
+        // walk, and it fails the whole apply with an opaque internal error.
+        execute: vi.fn().mockResolvedValue({ rows: [] }),
       }),
       execute: vi.fn().mockResolvedValue(undefined),
       executeQuery: vi.fn().mockResolvedValue([]),
@@ -1297,7 +1301,11 @@ describe("dispatchCollections, localized persistence failure", () => {
       getDrizzle: vi.fn().mockReturnValue({
         all: vi.fn().mockResolvedValue([]),
         run: vi.fn().mockResolvedValue(undefined),
-        execute: vi.fn().mockResolvedValue([]),
+        // `{ rows }` because this fake is postgres and node-postgres returns a QueryResult, not
+        // an array. The companion capability probe introspects through this handle and reads
+        // `.rows`, so a bare `[]` here is not "no columns" -- it is a shape the reader cannot
+        // walk, and it fails the whole apply with an opaque internal error.
+        execute: vi.fn().mockResolvedValue({ rows: [] }),
       }),
       execute: vi.fn().mockResolvedValue(undefined),
       executeQuery: vi.fn().mockResolvedValue([]),

--- a/packages/nextly/src/domains/i18n/migration/restore-archive.ts
+++ b/packages/nextly/src/domains/i18n/migration/restore-archive.ts
@@ -18,26 +18,35 @@
  * @module domains/i18n/migration/restore-archive
  */
 
-import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { and, eq, lte } from "drizzle-orm";
 
 import { nextlyI18nArchiveTables } from "../../../schemas/nextly-i18n-archive";
 import { COMPANION_UPDATED_AT_COLUMN } from "../companion-columns";
+import type { CompanionIntrospectAdapter } from "../runtime/companion-io";
 import {
   companionHasColumn,
   upsertCompanionRow,
 } from "../runtime/companion-io";
 
-/** Minimal adapter surface this helper needs — matches DrizzleAdapter. */
-export interface RestoreArchiveAdapter {
-  dialect: SupportedDialect;
-  executeQuery<T = unknown>(sql: string, params?: unknown[]): Promise<T[]>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Drizzle's db type is dialect-specific
-  getDrizzle(): any;
+/**
+ * The slice of Drizzle this helper drives: one scoped SELECT and one scoped DELETE. Declaring
+ * only what is used keeps the dialect-specific database type out of the port, so no `any` is
+ * needed — the same shape `teardown-entity-i18n` declares for its own single statement.
+ */
+interface ArchiveReadWriteDb {
+  select(columns: Record<string, unknown>): {
+    from(table: unknown): { where(condition: unknown): Promise<unknown> };
+  };
+  delete(table: unknown): { where(condition: unknown): Promise<unknown> };
 }
 
 export interface RestoreArchiveArgs {
-  adapter: RestoreArchiveAdapter;
+  /**
+   * The connection to replay through. This helper both writes companion rows and asks the
+   * database for the companion's physical shape, which is the introspecting surface rather than
+   * the narrower write-only one.
+   */
+  adapter: CompanionIntrospectAdapter;
   /** Entity slug exactly as the disable migration recorded it in `archive.collection`. */
   collection: string;
   /** Physical companion table to replay into, e.g. `dc_pages_locales`. */
@@ -86,7 +95,7 @@ export async function restoreI18nArchive(
   args: RestoreArchiveArgs
 ): Promise<RestoreArchiveResult> {
   const { adapter, collection, companionTableName, locale } = args;
-  const db = adapter.getDrizzle();
+  const db = adapter.getDrizzle<ArchiveReadWriteDb>();
   const { nextlyI18nArchive } = nextlyI18nArchiveTables(adapter.dialect);
 
   const where = locale

--- a/packages/nextly/src/domains/i18n/runtime/__tests__/companion-has-column.test.ts
+++ b/packages/nextly/src/domains/i18n/runtime/__tests__/companion-has-column.test.ts
@@ -1,0 +1,154 @@
+/**
+ * The capability probe has to tell ABSENT from UNREACHABLE.
+ *
+ * `companionHasColumn` answers one question — does this companion physically carry this column —
+ * and every caller treats a `false` as a fact about the schema. It used to be a
+ * `SELECT … LIMIT 0` inside a bare `catch`, which answered `false` for a dropped connection, a
+ * permission refusal and a genuinely absent column alike.
+ *
+ * That collapse is silent and it corrupts data rather than failing. `restoreI18nArchive` reads
+ * this to choose between clearing a locale's timestamp and omitting it: on `false` it omits, so
+ * an existing locale row keeps its NEWER timestamp while its content is replaced with OLDER
+ * archived material, and the translation then reads as current. Nothing surfaces, because the
+ * restore reports success.
+ *
+ * These tests pin the discrimination itself: a column list decides presence, and anything that
+ * stops the list being read propagates instead of becoming a schema claim.
+ *
+ * @module domains/i18n/runtime/__tests__/companion-has-column.test
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { companionHasColumn } from "../companion-io";
+
+const introspectLiveSnapshot = vi.fn();
+
+vi.mock("../../../schema/pipeline/diff/introspect-live", () => ({
+  get introspectLiveSnapshot() {
+    return introspectLiveSnapshot;
+  },
+}));
+
+/** An adapter that can introspect and nothing else — the probe needs no write surface. */
+function introspectingAdapter() {
+  const drizzle = { marker: "the caller's connection" };
+  return {
+    dialect: "postgresql" as const,
+    executeQuery: vi.fn(),
+    getDrizzle: <T = unknown>(): T => drizzle as T,
+    drizzle,
+  };
+}
+
+beforeEach(() => {
+  introspectLiveSnapshot.mockReset();
+});
+
+describe("companionHasColumn", () => {
+  it("reads presence from the column list, not from a statement that parses", async () => {
+    const adapter = introspectingAdapter();
+    introspectLiveSnapshot.mockResolvedValue({
+      tables: [
+        {
+          name: "dc_posts_locales",
+          columns: [
+            { name: "_parent" },
+            { name: "_locale" },
+            { name: "_updated_at" },
+          ],
+        },
+      ],
+    });
+
+    await expect(
+      companionHasColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).resolves.toBe(true);
+
+    // Scoped to the one table. Introspection is per-table on SQLite and an IN clause on the
+    // other two, so passing the whole managed namespace would turn a single question into a
+    // full-schema read on every probe.
+    expect(introspectLiveSnapshot).toHaveBeenCalledWith(
+      adapter.drizzle,
+      "postgresql",
+      ["dc_posts_locales"]
+    );
+  });
+
+  it("answers false for a column the table does not carry", async () => {
+    const adapter = introspectingAdapter();
+    introspectLiveSnapshot.mockResolvedValue({
+      tables: [
+        {
+          name: "dc_posts_locales",
+          columns: [{ name: "_parent" }, { name: "_locale" }],
+        },
+      ],
+    });
+
+    await expect(
+      companionHasColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).resolves.toBe(false);
+  });
+
+  it("answers false for a companion that is not there at all", async () => {
+    const adapter = introspectingAdapter();
+    // Introspection scoped to a table that does not exist simply returns no table for it. That
+    // is the same answer the replaced probe gave by failing its statement on the missing
+    // relation, so callers that already tolerate a missing companion are unaffected.
+    introspectLiveSnapshot.mockResolvedValue({ tables: [] });
+
+    await expect(
+      companionHasColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).resolves.toBe(false);
+  });
+
+  it("does not name another table's columns as its own", async () => {
+    const adapter = introspectingAdapter();
+    // A snapshot can carry more tables than were asked for. Matching on the name rather than
+    // taking the first entry is what keeps a sibling companion from answering for this one.
+    introspectLiveSnapshot.mockResolvedValue({
+      tables: [
+        {
+          name: "dc_pages_locales",
+          columns: [{ name: "_updated_at" }],
+        },
+        {
+          name: "dc_posts_locales",
+          columns: [{ name: "_parent" }],
+        },
+      ],
+    });
+
+    await expect(
+      companionHasColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).resolves.toBe(false);
+  });
+
+  it("🔴 propagates a failure to READ the shape instead of reporting the column absent", async () => {
+    const adapter = introspectingAdapter();
+    const unreachable = new Error("connection terminated unexpectedly");
+    introspectLiveSnapshot.mockRejectedValue(unreachable);
+
+    // The whole point. A resolved `false` here is indistinguishable, to every caller, from a
+    // companion that predates the column -- and the archive replay acts on that difference by
+    // preserving a newer timestamp over older restored content. A transient failure must not be
+    // able to author that decision, so it has to reach the caller as a failure.
+    await expect(
+      companionHasColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).rejects.toThrow(unreachable);
+  });
+
+  it("🔴 propagates a permission refusal, which reads exactly like an absent column", async () => {
+    const adapter = introspectingAdapter();
+    // A role that may write the companion but not read the catalog is the case a `catch` gets
+    // most confidently wrong: nothing is broken, every write succeeds, and the probe quietly
+    // reports every column of every companion as missing.
+    introspectLiveSnapshot.mockRejectedValue(
+      new Error("permission denied for table columns")
+    );
+
+    await expect(
+      companionHasColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).rejects.toThrow(/permission denied/);
+  });
+});

--- a/packages/nextly/src/domains/i18n/runtime/companion-io.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-io.ts
@@ -699,6 +699,15 @@ function isMissingTableError(error: unknown): boolean {
  * failure (transient, connection, permission) is rethrown, so a caller gating a
  * write on this never mistakes an unavailable database for an absent table and
  * silently skips the write.
+ *
+ * Stays a plan-only probe while its column-level sibling reads the catalog, and the difference
+ * is the call frequency rather than a preference. This one backs the cached readiness verdict
+ * that every localized write consults, so it runs once per entity per cache window on the
+ * request path; a catalog read there would reintroduce exactly the per-write introspection cost
+ * `companion-readiness` exists to remove. The column probes run on schema changes and
+ * migrations, where one extra round trip is not measurable. It is also already safe in the way
+ * a bare `catch` is not: {@link isMissingTableError} verifies the dialect's own wording for an
+ * absent RELATION, and everything else propagates.
  */
 export async function companionTableExists(
   adapter: CompanionWriteAdapter,
@@ -720,10 +729,10 @@ export async function companionTableExists(
 /**
  * Whether an EXISTING companion physically has the per-locale `_status` column. Used by the
  * runtime reconcile to decide whether a later Draft/Published toggle must ADD/DROP `_status`
- * on an already-provisioned companion. A missing column throws on the probe select → false.
+ * on an already-provisioned companion.
  */
 export async function companionHasStatusColumn(
-  adapter: CompanionWriteAdapter,
+  adapter: CompanionIntrospectAdapter,
   companionTableName: string
 ): Promise<boolean> {
   return companionHasColumn(adapter, companionTableName, "_status");
@@ -732,30 +741,48 @@ export async function companionHasStatusColumn(
 /**
  * Whether an EXISTING companion physically carries `column`.
  *
- * A plan-only `SELECT … LIMIT 0`, so the server parses the statement and returns no rows: the
- * cheapest question that still gets its answer from the database rather than from what a
- * configuration says should be there.
+ * Answered by reading the table's column list, through the same introspection the companion
+ * reconcile uses. The alternative — a plan-only `SELECT … LIMIT 0` and a `catch` — is cheaper by
+ * one round trip and wrong in two ways that matter here.
  *
- * 🔴 MUST NOT be called inside an open transaction. A query against a missing column marks the
- * whole PostgreSQL transaction aborted, after which the real statement dies with
- * `current transaction is aborted` and the error names an innocent one. That is the same hazard
- * `companion-readiness` documents, and it is why callers probe BEFORE they open one.
+ * 🔴 A `catch` cannot tell ABSENT from UNREACHABLE, and the two want opposite behaviour. A
+ * transient connection failure, or a role that may write but not select, would answer `false` —
+ * "this companion has no such column" — and every caller treats that as a fact about the schema.
+ * The archive replay is where it bites: `false` makes it choose `"omit"` over `"clear"`, so an
+ * existing locale row keeps its NEWER timestamp while its content is replaced with OLDER archived
+ * material, and the translation reads as current when it is not. A column list has no such
+ * ambiguity — the column is in it or it is not — and anything that stops the question being
+ * answered at all propagates instead of being flattened into a schema claim.
+ *
+ * The second reason is the repository's: database access is Drizzle only, and this was the last
+ * hand-built statement on the localization write path.
+ *
+ * 🔴 MUST NOT be called inside an open transaction. A failed query marks the whole PostgreSQL
+ * transaction aborted, after which the real statement dies with `current transaction is aborted`
+ * and the error names an innocent one. That is the same hazard `companion-readiness` documents,
+ * and it is why callers probe BEFORE they open one.
+ *
+ * A companion that does not exist has no columns, so it answers `false` — unchanged from the
+ * probe this replaces, where the statement failed on the missing relation.
  */
 export async function companionHasColumn(
-  adapter: CompanionWriteAdapter,
+  adapter: CompanionIntrospectAdapter,
   companionTableName: string,
   column: string
 ): Promise<boolean> {
-  const isMysql = adapter.dialect === "mysql";
-  const q = (id: string) => (isMysql ? `\`${id}\`` : `"${id}"`);
-  try {
-    await adapter.executeQuery(
-      `SELECT ${q(column)} FROM ${q(companionTableName)} LIMIT 0`
-    );
-    return true;
-  } catch {
-    return false;
-  }
+  const { introspectLiveSnapshot } = await import(
+    "../../schema/pipeline/diff/introspect-live"
+  );
+  const snapshot = await introspectLiveSnapshot(
+    adapter.getDrizzle(),
+    adapter.dialect,
+    [companionTableName]
+  );
+  return (
+    snapshot.tables
+      .find(t => t.name === companionTableName)
+      ?.columns.some(c => c.name === column) ?? false
+  );
 }
 
 /**


### PR DESCRIPTION
Closes two review findings on #1332 that turned out to be the same function, and one fix answers both.

### The defect

`companionHasColumn` attempted a statement naming the column and read **any** failure as "the column is not there":

```ts
try {
  await adapter.executeQuery(`SELECT ${q(column)} FROM ${q(table)} LIMIT 0`);
  return true;
} catch {
  return false;
}
```

A dropped connection answers `false`. A role permitted to write the companion but not read the catalogue answers `false`. Both are indistinguishable, to every caller, from a companion provisioned before the column existed — and callers treat that answer as a fact about the schema.

`restoreI18nArchive` is where it does damage rather than merely misreporting. It reads this to choose between clearing a locale's `_updated_at` and omitting it. On `false` it omits, so an existing locale row keeps its **newer** timestamp while its content is replaced with **older** archived material. The translation then reads as current when it is not, and the restore reports success, so nothing surfaces.

### The fix

Answered from the table's own column list, through `introspectLiveSnapshot`.

This is not a new position in this file. `mainTableHasColumns`, forty lines above, already chose introspection over a probe and wrote down why:

> Goes through the same introspection the schema pipeline uses rather than a `SELECT ... LIMIT 0` probe. That matters beyond convention: a probe cannot tell "this column does not exist" from "the database is unreachable" [...] Introspection fails loudly, and this deliberately does not catch.

Its sibling then did exactly the thing that comment warns against. This makes the two agree. It also removes the last hand-built statement from the localization write path, which is what `AGENTS.md:273` asks for.

A companion that does not exist has no columns and so still answers `false` — unchanged from the probe, which failed its statement on the missing relation.

### What is deliberately NOT changed

`companionTableExists` stays a plan-only probe, and the contrast is documented at both sites rather than left looking like an oversight. It backs the cached readiness verdict that **every localized write** consults, so it runs on the request path; a catalogue read there would reintroduce exactly the per-write introspection cost `companion-readiness` exists to remove. The column probes run on schema changes and migrations, where one extra round trip is not measurable. It is also already safe in the way a bare `catch` is not — `isMissingTableError` verifies the dialect's own missing-relation wording and everything else propagates.

### Also in here

- **`RestoreArchiveAdapter` deleted.** It was a hand-copied duplicate of `CompanionIntrospectAdapter` (its own comment: "Minimal adapter surface this helper needs — matches DrizzleAdapter"), and it carried an `eslint-disable no-explicit-any`. The Drizzle handle is now declared as the two statements the helper actually drives, in the same shape `teardown-entity-i18n` uses.
- **Two dispatcher fakes returned a bare `[]` from a postgres `execute`.** node-postgres returns `{ rows }`. Those doubles only ever passed because the old `catch` swallowed the resulting `TypeError` — so the swallow was holding up two tests built on a shape postgres never returns.

### Evidence

Six new tests, break-verified individually against the pre-fix implementation rather than as a suite:

    × reads presence from the column list, not from a statement that parses
    × answers false for a column the table does not carry
    × answers false for a companion that is not there at all
    × does not name another table's columns as its own
    × propagates a failure to READ the shape instead of reporting the column absent
    × propagates a permission refusal, which reads exactly like an absent column
     Tests  6 failed (6)          <- no survivors

and green on the fix:

    cd packages/nextly && pnpm run test               -> 790/790 files, 9792 passed | 42 skipped
    pnpm run check-types                              -> 0
    pnpm run lint                                     -> 0
    node scripts/check-comment-convention.mjs         -> 0
    pnpm exec changeset status                        -> 0
    integration (sqlite), restore-archive + companion-transition + companion-lifecycle
                                                      -> 3 files, 18 tests passed

The wider i18n integration run shows one failure, `enable-disable.integration.test.ts`. That is inherited from `main` and unrelated: a positional `INSERT` the companion outgrew. Fixed separately in #1338.
