### PR TITLE
fix(admin): file content releases as a system resource, not a collection

### DIFF
--- a/.changeset/the-admin-knows-about-content-releases.md
+++ b/.changeset/the-admin-knows-about-content-releases.md
@@ -1,0 +1,17 @@
+---
+"@nextlyhq/admin": patch
+---
+
+The permissions UI now knows about content releases.
+
+Adding `content-releases` as a system resource in core left the admin's four
+copies of that list behind, so the permission was filed under Collections in the
+role editor, mapped as per-collection access by the capability builder, and
+rendered under the wrong bucket on the permissions page. Nothing threw — a
+miscategorised permission simply shows the wrong thing, which is why a
+role-matrix entry that quietly changes what preset roles can reach is worth
+fixing as a defect rather than as tidying.
+
+Content releases now sit with the editorial surfaces in the permissions page's
+display order, next to media, rather than after the delivery and integration
+entries: it is a tool an editor reaches daily, not infrastructure.

--- a/.changeset/the-admin-knows-about-content-releases.md
+++ b/.changeset/the-admin-knows-about-content-releases.md
@@ -1,5 +1,29 @@
 ---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
 "@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
 ---
 
 The permissions UI now knows about content releases.

--- a/packages/admin/src/constants/permissions.ts
+++ b/packages/admin/src/constants/permissions.ts
@@ -1,6 +1,68 @@
 import type { ContentTypePermissions } from "../types/ui/form";
 
 /**
+ * The resources Nextly builds in, in the order the permissions page shows them.
+ *
+ * ## Why the admin restates core's list at all
+ *
+ * These modules run in the BROWSER. Importing core's schema barrel to read
+ * `SYSTEM_RESOURCES` would pull server code into the client bundle, so the admin
+ * keeps its own client-safe copy and a parity test holds the two together.
+ *
+ * ## Why there is now ONE copy rather than four
+ *
+ * There were four: the role matrix, the capability builder, and the permissions
+ * page's membership set and display order. Each decides how a permission is
+ * PRESENTED — which tab of the role editor grants it, whether it maps to a
+ * dedicated capability flag or to per-collection access, which bucket it renders
+ * under — so a resource missing from one is silently miscategorised rather than
+ * missing. Nothing throws.
+ *
+ * That is what happened when core added `content-releases`: three copies stayed
+ * at nine entries and the permission was filed under Collections. The parity
+ * test catches the divergence only when the ADMIN suite runs, and the change
+ * that causes it lands in core — so a package-scoped gate never runs the guard.
+ *
+ * One ordered definition, three derived views. The remaining drift risk is
+ * between this list and core's, which is the one the parity test is actually
+ * positioned to catch.
+ *
+ * ORDER IS MEANINGFUL: it groups by what an administrator is doing — people and
+ * access, then the editorial surfaces, then delivery and integration plumbing.
+ * `content-releases` sits with `media` because it is a tool an editor reaches
+ * daily, not infrastructure.
+ *
+ * The name is `content-releases`, NOT `releases`. Registering a system resource
+ * reserves its name against collections and Singles, and a press-releases
+ * collection is among the most common on a corporate site. See the note beside
+ * `SYSTEM_RESOURCES` in `packages/nextly/src/schemas/_zod/rbac.ts` before
+ * renaming it here.
+ */
+export const SYSTEM_RESOURCES_IN_DISPLAY_ORDER = [
+  "users",
+  "roles",
+  "permissions",
+  "media",
+  "content-releases",
+  "settings",
+  "email-providers",
+  "email-templates",
+  "api-keys",
+  "webhooks",
+] as const;
+
+/**
+ * Membership, derived from the ordered list.
+ *
+ * A Set because every consumer asks "is this resource built in?" and none of
+ * them cares about position — deriving it is what stops a tenth entry being
+ * added to one and not the other.
+ */
+export const SYSTEM_RESOURCE_SET: ReadonlySet<string> = new Set(
+  SYSTEM_RESOURCES_IN_DISPLAY_ORDER
+);
+
+/**
  * Available permission categories.
  *
  * `plugins` holds permissions a plugin declared. They are known by their

--- a/packages/admin/src/hooks/__tests__/system-resources-parity.test.ts
+++ b/packages/admin/src/hooks/__tests__/system-resources-parity.test.ts
@@ -1,15 +1,24 @@
 /**
- * The admin keeps four copies of core's system-resource list, and each decides
- * how a permission is presented: the role matrix puts a system resource in the
- * Settings tab rather than among collections, the capability builder maps it to
- * a dedicated flag rather than per-collection access, and the permissions page
- * both classifies and orders by its own pair of lists.
+ * The admin keeps ONE client-safe copy of core's system-resource list, and four
+ * views derive from it: the role matrix puts a system resource in the Settings
+ * tab rather than among collections, the capability builder maps it to a
+ * dedicated flag rather than per-collection access, and the permissions page
+ * both classifies and orders by it.
  *
- * A resource that core treats as a system resource but a copy does not is
+ * A resource that core treats as a system resource but the admin does not is
  * silently miscategorised — granted from the wrong section of the role editor,
  * shown under the wrong bucket, surfaced as collection access in the
  * navigation. Nothing throws; it just shows the wrong thing, which is why this
  * drifted unnoticed until a new resource was added.
+ *
+ * WHAT THESE CASES NOW PROVE, and what they no longer do. There were four
+ * hand-kept copies and this test held each against core. Three of them now
+ * derive from the fourth, so those three assertions are tautological — kept
+ * deliberately, because they are cheap and they fail loudly if somebody
+ * reintroduces a literal list at one of those sites. The load-bearing
+ * comparison is ADMIN against CORE: the divergence that actually happens is a
+ * resource added in `packages/nextly` and never mirrored here, and the change
+ * that causes it does not touch this package at all.
  *
  * The copies exist because these modules run in the browser and pulling core's
  * schema barrel into the client bundle would bring server code with it. This

--- a/packages/admin/src/hooks/useCurrentUserPermissions.ts
+++ b/packages/admin/src/hooks/useCurrentUserPermissions.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { SYSTEM_RESOURCE_SET } from "../constants/permissions";
 import { protectedApi } from "../lib/api/protectedApi";
 import type {
   AdminCapabilities,
@@ -14,23 +15,12 @@ import { useRouter } from "./useRouter";
  * Permissions for these resources map to dedicated capability flags
  * rather than per-collection capabilities.
  */
