### PR TITLE
feat(nextly): run the job queue from a scheduler, and register the work it can do

### DIFF
--- a/.changeset/run-the-job-queue-on-a-schedule.md
+++ b/.changeset/run-the-job-queue-on-a-schedule.md
@@ -1,0 +1,61 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Scheduled content releases now actually publish themselves.
+
+The background job runner has had everything it needed to do this except the two
+things that make it run: a way to be triggered, and a list of the work it knows
+how to do. Both are here. A release drain is registered as a job type at startup,
+and a new endpoint runs the queue.
+
+Point your scheduler at `/api/jobs/run` — Vercel Cron, a system cron, or anything
+that can make an HTTP request on an interval — and due releases publish without
+anyone being awake. Each pass is bounded, so an invocation finishes well inside a
+serverless time limit and the next one picks up where it stopped; the queue is a
+table in your database, so nothing is lost in between.
+
+Who may pull that trigger is the same question the webhook drain already
+answered, and it now has one answer rather than two. A scheduler authenticates
+with a shared secret — `NEXTLY_DRAIN_SECRET`, or Vercel's own `CRON_SECRET` —
+compared in constant time. A person authenticates normally and needs the new
+`manage-background-jobs` permission, which super-admins receive automatically.
+
+Running the queue by hand grants nothing else: every job runs as the person it
+was queued for, resolved when it runs, so pressing the trigger makes work that
+was already scheduled and already authorized happen now. It does not let the
+person who pressed it do that work themselves.
+
+`background-jobs` is now a reserved name. If you have a collection or Single
+called `background-jobs`, rename it before upgrading — a content type sharing a
+name with a system resource would have its permissions treated as the system's,
+and preset roles would quietly lose access to it.
+
+When a release fails to publish — its author was deleted, a write was refused —
+that member is now reported individually in your logs, with the document and the
+reason, rather than being counted and forgotten while the release silently waits
+for a retry that will never succeed.

--- a/packages/nextly/src/__tests__/direct-dispatch-cold-boot.test.ts
+++ b/packages/nextly/src/__tests__/direct-dispatch-cold-boot.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Every direct-dispatch branch is in the cold-boot list.
+ *
+ * `DIRECT_DISPATCH_SERVICES` exists because those handlers return BEFORE the
+ * shared dispatcher path that initialises services. Its docblock already warned
+ * that "a service added there without being added here silently loses cold-boot
+ * initialisation" — and the warning did not hold: `jobs` was added as a branch
+ * and omitted from the list, so on a cold serverless instance a valid scheduler
+ * request reached the handler with no initialised runtime.
+ *
+ * A comment cannot enforce that. This reads the two out of the source and makes
+ * the drift a failing test instead — for every service, not just the one that
+ * happened to be caught in review.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const SOURCE = readFileSync(
+  fileURLToPath(new URL("../routeHandler.ts", import.meta.url)),
+  "utf8"
+);
+
+/** The service names the file's own `DIRECT_DISPATCH_SERVICES` set lists. */
+function declaredServices(): string[] {
+  const block =
+    /const DIRECT_DISPATCH_SERVICES = new Set<string>\(\[([\s\S]*?)\]\)/.exec(
+      SOURCE
+    );
+  expect(block, "the set moved or was renamed").not.toBeNull();
+  return [...(block?.[1] ?? "").matchAll(/"([^"]+)"/g)].map(
+    m => m[1] as string
+  );
+}
+
+/**
+ * The service names the file directly dispatches.
+ *
+ * Scoped to the text AFTER the `DIRECT_DISPATCH_SERVICES.has(service)` guard,
+ * which is the boundary the file itself draws: everything past it returns
+ * without reaching the shared dispatcher. `service === "x"` also appears far
+ * earlier, in permission resolution, for services that DO go through the
+ * dispatcher and correctly are not in the set — a scan of the whole file reads
+ * those as missing entries and fails for a reason that is not a defect.
+ */
+function dispatchedServices(): string[] {
+  const guard = SOURCE.indexOf("DIRECT_DISPATCH_SERVICES.has(service)");
+  expect(guard, "the cold-boot guard moved or was renamed").toBeGreaterThan(-1);
+  const region = SOURCE.slice(guard);
+  return [...region.matchAll(/\bservice === "([^"]+)"/g)].map(
+    m => m[1] as string
+  );
+}
+
+describe("direct dispatch and cold-boot initialisation", () => {
+  it("finds both lists, so an empty comparison cannot pass vacuously", () => {
+    // The control. Two regexes that matched nothing would agree perfectly and
+    // report the strongest possible green about a file they never read.
+    expect(declaredServices().length).toBeGreaterThan(5);
+    expect(dispatchedServices().length).toBeGreaterThan(5);
+    // And the region really is a region: a boundary at the very end of the file
+    // would yield an empty scan that agrees with anything.
+    expect(dispatchedServices()).toContain("webhooks");
+  });
+
+  it("lists every directly dispatched service for cold-boot initialisation", () => {
+    const declared = new Set(declaredServices());
+    const missing = dispatchedServices().filter(name => !declared.has(name));
+
+    expect(missing).toEqual([]);
+  });
+});

--- a/packages/nextly/src/api/__tests__/jobs-run-route.test.ts
+++ b/packages/nextly/src/api/__tests__/jobs-run-route.test.ts
@@ -1,0 +1,142 @@
+/**
+ * The background job trigger route.
+ *
+ * The permission is driven through a REAL check rather than a spy: the fake
+ * `requireAnyPermission` grants what the caller actually holds, so these assert
+ * that a caller WITHOUT `manage-background-jobs` is refused — not merely that
+ * some permission function was called. A spy would pass just as happily if the
+ * route asked for the wrong permission.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const HELD = "x-test-permissions";
+
+const runJobsPass = vi.fn(
+  async (
+    _adapter: unknown,
+    _registry: unknown,
+    _options: { batchSize?: number; maxDurationMs?: number }
+  ) => ({
+    claimed: 2,
+    succeeded: 2,
+    failed: 0,
+    retried: 0,
+  })
+);
+
+const registry = { get: () => undefined, slugs: () => [] };
+const adapter = { select: async () => [] };
+
+vi.mock("../../di", () => ({
+  container: {
+    get: (name: string) => (name === "jobRegistry" ? registry : adapter),
+  },
+}));
+
+vi.mock("../../init", () => ({ getCachedNextly: async () => ({}) }));
+
+vi.mock("../../domains/jobs/jobs-runner", () => ({
+  runJobsPass: (...args: unknown[]) =>
+    (runJobsPass as unknown as (...a: unknown[]) => unknown)(...args),
+}));
+
+vi.mock("../../auth/middleware", () => ({
+  isErrorResponse: (r: { statusCode?: number }) => "statusCode" in r,
+  // Grants exactly the permissions the request says it holds, so the ROUTE's
+  // choice of permission is what decides the outcome.
+  requireAnyPermission: async (
+    req: Request,
+    needed: Array<{ action: string; resource: string }>
+  ) => {
+    const held = (req.headers.get(HELD) ?? "").split(",").filter(Boolean);
+    const ok = needed.some(n => held.includes(`${n.action}-${n.resource}`));
+    return ok
+      ? { userId: "u1", permissions: held, roles: [], authMethod: "session" }
+      : {
+          success: false,
+          statusCode: 403,
+          message: "Forbidden",
+          error: "Forbidden",
+          data: null,
+        };
+  },
+}));
+
+vi.mock("../../shared/lib/env", () => ({
+  env: { NEXTLY_ALLOWED_ORIGINS_PARSED: [] },
+}));
+
+vi.mock("../../auth/csrf/validate", () => ({ validateOrigin: () => true }));
+
+const { runJobsRoute } = await import("../jobs-run-route");
+
+function post(permissions?: string): Request {
+  return new Request("https://example.com/api/jobs/run", {
+    method: "POST",
+    headers: permissions ? { [HELD]: permissions } : {},
+  });
+}
+
+beforeEach(() => {
+  runJobsPass.mockClear();
+});
+
+describe("runJobsRoute", () => {
+  it("refuses an unauthenticated caller and runs nothing", async () => {
+    // A public job-drain endpoint is both a denial-of-service primitive and an
+    // information leak, so the refusal must happen BEFORE any work.
+    const response = await runJobsRoute(post());
+
+    expect(response.status).toBe(403);
+    expect(runJobsPass).not.toHaveBeenCalled();
+  });
+
+  it("refuses a caller holding a different administrative permission", async () => {
+    // `manage-settings` is the nearest existing umbrella and deliberately does
+    // NOT open this trigger; if it did, the new permission would be decorative.
+    const response = await runJobsRoute(post("manage-settings"));
+
+    expect(response.status).toBe(403);
+    expect(runJobsPass).not.toHaveBeenCalled();
+  });
+
+  it("runs a pass for a caller holding manage-background-jobs", async () => {
+    const response = await runJobsRoute(post("manage-background-jobs"));
+
+    expect(response.status).toBe(200);
+    expect(runJobsPass).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns the pass summary as the mutation item", async () => {
+    const response = await runJobsRoute(post("manage-background-jobs"));
+    const body = (await response.json()) as {
+      item: { claimed: number; succeeded: number };
+    };
+
+    expect(body.item).toEqual({
+      claimed: 2,
+      succeeded: 2,
+      failed: 0,
+      retried: 0,
+    });
+  });
+
+  it("runs the pass against the SHARED registry, not one of its own", async () => {
+    // A registry built per request would answer only for the job types that
+    // request happened to import, so a job queued elsewhere would be deferred
+    // forever while the queue looked empty.
+    await runJobsRoute(post("manage-background-jobs"));
+
+    expect(runJobsPass.mock.calls[0]?.[1]).toBe(registry);
+  });
+
+  it("bounds the pass so a serverless invocation cannot be killed mid-flight", async () => {
+    await runJobsRoute(post("manage-background-jobs"));
+
+    const options = runJobsPass.mock.calls[0]?.[2];
+    expect(options?.batchSize).toBeGreaterThan(0);
+    expect(options?.maxDurationMs).toBeGreaterThan(0);
+    expect(options?.maxDurationMs).toBeLessThan(60_000);
+  });
+});

--- a/packages/nextly/src/api/__tests__/jobs-run-route.test.ts
+++ b/packages/nextly/src/api/__tests__/jobs-run-route.test.ts
@@ -10,19 +10,31 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { RunJobsResult } from "../../domains/jobs/run-jobs";
+
 const HELD = "x-test-permissions";
+
+/**
+ * Typed as the REAL `RunJobsResult`. The first version of this mock invented a
+ * `succeeded` field the runner does not return, and because the module was
+ * mocked nothing type-checked the invention — the route documented and the test
+ * asserted a shape no caller would ever receive. Annotating the return type is
+ * what makes the compiler the oracle instead of the mock.
+ */
+const PASS_SUMMARY: RunJobsResult = {
+  claimed: 2,
+  done: 2,
+  failed: 0,
+  retried: 0,
+  unrecorded: 0,
+};
 
 const runJobsPass = vi.fn(
   async (
     _adapter: unknown,
     _registry: unknown,
     _options: { batchSize?: number; maxDurationMs?: number }
-  ) => ({
-    claimed: 2,
-    succeeded: 2,
-    failed: 0,
-    retried: 0,
-  })
+  ): Promise<RunJobsResult> => PASS_SUMMARY
 );
 
 const registry = { get: () => undefined, slugs: () => [] };
