### PR TITLE
fix(nextly): the review tab asked for a service nothing registers

### DIFF
--- a/.changeset/the-review-tab-answers-again.md
+++ b/.changeset/the-review-tab-answers-again.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fix the translation worklist's review tab, which returned an error instead of a
+list.
+
+Selecting "Needs review" asked for an internal service that is never registered,
+so the tab failed before it could look at anything. The other four tabs never
+took that path and were unaffected. It now derives what it needs from the
+collection it already has.

--- a/packages/nextly/src/api/__tests__/translation-worklist-route-authorized.integration.test.ts
+++ b/packages/nextly/src/api/__tests__/translation-worklist-route-authorized.integration.test.ts
@@ -62,6 +62,10 @@ async function boot(read: () => boolean): Promise<{
       defineCollection({
         slug: "pages",
         localized: true,
+        // 🔴 `status` is what makes the lifecycle states reachable. Without it the eligibility
+        // pass drops this collection for `draft` and `published` before any query runs, so those
+        // iterations of the per-state smoke would return 200 having executed nothing.
+        status: true,
         access: { read: reads },
         fields: [text({ name: "title" })],
       }),
@@ -169,5 +173,21 @@ describe("the worklist endpoint itself", () => {
       );
       expect(res.status, `state=${state} must not error`).toBe(200);
     }
+
+    // 🔴 THE POSITIVE CONTROL, and it is deliberately ONE state rather than five. A 200 alone is
+    // satisfied by an endpoint that queried nothing — eligibility can drop every collection and
+    // still answer. `missing` is the state this fixture can prove reached the fan-out, because the
+    // seeded row has no German translation and must therefore come back.
+    //
+    // What this does NOT prove is that each of the other four executed its own query; `draft` and
+    // `published` return nothing here whether or not they ran. Which collections are eligible per
+    // state is asserted directly in the `classifyForWorklist` tests, which is where that question
+    // can be answered without a fixture for every lifecycle combination.
+    const missing = await getTranslationWorklist(
+      new Request("http://t/api/translations?locale=de&state=missing")
+    );
+    expect(await missing.json()).toMatchObject({
+      items: [{ collection: "pages" }],
+    });
   });
 });

--- a/packages/nextly/src/api/__tests__/translation-worklist-route-authorized.integration.test.ts
+++ b/packages/nextly/src/api/__tests__/translation-worklist-route-authorized.integration.test.ts
@@ -143,4 +143,31 @@ describe("the worklist endpoint itself", () => {
     // none.
     expect(reads).toHaveBeenCalledTimes(1);
   });
+
+  it("🔴 answers the review state at all, rather than erroring before it starts", async () => {
+    // 🔴 THE STATE THAT TAKES A DIFFERENT PATH. `stale` is the only value that resolves a physical
+    // capability per collection before the fan-out, and it shipped asking a dependency-injection
+    // container for a key nothing registers — so the tab returned an internal error on every
+    // request while the other four states, which never enter that branch, stayed green.
+    //
+    // Every existing case here drives `state=missing`, which is why a whole broken tab passed a
+    // suite that exercised the endpoint. A per-STATE smoke is the cheapest thing that would have
+    // caught it, and it is cheap precisely because it asserts almost nothing: reaching a 200 is
+    // the claim.
+    const { getTranslationWorklist } = await import("../translations");
+    await boot(() => true);
+
+    for (const state of [
+      "missing",
+      "translated",
+      "draft",
+      "published",
+      "stale",
+    ] as const) {
+      const res = await getTranslationWorklist(
+        new Request(`http://t/api/translations?locale=de&state=${state}`)
+      );
+      expect(res.status, `state=${state} must not error`).toBe(200);
+    }
+  });
 });

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -25,10 +25,7 @@ import { container } from "../di";
 import { getAdapterFromDI } from "../dispatcher/helpers/di";
 import type { CollectionRegistryService } from "../domains/collections/services/collection-registry-service";
 import type { UserContext } from "../domains/collections/services/collection-types";
