### PR TITLE
fix(nextly): stop projecting a release whose author can no longer act

### DIFF
--- a/.changeset/withdrawn-authority-stops-a-scheduled-release.md
+++ b/.changeset/withdrawn-authority-stops-a-scheduled-release.md
@@ -1,0 +1,48 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Withdrawing somebody's access now stops their scheduled releases too.
+
+A release runs every action as the person who scheduled it, deliberately, so
+that scheduling cannot become a way to publish something you were not allowed to
+publish. The read side did not know that. It projected any due member of any
+scheduled release without checking whether that person still existed or was
+still active — so deactivating an employee stopped their scheduled publish from
+being written while every visitor went on seeing it as published.
+
+It was permanent rather than temporary. A member whose author cannot be resolved
+fails, a failed member holds its release open, and a release that stays
+scheduled goes on being projected forever.
+
+The read path now derives from the same answer the write path does: a due member
+is projected only while its author exists and is active. A member with no
+recorded author is not projected at all, matching the write path's refusal —
+there is nobody to act as, so it describes an effect no write could perform.
+
+If the lookup itself fails, nothing is projected rather than everything: a
+database that cannot answer must not be read as "everyone is still authorised".

--- a/packages/nextly/src/domains/releases/__tests__/helpers/live-author.ts
+++ b/packages/nextly/src/domains/releases/__tests__/helpers/live-author.ts
@@ -1,0 +1,66 @@
+/**
+ * A real, active user to attribute a release member to.
+ *
+ * The read path projects a due member only when its author still exists and is
+ * still active, matching the write path — which runs every action AS that
+ * person, so that scheduling cannot become a privilege escalation with a delay
+ * on it. A fixture that leaves `createdBy` unset is therefore describing a
+ * member no write could ever perform, and it is now correctly invisible.
+ *
+ * Seeding one real author is the smallest change that keeps these suites
+ * testing what they claim to test, rather than a projection that only worked
+ * because nobody was checked.
+ *
+ * @module domains/releases/__tests__/helpers/live-author
+ */
+import type { TestNextly } from "../../../../plugins/test-nextly";
+
+let seq = 0;
+
+/** Create an active user and return its id. */
+export async function seedLiveAuthor(t: TestNextly): Promise<string> {
+  seq += 1;
+  // Through the public Direct API rather than a service key, so this helper
+  // keeps working if the container's wiring is renamed.
+  const created = (await t.nextly.users.create({
+    email: `release-author-${seq}@example.com`,
+    password: "Str0ng!Passw0rd#2026",
+    data: { name: `Release Author ${seq}` },
+  })) as unknown as { item?: { id?: string }; id?: string };
+  const id = created.item?.id ?? created.id;
+  if (typeof id !== "string") {
+    throw new Error(`seedLiveAuthor: no id in ${JSON.stringify(created)}`);
+  }
+  // MEASURED: a user created through the Direct API lands with `is_active = 0`.
+  // So "created" is not "able to act", and a fixture that only created one would
+  // be seeding exactly the account the read path is supposed to refuse — every
+  // assertion would then pass for the wrong reason on a broken filter, and fail
+  // for the wrong reason on a correct one.
+  await setActive(t, id, true);
+  return id;
+}
+
+/**
+ * Set a user's active flag directly.
+ *
+ * Written straight to the column rather than through a service, so the fixture
+ * states the condition under test — "this account can/cannot act" — without
+ * depending on which of several service paths happens to set it.
+ */
+export async function setActive(
+  t: TestNextly,
+  id: string,
+  active: boolean
+): Promise<void> {
+  const adapter = t.adapter as unknown as {
+    executeQuery: (sql: string) => Promise<unknown>;
+  };
+  await adapter.executeQuery(
+    `UPDATE "users" SET "is_active" = ${active ? 1 : 0} WHERE "id" = '${id}'`
+  );
+}
+
+/** Withdraw a user's access, the way deactivating an account does. */
+export async function deactivate(t: TestNextly, id: string): Promise<void> {
+  await setActive(t, id, false);
+}

