### PR TITLE
fix(builder): read var(), quoted names and emitted tokens as CSS does

### DIFF
--- a/.changeset/read-a-font-family-value-as-css-does.md
+++ b/.changeset/read-a-font-family-value-as-css-does.md
@@ -1,0 +1,55 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Read a `font-family` value the way CSS does, in four places it did not.
+
+- A `var()` call is dynamic only when it names a custom property. CSS requires
+  the first argument to begin with `--`, so `var(foo)` computes to an invalid
+  `font-family` and the browser drops the declaration rather than falling
+  through to the next family. Treating every `var(` as dynamic gave a dropped
+  declaration an all-clear.
+- Quoted family content keeps its spacing verbatim. `" Brand "` names a family
+  whose name carries those spaces and is a different family from `Brand`;
+  matching it against a face called `Brand` claimed a file renders that does
+  not. Whitespace outside the quotes is still separation and still trims.
+- A bare `default` is invalid rather than a whole-value keyword. Unlike
+  `inherit`, `initial`, `unset`, `revert` and `revert-layer`, it is excluded
+  from `<family-name>`, so the browser drops a declaration reading it bare.
+- A comma inside `var(--font, Arial)` is not a family separator. Depth is
+  counted rather than flagged, because `var(--a, var(--b, serif))` nests.
+
+`emitTokenBlocks` now reports the tokens it wrote alongside the CSS and its
+issues. It refuses a token on five separate grounds, and a caller asking "which
+tokens does this site emit" had to restate all five — a second statement that
+agrees today and drifts the first time one changes. The fonts panel reports on
+that list, so a token the compiler refuses is no longer described as a typeface
+the site renders.
+
+The fonts panel draws a subset face with glyphs that face covers. A face limited
+to a non-Latin `unicodeRange` renders none of the Latin specimen, so the row
+demonstrated another subset or a fallback rather than the file it names.

