### PR TITLE
feat(admin): offer the needs-review tab, and name what it could not check

### DIFF
--- a/.changeset/find-the-translations-that-fell-behind.md
+++ b/.changeset/find-the-translations-that-fell-behind.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Find every translation that has fallen behind, in one place.
+
+The translation worklist gains a "Needs review" tab: the languages whose source
+was edited after they were written, across every collection, newest first. They
+are still translated and still published -- this is a second fact about a live
+translation, not a demotion -- so the tab is named for what to do about them
+rather than for what was measured.
+
+It also says what it could not check. A collection whose translations table does
+not yet record when each language was written cannot answer this question, and a
+collection that quietly contributes nothing to a list is indistinguishable from
+one with nothing to report. Those are now named on screen, with the one thing
+that fixes it: run `nextly migrate`. That is kept separate from the collections a
+single request could not cover, because reloading helps there and would only
+loop here.

--- a/.changeset/find-the-translations-that-fell-behind.md
+++ b/.changeset/find-the-translations-that-fell-behind.md
@@ -37,7 +37,9 @@ rather than for what was measured.
 It also says what it could not check. A collection whose translations table does
 not yet record when each language was written cannot answer this question, and a
 collection that quietly contributes nothing to a list is indistinguishable from
-one with nothing to report. Those are now named on screen, with the one thing
-that fixes it: run `nextly migrate`. That is kept separate from the collections a
-single request could not cover, because reloading helps there and would only
-loop here.
+one with nothing to report. Those are now named on screen, with the
+thing that fixes it -- `nextly migrate` on a deployed site, or a restart (or
+`nextly db:sync`) in development, because a development database kept in step by
+the sync and reload loop has no migration file that adds the column. That is kept
+separate from the collections a single request could not cover, because reloading
+helps there and would only loop here.

