### PR TITLE
feat(builder): choose which interaction state you are styling

### DIFF
--- a/.changeset/choose-the-state-you-are-styling.md
+++ b/.changeset/choose-the-state-you-are-styling.md
@@ -1,0 +1,41 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Choose which interaction state you are styling.
+
+The Style tab now opens with a None / Hover / Focused / Pressed control. Values
+you edit go to the chosen state, and the canvas draws the selected block in it,
+so what you are editing and what you are looking at are the same thing.
+
+Each state says whether it already holds styles of its own. Reading the values
+cannot tell you that: styles inherit, so a state you have never touched shows
+the base values and looks set. The marker is in the accessible name as well as
+on screen.
+
+Leaving the Style tab returns the canvas to the normal appearance, so a state
+switched on cannot be left behind on a tab that no longer shows the control.

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -45,6 +45,7 @@ import {
   offeredTiers,
   selectableTiers,
 } from "./canvas-width";
+import { radioGroupStep } from "./roving-radios";
 
 /**
  * Props for BreakpointSwitcher.
@@ -382,13 +383,10 @@ export function BreakpointSwitcher({
       className="nx-breakpoint-switcher inline-flex items-center gap-0.5 rounded-md border p-0.5"
       onKeyDown={event => {
         if (!ready) return;
-        if (event.key === "ArrowRight" || event.key === "ArrowDown") {
-          event.preventDefault();
-          move(1);
-        } else if (event.key === "ArrowLeft" || event.key === "ArrowUp") {
-          event.preventDefault();
-          move(-1);
-        }
+        const step = radioGroupStep(event.key);
+        if (step === null) return;
+        event.preventDefault();
+        move(step);
       }}
     >
       {options.map((option, index) => {

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -158,6 +158,110 @@ describe("what InspectorPanel forwards to the style tab", () => {
 
     expect(screen.queryByRole("combobox", { name: /add a class/i })).toBeNull();
   });
+
+  it("offers the state switcher when the host can act on the choice", () => {
+    register();
+    render(
+      <InspectorPanel
+        editor={editorFor(documentOf({}))}
+        styleState={{ onChange: vi.fn() }}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(
+      screen.getByRole("radiogroup", { name: "Interaction state" })
+    ).toBeDefined();
+  });
+
+  it("withholds it from a host that cannot act on the choice", () => {
+    /*
+     * The control, and a contract rather than a tidiness rule: this panel's
+     * state and `Canvas.forcedState` are ONE value, so a switcher whose
+     * selection nothing carries to the canvas would report a state the author
+     * is not looking at — the arrangement that contract exists to prevent.
+     */
+    register();
+    render(<InspectorPanel editor={editorFor(documentOf({}))} />);
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(
+      screen.queryByRole("radiogroup", { name: "Interaction state" })
+    ).toBeNull();
+  });
+
+  it("marks the states the SELECTED NODE has styles for", () => {
+    /*
+     * The chain, asserted through the rendered control rather than by
+     * inspecting props: the marker is only useful if the node's own stored
+     * styles reach it, and a switcher that received nothing renders perfectly
+     * while marking nothing at all.
+     */
+    register();
+    render(
+      <InspectorPanel
+        editor={editorFor(
+          documentOf({
+            styles: { hover: { base: { color: "#000001" } } },
+          } as Partial<BlockNode>)
+        )}
+        styleState={{ onChange: vi.fn() }}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(
+      screen.getByRole("radio", { name: /Hover.*has styles/ })
+    ).toBeDefined();
+    expect(screen.queryByRole("radio", { name: /Pressed.*has styles/ })).toBe(
+      null
+    );
+  });
+
+  it("reports the state the author chose", () => {
+    register();
+    const onStyleStateChange = vi.fn();
+    render(
+      <InspectorPanel
+        editor={editorFor(documentOf({}))}
+        styleState={{ onChange: onStyleStateChange }}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+    fireEvent.click(screen.getByRole("radio", { name: /^Hover/ }));
+
+    expect(onStyleStateChange).toHaveBeenCalledWith("hover");
+  });
+
+  it("drops the forced state when the author LEAVES the style tab", () => {
+    /*
+     * The one real cost of placing this control inside the Style tab is that it
+     * goes off screen with the tab, so a state left switched on becomes a
+     * canvas disagreeing with everything visible — editing the text of a button
+     * drawn mid-press, with no control on screen saying why.
+     *
+     * Asserted as the LAST call rather than as any call, because selecting the
+     * state also calls this and a test satisfied by that would pass with the
+     * reset deleted.
+     */
+    register();
+    const onStyleStateChange = vi.fn();
+    render(
+      <InspectorPanel
+        editor={editorFor(documentOf({}))}
+        styleState={{ state: "hover", onChange: onStyleStateChange }}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Content" }));
+
+    expect(onStyleStateChange).toHaveBeenLastCalledWith("base");
+  });
 });
 
 describe("InspectorPanel identity fields", () => {

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -35,7 +35,7 @@ import {
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
 
-import { InspectorPanel } from "./inspector-panel";
+import { editedStyleState, InspectorPanel } from "./inspector-panel";
 import { applyOp } from "./ops";
 import type { EditorState } from "./editor-state";
 
@@ -228,6 +228,39 @@ describe("what InspectorPanel forwards to the style tab", () => {
     ).toBeDefined();
     expect(screen.queryByRole("radio", { name: /Pressed.*has styles/ })).toBe(
       null
+    );
+  });
+
+  it("edits BASE when a host supplies a state with no setter", () => {
+    /*
+     * The binding permits `{ state: "hover" }` alone, and read literally that is
+     * a state nobody can leave: the switcher is withheld because nothing could
+     * act on a choice, the tab handler has no callback to return the canvas
+     * with, and the controls below would go on reading and writing hover with
+     * no visible control saying so — the arrangement this panel's contract
+     * exists to prevent, reached through the type rather than a miswiring.
+     *
+     * Asserted through the rendered controls rather than on a prop, because
+     * what matters is which state the panel EDITS. The class surface is the
+     * cheapest observable that differs, so the case reads the switcher's
+     * absence and the style panel's presence together.
+     */
+    register();
+    render(
+      <InspectorPanel
+        editor={editorFor(documentOf({}))}
+        styleState={{ state: "hover" }}
+      />
+    );
+
+    fireEvent.mouseDown(screen.getByRole("tab", { name: "Style" }));
+
+    expect(
+      screen.queryByRole("radiogroup", { name: "Interaction state" })
+    ).toBeNull();
+    expect(editedStyleState({ state: "hover" })).toBe("base");
+    expect(editedStyleState({ state: "hover", onChange: vi.fn() })).toBe(
+      "hover"
     );
   });
 

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -208,6 +208,16 @@ describe("what InspectorPanel forwards to the style tab", () => {
           } as Partial<BlockNode>)
         )}
         styleState={{ onChange: vi.fn() }}
+        /*
+         * The site's tiers, because the marker answers "set here, and
+         * expressible by this site" — without them it refuses rather than
+         * guessing, so a case omitting them would assert the refusal instead of
+         * the forwarding it is named for.
+         */
+        breakpoints={{
+          viewport: [{ id: "base", label: "Desktop" }],
+          container: [],
+        }}
       />
     );
 

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -423,6 +423,7 @@ export function InspectorPanel({
             state={styleState?.state}
             onSelect={styleState?.onChange}
             node={styleNode}
+            breakpoints={breakpoints}
           />
           <StyleInspectorPanel
             editor={editor}

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -57,17 +57,26 @@ import {
   lockStateOf,
   propPatch,
   renameOp,
+  selectedNode,
   type BlockIdentity,
   type EditableProp,
   type LockState,
 } from "./inspector";
 import { selectionLock } from "./selection-ops";
+import { StyleStateField } from "./state-switcher";
 import {
   StyleInspectorPanel,
   type StyleInspectorPanelProps,
 } from "./style-inspector-panel";
 import type { StylePolicy } from "./style-values";
 import { useRenderedTag } from "./use-rendered-tag";
+
+export interface StyleStateBinding {
+  /** The state being edited. `base` when omitted. */
+  state?: StyleState | undefined;
+  /** Choose a different one. Omitted withholds the control. */
+  onChange?: ((state: StyleState) => void) | undefined;
+}
 
 export interface InspectorPanelProps {
   /**
@@ -114,8 +123,20 @@ export interface InspectorPanelProps {
    * omitting it does not mean "allow" — it means the question was never asked.
    */
   policy?: StylePolicy;
-  /** The interaction state the Style tab edits. `base` when the host says nothing. */
-  styleState?: StyleState;
+  /**
+   * The interaction state the Style tab edits, and how to change it.
+   *
+   * ONE prop rather than a value and a setter beside each other, because they
+   * are one decision: this state and `Canvas.forcedState` must be the same
+   * value, and a host wiring them separately gets a panel reporting a state its
+   * canvas is not showing. Bundled, the pair travels together or not at all.
+   *
+   * `onChange` absent WITHHOLDS the switcher rather than disabling it. A host
+   * that cannot carry the choice to its canvas would otherwise show a control
+   * whose selection nothing follows — the arrangement that contract exists to
+   * prevent.
+   */
+  styleState?: StyleStateBinding;
   /** The breakpoint the Style tab edits. The unconditional one by default. */
   breakpoint?: BreakpointId;
   /**
@@ -195,6 +216,32 @@ const INSPECTOR_TABS = [
   { value: "advanced", label: "Advanced" },
 ] as const;
 
+/**
+ * The Style tab's own handler for a change of tab.
+ *
+ * Drops the forced interaction state when the author leaves the Style tab.
+ *
+ * The one real cost of placing the state control inside the Style tab is that
+ * it goes off screen with the tab, so a state left switched on becomes a canvas
+ * disagreeing with everything visible — the author edits the text of a button
+ * drawn mid-press, with no control on screen saying why. Dropping it here
+ * removes that state rather than documenting it.
+ *
+ * On the CHANGE rather than in an effect keyed on the tab: an effect would also
+ * fire on mount and on any re-render that reasserted the same tab, which would
+ * fight a host restoring a state deliberately. This runs exactly when a person
+ * leaves the tab.
+ */
+function tabChangeHandler(
+  setTab: (next: string) => void,
+  onStyleStateChange: ((state: StyleState) => void) | undefined
+): (next: string) => void {
+  return next => {
+    setTab(next);
+    if (next !== "style") onStyleStateChange?.("base");
+  };
+}
+
 export function InspectorPanel({
   editor,
   canvasRoot,
@@ -224,6 +271,14 @@ export function InspectorPanel({
     editor.document
   );
   const inspection = inspectSelection(editor.document, editor.selectedId);
+  /*
+   * The NODE rather than the inspection, because the marker is about stored
+   * styles and an inspection describes editable props. `selectedNode` answers
+   * for a block the registry does not know as well, which is right here: an
+   * unregistered block still has styles, and refusing to say which states carry
+   * them would be a worse answer than saying none.
+   */
+  const styleNode = selectedNode(editor.document, editor.selectedId);
 
   // Declared before the early returns below, because a hook has to run on every
   // render of this component and "no selection" is one of them.
@@ -318,7 +373,11 @@ export function InspectorPanel({
         told when it stops being the one on screen: it is force-mounted, so its
         own removal no longer tells it.
       */}
-      <Tabs value={tab} onValueChange={setTab} className="nx-inspector__tabs">
+      <Tabs
+        value={tab}
+        onValueChange={tabChangeHandler(setTab, styleState?.onChange)}
+        className="nx-inspector__tabs"
+      >
         <TabsList>
           {INSPECTOR_TABS.map(tab => (
             <TabsTrigger key={tab.value} value={tab.value}>
@@ -350,11 +409,26 @@ export function InspectorPanel({
         </TabsContent>
 
         <TabsContent value="style">
+          {/*
+            ABOVE the controls, because it decides what every one of them reads
+            and writes. Below them it would be a filter applied after the fact,
+            and an author would have edited a value before meeting the thing
+            that says which state the value belongs to.
+
+            Whether it appears at all is the FIELD's own decision — see
+            `StyleStateField`, which withholds itself from a host that cannot
+            carry the choice to its canvas.
+          */}
+          <StyleStateField
+            state={styleState?.state}
+            onSelect={styleState?.onChange}
+            node={styleNode}
+          />
           <StyleInspectorPanel
             editor={editor}
             renderedTag={renderedTag}
             policy={policy}
-            state={styleState}
+            state={styleState?.state}
             breakpoint={breakpoint}
             cascade={cascade}
             breakpoints={breakpoints}

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -232,6 +232,28 @@ const INSPECTOR_TABS = [
  * fight a host restoring a state deliberately. This runs exactly when a person
  * leaves the tab.
  */
+/**
+ * The state the panel actually edits, which is `base` unless a setter came with
+ * it.
+ *
+ * The binding permits a state without an `onChange`, and that shape has to mean
+ * something rather than being merely allowed. Read literally it is a state
+ * nobody can leave: the switcher is withheld because nothing could act on a
+ * choice, the tab handler has no callback to return the canvas with, and every
+ * control below would go on reading and writing a state with no visible control
+ * saying which one — the exact arrangement this panel's contract exists to
+ * prevent, reached through the type instead of through a miswiring.
+ *
+ * Normalised rather than refused, because a host part-way through adopting the
+ * control should get a working base editor rather than a broken one.
+ */
+export function editedStyleState(
+  binding: StyleStateBinding | undefined
+): StyleState {
+  if (binding?.onChange === undefined) return "base";
+  return binding.state ?? "base";
+}
+
 function tabChangeHandler(
   setTab: (next: string) => void,
   onStyleStateChange: ((state: StyleState) => void) | undefined
@@ -420,7 +442,7 @@ export function InspectorPanel({
             carry the choice to its canvas.
           */}
           <StyleStateField
-            state={styleState?.state}
+            state={editedStyleState(styleState)}
             onSelect={styleState?.onChange}
             node={styleNode}
             breakpoints={breakpoints}
@@ -429,7 +451,7 @@ export function InspectorPanel({
             editor={editor}
             renderedTag={renderedTag}
             policy={policy}
-            state={styleState?.state}
+            state={editedStyleState(styleState)}
             breakpoint={breakpoint}
             cascade={cascade}
             breakpoints={breakpoints}

--- a/packages/builder/src/inspector.ts
+++ b/packages/builder/src/inspector.ts
@@ -248,6 +248,26 @@ export function lockStateOf(
  * Describe the selected block for editing, or `null` when there is nothing to
  * edit. See {@link selectedBlock} for what "nothing" covers and why.
  */
+/**
+ * Whether the inspector can show anything for this selection.
+ *
+ * Exported because the CANVAS needs the same answer and cannot reach
+ * {@link inspectSelection}'s result: when this is false the panel replaces its
+ * whole tab strip, so a host still forcing an interaction state would draw the
+ * selected block mid-hover with the control that explains it off screen.
+ *
+ * Derived from {@link selectedBlock}, which is the lookup `inspectSelection`
+ * already starts with, so the two cannot disagree about what is inspectable —
+ * an unregistered block type is the case that separates them, and it reads as
+ * an ordinary selection to anything counting ids.
+ */
+export function selectionIsInspectable(
+  document: BlockDocument,
+  selectedId: string | null
+): boolean {
+  return selectedBlock(document, selectedId) !== null;
+}
+
 export function inspectSelection(
   document: BlockDocument,
   selectedId: string | null

--- a/packages/builder/src/roving-radios.ts
+++ b/packages/builder/src/roving-radios.ts
@@ -1,0 +1,33 @@
+/**
+ * How a radio group moves under the arrow keys, in one definition.
+ *
+ * Two controls in this package are radio groups with a roving tab stop — the
+ * canvas width switcher and the interaction-state switcher — and both have to
+ * agree about which keys move a selection and in which direction. Written out
+ * twice they agree on the day they are written: a later change teaching one of
+ * them Home and End, or correcting a direction under a right-to-left writing
+ * mode, silently leaves the other answering the old way, and nothing about
+ * either file looks wrong.
+ *
+ * Both axes, deliberately. The APG's radio-group pattern maps the vertical
+ * arrows onto the same movement as the horizontal ones whatever the visual
+ * orientation, so a control laid out in a row still answers to Down — which is
+ * what a screen-reader user pressing it expects, and what a control handling
+ * only its own axis fails to do.
+ *
+ * @module roving-radios
+ */
+
+/**
+ * Which way an arrow key moves within a radio group, or `null` for a key that
+ * is not one of them.
+ *
+ * `null` rather than `0` so a caller cannot accidentally treat "not an arrow
+ * key" as a move of no distance: the two need different handling, since only
+ * the first must leave the event alone for whatever else is listening.
+ */
+export function radioGroupStep(key: string): -1 | 1 | null {
+  if (key === "ArrowRight" || key === "ArrowDown") return 1;
+  if (key === "ArrowLeft" || key === "ArrowUp") return -1;
+  return null;
+}

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -39,6 +39,20 @@ export type { BuilderShellProps } from "./builder-shell";
  * keeps the cascade from being walked per control; `style-trace.ts` says why it
  * is compiled a second time.
  */
+/*
+ * The inspector's own answer to whether it can show anything for a selection,
+ * exported because a HOST needs it.
+ *
+ * A host drawing both the panel and the canvas has to keep them agreeing about
+ * the interaction state, and the panel withholds its whole tab strip — the
+ * state control with it — for a selection it cannot inspect. An unregistered
+ * block type is that case and reads as one ordinary selection to anything
+ * counting ids, so a host deriving the answer itself gets it wrong on exactly
+ * the input the predicate exists for.
+ *
+ * A pure function over a document, so it crosses this entry carrying no state
+ * and no React.
+ */
 export { selectionIsInspectable } from "./inspector";
 export { pageStyleTrace } from "./style-trace";
 

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -39,6 +39,7 @@ export type { BuilderShellProps } from "./builder-shell";
  * keeps the cascade from being walked per control; `style-trace.ts` says why it
  * is compiled a second time.
  */
+export { selectionIsInspectable } from "./inspector";
 export { pageStyleTrace } from "./style-trace";
 
 /**

--- a/packages/builder/src/state-switcher.test.tsx
+++ b/packages/builder/src/state-switcher.test.tsx
@@ -21,6 +21,18 @@ import { stateHasOwnValues } from "./style-values";
 
 afterEach(cleanup);
 
+/**
+ * The site's tiers, supplied to every marker case.
+ *
+ * The marker answers "set here, and expressible by this site", so it needs the
+ * tiers to answer at all — a case that omitted them would be asserting the
+ * refusal below rather than the marking it names.
+ */
+const SITE = {
+  viewport: [{ id: "base", label: "Desktop" }],
+  container: [],
+};
+
 const marked = (): string[] =>
   screen
     .getAllByRole("radio")
@@ -39,7 +51,14 @@ describe("which states report that they carry values", () => {
       focus: {},
     } as unknown as NodeStyles;
 
-    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={SITE}
+      />
+    );
 
     expect(marked()).toEqual(["Hover"]);
   });
@@ -55,10 +74,17 @@ describe("which states report that they carry values", () => {
       active: { base: {} },
     } as unknown as NodeStyles;
 
-    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={SITE}
+      />
+    );
 
     expect(marked()).toEqual([]);
-    expect(stateHasOwnValues(styles, "active", undefined)).toBe(false);
+    expect(stateHasOwnValues(styles, "active", SITE)).toBe(false);
   });
 
   it("leaves the base state unmarked even when it carries values", () => {
@@ -70,7 +96,14 @@ describe("which states report that they carry values", () => {
       hover: { base: { color: "#000002" } },
     } as unknown as NodeStyles;
 
-    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={SITE}
+      />
+    );
 
     expect(marked()).toEqual(["Hover"]);
   });
@@ -94,7 +127,14 @@ describe("which states report that they carry values", () => {
     } as unknown as NodeStyles;
 
     expect(() =>
-      render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />)
+      render(
+        <StateSwitcher
+          state="base"
+          onSelect={vi.fn()}
+          styles={styles}
+          breakpoints={SITE}
+        />
+      )
     ).not.toThrow();
 
     expect(marked()).toEqual(["Pressed"]);
@@ -107,10 +147,17 @@ describe("which states report that they carry values", () => {
       hover: { base: { color: "#000001" } },
     }) as NodeStyles;
 
-    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={SITE}
+      />
+    );
 
     expect(marked()).toEqual([]);
-    expect(stateHasOwnValues(styles, "hover", undefined)).toBe(false);
+    expect(stateHasOwnValues(styles, "hover", SITE)).toBe(false);
   });
 
   it("does NOT mark an ARRAY-shaped tier the compiler will emit nothing for", () => {
@@ -131,7 +178,14 @@ describe("which states report that they carry values", () => {
       active: { base: { color: "#000003" } },
     } as unknown as NodeStyles;
 
-    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={SITE}
+      />
+    );
 
     // `active` is the control: a real record beside the two bad shapes, so this
     // case cannot pass by the marker never appearing at all.
@@ -169,18 +223,39 @@ describe("which states report that they carry values", () => {
     expect(marked()).toEqual(["Pressed"]);
   });
 
-  it("counts every stored tier when the site's breakpoints are not known", () => {
+  it("marks NOTHING when the site's tiers are not known", () => {
     /*
-     * The question "which tiers exist" has not been asked, and treating an
-     * unasked question as "none exist" would report every state as unstyled —
-     * an absence answering as a verdict.
+     * A deliberate refusal rather than a default. The marker means "set here,
+     * and expressible by this site", and without the site's tiers that question
+     * cannot be asked: a value under a tier the sheet lacks reaches nobody, and
+     * which tiers the sheet has is exactly what is missing.
+     *
+     * It is also what bounds this by construction. A stored record arrives from
+     * storage and can be arbitrarily wide, and every way of walking it —
+     * `Object.keys`, `for...in` with an early break — asks the engine for the
+     * whole key list first, so an early exit bounds the body and not the
+     * enumeration. Measured: 0.08ms at a thousand keys, 10.75ms at a hundred
+     * thousand, 103ms at a million. Not walking it is the only fix.
+     *
+     * The control is the SAME styles marked when tiers ARE known, immediately
+     * below, so this cannot pass by the marker never appearing.
      */
     const styles = {
-      hover: { "some-tier": { color: "#000001" } },
+      hover: { base: { color: "#000001" } },
     } as unknown as NodeStyles;
 
     render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+    expect(marked()).toEqual([]);
 
+    cleanup();
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={SITE}
+      />
+    );
     expect(marked()).toEqual(["Hover"]);
   });
 
@@ -191,10 +266,8 @@ describe("which states report that they carry values", () => {
    * the code under test rather than a detail: `ownData` reads through
    * `Object.getOwnPropertyDescriptor` and returns `part.value`, so an accessor
    * has no `value` and reads as ABSENT without ever being invoked. A counter
-   * built from getters therefore stays at zero and every bound assertion passes
-   * against an unbounded reader — measured, both breaks survived it.
-   *
-   * The descriptor lookup itself is the work, so that is what is counted.
+   * built from getters stays at zero and every bound assertion passes against
+   * an unbounded reader — measured, both breaks survived it.
    */
   function countingTiers(width: number, valueAt: number) {
     const target: Record<string, unknown> = {};
@@ -210,50 +283,6 @@ describe("which states report that they carry values", () => {
     });
     return { proxy, counted };
   }
-
-  it("stops reading a wide stored map where the COMPILER stops", () => {
-    /*
-     * A stored record arrives from storage and can be arbitrarily wide. The
-     * compiler caps its own reads of these records at `MAX_SCANNED_KEYS`, so a
-     * payload it handles boundedly must not cost the Style tab an unbounded
-     * walk on every render, once per non-base state.
-     *
-     * The only value sits past the bound, so a bounded reader cannot see it —
-     * and `active` is the control, holding one within reach, so this cannot
-     * pass by nothing being marked at all.
-     */
-    const read = (width: number): number => {
-      const { proxy, counted } = countingTiers(width, width - 1);
-      render(
-        <StateSwitcher
-          state="base"
-          onSelect={vi.fn()}
-          styles={
-            {
-              hover: proxy,
-              active: { base: { color: "#000002" } },
-            } as unknown as NodeStyles
-          }
-        />
-      );
-      return counted.reads;
-    };
-
-    /*
-     * Asserted as INDEPENDENCE from the width rather than against a constant,
-     * because the constant is not the property. A bounded reader still costs
-     * several descriptor lookups per key it examines — measured, three — so
-     * pinning a number here would encode that arithmetic and fail the next time
-     * a guard is added, while an unbounded reader would still be caught only by
-     * accident. Two widths, four times apart, must cost the same.
-     */
-    const narrow = read(5000);
-    cleanup();
-    const wide = read(20000);
-
-    expect(wide).toBe(narrow);
-    expect(marked()).toEqual(["Pressed"]);
-  });
 
   it("asks only the tiers the SHEET has when breakpoints are known", () => {
     /*
@@ -287,7 +316,9 @@ describe("which states report that they carry values", () => {
   it("marks nothing when the host supplies no styles at all", () => {
     // Absent styles is "the question was not asked", which must not read as
     // "every state is unstyled" the way an empty object would.
-    render(<StateSwitcher state="base" onSelect={vi.fn()} />);
+    render(
+      <StateSwitcher state="base" onSelect={vi.fn()} breakpoints={SITE} />
+    );
 
     expect(marked()).toEqual([]);
   });
@@ -298,7 +329,14 @@ describe("which states report that they carry values", () => {
     // click through four states to find out.
     const styles = { hover: { base: { color: "#000001" } } } as NodeStyles;
 
-    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={SITE}
+      />
+    );
 
     expect(
       screen.getByRole("radio", { name: /Hover.*has styles/ })

--- a/packages/builder/src/state-switcher.test.tsx
+++ b/packages/builder/src/state-switcher.test.tsx
@@ -184,6 +184,106 @@ describe("which states report that they carry values", () => {
     expect(marked()).toEqual(["Hover"]);
   });
 
+  /**
+   * A stored tier map that COUNTS how much of itself was examined.
+   *
+   * A `get` accessor cannot be the instrument here, and that is a property of
+   * the code under test rather than a detail: `ownData` reads through
+   * `Object.getOwnPropertyDescriptor` and returns `part.value`, so an accessor
+   * has no `value` and reads as ABSENT without ever being invoked. A counter
+   * built from getters therefore stays at zero and every bound assertion passes
+   * against an unbounded reader — measured, both breaks survived it.
+   *
+   * The descriptor lookup itself is the work, so that is what is counted.
+   */
+  function countingTiers(width: number, valueAt: number) {
+    const target: Record<string, unknown> = {};
+    for (let i = 0; i < width; i += 1) {
+      target[`t${i}`] = i === valueAt ? { color: "#000001" } : {};
+    }
+    const counted = { reads: 0 };
+    const proxy = new Proxy(target, {
+      getOwnPropertyDescriptor(on, key) {
+        counted.reads += 1;
+        return Reflect.getOwnPropertyDescriptor(on, key);
+      },
+    });
+    return { proxy, counted };
+  }
+
+  it("stops reading a wide stored map where the COMPILER stops", () => {
+    /*
+     * A stored record arrives from storage and can be arbitrarily wide. The
+     * compiler caps its own reads of these records at `MAX_SCANNED_KEYS`, so a
+     * payload it handles boundedly must not cost the Style tab an unbounded
+     * walk on every render, once per non-base state.
+     *
+     * The only value sits past the bound, so a bounded reader cannot see it —
+     * and `active` is the control, holding one within reach, so this cannot
+     * pass by nothing being marked at all.
+     */
+    const read = (width: number): number => {
+      const { proxy, counted } = countingTiers(width, width - 1);
+      render(
+        <StateSwitcher
+          state="base"
+          onSelect={vi.fn()}
+          styles={
+            {
+              hover: proxy,
+              active: { base: { color: "#000002" } },
+            } as unknown as NodeStyles
+          }
+        />
+      );
+      return counted.reads;
+    };
+
+    /*
+     * Asserted as INDEPENDENCE from the width rather than against a constant,
+     * because the constant is not the property. A bounded reader still costs
+     * several descriptor lookups per key it examines — measured, three — so
+     * pinning a number here would encode that arithmetic and fail the next time
+     * a guard is added, while an unbounded reader would still be caught only by
+     * accident. Two widths, four times apart, must cost the same.
+     */
+    const narrow = read(5000);
+    cleanup();
+    const wide = read(20000);
+
+    expect(wide).toBe(narrow);
+    expect(marked()).toEqual(["Pressed"]);
+  });
+
+  it("asks only the tiers the SHEET has when breakpoints are known", () => {
+    /*
+     * The other half of the same bound. With the site's tiers in hand this must
+     * be driven by them rather than by the stored keys, so the width of what
+     * was stored stops mattering at all — a handful of lookups instead of one
+     * per stored tier.
+     */
+    const { proxy, counted } = countingTiers(5000, 4999);
+
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={{ hover: proxy } as unknown as NodeStyles}
+        breakpoints={{
+          viewport: [{ id: "base", label: "Desktop" }],
+          container: [],
+        }}
+      />
+    );
+
+    /*
+     * One lookup per tier the SITE has, so the stored width stops mattering
+     * entirely — not merely stops growing. A small absolute bound is the right
+     * assertion here for that reason: the sheet declares one tier.
+     */
+    expect(counted.reads).toBeLessThanOrEqual(8);
+  });
+
   it("marks nothing when the host supplies no styles at all", () => {
     // Absent styles is "the question was not asked", which must not read as
     // "every state is unstyled" the way an empty object would.

--- a/packages/builder/src/state-switcher.test.tsx
+++ b/packages/builder/src/state-switcher.test.tsx
@@ -113,6 +113,31 @@ describe("which states report that they carry values", () => {
     expect(stateHasOwnValues(styles, "hover")).toBe(false);
   });
 
+  it("does NOT mark an ARRAY-shaped tier the compiler will emit nothing for", () => {
+    /*
+     * An array is a non-null object, so a guard asking only that accepts
+     * `hover: []` and counts its numeric indexes as declarations. The compiler
+     * reads this envelope with `isPlainRecord` and emits nothing for an array,
+     * so a state marked from one is a state that cannot affect the page —
+     * worse than an unmarked one, because it sends an author looking for a
+     * value that was never going to apply.
+     *
+     * NONEMPTY arrays, at both levels, because an empty one is already refused
+     * by the length test and would pass on the broken implementation too.
+     */
+    const styles = {
+      hover: [{ color: "#000001" }],
+      focus: { base: ["#000002"] },
+      active: { base: { color: "#000003" } },
+    } as unknown as NodeStyles;
+
+    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+
+    // `active` is the control: a real record beside the two bad shapes, so this
+    // case cannot pass by the marker never appearing at all.
+    expect(marked()).toEqual(["Pressed"]);
+  });
+
   it("marks nothing when the host supplies no styles at all", () => {
     // Absent styles is "the question was not asked", which must not read as
     // "every state is unstyled" the way an empty object would.

--- a/packages/builder/src/state-switcher.test.tsx
+++ b/packages/builder/src/state-switcher.test.tsx
@@ -16,7 +16,8 @@ import * as React from "react";
 
 import type { NodeStyles } from "@nextlyhq/blocks-engine";
 
-import { StateSwitcher, stateHasOwnValues } from "./state-switcher";
+import { StateSwitcher } from "./state-switcher";
+import { stateHasOwnValues } from "./style-values";
 
 afterEach(cleanup);
 
@@ -72,6 +73,44 @@ describe("which states report that they carry values", () => {
     render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
 
     expect(marked()).toEqual(["Hover"]);
+  });
+
+  it("survives a malformed stored envelope rather than taking the tab down", () => {
+    /*
+     * The envelope arrives from STORAGE, and the field's guard admits this
+     * deliberately: it checks that `nodes` is an array and no more, so a
+     * migration, a DTCG import or a hand-edited row can leave a null state or a
+     * null breakpoint behind. Enumerating one throws during RENDER, which takes
+     * the whole Style tab down — removing the only surface that could repair
+     * the value that broke it.
+     *
+     * Both shapes in one case, because they fail at different levels: the state
+     * itself, and one breakpoint under a state that is otherwise fine.
+     */
+    const styles = {
+      hover: null,
+      focus: { base: null },
+      active: { base: { color: "#000001" } },
+    } as unknown as NodeStyles;
+
+    expect(() =>
+      render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />)
+    ).not.toThrow();
+
+    expect(marked()).toEqual(["Pressed"]);
+  });
+
+  it("ignores a state reached through the PROTOTYPE", () => {
+    // A state the compiler will not read must not be reported as styled: the
+    // marker would send an author looking for values that never reach the page.
+    const styles = Object.create({
+      hover: { base: { color: "#000001" } },
+    }) as NodeStyles;
+
+    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+
+    expect(marked()).toEqual([]);
+    expect(stateHasOwnValues(styles, "hover")).toBe(false);
   });
 
   it("marks nothing when the host supplies no styles at all", () => {

--- a/packages/builder/src/state-switcher.test.tsx
+++ b/packages/builder/src/state-switcher.test.tsx
@@ -58,7 +58,7 @@ describe("which states report that they carry values", () => {
     render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
 
     expect(marked()).toEqual([]);
-    expect(stateHasOwnValues(styles, "active")).toBe(false);
+    expect(stateHasOwnValues(styles, "active", undefined)).toBe(false);
   });
 
   it("leaves the base state unmarked even when it carries values", () => {
@@ -110,7 +110,7 @@ describe("which states report that they carry values", () => {
     render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
 
     expect(marked()).toEqual([]);
-    expect(stateHasOwnValues(styles, "hover")).toBe(false);
+    expect(stateHasOwnValues(styles, "hover", undefined)).toBe(false);
   });
 
   it("does NOT mark an ARRAY-shaped tier the compiler will emit nothing for", () => {
@@ -136,6 +136,52 @@ describe("which states report that they carry values", () => {
     // `active` is the control: a real record beside the two bad shapes, so this
     // case cannot pass by the marker never appearing at all.
     expect(marked()).toEqual(["Pressed"]);
+  });
+
+  it("does NOT mark a value stored under a tier the sheet no longer has", () => {
+    /*
+     * Deleting a breakpoint leaves values behind under its id. The compiler
+     * iterates the breakpoint contexts it was given and never looks at the
+     * rest — measured, the same node compiles to 73 bytes under a known tier
+     * and to an empty sheet under an unknown one — so marking that state sends
+     * an author looking for an appearance no visitor can see.
+     *
+     * `active` is the control: a value at a tier that DOES exist, in the same
+     * render, so this cannot pass by nothing being marked at all.
+     */
+    const styles = {
+      hover: { "deleted-tier": { color: "#000001" } },
+      active: { base: { color: "#000002" } },
+    } as unknown as NodeStyles;
+
+    render(
+      <StateSwitcher
+        state="base"
+        onSelect={vi.fn()}
+        styles={styles}
+        breakpoints={{
+          viewport: [{ id: "base", label: "Desktop" }],
+          container: [],
+        }}
+      />
+    );
+
+    expect(marked()).toEqual(["Pressed"]);
+  });
+
+  it("counts every stored tier when the site's breakpoints are not known", () => {
+    /*
+     * The question "which tiers exist" has not been asked, and treating an
+     * unasked question as "none exist" would report every state as unstyled —
+     * an absence answering as a verdict.
+     */
+    const styles = {
+      hover: { "some-tier": { color: "#000001" } },
+    } as unknown as NodeStyles;
+
+    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+
+    expect(marked()).toEqual(["Hover"]);
   });
 
   it("marks nothing when the host supplies no styles at all", () => {

--- a/packages/builder/src/state-switcher.test.tsx
+++ b/packages/builder/src/state-switcher.test.tsx
@@ -1,0 +1,164 @@
+// @vitest-environment jsdom
+
+/**
+ * The control that chooses which interaction state the Style tab edits.
+ *
+ * What is only true here is the marker: which states it reports as carrying
+ * values, and — the half a key test would miss — which it reports as empty.
+ * The switching itself is a radio group, and the cases below drive it through
+ * the keyboard as well as the pointer because selection follows focus.
+ *
+ * @module state-switcher.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+
+import type { NodeStyles } from "@nextlyhq/blocks-engine";
+
+import { StateSwitcher, stateHasOwnValues } from "./state-switcher";
+
+afterEach(cleanup);
+
+const marked = (): string[] =>
+  screen
+    .getAllByRole("radio")
+    .filter(el => el.querySelector("[data-nx-state-marked]") !== null)
+    .map(el => el.textContent ?? "");
+
+describe("which states report that they carry values", () => {
+  it("marks a state holding a declaration, and not one holding none", () => {
+    /*
+     * Both halves in one case, because the marker's whole job is to
+     * discriminate: a component that marked everything would satisfy the
+     * positive half alone, and that is the shape this control must not have.
+     */
+    const styles = {
+      hover: { base: { color: "#000001" } },
+      focus: {},
+    } as unknown as NodeStyles;
+
+    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+
+    expect(marked()).toEqual(["Hover"]);
+  });
+
+  it("does NOT mark a state whose breakpoint holds an empty value set", () => {
+    /*
+     * The separating case. Both levels of `NodeStyles` are sparse and either
+     * can survive empty — a state whose last declaration was cleared leaves the
+     * keys behind — so a key test reports it as styled while it carries
+     * nothing, which is the false reassurance this marker exists to remove.
+     */
+    const styles = {
+      active: { base: {} },
+    } as unknown as NodeStyles;
+
+    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+
+    expect(marked()).toEqual([]);
+    expect(stateHasOwnValues(styles, "active")).toBe(false);
+  });
+
+  it("leaves the base state unmarked even when it carries values", () => {
+    // It carries values on almost every block, so a dot there is on
+    // permanently — and a marker that is always lit costs the other three the
+    // meaning they depend on.
+    const styles = {
+      base: { base: { color: "#000001" } },
+      hover: { base: { color: "#000002" } },
+    } as unknown as NodeStyles;
+
+    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+
+    expect(marked()).toEqual(["Hover"]);
+  });
+
+  it("marks nothing when the host supplies no styles at all", () => {
+    // Absent styles is "the question was not asked", which must not read as
+    // "every state is unstyled" the way an empty object would.
+    render(<StateSwitcher state="base" onSelect={vi.fn()} />);
+
+    expect(marked()).toEqual([]);
+  });
+
+  it("says in the ACCESSIBLE NAME that a state has styles", () => {
+    // The one piece of information this control adds beyond its labels; a
+    // purely visual form withholds it from the people who can least afford to
+    // click through four states to find out.
+    const styles = { hover: { base: { color: "#000001" } } } as NodeStyles;
+
+    render(<StateSwitcher state="base" onSelect={vi.fn()} styles={styles} />);
+
+    expect(
+      screen.getByRole("radio", { name: /Hover.*has styles/ })
+    ).toBeTruthy();
+    expect(screen.queryByRole("radio", { name: /Focused.*has styles/ })).toBe(
+      null
+    );
+  });
+});
+
+describe("choosing a state", () => {
+  it("reports the state the author picked", () => {
+    const onSelect = vi.fn();
+    render(<StateSwitcher state="base" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByRole("radio", { name: /^Hover/ }));
+
+    expect(onSelect).toHaveBeenCalledWith("hover");
+  });
+
+  it("uses the product's words, not the engine's identifiers", () => {
+    /*
+     * `active` is the most misread term in CSS — authors take it to mean
+     * "current" rather than "being pressed" — so the label is asserted rather
+     * than left to follow whatever the engine happens to call the state.
+     */
+    render(<StateSwitcher state="base" onSelect={vi.fn()} />);
+
+    expect(screen.getAllByRole("radio").map(el => el.textContent)).toEqual([
+      "None",
+      "Hover",
+      "Focused",
+      "Pressed",
+    ]);
+  });
+
+  it("moves through the states with the arrow keys, selection following focus", () => {
+    // The APG radio-group behaviour, and right here: choosing a state is free
+    // and reversible, and seeing the canvas change while arrowing is the point.
+    const onSelect = vi.fn();
+    render(<StateSwitcher state="hover" onSelect={onSelect} />);
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowRight" });
+    expect(onSelect).toHaveBeenLastCalledWith("focus");
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowLeft" });
+    expect(onSelect).toHaveBeenLastCalledWith("base");
+  });
+
+  it("wraps at both ends rather than stopping", () => {
+    // A radio group is a ring; stopping at the end makes the fourth state cost
+    // three presses from the first and reads as the control being stuck.
+    const onSelect = vi.fn();
+    render(<StateSwitcher state="base" onSelect={onSelect} />);
+
+    fireEvent.keyDown(screen.getByRole("radiogroup"), { key: "ArrowLeft" });
+
+    expect(onSelect).toHaveBeenLastCalledWith("active");
+  });
+
+  it("keeps ONE tab stop, on the selected state", () => {
+    // A group that put every option in the tab order costs a keyboard user one
+    // Tab per state to cross a control they may not be using.
+    render(<StateSwitcher state="focus" onSelect={vi.fn()} />);
+
+    const stops = screen
+      .getAllByRole("radio")
+      .filter(el => el.getAttribute("tabindex") === "0");
+
+    expect(stops).toHaveLength(1);
+    expect(stops[0]?.textContent).toBe("Focused");
+  });
+});

--- a/packages/builder/src/state-switcher.tsx
+++ b/packages/builder/src/state-switcher.tsx
@@ -23,6 +23,7 @@
  */
 
 import {
+  type BreakpointSet,
   type NodeStyles,
   STYLE_STATES,
   type StyleState,
@@ -85,12 +86,20 @@ export interface StateSwitcherProps {
    * unstyled.
    */
   styles?: NodeStyles | undefined;
+  /**
+   * The site's breakpoints, so a marker counts only tiers the sheet has.
+   *
+   * A value stored under a deleted tier reaches no visitor, and marking it
+   * sends an author looking for an appearance nobody can see.
+   */
+  breakpoints?: BreakpointSet | undefined;
 }
 
 export function StateSwitcher({
   state,
   onSelect,
   styles,
+  breakpoints,
 }: StateSwitcherProps): React.JSX.Element {
   const radios = React.useRef<Array<HTMLButtonElement | null>>([]);
   const index = STYLE_STATES.indexOf(state);
@@ -143,7 +152,8 @@ export function StateSwitcher({
          * always lit is read as decoration, which costs the other three the
          * meaning they depend on.
          */
-        const marked = option !== "base" && stateHasOwnValues(styles, option);
+        const marked =
+          option !== "base" && stateHasOwnValues(styles, option, breakpoints);
         return (
           <button
             key={option}
@@ -230,6 +240,8 @@ export interface StyleStateFieldProps {
    * then knows it separately.
    */
   node?: { styles?: NodeStyles } | null | undefined;
+  /** The site's breakpoints, so a marker counts only tiers the sheet has. */
+  breakpoints?: BreakpointSet | undefined;
 }
 
 /**
@@ -250,11 +262,17 @@ export function StyleStateField({
   state = "base",
   onSelect,
   node,
+  breakpoints,
 }: StyleStateFieldProps): React.JSX.Element | null {
   if (onSelect === undefined) return null;
   return (
     <div className="nx-inspector__state">
-      <StateSwitcher state={state} onSelect={onSelect} styles={node?.styles} />
+      <StateSwitcher
+        state={state}
+        onSelect={onSelect}
+        styles={node?.styles}
+        breakpoints={breakpoints}
+      />
     </div>
   );
 }

--- a/packages/builder/src/state-switcher.tsx
+++ b/packages/builder/src/state-switcher.tsx
@@ -31,6 +31,7 @@ import { cn } from "@nextlyhq/ui/utils";
 import * as React from "react";
 
 import { radioGroupStep } from "./roving-radios";
+import { stateHasOwnValues } from "./style-values";
 
 /**
  * What each state is CALLED, in this product's vocabulary.
@@ -65,32 +66,6 @@ const STATE_HINTS: Readonly<Record<StyleState, string>> = {
   focus: "while it has keyboard focus",
   active: "while it is being pressed",
 };
-
-/**
- * Whether a state holds declarations OF ITS OWN.
- *
- * Presence of the key is not the property. Both levels of `NodeStyles` are
- * sparse and either can survive as an empty object — a state whose last
- * declaration was cleared, a breakpoint that was opened and left alone — so a
- * key test would report a state as styled when it carries nothing, which is
- * precisely the false reassurance this marker exists to remove.
- *
- * Node-local, deliberately. A hover appearance can also come from a named class
- * or a block-type default, and those are real, but this marker sits on the
- * control that decides what the panel WRITES, and the panel writes here. A dot
- * meaning "you have set something in this state" can be acted on; one meaning
- * "something, somewhere, affects this state" cannot.
- */
-export function stateHasOwnValues(
-  styles: NodeStyles | undefined,
-  state: StyleState
-): boolean {
-  const perBreakpoint = styles?.[state];
-  if (perBreakpoint === undefined) return false;
-  return Object.values(perBreakpoint).some(
-    values => values !== undefined && Object.keys(values).length > 0
-  );
-}
 
 /**
  * Props for StateSwitcher.

--- a/packages/builder/src/state-switcher.tsx
+++ b/packages/builder/src/state-switcher.tsx
@@ -177,10 +177,29 @@ export function StateSwitcher({
               <span
                 aria-hidden="true"
                 data-nx-state-marked="true"
-                className={cn(
-                  "size-1 rounded-full",
-                  selected ? "bg-accent-foreground" : "bg-muted-foreground"
-                )}
+                /*
+                 * `bg-current` — the button's own text colour — rather than a
+                 * named colour utility, and the reason is measured rather than
+                 * stylistic.
+                 *
+                 * A named one fails at TWO layers here, so fixing either alone
+                 * leaves the dot invisible. `bg-accent-foreground` is emitted
+                 * into no stylesheet this package produces or consumes: the
+                 * builder's own is built from these sources and this was its
+                 * only use, and the admin's emits `bg-muted-foreground` and not
+                 * the accent one. And the theme token behind it,
+                 * `--accent-foreground`, is undefined on both `:root` and
+                 * `.nx-builder-chrome` in the editor, so even a rule that WAS
+                 * emitted would paint transparent.
+                 *
+                 * `currentColor` depends on neither: it is a CSS keyword rather
+                 * than a theme lookup, so the utility is generated from this
+                 * use alone. It is also the better answer independently — the
+                 * dot takes the colour of the label it sits beside, so it stays
+                 * legible in both the selected and unselected states without
+                 * restating either, and cannot drift from them.
+                 */
+                className="size-1 rounded-full bg-current"
               />
             ) : null}
           </button>

--- a/packages/builder/src/state-switcher.tsx
+++ b/packages/builder/src/state-switcher.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+/**
+ * The control that chooses which interaction state the Style tab edits.
+ *
+ * **At the top of the Style tab, not in the canvas chrome.** A breakpoint is a
+ * fact about the whole page and belongs beside the canvas it resizes; a state
+ * is a fact about the SELECTED BLOCK, and the panel is already scoped to that
+ * block. Putting the two together would promise a symmetry that does not hold
+ * and would leave this control needing a dead state whenever nothing is
+ * selected. Webflow, Framer and Plasmic all place it inside the style panel for
+ * the same reason, so an author arriving from any of them finds it where they
+ * expect.
+ *
+ * **It reports which states already carry values**, which is the question
+ * reading the values cannot answer. Styles inherit: opening `focus` on a block
+ * with no focus styles shows the base values, so an author checking each state
+ * in turn sees plausible numbers everywhere and still cannot tell which ones
+ * were set. Marking the states that hold declarations of their own turns four
+ * clicks and a misreading into one glance.
+ *
+ * @module state-switcher
+ */
+
+import {
+  type NodeStyles,
+  STYLE_STATES,
+  type StyleState,
+} from "@nextlyhq/blocks-engine";
+import { cn } from "@nextlyhq/ui/utils";
+import * as React from "react";
+
+import { radioGroupStep } from "./roving-radios";
+
+/**
+ * What each state is CALLED, in this product's vocabulary.
+ *
+ * The engine's identifiers are CSS's — `base`, `hover`, `focus`, `active` — and
+ * they are the wrong words for the people using this control. `active` is the
+ * most misread term in CSS: authors reliably take it to mean "current" or
+ * "selected" rather than "being pressed". The labels describe what the visitor
+ * is DOING, which is the thing an author is styling.
+ *
+ * Typed as a total record rather than a lookup with a fallback, so adding a
+ * state to the engine fails to compile here instead of shipping a control with
+ * an unnamed option.
+ */
+const STATE_LABELS: Readonly<Record<StyleState, string>> = {
+  base: "None",
+  hover: "Hover",
+  focus: "Focused",
+  active: "Pressed",
+};
+
+/**
+ * What each state MEANS, for the accessible name and the tooltip.
+ *
+ * The label alone does not say what selecting it will do — "Pressed" names a
+ * state without saying whose, and a screen reader user gets no more from it
+ * than the word.
+ */
+const STATE_HINTS: Readonly<Record<StyleState, string>> = {
+  base: "the normal appearance, before any interaction",
+  hover: "while the pointer is over it",
+  focus: "while it has keyboard focus",
+  active: "while it is being pressed",
+};
+
+/**
+ * Whether a state holds declarations OF ITS OWN.
+ *
+ * Presence of the key is not the property. Both levels of `NodeStyles` are
+ * sparse and either can survive as an empty object — a state whose last
+ * declaration was cleared, a breakpoint that was opened and left alone — so a
+ * key test would report a state as styled when it carries nothing, which is
+ * precisely the false reassurance this marker exists to remove.
+ *
+ * Node-local, deliberately. A hover appearance can also come from a named class
+ * or a block-type default, and those are real, but this marker sits on the
+ * control that decides what the panel WRITES, and the panel writes here. A dot
+ * meaning "you have set something in this state" can be acted on; one meaning
+ * "something, somewhere, affects this state" cannot.
+ */
+export function stateHasOwnValues(
+  styles: NodeStyles | undefined,
+  state: StyleState
+): boolean {
+  const perBreakpoint = styles?.[state];
+  if (perBreakpoint === undefined) return false;
+  return Object.values(perBreakpoint).some(
+    values => values !== undefined && Object.keys(values).length > 0
+  );
+}
+
+/**
+ * Props for StateSwitcher.
+ * @experimental
+ */
+export interface StateSwitcherProps {
+  /** The state currently being edited. */
+  state: StyleState;
+  /** Choose a different state to edit and preview. */
+  onSelect: (state: StyleState) => void;
+  /**
+   * The selected node's stored styles, for reporting which states carry values.
+   *
+   * Optional because the marker is an affordance rather than the control: a
+   * host that cannot supply them gets a working switcher with nothing marked,
+   * which is honest. Supplying an empty object would claim every state is
+   * unstyled.
+   */
+  styles?: NodeStyles | undefined;
+}
+
+export function StateSwitcher({
+  state,
+  onSelect,
+  styles,
+}: StateSwitcherProps): React.JSX.Element {
+  const radios = React.useRef<Array<HTMLButtonElement | null>>([]);
+  const index = STYLE_STATES.indexOf(state);
+  /*
+   * A selection that is somehow not one of the states still leaves a reachable
+   * control: the roving tab stop falls back to the first option rather than to
+   * `-1`, which would put every option out of the tab order and strand a
+   * keyboard user on a group they cannot enter.
+   */
+  const activeIndex = index === -1 ? 0 : index;
+
+  /*
+   * Roving tabindex: one stop for the whole group, arrows move within it.
+   *
+   * The same model the breakpoint switcher uses, and for the same reason — a
+   * radio group that put every option in the tab order costs a keyboard user
+   * one Tab per state to cross a control they may not be using.
+   *
+   * Selection FOLLOWS focus, which is the APG's radio-group behaviour and is
+   * right here: choosing a state is free and instantly reversible, and the
+   * canvas showing the state under the cursor is the whole point of arrowing
+   * through them.
+   */
+  const move = (delta: number): void => {
+    const next =
+      (activeIndex + delta + STYLE_STATES.length) % STYLE_STATES.length;
+    const target = STYLE_STATES[next];
+    if (target === undefined) return;
+    onSelect(target);
+    radios.current[next]?.focus();
+  };
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Interaction state"
+      className="nx-state-switcher flex items-center gap-0.5 rounded-md border p-0.5"
+      onKeyDown={event => {
+        const step = radioGroupStep(event.key);
+        if (step === null) return;
+        event.preventDefault();
+        move(step);
+      }}
+    >
+      {STYLE_STATES.map((option, position) => {
+        const selected = option === state;
+        /*
+         * Not marked on `base`. It carries values on almost every block, so a
+         * dot there is on permanently and says nothing — and a marker that is
+         * always lit is read as decoration, which costs the other three the
+         * meaning they depend on.
+         */
+        const marked = option !== "base" && stateHasOwnValues(styles, option);
+        return (
+          <button
+            key={option}
+            ref={element => {
+              radios.current[position] = element;
+            }}
+            type="button"
+            role="radio"
+            aria-checked={selected}
+            /*
+             * The marker is in the ACCESSIBLE NAME, not only in the dot. It is
+             * the one piece of information this control adds beyond its labels,
+             * and a purely visual form withholds it from the people who can
+             * least afford to click through four states to find out.
+             */
+            aria-label={`${STATE_LABELS[option]} — ${STATE_HINTS[option]}${
+              marked ? ", has styles" : ""
+            }`}
+            title={`${STATE_LABELS[option]}: ${STATE_HINTS[option]}`}
+            tabIndex={position === activeIndex ? 0 : -1}
+            onClick={() => onSelect(option)}
+            className={cn(
+              "flex flex-1 items-center justify-center gap-1 rounded px-2 py-1 text-xs",
+              selected
+                ? "bg-accent text-accent-foreground"
+                : "text-muted-foreground"
+            )}
+          >
+            <span aria-hidden="true">{STATE_LABELS[option]}</span>
+            {marked ? (
+              <span
+                aria-hidden="true"
+                data-nx-state-marked="true"
+                className={cn(
+                  "size-1 rounded-full",
+                  selected ? "bg-accent-foreground" : "bg-muted-foreground"
+                )}
+              />
+            ) : null}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/**
+ * Props for StyleStateField.
+ * @experimental
+ */
+export interface StyleStateFieldProps {
+  /** The state currently being edited. `base` when the host says nothing. */
+  state?: StyleState | undefined;
+  /**
+   * Choose a different state, or `undefined` where nothing can act on the
+   * choice — which is what withholds the control.
+   */
+  onSelect?: ((state: StyleState) => void) | undefined;
+  /**
+   * The selected node, whose stored styles the markers are read from.
+   *
+   * The NODE rather than its styles, so the one place that knows a marker is
+   * about stored styles is also the place that reaches for them — a caller
+   * handed a styles-shaped prop has to know that much itself, and every caller
+   * then knows it separately.
+   */
+  node?: { styles?: NodeStyles } | null | undefined;
+}
+
+/**
+ * The switcher as a style panel mounts it, including whether to mount it.
+ *
+ * The condition lives with the CONTROL rather than at the call site, because it
+ * is a property of the control: this switcher's state and `Canvas.forcedState`
+ * are one value, so a host that cannot carry the choice to its canvas would get
+ * a switcher reporting a state the author is not looking at. Deciding that
+ * where the control is defined also keeps the panel free of a branch per
+ * optional prop, which is how a panel already rendering three tabs becomes one
+ * nobody can read.
+ *
+ * Both props accept an explicit `undefined` so a caller can forward whatever it
+ * holds without a conditional spread at every call site.
+ */
+export function StyleStateField({
+  state = "base",
+  onSelect,
+  node,
+}: StyleStateFieldProps): React.JSX.Element | null {
+  if (onSelect === undefined) return null;
+  return (
+    <div className="nx-inspector__state">
+      <StateSwitcher state={state} onSelect={onSelect} styles={node?.styles} />
+    </div>
+  );
+}

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -23,7 +23,6 @@
 import {
   breakpointContexts,
   isPlainRecord,
-  MAX_SCANNED_KEYS,
   isTokenRef,
   validateStyleValues,
   type BreakpointId,
@@ -296,9 +295,25 @@ function hasOwnKeys(value: unknown): value is Record<string, never> {
 /**
  * Whether a record carries at least one own key.
  *
- * `Object.keys(...).length > 0` answers the same question and reads every key
- * to do it. These records arrive from storage, so the width is not ours to
- * assume, and the answer is known at the first own key.
+ * The LOOP stops at the first own key; the ENUMERATION does not, and the
+ * difference is worth stating because it is easy to read this as bounded and it
+ * is not. `for...in` asks the engine for the record's key list before the body
+ * runs, so this is O(n) in the record's width however early it returns —
+ * measured here at 0.08ms for a thousand keys, 10.75ms for a hundred thousand
+ * and 103ms for a million. `Object.keys(...).length > 0` costs the same and
+ * allocates as well, which is the only reason to prefer this form.
+ *
+ * No bounded alternative exists at this layer: JavaScript has no O(1) emptiness
+ * test for a plain object, and this package publishes no list of style property
+ * names to probe instead. The width is therefore a property of the DOCUMENT,
+ * and the place to bound it is where a document is admitted.
+ *
+ * What makes that acceptable rather than merely unavoidable: the compiler
+ * enumerates the same record the same way — `validateStyleValues` iterates it
+ * with a bare `for...in` — so a values record wide enough to cost this marker
+ * anything has already cost the compile that produced the page. The bound the
+ * engine DOES apply, `MAX_SCANNED_KEYS` in `boundedKeys`, is over the
+ * breakpoint DEFINITIONS record, which this no longer walks at all.
  */
 function hasAnyOwnKey(record: object): boolean {
   for (const key in record) {
@@ -403,23 +418,27 @@ export function stateHasOwnValues(
   }
 
   /*
-   * With no breakpoints known, the stored keys are the only list there is, and
-   * every one of them counts — the question "which tiers exist" has not been
-   * asked, and treating an unasked question as "none exist" would report every
-   * state as unstyled.
+   * With no breakpoints known there is NO ANSWER, and this returns false rather
+   * than guessing one.
    *
-   * Read with an early break rather than through `Object.keys`, and stopped
-   * where `boundedKeys` stops. A reader walking the same untrusted records has
-   * to stop where the compiler stops, or a corrupt row costs this the unbounded
-   * scan that bound exists to prevent while compilation pays 256.
+   * The marker means "you have set something here that this site can express",
+   * and without the site's tiers that question cannot be asked at all — a value
+   * under a tier the sheet lacks reaches nobody, and which tiers the sheet has
+   * is exactly what is missing. Reporting from the stored keys instead would
+   * answer a different question and read as the same dot.
+   *
+   * It is also what makes this bounded BY CONSTRUCTION rather than by a cap.
+   * The stored record arrives from storage and can be arbitrarily wide, and
+   * every way of walking it — `Object.keys`, `for...in` with an early break —
+   * asks the engine for the whole key list first, so an early exit bounds the
+   * BODY and not the enumeration. Measured by review: a plain-object probe
+   * breaking after 256 entries still grew from ~32ms at 100,000 keys to ~573ms
+   * at 1,000,000. A cap cannot fix that; not enumerating can.
+   *
+   * The product always supplies them — `BlocksField` passes the same
+   * breakpoints it compiles the canvas against — so this is the path for a host
+   * that has not adopted the marker rather than a case an author reaches.
    */
-  let scanned = 0;
-  for (const tier in tiers) {
-    if (!Object.hasOwn(tiers, tier)) continue;
-    if (scanned >= MAX_SCANNED_KEYS) break;
-    scanned += 1;
-    if (holdsValues(tier)) return true;
-  }
   return false;
 }
 

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -338,6 +338,20 @@ function valuesAt(
  * state whose last declaration was cleared leaves the keys behind — so a
  * presence test reports a state as styled when it carries nothing, which is
  * precisely the false reassurance the marker exists to remove.
+ *
+ * REFUSED IS NOT UNSET, and this is the one boundary here that is a judgement
+ * rather than a fact about the shape. A declaration the current policy rejects
+ * emits no CSS, so validating here would make the marker agree with the sheet
+ * in that case too. It is deliberately not done: a policy is a HOST SETTING
+ * that changes without the document changing, so a value refused today is
+ * still the author's, still deliberate, and restored by a policy change. A
+ * marker that vanished for it would report their work as ABSENT rather than as
+ * refused — and refusal already has a better channel, the control that shows
+ * the value and says why it did not apply.
+ *
+ * So this answers "you have set something here that this site can express",
+ * and the tiers and shapes above are the part of that question decided by the
+ * document rather than by configuration.
  */
 export function stateHasOwnValues(
   styles: NodeStyles | undefined,

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -21,10 +21,12 @@
  */
 
 import {
+  breakpointContexts,
   isPlainRecord,
   isTokenRef,
   validateStyleValues,
   type BreakpointId,
+  type BreakpointSet,
   type NodeStyles,
   type StyleState,
   type StyleValue,
@@ -327,6 +329,11 @@ function valuesAt(
  * as styled that cannot affect the page is worse than an unmarked one, because
  * it sends an author looking for a value that was never going to apply.
  *
+ * A TIER THE SHEET HAS. A value stored under a breakpoint the site has since
+ * deleted is not reachable by any visitor — the compiler iterates the
+ * breakpoint contexts it was given and never looks at the rest — so counting it
+ * would mark a state whose appearance nobody can see.
+ *
  * EMPTY IS NOT SET. Both levels are sparse and either can survive empty — a
  * state whose last declaration was cleared leaves the keys behind — so a
  * presence test reports a state as styled when it carries nothing, which is
@@ -334,13 +341,33 @@ function valuesAt(
  */
 export function stateHasOwnValues(
   styles: NodeStyles | undefined,
-  state: StyleState
+  state: StyleState,
+  breakpoints: BreakpointSet | undefined
 ): boolean {
   if (!isPlainRecord(styles)) return false;
-  const breakpoints = ownData(styles, state);
-  if (!isPlainRecord(breakpoints)) return false;
-  return Object.keys(breakpoints).some(breakpoint => {
-    const values = ownData(breakpoints, breakpoint);
+  const tiers = ownData(styles, state);
+  if (!isPlainRecord(tiers)) return false;
+  /*
+   * Only the tiers the SHEET has, asked of the compiler's own reader rather
+   * than of the stored definitions. `breakpointContexts` is what decides which
+   * breakpoints a site actually has for the sheet — it drops a definition whose
+   * bound it cannot use and claims each id once — so a value stored under a
+   * tier that has since been deleted emits nothing at all. Measured: the same
+   * node compiles to 73 bytes under a known tier and to an empty sheet under an
+   * unknown one.
+   *
+   * With no breakpoints known, every stored tier counts. That is the honest
+   * answer rather than a lenient one: the question "which tiers exist" has not
+   * been asked, and treating an unasked question as "none exist" would report
+   * every state as unstyled.
+   */
+  const known =
+    breakpoints === undefined
+      ? undefined
+      : new Set(breakpointContexts(breakpoints).map(context => context.id));
+  return Object.keys(tiers).some(tier => {
+    if (known !== undefined && !known.has(tier)) return false;
+    const values = ownData(tiers, tier);
     return isPlainRecord(values) && Object.keys(values).length > 0;
   });
 }

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -301,6 +301,41 @@ function valuesAt(
   return hasOwnKeys(values) ? values : undefined;
 }
 
+/**
+ * Whether a state holds any declaration of its own, at any breakpoint.
+ *
+ * Here rather than beside the control that draws the answer, because this file
+ * is the chokepoint for reading this envelope and the reading is the whole
+ * difficulty. The value arrives from storage, so a migration, a DTCG import or
+ * a hand-edited row can leave `hover: null` or `{ base: null }` behind, and the
+ * field's own guard admits both — it checks that `nodes` is an array and no
+ * more, deliberately, so a malformed document stays repairable instead of
+ * throwing. `Object.values(null)` throws during RENDER, which takes the Style
+ * tab down and removes the only surface that could repair the value that broke
+ * it.
+ *
+ * Own keys at every level, for the reason `valuesAt` gives: a state or
+ * breakpoint reached through a PROTOTYPE is one the compiler will not read, so
+ * reporting it as styled would mark a state whose values never reach the page.
+ *
+ * EMPTY IS NOT SET. Both levels are sparse and either can survive empty — a
+ * state whose last declaration was cleared leaves the keys behind — so a
+ * presence test reports a state as styled when it carries nothing, which is
+ * precisely the false reassurance the marker exists to remove.
+ */
+export function stateHasOwnValues(
+  styles: NodeStyles | undefined,
+  state: StyleState
+): boolean {
+  if (!hasOwnKeys(styles)) return false;
+  const breakpoints = ownData(styles, state);
+  if (!hasOwnKeys(breakpoints)) return false;
+  return Object.keys(breakpoints).some(breakpoint => {
+    const values = ownData(breakpoints, breakpoint);
+    return hasOwnKeys(values) && Object.keys(values).length > 0;
+  });
+}
+
 /** The whole envelope with one state × breakpoint replaced, pruning what empties. */
 function withValues(
   styles: NodeStyles | undefined,

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -21,6 +21,7 @@
  */
 
 import {
+  isPlainRecord,
   isTokenRef,
   validateStyleValues,
   type BreakpointId,
@@ -318,6 +319,14 @@ function valuesAt(
  * breakpoint reached through a PROTOTYPE is one the compiler will not read, so
  * reporting it as styled would mark a state whose values never reach the page.
  *
+ * A PLAIN RECORD at every level, and the engine's own predicate rather than a
+ * looser one, for the same reason stated positively: this must agree with what
+ * the COMPILER will read. An array is a non-null object, so a guard asking only
+ * that would accept `hover: []` and count its numeric indexes as declarations —
+ * while `isPlainRecord` makes the compiler emit nothing for it. A state marked
+ * as styled that cannot affect the page is worse than an unmarked one, because
+ * it sends an author looking for a value that was never going to apply.
+ *
  * EMPTY IS NOT SET. Both levels are sparse and either can survive empty — a
  * state whose last declaration was cleared leaves the keys behind — so a
  * presence test reports a state as styled when it carries nothing, which is
@@ -327,12 +336,12 @@ export function stateHasOwnValues(
   styles: NodeStyles | undefined,
   state: StyleState
 ): boolean {
-  if (!hasOwnKeys(styles)) return false;
+  if (!isPlainRecord(styles)) return false;
   const breakpoints = ownData(styles, state);
-  if (!hasOwnKeys(breakpoints)) return false;
+  if (!isPlainRecord(breakpoints)) return false;
   return Object.keys(breakpoints).some(breakpoint => {
     const values = ownData(breakpoints, breakpoint);
-    return hasOwnKeys(values) && Object.keys(values).length > 0;
+    return isPlainRecord(values) && Object.keys(values).length > 0;
   });
 }
 

--- a/packages/builder/src/style-values.ts
+++ b/packages/builder/src/style-values.ts
@@ -23,6 +23,7 @@
 import {
   breakpointContexts,
   isPlainRecord,
+  MAX_SCANNED_KEYS,
   isTokenRef,
   validateStyleValues,
   type BreakpointId,
@@ -292,6 +293,20 @@ function hasOwnKeys(value: unknown): value is Record<string, never> {
   return typeof value === "object" && value !== null;
 }
 
+/**
+ * Whether a record carries at least one own key.
+ *
+ * `Object.keys(...).length > 0` answers the same question and reads every key
+ * to do it. These records arrive from storage, so the width is not ours to
+ * assume, and the answer is known at the first own key.
+ */
+function hasAnyOwnKey(record: object): boolean {
+  for (const key in record) {
+    if (Object.hasOwn(record, key)) return true;
+  }
+  return false;
+}
+
 function valuesAt(
   styles: NodeStyles | undefined,
   state: StyleState,
@@ -361,29 +376,51 @@ export function stateHasOwnValues(
   if (!isPlainRecord(styles)) return false;
   const tiers = ownData(styles, state);
   if (!isPlainRecord(tiers)) return false;
-  /*
-   * Only the tiers the SHEET has, asked of the compiler's own reader rather
-   * than of the stored definitions. `breakpointContexts` is what decides which
-   * breakpoints a site actually has for the sheet — it drops a definition whose
-   * bound it cannot use and claims each id once — so a value stored under a
-   * tier that has since been deleted emits nothing at all. Measured: the same
-   * node compiles to 73 bytes under a known tier and to an empty sheet under an
-   * unknown one.
-   *
-   * With no breakpoints known, every stored tier counts. That is the honest
-   * answer rather than a lenient one: the question "which tiers exist" has not
-   * been asked, and treating an unasked question as "none exist" would report
-   * every state as unstyled.
-   */
-  const known =
-    breakpoints === undefined
-      ? undefined
-      : new Set(breakpointContexts(breakpoints).map(context => context.id));
-  return Object.keys(tiers).some(tier => {
-    if (known !== undefined && !known.has(tier)) return false;
+
+  const holdsValues = (tier: string): boolean => {
     const values = ownData(tiers, tier);
-    return isPlainRecord(values) && Object.keys(values).length > 0;
-  });
+    return isPlainRecord(values) && hasAnyOwnKey(values);
+  };
+
+  /*
+   * Driven by the tiers the SHEET has, asked of the compiler's own reader.
+   * `breakpointContexts` is what decides which breakpoints a site actually has
+   * — it drops a definition whose bound it cannot use and claims each id once —
+   * so a value stored under a tier that has since been deleted emits nothing at
+   * all. Measured: the same node compiles to 73 bytes under a known tier and to
+   * an empty sheet under an unknown one.
+   *
+   * Iterating the KNOWN ids rather than the stored ones is also what bounds
+   * this. A stored record arrives from storage and can be arbitrarily wide, so
+   * asking it for its keys reads all of them before any filter can narrow the
+   * set — on every render, once per non-base state. Asking the sheet instead
+   * costs one lookup per tier the site actually has, which is a handful.
+   */
+  if (breakpoints !== undefined) {
+    return breakpointContexts(breakpoints).some(context =>
+      holdsValues(context.id)
+    );
+  }
+
+  /*
+   * With no breakpoints known, the stored keys are the only list there is, and
+   * every one of them counts — the question "which tiers exist" has not been
+   * asked, and treating an unasked question as "none exist" would report every
+   * state as unstyled.
+   *
+   * Read with an early break rather than through `Object.keys`, and stopped
+   * where `boundedKeys` stops. A reader walking the same untrusted records has
+   * to stop where the compiler stops, or a corrupt row costs this the unbounded
+   * scan that bound exists to prevent while compilation pays 256.
+   */
+  let scanned = 0;
+  for (const tier in tiers) {
+    if (!Object.hasOwn(tiers, tier)) continue;
+    if (scanned >= MAX_SCANNED_KEYS) break;
+    scanned += 1;
+    if (holdsValues(tier)) return true;
+  }
+  return false;
 }
 
 /** The whole envelope with one state × breakpoint replaced, pruning what empties. */

--- a/packages/plugin-page-builder/src/admin/BlocksField.styleState.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.styleState.test.tsx
@@ -1,0 +1,236 @@
+// @vitest-environment jsdom
+
+/**
+ * The interaction state reaching the canvas and the panel as ONE value.
+ *
+ * `state-switcher.test.tsx` asserts the control, and `inspector-panel.test.tsx`
+ * asserts that the panel offers and withholds it. What is only true HERE is the
+ * wiring: that the state the panel edits and the state the canvas forces are
+ * the same value, and that it is suppressed when the control that explains it
+ * is not on screen.
+ *
+ * The failure this guards is silent in the worst direction. Every derivation
+ * can be right while the two props disagree — the panel reports hover values,
+ * the canvas draws the base appearance, and nothing says so.
+ *
+ * The builder shell is replaced with recorders rather than rendered, as
+ * `BlocksField.breakpoints.test` does and for its reason: what is under test is
+ * which props this component passes.
+ *
+ * @module admin/BlocksField.styleState.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
+
+const seen: {
+  inspector: Record<string, unknown> | undefined;
+  canvas: Record<string, unknown> | undefined;
+} = { inspector: undefined, canvas: undefined };
+
+/**
+ * The selection the editor reports, which each case sets.
+ *
+ * A module-level box rather than a mock factory argument, because the mock is
+ * hoisted above every binding in this file — reading it at call time is what
+ * lets a case change the selection between renders.
+ */
+let selectionIds: string[] = ["a"];
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  const real = await importOriginal<Record<string, unknown>>();
+  const record =
+    (key: "inspector" | "canvas") =>
+    (props: Record<string, unknown>): React.JSX.Element => {
+      seen[key] = props;
+      return <div data-recorder={key} />;
+    };
+  const nothing = (): null => null;
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    BuilderShell: ({
+      inspector,
+      topBar,
+      children,
+    }: {
+      inspector: React.ReactNode;
+      topBar?: React.ReactNode;
+      children?: React.ReactNode;
+    }): React.JSX.Element => (
+      <div>
+        {topBar}
+        {inspector}
+        {children}
+      </div>
+    ),
+    BreakpointManager: nothing,
+    BreakpointSwitcher: nothing,
+    InspectorPanel: record("inspector"),
+    Canvas: record("canvas"),
+    BlockKeyboardActions: passthrough,
+    BlockContextMenu: passthrough,
+    BlockToolbar: nothing,
+    EditorCommandPalette: nothing,
+    DropIndicator: nothing,
+    InsertPanel: nothing,
+    LayersPanel: nothing,
+    OnboardingChecklist: nothing,
+    SelectionBreadcrumb: nothing,
+    SpacingOverlay: nothing,
+    useBuilderChecklist: () => ({
+      visible: false,
+      steps: [],
+      dismiss: () => {},
+    }),
+    useCanvasDrag: () => ({
+      handlers: {},
+      target: null,
+      draggingId: null,
+      draggingBlockName: null,
+    }),
+    useEditorState: () => ({
+      document: DOCUMENT,
+      selectedId: selectionIds[0] ?? null,
+      selection: { ids: selectionIds, primary: selectionIds[0] ?? null },
+      apply: () => null,
+      applyAll: () => null,
+      select: () => {},
+      undo: () => {},
+      redo: () => {},
+      canUndo: false,
+      canRedo: false,
+      undoDepth: 0,
+    }),
+    useInlineText: () => ({ onDoubleClick: () => {} }),
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
+  usePluginClientConfig: () => undefined,
+  useDocumentCheckpoint: () => ({ schedule: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  useSingleDocument: () => ({ data: undefined, isPending: false, error: null }),
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async () => ({ success: true }),
+    isPending: false,
+  }),
+}));
+
+const { BlocksField } = await import("./BlocksField");
+
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+function openEditor(): { rerender: () => void } {
+  const view = render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  return {
+    rerender: () => {
+      React.act(() => {
+        view.rerender(<Host />);
+      });
+    },
+  };
+}
+
+/** The state the panel was told to edit. */
+const panelState = (): unknown =>
+  (seen.inspector?.styleState as { state?: unknown } | undefined)?.state;
+
+/** The state the canvas was told to draw. */
+const canvasState = (): unknown => seen.canvas?.forcedState;
+
+/** Choose a state through the binding the panel was handed. */
+function chooseState(next: string): void {
+  const binding = seen.inspector?.styleState as
+    | { onChange?: (state: string) => void }
+    | undefined;
+  React.act(() => {
+    binding?.onChange?.(next);
+  });
+}
+
+beforeEach(() => {
+  selectionIds = ["a"];
+  seen.inspector = undefined;
+  seen.canvas = undefined;
+});
+afterEach(cleanup);
+
+describe("the interaction state reaching both surfaces", () => {
+  it("starts at base on both", () => {
+    openEditor();
+
+    expect(panelState()).toBe("base");
+    expect(canvasState()).toBe("base");
+  });
+
+  it("carries a chosen state to the panel AND the canvas", () => {
+    /*
+     * The whole wiring. The panel states no `liveStates`, so its provenance
+     * falls back to the edited state plus base — correct exactly while the
+     * canvas is simulating the state being edited, and wrong the moment it is
+     * not. Asserted on both props in one case, because a version that moved
+     * only one of them is the defect.
+     */
+    openEditor();
+
+    chooseState("hover");
+
+    expect(panelState()).toBe("hover");
+    expect(canvasState()).toBe("hover");
+  });
+
+  it("suppresses the state while SEVERAL blocks are selected", () => {
+    /*
+     * The inspector replaces its whole tab strip with a multi-selection
+     * summary, so the state control goes with it — and the panel's own tab
+     * handler cannot catch this, because the stored tab value is still `style`
+     * and no tab change happens. A forced state that outlives its control is a
+     * canvas drawn mid-hover with nothing on screen explaining why.
+     */
+    const view = openEditor();
+    chooseState("hover");
+    expect(canvasState()).toBe("hover");
+
+    selectionIds = ["a", "b"];
+    view.rerender();
+
+    expect(canvasState()).toBe("base");
+    expect(panelState()).toBe("base");
+  });
+
+  it("RESTORES the chosen state when the selection narrows again", () => {
+    /*
+     * Suppressed, not reset. Writing `base` into the state instead would
+     * silently discard what the author was editing, so shift-clicking a second
+     * block and clicking back would lose their place.
+     */
+    const view = openEditor();
+    chooseState("hover");
+
+    selectionIds = ["a", "b"];
+    view.rerender();
+    expect(canvasState()).toBe("base");
+
+    selectionIds = ["a"];
+    view.rerender();
+
+    expect(canvasState()).toBe("hover");
+    expect(panelState()).toBe("hover");
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.styleState.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.styleState.test.tsx
@@ -22,9 +22,37 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
-const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
+import { clearBlocks, registerBlocks } from "@nextlyhq/blocks-engine";
+
+/*
+ * REAL nodes, and one of them of a type the registry does not know.
+ *
+ * An empty document was the first shape here and it made the wiring cases green
+ * about a selection that did not exist: nothing was inspectable, so a
+ * derivation counting ids could not tell the difference. The unregistered node
+ * is the case a count cannot see at all — it reads as one ordinary selection
+ * while the panel shows no tabs for it.
+ */
+const DOCUMENT = {
+  formatVersion: 1,
+  kind: "page",
+  nodes: [
+    { id: "a", type: "acme/leaf", version: 1, props: {} },
+    { id: "b", type: "acme/leaf", version: 1, props: {} },
+    { id: "unknown", type: "acme/not-registered", version: 1, props: {} },
+  ],
+};
 
 const seen: {
   inspector: Record<string, unknown> | undefined;
@@ -164,6 +192,23 @@ function chooseState(next: string): void {
   });
 }
 
+beforeAll(() => {
+  clearBlocks();
+  registerBlocks(
+    [
+      {
+        name: "acme/leaf",
+        version: 1,
+        description: "A block.",
+        example: { props: {} },
+        render: () => null,
+      },
+    ] as never,
+    { source: "blocksfield-state-test" }
+  );
+});
+afterAll(clearBlocks);
+
 beforeEach(() => {
   selectionIds = ["a"];
   seen.inspector = undefined;
@@ -212,6 +257,27 @@ describe("the interaction state reaching both surfaces", () => {
 
     expect(canvasState()).toBe("base");
     expect(panelState()).toBe("base");
+  });
+
+  it("suppresses the state for a block the inspector cannot show", () => {
+    /*
+     * `inspectSelection` returns null for an unregistered block type, so the
+     * panel replaces its whole tab strip and the switcher goes with it — while
+     * the selection is a perfectly ordinary single id. A derivation counting
+     * ids therefore keeps forwarding the state, and the placeholder is drawn
+     * mid-hover with nothing on screen explaining why.
+     *
+     * The control is the SAME state on a registered block, immediately before,
+     * so this cannot pass by the state never reaching the canvas at all.
+     */
+    const view = openEditor();
+    chooseState("hover");
+    expect(canvasState()).toBe("hover");
+
+    selectionIds = ["unknown"];
+    view.rerender();
+
+    expect(canvasState()).toBe("base");
   });
 
   it("RESTORES the chosen state when the selection narrows again", () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -947,14 +947,29 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * edited state plus base — correct exactly while the canvas is simulating
    * that state. Wired from one value that precondition holds by construction.
    *
-   * A CONSTANT rather than state, because no control chooses it yet and state
-   * nothing writes is state that lints as unused and reads as unfinished. What
-   * matters now is that ONE value reaches both surfaces: the day a control
-   * arrives it replaces this line and finds both call sites already wired,
-   * rather than having to discover that the canvas and the panel were each
-   * defaulting on their own.
+   * ONE value reaching both surfaces, which is the property that matters: the
+   * panel states no `liveStates`, so its provenance falls back to the edited
+   * state plus base — correct exactly while the canvas is simulating the state
+   * being edited, and wrong the moment it is not. Held here rather than in
+   * either consumer so that precondition holds by construction; held in both,
+   * a control would report a value the canvas is not showing and nothing would
+   * say so.
+   *
+   * Editor state, not document state. Which state an author is LOOKING at is
+   * not a property of the page, so it is neither stored nor undoable, and two
+   * people editing one page can be looking at different states.
    */
-  const styleState: StyleState = "base";
+  const [styleState, setStyleState] = useState<StyleState>("base");
+  /*
+   * Memoised because it is a PROP OBJECT: rebuilt on every render it would be a new
+   * identity every time, and the panel it feeds is the one surface here that
+   * holds a draft. `setStyleState` is stable, so this changes exactly when the
+   * state does.
+   */
+  const styleStateBinding = useMemo(
+    () => ({ state: styleState, onChange: setStyleState }),
+    [styleState]
+  );
   const drag = useCanvasDrag({ editor, slots, nesting, canvasRoot });
   /*
    * Is a drag happening — of EITHER kind.
@@ -1682,7 +1697,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
             // inferring one from the document. Two refs would let the panel
             // read a canvas that is not the one on screen.
             canvasRoot={canvasElement}
-            styleState={styleState}
+            styleState={styleStateBinding}
             classLibrary={classes.library}
             classLibraryAbsence={classes.absence}
             onCreateClass={classes.create}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -75,6 +75,7 @@ import {
   EmptyContainerAppenders,
   InsertPanel,
   InspectorPanel,
+  selectionIsInspectable,
   pageStyleTrace,
   LayersPanel,
   TokensPanel,
@@ -890,12 +891,19 @@ function isSaveChord(event: KeyboardEvent): boolean {
  * The interaction state to SHOW, given the state being edited and how many
  * blocks are selected.
  *
- * Suppressed rather than reset while several are selected. The inspector
- * replaces its whole tab strip with a multi-selection summary, so the state
- * control goes with it — and the panel's own tab handler cannot catch that,
- * because the stored tab value is still `style` and no tab change happens. A
- * forced state outliving its control is a canvas drawn mid-hover with nothing
- * on screen explaining why.
+ * Suppressed rather than reset whenever the switcher is not on screen. The
+ * inspector replaces its whole tab strip — for a multi-selection, and for a
+ * selection it cannot inspect at all — so the state control goes with it, and
+ * the panel's own tab handler cannot catch either case because the stored tab
+ * value is still `style` and no tab change happens. A forced state outliving
+ * its control is a canvas drawn mid-hover with nothing on screen explaining
+ * why.
+ *
+ * Decides WHETHER THE CONTROL IS THERE rather than taking a selection count,
+ * because a count cannot see the second case: an unregistered block type reads
+ * as one ordinary selection while the panel shows no tabs for it. The
+ * inspectability half is asked of the same predicate the panel's own early
+ * return uses, so the two cannot disagree about what is inspectable.
  *
  * Derived rather than written back, so the author's choice SURVIVES: they
  * shift-click a second block, the canvas returns to the normal appearance, and
@@ -904,9 +912,13 @@ function isSaveChord(event: KeyboardEvent): boolean {
  */
 function shownStyleStateFor(
   editing: StyleState,
-  selectedCount: number
+  document: BlockDocument,
+  selectedIds: readonly string[],
+  selectedId: string | null
 ): StyleState {
-  return selectedCount > 1 ? "base" : editing;
+  const switcherIsOnScreen =
+    selectedIds.length <= 1 && selectionIsInspectable(document, selectedId);
+  return switcherIsOnScreen ? editing : "base";
 }
 
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
@@ -993,7 +1005,9 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   // canvas showing the same thing. See `shownStyleStateFor`.
   const shownStyleState = shownStyleStateFor(
     styleState,
-    editor.selection.ids.length
+    editor.document,
+    editor.selection.ids,
+    editor.selectedId
   );
   const styleStateBinding = useMemo(
     () => ({ state: shownStyleState, onChange: setStyleState }),

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -886,6 +886,29 @@ function isSaveChord(event: KeyboardEvent): boolean {
   );
 }
 
+/**
+ * The interaction state to SHOW, given the state being edited and how many
+ * blocks are selected.
+ *
+ * Suppressed rather than reset while several are selected. The inspector
+ * replaces its whole tab strip with a multi-selection summary, so the state
+ * control goes with it — and the panel's own tab handler cannot catch that,
+ * because the stored tab value is still `style` and no tab change happens. A
+ * forced state outliving its control is a canvas drawn mid-hover with nothing
+ * on screen explaining why.
+ *
+ * Derived rather than written back, so the author's choice SURVIVES: they
+ * shift-click a second block, the canvas returns to the normal appearance, and
+ * clicking back to one block restores the state they were editing. Writing
+ * `base` into the state instead would silently discard it.
+ */
+function shownStyleStateFor(
+  editing: StyleState,
+  selectedCount: number
+): StyleState {
+  return selectedCount > 1 ? "base" : editing;
+}
+
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
   onCommit,
@@ -966,9 +989,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * holds a draft. `setStyleState` is stable, so this changes exactly when the
    * state does.
    */
+  // ONE derivation feeding BOTH consumers, which is what keeps the panel and the
+  // canvas showing the same thing. See `shownStyleStateFor`.
+  const shownStyleState = shownStyleStateFor(
+    styleState,
+    editor.selection.ids.length
+  );
   const styleStateBinding = useMemo(
-    () => ({ state: styleState, onChange: setStyleState }),
-    [styleState]
+    () => ({ state: shownStyleState, onChange: setStyleState }),
+    [shownStyleState]
   );
   const drag = useCanvasDrag({ editor, slots, nesting, canvasRoot });
   /*
@@ -1897,7 +1926,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                 document={editor.document}
                 rootRef={canvasRoot}
                 onRoot={setCanvasElement}
-                forcedState={styleState}
+                forcedState={shownStyleState}
                 siteStyles={siteSheet(canvasSiteStyle)}
                 selectedId={editor.selectedId}
                 selectedIds={editor.selection.ids}


### PR DESCRIPTION
The control the founder chose: at the top of the Style tab, with a dot on the
states that already carry values.

Everything underneath this shipped in #1325, #1344, #1346, #1351 and #1356 —
the compiler emits forceable states, the canvas forces them on the right
elements, and `BlocksField` already handed ONE value to both `Canvas.forcedState`
and the panel. That value was a `const "base"`, so the feature was complete and
unreachable from the editor. This makes it reachable.

## The dot

It answers "have I already styled this state?", which is the question reading
the values cannot answer. Styles inherit, so opening Focused on a block with no
focus styles shows the base values and looks set — an author checking each state
in turn sees plausible numbers everywhere and still cannot tell which were set.

Three details that are decisions rather than details:

- **Presence of a key is not the property.** Both levels of `NodeStyles` are
  sparse and either can survive empty, so a key test reports a state as styled
  when it holds nothing — precisely the false reassurance the marker exists to
  remove. There is a test for the empty case, and it fails on the key test.
- **`base` is never marked.** It carries values on almost every block, so a dot
  there is on permanently, and a marker that is always lit is read as decoration
  — which costs the other three the meaning they depend on.
- **Node-local.** A hover appearance can also come from a class or a block
  default. The marker sits on the control that decides what the panel WRITES,
  and the panel writes to the node. "You have set something here" can be acted
  on; "something, somewhere, affects this" cannot.

The marker is in the accessible name as well as on screen.

## Leaving the tab

The one real cost of this placement is that the control goes off screen with the
tab, so a state left switched on becomes a canvas disagreeing with everything
visible. Leaving the Style tab returns it to `base`, which removes that state
rather than documenting it.

## Two things the fallow gate changed for the better

Both were introduced findings, and neither is suppressed:

**The arrow-key handler was duplicated** with `breakpoint-switcher.tsx`. I had
mirrored it deliberately, which is what this repo's one-question-one-implementation
rule forbids — two radio groups that must agree about which keys move a selection
will diverge the first time either learns Home and End. Extracted to
`roving-radios.ts`.

**`InspectorPanel` breached the complexity threshold**, and the cause was not
what it looked like. Three candidate additions each measured clean in isolation;
the actual cost was the sixteenth PROP, on a component already at the limit — the
metric counts props. So the state and its setter now travel as ONE prop, which
also states the contract better than two loose ones: this value and
`Canvas.forcedState` must agree, and a host wiring them separately gets a panel
reporting a state its canvas is not showing.

## Evidence

Break-verified individually; each fails only for its own reason:

| Break | Fails |
|---|---|
| key test instead of a value test | both discriminating marker cases |
| allow `base` to be marked | the base case alone |
| render the switcher with no handler | the withholding case alone |
| remove the tab-leave reset | the reset case alone |

Local gates: builder 2547/2547, plugin-page-builder 490/490, lint and
check-types clean, `fallow audit --base origin/main` passes over 8 changed files,
`changeset status` parses, comment convention clean. The pre-push hook's own
scoped test leg was run as the hook runs it.

## Verified in a running editor

A peer whose admin boots drove the real editor at this branch's head, pointer
parked off the canvas so a real `:hover` could not be mistaken for the forced
preview. Confirmed there:

- the control is present at the top of the Style tabpanel, `role="radiogroup"`,
  four radios carrying the hints in their accessible names;
- **the forced preview is not the pointer.** With `POINTER_IS_OVER_BOX` computed
  from `document.querySelectorAll(":hover")` on every read, the node's computed
  `background-color` went `rgba(0,0,0,0)` -> `rgb(255,0,0)` -> back, following
  the selector alone, with the pointer over the inspector throughout;
- the emitted rule is the intended mechanism:
  `.nx-pb-page.nx-pb-page .nx-pb-<hash>:where(:hover, .nx-pb-state-hover)`;
- the marker's accessible name carries `, has styles` on the state holding
  values and not on the others;
- switching to the Content tab clears the class from node and page root and
  returns the computed background;
- **each state marks the elements it should and no others**, with
  `[data-nx-selected="primary"]` resolved and checked intact at every step:

| state selected | classes on the node | classes on the page root |
|---|---|---|
| Hover | `nx-pb-state-hover` | `nx-pb-state-hover` |
| Focused | `nx-pb-state-focus` | *(none)* |
| Pressed | `nx-pb-state-active` | `nx-pb-state-active` |
| None | *(none)* | *(none)* |

That asymmetry is the point rather than an accident: `:hover` and `:active`
match an element and its ancestors, and `:focus-visible` does not — that is
`:focus-within`, a different selector the compiler does not emit. Marking the
chain for focus would put an enclosing block's focus styles on screen for an
appearance no visitor ever sees.

**Two things that review found, which the fixes above close.** The dot's colour
utility is emitted into no stylesheet this package produces or consumes, AND the
token behind it is undefined in the editor — so a fix emitting the utility alone
would still have painted transparent. `bg-current` depends on neither.

Worth recording: the accessible name carried `, has styles` correctly the whole
time the dot was invisible. The visual channel failed and the semantic one held,
which is the argument for putting the marker in both.

## Two things a verifier should know

**An empty container will make this look broken, and it is not this change.**
Measuring on a fresh empty Box reads `lab(96.52 ...)` instead of the authored
colour with the class correctly applied and the selector matching, because the
empty-container affordance wins on specificity:

```css
.nx-builder-chrome:not([data-nx-empty-elements="hidden"]) .nx-canvas [data-nx-slots]:empty {
  background: var(--nx-muted);
}
```

Roughly (0,5,0) against a `:where()`-wrapped (0,3,0), so it masks any authored
background in every state. Adding one child makes the authored colour appear
immediately.

**A state persists across a single-block selection change, deliberately.** An
author styling hover across several blocks should not re-pick it each time, and
Webflow behaves the same way. What must not persist is a state whose CONTROL is
off screen — that is the tab case and the multi-select case, both handled.

## Not verified

**Multi-select is untested end to end.** The peer's automation could not deliver
a real modifier click, so the selection changed without becoming a multi-select.
The unit test covers the derivation — including that the choice is suppressed
rather than discarded — but nobody has driven it in a browser. Stated as
untested rather than implied.

Everything else above was measured in a running editor rather than reasoned
about, because `/admin` does not boot in my own worktree: Tailwind's PostCSS
resolver fails on `@nextlyhq/builder/styles.css` through the pnpm symlink with
the artifact present, the export map correct, the symlink resolving and `.next`
cleared. The same commit boots cleanly in another worktree, which is positive
evidence that it is worktree-local rather than a property of this branch.