--- a/packages/nextly/src/domains/releases/__tests__/helpers/live-author.ts
+++ b/packages/nextly/src/domains/releases/__tests__/helpers/live-author.ts
@@ -43,9 +43,16 @@ export async function seedLiveAuthor(t: TestNextly): Promise<string> {
 /**
  * Set a user's active flag directly.
  *
- * Written straight to the column rather than through a service, so the fixture
- * states the condition under test — "this account can/cannot act" — without
- * depending on which of several service paths happens to set it.
+ * Written to the column rather than through a service, so the fixture states the
+ * condition under test — "this account can/cannot act" — without depending on
+ * which of several service paths happens to set it.
+ *
+ * Through the adapter's typed `update` rather than a SQL string. A hand-written
+ * `UPDATE "users" …` runs on SQLite and Postgres and FAILS on MySQL, which
+ * without `ANSI_QUOTES` reads a double-quoted token as a string literal rather
+ * than an identifier — so every test in the MySQL leg of
+ * `getConfiguredTestDialects` would have died in the fixture, before reaching
+ * the behaviour it claims to check.
  */
 export async function setActive(
   t: TestNextly,
@@ -53,10 +60,16 @@ export async function setActive(
   active: boolean
 ): Promise<void> {
   const adapter = t.adapter as unknown as {
-    executeQuery: (sql: string) => Promise<unknown>;
+    update: (
+      table: string,
+      values: Record<string, unknown>,
+      where: unknown
+    ) => Promise<unknown>;
   };
-  await adapter.executeQuery(
-    `UPDATE "users" SET "is_active" = ${active ? 1 : 0} WHERE "id" = '${id}'`
+  await adapter.update(
+    "users",
+    { isActive: active },
+    { and: [{ column: "id", op: "=", value: id }] }
   );
 }
 

--- a/packages/nextly/src/domains/releases/__tests__/release-reveals-draft.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-reveals-draft.integration.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import { ReleasesRepository } from "../releases-repository";
+import { seedLiveAuthor } from "./helpers/live-author";
 
 let current: TestNextly | undefined;
 
@@ -73,6 +74,9 @@ async function draftInRelease(
     entryId: id,
     locale: null,
     action: "publish",
+    // A live author: the read path projects a due member only when its author
+    // still exists and is active, matching the write path that runs AS them.
+    createdBy: await seedLiveAuthor(t),
   });
   if (scheduledAt !== null) {
     await repo.scheduleRelease(release.id, scheduledAt, "UTC");
@@ -106,6 +110,7 @@ async function publishedInTakedown(
     entryId: id,
     locale: null,
     action: "unpublish",
+    createdBy: await seedLiveAuthor(t),
   });
   if (scheduledAt !== null) {
     await repo.scheduleRelease(release.id, scheduledAt, "UTC");

--- a/packages/nextly/src/domains/releases/__tests__/release-reveals-in-expansion.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-reveals-in-expansion.integration.test.ts
@@ -34,6 +34,7 @@ import {
 } from "../../../plugins/test-nextly";
 import type { CollectionsHandler } from "../../../services/collections-handler";
 import { ReleasesRepository } from "../releases-repository";
+import { seedLiveAuthor } from "./helpers/live-author";
 
 let current: TestNextly | undefined;
 
@@ -103,6 +104,9 @@ async function postWithDraftAuthor(
     entryId: authorId,
     locale: null,
     action: "publish",
+    // A live author: the read path projects a due member only when its author
+    // still exists and is active, matching the write path that runs AS them.
+    createdBy: await seedLiveAuthor(t),
   });
   if (scheduledAt !== null) {
     await repo.scheduleRelease(release.id, scheduledAt, "UTC");
@@ -139,6 +143,7 @@ async function postWithWithdrawnAuthor(
     entryId: authorId,
     locale: null,
     action: "unpublish",
+    createdBy: await seedLiveAuthor(t),
   });
   if (scheduledAt !== null) {
     await repo.scheduleRelease(release.id, scheduledAt, "UTC");

--- a/packages/nextly/src/domains/releases/__tests__/release-reveals-single.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-reveals-single.integration.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../../plugins/test-nextly";
 import type { SingleEntryService } from "../../singles/services/single-entry-service";
 import { ReleasesRepository } from "../releases-repository";
+import { seedLiveAuthor } from "./helpers/live-author";
 
 let current: TestNextly | undefined;
 
@@ -78,6 +79,9 @@ async function draftedSingleInRelease(
     entryId: row.id,
     locale: null,
     action: "publish",
+    // A live author: the read path projects a due member only when its author
+    // still exists and is active, matching the write path that runs AS them.
+    createdBy: await seedLiveAuthor(t),
   });
   if (scheduledAt !== null) {
     await repo.scheduleRelease(release.id, scheduledAt, "UTC");
@@ -108,6 +112,7 @@ async function publishedSingleInTakedown(
     entryId: row.id,
     locale: null,
     action: "unpublish",
+    createdBy: await seedLiveAuthor(t),
   });
   if (scheduledAt !== null) {
     await repo.scheduleRelease(release.id, scheduledAt, "UTC");

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -508,6 +508,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: release.id,
           ...ref("e1"),
           action: "publish",
+          // Attributed, so this negative case fails for its OWN reason. An
+          // authorless member is now filtered before the timing, state and
+          // winner logic runs, so without this the assertion holds even if
+          // that logic breaks entirely.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(release.id, FUTURE, "UTC");
 
@@ -531,6 +536,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: release.id,
           ...ref("e1"),
           action: "publish",
+          // Attributed, so this negative case fails for its OWN reason. An
+          // authorless member is now filtered before the timing, state and
+          // winner logic runs, so without this the assertion holds even if
+          // that logic breaks entirely.
+          createdBy: await seedLiveAuthor(app),
         });
 
         expect(
@@ -555,6 +565,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: up.id,
           ...ref("e1"),
           action: "publish",
+          // Attributed, so this negative case fails for its OWN reason. An
+          // authorless member is now filtered before the timing, state and
+          // winner logic runs, so without this the assertion holds even if
+          // that logic breaks entirely.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(
           up.id,
@@ -567,6 +582,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: down.id,
           ...ref("e1"),
           action: "unpublish",
+          // Attributed, so this negative case fails for its OWN reason. An
+          // authorless member is now filtered before the timing, state and
+          // winner logic runs, so without this the assertion holds even if
+          // that logic breaks entirely.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(
           down.id,
@@ -724,6 +744,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: release.id,
           ...ref("e1"),
           action: "unpublish",
+          // Attributed, so this negative case fails for its OWN reason. An
+          // authorless member is now filtered before the timing, state and
+          // winner logic runs, so without this the assertion holds even if
+          // that logic breaks entirely.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(release.id, FUTURE, "UTC");
 
@@ -752,6 +777,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: release.id,
           ...ref("e1", "de"),
           action: "publish",
+          // Attributed, so this negative case fails for its OWN reason. An
+          // authorless member is now filtered before the timing, state and
+          // winner logic runs, so without this the assertion holds even if
+          // that logic breaks entirely.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(release.id, PAST, "UTC");
 
@@ -826,6 +856,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: release.id,
           ...ref("e1"),
           action: "publish",
+          // Attributed, so this negative case fails for its OWN reason. An
+          // authorless member is now filtered before the timing, state and
+          // winner logic runs, so without this the assertion holds even if
+          // that logic breaks entirely.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(release.id, PAST, "UTC");
 

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -645,6 +645,65 @@ describe.each(getConfiguredTestDialects())(
         ).resolves.toMatchObject({ reveal: [], hide: [] });
       });
 
