### PR TITLE
fix(builder): keep the description strip measuring whether it clips

### DIFF
--- a/.changeset/the-strip-keeps-measuring-itself.md
+++ b/.changeset/the-strip-keeps-measuring-itself.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The Insert panel's description strip keeps checking whether it is hiding text,
+rather than checking once per block.
+
+The strip becomes a focusable, named region when a description is too long to
+fit, so a keyboard can reach the part a pointer would scroll to. It measured
+that only when the highlighted block changed — so dragging the panel narrower,
+raising the browser zoom, or increasing the font size could push a description
+past the edge with nothing noticing. Its tail was then unreachable without a
+mouse. Widening the panel had the mirror problem: the description fitted again
+and the focus stop stayed, so tabbing toward the blocks went through a region
+that had nothing more to show.
+
+It now watches its own size, which catches every one of those, and re-checks on
+each render, which catches the case a size watcher cannot see: a block whose
+description is replaced with a longer one keeps its identity and its box, and
+only the text inside it grows.

--- a/packages/builder/src/insert-panel.test.tsx
+++ b/packages/builder/src/insert-panel.test.tsx
@@ -19,7 +19,13 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import {
@@ -699,6 +705,143 @@ describe("the grid, and the strip that describes it", () => {
     // and arriving somewhere unlabelled is its own defect.
     expect(after.getAttribute("aria-hidden")).toBeNull();
     expect(after.getAttribute("aria-label")).toBe("Block description");
+  });
+
+  /**
+   * Force the strip to report that its content overflows its box.
+   *
+   * jsdom lays nothing out, so `scrollHeight` and `clientHeight` are 0 on every
+   * element and a 400-character description overflows by exactly as much as a
+   * short one — which is to say not at all. Defining the two properties is what
+   * puts the branch under test at all.
+   */
+  function forceOverflow(element: HTMLElement, overflowing: boolean): void {
+    Object.defineProperty(element, "scrollHeight", {
+      value: overflowing ? 200 : 40,
+      configurable: true,
+    });
+    Object.defineProperty(element, "clientHeight", {
+      value: 80,
+      configurable: true,
+    });
+  }
+
+  /** Install a `ResizeObserver` whose callback the test can fire on demand. */
+  function drivableObserver(): { fire: () => void; restore: () => void } {
+    const previous = globalThis.ResizeObserver;
+    let callback: (() => void) | undefined;
+    globalThis.ResizeObserver = class {
+      constructor(fn: () => void) {
+        callback = fn;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+    return {
+      fire: () => {
+        callback?.();
+      },
+      restore: () => {
+        globalThis.ResizeObserver = previous;
+      },
+    };
+  }
+
+  it("re-measures when the STRIP RESIZES, with no change of subject", () => {
+    /*
+     * The panel is resizable, and browser zoom and font size move the box too.
+     * None of those re-render anything here, so a measurement taken only when
+     * the described block changes leaves a newly overflowing description out of
+     * the tab order with its tail unreachable — and leaves a dead focus stop
+     * behind when it stops overflowing.
+     *
+     * The subject deliberately never changes in this case. That is the whole
+     * property: a measurement keyed on the subject cannot see this.
+     */
+    const observer = drivableObserver();
+    try {
+      sevenBlocks();
+      render(<InsertPanel editor={editorSpy(documentOf())} />);
+      const body = document.querySelector(
+        ".nx-insert-panel__describes"
+      ) as HTMLElement;
+      expect(body.getAttribute("tabindex")).toBeNull();
+
+      forceOverflow(body, true);
+      act(() => {
+        observer.fire();
+      });
+
+      expect(
+        (
+          document.querySelector(".nx-insert-panel__describes") as HTMLElement
+        ).getAttribute("tabindex")
+      ).toBe("0");
+
+      // And back again, so this is not a one-way latch that accumulates focus
+      // stops as an author drags the panel about.
+      forceOverflow(body, false);
+      act(() => {
+        observer.fire();
+      });
+      expect(
+        (
+          document.querySelector(".nx-insert-panel__describes") as HTMLElement
+        ).getAttribute("tabindex")
+      ).toBeNull();
+    } finally {
+      observer.restore();
+    }
+  });
+
+  it("re-measures when the DESCRIPTION changes but the block does not", () => {
+    /*
+     * The other half, and a `ResizeObserver` cannot see it: a longer sentence
+     * inside a strip already at its bound grows `scrollHeight` while the border
+     * box stays exactly where it was, so the observer never fires. The entry's
+     * id is the BLOCK NAME, so replacing a definition's description leaves the
+     * subject unchanged too.
+     *
+     * A measurement keyed on the subject is therefore blind to this, which is
+     * why the effect carries no dependency list.
+     */
+    const defs = (description: string) =>
+      [
+        {
+          ...base,
+          name: "acme/solo",
+          description,
+          editor: { label: "Solo", category: "Layout" },
+        },
+      ] as never;
+
+    const view = render(
+      <InsertPanel
+        editor={editorSpy(documentOf())}
+        definitions={defs("Short.")}
+      />
+    );
+    const body = document.querySelector(
+      ".nx-insert-panel__describes"
+    ) as HTMLElement;
+    forceOverflow(body, false);
+    expect(body.getAttribute("tabindex")).toBeNull();
+
+    forceOverflow(body, true);
+    view.rerender(
+      <InsertPanel
+        editor={editorSpy(documentOf())}
+        definitions={defs("A much longer sentence about the very same block.")}
+      />
+    );
+
+    // Same block, same id, same box — only the text grew.
+    expect(
+      (
+        document.querySelector(".nx-insert-panel__describes") as HTMLElement
+      ).getAttribute("tabindex")
+    ).toBe("0");
   });
 
   it("bounds the strip, so a long description cannot eat the palette", () => {

--- a/packages/builder/src/insert-panel.tsx
+++ b/packages/builder/src/insert-panel.tsx
@@ -209,11 +209,47 @@ function DescriptionStrip({
    * of that range.
    */
   const [clipped, setClipped] = React.useState(false);
+  /*
+   * Re-measured from TWO signals, because clipping changes for two unrelated
+   * kinds of reason and neither covers the other.
+   *
+   * The box changes without React knowing: an author drags the panel wider,
+   * changes the browser zoom, or raises their font size. None of those
+   * re-render anything here, so an effect alone would leave a newly overflowing
+   * description out of the tab order with its tail unreachable — and leave a
+   * dead focus stop behind when it stops overflowing.
+   *
+   * The CONTENT changes without the box changing: a longer sentence inside a
+   * strip already at its bound grows `scrollHeight` while the border box stays
+   * exactly where it was, so a `ResizeObserver` never fires. That is a render,
+   * which is why the effect below carries no dependency list — every commit is
+   * a chance for the text to have changed, and naming which ones would be a
+   * second list to keep in step with the first.
+   *
+   * Setting the same boolean back is inert: React compares and does not
+   * re-render, so an effect with no dependencies cannot loop here.
+   */
+  const remeasure = React.useCallback(() => {
+    const element = body.current;
+    if (element === null) return;
+    setClipped(element.scrollHeight > element.clientHeight);
+  }, []);
+  React.useEffect(remeasure);
   React.useEffect(() => {
     const element = body.current;
     if (element === null) return;
-    element.scrollTop = 0;
-    setClipped(element.scrollHeight > element.clientHeight);
+    // Guarded by CALLABILITY rather than presence: jsdom defines the global on
+    // some setups without a working constructor, so a property test passes and
+    // the construction throws.
+    if (typeof ResizeObserver !== "function") return;
+    const observer = new ResizeObserver(remeasure);
+    observer.observe(element);
+    return () => {
+      observer.disconnect();
+    };
+  }, [remeasure]);
+  React.useEffect(() => {
+    if (body.current !== null) body.current.scrollTop = 0;
   }, [subject]);
   if (described === undefined) return null;
   /*


### PR DESCRIPTION
Closes the one finding I knowingly let land with #1340, so that it is owned rather than left.

## What was wrong

The Insert panel's description strip becomes a focusable, named region when a description is too long for its box, so a keyboard can reach the tail a pointer would scroll to. It measured that **only when the highlighted block changed**.

So dragging the panel narrower, raising the browser zoom, or increasing the font size pushed a description past the edge with nothing noticing — and its tail became unreachable without a mouse. Widening had the mirror problem: the description fitted again and the focus stop stayed, so tabbing toward the blocks went through a region with nothing left to show.

The panel is resizable by design, so this is ordinary use rather than an edge case.

## Two signals, because neither covers the other

- A **`ResizeObserver`** catches the box changing without a render — the panel drag, the zoom, the font size. React never re-renders for any of those.
- A **render-time read** catches the text changing without the box moving. A longer sentence inside a strip already at its bound grows `scrollHeight` while the border box stays exactly where it was, so the observer never fires. And since an entry is identified by its block name, replacing a definition's description leaves the subject unchanged too.

The render-time read carries no dependency list deliberately: every commit is a chance for the text to have changed, and naming which ones would be a second list to keep in step with the first. Writing the same boolean back is inert — React compares and does not re-render — so it cannot loop.

## Verification

Both paths break-verified, each against the mutation that removes what its name promises:

- removing the `ResizeObserver` fails the resize case and nothing else
- keying the measurement on the subject again fails the description case and nothing else

**The second test exists because the first mutation did not kill anything.** Keying on the subject left every case green, which meant the content path had no coverage at all — that gap was the finding, so I wrote the case that closes it rather than assuming the code was covered.

The resize case also asserts the reverse transition, so this is not a one-way latch accumulating focus stops as an author drags the panel about.

Overflow is forced with `defineProperty` rather than produced by a long description: jsdom lays nothing out, so `scrollHeight` and `clientHeight` are 0 on every element and a 400-character description overflows by exactly as much as a short one.

Gates: builder 2520, typecheck, lint, `fallow audit` pass with 0 introduced.