### PR TITLE
fix(builder): preview a state on every rendering, including late ones

### DIFF
--- a/.changeset/forced-state-reaches-every-rendering.md
+++ b/.changeset/forced-state-reaches-every-rendering.md
@@ -1,0 +1,44 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Preview an interaction state on every rendering of the selected block.
+
+A block inside `core/collection-loop` is drawn once per entry, so one selected
+node is many elements. The forced state reached only the first of them, which
+outlined every row while showing the hover appearance on one.
+
+A block whose render returns a promise now keeps its selection outline and its
+previewed state. React commits the Suspense fallback first and the resolved
+element later, and that second commit changes nothing the canvas was watching —
+so selecting an image or a collection loop left it unmarked until an unrelated
+edit happened to redraw it.
+
+A page rendered with the preview turned off no longer inherits a stored site
+sheet that had it on. The route's answer now wins in both directions, so a
+page's own rules and the shared class rules cannot disagree about what `:hover`
+selects.

--- a/packages/blocks-react/src/page-renderer.tsx
+++ b/packages/blocks-react/src/page-renderer.tsx
@@ -804,7 +804,14 @@ export function PageRenderer({
           // class and a block-type default are emitted here, so an editor that
           // asked only the page compile for forceable states gets a selected
           // block whose hover appearance comes from a class showing nothing.
-          ...(shared.previewStates === true ? { previewStates: true } : {}),
+          // ALWAYS written, rather than only when it is true. `siteInput` is
+          // spread above and can carry a preview flag of its own, so a
+          // conditional override is silently one-directional: a route turning
+          // the option OFF resolves correctly here and then loses to the value
+          // already in the spread, leaving the page sheet on published
+          // selectors while the class and block-default tiers use preview ones.
+          // Route-wins precedence has to be able to win downwards too.
+          previewStates: shared.previewStates === true,
           ...(shared.previewContainer == null
             ? {}
             : { previewContainer: shared.previewContainer }),

--- a/packages/blocks-react/src/site-sheet.test.tsx
+++ b/packages/blocks-react/src/site-sheet.test.tsx
@@ -293,3 +293,76 @@ describe("a node's named-class references", () => {
     expect(out).toContain(".nx-c-accent");
   });
 });
+
+describe("which preview answer the site sheet is compiled with", () => {
+  /**
+   * A named class carrying a hover style, which is the tier that separates the
+   * two sheets: it is emitted HERE and not with the page, so it is the only
+   * place the two compiles can disagree about what a state selector looks like.
+   */
+  const HOVER_CLASS = [
+    {
+      id: "c1",
+      slug: "card",
+      orderIndex: 0,
+      styles: { hover: { base: { color: "#000002" } } },
+    },
+  ];
+
+  function sheetFor(
+    route: boolean | undefined,
+    stored: boolean | undefined
+  ): string {
+    return renderToStaticMarkup(
+      <PageRenderer
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [
+              {
+                id: "n1",
+                type: "core/box",
+                version: 1,
+                props: {},
+                classes: ["c1"],
+              },
+            ],
+          } as unknown as BlockDocument
+        }
+        blocks={createBlockResolver([box])}
+        styleContext={{
+          breakpoints: BREAKPOINTS,
+          ...(route === undefined ? {} : { previewStates: route }),
+        }}
+        siteStyles={
+          {
+            breakpoints: BREAKPOINTS,
+            classes: HOVER_CLASS,
+            ...(stored === undefined ? {} : { previewStates: stored }),
+          } as never
+        }
+      />
+    );
+  }
+
+  const MARKER = "nx-pb-state-hover";
+
+  it("emits the forceable form when the route asks for it", () => {
+    // The control. Without it the refusal below could be a class that never
+    // reached the sheet at all, and every assertion here would agree.
+    expect(sheetFor(true, undefined)).toContain(MARKER);
+  });
+
+  it("obeys a route that turns the preview OFF over a stored sheet that had it ON", () => {
+    /*
+     * The route is reconciled as the winner, and a stored artifact saying
+     * otherwise must lose in BOTH directions. Overriding only when the resolved
+     * answer is `true` leaves the stored `true` standing in the spread the site
+     * sheet is built from — so the page's own rules compile to published
+     * selectors while the class tier compiles to preview ones, and one document
+     * carries two answers to what `:hover` means.
+     */
+    expect(sheetFor(false, true)).not.toContain(MARKER);
+  });
+});

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -2238,3 +2238,131 @@ describe("forcing the interaction state the panel is editing", () => {
     }
   });
 });