+      it("projects NOTHING when the WINNING member's author was deactivated", async () => {
+        // The read and the write must pick the same winner. Materialisation
+        // resolves the winner over EVERY member and judges the author
+        // afterwards, so removing candidates before the winner rule lets this
+        // seam pick a different one: the earlier publish below beats the later
+        // takedown once the takedown is filtered out, while the write path still
+        // picks the takedown, fails it, and performs nothing. The release stays
+        // scheduled, so the older publish would be projected indefinitely
+        // against a document nothing ever writes.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const active = await seedLiveAuthor(app);
+        const gone = await seedLiveAuthor(app);
+
+        const earlier = await repo.createRelease({ title: "Publish" });
+        await repo.addMember({
+          releaseId: earlier.id,
+          ...ref("e1"),
+          action: "publish",
+          createdBy: active,
+        });
+        await repo.scheduleRelease(earlier.id, PAST, "UTC");
+
+        const later = await repo.createRelease({ title: "Take down" });
+        await repo.addMember({
+          releaseId: later.id,
+          ...ref("e1"),
+          action: "unpublish",
+          createdBy: gone,
+        });
+        // Later than the publish, so it WINS the effect rule.
+        await repo.scheduleRelease(
+          later.id,
+          new Date(PAST.getTime() + 60_000),
+          "UTC"
+        );
+
+        // Precondition: with both authors live, the later takedown wins.
+        await expect(
+          repo.findDueDecisions({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).resolves.toMatchObject({ hide: ["e1"] });
+
+        await deactivate(app, gone);
+
+        // NOT `reveal: ["e1"]` — that is the older action the write path will
+        // never perform.
+        await expect(
+          repo.findDueDecisions({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).resolves.toEqual({ reveal: [], hide: [] });
+      });
+
       it("does NOT project a member with no recorded author", async () => {
         // The same verdict the materialiser reaches: there is nobody to act as,
         // and the only fallback is the privileged principal it refuses. So a

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -17,7 +17,7 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { seedLiveAuthor } from "./helpers/live-author";
+import { deactivate, seedLiveAuthor } from "./helpers/live-author";
 
 import { defineCollection, text } from "../../../config";
 import {
@@ -581,6 +581,106 @@ describe.each(getConfiguredTestDialects())(
             now: new Date(),
           })
         ).toMatchObject({ reveal: [] });
+      });
+
+      it("does NOT project a release whose author was DEACTIVATED", async () => {
+        // The property the write path already enforces and this seam did not.
+        // Materialisation runs every action as the member's author precisely so
+        // that scheduling cannot become a privilege escalation with a delay on
+        // it. Withdrawing that authority has to stop the projection too —
+        // otherwise the write is refused while the read goes on showing the
+        // effect, and because a refused member holds its release open, it shows
+        // it forever.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const author = await seedLiveAuthor(app);
+        const release = await repo.createRelease({ title: "Go live" });
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+          createdBy: author,
+        });
+        await repo.scheduleRelease(release.id, PAST, "UTC");
+
+        // Live author: the effect IS projected. Without this the case below
+        // could pass because the release was never projected for some other
+        // reason entirely.
+        await expect(
+          repo.findDueDecisions({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).resolves.toMatchObject({ reveal: ["e1"] });
+
+        await deactivate(app, author);
+
+        await expect(
+          repo.findDueDecisions({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).resolves.toMatchObject({ reveal: [], hide: [] });
+      });
+
+      it("does NOT project a member with no recorded author", async () => {
+        // The same verdict the materialiser reaches: there is nobody to act as,
+        // and the only fallback is the privileged principal it refuses. So a
+        // member like this describes an effect no write could ever perform.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const release = await repo.createRelease({ title: "Go live" });
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+        await repo.scheduleRelease(release.id, PAST, "UTC");
+
+        await expect(
+          repo.findDueDecisions({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).resolves.toMatchObject({ reveal: [], hide: [] });
+      });
+
+      it("does NOT project a TAKEDOWN whose author was deactivated either", async () => {
+        // Both directions, because they fail in opposite ways. A publish that
+        // still projects shows content the author may no longer publish; a
+        // takedown that still projects HIDES content on the say-so of somebody
+        // whose authority was withdrawn.
+        const app = await boot(dialect);
+        const repo = new ReleasesRepository(app.adapter);
+        const author = await seedLiveAuthor(app);
+        const release = await repo.createRelease({ title: "Take down" });
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "unpublish",
+          createdBy: author,
+        });
+        await repo.scheduleRelease(release.id, PAST, "UTC");
+        await expect(
+          repo.findDueDecisions({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).resolves.toMatchObject({ hide: ["e1"] });
+
+        await deactivate(app, author);
+
+        await expect(
+          repo.findDueDecisions({
+            scopeKind: "collection",
+            scopeSlug: "posts",
+            now: new Date(),
+          })
+        ).resolves.toMatchObject({ reveal: [], hide: [] });
       });
 
       it("names a document whose due release WITHDRAWS it", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -17,6 +17,8 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { seedLiveAuthor } from "./helpers/live-author";
+
 import { defineCollection, text } from "../../../config";
 import {
   createTestNextly,
@@ -482,6 +484,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: release.id,
           ...ref("e1"),
           action: "publish",
+          // A live author. `findDueDecisions` projects a member only when its
+          // author still exists and is active, matching the write path that runs
+          // AS them — an unattributed member describes an effect no write could
+          // perform, so it is correctly invisible.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(release.id, PAST, "UTC");
 
@@ -588,6 +595,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: release.id,
           ...ref("e1"),
           action: "unpublish",
+          // A live author. `findDueDecisions` projects a member only when its
+          // author still exists and is active, matching the write path that runs
+          // AS them — an unattributed member describes an effect no write could
+          // perform, so it is correctly invisible.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(release.id, PAST, "UTC");
 
@@ -672,6 +684,11 @@ describe.each(getConfiguredTestDialects())(
           releaseId: up.id,
           ...ref("e1", null),
           action: "publish",
+          // A live author. `findDueDecisions` projects a member only when its
+          // author still exists and is active, matching the write path that runs
+          // AS them — an unattributed member describes an effect no write could
+          // perform, so it is correctly invisible.
+          createdBy: await seedLiveAuthor(app),
         });
         await repo.scheduleRelease(up.id, PAST, "UTC");
 

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -56,6 +56,13 @@ export type ReleasesDbApi = VersionsDbApi & {
 
 const RELEASES = "nextly_releases";
 const MEMBERS = "nextly_release_members";
+/**
+ * Read ONLY to answer whether a member's author may still act. This module owns
+ * no user behaviour and writes nothing here; the alternative is resolving an
+ * identity per document on the hot read path, which is the cost the whole memo
+ * in `pending-transition-cache` exists to avoid.
+ */
+const USERS = "users";
 
 /** The document a member points at. */
 export interface DocumentRef {
@@ -548,12 +555,29 @@ export class ReleasesRepository {
     });
     if (members.length === 0) return NO_DECISIONS;
 
+    // A member whose author can no longer act is not projected.
+    //
+    // The write path already refuses one: materialisation runs every action as
+    // the member's `createdBy` precisely so that "schedule this" cannot become a
+    // privilege escalation with a delay on it. This seam used to ignore that
+    // entirely — it projected any due member of any scheduled release — so
+    // deactivating somebody stopped their scheduled publish from being WRITTEN
+    // while the read path went on making it LOOK applied. And because a refused
+    // member holds its release open, the release stayed `scheduled` forever and
+    // the projection with it. Not a window: permanent.
+    //
+    // Filtered here rather than derived from the materialiser's verdict because
+    // nothing triggers a drain yet, so a fix that waited for one would not fire
+    // at all. This one is correct on the next read.
+    const authorized = await this.filterByLiveAuthor(members);
+    if (authorized.length === 0) return NO_DECISIONS;
+
     const releases = await this.loadScheduledReleases(
-      members.map(m => m.releaseId)
+      authorized.map(m => m.releaseId)
     );
     if (releases.size === 0) return NO_DECISIONS;
 
-    const grouped = groupMembersByDocument(members, releases);
+    const grouped = groupMembersByDocument(authorized, releases);
 
     const reveal: string[] = [];
     const hide: string[] = [];
@@ -621,6 +645,57 @@ export class ReleasesRepository {
       if (row.scheduledAt !== null) instants.push(row.scheduledAt);
     }
     return instants;
+  }
+
+  /**
+   * The members whose author still exists and is still active.
+   *
+   * A second `IN` query rather than a join, matching {@link loadScheduledReleases}
+   * directly above: the adapter layer is dialect-agnostic and expresses no joins,
+   * and two small keyed reads are the shape this repository already pays on a
+   * read that reaches here at all.
+   *
+   * A member with NO recorded author is dropped without asking anybody. That is
+   * the same verdict the materialiser reaches — there is nobody to act as, and
+   * the only fallback is the privileged principal it refuses — so admitting it
+   * here would project an effect no write could ever perform.
+   *
+   * A failure PROPAGATES rather than resolving to "everyone is live". Answering
+   * that on a failed lookup would reinstate exactly the projection this exists to
+   * prevent, and it would do so precisely when the database is unhealthy. The
+   * caller treating a throw as "no release is due" would be wrong in the other
+   * direction, which is why the transition memo above propagates too.
+   */
+  private async filterByLiveAuthor(
+    members: ReleaseMemberRow[]
+  ): Promise<ReleaseMemberRow[]> {
+    const authorIds = [
+      ...new Set(
+        members
+          .map(m => m.createdBy)
+          .filter((id): id is string => typeof id === "string" && id !== "")
+      ),
+    ];
+    if (authorIds.length === 0) return [];
+
+    const rows = await this.db.select<{ id: string; isActive: boolean }>(
+      USERS,
+      {
+        columns: ["id", "isActive"],
+        where: {
+          and: [
+            { column: "id", op: "IN", value: authorIds },
+            // Asked of the database rather than filtered in memory, so a dialect
+            // storing this as 0/1 (SQLite) and one storing a real boolean answer
+            // the same question. A truthiness check here would read `0` as false
+            // on one dialect and the string "0" as TRUE on another.
+            { column: "isActive", op: "=", value: true },
+          ],
+        },
+      }
+    );
+    const live = new Set(rows.map(r => r.id));
+    return members.filter(m => m.createdBy !== null && live.has(m.createdBy));
   }
 
   private async loadScheduledReleases(

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -680,7 +680,7 @@ export class ReleasesRepository {
   }
 
   /**
-   * The members whose author still exists and is still active.
+   * Of the given author ids, those whose user still exists and is still active.
    *
    * A second `IN` query rather than a join, matching {@link loadScheduledReleases}
    * directly above: the adapter layer is dialect-agnostic and expresses no joins,

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -555,40 +555,72 @@ export class ReleasesRepository {
     });
     if (members.length === 0) return NO_DECISIONS;
 
-    // A member whose author can no longer act is not projected.
-    //
-    // The write path already refuses one: materialisation runs every action as
-    // the member's `createdBy` precisely so that "schedule this" cannot become a
-    // privilege escalation with a delay on it. This seam used to ignore that
-    // entirely — it projected any due member of any scheduled release — so
-    // deactivating somebody stopped their scheduled publish from being WRITTEN
-    // while the read path went on making it LOOK applied. And because a refused
-    // member holds its release open, the release stayed `scheduled` forever and
-    // the projection with it. Not a window: permanent.
-    //
-    // Filtered here rather than derived from the materialiser's verdict because
-    // nothing triggers a drain yet, so a fix that waited for one would not fire
-    // at all. This one is correct on the next read.
-    const authorized = await this.filterByLiveAuthor(members);
-    if (authorized.length === 0) return NO_DECISIONS;
-
     const releases = await this.loadScheduledReleases(
-      authorized.map(m => m.releaseId)
+      members.map(m => m.releaseId)
     );
     if (releases.size === 0) return NO_DECISIONS;
 
-    const grouped = groupMembersByDocument(authorized, releases);
+    const grouped = groupMembersByDocument(members, releases);
+
+    // The WINNER is resolved over every member, then validated. The order
+    // matters and the other way round is wrong.
+    //
+    // Materialisation runs each action as the winning member's `createdBy`, so
+    // that "schedule this" cannot become a privilege escalation with a delay on
+    // it — and it chooses that winner over ALL members, judging the author
+    // afterwards. Removing candidates here before the winner rule would let this
+    // seam pick a DIFFERENT member: an earlier publish by an active author beats
+    // a later takedown by a deactivated one, while the write path still picks
+    // the takedown, fails it, and performs nothing. The release stays scheduled,
+    // so reads would project that older publish indefinitely against a document
+    // the write path never touches.
+    //
+    // Validating the winner instead makes the two seams agree by construction:
+    // whatever materialisation would attempt is what this projects, and when
+    // that attempt cannot be authorised, this projects nothing.
+    const decisions: {
+      entryId: string;
+      effect: string;
+      memberId: string | null;
+    }[] = [];
+    for (const [entryId, due] of grouped) {
+      const decision = resolveReleaseEffect({ members: due, now: input.now });
+      if (decision.effect === null) continue;
+      decisions.push({
+        entryId,
+        effect: decision.effect,
+        memberId: decision.memberId,
+      });
+    }
+    if (decisions.length === 0) return NO_DECISIONS;
+
+    const authorOf = new Map(members.map(m => [m.id, m.createdBy]));
+    const live = await this.liveAuthorIds(
+      decisions
+        .map(d =>
+          d.memberId === null ? null : (authorOf.get(d.memberId) ?? null)
+        )
+        .filter((id): id is string => typeof id === "string" && id !== "")
+    );
 
     const reveal: string[] = [];
     const hide: string[] = [];
-    for (const [entryId, due] of grouped) {
-      const decision = resolveReleaseEffect({ members: due, now: input.now });
+    for (const decision of decisions) {
+      const author =
+        decision.memberId === null
+          ? null
+          : (authorOf.get(decision.memberId) ?? null);
+      // No recorded author, or one who can no longer act. The materialiser
+      // reaches the same verdict — there is nobody to act as, and the only
+      // fallback is the privileged principal it refuses — so projecting this
+      // would show an effect no write could perform.
+      if (author === null || !live.has(author)) continue;
       // BOTH directions. Reading only the publish half made a scheduled
       // takedown a no-op: the decision said `unpublish`, the id was simply left
       // out of the reveal set, and the ordinary `status = published` filter went
       // on returning the row it was supposed to withdraw.
-      if (decision.effect === "publish") reveal.push(entryId);
-      else if (decision.effect === "unpublish") hide.push(entryId);
+      if (decision.effect === "publish") reveal.push(decision.entryId);
+      else if (decision.effect === "unpublish") hide.push(decision.entryId);
     }
 
     // Disjoint, and now actually so: ONE group per document means one winning
@@ -666,17 +698,9 @@ export class ReleasesRepository {
    * caller treating a throw as "no release is due" would be wrong in the other
    * direction, which is why the transition memo above propagates too.
    */
-  private async filterByLiveAuthor(
-    members: ReleaseMemberRow[]
-  ): Promise<ReleaseMemberRow[]> {
-    const authorIds = [
-      ...new Set(
-        members
-          .map(m => m.createdBy)
-          .filter((id): id is string => typeof id === "string" && id !== "")
-      ),
-    ];
-    if (authorIds.length === 0) return [];
+  private async liveAuthorIds(ids: string[]): Promise<ReadonlySet<string>> {
+    const authorIds = [...new Set(ids)];
+    if (authorIds.length === 0) return new Set();
 
     const rows = await this.db.select<{ id: string; isActive: boolean }>(
       USERS,
@@ -694,8 +718,7 @@ export class ReleasesRepository {
         },
       }
     );
-    const live = new Set(rows.map(r => r.id));
-    return members.filter(m => m.createdBy !== null && live.has(m.createdBy));
+    return new Set(rows.map(r => r.id));
   }
 
   private async loadScheduledReleases(


### PR DESCRIPTION
The last substantive correctness gap in R-6 Content Releases, and the one with a security dimension. Codex raised it on #1323 (`apply-due-releases.ts:291`); this closes it.

## The gap

Materialisation runs every release action **as the member's author**, deliberately — the module's own docblock says running it as a trusted system principal *"would let a release publish content its author could not have published by hand, turning 'schedule this' into a privilege escalation with a delay on it."*

The read path knew nothing about that. `findDueDecisions` projected any due member of any scheduled release, resolving no author and checking nothing.

Measured, with a control:

| | author resolution / access checks |
|---|---|
| `findDueDecisions` | **0** |
| `apply-due-releases.ts` (control) | 8 |

So deactivating somebody stopped their scheduled publish from being **written** while every visitor went on seeing it as **published**.

**And it was permanent, not a window.** A member whose author cannot be resolved fails; a failed member holds its release open; a release that stays `scheduled` goes on being projected forever. It is also now genuinely reachable — R-2 task 8 (#1355) has registered the drain, so the refusal happens on every pass.

## The fix

A due member is projected only while its author exists and is active — derived in the query, as a second keyed `IN` read beside `loadScheduledReleases` rather than a join, because the adapter layer is dialect-agnostic and expresses none.

Chosen over deriving it from the materialiser's verdict, because that would not fire until a drain ran; this is correct on the **next read**.

Three decisions worth stating:

- **No recorded author → not projected.** The same verdict the materialiser reaches: there is nobody to act as, and the only fallback is the privileged principal it refuses. Such a member describes an effect no write could perform.
- **A failed lookup propagates.** Answering "everyone is live" would reinstate exactly the projection this prevents, and would do it precisely when the database is unhealthy.
- **`isActive` is asked of the database, not filtered in memory.** A truthiness check reads `0` as false on one dialect and the string `"0"` as **true** on another.

## What the existing tests were documenting

Nine integration tests went red the moment the check existed. Every fixture created members with **no author at all** — so each was exercising a release that no write could ever have performed. They now seed a real, active author.

That needed measuring too: **a user created through the Direct API lands with `is_active = 0`.** My first helper created an author and the filter correctly rejected it; I briefly took that as my filter being wrong. Worth knowing beyond this PR — a release scheduled from a freshly-created, unactivated account will never run.

## Verification

- `check-types` 0 · `lint` 0 · `changeset status` covers the 25-package lockstep group
- Releases unit: 84 passed. Integration across `releases` + `i18n` + `collections`: **67 files, 508 passed, 0 failed**
- **Break-verified**: removing the filter fails exactly the three new cases — *does NOT project a release whose author was DEACTIVATED*, *…a member with no recorded author*, *…a TAKEDOWN whose author was deactivated either* — and nothing else.
- Each new case asserts the **live-author precondition first**, so it cannot pass because the release was never projected for some unrelated reason.

Both directions are covered because they fail oppositely: a publish that still projects shows content its author may no longer publish; a takedown that still projects **hides** content on the say-so of somebody whose authority was withdrawn.

## Scope

Per-document access rules are deliberately **not** evaluated here — that is per-row work on the hottest read path, and the memo in `pending-transition-cache` exists to keep queries off it. This closes the escalation vector that was raised: withdrawn authority.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release decisions now appear only when their recorded author still exists and is active.
  * Decisions associated with missing or deactivated authors are excluded from release projections.

* **Bug Fixes**
  * Corrected release decision handling to select the winning member before validating author availability.

* **Tests**
  * Added coverage for author deactivation and missing-author scenarios across publishing, unpublishing, and winner selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->