### PR TITLE
feat(builder): show the interaction state the style panel is editing

### DIFF
--- a/.changeset/the-canvas-shows-the-state-being-edited.md
+++ b/.changeset/the-canvas-shows-the-state-being-edited.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Let the canvas show the interaction state the style panel is editing.
+
+A page cannot force a pseudo-class on itself, so an author switching the panel
+to hover was editing an appearance nothing could show them. A preview sheet now
+gives each state a class alternative beside its pseudo-class, and the canvas
+puts that class on the selected block — so hover, focus and active look on the
+canvas the way they will look to a visitor.
+
+The alternative, measuring which pseudo-classes actually match, was declined:
+the pointer is in the inspector whenever anyone is reading the panel, so a
+measured `:hover` is false every time and every hover control would report
+unset permanently.
+
+The marker sits inside the `:where()` that already wrapped each pseudo-class, so
+it carries no specificity and a previewed rule weighs exactly what the published
+one weighs. Published sheets do not ask for it and are unchanged.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -493,7 +493,11 @@ export type { BreakpointAxis } from "./style/breakpoint-axes";
 // two apart whenever they compile differently, and this is the set that decides
 // how much "enough" is.
 export { EMITTABLE_STRING_BOUNDS } from "./style/emittable-string-bounds";
-export { MAX_SCOPE_LENGTH } from "./style/compile-page";
+// `previewStateClass` is published because it is a CONTRACT between the
+// compiler and a previewing surface: the compiler writes it into a selector
+// and the surface puts it on an element. A name spelled in two places can be
+// spelled differently, which is why `NODE_ID_ATTRIBUTE` is published too.
+export { MAX_SCOPE_LENGTH, previewStateClass } from "./style/compile-page";
 export type { EmittableStringBound } from "./style/emittable-string-bounds";
 export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
 export type { StyleQuery, StyleSubject } from "./style/style-origin";