+
+describe("forcing a state onto a tree React commits over time", () => {
+  beforeAll(() => {
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/leaf",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+        {
+          /*
+           * A block that draws ITS OWN CHILD TWICE, which is what makes one
+           * node id many elements. `core/collection-loop` renders its children
+           * slot once per entry, so this is the shape of a shipping block
+           * rather than an invented one — and it is built here rather than
+           * inserted after the fact so that this case separates "reaches every
+           * copy" from "re-reads when the tree changes". A test that injected
+           * the second copy late would pass on either fix alone.
+           */
+          name: "acme/twice",
+          version: 1,
+          description: "A block that repeats its child.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement(
+              "div",
+              { className },
+              createElement("div", {
+                key: "one",
+                [NODE_ID_ATTRIBUTE]: "child",
+              }),
+              createElement("div", {
+                key: "two",
+                [NODE_ID_ATTRIBUTE]: "child",
+              })
+            ),
+        },
+      ] as never,
+      { source: "canvas-late-state-test" }
+    );
+  });
+  afterAll(clearBlocks);
+
+  const copiesOf = (id: string) =>
+    Array.from(document.querySelectorAll(`[${NODE_ID_ATTRIBUTE}="${id}"]`));
+
+  it("marks EVERY rendering of the selected node, not the first one found", async () => {
+    /*
+     * A node id is unique in a document and not in the tree drawn from it. The
+     * selection walk already marks every copy primary, so a forced state that
+     * stopped at the first would outline ten rows and preview the hover
+     * appearance on one — which reads as the state being broken.
+     *
+     * Asserted over the whole set rather than on copy two alone, so the case
+     * still separates if the order the copies are found in changes.
+     */
+    render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "loop", type: "acme/twice", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId="child"
+        forcedState="hover"
+      />
+    );
+    await act(async () => undefined);
+
+    const copies = copiesOf("child");
+    expect(copies).toHaveLength(2);
+    for (const copy of copies) {
+      expect(copy.getAttribute(SELECTED_ATTRIBUTE)).toBe("primary");
+      expect(copy.className).toContain(previewStateClass("hover"));
+    }
+  });
+
+  it("marks a node that arrives AFTER the commit the effect ran on", async () => {
+    /*
+     * The Suspense case, driven at the DOM rather than through a real promise:
+     * what the effect can observe is an element carrying the node id being
+     * inserted, and a resolving block is one way that happens. Nothing in the
+     * dependency list moves — same document, same selection, same forced state
+     * — so an effect that ran once and stopped leaves this element unmarked
+     * until an unrelated change happens to run it again.
+     *
+     * The block selected here is the one that does NOT exist at first render,
+     * which is what makes the assertion about arrival rather than about
+     * marking in general.
+     */
+    render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId="late"
+        forcedState="hover"
+      />
+    );
+    await act(async () => undefined);
+    expect(copiesOf("late")).toHaveLength(0);
+
+    const host = document.querySelector(`.${PAGE_ROOT_CLASS}`);
+    expect(host).not.toBeNull();
+    await act(async () => {
+      const arrived = document.createElement("div");
+      arrived.setAttribute(NODE_ID_ATTRIBUTE, "late");
+      host?.appendChild(arrived);
+    });
+
+    const [late] = copiesOf("late");
+    expect(late?.getAttribute(SELECTED_ATTRIBUTE)).toBe("primary");
+    expect(late?.className).toContain(previewStateClass("hover"));
+  });
+});

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -2365,4 +2365,52 @@ describe("forcing a state onto a tree React commits over time", () => {
     expect(late?.getAttribute(SELECTED_ATTRIBUTE)).toBe("primary");
     expect(late?.className).toContain(previewStateClass("hover"));
   });
