### PR TITLE
feat(builder): report which typefaces a site will actually render

### DIFF
--- a/.changeset/report-typefaces-a-site-will-not-render.md
+++ b/.changeset/report-typefaces-a-site-will-not-render.md
@@ -65,3 +65,8 @@ about what a browser will read.
 invalid. `font-family: Brand,` is a parse error the browser drops the whole
 declaration for, and reporting it as the single family `Brand` described a value
 the page never rendered.
+
+`BuilderShell`'s `openInsertPanelToken` is now `openPanelRequest`, carrying the
+panel alongside the count. Opening `insert` from the canvas appender and opening
+`tokens` from the fonts panel are the same request with a different subject, and
+two props would have been two answers to one question.

--- a/.changeset/report-typefaces-a-site-will-not-render.md
+++ b/.changeset/report-typefaces-a-site-will-not-render.md
@@ -49,10 +49,19 @@ Nothing is called missing or unavailable. A named family with no face may be
 installed on the reader's device, so the wording says what is true: this site
 provides no font file for it.
 
-`splitFamilyList` and `isUsableFamilyList` are now published from
-`@nextlyhq/blocks-engine`. Reading a family list is quoting, comma and CSS
-escape rules together — `"ACME, Inc", serif` is two families, not three — and
-`isUsableFamilyList` pairs the quoting rule with the identifier-run grammar that
-`FamilyPart.valid` leaves out. Asked alone, `valid` accepts `var(--x)` as a font
-called `var(--x)`. `familyToDtcg` now asks the same predicate, so the DTCG
-export and the panel cannot disagree about what a browser will read.
+`readFamilyList`, `familyPartKind` and `splitFamilyList` are now published from
+`@nextlyhq/blocks-engine`, and they classify rather than answering yes or no.
+CSS reads a family list four ways and a boolean misdescribes two of them: a
+stack holding `var(--font-geist)` is read perfectly and cannot be resolved from
+the text, and a lone `inherit` is valid while naming no family at all. Each item
+is classified as a name, a generic keyword, a `var()` substitution, a CSS-wide
+keyword, or invalid; the list's own reading follows from those.
+
+`familyToDtcg` asks the same reading and applies its own narrower rule to the
+answer, so the DTCG export and any surface reporting on a site cannot disagree
+about what a browser will read.
+
+`splitFamilyList` no longer discards empty items — it keeps them, marked
+invalid. `font-family: Brand,` is a parse error the browser drops the whole
+declaration for, and reporting it as the single family `Brand` described a value
+the page never rendered.

--- a/.changeset/report-typefaces-a-site-will-not-render.md
+++ b/.changeset/report-typefaces-a-site-will-not-render.md
@@ -1,0 +1,58 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Add the fonts panel, which reports which typefaces a site will actually render.
+
+`compileSiteSheet` emits `@font-face` blocks and token custom properties
+independently, so a `fontFamily` token naming a family the site loads no face
+for is emitted exactly like one that has it. The page then draws in whatever
+the browser reaches for next, nothing errors, and nothing is logged — the same
+silent substitution the sheet's own `tokenPrefix` note describes one property
+along.
+
+The panel joins the two lists, which is the only way to see it: the tokens
+studio edits one token and knows nothing about faces, and the inspector knows
+nothing about either. It authors nothing itself, so creating and renaming
+typeface tokens stays the studio's single job.
+
+Every family is drawn in itself. A list of typeface names set in the interface's
+own font asks an author to choose a typeface from its name, and a family the
+site does not provide renders in the fallback — so the substitution is visible
+rather than described.
+
+Nothing is called missing or unavailable. A named family with no face may be
+installed on the reader's device, so the wording says what is true: this site
+provides no font file for it.
+
+`splitFamilyList` and `isUsableFamilyList` are now published from
+`@nextlyhq/blocks-engine`. Reading a family list is quoting, comma and CSS
+escape rules together — `"ACME, Inc", serif` is two families, not three — and
+`isUsableFamilyList` pairs the quoting rule with the identifier-run grammar that
+`FamilyPart.valid` leaves out. Asked alone, `valid` accepts `var(--x)` as a font
+called `var(--x)`. `familyToDtcg` now asks the same predicate, so the DTCG
+export and the panel cannot disagree about what a browser will read.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -369,8 +369,10 @@ export {
   dtcgToTokens,
   isKind,
   tokensToDtcg,
+  isUsableFamilyList,
+  splitFamilyList,
 } from "./style/dtcg";