--- a/packages/admin/src/components/features/translations/TranslationWorklist.tsx
+++ b/packages/admin/src/components/features/translations/TranslationWorklist.tsx
@@ -187,6 +187,7 @@ function WorklistBody({
   source,
   stateLabel,
   complete,
+  state,
 }: {
   rows: readonly TranslationWorkRow[];
   target: string;
@@ -194,6 +195,8 @@ function WorklistBody({
   stateLabel: string;
   /** False when the server named collections it did not consult. */
   complete: boolean;
+  /** Which question was asked, because one of them cannot be answered completely. */
+  state: WorklistState;
 }) {
   if (rows.length === 0) {
     // Said, rather than shown as an empty list. A blank area under a filter
@@ -206,11 +209,24 @@ function WorklistBody({
     // for — the alert above warns that the answer is partial, but this
     // sentence would still assert the opposite, and a reader takes the
     // sentence in the table over the banner above it.
+    //
+    // 🔴 The review tab can NEVER make the unqualified claim, even when every collection was
+    // checked. Staleness compares two timestamps, and a language written before its collection
+    // began recording them has none to compare — so the comparison returns no match, exactly as it
+    // does for a language that is genuinely current. A fully checked collection can therefore hold
+    // rows nobody could compare, which makes "nothing needs review" a claim about documents the
+    // answer never reached.
+    //
+    // "Known to" is the whole fix and it costs nothing: the same qualifier the rest of this
+    // feature uses, where an unknown is never reported as up to date.
+    const scope = complete
+      ? "in this language"
+      : "in the collections that could be checked";
     return (
       <p className="px-4 py-10 text-center text-sm text-muted-foreground">
-        {complete
-          ? `Nothing ${stateLabel.toLowerCase()} in this language.`
-          : `Nothing ${stateLabel.toLowerCase()} in the collections that could be checked.`}
+        {state === "stale"
+          ? `Nothing is known to need review ${scope}.`
+          : `Nothing ${stateLabel.toLowerCase()} ${scope}.`}
       </p>
     );
   }
@@ -313,7 +329,13 @@ function NotConsultedNotice({ collections }: { collections: string[] }) {
  * to this tab, and no rows is indistinguishable from "nothing here needs review" — the reassuring
  * direction, and the exact claim this whole signal exists not to make by accident.
  */
-function CannotAnswerNotice({ collections }: { collections: string[] }) {
+function CannotAnswerNotice({
+  collections,
+  remedy,
+}: {
+  collections: string[];
+  remedy: "migrate" | "sync" | undefined;
+}) {
   if (collections.length === 0) return null;
   return (
     <Alert>
@@ -321,9 +343,18 @@ function CannotAnswerNotice({ collections }: { collections: string[] }) {
       <AlertDescription>
         These collections don&rsquo;t record when each language was last
         written, so nothing can tell whether their translations have fallen
-        behind: {collections.join(", ")}. Run <code>nextly migrate</code> to add
-        it — after that their languages are compared like everything else.
-        Existing translations keep working in the meantime.
+        behind: {collections.join(", ")}.{" "}
+        {remedy === "sync" ? (
+          <>
+            Restart the app (or re-run <code>nextly db:sync</code>) to add it
+          </>
+        ) : (
+          <>
+            Run <code>nextly migrate</code> to add it
+          </>
+        )}{" "}
+        — after that their languages are compared like everything else. Existing
+        translations keep working in the meantime.
       </AlertDescription>
     </Alert>
   );
@@ -336,12 +367,14 @@ function WorklistResult({
   source,
   stateLabel,
   complete,
+  state,
 }: {
   query: ReturnType<typeof useTranslationWorklist>;
   active: string | undefined;
   source: string;
   stateLabel: string;
   complete: boolean;
+  state: WorklistState;
 }) {
   if (query.isPending && active !== undefined) {
     return (
@@ -366,6 +399,7 @@ function WorklistResult({
       source={source}
       stateLabel={stateLabel}
       complete={complete}
+      state={state}
     />
   );
 }
@@ -463,7 +497,10 @@ export function TranslationWorklist({
       />
 
       <NotConsultedNotice collections={notConsulted} />
-      <CannotAnswerNotice collections={unanswerable} />
+      <CannotAnswerNotice
+        collections={unanswerable}
+        remedy={query.data?.meta.unanswerableRemedy}
+      />
 
       <div className="rounded-md border border-border">
         <WorklistResult
@@ -472,6 +509,7 @@ export function TranslationWorklist({
           source={source}
           stateLabel={stateLabel}
           complete={notConsulted.length === 0 && unanswerable.length === 0}
+          state={state}
         />
       </div>
 

--- a/packages/admin/src/components/features/translations/TranslationWorklist.tsx
+++ b/packages/admin/src/components/features/translations/TranslationWorklist.tsx
@@ -301,6 +301,34 @@ function NotConsultedNotice({ collections }: { collections: string[] }) {
   );
 }
 
+/**
+ * Collections that could not answer the question this tab asks, and what to do about it.
+ *
+ * 🔴 A SECOND notice rather than more names in the first, and the reason is the remedy. The one
+ * above ends with "Reload to see whether it was temporary", which is right for a fan-out cap and
+ * for a collection that could not be read — and wrong here, where reloading changes nothing and
+ * the operator would loop. This case has one specific fix and says it.
+ *
+ * 🔴 It also has to appear at all. A collection that cannot compare timestamps contributes no rows
+ * to this tab, and no rows is indistinguishable from "nothing here needs review" — the reassuring
+ * direction, and the exact claim this whole signal exists not to make by accident.
+ */
+function CannotAnswerNotice({ collections }: { collections: string[] }) {
+  if (collections.length === 0) return null;
+  return (
+    <Alert>
+      <AlertTitle>Some collections can&rsquo;t be checked yet</AlertTitle>
+      <AlertDescription>
+        These collections don&rsquo;t record when each language was last
+        written, so nothing can tell whether their translations have fallen
+        behind: {collections.join(", ")}. Run <code>nextly migrate</code> to add
+        it — after that their languages are compared like everything else.
+        Existing translations keep working in the meantime.
+      </AlertDescription>
+    </Alert>
+  );
+}
+
 /** Loading, failed, or the list itself — the three a read can be in. */
 function WorklistResult({
   query,
@@ -416,6 +444,7 @@ export function TranslationWorklist({
   const stateLabel =
     WORKLIST_STATES.find(t => t.value === state)?.label ?? "outstanding";
   const notConsulted = query.data?.meta.notConsulted ?? [];
+  const unanswerable = query.data?.meta.unanswerable ?? [];
 
   return (
     <div className="flex flex-col gap-4">
@@ -434,6 +463,7 @@ export function TranslationWorklist({
       />
 
       <NotConsultedNotice collections={notConsulted} />
+      <CannotAnswerNotice collections={unanswerable} />
 
       <div className="rounded-md border border-border">
         <WorklistResult
@@ -441,7 +471,7 @@ export function TranslationWorklist({
           active={active}
           source={source}
           stateLabel={stateLabel}
-          complete={notConsulted.length === 0}
+          complete={notConsulted.length === 0 && unanswerable.length === 0}
         />
       </div>
 

--- a/packages/admin/src/components/features/translations/__tests__/TranslationWorklist.test.tsx
+++ b/packages/admin/src/components/features/translations/__tests__/TranslationWorklist.test.tsx
@@ -305,6 +305,42 @@ describe("TranslationWorklist", () => {
     ).toBeInTheDocument();
   });
 
+  it("🔴 never claims nothing needs review, even on a complete answer", () => {
+    // Staleness compares two timestamps. A language written before its collection began recording
+    // them has none to compare, so the comparison returns no match — exactly as it does for a
+    // language that is genuinely current. Every collection can therefore be checked and the answer
+    // still not cover every row, which makes the unqualified claim one this tab can never make.
+    //
+    // The other four states CAN make it, which is why this is not a blanket hedge: "nothing to
+    // translate" is the answer a translator needs to be able to trust, and the control below keeps
+    // it readable.
+    worklistQuery.mockReturnValue(settled({ data: { items: [], meta: META } }));
+    renderWorklist({ state: "stale" });
+    expect(screen.getByText(/known to need review/i)).toBeInTheDocument();
+  });
+
+  it("names the migration remedy the server chose, not a hardcoded one", () => {
+    // 🔴 `nextly migrate` applies migration FILES. A development database kept in step by the sync
+    // and reload loop has no migration history carrying this column, so that advice leaves the
+    // notice unchanged after a developer follows it. The server knows which case it is in; this
+    // screen does not, so it renders what it was told.
+    worklistQuery.mockReturnValue(
+      settled({
+        data: {
+          items: [],
+          meta: {
+            ...META,
+            unanswerable: ["legacy"],
+            unanswerableRemedy: "sync" as const,
+          },
+        },
+      })
+    );
+    renderWorklist({ state: "stale" });
+    expect(screen.getByText(/db:sync/i)).toBeInTheDocument();
+    expect(screen.queryByText(/nextly migrate/i)).not.toBeInTheDocument();
+  });
+
   it("waits for the workspace metadata before declaring the app single-language", () => {
     // The locale config arrives with the workspace query, and `useLocalization`
     // reports `enabled: false` while it is in flight — the same value a real

--- a/packages/admin/src/pages/dashboard/translations/index.tsx
+++ b/packages/admin/src/pages/dashboard/translations/index.tsx
@@ -50,8 +50,14 @@ export default function TranslationsPage() {
       <PageContainer>
         <div className="mb-8">
           <h1 className="text-xl font-semibold tracking-tight">Translations</h1>
+          {/* 🔴 Generic, not "what needs translating". The review tab lists translations that ARE
+              written and may still be published -- their source simply moved on afterwards -- so a
+              subtitle promising untranslated work describes them as the opposite of what they are.
+              Naming the page's SUBJECT rather than one of its questions keeps it true whichever tab
+              is showing, and does not need updating when another is added. */}
           <p className="mt-1 text-sm font-normal text-muted-foreground">
-            What needs translating, across every collection, in one language.
+            Outstanding translation work, across every collection, in one
+            language.
           </p>
         </div>
         <TranslationWorklist

--- a/packages/admin/src/types/translations/__tests__/worklist.test.ts
+++ b/packages/admin/src/types/translations/__tests__/worklist.test.ts
@@ -56,32 +56,28 @@ describe("WORKLIST_STATES", () => {
     for (const state of LANGUAGE_STATES) expect(values).toContain(state);
   });
 
-  it("offers NO tab the server cannot answer", () => {
-    // 🔴 "Needs review" is built and withheld. The server answers that state with
-    // "nothing is known to be stale", because nothing can yet establish whether
-    // a companion physically carries the timestamp the answer depends on — so
-    // an always-empty tab would read as "this site has no stale translations",
-    // which is a claim, and the wrong one.
+  it("offers exactly ONE tab that is not a language state", () => {
+    // 🔴 The capability check landed, so "Needs review" is offered — and the vocabulary decision
+    // this guards did not change with it. `stale` is a FILTER, not a fifth `LanguageState`:
+    // staleness is orthogonal to all four, and a stale translation is still published if it was
+    // published. A fifth catalog member would make the classifier return "needs review" INSTEAD
+    // of "published" and take a live translation off every screen that renders a dot.
     //
-    // Asserted as a set difference rather than a count: a count stays green if
-    // a language state silently disappears while an extra tab arrives.
-    //
-    // This test is the one to INVERT when the capability check lands. The
-    // vocabulary decision it guards does not change — `stale` is a filter, not
-    // a fifth `LanguageState`, because staleness is orthogonal to all four and
-    // a stale translation is still published if it was published.
+    // Asserted as a set difference rather than a count: a count stays green if a language state
+    // silently disappears while an extra tab arrives.
     const extras = WORKLIST_STATES.map(s => s.value).filter(
       v => !(LANGUAGE_STATES as readonly string[]).includes(v)
     );
-    expect(extras).toEqual([]);
+    expect(extras).toEqual(["stale"]);
+    // And it is still absent from the catalog, which is where the orthogonality actually lives.
+    expect(LANGUAGE_STATES as readonly string[]).not.toContain("stale");
   });
 
   it("uses the language panel's own wording for every tab that IS a state", () => {
-    // A worklist with a vocabulary of its own would describe the same document
-    // differently depending on which screen asked. The stale tab is excluded
-    // because it has no entry there BY DESIGN -- see the test above -- and
-    // demanding one would force the fifth state into the catalog through the
-    // back door.
+    // A worklist with a vocabulary of its own would describe the same document differently
+    // depending on which screen asked. The review tab is skipped because it has no entry in the
+    // language-state catalog BY DESIGN -- see the test above -- and demanding one would force the
+    // fifth state into the catalog through the back door.
     for (const { value, label } of WORKLIST_STATES) {
       if (!(LANGUAGE_STATES as readonly string[]).includes(value)) continue;
       expect(label.toLowerCase()).toBe(
@@ -90,18 +86,19 @@ describe("WORKLIST_STATES", () => {
     }
   });
 
-  it("keeps `stale` askable while refusing to route a URL to it", () => {
-    // Two different facts, and the pairing is the point. `WorklistState` is
-    // what goes on the wire, so it carries every state the server accepts --
-    // `stale` included, which is why a caller holding one can name it.
+  it("routes a saved link naming `stale` to the review tab", () => {
+    // 🔴 The other half of the inversion. A URL is resolved against the TAB LIST, so while the tab
+    // was withheld a saved link fell back to the page's leading question — deliberately, because a
+    // page filtered by a state whose tab is not shown highlights nothing while listing a subset
+    // the reader cannot account for. Now the tab exists, the link resolves to it, and the two are
+    // consistent again for the same reason they were consistent before.
     const resolved: WorklistState = "stale";
     expect(resolved).toBe("stale");
-    // But a URL is resolved against the TAB LIST, not against the wire
-    // vocabulary, so a saved link naming `stale` does NOT reach the server as
-    // `stale`: it falls back to the question this page leads with. A page
-    // filtered by a state whose tab is not shown would highlight nothing while
-    // listing a subset the reader cannot account for.
-    expect(worklistStateFrom("stale")).toBe("missing");
+    expect(worklistStateFrom("stale")).toBe("stale");
+    // Unchanged and still the control: anything the tab list does not offer still falls back
+    // rather than reaching the server as an unknown state.
+    expect(worklistStateFrom("not-a-state")).toBe("missing");
+    expect(worklistStateFrom(undefined)).toBe("missing");
   });
 
   it("leads with the question this page exists to answer", () => {

--- a/packages/admin/src/types/translations/worklist.ts
+++ b/packages/admin/src/types/translations/worklist.ts
@@ -79,18 +79,18 @@ export const WORKLIST_STATES: readonly {
     value,
     label: asTabLabel(LANGUAGE_STATE_LABEL[value]),
   })),
-  // 🔴 No tab for `stale`, and its absence from this array is the whole statement.
+  // 🔴 "Needs review", not "Stale" or "Outdated", and the wording is the decision. The wire value
+  // says what the system MEASURED — a source written after its translation — while the label says
+  // what a person should DO about it. A translation whose source moved may well still be correct,
+  // so naming the state after the measurement would tell an author their work is wrong when all
+  // that is known is that it is worth a look.
   //
-  // The server answers that state with "nothing is known to be stale", because nothing can
-  // establish whether a given companion physically carries the timestamp the answer depends on. A
-  // tab that is always empty is worse than no tab: it reads as "this site has no stale
-  // translations", which is a claim, and the wrong one.
-  //
-  // The absence reaches the URL as well, and that is deliberate rather than a gap:
-  // `worklistStateFrom` resolves only what this array offers, so a saved link naming `stale`
-  // falls back to the question this page leads with. A page filtered by a state whose tab is not
-  // shown would highlight nothing while listing a subset the reader cannot account for, which is
-  // worse than answering a different question visibly.
+  // Offered now because the server can answer it honestly per collection: a translations table
+  // that physically records when each language was written participates, and one that does not is
+  // excluded AND NAMED in `unanswerable`. An always-empty tab would read as "this site has no
+  // stale translations", which is a claim and the wrong one — the naming is what stops the empty
+  // case making it.
+  { value: "stale", label: "Needs review" },
 ];
 
 /**
@@ -179,6 +179,18 @@ export type TranslationWorklistMeta = PaginationMeta & {
    * would invite a reader to check it and conclude something from its absence.
    */
   notConsulted?: string[];
+  /**
+   * Collections that cannot answer the question this tab asks, named separately.
+   *
+   * Kept apart from {@link notConsulted} because the remedy differs, and that is the only reason
+   * two lists are better than one here. A collection the fan-out did not reach wants a narrower
+   * search; one whose translations table predates the timestamp this tab compares wants
+   * `nextly migrate`. Merged, the actionable case hides among the unactionable ones.
+   *
+   * Only ever populated for the review tab — every other state answers from data every
+   * translations table has. Absent when nothing was excluded, so its PRESENCE is the signal.
+   */
+  unanswerable?: string[];
 };
 
 /** The canonical list envelope, carrying this read's own meta. */

--- a/packages/admin/src/types/translations/worklist.ts
+++ b/packages/admin/src/types/translations/worklist.ts
@@ -191,6 +191,16 @@ export type TranslationWorklistMeta = PaginationMeta & {
    * translations table has. Absent when nothing was excluded, so its PRESENCE is the signal.
    */
   unanswerable?: string[];
+  /**
+   * Which remedy applies to {@link unanswerable}, decided by the server.
+   *
+   * `nextly migrate` applies migration FILES. A development database kept in step by the sync and
+   * reload loop has no migration history carrying this column, so that advice can leave the notice
+   * unchanged after a developer follows it — the same distinction core makes when it explains an
+   * absent translations table. The wording lives here with the other admin strings; only the
+   * choice between them comes from the server, which is the side that knows.
+   */
+  unanswerableRemedy?: "migrate" | "sync";
 };
 
 /** The canonical list envelope, carrying this read's own meta. */

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -243,41 +243,87 @@ async function localizedCollections(): Promise<
 }
 
 /**
+ * How many capability probes run at once.
+ *
+ * Each probe is a live-schema introspection — several catalogue queries per table — and this runs
+ * once per collection. `Promise.all` over every collection is the shape `drift-check` already had
+ * to abandon: against a pool of five, ten collections saturated it and queued requests behind the
+ * connection timeout. Three keeps the wall-time win over serial without competing with the
+ * fan-out's own reads, which follow immediately after.
+ */
+const STALENESS_PROBE_CONCURRENCY = 3;
+
+/**
  * Ask each collection's translations table whether it physically records when a language was
  * written, which is what the staleness question compares.
  *
- * Resolved per collection rather than once, because the column arrives with a migration and a site
- * mid-upgrade genuinely has both kinds. Resolved on the pool before any transaction opens, and
- * concurrently — the fan-out below already issues one query per collection, so serialising these
- * would make the screen slower than the work it is preparing for.
+ * 🔴 Scoped to collections the caller can READ before anything reaches the database. A probe for a
+ * collection whose rows this caller may never see is work whose answer is discarded, and on a site
+ * with many collections that is the difference between a handful of introspections and one per
+ * collection.
+ *
+ * 🔴 A failed probe is NOT an absent column. `resolveCompanionColumn` propagates rather than
+ * swallowing, precisely so a transient fault cannot be mistaken for a schema fact — so the failure
+ * is caught HERE, at the collection boundary, and the slug is reported as one this answer did not
+ * cover. Letting it reject the whole fan-out would discard every healthy collection's rows over
+ * one bad catalogue read; letting it read as `false` would tell the operator to migrate a table
+ * that is already migrated.
  */
 async function resolveStalenessCapability<T extends LocalizedCollectionRef>(
-  collections: readonly T[]
-): Promise<(T & { canAnswerStaleness: boolean })[]> {
+  collections: readonly T[],
+  readable: ReadonlySet<string> | undefined
+): Promise<{
+  collections: (T & { canAnswerStaleness: boolean })[];
+  probeFailed: string[];
+}> {
+  const asked = collections.filter(
+    c => readable === undefined || readable.has(c.slug)
+  );
   const adapter = getAdapterFromDI();
   // No connection, no question. Reporting every collection as unable to answer is the honest
   // reading and the conservative one: the alternative is claiming they can, which would emit SQL
   // naming a column nothing has checked for.
   if (!adapter) {
-    return collections.map(c => ({ ...c, canAnswerStaleness: false }));
+    return {
+      collections: asked.map(c => ({ ...c, canAnswerStaleness: false })),
+      probeFailed: [],
+    };
   }
   const fileManager = container.get<CollectionFileManager>(
     "collectionFileManager"
   );
-  return Promise.all(
-    collections.map(async c => {
-      const companion = await fileManager.loadCompanionSchema(c.slug);
-      if (!companion) return { ...c, canAnswerStaleness: false };
-      return {
-        ...c,
-        canAnswerStaleness: await resolveCompanionColumn(
-          adapter,
-          companion.companionTableName,
-          COMPANION_UPDATED_AT_COLUMN
-        ),
-      };
-    })
+
+  const resolved: (T & { canAnswerStaleness: boolean })[] = [];
+  const probeFailed: string[] = [];
+  let cursor = 0;
+  const worker = async (): Promise<void> => {
+    while (cursor < asked.length) {
+      const c = asked[cursor++];
+      try {
+        const companion = await fileManager.loadCompanionSchema(c.slug);
+        resolved.push({
+          ...c,
+          canAnswerStaleness:
+            companion === null
+              ? false
+              : await resolveCompanionColumn(
+                  adapter,
+                  companion.companionTableName,
+                  COMPANION_UPDATED_AT_COLUMN
+                ),
+        });
+      } catch {
+        probeFailed.push(c.slug);
+      }
+    }
+  };
+  await Promise.all(
+    Array.from(
+      { length: Math.min(STALENESS_PROBE_CONCURRENCY, asked.length) },
+      worker
+    )
   );
+  return { collections: resolved, probeFailed };
 }
 
 /**
@@ -337,8 +383,11 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   // For `stale` it is unavoidable and the cost is accepted: this is an admin screen that already
   // fans out one query per collection, a collection that CAN answer is remembered and costs
   // nothing after the first ask, and the cost ends when the operator migrates.
-  const withStaleCapability =
-    state === "stale" ? await resolveStalenessCapability(localized) : localized;
+  const staleCapability =
+    state === "stale"
+      ? await resolveStalenessCapability(localized, readable)
+      : null;
+  const withStaleCapability = staleCapability?.collections ?? localized;
 
   const eligible = eligibleCollections(withStaleCapability, state, readable);
   const unanswerable = unanswerableCollections(
@@ -446,7 +495,14 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
   const unreadable = perCollection
     .map(r => r.slug)
     .filter((slug): slug is string => slug !== null);
-  const notConsulted = notConsultedSources(skippedCollections, unreadable);
+  // A collection whose capability probe failed belongs HERE and not in `unanswerable`: nothing
+  // was learned about its schema, so "run the migration" would be advice about a table that may
+  // already be migrated. "This answer did not cover it, look again" is the whole of what is known.
+  const notConsulted = notConsultedSources(
+    skippedCollections,
+    unreadable,
+    staleCapability?.probeFailed ?? []
+  );
 
   // Merged BEFORE the slice, which is the whole reason this fans out on the
   // server: ordered across collections rather than within each one.
@@ -487,7 +543,24 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
       // Kept apart from `notConsulted` on the wire for the same reason the service keeps them
       // apart: this is the one with a remedy. A screen that merges them tells an operator to
       // look again when what they need to do is migrate.
-      ...(unanswerable.length === 0 ? {} : { unanswerable }),
+      ...(unanswerable.length === 0
+        ? {}
+        : {
+            unanswerable,
+            // 🔴 WHICH remedy, decided where the environment is known. `nextly migrate` applies
+            // migration FILES, and a development database managed by the sync/HMR loop has no
+            // migration history containing this column — so that advice can leave the notice
+            // unchanged after the developer follows it. Core already makes this exact split in
+            // `companionNotReadyMessage`; this carries the same distinction to a screen that
+            // cannot see `NODE_ENV`.
+            //
+            // A discriminator rather than a sentence: the wording is an admin string and belongs
+            // with the other admin strings, while which case applies is a server fact.
+            unanswerableRemedy:
+              process.env.NODE_ENV === "production"
+                ? ("migrate" as const)
+                : ("sync" as const),
+          }),
     },
     { headers: PRIVATE_NO_STORE_HEADERS }
   );

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -37,11 +37,10 @@ import {
   authorizationGroups,
   countIsTrustworthy,
   byMostRecentlyUpdated,
-  eligibleCollections,
+  classifyForWorklist,
   hasTranslatableFields,
   notConsultedSources,
   planWorklistFanOut,
-  unanswerableCollections,
   translatedFilter,
   worklistTotal,
   worklistTotalPages,
@@ -389,8 +388,9 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
       : null;
   const withStaleCapability = staleCapability?.collections ?? localized;
 
-  const eligible = eligibleCollections(withStaleCapability, state, readable);
-  const unanswerable = unanswerableCollections(
+  // Classified once. The two lists are complements of one decision, so deriving them from two
+  // calls would let them disagree about a collection.
+  const { eligible, unanswerable } = classifyForWorklist(
     withStaleCapability,
     state,
     readable

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -22,14 +22,17 @@ import {
 } from "../auth/entity-read-access";
 import type { AuthContext } from "../auth/middleware";
 import { container } from "../di";
+import { getAdapterFromDI } from "../dispatcher/helpers/di";
 import type { CollectionRegistryService } from "../domains/collections/services/collection-registry-service";
 import type { UserContext } from "../domains/collections/services/collection-types";
+import { COMPANION_UPDATED_AT_COLUMN } from "../domains/i18n/companion-columns";
 import {
   TRANSLATION_FILTER_STATES,
   type TranslationFilterState,
 } from "../domains/i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../domains/i18n/config/types";
 import { isValidLocale } from "../domains/i18n/resolve-locale";
+import { resolveCompanionColumn } from "../domains/i18n/runtime/companion-readiness";
 import {
   authorizationGroups,
   countIsTrustworthy,
@@ -38,6 +41,7 @@ import {
   hasTranslatableFields,
   notConsultedSources,
   planWorklistFanOut,
+  unanswerableCollections,
   translatedFilter,
   worklistTotal,
   worklistTotalPages,
@@ -49,6 +53,7 @@ import {
 } from "../domains/i18n/services/translation-worklist-service";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
+import type { CollectionFileManager } from "../services/collection-file-manager";
 import type { CollectionsHandler } from "../services/collections-handler";
 
 import {
@@ -238,6 +243,44 @@ async function localizedCollections(): Promise<
 }
 
 /**
+ * Ask each collection's translations table whether it physically records when a language was
+ * written, which is what the staleness question compares.
+ *
+ * Resolved per collection rather than once, because the column arrives with a migration and a site
+ * mid-upgrade genuinely has both kinds. Resolved on the pool before any transaction opens, and
+ * concurrently — the fan-out below already issues one query per collection, so serialising these
+ * would make the screen slower than the work it is preparing for.
+ */
+async function resolveStalenessCapability<T extends LocalizedCollectionRef>(
+  collections: readonly T[]
+): Promise<(T & { canAnswerStaleness: boolean })[]> {
+  const adapter = getAdapterFromDI();
+  // No connection, no question. Reporting every collection as unable to answer is the honest
+  // reading and the conservative one: the alternative is claiming they can, which would emit SQL
+  // naming a column nothing has checked for.
+  if (!adapter) {
+    return collections.map(c => ({ ...c, canAnswerStaleness: false }));
+  }
+  const fileManager = container.get<CollectionFileManager>(
+    "collectionFileManager"
+  );
+  return Promise.all(
+    collections.map(async c => {
+      const companion = await fileManager.loadCompanionSchema(c.slug);
+      if (!companion) return { ...c, canAnswerStaleness: false };
+      return {
+        ...c,
+        canAnswerStaleness: await resolveCompanionColumn(
+          adapter,
+          companion.companionTableName,
+          COMPANION_UPDATED_AT_COLUMN
+        ),
+      };
+    })
+  );
+}
+
+/**
  * GET /api/translations
  *
  * Query params:
@@ -287,7 +330,22 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
     caller,
     localized.map(c => c.slug)
   );
-  const eligible = eligibleCollections(localized, state, readable);
+  // 🔴 Resolved ONLY for the state that reads it. The probe introspects, and a negative verdict is
+  // deliberately not remembered, so asking for every state would put one catalogue read per
+  // collection on every worklist request for a capability four of the five states never consult.
+  //
+  // For `stale` it is unavoidable and the cost is accepted: this is an admin screen that already
+  // fans out one query per collection, a collection that CAN answer is remembered and costs
+  // nothing after the first ask, and the cost ends when the operator migrates.
+  const withStaleCapability =
+    state === "stale" ? await resolveStalenessCapability(localized) : localized;
+
+  const eligible = eligibleCollections(withStaleCapability, state, readable);
+  const unanswerable = unanswerableCollections(
+    withStaleCapability,
+    state,
+    readable
+  );
   const { queried, skippedCollections } = planWorklistFanOut(eligible);
   const bySlug = new Map(eligible.map(c => [c.slug, c]));
 
@@ -426,6 +484,10 @@ export const getTranslationWorklist = withErrorHandler(async (req: Request) => {
       // Named, so the screen can say WHICH. Omitted entirely when the answer
       // covered everything, so the field's presence is itself the signal.
       ...(notConsulted.length === 0 ? {} : { notConsulted }),
+      // Kept apart from `notConsulted` on the wire for the same reason the service keeps them
+      // apart: this is the one with a remedy. A screen that merges them tells an operator to
+      // look again when what they need to do is migrate.
+      ...(unanswerable.length === 0 ? {} : { unanswerable }),
     },
     { headers: PRIVATE_NO_STORE_HEADERS }
   );

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -10,6 +10,7 @@ import {
   hasTranslatableFields,
   notConsultedSources,
   planWorklistFanOut,
+  unanswerableCollections,
   translatedFilter,
   worklistId,
   worklistTitle,
@@ -456,5 +457,90 @@ describe("authorizationGroups — a step that cannot advance", () => {
       ["b"],
       ["c"],
     ]);
+  });
+});
+
+describe("a collection that cannot answer the staleness question", () => {
+  const coll = (slug: string, canAnswerStaleness?: boolean) => ({
+    slug,
+    label: slug,
+    hasStatus: true,
+    ...(canAnswerStaleness === undefined ? {} : { canAnswerStaleness }),
+  });
+
+  it("is left out of the stale fan-out rather than contributing zero", () => {
+    // 🔴 The filter answers `1=0` for a companion that has no timestamp column, so querying it
+    // returns nothing — and nothing is indistinguishable from "this collection has no stale
+    // translations". Excluding it is what makes the difference reportable at all.
+    const eligible = eligibleCollections(
+      [coll("posts", true), coll("legacy", false)],
+      "stale",
+      undefined
+    );
+    expect(eligible.map(c => c.slug)).toEqual(["posts"]);
+  });
+
+  it("is NOT left out of the other four states, which never ask", () => {
+    // The capability is only consulted for `stale`; the flag is absent for every other state
+    // because the probe that fills it is not run. A filter that excluded on an unasked question
+    // would silently shrink every other tab.
+    for (const state of [
+      "missing",
+      "translated",
+      "draft",
+      "published",
+    ] as const) {
+      const eligible = eligibleCollections(
+        [coll("posts"), coll("legacy")],
+        state,
+        undefined
+      );
+      expect(eligible.map(c => c.slug)).toEqual(["posts", "legacy"]);
+    }
+  });
+
+  it("is NAMED, so a zero is never mistaken for good news", () => {
+    expect(
+      unanswerableCollections(
+        [coll("posts", true), coll("legacy", false)],
+        "stale",
+        undefined
+      )
+    ).toEqual(["legacy"]);
+  });
+
+  it("names nobody for a state that does not ask the question", () => {
+    expect(
+      unanswerableCollections(
+        [coll("posts", true), coll("legacy", false)],
+        "missing",
+        undefined
+      )
+    ).toEqual([]);
+  });
+
+  it("🔴 never names a collection the caller cannot read", () => {
+    // Same rule the fan-out already keeps: a slug reported back is a statement that the collection
+    // EXISTS. Someone with no right to know that must not learn it from a coverage notice, which
+    // is the softest-looking place for it to leak.
+    expect(
+      unanswerableCollections(
+        [coll("posts", false), coll("secret", false)],
+        "stale",
+        new Set(["posts"])
+      )
+    ).toEqual(["posts"]);
+  });
+
+  it("treats an unresolved capability as answerable, not as unanswerable", () => {
+    // `undefined` means the question was never asked — which is every state but `stale`, and also
+    // a collection the probe never reached. Excluding on it would turn "not asked" into "cannot",
+    // and quietly empty the tab.
+    expect(
+      eligibleCollections([coll("posts")], "stale", undefined).map(c => c.slug)
+    ).toEqual(["posts"]);
+    expect(
+      unanswerableCollections([coll("posts")], "stale", undefined)
+    ).toEqual([]);
   });
 });

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.test.ts
@@ -8,6 +8,7 @@ import {
   byMostRecentlyUpdated,
   eligibleCollections,
   hasTranslatableFields,
+  classifyForWorklist,
   notConsultedSources,
   planWorklistFanOut,
   unanswerableCollections,
@@ -542,5 +543,65 @@ describe("a collection that cannot answer the staleness question", () => {
     expect(
       unanswerableCollections([coll("posts")], "stale", undefined)
     ).toEqual([]);
+  });
+});
+
+describe("the two views cannot disagree", () => {
+  const coll = (slug: string, canAnswerStaleness?: boolean) => ({
+    slug,
+    label: slug,
+    hasStatus: true,
+    ...(canAnswerStaleness === undefined ? {} : { canAnswerStaleness }),
+  });
+
+  it("🔴 puts every readable collection in exactly one of the two lists", () => {
+    // The property the single classification exists for. Two filters with complementary
+    // predicates can drift: one later edit to eligibility excludes a collection without naming it,
+    // or names one that was still queried. The first is a silent zero presented as good news --
+    // the exact error this feature was built to prevent, arriving through the code that prevents
+    // it. Asserted as a PARTITION rather than as two independent expectations, because that is the
+    // invariant a future edit would break.
+    const all = [
+      coll("alpha", true),
+      coll("beta", false),
+      coll("gamma", true),
+      coll("delta", false),
+    ];
+    const { eligible, unanswerable } = classifyForWorklist(
+      all,
+      "stale",
+      undefined
+    );
+    const named = new Set(unanswerable);
+    const queried = new Set(eligible.map(c => c.slug));
+
+    expect([...queried].filter(s => named.has(s))).toEqual([]);
+    expect([...queried, ...named].sort()).toEqual([
+      "alpha",
+      "beta",
+      "delta",
+      "gamma",
+    ]);
+  });
+
+  it("keeps the derived views agreeing with the classification", () => {
+    // `eligibleCollections` and `unanswerableCollections` survive as narrow views because most
+    // callers want one of them. They must stay derivations, not re-implementations.
+    const all = [coll("alpha", true), coll("beta", false)];
+    const one = classifyForWorklist(all, "stale", undefined);
+    expect(eligibleCollections(all, "stale", undefined)).toEqual(one.eligible);
+    expect(unanswerableCollections(all, "stale", undefined)).toEqual(
+      one.unanswerable
+    );
+  });
+
+  it("names nobody an unreadable collection, in either view", () => {
+    const { eligible, unanswerable } = classifyForWorklist(
+      [coll("visible", false), coll("secret", false)],
+      "stale",
+      new Set(["visible"])
+    );
+    expect(eligible).toEqual([]);
+    expect(unanswerable).toEqual(["visible"]);
   });
 });

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -348,19 +348,55 @@ export function byMostRecentlyUpdated(
  * EVERY document and the worklist presents all of them as being in the state
  * that was asked for. Contributing nothing is the truthful answer; contributing
  * everything is the worst available one.
+ *
+ * 🔴 ONE PASS, producing both views. The excluded-and-named case arrives with the staleness
+ * question — a collection whose translations table cannot compare timestamps must be left out AND
+ * reported, because its exclusion is silent where a lifecycle exclusion is merely wrong. Written
+ * as two filters with complementary predicates, the two could drift: a later change to eligibility
+ * would exclude a collection without naming it, or name one that was still queried. Either is the
+ * reassuring coverage error this whole feature exists to prevent, arriving through the code meant
+ * to prevent it.
+ *
+ * So the classification happens once and both lists fall out of the same loop. `eligibleCollections`
+ * and `unanswerableCollections` are narrow views DERIVED from this, kept because most callers want
+ * only one of them.
  */
+export function classifyForWorklist<T extends LocalizedCollectionRef>(
+  localized: readonly T[],
+  state: TranslationFilterState,
+  readable: ReadonlySet<string> | undefined
+): { eligible: T[]; unanswerable: string[] } {
+  const wantsLifecycle = state === "draft" || state === "published";
+  const eligible: T[] = [];
+  const unanswerable: string[] = [];
+  for (const c of localized) {
+    if (readable !== undefined && !readable.has(c.slug)) continue;
+    if (wantsLifecycle && !c.hasStatus) continue;
+    if (state === "stale" && c.canAnswerStaleness === false) {
+      unanswerable.push(c.slug);
+      continue;
+    }
+    eligible.push(c);
+  }
+  return { eligible, unanswerable: unanswerable.sort() };
+}
+
+/** The collections this answer will query. Derived — see {@link classifyForWorklist}. */
 export function eligibleCollections<T extends LocalizedCollectionRef>(
   localized: readonly T[],
   state: TranslationFilterState,
   readable: ReadonlySet<string> | undefined
 ): T[] {
-  const wantsLifecycle = state === "draft" || state === "published";
-  return localized.filter(
-    c =>
-      (readable === undefined || readable.has(c.slug)) &&
-      (!wantsLifecycle || c.hasStatus) &&
-      (state !== "stale" || c.canAnswerStaleness !== false)
-  );
+  return classifyForWorklist(localized, state, readable).eligible;
+}
+
+/** The collections that could not answer. Derived — see {@link classifyForWorklist}. */
+export function unanswerableCollections<T extends LocalizedCollectionRef>(
+  localized: readonly T[],
+  state: TranslationFilterState,
+  readable: ReadonlySet<string> | undefined
+): string[] {
+  return classifyForWorklist(localized, state, readable).unanswerable;
 }
 
 /**
@@ -379,21 +415,6 @@ export function eligibleCollections<T extends LocalizedCollectionRef>(
  * without being named is indistinguishable from a collection with no stale translations, which is
  * the reassuring direction and the exact claim this feature exists not to make.
  */
-export function unanswerableCollections<T extends LocalizedCollectionRef>(
-  localized: readonly T[],
-  state: TranslationFilterState,
-  readable: ReadonlySet<string> | undefined
-): string[] {
-  if (state !== "stale") return [];
-  return localized
-    .filter(
-      c =>
-        (readable === undefined || readable.has(c.slug)) &&
-        c.canAnswerStaleness === false
-    )
-    .map(c => c.slug)
-    .sort();
-}
 
 /**
  * Which collections the fan-out will touch, and which the cap excluded.

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -237,6 +237,13 @@ export interface TranslationWorklistResult {
    * from the truth at a glance. The caller is expected to say so on screen.
    */
   skippedCollections: string[];
+  /**
+   * Collections that cannot answer the question that was asked, named separately.
+   *
+   * See {@link unanswerableCollections} for why this is not merged into the list above: this one
+   * has a remedy the caller can act on, and the others do not.
+   */
+  unanswerableCollections?: string[];
 }
 
 /** What the fan-out needs to know about one collection to query it. */
@@ -245,6 +252,15 @@ export interface LocalizedCollectionRef {
   label: string;
   /** Whether it has the draft/published lifecycle at all. */
   hasStatus: boolean;
+  /**
+   * Whether this collection's translations table can answer "has the source moved on since".
+   *
+   * A PHYSICAL fact, resolved against the database, not the declared shape — the declared one is
+   * unconditionally true and would claim every collection can answer. `undefined` means the
+   * question was never asked, which is the state for every filter other than `stale`; only an
+   * explicit `false` excludes.
+   */
+  canAnswerStaleness?: boolean;
 }
 
 /**
@@ -342,8 +358,41 @@ export function eligibleCollections<T extends LocalizedCollectionRef>(
   return localized.filter(
     c =>
       (readable === undefined || readable.has(c.slug)) &&
-      (!wantsLifecycle || c.hasStatus)
+      (!wantsLifecycle || c.hasStatus) &&
+      (state !== "stale" || c.canAnswerStaleness !== false)
   );
+}
+
+/**
+ * Which collections were asked a question they cannot answer, and so were left out.
+ *
+ * 🔴 SEPARATE from {@link notConsultedSources}, and the reason is the premise that one rests on:
+ * "the caller cannot act differently on them anyway". That is true of a collection the cap did not
+ * reach and one whose read failed — both mean "look again" — and it is FALSE here. A collection
+ * whose translations table predates the column this question is asked of has one specific remedy,
+ * `nextly migrate`, and folding it in with the others hides the one actionable case among the
+ * unactionable ones.
+ *
+ * 🔴 And it must be reported at all, which is the sharper point. An unanswerable LIFECYCLE filter
+ * returns every document, so excluding the collection silently is an improvement on something
+ * visibly wrong. An unanswerable STALENESS filter returns nothing — so a collection excluded
+ * without being named is indistinguishable from a collection with no stale translations, which is
+ * the reassuring direction and the exact claim this feature exists not to make.
+ */
+export function unanswerableCollections<T extends LocalizedCollectionRef>(
+  localized: readonly T[],
+  state: TranslationFilterState,
+  readable: ReadonlySet<string> | undefined
+): string[] {
+  if (state !== "stale") return [];
+  return localized
+    .filter(
+      c =>
+        (readable === undefined || readable.has(c.slug)) &&
+        c.canAnswerStaleness === false
+    )
+    .map(c => c.slug)
+    .sort();
 }
 
 /**


### PR DESCRIPTION
The last withheld piece of the staleness feature. A translation whose source has moved on is already marked in the language panel (#1352); this adds the worklist tab that finds them across a site — and, more importantly, tells the operator what it could **not** check.

## Why the tab was withheld, and what changed

A collection whose translations table predates the timestamp answers the filter with `1=0`. Zero rows. And zero rows is indistinguishable from "nothing here needs review" — the reassuring direction, and the exact claim this signal exists not to make by accident.

It can be offered now because such a collection is **excluded and named**.

`eligibleCollections` gains a `stale` arm mirroring the one that already keeps a statusless collection out of a lifecycle filter, for the reason that function already states:

> *"a lifecycle state is a question a statusless collection cannot answer… Contributing nothing is the truthful answer; contributing everything is the worst available one."*

The failure direction inverts — an unanswerable lifecycle filter returns **everything**, an unanswerable staleness filter returns **nothing** — so exclusion is right for both, but this one must additionally be *reported*, because a silent zero looks like good news.

## Why a second channel rather than more names in `notConsulted`

`notConsultedSources` deliberately merges the fan-out cap with a failed read, and documents its premise:

> *"the caller cannot act differently on them anyway"*

That is true of those two — both mean "look again" — and **false** here. A collection whose table predates the column has one specific remedy. Folding it in hides the actionable case among the unactionable ones, so the premise is respected where it holds and a separate `unanswerable` list carries the case where it does not.

The screen says both, with different endings:

> **Not everything was checked** — …*Reload to see whether it was temporary.*
> **Some collections can't be checked yet** — …*Run `nextly migrate` to add it.*

Telling this operator to reload would send them in a loop.

## Design notes

**`undefined` means "not asked", not "cannot".** The capability is only resolved for the state that reads it, so every other tab leaves it unset. Treating unset as unanswerable would silently empty all four.

**The label is "Needs review", not "Stale" or "Outdated".** The wire value says what was *measured* — a source written after its translation — and the label says what a person should *do*. A translation whose source moved may well still be correct; naming the tab after the measurement tells an author their work is wrong when all that is known is that it is worth a look.

**Cost, accepted and documented.** The fan-out probes per collection, and negatives are not cached, so an un-migrated site pays one catalogue read per collection per worklist request. Proportionate for an admin screen that already issues one query per collection, and it ends when the operator migrates. Only the review tab pays it; the other four never ask.

## Prior art

From `research:worklist-coverage-and-partial-results`. Enterprise data-table practice treats this as a lifecycle to design up front: *"Design the data lifecycle up front, including empty, **partial**, stale, and failed results… a new user with no records yet and a filter that returns nothing are two different empty states, and they need different copy."* This screen has four, and *partial* is the one that was missing.

## Evidence

Three breaks on the server, each failing only its own test:

    drop the stale eligibility arm    -> × is left out of the stale fan-out
    report regardless of readability  -> × never names a collection the caller cannot read
    treat unresolved as unanswerable  -> × treats an unresolved capability as answerable

The middle one guards a real leak: a slug in a coverage notice is a statement that the collection **exists**, and a notice is the softest-looking place for that to escape someone with no right to know it.

Two admin tests named themselves as *"the one to INVERT when the capability check lands"*. Both are inverted, and both keep asserting the vocabulary decision they were really guarding — `stale` is a filter, not a fifth `LanguageState`, because a stale translation is still published if it was published.

    packages/admin  vitest run components/features/translations types/translations -> 36 tests
    packages/nextly vitest run domains/i18n api                                    -> 54 files, 619 tests
    check-types 0, lint 0, comment-convention 0
    pre-push gate: nextly 797/797, admin 328/328

## Changeset

Its own, and correcting my first reading of this: #1352's note announced the marker on a LANGUAGE, not a screen that finds them across a site and not a coverage notice. Two user-visible additions with no release entry between them, which is exactly what a changeset is for.