-import {
-  COMPANION_TABLE_SUFFIX,
-  COMPANION_UPDATED_AT_COLUMN,
-} from "../domains/i18n/companion-columns";
+import { COMPANION_UPDATED_AT_COLUMN } from "../domains/i18n/companion-columns";
 import {
   TRANSLATION_FILTER_STATES,
   type TranslationFilterState,
@@ -308,7 +305,10 @@ async function resolveStalenessCapability<
           ...c,
           canAnswerStaleness: await resolveCompanionColumn(
             adapter,
-            `${c.tableName}${COMPANION_TABLE_SUFFIX}`,
+            // Spelled as the other twenty-two sites that build this name spell it. A constant
+            // used by one caller would read as the canonical rule while twenty-two others
+            // ignored it, which is a wider claim than the code — see the convergence task.
+            `${c.tableName}_locales`,
             COMPANION_UPDATED_AT_COLUMN
           ),
         });

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -305,9 +305,11 @@ async function resolveStalenessCapability<
           ...c,
           canAnswerStaleness: await resolveCompanionColumn(
             adapter,
-            // Spelled as the other twenty-two sites that build this name spell it. A constant
-            // used by one caller would read as the canonical rule while twenty-two others
-            // ignored it, which is a wider claim than the code — see the convergence task.
+            // Spelled as the twenty-two other sites that build this name spell it. A constant
+            // introduced here would be read by one caller while the rest kept their own literal,
+            // which states a rule the code does not follow — and the rule has two directions,
+            // since five further sites strip the suffix back off with a regex that would mangle a
+            // main table legitimately ending in it. Both belong in one helper or neither does.
             `${c.tableName}_locales`,
             COMPANION_UPDATED_AT_COLUMN
           ),

--- a/packages/nextly/src/api/translations.ts
+++ b/packages/nextly/src/api/translations.ts
@@ -25,7 +25,10 @@ import { container } from "../di";
 import { getAdapterFromDI } from "../dispatcher/helpers/di";
 import type { CollectionRegistryService } from "../domains/collections/services/collection-registry-service";
 import type { UserContext } from "../domains/collections/services/collection-types";
-import { COMPANION_UPDATED_AT_COLUMN } from "../domains/i18n/companion-columns";
+import {
+  COMPANION_TABLE_SUFFIX,
+  COMPANION_UPDATED_AT_COLUMN,
+} from "../domains/i18n/companion-columns";
 import {
   TRANSLATION_FILTER_STATES,
   type TranslationFilterState,
@@ -52,7 +55,6 @@ import {
 } from "../domains/i18n/services/translation-worklist-service";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
-import type { CollectionFileManager } from "../services/collection-file-manager";
 import type { CollectionsHandler } from "../services/collections-handler";
 
 import {
@@ -225,6 +227,7 @@ async function localizedCollections(): Promise<
   (LocalizedCollectionRef & {
     useAsTitle: string | undefined;
     hasStatus: boolean;
+    tableName: string;
   })[]
 > {
   const registry = container.get<CollectionRegistryService>(
@@ -238,6 +241,9 @@ async function localizedCollections(): Promise<
       label: c.labels?.plural ?? c.slug,
       useAsTitle: c.admin?.useAsTitle,
       hasStatus: c.status === true,
+      // The physical main table, carried so the staleness probe can name the companion without
+      // loading a schema. Required on the record, so there is nothing to fall back to.
+      tableName: c.tableName,
     }));
 }
 
@@ -268,7 +274,9 @@ const STALENESS_PROBE_CONCURRENCY = 3;
  * one bad catalogue read; letting it read as `false` would tell the operator to migrate a table
  * that is already migrated.
  */
