### PR TITLE
docs(nextly): narrow three claims to what the code actually does

### DIFF
--- a/.changeset/a-translation-says-when-its-source-moved.md
+++ b/.changeset/a-translation-says-when-its-source-moved.md
@@ -29,8 +29,12 @@
 Record when each language of a document was last written, so a later change can
 tell a finished translation from one whose source has moved on since.
 
-This release is the groundwork only: the timestamp is recorded on every write,
-for every kind of localized content, and nothing surfaces it yet.
+This release is the groundwork only: a language's timestamp moves when that
+language's CONTENT is written, for every kind of localized content, and nothing
+surfaces it yet. Publishing or unpublishing a language changes no words, so it
+leaves the timestamp alone -- otherwise a lifecycle change on the source
+language would report every translation as needing review on an edit nobody
+made.
 
 Collections that already exist are seeded from their version history, so their
 languages carry a timestamp from the moment this lands. Singles are not seeded,

--- a/packages/admin/src/types/translations/worklist.ts
+++ b/packages/admin/src/types/translations/worklist.ts
@@ -90,8 +90,7 @@ export const WORKLIST_STATES: readonly {
   // `worklistStateFrom` resolves only what this array offers, so a saved link naming `stale`
   // falls back to the question this page leads with. A page filtered by a state whose tab is not
   // shown would highlight nothing while listing a subset the reader cannot account for, which is
-  // worse than answering a different question visibly. Offering the tab is an edit to this array
-  // and nothing else.
+  // worse than answering a different question visibly.
 ];
 
 /**

--- a/packages/nextly/src/domains/i18n/runtime/companion-copy.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-copy.ts
@@ -279,9 +279,8 @@ export async function copyDefaultLocaleOntoMain(
  * The column is deliberately not declared on the companion's own Drizzle table — see
  * `readCompanionStamps` for why — so this drives a narrow handle built for the three columns it
  * needs, `buildCompanionStampTable`, rather than the companion's table. `.set()` can then name
- * the column, and the value is encoded by the same dialect mapping every other Drizzle write
- * uses; a hand-built statement would bind a `Date` straight to the driver and write the local
- * wall clock into a column that records no zone.
+ * the column while product database access stays on Drizzle, and the guard below is composed as
+ * a real condition instead of being concatenated into a statement.
  *
  * A companion that predates the column is not an error here: it simply has no stamp to clear, and
  * every locale on it already reads as UNKNOWN. Recognising that case takes a predicate that walks


### PR DESCRIPTION
Re-lands the last commit of #1341, which the merge outran. #1341 merged at `fe8e8f566`; `9cb4af5de` was still failing the pre-push gate on unrelated wall-clock timeouts and never reached the remote, so `main` carries three claims that are wider than the code and that #1341's own review threads say are fixed.

Verified by content rather than by merge state:

    main ef5921626 carries      the wire-contract docblock                   ✓
    main does NOT carry         the Date-rationale removal (companion-copy)  ✗
                                the "and nothing else" removal (worklist)    ✗
                                the "on every write" narrowing (changeset)   ✗

### The three

**`clearLocaleStamp` claimed a failure mode it cannot have.** The comment argued that a hand-built statement would bind a `Date` and write the local wall clock into a column that records no zone. That function assigns exactly one value:

```ts
.set({ [COMPANION_UPDATED_AT_COLUMN]: null })
```

No `Date` is bound, and `SET _updated_at = NULL` has no encoding to get wrong. The argument is real but belongs to `companionContentStamp`, where it already lives and where it IS load-bearing. The site now states what is true of it: the narrow handle keeps product database access on Drizzle when the column is deliberately absent from the companion's own table, and it lets the claim guard be composed as a condition rather than concatenated into a statement — which matters, because that guard is what stops a superseded worker clearing the stamp on every row of the SOURCE locale.

**The tab list said enabling the stale tab was "an edit to this array and nothing else."** It is not. The server still omits the physical-column capability the filter depends on, so a tab added alone would query an endpoint that answers `1=0` and render exactly the always-empty tab the comment two lines above argues against. Removed rather than rewritten: what enabling it takes is not this array's to describe, and spelling it out here would be the future-work narration an earlier finding on #1332 correctly objected to.

**The changeset said the timestamp is "recorded on every write."** Two mechanisms make that false:

```
companionContentStamp:  writesContent = keys.some(c => !COMPANION_STRUCTURAL_COLUMNS.has(c))
                        if (!writesContent) return {};
upsertCompanionRow:     if (Object.keys(withStatus).length === 0) return;
```

A status-only transition is not stamped and an empty update is not performed. The note now says a language's timestamp moves when that language's CONTENT is written, and states the exclusion positively: publishing or unpublishing changes no words, so it leaves the timestamp alone — otherwise a lifecycle change on the source language would report every translation as needing review on an edit nobody made.

### Verification

    cd packages/admin  && pnpm run check-types    -> 0        lint -> 0
    cd packages/nextly && pnpm run check-types    -> 0        lint -> 0
    node scripts/check-comment-convention.mjs     -> 0
    pnpm exec changeset status                    -> 0
    pre-push gate: admin 327/327 + 3124/3124, nextly 790/790 + 9792 passed | 42 skipped

No changeset of its own: this edits an existing one and changes no behaviour. The 25-package lockstep frontmatter is unchanged.
