### PR TITLE
feat(nextly): report a translation whose source has moved on

### DIFF
--- a/.changeset/a-translation-says-when-it-fell-behind.md
+++ b/.changeset/a-translation-says-when-it-fell-behind.md
@@ -42,6 +42,11 @@ has not run `nextly migrate` yet sees nothing new instead of an error, and every
 language there reports as unknown -- never as up to date, because a translation
 the system cannot vouch for must not be described as current.
 
+Singles carry the signal too. Their languages are stamped on every write like
+any other, so the comparison is as valid there -- but a Single's history is not
+seeded, so languages written before this shipped have no timestamp and stay
+unknown rather than being described as current.
+
 Nothing here asks a person to keep the signal honest. It is derived from when
 each language was last written, so re-saving a translation clears it as a
 consequence of the save, and no flag is left behind for someone to remember to

--- a/.changeset/a-translation-says-when-it-fell-behind.md
+++ b/.changeset/a-translation-says-when-it-fell-behind.md
@@ -1,0 +1,48 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A translation now says when its source has moved on since it was written.
+
+The timestamp each language already records is finally read. A language whose
+source was edited after it was translated is marked as needing review, and stays
+exactly what it was otherwise -- still translated, and still published if it was
+published. A translation that has fallen behind is not a demotion; it is a
+second fact about a language that is still live, and treating it as a state
+would take a working translation off the screen it belongs on.
+
+Reported only where it can be established. The signal depends on a column older
+translation tables do not carry, and whether a given one carries it is now
+checked against the database rather than assumed from configuration. A site that
+has not run `nextly migrate` yet sees nothing new instead of an error, and every
+language there reports as unknown -- never as up to date, because a translation
+the system cannot vouch for must not be described as current.
+
+Nothing here asks a person to keep the signal honest. It is derived from when
+each language was last written, so re-saving a translation clears it as a
+consequence of the save, and no flag is left behind for someone to remember to
+untick.

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -100,6 +100,7 @@ import type { PaginatedResponse } from "../../../types/pagination";
 import type { DynamicCollectionService } from "../../dynamic-collections";
 import { readFieldGroupType } from "../../field-groups/storage/field-group-type-key";
 import { resolveTypeColumns } from "../../field-groups/storage/resolve-storage-names";
