### PR TITLE
fix(builder): observe the canvas for the rendered tag, not a dependency list

### DIFF
--- a/.changeset/the-inspector-watches-the-canvas.md
+++ b/.changeset/the-inspector-watches-the-canvas.md
@@ -1,0 +1,18 @@
+---
+"@nextlyhq/builder": patch
+---
+
+Report a heading's typographic baseline even when its block renders
+asynchronously.
+
+The style inspector reads which element a node is drawn as by looking at the
+canvas. That read was driven by a dependency list, and the DOM moves for reasons
+no prop captures: a block whose `render` returns a promise commits its Suspense
+fallback first and its resolved root later, changing neither the canvas element,
+nor the selection, nor the document. The read therefore ran only before the
+marked element existed, and an async block resolving to a heading reported its
+font size as unset for as long as it stayed selected.
+
+The reader observes the canvas subtree now, including the node-id attribute
+itself — a node's id moving between elements changes the answer without adding
+or removing any.

--- a/.changeset/the-inspector-watches-the-canvas.md
+++ b/.changeset/the-inspector-watches-the-canvas.md
@@ -1,5 +1,29 @@
 ---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
 "@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
 ---
 
 Report a heading's typographic baseline even when its block renders

--- a/packages/builder/src/use-rendered-tag.test.tsx
+++ b/packages/builder/src/use-rendered-tag.test.tsx
@@ -13,7 +13,7 @@
  *
  * @module __tests__/use-rendered-tag
  */
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -43,6 +43,49 @@ describe("reading the tag from a canvas", () => {
     // as a ref it would not be, and the hook would never look again.
     view.rerender(<Reader root={canvas} />);
     expect(screen.getByTestId("tag").textContent).toBe("h1");
+  });
+
+  it("answers when an ASYNC block resolves inside a canvas already mounted", async () => {
+    /*
+     * A block whose `render` returns a promise commits its Suspense fallback
+     * first and its resolved root later. Nothing in this hook's arguments
+     * changes across that: the canvas element is the same, the selection is the
+     * same, the document is the same. So a dependency-driven read runs only
+     * BEFORE the marked element exists, and an async block resolving to a
+     * heading reports its size as unset for as long as it stays selected.
+     */
+    const canvas = document.createElement("div");
+    // The state during suspense: the canvas is mounted and the node is not
+    // drawn yet.
+    canvas.innerHTML = "<div>loading</div>";
+
+    render(<Reader root={canvas} />);
+    expect(screen.getByTestId("tag").textContent).toBe("unknown");
+
+    // The block resolves. No prop changes — only the DOM.
+    canvas.innerHTML = '<h1 data-nx-node="n1">A title</h1>';
+    await waitFor(() =>
+      expect(screen.getByTestId("tag").textContent).toBe("h1")
+    );
+  });
+
+  it("follows a node id that MOVES to a different element", async () => {
+    // Structure alone is not the whole question: a re-render can put the same
+    // id on a different element without adding or removing one, and the answer
+    // changes. That is why the observer watches the attribute too.
+    const canvas = document.createElement("div");
+    canvas.innerHTML =
+      '<h1 data-nx-node="n1">A title</h1><p id="other">text</p>';
+
+    render(<Reader root={canvas} />);
+    expect(screen.getByTestId("tag").textContent).toBe("h1");
+
+    const heading = canvas.querySelector("h1");
+    heading?.removeAttribute("data-nx-node");
+    canvas.querySelector("#other")?.setAttribute("data-nx-node", "n1");
+    await waitFor(() =>
+      expect(screen.getByTestId("tag").textContent).toBe("p")
+    );
   });
 
   it("goes back to unknown when the canvas goes away", () => {

--- a/packages/builder/src/use-rendered-tag.ts
+++ b/packages/builder/src/use-rendered-tag.ts
@@ -11,28 +11,36 @@
  *
  * @module use-rendered-tag
  */
+import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import * as React from "react";
 
 import type { EditorState } from "./editor-state";
 import { renderedTagOf } from "./style-subject";
 
 /**
- * Takes the ELEMENT rather than a ref, which is what makes the dependency list
- * honest. A ref is not reactive: the canvas mounts only once styles have loaded
- * while the inspector stays mounted throughout, so an effect listing a ref reads
- * `null` on its first run and is never told otherwise — the tag would stay
- * unknown for the rest of the session, and a heading would report its size as
- * unset exactly as it did before any of this existed.
+ * OBSERVED rather than merely re-read on a dependency change, because the
+ * question is about the DOM and the DOM moves for reasons no prop captures.
  *
- * Read AFTER a commit rather than during a render.
+ * Three ways it moves, and only the first is a dependency:
  *
- * The canvas and the inspector re-render together, so while a render body runs
- * the DOM still holds the PREVIOUS tag — an author switching a heading from
- * `h2` to `h1` would get the answer for `h2` until something else re-rendered.
+ * A block's level changes, so an `h2` becomes an `h1` — that is `document`. The
+ * canvas mounts, which happens only once styles have loaded while the inspector
+ * stays mounted throughout — that is why this takes the ELEMENT and not a ref,
+ * since a ref is not reactive and an effect listing one would read `null` on its
+ * first run and never be told otherwise. And a block whose `render` returns a
+ * PROMISE commits its Suspense fallback first and its resolved root later,
+ * changing nothing at all in this list — the marked element does not exist when
+ * the effect runs, and an async block resolving to a heading would report its
+ * size as unset forever.
  *
- * `document` is a dependency because the tag is a function of the node's props:
- * changing a heading's level changes what it renders without changing which
- * node is selected.
+ * A `MutationObserver` answers all three, so the dependency list is a
+ * scheduling detail rather than a claim about correctness. It watches the
+ * subtree for structure and for the node-id attribute itself, since a node's id
+ * moving between elements changes the answer without adding or removing any.
+ *
+ * Read AFTER a commit rather than during a render: the canvas and the inspector
+ * re-render together, so while a render body runs the DOM still holds the
+ * previous tag.
  */
 export function useRenderedTag(
   canvasRoot: HTMLElement | null | undefined,
@@ -41,10 +49,29 @@ export function useRenderedTag(
 ): string | undefined {
   const [tag, setTag] = React.useState<string | undefined>(undefined);
   React.useEffect(() => {
-    const next = renderedTagOf(canvasRoot, selectedId);
-    // Compared before setting, or an effect that runs whenever the document
-    // changes and sets unconditionally re-renders on every edit.
-    setTag(current => (current === next ? current : next));
+    // Compared before setting, here and in the observer, or a canvas that
+    // mutates on every keystroke re-renders the inspector on every keystroke.
+    const read = () => {
+      const next = renderedTagOf(canvasRoot, selectedId);
+      setTag(current => (current === next ? current : next));
+    };
+    read();
+
+    if (canvasRoot == null) return;
+    // `MutationObserver` is absent in some non-browser DOMs, and this hook is
+    // useful without it — the read above still answers for everything that IS a
+    // dependency. Guarded rather than assumed, because throwing here would take
+    // the inspector down on a surface that renders perfectly well otherwise.
+    if (typeof MutationObserver !== "function") return;
+    const observer = new MutationObserver(read);
+    observer.observe(canvasRoot, {
+      childList: true,
+      subtree: true,
+      attributeFilter: [NODE_ID_ATTRIBUTE],
+    });
+    return () => {
+      observer.disconnect();
+    };
   }, [canvasRoot, selectedId, document]);
   return tag;
 }


### PR DESCRIPTION
Follow-up to #1325, which merged with one thread still open.

## What was wrong

A block whose `render` returns a promise commits its Suspense fallback first and its resolved root later, changing neither `canvasRoot`, nor `selectedId`, nor `document`. The effect that reads which element a node is drawn as therefore ran only *before* the marked element existed — so an async block resolving to a heading reported its typography as **unset** for as long as it stayed selected.

Found by Codex on #1325 after merge.

## Why the fix is a different instrument, not another patch

This is the **third** variant of one mistake:

| # | how the DOM moved | what I did at the time |
|---|---|---|
| 1 | read during a render, before the commit | moved the read into an effect |
| 2 | canvas mounts late; a ref is not reactive | published the root as a value |
| 3 | async block resolves; nothing in the list changes | — |

Each was patched where it appeared. Three occurrences is the signal that the dependency list was the wrong instrument rather than an incomplete one: the question is about the DOM, and the DOM moves for reasons no prop captures.

A `MutationObserver` answers all three at once. The dependency list becomes a scheduling detail rather than a claim about correctness.

## Details worth a reviewer's attention

**It watches the node-id attribute, not just structure.** A re-render can put the same id on a *different* element without adding or removing any, and the answer changes.

**`MutationObserver` is guarded, not assumed.** It is absent from some non-browser DOMs; the hook is still useful without it, and throwing here would take down an inspector on a surface that renders perfectly well otherwise.

**The comparison before `setTag` is load-bearing.** A canvas mutates on every keystroke, and setting unconditionally would re-render the inspector on every keystroke.

## Verification

Two cases, each break-verified against the implementation that merged:

- removing the observer → the async case fails
- watching structure without the attribute → the moving-id case fails

builder: 2461 tests pass. Lint, typecheck, comment convention clean. `fallow audit --base origin/main` → **pass**, zero introduced across dead code, complexity, duplication and styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved rendered tag detection after asynchronous content finishes loading.
  - Updated tag tracking when elements move or change within the canvas.
  - Added support for detecting tag-level changes that occur without other input changes.
  - Prevented unnecessary updates when the rendered tag remains unchanged.

- **Tests**
  - Added coverage for asynchronous rendering and node movement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->