--- a/packages/blocks-engine/src/style/dtcg.ts
+++ b/packages/blocks-engine/src/style/dtcg.ts
@@ -409,6 +409,14 @@ function familyToDtcg(css: string): string | string[] | undefined {
 export function splitFamilyList(css: string): FamilyPart[] {
   const parts: FamilyPart[] = [];
   let current = "";
+  // What the quotes actually enclosed, collected separately.
+  //
+  // `current` cannot answer for a quoted item: it accumulates the whitespace
+  // around the string as well as the string, so `" Brand "` and ` "Brand" `
+  // both arrive as `" Brand "` and are indistinguishable. Trimming served the
+  // second and corrupted the first — a quoted name keeps its edge spaces,
+  // because inside quotes they are part of the family's name.
+  let inner = "";
   let quoted = false;
   let strings = 0;
   let outsideQuotes = "";
@@ -429,6 +437,9 @@ export function splitFamilyList(css: string): FamilyPart[] {
       // standard value.
       const escape = readCssEscape(css, index);
       current += escape.text;
+      // An escape inside quotes is part of the NAME, so it belongs to the
+      // quoted content too: `"ACME\\26 Co"` is the family `ACME&Co`.
+      if (quote !== undefined) inner += escape.text;
       raw += css.slice(index, escape.next);
       index = escape.next - 1;
       continue;
@@ -436,7 +447,10 @@ export function splitFamilyList(css: string): FamilyPart[] {
     if (quote !== undefined) {
       raw += char;
       if (char === quote) quote = undefined;
-      else current += char;
+      else {
+        current += char;
+        inner += char;
+      }
       continue;
     }
     if (char === '"' || char === "'") {
@@ -451,8 +465,11 @@ export function splitFamilyList(css: string): FamilyPart[] {
     if (char === "(") depth += 1;
     else if (char === ")" && depth > 0) depth -= 1;
     if (char === "," && depth === 0) {
-      parts.push(finishPart(current, quoted, strings, outsideQuotes, raw));
+      parts.push(
+        finishPart(current, inner, quoted, strings, outsideQuotes, raw)
+      );
       current = "";
+      inner = "";
       raw = "";
       quoted = false;
       strings = 0;
@@ -463,7 +480,7 @@ export function splitFamilyList(css: string): FamilyPart[] {
     current += char;
     raw += char;
   }
-  parts.push(finishPart(current, quoted, strings, outsideQuotes, raw));
+  parts.push(finishPart(current, inner, quoted, strings, outsideQuotes, raw));
 
   // Empty items are KEPT, marked invalid by `finishPart`. `Brand,` and
   // `Brand,, serif` are parse errors — CSS reads `<family-name>#`, which admits
@@ -567,14 +584,36 @@ export type FamilyPartKind =
   | "keyword"
   | "invalid";
 
+/** Any `var(` call, however written. Case-insensitive: CSS functions are. */
+const VAR_CALL = /\bvar\s*\(/i;
+
+/**
+ * Every `var(` in the text opening with a custom-property name.
+ *
+ * `--` is what makes an identifier a custom property, so `var(foo)` is not a
+ * substitution CSS will make. Written as "no occurrence of `var(` NOT followed
+ * by `--`", because one malformed call spoils the declaration however many
+ * well-formed ones sit beside it.
+ */
+const WELL_FORMED_VAR_CALLS =
+  /^(?:(?!\bvar\s*\()[\s\S])*(?:\bvar\s*\(\s*--[^\s,()]*(?:(?!\bvar\s*\()[\s\S])*)*$/i;
+
 /** Classify one family-list item. */
 export function familyPartKind(part: FamilyPart): FamilyPartKind {
   if (!part.valid) return "invalid";
   if (part.quoted) return "name";
   const lower = part.name.toLowerCase();
   // `var()` is checked before the grammar, because the grammar rejects the
-  // parentheses and would report a valid, common value as broken.
-  if (/\bvar\(/i.test(part.name)) return "dynamic";
+  // parentheses and would report a valid, common value as broken. It is checked
+  // for WELL-FORMEDNESS rather than presence: CSS requires the first argument
+  // to be a custom-property name, so `var(foo)` computes to an invalid
+  // `font-family` and the browser drops the declaration rather than falling
+  // through to the next family. Reading every `var(` as dynamic gave that an
+  // all-clear, which is the same shape as reading a dropped declaration as a
+  // working keyword.
+  if (VAR_CALL.test(part.name)) {
+    return WELL_FORMED_VAR_CALLS.test(part.name) ? "dynamic" : "invalid";
+  }
   if (CSS_WIDE_KEYWORDS.has(lower)) return "keyword";
   // Reserved, and not a whole-value keyword: bare `default` names no family and
   // the declaration is dropped, so it is invalid rather than a working value.
@@ -653,12 +692,16 @@ export interface FamilyPart {
  */
 function finishPart(
   current: string,
+  inner: string,
   quoted: boolean,
   strings: number,
   outsideQuotes: string,
   raw: string
 ): FamilyPart {
-  const name = current.trim();
+  // A QUOTED item is its quoted content verbatim: `" Brand "` names a family
+  // whose name has those spaces, and is a different family from `Brand`.
+  // Unquoted, the surrounding whitespace is separation and is trimmed.
+  const name = quoted ? inner : current.trim();
   const valid =
     name !== "" &&
     (quoted ? strings === 1 && outsideQuotes.trim() === "" : strings === 0);

--- a/packages/blocks-engine/src/style/site-tokens.ts
+++ b/packages/blocks-engine/src/style/site-tokens.ts
@@ -969,13 +969,24 @@ function tokenNamingRefusal(token: SiteToken): string | undefined {
 export function emitTokenBlocks(
   set: SiteTokenSet,
   selector: string
-): { css: string; issues: ValidationIssue[] } {
+): { css: string; issues: ValidationIssue[]; emitted: readonly SiteToken[] } {
   const { prefix, issue } = resolveTokenPrefix(set.prefix);
   const issues: ValidationIssue[] = issue ? [issue] : [];
 
   const light: string[] = [];
   const dark: string[] = [];
   const seen = new Map<string, string>();
+  /*
+   * The tokens this call actually WROTE.
+   *
+   * Reported rather than left to be re-derived, because the refusals above are
+   * five separate conditions — a name that is not a token name, no light value,
+   * a value the guard rejects, a value that fetches, and two identities landing
+   * on one custom property — and a caller asking "which tokens does this site
+   * emit" would have to restate all five. A second statement of them agrees
+   * today and drifts the first time one changes.
+   */
+  const emitted: SiteToken[] = [];
 
   for (const token of set.tokens) {
     const naming = tokenNamingRefusal(token);
@@ -1051,6 +1062,7 @@ export function emitTokenBlocks(
       continue;
     }
     seen.set(property, token.name);
+    emitted.push(token);
 
     // Reported, and then written anyway. A value that does not match its kind
     // is dropped by the browser where it is USED, which costs the author the
@@ -1087,9 +1099,11 @@ export function emitTokenBlocks(
         `The selector these tokens would be written under is longer than ${MAX_TOKEN_SELECTOR_LENGTH} characters, so none were written.`
       )
     );
-    return { css: "", issues };
+    // Nothing is written under an unusable selector, so nothing was emitted —
+    // whatever survived the per-token refusals above.
+    return { css: "", issues, emitted: [] };
   }
-  if (light.length === 0) return { css: "", issues };
+  if (light.length === 0) return { css: "", issues, emitted: [] };
 
   let css = `${selector}{${light.join(";")}}`;
   if (dark.length > 0) {
@@ -1099,5 +1113,5 @@ export function emitTokenBlocks(
         ? `@media (prefers-color-scheme:dark){${body}}`
         : `[${DARK_MODE_ATTRIBUTE}="dark"] ${body}`;
   }
-  return { css, issues };
+  return { css, issues, emitted };
 }

--- a/packages/builder/src/font-library.test.ts
+++ b/packages/builder/src/font-library.test.ts
@@ -132,6 +132,47 @@ describe("reading a font-family value against the faces a site loads", () => {
     }
   });
 
+  it("reads a MALFORMED var() as invalid, not as dynamic", () => {
+    // CSS requires the first argument to be a custom-property name, so
+    // `var(foo)` computes to an invalid font-family and the browser drops the
+    // declaration rather than falling through to `serif`. Reading every `var(`
+    // as dynamic gave a dropped declaration an all-clear.
+    expect(readStack("var(foo), serif", []).kind).toBe("invalid");
+    expect(readStack("var(--ok), serif", []).kind).toBe("dynamic");
+    // One malformed call spoils the value however many good ones sit beside it.
+    expect(readStack("var(--a), var(bad)", []).kind).toBe("invalid");
+  });
+
+  it("keeps the whitespace inside a QUOTED family name", () => {
+    // Inside quotes the spaces are part of the name, so `" Brand "` names a
+    // different family from `Brand` and must not match a face called `Brand`.
+    expect(readStack('" Brand "', [face("Brand")]).families[0]).toEqual({
+      family: " Brand ",
+      source: "not-provided",
+    });
+    // The control: whitespace OUTSIDE the quotes is separation, and still trims.
+    expect(readStack(' "Brand" ', [face("Brand")]).families[0]).toEqual({
+      family: "Brand",
+      source: "hosted",
+    });
+  });
+
+  it("reports only tokens the compiler actually writes", () => {
+    // `emitTokenBlocks` refuses a token whose name is not a token name, so it
+    // reaches no page. Reporting on it would describe a typeface the site never
+    // emits — and claim its hosted family renders when nothing references it.
+    const rows = fontTokenRows(
+      {
+        tokens: [
+          { name: "bad name", kind: "fontFamily", values: { light: "Brand" } },
+          { name: "brand.ok", kind: "fontFamily", values: { light: "Brand" } },
+        ],
+      },
+      [face("Brand")]
+    );
+    expect(rows.map(r => r.token.name)).toEqual(["brand.ok"]);
+  });
+
   it("counts only faces the compiler will actually emit", () => {
     // A remote src is refused by `validateFontFace`, so no `@font-face` reaches
     // the sheet. Counting it as hosted marks a token healthy against a file the

--- a/packages/builder/src/font-library.ts
+++ b/packages/builder/src/font-library.ts
@@ -18,6 +18,7 @@
  * @module font-library
  */
 import {
+  emitTokenBlocks,
   readFamilyList,
   validateFontFace,
   type FamilyListKind,
@@ -129,7 +130,10 @@ function sourceOf(
   // claim. So a site loading a face it called `serif` still gets the browser
   // default from a bare `serif`, and only a quoted value reaches its file.
   if (entry.kind === "generic") return "generic";
-  const key = entry.part.name.trim().toLowerCase();
+  // NOT trimmed. The reader already removed the separation around an unquoted
+  // name and kept a quoted one verbatim, so trimming here would undo that and
+  // match `" Brand "` — a different family — against a face called `Brand`.
+  const key = entry.part.name.toLowerCase();
   return hosted.has(key) ? "hosted" : "not-provided";
 }
 
@@ -201,8 +205,22 @@ export function fontTokenRows(
   tokens: SiteTokenSet | undefined,
   faces: readonly FontFaceDef[]
 ): FontTokenRow[] {
-  const all = tokens?.tokens ?? [];
-  return all
+  /*
+   * The tokens the compiler WRITES, not every token in the set.
+   *
+   * `emitTokenBlocks` refuses a token on five separate grounds — a name that is
+   * not a token name, no light value, a value its guard rejects, a value that
+   * fetches, and two identities landing on one custom property — and a refused
+   * token reaches no page. Reporting on it would describe a typeface the site
+   * never emits, and say its hosted family renders when nothing references it.
+   *
+   * Asked of the emitter rather than re-derived here: five conditions restated
+   * in a second place agree today and drift the first time one changes. The
+   * selector is the one the sheet uses, so the answer is the sheet's own.
+   */
+  if (tokens === undefined) return [];
+  const emitted = emitTokenBlocks(tokens, ":root").emitted;
+  return emitted
     .filter(token => token.kind === "fontFamily")
     .map(token => ({
       token,

--- a/packages/builder/src/fonts-panel.test.tsx
+++ b/packages/builder/src/fonts-panel.test.tsx
@@ -147,6 +147,29 @@ describe("the panel over a site that has been read", () => {
     expect(duplicateKey).toBe(false);
   });
 
+  it("draws a subset face with glyphs that face can actually render", () => {
+    // A face limited to the Greek range covers none of the Latin sentence, so
+    // the browser would draw the row from another subset or a fallback — the
+    // row would claim to demonstrate a file whose glyphs are nowhere on screen.
+    const greek: FontFaceDef = {
+      family: "Brand",
+      src: [{ url: "/fonts/brand-greek.woff2", format: "woff2" }],
+      unicodeRange: "U+0370-03FF",
+    };
+    render(<FontsPanel faces={[greek]} tokens={{ tokens: [] }} />);
+    expect(screen.getByText(/Αλμοστ/)).toBeTruthy();
+    expect(
+      screen.queryByText("Almost before we knew it, we had left the ground")
+    ).toBeNull();
+  });
+
+  it("keeps the Latin specimen for a face declaring no range", () => {
+    render(<FontsPanel faces={[face("Brand")]} tokens={{ tokens: [] }} />);
+    expect(
+      screen.getByText("Almost before we knew it, we had left the ground")
+    ).toBeTruthy();
+  });
+
   it("says a site with no faces has none, rather than staying silent", () => {
     render(<FontsPanel faces={[]} tokens={{ tokens: [] }} />);
     expect(screen.getByText(/loads no font files of its own/)).toBeTruthy();

--- a/packages/builder/src/fonts-panel.tsx
+++ b/packages/builder/src/fonts-panel.tsx
@@ -75,6 +75,50 @@ export interface FontsPanelProps {
 /** The specimen, one sentence with ascenders, descenders and round forms. */
 const SPECIMEN = "Almost before we knew it, we had left the ground";
 
+/**
+ * Specimen text for a face limited to one script.
+ *
+ * A face subset to a non-Latin `unicodeRange` covers none of the Latin sentence
+ * above, so the browser draws that row from another subset of the family or
+ * from a fallback — the row would claim to demonstrate a file whose glyphs are
+ * nowhere on screen. Ranges are matched by their START codepoint, which is what
+ * a `unicodeRange` names first and is enough to choose a script.
+ *
+ * Latin faces and faces declaring no range keep the sentence: it exercises
+ * ascenders, descenders and round forms, which is what a specimen is for.
+ */
+const SCRIPT_SPECIMENS: readonly {
+  readonly from: number;
+  readonly to: number;
+  readonly text: string;
+}[] = [
+  { from: 0x0370, to: 0x03ff, text: "Αλμοστ πριν το καταλάβουμε" },
+  { from: 0x0400, to: 0x04ff, text: "Почти прежде чем мы поняли" },
+  { from: 0x0590, to: 0x05ff, text: "כמעט לפני שידענו זאת" },
+  { from: 0x0600, to: 0x06ff, text: "تقريبا قبل أن ندرك ذلك" },
+  { from: 0x0900, to: 0x097f, text: "इससे पहले कि हमें पता चलता" },
+  { from: 0x0e00, to: 0x0e7f, text: "เกือบก่อนที่เราจะรู้ตัว" },
+  { from: 0x3040, to: 0x30ff, text: "気づく前に地面を離れていた" },
+  { from: 0xac00, to: 0xd7af, text: "우리가 알기도 전에 땅을 떠났다" },
+];
+
+/** The first codepoint a `unicodeRange` names, or nothing when unreadable. */
+function firstCodepoint(range: string | undefined): number | undefined {
+  if (range === undefined) return undefined;
+  const match = /U\+([0-9A-F]{1,6})/i.exec(range);
+  if (match?.[1] === undefined) return undefined;
+  const value = Number.parseInt(match[1], 16);
+  return Number.isNaN(value) ? undefined : value;
+}
+
+/** What to draw for one face, so the row demonstrates the file it names. */
+function specimenFor(face: FontFaceDef): string {
+  const start = firstCodepoint(face.unicodeRange);
+  if (start === undefined) return SPECIMEN;
+  const script = SCRIPT_SPECIMENS.find(s => start >= s.from && start <= s.to);
+  return script?.text ?? SPECIMEN;
+}
+
 /** The stack as CSS, so a specimen renders in the family it names. */
 function specimenStyle(value: string): React.CSSProperties {
   return { fontFamily: value };
@@ -246,7 +290,7 @@ function FaceList({
         <li className="nx-fonts__face" key={faceKey(face)}>
           <span className="nx-fonts__face-name">{face.family}</span>
           <span className="nx-fonts__specimen" style={faceSpecimenStyle(face)}>
-            {SPECIMEN}
+            {specimenFor(face)}
           </span>
         </li>
       ))}


### PR DESCRIPTION
Follow-up to #1343, which merged while these were being worked. Four Codex findings from its third review round, all verified against the code before acting.

## `var(foo)` was given an all-clear for a declaration the browser drops

CSS requires a `var()` call's first argument to be a custom-property name. `var(foo)` therefore computes to an invalid `font-family`, and the browser drops the whole declaration rather than falling through to `serif`. Reading every occurrence of `var(` as dynamic reported that as healthy.

Probed before and after:

```
var(foo), serif             invalid   (was: dynamic)
var(--ok), serif            dynamic
var(--a, var(--b, serif))   dynamic
var(--a), var(bad)          invalid   one malformed call spoils the value
VAR(--up), serif            dynamic   CSS functions are case-insensitive
```

The comma inside `var(--font, Arial)` is also no longer a family separator — depth is counted rather than flagged, because `var(--a, var(--b, serif))` nests and a boolean would close on the inner `)`.

## A quoted family kept its spaces, and then lost them again

`finishPart` trimmed every name, so `" Brand "` and ` "Brand" ` were indistinguishable — the parser could not tell content from separation. It now collects the quoted content in its own buffer, so a quoted name is verbatim and an unquoted one still trims.

That exposed the second half: `sourceOf` trimmed *again* at comparison time, which undid the fix. My own new test caught it before Codex had to. Escapes inside quotes needed the same treatment — `"ACME\26 Co"` is the family `ACME&Co`, and an existing engine test caught that within one run.

## Bare `default` is not a CSS-wide keyword

It must be quoted to name a font, which is why the importer's `FAMILY_MUST_QUOTE` carries it — but it is excluded from `<family-name>`, so the browser drops a declaration reading it bare. Reading it as a working whole-value keyword made the reader ignore a dropped declaration.

The reader now has `CSS_WIDE_KEYWORDS` (inherit, initial, unset, revert, revert-layer). My combined set turned out to be redundant rather than load-bearing — the importer already had its own — so removing it left the importer untouched.

## `emitTokenBlocks` now reports what it emitted

It refuses a token on **five** separate grounds: a name that is not a token name, no light value, a value its guard rejects, a value that fetches, and two identities landing on one custom property. The panel was reporting on the raw set, so a refused token was described as a typeface the site renders — and its hosted family claimed to render when nothing references it.

Restating five conditions in the builder would be the second implementation this codebase forbids. The emitter now returns `emitted` alongside `css` and `issues`, additively, and the panel reports on that.

## A subset face is demonstrated with glyphs it covers

A face limited to `U+0370-03FF` renders none of the Latin specimen, so the row drew from another subset or a fallback — claiming to demonstrate a file whose glyphs were nowhere on screen. Specimen text is now chosen by the range's first codepoint, with the Latin sentence kept for faces declaring no range.

## Verified visually, not only in jsdom

The panel was rendered to static markup, wrapped in the **built** `builder-chrome.css`, and screenshotted in light and dark. That confirmed in the rendered output: the italic/bold face draws italic and bold, the Greek subset draws Greek, a remote-`src` face is absent from a four-face input, the summary separates "ask first for a typeface this site provides no file for" from "hold a value no browser will read", and a dark-only failure is labelled "In dark mode:".

One thing the screenshot appeared to show — family names illegible in dark — was **my harness**, which set `color` on `body` outside the themed frame. Corrected and re-shot; both themes read correctly.

## Verification

Break-verified, each failing the test named in advance: `var()` presence over grammar, trimming at comparison, rows from the raw set, one specimen for every face. One caveat stated plainly: in three of those runs the `var()` test also failed, because I restored the engine source without rebuilding its `dist` until the end — the named test failed in each case regardless, and the final restored run is clean.

Build 0 · engine 1644 · builder 89 files / 2523 · plugin 490 · check-types 0 · three package lints 0 · root eslint 0 · comment convention 0 · fallow **pass**, all four `*_introduced` at 0 · changeset parses 25 packages.

A note on that fallow run: it first reported `styling_introduced: 11`, all at lines 204–1554 of a file whose new code starts at 2143. #1340 had rewritten that file on main and this branch was six commits behind, so the lines were attributed here. Rebasing returned it to 0. Reported because the arithmetic looked exactly like a real finding.
