### PR TITLE
fix(builder): measure the canvas region from an ancestor that generates a box

### DIFF
--- a/.changeset/the-canvas-measures-a-real-box.md
+++ b/.changeset/the-canvas-measures-a-real-box.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fit the canvas to the pane it is actually laid out in.
+
+The canvas measured its DOM parent to decide how far to shrink a pinned width.
+Since the block context menu arrived, that parent is a wrapper with
+`display: contents` — it generates no box, so it measures zero, and a zero
+region made the fit fall back to its identity. An author who pinned Tablet at
+1024px was editing at whatever width the pane happened to be, with the control
+still showing Tablet selected and no readout to contradict it.
+
+It now measures the nearest ancestor that actually generates a box.

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -857,6 +857,90 @@ describe("what the canvas reports about the box it got", () => {
   const zoomOf = (root: HTMLElement): string =>
     String((root.style as { zoom?: string }).zoom ?? "");
 
+  describe("which ancestor the region is measured from", () => {
+    /*
+     * `parentElement` is the DOM parent and not necessarily the element the
+     * canvas is laid out by. `display: contents` leaves a node in the tree
+     * while generating no box, so its children are laid out by ITS parent — and
+     * a `ResizeObserver` on one reports an inline size of zero. Measured in a
+     * browser: a boxless wrapper inside a 911px container observes `0` while
+     * the container observes `911`.
+     *
+     * The block context menu wraps the canvas in exactly such a node, and
+     * deliberately: a `span` around a block box would change the layout it is
+     * meant to be transparent over. So the canvas measured zero, `canvasScale`
+     * took its identity branch, and the fit was `1` forever — an author who
+     * pinned Tablet at 1024 edited at the region's own width with the control
+     * still showing Tablet selected.
+     */
+    it("skips an ancestor that generates no box", () => {
+      const wrapper = document.createElement("div");
+      wrapper.style.display = "contents";
+      const laidOutBy = document.createElement("div");
+      laidOutBy.id = "laid-out-by";
+      laidOutBy.append(wrapper);
+      document.body.append(laidOutBy);
+
+      render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={PREVIEWABLE}
+          preview={{ container: "nx-preview-viewport", width: 1024 }}
+        />,
+        { container: wrapper }
+      );
+
+      const watched = regionObserver()?.observed ?? [];
+      // The element it measures is the one that HAS a box, not the DOM parent.
+      expect(watched.map(element => (element as HTMLElement).id)).toContain(
+        "laid-out-by"
+      );
+      expect(watched).not.toContain(wrapper);
+
+      laidOutBy.remove();
+    });
+
+    it("measures the DOM parent when that parent has a box", () => {
+      /*
+       * The control. A walk that skipped every ancestor, or that returned the
+       * document element, would satisfy the case above while measuring
+       * something the canvas is not laid out by — and the fit would be computed
+       * against the whole window rather than the pane the canvas sits in.
+       */
+      const parent = document.createElement("div");
+      parent.id = "ordinary-parent";
+      document.body.append(parent);
+
+      render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={PREVIEWABLE}
+          preview={{ container: "nx-preview-viewport", width: 1024 }}
+        />,
+        { container: parent }
+      );
+
+      const watched = regionObserver()?.observed ?? [];
+      expect(watched.map(element => (element as HTMLElement).id)).toContain(
+        "ordinary-parent"
+      );
+
+      parent.remove();
+    });
+  });
+
   describe("a tier wider than the region it has to fit in", () => {
     it("takes its FULL width and is scaled down to the region", () => {
       /*

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -355,6 +355,47 @@ function useReportedInlineWidth(
  * observer at all — there is nothing for it to answer, and one that exists
  * anyway fires on every pane drag for a number nobody reads.
  */
+/**
+ * The nearest ancestor that actually lays the canvas out.
+ *
+ * NOT `parentElement`, which is the DOM parent and not necessarily the element
+ * whose width the canvas is fitted into. `display: contents` leaves a node in
+ * the tree while generating no box at all, so its children are laid out by ITS
+ * parent — and a `ResizeObserver` on one reports an inline size of zero.
+ * Measured in a browser: a boxless wrapper inside a 911px container observes
+ * `0` while the container observes `911`.
+ *
+ * That is not hypothetical here. The block context menu wraps the canvas in
+ * Radix's trigger and gives it `display: contents` deliberately, so a `span`
+ * around a block box does not change the layout it is meant to be transparent
+ * over. Measuring through it made `canvasScale` see a region of zero, take its
+ * identity branch, and report a fit of `1` forever: an author who pinned Tablet
+ * at 1024 was editing at the region's own width with the control still showing
+ * Tablet selected, and no width readout to contradict it.
+ *
+ * Written as a WALK rather than as a check for that one wrapper. The wrapper
+ * arrived legitimately and nothing connected it to a measurement two files
+ * away; the next one would do the same. Skipping every boxless ancestor is the
+ * property the measurement actually needs.
+ *
+ * `display: none` is deliberately NOT skipped past — it is boxless too, but its
+ * children generate no box either, so there is no canvas being laid out
+ * anywhere and the honest answer is the hidden ancestor itself, whose zero
+ * leaves the scale at its identity.
+ */
+function layoutRegionOf(element: HTMLElement | null): HTMLElement | null {
+  const view = element?.ownerDocument.defaultView ?? null;
+  if (view === null) return null;
+  for (
+    let node = element?.parentElement ?? null;
+    node !== null;
+    node = node.parentElement
+  ) {
+    if (view.getComputedStyle(node).display !== "contents") return node;
+  }
+  return null;
+}
+
 function useRegionWidth(
   box: React.RefObject<HTMLElement | null>,
   scaling: boolean
@@ -362,7 +403,7 @@ function useRegionWidth(
   const [width, setWidth] = useState<number | undefined>(undefined);
   useEffect(() => {
     if (!scaling) return;
-    const region = box.current?.parentElement ?? null;
+    const region = layoutRegionOf(box.current);
     if (region === null) return;
     if (typeof ResizeObserver !== "function") return;
     const observer = new ResizeObserver(entries => {


### PR DESCRIPTION
The canvas never fits. An author who pins a tier wider than the pane edits at the pane's width, with the control still reporting the tier they picked.

Diagnosed by the lane that introduced it (#1316), who handed over the measurement rather than editing a file with an open PR of mine on it. Every link confirmed here independently before taking it.

## What is wrong

`useRegionWidth` reads its region from `box.current.parentElement`. Since the block context menu arrived, that parent is Radix's trigger carrying `display: contents` — deliberately, so a `span` around a block box does not change the layout it is meant to be transparent over.

A boxless element measures zero. **Verified in a browser rather than reasoned about:**

| observed element | reported inline size |
|---|---|
| `display: contents` wrapper inside a 911px container | **0** |
| the 911px container itself | **911** |

`canvasScale` guards `!(region > 0)` by returning the identity, so the fit is `1` forever and `previewBoxStyle` takes its `maxWidth` branch instead of `width` + `zoom`.

## What an author sees

Pin **Tablet (1024)** in a 911px pane, and edit at **911px** — with the zoom control reporting "fitting, 100%" and the tier still shown as selected.

Nothing on screen contradicts it. The width readout that would have said `911px · Tablet` is suppressed because it compares **tiers**, and 911 and 1024 are the same tier. Any authored boundary between the two behaves differently from a real tablet.

**The control that says it is the wrapper and not the observer:** pinning Mobile (640, *narrower* than the region) works correctly — that path needs no scaling. The defect appears only where region-relative fitting is required, which is exactly what a zero region disables.

## The fix

A walk past boxless ancestors, not a check for that one wrapper. The wrapper arrived legitimately and nothing connected it to a measurement two files away; the next one would do the same.

`display: none` is deliberately **not** walked past. It is boxless too, but its children generate no box either — there is no canvas being laid out anywhere, so the hidden ancestor's zero is the honest answer. Skipping it would compute a fit for a canvas nobody can see.

## Verification

Two cases, break-verified in both directions:

- measuring `parentElement` fails the boxless case
- walking past **every** ancestor fails the control that pins an ordinary parent — which is what stops the fit being computed against the window rather than the pane

builder: 2467 tests pass. Lint, typecheck clean. `fallow audit --base origin/main` gives **pass**, zero introduced.

## One thing worth recording

This also disabled the fit that #1335 built on top, so a test asserting the zoom control shows a fit below 100% could never have passed in a browser. That lane recorded it at the time as "could not drive the canvas into a shrunk-fit state — verified at unit level only" and filed it as a coverage gap.

**The gap was this bug.** When a state is reachable in units and not in a browser, the difference between the two is a hypothesis about production, not a limitation of the harness.

---

## Verified against real layout, and end to end

**The unit tests here cannot distinguish the two states, and a reviewer should know it.** jsdom computes no layout, so the `ResizeObserver` is a stub reporting whatever the test hands it — the cases prove the walk selects a *different element*, not that the selected element has the *right width*. Both the fixed and the broken version can be made to pass by choosing what the stub reports. Raised by the lane that diagnosed the defect, and correct.

So it was measured twice, neither time by a unit test.

**The algorithm, in a browser** — a page reproducing the shipped DOM shape, canvas root inside a `display: contents` trigger inside a 911px pane:

| region source | element | observed | resulting fit |
|---|---|---|---|
| `parentElement` (before) | the boxless trigger | **0** | **1** |
| the walk (after) | the 911px pane | **911** | **0.8896** |

**The shipped editor, end to end** — run independently in another worktree by the lane that reported the defect, by cherry-picking this commit and driving the real `/admin`. Not run by me, and worth more for it:

| | canvas width | max-width | zoom | zoom control |
|---|---|---|---|---|
| before | 911px | 1024px | 1 | "fitting, 100%" |
| after | **1024px** | none | **0.889648** | **"fitting, 89%"** |

An author pinning Tablet now edits at the tier's real width, scaled to fit. **The control that would catch an over-walk holds too:** Mobile (640, *narrower* than the region) comes out at `640px`, `zoom: 1`, `100%` — no false scaling where none is needed. Zero console errors.

The `display: contents` wrapper stays in the tree; the walk goes past it rather than removing it, because the context menu needs it.

## Why the existing e2e never caught this

`e2e/tests/canvas/preview-container.spec.ts` already asserts the canvas *"PAINTS down into the region it was given"*, and has been green throughout.

Its harness renders `Canvas` **without** `BlockContextMenu` — `grep -c BlockContextMenu apps/playground/src/app/builder-canvas-preview/harness.tsx` returns `0`. So the canvas's parent there is a real box, the fit works, and the test passes honestly about a composition the product does not build.

That is also why #1335 recorded *"could not drive the canvas into a shrunk-fit state"* as a harness limitation. It was not one.

**A test can be green about a composition the product never builds**, and the divergence is invisible because both sides look reasonable in isolation. The remedy is structural: a harness and the product should compose from one function, and where they cannot, the harness should state what it omits and why — so the omission is a claim someone can check rather than an accident nobody sees. This one omitted the single wrapper that breaks the measurement, and nothing anywhere said so.
