### PR TITLE
fix(builder): open the Style tab when a state is restored

### DIFF
--- a/.changeset/open-style-when-a-state-is-restored.md
+++ b/.changeset/open-style-when-a-state-is-restored.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Open the Style tab when the editor restores a state you were editing.
+
+A host that reopens the builder on a block you were styling in its hover state
+now lands on the Style tab, with the state control in view. Previously the
+canvas drew the block mid-hover while the only control that explains or clears
+that state sat behind a tab nothing had opened.
+
+An ordinary mount still opens on Content.

--- a/packages/builder/src/inspector-panel.test.tsx
+++ b/packages/builder/src/inspector-panel.test.tsx
@@ -264,6 +264,51 @@ describe("what InspectorPanel forwards to the style tab", () => {
     );
   });
 
+  it("OPENS on Style when a host mounts with a state already chosen", () => {
+    /*
+     * A host restoring what an author was editing supplies a non-base state at
+     * mount. The tab handler cannot catch that — it fires on a CHANGE, and a
+     * mount is not one — so opening on Content would leave the canvas drawing
+     * the block mid-hover with the only control that explains or clears it
+     * behind a tab nobody was told to open.
+     *
+     * Asserted on the switcher being REACHABLE rather than on the tab's own
+     * state, because what the author needs is the control, and a test on the
+     * internal value would pass on a panel that opened the right tab and
+     * rendered nothing in it.
+     */
+    register();
+    render(
+      <InspectorPanel
+        editor={editorFor(documentOf({}))}
+        styleState={{ state: "hover", onChange: vi.fn() }}
+      />
+    );
+
+    expect(
+      screen.getByRole("radiogroup", { name: "Interaction state" })
+    ).toBeDefined();
+  });
+
+  it("still opens on Content for an ordinary mount", () => {
+    /*
+     * The control, and it carries the whole default: every existing caller
+     * names no state, and a panel that opened on Style for them would move a
+     * surface nobody asked to move.
+     */
+    register();
+    render(
+      <InspectorPanel
+        editor={editorFor(documentOf({}))}
+        styleState={{ onChange: vi.fn() }}
+      />
+    );
+
+    expect(
+      screen.queryByRole("radiogroup", { name: "Interaction state" })
+    ).toBeNull();
+  });
+
   it("reports the state the author chose", () => {
     register();
     const onStyleStateChange = vi.fn();

--- a/packages/builder/src/inspector-panel.tsx
+++ b/packages/builder/src/inspector-panel.tsx
@@ -254,6 +254,18 @@ export function editedStyleState(
   return binding.state ?? "base";
 }
 
+/**
+ * Which tab a mount opens on, given the state the host restored.
+ *
+ * `content` unless a state is in effect, which is the ordinary case and the
+ * behaviour every existing caller already has: a host that names no state, or
+ * names `base`, or supplies no setter — in which case {@link editedStyleState}
+ * has already resolved the state to `base` and there is nothing to explain.
+ */
+function openingTabFor(binding: StyleStateBinding | undefined): string {
+  return editedStyleState(binding) === "base" ? "content" : "style";
+}
+
 function tabChangeHandler(
   setTab: (next: string) => void,
   onStyleStateChange: ((state: StyleState) => void) | undefined
@@ -302,9 +314,23 @@ export function InspectorPanel({
    */
   const styleNode = selectedNode(editor.document, editor.selectedId);
 
-  // Declared before the early returns below, because a hook has to run on every
-  // render of this component and "no selection" is one of them.
-  const [tab, setTab] = React.useState<string>("content");
+  /*
+   * Declared before the early returns below, because a hook has to run on every
+   * render of this component and "no selection" is one of them.
+   *
+   * OPENS ON STYLE when a host mounts with a state already chosen. A binding
+   * naming a non-base state is a host restoring what an author was editing, and
+   * this panel's contract is that such a state and `Canvas.forcedState` are the
+   * same value — so opening on Content would leave the canvas drawing a block
+   * mid-hover with the only control that explains or clears it behind a tab
+   * nobody was told to open. The tab handler cannot catch that: it fires on a
+   * CHANGE, and a mount is not one.
+   *
+   * Honouring the state rather than clearing it, for the reason the multi-
+   * selection case does the same: the host asked for it deliberately, and
+   * resetting would silently discard what it restored.
+   */
+  const [tab, setTab] = React.useState<string>(() => openingTabFor(styleState));
 
   const commit = React.useCallback(
     (name: string, value: unknown) => {


### PR DESCRIPTION
A post-merge review finding on #1369.

A host mounting `InspectorPanel` with a state already chosen — restoring what
an author was editing — landed on Content. The canvas drew the block mid-hover
while the only control that explains or clears that state sat behind a tab
nothing had opened. `tabChangeHandler` could not catch it: it fires on a
change, and a mount is not one.

This is the fourth member of one family, and the family is the point: a forced
interaction state must never outlive the control that explains it. The other
three — leaving the Style tab, selecting several blocks, and selecting a block
the inspector cannot show — are already closed. This was the one route in that
was not a change at all.

## Honoured, not cleared

The opening tab is derived from the binding rather than the state being reset,
for the reason the multi-selection case suppresses rather than resets: the host
asked for that state deliberately, and clearing it would silently discard what
it restored.

An ordinary mount still opens on Content — no state named, or `base`, or no
setter, in which case the state has already resolved to `base` and there is
nothing to explain. That is every existing caller.

## Evidence

Break-verified in BOTH directions, which is what a two-valued default needs:

| Break | Fails |
|---|---|
| always open on Content | the restored-state case alone |
| always open on Style | the ordinary-mount control alone |

A test on the tab's internal value would have passed on a panel that opened the
right tab and rendered nothing in it, so both cases assert the switcher is
REACHABLE instead.

Local gates: builder 2595/2595, plugin-page-builder 512/512, lint and
check-types clean, `fallow audit` passes, `changeset status` parses, comment
convention clean.

## Unrelated, and worth knowing

CI on #1369's head reported a failure in `class-manager-panel.test.tsx` — not
this lane's file. Established by unreachability rather than by a re-run: that
test imports only `./class-manager-panel`, the engine, React and vitest, and
`class-manager-panel.tsx` imports none of the files #1369 touched. It passes
locally on main at 16.3s against a 30s package budget, so one case uses about
half the budget and needs a ~2x slowdown on a contended runner to blow it.
Recorded as `finding:builder-class-manager-test-uses-half-the-package-budget`
with the numbers and three candidate remedies, for whoever owns that panel.