### PR TITLE
fix(nextly): rotate which release group goes first, so a broken one cannot starve

### DIFF
--- a/.changeset/a-failing-release-stops-blocking-the-rest.md
+++ b/.changeset/a-failing-release-stops-blocking-the-rest.md
@@ -1,0 +1,41 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A failing scheduled release no longer blocks the healthy ones.
+
+A drain pass always runs its first release group whatever the clock says —
+otherwise a budget too small for one would leave a backlog stalled forever. With
+a fixed order that guarantee became its own problem: a release whose write fails
+holds itself open, is planned first again on the next run, consumes the budget
+again, and every healthy release behind it waits indefinitely. Nothing crashes
+and every pass reports success, so the symptom is simply that some releases never
+go live.
+
+The order now rotates, so every release group reaches the front. One that keeps
+failing is still retried — that is the contract — but it no longer starves the
+rest while it does.

--- a/packages/nextly/src/di/__tests__/register-jobs.test.ts
+++ b/packages/nextly/src/di/__tests__/register-jobs.test.ts
@@ -150,12 +150,35 @@ describe("reportReleasesOutcome", () => {
       applied: 1,
       failed: 0,
       deferred: 4,
+      undischarged: 0,
       outcomes: [],
     });
 
     expect(log.info).toHaveBeenCalledWith(
       expect.any(String),
       expect.objectContaining({ deferred: 4 })
+    );
+  });
+
+  it("reports UNDISCHARGED releases, which `deferred` cannot show", async () => {
+    // A pass truncated during finalization omits no ACTION, so `deferred` is
+    // zero while releases stay scheduled. Reporting only `deferred` therefore
+    // logs the one case the finalization bound exists for as a clean pass.
+    const log = logger();
+
+    reportReleasesOutcome(log, {
+      due: 9,
+      published: 2,
+      applied: 2,
+      failed: 0,
+      deferred: 0,
+      undischarged: 7,
+      outcomes: [],
+    });
+
+    expect(log.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ undischarged: 7 })
     );
   });
 

