### PR TITLE
feat(builder): mount the classes manager so an author can reach it

### DIFF
--- a/.changeset/olive-pugs-search.md
+++ b/.changeset/olive-pugs-search.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Mount the classes manager so an author can reach it: the panel reports that usage was not read rather than reporting an empty index, withholds a delete nothing can carry out, and shows a rename the host refused instead of clearing as though it landed.

--- a/packages/builder/src/builder-notices.test.tsx
+++ b/packages/builder/src/builder-notices.test.tsx
@@ -31,6 +31,7 @@ import {
   NoticeSinkProvider,
   useNoticeQueue,
 } from "./builder-notices";
+import { ClassManagerPanel } from "./class-manager-panel";
 import { ClassSelector } from "./class-selector";
 
 afterEach(cleanup);
@@ -218,5 +219,88 @@ describe("the queue", () => {
     fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
     fireEvent.click(raise);
     expect(screen.getByText("Same news")).toBeTruthy();
+  });
+});
+
+describe("a rename refused after the panel is gone", () => {
+  /**
+   * The manager in the shell's arrangement: the region above, and the panel
+   * mounted only while its own rail item is the open one.
+   *
+   * `BuilderShell` keys its content by the open panel, so switching away
+   * unmounts the whole manager — which is a coarser unmount than the class
+   * selector's per-node key and reaches the same dead `setState`.
+   */
+  function Manager({
+    open,
+    onRename,
+  }: {
+    open: boolean;
+    onRename: () => Promise<{ ok: false; reason: string }>;
+  }): React.ReactElement {
+    const notices = useNoticeQueue();
+    return (
+      <>
+        <BuilderNoticeRegion
+          notices={notices.notices}
+          onDismiss={notices.dismiss}
+        />
+        <NoticeSinkProvider raise={notices.raise}>
+          {open ? (
+            <ClassManagerPanel
+              documentClassIds={[]}
+              library={LIBRARY}
+              onRename={onRename}
+              usage={{}}
+            />
+          ) : null}
+        </NoticeSinkProvider>
+      </>
+    );
+  }
+
+  it("is still reported, from the surface the switch did not unmount", async () => {
+    let settle: ((v: { ok: false; reason: string }) => void) | undefined;
+    const pending = new Promise<{ ok: false; reason: string }>(resolve => {
+      settle = resolve;
+    });
+    const onRename = vi.fn(() => pending);
+
+    const view = render(<Manager onRename={onRename} open />);
+    const field = screen.getByLabelText("Name of hero");
+    fireEvent.change(field, { target: { value: "promo" } });
+    fireEvent.blur(field);
+    expect(onRename).toHaveBeenCalled();
+
+    // The author switches panels while the write is still on the network.
+    view.rerender(<Manager onRename={onRename} open={false} />);
+
+    await act(async () => {
+      settle?.({ ok: false, reason: "The site style is locked." });
+      await pending;
+    });
+
+    expect(screen.getByText("The site style is locked.")).toBeTruthy();
+  });
+
+  it("stays inline while the panel is still open", async () => {
+    // One refusal, one place to read it — the row can speak for itself here.
+    const onRename = vi.fn(async () => ({
+      ok: false as const,
+      reason: "The site style is locked.",
+    }));
+    render(<Manager onRename={onRename} open />);
+    const field = screen.getByLabelText("Name of hero");
+    fireEvent.change(field, { target: { value: "promo" } });
+    fireEvent.blur(field);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("alert").textContent).toMatch(
+      /site style is locked/
+    );
+    expect(screen.getByRole("status").textContent).toBe("");
   });
 });

--- a/packages/builder/src/builder-notices.tsx
+++ b/packages/builder/src/builder-notices.tsx
@@ -84,6 +84,47 @@ export function useNoticeSink(): RaiseNotice {
   return React.useMemo(() => sink ?? (() => undefined), [sink]);
 }
 
+/**
+ * Report a failure that may outlive the control raising it.
+ *
+ * Two surfaces need this and they had a copy each: the class selector, keyed by
+ * node, and the class manager, mounted only while its panel is the open one.
+ * Both dispatch a site-style write, both can be unmounted before it answers,
+ * and both must still tell the author.
+ *
+ * WHERE is the shared question and is answered here; WHETHER the caller can
+ * still show it is not, so that stays with the caller. The selector's inline
+ * message is scoped to the node the request was made against and must be
+ * withheld when the author has moved to another one — a rule the manager has no
+ * equivalent of. So `showInline` answers whether it took responsibility, and
+ * the notice is raised only when nothing did.
+ *
+ * The two are exclusive on purpose: a region repeating what is already on
+ * screen is one an author learns to stop reading.
+ */
+export function useSurvivingReport(): (
+  reason: string,
+  showInline: () => boolean
+) => void {
+  const raiseNotice = useNoticeSink();
+  /*
+   * Whether the caller can still draw. A ref rather than state because nothing
+   * renders from it and setting it must schedule no work: it is read inside a
+   * callback that has already outlived the render it came from.
+   */
+  const mounted = React.useRef(true);
+  React.useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+  return (reason, showInline) => {
+    if (mounted.current && showInline()) return;
+    raiseNotice(reason);
+  };
+}
+
 /** Put a sink in reach of everything the shell renders. */
 export function NoticeSinkProvider({
   raise,

--- a/packages/builder/src/class-library.ts
+++ b/packages/builder/src/class-library.ts
@@ -210,6 +210,32 @@ export function filterClassRows(
 }
 
 /**
+ * The rows whose name contains what the author typed.
+ *
+ * Beside {@link filterClassRows} rather than inside it, because they answer
+ * different questions: a filter narrows by what the INDEX or the open document
+ * says, and this narrows by the name. Folding them together would make one
+ * function whose result depends on two unrelated inputs, and the chips would
+ * then have to know about the query to explain an empty list.
+ *
+ * Matched on the SLUG alone. A class has no other name — the id is storage and
+ * an author never sees it — so matching an id would return rows for a string
+ * they cannot see in the list.
+ *
+ * Case-insensitive because a slug is lowercase by construction and an author
+ * typing capitals means the same class rather than none. Substring rather than
+ * prefix: the useful search on `hero-banner-wide` is `banner`.
+ */
+export function searchClassRows(
+  rows: readonly ClassRow[],
+  query: string
+): ClassRow[] {
+  const needle = query.trim().toLowerCase();
+  if (needle === "") return [...rows];
+  return rows.filter(row => row.slug.toLowerCase().includes(needle));
+}
+
+/**
  * The class ids on a node that the compiler will actually read.
  *
  * The engine applies the first `MAX_CLASSES_PER_NODE` and warns about the rest,

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -12,7 +12,13 @@
  * @module class-manager-panel.test
  */
 import type { NamedClass } from "@nextlyhq/blocks-engine";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -436,5 +442,80 @@ describe("a rename the host refuses", () => {
     fireEvent.change(field, { target: { value: "renamed" } });
     fireEvent.blur(field);
     expect(await screen.findByText(/could not be renamed/i)).toBeTruthy();
+  });
+});
+
+describe("a host that answers a rename with nothing", () => {
+  it("treats an undefined resolution as silence, not as failure", async () => {
+    /*
+     * A merely `async` handler already satisfied the older `void` contract, so
+     * these callers exist. Reading `.ok` off a resolved `Promise<void>` throws,
+     * the throw is caught, and a rename that SUCCEEDED is then reported to the
+     * author as having failed — the worst direction for this to go wrong in.
+     */
+    const onRename = vi.fn(async () => undefined);
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    await act(async () => {
+      fireEvent.change(field, { target: { value: "renamed" } });
+      fireEvent.blur(field);
+    });
+    /*
+     * The chain has to SETTLE before absence means anything. Asserting straight
+     * after the blur passes whether or not the guard is there, because the
+     * message it is looking for could not have been rendered yet — measured:
+     * removing the guard left this test green.
+     */
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onRename).toHaveBeenCalled();
+    expect(screen.queryByText(/could not be renamed/i)).toBeNull();
+  });
+});
+
+describe("two renames on one row, answered out of order", () => {
+  it("ignores a refusal the author has already moved past", async () => {
+    // The superseded attempt's answer describes a name that is no longer being
+    // asked for, so reporting it points at an edit that no longer exists.
+    let settleFirst: ((v: { ok: false; reason: string }) => void) | undefined;
+    const first = new Promise<{ ok: false; reason: string }>(resolve => {
+      settleFirst = resolve;
+    });
+    const onRename = vi
+      .fn()
+      .mockReturnValueOnce(first)
+      .mockResolvedValueOnce({ ok: true as const });
+
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "second" } });
+    fireEvent.blur(field);
+    fireEvent.change(nameField("hero"), { target: { value: "third" } });
+    fireEvent.blur(nameField("hero"));
+    await vi.waitFor(() => expect(onRename).toHaveBeenCalledTimes(2));
+
+    await act(async () => {
+      settleFirst?.({ ok: false, reason: "The first one was refused." });
+      await first.catch(() => undefined);
+    });
+    expect(screen.queryByText("The first one was refused.")).toBeNull();
   });
 });

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -660,3 +660,102 @@ describe("a library far larger than a screen", () => {
     }
   );
 });
+
+describe("reaching a class past the row cap", () => {
+  const many = Array.from({ length: 260 }, (_, index) => ({
+    id: `id-${index}`,
+    slug: `class-${index}`,
+    orderIndex: index,
+    styles: {},
+  }));
+
+  it(
+    "finds one by NAME that no filter could have selected",
+    { timeout: 30000 },
+    () => {
+      /*
+       * The cap keeps a large library from mounting two thousand inputs, and
+       * without a name search it is a wall: the chips narrow by index state and
+       * by the open page, so a class past the cap that neither selects could
+       * never be shown or renamed. `class-259` is the last row, on no page, and
+       * in an index that was never read — nothing else can reach it.
+       */
+      draw({ library: many, usage: undefined, documentClassIds: [] });
+      expect(screen.queryByLabelText("Name of class-259")).toBeNull();
+
+      fireEvent.change(screen.getByLabelText("Search classes"), {
+        target: { value: "class-259" },
+      });
+      expect(screen.getByLabelText("Name of class-259")).toBeTruthy();
+    }
+  );
+
+  it("says search is the way through, rather than naming the filters", () => {
+    // The note used to say to filter, which the surface could not honour once
+    // `usage` was absent and only "On this page" remained.
+    draw({ library: many, usage: undefined, documentClassIds: [] });
+    expect(screen.getByText(/Search by name to reach the rest/)).toBeTruthy();
+  });
+});
+
+describe("a revert typed while the first rename is still in flight", () => {
+  it("is DISPATCHED rather than read as a no-op", async () => {
+    /*
+     * `row.slug` is the stored name and does not move until a save comes back.
+     * An author who renames `hero` to `promo` and then types `hero` again
+     * inside that window is reverting, but the rendered slug still says `hero`
+     * — so comparing against it discarded the edit and the pending first write
+     * went on to persist `promo`.
+     */
+    const onRename = vi.fn(
+      () => new Promise<{ ok: true }>(() => undefined) // never settles
+    );
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "promo" } });
+    fireEvent.blur(field);
+    expect(onRename).toHaveBeenCalledTimes(1);
+
+    /*
+     * The row still renders `hero`, because nothing has come back — so typing
+     * `hero` has to arrive as a real DOM change. React's `onChange` does not
+     * fire when the value it is given equals the one already there, and the
+     * field reverted to `hero` when the draft cleared, so a single change to
+     * `hero` sets no draft at all and this would assert nothing.
+     */
+    fireEvent.change(nameField("hero"), { target: { value: "her" } });
+    fireEvent.change(nameField("hero"), { target: { value: "hero" } });
+    fireEvent.blur(nameField("hero"));
+
+    expect(onRename).toHaveBeenCalledTimes(2);
+    expect(onRename).toHaveBeenLastCalledWith("id-hero", "hero");
+  });
+
+  it("still treats a genuine no-op as one when nothing is pending", () => {
+    // The control: without this the fix would simply dispatch every commit,
+    // which writes a revision whose rendered output is identical to the last.
+    const onRename = vi.fn();
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "hero" } });
+    fireEvent.blur(field);
+    expect(onRename).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -627,25 +627,36 @@ describe("a library far larger than a screen", () => {
     styles: {},
   }));
 
-  it("bounds what it mounts, and says how much it did not show", () => {
-    /*
-     * The `All` filter matches the whole library, so an unbounded list mounts
-     * a text input per class — two thousand of them on a site near the limit.
-     * The remainder is NAMED rather than dropped quietly: this is the surface
-     * an author uses to decide a class is unused, so a list that silently
-     * stops is one they would read as complete.
-     */
-    render(
-      <ClassManagerPanel
-        library={many}
-        usage={{}}
-        documentClassIds={[]}
-        onRename={vi.fn()}
-        onDelete={vi.fn()}
-      />
-    );
-    const fields = screen.getAllByRole("textbox");
-    expect(fields.length).toBeLessThan(many.length);
-    expect(screen.getByText(/Showing \d+ of 260/)).toBeTruthy();
-  });
+  /*
+   * An explicit timeout, in the OPTIONS form. Mounting two hundred rows and
+   * their inputs costs the better part of a second on an idle machine, and the
+   * default five seconds is reached on a loaded one — this test timed out in a
+   * parallel run having passed in isolation. The number form (`it(name, ms,
+   * fn)`) is silently ignored by vitest, so it has to be this shape.
+   */
+  it(
+    "bounds what it mounts, and says how much it did not show",
+    { timeout: 30000 },
+    () => {
+      /*
+       * The `All` filter matches the whole library, so an unbounded list mounts
+       * a text input per class — two thousand of them on a site near the limit.
+       * The remainder is NAMED rather than dropped quietly: this is the surface
+       * an author uses to decide a class is unused, so a list that silently
+       * stops is one they would read as complete.
+       */
+      render(
+        <ClassManagerPanel
+          library={many}
+          usage={{}}
+          documentClassIds={[]}
+          onRename={vi.fn()}
+          onDelete={vi.fn()}
+        />
+      );
+      const fields = screen.getAllByRole("textbox");
+      expect(fields.length).toBeLessThan(many.length);
+      expect(screen.getByText(/Showing \d+ of 260/)).toBeTruthy();
+    }
+  );
 });

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -690,11 +690,39 @@ describe("reaching a class past the row cap", () => {
     }
   );
 
-  it("says search is the way through, rather than naming the filters", () => {
-    // The note used to say to filter, which the surface could not honour once
-    // `usage` was absent and only "On this page" remained.
-    draw({ library: many, usage: undefined, documentClassIds: [] });
-    expect(screen.getByText(/Search by name to reach the rest/)).toBeTruthy();
+  it(
+    "offers a control that reaches the tail whatever the names are",
+    { timeout: 30000 },
+    () => {
+      /*
+       * Search alone is not enough and the note must not imply it is: a library
+       * of `class-0` to `class-259` matches every query an author would think to
+       * type, so the last sixty stay unreachable however the message is worded.
+       * Raising the mounted count is what cannot depend on the naming.
+       */
+      draw({ library: many, usage: undefined, documentClassIds: [] });
+      expect(screen.getByText("Showing 200 of 260.")).toBeTruthy();
+      expect(screen.queryByLabelText("Name of class-259")).toBeNull();
+
+      fireEvent.click(screen.getByRole("button", { name: "Show 60 more" }));
+      expect(screen.getByLabelText("Name of class-259")).toBeTruthy();
+      // Nothing left to reach, so nothing left to offer.
+      expect(
+        screen.queryByRole("button", { name: /Show \d+ more/ })
+      ).toBeNull();
+    }
+  );
+
+  it("blames the FILTER, not a search that is not set", () => {
+    // With the box blank, "no classes match this search" sends an author to
+    // clear something they never typed and hides the chip that emptied the list.
+    draw({
+      library: many,
+      usage: undefined,
+      documentClassIds: [],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "On this page" }));
+    expect(screen.getByText("No classes match this filter.")).toBeTruthy();
   });
 });
 
