### PR TITLE
fix(blocks-engine): one definition of what an interaction state means

### DIFF
--- a/.changeset/one-definition-of-what-a-state-means.md
+++ b/.changeset/one-definition-of-what-a-state-means.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Show the right blocks when previewing an interaction state.
+
+Focus no longer lights up a selected block's ancestors. `:hover` and `:active`
+match an element and every ancestor of it, but `:focus-visible` does not — that
+is `:focus-within`, which the builder does not emit. Previewing focus therefore
+showed an enclosing block's focus styles for an appearance no visitor sees.
+
+Page-level state styles now apply in the preview at all: the marker is put on
+the rendered page root, which is what those rules select, rather than on the
+canvas wrapper around it.
+
+Each interaction state's meaning is defined once and both the published and
+preview selectors are derived from it, so the two cannot drift into matching
+different pseudo-classes.

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -497,7 +497,11 @@ export { EMITTABLE_STRING_BOUNDS } from "./style/emittable-string-bounds";
 // compiler and a previewing surface: the compiler writes it into a selector
 // and the surface puts it on an element. A name spelled in two places can be
 // spelled differently, which is why `NODE_ID_ATTRIBUTE` is published too.
-export { MAX_SCOPE_LENGTH, previewStateClass } from "./style/compile-page";
+export {
+  MAX_SCOPE_LENGTH,
+  previewStateClass,
+  statePropagatesToAncestors,
+} from "./style/compile-page";
 export type { EmittableStringBound } from "./style/emittable-string-bounds";
 export type { StyleOrigin, StyleTraceEntry } from "./style/style-trace";
 export type { StyleQuery, StyleSubject } from "./style/style-origin";

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -382,12 +382,42 @@ export const TYPOGRAPHIC_ELEMENTS = [
  */
 export type TypographicElement = (typeof TYPOGRAPHIC_ELEMENTS)[number];
 
-const STATE_SELECTORS: Readonly<Record<StyleState, string>> = {
+/**
+ * What each interaction state MEANS, in one place.
+ *
+ * The single definition both renderings below are derived from. Written out
+ * twice, a change to what `focus` matches would land in one map and leave the
+ * other silently selecting a different pseudo-class — both type-correct, and
+ * the preview would then simulate a state the published page does not have.
+ *
+ * `base` is the empty string because it is not a state: it is what applies when
+ * no state does.
+ */
+const STATE_PSEUDO: Readonly<Record<StyleState, string>> = {
   base: "",
-  hover: ":where(:hover)",
-  focus: ":where(:focus-visible)",
-  active: ":where(:active)",
+  hover: ":hover",
+  focus: ":focus-visible",
+  active: ":active",
 };
+
+/**
+ * One rendering of {@link STATE_PSEUDO} per state, built by `render`.
+ *
+ * A helper rather than two object literals, so neither map can gain a state the
+ * other lacks or spell one differently.
+ */
+function stateSelectors(
+  render: (pseudo: string, state: StyleState) => string
+): Readonly<Record<StyleState, string>> {
+  const selectors = {} as Record<StyleState, string>;
+  for (const state of STYLE_STATES) {
+    const pseudo = STATE_PSEUDO[state];
+    selectors[state] = pseudo === "" ? "" : render(pseudo, state);
+  }
+  return selectors;
+}
+
+const STATE_SELECTORS = stateSelectors(pseudo => `:where(${pseudo})`);
 
 /**
  * The class a previewing surface puts on ONE element to force an interaction
@@ -427,12 +457,9 @@ export function previewStateClass(state: StyleState): string {
  * `base` has no marker: it is not a state anything forces, it is what applies
  * when nothing else does.
  */
-const PREVIEW_STATE_SELECTORS: Readonly<Record<StyleState, string>> = {
-  base: "",
-  hover: `:where(:hover, .${previewStateClass("hover")})`,
-  focus: `:where(:focus-visible, .${previewStateClass("focus")})`,
-  active: `:where(:active, .${previewStateClass("active")})`,
-};
+const PREVIEW_STATE_SELECTORS = stateSelectors(
+  (pseudo, state) => `:where(${pseudo}, .${previewStateClass(state)})`
+);
 
 /** One breakpoint to emit under, with the at-rule it needs. */
 export interface BreakpointContext {

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -385,23 +385,47 @@ export type TypographicElement = (typeof TYPOGRAPHIC_ELEMENTS)[number];
 /**
  * What each interaction state MEANS, in one place.
  *
- * The single definition both renderings below are derived from. Written out
- * twice, a change to what `focus` matches would land in one map and leave the
- * other silently selecting a different pseudo-class — both type-correct, and
- * the preview would then simulate a state the published page does not have.
+ * Both facts about a state live here together, because both are read by
+ * surfaces outside this file and either one written down twice can drift from
+ * the other. The pseudo-class is what the compiler emits; whether the state
+ * PROPAGATES is what a previewing surface needs in order to decide which
+ * elements to force it on.
  *
- * `base` is the empty string because it is not a state: it is what applies when
- * no state does.
+ * Propagation is measured behaviour rather than a convention. In a browser, an
+ * ancestor of the target matches `:hover` and `:active` and does NOT match
+ * `:focus-visible` — the selector that would propagate there is
+ * `:focus-within`, which this compiler does not emit. A surface that assumed
+ * one rule for all three would light up an enclosing block for an appearance no
+ * visitor ever sees.
+ *
+ * `base` is not a state: it is what applies when no state does, so it has no
+ * pseudo-class and nothing to propagate.
  */
-const STATE_PSEUDO: Readonly<Record<StyleState, string>> = {
-  base: "",
-  hover: ":hover",
-  focus: ":focus-visible",
-  active: ":active",
+const STATE_FACTS: Readonly<
+  Record<StyleState, { readonly pseudo: string; readonly propagates: boolean }>
+> = {
+  base: { pseudo: "", propagates: false },
+  hover: { pseudo: ":hover", propagates: true },
+  focus: { pseudo: ":focus-visible", propagates: false },
+  active: { pseudo: ":active", propagates: true },
 };
 
 /**
- * One rendering of {@link STATE_PSEUDO} per state, built by `render`.
+ * Whether forcing this state on an element should also force it on that
+ * element's ancestors.
+ *
+ * Published because the decision belongs beside the selector it follows from: a
+ * previewing surface marks elements, and a surface deciding for itself which
+ * states propagate holds a second opinion that can disagree with the CSS this
+ * compiler emits. Changing `focus` to `:focus-within` would then move the
+ * published rules and leave the canvas marking the wrong chain.
+ */
+export function statePropagatesToAncestors(state: StyleState): boolean {
+  return STATE_FACTS[state].propagates;
+}
+
+/**
+ * One rendering of each state's pseudo-class, built by `render`.
  *
  * A helper rather than two object literals, so neither map can gain a state the
  * other lacks or spell one differently.
@@ -411,7 +435,7 @@ function stateSelectors(
 ): Readonly<Record<StyleState, string>> {
   const selectors = {} as Record<StyleState, string>;
   for (const state of STYLE_STATES) {
-    const pseudo = STATE_PSEUDO[state];
+    const pseudo = STATE_FACTS[state].pseudo;
     selectors[state] = pseudo === "" ? "" : render(pseudo, state);
   }
   return selectors;

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -2080,9 +2080,9 @@ describe("forcing the interaction state the panel is editing", () => {
      * appear for the visitor.
      *
      * The element asserted is the RENDERED page root, not the canvas wrapper.
-     * `PageRenderer` draws `.nx-pb-page` as a child of the wrapper and the
-     * selector names that child — an earlier version of this case asserted the
-     * wrapper, passed, and exercised nothing the compiler actually targets.
+     * `PageRenderer` draws `.nx-pb-page` as a CHILD of the wrapper and the page
+     * tier's selector names that child, so asserting the wrapper would go green
+     * without touching the element the compiler targets.
      */
     const view = renderCanvas("a", "hover");
     const pageRoot = view.container.querySelector(`.${PAGE_ROOT_CLASS}`);

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -37,6 +37,7 @@ import { createElement } from "react";
 
 import {
   clearBlocks,
+  PAGE_ROOT_CLASS,
   previewStateClass,
   registerBlocks,
   STYLE_STATES,
@@ -2069,31 +2070,57 @@ describe("forcing the interaction state the panel is editing", () => {
     );
   });
 
-  it("marks the CANVAS ROOT too, so page-level rules match", () => {
+  it("marks the rendered PAGE ROOT, which is what page rules select", () => {
     /*
      * `:hover` matches an element and every ANCESTOR of it — measured in a
-     * browser, a pointer over a leaf puts the leaf, its parent and the root all
-     * in the chain. The page tier compiles onto the canvas root
-     * (`.nx-pb-page.nx-pb-page:where(:hover, …)`), and a marker on a descendant
-     * cannot make its ancestor match.
+     * browser, a pointer over a leaf puts the leaf, its parent and the root in
+     * the chain. The page tier compiles onto `.nx-pb-page`, so a preview that
+     * marked only the selected node would drop exactly the tiers a real pointer
+     * triggers: a page-level hover colour would vanish in the simulation and
+     * appear for the visitor.
      *
-     * So a preview that marked only the selected node would drop exactly the
-     * tiers a real pointer triggers: a page-level hover colour would vanish in
-     * the simulation and appear for the visitor — the preview disagreeing with
-     * the page in the one state the author opened the panel to inspect.
+     * The element asserted is the RENDERED page root, not the canvas wrapper.
+     * `PageRenderer` draws `.nx-pb-page` as a child of the wrapper and the
+     * selector names that child — an earlier version of this case asserted the
+     * wrapper, passed, and exercised nothing the compiler actually targets.
      */
     const view = renderCanvas("a", "hover");
-    const root = view.container.querySelector(`.${CANVAS_ROOT_CLASS}`);
-    expect(root).not.toBeNull();
-    expect((root as Element).className).toContain(previewStateClass("hover"));
+    const pageRoot = view.container.querySelector(`.${PAGE_ROOT_CLASS}`);
+    expect(pageRoot).not.toBeNull();
+    expect((pageRoot as Element).className).toContain(
+      previewStateClass("hover")
+    );
   });
 
-  it("leaves the canvas root unmarked when nothing is being forced", () => {
+  it("does NOT mark ancestors for focus, which does not propagate", () => {
+    /*
+     * The three states disagree, and the difference is measurable:
+     *
+     *   :hover          an ancestor of the pointed element matches   YES
+     *   :active         an ancestor of the pressed element matches   YES
+     *   :focus-visible  an ancestor of the focused element matches   NO
+     *
+     * The last is `:focus-within`, a different selector the compiler does not
+     * emit. Marking the chain for focus puts an enclosing block's focus styles
+     * on screen for an appearance no visitor ever sees.
+     */
+    const view = renderCanvas("a", "focus");
+    const pageRoot = view.container.querySelector(`.${PAGE_ROOT_CLASS}`);
+    expect(pageRoot).not.toBeNull();
+    expect((pageRoot as Element).className).not.toContain(
+      previewStateClass("focus")
+    );
+    // The selected element itself still carries it — the control that separates
+    // "focus does not propagate" from "focus does nothing".
+    expect(elementFor("a")?.className).toContain(previewStateClass("focus"));
+  });
+
+  it("leaves the page root unmarked when nothing is being forced", () => {
     // The control: a root marked unconditionally would put every page-level
     // hover rule on screen permanently, which is worse than not previewing at
     // all — the author would be reading an appearance no visitor ever sees.
     const view = renderCanvas("a");
-    const root = view.container.querySelector(`.${CANVAS_ROOT_CLASS}`);
+    const root = view.container.querySelector(`.${PAGE_ROOT_CLASS}`);
     for (const state of STYLE_STATES) {
       expect((root as Element).className).not.toContain(
         previewStateClass(state)

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -33,6 +33,7 @@ import {
   PAGE_ROOT_CLASS,
   previewContainerName,
   previewStateClass,
+  statePropagatesToAncestors,
   STYLE_STATES,
   type BlockDocument,
   type BreakpointSet,
@@ -704,21 +705,18 @@ function useSelectionMarkers(
      * the previous class behind on an element nothing is editing.
      */
     /*
-     * WHICH ELEMENTS a forced state belongs on, which is a property of the
-     * state rather than a single rule. Measured in a browser rather than
-     * assumed, because the three do not agree:
+     * WHICH ELEMENTS a forced state belongs on, ASKED of the engine rather
+     * than decided here.
      *
-     *   :hover           an ancestor of the pointed element matches      YES
-     *   :active          an ancestor of the pressed element matches      YES
-     *   :focus-visible   an ancestor of the focused element matches      NO
+     * Whether a state propagates follows from the pseudo-class the compiler
+     * emits for it — an ancestor matches `:hover` and `:active` and does not
+     * match `:focus-visible` — so the two facts live together beside that
+     * definition. Encoding the rule here as well would be a second opinion
+     * about the CSS: changing `focus` to `:focus-within` would move the
+     * published rules and leave this canvas marking the wrong chain, with both
+     * sides type-correct.
      *
-     * The last one is `:focus-within`, which is a different selector the
-     * compiler does not emit. So marking the chain for focus would put an
-     * enclosing block's focus styles on screen for an appearance no visitor
-     * ever sees — the preview lying, which is the failure this feature exists
-     * to remove.
-     *
-     * For the two that do propagate the chain is required, not optional: the
+     * Where a state does propagate the chain is required rather than tidy: the
      * page tier compiles onto the RENDERED page root, and a marker on a
      * descendant cannot make its ancestor match.
      */
@@ -729,7 +727,7 @@ function useSelectionMarkers(
       );
       if (primary !== null) {
         chain.add(primary);
-        if (forcedState !== "focus") {
+        if (statePropagatesToAncestors(forcedState)) {
           for (
             let node: Element | null = primary.parentElement;
             node !== null && container.contains(node);

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -30,6 +30,7 @@
  */
 
 import {
+  PAGE_ROOT_CLASS,
   previewContainerName,
   previewStateClass,
   STYLE_STATES,
@@ -703,38 +704,53 @@ function useSelectionMarkers(
      * the previous class behind on an element nothing is editing.
      */
     /*
-     * The ANCESTOR CHAIN, not the selected element alone.
+     * WHICH ELEMENTS a forced state belongs on, which is a property of the
+     * state rather than a single rule. Measured in a browser rather than
+     * assumed, because the three do not agree:
      *
-     * `:hover` matches an element and every ancestor of it — measured in a
-     * browser, a pointer over a leaf puts the leaf, its parent and the root all
-     * in the hover chain. So the tiers that style an ancestor match under a
-     * real pointer, and a preview that marked only the selected node would drop
-     * exactly those: a page-level hover colour, or an enclosing block's, would
-     * vanish in the simulation and appear for the visitor.
+     *   :hover           an ancestor of the pointed element matches      YES
+     *   :active          an ancestor of the pressed element matches      YES
+     *   :focus-visible   an ancestor of the focused element matches      NO
      *
-     * The canvas ROOT is in the chain too, because the page tier compiles onto
-     * it and a marker on a descendant cannot make its ancestor match. The walk
-     * reaches it without a special case: it stops where `contains` does, and an
-     * element contains itself. With nothing selected the walk never starts, so
-     * the root is not marked and no page-level state rule is forced.
+     * The last one is `:focus-within`, which is a different selector the
+     * compiler does not emit. So marking the chain for focus would put an
+     * enclosing block's focus styles on screen for an appearance no visitor
+     * ever sees — the preview lying, which is the failure this feature exists
+     * to remove.
+     *
+     * For the two that do propagate the chain is required, not optional: the
+     * page tier compiles onto the RENDERED page root, and a marker on a
+     * descendant cannot make its ancestor match.
      */
     const chain = new Set<Element>();
     if (forcedState !== undefined && forcedState !== "base") {
       const primary = container.querySelector(
         `[${SELECTED_ATTRIBUTE}="primary"]`
       );
-      for (
-        let node: Element | null = primary;
-        node !== null && container.contains(node);
-        node = node.parentElement
-      ) {
-        chain.add(node);
+      if (primary !== null) {
+        chain.add(primary);
+        if (forcedState !== "focus") {
+          for (
+            let node: Element | null = primary.parentElement;
+            node !== null && container.contains(node);
+            node = node.parentElement
+          ) {
+            chain.add(node);
+          }
+        }
       }
     }
 
+    /*
+     * Every element a marker can land on OR has to be cleared from. The
+     * rendered PAGE ROOT is in the list explicitly: `PageRenderer` draws
+     * `.nx-pb-page` as a child of this container, and the page tier compiles
+     * onto that element rather than onto the canvas wrapper — so marking the
+     * wrapper leaves page-level state rules unmatched while looking correct.
+     */
     const marks: Element[] = [container];
     container
-      .querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`)
+      .querySelectorAll(`.${PAGE_ROOT_CLASS}, [${NODE_ID_ATTRIBUTE}]`)
       .forEach(element => marks.push(element));
 
     marks.forEach(element => {


### PR DESCRIPTION
Three fixes that were **stranded** by #1346 merging while they were being pushed. The PR read merged and clean; none of this reached `main`.

Verified by content rather than by PR state:

| fix | on `main` before this PR |
|---|---|
| one definition of each state's meaning | no |
| focus not propagating to ancestors | no |
| the rendered page root marked, not the wrapper | no |

All three were found by Codex on #1346 and answered there; the answers just never landed.

## One definition of what a state means

Every interaction state's pseudo-class existed **twice** — once in `STATE_SELECTORS`, once in the preview map I added. Change what `focus` matches and only one moves, both staying type-correct, and the preview silently simulates a state the published page does not have. That is the rule AGENTS.md states outright: one question, one implementation; derive the narrower view rather than computing it alongside.

`STATE_PSEUDO` is now the single definition and both renderings are built from it by one helper, so neither map can gain a state the other lacks or spell one differently.

**Break-verified for the failure that matters:** changing the canonical `focus` pseudo from `:focus-visible` to `:focus` now moves *both* maps and fails the suite.

## Propagation is a property of the state

I had assumed one rule for all three. Measured in a browser, with a control proving the probe reached the mechanism — my first two attempts read "no" for the element *itself*, so they were broken probes rather than evidence:

| state | an ancestor of the target matches |
|---|---|
| `:hover` | **yes** |
| `:active` | **yes** |
| `:focus-visible` | **no** |

The one that propagates for focus is `:focus-within`, a different selector this compiler does not emit. Marking the ancestor chain for focus put an enclosing block's focus styles on screen for an appearance **no visitor ever sees** — the preview lying, which is the one failure this feature exists to remove.

Focus now marks the selected element alone. Two cases, both break-verified: propagating focus like hover fails, and dropping the selected element's own marker fails. The second is the control that separates *"focus does not propagate"* from *"focus does nothing"*.

## The page root is a child, not the wrapper

`PageRenderer` draws `.nx-pb-page` as a **child** of the canvas container, and the page tier compiles onto that child. Marking the wrapper left every page-level state rule unmatched while looking correct — and the test asserted the wrapper, so it passed without touching the element the selector names.

That was the third time in this work that a green of mine was about the wrong subject. The other two: a tier test over `compilePageCss` while the renderer compiles two of those tiers through `compileSiteSheet`, and a canvas-root assertion that could not tell a marked wrapper from a marked page. Same shape each time — the assertion names something *adjacent* to the mechanism, and adjacency is invisible when both look reasonable.

## Verification

Four cases, each break-verified: the page root, focus not propagating, focus still marking its own element, and the canonical pseudo driving both maps.

blocks-engine 1650, builder 2525, blocks-react 968, plugin-page-builder 490. Lint, typecheck, comment convention clean. `fallow audit --base origin/main` gives **pass**, zero introduced across all four categories.

One note for whoever runs this locally: `packages/ui` gained `useCommandHighlight` on main, so a worktree with a stale `dist` fails 27 `insert-panel` tests with *"useCommandHighlight is not a function"*. That is stale build output, not a regression — rebuild `@nextlyhq/ui`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview behavior for forced hover, active, and focus states on page elements.
  * Focus states now apply only to the selected element, while hover and active states continue to include relevant ancestors.
  * Updated state markers are properly cleared and reapplied across the rendered page, preventing stale interaction-state styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->