--- a/packages/blocks-engine/src/style/compile-page.test.ts
+++ b/packages/blocks-engine/src/style/compile-page.test.ts
@@ -14,6 +14,7 @@ import {
   compilePageCss,
   MAX_SCANNED_KEYS,
   MAX_SCOPE_LENGTH,
+  previewStateClass,
 } from "./compile-page";
 import type { StyleCompileContext } from "./compile-page";
 import {
@@ -1833,5 +1834,108 @@ describe("element defaults", () => {
     expect(nodeRule).toContain("5rem");
     // Both present, and the node's selector is the heavier one.
     expect(nodeRule?.startsWith(PAGE_ROOT_SELECTOR)).toBe(true);
+  });
+});
+
+describe("previewing an interaction state", () => {
+  /** Every tier that can style the previewed element, in one document. */
+  function everyTier(previewStates: boolean): string {
+    const document = doc(
+      [
+        {
+          id: "n1",
+          type: "core/box",
+          version: 1,
+          props: {},
+          classes: ["c1"],
+          styles: { hover: { base: { color: "#000001" } } },
+        } as unknown as BlockNode,
+      ],
+      { styles: { hover: { base: { color: "#000005" } } } }
+    );
+    return css(document, {
+      ...CTX,
+      ...(previewStates ? { previewStates: true } : {}),
+      namedClasses: [
+        {
+          id: "c1",
+          slug: "card",
+          orderIndex: 0,
+          styles: { hover: { base: { color: "#000002" } } },
+        },
+      ],
+      blockBases: { "core/box": { hover: { base: { color: "#000003" } } } },
+      elementBases: { h1: { hover: { base: { color: "#000004" } } } },
+    } as unknown as StyleCompileContext);
+  }
+
+  it("is OFF unless a caller asks, so a published page carries no marker", () => {
+    // The default matters more than the feature: a visitor's browser decides
+    // its own `:hover`, and a class nothing will ever set is bytes on every
+    // page for nobody.
+    const out = everyTier(false);
+    expect(out).toContain(":where(:hover)");
+    expect(out).not.toContain("nx-pb-state-hover");
+  });
+
+  it("gives EVERY tier the forceable form, not just the node's own", () => {
+    // A forced state has to reach every rule that can match the element. A tier
+    // left behind shows half the appearance the author is editing — and the
+    // half that is missing is whichever one they did not set directly.
+    const out = everyTier(true);
+    const forced = out
+      .split("\n")
+      .filter(line => line.includes(`.${previewStateClass("hover")}`));
+    // Five tiers wrote a hover rule, so five must carry the marker. Asserting
+    // "contains the class" would pass with one.
+    expect(forced).toHaveLength(5);
+    // One distinguishable value per tier. Sentinels like `#node` read better
+    // and are not colours — the compiler drops an invalid value and emits
+    // nothing, so the whole fixture compiled to an empty sheet and every
+    // assertion over it was vacuous.
+    for (const value of [
+      "#000001",
+      "#000002",
+      "#000003",
+      "#000004",
+      "#000005",
+    ]) {
+      expect(
+        forced.some(rule => rule.includes(value)),
+        `no forced rule carried ${value}`
+      ).toBe(true);
+    }
+  });
+
+  it("joins the marker INSIDE the wrapper, so it adds no weight", () => {
+    /*
+     * The whole reason this is safe. `:where()` contributes nothing whatever it
+     * holds, so a previewed rule weighs exactly what the published one weighs.
+     * Measured in a browser: with the marker inside, a later equal-weight rule
+     * still won; moved outside, the earlier rule won because the class had
+     * added a class of its own.
+     *
+     * It matters because the style panel's provenance explains what a VISITOR
+     * gets. A preview that ranked its rules differently would describe an order
+     * nobody is served, in the one state the author opened the panel to see.
+     */
+    const out = everyTier(true);
+    for (const rule of out.split("\n")) {
+      if (!rule.includes(`.${previewStateClass("hover")}`)) continue;
+      // The marker never appears outside a `:where(...)` group.
+      const outside = rule
+        .replace(/:where\([^)]*\)/g, "")
+        .includes(previewStateClass("hover"));
+      expect(outside, `marker escaped its wrapper in: ${rule}`).toBe(false);
+    }
+  });
+
+  it("leaves `base` alone, which is not a state anything forces", () => {
+    const out = css(doc([node("n1", { base: { base: { color: "#111" } } })]), {
+      ...CTX,
+      previewStates: true,
+    } as unknown as StyleCompileContext);
+    expect(out).toContain(`${PAGE_ROOT_SELECTOR} .${nodeClassName("n1")} {`);
+    expect(out).not.toContain("nx-pb-state-base");
   });
 });

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -90,6 +90,25 @@ export interface StyleCompileContext {
    */
   previewContainer?: string;
   /**
+   * Emit each interaction state so a previewing surface can FORCE one on an
+   * element, by putting {@link previewStateClass} on it.
+   *
+   * For an editor, and off by default. A published page has no reason to carry
+   * a class nothing will ever set, and a visitor's browser decides its own
+   * `:hover`.
+   *
+   * SEPARATE from `previewContainer` although both describe a preview, because
+   * that one is only set when the site defines breakpoints — a site with none
+   * would silently get no state preview if this rode on it. Two surfaces can
+   * want one without the other.
+   *
+   * Costs nothing in weight: the marker joins the pseudo-class INSIDE the
+   * existing `:where()`, which contributes nothing whatever it holds. That is
+   * what lets the preview cascade match the published one exactly, which the
+   * style panel's provenance depends on — it explains what a VISITOR gets.
+   */
+  previewStates?: boolean;
+  /**
    * Which hosts this site will fetch from.
    *
    * A stylesheet is a fetching surface: `background-image: url(...)` makes the
@@ -368,6 +387,51 @@ const STATE_SELECTORS: Readonly<Record<StyleState, string>> = {
   hover: ":where(:hover)",
   focus: ":where(:focus-visible)",
   active: ":where(:active)",
+};
+
+/**
+ * The class a previewing surface puts on ONE element to force an interaction
+ * state on it.
+ *
+ * A page cannot force a pseudo-class on itself. There is no CSS or DOM way to
+ * make an element match `:hover` without a pointer — `Emulation.forcePseudoState`
+ * is a devtools protocol, not something a page can reach. So an editor that
+ * lets an author edit a hover appearance has to be given something it CAN
+ * toggle, and this is it.
+ *
+ * Named by the engine rather than by the editor because it is a contract
+ * between the two: the compiler writes it into a selector and the surface puts
+ * it on an element, and a name spelled in two places can be spelled
+ * differently. The same reason `NODE_ID_ATTRIBUTE` is published.
+ */
+export function previewStateClass(state: StyleState): string {
+  return `nx-pb-state-${state}`;
+}
+
+/**
+ * The state selectors a PREVIEW sheet uses, with the marker joined to the
+ * pseudo-class inside the existing wrapper.
+ *
+ * INSIDE `:where()`, which is the whole reason this is safe. `:where()`
+ * contributes nothing whatever it holds, so a previewed rule weighs exactly
+ * what the published one weighs and the preview cascade cannot differ from the
+ * cascade a visitor gets. Measured in a browser against the alternative: with
+ * the marker inside, a later equal-weight rule still won; moved outside, the
+ * earlier rule won because the class had added weight of its own.
+ *
+ * That equality is a requirement rather than a nicety. The style panel's
+ * provenance explains what the PUBLISHED page does, so a preview that ranked
+ * its rules differently would describe an order no visitor ever sees — in the
+ * one state the author opened the panel to inspect.
+ *
+ * `base` has no marker: it is not a state anything forces, it is what applies
+ * when nothing else does.
+ */
+const PREVIEW_STATE_SELECTORS: Readonly<Record<StyleState, string>> = {
+  base: "",
+  hover: `:where(:hover, .${previewStateClass("hover")})`,
+  focus: `:where(:focus-visible, .${previewStateClass("focus")})`,
+  active: `:where(:active, .${previewStateClass("active")})`,
 };
 
 /** One breakpoint to emit under, with the at-rule it needs. */
@@ -1124,6 +1188,8 @@ interface EnvelopeContext {
    * same elements are styled either way.
    */
   weightlessAnchor?: string;
+  /** Emit the forceable form of each interaction state. See the context field. */
+  previewStates?: boolean;
 }
 
 /** Compile one styles envelope into rules under one selector. */
@@ -1147,7 +1213,12 @@ function envelopeRules(
    */
   about: EnvelopeContext
 ): CssRule[] {
-  const { origin, trace, mayFetchUrl, weightlessAnchor } = about;
+  const { origin, trace, mayFetchUrl, weightlessAnchor, previewStates } = about;
+  // Chosen ONCE per envelope rather than per rule: it is a property of the
+  // compile, and re-deciding it inside the loop invites the two forms to
+  // disagree between a node's base rule and its hover one.
+  const stateSelectors =
+    previewStates === true ? PREVIEW_STATE_SELECTORS : STATE_SELECTORS;
   if (styles === undefined) return [];
   // A stored envelope that is not an object — `[]`, a string, `null` — styles
   // nothing, and this compiler reads persisted data whether or not a caller
@@ -1239,8 +1310,8 @@ function envelopeRules(
           // the only part that weighs.
           selector:
             weightlessAnchor === undefined
-              ? `${selector}${STATE_SELECTORS[state]}${rule.descendant}`
-              : `${weightlessAnchor} :where(${selector}${STATE_SELECTORS[state]}${rule.descendant})`,
+              ? `${selector}${stateSelectors[state]}${rule.descendant}`
+              : `${weightlessAnchor} :where(${selector}${stateSelectors[state]}${rule.descendant})`,
           declarations: rule.declarations,
         });
         // Recorded here, from the same declarations that were just emitted, in the same loop.
@@ -1603,6 +1674,11 @@ export function compilePageCss(
   const tokenPrefix = ctx.tokenPrefix ?? DEFAULT_TOKEN_PREFIX;
   const mayFetchUrl = ctx.mayFetchUrl;
   const scope = scopeSelector(ctx.scope, warnings);
+  // Read ONCE for the whole compile and handed to every tier. Every rule that
+  // can match the previewed element has to honour the forced state — a node's
+  // own hover, a class's, a block type's, the page's — so a tier that missed it
+  // would show half the appearance the author is editing.
+  const previewStates = ctx.previewStates === true;
   // What was WRITTEN, which is not always what was asked for: a scope this
   // compiler refuses is dropped and the sheet compiled global, and a caller that
   // recorded the request would store an artifact claiming an isolation its own
@@ -1677,7 +1753,7 @@ export function compilePageCss(
       warnings,
       budget,
       warningAllowance,
-      { origin: { kind: "page" }, trace, mayFetchUrl }
+      { origin: { kind: "page" }, trace, mayFetchUrl, previewStates }
     )
   );
 
@@ -1702,6 +1778,7 @@ export function compilePageCss(
         warningAllowance,
         {
           origin: { kind: "element", tag },
+          previewStates,
           trace,
           mayFetchUrl,
           weightlessAnchor: defaultsAnchor,
@@ -1754,6 +1831,7 @@ export function compilePageCss(
         warningAllowance,
         {
           origin: { kind: "blockType", type },
+          previewStates,
           trace,
           mayFetchUrl,
           weightlessAnchor: defaultsAnchor,
@@ -1903,6 +1981,7 @@ export function compilePageCss(
         warningAllowance,
         {
           origin: { kind: "class", id: cls.id, slug: cls.slug },
+          previewStates,
           trace,
           mayFetchUrl,
         }
@@ -1943,7 +2022,12 @@ export function compilePageCss(
         warnings,
         budget,
         warningAllowance,
-        { origin: { kind: "node", id: node.id }, trace, mayFetchUrl }
+        {
+          origin: { kind: "node", id: node.id },
+          trace,
+          mayFetchUrl,
+          previewStates,
+        }
       ),
       ...visibilityRules(
         node,

--- a/packages/blocks-engine/src/style/site-sheet.test.ts
+++ b/packages/blocks-engine/src/style/site-sheet.test.ts
@@ -13,6 +13,7 @@ import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
 
 import { compilePageCss } from "./compile-page";
 import type { NamedClass } from "./named-class";
+import { previewStateClass } from "./compile-page";
 import { compileSiteSheet } from "./site-sheet";
 
 const styles = (values: Record<string, unknown>): NodeStyles =>
@@ -323,5 +324,50 @@ describe("the site sheet's host-fetch policy", () => {
     const open = sheet({ classes: [tracking] });
     const closed = sheet({ classes: [tracking], mayFetchUrl: () => false });
     expect(closed.contentHash).not.toBe(open.contentHash);
+  });
+});
+
+describe("forceable interaction states", () => {
+  /** A class and a block default that each style a hover appearance. */
+  const hovering = {
+    classes: [
+      {
+        id: "c1",
+        slug: "card",
+        orderIndex: 0,
+        styles: { hover: { base: { color: "#000001" } } },
+      },
+    ],
+    blockBases: { "core/box": { hover: { base: { color: "#000002" } } } },
+  };
+
+  it("carries the marker into the SITE tiers when the caller asks", () => {
+    /*
+     * The tiers split across two sheets and the option must not. A named class
+     * and a block-type default are compiled HERE, not with the page — so an
+     * editor that asked only the page compile for forceable states gets a
+     * selected block whose hover appearance comes from a class showing nothing
+     * at all, which is the half of the feature nobody would notice missing
+     * until an author styled a block through a class.
+     */
+    const out = sheet({ ...hovering, previewStates: true }).css;
+
+    const forced = out
+      .split("\n")
+      .filter(line => line.includes(previewStateClass("hover")));
+    // Both tiers, asserted by their values: a filter that found one would
+    // satisfy "contains the marker" while half the sheet stayed pseudo-only.
+    expect(forced.some(rule => rule.includes("#000001"))).toBe(true);
+    expect(forced.some(rule => rule.includes("#000002"))).toBe(true);
+  });
+
+  it("carries none of it into a published sheet", () => {
+    // The default, which is what every route compiles: a visitor's browser
+    // decides its own `:hover`, and a class nothing will ever set is bytes on
+    // every page for nobody.
+    const out = sheet(hovering).css;
+
+    expect(out).toContain(":where(:hover)");
+    expect(out).not.toContain(previewStateClass("hover"));
   });
 });

--- a/packages/blocks-engine/src/style/site-sheet.ts
+++ b/packages/blocks-engine/src/style/site-sheet.ts
@@ -67,6 +67,16 @@ export interface SiteSheetInput {
    * tier does. See {@link BreakpointContextOptions.previewContainer}.
    */
   previewContainer?: string;
+  /**
+   * Emit each interaction state so a previewing surface can force one.
+   *
+   * Carried through for the same reason `previewContainer` is: a named class
+   * and a block-type default are compiled HERE, not with the page, so an editor
+   * that asked the page compile for forceable states and not this one gets a
+   * selected block whose hover appearance comes from a class showing nothing at
+   * all. The tiers split across two sheets; the option must not.
+   */
+  previewStates?: boolean;
 }
 
 /** The shared sheet and the name it is addressed by. */
@@ -177,6 +187,7 @@ export function compileSiteSheet(input: SiteSheetInput): SiteSheetArtifact {
     ...(input.previewContainer === undefined
       ? {}
       : { previewContainer: input.previewContainer }),
+    ...(input.previewStates === true ? { previewStates: true } : {}),
   });
   warnings.push(...tiers.warnings);
   if (tiers.css !== "") blocks.push(tiers.css);

--- a/packages/blocks-react/src/page-renderer.test.tsx
+++ b/packages/blocks-react/src/page-renderer.test.tsx
@@ -5963,6 +5963,7 @@ describe("a stated NULL among the reconciled inputs", () => {
       blockBases: null,
       tokenPrefix: null,
       previewContainer: null,
+      previewStates: null,
     });
 
     /*
@@ -5975,6 +5976,7 @@ describe("a stated NULL among the reconciled inputs", () => {
       "blockBases",
       "namedClasses",
       "previewContainer",
+      "previewStates",
       "tokenPrefix",
     ]);
     expect(Object.values(stripped).every(v => v === undefined)).toBe(true);

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -201,6 +201,7 @@ interface SiteInputRoles {
   blockBases: "reconciled-here";
   tokenPrefix: "reconciled-here";
   previewContainer: "reconciled-here";
+  previewStates: "reconciled-here";
   mayFetchUrl: "reconciled-elsewhere";
   fonts: "sheet-only";
   tokens: "sheet-only";
@@ -317,6 +318,7 @@ export function withoutStatedNulls(
     blockBases: shared.blockBases ?? undefined,
     tokenPrefix: shared.tokenPrefix ?? undefined,
     previewContainer: shared.previewContainer ?? undefined,
+    previewStates: shared.previewStates ?? undefined,
   };
 }
 
@@ -399,6 +401,11 @@ export function sharedStyleInputs(
       route.previewContainer,
       stored.previewContainer
     ),
+    // The same precedence, for the same reason: whether this surface is
+    // previewing an interaction state is a fact about THIS render, while a
+    // stored tier describes the site. A site record has no business turning
+    // forceable states on for a published page.
+    previewStates: firstStated(route.previewStates, stored.previewStates),
   });
 }
 
@@ -793,6 +800,11 @@ export function PageRenderer({
           // context above was given. A shared tier compiled for the published
           // page beneath node styles compiled for a preview surface puts two
           // answers to one breakpoint in one document.
+          // Carried into the SITE sheet as well as the page compile. A named
+          // class and a block-type default are emitted here, so an editor that
+          // asked only the page compile for forceable states gets a selected
+          // block whose hover appearance comes from a class showing nothing.
+          ...(shared.previewStates === true ? { previewStates: true } : {}),
           ...(shared.previewContainer == null
             ? {}
             : { previewContainer: shared.previewContainer }),

--- a/packages/blocks-react/src/shared-style-inputs.test.ts
+++ b/packages/blocks-react/src/shared-style-inputs.test.ts
@@ -141,6 +141,41 @@ describe("the stamp", () => {
       );
     });
 
+    it("the state-preview option, which changes every state selector", () => {
+      /*
+       * A preview sheet gives each interaction state a forceable form, so its
+       * selectors are not the published ones. Sharing a stamp would let
+       * `resolvePageStyles` — exported, and returning a storable `PageStyles` —
+       * hand back preview CSS stamped as published, and a live page would be
+       * served rules carrying a class nothing on it will ever set.
+       */
+      expect(sharedStyleInputsId(inputs({ previewStates: true }))).not.toBe(
+        sharedStyleInputsId(inputs())
+      );
+    });
+
+    it("adds NOTHING to the label of a page that never asked", () => {
+      /*
+       * The reason the option is spread into the label rather than given a
+       * slot: a fixed slot changes the array's SHAPE for every caller,
+       * invalidating every artifact already stored on the site to record a
+       * field that is unset on all of them.
+       *
+       * Asserted on the shape, not by comparing two current labels. Both sides
+       * of such a comparison carry whatever shape the code has, so it agrees
+       * with a fixed slot as readily as with a spread — measured: it did, and
+       * the break passed.
+       */
+      const absent = JSON.parse(sharedStyleInputsLabel(inputs())) as unknown[];
+      const asked = JSON.parse(
+        sharedStyleInputsLabel(inputs({ previewStates: true }))
+      ) as unknown[];
+
+      expect(asked).toHaveLength(absent.length + 1);
+      expect(asked.at(-1)).toBe("preview-states");
+      expect(absent).not.toContain("preview-states");
+    });
+
     it("the token prefix", () => {
       // Renders into every `var(--<prefix><name>)` the sheet references.
       expect(sharedStyleInputsId(inputs({ tokenPrefix: "--acme-" }))).not.toBe(

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -91,6 +91,17 @@ export type SharedStyleInputs = Pick<
   // baseline at all, and is refused rather than served.
   | "elementBases"
   | "previewContainer"
+  // A preview sheet's selectors DIFFER from a published sheet's — each
+  // interaction state gains a forceable form — so the two cannot share a
+  // stored artifact. Present here for the same reason `previewContainer` is:
+  // an artifact compiled one way and served the other is wrong in a way
+  // nothing downstream can detect.
+  //
+  // No `ENCODING` bump goes with it. The field is optional and absent means
+  // exactly what it meant before, so every artifact already stored stays valid
+  // for the contexts that produced it; only a caller that turns it ON computes
+  // a different identity, which is the point.
+  | "previewStates"
 >;
 
 /**
@@ -601,6 +612,18 @@ function labelFor(inputs: SharedStyleInputs, reading: Reading): string {
     // to different stylesheets, and a stamp that cannot see the difference
     // hands the first one's sheet to the second.
     blockBaseParts(inputs.elementBases, reading),
+    // A preview sheet gives every interaction state a forceable form, so its
+    // selectors are not the published ones and the two must not share a stored
+    // artifact. Without this, `resolvePageStyles` — exported, and returning a
+    // storable `PageStyles` — hands back preview CSS stamped as published, and
+    // a live page is served rules carrying a class nothing on it will ever set.
+    //
+    // SPREAD rather than appended as a slot, which is the same care
+    // `previewContainer` takes one element up: absent, this array's shape is
+    // exactly what it was, so every artifact already stored keeps its stamp.
+    // A fixed slot would have invalidated every page on the site to record a
+    // field that is unset on all of them.
+    ...(inputs.previewStates === true ? ["preview-states"] : []),
   ]);
 }
 

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -2069,6 +2069,38 @@ describe("forcing the interaction state the panel is editing", () => {
     );
   });
 
+  it("marks the CANVAS ROOT too, so page-level rules match", () => {
+    /*
+     * `:hover` matches an element and every ANCESTOR of it — measured in a
+     * browser, a pointer over a leaf puts the leaf, its parent and the root all
+     * in the chain. The page tier compiles onto the canvas root
+     * (`.nx-pb-page.nx-pb-page:where(:hover, …)`), and a marker on a descendant
+     * cannot make its ancestor match.
+     *
+     * So a preview that marked only the selected node would drop exactly the
+     * tiers a real pointer triggers: a page-level hover colour would vanish in
+     * the simulation and appear for the visitor — the preview disagreeing with
+     * the page in the one state the author opened the panel to inspect.
+     */
+    const view = renderCanvas("a", "hover");
+    const root = view.container.querySelector(`.${CANVAS_ROOT_CLASS}`);
+    expect(root).not.toBeNull();
+    expect((root as Element).className).toContain(previewStateClass("hover"));
+  });
+
+  it("leaves the canvas root unmarked when nothing is being forced", () => {
+    // The control: a root marked unconditionally would put every page-level
+    // hover rule on screen permanently, which is worse than not previewing at
+    // all — the author would be reading an appearance no visitor ever sees.
+    const view = renderCanvas("a");
+    const root = view.container.querySelector(`.${CANVAS_ROOT_CLASS}`);
+    for (const state of STYLE_STATES) {
+      expect((root as Element).className).not.toContain(
+        previewStateClass(state)
+      );
+    }
+  });
+
   it("clears the previous state when the panel moves to another one", () => {
     // hover -> focus. A marker left behind would have the canvas showing two
     // states at once, and the author would be reading an appearance that

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -35,7 +35,13 @@ import {
 import * as React from "react";
 import { createElement } from "react";
 
-import { clearBlocks, registerBlocks } from "@nextlyhq/blocks-engine";
+import {
+  clearBlocks,
+  previewStateClass,
+  registerBlocks,
+  STYLE_STATES,
+  type StyleState,
+} from "@nextlyhq/blocks-engine";
 
 import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 
@@ -2007,5 +2013,169 @@ describe("reporting the scale to a host that keeps changing its mind", () => {
     );
 
     expect(reports).toEqual([1.5, 0.75]);
+  });
+});
+
+describe("forcing the interaction state the panel is editing", () => {
+  beforeAll(() => {
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/leaf",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+      ] as never,
+      { source: "canvas-state-test" }
+    );
+  });
+  afterAll(clearBlocks);
+
+  function renderCanvas(selectedId: string | null, forcedState?: StyleState) {
+    return render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              { id: "a", type: "acme/leaf", version: 1, props: {} },
+              { id: "b", type: "acme/leaf", version: 1, props: {} },
+            ],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId={selectedId}
+        {...(forcedState === undefined ? {} : { forcedState })}
+      />
+    );
+  }
+
+  const elementFor = (id: string) =>
+    document.querySelector(`[${NODE_ID_ATTRIBUTE}="${id}"]`);
+
+  it("marks the PRIMARY selection and nothing else", () => {
+    // Forcing it page-wide would show every other block in a state nobody
+    // asked about, so the second node is the separating half of this case.
+    renderCanvas("a", "hover");
+
+    expect(elementFor("a")?.className).toContain(previewStateClass("hover"));
+    expect(elementFor("b")?.className).not.toContain(
+      previewStateClass("hover")
+    );
+  });
+
+  it("clears the previous state when the panel moves to another one", () => {
+    // hover -> focus. A marker left behind would have the canvas showing two
+    // states at once, and the author would be reading an appearance that
+    // cannot occur.
+    const view = renderCanvas("a", "hover");
+    expect(elementFor("a")?.className).toContain(previewStateClass("hover"));
+
+    view.rerender(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              { id: "a", type: "acme/leaf", version: 1, props: {} },
+              { id: "b", type: "acme/leaf", version: 1, props: {} },
+            ],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId="a"
+        forcedState="focus"
+      />
+    );
+
+    expect(elementFor("a")?.className).toContain(previewStateClass("focus"));
+    expect(elementFor("a")?.className).not.toContain(
+      previewStateClass("hover")
+    );
+  });
+
+  it("does not touch the class of an element whose marking is unchanged", () => {
+    /*
+     * `classList.remove` of a token that is NOT present still touches the
+     * attribute, and this canvas is observed: the empty-container appender
+     * watches the subtree for layout-relevant mutations and re-measures on one.
+     * An unconditional clear across every marked element made a selection
+     * change schedule a re-measure of the whole overlay — caught by that
+     * appender's own case, which asserts its control does not move for a
+     * mutation of its own output, and it moved.
+     *
+     * The WRITE is what this observes, because the write is the defect. Two
+     * earlier versions of this case watched for mutation records instead — one
+     * on the primary alone, one on the whole subtree — and both passed the
+     * break: the records never reached them, so each reported a guard it did
+     * not have.
+     *
+     * `c` is the separating node: never selected, so its marking does not
+     * change when the selection moves from `a` to `b`, and nothing should be
+     * written to it at all.
+     */
+    const nodes = ["a", "b", "c"].map(id => ({
+      id,
+      type: "acme/leaf",
+      version: 1,
+      props: {},
+    }));
+    const canvas = (selectedId: string) => (
+      <Canvas
+        document={{ formatVersion: 1, kind: "page", nodes } as never}
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId={selectedId}
+        forcedState="hover"
+      />
+    );
+
+    const view = render(canvas("a"));
+    const bystander = elementFor("c");
+    expect(bystander).not.toBeNull();
+    const remove = vi.spyOn((bystander as Element).classList, "remove");
+    const add = vi.spyOn((bystander as Element).classList, "add");
+
+    act(() => {
+      view.rerender(canvas("b"));
+    });
+
+    expect(remove).not.toHaveBeenCalled();
+    expect(add).not.toHaveBeenCalled();
+
+    // The other half: an element that KEEPS its marker must not have it
+    // written again. `c` cannot show this — it never wants one — so the
+    // now-selected `b` carries the case.
+    const kept = elementFor("b");
+    const keptAdd = vi.spyOn((kept as Element).classList, "add");
+    act(() => {
+      view.rerender(canvas("b"));
+    });
+    expect(keptAdd).not.toHaveBeenCalled();
+  });
+
+  it("forces nothing for `base`, or when the host states no state", () => {
+    // `base` is what applies when no state does, and the compiler emits no
+    // marker for it — so a canvas that marked it would be putting on a class
+    // no selector contains.
+    renderCanvas("a", "base");
+    for (const state of STYLE_STATES) {
+      expect(elementFor("a")?.className).not.toContain(
+        previewStateClass(state)
+      );
+    }
+    cleanup();
+
+    renderCanvas("a");
+    for (const state of STYLE_STATES) {
+      expect(elementFor("a")?.className).not.toContain(
+        previewStateClass(state)
+      );
+    }
   });
 });

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -31,8 +31,11 @@
 
 import {
   previewContainerName,
+  previewStateClass,
+  STYLE_STATES,
   type BlockDocument,
   type BreakpointSet,
+  type StyleState,
 } from "@nextlyhq/blocks-engine";
 import {
   NODE_ID_ATTRIBUTE,
@@ -661,7 +664,8 @@ function useSelectionMarkers(
   box: React.RefObject<HTMLElement | null>,
   marked: readonly string[],
   selectedId: string | null,
-  page: React.ReactNode
+  page: React.ReactNode,
+  forcedState: StyleState | undefined
 ): void {
   useEffect(() => {
     const container = box.current;
@@ -683,7 +687,52 @@ function useSelectionMarkers(
         id === selectedId ? "primary" : ""
       );
     });
-  }, [box, selectedId, marked, page]);
+
+    /*
+     * The forced interaction state, in the SAME walk rather than a second one.
+     * Both answer "what is marked on this element right now", and two walks
+     * over one question drift — one runs on a change the other does not.
+     *
+     * On the PRIMARY alone. A page cannot force a pseudo-class on itself, so
+     * the compiler emits a class alternative beside each one and this puts it
+     * on the element the panel is editing. Forcing it page-wide would show
+     * every other block in a state nobody asked about.
+     *
+     * Cleared from everything first, including the primary: a state that
+     * changes from hover to focus, or a selection that moves, must not leave
+     * the previous class behind on an element nothing is editing.
+     */
+    container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+      const id = element.getAttribute(NODE_ID_ATTRIBUTE);
+      // `base` is not a state anything forces: it is what applies when nothing
+      // else does, and the compiler emits no marker for it.
+      const wanted =
+        id === selectedId && forcedState !== undefined && forcedState !== "base"
+          ? previewStateClass(forcedState)
+          : undefined;
+
+      /*
+       * WRITTEN ONLY WHEN IT CHANGES, which is not a micro-optimisation.
+       *
+       * `classList.remove` of a token that is not present still touches the
+       * attribute, and this canvas is observed: the empty-container appender
+       * watches its subtree for layout-relevant mutations and re-measures on
+       * one. An unconditional clear across every marked element therefore made
+       * every selection change schedule a re-measure of the whole overlay,
+       * which its own test caught — it asserts the control does NOT move for a
+       * mutation of its own output, and it moved.
+       */
+      for (const state of STYLE_STATES) {
+        const marker = previewStateClass(state);
+        if (marker !== wanted && element.classList.contains(marker)) {
+          element.classList.remove(marker);
+        }
+      }
+      if (wanted !== undefined && !element.classList.contains(wanted)) {
+        element.classList.add(wanted);
+      }
+    });
+  }, [box, selectedId, marked, page, forcedState]);
 }
 
 /**
@@ -1068,8 +1117,30 @@ export interface CanvasProps {
    * element, so handing it over is more honest than a caller finding it by
    * class name: a query would be a second place that decides which element the
    * canvas root is.
+   *
+   * READ IT IN A HANDLER, NOT AN EFFECT, and that is a property of the call
+   * site rather than of this prop — so it travels with nothing and has to be
+   * said here. A ref answers "where is the canvas now" at press time, long
+   * after mount. An effect asking the same ref reads `null` on its first run
+   * and is never told otherwise, because assigning `.current` changes no
+   * dependency and this canvas mounts only once styles have loaded. Anything
+   * that must REACT to the canvas arriving takes {@link CanvasProps.onRoot}.
    */
   rootRef?: React.RefObject<HTMLDivElement | null>;