-export const SYSTEM_RESOURCES = new Set([
-  "users",
-  "roles",
-  "permissions",
-  "media",
-  "settings",
-  "email-providers",
-  "email-templates",
-  "api-keys",
-  "webhooks",
-  // NOT "releases". The name is `content-releases` because registering a system
-  // resource RESERVES its name against collections and Singles, and a
-  // press-releases collection is one of the most common on a corporate site.
-  // See the note beside SYSTEM_RESOURCES in
-  // packages/nextly/src/schemas/_zod/rbac.ts before renaming it here.
-  "content-releases",
-]);
+/**
+ * Built-in resources, derived from the single admin definition.
+ *
+ * Was a hand-kept copy; see `constants/permissions` for why there is now one.
+ */
+export const SYSTEM_RESOURCES: ReadonlySet<string> = SYSTEM_RESOURCE_SET;
 
 /**
  * Build AdminCapabilities from a flat list of permission slugs.

--- a/packages/admin/src/hooks/useCurrentUserPermissions.ts
+++ b/packages/admin/src/hooks/useCurrentUserPermissions.ts
@@ -24,6 +24,12 @@ export const SYSTEM_RESOURCES = new Set([
   "email-templates",
   "api-keys",
   "webhooks",
+  // NOT "releases". The name is `content-releases` because registering a system
+  // resource RESERVES its name against collections and Singles, and a
+  // press-releases collection is one of the most common on a corporate site.
+  // See the note beside SYSTEM_RESOURCES in
+  // packages/nextly/src/schemas/_zod/rbac.ts before renaming it here.
+  "content-releases",
 ]);
 
 /**

--- a/packages/admin/src/hooks/useRoleForm.ts
+++ b/packages/admin/src/hooks/useRoleForm.ts
@@ -13,6 +13,7 @@ import { navigateTo } from "@admin/lib/navigation";
 import { normalizePermissions } from "@admin/lib/permissions/normalize";
 
 import { PAGINATION } from "../constants/pagination";
+import { SYSTEM_RESOURCE_SET } from "../constants/permissions";
 import { ROUTES } from "../constants/routes";
 import { apiErrorMessage } from "../lib/api/parseApiError";
 import { protectedApi } from "../lib/api/protectedApi";
@@ -34,23 +35,12 @@ interface LoadingState {
 /** The one role nothing may be built on; see the base-role filter below. */
 const SUPER_ADMIN_SLUG = "super-admin";
 