@@ -710,7 +738,7 @@ describe("a revert typed while the first rename is still in flight", () => {
     const onRename = vi.fn(
       () => new Promise<{ ok: true }>(() => undefined) // never settles
     );
-    render(
+    const view = render(
       <ClassManagerPanel
         library={LIBRARY}
         usage={{}}
@@ -719,11 +747,26 @@ describe("a revert typed while the first rename is still in flight", () => {
         onDelete={vi.fn()}
       />
     );
-
     const field = nameField("hero");
     fireEvent.change(field, { target: { value: "promo" } });
     fireEvent.blur(field);
     expect(onRename).toHaveBeenCalledTimes(1);
+
+    /*
+     * The host now says this class is heading for `promo`, which is what it
+     * knows and the panel cannot: the write lives in the host's queue and
+     * outlives this panel.
+     */
+    view.rerender(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+        pendingSlugs={{ "id-hero": "promo" }}
+      />
+    );
 
     /*
      * The row still renders `hero`, because nothing has come back — so typing

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -759,3 +759,76 @@ describe("a revert typed while the first rename is still in flight", () => {
     expect(onRename).not.toHaveBeenCalled();
   });
 });
+
+describe("a host whose rename handler returns something else entirely", () => {
+  it("accepts a SYNCHRONOUS value without throwing out of the handler", async () => {
+    /*
+     * The contract this replaced was `=> void`, which TypeScript satisfies with
+     * any return type — `onRename={() => map.set(id, slug)}` was legal and
+     * common. Reaching for `.then` on that Map threw out of the event handler,
+     * so a working host broke on an internal detail of this panel.
+     */
+    const store = new Map<string, string>();
+    const onRename = vi.fn((classId: string, slug: string) =>
+      store.set(classId, slug)
+    );
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    /*
+     * The throw has to be OBSERVED rather than awaited. jsdom dispatches an
+     * event listener's exception to the virtual console instead of rethrowing
+     * to the caller, so `fireEvent` returns normally and the assertions below
+     * pass whether or not the handler blew up — measured: reaching for `.then`
+     * on the Map again left this test green.
+     */
+    const failures: unknown[] = [];
+    const onError = (event: ErrorEvent): void => {
+      failures.push(event.error);
+    };
+    window.addEventListener("error", onError);
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    window.removeEventListener("error", onError);
+
+    expect(failures).toEqual([]);
+    // The host was called and its value ignored, rather than interpreted.
+    expect(store.get("id-hero")).toBe("renamed");
+    expect(screen.queryByText(/could not be renamed/i)).toBeNull();
+  });
+
+  it("ignores a resolution that is not an outcome", async () => {
+    // An async helper resolving to some mutation result is equally legal, and
+    // reading `.ok` off it reported a SUCCESSFUL rename as failed.
+    const onRename = vi.fn(async () => ({ rowsAffected: 1 }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(onRename).toHaveBeenCalled();
+    expect(screen.queryByText(/could not be renamed/i)).toBeNull();
+  });
+});

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -519,3 +519,102 @@ describe("two renames on one row, answered out of order", () => {
     expect(screen.queryByText("The first one was refused.")).toBeNull();
   });
 });
+
+describe("a rename handler that fails before it returns", () => {
+  it("reports a SYNCHRONOUS throw like any other refusal", async () => {
+    // A permission or storage check that throws is a legitimate handler. The
+    // exception escaped the event handler, so the draft stayed and the author
+    // was told nothing.
+    const onRename = vi.fn(() => {
+      throw new Error("not allowed");
+    });
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+    expect(await screen.findByText(/could not be renamed/i)).toBeTruthy();
+  });
+});
+
+describe("a filter whose backing data disappears", () => {
+  it("CLEARS the selection rather than masking it", () => {
+    /*
+     * Deriving a display value while the stored one stayed selected left two
+     * answers to "which filter is active", and the hidden one came back the
+     * moment usage was readable again — narrowing a list the author had last
+     * seen showing everything.
+     */
+    const view = render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Not in index" }));
+    expect(
+      screen
+        .getByRole("button", { name: "Not in index" })
+        .getAttribute("aria-pressed")
+    ).toBe("true");
+
+    // Usage goes away, then comes back.
+    view.rerender(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    view.rerender(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole("button", { name: "All" }).getAttribute("aria-pressed")
+    ).toBe("true");
+  });
+});
+
+describe("deleting while the index was never read", () => {
+  it("does not claim the index knows of no document using it", () => {
+    // Rows are built from a placeholder empty map, so the usual wording would
+    // be reassurance derived from never having asked — offered immediately
+    // before an irreversible site-wide write.
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Delete hero" }));
+    // Addressed through the confirm button rather than by role: the filter
+    // chips are a `group` too, and matching both would assert about whichever
+    // came first.
+    const confirm = screen
+      .getByRole("button", { name: "Confirm deleting hero" })
+      .closest("div");
+    expect(confirm?.textContent).toContain("has not been read");
+    expect(confirm?.textContent).not.toContain("knows of no document");
+  });
+});

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -618,3 +618,34 @@ describe("deleting while the index was never read", () => {
     expect(confirm?.textContent).not.toContain("knows of no document");
   });
 });
+
+describe("a library far larger than a screen", () => {
+  const many = Array.from({ length: 260 }, (_, index) => ({
+    id: `id-${index}`,
+    slug: `class-${index}`,
+    orderIndex: index,
+    styles: {},
+  }));
+
+  it("bounds what it mounts, and says how much it did not show", () => {
+    /*
+     * The `All` filter matches the whole library, so an unbounded list mounts
+     * a text input per class — two thousand of them on a site near the limit.
+     * The remainder is NAMED rather than dropped quietly: this is the surface
+     * an author uses to decide a class is unused, so a list that silently
+     * stops is one they would read as complete.
+     */
+    render(
+      <ClassManagerPanel
+        library={many}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    const fields = screen.getAllByRole("textbox");
+    expect(fields.length).toBeLessThan(many.length);
+    expect(screen.getByText(/Showing \d+ of 260/)).toBeTruthy();
+  });
+});

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -357,3 +357,84 @@ describe("deleting", () => {
     expect(onDelete).toHaveBeenCalledWith("id-card");
   });
 });
