### PR TITLE
fix(ui): a resizable splitter must say what it divides

### DIFF
--- a/.changeset/a-splitter-says-what-it-divides.md
+++ b/.changeset/a-splitter-says-what-it-divides.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A resizable splitter now has to say what it divides, and the type is what
+enforces it.
+
+The handle between two panels is focusable, so a keyboard user lands on it
+whether or not anyone thought about them. `react-resizable-panels` supplies
+everything else about that element — the separator role, the orientation, and
+a position between a minimum and a maximum — but it cannot supply the one
+thing only the caller knows: what the two panels hold. Every handle in the
+admin was unnamed, so landing on one announced a bare number, "74", with
+nothing saying what was at 74 or what moving it would do.
+
+The name is now REQUIRED by the component's type rather than recommended in
+its documentation. A rule with nothing enforcing it is not a control, and this
+one had already been broken at every call site by people who had no reason to
+know: the handle looks like a divider, and dividers are not usually things you
+name. Either `aria-label` or `aria-labelledby` satisfies it, and the two cannot
+be combined — a second name is not a stronger label, it is an ambiguity
+resolved by precedence rules the author is not thinking about.
+
+The four splitters in the product are named for what sits on each side of them:
+the page builder's panel-and-canvas and canvas-and-inspector divisions, the API
+playground's request and response panes, and the translation editor's source
+and target.