+
+  it("clears an element that LOSES the node id it was marked for", async () => {
+    /*
+     * A render can move a node id between two elements that both already exist,
+     * changing no child list — which is the attribute-only case this effect
+     * subscribes to, and the one where the element left behind is reachable by
+     * neither the node-id selector nor the page root.
+     *
+     * Asserted on the OLD element rather than on the new one: marking the
+     * arrival is what the case above already covers, and a walk that marks the
+     * arrival while leaving the departure dressed draws two outlines and forces
+     * hover on a block nothing is editing.
+     */
+    render(
+      <Canvas
+        document={
+          {
+            formatVersion: 1,
+            kind: "page",
+            nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+          } as never
+        }
+        siteStyles={{ css: "", classes: {} } as never}
+        selectedId="movable"
+        forcedState="hover"
+      />
+    );
+
+    const host = document.querySelector(`.${PAGE_ROOT_CLASS}`);
+    const first = document.createElement("div");
+    const second = document.createElement("div");
+    first.setAttribute(NODE_ID_ATTRIBUTE, "movable");
+    await act(async () => {
+      host?.appendChild(first);
+      host?.appendChild(second);
+    });
+    expect(first.getAttribute(SELECTED_ATTRIBUTE)).toBe("primary");
+    expect(first.className).toContain(previewStateClass("hover"));
+
+    await act(async () => {
+      first.removeAttribute(NODE_ID_ATTRIBUTE);
+      second.setAttribute(NODE_ID_ATTRIBUTE, "movable");
+    });
+
+    expect(second.getAttribute(SELECTED_ATTRIBUTE)).toBe("primary");
+    expect(first.getAttribute(SELECTED_ATTRIBUTE)).toBeNull();
+    expect(first.className).not.toContain(previewStateClass("hover"));
+  });
 });

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -52,6 +52,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { CanvasDragHandlers } from "./canvas-drag";
 import { offeredTiers } from "./canvas-width";
 import { FIT_ZOOM, usableScale, type CanvasZoom } from "./canvas-zoom";
+import { observeRenderedTree } from "./rendered-tree";
 import { selectionModeFor, type SelectionMode } from "./selection";
 import { CANVAS_ROOT_CLASS } from "./shell-state";
 