-export type { DtcgNode } from "./style/dtcg";
+export type { DtcgNode, FamilyPart } from "./style/dtcg";
 export {
   checkContrast,
   compositeOver,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -369,10 +369,18 @@ export {
   dtcgToTokens,
   isKind,
   tokensToDtcg,
-  isUsableFamilyList,
+  familyPartKind,
+  readFamilyList,
   splitFamilyList,
 } from "./style/dtcg";
-export type { DtcgNode, FamilyPart } from "./style/dtcg";
+export type {
+  DtcgNode,
+  FamilyListKind,
+  FamilyListReading,
+  FamilyPart,
+  FamilyPartKind,
+  ReadFamilyPart,
+} from "./style/dtcg";
 export {
   checkContrast,
   compositeOver,

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -336,6 +336,7 @@ export {
   TOKEN_MODES,
   defaultSiteTokens,
   resolveSiteTokens,
+  cssString,
   emitFontFaces,
   emitTokenBlocks,
   isAuthorableTokenName,

--- a/packages/blocks-engine/src/style/dtcg.test.ts
+++ b/packages/blocks-engine/src/style/dtcg.test.ts
@@ -268,9 +268,17 @@ describe("export", () => {
     expect(document).toEqual({});
   });
 
-  it("still exports a family run separated by the whitespace CSS allows", () => {
+  it("exports a family run separated by CSS whitespace under its ONE name", () => {
     // The other side of that rule: a form feed IS whitespace to CSS, so the run
     // it separates is two identifiers and the token is expressible.
+    //
+    // Exported with the separator NORMALISED, because CSS joins the identifiers
+    // of an unquoted family with a single space to form the name it matches on.
+    // `My\u000cFont` and `My Font` are one family to a browser, so exporting
+    // the author's spelling would hand every tool reading the standard value a
+    // name carrying a form feed, which matches no installed font — and would
+    // make the same value compare unequal against the family a `@font-face`
+    // declares. A quoted name is untouched: there the whitespace is the name.
     const { document } = tokensToDtcg(
       tokens([
         {
@@ -281,7 +289,7 @@ describe("export", () => {
       ])
     );
     expect((document.f as Record<string, unknown>)?.$value).toEqual([
-      "My\u000cFont",
+      "My Font",
       "serif",
     ]);
   });

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -398,9 +398,11 @@ function familyToDtcg(css: string): string | string[] | undefined {
 /**
  * A CSS family list split into its families.
  *
- * The comma only separates families outside quotes: `"ACME, Inc", serif` names
- * two families, not three, and a plain split turns a real company's font into a
- * fallback list that fails over to a family called `Inc`. Quotes are removed
+ * The comma only separates families outside quotes AND outside parentheses.
+ * `"ACME, Inc", serif` names two families, not three — a plain split turns a
+ * real company's font into a fallback list failing over to a family called
+ * `Inc` — and `var(--font, Arial), sans-serif` names two, not three, because
+ * the first comma belongs to the custom property's fallback. Quotes are removed
  * because the name is the family, not the spelling, and backslash escapes are
  * resolved for the same reason.
  */
@@ -412,6 +414,10 @@ export function splitFamilyList(css: string): FamilyPart[] {
   let outsideQuotes = "";
   let raw = "";
   let quote: string | undefined;
+  // Parenthesis depth, so a comma inside `var(--font, Arial)` is not a
+  // separator. Counted rather than flagged: `var(--a, var(--b, serif))` nests,
+  // and a boolean would close on the inner `)`.
+  let depth = 0;
 
   for (let index = 0; index < css.length; index++) {
     const char = css[index];
@@ -442,7 +448,9 @@ export function splitFamilyList(css: string): FamilyPart[] {
       quoted = true;
       continue;
     }
-    if (char === ",") {
+    if (char === "(") depth += 1;
+    else if (char === ")" && depth > 0) depth -= 1;
+    if (char === "," && depth === 0) {
       parts.push(finishPart(current, quoted, strings, outsideQuotes, raw));
       current = "";
       raw = "";
@@ -466,13 +474,24 @@ export function splitFamilyList(css: string): FamilyPart[] {
 }
 
 /** Words that are keywords rather than family names when written bare. */
-const FAMILY_KEYWORD_NOT_A_NAME = new Set([
+/**
+ * Words an unquoted family name may not be, and what each one is.
+ *
+ * These stand for the whole declaration — `font-family: inherit` takes the
+ * parent's font — so a lone one is a valid value naming no family.
+ *
+ * `default` is deliberately NOT here. It must be quoted to name a font, which
+ * is why {@link FAMILY_MUST_QUOTE} carries it for the importer, but it is not a
+ * CSS-wide keyword: the font-family grammar excludes it from `<family-name>`,
+ * so a browser drops a declaration reading it bare. Reading it as a working
+ * whole-value keyword is how a dropped declaration reports as healthy.
+ */
+const CSS_WIDE_KEYWORDS = new Set([
   "inherit",
   "initial",
   "unset",
   "revert",
   "revert-layer",
-  "default",
 ]);
 
 // The five characters CSS calls whitespace. JavaScript's `\s` is a wider set —
@@ -492,6 +511,8 @@ const UNQUOTED_FAMILY = new RegExp(
   `^${IDENT_START}${IDENT_CHAR}*(?:${CSS_WS}+${IDENT_START}${IDENT_CHAR}*)*$`
 );
 const CSS_WS_EDGES = new RegExp(`^${CSS_WS}+|${CSS_WS}+$`, "g");
+/** A run of CSS whitespace, which separates identifiers within one family. */
+const CSS_WS_RUN = new RegExp(`${CSS_WS}+`, "g");
 
 /** Strip the whitespace CSS recognises from both ends, and only that. */
 function trimCssWhitespace(text: string): string {
@@ -554,7 +575,10 @@ export function familyPartKind(part: FamilyPart): FamilyPartKind {
   // `var()` is checked before the grammar, because the grammar rejects the
   // parentheses and would report a valid, common value as broken.
   if (/\bvar\(/i.test(part.name)) return "dynamic";
-  if (FAMILY_KEYWORD_NOT_A_NAME.has(lower)) return "keyword";
+  if (CSS_WIDE_KEYWORDS.has(lower)) return "keyword";
+  // Reserved, and not a whole-value keyword: bare `default` names no family and
+  // the declaration is dropped, so it is invalid rather than a working value.
+  if (lower === "default") return "invalid";
   if (GENERIC_FAMILIES.has(lower)) return "generic";
   if (!UNQUOTED_FAMILY.test(part.raw) || /[()]/.test(part.name))
     return "invalid";
@@ -646,7 +670,13 @@ function finishPart(
   // `String.trim` strips characters CSS does not treat as whitespace, so a
   // family led by one would have it removed here and pass a check the browser
   // fails.
-  return { name, raw: trimCssWhitespace(raw), quoted, valid };
+  // CSS separates the identifiers of an unquoted family with any run of its
+  // whitespace, and treats every run alike — `Brand   Sans` selects the face
+  // named `Brand Sans`. Keeping the author's spelling made an equivalent value
+  // compare unequal against the family a face declares. A QUOTED name keeps its
+  // spelling exactly: there the spaces are part of the name.
+  const collapsed = quoted ? name : name.replace(CSS_WS_RUN, " ");
+  return { name: collapsed, raw: trimCssWhitespace(raw), quoted, valid };
 }
 
 /**

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -374,28 +374,25 @@ function colorToDtcg(css: string): DtcgNode | undefined {
 
 /** A family list as one string or an array, which is what the format takes. */
 function familyToDtcg(css: string): string | string[] | undefined {
-  const parts = splitFamilyList(css);
-  if (parts.length === 0) return undefined;
-  // A family list holding `var(--brand-font)` has no DTCG form: the format
-  // stores NAMES, so exporting the text would describe a font literally called
-  // `var(--brand-font)` to every tool that reads the standard value rather than
-  // this vendor's extension. Reported as unrepresentable instead, which is the
-  // same answer a `clamp()` dimension already gets.
-  if (parts.some(part => !part.valid)) return undefined;
-  // A bare CSS-wide keyword is not a family name: `font-family: inherit` takes
-  // the parent's font, so exporting `"inherit"` as a `$value` would describe a
-  // font by that name to any tool reading the standard value. Quoted, it IS a
-  // name somebody chose.
-  if (
-    parts.some(
-      part =>
-        !part.quoted && FAMILY_KEYWORD_NOT_A_NAME.has(part.name.toLowerCase())
-    )
-  ) {
-    return undefined;
-  }
-  if (!isUsableFamilyList(parts)) return undefined;
-  return parts.length === 1 ? parts[0]?.name : parts.map(part => part.name);
+  const reading = readFamilyList(css);
+  // The format stores NAMES, and three of the four readings are not names.
+  //
+  // `dynamic` — a list holding `var(--brand-font)` has no DTCG form: exporting
+  // the text would describe a font literally called `var(--brand-font)` to
+  // every tool reading the standard value. The same answer a `clamp()`
+  // dimension already gets, and the reason this asks for the READING rather
+  // than a usability boolean: the browser reads that value fine, so a shared
+  // yes/no would have to call it either broken or exportable, and it is
+  // neither.
+  //
+  // `keyword` — `font-family: inherit` takes the parent's font, so exporting
+  // `"inherit"` would name a font nobody has. Quoted, it IS a name somebody
+  // chose, which `familyPartKind` already distinguishes.
+  //
+  // `invalid` — a value no browser reads was never a stack this site rendered.
+  if (reading.kind !== "families") return undefined;
+  const names = reading.parts.map(p => p.part.name);
+  return names.length === 1 ? names[0] : names;
 }
 
 /**
@@ -460,7 +457,12 @@ export function splitFamilyList(css: string): FamilyPart[] {
   }
   parts.push(finishPart(current, quoted, strings, outsideQuotes, raw));
 
-  return parts.filter(part => part.name !== "");
+  // Empty items are KEPT, marked invalid by `finishPart`. `Brand,` and
+  // `Brand,, serif` are parse errors — CSS reads `<family-name>#`, which admits
+  // no empty item — and a browser drops the whole declaration. Filtering them
+  // out here reported `Brand,` as the single family `Brand`, which is a value
+  // the page never rendered.
+  return parts;
 }
 
 /** Words that are keywords rather than family names when written bare. */
@@ -497,28 +499,115 @@ function trimCssWhitespace(text: string): string {
 }
 
 /**
- * Whether a split family list is one CSS will read.
+ * The CSS generic families, plus the `ui-*` system aliases.
  *
- * `FamilyPart.valid` answers the QUOTING rule alone — one string per item, and
- * nothing outside it. That is half the grammar. `<family-name>` is one string
- * OR a run of identifiers, so an unquoted item must also be an identifier run
- * carrying no parentheses: `10px, serif` tokenizes as a dimension and
- * `var(--x)` as a function, and a browser drops the whole declaration for
- * either.
- *
- * Exported and shared rather than repeated at each caller, because both halves
- * have to be asked together. Asking only `valid` accepts `var(--x)` as a font
- * called `var(--x)`, which is the answer a caller reading one half gets — and
- * it looks like a family until something tries to render it.
+ * Unquoted, these are KEYWORDS rather than names: `font-family: serif` asks for
+ * the browser's serif default, and no `@font-face` can claim it — the engine
+ * emits every face family quoted, so only a quoted value can name one.
  */
-export function isUsableFamilyList(parts: readonly FamilyPart[]): boolean {
-  if (parts.length === 0) return false;
-  return parts.every(
-    part =>
-      part.valid &&
-      (part.quoted ||
-        (UNQUOTED_FAMILY.test(part.raw) && !/[()]/.test(part.name)))
-  );
+const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+  "ui-serif",
+  "ui-sans-serif",
+  "ui-monospace",
+  "ui-rounded",
+  "math",
+  "emoji",
+  "fangsong",
+]);
+
+/**
+ * How CSS reads ONE item of a family list.
+ *
+ * Five outcomes rather than a boolean, because the callers ask different
+ * questions of the same text and a shared yes/no answers neither well. The DTCG
+ * export needs to know whether an item is a NAME it can write down; a surface
+ * reporting on a site needs to know whether the browser will resolve it, and
+ * what to say when it cannot.
+ *
+ * - `name` — a real family: a quoted string, or an unquoted identifier run.
+ * - `generic` — an unquoted generic keyword. Always resolves, names no file.
+ * - `dynamic` — carries a `var()` substitution. Valid CSS whose value is not
+ *   knowable from the text, which is a THIRD state and not a failure.
+ * - `keyword` — an unquoted CSS-wide keyword. Valid alone, and a parse error
+ *   in a list.
+ * - `invalid` — the grammar rejects it: `10px`, `"Bad" "Name"`, or an empty
+ *   item left by a stray comma.
+ */
+export type FamilyPartKind =
+  | "name"
+  | "generic"
+  | "dynamic"
+  | "keyword"
+  | "invalid";
+
+/** Classify one family-list item. */
+export function familyPartKind(part: FamilyPart): FamilyPartKind {
+  if (!part.valid) return "invalid";
+  if (part.quoted) return "name";
+  const lower = part.name.toLowerCase();
+  // `var()` is checked before the grammar, because the grammar rejects the
+  // parentheses and would report a valid, common value as broken.
+  if (/\bvar\(/i.test(part.name)) return "dynamic";
+  if (FAMILY_KEYWORD_NOT_A_NAME.has(lower)) return "keyword";
+  if (GENERIC_FAMILIES.has(lower)) return "generic";
+  if (!UNQUOTED_FAMILY.test(part.raw) || /[()]/.test(part.name))
+    return "invalid";
+  return "name";
+}
+
+/**
+ * How CSS reads a WHOLE family list.
+ *
+ * - `families` — the browser reads it and every item is resolvable from the text.
+ * - `dynamic` — the browser reads it, and at least one item is a `var()` whose
+ *   value this code cannot see. Reportable, but not as a fault.
+ * - `keyword` — a lone CSS-wide keyword. Valid, and names no family at all, so
+ *   there is nothing to resolve rather than something that failed to.
+ * - `invalid` — the browser drops the declaration.
+ */
+export type FamilyListKind = "families" | "dynamic" | "keyword" | "invalid";
+
+/** One classified item of a family list. */
+export interface ReadFamilyPart {
+  readonly part: FamilyPart;
+  readonly kind: FamilyPartKind;
+}
+
+/** A family list, split and classified in one call. */
+export interface FamilyListReading {
+  readonly kind: FamilyListKind;
+  readonly parts: readonly ReadFamilyPart[];
+}
+
+/**
+ * Split a `font-family` value and say how CSS reads it.
+ *
+ * The one place that judgement lives. `familyToDtcg` and any surface reporting
+ * on a site ask this and then apply their own narrower rule to the answer,
+ * rather than each re-deriving the grammar — two derivations of one question
+ * agree on the day they are written and diverge on the values that matter.
+ */
+export function readFamilyList(css: string): FamilyListReading {
+  const split = splitFamilyList(css);
+  const parts = split.map(part => ({ part, kind: familyPartKind(part) }));
+  if (parts.length === 0) return { kind: "invalid", parts };
+  if (parts.some(p => p.kind === "invalid")) return { kind: "invalid", parts };
+  const keywords = parts.filter(p => p.kind === "keyword");
+  if (keywords.length > 0) {
+    // A CSS-wide keyword stands for the WHOLE value. `inherit, serif` is a
+    // parse error, not a stack with a fallback.
+    return parts.length === 1
+      ? { kind: "keyword", parts }
+      : { kind: "invalid", parts };
+  }
+  if (parts.some(p => p.kind === "dynamic")) return { kind: "dynamic", parts };
+  return { kind: "families", parts };
 }
 
 /** One family from a list, how it was written, and whether CSS accepts it. */
@@ -546,9 +635,9 @@ function finishPart(
   raw: string
 ): FamilyPart {
   const name = current.trim();
-  const valid = quoted
-    ? strings === 1 && outsideQuotes.trim() === ""
-    : strings === 0;
+  const valid =
+    name !== "" &&
+    (quoted ? strings === 1 && outsideQuotes.trim() === "" : strings === 0);
   // The raw spelling is kept because the identifier-run check has to read what
   // was WRITTEN. `\\31 0px` is a legal identifier naming the family `10px`;
   // tested after decoding it looks like a dimension and a valid token is lost.

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -394,15 +394,7 @@ function familyToDtcg(css: string): string | string[] | undefined {
   ) {
     return undefined;
   }
-  // An unquoted item is a run of identifiers and nothing else. `10px, serif`
-  // tokenizes as a dimension, so a browser drops any declaration reading the
-  // token — exporting it as a family list shows a stack the site never used.
-  if (parts.some(part => !part.quoted && !UNQUOTED_FAMILY.test(part.raw))) {
-    return undefined;
-  }
-  if (parts.some(part => !part.quoted && /[()]/.test(part.name))) {
-    return undefined;
-  }
+  if (!isUsableFamilyList(parts)) return undefined;
   return parts.length === 1 ? parts[0]?.name : parts.map(part => part.name);
 }
 
@@ -415,7 +407,7 @@ function familyToDtcg(css: string): string | string[] | undefined {
  * because the name is the family, not the spelling, and backslash escapes are
  * resolved for the same reason.
  */
-function splitFamilyList(css: string): FamilyPart[] {
+export function splitFamilyList(css: string): FamilyPart[] {
   const parts: FamilyPart[] = [];
   let current = "";
   let quoted = false;
@@ -504,8 +496,33 @@ function trimCssWhitespace(text: string): string {
   return text.replace(CSS_WS_EDGES, "");
 }
 
+/**
+ * Whether a split family list is one CSS will read.
+ *
+ * `FamilyPart.valid` answers the QUOTING rule alone — one string per item, and
+ * nothing outside it. That is half the grammar. `<family-name>` is one string
+ * OR a run of identifiers, so an unquoted item must also be an identifier run
+ * carrying no parentheses: `10px, serif` tokenizes as a dimension and
+ * `var(--x)` as a function, and a browser drops the whole declaration for
+ * either.
+ *
+ * Exported and shared rather than repeated at each caller, because both halves
+ * have to be asked together. Asking only `valid` accepts `var(--x)` as a font
+ * called `var(--x)`, which is the answer a caller reading one half gets — and
+ * it looks like a family until something tries to render it.
+ */
+export function isUsableFamilyList(parts: readonly FamilyPart[]): boolean {
+  if (parts.length === 0) return false;
+  return parts.every(
+    part =>
+      part.valid &&
+      (part.quoted ||
+        (UNQUOTED_FAMILY.test(part.raw) && !/[()]/.test(part.name)))
+  );
+}
+
 /** One family from a list, how it was written, and whether CSS accepts it. */
-interface FamilyPart {
+export interface FamilyPart {
   name: string;
   /** As written, before escapes were resolved. */
   raw: string;

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -325,7 +325,17 @@ export {
  * Escaped rather than refused, because a backslash or a quote in a family name
  * is legal CSS and the escape is what the spec provides for exactly this.
  */
-function cssString(value: string): string {
+/**
+ * A value as the CONTENT of a CSS string, escaped so it cannot end one.
+ *
+ * Published because a family name reaches CSS from more than one place: the
+ * compiler writes `font-family:"…"` into the site sheet, and a surface drawing
+ * a specimen writes the same name into an inline style. Wrapping author data in
+ * quotes without this produces `"ACME "Pro""` for the perfectly legal family
+ * `ACME "Pro"` — the browser drops the declaration, and the specimen silently
+ * demonstrates the fallback instead of the face it names.
+ */
+export function cssString(value: string): string {
   let out = "";
   for (const char of value) {
     const code = char.codePointAt(0) ?? 0;

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -353,7 +353,7 @@ describe("opening the insert panel from outside the shell", () => {
         onExit={vi.fn()}
         store={store}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
 
@@ -392,7 +392,7 @@ describe("opening the insert panel from outside the shell", () => {
         onExit={vi.fn()}
         store={store}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
 
@@ -407,7 +407,7 @@ describe("opening the insert panel from outside the shell", () => {
         onExit={vi.fn()}
         store={store}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
     expect(screen.getByText("insert panel")).toBeTruthy();
@@ -420,7 +420,7 @@ describe("opening the insert panel from outside the shell", () => {
         onExit={vi.fn()}
         store={store}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={2}
+        openPanelRequest={{ panel: "insert", count: 2 }}
       />
     );
 
@@ -459,7 +459,7 @@ describe("opening the insert panel from outside the shell", () => {
         onExit={vi.fn()}
         store={store}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
 
@@ -498,7 +498,7 @@ describe("opening the insert panel from outside the shell", () => {
       <BuilderShell
         onExit={vi.fn()}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
 
@@ -567,7 +567,7 @@ describe("opening the insert panel from outside the shell", () => {
         onExit={vi.fn()}
         store={second}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
 
@@ -597,7 +597,7 @@ describe("opening the insert panel from outside the shell", () => {
     // close it had nothing to do with.
     //
     // A `className` change was tried here first and did not exercise this at
-    // all — neither `openInsertPanelToken` nor `update` depends on it, so the
+    // all — neither `openPanelRequest` nor `update` depends on it, so the
     // effect never re-runs and the guard is never reached. Only a dependency
     // the effect actually reads can demonstrate the guard is doing anything.
     stubContainerFits(true);
@@ -614,7 +614,7 @@ describe("opening the insert panel from outside the shell", () => {
         onExit={vi.fn()}
         store={storeOverBacking()}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
     expect(screen.getByText("insert panel")).toBeTruthy();
@@ -623,13 +623,13 @@ describe("opening the insert panel from outside the shell", () => {
     expect(screen.queryByText("insert panel")).toBeNull();
 
     // A DIFFERENT store object reading the same backing value — `update`
-    // changes identity, `openInsertPanelToken` does not.
+    // changes identity, `openPanelRequest` does not.
     rerender(
       <BuilderShell
         onExit={vi.fn()}
         store={storeOverBacking()}
         renderPanel={panel => <p>{panel} panel</p>}
-        openInsertPanelToken={1}
+        openPanelRequest={{ panel: "insert", count: 1 }}
       />
     );
 

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -119,7 +119,7 @@ export interface BuilderShellProps {
    */
   availablePanels?: readonly LeftPanel[];
   /**
-   * Opens the insert panel from OUTSIDE the shell, once per distinct value.
+   * Opens a panel from OUTSIDE the shell, once per distinct count.
    *
    * The rail is normally the only way to change which panel is open, and its
    * own click handler is a TOGGLE — pressing an already-open panel's item
@@ -135,10 +135,15 @@ export interface BuilderShellProps {
    * shape {@link PreferencesLoad.count} below has: not the state itself, but a
    * count of how many times the thing behind it happened.
    *
+   * The panel travels WITH the count rather than in a second prop. One caller
+   * asking for insert and another for tokens are the same request with a
+   * different subject, and two props would be two answers to one question —
+   * free to disagree about which panel a given count refers to.
+   *
    * Left `undefined` this does nothing, which is what every host that has no
    * such control gets by default.
    */
-  openInsertPanelToken?: number;
+  openPanelRequest?: { readonly panel: LeftPanel; readonly count: number };
   /**
    * Reports `showEmptyElements` to a host that needs to know whether the
    * canvas's empty-container chrome should be showing right now.
@@ -147,7 +152,7 @@ export interface BuilderShellProps {
    * and a caller drawing a SEPARATE overlay over the same canvas (the
    * empty-container appender, mounted through `Canvas`'s own `overlay` prop
    * rather than through this component's internals) has no way to reach it.
-   * This is the read half of that gap; `openInsertPanelToken` above is the
+   * This is the read half of that gap; `openPanelRequest` above is the
    * write half of a different one.
    *
    * Called for every value the preference takes, including the very first
@@ -1160,7 +1165,7 @@ function ShellRegions({
  */
 export function BuilderShell({
   store,
-  openInsertPanelToken,
+  openPanelRequest,
   onShowEmptyElementsChange,
   onZoomChange,
   appliedScale = 1,
@@ -1180,7 +1185,7 @@ export function BuilderShell({
   const [measureShell, shellFits] = useFitsFullShell();
 
   /*
-   * Applies an `openInsertPanelToken` change AT MOST ONCE — a ref rather than
+   * Applies an `openPanelRequest` change AT MOST ONCE — a ref rather than
    * state, because recording that a token was handled is not itself something a
    * re-render should follow from.
    *
@@ -1199,9 +1204,9 @@ export function BuilderShell({
    * the panel it actually renders, so a request naming a panel the host
    * cannot fill is absorbed there rather than needing a second check here.
    */
-  const handledInsertPanelToken = React.useRef<number | undefined>(undefined);
+  const handledPanelRequest = React.useRef<number | undefined>(undefined);
   React.useEffect(() => {
-    if (openInsertPanelToken === undefined) return;
+    if (openPanelRequest === undefined) return;
     /*
      * Nothing is applied until THIS store's read has landed, and that ordering
      * is the whole of this guard.
@@ -1235,10 +1240,11 @@ export function BuilderShell({
      * same flush it arrived in.
      */
     if (!loadedFromCurrentStore) return;
-    if (handledInsertPanelToken.current === openInsertPanelToken) return;
-    handledInsertPanelToken.current = openInsertPanelToken;
-    update(current => ({ ...current, leftPanel: "insert" }));
-  }, [openInsertPanelToken, update, loadedFromCurrentStore]);
+    if (handledPanelRequest.current === openPanelRequest.count) return;
+    handledPanelRequest.current = openPanelRequest.count;
+    const panel = openPanelRequest.panel;
+    update(current => ({ ...current, leftPanel: panel }));
+  }, [openPanelRequest, update, loadedFromCurrentStore]);
 
   /*
    * The read half of the same gap: told on every value `showEmptyElements`

--- a/packages/builder/src/font-library.test.ts
+++ b/packages/builder/src/font-library.test.ts
@@ -215,8 +215,44 @@ describe("the sentence the panel draws", () => {
   it("says the check ran even when nothing needs attention", () => {
     const rows = rowsFor(["serif"]);
     expect(tokenSummary(rows, rowsNeedingAttention(rows))).toBe(
-      "1 typeface token, each asking first for a family this site provides."
+      "1 typeface token, none asking first for a typeface this site provides no file for."
     );
+  });
+
+  it("does not claim a dynamic or keyword row asks for a provided family", () => {
+    // The all-clear must report what was CHECKED, not more. A var() stack has
+    // an unknown first choice and a lone `inherit` names no family at all, so
+    // "each asking first for a family this site provides" would claim something
+    // about rows this code cannot resolve.
+    const rows = rowsFor(["var(--x), serif", "inherit"]);
+    const summary = tokenSummary(rows, rowsNeedingAttention(rows));
+    expect(summary).toContain(
+      "none asking first for a typeface this site provides no file for"
+    );
+    expect(summary).not.toContain(
+      "each asking first for a family this site provides"
+    );
+  });
+
+  it("counts a token failing DIFFERENTLY in each mode under both headings", () => {
+    // Invalid in light and unprovided in dark. Deriving one count as
+    // `attention.length - other` forced this row into one heading and out of
+    // the other, omitting a problem `tokenNotes` reports on the same row.
+    const rows = fontTokenRows(
+      {
+        tokens: [
+          {
+            name: "brand.body",
+            kind: "fontFamily",
+            values: { light: "10px, serif", dark: "Ghost, serif" },
+          },
+        ],
+      },
+      []
+    );
+    const summary = tokenSummary(rows, rowsNeedingAttention(rows));
+    expect(summary).toContain("1 ask first for a typeface");
+    expect(summary).toContain("1 hold a value no browser will read");
   });
 
   it("counts UNREADABLE and UNPROVIDED separately", () => {

--- a/packages/builder/src/font-library.test.ts
+++ b/packages/builder/src/font-library.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The font-library rules, asserted on the cases that separate them.
+ *
+ * Every fixture here is chosen because a plausible wrong implementation gives a
+ * different answer on it: a quoted generic, a face whose family IS a generic
+ * keyword, a family name containing the separator, and a stack whose later
+ * entries rescue a first choice that does not resolve.
+ *
+ * @module font-library.test
+ */
+import type { FontFaceDef, SiteTokenSet } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import {
+  fontTokenRows,
+  readStack,
+  rowsNeedingAttention,
+  tokenNote,
+  tokenSummary,
+} from "./font-library";
+
+const face = (family: string): FontFaceDef => ({
+  family,
+  src: [{ url: "/fonts/f.woff2", format: "woff2" }],
+});
+
+const token = (
+  name: string,
+  light: string,
+  kind: SiteTokenSet["tokens"][number]["kind"] = "fontFamily"
+): SiteTokenSet["tokens"][number] => ({ name, kind, values: { light } });
+
+describe("reading a font-family value against the faces a site loads", () => {
+  it("calls a generic keyword generic, and the same word QUOTED a name", () => {
+    // `font-family: serif` asks the browser for its serif default;
+    // `font-family: "serif"` asks for a font somebody called serif. Reading
+    // both as the keyword would report a missing font as guaranteed.
+    expect(readStack("serif", []).families).toEqual([
+      { family: "serif", source: "generic" },
+    ]);
+    expect(readStack('"serif"', []).families).toEqual([
+      { family: "serif", source: "not-provided" },
+    ]);
+  });
+
+  it("prefers a HOSTED face over the generic of the same name", () => {
+    // A site may load a face called `serif`. That face is what renders, so
+    // reporting the browser default would name the wrong source.
+    expect(readStack("serif", [face("serif")]).families).toEqual([
+      { family: "serif", source: "hosted" },
+    ]);
+  });
+
+  it("treats a family name containing a comma as ONE family", () => {
+    // The separating case for the parser: a plain split turns a real company's
+    // font into a fallback list failing over to a family called `Inc`.
+    const reading = readStack('"ACME, Inc", serif', [face("ACME, Inc")]);
+    expect(reading.families).toEqual([
+      { family: "ACME, Inc", source: "hosted" },
+      { family: "serif", source: "generic" },
+    ]);
+  });
+
+  it("matches a family case-insensitively, in both directions", () => {
+    expect(readStack("Sans-Serif", []).families[0]?.source).toBe("generic");
+    expect(readStack("brand", [face("Brand")]).families[0]?.source).toBe(
+      "hosted"
+    );
+  });
+
+  it("reports the FIRST choice separately from whether anything renders", () => {
+    // The case the whole module exists for: the page draws, so nothing looks
+    // wrong, and the typeface the author picked is not the one on screen.
+    const reading = readStack("Brand, serif", []);
+    expect(reading.firstChoice).toEqual({
+      family: "Brand",
+      source: "not-provided",
+    });
+    expect(reading.guaranteed).toBe(true);
+  });
+
+  it("does not guarantee a stack of named families alone", () => {
+    const reading = readStack("Brand, Helvetica", []);
+    expect(reading.guaranteed).toBe(false);
+    expect(reading.usable).toBe(true);
+  });
+
+  it("reports an unusable value as unusable and names no families", () => {
+    // A stack carrying `var()` is not a family list the browser reads. Naming
+    // its families would describe a resolution that never happens.
+    const reading = readStack("var(--brand-font)", [face("Brand")]);
+    expect(reading.usable).toBe(false);
+    expect(reading.families).toEqual([]);
+    expect(reading.firstChoice).toBeUndefined();
+  });
+});
+
+describe("the rows a fonts panel draws", () => {
+  const tokens: SiteTokenSet = {
+    tokens: [
+      token("brand.body", "Brand, serif"),
+      token("brand.heading", "serif"),
+      // A font SIZE is typography and is not a typeface. Its presence is the
+      // control: a filter reading the whole set would put it in the list.
+      token("brand.size", "16px", "dimension"),
+    ],
+  };
+
+  it("lists fontFamily tokens ONLY", () => {
+    const rows = fontTokenRows(tokens, []);
+    expect(rows.map(r => r.token.name)).toEqual([
+      "brand.body",
+      "brand.heading",
+    ]);
+  });
+
+  it("answers an absent token set with no rows rather than throwing", () => {
+    expect(fontTokenRows(undefined, [])).toEqual([]);
+  });
+
+  it("draws attention to the row whose FIRST choice this site does not provide", () => {
+    const rows = fontTokenRows(tokens, []);
+    expect(rowsNeedingAttention(rows).map(r => r.token.name)).toEqual([
+      "brand.body",
+    ]);
+  });
+
+  it("stops drawing attention once a face for that family is loaded", () => {
+    // The must-move half: the same tokens, one face added, and the row leaves
+    // the list. Without this the filter could be returning a constant.
+    const rows = fontTokenRows(tokens, [face("Brand")]);
+    expect(rowsNeedingAttention(rows)).toEqual([]);
+  });
+
+  it("draws attention to an unusable value too", () => {
+    const rows = fontTokenRows(
+      { tokens: [token("brand.body", "var(--x)")] },
+      []
+    );
+    expect(rowsNeedingAttention(rows).map(r => r.token.name)).toEqual([
+      "brand.body",
+    ]);
+  });
+});
+
+describe("the sentence the panel draws", () => {
+  const rowsFor = (stacks: readonly string[], faces: FontFaceDef[] = []) =>
+    fontTokenRows({ tokens: stacks.map((v, i) => token(`t${i}`, v)) }, faces);
+
+  it("says the check ran even when nothing needs attention", () => {
+    // Silence is also what a panel that never checked would show, so a count of
+    // zero has to be stated rather than left off.
+    const rows = rowsFor(["serif"]);
+    expect(tokenSummary(rows, rowsNeedingAttention(rows))).toBe(
+      "1 typeface token, each asking first for a family this site provides."
+    );
+  });
+
+  it("counts the rows needing attention against the whole set", () => {
+    const rows = rowsFor(["Brand, serif", "serif"]);
+    expect(tokenSummary(rows, rowsNeedingAttention(rows))).toBe(
+      "1 of 2 ask first for a typeface this site provides no file for."
+    );
+  });
+
+  it("points at the Tokens panel when there is nothing to report on", () => {
+    expect(tokenSummary([], [])).toContain("Tokens panel");
+  });
+
+  it("never calls a family missing or unavailable", () => {
+    // The wording rule, asserted rather than trusted to review: a family this
+    // site loads no face for may still be installed on the reader's device.
+    const rows = rowsFor(["Brand, serif"]);
+    const note = tokenNote(rows[0]!) ?? "";
+    expect(note).toContain("provides no font file for it");
+    expect(note.toLowerCase()).not.toContain("missing");
+    expect(note.toLowerCase()).not.toContain("unavailable");
+    expect(
+      tokenSummary(rows, rowsNeedingAttention(rows)).toLowerCase()
+    ).not.toContain("missing");
+  });
+
+  it("says a DIFFERENT thing for an unusable value than for an unprovided one", () => {
+    // They are different outcomes: one applies nothing at all, the other
+    // applies the next family. One sentence for both would misdescribe one.
+    const unusable = tokenNote(rowsFor(["var(--x)"])[0]!) ?? "";
+    const unprovided = tokenNote(rowsFor(["Brand, serif"])[0]!) ?? "";
+    expect(unusable).toContain("applies nothing");
+    expect(unprovided).toContain("see the next family");
+    expect(unusable).not.toBe(unprovided);
+  });
+
+  it("says nothing about a row that is working as written", () => {
+    expect(tokenNote(rowsFor(["serif"])[0]!)).toBeUndefined();
+    expect(tokenNote(rowsFor(["Brand"], [face("Brand")])[0]!)).toBeUndefined();
+  });
+});

--- a/packages/builder/src/font-library.test.ts
+++ b/packages/builder/src/font-library.test.ts
@@ -15,7 +15,7 @@ import {
   fontTokenRows,
   readStack,
   rowsNeedingAttention,
-  tokenNote,
+  tokenNotes,
   tokenSummary,
 } from "./font-library";
 
@@ -43,10 +43,17 @@ describe("reading a font-family value against the faces a site loads", () => {
     ]);
   });
 
-  it("prefers a HOSTED face over the generic of the same name", () => {
-    // A site may load a face called `serif`. That face is what renders, so
-    // reporting the browser default would name the wrong source.
+  it("keeps a bare generic generic even when a face claims that name", () => {
+    // The engine emits every face family QUOTED — `font-family:"serif"` — and
+    // an unquoted `serif` in a stack is the CSS keyword, which no `@font-face`
+    // can claim. So a site loading a face it called `serif` still gets the
+    // browser default from a bare `serif`, and only a quoted value reaches the
+    // file. Reporting it as hosted would tell an author their file is in use
+    // when the page never loads it.
     expect(readStack("serif", [face("serif")]).families).toEqual([
+      { family: "serif", source: "generic" },
+    ]);
+    expect(readStack('"serif"', [face("serif")]).families).toEqual([
       { family: "serif", source: "hosted" },
     ]);
   });
@@ -82,16 +89,63 @@ describe("reading a font-family value against the faces a site loads", () => {
   it("does not guarantee a stack of named families alone", () => {
     const reading = readStack("Brand, Helvetica", []);
     expect(reading.guaranteed).toBe(false);
-    expect(reading.usable).toBe(true);
+    expect(reading.kind).toBe("families");
   });
 
-  it("reports an unusable value as unusable and names no families", () => {
-    // A stack carrying `var()` is not a family list the browser reads. Naming
-    // its families would describe a resolution that never happens.
-    const reading = readStack("var(--brand-font)", [face("Brand")]);
-    expect(reading.usable).toBe(false);
+  it("reports a value no browser reads as invalid, and names no families", () => {
+    // `10px` tokenizes as a dimension, so the browser drops the declaration.
+    // Naming its families would describe a resolution that never happens.
+    const reading = readStack("10px, serif", [face("Brand")]);
+    expect(reading.kind).toBe("invalid");
     expect(reading.families).toEqual([]);
     expect(reading.firstChoice).toBeUndefined();
+  });
+
+  it("reads a var() stack as DYNAMIC, not as broken", () => {
+    // The regression this file exists to stop. `var(--font-geist), sans-serif`
+    // is valid, common CSS — it is how a host-managed font is wired — and
+    // calling it unreadable tells an author their working token applies
+    // nothing.
+    const reading = readStack("var(--font-geist), sans-serif", []);
+    expect(reading.kind).toBe("dynamic");
+    expect(reading.families[0]).toEqual({
+      family: "var(--font-geist)",
+      source: "dynamic",
+    });
+    expect(reading.guaranteed).toBe(true);
+  });
+
+  it("reads a lone CSS-wide keyword as a keyword, and one in a LIST as invalid", () => {
+    // `inherit` is a working value naming no family; `inherit, serif` is a
+    // parse error. Treating the first as a font called "inherit" invents a
+    // problem, and the second as a stack invents a fallback.
+    expect(readStack("inherit", []).kind).toBe("keyword");
+    expect(readStack("inherit, serif", []).kind).toBe("invalid");
+  });
+
+  it("refuses a list with an empty item, however it was written", () => {
+    // A stray comma is a parse error the browser drops the whole declaration
+    // for. Discarding the empty item reported `Brand,` as the family `Brand` —
+    // a value the page never rendered.
+    for (const value of ["Brand,", ", Brand", "Brand,, serif"]) {
+      expect(readStack(value, [face("Brand")]).kind).toBe("invalid");
+    }
+  });
+
+  it("counts only faces the compiler will actually emit", () => {
+    // A remote src is refused by `validateFontFace`, so no `@font-face` reaches
+    // the sheet. Counting it as hosted marks a token healthy against a file the
+    // site never loads.
+    const remote: FontFaceDef = {
+      family: "Brand",
+      src: [{ url: "https://cdn.example.com/brand.woff2", format: "woff2" }],
+    };
+    expect(readStack("Brand", [remote]).families[0]?.source).toBe(
+      "not-provided"
+    );
+    expect(readStack("Brand", [face("Brand")]).families[0]?.source).toBe(
+      "hosted"
+    );
   });
 });
 
@@ -132,14 +186,25 @@ describe("the rows a fonts panel draws", () => {
     expect(rowsNeedingAttention(rows)).toEqual([]);
   });
 
-  it("draws attention to an unusable value too", () => {
+  it("draws attention to a value no browser will read", () => {
     const rows = fontTokenRows(
-      { tokens: [token("brand.body", "var(--x)")] },
+      { tokens: [token("brand.body", "10px, serif")] },
       []
     );
     expect(rowsNeedingAttention(rows).map(r => r.token.name)).toEqual([
       "brand.body",
     ]);
+  });
+
+  it("does NOT draw attention to a var() stack", () => {
+    // The control for the regression: a host-managed font is wired through a
+    // custom property, and flagging it would report working configuration as
+    // broken on the most idiomatic Next.js setup there is.
+    const rows = fontTokenRows(
+      { tokens: [token("brand.body", "var(--font-geist), sans-serif")] },
+      []
+    );
+    expect(rowsNeedingAttention(rows)).toEqual([]);
   });
 });
 
@@ -148,19 +213,22 @@ describe("the sentence the panel draws", () => {
     fontTokenRows({ tokens: stacks.map((v, i) => token(`t${i}`, v)) }, faces);
 
   it("says the check ran even when nothing needs attention", () => {
-    // Silence is also what a panel that never checked would show, so a count of
-    // zero has to be stated rather than left off.
     const rows = rowsFor(["serif"]);
     expect(tokenSummary(rows, rowsNeedingAttention(rows))).toBe(
       "1 typeface token, each asking first for a family this site provides."
     );
   });
 
-  it("counts the rows needing attention against the whole set", () => {
-    const rows = rowsFor(["Brand, serif", "serif"]);
-    expect(tokenSummary(rows, rowsNeedingAttention(rows))).toBe(
-      "1 of 2 ask first for a typeface this site provides no file for."
+  it("counts UNREADABLE and UNPROVIDED separately", () => {
+    // They have different remedies. One count covering both sends an author to
+    // fix the wrong thing: an unreadable value applies nothing at all, while an
+    // unprovided first family applies the next one.
+    const rows = rowsFor(["Brand, serif", "10px, serif", "serif"]);
+    const summary = tokenSummary(rows, rowsNeedingAttention(rows));
+    expect(summary).toContain(
+      "1 ask first for a typeface this site provides no file for"
     );
+    expect(summary).toContain("1 hold a value no browser will read");
   });
 
   it("points at the Tokens panel when there is nothing to report on", () => {
@@ -168,30 +236,57 @@ describe("the sentence the panel draws", () => {
   });
 
   it("never calls a family missing or unavailable", () => {
-    // The wording rule, asserted rather than trusted to review: a family this
-    // site loads no face for may still be installed on the reader's device.
     const rows = rowsFor(["Brand, serif"]);
-    const note = tokenNote(rows[0]!) ?? "";
-    expect(note).toContain("provides no font file for it");
-    expect(note.toLowerCase()).not.toContain("missing");
-    expect(note.toLowerCase()).not.toContain("unavailable");
-    expect(
-      tokenSummary(rows, rowsNeedingAttention(rows)).toLowerCase()
-    ).not.toContain("missing");
+    const text = tokenNotes(rows[0]!)[0]?.text ?? "";
+    expect(text).toContain("provides no font file for it");
+    expect(text.toLowerCase()).not.toContain("missing");
+    expect(text.toLowerCase()).not.toContain("unavailable");
   });
 
-  it("says a DIFFERENT thing for an unusable value than for an unprovided one", () => {
-    // They are different outcomes: one applies nothing at all, the other
-    // applies the next family. One sentence for both would misdescribe one.
-    const unusable = tokenNote(rowsFor(["var(--x)"])[0]!) ?? "";
-    const unprovided = tokenNote(rowsFor(["Brand, serif"])[0]!) ?? "";
-    expect(unusable).toContain("applies nothing");
+  it("says a DIFFERENT thing for an unreadable value than an unprovided one", () => {
+    const unreadable = tokenNotes(rowsFor(["10px, serif"])[0]!)[0]?.text ?? "";
+    const unprovided = tokenNotes(rowsFor(["Brand, serif"])[0]!)[0]?.text ?? "";
+    expect(unreadable).toContain("applies nothing");
     expect(unprovided).toContain("see the next family");
-    expect(unusable).not.toBe(unprovided);
+    expect(unreadable).not.toBe(unprovided);
+  });
+
+  it("does not promise a next family when the stack has none", () => {
+    // `Brand` alone has no later entry, so telling the author readers see "the
+    // next family in the list" names something that is not there.
+    const single = tokenNotes(rowsFor(["Brand"])[0]!)[0]?.text ?? "";
+    expect(single).toContain("the browser's default typeface");
+    expect(single).not.toContain("next family in the list");
   });
 
   it("says nothing about a row that is working as written", () => {
-    expect(tokenNote(rowsFor(["serif"])[0]!)).toBeUndefined();
-    expect(tokenNote(rowsFor(["Brand"], [face("Brand")])[0]!)).toBeUndefined();
+    expect(tokenNotes(rowsFor(["serif"])[0]!)).toEqual([]);
+    expect(tokenNotes(rowsFor(['"Brand"'], [face("Brand")])[0]!)).toEqual([]);
+    // A lone CSS-wide keyword is a deliberate working value, not a fault.
+    expect(tokenNotes(rowsFor(["inherit"])[0]!)).toEqual([]);
+    // And a var() stack is readable; reporting it would be the false claim.
+    expect(tokenNotes(rowsFor(["var(--x), serif"])[0]!)).toEqual([]);
+  });
+
+  it("reads the DARK value too, and names the mode when one is declared", () => {
+    // The emitter applies `values.dark` in dark mode, so a token sound in light
+    // and unprovided in dark would otherwise report an all-clear while every
+    // dark-mode reader gets a substitution.
+    const rows = fontTokenRows(
+      {
+        tokens: [
+          {
+            name: "brand.body",
+            kind: "fontFamily",
+            values: { light: '"Brand", serif', dark: "Ghost, serif" },
+          },
+        ],
+      },
+      [face("Brand")]
+    );
+    const notes = tokenNotes(rows[0]!);
+    expect(notes.map(n => n.mode)).toEqual(["dark"]);
+    expect(notes[0]?.text).toContain("Ghost");
+    expect(rowsNeedingAttention(rows)).toHaveLength(1);
   });
 });

--- a/packages/builder/src/font-library.ts
+++ b/packages/builder/src/font-library.ts
@@ -1,0 +1,246 @@
+/**
+ * What the site can actually render, and what it only claims to.
+ *
+ * The tokens studio already authors `fontFamily` tokens, and this module does
+ * not author anything: a second editor for one question is the defect this
+ * codebase names most often. What the studio cannot answer is whether a family
+ * it just stored will RENDER, because it edits one token and knows nothing
+ * about the faces the site loads.
+ *
+ * Nothing joins those two today. `compileSiteSheet` calls `emitFontFaces` and
+ * `emitTokenBlocks` independently, so a token naming a family with no face is
+ * emitted exactly like one that has it, and the page quietly draws in whatever
+ * the browser reaches for next. That is the failure the sheet's own
+ * `tokenPrefix` note describes for custom properties — "nothing errors: the
+ * reference resolves to nothing and the value silently does not apply" — and it
+ * is the same shape one property along.
+ *
+ * @module font-library
+ */
+import {
+  isUsableFamilyList,
+  splitFamilyList,
+  type FamilyPart,
+  type FontFaceDef,
+  type SiteToken,
+  type SiteTokenSet,
+} from "@nextlyhq/blocks-engine";
+
+/**
+ * Families every browser resolves without a face being loaded.
+ *
+ * The CSS generic families plus the `ui-*` system aliases. A stack ending in
+ * one of these always draws something, which is why a stack that ends in a
+ * generic is the shape to steer an author toward rather than away from.
+ *
+ * Held lowercase and compared lowercase: CSS family matching is
+ * case-insensitive for these keywords, and an author who typed `Sans-Serif`
+ * meant the generic.
+ */
+const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
+  "serif",
+  "sans-serif",
+  "monospace",
+  "cursive",
+  "fantasy",
+  "system-ui",
+  "ui-serif",
+  "ui-sans-serif",
+  "ui-monospace",
+  "ui-rounded",
+  "math",
+  "emoji",
+  "fangsong",
+]);
+
+/**
+ * Where a family's glyphs would come from.
+ *
+ * `not-provided` is deliberately not called "missing" or "unavailable". A named
+ * family this site loads no face for may still be installed on the reader's
+ * device — `Georgia` and `Helvetica` are the ordinary cases — so declaring it
+ * absent would be a claim about a machine this code cannot see. What IS true is
+ * that the site does not provide it, and that is what the word says.
+ */
+export type FamilySource = "hosted" | "generic" | "not-provided";
+
+/** One family from a stack, and where it would come from. */
+export interface FamilyReading {
+  /** The family name, with quotes removed and escapes resolved. */
+  readonly family: string;
+  readonly source: FamilySource;
+}
+
+/** A whole `font-family` value, read against the faces the site loads. */
+export interface StackReading {
+  /** Each family in the author's order. Empty when the value is unusable. */
+  readonly families: readonly FamilyReading[];
+  /**
+   * The author's FIRST choice, which is the one they were expressing.
+   *
+   * Separated from the rest because a stack is a fallback chain and every
+   * entry after the first is a concession. An author who wrote `Brand, serif`
+   * chose `Brand`; reporting the stack as fine because `serif` resolves would
+   * answer a question they did not ask.
+   */
+  readonly firstChoice: FamilyReading | undefined;
+  /**
+   * Whether the site guarantees SOMETHING renders.
+   *
+   * True when any family in the stack is generic or hosted. A stack of named
+   * families alone can still render — every one of them may be installed — so
+   * this is a floor, not a prediction.
+   */
+  readonly guaranteed: boolean;
+  /**
+   * Whether CSS accepts the value as written.
+   *
+   * A stack carrying `var(--x)`, a bare CSS-wide keyword, or an item the
+   * grammar rejects is not a family list the browser will read, so its families
+   * are not reported: naming them would describe a resolution that never
+   * happens.
+   */
+  readonly usable: boolean;
+}
+
+/** The families a set of faces provides, lowercased for comparison. */
+function hostedFamilies(faces: readonly FontFaceDef[]): ReadonlySet<string> {
+  return new Set(faces.map(face => face.family.trim().toLowerCase()));
+}
+
+function sourceOf(part: FamilyPart, hosted: ReadonlySet<string>): FamilySource {
+  const key = part.name.trim().toLowerCase();
+  // Hosted first: a site may load a face named `serif`, and the face it loads
+  // is what renders. Asking the generic set first would report the site's own
+  // font as a browser default.
+  if (hosted.has(key)) return "hosted";
+  // A QUOTED generic is a family name, not the keyword — `font-family: "serif"`
+  // asks for a font called serif. The same distinction `familyToDtcg` makes.
+  if (!part.quoted && GENERIC_FAMILIES.has(key)) return "generic";
+  return "not-provided";
+}
+
+/**
+ * Read one `font-family` value against the faces this site loads.
+ *
+ * The parser is the engine's, reached through its published export rather than
+ * rewritten here: a family list is quoting, comma and escape rules together,
+ * and `"ACME, Inc", serif` is two families rather than three. A second parser
+ * would agree on the easy cases and diverge exactly where a site's real font
+ * name is unusual.
+ */
+export function readStack(
+  value: string,
+  faces: readonly FontFaceDef[]
+): StackReading {
+  const parts = splitFamilyList(value);
+  // The engine's own composite, not `part.valid` alone: quoting is half the
+  // grammar, and the half left out is what accepts `var(--x)` as a font name.
+  const usable = isUsableFamilyList(parts);
+  if (!usable) {
+    return {
+      families: [],
+      firstChoice: undefined,
+      guaranteed: false,
+      usable: false,
+    };
+  }
+  const hosted = hostedFamilies(faces);
+  const families = parts.map(part => ({
+    family: part.name,
+    source: sourceOf(part, hosted),
+  }));
+  return {
+    families,
+    firstChoice: families[0],
+    guaranteed: families.some(f => f.source !== "not-provided"),
+    usable: true,
+  };
+}
+
+/** A `fontFamily` token, read against the faces the site loads. */
+export interface FontTokenRow {
+  readonly token: SiteToken;
+  /** The light-mode value's reading. Dark is not a separate typeface tier. */
+  readonly reading: StackReading;
+}
+
+/**
+ * Every `fontFamily` token in the set, with what each would render as.
+ *
+ * Only `fontFamily` tokens: a `dimension` holding a font SIZE is typography and
+ * is not a typeface, and including it would put rows in this panel that its
+ * question does not apply to.
+ */
+export function fontTokenRows(
+  tokens: SiteTokenSet | undefined,
+  faces: readonly FontFaceDef[]
+): FontTokenRow[] {
+  const all = tokens?.tokens ?? [];
+  return all
+    .filter(token => token.kind === "fontFamily")
+    .map(token => ({ token, reading: readStack(token.values.light, faces) }));
+}
+
+/**
+ * The rows worth an author's attention, and nothing else.
+ *
+ * A row is drawn to attention when its FIRST family is not provided by this
+ * site — that is the choice the author expressed, and the one that silently
+ * does not happen. A stack whose first family is hosted or generic is working
+ * as written, whatever its later entries say.
+ */
+export function rowsNeedingAttention(
+  rows: readonly FontTokenRow[]
+): FontTokenRow[] {
+  return rows.filter(
+    row =>
+      !row.reading.usable || row.reading.firstChoice?.source === "not-provided"
+  );
+}
+
+/**
+ * What the token list amounts to, in one sentence.
+ *
+ * Wording lives here rather than in the panel for the reason
+ * {@link class-library.usageSummary} does: the sentence makes a claim about
+ * evidence, and a claim is a rule. A panel composing it inline is a second
+ * place for that judgement to drift — and this one has to keep saying
+ * "provides no font file for" rather than "missing", which is exactly the kind
+ * of distinction that erodes when it lives in JSX.
+ *
+ * Stated even at zero. An author who reads a count knows the check ran, and
+ * silence is also what a panel that never checked would show.
+ */
+export function tokenSummary(
+  rows: readonly FontTokenRow[],
+  attention: readonly FontTokenRow[]
+): string {
+  if (rows.length === 0) {
+    return "This site has no typeface tokens yet. The Tokens panel creates them.";
+  }
+  if (attention.length === 0) {
+    const noun = rows.length === 1 ? "token" : "tokens";
+    return `${rows.length} typeface ${noun}, each asking first for a family this site provides.`;
+  }
+  return `${attention.length} of ${rows.length} ask first for a typeface this site provides no file for.`;
+}
+
+/**
+ * What to say about one token, or nothing when it needs no comment.
+ *
+ * Returns `undefined` for a row that is working as written, so the caller has a
+ * value to branch on rather than a condition to re-derive. The two failing
+ * shapes are genuinely different — an unusable value applies nothing at all,
+ * while a first choice this site does not provide applies the NEXT family — and
+ * collapsing them into one sentence would describe the wrong outcome for one.
+ */
+export function tokenNote(row: FontTokenRow): string | undefined {
+  const { token, reading } = row;
+  if (!reading.usable) {
+    return `"${token.values.light}" is not a font-family value a browser will read, so this token applies nothing.`;
+  }
+  const first = reading.firstChoice;
+  if (first?.source !== "not-provided") return undefined;
+  return `${first.family} is the typeface this token asks for first, and this site provides no font file for it. Readers without it installed see the next family in the list instead.`;
+}

--- a/packages/builder/src/font-library.ts
+++ b/packages/builder/src/font-library.ts
@@ -18,40 +18,14 @@
  * @module font-library
  */
 import {
-  isUsableFamilyList,
-  splitFamilyList,
-  type FamilyPart,
+  readFamilyList,
+  validateFontFace,
+  type FamilyListKind,
   type FontFaceDef,
+  type ReadFamilyPart,
   type SiteToken,
   type SiteTokenSet,
 } from "@nextlyhq/blocks-engine";
-
-/**
- * Families every browser resolves without a face being loaded.
- *
- * The CSS generic families plus the `ui-*` system aliases. A stack ending in
- * one of these always draws something, which is why a stack that ends in a
- * generic is the shape to steer an author toward rather than away from.
- *
- * Held lowercase and compared lowercase: CSS family matching is
- * case-insensitive for these keywords, and an author who typed `Sans-Serif`
- * meant the generic.
- */
-const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
-  "serif",
-  "sans-serif",
-  "monospace",
-  "cursive",
-  "fantasy",
-  "system-ui",
-  "ui-serif",
-  "ui-sans-serif",
-  "ui-monospace",
-  "ui-rounded",
-  "math",
-  "emoji",
-  "fangsong",
-]);
 
 /**
  * Where a family's glyphs would come from.
@@ -61,8 +35,13 @@ const GENERIC_FAMILIES: ReadonlySet<string> = new Set([
  * device — `Georgia` and `Helvetica` are the ordinary cases — so declaring it
  * absent would be a claim about a machine this code cannot see. What IS true is
  * that the site does not provide it, and that is what the word says.
+ *
+ * `dynamic` is a `var()` whose value only exists at render. Reporting it as
+ * provided or not would be a guess either way, and the guess that reads worst
+ * is the confident one: a host wiring a font through a custom property, which
+ * is how `next/font` exposes one, would be told their token is broken.
  */
-export type FamilySource = "hosted" | "generic" | "not-provided";
+export type FamilySource = "hosted" | "generic" | "dynamic" | "not-provided";
 
 /** One family from a stack, and where it would come from. */
 export interface FamilyReading {
@@ -73,96 +52,131 @@ export interface FamilyReading {
 
 /** A whole `font-family` value, read against the faces the site loads. */
 export interface StackReading {
-  /** Each family in the author's order. Empty when the value is unusable. */
+  /**
+   * How CSS reads the value, from the engine's own classification.
+   *
+   * Four states rather than usable/unusable, because the browser has four
+   * answers and collapsing them misdescribes two: a `var()` stack is read
+   * perfectly and cannot be resolved here, and a lone `inherit` is valid while
+   * naming no family at all.
+   */
+  readonly kind: FamilyListKind;
+  /** Each family in the author's order. Empty unless `kind` names families. */
   readonly families: readonly FamilyReading[];
   /**
    * The author's FIRST choice, which is the one they were expressing.
    *
-   * Separated from the rest because a stack is a fallback chain and every
-   * entry after the first is a concession. An author who wrote `Brand, serif`
-   * chose `Brand`; reporting the stack as fine because `serif` resolves would
-   * answer a question they did not ask.
+   * Separated from the rest because a stack is a fallback chain and every entry
+   * after the first is a concession. An author who wrote `Brand, serif` chose
+   * `Brand`; reporting the stack as fine because `serif` resolves would answer
+   * a question they did not ask.
    */
   readonly firstChoice: FamilyReading | undefined;
   /**
+   * Whether a family AFTER the first exists to fall back to.
+   *
+   * What separates "readers see the next family in the list" from "readers see
+   * the browser's default", which are different sentences and only one of them
+   * is true of a single-family stack.
+   */
+  readonly hasFallback: boolean;
+  /**
    * Whether the site guarantees SOMETHING renders.
    *
-   * True when any family in the stack is generic or hosted. A stack of named
-   * families alone can still render — every one of them may be installed — so
-   * this is a floor, not a prediction.
+   * True when any family is generic or hosted. A stack of named families alone
+   * can still render — every one may be installed — so this is a floor, not a
+   * prediction.
    */
   readonly guaranteed: boolean;
-  /**
-   * Whether CSS accepts the value as written.
-   *
-   * A stack carrying `var(--x)`, a bare CSS-wide keyword, or an item the
-   * grammar rejects is not a family list the browser will read, so its families
-   * are not reported: naming them would describe a resolution that never
-   * happens.
-   */
-  readonly usable: boolean;
 }
 
-/** The families a set of faces provides, lowercased for comparison. */
+/**
+ * The families a set of faces provides, lowercased for comparison.
+ *
+ * Only faces the compiler will actually EMIT. `emitFontFaces` drops a face
+ * whose `src` is empty, remote, or carries an unusable descriptor, and the
+ * stored tier deliberately keeps those shaped-but-invalid faces so their issues
+ * can be reported. Counting them here would mark a token healthy against a
+ * `@font-face` the site sheet does not contain.
+ */
 function hostedFamilies(faces: readonly FontFaceDef[]): ReadonlySet<string> {
-  return new Set(faces.map(face => face.family.trim().toLowerCase()));
+  return new Set(
+    faces
+      .filter(face => validateFontFace(face, "fonts").length === 0)
+      .map(face => face.family.trim().toLowerCase())
+  );
 }
 
-function sourceOf(part: FamilyPart, hosted: ReadonlySet<string>): FamilySource {
-  const key = part.name.trim().toLowerCase();
-  // Hosted first: a site may load a face named `serif`, and the face it loads
-  // is what renders. Asking the generic set first would report the site's own
-  // font as a browser default.
-  if (hosted.has(key)) return "hosted";
-  // A QUOTED generic is a family name, not the keyword — `font-family: "serif"`
-  // asks for a font called serif. The same distinction `familyToDtcg` makes.
-  if (!part.quoted && GENERIC_FAMILIES.has(key)) return "generic";
-  return "not-provided";
+function sourceOf(
+  entry: ReadFamilyPart,
+  hosted: ReadonlySet<string>
+): FamilySource {
+  if (entry.kind === "dynamic") return "dynamic";
+  // Generic BEFORE hosted, which is the opposite of what it seems it should be.
+  // The engine emits every face family quoted — `font-family:"serif"` — and an
+  // unquoted `serif` in a stack is the CSS keyword, which no `@font-face` can
+  // claim. So a site loading a face it called `serif` still gets the browser
+  // default from a bare `serif`, and only a quoted value reaches its file.
+  if (entry.kind === "generic") return "generic";
+  const key = entry.part.name.trim().toLowerCase();
+  return hosted.has(key) ? "hosted" : "not-provided";
 }
 
 /**
  * Read one `font-family` value against the faces this site loads.
  *
- * The parser is the engine's, reached through its published export rather than
- * rewritten here: a family list is quoting, comma and escape rules together,
- * and `"ACME, Inc", serif` is two families rather than three. A second parser
- * would agree on the easy cases and diverge exactly where a site's real font
- * name is unusual.
+ * The split and the classification are the engine's, asked through one call.
+ * A family list is quoting, comma, escape and identifier rules together —
+ * `"ACME, Inc", serif` is two families rather than three, and `Brand,` is a
+ * parse error the browser drops the declaration for. A second reading of that
+ * grammar here would agree on the easy values and diverge on the ones a site's
+ * real font name produces.
  */
 export function readStack(
   value: string,
   faces: readonly FontFaceDef[]
 ): StackReading {
-  const parts = splitFamilyList(value);
-  // The engine's own composite, not `part.valid` alone: quoting is half the
-  // grammar, and the half left out is what accepts `var(--x)` as a font name.
-  const usable = isUsableFamilyList(parts);
-  if (!usable) {
+  const reading = readFamilyList(value);
+  if (reading.kind !== "families" && reading.kind !== "dynamic") {
     return {
+      kind: reading.kind,
       families: [],
       firstChoice: undefined,
+      hasFallback: false,
       guaranteed: false,
-      usable: false,
     };
   }
   const hosted = hostedFamilies(faces);
-  const families = parts.map(part => ({
-    family: part.name,
-    source: sourceOf(part, hosted),
+  const families = reading.parts.map(entry => ({
+    family: entry.part.name,
+    source: sourceOf(entry, hosted),
   }));
   return {
+    kind: reading.kind,
     families,
     firstChoice: families[0],
+    hasFallback: families.length > 1,
     guaranteed: families.some(f => f.source !== "not-provided"),
-    usable: true,
   };
 }
+
+/** Which value of a token is being read. */
+export type TokenMode = "light" | "dark";
 
 /** A `fontFamily` token, read against the faces the site loads. */
 export interface FontTokenRow {
   readonly token: SiteToken;
-  /** The light-mode value's reading. Dark is not a separate typeface tier. */
+  /** The light value's reading. Always present: `values.light` is required. */
   readonly reading: StackReading;
+  /**
+   * The dark value's reading, when the token defines one.
+   *
+   * Read because the emitter applies it: a token whose light stack is hosted
+   * and whose dark stack is not would otherwise report an all-clear while every
+   * dark-mode reader gets a substitution. Absent when the token states no dark
+   * value, which is not the same as stating the same value twice.
+   */
+  readonly darkReading: StackReading | undefined;
 }
 
 /**
@@ -179,23 +193,80 @@ export function fontTokenRows(
   const all = tokens?.tokens ?? [];
   return all
     .filter(token => token.kind === "fontFamily")
-    .map(token => ({ token, reading: readStack(token.values.light, faces) }));
+    .map(token => ({
+      token,
+      reading: readStack(token.values.light, faces),
+      darkReading:
+        token.values.dark === undefined
+          ? undefined
+          : readStack(token.values.dark, faces),
+    }));
+}
+
+/** One thing worth saying about one mode of one token. */
+export interface TokenNote {
+  readonly mode: TokenMode;
+  readonly text: string;
+}
+
+/** Whether a single reading is one an author should look at. */
+function needsAttention(reading: StackReading): boolean {
+  if (reading.kind === "invalid") return true;
+  // A lone CSS-wide keyword is a deliberate, working value — `inherit` takes
+  // the parent's font — so it names no typeface and needs no comment.
+  if (reading.kind === "keyword") return false;
+  return reading.firstChoice?.source === "not-provided";
+}
+
+/** What to say about one reading, or nothing when it is working as written. */
+function noteFor(reading: StackReading, value: string): string | undefined {
+  if (reading.kind === "invalid") {
+    return `"${value}" is not a font-family value a browser will read, so this token applies nothing.`;
+  }
+  if (reading.kind === "keyword") return undefined;
+  const first = reading.firstChoice;
+  if (first?.source !== "not-provided") return undefined;
+  // Branching on whether a later family EXISTS. Telling an author of a
+  // single-family stack that readers "see the next family in the list" names an
+  // entry that is not there, and points them at a fallback they never wrote.
+  const consequence = reading.hasFallback
+    ? "Readers without it installed see the next family in the list instead."
+    : "Readers without it installed see the browser's default typeface instead.";
+  return `${first.family} is the typeface this token asks for first, and this site provides no font file for it. ${consequence}`;
 }
 
 /**
- * The rows worth an author's attention, and nothing else.
+ * Everything worth saying about one token, one entry per affected mode.
  *
- * A row is drawn to attention when its FIRST family is not provided by this
- * site — that is the choice the author expressed, and the one that silently
- * does not happen. A stack whose first family is hosted or generic is working
- * as written, whatever its later entries say.
+ * A list rather than a string because a token can be sound in light and not in
+ * dark, and one sentence for both would have to name a mode it did not check.
+ */
+export function tokenNotes(row: FontTokenRow): readonly TokenNote[] {
+  const notes: TokenNote[] = [];
+  const light = noteFor(row.reading, row.token.values.light);
+  if (light !== undefined) notes.push({ mode: "light", text: light });
+  const dark = row.token.values.dark;
+  if (row.darkReading !== undefined && dark !== undefined) {
+    const darkNote = noteFor(row.darkReading, dark);
+    if (darkNote !== undefined) notes.push({ mode: "dark", text: darkNote });
+  }
+  return notes;
+}
+
+/**
+ * The rows worth an author's attention, in EITHER mode.
+ *
+ * A row is drawn to attention when a mode's value cannot be read at all, or
+ * when its FIRST family is one this site does not provide — that is the choice
+ * the author expressed, and the one that silently does not happen.
  */
 export function rowsNeedingAttention(
   rows: readonly FontTokenRow[]
 ): FontTokenRow[] {
   return rows.filter(
     row =>
-      !row.reading.usable || row.reading.firstChoice?.source === "not-provided"
+      needsAttention(row.reading) ||
+      (row.darkReading !== undefined && needsAttention(row.darkReading))
   );
 }
 
@@ -204,10 +275,14 @@ export function rowsNeedingAttention(
  *
  * Wording lives here rather than in the panel for the reason
  * {@link class-library.usageSummary} does: the sentence makes a claim about
- * evidence, and a claim is a rule. A panel composing it inline is a second
- * place for that judgement to drift — and this one has to keep saying
- * "provides no font file for" rather than "missing", which is exactly the kind
- * of distinction that erodes when it lives in JSX.
+ * evidence, and a claim is a rule. It also has to keep saying "provides no font
+ * file for" rather than "missing", which is exactly the kind of distinction
+ * that erodes when it lives in JSX.
+ *
+ * The two failing shapes are counted SEPARATELY. A value the browser will not
+ * read applies nothing at all, while a stack whose first family is unprovided
+ * applies the next one — different outcomes with different remedies, and one
+ * count covering both sends an author to fix the wrong thing.
  *
  * Stated even at zero. An author who reads a count knows the check ran, and
  * silence is also what a panel that never checked would show.
@@ -223,24 +298,20 @@ export function tokenSummary(
     const noun = rows.length === 1 ? "token" : "tokens";
     return `${rows.length} typeface ${noun}, each asking first for a family this site provides.`;
   }
-  return `${attention.length} of ${rows.length} ask first for a typeface this site provides no file for.`;
-}
-
-/**
- * What to say about one token, or nothing when it needs no comment.
- *
- * Returns `undefined` for a row that is working as written, so the caller has a
- * value to branch on rather than a condition to re-derive. The two failing
- * shapes are genuinely different — an unusable value applies nothing at all,
- * while a first choice this site does not provide applies the NEXT family — and
- * collapsing them into one sentence would describe the wrong outcome for one.
- */
-export function tokenNote(row: FontTokenRow): string | undefined {
-  const { token, reading } = row;
-  if (!reading.usable) {
-    return `"${token.values.light}" is not a font-family value a browser will read, so this token applies nothing.`;
+  const unreadable = attention.filter(
+    row => row.reading.kind === "invalid" || row.darkReading?.kind === "invalid"
+  ).length;
+  const unprovided = attention.length - unreadable;
+  const parts: string[] = [];
+  if (unprovided > 0) {
+    parts.push(
+      `${unprovided} ask first for a typeface this site provides no file for`
+    );
   }
-  const first = reading.firstChoice;
-  if (first?.source !== "not-provided") return undefined;
-  return `${first.family} is the typeface this token asks for first, and this site provides no font file for it. Readers without it installed see the next family in the list instead.`;
+  if (unreadable > 0) {
+    parts.push(
+      `${unreadable} hold a value no browser will read, so they apply nothing`
+    );
+  }
+  return `Of ${rows.length} typeface tokens, ${parts.join("; ")}.`;
 }

--- a/packages/builder/src/font-library.ts
+++ b/packages/builder/src/font-library.ts
@@ -91,19 +91,30 @@ export interface StackReading {
 }
 
 /**
- * The families a set of faces provides, lowercased for comparison.
+ * The faces the compiler will actually EMIT.
  *
- * Only faces the compiler will actually EMIT. `emitFontFaces` drops a face
- * whose `src` is empty, remote, or carries an unusable descriptor, and the
- * stored tier deliberately keeps those shaped-but-invalid faces so their issues
- * can be reported. Counting them here would mark a token healthy against a
- * `@font-face` the site sheet does not contain.
+ * `emitFontFaces` drops a face whose `src` is empty, remote, or carries an
+ * unusable descriptor, while the stored tier deliberately keeps those
+ * shaped-but-invalid faces so their issues can be reported. Anything reading
+ * "what does this site load" has to ask this rather than the raw list —
+ * counting a refused face marks a token healthy against a `@font-face` the site
+ * sheet does not contain, and listing one tells an author a file loads when it
+ * does not.
+ *
+ * Exported so the panel's list and the token analysis cannot disagree about
+ * which faces exist. Two filters would agree today and drift on the next
+ * validation rule the engine adds.
  */
+export function emittableFaces(
+  faces: readonly FontFaceDef[]
+): readonly FontFaceDef[] {
+  return faces.filter(face => validateFontFace(face, "fonts").length === 0);
+}
+
+/** The families those faces provide, lowercased for comparison. */
 function hostedFamilies(faces: readonly FontFaceDef[]): ReadonlySet<string> {
   return new Set(
-    faces
-      .filter(face => validateFontFace(face, "fonts").length === 0)
-      .map(face => face.family.trim().toLowerCase())
+    emittableFaces(faces).map(face => face.family.trim().toLowerCase())
   );
 }
 
@@ -296,12 +307,32 @@ export function tokenSummary(
   }
   if (attention.length === 0) {
     const noun = rows.length === 1 ? "token" : "tokens";
-    return `${rows.length} typeface ${noun}, each asking first for a family this site provides.`;
+    // Deliberately not "each asking first for a family this site provides".
+    // A `var()` stack has an unknown first choice and a lone `inherit` has no
+    // family at all, so that sentence would claim something checked about rows
+    // this code cannot check — the same over-claim the class manager avoids by
+    // reporting absence of evidence rather than absence of usage.
+    return `${rows.length} typeface ${noun}, none asking first for a typeface this site provides no file for.`;
   }
-  const unreadable = attention.filter(
-    row => row.reading.kind === "invalid" || row.darkReading?.kind === "invalid"
-  ).length;
-  const unprovided = attention.length - unreadable;
+  // Counted per ROW-MODE rather than by subtraction. A token invalid in one
+  // mode and unprovided in the other belongs in BOTH counts, and deriving one
+  // as `attention.length - other` forced it to zero — omitting a problem
+  // `tokenNotes` was reporting on the very same row.
+  let unreadable = 0;
+  let unprovided = 0;
+  for (const row of attention) {
+    const readings = [row.reading, row.darkReading].filter(
+      (r): r is StackReading => r !== undefined
+    );
+    if (readings.some(r => r.kind === "invalid")) unreadable += 1;
+    if (
+      readings.some(
+        r => r.kind !== "invalid" && r.firstChoice?.source === "not-provided"
+      )
+    ) {
+      unprovided += 1;
+    }
+  }
   const parts: string[] = [];
   if (unprovided > 0) {
     parts.push(

--- a/packages/builder/src/fonts-panel.test.tsx
+++ b/packages/builder/src/fonts-panel.test.tsx
@@ -86,7 +86,11 @@ describe("the panel over a site that has been read", () => {
     // could be a constant.
     render(<FontsPanel faces={[face("Brand")]} tokens={tokens} />);
     expect(screen.queryByText(/ask first for a typeface/)).toBeNull();
-    expect(screen.getByText(/each asking first for a family/)).toBeTruthy();
+    expect(
+      screen.getByText(
+        /none asking first for a typeface this site provides no file for/
+      )
+    ).toBeTruthy();
   });
 
   it("offers the jump to Tokens only when the host supplied one", () => {

--- a/packages/builder/src/fonts-panel.test.tsx
+++ b/packages/builder/src/fonts-panel.test.tsx
@@ -71,7 +71,11 @@ describe("the panel over a site that has been read", () => {
 
   it("reports the token whose first choice the site does not provide", () => {
     render(<FontsPanel faces={[]} tokens={tokens} />);
-    expect(screen.getByText(/1 of 2 ask first for a typeface/)).toBeTruthy();
+    expect(
+      screen.getByText(
+        /1 ask first for a typeface this site provides no file for/
+      )
+    ).toBeTruthy();
     expect(
       screen.getByText(/Brand is the typeface this token asks for first/)
     ).toBeTruthy();
@@ -94,6 +98,49 @@ describe("the panel over a site that has been read", () => {
 
     rerender(<FontsPanel faces={[]} tokens={tokens} />);
     expect(screen.queryByRole("button", { name: "Edit in Tokens" })).toBeNull();
+  });
+
+  it("demonstrates each face with its OWN weight and style", () => {
+    // Family alone selects the browser's normal upright face, so a site loading
+    // regular and italic of one family would draw two identical specimens —
+    // the list would then demonstrate the opposite of what it claims.
+    const italic: FontFaceDef = {
+      family: "Brand",
+      src: [{ url: "/fonts/brand-i.woff2", format: "woff2" }],
+      style: "italic",
+      weight: "700",
+    };
+    render(
+      <FontsPanel faces={[face("Brand"), italic]} tokens={{ tokens: [] }} />
+    );
+    const specimens = screen.getAllByText(
+      "Almost before we knew it, we had left the ground"
+    );
+    expect(specimens.some(el => el.style.fontStyle === "italic")).toBe(true);
+    expect(specimens.some(el => el.style.fontWeight === "700")).toBe(true);
+  });
+
+  it("keys subset faces apart rather than colliding them", () => {
+    // Subsetting by `unicodeRange` is how a large script ships, and those faces
+    // share family, weight and style by design. A key on those three alone
+    // collides, and React cannot reconcile the rows.
+    const warn = vi.spyOn(console, "error").mockImplementation(() => {});
+    const latin: FontFaceDef = {
+      family: "Brand",
+      src: [{ url: "/fonts/brand-latin.woff2", format: "woff2" }],
+      unicodeRange: "U+0000-00FF",
+    };
+    const greek: FontFaceDef = {
+      family: "Brand",
+      src: [{ url: "/fonts/brand-greek.woff2", format: "woff2" }],
+      unicodeRange: "U+0370-03FF",
+    };
+    render(<FontsPanel faces={[latin, greek]} tokens={{ tokens: [] }} />);
+    const duplicateKey = warn.mock.calls.some(call =>
+      String(call[0]).includes("same key")
+    );
+    warn.mockRestore();
+    expect(duplicateKey).toBe(false);
   });
 
   it("says a site with no faces has none, rather than staying silent", () => {

--- a/packages/builder/src/fonts-panel.test.tsx
+++ b/packages/builder/src/fonts-panel.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+
+/**
+ * The fonts panel, driven as an author meets it.
+ *
+ * `font-library.test` asserts the rules; what is only true HERE is the wiring:
+ * that a read still in flight is not drawn as a site with no fonts, that the
+ * specimen carries the family it names so the substitution is VISIBLE rather
+ * than described, and that the jump to the tokens studio appears only when the
+ * host offers one.
+ *
+ * @module fonts-panel.test
+ */
+import type { FontFaceDef, SiteTokenSet } from "@nextlyhq/blocks-engine";
+import { cleanup, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { FontsPanel } from "./fonts-panel";
+
+afterEach(cleanup);
+
+const face = (family: string): FontFaceDef => ({
+  family,
+  src: [{ url: "/fonts/f.woff2", format: "woff2" }],
+});
+
+const tokens: SiteTokenSet = {
+  tokens: [
+    {
+      name: "brand.body",
+      kind: "fontFamily",
+      values: { light: "Brand, serif" },
+    },
+    { name: "brand.ui", kind: "fontFamily", values: { light: "system-ui" } },
+  ],
+};
+
+describe("a fonts read that has not come back", () => {
+  it("is drawn as loading, NOT as a site with no fonts", () => {
+    // The third state. A site that self-hosts nothing legitimately has no
+    // faces, and an author must not read "no font files" for a pending read.
+    render(<FontsPanel faces={undefined} tokens={tokens} />);
+    expect(screen.getByText("Loading fonts…")).toBeTruthy();
+    expect(screen.queryByText(/loads no font files/)).toBeNull();
+  });
+
+  it("says a FAILED read failed, which is a different sentence", () => {
+    render(<FontsPanel faces={undefined} tokens={tokens} absence="failed" />);
+    expect(
+      screen.getByText("This site's fonts could not be read.")
+    ).toBeTruthy();
+  });
+});
+
+describe("the panel over a site that has been read", () => {
+  it("draws each specimen in the family it names", () => {
+    // The prior-art finding: a list of typeface names set in the interface's
+    // own font asks an author to choose a typeface from its name. Asserted on
+    // the rendered style rather than on a prop, because the style IS the
+    // affordance.
+    render(<FontsPanel faces={[face("Brand")]} tokens={tokens} />);
+    const specimens = screen.getAllByText(
+      "Almost before we knew it, we had left the ground"
+    );
+    const families = specimens.map(el => el.style.fontFamily);
+    expect(families).toContain('"Brand"');
+    // The TOKEN specimen carries the whole stack, not just its first family.
+    expect(families).toContain("Brand, serif");
+  });
+
+  it("reports the token whose first choice the site does not provide", () => {
+    render(<FontsPanel faces={[]} tokens={tokens} />);
+    expect(screen.getByText(/1 of 2 ask first for a typeface/)).toBeTruthy();
+    expect(
+      screen.getByText(/Brand is the typeface this token asks for first/)
+    ).toBeTruthy();
+  });
+
+  it("stops reporting it once the site loads that face", () => {
+    // The must-move half: same tokens, one face added. Without it the report
+    // could be a constant.
+    render(<FontsPanel faces={[face("Brand")]} tokens={tokens} />);
+    expect(screen.queryByText(/ask first for a typeface/)).toBeNull();
+    expect(screen.getByText(/each asking first for a family/)).toBeTruthy();
+  });
+
+  it("offers the jump to Tokens only when the host supplied one", () => {
+    const onOpenTokens = vi.fn();
+    const { rerender } = render(
+      <FontsPanel faces={[]} tokens={tokens} onOpenTokens={onOpenTokens} />
+    );
+    expect(screen.getByRole("button", { name: "Edit in Tokens" })).toBeTruthy();
+
+    rerender(<FontsPanel faces={[]} tokens={tokens} />);
+    expect(screen.queryByRole("button", { name: "Edit in Tokens" })).toBeNull();
+  });
+
+  it("says a site with no faces has none, rather than staying silent", () => {
+    render(<FontsPanel faces={[]} tokens={{ tokens: [] }} />);
+    expect(screen.getByText(/loads no font files of its own/)).toBeTruthy();
+    expect(screen.getByText(/no typeface tokens yet/)).toBeTruthy();
+  });
+});

--- a/packages/builder/src/fonts-panel.tsx
+++ b/packages/builder/src/fonts-panel.tsx
@@ -1,0 +1,264 @@
+/**
+ * The fonts panel: what this site can render, and which choices will not happen.
+ *
+ * A panel over {@link font-library}. It authors nothing, and that is a design
+ * decision rather than an omission: {@link tokens-panel} already creates and
+ * renames `fontFamily` tokens, and a second surface editing the same tokens
+ * would be two implementations of one question — the defect this codebase names
+ * more often than any other.
+ *
+ * ## The question this answers, which the tokens studio cannot
+ *
+ * The studio edits one token and knows nothing about the faces the site loads.
+ * `compileSiteSheet` calls `emitFontFaces` and `emitTokenBlocks` independently,
+ * so a token naming a family with no face is emitted exactly like one that has
+ * it, and the page draws in whatever the browser reaches for next. Nothing
+ * errors and nothing is logged. Joining the two lists is the only way to see
+ * it, and joining them needs both, which is why it lives here.
+ *
+ * ## Every family is drawn in ITSELF
+ *
+ * A list of typeface names set in the interface's own font asks an author to
+ * choose a typeface from its name, which is guessing. Webflow, Framer and
+ * Elementor all render the specimen in the face it names, and the one thing
+ * every review of a weak font picker says is that it did not. The specimen is
+ * also the honest signal here: a family this site does not provide renders in
+ * the fallback, so an author SEES the substitution rather than reading about it.
+ *
+ * ## What it will not say
+ *
+ * Never "missing" or "unavailable" for a family with no face. A named family
+ * may be installed on the reader's device — `Georgia` and `Helvetica` are the
+ * ordinary cases — so declaring it absent is a claim about a machine this code
+ * cannot see. The wording says what is true: this site provides no face for it.
+ * The same discipline the class manager applies to a usage count it knows can
+ * under-count.
+ *
+ * @module fonts-panel
+ */
+import type { FontFaceDef, SiteTokenSet } from "@nextlyhq/blocks-engine";
+import type * as React from "react";
+
+import {
+  fontTokenRows,
+  rowsNeedingAttention,
+  tokenNote,
+  tokenSummary,
+} from "./font-library";
+import type { FamilyReading, FontTokenRow } from "./font-library";
+
+export interface FontsPanelProps {
+  /**
+   * The faces this site loads, or `undefined` while the host has not read them.
+   *
+   * A real third state rather than an empty list, for the reason the class
+   * manager has one: a site that self-hosts nothing legitimately has no faces,
+   * and an author must not be shown "no fonts" for a read still in flight.
+   */
+  faces: readonly FontFaceDef[] | undefined;
+  /** The site's tokens, whose `fontFamily` members this reads. */
+  tokens: SiteTokenSet | undefined;
+  /** Why the faces are absent, when they are. */
+  absence?: "pending" | "failed";
+  /**
+   * Open the tokens panel, when the host offers one.
+   *
+   * The fix for a token naming a family this site does not provide is to edit
+   * that token, and editing it belongs to the studio. Offering the jump rather
+   * than the field is what keeps one editor for one question.
+   */
+  onOpenTokens?: () => void;
+}
+
+/** The specimen, one sentence with ascenders, descenders and round forms. */
+const SPECIMEN = "Almost before we knew it, we had left the ground";
+
+/** The stack as CSS, so a specimen renders in the family it names. */
+function specimenStyle(value: string): React.CSSProperties {
+  return { fontFamily: value };
+}
+
+/** What a family's source means, in words an author can act on. */
+function sourceNote(reading: FamilyReading): string {
+  switch (reading.source) {
+    case "hosted":
+      return "this site loads a font file for it";
+    case "generic":
+      return "a generic family every browser resolves";
+    case "not-provided":
+      return "this site provides no font file for it — readers see it only if it is already installed on their device";
+  }
+}
+
+function FamilyLine({
+  reading,
+}: {
+  reading: FamilyReading;
+}): React.JSX.Element {
+  return (
+    <li className="nx-fonts__family">
+      <span className="nx-fonts__family-name">{reading.family}</span>
+      <span className="nx-fonts__family-note">{sourceNote(reading)}</span>
+    </li>
+  );
+}
+
+/** The one sentence a row needs, or nothing. Its own component so the row is layout. */
+function TokenNote({
+  row,
+  onOpenTokens,
+}: {
+  row: FontTokenRow;
+  onOpenTokens?: () => void;
+}): React.JSX.Element | null {
+  const note = tokenNote(row);
+  if (note === undefined) return null;
+  return (
+    <p className="nx-fonts__note nx-fonts__note--attention">
+      {note}
+      {onOpenTokens === undefined ? null : (
+        <>
+          {" "}
+          <button
+            type="button"
+            className="nx-fonts__jump"
+            onClick={onOpenTokens}
+          >
+            Edit in Tokens
+          </button>
+        </>
+      )}
+    </p>
+  );
+}
+
+function TokenRow({
+  row,
+  onOpenTokens,
+}: {
+  row: FontTokenRow;
+  onOpenTokens?: () => void;
+}): React.JSX.Element {
+  return (
+    <li className="nx-fonts__token">
+      <div className="nx-fonts__token-head">
+        <span className="nx-fonts__token-name">{row.token.name}</span>
+        {/*
+          The specimen carries the token's WHOLE stack, so what is drawn is what
+          the page draws. Rendering only the first family would show the author
+          a typeface the browser may never reach.
+        */}
+        <span
+          className="nx-fonts__specimen"
+          style={specimenStyle(row.token.values.light)}
+        >
+          {SPECIMEN}
+        </span>
+      </div>
+      <TokenNote row={row} onOpenTokens={onOpenTokens} />
+      <ul className="nx-fonts__families">
+        {row.reading.families.map(family => (
+          <FamilyLine key={family.family} reading={family} />
+        ))}
+      </ul>
+    </li>
+  );
+}
+
+/** The faces the site loads, each drawn in itself. */
+function FaceList({
+  faces,
+}: {
+  faces: readonly FontFaceDef[];
+}): React.JSX.Element {
+  if (faces.length === 0) {
+    return (
+      <p className="nx-fonts__note">
+        This site loads no font files of its own. Tokens may still name generic
+        families, and any typeface a reader has installed.
+      </p>
+    );
+  }
+  return (
+    <ul className="nx-fonts__faces">
+      {faces.map(face => (
+        <li
+          className="nx-fonts__face"
+          key={`${face.family}:${face.weight ?? ""}:${face.style ?? ""}`}
+        >
+          <span className="nx-fonts__face-name">{face.family}</span>
+          <span
+            className="nx-fonts__specimen"
+            style={specimenStyle(`"${face.family}"`)}
+          >
+            {SPECIMEN}
+          </span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+/** Faces absent: a read in flight and a read that failed need different words. */
+function FacesAbsent({
+  absence,
+}: {
+  absence?: "pending" | "failed";
+}): React.JSX.Element {
+  return (
+    <div className="nx-fonts">
+      <p className="nx-inspector__note">
+        {absence === "failed"
+          ? "This site's fonts could not be read."
+          : "Loading fonts…"}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * The panel.
+ *
+ * Faces first, then tokens: the faces are what the site HAS, and a token is a
+ * claim measured against them. Reading the claims before the evidence would put
+ * every "no font file for it" note in front of the list that explains it.
+ */
+export function FontsPanel({
+  faces,
+  tokens,
+  absence,
+  onOpenTokens,
+}: FontsPanelProps): React.JSX.Element {
+  if (faces === undefined) return <FacesAbsent absence={absence} />;
+
+  const rows = fontTokenRows(tokens, faces);
+
+  return (
+    <div className="nx-fonts">
+      <section aria-labelledby="nx-fonts-faces">
+        <h3 className="nx-fonts__heading" id="nx-fonts-faces">
+          Font files this site loads
+        </h3>
+        <FaceList faces={faces} />
+      </section>
+
+      <section aria-labelledby="nx-fonts-tokens">
+        <h3 className="nx-fonts__heading" id="nx-fonts-tokens">
+          Typeface tokens
+        </h3>
+        <p className="nx-fonts__note" role="status">
+          {tokenSummary(rows, rowsNeedingAttention(rows))}
+        </p>
+        <ul className="nx-fonts__tokens">
+          {rows.map(row => (
+            <TokenRow
+              key={row.token.id ?? row.token.name}
+              row={row}
+              onOpenTokens={onOpenTokens}
+            />
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}

--- a/packages/builder/src/fonts-panel.tsx
+++ b/packages/builder/src/fonts-panel.tsx
@@ -42,7 +42,7 @@ import type * as React from "react";
 import {
   fontTokenRows,
   rowsNeedingAttention,
-  tokenNote,
+  tokenNotes,
   tokenSummary,
 } from "./font-library";
 import type { FamilyReading, FontTokenRow } from "./font-library";
@@ -78,6 +78,39 @@ function specimenStyle(value: string): React.CSSProperties {
   return { fontFamily: value };
 }
 
+/**
+ * A face's own specimen, drawn with the descriptors that face declares.
+ *
+ * Family alone selects the browser's normal weight and upright style, so a
+ * site loading regular, bold and italic of one family would draw three
+ * identical rows — the specimen would then demonstrate the opposite of what
+ * the list claims, which is worse than no specimen.
+ */
+function faceSpecimenStyle(face: FontFaceDef): React.CSSProperties {
+  return {
+    fontFamily: `"${face.family}"`,
+    ...(face.weight === undefined ? {} : { fontWeight: face.weight }),
+    ...(face.style === undefined ? {} : { fontStyle: face.style }),
+  };
+}
+
+/**
+ * A key that separates the faces a family is really split into.
+ *
+ * Subsetting by `unicodeRange` is the ordinary way to ship a large script, and
+ * those faces share family, weight and style by design — keyed on those three
+ * alone they collide, and React cannot reconcile the rows.
+ */
+function faceKey(face: FontFaceDef): string {
+  return [
+    face.family,
+    face.weight ?? "",
+    face.style ?? "",
+    face.unicodeRange ?? "",
+    face.src.map(source => source.url).join("|"),
+  ].join("::");
+}
+
 /** What a family's source means, in words an author can act on. */
 function sourceNote(reading: FamilyReading): string {
   switch (reading.source) {
@@ -85,6 +118,8 @@ function sourceNote(reading: FamilyReading): string {
       return "this site loads a font file for it";
     case "generic":
       return "a generic family every browser resolves";
+    case "dynamic":
+      return "a custom property, resolved when the page renders — what it holds cannot be read from here";
     case "not-provided":
       return "this site provides no font file for it — readers see it only if it is already installed on their device";
   }
@@ -103,32 +138,44 @@ function FamilyLine({
   );
 }
 
-/** The one sentence a row needs, or nothing. Its own component so the row is layout. */
-function TokenNote({
+/**
+ * What a row needs said, one line per affected mode.
+ *
+ * Its own component so the row stays layout, and a list because a token can be
+ * sound in light and not in dark. The mode is named only when the token
+ * actually declares a dark value: naming it otherwise would imply a mode the
+ * author never configured.
+ */
+function TokenNotes({
   row,
   onOpenTokens,
 }: {
   row: FontTokenRow;
   onOpenTokens?: () => void;
 }): React.JSX.Element | null {
-  const note = tokenNote(row);
-  if (note === undefined) return null;
+  const notes = tokenNotes(row);
+  if (notes.length === 0) return null;
+  const named = row.darkReading !== undefined;
   return (
-    <p className="nx-fonts__note nx-fonts__note--attention">
-      {note}
-      {onOpenTokens === undefined ? null : (
-        <>
-          {" "}
-          <button
-            type="button"
-            className="nx-fonts__jump"
-            onClick={onOpenTokens}
-          >
-            Edit in Tokens
-          </button>
-        </>
-      )}
-    </p>
+    <>
+      {notes.map(note => (
+        <p className="nx-fonts__note nx-fonts__note--attention" key={note.mode}>
+          {named ? `In ${note.mode} mode: ${note.text}` : note.text}
+          {onOpenTokens === undefined ? null : (
+            <>
+              {" "}
+              <button
+                type="button"
+                className="nx-fonts__jump"
+                onClick={onOpenTokens}
+              >
+                Edit in Tokens
+              </button>
+            </>
+          )}
+        </p>
+      ))}
+    </>
   );
 }
 
@@ -155,7 +202,7 @@ function TokenRow({
           {SPECIMEN}
         </span>
       </div>
-      <TokenNote row={row} onOpenTokens={onOpenTokens} />
+      <TokenNotes row={row} onOpenTokens={onOpenTokens} />
       <ul className="nx-fonts__families">
         {row.reading.families.map(family => (
           <FamilyLine key={family.family} reading={family} />
@@ -182,15 +229,9 @@ function FaceList({
   return (
     <ul className="nx-fonts__faces">
       {faces.map(face => (
-        <li
-          className="nx-fonts__face"
-          key={`${face.family}:${face.weight ?? ""}:${face.style ?? ""}`}
-        >
+        <li className="nx-fonts__face" key={faceKey(face)}>
           <span className="nx-fonts__face-name">{face.family}</span>
-          <span
-            className="nx-fonts__specimen"
-            style={specimenStyle(`"${face.family}"`)}
-          >
+          <span className="nx-fonts__specimen" style={faceSpecimenStyle(face)}>
             {SPECIMEN}
           </span>
         </li>

--- a/packages/builder/src/fonts-panel.tsx
+++ b/packages/builder/src/fonts-panel.tsx
@@ -36,10 +36,12 @@
  *
  * @module fonts-panel
  */
+import { cssString } from "@nextlyhq/blocks-engine";
 import type { FontFaceDef, SiteTokenSet } from "@nextlyhq/blocks-engine";
 import type * as React from "react";
 
 import {
+  emittableFaces,
   fontTokenRows,
   rowsNeedingAttention,
   tokenNotes,
@@ -88,7 +90,12 @@ function specimenStyle(value: string): React.CSSProperties {
  */
 function faceSpecimenStyle(face: FontFaceDef): React.CSSProperties {
   return {
-    fontFamily: `"${face.family}"`,
+    // Escaped through the engine's own `cssString`, the way `emitFontFaces`
+    // writes the same name into the site sheet. Quoting author data by hand
+    // produces `"ACME "Pro""` for a legal family, the browser drops the
+    // declaration, and the specimen demonstrates the fallback — the one lie
+    // this panel must not tell.
+    fontFamily: `"${cssString(face.family)}"`,
     ...(face.weight === undefined ? {} : { fontWeight: face.weight }),
     ...(face.style === undefined ? {} : { fontStyle: face.style }),
   };
@@ -218,7 +225,14 @@ function FaceList({
 }: {
   faces: readonly FontFaceDef[];
 }): React.JSX.Element {
-  if (faces.length === 0) {
+  // The list says "font files this site loads", so it shows what the compiler
+  // will emit. A shaped-but-refused face — a remote `src`, an empty one — is
+  // kept by the stored tier so its issues can be reported, and listing it here
+  // would claim a file loads when the site sheet contains no `@font-face` for
+  // it. The empty state is derived from the same list, so a site whose only
+  // faces are refused correctly reads as loading none.
+  const emittable = emittableFaces(faces);
+  if (emittable.length === 0) {
     return (
       <p className="nx-fonts__note">
         This site loads no font files of its own. Tokens may still name generic
@@ -228,7 +242,7 @@ function FaceList({
   }
   return (
     <ul className="nx-fonts__faces">
-      {faces.map(face => (
+      {emittable.map(face => (
         <li className="nx-fonts__face" key={faceKey(face)}>
           <span className="nx-fonts__face-name">{face.family}</span>
           <span className="nx-fonts__specimen" style={faceSpecimenStyle(face)}>

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -425,3 +425,22 @@ export type {
   DeletionWarning,
   NameRefusal,
 } from "./class-library";
+
+/**
+ * The fonts panel, and the rules it draws from.
+ *
+ * A reader over the site's faces and its `fontFamily` tokens rather than an
+ * editor: creating and renaming those tokens belongs to the tokens studio, and
+ * the question this answers — whether a family a token names will actually
+ * render — needs both lists at once, which is why neither the studio nor the
+ * inspector can ask it.
+ */
+export { FontsPanel } from "./fonts-panel";
+export type { FontsPanelProps } from "./fonts-panel";
+export { fontTokenRows, readStack, rowsNeedingAttention } from "./font-library";
+export type {
+  FamilyReading,
+  FamilySource,
+  FontTokenRow,
+  StackReading,
+} from "./font-library";

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -2139,3 +2139,126 @@
   outline: 2px solid var(--nx-ring);
   outline-offset: 2px;
 }
+
+/* --- fonts panel ----------------------------------------------------------
+   Token-driven throughout, per the admin styling rule: every colour here is an
+   `--nx-*` custom property so the panel works in both modes without a second
+   palette. */
+
+/* One stacking rule for every column in the panel, varying only the gap. Four
+   near-identical flex blocks is the duplication the CSS audit names, and the
+   copies drift: a spacing change made in three of them looks done. */
+.nx-fonts,
+.nx-fonts__faces,
+.nx-fonts__tokens,
+.nx-fonts__face,
+.nx-fonts__token,
+.nx-fonts__families {
+  display: flex;
+  flex-direction: column;
+}
+
+.nx-fonts {
+  gap: 1rem;
+}
+
+.nx-fonts__faces,
+.nx-fonts__tokens {
+  gap: 0.5rem;
+}
+
+.nx-fonts__face,
+.nx-fonts__token {
+  gap: 0.25rem;
+  border: 1px solid var(--nx-border);
+  border-radius: 0.375rem;
+  padding: 0.5rem;
+}
+
+.nx-fonts__families {
+  gap: 0.125rem;
+}
+
+.nx-fonts__faces,
+.nx-fonts__tokens,
+.nx-fonts__families {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nx-fonts__heading {
+  margin: 0 0 0.375rem;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--nx-muted-foreground);
+}
+
+.nx-fonts__face-name,
+.nx-fonts__token-name,
+.nx-fonts__family-name {
+  font-family: var(--font-mono, monospace);
+}
+
+.nx-fonts__face-name,
+.nx-fonts__token-name {
+  font-size: var(--text-xs);
+  color: var(--nx-muted-foreground);
+}
+
+/* The specimen is the affordance, so it is given room and never wraps into the
+   chrome around it. `clip` rather than `ellipsis`: a truncated typeface still
+   shows its letterforms, and an ellipsis would sit in the panel's font rather
+   than the specimen's, which is the one place a substitution must not appear. */
+.nx-fonts__specimen {
+  display: block;
+  font-size: var(--text-lg);
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: clip;
+  color: var(--nx-foreground);
+}
+
+.nx-fonts__family {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+}
+
+.nx-fonts__family,
+.nx-fonts__family-note,
+.nx-fonts__note {
+  font-size: var(--text-xs);
+}
+
+.nx-fonts__family-note,
+.nx-fonts__note {
+  color: var(--nx-muted-foreground);
+  margin: 0;
+}
+
+/* Attention is carried by a border and the foreground colour rather than by
+   colour alone, so it survives a reader who cannot separate the two. */
+.nx-fonts__note--attention {
+  border-inline-start: 2px solid var(--nx-ring);
+  padding-inline-start: 0.5rem;
+  color: var(--nx-foreground);
+}
+
+.nx-fonts__jump {
+  border: 0;
+  padding: 0;
+  background: none;
+  color: var(--nx-ring);
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.nx-fonts__jump:focus-visible {
+  outline: 2px solid var(--nx-ring);
+  outline-offset: 2px;
+}

--- a/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
@@ -72,7 +72,7 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
   return {
     ...real,
     // Captures the WHOLE props object — `onShowEmptyElementsChange` and
-    // `openInsertPanelToken` are what this file drives, and a narrower
+    // `openPanelRequest` are what this file drives, and a narrower
     // destructure (as the sibling files use for a shell that ignores those)
     // would silently discard them.
     BuilderShell: (

--- a/packages/plugin-page-builder/src/admin/BlocksField.fonts.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.fonts.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+
+/**
+ * The fonts panel reaching an author, which is a different claim from the panel
+ * working.
+ *
+ * `class-library.test.ts` in the builder asserts the RULES and
+ * `class-selector.test.tsx` asserts the surface. What is only true HERE is the
+ * wiring: that this component hands the inspector a library at all, that it
+ * tells a read still in flight apart from a library that is genuinely empty,
+ * and that creating a class writes the `classes` section and answers with the
+ * id rather than applying it.
+ *
+ * Every rule can be correct while the props are absent — the selector renders
+ * perfectly in isolation, its own tests pass, and no author ever sees it. That
+ * failure has already happened once on this chain, one component further up.
+ *
+ * The builder shell is replaced with recorders rather than rendered, as
+ * `BlocksField.breakpoints.test` does and for its reason: what is under test is
+ * which props this component passes.
+ *
+ * @module admin/BlocksField.classes.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
+
+/** Props the inspector recorder captured on the most recent render. */
+const seen: { inspector: Record<string, unknown> | undefined } = {
+  inspector: undefined,
+};
+
+/** What `usePluginClientConfig` answers with for the test in hand. */
+let clientConfig: Record<string, unknown> | undefined;
+/** What the stored site-style read reports, so `pending` can be driven. */
+let storedRead: { data: unknown; isPending: boolean; error: unknown };
+/** What a save answers, and what it was handed. */
+let saveResult: { success: boolean } | Error;
+const saved: Array<Record<string, unknown>> = [];
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  const real = await importOriginal<Record<string, unknown>>();
+  const nothing = (): null => null;
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    /*
+      The shell here CALLS `renderPanel`, which the sibling tests' shell does
+      not. What is under test is the branch itself: a panel exported, styled and
+      covered by its own tests is still invisible to every author while nothing
+      renders it, and that is the failure this file exists to catch rather than
+      anything about how the panel behaves.
+    */
+    BuilderShell: ({
+      renderPanel,
+      availablePanels,
+    }: {
+      renderPanel?: (panel: string) => React.ReactNode;
+      availablePanels?: readonly string[];
+    }): React.JSX.Element => (
+      <div>
+        <div data-testid="rail">{(availablePanels ?? []).join(",")}</div>
+        <div data-testid="panel">{renderPanel?.("fonts")}</div>
+      </div>
+    ),
+    BlockKeyboardActions: passthrough,
+    BlockToolbar: nothing,
+    BreakpointManager: nothing,
+    BreakpointSwitcher: nothing,
+    InspectorPanel: nothing,
+    InsertPanel: nothing,
+    LayersPanel: nothing,
+    TokensStudio: nothing,
+    BlockContextMenu: passthrough,
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
+  usePluginClientConfig: () => clientConfig,
+  useDocumentCheckpoint: () => ({ schedule: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  /*
+   * Reached only on the refusal path, where `site-style-client` asks it to turn
+   * a rejection into per-field messages. Answering none exercises the branch
+   * that must still refuse when the transport could not describe why.
+   */
+  validationIssues: () => [],
+  useSingleDocument: () => storedRead,
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async (value: Record<string, unknown>) => {
+      saved.push(value);
+      if (saveResult instanceof Error) throw saveResult;
+      return saveResult;
+    },
+    isPending: false,
+  }),
+}));
+
+const { BlocksField } = await import("./BlocksField");
+
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+function openEditor(): void {
+  render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+}
+
+/** What the inspector was handed for the class surface. */
+function classProps(): {
+  classLibrary?: readonly { id: string; slug: string }[];
+  classLibraryAbsence?: "pending" | "failed";
+  onCreateClass?: (
+    slug: string
+  ) => Promise<{ ok: true; classId: string } | { ok: false; reason: string }>;
+} {
+  return (seen.inspector ?? {}) as never;
+}
+
+beforeEach(() => {
+  seen.inspector = undefined;
+  clientConfig = {};
+  storedRead = { data: undefined, isPending: false, error: null };
+  saveResult = { success: true };
+  saved.length = 0;
+});
+
+afterEach(cleanup);
+
+describe("the fonts panel reaching an author", () => {
+  it("offers the fonts rail slot at all", () => {
+    // The slot was reserved and dark for the whole of Phase 4: `PANEL_CHROME`
+    // named it, `LEFT_PANELS` listed it, and nothing rendered into it, so the
+    // shell drew it disabled as "coming soon".
+    storedRead = {
+      data: { fonts: [], tokens: { tokens: [] } },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    expect(screen.getByTestId("rail").textContent).toContain("fonts");
+  });
+
+  it("hands it the site's faces and tokens, not an empty list", () => {
+    storedRead = {
+      data: {
+        fonts: [
+          { family: "Brand", src: [{ url: "/f.woff2", format: "woff2" }] },
+        ],
+        tokens: {
+          tokens: [
+            {
+              name: "brand.body",
+              kind: "fontFamily",
+              values: { light: "Ghost, serif" },
+            },
+          ],
+        },
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    const panel = screen.getByTestId("panel");
+    // The face reached it...
+    expect(panel.textContent).toContain("Brand");
+    // ...and so did the token, which is the half that needs BOTH props: the
+    // report is a join, so passing faces alone would draw a silent all-clear.
+    expect(panel.textContent).toContain("Ghost");
+  });
+
+  it("draws a read still in flight as loading rather than as a site with no fonts", () => {
+    // The third state, asserted at the WIRING rather than only in the panel:
+    // the panel cannot tell pending from empty unless this file passes
+    // `undefined`, and passing `[]` while pending is the plausible bug.
+    storedRead = { data: undefined, isPending: true, error: null };
+    openEditor();
+    expect(screen.getByTestId("panel").textContent).toContain("Loading fonts");
+  });
+
+  it("says a failed read failed", () => {
+    storedRead = {
+      data: undefined,
+      isPending: false,
+      error: new Error("nope"),
+    };
+    openEditor();
+    expect(screen.getByTestId("panel").textContent).toContain(
+      "could not be read"
+    );
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -49,7 +49,11 @@ import {
   type FontFaceDef,
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
-import { DEFAULT_PREFERENCES, registrySlotSource } from "@nextlyhq/builder";
+import {
+  DEFAULT_PREFERENCES,
+  registrySlotSource,
+  type LeftPanel,
+} from "@nextlyhq/builder";
 import {
   BlockKeyboardActions,
   authoredBreakpoints,
@@ -431,6 +435,26 @@ function offerableFaces(
 ): readonly FontFaceDef[] | undefined {
   if (pending || error !== null) return undefined;
   return style?.fonts ?? [];
+}
+
+/**
+ * The tokens as the PAGE renders them, defaults included.
+ *
+ * Deliberately not `offerableTokens`. A studio edits what the site AUTHORED —
+ * showing the engine's defaults as rows an author can rename would offer edits
+ * that write nothing — while a report on what the page draws has to read what
+ * the page draws. `resolveSiteTokens` layers the engine's own underneath, and
+ * one of them is `font.body: system-ui`, a real typeface every site renders
+ * with. Reading the authored set had the panel announce "no typeface tokens"
+ * for a site whose every page was using one.
+ */
+function renderedTokens(
+  style: SiteStyleData | undefined,
+  pending: boolean,
+  error: unknown
+): SiteTokenSet | undefined {
+  if (pending || error !== null) return undefined;
+  return resolveSiteTokens(style?.tokens);
 }
 
 function offerableTokens(
@@ -1460,12 +1484,24 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * nothing the second time. Starts `undefined` rather than `0` so mounting
    * the editor is not itself a press.
    */
-  const [openInsertPanelToken, setOpenInsertPanelToken] = useState<
-    number | undefined
+  /*
+   * A request to open one panel, carrying its own count so the shell can tell a
+   * second press from the first. One piece of state for every panel that asks:
+   * the appender opens `insert`, and the fonts panel sends an author to
+   * `tokens` to fix a typeface the site does not provide.
+   */
+  const [openPanelRequest, setOpenPanelRequest] = useState<
+    { panel: LeftPanel; count: number } | undefined
   >(undefined);
-  const openInsertPanel = useCallback(() => {
-    setOpenInsertPanelToken(current => (current ?? 0) + 1);
+  const requestPanel = useCallback((panel: LeftPanel) => {
+    setOpenPanelRequest(current => ({
+      panel,
+      count: (current?.count ?? 0) + 1,
+    }));
   }, []);
+  const openInsertPanel = useCallback(() => {
+    requestPanel("insert");
+  }, [requestPanel]);
 
   /*
    * Whether the author wants empty-container chrome showing at all, mirrored
@@ -1517,7 +1553,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // Forces the insert panel open from the empty-container appender,
         // which lives on the canvas below rather than beside the rail that
         // normally opens a panel.
-        openInsertPanelToken={openInsertPanelToken}
+        openPanelRequest={openPanelRequest}
         // The read half of the same gap: mirrors the shell's own preference
         // so the appender below can be suppressed by the SAME switch that
         // already suppresses the placeholder box it sits over.
@@ -1714,12 +1750,20 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                   siteStylePending,
                   siteStyleError
                 )}
-                tokens={offerableTokens(
+                tokens={renderedTokens(
                   canvasSiteStyle,
                   siteStylePending,
                   siteStyleError
                 )}
                 absence={siteStyleError !== null ? "failed" : "pending"}
+                /*
+                  The fix for a token naming a family this site does not provide
+                  is to edit that token, and editing belongs to the studio. This
+                  shell offers one, so the jump is wired: without the callback
+                  the panel suppresses the action and an author is left to find
+                  the right panel and the right row themselves.
+                */
+                onOpenTokens={() => requestPanel("tokens")}
               />
             ),
             /*

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -46,6 +46,7 @@ import {
   type NamedClass,
   type SiteTokenSet,
   type BreakpointId,
+  type FontFaceDef,
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import { DEFAULT_PREFERENCES, registrySlotSource } from "@nextlyhq/builder";
@@ -81,6 +82,7 @@ import {
   useInlineEditing,
   documentAfter,
   type InlineEditOutcome,
+  FontsPanel,
 } from "@nextlyhq/builder/shell";
 import {
   loadInlineRichTextEditor,
@@ -171,7 +173,7 @@ export interface BlocksFieldProps<
  * and shrink the canvas to show it, which is why this grows one entry at a time
  * rather than being declared ahead of the panels.
  */
-const AVAILABLE_PANELS = ["insert", "layers", "tokens"] as const;
+const AVAILABLE_PANELS = ["insert", "layers", "tokens", "fonts"] as const;
 
 /**
  * With an entry-fields panel to fill, `settings` joins them.
@@ -409,6 +411,28 @@ function useCheckpoints<TFieldValues extends FieldValues>({
  * "the question was never asked" and offers no picker at all — which is the
  * truth here, and is different from a site that defines no tokens.
  */
+/**
+ * The faces the site loads, or `undefined` while that is not yet known.
+ *
+ * The same third state `offerableTokens` keeps, and for the same reason: a site
+ * that self-hosts nothing legitimately has no faces, so a surface cannot tell
+ * "none stored" from "the read has not come back" by looking at the value. The
+ * fonts panel draws those two differently, and would otherwise report a site
+ * mid-load as one loading no fonts at all.
+ *
+ * Unlike tokens there are no engine defaults to layer underneath — a font file
+ * is something a site provides or does not — so the resolved list is returned
+ * as it stands, including an empty one.
+ */
+function offerableFaces(
+  style: SiteStyleData | undefined,
+  pending: boolean,
+  error: unknown
+): readonly FontFaceDef[] | undefined {
+  if (pending || error !== null) return undefined;
+  return style?.fonts ?? [];
+}
+
 function offerableTokens(
   style: SiteStyleData | undefined,
   pending: boolean,
@@ -1648,16 +1672,22 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
           ) : undefined
         }
         renderPanel={panel => {
-          if (panel === "insert") {
-            return (
+          /*
+            A lookup rather than a chain of comparisons, so the arrow answers
+            in one step and adding a panel is one entry rather than one more
+            branch. It also states the pairing the shell needs: every key here
+            is a panel this file can fill, and `AVAILABLE_PANELS` is what the
+            rail offers — reading them side by side is how a panel that is
+            offered and renders nothing gets noticed.
+          */
+          const panels: Partial<Record<string, () => React.ReactNode>> = {
+            insert: () => (
               <InsertPanel
                 editor={editor}
                 categoryOrder={CORE_CATEGORIES}
                 beginInsertDrag={drag.beginInsertDrag}
               />
-            );
-          }
-          if (panel === "layers") {
+            ),
             /*
               The panel cannot work this out for itself. It is drawn here, in
               the shell's panel region, while `BlockKeyboardActions` below wraps
@@ -1665,10 +1695,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
               read from where it sits reports what this file knows by writing
               both. Passed as a fact rather than inferred.
             */
-            return <LayersPanel editor={editor} moveHints />;
-          }
-          if (panel === "tokens") {
-            return (
+            layers: () => <LayersPanel editor={editor} moveHints />,
+            tokens: () => (
               <TokensStudio
                 merged={offerableTokens(
                   canvasSiteStyle,
@@ -1678,17 +1706,32 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                 supplied={configSiteStyle?.tokens}
                 pending={siteStylePending}
               />
-            );
-          }
-          /*
-           * The entry's own fields — SEO, relations, whatever this collection
-           * declares — which the takeover removed from the page behind this
-           * editor. Rendered by the ADMIN's closure, not reconstructed here: how
-           * a field is drawn is the entry form's contract, and a second
-           * renderer would drift from it.
-           */
-          if (panel === "settings") return renderEntryFields?.(name) ?? null;
-          return null;
+            ),
+            fonts: () => (
+              <FontsPanel
+                faces={offerableFaces(
+                  canvasSiteStyle,
+                  siteStylePending,
+                  siteStyleError
+                )}
+                tokens={offerableTokens(
+                  canvasSiteStyle,
+                  siteStylePending,
+                  siteStyleError
+                )}
+                absence={siteStyleError !== null ? "failed" : "pending"}
+              />
+            ),
+            /*
+              The entry's own fields — SEO, relations, whatever this collection
+              declares — which the takeover removed from the page behind this
+              editor. Rendered by the ADMIN's closure, not reconstructed here:
+              how a field is drawn is the entry form's contract, and a second
+              renderer would drift from it.
+            */
+            settings: () => renderEntryFields?.(name) ?? null,
+          };
+          return panels[panel]?.() ?? null;
         }}
       >
         {/*


### PR DESCRIPTION
Closes C-11. The scope is narrower than the original ruling and the reason is measured, not assumed — see "Why no Google picker" below.

## The defect this surfaces

`compileSiteSheet` calls `emitFontFaces` and `emitTokenBlocks` **independently**. So a `fontFamily` token naming a family the site loads no face for is emitted exactly like one that has it, the page draws in whatever the browser reaches for next, and nothing errors or logs. It is the same silent substitution the sheet's own `tokenPrefix` note already describes one property along — *"nothing errors: the reference resolves to nothing and the value silently does not apply."*

Seeing it requires both lists at once. The tokens studio edits one token and knows nothing about faces; the inspector knows nothing about either. That is why the panel exists, and it is the whole of what it does.

## It authors nothing, deliberately

`tokens-panel` already creates and renames `fontFamily` tokens — `tokens-studio.ts` has carried `fontFamily: "Font"` with a default all along. A second surface editing the same tokens would be two implementations of one question. When a token needs changing, the panel says so and offers a jump to the studio.

## Every family is drawn in itself

A list of typeface names set in the interface's own font asks an author to choose a typeface from its name, which is guessing. Webflow, Framer and Elementor all render the specimen in the face it names. Here it does double duty: a family the site does not provide renders in the *fallback*, so the author **sees** the substitution rather than reading about it. The token specimen carries the whole stack, not the first family, so what is drawn is what the page draws.

## Nothing is called missing

A named family with no face may be installed on the reader's device — `Georgia` and `Helvetica` are the ordinary cases — so declaring it absent is a claim about a machine this code cannot see. The wording says what is true: *this site provides no font file for it*. Asserted in a test rather than left to review, the same discipline the class manager applies to a usage count known to under-count.

## Why no Google picker (narrower than the original ruling)

`decision:pb-fonts-upload-scope` chose *register-and-emit only: Google Fonts + system stacks; upload follows F5*. Research established that scope cannot be delivered as stated:

- `next/font/google` is **build-time only** — it downloads to `.next/static/media` and re-throws on network failure in production. It needs the family as a static import, so it cannot serve a runtime-authored font. `emitFontFaces` is the right path, and `next/font` remains right for the host app's own fonts. Different populations, not competing options.
- `validateFontFace` already refuses any non-same-origin `src`, protocol-relative included, and its message names the reason: *"a font fetched from elsewhere tells that server every visitor's IP address before the page can be read."* That matches the Munich ruling of 2022-01-20 on Google Fonts and the GDPR.

So a Google font cannot be registered at all without storage, because the only URL an author could supply is the one the engine refuses. `decision:pb-fonts-google-compliance` records the founder narrowing this to system stacks and host-declared faces. The panel emits no author-supplied URL.

## Engine change: one predicate instead of two half-answers

`splitFamilyList` and `isUsableFamilyList` are now published. Reading a family list is quoting, comma and CSS-escape rules together — `"ACME, Inc", serif` is two families, not three — so a second parser in `builder` would agree on easy cases and diverge exactly where a site's real font name is unusual.

`isUsableFamilyList` is an extraction, not a new rule: `FamilyPart.valid` answers the **quoting** half, and `familyToDtcg` applied the identifier-run and parenthesis checks separately inline. Asked alone, `valid` accepts `var(--x)` as a font called `var(--x)` — which is exactly the bug my first draft shipped, caught by its own test. `familyToDtcg` now asks the same predicate, so the DTCG export and the panel cannot disagree about what a browser reads.

## Verification

19 rules tests and 7 panel tests. Break-verified, each failing the test named in advance:

| break | test that failed |
|---|---|
| ignore the `quoted` flag | *calls a generic keyword generic, and the same word QUOTED a name* |
| `rowsNeedingAttention` returns everything | *stops drawing attention once a face for that family is loaded* |
| engine composite degraded to the quoting half | builder *reports an unusable value* **and 3 engine dtcg tests** |
| specimen renders only the first family | *draws each specimen in the family it names* |
| pending read drawn as an empty site | *is drawn as loading, NOT as a site with no fonts* |

The third is the one worth noting: it fails in **both** packages, which is what shows the shared predicate is load-bearing rather than decorative.

## Gates

Build 0 · engine 1628 tests · builder 87 files / 2476 tests · check-types 0 · builder lint `--max-warnings 0` 0 · engine lint 0 · root eslint 0 · comment convention 0 · fallow **pass**, all four `*_introduced` at 0 over 7 changed files · `changeset status` parses all 25 lockstep packages.

fallow first failed with `complexity_introduced: 2` — `FontsPanel` at CRAP 56.0 and `TokenRow` at 30.0, both `exceeded: "crap"`. Fixed by extraction (`FacesAbsent`, `FaceList`, `TokenNote`, and the wording rules moved to `font-library` beside their sibling `usageSummary`), never by suppression.

**Note on Integration:** this branch is cut from `c91ddbed4`, which is red on all three dialects — a positional `INSERT INTO "dc_pages_locales"` with four values against a companion that gained `_updated_at`. Another lane owns that fix. An Integration red here is inherited.