--- a/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
+++ b/packages/admin/src/components/features/entries/APIPlayground/APIPlayground.tsx
@@ -907,7 +907,11 @@ export function APIPlayground({
               <ResizablePanel id="request" minSize="25%">
                 {requestPane}
               </ResizablePanel>
-              <ResizableHandle withGrip className="mx-4" />
+              <ResizableHandle
+                withGrip
+                className="mx-4"
+                aria-label="Request and response"
+              />
               <ResizablePanel id="response" minSize="30%">
                 {responsePane}
               </ResizablePanel>

--- a/packages/admin/src/components/features/entries/TranslationMode/TranslationPanes.tsx
+++ b/packages/admin/src/components/features/entries/TranslationMode/TranslationPanes.tsx
@@ -137,7 +137,7 @@ function ActivePanes({
         <ResizablePanel id="translation-source" minSize="25%" defaultSize="40%">
           <SourceDocumentPane source={source} />
         </ResizablePanel>
-        <ResizableHandle withGrip />
+        <ResizableHandle withGrip aria-label="Source and translation" />
         <ResizablePanel id="translation-target" minSize="30%">
           {/* A container of its own, and this is the whole of the editor's
               layout adaptation. `@container/content` is declared on the

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -1054,7 +1054,13 @@ function ShellRegions({
                   </React.Fragment>
                 </section>
               </ResizablePanel>
-              <ResizableHandle withGrip />
+              {/* Named for what it DIVIDES rather than for itself. A keyboard
+                  user lands here between two regions and hears its position;
+                  "Panel and canvas" is what makes the position mean something.
+                  The panel side is named by its role rather than by which
+                  panel is open, because the name would otherwise change under
+                  a user who is standing on it. */}
+              <ResizableHandle withGrip aria-label="Panel and canvas" />
             </>
           ) : null}
 
@@ -1106,7 +1112,7 @@ function ShellRegions({
             </div>
           </ResizablePanel>
 
-          <ResizableHandle withGrip />
+          <ResizableHandle withGrip aria-label="Canvas and inspector" />
 
           <ResizablePanel
             id="inspector"

--- a/packages/ui/src/components/resizable.test-d.ts
+++ b/packages/ui/src/components/resizable.test-d.ts
@@ -1,0 +1,41 @@
+/**
+ * The splitter's name is a TYPE requirement, and only the checker can say so.
+ *
+ * A runtime test can assert that a name which was supplied arrives on the
+ * element. It cannot assert the interesting half — that a call site omitting
+ * the name does not compile — because such a call site never runs. So the
+ * contract lives here, where `check-types` evaluates it.
+ *
+ * Written with `expectTypeOf` rather than `@ts-expect-error`. That directive
+ * suppresses ANY error on the line beneath it, so it keeps passing when the
+ * line starts failing for an unrelated reason and keeps passing after the
+ * rejection it was written for stops happening. These assertions are evaluated
+ * by the checker and name the property they are about.
+ *
+ * @module resizable.test-d
+ */
+import type * as React from "react";
+import { expectTypeOf } from "vitest";
+
+import type { ResizableHandle } from "./resizable";
+
+type HandleProps = React.ComponentProps<typeof ResizableHandle>;
+
+// Either form of name satisfies it. Both are asserted rather than one, because
+// a caller labelling by reference to visible text is as correct as one
+// spelling the name out, and a contract accepting only the first would push
+// call sites into duplicating a string that already exists on the page.
+expectTypeOf<{ "aria-label": string }>().toMatchTypeOf<HandleProps>();
+expectTypeOf<{ "aria-labelledby": string }>().toMatchTypeOf<HandleProps>();
+
+// The whole point: no name, no handle. Without this the two assertions above
+// pass against a component that requires nothing at all.
+expectTypeOf<{ withGrip: true }>().not.toMatchTypeOf<HandleProps>();
+expectTypeOf<Record<string, never>>().not.toMatchTypeOf<HandleProps>();
+
+// Two names on one element is an ambiguity resolved by precedence rules the
+// author is not thinking about, so it is refused rather than silently ranked.
+expectTypeOf<{
+  "aria-label": string;
+  "aria-labelledby": string;
+}>().not.toMatchTypeOf<HandleProps>();

--- a/packages/ui/src/components/resizable.test.tsx
+++ b/packages/ui/src/components/resizable.test.tsx
@@ -32,7 +32,7 @@ const renderGroup = (orientation: "horizontal" | "vertical") => {
   const { container } = render(
     <ResizablePanelGroup orientation={orientation}>
       <ResizablePanel id="a" />
-      <ResizableHandle />
+      <ResizableHandle aria-label="A and B" />
       <ResizablePanel id="b" />
     </ResizablePanelGroup>
   );
@@ -66,5 +66,30 @@ describe("the resize handle", () => {
     expect(separator?.getAttribute("aria-valuemax")).toBe("100");
     // Reachable by keyboard at all.
     expect(separator?.getAttribute("tabindex")).toBe("0");
+  });
+});
+
+describe("naming the splitter", () => {
+  it("carries the accessible name the caller gave it", () => {
+    /*
+     * The handle is FOCUSABLE, so a keyboard user lands on it whether or not
+     * anyone remembered to name it, and the library supplies everything about
+     * this element except the name: role, orientation, and a position between
+     * a minimum and a maximum. Announced without a name that is "74" and
+     * nothing about what is at 74.
+     *
+     * The range attributes are asserted alongside, as the control. They come
+     * from the library rather than from this component, so a case checking
+     * only the name would keep passing if the element stopped being a
+     * splitter at all.
+     */
+    const separator = renderGroup("horizontal");
+
+    expect(separator?.getAttribute("aria-label")).toBe("A and B");
+    expect(separator?.getAttribute("role")).toBe("separator");
+    expect(separator?.getAttribute("tabindex")).toBe("0");
+    expect(separator?.getAttribute("aria-valuemin")).toBe("0");
+    expect(separator?.getAttribute("aria-valuemax")).toBe("100");
+    expect(separator?.getAttribute("aria-valuenow")).not.toBeNull();
   });
 });

--- a/packages/ui/src/components/resizable.tsx
+++ b/packages/ui/src/components/resizable.tsx
@@ -35,6 +35,9 @@
  * **Accessibility**:
  * - The handle is a `separator` with `aria-valuenow`/`aria-valuemin`/`aria-valuemax`, supplied by
  *   the library, so a screen reader announces the split as a percentage
+ * - Its accessible NAME is required by the type, because the library supplies everything except
+ *   that: a focusable separator with a position and no name announces "74" and leaves a keyboard
+ *   user to guess what is at 74. Only the caller knows what the two panels hold
  * - Arrow keys resize, Home/End collapse and expand, Enter toggles a collapsible panel
  * - The hit area is larger than the visible line, so the target is reachable without precision
  *   pointing (WCAG 2.5.8 Target Size)
@@ -49,11 +52,11 @@
  *   <ResizablePanel id="layers" minSize="15%" collapsible>
  *     <LayersPanel />
  *   </ResizablePanel>
- *   <ResizableHandle withGrip />
+ *   <ResizableHandle withGrip aria-label="Layers and canvas" />
  *   <ResizablePanel id="canvas">
  *     <Canvas />
  *   </ResizablePanel>
- *   <ResizableHandle withGrip />
+ *   <ResizableHandle withGrip aria-label="Canvas and inspector" />
  *   <ResizablePanel id="inspector" minSize="20%">
  *     <Inspector />
  *   </ResizablePanel>
@@ -70,6 +73,24 @@ import type * as React from "react";
 import * as ResizablePrimitive from "react-resizable-panels";
 
 import { cn } from "../lib/utils";
+
+/**
+ * A splitter's accessible name, which the caller must supply one way or the
+ * other.
+ *
+ * REQUIRED rather than documented, because the handle is focusable: a keyboard
+ * user lands on it whether or not anyone remembered, and an unnamed separator
+ * announces its position — "74" — with nothing saying what is at 74. The
+ * caller is the only one who can name it, since only the caller knows what the
+ * two panels hold, so the type is the only place the requirement can live.
+ *
+ * Either attribute satisfies it and neither may be paired with the other: two
+ * names on one element is not a stronger label, it is an ambiguity resolved by
+ * precedence rules nobody writing the call site is thinking about.
+ */
+type SplitterName =
+  | { "aria-label": string; "aria-labelledby"?: never }
+  | { "aria-labelledby": string; "aria-label"?: never };
 
 /**
  * A group of resizable panels, laid out horizontally or vertically.
@@ -107,9 +128,13 @@ const ResizableHandle = ({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
-  withGrip?: boolean;
-}) => (
+}: Omit<
+  React.ComponentProps<typeof ResizablePrimitive.Separator>,
+  "aria-label" | "aria-labelledby"
+> &
+  SplitterName & {
+    withGrip?: boolean;
+  }) => (
   <ResizablePrimitive.Separator
     className={cn(
       // The drawn line is 1px; the element around it is wider and transparent, so the pointer


### PR DESCRIPTION
Every resizable splitter in the admin was focusable and unnamed. Landing on one with a keyboard announced `74` — a position, with nothing saying what was at 74 or what moving it would do.

## What was actually wrong

I filed the original finding claiming the range attributes were missing too. **That was wrong, and I have corrected it.** Rendering the primitive and reading every attribute:

```
role="separator"  tabindex="0"  aria-orientation="vertical"
aria-controls="a"  aria-valuemin="0"  aria-valuemax="100"  aria-valuenow="74"
aria-label=<absent>  aria-valuetext=<absent>
```

`react-resizable-panels` supplies all of the range, and `resizable.tsx` documented that correctly. The one thing genuinely absent is the **accessible name** — and it is the one thing the library cannot supply, because only the caller knows what the two panels hold.

## The fix is a type, not a convention

The docblock already said the handle was accessible. It had still been left unnamed at **all four call sites**, by people with no reason to know: a divider does not look like a thing you name. A documented rule with nothing enforcing it is not a control, so the name is now required by the component's type.

Either `aria-label` or `aria-labelledby` satisfies it, and the two cannot be combined — a second name is not a stronger label, it is an ambiguity resolved by precedence rules the author is not thinking about.

The four splitters are named for what sits on each side: the page builder's **Panel and canvas** and **Canvas and inspector**, the API playground's **Request and response**, and the translation editor's **Source and translation**.

## Verification

A runtime test cannot assert the interesting half — a call site that omits the name never runs — so the contract is in `resizable.test-d.ts` where `check-types` evaluates it. Written with `expectTypeOf` rather than `@ts-expect-error`, which suppresses *any* error on the following line and so keeps passing both when the line starts failing for an unrelated reason and after the rejection it was written for stops happening.

Break-verified in both directions, and the evidence is the **diagnostic**, not the red:

- removing the requirement fails at exactly lines 33, 34 and 41 — the three "must be rejected" assertions, and only those; the two positive assertions stay green
- removing `aria-label` from a real call site fails with `TS2322: Type '{ withGrip: true; }' is not assignable`, so the boundary reaches the code people actually write

The runtime case asserts the name arrives on the element, with the range attributes alongside as a control — a case checking only the name would keep passing if the element stopped being a splitter at all.

Gates: ui 1139, builder 2463, admin 3124, typecheck, lint, `fallow audit` pass with 0 introduced.

One thing this does not do: `aria-valuetext` is still absent, so the position is announced as a bare number rather than a percentage. The range attributes make that intelligible to most screen readers, and adding valuetext needs the live layout, which the handle does not have. Left deliberately.