@@ -672,114 +673,153 @@ function useSelectionMarkers(
   useEffect(() => {
     const container = box.current;
     if (container === null) return;
-    // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
-    // that declares its iterator, and this package compiles without one — so the
-    // loop that reads more naturally does not type-check here.
-    container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
-      const id = element.getAttribute(NODE_ID_ATTRIBUTE);
-      if (id === null || !marked.includes(id)) {
-        element.removeAttribute(SELECTED_ATTRIBUTE);
-        return;
-      }
-      // The VALUE carries which member the panels answer for. A boolean
-      // attribute could not, and a second attribute for the primary would be a
-      // state where a block is primary without being selected.
-      element.setAttribute(
-        SELECTED_ATTRIBUTE,
-        id === selectedId ? "primary" : ""
-      );
-    });
-
     /*
-     * The forced interaction state, in the SAME walk rather than a second one.
-     * Both answer "what is marked on this element right now", and two walks
-     * over one question drift — one runs on a change the other does not.
+     * NAMED and re-run rather than written straight into the effect, because
+     * the dependency list is not the only thing that changes the answer.
      *
-     * On the PRIMARY alone. A page cannot force a pseudo-class on itself, so
-     * the compiler emits a class alternative beside each one and this puts it
-     * on the element the panel is editing. Forcing it page-wide would show
-     * every other block in a state nobody asked about.
-     *
-     * Cleared from everything first, including the primary: a state that
-     * changes from hover to focus, or a selection that moves, must not leave
-     * the previous class behind on an element nothing is editing.
+     * A block whose `render` returns a promise commits its Suspense fallback
+     * first and its resolved root later. That second commit inserts the element
+     * carrying the node id while changing no prop, no state and no id in this
+     * list — so an effect that ran once would have marked a tree the resolved
+     * block was not in yet, and would leave it unmarked until an unrelated
+     * selection or document change happened to run this again. Selecting a
+     * `core/collection-loop` showed exactly that: no outline and no forced
+     * state, on an ordinary shipping block.
      */
-    /*
-     * WHICH ELEMENTS a forced state belongs on, ASKED of the engine rather
-     * than decided here.
-     *
-     * Whether a state propagates follows from the pseudo-class the compiler
-     * emits for it — an ancestor matches `:hover` and `:active` and does not
-     * match `:focus-visible` — so the two facts live together beside that
-     * definition. Encoding the rule here as well would be a second opinion
-     * about the CSS: changing `focus` to `:focus-within` would move the
-     * published rules and leave this canvas marking the wrong chain, with both
-     * sides type-correct.
-     *
-     * Where a state does propagate the chain is required rather than tidy: the
-     * page tier compiles onto the RENDERED page root, and a marker on a
-     * descendant cannot make its ancestor match.
-     */
-    const chain = new Set<Element>();
-    if (forcedState !== undefined && forcedState !== "base") {
-      const primary = container.querySelector(
-        `[${SELECTED_ATTRIBUTE}="primary"]`
-      );
-      if (primary !== null) {
-        chain.add(primary);
-        if (statePropagatesToAncestors(forcedState)) {
-          for (
-            let node: Element | null = primary.parentElement;
-            node !== null && container.contains(node);
-            node = node.parentElement
-          ) {
-            chain.add(node);
-          }
+    const mark = (): void => {
+      // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
+      // that declares its iterator, and this package compiles without one — so the
+      // loop that reads more naturally does not type-check here.
+      container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+        const id = element.getAttribute(NODE_ID_ATTRIBUTE);
+        if (id === null || !marked.includes(id)) {
+          element.removeAttribute(SELECTED_ATTRIBUTE);
+          return;
         }
-      }
-    }
-
-    /*
-     * Every element a marker can land on OR has to be cleared from. The
-     * rendered PAGE ROOT is in the list explicitly: `PageRenderer` draws
-     * `.nx-pb-page` as a child of this container, and the page tier compiles
-     * onto that element rather than onto the canvas wrapper — so marking the
-     * wrapper leaves page-level state rules unmatched while looking correct.
-     */
-    const marks: Element[] = [container];
-    container
-      .querySelectorAll(`.${PAGE_ROOT_CLASS}, [${NODE_ID_ATTRIBUTE}]`)
-      .forEach(element => marks.push(element));
-
-    marks.forEach(element => {
-      // `base` is not a state anything forces: it is what applies when nothing
-      // else does, and the compiler emits no marker for it.
-      const wanted =
-        chain.has(element) && forcedState !== undefined
-          ? previewStateClass(forcedState)
-          : undefined;
+        // The VALUE carries which member the panels answer for. A boolean
+        // attribute could not, and a second attribute for the primary would be a
+        // state where a block is primary without being selected.
+        //
+        // Compared before writing, for the reason the class below is: this walk
+        // re-runs on every change to the rendered tree, and `setAttribute`
+        // queues a mutation record even when the value it writes is the value
+        // already there. Unguarded, marking a tree that did not change is
+        // itself a change — the spacing overlay observes this subtree and
+        // re-measures on one, so its own output would arrive back here as a
+        // reason to write again.
+        const value = id === selectedId ? "primary" : "";
+        if (element.getAttribute(SELECTED_ATTRIBUTE) !== value) {
+          element.setAttribute(SELECTED_ATTRIBUTE, value);
+        }
+      });
 
       /*
-       * WRITTEN ONLY WHEN IT CHANGES, which is not a micro-optimisation.
+       * The forced interaction state, in the SAME walk rather than a second one.
+       * Both answer "what is marked on this element right now", and two walks
+       * over one question drift — one runs on a change the other does not.
        *
-       * `classList.remove` of a token that is not present still touches the
-       * attribute, and this canvas is observed: the empty-container appender
-       * watches its subtree for layout-relevant mutations and re-measures on
-       * one. An unconditional clear across every marked element therefore made
-       * every selection change schedule a re-measure of the whole overlay,
-       * which its own test caught — it asserts the control does NOT move for a
-       * mutation of its own output, and it moved.
+       * On the PRIMARY alone. A page cannot force a pseudo-class on itself, so
+       * the compiler emits a class alternative beside each one and this puts it
+       * on the element the panel is editing. Forcing it page-wide would show
+       * every other block in a state nobody asked about.
+       *
+       * Cleared from everything first, including the primary: a state that
+       * changes from hover to focus, or a selection that moves, must not leave
+       * the previous class behind on an element nothing is editing.
        */
-      for (const state of STYLE_STATES) {
-        const marker = previewStateClass(state);
-        if (marker !== wanted && element.classList.contains(marker)) {
-          element.classList.remove(marker);
+      /*
+       * WHICH ELEMENTS a forced state belongs on, ASKED of the engine rather
+       * than decided here.
+       *
+       * Whether a state propagates follows from the pseudo-class the compiler
+       * emits for it — an ancestor matches `:hover` and `:active` and does not
+       * match `:focus-visible` — so the two facts live together beside that
+       * definition. Encoding the rule here as well would be a second opinion
+       * about the CSS: changing `focus` to `:focus-within` would move the
+       * published rules and leave this canvas marking the wrong chain, with both
+       * sides type-correct.
+       *
+       * Where a state does propagate the chain is required rather than tidy: the
+       * page tier compiles onto the RENDERED page root, and a marker on a
+       * descendant cannot make its ancestor match.
+       */
+      const chain = new Set<Element>();
+      if (forcedState !== undefined && forcedState !== "base") {
+        /*
+         * EVERY rendering of the primary node, not the first one found.
+         *
+         * A node id is unique in a DOCUMENT and not in the tree drawn from it:
+         * `core/collection-loop` draws its children once per entry, so one
+         * selected node is many elements, and the walk above has already marked
+         * all of them primary. Taking `querySelector` here would preview the
+         * state on whichever copy came first in DOM order — the outline on ten
+         * rows and the hover appearance on one, which reads as the state being
+         * broken rather than as the preview being partial.
+         */
+        container
+          .querySelectorAll(`[${SELECTED_ATTRIBUTE}="primary"]`)
+          .forEach(primary => {
+            chain.add(primary);
+            if (!statePropagatesToAncestors(forcedState)) return;
+            for (
+              let node: Element | null = primary.parentElement;
+              node !== null && container.contains(node);
+              node = node.parentElement
+            ) {
+              chain.add(node);
+            }
+          });
+      }
+
+      /*
+       * Every element a marker can land on OR has to be cleared from. The
+       * rendered PAGE ROOT is in the list explicitly: `PageRenderer` draws
+       * `.nx-pb-page` as a child of this container, and the page tier compiles
+       * onto that element rather than onto the canvas wrapper — so marking the
+       * wrapper leaves page-level state rules unmatched while looking correct.
+       */
+      const marks: Element[] = [container];
+      container
+        .querySelectorAll(`.${PAGE_ROOT_CLASS}, [${NODE_ID_ATTRIBUTE}]`)
+        .forEach(element => marks.push(element));
+
+      marks.forEach(element => {
+        // `base` is not a state anything forces: it is what applies when nothing
+        // else does, and the compiler emits no marker for it.
+        const wanted =
+          chain.has(element) && forcedState !== undefined
+            ? previewStateClass(forcedState)
+            : undefined;
+
+        /*
+         * WRITTEN ONLY WHEN IT CHANGES, which is not a micro-optimisation.
+         *
+         * `classList.remove` of a token that is not present still touches the
+         * attribute, and this canvas is observed: the empty-container appender
+         * watches its subtree for layout-relevant mutations and re-measures on
+         * one. An unconditional clear across every marked element therefore made
+         * every selection change schedule a re-measure of the whole overlay,
+         * which its own test caught — it asserts the control does NOT move for a
+         * mutation of its own output, and it moved.
+         */
+        for (const state of STYLE_STATES) {
+          const marker = previewStateClass(state);
+          if (marker !== wanted && element.classList.contains(marker)) {
+            element.classList.remove(marker);
+          }
         }
-      }
-      if (wanted !== undefined && !element.classList.contains(wanted)) {
-        element.classList.add(wanted);
-      }
-    });
+        if (wanted !== undefined && !element.classList.contains(wanted)) {
+          element.classList.add(wanted);
+        }
+      });
+    };
+
+    mark();
+    // Subscribed AFTER the first pass, because an observer reports what changes
+    // from the moment it attaches and says nothing about the tree already
+    // there. Writing the markers cannot re-enter this: what counts as the tree
+    // changing excludes every attribute `mark` writes.
+    return observeRenderedTree(container, mark);
   }, [box, selectedId, marked, page, forcedState]);
 }
 

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -687,13 +687,45 @@ function useSelectionMarkers(
      * state, on an ordinary shipping block.
      */
     const mark = (): void => {
+      /*
+       * Every element a marker can land on OR currently carries one, which are
+       * not the same set. A render can move a node id from one existing element
+       * to another without touching the child list — the attribute case this
+       * effect subscribes to — and the element that LOST the id then matches
+       * nothing selected by node id. Left out, it keeps the selection attribute
+       * and the state class it was last given: a second outline around a block
+       * nothing is editing, and a hover appearance forced on it.
+       *
+       * The rendered PAGE ROOT is named explicitly rather than reached by one
+       * of the marker selectors: `PageRenderer` draws `.nx-pb-page` as a child
+       * of this container and the page tier compiles onto that element rather
+       * than onto the canvas wrapper, so it must be markable before it has ever
+       * been marked.
+       */
+      const touched = new Set<Element>([container]);
       // `forEach` rather than `for…of`: a `NodeList` is only iterable under a lib
       // that declares its iterator, and this package compiles without one — so the
       // loop that reads more naturally does not type-check here.
-      container.querySelectorAll(`[${NODE_ID_ATTRIBUTE}]`).forEach(element => {
+      container
+        .querySelectorAll(
+          [
+            `.${PAGE_ROOT_CLASS}`,
+            `[${NODE_ID_ATTRIBUTE}]`,
+            `[${SELECTED_ATTRIBUTE}]`,
+            ...STYLE_STATES.map(state => `.${previewStateClass(state)}`),
+          ].join(", ")
+        )
+        .forEach(element => touched.add(element));
+
+      touched.forEach(element => {
         const id = element.getAttribute(NODE_ID_ATTRIBUTE);
         if (id === null || !marked.includes(id)) {
-          element.removeAttribute(SELECTED_ATTRIBUTE);
+          // Guarded like the writes below: this walk now visits the page root
+          // and the container, which never carry the attribute, and removing an
+          // absent one still touches the element.
+          if (element.hasAttribute(SELECTED_ATTRIBUTE)) {
+            element.removeAttribute(SELECTED_ATTRIBUTE);
+          }
           return;
         }
         // The VALUE carries which member the panels answer for. A boolean
@@ -771,17 +803,9 @@ function useSelectionMarkers(
           });
       }
 
-      /*
-       * Every element a marker can land on OR has to be cleared from. The
-       * rendered PAGE ROOT is in the list explicitly: `PageRenderer` draws
-       * `.nx-pb-page` as a child of this container, and the page tier compiles
-       * onto that element rather than onto the canvas wrapper — so marking the
-       * wrapper leaves page-level state rules unmatched while looking correct.
-       */
-      const marks: Element[] = [container];
-      container
-        .querySelectorAll(`.${PAGE_ROOT_CLASS}, [${NODE_ID_ATTRIBUTE}]`)
-        .forEach(element => marks.push(element));
+      // The SAME set the selection was written from, so the two markers cannot
+      // disagree about which elements exist.
+      const marks: Element[] = Array.from(touched);
 
       marks.forEach(element => {
         // `base` is not a state anything forces: it is what applies when nothing

--- a/packages/builder/src/layering.test.ts
+++ b/packages/builder/src/layering.test.ts
@@ -135,9 +135,27 @@ function sourceFiles(dir: string): string[] {
   );
 }
 
-/** Every module specifier a file imports. */
+/**
+ * Every module specifier a file imports.
+ *
+ * MEMOISED, because the answer cannot change during a run and every contract
+ * below sweeps the whole package: without this each one re-reads and re-parses
+ * all of them, so the cost is the file count times the number of contracts
+ * rather than the file count. That is disk-bound work on a shared runner, and
+ * it put a single contract 200ms past the default 5s timeout while the same
+ * test took under half a second locally — a red that says nothing about the
+ * import graph it exists to check.
+ *
+ * Keyed by absolute path, which is what `sourceFiles` yields.
+ */
+const importCache = new Map<string, string[]>();
+
 function importsOf(file: string): string[] {
-  return importedSpecifiers(readFileSync(file, "utf8"), file);
+  const cached = importCache.get(file);
+  if (cached !== undefined) return cached;
+  const specifiers = importedSpecifiers(readFileSync(file, "utf8"), file);
+  importCache.set(file, specifiers);
+  return specifiers;
 }
 
 /**

--- a/packages/builder/src/rendered-tree.ts
+++ b/packages/builder/src/rendered-tree.ts
@@ -1,0 +1,68 @@
+/**
+ * When the rendered tree has changed, in one definition.
+ *
+ * The canvas draws a document React commits over time rather than all at once,
+ * and two separate readers need to know when that drawing moved: the inspector,
+ * which reads the element a node was drawn as, and the canvas itself, which
+ * marks the selection and the interaction state onto those elements. Both ask
+ * the same question, so both subscribe through here.
+ *
+ * A dependency list cannot answer it. A block whose `render` returns a promise
+ * commits its Suspense fallback first and its resolved root later, and that
+ * second commit changes no prop, no state and no id — `core/collection-loop`
+ * awaits `data.find`, so this is an ordinary shipping block rather than an edge
+ * case. A reader keyed on props alone sees the fallback, finds none of the
+ * elements it was looking for, and never looks again.
+ *
+ * A plain function rather than a hook, because the two callers schedule
+ * differently — one owns React state, the other writes to the DOM — and only
+ * the subscription is common. Making it a hook would force one scheduling shape
+ * onto both and put a spread dependency list in each.
+ *
+ * @module rendered-tree
+ */
+import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
+
+/**
+ * What counts as the rendered tree changing.
+ *
+ * Structure, because that is how a resolved block arrives. The node id
+ * ATTRIBUTE as well, because a node's id moving between elements changes which
+ * element every reader here is talking about while adding and removing none.
+ *
+ * No other attribute, and that is load-bearing rather than economical. Both
+ * callers WRITE to elements inside the tree they observe — the marker walk sets
+ * the selection attribute and the state class — so an observer that watched
+ * attributes broadly would be triggered by its own output and re-enter for as
+ * long as the canvas is mounted. The node id is written by the renderer and by
+ * nothing that reads it here, which is what makes it safe to watch.
+ */
+const RENDERED_TREE_MUTATIONS: MutationObserverInit = {
+  childList: true,
+  subtree: true,
+  attributeFilter: [NODE_ID_ATTRIBUTE],
+};
+
+/**
+ * Call `read` whenever the rendered tree under `root` changes.
+ *
+ * Returns the unsubscribe. Callers are expected to `read()` once themselves
+ * first: an observer reports changes from the moment it is attached and says
+ * nothing about the tree that is already there.
+ *
+ * `MutationObserver` is absent in some non-browser DOMs, and both callers are
+ * useful without it — each still reads on the changes that ARE dependencies.
+ * Guarded rather than assumed, because throwing here would take the editor down
+ * on a surface that otherwise renders perfectly well.
+ */
+export function observeRenderedTree(
+  root: Element,
+  read: () => void
+): () => void {
+  if (typeof MutationObserver !== "function") return () => undefined;
+  const observer = new MutationObserver(read);
+  observer.observe(root, RENDERED_TREE_MUTATIONS);
+  return () => {
+    observer.disconnect();
+  };
+}

--- a/packages/builder/src/use-rendered-tag.ts
+++ b/packages/builder/src/use-rendered-tag.ts
@@ -11,10 +11,10 @@
  *
  * @module use-rendered-tag
  */
-import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import * as React from "react";
 
 import type { EditorState } from "./editor-state";
+import { observeRenderedTree } from "./rendered-tree";
 import { renderedTagOf } from "./style-subject";
 
 /**
@@ -33,10 +33,10 @@ import { renderedTagOf } from "./style-subject";
  * the effect runs, and an async block resolving to a heading would report its
  * size as unset forever.
  *
- * A `MutationObserver` answers all three, so the dependency list is a
- * scheduling detail rather than a claim about correctness. It watches the
- * subtree for structure and for the node-id attribute itself, since a node's id
- * moving between elements changes the answer without adding or removing any.
+ * Observing the rendered tree answers all three, so the dependency list is a
+ * scheduling detail rather than a claim about correctness. WHAT counts as the
+ * tree changing lives in `rendered-tree`, shared with the canvas's own marker
+ * walk: both ask one question, and two answers to it drift.
  *
  * Read AFTER a commit rather than during a render: the canvas and the inspector
  * re-render together, so while a render body runs the DOM still holds the
@@ -58,20 +58,7 @@ export function useRenderedTag(
     read();
 
     if (canvasRoot == null) return;
-    // `MutationObserver` is absent in some non-browser DOMs, and this hook is
-    // useful without it — the read above still answers for everything that IS a
-    // dependency. Guarded rather than assumed, because throwing here would take
-    // the inspector down on a surface that renders perfectly well otherwise.
-    if (typeof MutationObserver !== "function") return;
-    const observer = new MutationObserver(read);
-    observer.observe(canvasRoot, {
-      childList: true,
-      subtree: true,
-      attributeFilter: [NODE_ID_ATTRIBUTE],
-    });
-    return () => {
-      observer.disconnect();
-    };
+    return observeRenderedTree(canvasRoot, read);
   }, [canvasRoot, selectedId, document]);
   return tag;
 }

--- a/packages/builder/vitest.config.ts
+++ b/packages/builder/vitest.config.ts
@@ -17,6 +17,17 @@ import { TEST_GLOBS } from "./src/source-modules";
  * that omitted an extension the guard accepted would let a file import `vitest`
  * and never be run. Both now come from one list in `src/source-modules.ts`.
  *
+ * `testTimeout` is raised for the same reason the environment is lowered. The
+ * default budget is aimed at a unit test, and the layering contracts are not
+ * one: each reads every module in the package off disk and parses it, which is
+ * IO-bound work whose duration is decided by how loaded the machine is rather
+ * than by anything in the import graph. Measured, one contract ran in under
+ * half a second here and timed out 200ms past five seconds on a contended
+ * runner — a red that reports nothing about the property it checks, on a
+ * suite where the cost is bounded by the file count and cannot run away.
+ * `blocks-engine`, whose suite is static analysis for the same reason, already
+ * carries this budget.
+ *
  * `globalSetup` is what keeps that derivation honest. Narrowing the one list
  * narrows these globs too, and a suite that stops being collected reports the
  * same green as a suite that passed — so the check that the runner still
@@ -28,6 +39,7 @@ import { TEST_GLOBS } from "./src/source-modules";
 export default defineConfig({
   test: {
     environment: "node",
+    testTimeout: 30_000,
     include: TEST_GLOBS,
     globalSetup: ["./vitest.global-setup.ts"],
     // Runs fresh inside EACH test file's own resolved environment, which is


### PR DESCRIPTION
Closes four post-merge review findings on #1346.

## What was wrong

**A node id is unique in a document, not in the tree drawn from it.**
`core/collection-loop` renders its children slot once per entry, so one
selected node is many elements. The selection walk already marked every copy
primary; the forced state stopped at the first. The result was an outline on
ten rows and the hover appearance on one, which reads as the state being
broken rather than as the preview being partial.

**React commits a tree over time.** A block whose `render` returns a promise
commits its Suspense fallback first and its resolved root later. That second
commit changes no prop, no state and no id — so the marker effect had already
run against a tree the resolved block was not in yet, and left it unmarked
until an unrelated edit happened to run it again. `core/collection-loop`
awaits `data.find`, so this is an ordinary shipping block.

`useRenderedTag` already had to answer this question for the inspector, and
its docblock already named this exact failure mode. That answer now lives in
one module and both readers subscribe through it.

**Marking had to become idempotent**, which it did not previously need to be.
`setAttribute` queues a mutation record even when it writes the value already
there, and the spacing overlay observes this subtree and re-measures on one —
so a walk that now re-runs on every tree change fed its own output back to it.
The selection attribute is compared before it is written, the same discipline
the state class beside it already used. `spacing-overlay.test.tsx` caught this.

**The site sheet kept a stored preview flag the route had turned off.**
Overriding only when the resolved answer was `true` is one-directional: with
`siteStyles.previewStates: true` and the route resolving `false`, the spread
left `true` standing. The page compiled to published selectors and the class
tier to preview ones — one document, two answers to what `:hover` selects.

## On the fourth finding

The review proposed scoping the primary lookup to `CANVAS_ROOT_CLASS`, on the
premise that a nested `Canvas` can repeat a node id. The premise does not hold
here — the only `<Canvas` sites are `BlocksField` and two playground harnesses,
so the product never nests one — and that fix would not have helped anyway,
because every duplicate copy lives in the *same* canvas. The duplication is
real, but it arrives through loop repetition. That is what is fixed.

## Evidence

Each test was break-verified individually, and each fails only for its own
mechanism:

| Break | Fails | Survives |
|---|---|---|
| mark only the first primary | every-rendering | late-arrival |
| drop the tree subscription | late-arrival | every-rendering |
| restore the conditional override | route-wins-downward | the control |
| remove the attribute guard | overlay self-mutation | — |

The site-sheet case ships with a control asserting the marker *does* appear
when asked; without it the refusal would have passed against a class that
never reached the sheet at all, which is how it was first written.

Local gates, run from each package directory: builder 2534/2534,
blocks-react 970/970, blocks-engine 1650/1650, lint and check-types clean,
`fallow audit --base origin/main` passes over 6 changed files,
`changeset status` parses.

Not covered here: whether the editor visibly switches state end to end.
`/admin` does not boot in this worktree (Tailwind's PostCSS resolver fails on
`@nextlyhq/builder/styles.css` through the pnpm symlink), so that claim is
unverified rather than verified — flagged, not implied.