+  /**
+   * The interaction state the panel is editing, forced on the primary
+   * selection so an author can SEE what they are editing.
+   *
+   * A page cannot force a pseudo-class on itself — there is no CSS or DOM way
+   * to make an element match `:hover` without a pointer. So the sheet has to be
+   * compiled with `previewStates`, which gives each state a class alternative
+   * beside its pseudo-class, and this canvas puts that class on one element.
+   * Passed a state without that compile, nothing happens and nothing breaks:
+   * the class is simply in no selector.
+   *
+   * `base` forces nothing. It is what applies when no state does.
+   */
+  forcedState?: StyleState;
   /**
    * The same element, published as a VALUE so a caller can react to it
    * appearing.
@@ -1203,6 +1274,7 @@ export function Canvas({
   document,
   rootRef,
   onRoot,
+  forcedState,
   siteStyles,
   selectedId = null,
   selectedIds,
@@ -1218,25 +1290,32 @@ export function Canvas({
 }: CanvasProps) {
   const root = useRef<HTMLDivElement | null>(null);
 
-  // Published after paint rather than through a merged ref callback: the
-  // element is the same for the life of the mount, and one assignment here is
-  // easier to follow than a callback that has to keep two refs agreeing.
+  /*
+   * ONE assignment site for both publications.
+   *
+   * They are two APIs because they answer two questions — `rootRef` is read in
+   * a pointer handler and asks "where is the canvas now"; `onRoot` is a value
+   * so a reader can REACT to the canvas arriving, which a ref cannot express
+   * because assigning `.current` changes no dependency. Neither can serve the
+   * other's caller.
+   *
+   * But two effects deciding what the element is could drift: an edit to one is
+   * invisible to the other, and the two would then hand out different answers
+   * with nothing to report it. One effect, one element, published twice.
+   *
+   * After paint rather than through a merged ref callback: the element is the
+   * same for the life of the mount, and one assignment here is easier to follow
+   * than a callback keeping two refs agreeing.
+   */
   useEffect(() => {
-    if (rootRef === undefined) return;
-    rootRef.current = root.current;
+    const element = root.current;
+    if (rootRef !== undefined) rootRef.current = element;
+    onRoot?.(element);
     return () => {
-      rootRef.current = null;
+      if (rootRef !== undefined) rootRef.current = null;
+      onRoot?.(null);
     };
-  }, [rootRef]);
-
-  // The same element as a value, for readers that must react to it arriving.
-  useEffect(() => {
-    if (onRoot === undefined) return;
-    onRoot(root.current);
-    return () => {
-      onRoot(null);
-    };
-  }, [onRoot]);
+  }, [rootRef, onRoot]);
 
   /*
    * What to mark. The primary alone when a host has not adopted the set yet,
@@ -1285,7 +1364,7 @@ export function Canvas({
     [rendered, document, sheet]
   );
 
-  useSelectionMarkers(root, marked, selectedId, page);
+  useSelectionMarkers(root, marked, selectedId, page, forcedState);
 
   return (
     <div

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -702,12 +702,46 @@ function useSelectionMarkers(
      * changes from hover to focus, or a selection that moves, must not leave
      * the previous class behind on an element nothing is editing.
      */
