### PR TITLE
feat(nextly): tell a job how long its tick is

### DIFF
--- a/.changeset/a-job-knows-how-long-its-tick-is.md
+++ b/.changeset/a-job-knows-how-long-its-tick-is.md
@@ -1,0 +1,50 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A background job now knows how long it has.
+
+Jobs run on a tick — a scheduler calls your site, the runner works through what is
+due, and the platform ends the request. Work that walks an open-ended set, like
+publishing every release that has come due, has to stop somewhere sensible and
+leave the rest for the next tick. Until now nothing told it where that was: the
+runner held the budget and never mentioned it, so anything wanting to be a good
+citizen had to be handed the number separately.
+
+Every job handler now receives `deadline` — the instant its pass intends to stop.
+Short jobs can ignore it. A job that walks a large set should stop when it passes
+and leave the remainder queued, which is safe because the queue is durable and
+the next tick continues where this one left off.
+
+Stopping early must leave the remaining work queued rather than marking it done.
+Work that was never attempted produces no error, and an absence of failure is
+easily mistaken for success.
+
+Also fixed: a recurring job whose slug was near the maximum length was accepted
+when you defined it and then silently refused when the runner tried to queue it,
+so it never ran. Such a slug is now rejected where you write it, with a message
+naming the real limit.

--- a/packages/nextly/src/domains/jobs/__tests__/job-deadline.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-deadline.test.ts
@@ -63,18 +63,37 @@ const noContentApi = new Proxy({} as never, {
   },
 });
 
-/** Runs a pass and returns the contexts every handler invocation received. */
+/** How far the clock moves between one job finishing and the next starting. */
+const GAP_MS = 1_000;
+
+/**
+ * Runs a pass and returns the contexts every handler invocation received.
+ *
+ * **The clock ADVANCES between jobs**, and that is what gives these tests their
+ * discriminating power. With a frozen clock, an implementation that computed
+ * `now() + maxDurationMs` separately for every job would hand out an identical
+ * instant to each one and satisfy a "they all match" assertion perfectly — the
+ * test would pass against exactly the design it exists to rule out.
+ *
+ * Advancing it inside the handler, rather than on every `now()` call, keeps the
+ * movement to the boundary between jobs: nothing inside a single job's own
+ * bookkeeping shifts, so the only thing the assertions can be reading is where
+ * the deadline is anchored.
+ */
 async function contextsFrom(
   ids: string[],
   maxDurationMs: number
 ): Promise<JobContext[]> {
   const seen: JobContext[] = [];
+  let clock = NOW.getTime();
+
   const registry = new JobRegistry();
   registry.register(
     defineJob({
       slug: "test:capture",
       handler: async (_input, context) => {
         seen.push(context);
+        clock += GAP_MS;
       },
     })
   );
@@ -86,7 +105,7 @@ async function contextsFrom(
       findUser: async () => ({ id: "u1", isActive: true }),
       listRoleSlugs: async () => ["editor"],
     },
-    now: () => NOW,
+    now: () => new Date(clock),
     maxDurationMs,
     contentApi: noContentApi,
   });
@@ -116,7 +135,7 @@ describe("the deadline a handler is given", () => {
     expect(context?.deadline.getTime()).toBe(NOW.getTime() + 5_000);
   });
 