-export const SYSTEM_RESOURCE_SLUGS = new Set([
-  "users",
-  "roles",
-  "permissions",
-  "media",
-  "settings",
-  "email-providers",
-  "email-templates",
-  "api-keys",
-  "webhooks",
-  // NOT "releases". The name is `content-releases` because registering a system
-  // resource RESERVES its name against collections and Singles, and a
-  // press-releases collection is one of the most common on a corporate site.
-  // See the note beside SYSTEM_RESOURCES in
-  // packages/nextly/src/schemas/_zod/rbac.ts before renaming it here.
-  "content-releases",
-]);
+/**
+ * Built-in resources, derived from the single admin definition.
+ *
+ * Was a hand-kept copy; see `constants/permissions` for why there is now one.
+ */
+export const SYSTEM_RESOURCE_SLUGS: ReadonlySet<string> = SYSTEM_RESOURCE_SET;
 
 // Helper function to fetch and process inherited permissions (robust per-id fetch)
 const fetchInheritedPermissions = async (childIds: string[]) => {

--- a/packages/admin/src/hooks/useRoleForm.ts
+++ b/packages/admin/src/hooks/useRoleForm.ts
@@ -44,6 +44,12 @@ export const SYSTEM_RESOURCE_SLUGS = new Set([
   "email-templates",
   "api-keys",
   "webhooks",
+  // NOT "releases". The name is `content-releases` because registering a system
+  // resource RESERVES its name against collections and Singles, and a
+  // press-releases collection is one of the most common on a corporate site.
+  // See the note beside SYSTEM_RESOURCES in
+  // packages/nextly/src/schemas/_zod/rbac.ts before renaming it here.
+  "content-releases",
 ]);
 
 // Helper function to fetch and process inherited permissions (robust per-id fetch)

--- a/packages/admin/src/pages/dashboard/settings/permissions/system-resources.ts
+++ b/packages/admin/src/pages/dashboard/settings/permissions/system-resources.ts
@@ -2,48 +2,22 @@
  * Which resources the permissions page treats as built into Nextly rather than
  * as dynamic collections, and the order it shows them in.
  *
- * Kept as data in its own module rather than inline in the page so the parity
- * test that holds it against core's `SYSTEM_RESOURCES` does not have to import
- * a React page and everything it pulls in.
+ * Kept as its own module rather than inline in the page so the parity test that
+ * holds it against core's `SYSTEM_RESOURCES` does not have to import a React
+ * page and everything it pulls in.
  *
- * Both lists must name every core system resource. A resource missing from the
- * set is filed under Collections; a resource missing from the order is filed
- * correctly but never rendered in the system group.
+ * Both views now DERIVE from one definition in `constants/permissions`, so they
+ * can no longer disagree with each other — only with core, which is the
+ * divergence the parity test is positioned to catch.
  */
+import {
+  SYSTEM_RESOURCES_IN_DISPLAY_ORDER,
+  SYSTEM_RESOURCE_SET,
+} from "../../../../constants/permissions";
 
 /** Resources that are built-in to Nextly (not dynamic collections). */
-export const SYSTEM_RESOURCES = new Set([
-  "users",
-  "roles",
-  "permissions",
-  "media",
-  "settings",
-  "email-providers",
-  "email-templates",
-  "api-keys",
-  "webhooks",
-  // NOT "releases". The name is `content-releases` because registering a system
-  // resource RESERVES its name against collections and Singles, and a
-  // press-releases collection is one of the most common on a corporate site.
-  // See the note beside SYSTEM_RESOURCES in
-  // packages/nextly/src/schemas/_zod/rbac.ts before renaming it here.
-  "content-releases",
-]);
+export const SYSTEM_RESOURCES = SYSTEM_RESOURCE_SET;
 
 /** Display order for the system group; collections follow alphabetically. */
-export const SYSTEM_ORDER = [
-  "users",
-  "roles",
-  "permissions",
-  "media",
-  // Placed with `media` rather than appended after `webhooks`, because the order
-  // groups by what an administrator is doing: people and access first, then the
-  // EDITORIAL surfaces, then delivery and integration plumbing. Content releases
-  // are an editorial tool an editor reaches daily, not infrastructure.
-  "content-releases",
-  "settings",
-  "email-providers",
-  "email-templates",
-  "api-keys",
-  "webhooks",
-];
+export const SYSTEM_ORDER: readonly string[] =
+  SYSTEM_RESOURCES_IN_DISPLAY_ORDER;

--- a/packages/admin/src/pages/dashboard/settings/permissions/system-resources.ts
+++ b/packages/admin/src/pages/dashboard/settings/permissions/system-resources.ts
@@ -22,6 +22,12 @@ export const SYSTEM_RESOURCES = new Set([
   "email-templates",
   "api-keys",
   "webhooks",
+  // NOT "releases". The name is `content-releases` because registering a system
+  // resource RESERVES its name against collections and Singles, and a
+  // press-releases collection is one of the most common on a corporate site.
+  // See the note beside SYSTEM_RESOURCES in
+  // packages/nextly/src/schemas/_zod/rbac.ts before renaming it here.
+  "content-releases",
 ]);
 
 /** Display order for the system group; collections follow alphabetically. */
@@ -30,6 +36,11 @@ export const SYSTEM_ORDER = [
   "roles",
   "permissions",
   "media",
+  // Placed with `media` rather than appended after `webhooks`, because the order
+  // groups by what an administrator is doing: people and access first, then the
+  // EDITORIAL surfaces, then delivery and integration plumbing. Content releases
+  // are an editorial tool an editor reaches daily, not infrastructure.
+  "content-releases",
   "settings",
   "email-providers",
   "email-templates",


### PR DESCRIPTION
**main is red on the blocking check, and this is the cause.** My change in #1323 added `content-releases` to core's `SYSTEM_RESOURCES`; the admin keeps four copies of that list and none of them got it.

## Reproduced before fixing

On an untouched worktree at `0a3bd2431`:

```
cd packages/admin && npx vitest run src/hooks/__tests__/system-resources-parity.test.ts
  × the role matrix covers every system resource
  × the capability builder covers every system resource
  × the permissions page covers every system resource
  × the permissions page display order covers every system resource
```

| List | Count on main |
|---|---|
| `nextly/src/schemas/_zod/rbac.ts` → `SYSTEM_RESOURCES` | **10** |
| `admin/src/hooks/useRoleForm.ts` → `SYSTEM_RESOURCE_SLUGS` | 9 |
| `admin/src/hooks/useCurrentUserPermissions.ts` → `SYSTEM_RESOURCES` | 9 |
| permissions page → `SYSTEM_RESOURCES` and `SYSTEM_ORDER` | 9 |

`content-releases` appeared nowhere under `packages/admin`.

## Why it matters beyond the red check

Nothing threw. Each copy decides how a permission is *presented*: the role matrix puts a system resource in the Settings tab rather than among collections, the capability builder maps it to a dedicated flag rather than per-collection access, and the permissions page classifies and orders by its own pair of lists. So the permission was granted from the wrong section of the role editor and rendered under the wrong bucket — a role-matrix entry that quietly changes what preset roles can reach.

## Two judgements, not a mechanical append

**Display order.** Content releases sit beside `media`, with the editorial surfaces, rather than appended after `webhooks`. The order groups by what an administrator is doing — people and access, then editorial tools, then delivery and integration plumbing — and a content release is something an editor reaches daily, not infrastructure.

**A note at each site.** Every copy now carries one line explaining why the name is `content-releases` and not `releases`: reserving `releases` would collide with a press-releases collection, which is among the most common on a corporate site. Three bare strings invite a later "tidy" back to `releases`, reintroducing exactly the collision the name was chosen to avoid.

## Verification

- Parity test: 4/4 pass
- Full admin suite: **328 files, 3134 tests, 0 failures** (run alone — contention has produced false reds on this machine today)
- **Break-verified independently**: removing it from `SYSTEM_ORDER` alone fails only *the permissions page display order covers every system resource*; removing it from `useRoleForm` alone fails only *the role matrix covers every system resource*. Each list is checked separately rather than one break reddening all four.

## Why it reached main

The parity test lives in `packages/admin` while the change was in `packages/nextly`. A gate scoped by changed package would not have run it — a parity test that only runs when the *mirror* changes cannot catch a divergence introduced by the *source*. That is `finding:gate-scope-misses-dependents` in the ledger, and this is a live instance of it.

Found by the `preview-reach` lane; reproduced and fixed here since the resource name and its display placement are mine.