+
+describe("a host that could not read the usage index", () => {
+  it("says the reading is absent rather than reporting an empty index", () => {
+    // An empty map and an unread index are different facts, and only one of
+    // them is a statement about the site. Printing "Not in index" against
+    // every class from a read that never happened is the direction that reads
+    // as permission to delete.
+    draw({ usage: undefined });
+    expect(screen.getAllByText(/Usage not read/).length).toBeGreaterThan(0);
+    expect(screen.queryByText("Not in index")).toBeNull();
+  });
+
+  it("withdraws the filter it can no longer answer", () => {
+    draw({ usage: undefined });
+    expect(screen.queryByRole("button", { name: "Not in index" })).toBeNull();
+    // The control: the filters it CAN answer are still offered, so this is a
+    // withdrawal rather than the chips having failed to render at all.
+    expect(screen.getByRole("button", { name: "All" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "On this page" })).toBeTruthy();
+  });
+
+  it("still answers on-this-page, which the open document decides", () => {
+    // That question never went through the index, so losing the index must
+    // not cost it.
+    draw({ usage: undefined });
+    expect(screen.getByText(/on this page/)).toBeTruthy();
+  });
+});
+
+describe("a host with no way to carry out a delete", () => {
+  it("offers no Delete at all rather than a disabled one", () => {
+    draw({ onDelete: undefined });
+    // The control first: an absent button is also what a panel that rendered
+    // nothing looks like.
+    expect(nameField("hero")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Delete hero" })).toBeNull();
+  });
+});
+
+describe("a rename the host refuses", () => {
+  it("shows the reason rather than clearing as though it landed", async () => {
+    const onRename = vi.fn(async () => ({
+      ok: false as const,
+      reason: "The site style is locked.",
+    }));
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+    expect(await screen.findByText("The site style is locked.")).toBeTruthy();
+  });
+
+  it("treats a REJECTED write as a refusal too", async () => {
+    // The contract is to answer, but a thrown error arrives all the same, and
+    // without handling it the row clears and says nothing.
+    const onRename = vi.fn(async () => {
+      throw new Error("network");
+    });
+    render(
+      <ClassManagerPanel
+        library={LIBRARY}
+        usage={{}}
+        documentClassIds={[]}
+        onRename={onRename}
+        onDelete={vi.fn()}
+      />
+    );
+    const field = nameField("hero");
+    fireEvent.change(field, { target: { value: "renamed" } });
+    fireEvent.blur(field);
+    expect(await screen.findByText(/could not be renamed/i)).toBeTruthy();
+  });
+});

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -290,6 +290,21 @@ function FilterChips({
   );
 }
 
+/**
+ * How many rows the manager mounts at once.
+ *
+ * A library may hold `MAX_NAMED_CLASSES`, and the `All` filter matches every
+ * one — so opening the panel on a large site would mount two thousand rows and
+ * two thousand text inputs synchronously. The selector caps its own results at
+ * fifty for exactly this reason; the manager needs a bound of the same kind,
+ * and a larger one because reading a list IS what this surface is for.
+ *
+ * The remainder is REPORTED rather than dropped quietly: a list that silently
+ * stops is a list an author believes is complete, and this one is the surface
+ * they would use to decide a class is safe to delete.
+ */
+const MAX_MANAGED_ROWS = 200;
+
 function ClassList({
   rows,
   library,
@@ -308,21 +323,30 @@ function ClassList({
   if (rows.length === 0) {
     return <p className="nx-inspector__note">No classes match this filter.</p>;
   }
+  const shown = rows.slice(0, MAX_MANAGED_ROWS);
+  const hidden = rows.length - shown.length;
   return (
-    <ul className="nx-classman__list">
-      {rows.map(row => (
-        <li key={row.id} className="nx-classman__row">
-          <ClassRowView
-            row={row}
-            library={library}
-            isSupplied={supplied.has(row.id)}
-            usageKnown={usageKnown}
-            onRename={onRename}
-            onDelete={onDelete}
-          />
-        </li>
-      ))}
-    </ul>
+    <>
+      {hidden > 0 ? (
+        <p className="nx-inspector__note">
+          {`Showing ${shown.length} of ${rows.length}. Filter to reach the rest.`}
+        </p>
+      ) : null}
+      <ul className="nx-classman__list">
+        {shown.map(row => (
+          <li key={row.id} className="nx-classman__row">
+            <ClassRowView
+              row={row}
+              library={library}
+              isSupplied={supplied.has(row.id)}
+              usageKnown={usageKnown}
+              onRename={onRename}
+              onDelete={onDelete}
+            />
+          </li>
+        ))}
+      </ul>
+    </>
   );
 }
 
@@ -440,6 +464,14 @@ function NameField({
      * of the contract, and letting it escape the event handler left the draft
      * uncleared and the author told nothing at all.
      */
+    /*
+     * Superseded BEFORE the call, not after it. Advancing only once a promise
+     * came back meant a newer rename that returned synchronous `void`, or that
+     * threw, never took the number — so an older pending promise could resolve
+     * afterwards and overwrite or clear what the newer attempt had said.
+     */
+    attempt.current += 1;
+    const mine = attempt.current;
     let answered: ClassRenameAnswer;
     try {
       answered = onRename(row.id, outcome.slug);
@@ -458,8 +490,6 @@ function NameField({
     setDraft(null);
     setRefused(null);
     if (answered === undefined) return;
-    attempt.current += 1;
-    const mine = attempt.current;
     void answered
       .then(result => {
         // Superseded: a newer rename on this row is the one being awaited, and

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -175,6 +175,21 @@ export interface ClassManagerPanelProps {
    */
   documentScan?: "complete" | "partial";
   /**
+   * The name each class is currently being RENAMED to, keyed by id.
+   *
+   * A rename is a network write and `library` does not move until it comes
+   * back, so the rendered slug is stale for as long as it is in flight. An
+   * author who renames `hero` to `promo` and types `hero` again inside that
+   * window is reverting — and comparing against the rendered name reads it as
+   * a no-op and lets the first write land.
+   *
+   * Supplied by the HOST rather than remembered here, because the host owns the
+   * write queue and this panel does not survive a switch to another rail panel.
+   * A field holding it locally lost it on exactly the switch that makes the
+   * window long enough to matter.
+   */
+  pendingSlugs?: Readonly<Record<string, string>>;
+  /**
    * The classes something ELSE supplies, which the stored library layers over.
    *
    * Needed because these two are not equally editable, exactly as the tokens
@@ -213,6 +228,7 @@ export function ClassManagerPanel({
   library,
   absence,
   documentScan,
+  pendingSlugs,
   usage,
   documentClassIds,
   suppliedClassIds,
@@ -294,6 +310,8 @@ export function ClassManagerPanel({
       <ClassSearch query={query} onChange={setQuery} />
       <ClassList
         rows={rows}
+        searching={query.trim() !== ""}
+        pendingSlugs={pendingSlugs}
         library={library}
         supplied={new Set(suppliedClassIds ?? [])}
         usageKnown={usageKnown}
@@ -378,6 +396,8 @@ const MAX_MANAGED_ROWS = 200;
 
 function ClassList({
   rows,
+  searching,
+  pendingSlugs,
   library,
   supplied,
   usageKnown,
@@ -385,22 +405,44 @@ function ClassList({
   onDelete,
 }: {
   rows: readonly ClassRow[];
+  /** Whether a search is narrowing them, for the empty-list wording. */
+  searching: boolean;
+  pendingSlugs?: Readonly<Record<string, string>>;
   library: readonly NamedClass[];
   supplied: ReadonlySet<string>;
   usageKnown: boolean;
   onRename: ClassManagerPanelProps["onRename"];
   onDelete?: (classId: string) => void;
 }): React.ReactElement {
+  /*
+   * How many rows are mounted right now. Raised by the control below rather
+   * than fixed, because a search cannot be relied on to reach the tail: a
+   * library of `class-0` to `class-259` matches every query an author is
+   * likely to type, and the last sixty would stay unreachable however the
+   * message was worded.
+   */
+  const [limit, setLimit] = React.useState(MAX_MANAGED_ROWS);
   if (rows.length === 0) {
-    return <p className="nx-inspector__note">No classes match this search.</p>;
+    return (
+      <p className="nx-inspector__note">
+        {/*
+          Which narrowing produced the empty list. Blaming the search when the
+          box is blank sends an author to clear something that is not set, and
+          hides the filter that actually did it.
+        */}
+        {searching
+          ? "No classes match this search."
+          : "No classes match this filter."}
+      </p>
+    );
   }
-  const shown = rows.slice(0, MAX_MANAGED_ROWS);
+  const shown = rows.slice(0, limit);
   const hidden = rows.length - shown.length;
   return (
     <>
       {hidden > 0 ? (
         <p className="nx-inspector__note">
-          {`Showing ${shown.length} of ${rows.length}. Search by name to reach the rest.`}
+          {`Showing ${shown.length} of ${rows.length}.`}
         </p>
       ) : null}
       <ul className="nx-classman__list">
@@ -408,6 +450,7 @@ function ClassList({
           <li key={row.id} className="nx-classman__row">
             <ClassRowView
               row={row}
+              pendingSlug={pendingSlugs?.[row.id]}
               library={library}
               isSupplied={supplied.has(row.id)}
               usageKnown={usageKnown}
@@ -417,12 +460,24 @@ function ClassList({
           </li>
         ))}
       </ul>
+      {hidden > 0 ? (
+        <Button
+          className="nx-classman__more"
+          onClick={() => setLimit(current => current + MAX_MANAGED_ROWS)}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          {`Show ${Math.min(hidden, MAX_MANAGED_ROWS)} more`}
+        </Button>
+      ) : null}
     </>
   );
 }
 
 function ClassRowView({
   row,
+  pendingSlug,
   library,
   isSupplied,
   usageKnown,
@@ -430,6 +485,8 @@ function ClassRowView({
   onDelete,
 }: {
   row: ClassRow;
+  /** The name this class is being renamed to, when a write is in flight. */
+  pendingSlug?: string;
   library: readonly NamedClass[];
   isSupplied: boolean;
   usageKnown: boolean;
@@ -441,7 +498,12 @@ function ClassRowView({
   return (
     <>
       <div className="nx-classman__fields">
-        <NameField row={row} library={library} onRename={onRename} />
+        <NameField
+          library={library}
+          onRename={onRename}
+          pendingSlug={pendingSlug}
+          row={row}
+        />
         <UsageNote row={row} usageKnown={usageKnown} />
         {isSupplied ? (
           // Named rather than shown disabled. A greyed button invites an
@@ -485,10 +547,12 @@ function ClassRowView({
  */
 function NameField({
   row,
+  pendingSlug,
   library,
   onRename,
 }: {
   row: ClassRow;
+  pendingSlug?: string;
   library: readonly NamedClass[];
   onRename: ClassManagerPanelProps["onRename"];
 }): React.ReactElement {
@@ -510,19 +574,6 @@ function NameField({
    * with the orders reversed, keeps reporting one the retry already fixed.
    */
   const attempt = React.useRef(0);
-  /*
-   * The name this row was last ASKED to take, which is not what it renders.
-   *
-   * `row.slug` is the STORED name and does not move until a save comes back
-   * through the cache. An author who renames `old` to `new` and then types
-   * `old` again inside that window is making a real edit — a revert — but the
-   * rendered slug still says `old`, so the no-op branch below discarded it and
-   * the pending first write went on to persist `new`.
-   *
-   * Cleared on refusal, because a write that did not land leaves the class
-   * with the name it already had.
-   */
-  const requested = React.useRef<string | null>(null);
   /*
    * Where a refusal goes when this row is no longer on screen.
    *
@@ -552,9 +603,13 @@ function NameField({
      * write a revision whose rendered output is identical to the one before it.
      * The draft still clears, because the author did finish editing.
      */
-    // Compared against what this row was last asked to become, falling back to
-    // the stored name when nothing is in flight.
-    if (outcome.slug === (requested.current ?? row.slug)) {
+    /*
+     * Compared against the name this class is HEADING FOR, which is the
+     * pending one while a write is in flight and the stored one otherwise.
+     * Comparing against the rendered slug read a revert as a no-op and let the
+     * superseded write land.
+     */
+    if (outcome.slug === (pendingSlug ?? row.slug)) {
       setDraft(null);
       return;
     }
@@ -573,13 +628,11 @@ function NameField({
      */
     attempt.current += 1;
     const mine = attempt.current;
-    requested.current = outcome.slug;
     let answered: ClassRenameAnswer;
     try {
       answered = onRename(row.id, outcome.slug);
     } catch {
       setDraft(null);
-      requested.current = null;
       report("This class could not be renamed.");
       return;
     }
@@ -607,7 +660,6 @@ function NameField({
           setRefused(null);
           return;
         }
-        requested.current = null;
         report(result.reason);
       })
       /*
@@ -618,7 +670,6 @@ function NameField({
        */
       .catch(() => {
         if (attempt.current !== mine) return;
-        requested.current = null;
         report("This class could not be renamed.");
       });
   };

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -137,6 +137,15 @@ export interface ClassManagerPanelProps {
   /** The class ids the open document applies, for the on-this-page filter. */
   documentClassIds: readonly string[];
   /**
+   * Whether that list covers the whole document.
+   *
+   * The walk producing it stops at the document's node ceiling, so a class
+   * applied past that bound is missing from the list — and its absence must
+   * not be read as "not on this page". `"partial"` says so on the surface
+   * rather than leaving the filter to make a claim it cannot support.
+   */
+  documentScan?: "complete" | "partial";
+  /**
    * The classes something ELSE supplies, which the stored library layers over.
    *
    * Needed because these two are not equally editable, exactly as the tokens
@@ -174,6 +183,7 @@ export interface ClassManagerPanelProps {
 export function ClassManagerPanel({
   library,
   absence,
+  documentScan,
   usage,
   documentClassIds,
   suppliedClassIds,
@@ -188,9 +198,18 @@ export function ClassManagerPanel({
    * an empty panel with nothing to explain it.
    */
   const offerable = offerableFilters(usage !== undefined);
-  const active = offerable.some(entry => entry.value === filter)
-    ? filter
-    : "all";
+  const stillOffered = offerable.some(entry => entry.value === filter);
+  /*
+   * CLEARED rather than masked. Deriving a display value while the stored one
+   * stayed `"not-in-index"` left two answers to "which filter is active", and
+   * the hidden one came back the moment usage was readable again — narrowing a
+   * list the author had last seen showing everything, with no chip to explain
+   * why.
+   */
+  React.useEffect(() => {
+    if (!stillOffered) setFilter("all");
+  }, [stillOffered]);
+  const active = stillOffered ? filter : "all";
 
   if (library === undefined) {
     return (
@@ -215,6 +234,15 @@ export function ClassManagerPanel({
       <div className="nx-classman__head">
         <h2 className="nx-classman__title">Classes</h2>
       </div>
+      {documentScan === "partial" ? (
+        // Stated rather than silently narrowing: the page filter and the row
+        // marks are still TRUE where they appear, and it is their absence that
+        // cannot be trusted.
+        <p className="nx-inspector__note">
+          This page has more blocks than can be read at once, so a class it uses
+          may not be marked here.
+        </p>
+      ) : null}
       {usageKnown ? null : (
         // Stated once, at the top, rather than on every row. It is a property
         // of this reading of the site, not of any one class.
@@ -340,6 +368,7 @@ function ClassRowView({
       {confirming && onDelete !== undefined ? (
         <DeleteConfirm
           row={row}
+          usageKnown={usageKnown}
           onCancel={() => setConfirming(false)}
           onConfirm={() => {
             setConfirming(false);
@@ -404,7 +433,21 @@ function NameField({
       setDraft(null);
       return;
     }
-    const answered = onRename(row.id, outcome.slug);
+    /*
+     * Called inside a boundary that catches a SYNCHRONOUS throw, so a handler
+     * failing before it returns is treated exactly as one that rejects. A
+     * permission or storage check that throws is a legitimate implementation
+     * of the contract, and letting it escape the event handler left the draft
+     * uncleared and the author told nothing at all.
+     */
+    let answered: ClassRenameAnswer;
+    try {
+      answered = onRename(row.id, outcome.slug);
+    } catch {
+      setDraft(null);
+      setRefused("This class could not be renamed.");
+      return;
+    }
     /*
      * The draft clears immediately, because the author DID finish editing and
      * a field that holds their text hostage until the network answers reads as
@@ -532,10 +575,12 @@ function UsageNote({
  */
 function DeleteConfirm({
   row,
+  usageKnown,
   onCancel,
   onConfirm,
 }: {
   row: ClassRow;
+  usageKnown: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }): React.ReactElement {
@@ -543,9 +588,18 @@ function DeleteConfirm({
   return (
     <div className="nx-classman__confirm" role="group">
       <p className="nx-classman__issue">
-        {warning.hasIndexedUsage
-          ? `Delete “${row.slug}”? The index has it on ${warning.indexedDocuments} document(s), and deleting removes it from every document that carries it. That number is what the index recorded, and it can be wrong in either direction.`
-          : `Delete “${row.slug}”? The index knows of no document using it, but it cannot rule one out.`}
+        {/*
+          Three wordings, because there are three states and the middle one is
+          the dangerous one to collapse. Rows are built from an empty map when
+          no index was read, so "knows of no document using it" would be
+          reassurance derived entirely from never having asked — offered
+          immediately before an irreversible site-wide write.
+        */}
+        {!usageKnown
+          ? `Delete “${row.slug}”? Where this class is used has not been read, so there is no telling how many documents carry it. Deleting removes it from every one of them.`
+          : warning.hasIndexedUsage
+            ? `Delete “${row.slug}”? The index has it on ${warning.indexedDocuments} document(s), and deleting removes it from every document that carries it. That number is what the index recorded, and it can be wrong in either direction.`
+            : `Delete “${row.slug}”? The index knows of no document using it, but it cannot rule one out.`}
       </p>
       <Button type="button" size="sm" variant="ghost" onClick={onCancel}>
         Cancel

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -43,6 +43,7 @@ import {
   classRows,
   deletionWarning,
   filterClassRows,
+  searchClassRows,
   renamedClassName,
   usageSummary,
   type ClassFilter,
@@ -192,6 +193,17 @@ export function ClassManagerPanel({
 }: ClassManagerPanelProps): React.ReactElement {
   const [filter, setFilter] = React.useState<ClassFilter>("all");
   /*
+   * The name search, which is what makes every class REACHABLE.
+   *
+   * The list is capped so a library near its ceiling does not mount two
+   * thousand rows and their inputs at once. Without a search that cap is a
+   * wall: the chips narrow by index state and by the open page, so a class
+   * past the cap that no filter happens to select could never be shown or
+   * renamed — and the note under the cap said to filter, which was advice the
+   * surface could not honour.
+   */
+  const [query, setQuery] = React.useState("");
+  /*
    * A filter the panel no longer offers cannot stay selected. `usage` is a
    * host prop and can go from read to unread between renders, which would
    * otherwise leave the list narrowed by a chip that is no longer on screen —
@@ -224,9 +236,9 @@ export function ClassManagerPanel({
   }
 
   const usageKnown = usage !== undefined;
-  const rows = filterClassRows(
-    classRows(library, usage ?? {}, documentClassIds),
-    active
+  const rows = searchClassRows(
+    filterClassRows(classRows(library, usage ?? {}, documentClassIds), active),
+    query
   );
 
   return (
@@ -251,6 +263,7 @@ export function ClassManagerPanel({
         </p>
       )}
       <FilterChips active={active} filters={offerable} onChange={setFilter} />
+      <ClassSearch query={query} onChange={setQuery} />
       <ClassList
         rows={rows}
         library={library}
@@ -258,6 +271,36 @@ export function ClassManagerPanel({
         usageKnown={usageKnown}
         onRename={onRename}
         onDelete={onDelete}
+      />
+    </div>
+  );
+}
+
+/**
+ * The name search.
+ *
+ * Uncontrolled by the filter chips: narrowing by name and narrowing by index
+ * state are separate choices, and clearing one must not clear the other.
+ */
+function ClassSearch({
+  query,
+  onChange,
+}: {
+  query: string;
+  onChange: (next: string) => void;
+}): React.ReactElement {
+  const id = React.useId();
+  return (
+    <div className="nx-classman__search">
+      <label className="sr-only" htmlFor={id}>
+        Search classes
+      </label>
+      <Input
+        id={id}
+        onChange={event => onChange(event.target.value)}
+        placeholder="Search classes"
+        type="search"
+        value={query}
       />
     </div>
   );
@@ -321,7 +364,7 @@ function ClassList({
   onDelete?: (classId: string) => void;
 }): React.ReactElement {
   if (rows.length === 0) {
-    return <p className="nx-inspector__note">No classes match this filter.</p>;
+    return <p className="nx-inspector__note">No classes match this search.</p>;
   }
   const shown = rows.slice(0, MAX_MANAGED_ROWS);
   const hidden = rows.length - shown.length;
@@ -329,7 +372,7 @@ function ClassList({
     <>
       {hidden > 0 ? (
         <p className="nx-inspector__note">
-          {`Showing ${shown.length} of ${rows.length}. Filter to reach the rest.`}
+          {`Showing ${shown.length} of ${rows.length}. Search by name to reach the rest.`}
         </p>
       ) : null}
       <ul className="nx-classman__list">
@@ -439,6 +482,19 @@ function NameField({
    * with the orders reversed, keeps reporting one the retry already fixed.
    */
   const attempt = React.useRef(0);
+  /*
+   * The name this row was last ASKED to take, which is not what it renders.
+   *
+   * `row.slug` is the STORED name and does not move until a save comes back
+   * through the cache. An author who renames `old` to `new` and then types
+   * `old` again inside that window is making a real edit — a revert — but the
+   * rendered slug still says `old`, so the no-op branch below discarded it and
+   * the pending first write went on to persist `new`.
+   *
+   * Cleared on refusal, because a write that did not land leaves the class
+   * with the name it already had.
+   */
+  const requested = React.useRef<string | null>(null);
   const id = React.useId();
   const outcome =
     draft === null ? null : renamedClassName(draft, row.id, library);
@@ -453,7 +509,9 @@ function NameField({
      * write a revision whose rendered output is identical to the one before it.
      * The draft still clears, because the author did finish editing.
      */
-    if (outcome.slug === row.slug) {
+    // Compared against what this row was last asked to become, falling back to
+    // the stored name when nothing is in flight.
+    if (outcome.slug === (requested.current ?? row.slug)) {
       setDraft(null);
       return;
     }
@@ -472,11 +530,13 @@ function NameField({
      */
     attempt.current += 1;
     const mine = attempt.current;
+    requested.current = outcome.slug;
     let answered: ClassRenameAnswer;
     try {
       answered = onRename(row.id, outcome.slug);
     } catch {
       setDraft(null);
+      requested.current = null;
       setRefused("This class could not be renamed.");
       return;
     }
@@ -502,6 +562,7 @@ function NameField({
           setRefused(null);
           return;
         }
+        requested.current = null;
         setRefused(result.reason);
       })
       /*
@@ -512,6 +573,7 @@ function NameField({
        */
       .catch(() => {
         if (attempt.current !== mine) return;
+        requested.current = null;
         setRefused("This class could not be renamed.");
       });
   };

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -91,6 +91,21 @@ export type ClassRenameOutcome =
   | { readonly ok: true }
   | { readonly ok: false; readonly reason: string };
 
+/**
+ * What a rename may answer with, including answering nothing.
+ *
+ * `Promise<void>` is in the union deliberately. A host whose handler is merely
+ * `async` already satisfied the older `void` contract — TypeScript accepts any
+ * return type where `void` is declared — so narrowing to the outcome alone
+ * would stop those callers compiling. The runtime cost is worse than the
+ * compile one: a resolved `Promise<void>` read as `result.ok` throws, the throw
+ * is caught, and a rename that SUCCEEDED is reported to the author as failed.
+ *
+ * So an `undefined` resolution means the host is not reporting, which is the
+ * same silence the synchronous form has always meant.
+ */
+export type ClassRenameAnswer = void | Promise<ClassRenameOutcome | void>;
+
 export interface ClassManagerPanelProps {
   /**
    * The site's class library, or `undefined` while the host has not read it.
@@ -100,6 +115,16 @@ export interface ClassManagerPanelProps {
    * and an author must not be shown "no classes" for a library still loading.
    */
   library: readonly NamedClass[] | undefined;
+  /**
+   * Why the library is absent, when it is.
+   *
+   * A read that FAILED will not finish, and a surface that goes on saying
+   * "loading" describes a state the site is not in — the author waits for
+   * something that is never coming rather than retrying or reporting it. The
+   * selector and the fonts panel already draw this distinction; the manager
+   * discarded it and showed one wording for both.
+   */
+  absence?: "pending" | "failed";
   /**
    * Documents known to reference each class, keyed by id. A floor.
    *
@@ -133,10 +158,7 @@ export interface ClassManagerPanelProps {
    * silent leaves the row looking renamed whatever happened, so returning a
    * {@link ClassRenameOutcome} is how a refusal reaches the author.
    */
-  onRename: (
-    classId: string,
-    slug: string
-  ) => void | Promise<ClassRenameOutcome>;
+  onRename: (classId: string, slug: string) => ClassRenameAnswer;
   /**
    * Delete a class, removing it from every document that references it.
    *
@@ -151,6 +173,7 @@ export interface ClassManagerPanelProps {
 /** Every class the site renders, filtered, renameable and deletable. */
 export function ClassManagerPanel({
   library,
+  absence,
   usage,
   documentClassIds,
   suppliedClassIds,
@@ -172,7 +195,11 @@ export function ClassManagerPanel({
   if (library === undefined) {
     return (
       <div className="nx-classman">
-        <p className="nx-inspector__note">Loading classes…</p>
+        <p className="nx-inspector__note">
+          {absence === "failed"
+            ? "This site's classes could not be read."
+            : "Loading classes…"}
+        </p>
       </div>
     );
   }
@@ -349,6 +376,16 @@ function NameField({
    * because a stale reason beside a fresh draft describes neither.
    */
   const [refused, setRefused] = React.useState<string | null>(null);
+  /*
+   * Which rename this row is currently waiting on.
+   *
+   * An author can commit a second rename while the first is still in flight,
+   * and the answers can arrive in either order. Without this, a refusal from
+   * the superseded attempt lands after the newer edit cleared it, and the row
+   * reports a failure for a rename that is no longer being attempted — or,
+   * with the orders reversed, keeps reporting one the retry already fixed.
+   */
+  const attempt = React.useRef(0);
   const id = React.useId();
   const outcome =
     draft === null ? null : renamedClassName(draft, row.id, library);
@@ -378,9 +415,21 @@ function NameField({
     setDraft(null);
     setRefused(null);
     if (answered === undefined) return;
+    attempt.current += 1;
+    const mine = attempt.current;
     void answered
       .then(result => {
-        if (!result.ok) setRefused(result.reason);
+        // Superseded: a newer rename on this row is the one being awaited, and
+        // this answer describes a name the author has already moved past.
+        if (attempt.current !== mine) return;
+        // `undefined` is a host that does not report, which is silence rather
+        // than refusal — reading `.ok` off it would throw, and the catch below
+        // would then present a SUCCESSFUL rename as a failed one.
+        if (result === undefined || result.ok) {
+          setRefused(null);
+          return;
+        }
+        setRefused(result.reason);
       })
       /*
        * A REJECTED promise is a refusal too. The contract is to answer, but a
@@ -389,6 +438,7 @@ function NameField({
        * was added to remove.
        */
       .catch(() => {
+        if (attempt.current !== mine) return;
         setRefused("This class could not be renamed.");
       });
   };

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -62,6 +62,35 @@ const FILTERS: ReadonlyArray<{ value: ClassFilter; label: string }> = [
   { value: "on-this-page", label: "On this page" },
 ];
 
+/**
+ * The filters that can be answered from what the host supplied.
+ *
+ * "Not in index" is withheld when no usage was read, rather than answered from
+ * the empty map that stands in for one. Every class would satisfy it, which
+ * reads as a site where nothing is used — the most alarming possible reading,
+ * produced entirely by not having asked.
+ */
+function offerableFilters(
+  usageKnown: boolean
+): ReadonlyArray<{ value: ClassFilter; label: string }> {
+  return usageKnown
+    ? FILTERS
+    : FILTERS.filter(filter => filter.value !== "not-in-index");
+}
+
+/**
+ * What a host answers a rename with, when it answers at all.
+ *
+ * A persisted rename is a network write and can be refused. A host that returns
+ * nothing is taken at its word and the row simply clears, which keeps every
+ * existing caller working; one that returns this gets its refusal SHOWN rather
+ * than swallowed, which is the difference between a rename that failed and a
+ * rename that appears to have worked until the next read.
+ */
+export type ClassRenameOutcome =
+  | { readonly ok: true }
+  | { readonly ok: false; readonly reason: string };
+
 export interface ClassManagerPanelProps {
   /**
    * The site's class library, or `undefined` while the host has not read it.
@@ -71,8 +100,15 @@ export interface ClassManagerPanelProps {
    * and an author must not be shown "no classes" for a library still loading.
    */
   library: readonly NamedClass[] | undefined;
-  /** Documents known to reference each class, keyed by id. A floor. */
-  usage: ClassUsageCounts;
+  /**
+   * Documents known to reference each class, keyed by id. A floor.
+   *
+   * `undefined` is a THIRD state, not an empty index: a host that cannot read
+   * the usage index has not established that nothing uses these classes, and
+   * an empty map would say exactly that. The rows then report the absence of
+   * the reading rather than an absence of usage.
+   */
+  usage?: ClassUsageCounts;
   /** The class ids the open document applies, for the on-this-page filter. */
   documentClassIds: readonly string[];
   /**
@@ -90,10 +126,26 @@ export interface ClassManagerPanelProps {
    * one, so it is withheld and the row says why.
    */
   suppliedClassIds?: readonly string[];
-  /** Rename a class. The slug has already passed the engine's grammar. */
-  onRename: (classId: string, slug: string) => void;
-  /** Delete a class, removing it from every document that references it. */
-  onDelete: (classId: string) => void;
+  /**
+   * Rename a class. The slug has already passed the engine's grammar.
+   *
+   * May answer with the outcome. A host that persists asynchronously and stays
+   * silent leaves the row looking renamed whatever happened, so returning a
+   * {@link ClassRenameOutcome} is how a refusal reaches the author.
+   */
+  onRename: (
+    classId: string,
+    slug: string
+  ) => void | Promise<ClassRenameOutcome>;
+  /**
+   * Delete a class, removing it from every document that references it.
+   *
+   * Optional, because that removal is a site-wide write and a host without one
+   * cannot honour what the word promises. Absent, no Delete is offered at all:
+   * a disabled one invites an author to hunt for the permission that would
+   * enable it, and there is none to find.
+   */
+  onDelete?: (classId: string) => void;
 }
 
 /** Every class the site renders, filtered, renameable and deletable. */
@@ -106,6 +158,16 @@ export function ClassManagerPanel({
   onDelete,
 }: ClassManagerPanelProps): React.ReactElement {
   const [filter, setFilter] = React.useState<ClassFilter>("all");
+  /*
+   * A filter the panel no longer offers cannot stay selected. `usage` is a
+   * host prop and can go from read to unread between renders, which would
+   * otherwise leave the list narrowed by a chip that is no longer on screen —
+   * an empty panel with nothing to explain it.
+   */
+  const offerable = offerableFilters(usage !== undefined);
+  const active = offerable.some(entry => entry.value === filter)
+    ? filter
+    : "all";
 
   if (library === undefined) {
     return (
@@ -115,9 +177,10 @@ export function ClassManagerPanel({
     );
   }
 
+  const usageKnown = usage !== undefined;
   const rows = filterClassRows(
-    classRows(library, usage, documentClassIds),
-    filter
+    classRows(library, usage ?? {}, documentClassIds),
+    active
   );
 
   return (
@@ -125,11 +188,19 @@ export function ClassManagerPanel({
       <div className="nx-classman__head">
         <h2 className="nx-classman__title">Classes</h2>
       </div>
-      <FilterChips active={filter} onChange={setFilter} />
+      {usageKnown ? null : (
+        // Stated once, at the top, rather than on every row. It is a property
+        // of this reading of the site, not of any one class.
+        <p className="nx-inspector__note">
+          Where these classes are used has not been read.
+        </p>
+      )}
+      <FilterChips active={active} filters={offerable} onChange={setFilter} />
       <ClassList
         rows={rows}
         library={library}
         supplied={new Set(suppliedClassIds ?? [])}
+        usageKnown={usageKnown}
         onRename={onRename}
         onDelete={onDelete}
       />
@@ -139,14 +210,16 @@ export function ClassManagerPanel({
 
 function FilterChips({
   active,
+  filters,
   onChange,
 }: {
   active: ClassFilter;
+  filters: ReadonlyArray<{ value: ClassFilter; label: string }>;
   onChange: (filter: ClassFilter) => void;
 }): React.ReactElement {
   return (
     <div className="nx-classman__filters" role="group" aria-label="Filter">
-      {FILTERS.map(({ value, label }) => (
+      {filters.map(({ value, label }) => (
         <Button
           key={value}
           type="button"
@@ -166,14 +239,16 @@ function ClassList({
   rows,
   library,
   supplied,
+  usageKnown,
   onRename,
   onDelete,
 }: {
   rows: readonly ClassRow[];
   library: readonly NamedClass[];
   supplied: ReadonlySet<string>;
-  onRename: (classId: string, slug: string) => void;
-  onDelete: (classId: string) => void;
+  usageKnown: boolean;
+  onRename: ClassManagerPanelProps["onRename"];
+  onDelete?: (classId: string) => void;
 }): React.ReactElement {
   if (rows.length === 0) {
     return <p className="nx-inspector__note">No classes match this filter.</p>;
@@ -186,6 +261,7 @@ function ClassList({
             row={row}
             library={library}
             isSupplied={supplied.has(row.id)}
+            usageKnown={usageKnown}
             onRename={onRename}
             onDelete={onDelete}
           />
@@ -199,14 +275,16 @@ function ClassRowView({
   row,
   library,
   isSupplied,
+  usageKnown,
   onRename,
   onDelete,
 }: {
   row: ClassRow;
   library: readonly NamedClass[];
   isSupplied: boolean;
-  onRename: (classId: string, slug: string) => void;
-  onDelete: (classId: string) => void;
+  usageKnown: boolean;
+  onRename: ClassManagerPanelProps["onRename"];
+  onDelete?: (classId: string) => void;
 }): React.ReactElement {
   const [confirming, setConfirming] = React.useState(false);
 
@@ -214,13 +292,13 @@ function ClassRowView({
     <>
       <div className="nx-classman__fields">
         <NameField row={row} library={library} onRename={onRename} />
-        <UsageNote row={row} />
+        <UsageNote row={row} usageKnown={usageKnown} />
         {isSupplied ? (
           // Named rather than shown disabled. A greyed button invites an
           // author to hunt for the permission that would enable it, and there
           // is none — the class comes from the site's own configuration.
           <span className="nx-classman__origin">Default</span>
-        ) : (
+        ) : onDelete === undefined ? null : (
           <Button
             type="button"
             size="sm"
@@ -232,7 +310,7 @@ function ClassRowView({
           </Button>
         )}
       </div>
-      {confirming ? (
+      {confirming && onDelete !== undefined ? (
         <DeleteConfirm
           row={row}
           onCancel={() => setConfirming(false)}
@@ -261,9 +339,16 @@ function NameField({
 }: {
   row: ClassRow;
   library: readonly NamedClass[];
-  onRename: (classId: string, slug: string) => void;
+  onRename: ClassManagerPanelProps["onRename"];
 }): React.ReactElement {
   const [draft, setDraft] = React.useState<string | null>(null);
+  /*
+   * A refusal from the HOST, which is a different failure from a name the
+   * grammar rejects: the name was fine and the write did not land. Held apart
+   * so the two cannot overwrite one another, and cleared on the next edit
+   * because a stale reason beside a fresh draft describes neither.
+   */
+  const [refused, setRefused] = React.useState<string | null>(null);
   const id = React.useId();
   const outcome =
     draft === null ? null : renamedClassName(draft, row.id, library);
@@ -278,8 +363,34 @@ function NameField({
      * write a revision whose rendered output is identical to the one before it.
      * The draft still clears, because the author did finish editing.
      */
-    if (outcome.slug !== row.slug) onRename(row.id, outcome.slug);
+    if (outcome.slug === row.slug) {
+      setDraft(null);
+      return;
+    }
+    const answered = onRename(row.id, outcome.slug);
+    /*
+     * The draft clears immediately, because the author DID finish editing and
+     * a field that holds their text hostage until the network answers reads as
+     * frozen. A refusal arrives beside the row instead, naming the class it is
+     * about — the row is still there to name it, which is why this needs no
+     * shell-level surface the way an unmounting control does.
+     */
     setDraft(null);
+    setRefused(null);
+    if (answered === undefined) return;
+    void answered
+      .then(result => {
+        if (!result.ok) setRefused(result.reason);
+      })
+      /*
+       * A REJECTED promise is a refusal too. The contract is to answer, but a
+       * thrown error or a rejected write arrives here all the same, and without
+       * this the row clears and says nothing — the exact silence the outcome
+       * was added to remove.
+       */
+      .catch(() => {
+        setRefused("This class could not be renamed.");
+      });
   };
 
   return (
@@ -294,7 +405,10 @@ function NameField({
         aria-describedby={
           outcome !== null && !outcome.ok ? `${id}-why` : undefined
         }
-        onChange={event => setDraft(event.target.value)}
+        onChange={event => {
+          setDraft(event.target.value);
+          setRefused(null);
+        }}
         onBlur={commit}
         onKeyDown={event => {
           if (commitOnEnter(event, commit)) return;
@@ -304,6 +418,11 @@ function NameField({
       {outcome !== null && !outcome.ok ? (
         <p className="nx-classman__issue" id={`${id}-why`} role="alert">
           {REFUSALS[outcome.refusal]}
+        </p>
+      ) : null}
+      {refused !== null ? (
+        <p className="nx-classman__issue" role="alert">
+          {refused}
         </p>
       ) : null}
     </div>
@@ -326,10 +445,25 @@ const REFUSALS = {
  * thing beside a confirmation saying another is two uncertainty policies for
  * one number, and the row is the one an author reads far more often.
  */
-function UsageNote({ row }: { row: ClassRow }): React.ReactElement {
+function UsageNote({
+  row,
+  usageKnown,
+}: {
+  row: ClassRow;
+  usageKnown: boolean;
+}): React.ReactElement {
   return (
     <span className="nx-classman__usage">
-      {usageSummary(row)}
+      {/*
+        `usageSummary` answers about the INDEX, and with no index read there is
+        nothing for it to answer about. Letting it run on the empty map that
+        stands in for one would print "Not in index" against every class — a
+        statement about the site, made from never having looked.
+
+        "On this page" survives, because it is answered by the open document
+        rather than by the index and is just as true either way.
+      */}
+      {usageKnown ? usageSummary(row) : "Usage not read"}
       {row.onThisPage ? " · on this page" : ""}
     </span>
   );

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -39,6 +39,7 @@ import type { NamedClass } from "@nextlyhq/blocks-engine";
 import { Button, Input } from "@nextlyhq/ui";
 import * as React from "react";
 
+import { useSurvivingReport } from "./builder-notices";
 import {
   classRows,
   deletionWarning,
@@ -93,19 +94,46 @@ export type ClassRenameOutcome =
   | { readonly ok: false; readonly reason: string };
 
 /**
- * What a rename may answer with, including answering nothing.
+ * What a rename may answer with, which is ANYTHING.
  *
- * `Promise<void>` is in the union deliberately. A host whose handler is merely
- * `async` already satisfied the older `void` contract — TypeScript accepts any
- * return type where `void` is declared — so narrowing to the outcome alone
- * would stop those callers compiling. The runtime cost is worse than the
- * compile one: a resolved `Promise<void>` read as `result.ok` throws, the throw
- * is caught, and a rename that SUCCEEDED is reported to the author as failed.
+ * `unknown` rather than a union, because the contract this replaced was
+ * `=> void` and TypeScript accepts every return type where `void` is declared.
+ * `onRename={() => map.set(id, slug)}` and an async helper resolving to some
+ * mutation result both satisfied it, so any narrower union stops existing
+ * callers compiling — and a union that merely ADDS `Promise<void>` still
+ * rejects them.
  *
- * So an `undefined` resolution means the host is not reporting, which is the
- * same silence the synchronous form has always meant.
+ * The runtime cost of narrowing was the worse half. A synchronous non-undefined
+ * return reaching `.then` throws out of the event handler, and a resolved
+ * `Promise<void>` read as `result.ok` threw and was caught — reporting a rename
+ * that SUCCEEDED as failed.
+ *
+ * So nothing is assumed about the answer. It is interpreted only once it has
+ * been shown to be a promise, and its resolution only once it has been shown to
+ * be an outcome; anything else is a host that does not report, which is the
+ * silence the `void` form always meant.
  */
-export type ClassRenameAnswer = void | Promise<ClassRenameOutcome | void>;
+export type ClassRenameAnswer = unknown;
+
+/** Whether a value can be awaited, without assuming it is a native promise. */
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "then" in value &&
+    typeof value.then === "function"
+  );
+}
+
+/** Whether a resolution is an outcome this panel can report, or something else. */
+function isRenameOutcome(value: unknown): value is ClassRenameOutcome {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    typeof value.ok === "boolean"
+  );
+}
 
 export interface ClassManagerPanelProps {
   /**
@@ -495,6 +523,21 @@ function NameField({
    * with the name it already had.
    */
   const requested = React.useRef<string | null>(null);
+  /*
+   * Where a refusal goes when this row is no longer on screen.
+   *
+   * `BuilderShell` keys its content by the open panel, so switching panels or
+   * leaving the editor unmounts this field while a save is still on the
+   * network, and `setRefused` then reaches nothing. This row can always show
+   * one while it exists, so it always takes responsibility.
+   */
+  const survive = useSurvivingReport();
+  const report = (reason: string): void => {
+    survive(reason, () => {
+      setRefused(reason);
+      return true;
+    });
+  };
   const id = React.useId();
   const outcome =
     draft === null ? null : renamedClassName(draft, row.id, library);
@@ -537,7 +580,7 @@ function NameField({
     } catch {
       setDraft(null);
       requested.current = null;
-      setRefused("This class could not be renamed.");
+      report("This class could not be renamed.");
       return;
     }
     /*
@@ -549,21 +592,23 @@ function NameField({
      */
     setDraft(null);
     setRefused(null);
-    if (answered === undefined) return;
-    void answered
+    // A host that answered with something un-awaitable is one that does not
+    // report. Reaching for `.then` on it threw out of this event handler.
+    if (!isPromiseLike(answered)) return;
+    void Promise.resolve(answered)
       .then(result => {
         // Superseded: a newer rename on this row is the one being awaited, and
         // this answer describes a name the author has already moved past.
         if (attempt.current !== mine) return;
-        // `undefined` is a host that does not report, which is silence rather
-        // than refusal — reading `.ok` off it would throw, and the catch below
-        // would then present a SUCCESSFUL rename as a failed one.
-        if (result === undefined || result.ok) {
+        // Anything that is not an outcome is silence rather than refusal —
+        // reading `.ok` off it would throw, and the catch below would then
+        // present a SUCCESSFUL rename as a failed one.
+        if (!isRenameOutcome(result) || result.ok) {
           setRefused(null);
           return;
         }
         requested.current = null;
-        setRefused(result.reason);
+        report(result.reason);
       })
       /*
        * A REJECTED promise is a refusal too. The contract is to answer, but a
@@ -574,7 +619,7 @@ function NameField({
       .catch(() => {
         if (attempt.current !== mine) return;
         requested.current = null;
-        setRefused("This class could not be renamed.");
+        report("This class could not be renamed.");
       });
   };
 

--- a/packages/builder/src/class-selector.tsx
+++ b/packages/builder/src/class-selector.tsx
@@ -39,7 +39,7 @@ import type { NamedClass } from "@nextlyhq/blocks-engine";
 import { Button, Input } from "@nextlyhq/ui";
 import * as React from "react";
 
-import { useNoticeSink } from "./builder-notices";
+import { useSurvivingReport } from "./builder-notices";
 import {
   appliedClasses,
   nodeHasRoom,
@@ -248,19 +248,7 @@ export function ClassSelector({
    * instance and reaches nothing, which is silence about a class that was not
    * created. The shell outlives the key and can still speak.
    */
-  const raiseNotice = useNoticeSink();
-  /*
-   * Whether this instance can still draw. A ref rather than state because
-   * nothing renders from it and setting it must schedule no work: it is read
-   * inside a callback that has already outlived the render it came from.
-   */
-  const mounted = React.useRef(true);
-  React.useEffect(() => {
-    mounted.current = true;
-    return () => {
-      mounted.current = false;
-    };
-  }, []);
+  const survive = useSurvivingReport();
   const listId = React.useId();
   /*
    * What the node holds RIGHT NOW, for the callback that runs after a save.
@@ -307,15 +295,18 @@ export function ClassSelector({
    * learn to stop reading.
    */
   const reportRefusal = (about: string, reason: string): void => {
-    if (mounted.current && currentNodeId.current === about) {
+    survive(reason, () => {
+      // Withheld when the author has moved to another block: the inline message
+      // is scoped to the node the request was made against, and shown beside a
+      // different one it describes an element that is not selected.
+      if (currentNodeId.current !== about) return false;
       setFailure({
         about,
         whenIds: currentIds.current,
         issue: { kind: "not-created", reason },
       });
-      return;
-    }
-    raiseNotice(reason);
+      return true;
+    });
   };
 
   /*

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -399,7 +399,13 @@ export type { SelectionBreadcrumbProps } from "./breadcrumb";
  * not the save.
  */
 export { ClassSelector } from "./class-selector";
-export type { ClassSelectorProps } from "./class-selector";
+/*
+ * `ClassCreation` travels with the selector's props because a HOST implements
+ * `onCreateClass` and has to name what it answers with. It was reachable only
+ * through `ClassSelectorProps["onCreateClass"]`, which spells one type as a
+ * lookup into another and reads as though the answer were private.
+ */
+export type { ClassCreation, ClassSelectorProps } from "./class-selector";
 /*
  * The notice surface is deliberately NOT exported.
  *

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -414,7 +414,10 @@ export type { ClassSelectorProps } from "./class-selector";
  * change rather than an export, so it waits for a host that wants it.
  */
 export { ClassManagerPanel } from "./class-manager-panel";
-export type { ClassManagerPanelProps } from "./class-manager-panel";
+export type {
+  ClassManagerPanelProps,
+  ClassRenameOutcome,
+} from "./class-manager-panel";
 export {
   classRows,
   filterClassRows,

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -2015,6 +2015,16 @@
   font-weight: 600;
 }
 
+/*
+ * The name search. Full width because it is the only control that can reach a
+ * class past the row cap, and a narrow box beside the chips reads as an
+ * afterthought rather than as the way through a long library.
+ */
+.nx-classman__search {
+  display: flex;
+  padding: 0 var(--space-3) var(--space-2);
+}
+
 .nx-classman__filters {
   display: flex;
   flex-wrap: wrap;

--- a/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
@@ -398,6 +398,40 @@ describe("the classes manager reaching an author", () => {
     );
   });
 
+  it("carries a ZERO limit rather than substituting the default", () => {
+    // A host that sets `maxNodes: 0` gets a renderer that draws nothing.
+    // Narrowing that away in the admin would mark classes as present on a page
+    // rendering none of them.
+    clientConfig = { limits: { maxNodes: 0 } };
+    openWith = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "core/text", props: {}, classes: ["id-card"] }],
+    };
+    storedRead = {
+      data: {
+        classes: [{ id: "id-card", slug: "card", orderIndex: 0, styles: {} }],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    const panel = screen.getByTestId("panel");
+    // The row is there (the control), and it is NOT marked as on this page.
+    expect(screen.getByLabelText("Name of card")).toBeTruthy();
+    expect(panel.textContent).not.toContain("on this page");
+  });
+
+  /*
+   * The DECODE of `null` back to an infinite bound is not asserted here, and
+   * that is deliberate rather than an oversight: separating it from the engine
+   * default needs a document larger than `MAX_NODES` (5000), which no test in
+   * this file can build cheaply. What is asserted instead is the half that
+   * actually breaks — the ENCODE, in `plugin.clientConfig.test`, because an
+   * unencoded `Infinity` fails the client-config round trip and takes boot
+   * down.
+   */
+
   it("says a failed read failed, rather than loading forever", () => {
     // A read that FAILED will not finish. A panel still saying "loading"
     // describes a state the site is not in, and the author waits for something

--- a/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
@@ -29,6 +29,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
 
+/** The document the editor opens with, when a test needs one with nodes in it. */
+let openWith: unknown;
+
 /** Props the inspector recorder captured on the most recent render. */
 const seen: { inspector: Record<string, unknown> | undefined } = {
   inspector: undefined,
@@ -40,6 +43,8 @@ let clientConfig: Record<string, unknown> | undefined;
 let storedRead: { data: unknown; isPending: boolean; error: unknown };
 /** What a save answers, and what it was handed. */
 let saveResult: { success: boolean } | Error;
+/** When set, every save blocks on this until the test releases it. */
+let holdSaves: Promise<void> | null;
 const saved: Array<Record<string, unknown>> = [];
 
 vi.mock("@nextlyhq/builder/shell", async importOriginal => {
@@ -101,6 +106,13 @@ vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
   useUpdateSingleDocument: () => ({
     mutateAsync: async (value: Record<string, unknown>) => {
       saved.push(value);
+      /*
+       * Held open when the test asks. A mock that resolves immediately closes
+       * the very window these tests exist to enter: the second edit then
+       * composes after the first has already advanced the base, and passes
+       * whether or not composition is serialised.
+       */
+      if (holdSaves !== null) await holdSaves;
       if (saveResult instanceof Error) throw saveResult;
       return saveResult;
     },
@@ -111,7 +123,7 @@ vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
 const { BlocksField } = await import("./BlocksField");
 
 function Host(): React.JSX.Element {
-  const { control } = useForm({ defaultValues: { body: undefined } });
+  const { control } = useForm({ defaultValues: { body: openWith } });
   return <BlocksField name="body" control={control} />;
 }
 
@@ -136,6 +148,8 @@ beforeEach(() => {
   clientConfig = {};
   storedRead = { data: undefined, isPending: false, error: null };
   saveResult = { success: true };
+  holdSaves = null;
+  openWith = undefined;
   saved.length = 0;
 });
 
@@ -260,6 +274,56 @@ describe("the classes manager reaching an author", () => {
     expect(await screen.findByText("The site style is locked.")).toBeTruthy();
   });
 
+  it("composes a queued rename AFTER the one before it settles", async () => {
+    /*
+     * The window that matters: both edits are made while the FIRST save is
+     * still on the network. Serialising transmission alone is not enough —
+     * the second payload is already built by then, so it carries the first
+     * class's old slug and writing it undoes that rename while reporting
+     * success.
+     *
+     * The save is held open deliberately. With a mock that resolves at once,
+     * the second edit composes after the first has advanced the base, and the
+     * test passes against code that does not serialise composition at all.
+     */
+    let release: (() => void) | undefined;
+    holdSaves = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    storedRead = {
+      data: {
+        classes: [
+          { id: "id-card", slug: "card", orderIndex: 0, styles: {} },
+          { id: "id-hero", slug: "hero", orderIndex: 1, styles: {} },
+        ],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+
+    // BOTH edits committed before anything is released.
+    const first = screen.getByLabelText("Name of card");
+    fireEvent.change(first, { target: { value: "panel" } });
+    fireEvent.blur(first);
+    const second = screen.getByLabelText("Name of hero");
+    fireEvent.change(second, { target: { value: "banner" } });
+    fireEvent.blur(second);
+
+    await act(async () => {
+      release?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(saved.length).toBe(2));
+
+    const last = JSON.stringify(saved[saved.length - 1]);
+    expect(last).toContain("banner");
+    expect(last).toContain("panel");
+    expect(last).not.toContain('"card"');
+  });
+
   it("builds a second rename on the FIRST, not on the stale render", async () => {
     /*
      * Every write here replaces the whole class list, and the rendered library
@@ -297,6 +361,41 @@ describe("the classes manager reaching an author", () => {
     expect(last).toContain("banner");
     expect(last).toContain("panel");
     expect(last).not.toContain('"card"');
+  });
+
+  it("uses the HOST's limits to decide what the page applies", () => {
+    /*
+     * A site that raised or lowered `limits` renders under those, and a walk
+     * here under the engine's defaults selects different nodes — reporting a
+     * class as absent from a page that renders it. A ceiling of one node means
+     * only the first is read, so the second node's class is not marked.
+     */
+    clientConfig = { limits: { maxNodes: 1 } };
+    // Two nodes, each carrying a class, so a ceiling of one truncates the walk.
+    openWith = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "n1", type: "core/text", props: {}, classes: ["id-card"] },
+        { id: "n2", type: "core/text", props: {}, classes: ["id-hero"] },
+      ],
+    };
+    storedRead = {
+      data: {
+        classes: [
+          { id: "id-card", slug: "card", orderIndex: 0, styles: {} },
+          { id: "id-hero", slug: "hero", orderIndex: 1, styles: {} },
+        ],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    // Reading fewer nodes than the document holds is reported, rather than the
+    // shortfall being presented as "these classes are not on this page".
+    expect(screen.getByTestId("panel").textContent).toContain(
+      "more blocks than can be read at once"
+    );
   });
 
   it("says a failed read failed, rather than loading forever", () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
@@ -1,0 +1,262 @@
+// @vitest-environment jsdom
+
+/**
+ * The classes manager reaching an author, which is a different claim from the
+ * panel working.
+ *
+ * `class-manager-panel.test.tsx` in the builder asserts the surface and
+ * `class-library.test.ts` asserts the rules. Both passed for weeks while the
+ * panel was exported, styled, covered — and rendered by nothing, so no author
+ * could open it. That is the failure this file exists to catch, and it has
+ * already happened once on this chain for the fonts panel.
+ *
+ * The builder shell is replaced with recorders rather than rendered, as the
+ * sibling files do: what is under test is which props this component passes,
+ * and that `renderPanel` answers for this key at all.
+ *
+ * @module admin/BlocksField.classesPanel.test
+ */
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
+
+/** Props the inspector recorder captured on the most recent render. */
+const seen: { inspector: Record<string, unknown> | undefined } = {
+  inspector: undefined,
+};
+
+/** What `usePluginClientConfig` answers with for the test in hand. */
+let clientConfig: Record<string, unknown> | undefined;
+/** What the stored site-style read reports, so `pending` can be driven. */
+let storedRead: { data: unknown; isPending: boolean; error: unknown };
+/** What a save answers, and what it was handed. */
+let saveResult: { success: boolean } | Error;
+const saved: Array<Record<string, unknown>> = [];
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  const real = await importOriginal<Record<string, unknown>>();
+  const nothing = (): null => null;
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    /*
+      The shell here CALLS `renderPanel`, which the sibling tests' shell does
+      not. What is under test is the branch itself: a panel exported, styled and
+      covered by its own tests is still invisible to every author while nothing
+      renders it, and that is the failure this file exists to catch rather than
+      anything about how the panel behaves.
+    */
+    BuilderShell: ({
+      renderPanel,
+      availablePanels,
+    }: {
+      renderPanel?: (panel: string) => React.ReactNode;
+      availablePanels?: readonly string[];
+    }): React.JSX.Element => (
+      <div>
+        <div data-testid="rail">{(availablePanels ?? []).join(",")}</div>
+        <div data-testid="panel">{renderPanel?.("classes")}</div>
+      </div>
+    ),
+    BlockKeyboardActions: passthrough,
+    BlockToolbar: nothing,
+    BreakpointManager: nothing,
+    BreakpointSwitcher: nothing,
+    InspectorPanel: nothing,
+    InsertPanel: nothing,
+    LayersPanel: nothing,
+    TokensStudio: nothing,
+    BlockContextMenu: passthrough,
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
+  usePluginClientConfig: () => clientConfig,
+  useDocumentCheckpoint: () => ({ schedule: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  /*
+   * Reached only on the refusal path, where `site-style-client` asks it to turn
+   * a rejection into per-field messages. Answering none exercises the branch
+   * that must still refuse when the transport could not describe why.
+   */
+  validationIssues: () => [],
+  useSingleDocument: () => storedRead,
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async (value: Record<string, unknown>) => {
+      saved.push(value);
+      if (saveResult instanceof Error) throw saveResult;
+      return saveResult;
+    },
+    isPending: false,
+  }),
+}));
+
+const { BlocksField } = await import("./BlocksField");
+
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+function openEditor(): void {
+  render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+}
+
+/** What the inspector was handed for the class surface. */
+function classProps(): {
+  classLibrary?: readonly { id: string; slug: string }[];
+  classLibraryAbsence?: "pending" | "failed";
+  onCreateClass?: (
+    slug: string
+  ) => Promise<{ ok: true; classId: string } | { ok: false; reason: string }>;
+} {
+  return (seen.inspector ?? {}) as never;
+}
+
+beforeEach(() => {
+  seen.inspector = undefined;
+  clientConfig = {};
+  storedRead = { data: undefined, isPending: false, error: null };
+  saveResult = { success: true };
+  saved.length = 0;
+});
+
+afterEach(cleanup);
+
+describe("the classes manager reaching an author", () => {
+  it("offers the classes rail slot at all", () => {
+    // The slot was reserved and dark: `LEFT_PANELS` named it and nothing
+    // rendered into it, so the shell drew it disabled as "coming soon".
+    storedRead = { data: { classes: [] }, isPending: false, error: null };
+    openEditor();
+    expect(screen.getByTestId("rail").textContent).toContain("classes");
+  });
+
+  it("renders the manager into that slot rather than nothing", () => {
+    storedRead = {
+      data: {
+        classes: [{ id: "id-card", slug: "card", orderIndex: 0, styles: {} }],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    const panel = screen.getByTestId("panel");
+    expect(panel.textContent).toContain("Classes");
+    // The site's OWN class reached it. An empty panel would satisfy the
+    // heading assertion alone, which is the shape this file exists to refuse.
+    expect(panel.textContent).toContain("card");
+  });
+
+  it("draws a read still in flight as loading, not as a site with no classes", () => {
+    storedRead = { data: undefined, isPending: true, error: null };
+    openEditor();
+    expect(screen.getByTestId("panel").textContent).toContain(
+      "Loading classes"
+    );
+  });
+
+  it("says usage was not read, rather than reporting an empty index", () => {
+    /*
+     * The usage index is a collection and this surface has no read for one.
+     * Passing an empty map would print "Not in index" against every class,
+     * which is a statement about the site made from never having asked — and
+     * it is the direction that reads as permission to delete.
+     */
+    storedRead = {
+      data: {
+        classes: [{ id: "id-card", slug: "card", orderIndex: 0, styles: {} }],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    const panel = screen.getByTestId("panel");
+    expect(panel.textContent).toContain("Usage not read");
+    expect(panel.textContent).not.toContain("Not in index");
+  });
+
+  it("offers no Delete while nothing can carry out one", () => {
+    // Deleting must strip the class from every document holding it, and no
+    // such write exists. A control that cannot keep its promise is withheld
+    // rather than shown disabled.
+    storedRead = {
+      data: {
+        classes: [{ id: "id-card", slug: "card", orderIndex: 0, styles: {} }],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    /*
+     * The control first. An absent button is equally what a panel that never
+     * rendered looks like, so without something that must be FOUND this
+     * assertion is satisfied by the very defect the file exists to catch —
+     * measured: it passed with `renderPanel` answering nothing for this key.
+     */
+    expect(screen.getByLabelText("Name of card")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Delete card" })).toBeNull();
+  });
+
+  it("writes the classes section when a name is committed", async () => {
+    storedRead = {
+      data: {
+        classes: [{ id: "id-card", slug: "card", orderIndex: 0, styles: {} }],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    const field = screen.getByLabelText("Name of card");
+    fireEvent.change(field, { target: { value: "panel" } });
+    fireEvent.blur(field);
+    await vi.waitFor(() => expect(saved.length).toBeGreaterThan(0));
+    expect(JSON.stringify(saved)).toContain("panel");
+  });
+
+  it("shows a refused rename rather than clearing as though it landed", async () => {
+    // The field clears as soon as the author finishes typing, so a refusal
+    // that reported nothing would leave the row reading as renamed until some
+    // later read contradicted it.
+    storedRead = {
+      data: {
+        classes: [{ id: "id-card", slug: "card", orderIndex: 0, styles: {} }],
+      },
+      isPending: false,
+      error: null,
+    };
+    saveResult = new Error("The site style is locked.");
+    openEditor();
+    const field = screen.getByLabelText("Name of card");
+    await act(async () => {
+      fireEvent.change(field, { target: { value: "panel" } });
+      fireEvent.blur(field);
+    });
+    // The write WAS attempted — otherwise a refusal never shown and a refusal
+    // never requested look identical, and the assertion below would pass on a
+    // panel that simply does not rename.
+    expect(saved.length).toBeGreaterThan(0);
+    // The HOST's own reason, carried through verbatim rather than replaced by
+    // a generic one. A surface that substitutes its own wording tells the
+    // author less than the server already said.
+    expect(await screen.findByText("The site style is locked.")).toBeTruthy();
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
@@ -497,6 +497,59 @@ describe("the classes manager reaching an author", () => {
     expect(second).toBe(first);
   });
 
+  it("remembers the name a class is heading for while its write is open", async () => {
+    /*
+     * The panel cannot remember this: the rail unmounts it on every switch, so
+     * a field holding its own pending name loses it on exactly the switch that
+     * makes the window long enough to matter. The HOST owns the write queue and
+     * therefore the answer.
+     *
+     * Driven end to end: rename `card` to `panel` with the save held open, then
+     * type `card` again. That is a REVERT, and it must reach the host rather
+     * than being read as a no-op against the still-rendered `card`.
+     */
+    let release: (() => void) | undefined;
+    holdSaves = new Promise<void>(resolve => {
+      release = resolve;
+    });
+    storedRead = {
+      data: {
+        classes: [{ id: "id-card", slug: "card", orderIndex: 0, styles: {} }],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+
+    const first = screen.getByLabelText("Name of card");
+    fireEvent.change(first, { target: { value: "panel" } });
+    fireEvent.blur(first);
+    await vi.waitFor(() => expect(saved.length).toBe(1));
+
+    // React fires no change when the value equals the one already there, and
+    // the field reverted to `card` when the draft cleared.
+    fireEvent.change(screen.getByLabelText("Name of card"), {
+      target: { value: "car" },
+    });
+    fireEvent.change(screen.getByLabelText("Name of card"), {
+      target: { value: "card" },
+    });
+    fireEvent.blur(screen.getByLabelText("Name of card"));
+
+    await act(async () => {
+      release?.();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await vi.waitFor(() => expect(saved.length).toBe(2));
+
+    // The revert was written LAST, so it is the one that stands.
+    const last = JSON.stringify(saved[saved.length - 1]);
+    expect(last).toContain('"card"');
+    expect(last).not.toContain("panel");
+  });
+
   it("says a failed read failed, rather than loading forever", () => {
     // A read that FAILED will not finish. A panel still saying "loading"
     // describes a state the site is not in, and the author waits for something

--- a/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
@@ -67,20 +67,36 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     BuilderShell: ({
       renderPanel,
       availablePanels,
+      inspector,
     }: {
       renderPanel?: (panel: string) => React.ReactNode;
       availablePanels?: readonly string[];
+      inspector?: React.ReactNode;
     }): React.JSX.Element => (
       <div>
         <div data-testid="rail">{(availablePanels ?? []).join(",")}</div>
         <div data-testid="panel">{renderPanel?.("classes")}</div>
+        {/* Rendered, not merely constructed: the inspector recorder only runs
+            when the element is actually drawn, and the class-creation callback
+            reaches the queue through it. */}
+        <div data-testid="inspector">{inspector}</div>
       </div>
     ),
     BlockKeyboardActions: passthrough,
     BlockToolbar: nothing,
     BreakpointManager: nothing,
     BreakpointSwitcher: nothing,
-    InspectorPanel: nothing,
+    /*
+     * Recorded rather than stubbed out: the class-CREATION callback reaches the
+     * author through the inspector, and it shares the write queue with the
+     * manager's rename. Some properties of that queue are only reachable
+     * through creation, because they need a site with no stored classes — a
+     * state in which the manager has no rows to drive.
+     */
+    InspectorPanel: (props: Record<string, unknown>): React.JSX.Element => {
+      seen.inspector = props;
+      return <div data-recorder="inspector" />;
+    },
     InsertPanel: nothing,
     LayersPanel: nothing,
     TokensStudio: nothing,
@@ -122,17 +138,40 @@ vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
 
 const { BlocksField } = await import("./BlocksField");
 
-function Host(): React.JSX.Element {
+/**
+ * `tick` exists only to force a re-render from the test.
+ *
+ * Some properties of the write queue are about what happens when the editor
+ * RENDERS during an in-flight save, and nothing a test can click reaches that
+ * without also changing the state under test.
+ */
+function Host({ tick = 0 }: { tick?: number }): React.JSX.Element {
   const { control } = useForm({ defaultValues: { body: openWith } });
-  return <BlocksField name="body" control={control} />;
+  return (
+    <>
+      <span data-testid="tick">{tick}</span>
+      <BlocksField name="body" control={control} />
+    </>
+  );
 }
 
-function openEditor(): void {
-  render(<Host />);
+function openEditor(): ReturnType<typeof render> {
+  const view = render(<Host />);
   fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  return view;
 }
 
 /** What the inspector was handed for the class surface. */
+/** The inspector recorder's most recent props, for the class surface. */
+function seenInspector(): {
+  classLibrary?: readonly unknown[];
+  onCreateClass?: (
+    slug: string
+  ) => Promise<{ ok: true; classId: string } | { ok: false; reason: string }>;
+} {
+  return (seen.inspector ?? {}) as never;
+}
+
 function classProps(): {
   classLibrary?: readonly { id: string; slug: string }[];
   classLibraryAbsence?: "pending" | "failed";
@@ -431,6 +470,32 @@ describe("the classes manager reaching an author", () => {
    * unencoded `Infinity` fails the client-config round trip and takes boot
    * down.
    */
+
+  it("hands out the SAME empty library across renders", () => {
+    /*
+     * `?? []` built a new array every render. `useClassWrites` reads a changed
+     * identity as "the host has re-read" and resets the write base to it, so a
+     * site whose stored style declares no classes looked like it was re-reading
+     * continuously — and a render during an in-flight save could restore the
+     * stale list before the next queued write composed its payload.
+     *
+     * Asserted as the IDENTITY the surface is handed, which is the property the
+     * write base keys on. Driving two creations through a held-open save does
+     * not reach it: the composition callbacks run as microtasks and React has
+     * not flushed the effect that resets the base by then, so that test passed
+     * with the churn restored and was removed rather than kept as a green.
+     */
+    storedRead = { data: {}, isPending: false, error: null };
+    const view = openEditor();
+    const first = seenInspector().classLibrary;
+    view.rerender(<Host tick={1} />);
+    const second = seenInspector().classLibrary;
+
+    // The control: a read that answered must yield a library at all, or `toBe`
+    // below would be comparing undefined with undefined and pass on nothing.
+    expect(first).toBeDefined();
+    expect(second).toBe(first);
+  });
 
   it("says a failed read failed, rather than loading forever", () => {
     // A read that FAILED will not finish. A panel still saying "loading"

--- a/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
@@ -259,4 +259,54 @@ describe("the classes manager reaching an author", () => {
     // author less than the server already said.
     expect(await screen.findByText("The site style is locked.")).toBeTruthy();
   });
+
+  it("builds a second rename on the FIRST, not on the stale render", async () => {
+    /*
+     * Every write here replaces the whole class list, and the rendered library
+     * does not refresh until the save comes back through the cache. Two
+     * renames inside that window both composed from the same snapshot, so the
+     * second wrote a list in which the first rename never happened — and it
+     * reported success while undoing it.
+     */
+    storedRead = {
+      data: {
+        classes: [
+          { id: "id-card", slug: "card", orderIndex: 0, styles: {} },
+          { id: "id-hero", slug: "hero", orderIndex: 1, styles: {} },
+        ],
+      },
+      isPending: false,
+      error: null,
+    };
+    openEditor();
+    await act(async () => {
+      const first = screen.getByLabelText("Name of card");
+      fireEvent.change(first, { target: { value: "panel" } });
+      fireEvent.blur(first);
+    });
+    await act(async () => {
+      const second = screen.getByLabelText("Name of hero");
+      fireEvent.change(second, { target: { value: "banner" } });
+      fireEvent.blur(second);
+    });
+
+    expect(saved.length).toBe(2);
+    // The SECOND payload is the one that decides, because it is written last.
+    // It must carry both renames; carrying only its own is the defect.
+    const last = JSON.stringify(saved[saved.length - 1]);
+    expect(last).toContain("banner");
+    expect(last).toContain("panel");
+    expect(last).not.toContain('"card"');
+  });
+
+  it("says a failed read failed, rather than loading forever", () => {
+    // A read that FAILED will not finish. A panel still saying "loading"
+    // describes a state the site is not in, and the author waits for something
+    // that is never coming.
+    storedRead = { data: undefined, isPending: false, error: new Error("403") };
+    openEditor();
+    const panel = screen.getByTestId("panel");
+    expect(panel.textContent).toContain("could not be read");
+    expect(panel.textContent).not.toContain("Loading classes");
+  });
 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -824,6 +824,28 @@ function useClassSurface(
    * class.
    */
   const writes = useClassWrites(library);
+  /*
+   * Which name each class is heading for while its rename is on the network.
+   *
+   * Held HERE because it must survive the manager panel being unmounted, which
+   * the rail does on every switch. State rather than a ref: the panel renders
+   * from it, so a change has to reach the screen.
+   */
+  const [pendingSlugs, setPendingSlugs] = useState<Record<string, string>>({});
+  const markPending = useCallback(
+    (classId: string, slug: string | undefined) => {
+      setPendingSlugs(current => {
+        if (slug === undefined) {
+          if (!(classId in current)) return current;
+          const { [classId]: _gone, ...rest } = current;
+          return rest;
+        }
+        if (current[classId] === slug) return current;
+        return { ...current, [classId]: slug };
+      });
+    },
+    []
+  );
   return {
     library,
     /*
@@ -839,12 +861,14 @@ function useClassSurface(
      * save would then delete those classes rather than add one.
      */
     create: useCreateClass(writes, configured),
+    /** Which classes are mid-rename, for the manager's no-op check. */
+    pendingSlugs,
     /*
      * Withheld the same way and for the same reason: renaming against a
      * library missing everything stored would save that partial list, which
      * deletes the classes it could not see rather than renaming one.
      */
-    rename: useRenameClass(writes, configured),
+    rename: useRenameClass(writes, configured, markPending),
   };
 }
 
@@ -928,41 +952,64 @@ function useCreateClass(
  */
 function useRenameClass(
   writes: ClassWrites,
-  configured: readonly NamedClass[] | undefined
+  configured: readonly NamedClass[] | undefined,
+  /**
+   * Record which name a class is heading for while its write is in flight.
+   *
+   * Held by the CALLER rather than by the panel, because a rename outlives the
+   * panel: switching rail panels unmounts the manager, and a field remembering
+   * its own pending name lost it on exactly the switch that makes the window
+   * long enough to matter. Without it, an author who reverts a rename after
+   * coming back has the revert read as a no-op while the first write lands.
+   */
+  markPending: (classId: string, slug: string | undefined) => void
 ) {
   const { save: saveSection } = useSaveSiteStyle();
   return useCallback(
-    async (classId: string, slug: string): Promise<ClassRenameOutcome> =>
-      writes.run<ClassRenameOutcome>(async existing => {
-        if (existing === undefined) {
+    async (classId: string, slug: string): Promise<ClassRenameOutcome> => {
+      markPending(classId, slug);
+      try {
+        return await writes.run<ClassRenameOutcome>(async existing => {
+          if (existing === undefined) {
+            return {
+              result: {
+                ok: false as const,
+                reason:
+                  "This site's classes could not be read, so none can be renamed.",
+              },
+            };
+          }
+          const next = existing.map(entry =>
+            entry.id === classId ? { ...entry, slug } : entry
+          );
+          const result = await saveSection(
+            "classes",
+            classOverrideOf(configured, next)
+          );
+          if (result.saved) return { result: { ok: true as const }, next };
+          const reasons = Object.values(result.issues);
           return {
             result: {
               ok: false as const,
               reason:
-                "This site's classes could not be read, so none can be renamed.",
+                reasons.length > 0
+                  ? reasons.join(" ")
+                  : "This class could not be renamed.",
             },
           };
-        }
-        const next = existing.map(entry =>
-          entry.id === classId ? { ...entry, slug } : entry
-        );
-        const result = await saveSection(
-          "classes",
-          classOverrideOf(configured, next)
-        );
-        if (result.saved) return { result: { ok: true as const }, next };
-        const reasons = Object.values(result.issues);
-        return {
-          result: {
-            ok: false as const,
-            reason:
-              reasons.length > 0
-                ? reasons.join(" ")
-                : "This class could not be renamed.",
-          },
-        };
-      }),
-    [writes, configured, saveSection]
+        });
+      } finally {
+        /*
+         * Cleared however it went, and in a `finally` so a rejection cannot
+         * leave a class permanently reading as mid-rename. A refused write
+         * leaves the class with the name it had; a successful one is followed
+         * by a read carrying the new one. Either way the stored slug is the
+         * answer again.
+         */
+        markPending(classId, undefined);
+      }
+    },
+    [writes, configured, saveSection, markPending]
   );
 }
 
@@ -2070,6 +2117,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             classes: () => (
               <ClassManagerPanel
                 absence={classes.absence}
+                pendingSlugs={classes.pendingSlugs}
                 documentClassIds={documentClasses.ids}
                 /*
                   Whether that walk reached the whole document. It stops at the

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -780,13 +780,27 @@ function classReadFailed(pending: boolean, error: unknown): boolean {
  * a surface cannot tell "nothing is stored" from "the read has not come back"
  * by looking at the value.
  */
+/**
+ * The empty library, as ONE value rather than a fresh array each time.
+ *
+ * `?? []` builds a new array on every render, and `useClassWrites` reads a
+ * changed identity as "the host has re-read" — so a site whose stored style
+ * declares no classes looked like it was re-reading continuously, and any
+ * render during an in-flight save reset the write base to the stale list. The
+ * next queued write then composed from it and discarded the edit before it,
+ * while reporting success.
+ */
+const NO_CLASSES: readonly NamedClass[] = Object.freeze([]);
+
 function readableClassLibrary(
   siteStyle: { classes?: readonly NamedClass[] } | undefined,
   pending: boolean,
   failed: boolean
 ): readonly NamedClass[] | undefined {
   if (pending || failed) return undefined;
-  return siteStyle?.classes ?? [];
+  // `undefined` above and `NO_CLASSES` here stay distinct: the first is a read
+  // that has not answered, the second is one that answered with nothing.
+  return siteStyle?.classes ?? NO_CLASSES;
 }
 
 function useClassSurface(

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -87,7 +87,9 @@ import {
   useInlineEditing,
   documentAfter,
   type InlineEditOutcome,
+  ClassManagerPanel,
   FontsPanel,
+  type ClassRenameOutcome,
 } from "@nextlyhq/builder/shell";
 import {
   loadInlineRichTextEditor,
@@ -122,6 +124,7 @@ import {
   type Path,
 } from "react-hook-form";
 
+import { classUsageOf } from "../class-usage";
 import { emptyBlockDocument } from "../fields/blocks-document";
 import { hostFetchPolicy, readRemotePatterns } from "../host-policy";
 import {
@@ -178,7 +181,13 @@ export interface BlocksFieldProps<
  * and shrink the canvas to show it, which is why this grows one entry at a time
  * rather than being declared ahead of the panels.
  */
-const AVAILABLE_PANELS = ["insert", "layers", "tokens", "fonts"] as const;
+const AVAILABLE_PANELS = [
+  "insert",
+  "layers",
+  "tokens",
+  "fonts",
+  "classes",
+] as const;
 
 /**
  * With an entry-fields panel to fill, `settings` joins them.
@@ -613,6 +622,35 @@ function TokensStudio({
  * just created and applied wins over the ones already there rather than being
  * silently overridden by them.
  */
+/**
+ * Whether a read has FAILED rather than merely not finished yet.
+ *
+ * A separate function because "not arrived" and "will never arrive" are
+ * different states with different wording, and reading them from one
+ * expression inside the hook made the hook answer two questions at once.
+ */
+function classReadFailed(pending: boolean, error: unknown): boolean {
+  return !pending && error !== null && error !== undefined;
+}
+
+/**
+ * The library to show, or `undefined` while it is not known.
+ *
+ * `undefined` while the read is in flight, and the resolved list once it is
+ * not — including an empty one. `useSiteStyle` names `pending` as a real third
+ * state for exactly this reason: the defaults alone are a legitimate answer, so
+ * a surface cannot tell "nothing is stored" from "the read has not come back"
+ * by looking at the value.
+ */
+function readableClassLibrary(
+  siteStyle: { classes?: readonly NamedClass[] } | undefined,
+  pending: boolean,
+  failed: boolean
+): readonly NamedClass[] | undefined {
+  if (pending || failed) return undefined;
+  return siteStyle?.classes ?? [];
+}
+
 function useClassSurface(
   siteStyle: { classes?: readonly NamedClass[] } | undefined,
   pending: boolean,
@@ -620,16 +658,12 @@ function useClassSurface(
   /** The site's own config, whose classes storage layers over. */
   config: { classes?: readonly NamedClass[] } | undefined
 ) {
-  /*
-   * `undefined` while the read is in flight, and the resolved list once it is
-   * not — including an empty one. `useSiteStyle` names `pending` as a real
-   * third state for exactly this reason: the defaults alone are a legitimate
-   * answer, so a surface cannot tell "nothing is stored" from "the read has
-   * not come back" by looking at the value. Decided here rather than in the
-   * markup, so the component that renders the inspector holds no branch.
-   */
-  const failed = !pending && error !== null && error !== undefined;
-  const library = pending || failed ? undefined : (siteStyle?.classes ?? []);
+  // Derived outside the hook, so this decides nothing and only distributes what
+  // was decided — which is what keeps the component rendering the inspector
+  // free of the branch.
+  const failed = classReadFailed(pending, error);
+  const library = readableClassLibrary(siteStyle, pending, failed);
+  const configured = config?.classes;
   return {
     library,
     /*
@@ -644,7 +678,13 @@ function useClassSurface(
      * against it would compose a library missing everything stored — and the
      * save would then delete those classes rather than add one.
      */
-    create: useCreateClass(library, config?.classes),
+    create: useCreateClass(library, configured),
+    /*
+     * Withheld the same way and for the same reason: renaming against a
+     * library missing everything stored would save that partial list, which
+     * deletes the classes it could not see rather than renaming one.
+     */
+    rename: useRenameClass(library, configured),
   };
 }
 
@@ -693,6 +733,58 @@ function useCreateClass(
           reasons.length > 0
             ? reasons.join(" ")
             : "This class could not be saved.",
+      };
+    },
+    [library, configured, saveSection]
+  );
+}
+
+/**
+ * Rename one class, through the same section write that creates one.
+ *
+ * Answers the OUTCOME rather than reporting success by staying quiet. A site
+ * style save is a network write and the panel clears its field as soon as the
+ * author finishes typing, so a refusal that returned nothing would leave the
+ * row reading as renamed until the next read contradicted it.
+ */
+function useRenameClass(
+  library: readonly NamedClass[] | undefined,
+  configured: readonly NamedClass[] | undefined
+) {
+  const { save: saveSection } = useSaveSiteStyle();
+  return useCallback(
+    async (classId: string, slug: string): Promise<ClassRenameOutcome> => {
+      if (library === undefined) {
+        return {
+          ok: false,
+          reason:
+            "This site's classes could not be read, so none can be renamed.",
+        };
+      }
+      const next = library.map(entry =>
+        entry.id === classId ? { ...entry, slug } : entry
+      );
+      /*
+       * Only what DIFFERS from the site's own config classes, exactly as
+       * creating one does. Saving the merged library whole would copy every
+       * config class into the database and mask the site's own code from then
+       * on — and a rename is the operation where that is easiest to miss,
+       * because the visible result looks identical either way.
+       */
+      const result = await saveSection(
+        "classes",
+        classOverrideOf(configured, next)
+      );
+      if (result.saved) return { ok: true };
+      const reasons = Object.values(result.issues);
+      // An empty `issues` is still a refusal — the transport could not describe
+      // it. Reporting it as saved is the one outcome that must never be silent.
+      return {
+        ok: false,
+        reason:
+          reasons.length > 0
+            ? reasons.join(" ")
+            : "This class could not be renamed.",
       };
     },
     [library, configured, saveSection]
@@ -1429,6 +1521,27 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   useCheckpoints({ name, control, document: editor.document });
 
   /*
+   * Which classes the OPEN document renders, for the manager's on-this-page
+   * filter.
+   *
+   * `classUsageOf` rather than a walk written here: it is the same traversal
+   * the style compiler and the usage index already share, and two walks with
+   * equal limits reached by different routes select different nodes — a class
+   * on a node one walk reaches and the other does not would be reported as
+   * absent from a page that renders it.
+   *
+   * `complete` is deliberately unread. It says whether the walk hit the
+   * document's node ceiling, which bounds what this could CLAIM about usage —
+   * and this claims nothing about usage. It answers one question, "does the
+   * open page apply this class", and a truncated walk answers that for fewer
+   * nodes rather than answering it wrongly.
+   */
+  const documentClassIds = useMemo(
+    () => classUsageOf(editor.document).ids,
+    [editor.document]
+  );
+
+  /*
    * Tell the form this editor holds work its values do not contain, so the
    * navigation guard warns and the save shortcut works while the canvas is
    * open. `undoDepth` rather than comparing documents: an edit and its undo
@@ -1773,6 +1886,25 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                 )}
                 supplied={configSiteStyle?.tokens}
                 pending={siteStylePending}
+              />
+            ),
+            classes: () => (
+              <ClassManagerPanel
+                documentClassIds={documentClassIds}
+                library={classes.library}
+                onRename={classes.rename}
+                /*
+                  No `usage`, and no `onDelete`. The usage index is a
+                  collection and this surface has no read for one, so the panel
+                  reports that nothing was read rather than reporting an empty
+                  index — which would say every class is unused. Deleting needs
+                  that same reach plus a write stripping the class from every
+                  document holding it, so it is withheld entirely rather than
+                  offered as a control that cannot keep its promise.
+                */
+                suppliedClassIds={configSiteStyle?.classes?.map(
+                  entry => entry.id
+                )}
               />
             ),
             fonts: () => (

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -623,6 +623,56 @@ function TokensStudio({
  * silently overridden by them.
  */
 /**
+ * The library a class write must build on, which is not always the rendered one.
+ *
+ * Every write here is read-modify-write over the WHOLE section: the payload is
+ * the complete class list, because that is what `saveSection` stores. So the
+ * list a write composes from decides what survives it, and the rendered
+ * `library` is stale for as long as a save takes to come back through the
+ * cache.
+ *
+ * Two edits inside that window both compose from the same snapshot. The shared
+ * mutation scope serialises TRANSMISSION, so both land — but the second payload
+ * was already computed without the first, and writing it undoes the first edit
+ * while reporting success. Renaming two classes quickly restores the first
+ * name; creating two classes quickly deletes the first class.
+ *
+ * So a completed write ADVANCES the base, and a fresh read from the host
+ * REPLACES it: the server's answer is authoritative the moment it arrives, and
+ * anything composed locally after it was composed against older facts.
+ *
+ * Identity is what separates the two cases. `library` is a new array whenever
+ * the host has re-read, so comparing the reference the base was taken from
+ * against the one in hand distinguishes "the host has answered since" from
+ * "nothing has changed but our own writes".
+ */
+function useClassWriteBase(library: readonly NamedClass[] | undefined): {
+  base: () => readonly NamedClass[] | undefined;
+  advance: (next: readonly NamedClass[]) => void;
+} {
+  const held = useRef<{
+    from: readonly NamedClass[] | undefined;
+    value: readonly NamedClass[] | undefined;
+  }>({ from: library, value: library });
+
+  const base = useCallback((): readonly NamedClass[] | undefined => {
+    if (held.current.from !== library) {
+      held.current = { from: library, value: library };
+    }
+    return held.current.value;
+  }, [library]);
+
+  const advance = useCallback(
+    (next: readonly NamedClass[]) => {
+      held.current = { from: library, value: next };
+    },
+    [library]
+  );
+
+  return { base, advance };
+}
+
+/**
  * Whether a read has FAILED rather than merely not finished yet.
  *
  * A separate function because "not arrived" and "will never arrive" are
@@ -696,16 +746,20 @@ function useCreateClass(
   // largest component in this file, and a dependency a hook can obtain for
   // itself is a statement that does not need to live there.
   const { save: saveSection } = useSaveSiteStyle();
+  const { base, advance } = useClassWriteBase(library);
   return useCallback(
     async (slug: string) => {
-      if (library === undefined) {
+      // The base rather than the rendered library, for the reason the rename
+      // uses it: two creations inside one save's window both composed from the
+      // same snapshot, and the second wrote a list without the first class.
+      const existing = base();
+      if (existing === undefined) {
         return {
           ok: false as const,
           reason:
             "This site's classes could not be read, so none can be added.",
         };
       }
-      const existing = library;
       const classId = newId();
       const next: NamedClass[] = [
         ...existing,
@@ -722,7 +776,12 @@ function useCreateClass(
         "classes",
         classOverrideOf(configured, next)
       );
-      if (result.saved) return { ok: true as const, classId };
+      if (result.saved) {
+        // Only on success, so a refused write does not become the base the
+        // next edit builds on.
+        advance(next);
+        return { ok: true as const, classId };
+      }
       const reasons = Object.values(result.issues);
       // An empty `issues` is still a refusal — the transport could not describe
       // it. Reporting it as saved is the one outcome that must never be silent,
@@ -735,7 +794,7 @@ function useCreateClass(
             : "This class could not be saved.",
       };
     },
-    [library, configured, saveSection]
+    [base, advance, configured, saveSection]
   );
 }
 
@@ -752,16 +811,21 @@ function useRenameClass(
   configured: readonly NamedClass[] | undefined
 ) {
   const { save: saveSection } = useSaveSiteStyle();
+  const { base, advance } = useClassWriteBase(library);
   return useCallback(
     async (classId: string, slug: string): Promise<ClassRenameOutcome> => {
-      if (library === undefined) {
+      // The base rather than the rendered library: a rename committed while an
+      // earlier one is still in flight must build on that earlier one, or it
+      // writes a list in which the first rename never happened.
+      const existing = base();
+      if (existing === undefined) {
         return {
           ok: false,
           reason:
             "This site's classes could not be read, so none can be renamed.",
         };
       }
-      const next = library.map(entry =>
+      const next = existing.map(entry =>
         entry.id === classId ? { ...entry, slug } : entry
       );
       /*
@@ -775,7 +839,12 @@ function useRenameClass(
         "classes",
         classOverrideOf(configured, next)
       );
-      if (result.saved) return { ok: true };
+      if (result.saved) {
+        // Only on success. A refused write changed nothing, so advancing would
+        // build the next edit on a list the server never accepted.
+        advance(next);
+        return { ok: true };
+      }
       const reasons = Object.values(result.issues);
       // An empty `issues` is still a refusal — the transport could not describe
       // it. Reporting it as saved is the one outcome that must never be silent.
@@ -787,7 +856,7 @@ function useRenameClass(
             : "This class could not be renamed.",
       };
     },
-    [library, configured, saveSection]
+    [base, advance, configured, saveSection]
   );
 }
 
@@ -1890,6 +1959,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             ),
             classes: () => (
               <ClassManagerPanel
+                absence={classes.absence}
                 documentClassIds={documentClassIds}
                 library={classes.library}
                 onRename={classes.rename}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -734,10 +734,25 @@ function readDocumentLimits(
   const merged: DocumentLimits = { ...DEFAULT_LIMITS };
   for (const key of Object.keys(DEFAULT_LIMITS) as (keyof DocumentLimits)[]) {
     const supplied = declared[key];
+    /*
+     * Zero and Infinity are both LEGITIMATE bounds, so neither may be narrowed
+     * away here. A host setting `maxNodes: 0` gets a renderer that draws
+     * nothing, and substituting the default would have the panel mark classes
+     * as present on a page that renders none of them; the engine supports an
+     * infinite byte limit outright. What is refused is a value that is not a
+     * number, or one below zero, which no bound can mean.
+     */
+    // `null` is the wire spelling for an INFINITE bound: `Infinity` is not a
+    // JSON value and the client config is refused unless it survives the round
+    // trip unchanged, so the publisher encodes it and this decodes it.
+    if (supplied === null) {
+      merged[key] = Number.POSITIVE_INFINITY;
+      continue;
+    }
     if (
       typeof supplied === "number" &&
-      Number.isFinite(supplied) &&
-      supplied > 0
+      !Number.isNaN(supplied) &&
+      supplied >= 0
     ) {
       merged[key] = supplied;
     }

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -35,6 +35,9 @@
 
 import {
   resolveSiteTokens,
+  isPlainRecord,
+  DEFAULT_LIMITS,
+  type DocumentLimits,
   getBlock,
   hasBlock,
   registerBlocks,
@@ -88,6 +91,7 @@ import {
   documentAfter,
   type InlineEditOutcome,
   ClassManagerPanel,
+  type ClassCreation,
   FontsPanel,
   type ClassRenameOutcome,
 } from "@nextlyhq/builder/shell";
@@ -623,7 +627,7 @@ function TokensStudio({
  * silently overridden by them.
  */
 /**
- * The library a class write must build on, which is not always the rendered one.
+ * One serialised writer for every whole-section class write.
  *
  * Every write here is read-modify-write over the WHOLE section: the payload is
  * the complete class list, because that is what `saveSection` stores. So the
@@ -631,45 +635,114 @@ function TokensStudio({
  * `library` is stale for as long as a save takes to come back through the
  * cache.
  *
- * Two edits inside that window both compose from the same snapshot. The shared
- * mutation scope serialises TRANSMISSION, so both land — but the second payload
- * was already computed without the first, and writing it undoes the first edit
- * while reporting success. Renaming two classes quickly restores the first
- * name; creating two classes quickly deletes the first class.
+ * Two things follow, and each was a separate defect.
  *
- * So a completed write ADVANCES the base, and a fresh read from the host
- * REPLACES it: the server's answer is authoritative the moment it arrives, and
- * anything composed locally after it was composed against older facts.
+ * **Composition must happen inside the queue, not before it.** Serialising
+ * only TRANSMISSION is not enough: both callers compose their payload, then
+ * queue, so the second was already built without the first. `run` therefore
+ * takes a FUNCTION and calls it after the previous write settles, so every
+ * payload is composed against the result of the one before it.
  *
- * Identity is what separates the two cases. `library` is a new array whenever
- * the host has re-read, so comparing the reference the base was taken from
- * against the one in hand distinguishes "the host has answered since" from
- * "nothing has changed but our own writes".
+ * **One base, shared.** Creating and renaming are the same read-modify-write
+ * over the same list. Two independent bases meant a rename that had not yet
+ * refreshed was invisible to a creation, which then wrote a list carrying the
+ * old slug — and in the other order, dropped the new class.
+ *
+ * A completed write ADVANCES the base; a fresh read from the host REPLACES it,
+ * because the server's answer is authoritative the moment it arrives.
  */
-function useClassWriteBase(library: readonly NamedClass[] | undefined): {
-  base: () => readonly NamedClass[] | undefined;
-  advance: (next: readonly NamedClass[]) => void;
-} {
-  const held = useRef<{
-    from: readonly NamedClass[] | undefined;
-    value: readonly NamedClass[] | undefined;
-  }>({ from: library, value: library });
+interface ClassWrites {
+  /**
+   * Run one whole-section write, composed against the freshest list.
+   *
+   * The callback receives the base and answers with the payload it composed
+   * plus its own result. Returning `next` separately is what lets this advance
+   * the base ONLY when the write succeeded — a refused write changed nothing,
+   * and building the following edit on it would persist something the server
+   * rejected.
+   */
+  run: <T>(
+    write: (existing: readonly NamedClass[] | undefined) => Promise<{
+      result: T;
+      next?: readonly NamedClass[];
+    }>
+  ) => Promise<T>;
+}
 
-  const base = useCallback((): readonly NamedClass[] | undefined => {
-    if (held.current.from !== library) {
-      held.current = { from: library, value: library };
-    }
-    return held.current.value;
+function useClassWrites(
+  library: readonly NamedClass[] | undefined
+): ClassWrites {
+  const held = useRef(library);
+  /*
+   * The host's answer supersedes anything composed locally. This runs only
+   * when `library` changes identity, which is exactly when a re-read has
+   * landed — during a save's window the identity is unchanged and the base
+   * keeps whatever the writes advanced it to.
+   */
+  useEffect(() => {
+    held.current = library;
   }, [library]);
 
-  const advance = useCallback(
-    (next: readonly NamedClass[]) => {
-      held.current = { from: library, value: next };
+  // The chain every write joins. Held as a ref so it survives re-renders: a
+  // queue recreated on render would let two writes run concurrently again.
+  const tail = useRef<Promise<unknown>>(Promise.resolve());
+
+  const run = useCallback(
+    <T,>(
+      write: (existing: readonly NamedClass[] | undefined) => Promise<{
+        result: T;
+        next?: readonly NamedClass[];
+      }>
+    ): Promise<T> => {
+      const started = tail.current.then(async () => {
+        const answered = await write(held.current);
+        if (answered.next !== undefined) held.current = answered.next;
+        return answered.result;
+      });
+      // The chain must not break on a rejection, or every later write is
+      // rejected with an error belonging to an edit the author has forgotten.
+      tail.current = started.then(
+        () => undefined,
+        () => undefined
+      );
+      return started;
     },
-    [library]
+    []
   );
 
-  return { base, advance };
+  return { run };
+}
+
+/**
+ * The document bounds the host renders under, as published to the browser.
+ *
+ * Read DEFENSIVELY and one key at a time: `clientConfig` is JSON that crossed a
+ * transport, so nothing here can assume a shape. Anything unreadable falls back
+ * to the engine's defaults, which is what the renderer itself falls back to —
+ * so the two still agree rather than diverging in the direction that would
+ * misreport which classes a page applies.
+ */
+function readDocumentLimits(
+  clientConfig: Record<string, unknown> | undefined
+): DocumentLimits {
+  const declared = clientConfig?.limits;
+  if (!isPlainRecord(declared)) return DEFAULT_LIMITS;
+  // Built by overriding the defaults key by key rather than by asserting a
+  // shape onto the transported value: the keys come from `DEFAULT_LIMITS`, so
+  // a bound the engine adds later is carried without this being edited, and a
+  // key the host sent that the engine does not have is ignored.
+  const merged: DocumentLimits = { ...DEFAULT_LIMITS };
+  for (const key of Object.keys(DEFAULT_LIMITS) as (keyof DocumentLimits)[]) {
+    const supplied = declared[key];
+    if (
+      typeof supplied === "number" &&
+      Number.isFinite(supplied) &&
+      supplied > 0
+    ) {
+      merged[key] = supplied;
+    }
+  }
+  return merged;
 }
 
 /**
@@ -714,6 +787,14 @@ function useClassSurface(
   const failed = classReadFailed(pending, error);
   const library = readableClassLibrary(siteStyle, pending, failed);
   const configured = config?.classes;
+  /*
+   * ONE writer for both edits. Creating and renaming are the same
+   * read-modify-write over the same list, so two independent queues let a
+   * rename that had not yet refreshed be invisible to a creation — which then
+   * wrote a list carrying the old slug, and in the other order dropped the new
+   * class.
+   */
+  const writes = useClassWrites(library);
   return {
     library,
     /*
@@ -728,73 +809,83 @@ function useClassSurface(
      * against it would compose a library missing everything stored — and the
      * save would then delete those classes rather than add one.
      */
-    create: useCreateClass(library, configured),
+    create: useCreateClass(writes, configured),
     /*
      * Withheld the same way and for the same reason: renaming against a
      * library missing everything stored would save that partial list, which
      * deletes the classes it could not see rather than renaming one.
      */
-    rename: useRenameClass(library, configured),
+    rename: useRenameClass(writes, configured),
   };
 }
 
 function useCreateClass(
-  library: readonly NamedClass[] | undefined,
+  writes: ClassWrites,
   configured: readonly NamedClass[] | undefined
 ) {
   // Its own write handle rather than one passed in. The caller is already the
   // largest component in this file, and a dependency a hook can obtain for
   // itself is a statement that does not need to live there.
   const { save: saveSection } = useSaveSiteStyle();
-  const { base, advance } = useClassWriteBase(library);
   return useCallback(
-    async (slug: string) => {
-      // The base rather than the rendered library, for the reason the rename
-      // uses it: two creations inside one save's window both composed from the
-      // same snapshot, and the second wrote a list without the first class.
-      const existing = base();
-      if (existing === undefined) {
+    async (slug: string) =>
+      // Composed INSIDE the queue, so a creation following a rename builds on
+      // that rename rather than on the list they both started from.
+      //
+      // The result type is stated rather than inferred: inference takes the
+      // first branch it meets, which is the refusal, and the success branch
+      // then fails to assign.
+      writes.run<ClassCreation>(async existing => {
+        if (existing === undefined) {
+          return {
+            result: {
+              ok: false as const,
+              reason:
+                "This site's classes could not be read, so none can be added.",
+            },
+          };
+        }
+        const classId = newId();
+        const next: NamedClass[] = [
+          ...existing,
+          {
+            id: classId,
+            slug,
+            orderIndex: nextOrderIndex(existing),
+            styles: {},
+          },
+        ];
+        /*
+         * Only what DIFFERS from the site's own config classes. The base is the
+         * MERGED set the canvas compiles, so saving it whole would copy every
+         * config class into the database on the first creation and mask the
+         * site's code from then on — the argument `tokenOverrideOf` already
+         * makes for tokens.
+         */
+        const result = await saveSection(
+          "classes",
+          classOverrideOf(configured, next)
+        );
+        // `next` is returned ONLY on success, so a refused write never becomes
+        // the base the following edit builds on.
+        if (result.saved) {
+          return { result: { ok: true as const, classId }, next };
+        }
+        const reasons = Object.values(result.issues);
+        // An empty `issues` is still a refusal — the transport could not
+        // describe it. Reporting it as saved is the one outcome that must never
+        // be silent, which is the rule the breakpoints writer below follows too.
         return {
-          ok: false as const,
-          reason:
-            "This site's classes could not be read, so none can be added.",
+          result: {
+            ok: false as const,
+            reason:
+              reasons.length > 0
+                ? reasons.join(" ")
+                : "This class could not be saved.",
+          },
         };
-      }
-      const classId = newId();
-      const next: NamedClass[] = [
-        ...existing,
-        { id: classId, slug, orderIndex: nextOrderIndex(existing), styles: {} },
-      ];
-      /*
-       * Only what DIFFERS from the site's own config classes. `library` is the
-       * MERGED set the canvas compiles, so saving it whole would copy every
-       * config class into the database on the first creation and mask the
-       * site's code from then on — the argument `tokenOverrideOf` already
-       * makes for tokens.
-       */
-      const result = await saveSection(
-        "classes",
-        classOverrideOf(configured, next)
-      );
-      if (result.saved) {
-        // Only on success, so a refused write does not become the base the
-        // next edit builds on.
-        advance(next);
-        return { ok: true as const, classId };
-      }
-      const reasons = Object.values(result.issues);
-      // An empty `issues` is still a refusal — the transport could not describe
-      // it. Reporting it as saved is the one outcome that must never be silent,
-      // which is the rule the breakpoints writer below follows too.
-      return {
-        ok: false as const,
-        reason:
-          reasons.length > 0
-            ? reasons.join(" ")
-            : "This class could not be saved.",
-      };
-    },
-    [base, advance, configured, saveSection]
+      }),
+    [writes, configured, saveSection]
   );
 }
 
@@ -807,56 +898,42 @@ function useCreateClass(
  * row reading as renamed until the next read contradicted it.
  */
 function useRenameClass(
-  library: readonly NamedClass[] | undefined,
+  writes: ClassWrites,
   configured: readonly NamedClass[] | undefined
 ) {
   const { save: saveSection } = useSaveSiteStyle();
-  const { base, advance } = useClassWriteBase(library);
   return useCallback(
-    async (classId: string, slug: string): Promise<ClassRenameOutcome> => {
-      // The base rather than the rendered library: a rename committed while an
-      // earlier one is still in flight must build on that earlier one, or it
-      // writes a list in which the first rename never happened.
-      const existing = base();
-      if (existing === undefined) {
+    async (classId: string, slug: string): Promise<ClassRenameOutcome> =>
+      writes.run<ClassRenameOutcome>(async existing => {
+        if (existing === undefined) {
+          return {
+            result: {
+              ok: false as const,
+              reason:
+                "This site's classes could not be read, so none can be renamed.",
+            },
+          };
+        }
+        const next = existing.map(entry =>
+          entry.id === classId ? { ...entry, slug } : entry
+        );
+        const result = await saveSection(
+          "classes",
+          classOverrideOf(configured, next)
+        );
+        if (result.saved) return { result: { ok: true as const }, next };
+        const reasons = Object.values(result.issues);
         return {
-          ok: false,
-          reason:
-            "This site's classes could not be read, so none can be renamed.",
+          result: {
+            ok: false as const,
+            reason:
+              reasons.length > 0
+                ? reasons.join(" ")
+                : "This class could not be renamed.",
+          },
         };
-      }
-      const next = existing.map(entry =>
-        entry.id === classId ? { ...entry, slug } : entry
-      );
-      /*
-       * Only what DIFFERS from the site's own config classes, exactly as
-       * creating one does. Saving the merged library whole would copy every
-       * config class into the database and mask the site's own code from then
-       * on — and a rename is the operation where that is easiest to miss,
-       * because the visible result looks identical either way.
-       */
-      const result = await saveSection(
-        "classes",
-        classOverrideOf(configured, next)
-      );
-      if (result.saved) {
-        // Only on success. A refused write changed nothing, so advancing would
-        // build the next edit on a list the server never accepted.
-        advance(next);
-        return { ok: true };
-      }
-      const reasons = Object.values(result.issues);
-      // An empty `issues` is still a refusal — the transport could not describe
-      // it. Reporting it as saved is the one outcome that must never be silent.
-      return {
-        ok: false,
-        reason:
-          reasons.length > 0
-            ? reasons.join(" ")
-            : "This class could not be renamed.",
-      };
-    },
-    [base, advance, configured, saveSection]
+      }),
+    [writes, configured, saveSection]
   );
 }
 
@@ -1605,9 +1682,13 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * open page apply this class", and a truncated walk answers that for fewer
    * nodes rather than answering it wrongly.
    */
-  const documentClassIds = useMemo(
-    () => classUsageOf(editor.document).ids,
-    [editor.document]
+  const documentClasses = useMemo(
+    // The HOST's limits, not the engine's defaults. A site that raised or
+    // lowered them renders under those, and a walk here under different bounds
+    // selects different nodes — which would report a class as absent from a
+    // page that renders it, or present on one that does not.
+    () => classUsageOf(editor.document, readDocumentLimits(clientConfig)),
+    [editor.document, clientConfig]
   );
 
   /*
@@ -1960,7 +2041,13 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             classes: () => (
               <ClassManagerPanel
                 absence={classes.absence}
-                documentClassIds={documentClassIds}
+                documentClassIds={documentClasses.ids}
+                /*
+                  Whether that walk reached the whole document. It stops at the
+                  node ceiling, and a class applied past it is missing from the
+                  list — which the panel must not read as "not on this page".
+                */
+                documentScan={documentClasses.complete ? "complete" : "partial"}
                 library={classes.library}
                 onRename={classes.rename}
                 /*

--- a/packages/plugin-page-builder/src/plugin-client-config.test.ts
+++ b/packages/plugin-page-builder/src/plugin-client-config.test.ts
@@ -1,0 +1,57 @@
+/**
+ * What the page builder publishes to the browser, and whether it can be.
+ *
+ * `clientConfig` is refused at BOOT unless it survives a JSON round trip
+ * unchanged. That makes the check worth having here rather than trusting the
+ * shape: the failure is not a wrong value in the admin, it is the whole plugin
+ * failing to start.
+ *
+ * @module plugin-client-config.test
+ */
+import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { pageBuilder } from "./plugin";
+
+/** The config as the boot-time validator sees it. */
+function clientConfig(plugin: ReturnType<typeof pageBuilder>): unknown {
+  return (
+    plugin.contributes as { admin?: { clientConfig?: unknown } } | undefined
+  )?.admin?.clientConfig;
+}
+
+describe("the limits published to the admin", () => {
+  it("survives the round trip the boot check demands, with an INFINITE bound", () => {
+    /*
+     * The engine supports an infinite byte limit outright. `Infinity` is not a
+     * JSON value though — it round-trips to `null` — so publishing it raw makes
+     * the config differ from its own serialisation, which is exactly what the
+     * validator refuses.
+     */
+    const config = clientConfig(
+      pageBuilder({ limits: { ...DEFAULT_LIMITS, maxBytes: Infinity } })
+    );
+    expect(config).toBeDefined();
+    expect(JSON.parse(JSON.stringify(config))).toEqual(config);
+  });
+
+  it("spells an infinite bound as null rather than dropping it", () => {
+    // Dropping the key would have the admin fall back to the engine default,
+    // which is a bound where the host asked for none.
+    const config = clientConfig(
+      pageBuilder({ limits: { ...DEFAULT_LIMITS, maxBytes: Infinity } })
+    ) as { limits?: Record<string, unknown> };
+    expect(config.limits).toBeDefined();
+    expect(Object.keys(config.limits ?? {})).toContain("maxBytes");
+    expect(config.limits?.maxBytes).toBeNull();
+  });
+
+  it("carries a finite bound through untouched", () => {
+    // The control: a finite value must NOT be turned into null, or every
+    // configured bound would read as "no bound" in the admin.
+    const config = clientConfig(
+      pageBuilder({ limits: { ...DEFAULT_LIMITS, maxNodes: 12 } })
+    ) as { limits?: Record<string, unknown> };
+    expect(config.limits?.maxNodes).toBe(12);
+  });
+});

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -412,6 +412,7 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
         // key already says.
         ...(opts.remotePatterns !== undefined ||
         opts.checklist !== undefined ||
+        opts.limits !== undefined ||
         opts.siteStyle !== undefined
           ? {
               clientConfig: {
@@ -428,6 +429,15 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
                 ...(opts.siteStyle === undefined
                   ? {}
                   : { siteStyle: configStyle }),
+                /*
+                 * The bounds the renderer draws under, so the admin asks the
+                 * same question the page answers. The classes manager walks the
+                 * open document to say which classes a page applies, and a walk
+                 * under different limits selects different nodes — reporting a
+                 * class as absent from a page that renders it. Plain numbers,
+                 * and nothing secret: the published page is drawn under them.
+                 */
+                ...(opts.limits === undefined ? {} : { limits: opts.limits }),
               },
             }
           : {}),

--- a/packages/plugin-page-builder/src/plugin.ts
+++ b/packages/plugin-page-builder/src/plugin.ts
@@ -257,6 +257,27 @@ export interface PageBuilderOptions {
  * The Page Builder plugin factory. Call it in a host app's
  * `defineConfig({ plugins: [pageBuilder()] })`.
  */
+/**
+ * Document limits in a form that survives the client-config round trip.
+ *
+ * `clientConfig` is refused at BOOT unless it is delivered unchanged through
+ * JSON, and `Infinity` is not a JSON value — it round-trips to `null`, so
+ * publishing it raw takes the whole plugin down. An infinite bound is
+ * deliberately supported by the engine, whose byte measurement refuses to
+ * reject one, so it has to be carried rather than dropped.
+ *
+ * `null` is the wire spelling for "no bound", and the admin reads it back as
+ * `Infinity`. Encoded here because this is where the value crosses into JSON.
+ */
+function jsonSafeLimits(limits: DocumentLimits): Record<string, number | null> {
+  return Object.fromEntries(
+    Object.entries(limits).map(([key, value]) => [
+      key,
+      Number.isFinite(value) ? value : null,
+    ])
+  );
+}
+
 export const pageBuilder = (opts: PageBuilderOptions = {}) => {
   // Resolved once, with no stored tier: at config time there is no database to
   // read, so what the factory can wire into the validator and the canvas is
@@ -437,7 +458,9 @@ export const pageBuilder = (opts: PageBuilderOptions = {}) => {
                  * class as absent from a page that renders it. Plain numbers,
                  * and nothing secret: the published page is drawn under them.
                  */
-                ...(opts.limits === undefined ? {} : { limits: opts.limits }),
+                ...(opts.limits === undefined
+                  ? {}
+                  : { limits: jsonSafeLimits(opts.limits) }),
               },
             }
           : {}),


### PR DESCRIPTION
`ClassManagerPanel` has been on `main` since C-9 — exported from `shell.ts`, styled, and covered by its own tests. Nothing rendered it, so no author could open the classes manager. `AVAILABLE_PANELS` read `["insert","layers","tokens","fonts"]` and the shell drew the classes rail slot disabled as "coming soon".

This mounts it, with the two halves it cannot honestly offer yet withheld rather than faked.

## What an author gets

Every class the site renders, searchable and filterable, with the name edited in place — the shape `TokensPanel` already established here, because the common edit is renaming one class and a detail form turns that into two clicks and a context switch.

## What is withheld, and why that is not a gap

**Usage counts.** The class-usage index is a COLLECTION, and `plugin-sdk/admin` publishes only `useSingleDocument` — there is no plugin-facing read for one. Rather than pass an empty map, `usage` is now a real third state: absent means "not read", the rows say `Usage not read`, and the "Not in index" filter is withdrawn.

That distinction is the whole point. An empty map would print "Not in index" against every class on the site — a statement about the site, made from never having asked, and in the direction that reads as permission to delete.

**Delete.** Removing a class means stripping it from every document that references it, which needs that same reach plus a site-wide write. No `onDelete` is passed, and the panel then offers no Delete at all rather than a disabled one — following the reasoning already in the file for a config-supplied class: *"a greyed button invites an author to hunt for the permission that would enable it, and there is none."*

Per the founder's ruling, delete will run as a background job once the jobs surface reaches plugins, so the author is not held at a spinner while 40 pages are rewritten and a closed tab cannot leave the work half-done.

## Rename answers, rather than going quiet

`onRename` may now return a `ClassRenameOutcome`. The field clears the moment the author finishes typing — holding their text until the network answers reads as frozen — so a refusal that returned nothing would leave the row looking renamed until some later read contradicted it. Both the refused and the REJECTED paths report; the host's own reason is carried through verbatim rather than replaced with a generic one.

Existing callers passing a `void` function keep working untouched.

## Verification

The mount is asserted through `renderPanel` itself, not through the rail list. Break-verified by making `renderPanel` no longer answer for `"classes"`:

- with the panel unmounted, **6 of 7 fail**
- `offers the classes rail slot at all` still passes — which is exactly why a rail assertion alone would not have caught the original bug

That break also exposed a flaw in one of my own tests. `offers no Delete while nothing can carry out one` passed with the panel not rendered at all: an absent button is equally what nothing-rendered looks like. It now asserts the row is present first, and fails under the break like the rest.

Treating `usage` as always-read fails exactly the two tests naming that behaviour, and no others.

Rendered to static markup under the BUILT `builder-chrome.css` and screenshotted in both themes: the filters correctly show only "All" and "On this page", the on-this-page class is marked, the config-supplied class reads "Default", and no Delete appears.

Gates, each read from its own exit status: `pnpm build` clean; `check-types` 22/22; lint clean for builder and plugin-page-builder; builder 2532 / 89 files; plugin-page-builder 497 / 46; blocks-engine 1650 / 37; comment convention exit 0; `changeset status` exit 0.

`fallow` initially FAILED with one introduced complexity finding — `useClassSurface`, `exceeded: crap`, from the branch the rename added. Fixed by extracting `classReadFailed` and `readableClassLibrary`, never suppressed; `complexity_introduced` is back to 0 and the verdict is `pass`.

## Not in this PR

`finding:classes-manager-has-no-client-path-to-its-index` covers the read and the delete write. It is independent of #1363 and touches no plugin-sdk export or surface snapshot.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Classes panel to the page editor for viewing, creating, renaming, filtering, and deleting classes.
  - Displays loading, unavailable, unread, and partially scanned usage states.
  - Supports host-controlled rename refusals with clear feedback.
  - Applies configured document limits when calculating class usage.

- **Bug Fixes**
  - Prevents stale or out-of-order updates during rapid edits.
  - Hides unsupported filters and deletion controls.
  - Resets invalid filters and preserves class data when usage information is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->