@@ -69,6 +81,10 @@ vi.mock("../../shared/lib/env", () => ({
 
 vi.mock("../../auth/csrf/validate", () => ({ validateOrigin: () => true }));
 
+vi.mock("../../dispatcher/helpers/di", () => ({
+  getLoggerFromDI: () => undefined,
+}));
+
 const { runJobsRoute } = await import("../jobs-run-route");
 
 function post(permissions?: string): Request {
@@ -110,16 +126,12 @@ describe("runJobsRoute", () => {
 
   it("returns the pass summary as the mutation item", async () => {
     const response = await runJobsRoute(post("manage-background-jobs"));
-    const body = (await response.json()) as {
-      item: { claimed: number; succeeded: number };
-    };
+    const body = (await response.json()) as { item: RunJobsResult };
 
-    expect(body.item).toEqual({
-      claimed: 2,
-      succeeded: 2,
-      failed: 0,
-      retried: 0,
-    });
+    // Compared against the runner's OWN result, not a shape retyped here: a
+    // hand-written expectation is a second description of `RunJobsResult` and
+    // would keep passing after the real one changed.
+    expect(body.item).toEqual(PASS_SUMMARY);
   });
 
   it("runs the pass against the SHARED registry, not one of its own", async () => {

--- a/packages/nextly/src/api/__tests__/trigger-auth.test.ts
+++ b/packages/nextly/src/api/__tests__/trigger-auth.test.ts
@@ -1,0 +1,160 @@
+/**
+ * The shared scheduler-trigger authorizer.
+ *
+ * This boundary decides who may cause side effects on a schedule, and until
+ * now nothing tested it: no test in the package referenced `NEXTLY_DRAIN_SECRET`
+ * or `CRON_SECRET` at all, so the webhook drain's auth path was covered only by
+ * tests of the drain ENGINE, which never reach it. Every case below fails if the
+ * corresponding guard is removed.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthContext, ErrorResponse } from "../../auth/middleware";
+
+const LONG_SECRET = "s".repeat(32);
+const OTHER_SECRET = "x".repeat(32);
+
+const envMock: {
+  NEXTLY_DRAIN_SECRET?: string;
+  CRON_SECRET?: string;
+  NEXTLY_ALLOWED_ORIGINS_PARSED: string[];
+} = { NEXTLY_ALLOWED_ORIGINS_PARSED: ["https://admin.example.com"] };
+
+let originIsValid = true;
+
+vi.mock("../../shared/lib/env", () => ({
+  get env() {
+    return envMock;
+  },
+}));
+
+vi.mock("../../auth/csrf/validate", () => ({
+  validateOrigin: () => originIsValid,
+}));
+
+const { authorizeTrigger } = await import("../trigger-auth");
+
+/** An authenticated caller the permission check accepts. */
+function allow(authMethod: "session" | "api-key"): () => Promise<AuthContext> {
+  return async () =>
+    ({
+      userId: "u1",
+      permissions: [],
+      roles: [],
+      authMethod,
+    }) as AuthContext;
+}
+
+/** A caller the permission check refuses. */
+const deny = async (): Promise<ErrorResponse> => ({
+  success: false,
+  statusCode: 403,
+  message: "Forbidden",
+  error: "Forbidden",
+  data: null,
+});
+
+function request(
+  method: string,
+  headers: Record<string, string> = {}
+): Request {
+  return new Request("https://example.com/api/jobs/run", { method, headers });
+}
+
+/** Run the authorizer and report only whether it threw. */
+async function authorized(
+  req: Request,
+  permission: Parameters<typeof authorizeTrigger>[1]["requirePermission"]
+): Promise<boolean> {
+  try {
+    await authorizeTrigger(req, { requirePermission: permission, reason: "t" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+beforeEach(() => {
+  envMock.NEXTLY_DRAIN_SECRET = LONG_SECRET;
+  envMock.CRON_SECRET = undefined;
+  envMock.NEXTLY_ALLOWED_ORIGINS_PARSED = ["https://admin.example.com"];
+  originIsValid = true;
+});
+
+describe("authorizeTrigger — the scheduler path", () => {
+  it("admits a GET bearing the drain secret", async () => {
+    const ok = await authorized(
+      request("GET", { authorization: `Bearer ${LONG_SECRET}` }),
+      deny
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("admits a GET bearing Vercel's CRON_SECRET", async () => {
+    envMock.NEXTLY_DRAIN_SECRET = undefined;
+    envMock.CRON_SECRET = LONG_SECRET;
+    const ok = await authorized(
+      request("GET", { authorization: `Bearer ${LONG_SECRET}` }),
+      deny
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("refuses a secret shorter than 32 characters even when it matches", async () => {
+    // The whole point of the length floor: a platform-wide CRON_SECRET too
+    // short to be a safe authorizer must be IGNORED rather than honoured, and
+    // an exact match is the only case where honouring it is tempting.
+    envMock.NEXTLY_DRAIN_SECRET = undefined;
+    envMock.CRON_SECRET = "short";
+    const ok = await authorized(
+      request("GET", { authorization: "Bearer short" }),
+      deny
+    );
+    expect(ok).toBe(false);
+  });
+
+  it("refuses a bearer token that is not the configured secret", async () => {
+    const ok = await authorized(
+      request("GET", { authorization: `Bearer ${OTHER_SECRET}` }),
+      deny
+    );
+    expect(ok).toBe(false);
+  });
+});
+
+describe("authorizeTrigger — the human path", () => {
+  it("refuses a GET with no secret, even from a permitted caller", async () => {
+    // A GET is reachable by a cross-site top-level navigation carrying the
+    // victim's SameSite=Lax session cookie. Admitting one here would make every
+    // trigger a CSRF gadget, so the permission holder is refused BECAUSE the
+    // method is GET.
+    const ok = await authorized(request("GET"), allow("session"));
+    expect(ok).toBe(false);
+  });
+
+  it("admits a POST from a permitted session on a valid origin", async () => {
+    const ok = await authorized(request("POST"), allow("session"));
+    expect(ok).toBe(true);
+  });
+
+  it("refuses a POST from a caller the permission check denies", async () => {
+    const ok = await authorized(request("POST"), deny);
+    expect(ok).toBe(false);
+  });
+
+  it("refuses a permitted session whose origin does not match", async () => {
+    originIsValid = false;
+    const ok = await authorized(request("POST"), allow("session"));
+    expect(ok).toBe(false);
+  });
+
+  it("admits an API key on a mismatched origin, which a cookie may not", async () => {
+    // The exemption is the reason the two are distinguished at all: an API key
+    // carries no ambient cookie and sends no browser Origin, so an origin check
+    // would refuse every legitimate machine caller while protecting nothing.
+    originIsValid = false;
+    const ok = await authorized(request("POST"), allow("api-key"));
+    expect(ok).toBe(true);
+  });
+});

--- a/packages/nextly/src/api/jobs-run-route.ts
+++ b/packages/nextly/src/api/jobs-run-route.ts
@@ -1,0 +1,106 @@
+/**
+ * The background job trigger.
+ *
+ * A queue only works if something drains it. This is that something's front
+ * door: a scheduler calls it on an interval, and an operator can call it by
+ * hand when they would rather not wait for the next tick.
+ *
+ * ## Why this adds no authorization of its own
+ *
+ * The webhook drain answered "who may pull a scheduler trigger" first, and its
+ * answer — a shared secret compared constant-time, or an authenticated human
+ * with a permission, with GET refused on the human path because a cross-site
+ * navigation carries a `SameSite=Lax` cookie — is security reasoning that must
+ * not exist twice. It lives in `api/trigger-auth.ts`; this route supplies the
+ * one thing that genuinely differs between triggers, which is the permission a
+ * human needs.
+ *
+ * ## What pulling this trigger does and does not confer
+ *
+ * It does not let the caller perform the queued work. Every job runs as the
+ * identity it was queued with, reconstructed at execution and failing closed if
+ * that identity no longer resolves. A holder of `manage-background-jobs` makes
+ * already-queued, already-authorized work happen NOW; they do not acquire the
+ * authority to do it themselves.
+ *
+ * @module api/jobs-run-route
+ */
+
+import { requireAnyPermission } from "../auth/middleware";
+import { container } from "../di";
+import type { JobRegistry } from "../domains/jobs/job-registry";
+import {
+  runJobsPass,
+  type JobsPassDatabase,
+} from "../domains/jobs/jobs-runner";
+import { getCachedNextly } from "../init";
+
+import { respondMutation } from "./response-shapes";
+import { authorizeTrigger } from "./trigger-auth";
+import { withErrorHandler } from "./with-error-handler";
+
+/**
+ * Bounds for one triggered pass.
+ *
+ * A trigger runs inside a request, and a serverless platform kills a request
+ * that overruns its limit — mid-pass, with no chance to finalize. The queue is
+ * durable, so a pass that stops early is not lost work: the next tick continues
+ * from the same table. These numbers buy that safety, not throughput.
+ */
+const JOBS_RUN_BATCH_SIZE = 10;
+/** Wall-clock budget for the pass, well inside a default serverless limit. */
+const JOBS_RUN_MAX_DURATION_MS = 20_000;
+
+/**
+ * What a human needs to run the queue by hand.
+ *
+ * `manage-background-jobs` and nothing else: there is no `update` to widen from
+ * the way `webhooks` has one, because running the queue is the only background
+ * job surface that exists to authorize yet.
+ */
+function requireJobsRunPermission(
+  request: Request
+): ReturnType<typeof requireAnyPermission> {
+  return requireAnyPermission(request, [
+    { action: "manage", resource: "background-jobs" },
+  ]);
+}
+
+/**
+ * Run one background job pass: claim the jobs that are due and execute them.
+ *
+ * Idempotent and safe to call repeatedly — a scheduler (e.g. Vercel Cron, which
+ * triggers with a GET) hits this on an interval, and a job's lease means two
+ * overlapping passes cannot run the same job twice. Accepts GET or POST.
+ *
+ * Auth: a shared `NEXTLY_DRAIN_SECRET` or Vercel's `CRON_SECRET` (bearer,
+ * constant-time) OR an authenticated caller with `manage-background-jobs`. Not
+ * session-only: a scheduler has no session.
+ *
+ * Response: the canonical mutation envelope `{ message, item }`, where `item`
+ * is the pass summary (claimed, succeeded, failed, retried).
+ */
+export const runJobsRoute = withErrorHandler(
+  async (request: Request): Promise<Response> => {
+    await authorizeTrigger(request, {
+      requirePermission: requireJobsRunPermission,
+      reason: "jobs-run",
+    });
+
+    await getCachedNextly();
+    // The runtime adapter satisfies the jobs table surface AND the users read
+    // the identity resolver needs; resolve it as exactly that from the
+    // container. The registry is the shared singleton, so this pass can run
+    // every job type the installation registered rather than whichever ones
+    // this module happens to import.
+    const adapter = container.get<JobsPassDatabase>("adapter");
+    const registry = container.get<JobRegistry>("jobRegistry");
+
+    const result = await runJobsPass(adapter, registry, {
+      batchSize: JOBS_RUN_BATCH_SIZE,
+      maxDurationMs: JOBS_RUN_MAX_DURATION_MS,
+    });
+
+    return respondMutation("Background job pass completed.", result);
+  }
+);

--- a/packages/nextly/src/api/jobs-run-route.ts
+++ b/packages/nextly/src/api/jobs-run-route.ts
@@ -28,6 +28,7 @@
 
 import { requireAnyPermission } from "../auth/middleware";
 import { container } from "../di";
+import { getLoggerFromDI } from "../dispatcher/helpers/di";
 import type { JobRegistry } from "../domains/jobs/job-registry";
 import {
   runJobsPass,
@@ -78,7 +79,10 @@ function requireJobsRunPermission(
  * session-only: a scheduler has no session.
  *
  * Response: the canonical mutation envelope `{ message, item }`, where `item`
- * is the pass summary (claimed, succeeded, failed, retried).
+ * is `RunJobsResult` — `claimed`, `done`, `failed`, `retried`, and
+ * `unrecorded`, the attempts whose outcome could not be written because the
+ * lease had already passed to another runner. Named from the type rather than
+ * described here in prose, so the two cannot drift.
  */
 export const runJobsRoute = withErrorHandler(
   async (request: Request): Promise<Response> => {
@@ -99,6 +103,14 @@ export const runJobsRoute = withErrorHandler(
     const result = await runJobsPass(adapter, registry, {
       batchSize: JOBS_RUN_BATCH_SIZE,
       maxDurationMs: JOBS_RUN_MAX_DURATION_MS,
+      // A sweep that cannot be queued is the failure that hides itself: the
+      // pass succeeds, reports zero work, and the thing it was meant to keep
+      // running silently stops. Said out loud rather than swallowed.
+      onSweepError: (error, slug) =>
+        getLoggerFromDI()?.error("A sweep could not be queued", {
+          slug,
+          error: error instanceof Error ? error.message : String(error),
+        }),
     });
 
     return respondMutation("Background job pass completed.", result);

--- a/packages/nextly/src/api/trigger-auth.ts
+++ b/packages/nextly/src/api/trigger-auth.ts
@@ -1,0 +1,133 @@
+/**
+ * Who may pull a scheduler trigger.
+ *
+ * A trigger is a side-effecting endpoint a scheduler calls on an interval and an
+ * operator can call by hand: the webhook drain, the job runner, and whatever
+ * drains next. Every one of them faces the same question — is this caller a
+ * scheduler holding the shared secret, or a human with the permission to do this
+ * by hand? — and the answer has enough security reasoning in it that a second
+ * copy would be a second place for that reasoning to be wrong.
+ *
+ * The webhook drain answered it first and this is its answer, moved rather than
+ * rewritten. What varies between triggers is one thing: which permission a
+ * human needs. That is a parameter; everything else below is shared.
+ *
+ * @module api/trigger-auth
+ */
+
+import { createHash, timingSafeEqual } from "node:crypto";
+
+import { validateOrigin } from "../auth/csrf/validate";
+import {
+  isErrorResponse,
+  type AuthContext,
+  type ErrorResponse,
+} from "../auth/middleware";
+import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+import { NextlyError } from "../errors/nextly-error";
+import { env } from "../shared/lib/env";
+
+/**
+ * Minimum length for a secret that may authorize a trigger.
+ *
+ * Enforced HERE rather than only in the env schema, so a platform-wide
+ * `CRON_SECRET` too short to be a safe authorizer is ignored rather than
+ * accepted — and its length never blocks app boot for a deployment that does not
+ * use any trigger.
+ */
+const MIN_TRIGGER_SECRET_LENGTH = 32;
+
+/** The bearer token on the request, or null when there is no bearer header. */
+function bearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header) return null;
+  const [scheme, token] = header.split(" ");
+  return scheme?.toLowerCase() === "bearer" && token ? token : null;
+}
+
+/**
+ * Constant-time string compare. Both sides are hashed to a fixed length first so
+ * `timingSafeEqual` never throws on a length mismatch and the comparison leaks
+ * neither the secret's length nor its content through timing.
+ */
+function constantTimeEqual(a: string, b: string): boolean {
+  const ah = createHash("sha256").update(a).digest();
+  const bh = createHash("sha256").update(b).digest();
+  return timingSafeEqual(ah, bh);
+}
+
+/**
+ * The permission check for the human path, supplied by the trigger.
+ *
+ * The middleware's OWN return type rather than a structural approximation of
+ * it: a hand-written `{ authMethod?: string }` would be a second description of
+ * `AuthContext`, and `isErrorResponse` narrows the real union rather than
+ * whatever shape happened to be written here.
+ */
+export type TriggerPermissionCheck = (
+  request: Request
+) => Promise<AuthContext | ErrorResponse>;
+
+/**
+ * Authorize a scheduler trigger, or throw.
+ *
+ * TWO PATHS, and the difference between them is the whole security argument.
+ *
+ * A scheduler presents a shared secret as a bearer token — Nextly's
+ * `NEXTLY_DRAIN_SECRET` or Vercel Cron's `CRON_SECRET`, which is what Vercel
+ * actually sends. Compared constant-time against each configured value. A bearer
+ * token is not sent on a cross-site request, so this path is not CSRF-exposed,
+ * and a non-matching bearer falls through to be tried as an API key below.
+ *
+ * A human uses the session or an API key, and that path is POST-ONLY. A GET can
+ * be driven by a cross-site top-level navigation carrying the victim's
+ * `SameSite=Lax` session cookie, so letting a GET reach the session path would
+ * make this a CSRF trigger. A `SameSite=Lax` cookie is not sent on a cross-site
+ * POST, which is the same baseline the rest of the session-authenticated REST
+ * API relies on.
+ *
+ * On top of `SameSite=Lax`, the cookie path also requires a same-origin
+ * `Origin`/`Referer`, so a same-site or misconfigured browser context cannot
+ * forge a side-effecting trigger. API-key auth is exempt: it carries no ambient
+ * cookie and sends no browser `Origin`.
+ */
+export async function authorizeTrigger(
+  request: Request,
+  options: {
+    /** What a human needs to pull this trigger by hand. */
+    requirePermission: TriggerPermissionCheck;
+    /** Distinguishes this trigger's refusals in the log. */
+    reason: string;
+  }
+): Promise<void> {
+  const presented = bearerToken(request);
+  if (presented) {
+    for (const secret of [env.NEXTLY_DRAIN_SECRET, env.CRON_SECRET]) {
+      if (
+        secret &&
+        secret.length >= MIN_TRIGGER_SECRET_LENGTH &&
+        constantTimeEqual(presented, secret)
+      ) {
+        return;
+      }
+    }
+  }
+
+  if (request.method.toUpperCase() === "GET") {
+    throw NextlyError.forbidden({
+      logContext: { reason: `${options.reason}-get-requires-secret` },
+    });
+  }
+
+  const authResult = await options.requirePermission(request);
+  if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
+
+  if (
+    authResult.authMethod !== "api-key" &&
+    !validateOrigin(request, env.NEXTLY_ALLOWED_ORIGINS_PARSED)
+  ) {
+    throw NextlyError.forbidden({
+      logContext: { reason: `${options.reason}-origin-mismatch` },
+    });
+  }
+}

--- a/packages/nextly/src/api/webhooks.ts
+++ b/packages/nextly/src/api/webhooks.ts
@@ -27,11 +27,8 @@
  * @module api/webhooks
  */
 
-import { createHash, timingSafeEqual } from "node:crypto";
-
 import { z } from "zod";
 
-import { validateOrigin } from "../auth/csrf/validate";
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
@@ -54,7 +51,6 @@ import {
   UpdateWebhookSchema,
 } from "../schemas/_zod/webhooks";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
-import { env } from "../shared/lib/env";
 
 import { readJsonBody } from "./read-json-body";
 import {
@@ -64,6 +60,7 @@ import {
   respondList,
   respondMutation,
 } from "./response-shapes";
+import { authorizeTrigger } from "./trigger-auth";
 import { withErrorHandler } from "./with-error-handler";
 import { nextlyValidationFromZod } from "./zod-to-nextly-error";
 
@@ -149,13 +146,6 @@ function denySessionOnly(
 }
 
 /**
- * Minimum length for a secret that may authorize the drain trigger. Enforced at
- * the auth boundary so a short platform-wide `CRON_SECRET` is ignored without
- * failing app boot (see env.ts).
- */
-const MIN_DRAIN_SECRET_LENGTH = 32;
-
-/**
  * Per-invocation work bounds for the cron/manual drain trigger. A scheduler tick
  * runs inside a platform execution limit (Vercel Cron functions default to tens
  * of seconds), so one request must NOT try to drain an unbounded backlog: it
@@ -173,87 +163,22 @@ const MIN_DRAIN_SECRET_LENGTH = 32;
  */
 const DRAIN_MAX_ROUNDS = 10;
 const DRAIN_DELIVER_BATCH = 25;
-// Bound fan-out too, not just delivery: at the engine default (100) ten rounds
-// could fan out 1,000 events into 1,000 × endpoints delivery rows in one tick —
-// database work the delivery deadline does not cover. Keep it near the delivery
-// batch so a tick creates roughly what it can attempt; the rest waits.
 const DRAIN_FANOUT_BATCH = 50;
 const DRAIN_MAX_DURATION_MS = 25_000;
 
-/** The bearer token on the request, or null when there is no bearer header. */
-function bearerToken(request: Request): string | null {
-  const header = request.headers.get("authorization");
-  if (!header) return null;
-  const [scheme, token] = header.split(" ");
-  return scheme?.toLowerCase() === "bearer" && token ? token : null;
-}
-
 /**
- * Constant-time string compare. Both sides are hashed to a fixed length first so
- * `timingSafeEqual` never throws on a length mismatch and the comparison leaks
- * neither the secret's length nor its content through timing.
- */
-function constantTimeEqual(a: string, b: string): boolean {
-  const ah = createHash("sha256").update(a).digest();
-  const bh = createHash("sha256").update(b).digest();
-  return timingSafeEqual(ah, bh);
-}
-
-/**
- * Authorize a drain trigger. The cron path matches the shared drain secret
- * presented as a bearer token (Vercel Cron sends `Authorization: Bearer
- * <CRON_SECRET>`); constant-time so it leaks nothing. Anything else must be an
- * authenticated caller able to manage webhooks — a non-matching bearer simply
- * falls through to be tried as an API key by the permission check.
+ * Authorize a webhook drain trigger.
+ *
+ * The posture — scheduler bearer secret, or a human with webhook-update through
+ * a POST from a same-origin context — is the one every trigger in this codebase
+ * shares, so it lives in `trigger-auth` and this names only what is specific to
+ * webhooks: the permission a human needs.
  */
 async function authorizeDrain(request: Request): Promise<void> {
-  const presented = bearerToken(request);
-  if (presented) {
-    // A scheduler presents a shared secret as a bearer token — either Nextly's
-    // NEXTLY_DRAIN_SECRET or Vercel Cron's CRON_SECRET (what Vercel actually
-    // sends). Constant-time against each configured value. A bearer token is not
-    // sent on a cross-site request, so this path is not CSRF-exposed.
-    //
-    // The entropy floor is enforced HERE, not only in the env schema, so a
-    // platform-wide CRON_SECRET that is too short to be a safe authorizer is
-    // ignored rather than accepted — and its length never blocks app boot for a
-    // deployment that doesn't use the drain.
-    for (const secret of [env.NEXTLY_DRAIN_SECRET, env.CRON_SECRET]) {
-      if (
-        secret &&
-        secret.length >= MIN_DRAIN_SECRET_LENGTH &&
-        constantTimeEqual(presented, secret)
-      ) {
-        return;
-      }
-    }
-  }
-  // GET is authorized ONLY by the shared bearer secret above. A GET can be
-  // driven by a cross-site top-level navigation, which carries the victim's
-  // `SameSite=Lax` session cookie, so falling through to the session/API-key
-  // path here would be a CSRF trigger. The session/API-key path (a manual admin
-  // drain) is therefore POST-only: a `SameSite=Lax` cookie is not sent on a
-  // cross-site POST, the same baseline the rest of the session-authenticated
-  // REST API relies on.
-  if (request.method.toUpperCase() === "GET") {
-    throw NextlyError.forbidden({
-      logContext: { reason: "drain-get-requires-secret" },
-    });
-  }
-  const authResult = await requireWebhookPermission(request, "update");
-  if (isErrorResponse(authResult)) throw toNextlyAuthError(authResult);
-  // Defense in depth for the cookie path: on top of `SameSite=Lax`, require a
-  // same-origin `Origin`/`Referer` so a same-site or misconfigured browser
-  // context cannot forge this side-effecting trigger. API-key auth carries no
-  // ambient cookie and sends no browser Origin, so it is exempt.
-  if (
-    authResult.authMethod !== "api-key" &&
-    !validateOrigin(request, env.NEXTLY_ALLOWED_ORIGINS_PARSED)
-  ) {
-    throw NextlyError.forbidden({
-      logContext: { reason: "drain-origin-mismatch" },
-    });
-  }
+  await authorizeTrigger(request, {
+    requirePermission: req => requireWebhookPermission(req, "update"),
+    reason: "drain",
+  });
 }
 
 /**

--- a/packages/nextly/src/collections/config/__tests__/newly-reserved-slug.test.ts
+++ b/packages/nextly/src/collections/config/__tests__/newly-reserved-slug.test.ts
@@ -66,10 +66,27 @@ describe("a slug that became reserved in this version", () => {
     );
   });
 
+  it("tells a `background-jobs` owner the rule changed too", () => {
+    // The list entry alone is not the guarantee: a note nothing reads is
+    // indistinguishable from a missing one, so each newly reserved name is
+    // checked where an operator actually meets it.
+    const result = validateCollectionConfig({
+      slug: "background-jobs",
+      fields: [{ name: "title", type: "text" }],
+    } as unknown as CollectionConfig);
+
+    const message = reservedError(result.errors.map(e => e.message));
+    expect(message).toContain("became a reserved system resource");
+    expect(message).toContain("must rename it");
+  });
+
   it("carries a note for every name added to the reserved list since 0.0.1", () => {
     // The list and its explanations drift apart silently: adding a name to
     // SYSTEM_RESOURCES is one line, and nothing about that line fails when the
     // sentence an operator needs is missing.
-    expect([...NEWLY_RESERVED_SLUG_NOTES.keys()]).toEqual(["content-releases"]);
+    expect([...NEWLY_RESERVED_SLUG_NOTES.keys()]).toEqual([
+      "content-releases",
+      "background-jobs",
+    ]);
   });
 });

--- a/packages/nextly/src/di/__tests__/register-jobs.test.ts
+++ b/packages/nextly/src/di/__tests__/register-jobs.test.ts
@@ -90,6 +90,13 @@ describe("the registered job types", () => {
     const registry = singletons.get("jobRegistry") as JobRegistry;
     expect(registry.get(RELEASES_DRAIN_JOB)).toBeDefined();
 
+    // And registered as a SWEEP. Being in the registry only means the runner
+    // can find the handler; a release comes due at an instant with no request
+    // attached, so unless a trigger keeps one queued there is never a row to
+    // find. Registered-but-not-a-sweep is the same silent failure as
+    // defined-but-not-registered, one layer along.
+    expect(registry.sweeps().map(d => d.slug)).toContain(RELEASES_DRAIN_JOB);
+
     vi.doUnmock("../container");
     vi.resetModules();
   });

--- a/packages/nextly/src/di/__tests__/register-jobs.test.ts
+++ b/packages/nextly/src/di/__tests__/register-jobs.test.ts
@@ -1,0 +1,176 @@
+/**
+ * The jobs DI registration.
+ *
+ * Two things are asserted here that nothing else can see. The first is that
+ * `releases:drain` is actually REGISTERED — before this registration existed,
+ * `createReleasesDrainJob` was exported and constructed by nothing, so the job
+ * type was defined and unrunnable, and a queued row for it would be deferred on
+ * every pass forever while the queue looked simply empty. A test that asserts
+ * the definition exists passes in exactly that broken state; only the registry
+ * lookup tells the two apart.
+ *
+ * The second is that the reporter reports. `createReleasesDrainJob` demands
+ * `onOutcome` rather than defaulting it, because a pass can fail individual
+ * members while the job row completes successfully, and a no-op there would
+ * leave a release that never publishes with no trace anywhere.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { ApplyDueReleasesResult } from "../../domains/releases/apply-due-releases";
+import type { JobRegistry } from "../../domains/jobs/job-registry";
+import { RELEASES_DRAIN_JOB } from "../../domains/releases/releases-drain-job";
+import type { Logger } from "../../shared/types";
+
+import { reportReleasesOutcome } from "../registrations/register-jobs";
+
+function logger(): Logger & { error: ReturnType<typeof vi.fn> } {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger & { error: ReturnType<typeof vi.fn> };
+}
+
+function failedMember(releaseId: string, memberId: string) {
+  return {
+    ref: {
+      scopeKind: "collection" as const,
+      scopeSlug: "posts",
+      entryId: `entry-${memberId}`,
+      locale: null,
+    },
+    memberId,
+    releaseId,
+    effect: "publish" as const,
+    failure: "author-unresolvable" as unknown as never,
+    detail: "the author no longer exists",
+  };
+}
+
+function result(
+  over: Partial<ApplyDueReleasesResult> = {}
+): ApplyDueReleasesResult {
+  return {
+    due: 1,
+    published: 1,
+    applied: 1,
+    failed: 0,
+    outcomes: [],
+    ...over,
+  } as ApplyDueReleasesResult;
+}
+
+describe("the registered job types", () => {
+  it("registers releases:drain, so a queued release drain can actually run", async () => {
+    // The REAL JobRegistry, and the assertion is a lookup by slug — the same
+    // call the runner makes. Asserting that `register` was invoked would pass
+    // against a registry that then failed to hold the definition, and "the
+    // runner can find it" is the property that matters.
+    const singletons = new Map<string, unknown>();
+
+    vi.resetModules();
+    vi.doMock("../container", () => ({
+      container: {
+        registerSingleton: (name: string, factory: () => unknown) => {
+          singletons.set(name, factory());
+        },
+      },
+    }));
+
+    const { registerJobServices } = await import(
+      "../registrations/register-jobs"
+    );
+    registerJobServices({
+      adapter: { select: async () => [] },
+      logger: logger(),
+    } as never);
+
+    const registry = singletons.get("jobRegistry") as JobRegistry;
+    expect(registry.get(RELEASES_DRAIN_JOB)).toBeDefined();
+
+    vi.doUnmock("../container");
+    vi.resetModules();
+  });
+
+  it("registers a repository, so something can enqueue work", async () => {
+    const singletons = new Map<string, unknown>();
+
+    vi.resetModules();
+    vi.doMock("../container", () => ({
+      container: {
+        registerSingleton: (name: string, factory: () => unknown) => {
+          singletons.set(name, factory());
+        },
+      },
+    }));
+
+    const { registerJobServices } = await import(
+      "../registrations/register-jobs"
+    );
+    // Imported INSIDE the reset module graph. `vi.resetModules()` gives the
+    // dynamic import a fresh copy of every module, so a statically imported
+    // class is a different class here and `instanceof` compares across two
+    // graphs rather than testing anything.
+    const { JobsRepository } = await import(
+      "../../domains/jobs/jobs-repository"
+    );
+    registerJobServices({
+      adapter: { select: async () => [] },
+      logger: logger(),
+    } as never);
+
+    expect(singletons.get("jobsRepository")).toBeInstanceOf(JobsRepository);
+
+    vi.doUnmock("../container");
+    vi.resetModules();
+  });
+});
+
+describe("reportReleasesOutcome", () => {
+  it("reports each failed member individually, not just a count", async () => {
+    // "3 failed" says something is wrong; the document and the reason are what
+    // let an operator fix it. A release stuck on one deactivated author is
+    // indistinguishable from three unrelated problems until you can see which.
+    const log = logger();
+
+    reportReleasesOutcome(
+      log,
+      result({
+        failed: 2,
+        outcomes: [failedMember("r1", "m1"), failedMember("r1", "m2")],
+      })
+    );
+
+    expect(log.error).toHaveBeenCalledTimes(2);
+    const reported = log.error.mock.calls.map(
+      call => (call[1] as { memberId: string }).memberId
+    );
+    expect(reported).toEqual(["m1", "m2"]);
+  });
+
+  it("reports a member failure even when the pass otherwise succeeded", async () => {
+    // The exact case that makes `onOutcome` required: the job row completes,
+    // so nothing upstream treats this as a failure at all.
+    const log = logger();
+
+    reportReleasesOutcome(
+      log,
+      result({ applied: 5, failed: 1, outcomes: [failedMember("r1", "m9")] })
+    );
+
+    expect(log.error).toHaveBeenCalledTimes(1);
+  });
+
+  it("says nothing when no release was due", async () => {
+    // A sweep runs on an interval and is silent by design; a line per tick
+    // would bury the pass that mattered.
+    const log = logger();
+
+    reportReleasesOutcome(log, result({ due: 0, published: 0, applied: 0 }));
+
+    expect(log.info).not.toHaveBeenCalled();
+    expect(log.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -196,6 +196,7 @@ import {
   registerComponentServices,
   registerDashboardServices,
   registerEmailServices,
+  registerJobServices,
   registerMediaServices,
   registerMetaServices,
   registerRevalidationServices,
@@ -1051,6 +1052,9 @@ export async function registerServices(
   // lazily when a write flushes its intents.
   registerRevalidationServices(ctx);
   registerCollectionServices(ctx);
+  // After collections: the releases job type registered here reaches content
+  // through the Direct API, so the services that back it must already exist.
+  registerJobServices(ctx);
   registerMediaServices(ctx);
   registerMetaServices(ctx);
   registerSingleServices(ctx);

--- a/packages/nextly/src/di/registrations/index.ts
+++ b/packages/nextly/src/di/registrations/index.ts
@@ -10,6 +10,7 @@ export { registerCollectionServices } from "./register-collections";
 export { registerComponentServices } from "./register-components";
 export { registerDashboardServices } from "./register-dashboard";
 export { registerEmailServices } from "./register-email";
+export { registerJobServices } from "./register-jobs";
 export { registerMediaServices } from "./register-media";
 export { registerMetaServices } from "./register-meta";
 export { registerRevalidationServices } from "./register-revalidation";

--- a/packages/nextly/src/di/registrations/register-jobs.ts
+++ b/packages/nextly/src/di/registrations/register-jobs.ts
@@ -1,0 +1,115 @@
+/**
+ * Background job DI registrations.
+ *
+ * Two singletons, and the reason there are two is the whole shape of the
+ * domain: `jobsRepository` is where jobs are WRITTEN — anything that wants work
+ * done later enqueues through it — and `jobRegistry` is where the code that
+ * performs them is looked up. A trigger needs both, and it must find the same
+ * two every pass: a registry built per request would answer for whatever job
+ * types that request happened to import, so a job queued by one route could be
+ * unrunnable from another.
+ *
+ * This is also the site that turns a job DEFINITION into a registered one.
+ * `defineJob` produces a value; until something puts it in a registry the
+ * runner cannot see it, and a queued row for its slug is deferred forever while
+ * looking exactly like an empty queue. Every built-in job type is registered
+ * here, so "which jobs can this installation run" has one answer that a reader
+ * can check.
+ *
+ * @module di/registrations/register-jobs
+ */
+
+import { nextly } from "../../direct-api/nextly";
+import { JobRegistry } from "../../domains/jobs/job-registry";
+import { JobsRepository } from "../../domains/jobs/jobs-repository";
+import { databaseRunAs } from "../../domains/jobs/jobs-runner";
+import type { ApplyDueReleasesResult } from "../../domains/releases/apply-due-releases";
+import { createReleasesDrainJob } from "../../domains/releases/releases-drain-job";
+import type { Logger } from "../../services/shared";
+import { container } from "../container";
+
+import type { RegistrationContext } from "./types";
+
+/**
+ * Report what a releases pass did, and say so loudly when a member failed.
+ *
+ * `createReleasesDrainJob` requires this rather than defaulting it, and the
+ * requirement is the point: a pass can fail individual members while the job
+ * row completes successfully — a deleted author, a refused write, a release
+ * cancelled mid-pass. Those releases stay `scheduled` and are retried on every
+ * later sweep, so without a report the only trace of a release that will never
+ * publish is a returned object nobody read.
+ *
+ * Failures are logged per member, not as a count. "3 failed" tells an operator
+ * that something is wrong; the document and the reason are what let them fix
+ * it, and a release stuck on one deactivated author is indistinguishable from
+ * three unrelated problems until you can see which is which.
+ *
+ * Exported so that contract is testable. It is the reason `onOutcome` is a
+ * required parameter rather than an optional one, and a reporter whose only
+ * guard is a comment is a guarantee nobody can prove still holds.
+ */
+export function reportReleasesOutcome(
+  logger: Logger,
+  result: ApplyDueReleasesResult
+): void {
+  if (result.due === 0) return;
+
+  logger.info("Content releases pass completed", {
+    due: result.due,
+    published: result.published,
+    applied: result.applied,
+    failed: result.failed,
+  });
+
+  for (const outcome of result.outcomes) {
+    if (outcome.failure === null) continue;
+    logger.error("A release member could not be materialised", {
+      releaseId: outcome.releaseId,
+      memberId: outcome.memberId,
+      scopeKind: outcome.ref.scopeKind,
+      scopeSlug: outcome.ref.scopeSlug,
+      entryId: outcome.ref.entryId,
+      locale: outcome.ref.locale,
+      effect: outcome.effect,
+      failure: outcome.failure,
+      detail: outcome.detail,
+    });
+  }
+}
+
+export function registerJobServices(ctx: RegistrationContext): void {
+  const { adapter, logger } = ctx;
+
+  container.registerSingleton<JobsRepository>(
+    "jobsRepository",
+    () => new JobsRepository(adapter)
+  );
+
+  container.registerSingleton<JobRegistry>("jobRegistry", () => {
+    const registry = new JobRegistry();
+
+    // Content releases, consumer #1 of the runner. Constructed here rather than
+    // in the releases domain because a job type is only real once something
+    // registers it, and the registry is the thing that decides which jobs an
+    // installation can run.
+    //
+    // `runAs` is the means to RESOLVE an identity, never a principal: the pass
+    // resolves each member's own author, so one release carrying members by
+    // different people fails only the member whose author is gone. Passing a
+    // principal here instead would turn "schedule this" into a privilege
+    // escalation with a delay on it.
+    registry.register(
+      createReleasesDrainJob({
+        db: adapter,
+        // The Direct API facade, whose operations survive extraction; the
+        // handler binds each call to the member's own resolved identity.
+        contentApi: nextly,
+        runAs: databaseRunAs(adapter),
+        onOutcome: result => reportReleasesOutcome(logger, result),
+      })
+    );
+
+    return registry;
+  });
+}

--- a/packages/nextly/src/dispatcher/types.ts
+++ b/packages/nextly/src/dispatcher/types.ts
@@ -23,6 +23,7 @@ export type ServiceType =
   | "emailTemplates"
   | "apiKeys"
   | "webhooks"
+  | "jobs"
   | "generalSettings"
   | "previewLinks"
   | "previewUrl"

--- a/packages/nextly/src/domains/auth/services/permission-seed-service.ts
+++ b/packages/nextly/src/domains/auth/services/permission-seed-service.ts
@@ -304,6 +304,23 @@ const SYSTEM_PERMISSIONS: SystemPermissionDef[] = [
     description:
       "Permission to schedule or cancel a content release, which is what makes its content go live",
   },
+  // Background jobs. ONE permission, not a CRUD set: the only surface that
+  // checks anything today is the trigger that runs a drain pass by hand, and a
+  // permission nothing enforces teaches the admin a vocabulary the server
+  // ignores. `read-background-jobs` arrives with the queue view that reads it.
+  //
+  // Pulling the trigger confers no authority over the work itself. Every job
+  // runs as the identity it was queued with, reconstructed at execution, so a
+  // holder of this permission makes already-queued, already-authorized work
+  // happen NOW — they do not gain the power to perform it.
+  {
+    name: "Manage Background Jobs",
+    slug: "manage-background-jobs",
+    action: "manage",
+    resource: "background-jobs",
+    description:
+      "Permission to run the background job queue by hand, outside its schedule",
+  },
 ];
 
 /**

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-runner-sweeps.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-runner-sweeps.test.ts
@@ -1,0 +1,115 @@
+/**
+ * A sweep is queued by the trigger, because nothing else can queue it.
+ *
+ * `releases:drain` was registered and never ran: a release comes due at an
+ * instant with no request attached, so no code path is ever in a position to
+ * enqueue it. The queue stayed empty and looked exactly like a queue with
+ * nothing to do.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import { JobRegistry, defineJob } from "../job-registry";
+import { runJobsPass, sweepDedupeKey } from "../jobs-runner";
+
+function registryWith(...defs: ReturnType<typeof defineJob>[]): JobRegistry {
+  const registry = new JobRegistry();
+  for (const d of defs) registry.register(d);
+  return registry;
+}
+
+/** An adapter that records enqueues and claims nothing. */
+function adapterSpy() {
+  const inserted: Array<Record<string, unknown>> = [];
+  return {
+    inserted,
+    insert: async (_table: string, row: Record<string, unknown>) => {
+      inserted.push(row);
+      return row;
+    },
+    select: async () => [],
+    selectOne: async () => null,
+    updateCount: async () => 0,
+    delete: async () => 0,
+    transaction: async <T>(fn: (tx: unknown) => Promise<T>): Promise<T> =>
+      fn({ select: async () => [], updateCount: async () => 0 }),
+  };
+}
+
+const noop = defineJob({ slug: "test:noop", handler: async () => {} });
+const sweeper = defineJob({
+  slug: "test:sweep",
+  handler: async () => {},
+  sweep: true,
+});
+
+describe("a pass keeps its sweeps queued", () => {
+  it("enqueues a registered sweep", async () => {
+    const adapter = adapterSpy();
+
+    await runJobsPass(adapter as never, registryWith(sweeper), {
+      retentionMs: null,
+    });
+
+    const slugs = adapter.inserted.map(row => row.slug);
+    expect(slugs).toContain("test:sweep");
+  });
+
+  it("does NOT enqueue a job type that is not a sweep", async () => {
+    // The control. A pass that queued every registered type would fill the
+    // table with work nobody asked for, and would make the assertion above
+    // pass for a reason that has nothing to do with `sweep`.
+    const adapter = adapterSpy();
+
+    await runJobsPass(adapter as never, registryWith(noop), {
+      retentionMs: null,
+    });
+
+    const slugs = adapter.inserted.map(row => row.slug);
+    expect(slugs).not.toContain("test:noop");
+  });
+
+  it("queues it under a stable dedupe key, so a second trigger adds no copy", async () => {
+    // The key is what makes this safe to do on every tick. Two schedulers, or
+    // one scheduler and an impatient operator, must not stack up sweeps.
+    const adapter = adapterSpy();
+
+    await runJobsPass(adapter as never, registryWith(sweeper), {
+      retentionMs: null,
+    });
+
+    expect(adapter.inserted[0]?.dedupe_key).toBe(sweepDedupeKey("test:sweep"));
+  });
+
+  it("gives the sweep no principal", async () => {
+    // A sweep acts as nobody and resolves each item's own identity when it
+    // performs it. A user here would be an authority lent to work that never
+    // asked for it — a privilege escalation with a delay on it.
+    const adapter = adapterSpy();
+
+    await runJobsPass(adapter as never, registryWith(sweeper), {
+      retentionMs: null,
+    });
+
+    expect(adapter.inserted[0]?.run_as_user_id).toBeNull();
+  });
+
+  it("still drains when a sweep cannot be queued", async () => {
+    // Housekeeping is not the work. The jobs already in the table are real, and
+    // refusing to run them because an insert failed turns a hiccup into a
+    // stalled queue.
+    const adapter = adapterSpy();
+    adapter.insert = async () => {
+      throw new Error("insert refused");
+    };
+    const onSweepError = vi.fn();
+
+    const result = await runJobsPass(adapter as never, registryWith(sweeper), {
+      retentionMs: null,
+      onSweepError,
+    });
+
+    expect(onSweepError).toHaveBeenCalledTimes(1);
+    expect(result.claimed).toBe(0);
+  });
+});

--- a/packages/nextly/src/domains/jobs/index.ts
+++ b/packages/nextly/src/domains/jobs/index.ts
@@ -46,5 +46,6 @@ export {
 export {
   databaseRunAs,
   runJobsPass,
+  type JobsPassDatabase,
   type RunJobsPassOptions,
 } from "./jobs-runner";

--- a/packages/nextly/src/domains/jobs/index.ts
+++ b/packages/nextly/src/domains/jobs/index.ts
@@ -46,6 +46,7 @@ export {
 export {
   databaseRunAs,
   runJobsPass,
+  sweepDedupeKey,
   type JobsPassDatabase,
   type RunJobsPassOptions,
 } from "./jobs-runner";

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -78,6 +78,16 @@ export interface JobDefinition<TInput = unknown> {
   slug: string;
   handler: (input: TInput, context: JobContext) => Promise<void>;
   retry: JobRetryPolicy;
+  /**
+   * Whether a trigger should keep one of these queued at all times.
+   *
+   * A job type is normally queued by whoever wants the work: something happens,
+   * a row is written, a pass runs it. A SWEEP has no such moment — it asks a
+   * question of the database ("which releases have come due?") at an instant
+   * with no request attached, so nothing is ever in a position to enqueue it,
+   * and a handler that nothing enqueues is a handler that never runs.
+   */
+  sweep: boolean;
 }
 
 export interface JobDefinitionInput<TInput = unknown> {
@@ -85,6 +95,8 @@ export interface JobDefinitionInput<TInput = unknown> {
   handler: (input: TInput, context: JobContext) => Promise<void>;
   /** Defaults to {@link DEFAULT_MAX_ATTEMPTS} attempts. */
   retry?: Partial<JobRetryPolicy>;
+  /** Keep one queued at all times; see {@link JobDefinition.sweep}. */
+  sweep?: boolean;
 }
 
 /**
@@ -125,7 +137,12 @@ export function defineJob<TInput = unknown>(
     });
   }
 
-  return { slug, handler: input.handler, retry: { maxAttempts } };
+  return {
+    slug,
+    handler: input.handler,
+    retry: { maxAttempts },
+    sweep: input.sweep ?? false,
+  };
 }
 
 /**
@@ -166,5 +183,19 @@ export class JobRegistry {
    */
   slugs(): string[] {
     return [...this.definitions.keys()].sort();
+  }
+
+  /**
+   * Every job type that must be kept queued, sorted.
+   *
+   * Read by a trigger before it drains, so the pass finds the sweep it is about
+   * to run. Derived from the definitions rather than listed separately: a
+   * second list is a second place to forget a job type, and forgetting it here
+   * is invisible — the queue simply stays empty.
+   */
+  sweeps(): JobDefinition<never>[] {
+    return [...this.definitions.values()]
+      .filter(definition => definition.sweep)
+      .sort((a, b) => a.slug.localeCompare(b.slug));
   }
 }

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -45,6 +45,14 @@ function executorOf(db: UsersReadDb): unknown {
     : undefined;
 }
 
+/**
+ * The database surface one pass needs: the jobs table plus the users read the
+ * identity resolver performs. Named as the minimal intersection, rather than the
+ * concrete adapter type, so a caller resolves it from the DI container as
+ * exactly what a pass uses — the same reason `WebhookDrainDatabase` exists.
+ */
+export type JobsPassDatabase = JobsDatabase & UsersReadDb;
+
 /** How long a finished job row is kept before a pass may remove it. */
 export const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
 
@@ -143,7 +151,7 @@ export function databaseRunAs(
  * budget is spent; jobs scheduled for a future retry are left for a later pass.
  */
 export async function runJobsPass(
-  adapter: JobsDatabase & UsersReadDb,
+  adapter: JobsPassDatabase,
   registry: JobRegistry,
   options?: RunJobsPassOptions
 ): Promise<RunJobsResult> {

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -90,6 +90,8 @@ export interface RunJobsPassOptions {
   retentionMs?: number | null;
   /** Rows one pass may remove. */
   pruneLimit?: number;
+  /** Told when a sweep could not be queued; the pass proceeds regardless. */
+  onSweepError?: (error: unknown, slug: string) => void;
 }
 
 /**
@@ -150,12 +152,75 @@ export function databaseRunAs(
  * Returns once nothing further is immediately actionable or the wall-clock
  * budget is spent; jobs scheduled for a future retry are left for a later pass.
  */
+/**
+ * The dedupe key that keeps exactly one of a sweep outstanding.
+ *
+ * Stable, so a second trigger firing while the first sweep is still queued or
+ * running is refused as a duplicate rather than queueing a second copy. It stops
+ * being a duplicate the moment the row goes terminal: `finalize` clears
+ * `dedupe_key` for precisely this reason, so the next trigger queues a fresh
+ * sweep instead of finding the key held forever by a job that has been and gone.
+ */
+export function sweepDedupeKey(slug: string): string {
+  return `sweep:${slug}`;
+}
+
+/**
+ * Make sure every sweep this installation registered has a row waiting.
+ *
+ * Without this, a registered sweep is a handler nobody enqueues. `releases:drain`
+ * is the case that proves it: a release comes due at an instant with no request
+ * attached, so no code path is ever in a position to queue the work, and the
+ * queue stays empty while looking exactly like a queue with nothing to do.
+ *
+ * Failures here do not fail the pass. The jobs already in the table are real
+ * work, and refusing to run them because a housekeeping insert failed would turn
+ * a recoverable hiccup into a stalled queue.
+ */
+async function queueSweeps(
+  repository: JobsRepository,
+  registry: JobRegistry,
+  now: Date,
+  logger?: (error: unknown, slug: string) => void
+): Promise<void> {
+  for (const definition of registry.sweeps()) {
+    try {
+      await repository.enqueue({
+        slug: definition.slug,
+        input: null,
+        // Due immediately: the trigger firing IS the schedule. A future `runAt`
+        // would make the sweep wait for a tick after the one that queued it.
+        runAt: null,
+        // No principal. A sweep acts as nobody and resolves each item's own
+        // identity when it performs it; a user here would be an authority the
+        // sweep could lend to work that never asked for it.
+        runAsUserId: null,
+        dedupeKey: sweepDedupeKey(definition.slug),
+        now,
+      });
+    } catch (error) {
+      logger?.(error, definition.slug);
+    }
+  }
+}
+
 export async function runJobsPass(
   adapter: JobsPassDatabase,
   registry: JobRegistry,
   options?: RunJobsPassOptions
 ): Promise<RunJobsResult> {
   const repository = new JobsRepository(adapter);
+
+  // BEFORE the drain, so the pass that queues a sweep is also the pass that
+  // runs it. Queueing afterwards would leave every sweep waiting for the NEXT
+  // trigger, doubling the latency of everything that depends on one.
+  await queueSweeps(
+    repository,
+    registry,
+    (options?.now ?? (() => new Date()))(),
+    options?.onSweepError
+  );
+
   const result = await runJobs({
     store: repository,
     registry,

--- a/packages/nextly/src/domains/releases/releases-drain-job.ts
+++ b/packages/nextly/src/domains/releases/releases-drain-job.ts
@@ -64,6 +64,11 @@ export function createReleasesDrainJob(deps: {
 }): JobDefinition<unknown> {
   return defineJob({
     slug: RELEASES_DRAIN_JOB,
+    // A sweep: a release comes due at an instant with no request attached, so
+    // nothing is ever in a position to enqueue this. A trigger keeps one queued
+    // instead. Without it the handler is registered and never runs, which looks
+    // exactly like a site with no releases due.
+    sweep: true,
     handler: async () => {
       const result = await applyDueReleases({
         repository: new ReleasesRepository(deps.db),

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2005,6 +2005,35 @@ function parseApiKeyRoutes(
   return null;
 }
 
+/**
+ * GET or POST /api/jobs/run → run one background job pass.
+ *
+ * `run` is the only path under `jobs`, and it is an operation rather than an
+ * id: there is no per-job REST surface yet, so nothing can collide with it.
+ * GET is accepted because Vercel Cron triggers with a GET; the pass is
+ * idempotent under its lease, and the route authorizes either method.
+ */
+function parseJobRoutes(
+  id: string | undefined,
+  subresource: string | undefined,
+  httpMethod: string,
+  routeParams: Record<string, string>
+): ParsedRoute | null {
+  if (id !== "run" || subresource) return null;
+  if (httpMethod !== "POST" && httpMethod !== "GET") return null;
+  // Running the queue is not a CRUD OperationType, but the dispatch guard
+  // rejects a route with no operation before the direct-dispatch jobs branch
+  // runs, so a truthy value is required. The handler does its own
+  // authorization and this value is otherwise unused — the same accommodation
+  // the webhook drain makes one function below.
+  return {
+    service: "jobs",
+    operation: "single",
+    method: "runJobs",
+    routeParams,
+  };
+}
+
 function parseWebhookRoutes(
   id: string | undefined,
   subresource: string | undefined,
@@ -2596,6 +2625,12 @@ export function parseRestRoute(
       httpMethod,
       routeParams
     );
+    if (result) return result;
+  }
+
+  // Handle the background job trigger
+  if (resource === "jobs") {
+    const result = parseJobRoutes(id, subresource, httpMethod, routeParams);
     if (result) return result;
   }
 

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -54,6 +54,7 @@ import {
   updateImageSize,
   deleteImageSize,
 } from "./api/image-sizes";
+import { runJobsRoute } from "./api/jobs-run-route";
 import { mintPreviewLink, revokePreviewLinks } from "./api/preview-links";
 import { resolveEntryPreviewUrl } from "./api/preview-url";
 import { readOrGenerateRequestId, withRequestIdHeader } from "./api/request-id";
@@ -1018,6 +1019,13 @@ async function handleServiceRequest(
   // before they can read it.
   if (service === "webhooks") {
     return handleWebhookRequest(req, method, routeParams);
+  }
+
+  // ==================== JOBS DIRECT DISPATCH ====================
+  // Beside the webhook drain and for the same reason: the handler owns its own
+  // authorization, and it must stay above the shared body read below.
+  if (service === "jobs") {
+    return runJobsRoute(req);
   }
 
   // ==================== PREVIEW LINKS DIRECT DISPATCH ====================

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -342,6 +342,7 @@ async function handleApiKeyRequest(
 const DIRECT_DISPATCH_SERVICES = new Set<string>([
   "apiKeys",
   "webhooks",
+  "jobs",
   "generalSettings",
   "previewLinks",
   "previewUrl",

--- a/packages/nextly/src/schemas/_zod/rbac.ts
+++ b/packages/nextly/src/schemas/_zod/rbac.ts
@@ -34,6 +34,12 @@ export const SYSTEM_RESOURCES = [
   // permissions reclassified as system permissions, silently costing preset
   // roles their access.
   "content-releases",
+  // NOT "jobs", for the reason "content-releases" is not "releases": a system
+  // resource RESERVES its name, and "jobs" is a word real sites use for
+  // content — a careers page or a job board is an ordinary collection. This
+  // one reads as a system concept and cannot be mistaken for content, which is
+  // the whole test.
+  "background-jobs",
 ] as const;
 
 export type SystemResource = (typeof SYSTEM_RESOURCES)[number];
@@ -66,6 +72,14 @@ export const NEWLY_RESERVED_SLUG_NOTES: ReadonlyMap<string, string> = new Map([
       "the read-, create- and publish-content-releases permissions are seeded under this name, " +
       "so a content entity sharing it would have its own permissions treated as system-owned " +
       "and preset roles would silently lose access to it.",
+  ],
+  [
+    "background-jobs",
+    "This name became a reserved system resource when the background job runner gained its trigger. " +
+      "An installation that already has a collection or Single with this slug must rename it: " +
+      "the manage-background-jobs permission is seeded under this name, so a content entity " +
+      "sharing it would have its own permissions treated as system-owned and preset roles " +
+      "would silently lose access to it.",
   ],
 ]);
 


### PR DESCRIPTION
## What a user gets

Scheduled content releases publish themselves. Point a scheduler at
`/api/jobs/run` — Vercel Cron, a system cron, anything that can make an HTTP
request on an interval — and due releases go live with nobody awake.

## Why it was not already working

R-2 built the queue, the lease, the backoff, the identity resolution and the
orchestration. It was missing the two things that make a runner run: a way to be
triggered, and a list of the work it knows how to do.

The second one is worth stating plainly, because it looked finished.
`createReleasesDrainJob` is exported from `index.ts` and **called by nothing**.
`defineJob` produces a value; until something puts it in a registry the runner
cannot see it. A queued `releases:drain` row would be deferred on every pass
forever — and a queue that never drains looks exactly like an empty one. A test
asserting the definition exists passes in precisely that broken state, which is
why the new test asserts the **registry lookup** instead.

## Auth, and why this route contains none

"Who may pull a scheduler trigger" was answered by the webhook drain, and the
previous commit on this branch moved that answer into `api/trigger-auth.ts`. This
route supplies the one thing that differs between triggers — the permission a
human needs — and adds nothing else.

- A scheduler presents `NEXTLY_DRAIN_SECRET` or Vercel's `CRON_SECRET` as a
  bearer token, compared constant-time.
- A person authenticates normally and needs the new `manage-background-jobs`,
  seeded like any other system permission and granted to super_admin on boot.
- GET is refused on the human path: a cross-site top-level navigation carries a
  `SameSite=Lax` cookie, so admitting one would make this a CSRF trigger.

**Pulling the trigger confers no authority over the work.** Every job runs as the
identity it was queued with, reconstructed at execution and failing closed. A
holder makes already-queued, already-authorized work happen *now*; they do not
gain the power to perform it.

### The resource is `background-jobs`, not `jobs`

Registering a system resource RESERVES the name, and `jobs` is a word real sites
use for content — a careers page or a job board is an ordinary collection. This
is the same reasoning that made `releases` into `content-releases`, and it
carries the same operator note, now checked where an operator actually meets it
rather than only in a list.

## A gap this closes that was not on the plan

**The authorizer had no test coverage at all.** No test in the package referenced
`NEXTLY_DRAIN_SECRET` or `CRON_SECRET` (control: other env vars *are* referenced,
so the search works). The webhook drain's auth path was covered only by tests of
the drain *engine*, which never reach it. It now has nine tests, one per guard.

## Constraints honoured, given in writing by the releases lane

- **The runner imposes no identity on the handler.** `RunAsDeps` is the means to
  *resolve* an identity, never a principal; the pass resolves each member's own
  author, so one release carrying members by different people fails only the
  member whose author is gone.
- **`onOutcome` stays required.** The wiring supplies a real reporter that logs
  each failed member with its document and reason — a pass can fail members while
  the job row completes, and those releases retry silently forever otherwise.

## Verification

| gate | result |
| --- | --- |
| `check-types` | pass |
| `lint` | pass (0 warnings) |
| unit suite | **799 files / 9865 passed, 42 skipped** |
| integration: di, init, auth | 16 files / 76 passed |
| integration: jobs, releases, webhooks | 25 files / 263 passed |
| `fallow --base origin/main` | `verdict: pass`, `changed_files_count: 17`, every `*_introduced` **0** |

**Break-verified, whole file each time, one mutation per guard.** All 14 killed
exactly the test named for that guard. The two worth naming:

- *Never register the releases job* — reproduces the pre-existing broken state,
  and is caught.
- *Ask for `manage-settings` instead* — proves the permission test discriminates
  on the permission's identity rather than on some check having run.

**One caveat, stated rather than hidden.** An early full-suite run reported 8
failures whose names I did not capture. Two subsequent full runs were green at an
identical 799 files / 9865 tests, so nothing was silently uncollected, but I
cannot explain that run and am not claiming it away.

Plan: `plans/2026-08-26-R-2-jobs-domain-plan.md`, Task 8. Tasks 9 and 10 follow.