+import { COMPANION_UPDATED_AT_COLUMN } from "../../i18n/companion-columns";
 import {
   buildCompanionExists,
   buildLocalizedOrderExpr,
@@ -117,7 +118,10 @@ import {
   resolveFallbackChain,
   resolveRequestedLocale,
 } from "../../i18n/resolve-locale";
-import { resolveCompanionSchemaReadiness } from "../../i18n/runtime/companion-readiness";
+import {
+  resolveCompanionColumn,
+  resolveCompanionSchemaReadiness,
+} from "../../i18n/runtime/companion-readiness";
 import {
   NO_DECISIONS,
   type ReleaseDecisions,
@@ -458,18 +462,28 @@ export class CollectionQueryService extends BaseService {
       locales: this.localization.locales.map(l => l.code),
       defaultLocale: this.localization.defaultLocale,
       hasStatus: companion.hasStatus,
-      // 🔴 `staleness` is deliberately NOT supplied, so every locale reports its staleness as
-      // UNKNOWN.
+      // 🔴 Supplied only when the companion PHYSICALLY carries the column, which is a different
+      // question from whether the schema declares it. `companion.hasUpdatedAt` reports the
+      // DECLARED shape and is unconditionally true, so trusting it would emit SQL naming a column
+      // a pre-existing companion may not have and fail the whole read for that collection.
       //
-      // Nothing here can establish whether a given companion physically carries `_updated_at`.
-      // `hasUpdatedAt` on the schema reports the DECLARED shape and is unconditionally true, which
-      // is a claim about a column nobody checked, and a companion created before the column
-      // existed has no path that adds it. Reporting staleness from a capability that cannot be
-      // checked is the one thing this must not do: a wrong "needs review" is indistinguishable
-      // from a right one to the person reading it.
+      // Omission is the mechanism rather than a flag, because absent is already the defined answer
+      // for a caller that cannot ask: every locale then reports UNKNOWN, which is never rendered
+      // as up to date. A wrong "needs review" is indistinguishable from a right one to the person
+      // reading it, so the conservative direction is the only safe default.
       //
-      // Omission is the mechanism rather than a flag, because it is already the defined answer for
-      // a caller that cannot ask — see `readCompanionStamps`.
+      // Resolved on the pool BEFORE any transaction opens — a failed probe inside one marks the
+      // whole PostgreSQL transaction aborted and the error then names an innocent statement.
+      staleness: (await resolveCompanionColumn(
+        this.adapter,
+        companion.companionTableName,
+        COMPANION_UPDATED_AT_COLUMN
+      ))
+        ? {
+            companionTableName: companion.companionTableName,
+            dialect: this.adapter.dialect,
+          }
+        : undefined,
 
       // On a status-scoped read, don't report a draft-only translation as present.
       statusValue:
@@ -584,17 +598,23 @@ export class CollectionQueryService extends BaseService {
       mainIdColumn,
       localizedColumns: companion.localizedFields.map(f => f.column),
       hasStatus: companion.hasStatus,
-      // 🔴 Left absent, which makes the `stale` filter answer `1=0` — nothing here is KNOWN to be
-      // stale.
+      // 🔴 The PHYSICAL answer, not the declared one, and it is the same probe the per-row badge
+      // resolves — so the tab and the badge cannot disagree about whether the question is even
+      // askable for this collection.
       //
       // `companion.hasUpdatedAt` reports the DECLARED shape and is unconditionally true, which is
-      // a claim about a physical column that nothing has checked. A companion created before the
-      // column existed has no path that adds it, so emitting SQL naming it would fail the query
-      // for that collection — and a filter that cannot be evaluated is worse than one returning
-      // nothing, because the worklist would present every document as needing review.
+      // a claim about a physical column that nothing has checked. Emitting SQL naming a column a
+      // pre-existing companion lacks would fail the query for that collection, and a filter that
+      // cannot be evaluated is worse than one returning nothing: the worklist would present every
+      // document as needing review.
       //
-      // Absent is already the defined answer for "cannot answer", so this is the designed
-      // conservative path rather than a flag.
+      // False leaves the `stale` arm answering `1=0` — nothing is KNOWN to be stale — which is
+      // the defined answer for "cannot ask" rather than a claim that nothing is.
+      hasUpdatedAt: await resolveCompanionColumn(
+        this.adapter,
+        companion.companionTableName,
+        COMPANION_UPDATED_AT_COLUMN
+      ),
       defaultLocale: this.localization.defaultLocale,
       filter,
     });

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -474,6 +474,14 @@ export class CollectionQueryService extends BaseService {
       //
       // Resolved on the pool BEFORE any transaction opens — a failed probe inside one marks the
       // whole PostgreSQL transaction aborted and the error then names an innocent statement.
+      //
+      // Unconditional here, unlike the filter path, and the difference is that this read NEEDS the
+      // answer: there is no badge without it. A companion that already carries the column answers
+      // from the remembered verdict and costs nothing; one that predates it pays an introspection
+      // per list read, because a negative is deliberately not remembered and the migration that
+      // would end that cost runs in another process. That is the same trade `companion-readiness`
+      // already makes for an entity in a `pre-migration` state, and it is bounded the same way —
+      // it stops the moment the operator migrates.
       staleness: (await resolveCompanionColumn(
         this.adapter,
         companion.companionTableName,
@@ -610,11 +618,19 @@ export class CollectionQueryService extends BaseService {
       //
       // False leaves the `stale` arm answering `1=0` — nothing is KNOWN to be stale — which is
       // the defined answer for "cannot ask" rather than a claim that nothing is.
-      hasUpdatedAt: await resolveCompanionColumn(
-        this.adapter,
-        companion.companionTableName,
-        COMPANION_UPDATED_AT_COLUMN
-      ),
+      //
+      // 🔴 Resolved ONLY for the state that reads it. The probe introspects, and a NEGATIVE verdict
+      // is deliberately not cached — so on a companion that predates the column, asking here
+      // unconditionally would put a catalogue query on every filtered list, twice per page, for a
+      // capability the other four states never consult. The one state that needs it pays for it.
+      hasUpdatedAt:
+        filter.state === "stale"
+          ? await resolveCompanionColumn(
+              this.adapter,
+              companion.companionTableName,
+              COMPANION_UPDATED_AT_COLUMN
+            )
+          : undefined,
       defaultLocale: this.localization.defaultLocale,
       filter,
     });

--- a/packages/nextly/src/domains/i18n/companion-join.test.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.test.ts
@@ -115,9 +115,38 @@ describe("populateTranslationStatus (read failures)", () => {
 
 describe("populateTranslationStatus — staleness (i18n B2)", () => {
   /** A db returning fixed companion rows, so the assertion is about the derivation. */
-  function dbReturning(rows: Record<string, unknown>[]) {
+  /**
+   * The two reads this function makes, kept apart.
+   *
+   * 🔴 The staleness read passes a PROJECTION and the companion read does not, which is what lets
+   * one fake serve both honestly. It matters that they are separated: staleness is decided by the
+   * database now — a correlated `EXISTS` comparing the two rows' stamps — so a fake that answered
+   * both reads with the same rows would report every locale stale and every assertion here would
+   * pass for a reason unrelated to what it names.
+   *
+   * These tests therefore assert what THIS function decides given the database's answer:
+   * orthogonality, content gating, and what happens when the answer cannot be obtained. The
+   * comparison itself is asserted against a real database in
+   * `runtime/__tests__/companion-updated-at.test.ts`, which is the only place it can be.
+   */
+  function dbReturning(
+    rows: Record<string, unknown>[],
+    staleLocales: string[] = []
+  ) {
     return {
-      select: () => ({ from: () => ({ where: () => Promise.resolve(rows) }) }),
+      select: (projection?: Record<string, unknown>) => ({
+        from: () => ({
+          where: () =>
+            Promise.resolve(
+              projection
+                ? staleLocales.map(locale => ({
+                    _parent: "doc1",
+                    _locale: locale,
+                  }))
+                : rows
+            ),
+        }),
+      }),
     } as never;
   }
 
@@ -187,13 +216,13 @@ describe("populateTranslationStatus — staleness (i18n B2)", () => {
 
   async function metaFor(
     rows: Record<string, unknown>[],
-    options: { canReadStamps?: boolean } = {}
+    options: { canReadStamps?: boolean; staleLocales?: string[] } = {}
   ): Promise<
     Record<string, { translated: boolean; status?: string; stale?: boolean }>
   > {
     const row: Record<string, unknown> = { id: "doc1" };
     await populateTranslationStatus({
-      db: dbReturning(rows),
+      db: dbReturning(rows, options.staleLocales),
       companionTable: { _parent: "p", _locale: "l" },
       localizedFields: [{ name: "title", column: "title" }],
       rows: [row],
@@ -213,47 +242,50 @@ describe("populateTranslationStatus — staleness (i18n B2)", () => {
     return row._translations as never;
   }
 
-  it("flags a translation whose source was written afterwards", async () => {
-    const meta = await metaFor([
-      companionRow(SOURCE, "Hello again", new Date(2000)),
-      companionRow(TARGET, "Bonjour", new Date(1000)),
-    ]);
+  it("appends staleness to the state instead of replacing it", async () => {
+    const meta = await metaFor(
+      [
+        companionRow(SOURCE, "Hello again", new Date(2000)),
+        companionRow(TARGET, "Bonjour", new Date(1000)),
+      ],
+      { staleLocales: [TARGET] }
+    );
 
     expect(meta[TARGET].stale).toBe(true);
-    // 🔴 And it keeps the state it was in. This pair is the assertion: `stale`
-    // is a SECOND fact about the language, so a reader that renders it as a
-    // replacement takes a live translation out of "published" on every screen.
+    // 🔴 This pair is the assertion, and it is the one thing only this function can get wrong:
+    // `stale` is a SECOND fact about the language, so a reader that renders it as a replacement
+    // takes a live translation out of "published" on every screen. Whether the language IS stale
+    // is the database's answer, supplied above.
     expect(meta[TARGET].translated).toBe(true);
     expect(meta[TARGET].status).toBe("published");
   });
 
-  it("does not flag one written after its source", async () => {
+  it("invents no staleness the database did not report", async () => {
     const meta = await metaFor([
       companionRow(SOURCE, "Hello", new Date(1000)),
       companionRow(TARGET, "Bonjour", new Date(2000)),
     ]);
 
-    // The control. Without it, "always stale" passes the case above.
+    // The control. Without it, "always stale" passes the case above. Note the rows carry stamps
+    // and the answer is still absent: this function does not look at them, and a version that
+    // started to would be reintroducing the second implementation this one was collapsed into.
     expect(meta[TARGET].stale).toBeUndefined();
   });
 
-  it("leaves staleness ABSENT when either timestamp is unknown", async () => {
-    // Absent rather than `false`, and the difference carries weight: a consumer
-    // reading `stale === false` should be reading a real "not stale", not an
-    // unknown wearing its clothes. A row written before `_updated_at` existed
-    // cannot answer, and must never be rendered as up to date.
-    const unstampedTarget = await metaFor([
-      companionRow(SOURCE, "Hello again", new Date(2000)),
-      companionRow(TARGET, "Bonjour", null),
-    ]);
-    expect(unstampedTarget[TARGET].stale).toBeUndefined();
-    expect(unstampedTarget[TARGET].translated).toBe(true);
-
-    const unstampedSource = await metaFor([
-      companionRow(SOURCE, "Hello", null),
-      companionRow(TARGET, "Bonjour", new Date(1000)),
-    ]);
-    expect(unstampedSource[TARGET].stale).toBeUndefined();
+  it("leaves staleness ABSENT rather than false for a locale not reported", async () => {
+    // Absent rather than `false`, and the difference carries weight: a consumer reading
+    // `stale === false` should be reading a real "not stale", not an unknown wearing its clothes.
+    // A locale the comparison could not be made for — one written before `_updated_at` existed —
+    // is simply not in the reported set, and must never be rendered as up to date.
+    const meta = await metaFor(
+      [
+        companionRow(SOURCE, "Hello again", new Date(2000)),
+        companionRow(TARGET, "Bonjour", null),
+      ],
+      { staleLocales: [] }
+    );
+    expect(meta[TARGET].stale).toBeUndefined();
+    expect(meta[TARGET].translated).toBe(true);
   });
 
   it("does not flag a language that has no content", async () => {

--- a/packages/nextly/src/domains/i18n/companion-join.ts
+++ b/packages/nextly/src/domains/i18n/companion-join.ts
@@ -636,7 +636,6 @@ function buildStaleCondition(args: {
   const src = sql.identifier("nx_stale_source");
   const parent = sql.identifier("_parent");
   const localeCol = sql.identifier("_locale");
-  const stamp = sql.identifier(COMPANION_UPDATED_AT_COLUMN);
 
   return sql`EXISTS (
     SELECT 1 FROM ${table} ${tgt}
@@ -647,9 +646,34 @@ function buildStaleCondition(args: {
       SELECT 1 FROM ${table} ${src}
       WHERE ${src}.${parent} = ${mainIdColumn}
       AND ${src}.${localeCol} = ${defaultLocale}
-      AND ${src}.${stamp} > ${tgt}.${stamp}
+      AND ${sourceMovedAfterTarget(src, tgt)}
     )
   )`;
+}
+
+/** A table alias as `sql.identifier` produces it — derived, so it cannot drift from that call. */
+type TableAlias = ReturnType<typeof sql.identifier>;
+
+/**
+ * The rule: the source row was written strictly after the target row.
+ *
+ * 🔴 ONE spelling, used by the filter arm above and by {@link readStaleLocales}, because the
+ * worklist tab and the per-row badge answer the same question about the same document and must
+ * not be able to disagree. They ran as two implementations — this predicate in SQL and a JS twin
+ * comparing two `Date`s — and the twin's own comment admitted the hazard while keeping it.
+ *
+ * Both operands are nullable, and SQL's three-valued logic is the whole null policy: `NULL > x`
+ * and `x > NULL` are UNKNOWN, which no `WHERE` admits. So a locale with no stamp — one written
+ * before the column existed, or seeded from a history that had none — is never reported stale,
+ * which is what UNKNOWN has to mean here. Writing that as an explicit `IS NOT NULL` guard would
+ * state the same thing twice and let the two drift.
+ *
+ * STRICT, not `>=`. Equal stamps are a translation saved alongside its source, and on SQLite they
+ * are also two writes inside one second, because the column stores whole seconds there.
+ */
+function sourceMovedAfterTarget(source: TableAlias, target: TableAlias): SQL {
+  const stamp = sql.identifier(COMPANION_UPDATED_AT_COLUMN);
+  return sql`${source}.${stamp} > ${target}.${stamp}`;
 }
 
 /** Per-locale translation state for one entry (i18n M7 — translation-status overview). */
@@ -796,63 +820,53 @@ function markPendingChanges(
  * anything else, so a permission fault or a dropped connection still surfaces instead of being
  * reported as "this site has no staleness information".
  */
-async function readCompanionStamps(
+async function readStaleLocales(
   db: SelectableDb,
   companionTableName: string,
   dialect: SupportedDialect,
   ids: (string | number)[],
-  locales: string[]
-): Promise<Map<string, Date>> {
-  const out = new Map<string, Date>();
+  locales: string[],
+  defaultLocale: string
+): Promise<Set<string>> {
+  const out = new Set<string>();
   if (ids.length === 0 || locales.length === 0) return out;
 
   const stamp = buildCompanionStampTable(companionTableName, dialect);
+  // The outer row, addressed by the table's own name: `.from()` emits it unaliased, so the
+  // correlated subquery can reach it without the projection having to carry it.
+  const target = sql.identifier(companionTableName);
+  const source = sql.identifier("nx_stale_source");
+  const parent = sql.identifier("_parent");
+  const localeCol = sql.identifier("_locale");
+
   let rows: Record<string, unknown>[];
   try {
     rows = await db
-      .select({
-        _parent: stamp.parent,
-        _locale: stamp.locale,
-        [COMPANION_UPDATED_AT_COLUMN]: stamp.updatedAt,
-      })
+      .select({ _parent: stamp.parent, _locale: stamp.locale })
       .from(stamp.table)
       .where(
         and(
           inArray(stamp.parent as never, ids),
-          inArray(stamp.locale as never, locales)
+          inArray(stamp.locale as never, locales),
+          sql`EXISTS (
+            SELECT 1 FROM ${target} ${source}
+            WHERE ${source}.${parent} = ${target}.${parent}
+            AND ${source}.${localeCol} = ${defaultLocale}
+            AND ${sourceMovedAfterTarget(source, target)}
+          )`
         )
       );
   } catch (error) {
+    // A companion provisioned before the column exists. Reported as "nothing is KNOWN to be
+    // stale", never as "nothing is stale" — the caller renders an absent entry as unknown.
     if (isMissingColumnError(error, COMPANION_UPDATED_AT_COLUMN)) return out;
     throw error;
   }
 
   for (const row of rows) {
-    const at = toStampDate(row[COMPANION_UPDATED_AT_COLUMN]);
-    if (at !== null) {
-      out.set(`${String(row._parent)}::${String(row._locale)}`, at);
-    }
+    out.add(`${String(row._parent)}::${String(row._locale)}`);
   }
   return out;
-}
-
-/**
- * One raw `_updated_at` value as a `Date`, or `null` when it cannot be one.
- *
- * Drizzle decodes the column for every dialect it declares, so a `Date` is the expected shape.
- * A raw epoch is still accepted because a driver that returns one unmapped would otherwise be
- * read as "no stamp", which is silently wrong rather than loudly wrong.
- *
- * Anything else answers `null` and the caller reports UNKNOWN. Guessing at an unrecognised shape
- * is what would turn a driver change into wrong staleness answers rather than absent ones.
- */
-function toStampDate(raw: unknown): Date | null {
-  if (raw instanceof Date) return Number.isNaN(raw.getTime()) ? null : raw;
-  if (typeof raw === "number") {
-    const at = new Date(raw * 1000);
-    return Number.isNaN(at.getTime()) ? null : at;
-  }
-  return null;
 }
 
 /**
@@ -905,29 +919,6 @@ export function isMissingColumnError(error: unknown, column: string): boolean {
   return false;
 }
 
-/**
- * Was the SOURCE row written after the TARGET row was? (i18n B2.)
- *
- * The JS twin of the `stale` SQL arm, and deliberately the same rule: content is checked by the
- * caller, both timestamps must be present, and the comparison is strict. Two spellings of "is
- * this stale" would let the worklist tab and the per-row badge disagree about one document, which
- * is the shape of defect this module already carries a fix for.
- *
- * Reads a `Date` because that is what the column's declared `timestamp` kind decodes to on all
- * three dialects. Anything else — a driver returning a raw epoch, a column that was never
- * declared and so never selected — answers `false` rather than guessing, because a wrong
- * comparison here reports a translation nobody touched as needing review.
- */
-function isStaleAgainstSource(
-  targetAt: Date | undefined,
-  sourceAt: Date | undefined
-): boolean {
-  if (targetAt === undefined || sourceAt === undefined) return false;
-  // Strict, matching the SQL. Equal stamps are a translation saved alongside its source — and on
-  // SQLite they are also two writes inside one second, since the column stores whole seconds.
-  return sourceAt.getTime() > targetAt.getTime();
-}
-
 export async function populateTranslationStatus(
   args: TranslationStatusArgs
 ): Promise<void> {
@@ -973,15 +964,16 @@ export async function populateTranslationStatus(
 
   // One extra query for the whole page rather than one per row, and skipped entirely when the
   // caller supplies no reader.
-  const stamps = args.staleness
-    ? await readCompanionStamps(
+  const staleKeys = args.staleness
+    ? await readStaleLocales(
         db,
         args.staleness.companionTableName,
         args.staleness.dialect,
         ids,
-        locales
+        locales,
+        defaultLocale
       )
-    : new Map<string, Date>();
+    : new Set<string>();
 
   for (const row of rows) {
     const perLocaleRows = byParent.get(row[idKey]) ?? {};
@@ -994,8 +986,8 @@ export async function populateTranslationStatus(
         defaultLocale,
         hasStatus,
         statusValue: args.statusValue,
-        stampFor: (locale: string) =>
-          stamps.get(`${String(row[idKey])}::${locale}`),
+        isStale: (locale: string) =>
+          staleKeys.has(`${String(row[idKey])}::${locale}`),
       });
     }
     markPendingChanges(
@@ -1039,8 +1031,14 @@ function buildLocaleMeta(args: {
   defaultLocale: string;
   hasStatus: boolean;
   statusValue: string | undefined;
-  /** When this locale was last written, or `undefined` when nothing is known. */
-  stampFor: (locale: string) => Date | undefined;
+  /**
+   * Whether the database reported this locale as stale against the source.
+   *
+   * `false` covers both "the source has not moved" and "nothing is known", because the caller
+   * cannot act on the difference: an absent entry is a locale the comparison could not be made
+   * for, and the answer to both is the same — do not mark it.
+   */
+  isStale: (locale: string) => boolean;
 }): LocaleTranslationMeta {
   const { code, perLocaleRows, localizedFields, defaultLocale, hasStatus } =
     args;
@@ -1060,17 +1058,13 @@ function buildLocaleMeta(args: {
   // `stale === false` is reading a real "not stale" rather than an unknown wearing its clothes.
   //
   // 🔴 `code !== defaultLocale` is BELT-AND-BRACES and is kept deliberately, so it does not read
-  // as load-bearing to the next person: for the source locale, `companionRow` and the source row
-  // are the same object, so the strict comparison is already false. That redundancy rests on
-  // object IDENTITY rather than on a rule, though — a future normalisation that handed this a
-  // copy, or a rounded timestamp, could make a row compare greater than itself — so the state the
+  // as load-bearing to the next person: the comparison joins the source row to itself for that
+  // locale, and no row is written strictly after itself, so the database already answers false.
+  // That redundancy rests on the comparison staying STRICT, though — relaxing it to `>=` to admit
+  // same-second writes would make every source locale report itself stale — so the state the
   // guard asserts is spelled out rather than inferred. No test separates the two mechanisms, and
   // none can while both hold.
-  if (
-    code !== defaultLocale &&
-    hasContent &&
-    isStaleAgainstSource(args.stampFor(code), args.stampFor(defaultLocale))
-  ) {
+  if (code !== defaultLocale && hasContent && args.isStale(code)) {
     entry.stale = true;
   }
   return entry;

--- a/packages/nextly/src/domains/i18n/runtime/__tests__/companion-column-verdict.test.ts
+++ b/packages/nextly/src/domains/i18n/runtime/__tests__/companion-column-verdict.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Remembering that a companion HAS a column, and deliberately not remembering that it has not.
+ *
+ * The staleness read names `_updated_at` in SQL, and naming a column a companion does not carry
+ * fails the whole query for that collection. So the read is gated on a physical check — and that
+ * check runs often enough that it has to be cached, which makes WHICH answers are cached the
+ * entire design.
+ *
+ * `true` is safe to remember: the reconcile is additive by policy, and a field that stops being
+ * localized keeps its column rather than dropping it, so nothing ordinary takes a column away.
+ * `false` is not safe to remember: `nextly migrate` runs in a different process, so a negative
+ * verdict outlives the migration that made it wrong — and the symptom is the feature quietly
+ * staying off for that collection, which nobody sees, rather than an error anyone reports.
+ *
+ * @module domains/i18n/runtime/__tests__/companion-column-verdict.test
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  cachedCompanionColumn,
+  expireCompanionReadiness,
+  forgetCompanionReadiness,
+  resolveCompanionColumn,
+} from "../companion-readiness";
+
+const introspectLiveSnapshot = vi.fn();
+
+vi.mock("../../../schema/pipeline/diff/introspect-live", () => ({
+  get introspectLiveSnapshot() {
+    return introspectLiveSnapshot;
+  },
+}));
+
+/** A fresh adapter per test, so one test's verdicts can never answer another's question. */
+function adapterWith(columnsByTable: Record<string, string[]>) {
+  const drizzle = {};
+  introspectLiveSnapshot.mockImplementation(
+    (_db: unknown, _dialect: string, tables: string[]) => {
+      const name = tables[0];
+      const columns = columnsByTable[name];
+      if (!columns) return Promise.resolve({ tables: [] });
+      return Promise.resolve({
+        tables: [{ name, columns: columns.map(c => ({ name: c })) }],
+      });
+    }
+  );
+  return {
+    dialect: "postgresql" as const,
+    executeQuery: vi.fn(),
+    getDrizzle: <T = unknown>(): T => drizzle as T,
+  };
+}
+
+// Reset here rather than in each test: a call count is the property under test in most of them,
+// and a case that forgot its own reset would inherit the previous one's calls and pass or fail
+// for a reason that has nothing to do with what it names.
+beforeEach(() => {
+  introspectLiveSnapshot.mockReset();
+});
+
+describe("companion column verdicts", () => {
+  it("introspects once for a column that is there, then answers from memory", async () => {
+    const adapter = adapterWith({
+      dc_posts_locales: ["_parent", "_locale", "_updated_at"],
+    });
+
+    expect(
+      await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBe(true);
+    expect(introspectLiveSnapshot).toHaveBeenCalledTimes(1);
+
+    // The reason the cache exists. Without it every read that wants staleness pays a catalogue
+    // query per collection, which is the cost `companion-readiness` was written to remove.
+    expect(
+      await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBe(true);
+    expect(
+      await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBe(true);
+    expect(introspectLiveSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("🔴 keeps asking while the column is absent, so a migration is picked up", async () => {
+    const adapter = adapterWith({ dc_posts_locales: ["_parent", "_locale"] });
+
+    expect(
+      await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBe(false);
+    expect(
+      await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBe(false);
+    // 🔴 Two calls, two queries. Remembering `false` would keep the staleness read switched off
+    // for this collection until the process reloaded, even after `nextly migrate` added the
+    // column in another process — and a feature that silently stays off has no symptom anyone
+    // reports.
+    expect(introspectLiveSnapshot).toHaveBeenCalledTimes(2);
+  });
+
+  it("sees the column the moment a migration adds it", async () => {
+    const columns: Record<string, string[]> = {
+      dc_posts_locales: ["_parent", "_locale"],
+    };
+    const adapter = adapterWith(columns);
+
+    expect(
+      await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBe(false);
+    // Another process runs the migration.
+    columns.dc_posts_locales = ["_parent", "_locale", "_updated_at"];
+    expect(
+      await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBe(true);
+  });
+
+  it("🔴 propagates a failure instead of recording the column as absent", async () => {
+    const adapter = adapterWith({});
+    introspectLiveSnapshot.mockRejectedValue(
+      new Error("connection terminated unexpectedly")
+    );
+
+    // A resolved `false` here would be a claim about the schema made from a transient fault, and
+    // the caller cannot tell it from a companion that genuinely predates the column.
+    await expect(
+      resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).rejects.toThrow(/connection terminated/);
+  });
+
+  it("answers UNKNOWN rather than false when nothing has been resolved", async () => {
+    const adapter = adapterWith({});
+    // The in-transaction form. `undefined` is not "absent" — it is "nobody has looked", and a
+    // caller that cannot look must omit whatever names the column rather than assume either way.
+    expect(
+      cachedCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBeUndefined();
+    expect(introspectLiveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("forgets a companion's columns when the companion itself is forgotten", async () => {
+    const adapter = adapterWith({
+      dc_posts_locales: ["_parent", "_locale", "_updated_at"],
+      dc_pages_locales: ["_parent", "_locale", "_updated_at"],
+    });
+    await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at");
+    await resolveCompanionColumn(adapter, "dc_pages_locales", "_updated_at");
+
+    forgetCompanionReadiness(adapter, "dc_posts_locales");
+
+    // 🔴 A replaced companion must not inherit the shape of the one it replaced. Dropping the
+    // table verdict while keeping its column verdicts would leave exactly that claim standing.
+    expect(
+      cachedCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBeUndefined();
+    // Scoped to the one companion, not the connection.
+    expect(
+      cachedCompanionColumn(adapter, "dc_pages_locales", "_updated_at")
+    ).toBe(true);
+  });
+
+  it("does not let one connection vouch for another's schema", async () => {
+    const first = adapterWith({
+      dc_posts_locales: ["_parent", "_locale", "_updated_at"],
+    });
+    await resolveCompanionColumn(first, "dc_posts_locales", "_updated_at");
+
+    // A second database, a test harness booting a fresh adapter, an instance replaced on reload:
+    // `dc_posts_locales` in each is a different table, and a verdict shared between them lets the
+    // first vouch for a companion the second has never migrated.
+    const second = adapterWith({
+      dc_posts_locales: ["_parent", "_locale", "_updated_at"],
+    });
+    expect(
+      cachedCompanionColumn(second, "dc_posts_locales", "_updated_at")
+    ).toBeUndefined();
+  });
+
+  it("re-verifies after the test seam expires a verdict", async () => {
+    const adapter = adapterWith({
+      dc_posts_locales: ["_parent", "_locale", "_updated_at"],
+    });
+    await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at");
+    expect(introspectLiveSnapshot).toHaveBeenCalledTimes(1);
+
+    expireCompanionReadiness(adapter);
+
+    expect(
+      cachedCompanionColumn(adapter, "dc_posts_locales", "_updated_at")
+    ).toBeUndefined();
+    await resolveCompanionColumn(adapter, "dc_posts_locales", "_updated_at");
+    expect(introspectLiveSnapshot).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/nextly/src/domains/i18n/runtime/__tests__/companion-updated-at.test.ts
+++ b/packages/nextly/src/domains/i18n/runtime/__tests__/companion-updated-at.test.ts
@@ -28,6 +28,8 @@ import { VERSIONS_TABLE } from "../../../../schemas/versions/types";
 import { DynamicCollectionSchemaService } from "../../../dynamic-collections/services/dynamic-collection-schema-service";
 import { splitStatements } from "../../../schema/pipeline/sql-statement-utils";
 import { COMPANION_UPDATED_AT_COLUMN } from "../../companion-columns";
+import { populateTranslationStatus } from "../../companion-join";
+import { buildCompanionRuntimeTable } from "../companion-registration";
 import { buildCompanionReconcileStatements } from "../../migration/reconcile-companion";
 import {
   companionContentStamp,
@@ -784,6 +786,149 @@ describe("companion `_updated_at`", () => {
       // unavailable, and inventing one would be worse than leaving it unknown.
       expect(statements.some(s => s.includes("ADD COLUMN"))).toBe(true);
       expect(statements.some(s => s.includes(VERSIONS_TABLE))).toBe(false);
+    });
+  });
+
+  /**
+   * The comparison itself, against a real database.
+   *
+   * 🔴 THIS IS THE ONLY PLACE THE STALENESS RULE CAN BE ASSERTED. It used to have a JS twin that a
+   * unit test could drive with two `Date`s, and the twin's own comment admitted the hazard: two
+   * spellings of "is this stale" let the worklist tab and the per-row badge disagree about one
+   * document. The twin is gone and the database is the single oracle, so a fake that cannot
+   * evaluate a `WHERE` cannot test this — it would answer every locale stale and every assertion
+   * would pass for a reason unrelated to its name.
+   *
+   * Driven through `populateTranslationStatus` rather than the private reader, because the badge
+   * is what a person sees and the reader is an implementation detail of it.
+   */
+  describe("the staleness comparison, decided by the database", () => {
+    /** Write one locale with an explicit stamp, or with none at all. */
+    async function writeLocale(
+      locale: string,
+      title: string,
+      at: Date | null
+    ): Promise<void> {
+      await upsertCompanionRow(
+        adapter,
+        COMPANION,
+        "p1",
+        locale,
+        { title },
+        undefined,
+        at === null ? { updatedAt: "omit" } : { now: at }
+      );
+    }
+
+    /** The per-locale metadata the entry list and language panel render. */
+    async function metaForRow(): Promise<
+      Record<string, { translated: boolean; stale?: boolean }>
+    > {
+      const row: Record<string, unknown> = { id: "p1" };
+      await populateTranslationStatus({
+        db: adapter.getDrizzle(),
+        // 🔴 The REAL companion table, not the narrow stamp handle. The stamp handle declares
+        // three structural columns and no translated ones, so a row read through it carries no
+        // `title` — `hasContent` would be false for every locale and the badge would never be
+        // reached, which is a green that proves nothing.
+        companionTable: buildCompanionRuntimeTable({
+          slug: "posts",
+          tableName: MAIN,
+          fields: [{ name: "title", type: "text", localized: true }] as never,
+          dialect: "sqlite",
+          localized: true,
+        })?.table,
+        localizedFields: [{ name: "title", column: "title" }],
+        rows: [row],
+        locales: ["en", "fr"],
+        defaultLocale: "en",
+        hasStatus: false,
+        readiness: "ready",
+        staleness: { companionTableName: COMPANION, dialect: "sqlite" },
+      });
+      return row._translations as never;
+    }
+
+    it("reports the target stale when the source was written after it", async () => {
+      await createCompanion();
+      await writeLocale("fr", "Bonjour", new Date("2026-08-28T09:00:00.000Z"));
+      await writeLocale(
+        "en",
+        "Hello again",
+        new Date("2026-08-28T10:00:00.000Z")
+      );
+
+      const meta = await metaForRow();
+      expect(meta.fr.stale).toBe(true);
+      // Still translated. Staleness is a second fact, not a demotion.
+      expect(meta.fr.translated).toBe(true);
+    });
+
+    it("reports nothing stale when the target was written after the source", async () => {
+      await createCompanion();
+      await writeLocale("en", "Hello", new Date("2026-08-28T09:00:00.000Z"));
+      await writeLocale("fr", "Bonjour", new Date("2026-08-28T10:00:00.000Z"));
+
+      // The control. Without it, "always stale" satisfies the case above.
+      const meta = await metaForRow();
+      expect(meta.fr.stale).toBeUndefined();
+    });
+
+    it("reports nothing stale when the two were written in the same second", async () => {
+      await createCompanion();
+      const at = new Date("2026-08-28T09:00:00.000Z");
+      await writeLocale("en", "Hello", at);
+      await writeLocale("fr", "Bonjour", at);
+
+      // 🔴 STRICT, and on SQLite this is not a corner case: the column stores whole seconds, so a
+      // translation saved alongside its source lands on the same value. `>=` would report every
+      // such pair stale, and would also make the source locale stale against itself.
+      const meta = await metaForRow();
+      expect(meta.fr.stale).toBeUndefined();
+    });
+
+    it("never reports the SOURCE locale stale against itself", async () => {
+      await createCompanion();
+      await writeLocale("en", "Hello", new Date("2026-08-28T09:00:00.000Z"));
+      await writeLocale("fr", "Bonjour", new Date("2026-08-28T08:00:00.000Z"));
+
+      const meta = await metaForRow();
+      expect(meta.fr.stale).toBe(true);
+      // 🔴 TWO independent mechanisms produce this and THIS TEST CANNOT SEPARATE THEM, which is
+      // stated rather than implied because the obvious reading is wrong. The database compares the
+      // source row to itself and answers false only while the comparison stays strict; the caller
+      // also refuses to mark the default locale at all. Relaxing the comparison to `>=` leaves
+      // this case passing on the caller's guard alone — measured, not assumed. The strictness is
+      // pinned by the same-second case above, which the guard does not cover.
+      expect(meta.en.stale).toBeUndefined();
+    });
+
+    it("leaves a locale with NO stamp unknown rather than fresh", async () => {
+      await createCompanion();
+      await writeLocale("fr", "Bonjour", null);
+      await writeLocale(
+        "en",
+        "Hello again",
+        new Date("2026-08-28T10:00:00.000Z")
+      );
+
+      // 🔴 The reassuring direction is the dangerous one. `NULL > x` is UNKNOWN in SQL and no
+      // WHERE admits it, so a locale written before the column existed is absent from the answer
+      // and renders as unknown — never as up to date, which is the claim this feature must not
+      // make about a translation it cannot vouch for.
+      const meta = await metaForRow();
+      expect(meta.fr.stale).toBeUndefined();
+      expect(meta.fr.translated).toBe(true);
+    });
+
+    it("leaves a target unknown when the SOURCE has no stamp", async () => {
+      await createCompanion();
+      await writeLocale("fr", "Bonjour", new Date("2026-08-28T09:00:00.000Z"));
+      await writeLocale("en", "Hello", null);
+
+      // The other side of the same three-valued rule: nothing to compare against is not "fresh".
+      const meta = await metaForRow();
+      expect(meta.fr.stale).toBeUndefined();
     });
   });
 });

--- a/packages/nextly/src/domains/i18n/runtime/companion-readiness.ts
+++ b/packages/nextly/src/domains/i18n/runtime/companion-readiness.ts
@@ -75,6 +75,15 @@ export type CompanionReadiness = "ready" | "pre-migration" | "broken";
  */
 interface ReadinessCacheBag {
   __nextly_companionReadiness?: WeakMap<object, Map<string, number>>;
+  /**
+   * Positive column verdicts, per adapter, by companion table and then by column.
+   *
+   * Nested rather than keyed on a joined `table:column` string so that forgetting one companion
+   * drops every column verdict for it in one operation. A provisioning path that replaces a
+   * companion invalidates a TABLE, and it must not leave behind a verdict claiming the
+   * replacement carries a column nobody has looked at.
+   */
+  __nextly_companionColumns?: WeakMap<object, Map<string, Map<string, number>>>;
 }
 
 /**
@@ -259,9 +268,14 @@ export function forgetCompanionReadiness(
 ): void {
   if (companionTableName === undefined) {
     readyTables(scope).clear();
+    columnVerdicts(scope).clear();
     return;
   }
   readyTables(scope).delete(companionTableName);
+  // Column verdicts describe THIS table, so they die with it. Keeping them would let a replaced
+  // companion inherit the shape of the one it replaced, which is the exact claim this whole
+  // module exists to stop being made from memory.
+  columnVerdicts(scope).delete(companionTableName);
 }
 
 /** Test seam: drop every verdict for this connection and re-verify on the next resolve. */
@@ -269,4 +283,88 @@ export function expireCompanionReadiness(scope: ReadinessScope): void {
   for (const table of readyTables(scope).keys()) {
     readyTables(scope).set(table, 0);
   }
+  for (const columns of columnVerdicts(scope).values()) {
+    for (const column of columns.keys()) columns.set(column, 0);
+  }
+}
+
+function columnVerdicts(
+  scope: ReadinessScope
+): Map<string, Map<string, number>> {
+  const bag = globalThis as ReadinessCacheBag;
+  bag.__nextly_companionColumns ??= new WeakMap<
+    object,
+    Map<string, Map<string, number>>
+  >();
+  let tables = bag.__nextly_companionColumns.get(scope);
+  if (!tables) {
+    tables = new Map<string, Map<string, number>>();
+    bag.__nextly_companionColumns.set(scope, tables);
+  }
+  return tables;
+}
+
+/**
+ * The remembered verdict for one column, or `undefined` when there is none. Never queries, so it
+ * is the only form safe to call from inside an open transaction.
+ *
+ * 🔴 `undefined` is NOT "the column is absent". It means nothing has established either way, and
+ * a caller that cannot find out must behave as it would for a companion that lacks the column:
+ * omit whatever names it. That is the conservative direction — omitting the staleness inputs
+ * reports UNKNOWN, while naming a column that is not there fails the whole query for that
+ * collection.
+ *
+ * Only `true` is ever returned, because only `true` is ever stored. See
+ * {@link resolveCompanionColumn}.
+ */
+export function cachedCompanionColumn(
+  scope: ReadinessScope,
+  companionTableName: string,
+  column: string
+): true | undefined {
+  const columns = columnVerdicts(scope).get(companionTableName);
+  return isFresh(columns?.get(column)) ? true : undefined;
+}
+
+/**
+ * Whether an existing companion physically carries `column`, remembering only that it does.
+ *
+ * 🔴 MUST NOT be called inside an open transaction. It queries, and a query that fails marks the
+ * whole PostgreSQL transaction aborted, after which the real statement dies with
+ * `current transaction is aborted` naming an innocent one. Callers resolve before they open one;
+ * inside a transaction they read {@link cachedCompanionColumn}, which cannot query.
+ *
+ * 🔴 ONLY THE POSITIVE ANSWER IS REMEMBERED, and the asymmetry is the whole design — the same one
+ * {@link resolveCompanionReadiness} makes about `ready`, for the same reason.
+ *
+ * A column is added by a migration and never removed: the reconcile is additive by policy, and a
+ * field that stops being localized leaves its column in place rather than dropping it. So `true`
+ * describes a state nothing ordinary undoes, and a stale `true` is bounded by the TTL anyway.
+ *
+ * `false` is the opposite. `nextly migrate` runs in a different process from the server, so a
+ * negative verdict can outlive the migration that made it wrong — and it would keep the staleness
+ * read switched off for that collection until the process reloads, which is a feature silently
+ * absent rather than an error anyone sees. Re-asking costs one introspection per resolve on a
+ * path that is not the request path.
+ */
+export async function resolveCompanionColumn(
+  adapter: CompanionIntrospectAdapter,
+  companionTableName: string,
+  column: string
+): Promise<boolean> {
+  if (cachedCompanionColumn(adapter, companionTableName, column)) return true;
+  const { companionHasColumn } = await import("./companion-io");
+  // Deliberately not caught. `companionHasColumn` answers from the table's own column list, so
+  // absent is absent and anything that stops the list being read is a failure rather than a claim
+  // about the schema — see its own comment. Swallowing here would rebuild exactly the collapse it
+  // was changed to remove.
+  const present = await companionHasColumn(adapter, companionTableName, column);
+  if (!present) return false;
+  let columns = columnVerdicts(adapter).get(companionTableName);
+  if (!columns) {
+    columns = new Map<string, number>();
+    columnVerdicts(adapter).set(companionTableName, columns);
+  }
+  columns.set(column, Date.now());
+  return true;
 }

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -82,6 +82,7 @@ import {
 import type { Logger } from "../../../shared/types";
 import { relationKey } from "../../collections/services/collection-relationship-service";
 import { resolveLocalizedFieldNames } from "../../i18n/classify-fields";
+import { COMPANION_UPDATED_AT_COLUMN } from "../../i18n/companion-columns";
 import {
   populateCompanionFields,
   populateTranslationStatus,
@@ -99,6 +100,7 @@ import {
 } from "../../i18n/runtime/companion-io";
 import {
   isCompanionReady,
+  resolveCompanionColumn,
   resolveCompanionSchemaReadiness,
 } from "../../i18n/runtime/companion-readiness";
 import {
@@ -2205,6 +2207,25 @@ export class SingleQueryService extends BaseService {
       // The Single's own row id keys the companion `_parent`, same as the collection path.
       idKey: "id",
       readiness: await resolveCompanionSchemaReadiness(this.adapter, companion),
+      // 🔴 Singles carry the signal too, and the same physical check gates it. Every companion
+      // write is stamped whatever the entity, so a Single's languages accumulate truthful
+      // timestamps and the comparison is as valid here as on a collection.
+      //
+      // What a Single does NOT get is the history back-fill — `versionScopeForEntityKind` returns
+      // nothing for it by scope, not by structure. That leaves languages written before this
+      // shipped with no stamp, and no stamp is absent from the answer rather than reported fresh.
+      // So a Single reports staleness for what it can vouch for and stays silent about the rest,
+      // which is the same conservative direction the whole feature takes.
+      staleness: (await resolveCompanionColumn(
+        this.adapter,
+        companion.companionTableName,
+        COMPANION_UPDATED_AT_COLUMN
+      ))
+        ? {
+            companionTableName: companion.companionTableName,
+            dialect: this.adapter.dialect,
+          }
+        : undefined,
     });
   }
 


### PR DESCRIPTION
Turns on the staleness READ that #1332 deliberately withheld. A language whose source was edited after it was translated is now marked as needing review — and stays translated and published, because it is both.

The admin already renders the flag (`LanguagePanel` reads `translations[locale].stale`, and the label appends "source changed since"), so this ships visible behaviour with no admin changes. The worklist tab is deliberately NOT here; it needs an empty-state for collections that cannot answer, and that is its own change.

## Two implementations became one

"Is this translation stale" existed twice: as SQL in the filter arm, and as a JavaScript comparison of two `Date`s for the per-row flag. The twin's own docblock admitted the hazard while keeping it — two spellings let the worklist tab and the language panel disagree about **one document**, one saying it needs review while the other says it is fine.

The stamp read now asks the database which locales are stale and returns that set. Both consumers derive from one comparison, stated once:

```ts
function sourceMovedAfterTarget(source: TableAlias, target: TableAlias): SQL {
  return sql`${source}.${stamp} > ${target}.${stamp}`;
}
```

That also puts the null policy where it belongs. Both operands are nullable and SQL's three-valued logic already answers it: `NULL > x` is UNKNOWN and no `WHERE` admits it, so a language with no stamp is absent from the result rather than reported fresh. An explicit `IS NOT NULL` guard would state the same rule a second time and let the two drift.

`isStaleAgainstSource` and its `toStampDate` decoder — its only consumer — are deleted.

## Physical capability, not declared

`companion.hasUpdatedAt` is unconditionally `true`: a claim about a column nothing has checked. Both read inputs are now gated on a real check of the table's columns, cached beside the readiness verdict it belongs with.

**Only the positive answer is remembered**, and the asymmetry is the design:

- a column is added by a migration and never removed (the reconcile is additive by policy, and a de-localized field keeps its column), so `true` is safe to be stale about, bounded by the same TTL readiness uses;
- a remembered `false` would outlive the migration that made it wrong — `nextly migrate` runs in a different process — and the symptom is the signal silently staying off for that collection until a reload, which nobody reports.

Both consumers resolve the same probe, so the tab and the badge cannot disagree about whether the question is even askable. Failures propagate rather than becoming `false`, for the reason #1342 established: a transient fault must not become a claim about the schema.

## Prior art

Filed as `research:translation-staleness-prior-art`. Two models exist and the unit of translation decides which is right:

- **Weblate** (string-level) makes it a distinct STATE, "Needs rewriting" — which works because a string carries one fact.
- **Drupal** (document-level) makes it a FLAG orthogonal to publishing: "their workflow status is independent of the status of the other languages."

nextly is document-level with a per-locale publish lifecycle, so the Drupal shape is the apt one and #1332's orthogonal-flag decision is right. Collapsing the two would make the entry list stop reporting a live translation as live.

Where this is better than the prior art: Drupal's flag is **stored and manually cleared**, and their issue queue records the consequence — "remember to uncheck 'needs updating'". People forget, so it drifts in the reassuring direction. This one is derived, so re-saving clears it as a consequence of the save.

The hazard taken from Drupal: their outdated flag is **disabled entirely under content moderation**, a core bug open since 2018 — the staleness × publish-lifecycle seam is exactly where the closest prior art broke. #1332 avoided the write half (a lifecycle transition writes no stamp). This is the read half: a stale translation keeps reporting as published.

## Evidence

The comparison is asserted against a **real database**, which is the only place it can be now that no JavaScript performs it. Break-verified:

    >  to  >=      ->  × reports nothing stale when the two were written in the same second
    reversed       ->  × reports the target stale when the source was written after it
                       × reports nothing stale when the target was written after the source
                       × never reports the SOURCE locale stale against itself

The capability probe, three independent breaks, each failing only its own tests:

    cache the negative too     ->  × keeps asking while the column is absent
                                   × sees the column the moment a migration adds it
    swallow failure into false ->  × propagates a failure instead of recording absent
    forget table, keep columns ->  × forgets a companion's columns when forgotten

**Two test defects fixed along the way, both of which were passing.** The unit fake answered every read with the same rows, so it could not evaluate a `WHERE` — one staleness assertion was passing for a reason unrelated to its name once the comparison moved to SQL. The fake is now split on the projection, so the staleness read and the companion read answer separately, and those tests assert what that layer actually decides. Separately, one new integration test claimed the database refuses to mark the source locale stale against itself; break-verification showed the caller's `code !== defaultLocale` guard satisfies it and the test cannot separate the two mechanisms. That is now stated in the test rather than implied.

    cd packages/nextly && pnpm run check-types  -> 0     lint -> 0
    vitest run src/domains/i18n src/domains/collections  -> 51 files, 780 tests
    node scripts/check-comment-convention.mjs   -> 0
    pnpm exec changeset status                  -> 0

## Note on main

`main` is currently red on `packages/admin/src/hooks/__tests__/system-resources-parity.test.ts` (4 failures), reproduced on an untouched main worktree at `0a3bd2431`. Core's `SYSTEM_RESOURCES` gained `content-releases`; three admin lists still carry nine. Unrelated to this change, reported to the lane that owns it.
