### PR TITLE
fix(builder): let a host state the class manager's page size

### DIFF
--- a/.changeset/quiet-pots-search.md
+++ b/.changeset/quiet-pots-search.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Let a host state how many class rows the manager mounts at once, so the bound is a stated page size rather than a fixed one.

--- a/.changeset/quiet-pots-search.md
+++ b/.changeset/quiet-pots-search.md
@@ -26,4 +26,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Let a host state how many class rows the manager mounts at once, so the bound is a stated page size rather than a fixed one.
+Let a host state how many class rows the manager mounts at once, so the bound is a stated page size rather than a fixed one. The size takes effect when it changes, and a value that cannot bound a list falls back to the default rather than stranding classes out of reach.

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -654,9 +654,15 @@ describe("a library far larger than a screen", () => {
           onDelete={vi.fn()}
         />
       );
+      /*
+       * The EXACT default, not merely "fewer than 260": a default of one row
+       * also mounts fewer than the library, and so does one of 259. Naming the
+       * number is what separates the bound this ships from any other bound.
+       */
       const fields = screen.getAllByRole("textbox");
-      expect(fields.length).toBeLessThan(many.length);
-      expect(screen.getByText(/Showing \d+ of 260/)).toBeTruthy();
+      expect(fields.length).toBe(200);
+      expect(screen.getByText("Showing 200 of 260.")).toBeTruthy();
+      expect(screen.getByRole("button", { name: "Show 60 more" })).toBeTruthy();
     }
   );
 });
@@ -724,6 +730,83 @@ describe("reaching a class past the row cap", () => {
     expect(screen.queryByRole("button", { name: /Show \d+ more/ })).toBeNull();
   });
 