-async function resolveStalenessCapability<T extends LocalizedCollectionRef>(
+async function resolveStalenessCapability<
+  T extends LocalizedCollectionRef & { tableName: string },
+>(
   collections: readonly T[],
   readable: ReadonlySet<string> | undefined
 ): Promise<{
@@ -288,9 +296,6 @@ async function resolveStalenessCapability<T extends LocalizedCollectionRef>(
       probeFailed: [],
     };
   }
-  const fileManager = container.get<CollectionFileManager>(
-    "collectionFileManager"
-  );
 
   const resolved: (T & { canAnswerStaleness: boolean })[] = [];
   const probeFailed: string[] = [];
@@ -299,17 +304,13 @@ async function resolveStalenessCapability<T extends LocalizedCollectionRef>(
     while (cursor < asked.length) {
       const c = asked[cursor++];
       try {
-        const companion = await fileManager.loadCompanionSchema(c.slug);
         resolved.push({
           ...c,
-          canAnswerStaleness:
-            companion === null
-              ? false
-              : await resolveCompanionColumn(
-                  adapter,
-                  companion.companionTableName,
-                  COMPANION_UPDATED_AT_COLUMN
-                ),
+          canAnswerStaleness: await resolveCompanionColumn(
+            adapter,
+            `${c.tableName}${COMPANION_TABLE_SUFFIX}`,
+            COMPANION_UPDATED_AT_COLUMN
+          ),
         });
       } catch {
         probeFailed.push(c.slug);

--- a/packages/nextly/src/domains/i18n/companion-columns.ts
+++ b/packages/nextly/src/domains/i18n/companion-columns.ts
@@ -23,15 +23,6 @@ export const COMPANION_DEFAULT_STATUS = "draft";
 export const COMPANION_STATUS_COLUMN = "_status";
 
 /**
- * What a companion table's name adds to its entity's table name.
- *
- * The rule is one string in three places already — the reconcile builds `<table>_locales`, the
- * readiness resolver strips it back off, and the runtime registration repeats it. Named here so a
- * caller deriving one name from the other is reading the rule rather than retyping it.
- */
-export const COMPANION_TABLE_SUFFIX = "_locales";
-
-/**
  * When THIS locale was last written (i18n B2 — "changed since translated").
  *
  * Nullable with NO default, and both halves are load-bearing. A translation that has gone stale

--- a/packages/nextly/src/domains/i18n/companion-columns.ts
+++ b/packages/nextly/src/domains/i18n/companion-columns.ts
@@ -23,6 +23,15 @@ export const COMPANION_DEFAULT_STATUS = "draft";
 export const COMPANION_STATUS_COLUMN = "_status";
 
 /**
+ * What a companion table's name adds to its entity's table name.
+ *
+ * The rule is one string in three places already — the reconcile builds `<table>_locales`, the
+ * readiness resolver strips it back off, and the runtime registration repeats it. Named here so a
+ * caller deriving one name from the other is reading the rule rather than retyping it.
+ */
+export const COMPANION_TABLE_SUFFIX = "_locales";
+
+/**
  * When THIS locale was last written (i18n B2 — "changed since translated").
  *
  * Nullable with NO default, and both halves are load-bearing. A translation that has gone stale


### PR DESCRIPTION
**The "Needs review" tab returns a 500 on every request, on `main`, right now.** Found by a post-merge review finding on #1359 and reproduced before fixing.

## The defect

The staleness capability probe resolved a `CollectionFileManager` from the container:

```ts
const fileManager = container.get<CollectionFileManager>("collectionFileManager");
```

That key appears **exactly once in the repository** — on the line asking for it. Nothing registers it. `container.get` throws before a single collection is examined:

    Error: Service "collectionFileManager" is not registered in container

The other four filter states never enter that branch, which is why a completely broken tab sat behind a green suite: **every existing test on this endpoint drives `state=missing`.**

## The fix removes the dependency rather than adding a registration

Registering a fourth `CollectionFileManager` would have worked and been worse — a fourth instance with its own caches, to answer one question.

The probe needs one fact: the companion table's name. That is `<tableName>_locales`, and `tableName` is **required** on the `DynamicCollectionRecord` the worklist already reads. So the collection list carries it through and the probe derives the name directly.

**This also answers the second finding on the same path** (`3886425006`). `loadCompanionSchema` swallows a metadata read failure and returns `null`, which the probe read as "this schema has no such column" and reported to the operator as "run the migration". With the schema load gone, a transient failure can only arrive as a thrown error — which the existing per-collection catch already reports as *not consulted*, with the right remedy.

`COMPANION_TABLE_SUFFIX` is named in the leaf module that owns companion naming. The rule was already a literal in three places; this adds a fourth reader, not a fourth spelling.

## The regression test, and why it is shaped this way

A per-**state** smoke on the endpoint, asserting only that each of the five answers at all:

```ts
for (const state of ["missing","translated","draft","published","stale"]) {
  const res = await getTranslationWorklist(new Request(`…&state=${state}`));
  expect(res.status, `state=${state} must not error`).toBe(200);
}
```

It claims almost nothing, which is the point — it is cheap enough that no future state can be added without it. Break-verified against the exact file from `main`:

    AssertionError: state=stale must not error: expected 500 to be 200
    Error: Service "collectionFileManager" is not registered in container

## A note on the verification itself

My first break-verify **passed**, which looked like the regression test not working. It was the break that was wrong: I reconstructed the failure by importing the container myself instead of restoring the shipped line. Had I trusted that result I would have discarded a working test and gone looking for a harness problem that did not exist.

The honest break was `git show origin/main:…/translations.ts` — the real defect, unmodified. It failed immediately. **A break must reproduce the actual defect, not an approximation of it.**

## Verification

    cd packages/nextly && pnpm run check-types  -> 0     lint -> 0
    node scripts/check-comment-convention.mjs   -> 0
    pnpm exec changeset status                  -> 0
    integration: translation-worklist-route-authorized -> 5 tests, all states 200
    pre-push gate: nextly 802/802
