### PR TITLE
fix(nextly): do not probe a companion that is not there

### DIFF
--- a/.changeset/ask-only-where-the-answer-is-used.md
+++ b/.changeset/ask-only-where-the-answer-is-used.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Stop asking the database a question whose answer is thrown away.
+
+A site whose translations tables have not been migrated yet was paying an extra
+catalogue lookup on every content list and every single-document read, to
+establish something the code immediately discarded: whether a translations table
+records when each language was written, for entities whose translations table is
+not there at all.
+
+Nothing about what anyone sees changes. The lookup is now made only where its
+answer is used.

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -452,11 +452,20 @@ export class CollectionQueryService extends BaseService {
       collectionName,
       rows.map(r => r.id).filter((id): id is string => typeof id === "string")
     );
+    // 🔴 Resolved ONCE and read twice. `populateTranslationStatus` returns immediately for any
+    // verdict but `ready`, so probing the column for a companion that is not there introspects a
+    // table that does not exist to answer a question nobody will ask — and since a negative column
+    // verdict is deliberately not remembered, it does that on every list read until the operator
+    // migrates. Resolving it inline in the argument list is what hid the ordering.
+    const readiness = await resolveCompanionSchemaReadiness(
+      this.adapter,
+      companion
+    );
     await populateTranslationStatus({
       db: this.db as never,
       companionTable: companion.table,
       pendingChangeLocales,
-      readiness: await resolveCompanionSchemaReadiness(this.adapter, companion),
+      readiness,
       localizedFields: companion.localizedFields,
       rows,
       locales: this.localization.locales.map(l => l.code),
@@ -482,16 +491,18 @@ export class CollectionQueryService extends BaseService {
       // would end that cost runs in another process. That is the same trade `companion-readiness`
       // already makes for an entity in a `pre-migration` state, and it is bounded the same way —
       // it stops the moment the operator migrates.
-      staleness: (await resolveCompanionColumn(
-        this.adapter,
-        companion.companionTableName,
-        COMPANION_UPDATED_AT_COLUMN
-      ))
-        ? {
-            companionTableName: companion.companionTableName,
-            dialect: this.adapter.dialect,
-          }
-        : undefined,
+      staleness:
+        readiness === "ready" &&
+        (await resolveCompanionColumn(
+          this.adapter,
+          companion.companionTableName,
+          COMPANION_UPDATED_AT_COLUMN
+        ))
+          ? {
+              companionTableName: companion.companionTableName,
+              dialect: this.adapter.dialect,
+            }
+          : undefined,
 
       // On a status-scoped read, don't report a draft-only translation as present.
       statusValue:

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -2195,6 +2195,12 @@ export class SingleQueryService extends BaseService {
             [docId]
           )
         : undefined;
+    // Resolved once and read twice — see the collection path for why probing a companion that is
+    // not `ready` costs an introspection for an answer that is discarded.
+    const readiness = await resolveCompanionSchemaReadiness(
+      this.adapter,
+      companion
+    );
     await populateTranslationStatus({
       db: this.adapter.getDrizzle(),
       companionTable: companion.table,
@@ -2206,7 +2212,7 @@ export class SingleQueryService extends BaseService {
       hasStatus: companion.hasStatus,
       // The Single's own row id keys the companion `_parent`, same as the collection path.
       idKey: "id",
-      readiness: await resolveCompanionSchemaReadiness(this.adapter, companion),
+      readiness,
       // 🔴 Singles carry the signal too, and the same physical check gates it. Every companion
       // write is stamped whatever the entity, so a Single's languages accumulate truthful
       // timestamps and the comparison is as valid here as on a collection.
@@ -2216,16 +2222,18 @@ export class SingleQueryService extends BaseService {
       // shipped with no stamp, and no stamp is absent from the answer rather than reported fresh.
       // So a Single reports staleness for what it can vouch for and stays silent about the rest,
       // which is the same conservative direction the whole feature takes.
-      staleness: (await resolveCompanionColumn(
-        this.adapter,
-        companion.companionTableName,
-        COMPANION_UPDATED_AT_COLUMN
-      ))
-        ? {
-            companionTableName: companion.companionTableName,
-            dialect: this.adapter.dialect,
-          }
-        : undefined,
+      staleness:
+        readiness === "ready" &&
+        (await resolveCompanionColumn(
+          this.adapter,
+          companion.companionTableName,
+          COMPANION_UPDATED_AT_COLUMN
+        ))
+          ? {
+              companionTableName: companion.companionTableName,
+              dialect: this.adapter.dialect,
+            }
+          : undefined,
     });
   }
 


### PR DESCRIPTION
Answers a review finding on #1352 after it merged: the `_updated_at` capability was resolved even when the companion is not there at all.

## The defect

`populateTranslationStatus` returns immediately for any readiness verdict but `ready`:

```ts
if (args.readiness !== "ready") return;
```

So for a `pre-migration` or `broken` companion, the staleness inputs were computed and then discarded — and computing them means introspecting a table that does not exist. Because a **negative column verdict is deliberately not cached** (a migration runs in another process, so remembering "absent" would outlive the migration that made it wrong), that introspection happened on **every list read and every Single read** until the operator migrated.

## The fix

Readiness is resolved once into a name and read twice:

```ts
const readiness = await resolveCompanionSchemaReadiness(this.adapter, companion);
await populateTranslationStatus({
  readiness,
  staleness:
    readiness === "ready" && (await resolveCompanionColumn(...)) ? { ... } : undefined,
});
```

Resolving it inline in the argument list is what hid the ordering — the two calls looked independent because neither could see the other. Both call sites, collections and Singles, had the same shape.

**Behaviour is unchanged.** For a companion that is not `ready` those inputs were already thrown away, so this removes a query and nothing else.

## Why there is no new test

The property is a query count with no observable behavioural difference, and the two states it distinguishes (`pre-migration`, `broken`) already discard the inputs. A test would have to count catalogue reads through the Drizzle handle; the cache seam cannot discriminate, because a `ready` companion resolves the same probe on every list. Stating that rather than writing a test that restates the conditional.

## Verification

    cd packages/nextly && pnpm run check-types  -> 0     lint -> 0
    vitest run domains/{i18n,collections,singles} -> 68 files, 1008 tests
    node scripts/check-comment-convention.mjs   -> 0
    pnpm exec changeset status                  -> 0
    pre-push gate: nextly 797/797, admin 328/328
