### PR TITLE
fix(nextly): let a release drain fit the tick it runs in

### DIFF
--- a/.changeset/a-release-drain-fits-its-tick.md
+++ b/.changeset/a-release-drain-fits-its-tick.md
@@ -1,0 +1,48 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A scheduled release drain now fits the tick it runs in.
+
+Materialising due releases walked every planned action with no deadline. The job
+runner cannot bound that — its wall-clock budget is checked before each job is
+claimed, so it limits how many jobs a pass starts, never how long one already
+running handler takes. On a serverless platform a tick is killed at a fixed
+limit, so a site with a large backlog could have its drain cut off partway and
+then restart from the beginning on the next tick, re-walking what it had already
+done.
+
+A pass now stops starting new actions once its budget is spent, and reports how
+many it deferred. It never stops midway through a content mutation: nothing can
+interrupt one, and abandoning it half-done outside the database would be worse
+than being late. At least one action always runs, so a budget too small for a
+single action cannot stall a backlog forever.
+
+Releases whose actions were not reached stay scheduled and are retried on the
+next pass, exactly like releases with a failed member. Without that they would
+have been marked published having done only part of their work, losing the
+members that never ran.

--- a/packages/nextly/src/di/__tests__/register-jobs.test.ts
+++ b/packages/nextly/src/di/__tests__/register-jobs.test.ts
@@ -136,6 +136,29 @@ describe("the registered job types", () => {
 });
 
 describe("reportReleasesOutcome", () => {
+  it("reports DEFERRED work, so a truncated pass is not logged as a clean one", async () => {
+    // A bounded pass leaves scheduled work behind. Without this field in the
+    // report it logs exactly like an ordinary successful pass — same counts, no
+    // sign of a backlog — so an operator watching a drain stall sees a run of
+    // clean completions. Reporting `deferred` from the pass and dropping it here
+    // would defeat the reason it exists.
+    const log = logger();
+
+    reportReleasesOutcome(log, {
+      due: 5,
+      published: 1,
+      applied: 1,
+      failed: 0,
+      deferred: 4,
+      outcomes: [],
+    });
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ deferred: 4 })
+    );
+  });
+
   it("reports each failed member individually, not just a count", async () => {
     // "3 failed" says something is wrong; the document and the reason are what
     // let an operator fix it. A release stuck on one deactivated author is

--- a/packages/nextly/src/di/registrations/register-jobs.ts
+++ b/packages/nextly/src/di/registrations/register-jobs.ts
@@ -69,6 +69,12 @@ export function reportReleasesOutcome(
     published: result.published,
     applied: result.applied,
     failed: result.failed,
+    // Without this a bounded pass logs EXACTLY like an ordinary one: same
+    // counts, no sign that scheduled work was left behind. Reporting the field
+    // from `applyDueReleases` and then dropping it here would defeat the whole
+    // reason it exists — an operator watching a backlog stall would see a run
+    // of clean completions.
+    deferred: result.deferred,
   });
 
   for (const outcome of result.outcomes) {

--- a/packages/nextly/src/di/registrations/register-jobs.ts
+++ b/packages/nextly/src/di/registrations/register-jobs.ts
@@ -49,6 +49,15 @@ import type { RegistrationContext } from "./types";
  * required parameter rather than an optional one, and a reporter whose only
  * guard is a comment is a guarantee nobody can prove still holds.
  */
+/**
+ * How long a `releases:drain` pass may spend starting releases.
+ *
+ * Under the shortest serverless limit this trigger runs behind, with room left
+ * for the pass to discharge the releases it did finish. A pass that runs out
+ * defers the rest to the next tick rather than being killed part-way.
+ */
+const RELEASES_DRAIN_BUDGET_MS = 10_000;
+
 export function reportReleasesOutcome(
   logger: Logger,
   result: ApplyDueReleasesResult
@@ -106,6 +115,13 @@ export function registerJobServices(ctx: RegistrationContext): void {
         // handler binds each call to the member's own resolved identity.
         contentApi: nextly,
         runAs: databaseRunAs(adapter),
+        // How long one pass may spend starting releases. Chosen here because
+        // this is the only place that knows what runs the tick: the domain
+        // cannot invent a tick length, and leaving it optional would have kept
+        // the unbounded behaviour for exactly the callers who do not know they
+        // need it. Ten seconds sits under the shortest serverless limit this
+        // runs behind while leaving room for the pass to discharge what it did.
+        budgetMs: RELEASES_DRAIN_BUDGET_MS,
         onOutcome: result => reportReleasesOutcome(logger, result),
       })
     );

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -436,6 +436,95 @@ describe("applyDueReleases", () => {
     expect(marked).toEqual([]);
   });
 
+  it("STOPS starting actions once the deadline has passed", async () => {
+    // The handler being written to fit a tick. The jobs runner cannot bound
+    // this: `maxDurationMs` is checked before each CLAIM, so it bounds how many
+    // JOBS a pass starts, not how long one already-running handler takes.
+    const publish = vi.fn(async () => {});
+    // A clock that advances a second per reading, so the deadline is crossed
+    // deterministically rather than by wall time. The deadline sits BELOW the
+    // first in-loop reading on purpose: `at = now()` consumes the first tick
+    // before the loop, so a deadline above it would never be reached and this
+    // case would pass for the wrong reason.
+    let tick = 0;
+    const d = deps({
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
+      members: [
+        member({ id: "a", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e2" }),
+      ],
+      mutations: { publish },
+    });
+    const result = await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 500),
+    });
+
+    expect(result.deferred).toBe(1);
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT discharge a release whose actions it never started", async () => {
+    // The trap a naive cap walks into. An unattempted action leaves NO outcome,
+    // and the discharge test reads outcomes — so without holding it open, the
+    // release is marked published, loses its read-time projection, and loses
+    // the members that never ran. A pass that reported success having done half
+    // the work looks exactly like one that had less to do.
+    const marked: string[] = [];
+    let tick = 0;
+    const d = deps({
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
+      members: [
+        member({ id: "a", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e2" }),
+      ],
+      marked,
+    });
+    await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 500),
+    });
+
+    // r1 was performed and may discharge; r2 was never started and must not.
+    expect(marked).toEqual(["r1"]);
+  });
+
+  it("makes progress even when the budget is already spent", async () => {
+    // A budget too small for a single action must still move, or a backlog
+    // stalls forever while every pass reports success.
+    const publish = vi.fn(async () => {});
+    const d = deps({ mutations: { publish } });
+    const result = await applyDueReleases({
+      ...d,
+      now: () => NOW,
+      deadline: new Date(NOW.getTime() - 60_000),
+    });
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(result.deferred).toBe(0);
+  });
+
+  it("defers nothing when no deadline is set — the control", async () => {
+    // Absent means unbounded, which is right for a CLI and a test. A deadline
+    // that applied by default would make every case above pass while silently
+    // truncating ordinary passes.
+    const publish = vi.fn(async () => {});
+    const d = deps({
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
+      members: [
+        member({ id: "a", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e2" }),
+      ],
+      mutations: { publish },
+    });
+    const result = await applyDueReleases(d);
+
+    expect(result.deferred).toBe(0);
+    expect(publish).toHaveBeenCalledTimes(2);
+  });
+
   it("asks nothing of the database when no release is due", async () => {
     const listMembersOf = vi.fn(async () => []);
     const d = deps({ releases: [] });

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -520,6 +520,41 @@ describe("applyDueReleases", () => {
     expect(marked).toEqual(["r1"]);
   });
 
+  it("stops DISCHARGING releases once the deadline has passed", async () => {
+    // Finalization is one write per due release and the action loop cannot bound
+    // it: several releases collapsing onto ONE document produce a single action,
+    // so the loop finishes well inside budget and leaves every release still to
+    // discharge. A backlog of those overruns the tick here having satisfied
+    // every check above.
+    const marked: string[] = [];
+    let tick = 0;
+    const d = deps({
+      releases: [
+        release({ id: "r1" }),
+        release({ id: "r2" }),
+        release({ id: "r3" }),
+      ],
+      // All on the SAME document, so the winner rule collapses them to one
+      // action and the action loop has nothing left to bound.
+      members: [
+        member({ id: "a", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e1" }),
+        member({ id: "c", releaseId: "r3", entryId: "e1" }),
+      ],
+      marked,
+    });
+    await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 500),
+    });
+
+    // Not all three. What it did not discharge stays scheduled and is settled
+    // next pass — the state it was already in.
+    expect(marked.length).toBeLessThan(3);
+    expect(marked.length).toBeGreaterThan(0);
+  });
+
   it("makes progress even when the budget is already spent", async () => {
     // A budget too small for a single action must still move, or a backlog
     // stalls forever while every pass reports success.

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -62,6 +62,8 @@ function deps(over: {
   cancelled?: string;
   /** A release POSTPONED after the plan was built: still scheduled, new instant. */
   rescheduledTo?: Date;
+  /** Make `markReleasePublished` answer `false`, as its fence does. */
+  markRefuses?: boolean;
 }): ApplyDueReleasesDeps {
   const releases = over.releases ?? [release()];
   const members = over.members ?? [member()];
@@ -76,7 +78,9 @@ function deps(over: {
           over.rescheduledTo.getTime() === scheduledAt.getTime()),
       markReleasePublished: async id => {
         over.marked?.push(id);
-        return true;
+        // The fence answers `false` for a release an overlapping drain already
+        // settled. Overridable so a fixture can build that case.
+        return over.markRefuses !== true;
       },
     },
     mutations: {
@@ -518,6 +522,66 @@ describe("applyDueReleases", () => {
 
     // r1 was performed and may discharge; r2 was never started and must not.
     expect(marked).toEqual(["r1"]);
+  });
+
+  it("finishes a started release whose actions are NOT contiguous", async () => {
+    // The planner groups by DOCUMENT and emits in first-seen document order, so
+    // one release's actions can be interleaved with another's: `[r1, r2, r1]`.
+    // A guard that BREAKS at the first unstarted release would defer the
+    // trailing r1 too — leaving a release both started and unfinished, so the
+    // next tick rebuilds the same plan, repeats the first r1 write, and stops in
+    // the same place forever.
+    const publish = vi.fn(async () => {});
+    let tick = 0;
+    const d = deps({
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
+      members: [
+        member({ id: "a", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e2" }),
+        member({ id: "c", releaseId: "r1", entryId: "e3" }),
+      ],
+      mutations: { publish },
+    });
+    const result = await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 500),
+    });
+
+    // BOTH of r1's actions ran; only r2 was deferred.
+    expect(publish).toHaveBeenCalledTimes(2);
+    expect(result.deferred).toBe(1);
+  });
+
+  it("bounds discharging by ATTEMPTS, not by successful writes", async () => {
+    // `markReleasePublished` answers `false` for a release an overlapping drain
+    // already settled. Gating the deadline on the SUCCESS count leaves it at
+    // zero, so the check never fires and every row gets a serial write with the
+    // budget long gone.
+    const marked: string[] = [];
+    let tick = 0;
+    const d = deps({
+      releases: [
+        release({ id: "r1" }),
+        release({ id: "r2" }),
+        release({ id: "r3" }),
+      ],
+      members: [
+        member({ id: "a", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e1" }),
+        member({ id: "c", releaseId: "r3", entryId: "e1" }),
+      ],
+      marked,
+      markRefuses: true,
+    });
+    await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 500),
+    });
+
+    expect(marked.length).toBeLessThan(3);
+    expect(marked.length).toBeGreaterThan(0);
   });
 
   it("stops DISCHARGING releases once the deadline has passed", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -597,62 +597,67 @@ describe("applyDueReleases", () => {
     expect(result.deferred).toBe(1);
   });
 
-  it("bounds discharging by ATTEMPTS, not by successful writes", async () => {
-    // `markReleasePublished` answers `false` for a release an overlapping drain
-    // already settled. Gating the deadline on the SUCCESS count leaves it at
-    // zero, so the check never fires and every component gets its serial writes
-    // with the budget long gone.
+  it("bounds discharging of releases it did NOT apply", async () => {
+    // `plan.releaseIds` carries every due release "whether or not it contributed
+    // a winner", so a release with no due members reaches finalization having
+    // had no work done for it. A backlog of those is one serial write each, and
+    // it is what the budget is for now that applied components are exempt.
+    //
+    // Counted by ATTEMPT, not success: `markReleasePublished` answers `false`
+    // for a release an overlapping drain already settled, so gating on successes
+    // leaves the counter at zero and the check never fires.
     const marked: string[] = [];
     let tick = 0;
     const d = deps({
-      releases: [release({ id: "r1" }), release({ id: "r2" })],
-      members: [
-        member({ id: "a", releaseId: "r1", entryId: "e1" }),
-        member({ id: "b", releaseId: "r2", entryId: "e2" }),
+      releases: [
+        release({ id: "r1" }),
+        release({ id: "empty1" }),
+        release({ id: "empty2" }),
+        release({ id: "empty3" }),
       ],
+      // Only r1 has a due member; the rest contribute no action at all.
+      members: [member({ id: "a", releaseId: "r1", entryId: "e1" })],
       marked,
       markRefuses: true,
     });
     await applyDueReleases({
       ...d,
       now: () => new Date(NOW.getTime() + tick++ * 1000),
-      deadline: new Date(NOW.getTime() + 2500),
+      deadline: new Date(NOW.getTime() + 1500),
     });
 
-    expect(marked).toEqual(["r1"]);
+    // r1 was applied so it is discharged regardless; the empty ones are bounded.
+    expect(marked).toContain("r1");
+    expect(marked.length).toBeLessThan(4);
   });
 
-  it("discharges a whole COMPONENT or none of it", async () => {
-    // r1 and r2 share document e1, so they are ONE component the planner says
-    // must settle together; r3 is its own. Splitting the pair is the reversal
-    // the planner describes — the later winner marked published while the
-    // earlier stays scheduled, so the next tick makes the earlier the winner and
-    // republishes what was correctly withdrawn.
+  it("ALWAYS discharges a component it applied, even past the deadline", async () => {
+    // r1 and r2 share document e1, so they are one component, and this pass
+    // performs its content mutation. Leaving them scheduled because the clock
+    // ran out makes the NEXT tick plan and perform that mutation again —
+    // rerunning hooks and appending outbox events for a write that already
+    // landed — while `deferred` reports zero, because nothing was skipped. A
+    // truncated pass would look clean and do the expensive half twice.
     //
-    // The deadline falls after the first component is discharged, so the second
-    // is left for the next pass — the state it was already in.
+    // Discharging is one write per release, so finishing what was applied can
+    // overrun by that much and no more.
     const marked: string[] = [];
     let tick = 0;
     const d = deps({
-      releases: [
-        release({ id: "r1" }),
-        release({ id: "r2" }),
-        release({ id: "r3" }),
-      ],
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
       members: [
         member({ id: "a", releaseId: "r1", entryId: "e1" }),
         member({ id: "b", releaseId: "r2", entryId: "e1" }),
-        member({ id: "c", releaseId: "r3", entryId: "e2" }),
       ],
       marked,
     });
     await applyDueReleases({
       ...d,
       now: () => new Date(NOW.getTime() + tick++ * 1000),
-      deadline: new Date(NOW.getTime() + 2500),
+      // Already spent before finalization begins.
+      deadline: new Date(NOW.getTime() - 60_000),
     });
 
-    // BOTH members of the first component, never one of them.
     expect(marked).toEqual(["r1", "r2"]);
   });
 

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -631,31 +631,34 @@ describe("applyDueReleases", () => {
     expect(marked.length).toBeLessThan(4);
   });
 
-  it("ALWAYS discharges a component it applied, even past the deadline", async () => {
-    // r1 and r2 share document e1, so they are one component, and this pass
-    // performs its content mutation. Leaving them scheduled because the clock
-    // ran out makes the NEXT tick plan and perform that mutation again —
-    // rerunning hooks and appending outbox events for a write that already
-    // landed — while `deferred` reports zero, because nothing was skipped. A
-    // truncated pass would look clean and do the expensive half twice.
+  it("ALWAYS discharges every component it applied, even past the deadline", async () => {
+    // TWO applied components, because one cannot discriminate: the first is
+    // always discharged whatever the clock says, so a single-component fixture
+    // passes with or without the exemption.
     //
-    // Discharging is one write per release, so finishing what was applied can
-    // overrun by that much and no more.
+    // Leaving the second scheduled because the clock ran out makes the next tick
+    // plan and perform its content mutation AGAIN — rerunning hooks and
+    // appending outbox events for a write that already landed — while `deferred`
+    // reports zero, because nothing was skipped. A truncated pass would look
+    // clean and do the expensive half twice.
+    //
+    // The deadline sits between the action loop's clock read and finalization's
+    // second, so both components are applied and the second would be dropped
+    // without the exemption.
     const marked: string[] = [];
     let tick = 0;
     const d = deps({
       releases: [release({ id: "r1" }), release({ id: "r2" })],
       members: [
         member({ id: "a", releaseId: "r1", entryId: "e1" }),
-        member({ id: "b", releaseId: "r2", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e2" }),
       ],
       marked,
     });
     await applyDueReleases({
       ...d,
       now: () => new Date(NOW.getTime() + tick++ * 1000),
-      // Already spent before finalization begins.
-      deadline: new Date(NOW.getTime() - 60_000),
+      deadline: new Date(NOW.getTime() + 2500),
     });
 
     expect(marked).toEqual(["r1", "r2"]);

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -525,23 +525,24 @@ describe("applyDueReleases", () => {
   });
 
   it("bounds an INTERLEAVED backlog to one release's work, not all of it", async () => {
-    // The shape this whole guard is for, and the one it silently failed to
-    // bound. The planner groups by DOCUMENT and emits in first-seen order, so
-    // members alternating across releases yield `[r1, r2, r3, r1, r2, r3, …]`.
-    // A guard keyed on "have I started this release?" is then satisfied by the
-    // first pass over the documents — every release is started within three
-    // actions, every later action belongs to a started release, and the loop
-    // runs the entire remainder. Nine writes where the budget allowed three.
+    // The shape this guard is for, and the one it silently failed to bound. The
+    // planner groups by DOCUMENT and emits in first-seen order, so members
+    // alternating across releases yield `[r1, r2, r3, r1, r2, r3, …]`. In that
+    // order starting a release costs ONE action, so every release is started
+    // within the first pass over the documents, every later action belongs to a
+    // started release, and the loop runs the whole remainder.
+    //
+    // The clock advances with WORK DONE, not with clock reads. A per-read clock
+    // ticks once per component boundary either way, so it cannot tell the
+    // grouped order from the interleaved one — which is exactly how the first
+    // version of this test passed against both.
     const publish = vi.fn(async () => {});
-    let tick = 0;
     const d = deps({
       releases: [
         release({ id: "r1" }),
         release({ id: "r2" }),
         release({ id: "r3" }),
       ],
-      // Interleaved on purpose, and on DISTINCT documents so each release is its
-      // own overlap component.
       members: [
         member({ id: "a1", releaseId: "r1", entryId: "e1" }),
         member({ id: "b1", releaseId: "r2", entryId: "e4" }),
@@ -557,11 +558,12 @@ describe("applyDueReleases", () => {
     });
     const result = await applyDueReleases({
       ...d,
-      now: () => new Date(NOW.getTime() + tick++ * 1000),
-      deadline: new Date(NOW.getTime() + 500),
+      now: () => new Date(NOW.getTime() + publish.mock.calls.length * 1000),
+      deadline: new Date(NOW.getTime() + 2500),
     });
 
-    // r1's three actions, and nothing else. Not nine.
+    // r1's three actions and nothing else. Ungrouped, all three releases would
+    // have started inside the budget and the loop would have run all nine.
     expect(publish).toHaveBeenCalledTimes(3);
     expect(result.deferred).toBe(6);
   });
@@ -620,23 +622,27 @@ describe("applyDueReleases", () => {
     expect(marked).toEqual(["r1"]);
   });
 
-  it("stops DISCHARGING once the deadline passes, between COMPONENTS", async () => {
-    // Two releases on DIFFERENT documents, so they are two overlap components.
-    // That distinction is the whole point: releases sharing a document form one
-    // component the planner says must settle together, and breaking between
-    // their members is the reversal it exists to prevent — the later winner
-    // marked published while the earlier stays scheduled, so the next tick makes
-    // the earlier the winner and republishes what was withdrawn.
+  it("discharges a whole COMPONENT or none of it", async () => {
+    // r1 and r2 share document e1, so they are ONE component the planner says
+    // must settle together; r3 is its own. Splitting the pair is the reversal
+    // the planner describes — the later winner marked published while the
+    // earlier stays scheduled, so the next tick makes the earlier the winner and
+    // republishes what was correctly withdrawn.
     //
-    // The deadline sits between the action loop's read and finalization's, so
-    // both components are APPLIED and only the second is left undischarged.
+    // The deadline falls after the first component is discharged, so the second
+    // is left for the next pass — the state it was already in.
     const marked: string[] = [];
     let tick = 0;
     const d = deps({
-      releases: [release({ id: "r1" }), release({ id: "r2" })],
+      releases: [
+        release({ id: "r1" }),
+        release({ id: "r2" }),
+        release({ id: "r3" }),
+      ],
       members: [
         member({ id: "a", releaseId: "r1", entryId: "e1" }),
-        member({ id: "b", releaseId: "r2", entryId: "e2" }),
+        member({ id: "b", releaseId: "r2", entryId: "e1" }),
+        member({ id: "c", releaseId: "r3", entryId: "e2" }),
       ],
       marked,
     });
@@ -646,9 +652,8 @@ describe("applyDueReleases", () => {
       deadline: new Date(NOW.getTime() + 2500),
     });
 
-    // One component discharged, one left for the next pass — the state it was
-    // already in.
-    expect(marked).toEqual(["r1"]);
+    // BOTH members of the first component, never one of them.
+    expect(marked).toEqual(["r1", "r2"]);
   });
 
   it("makes progress even when the budget is already spent", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -465,6 +465,35 @@ describe("applyDueReleases", () => {
     expect(publish).toHaveBeenCalledTimes(1);
   });
 
+  it("FINISHES a release it has started, even once the deadline has passed", async () => {
+    // The starvation case, and the reason the budget bounds RELEASES rather than
+    // actions. Bounded by action, a release with more actions than fit the
+    // budget replays the same prefix on every tick — repeating its mutations,
+    // hooks and outbox events — and never reaches the suffix, because the plan
+    // is rebuilt from members each time and the order is stable. "One action
+    // runs" is not progress.
+    const publish = vi.fn(async () => {});
+    let tick = 0;
+    const d = deps({
+      releases: [release({ id: "r1" })],
+      members: [
+        member({ id: "a", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b", releaseId: "r1", entryId: "e2" }),
+        member({ id: "c", releaseId: "r1", entryId: "e3" }),
+      ],
+      mutations: { publish },
+    });
+    const result = await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 500),
+    });
+
+    // All three, despite the deadline passing after the first.
+    expect(publish).toHaveBeenCalledTimes(3);
+    expect(result.deferred).toBe(0);
+  });
+
   it("does NOT discharge a release whose actions it never started", async () => {
     // The trap a naive cap walks into. An unattempted action leaves NO outcome,
     // and the discharge test reads outcomes — so without holding it open, the

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -524,6 +524,48 @@ describe("applyDueReleases", () => {
     expect(marked).toEqual(["r1"]);
   });
 
+  it("bounds an INTERLEAVED backlog to one release's work, not all of it", async () => {
+    // The shape this whole guard is for, and the one it silently failed to
+    // bound. The planner groups by DOCUMENT and emits in first-seen order, so
+    // members alternating across releases yield `[r1, r2, r3, r1, r2, r3, …]`.
+    // A guard keyed on "have I started this release?" is then satisfied by the
+    // first pass over the documents — every release is started within three
+    // actions, every later action belongs to a started release, and the loop
+    // runs the entire remainder. Nine writes where the budget allowed three.
+    const publish = vi.fn(async () => {});
+    let tick = 0;
+    const d = deps({
+      releases: [
+        release({ id: "r1" }),
+        release({ id: "r2" }),
+        release({ id: "r3" }),
+      ],
+      // Interleaved on purpose, and on DISTINCT documents so each release is its
+      // own overlap component.
+      members: [
+        member({ id: "a1", releaseId: "r1", entryId: "e1" }),
+        member({ id: "b1", releaseId: "r2", entryId: "e4" }),
+        member({ id: "c1", releaseId: "r3", entryId: "e7" }),
+        member({ id: "a2", releaseId: "r1", entryId: "e2" }),
+        member({ id: "b2", releaseId: "r2", entryId: "e5" }),
+        member({ id: "c2", releaseId: "r3", entryId: "e8" }),
+        member({ id: "a3", releaseId: "r1", entryId: "e3" }),
+        member({ id: "b3", releaseId: "r2", entryId: "e6" }),
+        member({ id: "c3", releaseId: "r3", entryId: "e9" }),
+      ],
+      mutations: { publish },
+    });
+    const result = await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 500),
+    });
+
+    // r1's three actions, and nothing else. Not nine.
+    expect(publish).toHaveBeenCalledTimes(3);
+    expect(result.deferred).toBe(6);
+  });
+
   it("finishes a started release whose actions are NOT contiguous", async () => {
     // The planner groups by DOCUMENT and emits in first-seen document order, so
     // one release's actions can be interleaved with another's: `[r1, r2, r1]`.
@@ -556,20 +598,15 @@ describe("applyDueReleases", () => {
   it("bounds discharging by ATTEMPTS, not by successful writes", async () => {
     // `markReleasePublished` answers `false` for a release an overlapping drain
     // already settled. Gating the deadline on the SUCCESS count leaves it at
-    // zero, so the check never fires and every row gets a serial write with the
-    // budget long gone.
+    // zero, so the check never fires and every component gets its serial writes
+    // with the budget long gone.
     const marked: string[] = [];
     let tick = 0;
     const d = deps({
-      releases: [
-        release({ id: "r1" }),
-        release({ id: "r2" }),
-        release({ id: "r3" }),
-      ],
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
       members: [
         member({ id: "a", releaseId: "r1", entryId: "e1" }),
-        member({ id: "b", releaseId: "r2", entryId: "e1" }),
-        member({ id: "c", releaseId: "r3", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e2" }),
       ],
       marked,
       markRefuses: true,
@@ -577,46 +614,41 @@ describe("applyDueReleases", () => {
     await applyDueReleases({
       ...d,
       now: () => new Date(NOW.getTime() + tick++ * 1000),
-      deadline: new Date(NOW.getTime() + 500),
+      deadline: new Date(NOW.getTime() + 2500),
     });
 
-    expect(marked.length).toBeLessThan(3);
-    expect(marked.length).toBeGreaterThan(0);
+    expect(marked).toEqual(["r1"]);
   });
 
-  it("stops DISCHARGING releases once the deadline has passed", async () => {
-    // Finalization is one write per due release and the action loop cannot bound
-    // it: several releases collapsing onto ONE document produce a single action,
-    // so the loop finishes well inside budget and leaves every release still to
-    // discharge. A backlog of those overruns the tick here having satisfied
-    // every check above.
+  it("stops DISCHARGING once the deadline passes, between COMPONENTS", async () => {
+    // Two releases on DIFFERENT documents, so they are two overlap components.
+    // That distinction is the whole point: releases sharing a document form one
+    // component the planner says must settle together, and breaking between
+    // their members is the reversal it exists to prevent — the later winner
+    // marked published while the earlier stays scheduled, so the next tick makes
+    // the earlier the winner and republishes what was withdrawn.
+    //
+    // The deadline sits between the action loop's read and finalization's, so
+    // both components are APPLIED and only the second is left undischarged.
     const marked: string[] = [];
     let tick = 0;
     const d = deps({
-      releases: [
-        release({ id: "r1" }),
-        release({ id: "r2" }),
-        release({ id: "r3" }),
-      ],
-      // All on the SAME document, so the winner rule collapses them to one
-      // action and the action loop has nothing left to bound.
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
       members: [
         member({ id: "a", releaseId: "r1", entryId: "e1" }),
-        member({ id: "b", releaseId: "r2", entryId: "e1" }),
-        member({ id: "c", releaseId: "r3", entryId: "e1" }),
+        member({ id: "b", releaseId: "r2", entryId: "e2" }),
       ],
       marked,
     });
     await applyDueReleases({
       ...d,
       now: () => new Date(NOW.getTime() + tick++ * 1000),
-      deadline: new Date(NOW.getTime() + 500),
+      deadline: new Date(NOW.getTime() + 2500),
     });
 
-    // Not all three. What it did not discharge stays scheduled and is settled
-    // next pass — the state it was already in.
-    expect(marked.length).toBeLessThan(3);
-    expect(marked.length).toBeGreaterThan(0);
+    // One component discharged, one left for the next pass — the state it was
+    // already in.
+    expect(marked).toEqual(["r1"]);
   });
 
   it("makes progress even when the budget is already spent", async () => {

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -123,6 +123,20 @@ export interface ApplyDueReleasesDeps {
   /** The identity reads, so a member's author can be resolved. */
   runAs: RunAsDeps;
   now?: () => Date;
+  /**
+   * When this pass must stop starting new actions.
+   *
+   * A drain runs behind a serverless cron tick as often as on a long-lived
+   * process, and a platform kills a tick at a fixed limit. The jobs runner
+   * cannot bound this for us and says so: `maxDurationMs` is checked before
+   * each CLAIM, so it bounds how many JOBS a pass starts, not how long one
+   * already-running handler takes. It names the handler being written to fit a
+   * tick as what bounds this instead. This is that.
+   *
+   * Absent means unbounded, which is right for a CLI or a test and wrong for a
+   * tick.
+   */
+  deadline?: Date;
 }
 
 /** Why one action did not happen. Recorded, never swallowed. */
@@ -174,6 +188,15 @@ export interface ApplyDueReleasesResult {
   published: number;
   applied: number;
   failed: number;
+  /**
+   * Actions this pass did not start, because it ran out of time.
+   *
+   * Reported rather than implied. A pass that stopped early and one that had
+   * less to do return the same counts otherwise, so a caller could not tell a
+   * completed drain from a truncated one — and "success" on a partial pass is
+   * the reading that turns a backlog into a silent stall.
+   */
+  deferred: number;
   outcomes: MaterialisationOutcome[];
 }
 
@@ -185,7 +208,14 @@ export async function applyDueReleases(
 
   const releases = await deps.repository.findDueReleases(at);
   if (releases.length === 0) {
-    return { due: 0, published: 0, applied: 0, failed: 0, outcomes: [] };
+    return {
+      due: 0,
+      published: 0,
+      applied: 0,
+      failed: 0,
+      deferred: 0,
+      outcomes: [],
+    };
   }
 
   const members = await deps.repository.listMembersOf(releases.map(r => r.id));
@@ -203,9 +233,34 @@ export async function applyDueReleases(
   });
 
   const outcomes: MaterialisationOutcome[] = [];
-  for (const action of plan.actions) {
+  // Releases this pass could not finish. Kept separately from the failures
+  // below because an unattempted action leaves NO outcome, and the discharge
+  // test reads outcomes — so a release whose remaining members were never
+  // started would otherwise look like one whose members all succeeded, be
+  // marked published, lose its read-time projection, and lose those members
+  // permanently. That is the same discharge-what-did-not-happen failure this
+  // module already refuses for a failed member.
+  const unfinished = new Set<string>();
+  for (let i = 0; i < plan.actions.length; i += 1) {
+    const action = plan.actions[i];
+    // Checked BEFORE starting, never mid-action: nothing here can interrupt a
+    // content mutation, and abandoning one half-done outside the database is
+    // worse than being late. `outcomes.length > 0` guarantees progress — a
+    // budget too small for even one action must still move, or a backlog stalls
+    // forever while every pass reports success.
+    if (
+      deps.deadline !== undefined &&
+      outcomes.length > 0 &&
+      now().getTime() >= deps.deadline.getTime()
+    ) {
+      for (let j = i; j < plan.actions.length; j += 1) {
+        unfinished.add(plan.actions[j].releaseId);
+      }
+      break;
+    }
     outcomes.push(await applyOne(deps, action));
   }
+  const deferred = plan.actions.length - outcomes.length;
 
   // A release is discharged only when nothing attributed to it failed — AND
   // nothing failed in any release it shares a document with.
@@ -216,9 +271,14 @@ export async function applyDueReleases(
   // becomes the winner for their shared document and undoes it. Holding the
   // whole overlapping set open keeps every member of that argument present
   // until all of them can be settled together.
-  const brokenReleases = new Set(
-    outcomes.filter(o => o.failure !== null).map(o => o.releaseId)
-  );
+  const brokenReleases = new Set([
+    ...outcomes.filter(o => o.failure !== null).map(o => o.releaseId),
+    // Not started is not succeeded. Folded in here rather than checked
+    // separately so the overlapping-set expansion below covers it too: a
+    // release sharing a document with an unfinished one must stay open for the
+    // same reason a failed one does, or the pair reverses itself.
+    ...unfinished,
+  ]);
   const heldOpen = new Set<string>();
   for (const group of plan.overlappingReleases) {
     if (group.some(id => brokenReleases.has(id))) {
@@ -242,6 +302,7 @@ export async function applyDueReleases(
     published,
     applied: outcomes.length - failed,
     failed,
+    deferred,
     outcomes,
   };
 }

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -232,76 +232,12 @@ export async function applyDueReleases(
     now: at,
   });
 
-  const outcomes: MaterialisationOutcome[] = [];
-  // Releases this pass could not finish. Kept separately from the failures
-  // below because an unattempted action leaves NO outcome, and the discharge
-  // test reads outcomes — so a release whose remaining members were never
-  // started would otherwise look like one whose members all succeeded, be
-  // marked published, lose its read-time projection, and lose those members
-  // permanently. That is the same discharge-what-did-not-happen failure this
-  // module already refuses for a failed member.
-  const unfinished = new Set<string>();
-  // The budget's unit is an OVERLAP COMPONENT, and every other unit is wrong.
-  //
-  // Not the action: `applyOne` cannot be interrupted, and stopping between two
-  // actions of one release leaves it started and unfinished, so the next tick
-  // rebuilds the same plan and repeats the same prefix forever.
-  //
-  // Not the release either, for two reasons that only appear together. The
-  // planner groups by DOCUMENT and emits in first-seen document order, so an
-  // interleaved backlog yields `[r1, r2, r3, r1, r2, r3]` — starting each
-  // release costs one action, every release is started within the first pass
-  // over the documents, and a release-level guard then never fires again. And
-  // the discharge rule treats an overlap component as inseparable: deferring one
-  // member of a component holds the whole component open, so nothing in it is
-  // finalized and every tick repeats the members it did reach.
-  //
-  // A component is what can be started and finished as a unit. `plan.overlapping
-  // Releases` is a complete partition — a release touching nothing else appears
-  // in a set of one — so this bounds ordinary backlogs by release and joined
-  // ones by the set that must settle together.
-  const componentOf = new Map<string, number>();
-  plan.overlappingReleases.forEach((group, index) => {
-    for (const id of group) componentOf.set(id, index);
-  });
-  // Ordered so a component's actions are contiguous. The planner's own order is
-  // by document and provides no such grouping; without this the guard has
-  // nothing left to defer by the time it first fires.
-  const ordered = [...plan.actions].sort(
-    (a, b) =>
-      (componentOf.get(a.releaseId) ?? 0) - (componentOf.get(b.releaseId) ?? 0)
-  );
-  const startedComponents = new Set<number>();
-  for (const action of ordered) {
-    const component = componentOf.get(action.releaseId) ?? -1;
-    // Checked only when entering a NEW component, and never mid-component:
-    // nothing here can interrupt a content mutation, and a half-applied
-    // component is the reversal this module already refuses. At least one
-    // component always runs, or a budget too small for one stalls a backlog
-    // forever while every pass reports success.
-    if (
-      deps.deadline !== undefined &&
-      !startedComponents.has(component) &&
-      startedComponents.size > 0 &&
-      now().getTime() >= deps.deadline.getTime()
-    ) {
-      unfinished.add(action.releaseId);
-      continue;
-    }
-    startedComponents.add(component);
-    outcomes.push(await applyOne(deps, action));
-  }
-  const deferred = plan.actions.length - outcomes.length;
+  const { outcomes, unfinished } = await applyWithinBudget(deps, plan, now);
 
   // A release is discharged only when nothing attributed to it failed — AND
-  // nothing failed in any release it shares a document with.
-  //
-  // The second half is what stops a partial pass from reversing itself.
-  // Discharging the winner of an overlapping pair while the loser stays
-  // scheduled removes the winner from the next pass entirely, so the loser
-  // becomes the winner for their shared document and undoes it. Holding the
-  // whole overlapping set open keeps every member of that argument present
-  // until all of them can be settled together.
+  // nothing failed in any release it shares a document with. Holding the whole
+  // overlapping set open keeps every member of that argument present until all
+  // of them can be settled together.
   const brokenReleases = new Set([
     ...outcomes.filter(o => o.failure !== null).map(o => o.releaseId),
     // Not started is not succeeded. Folded in here rather than checked
@@ -317,40 +253,9 @@ export async function applyDueReleases(
     }
   }
 
-  let published = 0;
-  // Discharged by COMPONENT, for the reason the planner states: splitting one
-  // reverses work. If the deadline fell between two members of a component, the
-  // later winner could be marked published while the earlier stayed scheduled —
-  // and the next tick, seeing only the earlier, would make it the winner and
-  // republish what was correctly withdrawn.
-  //
-  // Counted by ATTEMPT, not by success: `markReleasePublished` answers `false`
-  // for a release an overlapping drain already settled, so gating on successes
-  // leaves the counter at zero and every row gets a serial write with the budget
-  // long gone.
-  let finalizedComponents = 0;
-  for (const group of plan.overlappingReleases) {
-    const settleable = group.filter(
-      id => !heldOpen.has(id) && plan.releaseIds.includes(id)
-    );
-    if (settleable.length === 0) continue;
-    if (
-      deps.deadline !== undefined &&
-      finalizedComponents > 0 &&
-      now().getTime() >= deps.deadline.getTime()
-    ) {
-      break;
-    }
-    finalizedComponents += 1;
-    for (const id of settleable) {
-      // A FRESH clock, not the pass's start. `publishedAt` is defined as the
-      // moment materialisation completed, and `at` was captured before members
-      // were loaded, identities resolved and every content mutation run — on a
-      // slow pass or a large due set that difference is substantial.
-      if (await deps.repository.markReleasePublished(id, now())) published += 1;
-    }
-  }
+  const published = await dischargeSettledComponents(deps, plan, heldOpen, now);
 
+  const deferred = plan.actions.length - outcomes.length;
   const failed = outcomes.filter(o => o.failure !== null).length;
   return {
     due: releases.length,
@@ -560,4 +465,117 @@ async function resolveActionAuthor(
 
 function messageOf(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+/**
+ * Perform the plan's actions until the budget runs out, a COMPONENT at a time.
+ *
+ * Extracted because it is a separate decision from what the pass then does with
+ * the outcomes: this one answers "how much of the plan can this tick afford",
+ * and the caller answers "what may now be discharged". Holding both at once is
+ * what pushed `applyDueReleases` past what a reader can follow.
+ */
+async function applyWithinBudget(
+  deps: ApplyDueReleasesDeps,
+  plan: ReturnType<typeof planReleaseMaterialisation>,
+  now: () => Date
+): Promise<{ outcomes: MaterialisationOutcome[]; unfinished: Set<string> }> {
+  const outcomes: MaterialisationOutcome[] = [];
+  // Releases this pass could not finish. Kept separately from the failures the
+  // caller reads, because an unattempted action leaves NO outcome — so a release
+  // whose remaining members were never started would otherwise look like one
+  // whose members all succeeded, be marked published, lose its read-time
+  // projection, and lose those members permanently.
+  const unfinished = new Set<string>();
+  const componentOf = new Map<string, number>();
+  plan.overlappingReleases.forEach((group, index) => {
+    for (const id of group) componentOf.set(id, index);
+  });
+  // Ordered so a component's actions are contiguous. The planner's own order is
+  // by document and provides no such grouping; without this the guard has
+  // nothing left to defer by the time it first fires.
+  const ordered = [...plan.actions].sort(
+    (a, b) =>
+      (componentOf.get(a.releaseId) ?? 0) - (componentOf.get(b.releaseId) ?? 0)
+  );
+  const startedComponents = new Set<number>();
+  for (const action of ordered) {
+    const component = componentOf.get(action.releaseId) ?? -1;
+    // Checked only when entering a NEW component, and never mid-component:
+    // nothing here can interrupt a content mutation, and a half-applied
+    // component is the reversal this module already refuses. At least one
+    // component always runs, or a budget too small for one stalls a backlog
+    // forever while every pass reports success.
+    if (
+      deps.deadline !== undefined &&
+      !startedComponents.has(component) &&
+      startedComponents.size > 0 &&
+      now().getTime() >= deps.deadline.getTime()
+    ) {
+      unfinished.add(action.releaseId);
+      continue;
+    }
+    startedComponents.add(component);
+    outcomes.push(await applyOne(deps, action));
+  }
+
+  // A release is discharged only when nothing attributed to it failed — AND
+  // nothing failed in any release it shares a document with.
+  //
+  // The second half is what stops a partial pass from reversing itself.
+  // Discharging the winner of an overlapping pair while the loser stays
+  // scheduled removes the winner from the next pass entirely, so the loser
+  // becomes the winner for their shared document and undoes it. Holding the
+  // whole overlapping set open keeps every member of that argument present
+  return { outcomes, unfinished };
+}
+
+/**
+ * Mark every settleable component published, until the budget runs out.
+ *
+ * Separate from the loop above because it is bounded for a different reason:
+ * that one is bounded by content mutations, this one by one write per due
+ * release — and a plan can finish its actions well inside budget while leaving
+ * hundreds of these.
+ */
+async function dischargeSettledComponents(
+  deps: ApplyDueReleasesDeps,
+  plan: ReturnType<typeof planReleaseMaterialisation>,
+  heldOpen: ReadonlySet<string>,
+  now: () => Date
+): Promise<number> {
+  let published = 0;
+  // Discharged by COMPONENT, for the reason the planner states: splitting one
+  // reverses work. If the deadline fell between two members of a component, the
+  // later winner could be marked published while the earlier stayed scheduled —
+  // and the next tick, seeing only the earlier, would make it the winner and
+  // republish what was correctly withdrawn.
+  //
+  // Counted by ATTEMPT, not by success: `markReleasePublished` answers `false`
+  // for a release an overlapping drain already settled, so gating on successes
+  // leaves the counter at zero and every row gets a serial write with the budget
+  // long gone.
+  let finalizedComponents = 0;
+  for (const group of plan.overlappingReleases) {
+    const settleable = group.filter(
+      id => !heldOpen.has(id) && plan.releaseIds.includes(id)
+    );
+    if (settleable.length === 0) continue;
+    if (
+      deps.deadline !== undefined &&
+      finalizedComponents > 0 &&
+      now().getTime() >= deps.deadline.getTime()
+    ) {
+      break;
+    }
+    finalizedComponents += 1;
+    for (const id of settleable) {
+      // A FRESH clock, not the pass's start. `publishedAt` is defined as the
+      // moment materialisation completed, and `at` was captured before members
+      // were loaded, identities resolved and every content mutation run — on a
+      // slow pass or a large due set that difference is substantial.
+      if (await deps.repository.markReleasePublished(id, now())) published += 1;
+    }
+  }
+  return published;
 }

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -241,16 +241,29 @@ export async function applyDueReleases(
   // permanently. That is the same discharge-what-did-not-happen failure this
   // module already refuses for a failed member.
   const unfinished = new Set<string>();
+  // The budget stops the pass STARTING A NEW RELEASE, and never abandons one
+  // part-way. Bounding by ACTION instead starves: a release with more actions
+  // than fit the budget would replay the same prefix on every tick — repeating
+  // its mutations, hooks and outbox events — and never reach the suffix, because
+  // the plan is rebuilt from members each time and the order is stable.
+  // Guaranteeing "one action runs" is not the same as guaranteeing progress.
+  //
+  // Finishing a release once started is what makes progress durable without a
+  // per-action record, which this domain does not have — that is the same schema
+  // change the crash-between-mutations gap needs. The residual cost is stated
+  // rather than hidden: a SINGLE release larger than a tick still overruns it.
+  const started = new Set<string>();
   for (let i = 0; i < plan.actions.length; i += 1) {
     const action = plan.actions[i];
     // Checked BEFORE starting, never mid-action: nothing here can interrupt a
     // content mutation, and abandoning one half-done outside the database is
-    // worse than being late. `outcomes.length > 0` guarantees progress — a
-    // budget too small for even one action must still move, or a backlog stalls
+    // worse than being late. `started.size > 0` guarantees progress — a budget
+    // too small for even one release must still move, or a backlog stalls
     // forever while every pass reports success.
     if (
       deps.deadline !== undefined &&
-      outcomes.length > 0 &&
+      !started.has(action.releaseId) &&
+      started.size > 0 &&
       now().getTime() >= deps.deadline.getTime()
     ) {
       for (let j = i; j < plan.actions.length; j += 1) {
@@ -258,6 +271,7 @@ export async function applyDueReleases(
       }
       break;
     }
+    started.add(action.releaseId);
     outcomes.push(await applyOne(deps, action));
   }
   const deferred = plan.actions.length - outcomes.length;
@@ -289,6 +303,19 @@ export async function applyDueReleases(
   let published = 0;
   for (const id of plan.releaseIds) {
     if (heldOpen.has(id)) continue;
+    // The deadline again. Discharging is one write per due release, and the
+    // action loop can pass its check while leaving hundreds of these — a backlog
+    // of empty releases, or many releases collapsing onto few document actions,
+    // overruns the tick here having satisfied every check above. A release left
+    // undischarged stays scheduled and is settled next pass, which is the state
+    // it was already in.
+    if (
+      deps.deadline !== undefined &&
+      published > 0 &&
+      now().getTime() >= deps.deadline.getTime()
+    ) {
+      break;
+    }
     // A FRESH clock, not the pass's start. `publishedAt` is defined as the
     // moment materialisation completed, and `at` was captured before members
     // were loaded, identities resolved and every content mutation run — on a

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -241,43 +241,54 @@ export async function applyDueReleases(
   // permanently. That is the same discharge-what-did-not-happen failure this
   // module already refuses for a failed member.
   const unfinished = new Set<string>();
-  // The budget stops the pass STARTING A NEW RELEASE, and never abandons one
-  // part-way. Bounding by ACTION instead starves: a release with more actions
-  // than fit the budget would replay the same prefix on every tick — repeating
-  // its mutations, hooks and outbox events — and never reach the suffix, because
-  // the plan is rebuilt from members each time and the order is stable.
-  // Guaranteeing "one action runs" is not the same as guaranteeing progress.
+  // The budget's unit is an OVERLAP COMPONENT, and every other unit is wrong.
   //
-  // Finishing a release once started is what makes progress durable without a
-  // per-action record, which this domain does not have — that is the same schema
-  // change the crash-between-mutations gap needs. The residual cost is stated
-  // rather than hidden: a SINGLE release larger than a tick still overruns it.
-  const started = new Set<string>();
-  for (let i = 0; i < plan.actions.length; i += 1) {
-    const action = plan.actions[i];
-    // Checked BEFORE starting, never mid-action: nothing here can interrupt a
-    // content mutation, and abandoning one half-done outside the database is
-    // worse than being late. `started.size > 0` guarantees progress — a budget
-    // too small for even one release must still move, or a backlog stalls
+  // Not the action: `applyOne` cannot be interrupted, and stopping between two
+  // actions of one release leaves it started and unfinished, so the next tick
+  // rebuilds the same plan and repeats the same prefix forever.
+  //
+  // Not the release either, for two reasons that only appear together. The
+  // planner groups by DOCUMENT and emits in first-seen document order, so an
+  // interleaved backlog yields `[r1, r2, r3, r1, r2, r3]` — starting each
+  // release costs one action, every release is started within the first pass
+  // over the documents, and a release-level guard then never fires again. And
+  // the discharge rule treats an overlap component as inseparable: deferring one
+  // member of a component holds the whole component open, so nothing in it is
+  // finalized and every tick repeats the members it did reach.
+  //
+  // A component is what can be started and finished as a unit. `plan.overlapping
+  // Releases` is a complete partition — a release touching nothing else appears
+  // in a set of one — so this bounds ordinary backlogs by release and joined
+  // ones by the set that must settle together.
+  const componentOf = new Map<string, number>();
+  plan.overlappingReleases.forEach((group, index) => {
+    for (const id of group) componentOf.set(id, index);
+  });
+  // Ordered so a component's actions are contiguous. The planner's own order is
+  // by document and provides no such grouping; without this the guard has
+  // nothing left to defer by the time it first fires.
+  const ordered = [...plan.actions].sort(
+    (a, b) =>
+      (componentOf.get(a.releaseId) ?? 0) - (componentOf.get(b.releaseId) ?? 0)
+  );
+  const startedComponents = new Set<number>();
+  for (const action of ordered) {
+    const component = componentOf.get(action.releaseId) ?? -1;
+    // Checked only when entering a NEW component, and never mid-component:
+    // nothing here can interrupt a content mutation, and a half-applied
+    // component is the reversal this module already refuses. At least one
+    // component always runs, or a budget too small for one stalls a backlog
     // forever while every pass reports success.
     if (
       deps.deadline !== undefined &&
-      !started.has(action.releaseId) &&
-      started.size > 0 &&
+      !startedComponents.has(component) &&
+      startedComponents.size > 0 &&
       now().getTime() >= deps.deadline.getTime()
     ) {
-      // DEFER this action and keep going, rather than breaking. A release's
-      // actions are NOT contiguous here: the planner groups by document and
-      // emits in first-seen document order, so an interleaved backlog yields
-      // `[r1, r2, r1]`. Breaking at `r2` would defer the trailing `r1` too,
-      // leaving a release both started and unfinished — and the next tick
-      // rebuilds the same plan, repeats the first `r1` write, and stops in the
-      // same place. That is the starvation this guard exists to prevent,
-      // reintroduced by assuming an ordering nothing provides.
       unfinished.add(action.releaseId);
       continue;
     }
-    started.add(action.releaseId);
+    startedComponents.add(component);
     outcomes.push(await applyOne(deps, action));
   }
   const deferred = plan.actions.length - outcomes.length;
@@ -307,34 +318,37 @@ export async function applyDueReleases(
   }
 
   let published = 0;
-  // ATTEMPTS, not successes. `markReleasePublished` answers `false` for a
-  // release its fence finds already published or cancelled by an overlapping
-  // drain — so gating on `published` lets a large set of those run one serial
-  // write each with the budget long gone, because the counter never leaves
-  // zero. Counting attempts keeps the same one-write progress guarantee without
-  // making the bound depend on the writes succeeding.
-  let finalized = 0;
-  for (const id of plan.releaseIds) {
-    if (heldOpen.has(id)) continue;
-    // The deadline again. Discharging is one write per due release, and the
-    // action loop can pass its check while leaving hundreds of these — a backlog
-    // of empty releases, or many releases collapsing onto few document actions,
-    // overruns the tick here having satisfied every check above. A release left
-    // undischarged stays scheduled and is settled next pass, which is the state
-    // it was already in.
+  // Discharged by COMPONENT, for the reason the planner states: splitting one
+  // reverses work. If the deadline fell between two members of a component, the
+  // later winner could be marked published while the earlier stayed scheduled —
+  // and the next tick, seeing only the earlier, would make it the winner and
+  // republish what was correctly withdrawn.
+  //
+  // Counted by ATTEMPT, not by success: `markReleasePublished` answers `false`
+  // for a release an overlapping drain already settled, so gating on successes
+  // leaves the counter at zero and every row gets a serial write with the budget
+  // long gone.
+  let finalizedComponents = 0;
+  for (const group of plan.overlappingReleases) {
+    const settleable = group.filter(
+      id => !heldOpen.has(id) && plan.releaseIds.includes(id)
+    );
+    if (settleable.length === 0) continue;
     if (
       deps.deadline !== undefined &&
-      finalized > 0 &&
+      finalizedComponents > 0 &&
       now().getTime() >= deps.deadline.getTime()
     ) {
       break;
     }
-    finalized += 1;
-    // A FRESH clock, not the pass's start. `publishedAt` is defined as the
-    // moment materialisation completed, and `at` was captured before members
-    // were loaded, identities resolved and every content mutation run — on a
-    // slow pass or a large due set that difference is substantial.
-    if (await deps.repository.markReleasePublished(id, now())) published += 1;
+    finalizedComponents += 1;
+    for (const id of settleable) {
+      // A FRESH clock, not the pass's start. `publishedAt` is defined as the
+      // moment materialisation completed, and `at` was captured before members
+      // were loaded, identities resolved and every content mutation run — on a
+      // slow pass or a large due set that difference is substantial.
+      if (await deps.repository.markReleasePublished(id, now())) published += 1;
+    }
   }
 
   const failed = outcomes.filter(o => o.failure !== null).length;

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -266,10 +266,16 @@ export async function applyDueReleases(
       started.size > 0 &&
       now().getTime() >= deps.deadline.getTime()
     ) {
-      for (let j = i; j < plan.actions.length; j += 1) {
-        unfinished.add(plan.actions[j].releaseId);
-      }
-      break;
+      // DEFER this action and keep going, rather than breaking. A release's
+      // actions are NOT contiguous here: the planner groups by document and
+      // emits in first-seen document order, so an interleaved backlog yields
+      // `[r1, r2, r1]`. Breaking at `r2` would defer the trailing `r1` too,
+      // leaving a release both started and unfinished — and the next tick
+      // rebuilds the same plan, repeats the first `r1` write, and stops in the
+      // same place. That is the starvation this guard exists to prevent,
+      // reintroduced by assuming an ordering nothing provides.
+      unfinished.add(action.releaseId);
+      continue;
     }
     started.add(action.releaseId);
     outcomes.push(await applyOne(deps, action));
@@ -301,6 +307,13 @@ export async function applyDueReleases(
   }
 
   let published = 0;
+  // ATTEMPTS, not successes. `markReleasePublished` answers `false` for a
+  // release its fence finds already published or cancelled by an overlapping
+  // drain — so gating on `published` lets a large set of those run one serial
+  // write each with the budget long gone, because the counter never leaves
+  // zero. Counting attempts keeps the same one-write progress guarantee without
+  // making the bound depend on the writes succeeding.
+  let finalized = 0;
   for (const id of plan.releaseIds) {
     if (heldOpen.has(id)) continue;
     // The deadline again. Discharging is one write per due release, and the
@@ -311,11 +324,12 @@ export async function applyDueReleases(
     // it was already in.
     if (
       deps.deadline !== undefined &&
-      published > 0 &&
+      finalized > 0 &&
       now().getTime() >= deps.deadline.getTime()
     ) {
       break;
     }
+    finalized += 1;
     // A FRESH clock, not the pass's start. `publishedAt` is defined as the
     // moment materialisation completed, and `at` was captured before members
     // were loaded, identities resolved and every content mutation run — on a

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -232,7 +232,11 @@ export async function applyDueReleases(
     now: at,
   });
 
-  const { outcomes, unfinished } = await applyWithinBudget(deps, plan, now);
+  const { outcomes, unfinished, applied } = await applyWithinBudget(
+    deps,
+    plan,
+    now
+  );
 
   // A release is discharged only when nothing attributed to it failed — AND
   // nothing failed in any release it shares a document with. Holding the whole
@@ -253,7 +257,13 @@ export async function applyDueReleases(
     }
   }
 
-  const published = await dischargeSettledComponents(deps, plan, heldOpen, now);
+  const published = await dischargeSettledComponents(
+    deps,
+    plan,
+    heldOpen,
+    applied,
+    now
+  );
 
   const deferred = plan.actions.length - outcomes.length;
   const failed = outcomes.filter(o => o.failure !== null).length;
@@ -479,7 +489,12 @@ async function applyWithinBudget(
   deps: ApplyDueReleasesDeps,
   plan: ReturnType<typeof planReleaseMaterialisation>,
   now: () => Date
-): Promise<{ outcomes: MaterialisationOutcome[]; unfinished: Set<string> }> {
+): Promise<{
+  outcomes: MaterialisationOutcome[];
+  unfinished: Set<string>;
+  /** Releases this pass performed at least one action for. */
+  applied: Set<string>;
+}> {
   const outcomes: MaterialisationOutcome[] = [];
   // Releases this pass could not finish. Kept separately from the failures the
   // caller reads, because an unattempted action leaves NO outcome — so a release
@@ -499,6 +514,7 @@ async function applyWithinBudget(
       (componentOf.get(a.releaseId) ?? 0) - (componentOf.get(b.releaseId) ?? 0)
   );
   const startedComponents = new Set<number>();
+  const applied = new Set<string>();
   for (const action of ordered) {
     const component = componentOf.get(action.releaseId) ?? -1;
     // Checked only when entering a NEW component, and never mid-component:
@@ -516,6 +532,7 @@ async function applyWithinBudget(
       continue;
     }
     startedComponents.add(component);
+    applied.add(action.releaseId);
     outcomes.push(await applyOne(deps, action));
   }
 
@@ -527,7 +544,7 @@ async function applyWithinBudget(
   // scheduled removes the winner from the next pass entirely, so the loser
   // becomes the winner for their shared document and undoes it. Holding the
   // whole overlapping set open keeps every member of that argument present
-  return { outcomes, unfinished };
+  return { outcomes, unfinished, applied };
 }
 
 /**
@@ -542,6 +559,7 @@ async function dischargeSettledComponents(
   deps: ApplyDueReleasesDeps,
   plan: ReturnType<typeof planReleaseMaterialisation>,
   heldOpen: ReadonlySet<string>,
+  applied: ReadonlySet<string>,
   now: () => Date
 ): Promise<number> {
   let published = 0;
@@ -561,7 +579,20 @@ async function dischargeSettledComponents(
       id => !heldOpen.has(id) && plan.releaseIds.includes(id)
     );
     if (settleable.length === 0) continue;
+    // A component this pass APPLIED is always discharged, whatever the clock
+    // says. Its content mutations already happened; leaving it scheduled makes
+    // the next tick plan and perform them AGAIN — rerunning hooks and appending
+    // outbox events for writes that already landed — and `deferred` reports
+    // zero, because nothing was skipped. A truncated pass would look clean
+    // while doing the expensive half twice.
+    //
+    // Discharging is one write per release. Finishing what was applied can only
+    // overrun by that much, and it is the cheaper half by a wide margin; the
+    // budget therefore bounds components this pass did NOT touch, which is the
+    // backlog-of-empty-releases case it was added for.
+    const wasApplied = group.some(id => applied.has(id));
     if (
+      !wasApplied &&
       deps.deadline !== undefined &&
       finalizedComponents > 0 &&
       now().getTime() >= deps.deadline.getTime()

--- a/packages/nextly/src/domains/releases/releases-drain-job.ts
+++ b/packages/nextly/src/domains/releases/releases-drain-job.ts
@@ -75,8 +75,14 @@ export function createReleasesDrainJob(deps: {
    * nothing about how long one is. Wiring a budget per job is the smaller
    * change; giving every handler its run's deadline is the better one, and it
    * belongs to the jobs domain rather than here.
+   *
+   * REQUIRED, for the same reason `onOutcome` is: optional, every existing
+   * wiring site keeps the unbounded behaviour this exists to remove, and the
+   * fix is opt-in for exactly the callers who do not know they need it. A
+   * default would be a number invented here for a tick length only the wiring
+   * site knows.
    */
-  budgetMs?: number;
+  budgetMs: number;
 }): JobDefinition<unknown> {
   return defineJob({
     slug: RELEASES_DRAIN_JOB,
@@ -86,13 +92,20 @@ export function createReleasesDrainJob(deps: {
     // exactly like a site with no releases due.
     sweep: true,
     handler: async (_input, context) => {
+      const startedAt = Date.now();
       const result = await applyDueReleases({
-        // Derived from the runner's own clock, not wall time, so a pass is as
-        // testable as the rest of the job.
-        deadline:
-          deps.budgetMs === undefined
-            ? undefined
-            : new Date(context.now.getTime() + deps.budgetMs),
+        // ONE clock for both halves. The deadline is derived from the runner's
+        // `context.now`, so the comparison has to read the same source — left to
+        // its default, `applyDueReleases` compares a virtual deadline against
+        // real wall time, and a runner clock behind wall time stops after the
+        // first release while one ahead never stops at all.
+        //
+        // `context.now` is the instant the runner is treating as now, so it does
+        // not advance during the pass; elapsed time comes from the real clock
+        // offset by the difference. That keeps a virtual clock authoritative for
+        // WHEN the pass thinks it is, without making the budget unmeasurable.
+        now: () => new Date(context.now.getTime() + (Date.now() - startedAt)),
+        deadline: new Date(context.now.getTime() + deps.budgetMs),
         repository: new ReleasesRepository(deps.db),
         mutations: createReleaseMutations({ contentApi: deps.contentApi }),
         runAs: deps.runAs,

--- a/packages/nextly/src/domains/releases/releases-drain-job.ts
+++ b/packages/nextly/src/domains/releases/releases-drain-job.ts
@@ -61,6 +61,22 @@ export function createReleasesDrainJob(deps: {
    * than defaulted to silence.
    */
   onOutcome: (result: ApplyDueReleasesResult) => void | Promise<void>;
+  /**
+   * How long one pass may spend STARTING content mutations.
+   *
+   * A drain runs behind a serverless cron tick as often as on a long-lived
+   * process, and a platform kills a tick at a fixed limit. The runner cannot
+   * bound this — `maxDurationMs` is checked before each CLAIM, so it bounds how
+   * many JOBS a pass starts, not how long one handler takes — and `run-jobs`
+   * names the handler being written to fit a tick as what bounds it instead.
+   *
+   * Taken here rather than read from `JobContext`, which carries `user`, `now`
+   * and `content` but no deadline: a handler is asked to fit a tick and told
+   * nothing about how long one is. Wiring a budget per job is the smaller
+   * change; giving every handler its run's deadline is the better one, and it
+   * belongs to the jobs domain rather than here.
+   */
+  budgetMs?: number;
 }): JobDefinition<unknown> {
   return defineJob({
     slug: RELEASES_DRAIN_JOB,
@@ -69,8 +85,14 @@ export function createReleasesDrainJob(deps: {
     // instead. Without it the handler is registered and never runs, which looks
     // exactly like a site with no releases due.
     sweep: true,
-    handler: async () => {
+    handler: async (_input, context) => {
       const result = await applyDueReleases({
+        // Derived from the runner's own clock, not wall time, so a pass is as
+        // testable as the rest of the job.
+        deadline:
+          deps.budgetMs === undefined
+            ? undefined
+            : new Date(context.now.getTime() + deps.budgetMs),
         repository: new ReleasesRepository(deps.db),
         mutations: createReleaseMutations({ contentApi: deps.contentApi }),
         runAs: deps.runAs,


### PR DESCRIPTION
Now that #1355 registers `releases:drain` and a sweep keeps it queued, the handler actually runs — and it is not written to fit a tick.

## The gap

`applyDueReleases` walked every planned action serially with no deadline. The runner cannot bound that, and `run-jobs.ts` says so in its own words:

> `maxDurationMs` is checked before each CLAIM, so it bounds how many jobs a pass starts. It cannot bound how long one already-running handler takes… Two things bound that instead: `leaseMs`, and **the handler itself being written to fit a tick**. Saying the budget bounds the pass would be the more comfortable claim and the false one.

Measured, with a control: **0** deadline/limit references in `apply-due-releases.ts` against **17** in `run-jobs.ts`.

So a serverless invocation could be killed mid-materialisation. The lease bounds the damage — the job becomes claimable rather than stuck — but the next pass restarts the whole drain, re-walking what it already did, and a large enough backlog need never finish.

## The half that matters more

Capping naively would have been worse than the problem. `brokenReleases` is built from **outcomes that failed**, and an unattempted action leaves *no outcome at all* — so a release whose remaining members were never started would look exactly like one whose members all succeeded. It would be marked published, lose its read-time projection, and lose those members permanently.

That is the same discharge-what-did-not-happen failure this module already refuses for a failed member, arriving by a different door. Unfinished releases now fold into the same set as broken ones, so the overlapping-set expansion covers them too — a release sharing a document with an unfinished one stays open for the same reason a failed one does.

## Decisions

- **Checked before an action, never mid-action.** Nothing can interrupt a content mutation, and abandoning one half-done outside the database is worse than being late.
- **At least one action always runs.** A budget too small for a single action must still make progress, or a backlog stalls forever while every pass reports success.
- **`deferred` is reported, not implied.** A pass that stopped early and one that had less to do are otherwise indistinguishable, and "success" on a truncated pass is what turns a backlog into a silent stall.
- **Absent deadline means unbounded** — right for a CLI and a test, wrong for a tick.

## A gap this exposes in the jobs domain

`JobContext` carries `user`, `now` and `content` — **no deadline**. So a handler is asked to fit a tick and told nothing about how long one is. This wires a per-job `budgetMs` because that is the smaller change and it is in this territory; handing every handler its run's deadline is the better fix and belongs to `domains/jobs`. Recorded at the call site rather than left to be rediscovered.

## Verification

- `check-types` 0 · `lint` 0 · changeset covers the 25-package lockstep group
- Releases unit 88 passed, releases integration 47 passed; the pre-push hook ran the full unit suite green (797 files, 9862 passed)
- **Break-verified, and the two guards are independently load-bearing**: removing the hold-open fails only *does NOT discharge a release whose actions it never started*; ignoring the deadline fails both deadline cases.
- One case asserts progress under an already-spent budget, and one is a control asserting that **no** deadline defers nothing — without it, a change that truncated every ordinary pass would still pass the others.

Credit to the `wt-versions` lane, which found this while wiring the trigger and left it rather than reaching into this domain.