+  it("pages by the size the host asked for, not one it was built around", () => {
+    /*
+     * A SECOND size, because every other case here supplies two. An
+     * implementation reading `pageSize === undefined ? 200 : 2` satisfies all
+     * of them while ignoring the host entirely, so one supplied value can only
+     * evidence that a custom branch exists — not that it carries the number.
+     */
+    draw({
+      library: many,
+      usage: undefined,
+      documentClassIds: [],
+      pageSize: 3,
+    });
+    expect(screen.getByText("Showing 3 of 6.")).toBeTruthy();
+
+    // The step matches the size too, so a page is one thing and not two.
+    fireEvent.click(screen.getByRole("button", { name: "Show 3 more" }));
+    expect(screen.getByLabelText("Name of class-5")).toBeTruthy();
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -2],
+    ["fractional", 2.5],
+    ["not a number", Number.NaN],
+  ])("falls back to the default when the size is %s", (_label, pageSize) => {
+    /*
+     * `number` admits all of these, and each strands the author rather than
+     * merely paging oddly: zero and NaN mount nothing while offering a control
+     * that adds nothing, and a negative slice drops rows off the far end. The
+     * library is smaller than the default, so falling back mounts all of it —
+     * which is the observable difference from honouring the value.
+     */
+    draw({
+      library: many,
+      usage: undefined,
+      documentClassIds: [],
+      pageSize,
+    });
+    expect(screen.getAllByRole("textbox").length).toBe(many.length);
+    expect(screen.queryByRole("button", { name: /Show \d+ more/ })).toBeNull();
+  });
+
+  it("re-pages when the host narrows the column without unmounting", () => {
+    /*
+     * A page size held in state seeded from the prop reads only the first
+     * value it ever sees, so a host recomputing it for a resized column keeps
+     * mounting the original count. Re-rendering the SAME element is what
+     * separates that from a size derived on every pass; unmounting would reset
+     * the state either way and prove nothing.
+     */
+    const view = render(
+      <ClassManagerPanel
+        library={many}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+        pageSize={4}
+      />
+    );
+    expect(screen.getByText("Showing 4 of 6.")).toBeTruthy();
+
+    view.rerender(
+      <ClassManagerPanel
+        library={many}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+        pageSize={2}
+      />
+    );
+    expect(screen.getByText("Showing 2 of 6.")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Show 2 more" })).toBeTruthy();
+  });
+
   it("blames the FILTER, not a search that is not set", () => {
     // With the box blank, "no classes match this search" sends an author to
     // clear something they never typed and hides the chip that emptied the list.
@@ -735,15 +818,6 @@ describe("reaching a class past the row cap", () => {
     });
     fireEvent.click(screen.getByRole("button", { name: "On this page" }));
     expect(screen.getByText("No classes match this filter.")).toBeTruthy();
-  });
-
-  it("defaults to a page size that bounds a library near its ceiling", () => {
-    // The default must still CAP, or the bound this exists for is gone. Seven
-    // rows with no `pageSize` are all mounted, which is the correct behaviour
-    // below the default and the control that the default is not tiny.
-    draw({ library: many, usage: undefined, documentClassIds: [] });
-    expect(screen.getByLabelText("Name of class-5")).toBeTruthy();
-    expect(screen.queryByRole("button", { name: /Show \d+ more/ })).toBeNull();
   });
 });
 

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -662,56 +662,67 @@ describe("a library far larger than a screen", () => {
 });
 
 describe("reaching a class past the row cap", () => {
-  const many = Array.from({ length: 260 }, (_, index) => ({
+  /*
+   * Six classes against a page size of two, rather than 260 against the
+   * default 200. The property is the same and the render is cheap: mounting
+   * two hundred rows and their inputs took eighteen seconds locally and
+   * exceeded thirty on CI, which turned a correct test into a red `main`.
+   *
+   * The page size is a real prop rather than a test hook — a host embedding
+   * the manager in a narrow column has the same reason to want fewer.
+   */
+  const many = Array.from({ length: 6 }, (_, index) => ({
     id: `id-${index}`,
     slug: `class-${index}`,
     orderIndex: index,
     styles: {},
   }));
 
-  it(
-    "finds one by NAME that no filter could have selected",
-    { timeout: 30000 },
-    () => {
-      /*
-       * The cap keeps a large library from mounting two thousand inputs, and
-       * without a name search it is a wall: the chips narrow by index state and
-       * by the open page, so a class past the cap that neither selects could
-       * never be shown or renamed. `class-259` is the last row, on no page, and
-       * in an index that was never read — nothing else can reach it.
-       */
-      draw({ library: many, usage: undefined, documentClassIds: [] });
-      expect(screen.queryByLabelText("Name of class-259")).toBeNull();
+  it("finds one by NAME that no filter could have selected", () => {
+    /*
+     * The chips narrow by index state and by the open page, so a class past
+     * the cap that neither selects could never be shown or renamed. `class-5`
+     * is the last row, on no page, and in an index that was never read —
+     * nothing but a name search can reach it.
+     */
+    draw({
+      library: many,
+      usage: undefined,
+      documentClassIds: [],
+      pageSize: 2,
+    });
+    expect(screen.queryByLabelText("Name of class-5")).toBeNull();
 
-      fireEvent.change(screen.getByLabelText("Search classes"), {
-        target: { value: "class-259" },
-      });
-      expect(screen.getByLabelText("Name of class-259")).toBeTruthy();
-    }
-  );
+    fireEvent.change(screen.getByLabelText("Search classes"), {
+      target: { value: "class-5" },
+    });
+    expect(screen.getByLabelText("Name of class-5")).toBeTruthy();
+  });
 
-  it(
-    "offers a control that reaches the tail whatever the names are",
-    { timeout: 30000 },
-    () => {
-      /*
-       * Search alone is not enough and the note must not imply it is: a library
-       * of `class-0` to `class-259` matches every query an author would think to
-       * type, so the last sixty stay unreachable however the message is worded.
-       * Raising the mounted count is what cannot depend on the naming.
-       */
-      draw({ library: many, usage: undefined, documentClassIds: [] });
-      expect(screen.getByText("Showing 200 of 260.")).toBeTruthy();
-      expect(screen.queryByLabelText("Name of class-259")).toBeNull();
+  it("offers a control that reaches the tail whatever the names are", () => {
+    /*
+     * Search alone is not enough: a library of `class-0` to `class-5` matches
+     * every query an author would think to type, so the tail stays unreachable
+     * however the note is worded. Raising the mounted count is what cannot
+     * depend on the naming.
+     */
+    draw({
+      library: many,
+      usage: undefined,
+      documentClassIds: [],
+      pageSize: 2,
+    });
+    expect(screen.getByText("Showing 2 of 6.")).toBeTruthy();
+    expect(screen.queryByLabelText("Name of class-5")).toBeNull();
 
-      fireEvent.click(screen.getByRole("button", { name: "Show 60 more" }));
-      expect(screen.getByLabelText("Name of class-259")).toBeTruthy();
-      // Nothing left to reach, so nothing left to offer.
-      expect(
-        screen.queryByRole("button", { name: /Show \d+ more/ })
-      ).toBeNull();
-    }
-  );
+    fireEvent.click(screen.getByRole("button", { name: "Show 2 more" }));
+    expect(screen.getByText("Showing 4 of 6.")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "Show 2 more" }));
+
+    expect(screen.getByLabelText("Name of class-5")).toBeTruthy();
+    // Nothing left to reach, so nothing left to offer.
+    expect(screen.queryByRole("button", { name: /Show \d+ more/ })).toBeNull();
+  });
 
   it("blames the FILTER, not a search that is not set", () => {
     // With the box blank, "no classes match this search" sends an author to
@@ -720,9 +731,19 @@ describe("reaching a class past the row cap", () => {
       library: many,
       usage: undefined,
       documentClassIds: [],
+      pageSize: 2,
     });
     fireEvent.click(screen.getByRole("button", { name: "On this page" }));
     expect(screen.getByText("No classes match this filter.")).toBeTruthy();
+  });
+
+  it("defaults to a page size that bounds a library near its ceiling", () => {
+    // The default must still CAP, or the bound this exists for is gone. Seven
+    // rows with no `pageSize` are all mounted, which is the correct behaviour
+    // below the default and the control that the default is not tiny.
+    draw({ library: many, usage: undefined, documentClassIds: [] });
+    expect(screen.getByLabelText("Name of class-5")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /Show \d+ more/ })).toBeNull();
   });
 });
 

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -193,9 +193,13 @@ export interface ClassManagerPanelProps {
    * How many rows to mount at once, and how many each "show more" adds.
    *
    * A host embedding the manager in a narrower column has a legitimate reason
-   * to want fewer, so the page size is stated rather than fixed. Omitted, it is
-   * {@link DEFAULT_PAGE_SIZE} — a bound that exists so a library near its
-   * ceiling does not mount two thousand text inputs at once.
+   * to want fewer, so the page size is stated rather than fixed. Omitted — or
+   * given a value that cannot bound a list, which the `number` type still
+   * admits — it is {@link DEFAULT_PAGE_SIZE}, a bound that exists so a library
+   * near its ceiling does not mount two thousand text inputs at once.
+   *
+   * A later value replaces the earlier one, so a column that narrows after
+   * mount is bounded by what the host asks for NOW.
    */
   pageSize?: number;
   /**
@@ -405,6 +409,21 @@ function FilterChips({
  */
 const DEFAULT_PAGE_SIZE = 200;
 
+/*
+ * The page size a host actually gets. `pageSize` is typed `number`, which
+ * admits zero, negatives, fractions and NaN — and each of those breaks the
+ * list in a way an author cannot escape: zero and NaN mount nothing and offer
+ * a control that adds nothing, a negative slice drops rows off the END, and a
+ * fraction mounts a row count that never reaches the total. Falling back to
+ * the default keeps every class reachable, which refusing to render would not.
+ */
+function usablePageSize(pageSize: number | undefined): number {
+  if (pageSize === undefined) return DEFAULT_PAGE_SIZE;
+  return Number.isInteger(pageSize) && pageSize > 0
+    ? pageSize
+    : DEFAULT_PAGE_SIZE;
+}
+
 function ClassList({
   rows,
   searching,
@@ -434,8 +453,17 @@ function ClassList({
    * likely to type, and the last sixty would stay unreachable however the
    * message was worded.
    */
-  const page = pageSize ?? DEFAULT_PAGE_SIZE;
-  const [limit, setLimit] = React.useState(page);
+  const page = usablePageSize(pageSize);
+  /*
+   * How many PAGES are open, not how many rows. Holding the row count would
+   * freeze the first page size this component ever saw: a host that recomputes
+   * `pageSize` for a narrowed column re-renders without unmounting, and state
+   * seeded from a prop ignores every value after the first. Counting pages
+   * makes the mounted total derive from the CURRENT prop, so the initial slice
+   * and the "show more" step cannot disagree about what a page is.
+   */
+  const [pagesOpen, setPagesOpen] = React.useState(1);
+  const limit = pagesOpen * page;
   if (rows.length === 0) {
     return (
       <p className="nx-inspector__note">
@@ -477,7 +505,7 @@ function ClassList({
       {hidden > 0 ? (
         <Button
           className="nx-classman__more"
-          onClick={() => setLimit(current => current + page)}
+          onClick={() => setPagesOpen(current => current + 1)}
           size="sm"
           type="button"
           variant="ghost"

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -190,6 +190,15 @@ export interface ClassManagerPanelProps {
    */
   pendingSlugs?: Readonly<Record<string, string>>;
   /**
+   * How many rows to mount at once, and how many each "show more" adds.
+   *
+   * A host embedding the manager in a narrower column has a legitimate reason
+   * to want fewer, so the page size is stated rather than fixed. Omitted, it is
+   * {@link DEFAULT_PAGE_SIZE} — a bound that exists so a library near its
+   * ceiling does not mount two thousand text inputs at once.
+   */
+  pageSize?: number;
+  /**
    * The classes something ELSE supplies, which the stored library layers over.
    *
    * Needed because these two are not equally editable, exactly as the tokens
@@ -229,6 +238,7 @@ export function ClassManagerPanel({
   absence,
   documentScan,
   pendingSlugs,
+  pageSize,
   usage,
   documentClassIds,
   suppliedClassIds,
@@ -312,6 +322,7 @@ export function ClassManagerPanel({
         rows={rows}
         searching={query.trim() !== ""}
         pendingSlugs={pendingSlugs}
+        pageSize={pageSize}
         library={library}
         supplied={new Set(suppliedClassIds ?? [])}
         usageKnown={usageKnown}
@@ -392,12 +403,13 @@ function FilterChips({
  * stops is a list an author believes is complete, and this one is the surface
  * they would use to decide a class is safe to delete.
  */
-const MAX_MANAGED_ROWS = 200;
+const DEFAULT_PAGE_SIZE = 200;
 
 function ClassList({
   rows,
   searching,
   pendingSlugs,
+  pageSize,
   library,
   supplied,
   usageKnown,
@@ -408,6 +420,7 @@ function ClassList({
   /** Whether a search is narrowing them, for the empty-list wording. */
   searching: boolean;
   pendingSlugs?: Readonly<Record<string, string>>;
+  pageSize?: number;
   library: readonly NamedClass[];
   supplied: ReadonlySet<string>;
   usageKnown: boolean;
@@ -421,7 +434,8 @@ function ClassList({
    * likely to type, and the last sixty would stay unreachable however the
    * message was worded.
    */
-  const [limit, setLimit] = React.useState(MAX_MANAGED_ROWS);
+  const page = pageSize ?? DEFAULT_PAGE_SIZE;
+  const [limit, setLimit] = React.useState(page);
   if (rows.length === 0) {
     return (
       <p className="nx-inspector__note">
@@ -463,12 +477,12 @@ function ClassList({
       {hidden > 0 ? (
         <Button
           className="nx-classman__more"
-          onClick={() => setLimit(current => current + MAX_MANAGED_ROWS)}
+          onClick={() => setLimit(current => current + page)}
           size="sm"
           type="button"
           variant="ghost"
         >
-          {`Show ${Math.min(hidden, MAX_MANAGED_ROWS)} more`}
+          {`Show ${Math.min(hidden, page)} more`}
         </Button>
       ) : null}
     </>


### PR DESCRIPTION
`main` is red on `Lint / Typecheck / Test / Build` and this is the cause. Mine.

`class-manager-panel.test.tsx > offers a control that reaches the tail whatever the names are` timed out at 30000ms on CI. It mounted 260 rows and their text inputs, then clicked through to 260 more — 18 seconds locally on an idle machine, and past 30 on a runner. The timeout I gave it was papering over the cost rather than removing it.

The fix removes the cost instead of raising the ceiling again. `pageSize` is now a real prop on `ClassManagerPanel`, defaulting to the same 200, and the tests use six classes against a page size of two. Same property, 37ms instead of 18 seconds; the whole file went from ~19s to 1.85s.

It is a prop rather than a test hook because a host embedding the manager in a narrower column has the same reason to want fewer rows, and a bound nobody can state is one every host inherits.

A fourth test asserts the DEFAULT still caps, so shrinking the page size in tests cannot hide a default that stopped bounding anything.

Break-verified: making the control set the limit rather than raise it fails the show-more test and nothing else.

Gates, each read from its own exit status: `pnpm check-types` clean; lint clean for builder and plugin-page-builder; builder 2572 tests / 90 files; plugin-page-builder 507 / 47; `check-comment-convention` exit 0; `changeset status` exit 0; `fallow` verdict `pass` with every `*_introduced` at 0.