-    container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
-      const id = element.getAttribute(NODE_ID_ATTRIBUTE);
+    /*
+     * The ANCESTOR CHAIN, not the selected element alone.
+     *
+     * `:hover` matches an element and every ancestor of it — measured in a
+     * browser, a pointer over a leaf puts the leaf, its parent and the root all
+     * in the hover chain. So the tiers that style an ancestor match under a
+     * real pointer, and a preview that marked only the selected node would drop
+     * exactly those: a page-level hover colour, or an enclosing block's, would
+     * vanish in the simulation and appear for the visitor.
+     *
+     * The canvas ROOT is in the chain too, because the page tier compiles onto
+     * it and a marker on a descendant cannot make its ancestor match. The walk
+     * reaches it without a special case: it stops where `contains` does, and an
+     * element contains itself. With nothing selected the walk never starts, so
+     * the root is not marked and no page-level state rule is forced.
+     */
+    const chain = new Set<Element>();
+    if (forcedState !== undefined && forcedState !== "base") {
+      const primary = container.querySelector(
+        `[${SELECTED_ATTRIBUTE}="primary"]`
+      );
+      for (
+        let node: Element | null = primary;
+        node !== null && container.contains(node);
+        node = node.parentElement
+      ) {
+        chain.add(node);
+      }
+    }
+
+    const marks: Element[] = [container];
+    container
+      .querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`)
+      .forEach(element => marks.push(element));
+
+    marks.forEach(element => {
       // `base` is not a state anything forces: it is what applies when nothing
       // else does, and the compiler emits no marker for it.
       const wanted =
-        id === selectedId && forcedState !== undefined && forcedState !== "base"
+        chain.has(element) && forcedState !== undefined
           ? previewStateClass(forcedState)
           : undefined;
 

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -193,7 +193,24 @@ export interface StyleInspectorPanelProps {
    * than a guess.
    */
   renderedTag?: string;
-  /** The interaction state being edited. `base` when the host says nothing. */
+  /**
+   * The interaction state being edited. `base` when the host says nothing.
+   *
+   * A host that renders a canvas should hand the SAME value to
+   * `Canvas.forcedState`, and the two are one decision rather than two.
+   * Provenance depends on it: this panel states no `liveStates`, so
+   * `styleProvenance` falls back to the edited state plus base — correct
+   * exactly when the canvas is simulating the state being edited, and wrong the
+   * moment it is not. Wired from one value, that precondition holds by
+   * construction; wired from two, a control reports a value the browser is not
+   * showing and nothing says so.
+   *
+   * Measuring the real pseudo-classes instead was considered and declined. The
+   * pointer is in the inspector whenever anyone is reading the panel, so a
+   * measured `:hover` is false every time and every hover control would report
+   * unset permanently — the affordance switched off in the exact state the
+   * author opened it to inspect.
+   */
   state?: StyleState;
   /** The breakpoint being edited. The unconditional one when the host says nothing. */
   breakpoint?: BreakpointId;

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -1259,6 +1259,19 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
          * the desktop tier live while the box paints the tablet one.
          */
         ...(offeredTiers(breakpoints).length === 0 ? {} : { previewContainer }),
+        /*
+         * Unconditional, unlike the container above. A page cannot force a
+         * pseudo-class on itself, so the sheet has to carry a class alternative
+         * beside each one before the canvas can show an author the hover
+         * appearance they are editing — and whether they are editing one is not
+         * known when the sheet is compiled.
+         *
+         * It costs a few bytes per state rule in a sheet only the editor sees,
+         * and nothing at all in weight: the marker sits inside the `:where()`
+         * that already wrapped the pseudo-class, which contributes nothing. The
+         * published sheet is compiled elsewhere and never asks for this.
+         */
+        previewStates: true,
       },
       ...(remotePatterns === undefined
         ? {}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -47,6 +47,7 @@ import {
   type SiteTokenSet,
   type BreakpointId,
   type FontFaceDef,
+  type StyleState,
 } from "@nextlyhq/blocks-engine";
 import { CORE_CATEGORIES, coreBlocks } from "@nextlyhq/blocks-react/blocks";
 import {
@@ -937,6 +938,23 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const [canvasElement, setCanvasElement] = useState<HTMLDivElement | null>(
     null
   );
+  /*
+   * The interaction state being edited, owned HERE so the panel and the canvas
+   * cannot disagree about it.
+   *
+   * One value handed to both surfaces rather than two defaults that happen to
+   * match: the panel states no `liveStates`, so provenance falls back to the
+   * edited state plus base — correct exactly while the canvas is simulating
+   * that state. Wired from one value that precondition holds by construction.
+   *
+   * A CONSTANT rather than state, because no control chooses it yet and state
+   * nothing writes is state that lints as unused and reads as unfinished. What
+   * matters now is that ONE value reaches both surfaces: the day a control
+   * arrives it replaces this line and finds both call sites already wired,
+   * rather than having to discover that the canvas and the panel were each
+   * defaulting on their own.
+   */
+  const styleState: StyleState = "base";
   const drag = useCanvasDrag({ editor, slots, nesting, canvasRoot });
   /*
    * Is a drag happening — of EITHER kind.
@@ -1664,6 +1682,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             // inferring one from the document. Two refs would let the panel
             // read a canvas that is not the one on screen.
             canvasRoot={canvasElement}
+            styleState={styleState}
             classLibrary={classes.library}
             classLibraryAbsence={classes.absence}
             onCreateClass={classes.create}
@@ -1863,6 +1882,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                 document={editor.document}
                 rootRef={canvasRoot}
                 onRoot={setCanvasElement}
+                forcedState={styleState}
                 siteStyles={siteSheet(canvasSiteStyle)}
                 selectedId={editor.selectedId}
                 selectedIds={editor.selection.ids}


### PR DESCRIPTION
Closes `task:pb-canvas-preview-edited-state`. Founder ruling of 2026-08-24: the canvas force-previews the edited state.

## The problem

The style panel edits a state — base, hover, focus, active — and **nothing applied that state to the canvas**. An author who switched to hover was editing an appearance nothing could show them, and provenance was told the edited state was live while the browser displayed base.

## Why forcing, and not measuring

The alternative was to measure which pseudo-classes actually match and report only those. It was declined, and the asymmetry with breakpoints is the reason: a breakpoint mismatch is resolvable — resize the canvas and the query matches. A hover mismatch is not. **The pointer is in the inspector whenever anyone is reading the panel**, so a measured `:hover` is false every time and every hover control would report unset permanently. That is not honest-quiet; it is the affordance switched off in the exact state the author opened it to inspect.

## The mechanism, and the constraint that forces it

A page cannot force a pseudo-class on itself. There is no CSS or DOM way to make an element match `:hover` without a pointer — `Emulation.forcePseudoState` is a devtools protocol, unreachable from a page. So the sheet has to carry something the editor CAN toggle.

Under `previewStates`, each state gains a class alternative **inside the `:where()` that already wrapped its pseudo-class**:

```css
.nx-pb-page.nx-pb-page .nx-pb-a1b2:where(:hover, .nx-pb-state-hover) { … }
```

**Inside is the whole reason it is safe.** `:where()` contributes nothing whatever it holds, so a previewed rule weighs exactly what the published one weighs. Measured in a browser with a control pair: marker inside, a later equal-weight rule still won; marker outside, the earlier rule won because the class had added weight of its own.

That equality is a requirement, not tidiness — the panel's provenance explains what a **visitor** gets, so a preview that ranked differently would describe an order nobody is served, in the one state the author opened the panel to see.

Prior art: Webflow's Designer exposes `getPseudoMode`, so its canvas genuinely has a pseudo mode. No public setter is documented, so the internal mechanism is not published.

## What reviewers should look at

**Every tier honours it** — node, class, block type, element, page. A forced state must reach every rule that can match the element; a tier left behind shows half the appearance being edited, and the missing half is whichever one the author did not set directly.

**The marker is written only when it changes.** `classList.remove` of an absent token still touches the attribute, and this canvas is observed — the empty-container appender re-measures on a layout-relevant mutation. An unconditional clear made every selection change schedule a re-measure of the whole overlay. **Its own test caught this**, which is why the guard exists.

**`rootRef` and `onRoot` now publish from one assignment site.** They stay two APIs because they answer two questions — a ref is read in a pointer handler and asks where the canvas is now; a value lets a reader react to it arriving. But two effects deciding what the element is could drift. `rootRef`'s docblock now records that it is safe because of *where* it is read, since that is a property of the call site and travels with nothing.

**The compile input enters the artifact identity, and typing it in was not enough.** `labelFor` has to serialise it — the trap this file was caught in once already with `elementBases`. It is spread in, present only when asked, so a fixed slot does not change the label's shape for every caller and invalidate every artifact already stored.

## Not in this PR

There is no state-selector UI yet, so the stock editor always sits at `base`. `Canvas.forcedState` and `InspectorPanel.styleState` are public props an integrator can use today. The selector is a deliberate follow-up — it is a visual design decision that deserves its own review rather than being buried in three packages of plumbing.

## Verification

12 cases, each break-verified. Three are worth naming because they first passed their break:

- the artifact-identity control compared two *current* labels, which agrees with a fixed slot as readily as a conditional spread — it now asserts the label's shape
- the mutation guard watched for records on the primary, then on the whole subtree; neither ever received them. It observes the **write** now, because the write is the defect
- the every-tier fixture compiled to nothing, because sentinels like `#node` are not colours and the compiler correctly drops an invalid value

blocks-engine 1648, builder 2463, blocks-react 968. Lint, typecheck, comment convention clean. `fallow audit --base origin/main` → **pass**, zero introduced across all four categories.