-  it("is the SAME instant for every job in one pass", async () => {
+  it("is the SAME instant for every job, even as the clock moves between them", async () => {
     // One pass, one deadline. A fresh budget per job would be a promise the
     // runner cannot keep — the invocation dies at one instant whatever a later
     // job was told, and a job starting late genuinely has less room.
@@ -125,5 +144,31 @@ describe("the deadline a handler is given", () => {
     expect(contexts).toHaveLength(3);
     const instants = new Set(contexts.map(c => c.deadline.getTime()));
     expect(instants.size).toBe(1);
+  });
+
+  it("stays anchored to the pass's START, not to when each job began", async () => {
+    // The assertion that actually rules out a per-job budget. Each job starts
+    // GAP_MS later than the last, so an implementation computing
+    // `now() + maxDurationMs` per job would hand the third job an instant
+    // 2 * GAP_MS beyond the first. Anchored to the start, all three equal
+    // NOW + budget however long the pass has been running.
+    const contexts = await contextsFrom(["a", "b", "c"], 20_000);
+
+    for (const context of contexts) {
+      expect(context.deadline.getTime()).toBe(NOW.getTime() + 20_000);
+    }
+  });
+
+  it("gives each handler its own Date, so one cannot move another's", async () => {
+    // `Date` is mutable. Sharing one object lets a handler that applies a safety
+    // margin with `setTime` silently change the deadline every later job in the
+    // pass is handed.
+    const contexts = await contextsFrom(["a", "b"], 20_000);
+
+    expect(contexts[0]?.deadline).not.toBe(contexts[1]?.deadline);
+
+    const before = contexts[1]?.deadline.getTime();
+    contexts[0]?.deadline.setTime(0);
+    expect(contexts[1]?.deadline.getTime()).toBe(before);
   });
 });

--- a/packages/nextly/src/domains/jobs/__tests__/job-deadline.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-deadline.test.ts
@@ -1,0 +1,129 @@
+/**
+ * A handler is told how long the tick is.
+ *
+ * `run-jobs` names two things that bound a RUNNING handler — the lease, and
+ * "the handler itself being written to fit a tick" — and until now it told the
+ * handler nothing about how long a tick is. Every handler that wanted to comply
+ * had to be handed a budget out of band, which is a second description of a
+ * number the runner already holds.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { JobRegistry, defineJob, type JobContext } from "../job-registry";
+import type { JobRow } from "../jobs-repository";
+import { runJobs, type JobsStore } from "../run-jobs";
+
+const NOW = new Date("2026-08-29T12:00:00.000Z");
+
+function row(id: string): JobRow {
+  return {
+    id,
+    slug: "test:capture",
+    input: null,
+    state: "pending",
+    runAt: null,
+    runAsUserId: null,
+    dedupeKey: null,
+    attemptCount: 0,
+    nextAttemptAt: null,
+    lockedBy: null,
+    lockedUntil: null,
+    lastError: null,
+    createdAt: NOW,
+    updatedAt: NOW,
+  };
+}
+
+/** Hands out each row once, so a pass cannot loop forever. */
+function store(rows: JobRow[]): JobsStore {
+  let handed = false;
+  return {
+    findDue: async () => {
+      if (handed) return [];
+      handed = true;
+      return rows;
+    },
+    claim: async id => rows.find(r => r.id === id) ?? null,
+    markAttempt: async () => true,
+    renewLease: async () => true,
+    finalize: async () => true,
+  };
+}
+
+/**
+ * A content API that refuses to be called — these cases do not exercise content
+ * operations, and a silent no-op would let one start using it without saying so.
+ */
+const noContentApi = new Proxy({} as never, {
+  get: (_t, name) => () => {
+    throw new Error(
+      `content.${String(name)} called by a test that does not stub it`
+    );
+  },
+});
+
+/** Runs a pass and returns the contexts every handler invocation received. */
+async function contextsFrom(
+  ids: string[],
+  maxDurationMs: number
+): Promise<JobContext[]> {
+  const seen: JobContext[] = [];
+  const registry = new JobRegistry();
+  registry.register(
+    defineJob({
+      slug: "test:capture",
+      handler: async (_input, context) => {
+        seen.push(context);
+      },
+    })
+  );
+
+  await runJobs({
+    store: store(ids.map(row)),
+    registry,
+    runAs: {
+      findUser: async () => ({ id: "u1", isActive: true }),
+      listRoleSlugs: async () => ["editor"],
+    },
+    now: () => NOW,
+    maxDurationMs,
+    contentApi: noContentApi,
+  });
+
+  return seen;
+}
+
+describe("the deadline a handler is given", () => {
+  it("reaches the handler on its context", async () => {
+    const [context] = await contextsFrom(["a"], 20_000);
+
+    expect(context?.deadline).toBeInstanceOf(Date);
+  });
+
+  it("is the pass's start plus its budget, not an arbitrary instant", async () => {
+    // Asserted against the two inputs that produce it rather than a copied
+    // constant: an expectation restating the number would keep passing after
+    // the runner started computing a different one.
+    const [context] = await contextsFrom(["a"], 20_000);
+
+    expect(context?.deadline.getTime()).toBe(NOW.getTime() + 20_000);
+  });
+
+  it("moves when the budget moves", async () => {
+    const [context] = await contextsFrom(["a"], 5_000);
+
+    expect(context?.deadline.getTime()).toBe(NOW.getTime() + 5_000);
+  });
+
+  it("is the SAME instant for every job in one pass", async () => {
+    // One pass, one deadline. A fresh budget per job would be a promise the
+    // runner cannot keep — the invocation dies at one instant whatever a later
+    // job was told, and a job starting late genuinely has less room.
+    const contexts = await contextsFrom(["a", "b", "c"], 20_000);
+
+    expect(contexts).toHaveLength(3);
+    const instants = new Set(contexts.map(c => c.deadline.getTime()));
+    expect(instants.size).toBe(1);
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-runner-sweeps.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-runner-sweeps.test.ts
@@ -9,7 +9,12 @@
 
 import { describe, expect, it, vi } from "vitest";
 
-import { JobRegistry, defineJob } from "../job-registry";
+import {
+  JobRegistry,
+  MAX_JOB_SLUG_LENGTH,
+  SWEEP_KEY_PREFIX,
+  defineJob,
+} from "../job-registry";
 import { runJobsPass, sweepDedupeKey } from "../jobs-runner";
 
 function registryWith(...defs: ReturnType<typeof defineJob>[]): JobRegistry {
@@ -41,6 +46,44 @@ const sweeper = defineJob({
   slug: "test:sweep",
   handler: async () => {},
   sweep: true,
+});
+
+describe("a sweep's slug is charged for its dedupe key", () => {
+  it("refuses a sweep slug that would produce an over-long dedupe key", () => {
+    // The two limits are equal (191), so a slug at the maximum yields a key
+    // over it. Caught at definition, where a person is reading the error —
+    // not at enqueue, which runs on a scheduler tick with nobody watching, and
+    // where a refused sweep is deliberately swallowed so it cannot fail a pass.
+    expect(() =>
+      defineJob({
+        slug: "s".repeat(MAX_JOB_SLUG_LENGTH),
+        handler: async () => {},
+        sweep: true,
+      })
+    ).toThrow(/dedupe key is derived from it/);
+  });
+
+  it("accepts the same slug when it is NOT a sweep", () => {
+    // The control. Charging every job type for a prefix only sweeps use would
+    // narrow a limit that works, and would make the case above pass for a
+    // reason unrelated to sweeps.
+    expect(() =>
+      defineJob({
+        slug: "s".repeat(MAX_JOB_SLUG_LENGTH),
+        handler: async () => {},
+      })
+    ).not.toThrow();
+  });
+
+  it("accepts a sweep slug that leaves room for the prefix", () => {
+    expect(() =>
+      defineJob({
+        slug: "s".repeat(MAX_JOB_SLUG_LENGTH - SWEEP_KEY_PREFIX.length),
+        handler: async () => {},
+        sweep: true,
+      })
+    ).not.toThrow();
+  });
 });
 
 describe("a pass keeps its sweeps queued", () => {

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -26,6 +26,7 @@ import { NextlyError } from "../../errors";
 import type { UserContext } from "../collections/services/collection-types";
 
 import type { JobContentApi } from "./job-content-api";
+import { MAX_PORTABLE_KEY_LENGTH, MAX_SWEEP_SLUG_LENGTH } from "./portable-key";
 
 /** Attempts a job gets before it is given up on. */
 export const DEFAULT_MAX_ATTEMPTS = 5;
@@ -39,20 +40,9 @@ export const DEFAULT_MAX_ATTEMPTS = 5;
  * dialect, rather than accepted at definition and failing only at enqueue time
  * and only on MySQL.
  */
-export const MAX_JOB_SLUG_LENGTH = 191;
+export const MAX_JOB_SLUG_LENGTH = MAX_PORTABLE_KEY_LENGTH;
 
-/**
- * What a sweep's dedupe key is prefixed with.
- *
- * Lives here, with the validation that charges for it, rather than beside the
- * function that builds the key: a sweep's key is DERIVED from its slug and held
- * to the same portable length limit the slug is, so the prefix spends part of
- * the slug's budget. Without accounting for it, a slug of 186-191 characters is
- * accepted by `defineJob` and its key refused by `enqueue` — and because
- * queueing a sweep is deliberately allowed to fail without failing the pass,
- * the only symptom is a job type that never runs.
- */
-export const SWEEP_KEY_PREFIX = "sweep:";
+export { SWEEP_KEY_PREFIX, MAX_SWEEP_SLUG_LENGTH } from "./portable-key";
 
 /** What a handler is told about the run it is in. */
 export interface JobContext {
@@ -166,12 +156,9 @@ export function defineJob<TInput = unknown>(
   // A sweep is charged for its own dedupe key here, where the slug is refused
   // with a message naming the real budget — rather than at enqueue, which runs
   // on a scheduler tick with nobody watching.
-  if (
-    input.sweep &&
-    SWEEP_KEY_PREFIX.length + slug.length > MAX_JOB_SLUG_LENGTH
-  ) {
+  if (input.sweep && slug.length > MAX_SWEEP_SLUG_LENGTH) {
     throw NextlyError.invalidInput({
-      message: `A sweep's slug may be at most ${MAX_JOB_SLUG_LENGTH - SWEEP_KEY_PREFIX.length} characters, because its dedupe key is derived from it.`,
+      message: `A sweep's slug may be at most ${MAX_SWEEP_SLUG_LENGTH} characters, because its dedupe key is derived from it.`,
       logContext: { slug, length: slug.length },
     });
   }

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -41,6 +41,19 @@ export const DEFAULT_MAX_ATTEMPTS = 5;
  */
 export const MAX_JOB_SLUG_LENGTH = 191;
 
+/**
+ * What a sweep's dedupe key is prefixed with.
+ *
+ * Lives here, with the validation that charges for it, rather than beside the
+ * function that builds the key: a sweep's key is DERIVED from its slug and held
+ * to the same portable length limit the slug is, so the prefix spends part of
+ * the slug's budget. Without accounting for it, a slug of 186-191 characters is
+ * accepted by `defineJob` and its key refused by `enqueue` — and because
+ * queueing a sweep is deliberately allowed to fail without failing the pass,
+ * the only symptom is a job type that never runs.
+ */
+export const SWEEP_KEY_PREFIX = "sweep:";
+
 /** What a handler is told about the run it is in. */
 export interface JobContext {
   /**
@@ -123,6 +136,19 @@ export function defineJob<TInput = unknown>(
   if (slug.length > MAX_JOB_SLUG_LENGTH) {
     throw NextlyError.invalidInput({
       message: `A job slug may be at most ${MAX_JOB_SLUG_LENGTH} characters.`,
+      logContext: { slug, length: slug.length },
+    });
+  }
+
+  // A sweep is charged for its own dedupe key here, where the slug is refused
+  // with a message naming the real budget — rather than at enqueue, which runs
+  // on a scheduler tick with nobody watching.
+  if (
+    input.sweep &&
+    SWEEP_KEY_PREFIX.length + slug.length > MAX_JOB_SLUG_LENGTH
+  ) {
+    throw NextlyError.invalidInput({
+      message: `A sweep's slug may be at most ${MAX_JOB_SLUG_LENGTH - SWEEP_KEY_PREFIX.length} characters, because its dedupe key is derived from it.`,
       logContext: { slug, length: slug.length },
     });
   }

--- a/packages/nextly/src/domains/jobs/job-registry.ts
+++ b/packages/nextly/src/domains/jobs/job-registry.ts
@@ -81,6 +81,29 @@ export interface JobContext {
    * default.
    */
   content: JobContentApi;
+  /**
+   * The instant the pass running this job intends to stop.
+   *
+   * The runner cannot enforce it. `maxDurationMs` is checked before each CLAIM,
+   * so it bounds how many jobs a pass STARTS and nothing more: once a handler is
+   * running, nothing here can interrupt a promise mid-flight, and a cancellation
+   * the handler did not cooperate with would abandon whatever it had half-done
+   * outside the database.
+   *
+   * So `run-jobs` names two things that bound a running handler — the lease, and
+   * "the handler itself being written to fit a tick". This is what makes the
+   * second one possible. Without it the runner asks handlers to fit a budget it
+   * never tells them, and every handler that wants to comply has to be handed
+   * one out of band, which is a second description of the same number.
+   *
+   * A handler that ignores it is not wrong; most jobs are short. A handler that
+   * walks an unbounded set — every due release, every stale entry — should stop
+   * when this passes and leave the rest, because the queue is durable and the
+   * next tick continues. **Stopping early must DEFER the remainder, never
+   * discharge it:** work that was never attempted produces no failure, and an
+   * absent failure reads as success.
+   */
+  deadline: Date;
 }
 
 export interface JobRetryPolicy {

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -37,10 +37,11 @@ import { NextlyError } from "../../errors";
 import type { JobState } from "../../schemas/jobs/types";
 import { isUniqueViolation } from "../../shared/lib/unique-violation";
 
+import { MAX_PORTABLE_KEY_LENGTH } from "./portable-key";
+
 const JOBS = "nextly_jobs";
 
 /** The longest value every supported dialect can store in an indexed column. */
-const MAX_PORTABLE_KEY_LENGTH = 191;
 
 /**
  * The transaction surface the lease claim needs (subset of the adapter tx).

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -14,8 +14,9 @@ import { nextly } from "../../direct-api/nextly";
 import { listRoleSlugsForUserStrict } from "../../services/lib/permissions";
 import type { RunAsDeps, RunAsUser } from "../../shared/lib/resolve-run-as";
 
-import { SWEEP_KEY_PREFIX, type JobRegistry } from "./job-registry";
+import type { JobRegistry } from "./job-registry";
 import { JobsRepository, type JobsDatabase } from "./jobs-repository";
+import { SWEEP_KEY_PREFIX } from "./portable-key";
 import { runJobs, type RunJobsResult } from "./run-jobs";
 
 /**

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -14,7 +14,7 @@ import { nextly } from "../../direct-api/nextly";
 import { listRoleSlugsForUserStrict } from "../../services/lib/permissions";
 import type { RunAsDeps, RunAsUser } from "../../shared/lib/resolve-run-as";
 
-import type { JobRegistry } from "./job-registry";
+import { SWEEP_KEY_PREFIX, type JobRegistry } from "./job-registry";
 import { JobsRepository, type JobsDatabase } from "./jobs-repository";
 import { runJobs, type RunJobsResult } from "./run-jobs";
 
@@ -162,7 +162,7 @@ export function databaseRunAs(
  * sweep instead of finding the key held forever by a job that has been and gone.
  */
 export function sweepDedupeKey(slug: string): string {
-  return `sweep:${slug}`;
+  return `${SWEEP_KEY_PREFIX}${slug}`;
 }
 
 /**

--- a/packages/nextly/src/domains/jobs/portable-key.ts
+++ b/packages/nextly/src/domains/jobs/portable-key.ts
@@ -1,0 +1,46 @@
+/**
+ * The bound every key stored on a job row is held to, and the keys derived from
+ * one another.
+ *
+ * A leaf module with no imports, so both the registry (which validates a slug
+ * when a job type is DEFINED) and the repository (which validates it again when
+ * a row is WRITTEN) can read the same number without either importing the other.
+ *
+ * They previously declared it separately — `MAX_JOB_SLUG_LENGTH` here and
+ * `MAX_PORTABLE_KEY_LENGTH` there — and agreed only because both said 191. Two
+ * constants for one limit is one edit away from a definition that is accepted
+ * and an enqueue that refuses it, which for a sweep means a job type registered
+ * and never run, with no error anywhere.
+ *
+ * @module domains/jobs/portable-key
+ */
+
+/**
+ * The longest key MySQL will index in `varchar(191)` utf8mb4 — the narrowest of
+ * the three dialects, so it is the bound all of them are held to. PostgreSQL and
+ * SQLite would accept more; a slug that worked on two dialects and threw on the
+ * third would be a portability bug discovered at enqueue time, on a scheduler
+ * tick, with nobody watching.
+ */
+export const MAX_PORTABLE_KEY_LENGTH = 191;
+
+/**
+ * What a sweep's dedupe key is prefixed with.
+ *
+ * Lives beside the limit because it SPENDS part of it: a sweep's key is its slug
+ * behind this prefix, and both are held to {@link MAX_PORTABLE_KEY_LENGTH}. A
+ * sweep slug is therefore budgeted at {@link MAX_SWEEP_SLUG_LENGTH}, and pairing
+ * the two here is what keeps that arithmetic from being restated somewhere it
+ * can drift.
+ */
+export const SWEEP_KEY_PREFIX = "sweep:";
+
+/**
+ * The longest slug a SWEEP may carry, derived rather than written down.
+ *
+ * Deriving it is the point of this module. Written as its own number it would be
+ * correct until somebody changed the prefix or the limit, and the failure it
+ * guards against is silent.
+ */
+export const MAX_SWEEP_SLUG_LENGTH =
+  MAX_PORTABLE_KEY_LENGTH - SWEEP_KEY_PREFIX.length;

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -329,7 +329,12 @@ async function runOne(
         user: identity.user,
         now: now(),
         content: createJobContentApi(identity.user, deps.contentApi),
-        deadline,
+        // A FRESH Date per invocation, from the pass's fixed instant. `Date` is
+        // mutable, so handing every handler the same object lets one that calls
+        // `setTime` on it — applying a safety margin, say — silently move the
+        // deadline every later job in this pass is given. Copying costs nothing
+        // and makes the value behave the way its readers assume it does.
+        deadline: new Date(deadline.getTime()),
       })
     );
   } catch (error) {

--- a/packages/nextly/src/domains/jobs/run-jobs.ts
+++ b/packages/nextly/src/domains/jobs/run-jobs.ts
@@ -155,6 +155,12 @@ export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
   const leaseMs = deps.leaseMs ?? DEFAULT_LEASE_MS;
 
   const startedAt = now().getTime();
+  // The whole pass shares ONE deadline, rather than each job receiving a fresh
+  // budget when it starts. A per-job budget would be a promise the runner cannot
+  // keep: the invocation dies at this instant whatever a later job was told, so
+  // a job starting late genuinely has little time, and saying otherwise is how a
+  // handler gets killed mid-write believing it had room.
+  const deadline = new Date(startedAt + maxDurationMs);
   const result: RunJobsResult = {
     claimed: 0,
     done: 0,
@@ -177,7 +183,7 @@ export async function runJobs(deps: RunJobsDeps): Promise<RunJobsResult> {
     if (job === null) continue;
     result.claimed += 1;
 
-    const outcome = await runOne(deps, job, runnerId, now);
+    const outcome = await runOne(deps, job, runnerId, now, deadline);
     if (outcome === LEASE_LOST) {
       result.unrecorded += 1;
       continue;
@@ -219,7 +225,9 @@ async function runOne(
   deps: RunJobsDeps,
   job: JobRow,
   runnerId: string,
-  now: () => Date
+  now: () => Date,
+  /** The pass's wall-clock deadline, handed to the handler on its context. */
+  deadline: Date
 ): Promise<FinalizeInput | typeof LEASE_LOST> {
   const terminal = (lastError: string): FinalizeInput => {
     return {
@@ -321,6 +329,7 @@ async function runOne(
         user: identity.user,
         now: now(),
         content: createJobContentApi(identity.user, deps.contentApi),
+        deadline,
       })
     );
   } catch (error) {


### PR DESCRIPTION
Two things, both in `domains/jobs`. Follows #1355.

## 1. A stranded fix from #1355

**#1355 merged without its last commit.** It merged at `08:31:11Z`; `908d3847` was pushed after the merge was computed, so it is not on `main`. Verified by content rather than by the PR's state, which reads merged and complete either way:

```
main has authorizeTrigger (commit 1)  -> yes
main has queueSweeps      (commit 2)  -> yes
main has SWEEP_KEY_PREFIX (commit 3)  -> NO
```

That commit is cherry-picked here unchanged. What it fixes: `MAX_JOB_SLUG_LENGTH` and `MAX_PORTABLE_KEY_LENGTH` are both 191, and a sweep's dedupe key is its slug behind a `sweep:` prefix — so a slug of 186–191 characters was accepted by `defineJob` and its derived key refused by `enqueue`. Because queueing a sweep is deliberately allowed to fail without failing the pass, **the only symptom was a registered job type that never ran.** Now refused where it is written, with a message naming the real budget.

## 2. A job is told how long its tick is

`run-jobs.ts` names two things that bound a *running* handler — the lease, and *"the handler itself being written to fit a tick"* — and then tells the handler nothing about how long a tick is. So every handler that wants to comply must be handed a budget out of band. #1360 is doing exactly that right now with its own `budgetMs` parameter, which is a second description of a number the runner already holds.

`JobContext` now carries `deadline`.

**One deadline for the whole pass, not a fresh budget per job.** The invocation dies at one instant whatever a later job was told, so a job starting late genuinely has less room; handing it a full budget would be a promise the runner cannot keep, and is how a handler gets killed mid-write believing it had space.

**The runner still cannot enforce it, and the docblock says so.** Nothing can interrupt a promise mid-flight, and a cancellation the handler did not cooperate with would abandon whatever it had half-done outside the database. This makes the handler's half of the contract *possible*, not automatic.

The docblock also carries the warning the releases lane paid for: **stopping early must DEFER the remainder, never discharge it.** Work never attempted produces no failure outcome, and an absent failure reads as success — which in their case would have marked a release published with members silently lost.

## Verification

| gate | result |
| --- | --- |
| `check-types` | pass |
| `lint` | pass (0 warnings) |
| unit suite | **803 files / 9893 passed**, 42 skipped |
| integration (jobs, releases) | 60 passed |
| `fallow --base origin/main` | `verdict: pass`, `changed_files_count: 5`, every `*_introduced` **0** |

Break-verified, whole file each time. Three mutations, each killing the tests named for it: not passing the deadline (all four fail), ignoring the configured budget (the two that assert it derives from the input), and giving each job a fresh budget (the same-instant case).

**One caveat.** On one full-suite run `export-contract.test.ts` failed at exactly 10003ms — a timeout, not an assertion. It passes alone (91 tests, 6.85s) and the suite is green at a stable 803 files. This machine is running a dozen lanes and this is the third load-induced flake observed today across two sessions; a first-attempt red here is not evidence until it reproduces. The figure worth reading is the **file count**, since a run that collected fewer files would pass while proving less.

Also worth stating: `CI` and `Integration` have been queued and never started on several recent `main` commits, so main's health is currently unestablished and local gates are the only real evidence.