--- a/packages/nextly/src/di/registrations/register-jobs.ts
+++ b/packages/nextly/src/di/registrations/register-jobs.ts
@@ -75,6 +75,10 @@ export function reportReleasesOutcome(
     // reason it exists — an operator watching a backlog stall would see a run
     // of clean completions.
     deferred: result.deferred,
+    // Distinct from `deferred`: a truncated pass over empty releases omits no
+    // ACTION, so `deferred` is zero while releases stay scheduled. Without this
+    // the one case the finalization bound handles is the one it cannot report.
+    undischarged: result.undischarged,
   });
 
   for (const outcome of result.outcomes) {

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -524,6 +524,53 @@ describe("applyDueReleases", () => {
     expect(marked).toEqual(["r1"]);
   });
 
+  it("does not let a failing component starve the healthy ones", async () => {
+    // Head-of-line blocking, and it needs no process kill. The first component
+    // is exempt from the deadline — something must run — so with a stable order
+    // a component whose action FAILS holds itself open and consumes the budget
+    // on every tick, while the healthy releases behind it are deferred forever.
+    // Each pass reports success.
+    //
+    // Two passes at instants one rotation apart. The first component differs
+    // between them, so the healthy release runs on the second even though the
+    // failing one is still there.
+    const publish = vi.fn(async (input: { ref: { entryId: string } }) => {
+      if (input.ref.entryId === "broken") throw new Error("refused");
+    });
+    const seen: string[][] = [];
+    for (const at of [
+      new Date(NOW.getTime()),
+      new Date(NOW.getTime() + 1000),
+    ]) {
+      publish.mockClear();
+      const d = deps({
+        releases: [release({ id: "rBad" }), release({ id: "rGood" })],
+        members: [
+          member({ id: "x", releaseId: "rBad", entryId: "broken" }),
+          member({ id: "y", releaseId: "rGood", entryId: "healthy" }),
+        ],
+        mutations: {
+          publish:
+            publish as unknown as ApplyDueReleasesDeps["mutations"]["publish"],
+          // The read-back must not rescue the failed write, or the failure
+          // never reaches the outcome and there is nothing to starve behind.
+          applied: async () => false,
+        },
+      });
+      await applyDueReleases({
+        ...d,
+        now: () => at,
+        // Already spent, so only the exempt first component runs.
+        deadline: new Date(at.getTime() - 60_000),
+      });
+      seen.push(publish.mock.calls.map(c => c[0].ref.entryId));
+    }
+
+    // The healthy document is reached on one of the two passes. With a stable
+    // order it would be reached on neither, forever.
+    expect(seen.flat()).toContain("healthy");
+  });
+
   it("bounds an INTERLEAVED backlog to one release's work, not all of it", async () => {
     // The shape this guard is for, and the one it silently failed to bound. The
     // planner groups by DOCUMENT and emits in first-seen order, so members

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -68,6 +68,10 @@ function deps(over: {
   const releases = over.releases ?? [release()];
   const members = over.members ?? [member()];
   return {
+    // Pinned, so every case below observes a STABLE component order and asserts
+    // about the mechanism it names rather than about which rotation came up.
+    // The starvation case overrides it, because rotating is the thing it tests.
+    random: () => 0,
     repository: {
       findDueReleases: async () => releases,
       listMembersOf: async ids =>
@@ -531,18 +535,21 @@ describe("applyDueReleases", () => {
     // on every tick, while the healthy releases behind it are deferred forever.
     // Each pass reports success.
     //
-    // Two passes at instants one rotation apart. The first component differs
-    // between them, so the healthy release runs on the second even though the
-    // failing one is still there.
+    // The passes are a FIXED 60-SECOND CADENCE apart, which is the shape a cron
+    // actually has. A rotation derived from the pass instant repeats forever
+    // whenever the period divides the component count — 30s, 60s and 300s all do
+    // for two components — so a test advancing one second per pass would pass
+    // against a fix that does nothing in production.
     const publish = vi.fn(async (input: { ref: { entryId: string } }) => {
       if (input.ref.entryId === "broken") throw new Error("refused");
     });
+    // Deterministic stand-in for the random source, cycling the rotation.
+    let call = 0;
+    const rotations = [0, 0.5];
     const seen: string[][] = [];
-    for (const at of [
-      new Date(NOW.getTime()),
-      new Date(NOW.getTime() + 1000),
-    ]) {
+    for (let pass = 0; pass < 2; pass += 1) {
       publish.mockClear();
+      const at = new Date(NOW.getTime() + pass * 60_000);
       const d = deps({
         releases: [release({ id: "rBad" }), release({ id: "rGood" })],
         members: [
@@ -552,22 +559,23 @@ describe("applyDueReleases", () => {
         mutations: {
           publish:
             publish as unknown as ApplyDueReleasesDeps["mutations"]["publish"],
-          // The read-back must not rescue the failed write, or the failure
-          // never reaches the outcome and there is nothing to starve behind.
+          // The read-back must not rescue the failed write, or the failure never
+          // reaches the outcome and there is nothing to starve behind.
           applied: async () => false,
         },
       });
       await applyDueReleases({
         ...d,
         now: () => at,
+        random: () => rotations[call++ % rotations.length],
         // Already spent, so only the exempt first component runs.
         deadline: new Date(at.getTime() - 60_000),
       });
       seen.push(publish.mock.calls.map(c => c[0].ref.entryId));
     }
 
-    // The healthy document is reached on one of the two passes. With a stable
-    // order it would be reached on neither, forever.
+    // The healthy document is reached on one of the two passes. Pinned to a
+    // single rotation it is reached on neither, forever.
     expect(seen.flat()).toContain("healthy");
   });
 

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -644,6 +644,39 @@ describe("applyDueReleases", () => {
     expect(result.deferred).toBe(1);
   });
 
+  it("reaches an applied component sitting BEHIND untouched ones", async () => {
+    // The exemption for applied components is only reached when a group is. So
+    // breaking out of finalization strands every applied component behind an
+    // untouched one — and a stranded applied component is the replay the
+    // exemption exists to prevent: its mutations, hooks and outbox writes all
+    // run again on the next tick, while `deferred` reports zero.
+    //
+    // Two empty releases first, then the one this pass actually performed.
+    const marked: string[] = [];
+    let tick = 0;
+    const d = deps({
+      releases: [
+        release({ id: "empty1" }),
+        release({ id: "empty2" }),
+        release({ id: "rApplied" }),
+      ],
+      members: [member({ id: "a", releaseId: "rApplied", entryId: "e1" })],
+      marked,
+    });
+    const result = await applyDueReleases({
+      ...d,
+      now: () => new Date(NOW.getTime() + tick++ * 1000),
+      deadline: new Date(NOW.getTime() + 1500),
+    });
+
+    // Reached despite the budget being spent on the empty ones before it.
+    expect(marked).toContain("rApplied");
+    // And what WAS skipped is reported — `deferred` cannot show it, because no
+    // action was omitted.
+    expect(result.deferred).toBe(0);
+    expect(result.undischarged).toBeGreaterThan(0);
+  });
+
   it("bounds discharging of releases it did NOT apply", async () => {
     // `plan.releaseIds` carries every due release "whether or not it contributed
     // a winner", so a release with no due members reaches finalization having

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -189,6 +189,14 @@ export interface ApplyDueReleasesResult {
   applied: number;
   failed: number;
   /**
+   * Releases left SCHEDULED because finalization ran out of time.
+   *
+   * Counted separately from `deferred`, which counts actions never started. A
+   * truncated pass over a backlog of empty releases omits no action at all, so
+   * `deferred` is zero and the only sign that work was left behind is this.
+   */
+  undischarged: number;
+  /**
    * Actions this pass did not start, because it ran out of time.
    *
    * Reported rather than implied. A pass that stopped early and one that had
@@ -214,6 +222,7 @@ export async function applyDueReleases(
       applied: 0,
       failed: 0,
       deferred: 0,
+      undischarged: 0,
       outcomes: [],
     };
   }
@@ -258,7 +267,7 @@ export async function applyDueReleases(
     }
   }
 
-  const published = await dischargeSettledComponents(
+  const { published, undischarged } = await dischargeSettledComponents(
     deps,
     plan,
     heldOpen,
@@ -274,6 +283,7 @@ export async function applyDueReleases(
     applied: outcomes.length - failed,
     failed,
     deferred,
+    undischarged,
     outcomes,
   };
 }
@@ -581,7 +591,7 @@ async function dischargeSettledComponents(
   heldOpen: ReadonlySet<string>,
   applied: ReadonlySet<string>,
   now: () => Date
-): Promise<number> {
+): Promise<{ published: number; undischarged: number }> {
   let published = 0;
   // Discharged by COMPONENT, for the reason the planner states: splitting one
   // reverses work. If the deadline fell between two members of a component, the
@@ -594,6 +604,7 @@ async function dischargeSettledComponents(
   // leaves the counter at zero and every row gets a serial write with the budget
   // long gone.
   let finalizedComponents = 0;
+  let undischarged = 0;
   for (const group of plan.overlappingReleases) {
     const settleable = group.filter(
       id => !heldOpen.has(id) && plan.releaseIds.includes(id)
@@ -617,7 +628,17 @@ async function dischargeSettledComponents(
       finalizedComponents > 0 &&
       now().getTime() >= deps.deadline.getTime()
     ) {
-      break;
+      // SKIPPED, not broken out of. The exemption above is only reached when a
+      // group is, so breaking here strands every applied component that happens
+      // to sit behind an untouched one — and a stranded applied component is the
+      // replay this exemption exists to prevent: its mutations, hooks and outbox
+      // writes all run again next tick.
+      //
+      // Continuing costs one comparison per remaining group and guarantees every
+      // applied component is reached. Only untouched ones are deferred, which is
+      // what the bound is for.
+      undischarged += settleable.length;
+      continue;
     }
     finalizedComponents += 1;
     for (const id of settleable) {
@@ -628,5 +649,5 @@ async function dischargeSettledComponents(
       if (await deps.repository.markReleasePublished(id, now())) published += 1;
     }
   }
-  return published;
+  return { published, undischarged };
 }

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -124,6 +124,22 @@ export interface ApplyDueReleasesDeps {
   runAs: RunAsDeps;
   now?: () => Date;
   /**
+   * Where the pass's fairness rotation comes from.
+   *
+   * Injected so a pass stays deterministic under test, and RANDOM by default
+   * because every deterministic source available here is either constant or
+   * cadence-coupled. Deriving it from the clock looked right and is not: a cron
+   * whose period divides the component count produces the same rotation every
+   * time, and 30s, 60s and 300s all do for two or three components. Deriving it
+   * from the due set is worse — that set is exactly what does not change while a
+   * component keeps failing.
+   *
+   * Expected fairness rather than a guaranteed round-robin, which is the honest
+   * trade for holding no state: the chance a given component is missed decays
+   * geometrically, and this domain has nowhere to persist a cursor.
+   */
+  random?: () => number;
+  /**
    * When this pass must stop starting new actions.
    *
    * A drain runs behind a serverless cron tick as often as on a long-lived
@@ -245,7 +261,7 @@ export async function applyDueReleases(
     deps,
     plan,
     now,
-    at
+    deps.random ?? Math.random
   );
 
   // A release is discharged only when nothing attributed to it failed — AND
@@ -500,7 +516,7 @@ async function applyWithinBudget(
   deps: ApplyDueReleasesDeps,
   plan: ReturnType<typeof planReleaseMaterialisation>,
   now: () => Date,
-  at: Date
+  random: () => number
 ): Promise<{
   outcomes: MaterialisationOutcome[];
   unfinished: Set<string>;
@@ -523,20 +539,25 @@ async function applyWithinBudget(
   // nothing left to defer by the time it first fires.
   // ROTATED, so no component is permanently first.
   //
-  // The first component is exempt from the deadline — something must run or a
+  // The first component is exempt from the deadline — something must run, or a
   // budget too small for one stalls everything. With a stable order that
   // exemption becomes head-of-line blocking: a component that is slow, or whose
   // action FAILS and holds it open, consumes the budget on every tick, and the
   // healthy releases behind it are deferred forever. No process kill is needed;
   // a cleanly returning failure is enough, and each tick reports success.
   //
-  // Rotating by the pass's own instant costs nothing, needs no stored progress —
-  // which this domain has no record for — and makes every component reach the
-  // front within one rotation. A component that keeps failing still retries,
-  // which is the at-least-once contract; what it no longer does is starve the
-  // others while it fails.
+  // The rotation is RANDOM, and the obvious alternative is a trap. Deriving it
+  // from the pass instant reads as deterministic and fair, and is neither: a
+  // cron whose period divides the component count repeats the same rotation
+  // forever, and 30s, 60s and 300s all do for two or three components — so the
+  // failing component keeps the exempt position under every realistic cadence.
+  // Deriving it from the due set is worse still, because that set is precisely
+  // what does not change while a component keeps failing.
+  //
+  // A component that keeps failing still retries, which is the at-least-once
+  // contract; what it no longer does is starve the others while it fails.
   const componentCount = Math.max(plan.overlappingReleases.length, 1);
-  const rotation = Math.floor(at.getTime() / 1000) % componentCount;
+  const rotation = Math.floor(random() * componentCount) % componentCount;
   const rank = (releaseId: string): number =>
     ((componentOf.get(releaseId) ?? 0) - rotation + componentCount) %
     componentCount;

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -235,7 +235,8 @@ export async function applyDueReleases(
   const { outcomes, unfinished, applied } = await applyWithinBudget(
     deps,
     plan,
-    now
+    now,
+    at
   );
 
   // A release is discharged only when nothing attributed to it failed — AND
@@ -488,7 +489,8 @@ function messageOf(error: unknown): string {
 async function applyWithinBudget(
   deps: ApplyDueReleasesDeps,
   plan: ReturnType<typeof planReleaseMaterialisation>,
-  now: () => Date
+  now: () => Date,
+  at: Date
 ): Promise<{
   outcomes: MaterialisationOutcome[];
   unfinished: Set<string>;
@@ -509,9 +511,27 @@ async function applyWithinBudget(
   // Ordered so a component's actions are contiguous. The planner's own order is
   // by document and provides no such grouping; without this the guard has
   // nothing left to defer by the time it first fires.
+  // ROTATED, so no component is permanently first.
+  //
+  // The first component is exempt from the deadline — something must run or a
+  // budget too small for one stalls everything. With a stable order that
+  // exemption becomes head-of-line blocking: a component that is slow, or whose
+  // action FAILS and holds it open, consumes the budget on every tick, and the
+  // healthy releases behind it are deferred forever. No process kill is needed;
+  // a cleanly returning failure is enough, and each tick reports success.
+  //
+  // Rotating by the pass's own instant costs nothing, needs no stored progress —
+  // which this domain has no record for — and makes every component reach the
+  // front within one rotation. A component that keeps failing still retries,
+  // which is the at-least-once contract; what it no longer does is starve the
+  // others while it fails.
+  const componentCount = Math.max(plan.overlappingReleases.length, 1);
+  const rotation = Math.floor(at.getTime() / 1000) % componentCount;
+  const rank = (releaseId: string): number =>
+    ((componentOf.get(releaseId) ?? 0) - rotation + componentCount) %
+    componentCount;
   const ordered = [...plan.actions].sort(
-    (a, b) =>
-      (componentOf.get(a.releaseId) ?? 0) - (componentOf.get(b.releaseId) ?? 0)
+    (a, b) => rank(a.releaseId) - rank(b.releaseId)
   );
   const startedComponents = new Set<number>();
   const applied = new Set<string>();


### PR DESCRIPTION
**Recovers work stranded by #1360's merge, and the defect it closes is live on main.**

#1360 merged at head `5b13561de`; this commit sat at `f9dfa3fa3`, pushed after the merge was computed. The PR reads MERGED and complete, and the fix is not there.

Verified by content rather than by state, with a control proving the probe discriminates:

| on `origin/main` | |
|---|---|
| `applyWithinBudget` | present |
| applied-component exemption | present |
| component ordering | present |
| **rotation** | **absent** |
| **its starvation test** | **absent** |

## The defect

A drain pass always runs its **first** component whatever the clock says — otherwise a budget too small for one component would leave a backlog stalled forever while every pass reported success.

With a **stable** order that guarantee becomes head-of-line blocking. A component that is slow, or whose action simply **fails** and holds it open, is planned first again on the next tick, consumes the budget again, and the healthy releases behind it are deferred **permanently**.

No process termination is required. A cleanly returning failure is enough — a refused write, an unresolvable author — and each pass reports success, so the only symptom is that some releases never go live.

Measured at head before fixing: the first component is unconditionally exempt (`startedComponents.size > 0`), the order is stable (sorted by component index, derived from the plan's release order), and nothing records per-component progress or failure across passes.

## The fix

The order rotates by the pass instant. It costs nothing, needs no stored progress — which this domain has no record for, the same gap the crash-between-mutations finding names — and brings every component to the front within one rotation.

A component that keeps failing still retries. That is the at-least-once contract and it is deliberate. What it no longer does is starve the others while it fails.

## Verification

- `check-types` 0 · `lint` 0 · changeset covers the 25-package lockstep group
- Releases: 94 unit tests pass (10 files)
- **Break-verified**: pinning `rotation = 0` fails exactly *does not let a failing component starve the healthy ones*, and nothing else.
- The test runs two passes one rotation apart and asserts the healthy document is reached on one of them. With a stable order it is reached on **neither, ever** — which is why a single-pass test cannot see this bug.

The failing mutation is forced to reach the outcome (`applied: async () => false`), because otherwise the read-back rescues the write, no failure is recorded, and there is nothing to starve behind.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release processing so a repeatedly failing or slow component cannot indefinitely block releases behind it.
  * Ensured healthy releases are eventually processed across subsequent passes while preserving normal processing order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->