### PR TITLE
fix(ui): save a typed colour when it is finished, not per keystroke

### DIFF
--- a/.changeset/finish-a-typed-colour-before-saving-it.md
+++ b/.changeset/finish-a-typed-colour-before-saving-it.md
@@ -1,0 +1,40 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Stop the colour picker saving a colour you did not finish typing.
+
+Typing a hex colour used to save on every keystroke. Because a prefix of a
+valid colour is itself a valid colour — `#123456` passes through `#123` and
+`#1234` — stopping partway left the last of those saved. Typing `#123456` and
+pausing at `#12345` stored `#11223344`, a colour nobody typed, replacing what
+was there.
+
+A typed colour is now saved when you finish it: press Enter, or leave the
+field. Dragging on the surface and the sliders is unchanged and still updates
+as you move. Dismissing the picker mid-word discards the unfinished text and
+leaves your stored colour alone.

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -394,6 +394,14 @@ describe("the contrast verdict is reachable from the control it describes", () =
   });
 });
 
+/** Move the picker the way a DRAG does: continuously, with no finish to wait for. */
+function movePicker(): void {
+  fireEvent.keyDown(
+    screen.getByRole("application", { name: /Saturation and brightness/ }),
+    { key: "ArrowRight" }
+  );
+}
+
 describe("a picker gesture is ONE editor operation", () => {
   it("does not write while the picker is being moved, and writes once on close", async () => {
     // The UI picker fires `onColorChange` on every pointer event, so committing
@@ -405,16 +413,18 @@ describe("a picker gesture is ONE editor operation", () => {
     const editor = mount(styles("#3b82f6"));
     fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
 
-    // The picker's own hex field stands in for the drag: it reaches the same
-    // `onColorChange` the surface and sliders do.
-    const hex = screen
-      .getAllByRole("textbox")
-      .find(input => input !== screen.getByRole("textbox", { name: "Color" }));
-    expect(hex).toBeDefined();
-    if (hex === undefined) return;
-    fireEvent.change(hex, { target: { value: "#ff0000" } });
-    fireEvent.change(hex, { target: { value: "#00ff00" } });
-    fireEvent.change(hex, { target: { value: "#0000ff" } });
+    /*
+     * The SURFACE, not the hex field. The field used to stand in for a drag
+     * because typing published on every keystroke exactly as dragging does; it
+     * no longer does — a typed colour is reported when the author finishes it —
+     * so the field would reach a different path from the one this case names,
+     * and every assertion below would go on passing while saying nothing about
+     * a drag. The surface is keyboard-operable, which is what makes a real move
+     * expressible without pointer geometry jsdom cannot supply.
+     */
+    movePicker();
+    movePicker();
+    movePicker();
 
     // Three moves, no writes.
     expect(editor.applyAll).not.toHaveBeenCalled();
@@ -535,6 +545,9 @@ describe("the picker can replace a stored token with a literal", () => {
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    // FINISHED, because a typed colour is reported when the author finishes
+    // it rather than per keystroke.
+    fireEvent.blur(hex);
 
     // The swatch now follows the draft rather than snapping back to the token.
     expect(
@@ -564,6 +577,9 @@ describe("a picker gesture survives the field being replaced", () => {
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    // FINISHED, because a typed colour is reported when the author finishes
+    // it rather than per keystroke.
+    fireEvent.blur(hex);
     expect(editor.applyAll).not.toHaveBeenCalled();
 
     // Unmount without ever closing the popover.
@@ -596,6 +612,9 @@ describe("a discrete choice supersedes an unfinished gesture", () => {
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    // FINISHED, because a typed colour is reported when the author finishes
+    // it rather than per keystroke.
+    fireEvent.blur(hex);
 
     // Now pick a token preset, which commits immediately.
     fireEvent.click(screen.getByRole("button", { name: "color.ink" }));
@@ -621,6 +640,9 @@ describe("a discrete choice supersedes an unfinished gesture", () => {
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    // FINISHED, because a typed colour is reported when the author finishes
+    // it rather than per keystroke.
+    fireEvent.blur(hex);
 
     fireEvent.click(screen.getByRole("button", { name: "Clear Color" }));
     expect(editor.applyAll).toHaveBeenCalledTimes(1);
@@ -647,6 +669,9 @@ describe("a superseded gesture stays superseded even when the choice is refused"
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    // FINISHED, because a typed colour is reported when the author finishes
+    // it rather than per keystroke.
+    fireEvent.blur(hex);
 
     fireEvent.click(screen.getByRole("button", { name: "color.ink" }));
     const afterToken = editor.applyAll.mock.calls.length;
@@ -680,6 +705,9 @@ describe("clearing a token while the picker is open", () => {
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    // FINISHED, because a typed colour is reported when the author finishes
+    // it rather than per keystroke.
+    fireEvent.blur(hex);
 
     // The real order: React's handler on the button, then the document
     // dismissal Radix listens for, then the click.
@@ -753,6 +781,9 @@ describe("a dismissal that is NOT a superseding control", () => {
     expect(hex).toBeDefined();
     if (hex === undefined) return;
     fireEvent.change(hex, { target: { value: "#ff0000" } });
+    // FINISHED, because a typed colour is reported when the author finishes
+    // it rather than per keystroke.
+    fireEvent.blur(hex);
     expect(editor.applyAll).not.toHaveBeenCalled();
 
     // Somewhere outside the picker that commits nothing of its own.
@@ -1085,6 +1116,13 @@ describe("a Reset beside a picker mid-gesture", () => {
     expect(picker).toBeDefined();
     if (picker === undefined) return;
     fireEvent.change(picker, { target: { value: hex } });
+    /*
+     * FINISHED, because a typed colour is reported when the author finishes it
+     * rather than per keystroke. That reports the colour ONCE, which is what
+     * leaves a gesture pending — the panel records a picker report and writes
+     * on close, so a report is not itself a write.
+     */
+    fireEvent.blur(picker);
   };
 
   it("drops the gesture the Reset replaced, rather than queueing it", async () => {

--- a/packages/builder/src/style-colour-panel.test.tsx
+++ b/packages/builder/src/style-colour-panel.test.tsx
@@ -1125,6 +1125,34 @@ describe("a Reset beside a picker mid-gesture", () => {
     fireEvent.blur(picker);
   };
 
+  it("keeps a colour typed and then DISMISSED by clicking away", async () => {
+    /*
+     * The path `fireEvent.blur` cannot reach. Radix runs its dismiss layer from
+     * an outside `pointerdown` and unmounts the content there, so a blur may
+     * never be delivered — which would lose a complete colour the author typed,
+     * trading a silent wrong write for a silent lost one.
+     *
+     * Driven as a real outside press rather than as a blur, because a blur is
+     * the thing in question.
+     */
+    const editor = mountWithResets([{ property: "color" }]);
+    fireEvent.click(screen.getByRole("button", { name: "Colour for Color" }));
+    await settle();
+
+    const picker = within(screen.getByRole("dialog")).getAllByRole(
+      "textbox"
+    )[0];
+    expect(picker).toBeDefined();
+    if (picker === undefined) return;
+    fireEvent.change(picker, { target: { value: "#ff0000" } });
+
+    fireEvent.pointerDown(document.body);
+    fireEvent.click(document.body);
+    await settle();
+
+    expect(JSON.stringify(editor.applyAll.mock.calls)).toContain("#ff0000");
+  });
+
   it("drops the gesture the Reset replaced, rather than queueing it", async () => {
     /*
      * Reset supersedes the gesture, so the picker must DISCARD it — not merely

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -742,6 +742,44 @@ describe("a colour typed one character at a time", () => {
     expect(onSwatchSelect).toHaveBeenCalled();
   });
 
+  it("finishes a deferred draft when the press replaced NOTHING", () => {
+    /*
+     * The other half of the null-destination guard. Skipping that blur hands
+     * the draft to the press's own action — but a swatch with no handler
+     * replaces nothing, and focus has already left the field, so no further
+     * blur is coming. Left there, the draft dies with the picker.
+     *
+     * The control is the case above it, where the swatch DOES have a handler
+     * and this must stay quiet: without that pair, a picker finishing on every
+     * click would satisfy this one.
+     */
+    const onColorChange = vi.fn();
+    render(
+      <ColorPicker
+        color="#000000"
+        onColorChange={onColorChange}
+        swatches={[{ id: "p", label: "Primary", color: "#3b82f6", value: "p" }]}
+      />
+    );
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+
+    const preset = screen.getByRole("button", { name: "Primary" });
+    preset.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+    );
+    field.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: null })
+    );
+    preset.dispatchEvent(
+      new PointerEvent("pointerup", { bubbles: true, cancelable: true })
+    );
+    fireEvent.click(preset);
+
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
   it("DOES finish on a blur with no destination when no press is in progress", () => {
     // The control for the case above: focus leaving to nowhere — a window
     // losing focus, say — is still a finish.

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -443,6 +443,41 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange).toHaveBeenCalledTimes(1);
   });
 
+  it("reports ONCE when an outside press and its blur arrive together", () => {
+    /*
+     * An outside press moves focus, so the dismissal path and the blur path can
+     * BOTH finish the same draft. `setDraftHex(null)` is only queued, so unless
+     * something flushes between them each reads a still-non-null draft and
+     * reports the colour twice — duplicate persistence for one edit.
+     *
+     * Dispatched NATIVELY rather than through `fireEvent`, which wraps each
+     * call in `act` and flushes between them: that ordering is the safe one and
+     * would pass against the version that had the bug. These two go out in one
+     * turn, which is the ordering in question.
+     */
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    outside.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+    );
+    /*
+     * `focusout`, not `blur`. React delegates from the root and maps `onBlur`
+     * onto the bubbling `focusout`, so a non-bubbling native `blur` never
+     * reaches the handler at all — a first attempt used one, and the case then
+     * passed against the broken version because the second path never ran.
+     */
+    field.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+
+    expect(onColorChange).toHaveBeenCalledTimes(1);
+    expect(onColorChange.mock.calls[0]?.[0]?.toLowerCase()).toBe("#123456");
+  });
+
   it("reports NOTHING when the picker GOES AWAY mid-draft", () => {
     /*
      * Dismissal is not a finish. Escape means cancel, so a draft dying with the

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -467,10 +467,10 @@ describe("a colour typed one character at a time", () => {
       new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
     );
     /*
-     * `focusout`, not `blur`. React delegates from the root and maps `onBlur`
-     * onto the bubbling `focusout`, so a non-bubbling native `blur` never
-     * reaches the handler at all — a first attempt used one, and the case then
-     * passed against the broken version because the second path never ran.
+     * `focusout`, not `blur`. React delegates from its root and maps `onBlur`
+     * onto the bubbling `focusout`, so a non-bubbling native `blur` reaches no
+     * handler: the second path would not run, and this case would be green
+     * because nothing happened twice rather than because the guard held.
      */
     field.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
 
@@ -503,9 +503,53 @@ describe("a colour typed one character at a time", () => {
     preset.dispatchEvent(
       new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
     );
-    field.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    /*
+     * With `relatedTarget`, because that is what a browser supplies and it is
+     * what the handler reads: focus is moving TO the preset, which is inside
+     * the picker, so this blur is not a finish.
+     */
+    field.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: preset })
+    );
+    fireEvent.click(preset);
 
     expect(onColorChange).not.toHaveBeenCalledWith("#123456");
+  });
+
+  it("keeps a draft when the EYEDROPPER is cancelled", () => {
+    /*
+     * The eyedropper's button is inside the picker, so pressing it is not a
+     * dismissal — but it is not a replacement either until sampling succeeds.
+     * Cancelling leaves nothing to replace the value with, so a draft dropped
+     * on the press would be lost with nothing put in its place.
+     */
+    const onColorChange = vi.fn();
+    const windowWithEyeDropper = window as unknown as Record<string, unknown>;
+    windowWithEyeDropper.EyeDropper = class {
+      open(): Promise<{ sRGBHex: string }> {
+        return Promise.reject(new Error("dismissed"));
+      }
+    };
+
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+
+    const eyedropper = screen.getByRole("button", {
+      name: "Pick a colour from the screen",
+    });
+    eyedropper.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+    );
+    field.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: eyedropper })
+    );
+
+    // Still there to be finished, rather than silently gone.
+    fireEvent.keyDown(field, { key: "Enter" });
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+
+    delete windowWithEyeDropper.EyeDropper;
   });
 
   it("keeps a draft when the press is the FIELD itself", () => {
@@ -612,10 +656,10 @@ describe("a colour typed one character at a time", () => {
      * surface is the conventional answer; and clicking away moves focus out of
      * the field first, so that path commits through the blur instead.
      *
-     * Reporting from an unmount was tried and removed: a host that coalesces a
-     * picker gesture on close has already decided what to write by then, so the
-     * value is published into nothing — `style-colour-panel` writes once on
-     * close and saw zero.
+     * Reporting from an unmount would arrive after a host that coalesces a
+     * picker gesture on close has already decided what to write, so the value
+     * would be published into nothing — `style-colour-panel` writes once on
+     * close.
      *
      * A COMPLETE colour is used deliberately. The unfinished case below would
      * pass on a picker that simply never reported, so this one carries the

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -478,6 +478,134 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange.mock.calls[0]?.[0]?.toLowerCase()).toBe("#123456");
   });
 
+  it("does not report a draft a PRESET replaces", () => {
+    /*
+     * The browser blurs the field before the preset's press becomes a click, so
+     * a draft left in place is published first and the replacement second —
+     * two edits recorded for the one the author made, and for a preset an
+     * `onColorChange` beside the `onSwatchSelect` that was the point.
+     */
+    const onColorChange = vi.fn();
+    const onSwatchSelect = vi.fn();
+    render(
+      <ColorPicker
+        color="#000000"
+        onColorChange={onColorChange}
+        onSwatchSelect={onSwatchSelect}
+        swatches={[{ id: "p", label: "Primary", color: "#3b82f6", value: "p" }]}
+      />
+    );
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+
+    const preset = screen.getByRole("button", { name: "Primary" });
+    preset.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+    );
+    field.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+
+    expect(onColorChange).not.toHaveBeenCalledWith("#123456");
+  });
+
+  it("keeps a draft when the press is the FIELD itself", () => {
+    /*
+     * The control for the case above, and the one a blanket "inside presses
+     * drop the draft" rule would break: clicking into the field to move the
+     * caret must not discard what is being typed.
+     */
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+    field.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+    );
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
+  it("drops a draft the HOST replaces", () => {
+    /*
+     * An undo, or an edit made elsewhere, arrives as a new `color`. Text typed
+     * against the old value is stale, and left in place the next blur publishes
+     * it back over the value that just arrived.
+     */
+    const onColorChange = vi.fn();
+    const view = render(
+      <ColorPicker color="#000000" onColorChange={onColorChange} />
+    );
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+    view.rerender(
+      <ColorPicker color="#00ff00" onColorChange={onColorChange} />
+    );
+    fireEvent.blur(hexField());
+
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("leaves Enter to the IME while a composition is active", () => {
+    // Accepting a candidate is not finishing a colour; consuming that Enter
+    // blocks the acceptance and reports the pre-composition text.
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+    fireEvent.keyDown(hexField(), { key: "Enter", isComposing: true });
+
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("works inside a SHADOW ROOT, where a press on the field keeps its draft", () => {
+    /*
+     * What this DOES prove: the picker functions when mounted inside a shadow
+     * root — the listener attaches, a press on the field is read as inside, and
+     * the draft survives to be finished.
+     *
+     * What it does NOT prove, stated because the name would otherwise imply it:
+     * the `composedPath` branch that exists for this case. A composed event
+     * crossing a shadow boundary is retargeted to the HOST in a browser, so a
+     * containment test would find an element the picker does not contain and
+     * read a press on the field as an outside dismissal. jsdom does not
+     * reproduce that retargeting — measured, removing the `composedPath` branch
+     * leaves this case passing — so the branch is reasoned from the spec rather
+     * than covered here, and a reader should not take this green as evidence
+     * for it.
+     */
+    const holder = document.createElement("div");
+    document.body.appendChild(holder);
+    const shadow = holder.attachShadow({ mode: "open" });
+    const mount = document.createElement("div");
+    shadow.appendChild(mount);
+
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />, {
+      container: mount,
+    });
+
+    // BY ITS ID, not the first input in the tree — the sliders come first, and
+    // a probe that grabbed one of those tested the hue control while claiming
+    // to test the hex field.
+    const field = shadow.querySelector<HTMLInputElement>('input[id$="-hex"]');
+    expect(field).not.toBeNull();
+    if (field === null) return;
+
+    fireEvent.change(field, { target: { value: "#123456" } });
+    field.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        composed: true,
+        cancelable: true,
+      })
+    );
+    fireEvent.keyDown(field, { key: "Enter" });
+
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
   it("reports NOTHING when the picker GOES AWAY mid-draft", () => {
     /*
      * Dismissal is not a finish. Escape means cancel, so a draft dying with the

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -414,6 +414,35 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange.mock.calls[0]?.[0]?.toLowerCase()).toBe("#123456");
   });
 
+  it("reports NOTHING when focus merely passes through the field", () => {
+    /*
+     * Tabbing into the hex field and out again is not an edit. Reading the
+     * field's VALUE on blur rather than the draft would report the colour
+     * already on screen every time, so an untouched control looks edited and a
+     * host that persists each callback writes for nothing.
+     */
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#3b82f6" onColorChange={onColorChange} />);
+
+    fireEvent.focus(hexField());
+    fireEvent.blur(hexField());
+
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("reports a finished colour ONCE, not again on the way out", () => {
+    // Enter finishes it; the blur that follows has no draft left to report, so
+    // a host persisting each callback does not see the same edit twice.
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+    fireEvent.keyDown(hexField(), { key: "Enter" });
+    fireEvent.blur(hexField());
+
+    expect(onColorChange).toHaveBeenCalledTimes(1);
+  });
+
   it("reports NOTHING when the picker GOES AWAY mid-draft", () => {
     /*
      * Dismissal is not a finish. Escape means cancel, so a draft dying with the

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -95,13 +95,19 @@ describe("choosing a preset", () => {
 });
 
 describe("the hex field", () => {
-  it("publishes a colour once it is one", () => {
+  it("publishes a colour once it is one AND finished", () => {
+    /*
+     * The finish is the addition, and the reason is in the case below it: a
+     * prefix of a valid colour is itself a valid colour, so publishing per
+     * keystroke let an intermediate stand as the stored value whenever the
+     * author stopped early.
+     */
     const onColorChange = vi.fn();
     render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
 
-    fireEvent.change(screen.getByLabelText("Hex colour"), {
-      target: { value: "#3b82f6" },
-    });
+    const field = screen.getByLabelText("Hex colour");
+    fireEvent.change(field, { target: { value: "#3b82f6" } });
+    fireEvent.blur(field);
 
     expect(onColorChange).toHaveBeenCalledWith("#3b82f6");
   });
@@ -293,9 +299,11 @@ describe("hue survives a colour that has none", () => {
     const onColorChange = vi.fn();
     render(<Controlled initial="#0000ff" onColorChange={onColorChange} />);
 
-    fireEvent.change(screen.getByLabelText("Hex colour"), {
-      target: { value: "#000000" },
-    });
+    const field = screen.getByLabelText("Hex colour");
+    fireEvent.change(field, { target: { value: "#000000" } });
+    // FINISHED, because a typed colour is reported when the author finishes it
+    // and this case needs the surface actually moved to black before it arrows.
+    fireEvent.blur(field);
     // Black is unlit AS WELL as colourless, so brightness and saturation both
     // have to come back up before any hue is observable at all. A single step
     // on one axis lands on `#030303`, which is grey whichever hue is stored —
@@ -352,5 +360,111 @@ describe("recent colours", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "#ff0000" }));
     expect(onColorChange).toHaveBeenCalledWith("#ff0000");
+  });
+});
+
+describe("a colour typed one character at a time", () => {
+  const hexField = () => screen.getByLabelText("Hex colour");
+
+  it("reports NOTHING until the author finishes it", () => {
+    /*
+     * The defect this closes, in the sequence it was measured in. `parseHex`
+     * accepts 3, 4, 6 and 8 digits, so a PREFIX of a valid colour is itself a
+     * valid colour: `#123456` passes through `#123` and `#1234` on the way.
+     * Publishing each of those made the last one stick whenever the author
+     * paused — `#12345` left the host holding `#11223344`, a colour nobody
+     * typed, silently replacing the stored one.
+     *
+     * Asserted on the CALL COUNT as well as the value, because a version that
+     * published the right final colour after publishing two wrong ones would
+     * satisfy a value-only assertion while the defect was still live: the harm
+     * is what a host commits when the author stops early.
+     */
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    for (const text of ["#1", "#12", "#123", "#1234", "#12345"]) {
+      fireEvent.change(hexField(), { target: { value: text } });
+    }
+
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("reports the colour once ENTER finishes it", () => {
+    // The control. Without it the case above passes on a picker that never
+    // reports anything at all.
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+    fireEvent.keyDown(hexField(), { key: "Enter" });
+
+    expect(onColorChange).toHaveBeenCalledTimes(1);
+    expect(onColorChange.mock.calls[0]?.[0]?.toLowerCase()).toBe("#123456");
+  });
+
+  it("reports it on leaving the field", () => {
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+    fireEvent.blur(hexField());
+
+    expect(onColorChange).toHaveBeenCalledTimes(1);
+    expect(onColorChange.mock.calls[0]?.[0]?.toLowerCase()).toBe("#123456");
+  });
+
+  it("reports NOTHING when the picker GOES AWAY mid-draft", () => {
+    /*
+     * Dismissal is not a finish. Escape means cancel, so a draft dying with the
+     * surface is the conventional answer; and clicking away moves focus out of
+     * the field first, so that path commits through the blur instead.
+     *
+     * Reporting from an unmount was tried and removed: a host that coalesces a
+     * picker gesture on close has already decided what to write by then, so the
+     * value is published into nothing — `style-colour-panel` writes once on
+     * close and saw zero.
+     *
+     * A COMPLETE colour is used deliberately. The unfinished case below would
+     * pass on a picker that simply never reported, so this one carries the
+     * discrimination: the value was reportable and was still not reported.
+     */
+    const onColorChange = vi.fn();
+    const view = render(
+      <ColorPicker color="#000000" onColorChange={onColorChange} />
+    );
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+    view.unmount();
+
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("reports NOTHING when an unfinished colour goes away", () => {
+    // The measured case end to end: stop at five digits, dismiss, and the host
+    // must still hold what it held.
+    const onColorChange = vi.fn();
+    const view = render(
+      <ColorPicker color="#000000" onColorChange={onColorChange} />
+    );
+
+    fireEvent.change(hexField(), { target: { value: "#12345" } });
+    view.unmount();
+
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("shows the STORED colour again after an unfinished draft is dropped", () => {
+    // What is shown and what is saved have to agree once the draft is gone.
+    // They did not before: the field kept the text while the host held a stale
+    // intermediate.
+    render(<ColorPicker color="#000000" onColorChange={vi.fn()} />);
+
+    fireEvent.change(hexField(), { target: { value: "#12345" } });
+    fireEvent.blur(hexField());
+
+    expect((hexField() as HTMLInputElement).value.toLowerCase()).toBe(
+      "#000000"
+    );
   });
 });

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -795,6 +795,48 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange).toHaveBeenCalledWith("#123456");
   });
 
+  it("reports ONLY the sample when the EYEDROPPER succeeds after a null blur", async () => {
+    /*
+     * Sampling resolves later than the click that would otherwise settle the
+     * deferred finish, so the typed colour was reported first and the sampled
+     * one after it — two persisted edits for the one the author made.
+     *
+     * Asserted on the CALL COUNT as well as the value: reporting `#abcdef`
+     * last is true of the broken version too.
+     */
+    const onColorChange = vi.fn();
+    const windowWithEyeDropper = window as unknown as Record<string, unknown>;
+    windowWithEyeDropper.EyeDropper = class {
+      open(): Promise<{ sRGBHex: string }> {
+        return Promise.resolve({ sRGBHex: "#abcdef" });
+      }
+    };
+
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+
+    const eyedropper = screen.getByRole("button", {
+      name: "Pick a colour from the screen",
+    });
+    eyedropper.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+    );
+    field.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: null })
+    );
+    eyedropper.dispatchEvent(
+      new PointerEvent("pointerup", { bubbles: true, cancelable: true })
+    );
+    fireEvent.click(eyedropper);
+    await act(async () => undefined);
+
+    expect(onColorChange).toHaveBeenCalledTimes(1);
+    expect(onColorChange.mock.calls[0]?.[0]?.toLowerCase()).toBe("#abcdef");
+
+    delete windowWithEyeDropper.EyeDropper;
+  });
+
   it("keeps a draft when the EYEDROPPER is cancelled", async () => {
     /*
      * The eyedropper's button is inside the picker, so pressing it is not a

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -516,6 +516,73 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange).not.toHaveBeenCalledWith("#123456");
   });
 
+  it("finishes a colour when the KEYBOARD leaves the picker entirely", () => {
+    /*
+     * Type, tab to a control further inside the picker, then tab out without
+     * activating it. Watched at the field alone this was lost: the field's own
+     * blur was declined because focus had moved to something inside, and
+     * nothing watched the boundary focus actually crossed. No pointer is
+     * involved, so the press listener cannot cover it either.
+     */
+    const onColorChange = vi.fn();
+    render(
+      <ColorPicker
+        color="#000000"
+        onColorChange={onColorChange}
+        swatches={[{ id: "p", label: "Primary", color: "#3b82f6", value: "p" }]}
+      />
+    );
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+
+    // Field -> preset: still inside, so nothing is finished yet.
+    const preset = screen.getByRole("button", { name: "Primary" });
+    field.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: preset })
+    );
+    expect(onColorChange).not.toHaveBeenCalled();
+
+    // Preset -> somewhere else entirely: the picker has been left.
+    const outside = document.createElement("button");
+    document.body.appendChild(outside);
+    preset.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: outside })
+    );
+
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
+  it("does not finish a TOUCH press that becomes a scroll", () => {
+    /*
+     * An outside touch press may become a scroll or a long press rather than a
+     * tap, and a dismissable layer waits for the resulting click before
+     * dismissing for that reason. Finishing on the press would publish a draft
+     * while the picker stays open and the field is still being edited.
+     */
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    outside.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        pointerType: "touch",
+      })
+    );
+
+    // A scroll produces no click, so nothing finished.
+    expect(onColorChange).not.toHaveBeenCalled();
+
+    // The control: the same press completing as a TAP does finish it.
+    outside.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
   it("keeps a draft when the EYEDROPPER is cancelled", () => {
     /*
      * The eyedropper's button is inside the picker, so pressing it is not a

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -578,8 +578,72 @@ describe("a colour typed one character at a time", () => {
     // A scroll produces no click, so nothing finished.
     expect(onColorChange).not.toHaveBeenCalled();
 
-    // The control: the same press completing as a TAP does finish it.
+    /*
+     * And the wait does not OUTLIVE the gesture. Treating the next click as the
+     * original tap is what a version retaining the listener would also pass, so
+     * this presses again first — the press that ends the abandoned wait — and
+     * the click that follows belongs to a gesture that started inside the
+     * field, which finishes nothing.
+     */
+    const field = hexField() as HTMLInputElement;
+    field.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        pointerType: "touch",
+      })
+    );
+    field.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("finishes a TOUCH tap that completes outside", () => {
+    /*
+     * The control for the case above: without it, a picker that had simply
+     * stopped finishing on touch altogether would satisfy every assertion
+     * there.
+     */
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    outside.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        pointerType: "touch",
+      })
+    );
     outside.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
+  it("keeps a draft when a swatch has NO handler to replace it with", () => {
+    /*
+     * `onSwatchSelect` is optional and the type permits swatches without it.
+     * Dropping a draft for a callback that does nothing loses the typed colour
+     * and puts nothing in its place — the swatch does not reach the host
+     * either, so the edit simply disappears.
+     */
+    const onColorChange = vi.fn();
+    render(
+      <ColorPicker
+        color="#000000"
+        onColorChange={onColorChange}
+        swatches={[{ id: "p", label: "Primary", color: "#3b82f6", value: "p" }]}
+      />
+    );
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+    fireEvent.click(screen.getByRole("button", { name: "Primary" }));
+
+    // Still there to be finished.
+    fireEvent.keyDown(field, { key: "Enter" });
     expect(onColorChange).toHaveBeenCalledWith("#123456");
   });
 

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -691,6 +691,72 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange).toHaveBeenCalledWith("#123456");
   });
 
+  it("leaves Enter to a legacy IME reporting only keyCode 229", () => {
+    // Older engines report the composition as `keyCode` 229 with `isComposing`
+    // false, so reading one signal blocks candidate acceptance on exactly the
+    // engines that need the guard most.
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+    fireEvent.keyDown(hexField(), { key: "Enter", keyCode: 229 });
+
+    expect(onColorChange).not.toHaveBeenCalled();
+  });
+
+  it("does not finish on a blur with NO destination during an inside press", () => {
+    /*
+     * Some engines do not focus a button when it is pressed, so the field's
+     * `focusout` arrives with a null `relatedTarget` and reads as focus leaving
+     * the picker — finishing the draft before the swatch click can supersede
+     * it, which is the double report the whole arrangement avoids.
+     *
+     * The control is the same blur with NO press in progress, below, which must
+     * still finish: without it this case would pass on a picker that ignored
+     * every null-destination blur.
+     */
+    const onColorChange = vi.fn();
+    const onSwatchSelect = vi.fn();
+    render(
+      <ColorPicker
+        color="#000000"
+        onColorChange={onColorChange}
+        onSwatchSelect={onSwatchSelect}
+        swatches={[{ id: "p", label: "Primary", color: "#3b82f6", value: "p" }]}
+      />
+    );
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+
+    const preset = screen.getByRole("button", { name: "Primary" });
+    preset.dispatchEvent(
+      new PointerEvent("pointerdown", { bubbles: true, cancelable: true })
+    );
+    field.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: null })
+    );
+    fireEvent.click(preset);
+
+    expect(onColorChange).not.toHaveBeenCalled();
+    expect(onSwatchSelect).toHaveBeenCalled();
+  });
+
+  it("DOES finish on a blur with no destination when no press is in progress", () => {
+    // The control for the case above: focus leaving to nowhere — a window
+    // losing focus, say — is still a finish.
+    const onColorChange = vi.fn();
+    render(<ColorPicker color="#000000" onColorChange={onColorChange} />);
+
+    const field = hexField() as HTMLInputElement;
+    fireEvent.change(field, { target: { value: "#123456" } });
+    field.dispatchEvent(
+      new FocusEvent("focusout", { bubbles: true, relatedTarget: null })
+    );
+
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
   it("keeps a draft when the EYEDROPPER is cancelled", async () => {
     /*
      * The eyedropper's button is inside the picker, so pressing it is not a

--- a/packages/ui/src/components/color-picker.test.tsx
+++ b/packages/ui/src/components/color-picker.test.tsx
@@ -9,7 +9,13 @@
  * nothing would report the loss. The colour and the meaning are different
  * things, and only the host knows the second.
  */
-import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
 import * as React from "react";
 import { renderToString } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -597,6 +603,44 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange).not.toHaveBeenCalled();
   });
 
+  it("finishes a TOUCH tap whose wait spans a RERENDER", () => {
+    /*
+     * An outside target that sets state from its own `pointerdown` rerenders
+     * this picker before the click arrives. The listeners are re-registered on
+     * every render so their closures stay current, and ending the wait in that
+     * cleanup killed a legitimate one — the completion was removed and a
+     * finished colour never reached the host.
+     *
+     * A render is not an abandoned gesture. What ends a wait is a new press, a
+     * cancelled gesture, or the picker going away.
+     */
+    const onColorChange = vi.fn();
+    const view = render(
+      <ColorPicker color="#000000" onColorChange={onColorChange} />
+    );
+
+    fireEvent.change(hexField(), { target: { value: "#123456" } });
+
+    const outside = document.createElement("div");
+    document.body.appendChild(outside);
+    outside.dispatchEvent(
+      new PointerEvent("pointerdown", {
+        bubbles: true,
+        cancelable: true,
+        pointerType: "touch",
+      })
+    );
+
+    // The rerender the outside handler's own state change would cause.
+    view.rerender(
+      <ColorPicker color="#000000" onColorChange={onColorChange} />
+    );
+
+    outside.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+
+    expect(onColorChange).toHaveBeenCalledWith("#123456");
+  });
+
   it("finishes a TOUCH tap that completes outside", () => {
     /*
      * The control for the case above: without it, a picker that had simply
@@ -647,7 +691,7 @@ describe("a colour typed one character at a time", () => {
     expect(onColorChange).toHaveBeenCalledWith("#123456");
   });
 
-  it("keeps a draft when the EYEDROPPER is cancelled", () => {
+  it("keeps a draft when the EYEDROPPER is cancelled", async () => {
     /*
      * The eyedropper's button is inside the picker, so pressing it is not a
      * dismissal — but it is not a replacement either until sampling succeeds.
@@ -675,6 +719,14 @@ describe("a colour typed one character at a time", () => {
     field.dispatchEvent(
       new FocusEvent("focusout", { bubbles: true, relatedTarget: eyedropper })
     );
+    /*
+     * CLICKED and awaited, so the sampling actually runs and rejects. Pressing
+     * alone never calls it, and the case would then pass against a version that
+     * cleared the draft before awaiting or inside the cancellation handler —
+     * which is the whole of what it exists to check.
+     */
+    fireEvent.click(eyedropper);
+    await act(async () => undefined);
 
     // Still there to be finished, rather than silently gone.
     fireEvent.keyDown(field, { key: "Enter" });

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -167,6 +167,7 @@ export function ColorPicker<TValue = string>({
   className,
 }: ColorPickerProps<TValue>) {
   const fieldId = React.useId();
+  const rootRef = React.useRef<HTMLDivElement>(null);
   const surfaceRef = React.useRef<HTMLDivElement>(null);
   const [hsva, setHsva] = React.useState<Hsva>(() => toHsva(color));
   // What the hex field shows while it is being typed into. A half-typed value
@@ -214,9 +215,14 @@ export function ColorPicker<TValue = string>({
    * after a host that coalesces a gesture on close has already decided what to
    * write, which is a value published into nothing.
    */
-  const commitDraft = (text: string | null): void => {
-    setDraftHex(null);
+  const commitDraft = (): void => {
+    const text = draftHex;
+    // NOTHING TYPED, nothing to report. Reading the field's value instead would
+    // publish the colour already on screen every time focus merely passed
+    // through — a save for an edit nobody made, and a second one for an edit
+    // already reported by Enter.
     if (text === null) return;
+    setDraftHex(null);
     const parsed = parseHex(text);
     // An unfinishable draft is DISCARDED rather than reported. The field
     // returns to the colour that is actually stored, so what is shown and what
@@ -226,6 +232,47 @@ export function ColorPicker<TValue = string>({
     setHsva(prev => hsvaFrom(parsed, parsed.alpha, prev.h));
     onColorChange(toHex(parsed, showAlpha ? parsed.alpha : 1));
   };
+
+  /*
+   * A press OUTSIDE is a finish, and it is the one a blur cannot catch.
+   *
+   * Measured rather than assumed: a dismissable layer runs from the outside
+   * `pointerdown` and unmounts this content there, so the focus change that
+   * would have produced a blur never happens and a complete typed colour was
+   * lost with no report at all. A test driving `blur` directly cannot see that
+   * — the blur is the thing in question — so the case that proves it presses
+   * outside for real.
+   *
+   * CAPTURE, because the ordering is the whole point: a capture listener on the
+   * document runs before the dismiss layer's own, so the value is reported
+   * while this is still mounted. Reporting from an unmount instead was tried
+   * and removed — a host that coalesces a picker gesture on close has already
+   * decided what to write by then.
+   *
+   * Escape is untouched and still cancels: it dismisses without a pointer, so
+   * nothing here runs and the draft dies with the surface, which is what a
+   * cancel means.
+   */
+  const latestCommit = React.useRef(commitDraft);
+  React.useEffect(() => {
+    latestCommit.current = commitDraft;
+  });
+  React.useEffect(() => {
+    const onPointerDown = (event: PointerEvent): void => {
+      const root = rootRef.current;
+      if (root === null) return;
+      const target = event.target;
+      // A press INSIDE is not a dismissal — a swatch, a slider, the field
+      // itself — and committing there would report a draft the press is about
+      // to replace.
+      if (target instanceof Node && root.contains(target)) return;
+      latestCommit.current();
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+    };
+  }, []);
 
   const commit = (next: Hsva): void => {
     setHsva(next);
@@ -303,7 +350,7 @@ export function ColorPicker<TValue = string>({
   };
 
   return (
-    <div className={cn("w-64 space-y-3", className)}>
+    <div ref={rootRef} className={cn("w-64 space-y-3", className)}>
       <div
         ref={surfaceRef}
         role="application"
@@ -413,9 +460,9 @@ export function ColorPicker<TValue = string>({
             // Kept off the surrounding form, which may have a submit of its own:
             // finishing a colour is not submitting whatever contains it.
             event.preventDefault();
-            commitDraft(event.currentTarget.value);
+            commitDraft();
           }}
-          onBlur={event => commitDraft(event.target.value)}
+          onBlur={() => commitDraft()}
         />
         {canPickFromScreen && (
           <Button

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -136,6 +136,21 @@ interface EyeDropperLike {
 }
 
 /**
+ * Whether an event target is a node in ANY document.
+ *
+ * `instanceof Node` cannot answer this: it is bound to one JavaScript realm, so
+ * a target from an iframe or a pop-out fails it while being a perfectly good
+ * node. Probing for the property the DOM guarantees is realm-independent, and
+ * `Partial<Node>` is the honest shape to probe through — the value is not known
+ * to be a node until this returns.
+ */
+function isNode(value: EventTarget | null): value is Node {
+  return (
+    value !== null && typeof (value as Partial<Node>).nodeType === "number"
+  );
+}
+
+/**
  * A colour control: a saturation square, a hue strip, optional alpha, a hex
  * field, and any presets the host supplies.
  *
@@ -173,6 +188,16 @@ export function ColorPicker<TValue = string>({
   // What the hex field shows while it is being typed into. A half-typed value
   // is not a colour, and reformatting it on every keystroke moves the caret.
   const [draftHex, setDraftHex] = React.useState<string | null>(null);
+  /*
+   * The same draft, held where a SECOND finish in the same dispatch can see it.
+   *
+   * `setDraftHex(null)` is queued, not applied, so two paths that both finish —
+   * an outside press moving focus, and the blur that press produces — can each
+   * read a still-non-null draft and report the colour twice. React renders
+   * between them only if something flushes, which is what makes a test
+   * dispatching the events separately miss it entirely.
+   */
+  const draftRef = React.useRef<string | null>(null);
 
   // Re-seeded when the host supplies a colour this picker did not produce.
   // Comparing the RENDERED hex rather than the prop avoids a loop: the same
@@ -216,7 +241,10 @@ export function ColorPicker<TValue = string>({
    * write, which is a value published into nothing.
    */
   const commitDraft = (): void => {
-    const text = draftHex;
+    const text = draftRef.current;
+    // Taken BEFORE anything else, so a second caller in this same dispatch
+    // finds nothing to report rather than the value this one is publishing.
+    draftRef.current = null;
     // NOTHING TYPED, nothing to report. Reading the field's value instead would
     // publish the colour already on screen every time focus merely passed
     // through — a save for an edit nobody made, and a second one for an edit
@@ -265,11 +293,20 @@ export function ColorPicker<TValue = string>({
     const root = rootRef.current;
     if (root === null) return;
     const onPointerDown = (event: Event): void => {
-      const target = event.target;
-      // A press INSIDE is not a dismissal — a swatch, a slider, the field
-      // itself — and committing there would report a draft the press is about
-      // to replace.
-      if (target instanceof Node && root.contains(target)) return;
+      /*
+       * A press INSIDE is not a dismissal — a swatch, a slider, the field
+       * itself — and committing there would report a draft the press is about
+       * to replace.
+       *
+       * Recognised WITHOUT `instanceof`, which is realm-bound: rendered into an
+       * iframe or a pop-out the target belongs to that document's own
+       * JavaScript realm and is not an instance of this one's `Node`, so every
+       * press — the hex field included — would read as outside and commit the
+       * draft the author was still typing. `contains` is a tree operation and
+       * does not care which realm the node came from; the shape test in front
+       * of it is what keeps a non-node target from reaching it.
+       */
+      if (isNode(event.target) && root.contains(event.target)) return;
       commitDraft();
     };
     /*
@@ -288,6 +325,7 @@ export function ColorPicker<TValue = string>({
 
   const commit = (next: Hsva): void => {
     setHsva(next);
+    draftRef.current = null;
     setDraftHex(null);
     onColorChange(toHexString(next, showAlpha));
   };
@@ -466,7 +504,10 @@ export function ColorPicker<TValue = string>({
            * effect above, which compares the rendered hex against the host's
            * prop and would pull a half-typed value straight back.
            */
-          onChange={event => setDraftHex(event.target.value)}
+          onChange={event => {
+            draftRef.current = event.target.value;
+            setDraftHex(event.target.value);
+          }}
           onKeyDown={event => {
             if (event.key !== "Enter") return;
             // Kept off the surrounding form, which may have a submit of its own:

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -185,6 +185,11 @@ export function ColorPicker<TValue = string>({
   const fieldId = React.useId();
   /** The picker's own subtree, for telling a press inside it from a dismissal. */
   const rootRef = React.useRef<HTMLDivElement>(null);
+  /**
+   * Whether a press that began INSIDE this picker is still in progress, so a
+   * blur carrying no destination can be told from focus genuinely leaving.
+   */
+  const insidePress = React.useRef(false);
   /** Undoes a touch press that is waiting to see whether it becomes a tap. */
   const pendingTap = React.useRef<(() => void) | null>(null);
   /**
@@ -362,6 +367,15 @@ export function ColorPicker<TValue = string>({
       const inside =
         path.includes(root) ||
         (isNode(event.target) && root.contains(event.target));
+      /*
+       * RECORDED, because a blur cannot always tell where focus went. Some
+       * engines do not focus a button on press, so the field's `focusout`
+       * arrives with a null `relatedTarget` and reads as focus leaving the
+       * picker entirely — finishing the draft before the swatch or eyedropper
+       * click can supersede it, which is the double report this all exists to
+       * avoid. Cleared when the press ends.
+       */
+      insidePress.current = true;
       // A press inside decides NOTHING about the draft. Whether it becomes a
       // replacement is not knowable here — the eyedropper's button is inside
       // and its sampling can be cancelled, leaving nothing to replace with —
@@ -417,14 +431,22 @@ export function ColorPicker<TValue = string>({
      * gives when a press becomes a scroll rather than a tap.
      */
     const onPointerCancel = (): void => {
+      insidePress.current = false;
       pendingTap.current?.();
       pendingTap.current = null;
     };
+    // The press ENDING is what releases the blur above, whether or not it
+    // became a click.
+    const onPointerUp = (): void => {
+      insidePress.current = false;
+    };
     owner.addEventListener("pointerdown", onPointerDown, true);
     owner.addEventListener("pointercancel", onPointerCancel, true);
+    owner.addEventListener("pointerup", onPointerUp, true);
     return () => {
       owner.removeEventListener("pointerdown", onPointerDown, true);
       owner.removeEventListener("pointercancel", onPointerCancel, true);
+      owner.removeEventListener("pointerup", onPointerUp, true);
     };
   });
 
@@ -543,6 +565,10 @@ export function ColorPicker<TValue = string>({
         const next = event.relatedTarget;
         const root = rootRef.current;
         if (root !== null && isNode(next) && root.contains(next)) return;
+        // A blur with NO destination during a press that began inside is that
+        // press, not a departure: some engines do not focus a button when it is
+        // pressed, and finishing here would beat the click that supersedes it.
+        if (next === null && insidePress.current) return;
         commitDraft();
       }}
     >
@@ -658,11 +684,12 @@ export function ColorPicker<TValue = string>({
             /*
              * An Enter that ACCEPTS AN IME CANDIDATE is not a finish. Consuming
              * it blocks the acceptance and reports whatever was in the field
-             * before the composition resolved. The shortcut manager in this
-             * package treats composing keystrokes as the IME's for the same
+             * before the composition resolved. Both signals are read because
+             * older engines report the composition only as `keyCode` 229, and
+             * this repository's other IME guards check the pair for that
              * reason.
              */
-            if (event.nativeEvent.isComposing) return;
+            if (event.nativeEvent.isComposing || event.keyCode === 229) return;
             // Kept off the surrounding form, which may have a submit of its own:
             // finishing a colour is not submitting whatever contains it.
             event.preventDefault();

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -563,10 +563,28 @@ export function ColorPicker<TValue = string>({
       | (new () => EyeDropperLike)
       | undefined;
     if (!ctor) return;
+    /*
+     * This press OWNS whatever finish its own blur deferred. Sampling either
+     * replaces the draft or is cancelled, and both answers arrive later than
+     * the click — so leaving the deferral to be settled on that click reports
+     * the typed colour first and the sampled one after it, two edits for the
+     * one the author made.
+     *
+     * Claimed synchronously, before the first await, because the click that
+     * would otherwise settle it is already on its way.
+     */
+    const owed = owedFinish.current;
+    owedFinish.current = false;
     let sampled: string;
     try {
       sampled = (await new ctor().open()).sRGBHex;
     } catch {
+      /*
+       * Dismissed, so nothing replaces the draft and the finish its own blur
+       * deferred is now due: focus has already left the field, and no further
+       * blur is coming to carry it.
+       */
+      if (owed) commitDraft();
       // The user dismissed the picker. Not an error, and nothing to report.
       // Scoped to `open()` alone: with the commit inside this block, a host
       // whose `onColorChange` throws — a failing save, a rejected validation —

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -183,6 +183,7 @@ export function ColorPicker<TValue = string>({
 }: ColorPickerProps<TValue>) {
   const fieldId = React.useId();
   const rootRef = React.useRef<HTMLDivElement>(null);
+  const fieldRef = React.useRef<HTMLInputElement>(null);
   const surfaceRef = React.useRef<HTMLDivElement>(null);
   const [hsva, setHsva] = React.useState<Hsva>(() => toHsva(color));
   // What the hex field shows while it is being typed into. A half-typed value
@@ -214,6 +215,13 @@ export function ColorPicker<TValue = string>({
       // in must not silently move the surface's hue to red. Read from the
       // updater rather than from `hsva`, so the effect does not re-run on a
       // hue change it is not interested in.
+      /*
+       * The DRAFT goes with it. A colour arriving from the host — an undo, an
+       * edit made elsewhere — replaces what is stored, so text typed against
+       * the old value is stale: left in place, the next blur would publish it
+       * back over the value that just arrived.
+       */
+      dropDraft();
       setHsva(prev => hsvaFrom(incoming, incoming.alpha, prev.h));
     }
   }, [color, rendered, showAlpha]);
@@ -240,6 +248,17 @@ export function ColorPicker<TValue = string>({
    * after a host that coalesces a gesture on close has already decided what to
    * write, which is a value published into nothing.
    */
+  /*
+   * Forget the draft without reporting it, for everything that SUPERSEDES one:
+   * a preset, a recent colour, a drag, or the host pushing a new colour in. The
+   * ref and the state move together, and the ref moves synchronously, because a
+   * blur that has already been queued will read it before React renders.
+   */
+  const dropDraft = (): void => {
+    draftRef.current = null;
+    setDraftHex(null);
+  };
+
   const commitDraft = (): void => {
     const text = draftRef.current;
     // Taken BEFORE anything else, so a second caller in this same dispatch
@@ -298,15 +317,40 @@ export function ColorPicker<TValue = string>({
        * itself — and committing there would report a draft the press is about
        * to replace.
        *
-       * Recognised WITHOUT `instanceof`, which is realm-bound: rendered into an
-       * iframe or a pop-out the target belongs to that document's own
-       * JavaScript realm and is not an instance of this one's `Node`, so every
-       * press — the hex field included — would read as outside and commit the
-       * draft the author was still typing. `contains` is a tree operation and
-       * does not care which realm the node came from; the shape test in front
-       * of it is what keeps a non-node target from reaching it.
+       * Recognised through the COMPOSED PATH first, because a composed event
+       * crossing a shadow boundary is retargeted to the host by the time it
+       * reaches this document: `root` does not contain that host, so a press on
+       * the hex field itself would read as outside and publish a half-typed
+       * prefix — clicking to move the caret after `#123` would store `#112233`.
+       *
+       * The containment test behind it covers the ordinary case and is written
+       * WITHOUT `instanceof`, which is realm-bound: in an iframe or a pop-out
+       * the target belongs to that document's own JavaScript realm and is not
+       * an instance of this one's `Node`. `contains` is a tree operation and
+       * does not care which realm a node came from.
        */
-      if (isNode(event.target) && root.contains(event.target)) return;
+      const path =
+        typeof event.composedPath === "function" ? event.composedPath() : [];
+      const inside =
+        path.includes(root) ||
+        (isNode(event.target) && root.contains(event.target));
+      if (inside) {
+        /*
+         * A press inside that is NOT the field replaces the value: a preset, a
+         * recent colour, the surface. The browser blurs the field before that
+         * press becomes a click, so leaving the draft would have the blur
+         * publish the typed literal first and the replacement second — two
+         * edits recorded for one the author made, and for a preset an
+         * `onColorChange` beside the `onSwatchSelect` that was the point.
+         */
+        const field = fieldRef.current;
+        const inField =
+          field !== null &&
+          (path.includes(field) ||
+            (isNode(event.target) && field.contains(event.target)));
+        if (!inField) dropDraft();
+        return;
+      }
       commitDraft();
     };
     /*
@@ -325,8 +369,7 @@ export function ColorPicker<TValue = string>({
 
   const commit = (next: Hsva): void => {
     setHsva(next);
-    draftRef.current = null;
-    setDraftHex(null);
+    dropDraft();
     onColorChange(toHexString(next, showAlpha));
   };
 
@@ -496,6 +539,7 @@ export function ColorPicker<TValue = string>({
         </label>
         <Input
           id={`${fieldId}-hex`}
+          ref={fieldRef}
           className="font-mono"
           value={draftHex ?? rendered}
           /*
@@ -510,6 +554,14 @@ export function ColorPicker<TValue = string>({
           }}
           onKeyDown={event => {
             if (event.key !== "Enter") return;
+            /*
+             * An Enter that ACCEPTS AN IME CANDIDATE is not a finish. Consuming
+             * it blocks the acceptance and reports whatever was in the field
+             * before the composition resolved. The shortcut manager in this
+             * package treats composing keystrokes as the IME's for the same
+             * reason.
+             */
+            if (event.nativeEvent.isComposing) return;
             // Kept off the surrounding form, which may have a submit of its own:
             // finishing a colour is not submitting whatever contains it.
             event.preventDefault();

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -15,6 +15,7 @@ import {
   surfacePointFor,
   toHex,
 } from "../lib/color";
+import { useIsomorphicLayoutEffect } from "../lib/isomorphic-layout-effect";
 import { cn } from "../lib/utils";
 
 import { Button } from "./button";
@@ -184,6 +185,8 @@ export function ColorPicker<TValue = string>({
   const fieldId = React.useId();
   /** The picker's own subtree, for telling a press inside it from a dismissal. */
   const rootRef = React.useRef<HTMLDivElement>(null);
+  /** Undoes a touch press that is waiting to see whether it becomes a tap. */
+  const pendingTap = React.useRef<(() => void) | null>(null);
   /**
    * The saturation area, whose BOX is what turns a pointer position into a
    * saturation and brightness pair — the mapping needs the rectangle, not the
@@ -301,7 +304,11 @@ export function ColorPicker<TValue = string>({
    * and removed — a host that coalesces a picker gesture on close has already
    * decided what to write by then.
    *
-   * RE-REGISTERED every render, with no dependency list, which is deliberate.
+   * RE-REGISTERED every render, with no dependency list, and at LAYOUT timing.
+   * A passive effect leaves the previous listener installed until its cleanup
+   * runs, so a native press arriving after a render that changed `showAlpha` or
+   * `onColorChange` would reach the closure from the render before it — an old
+   * alpha, or a consumer that is no longer the current one.
    * The obvious alternative keeps the handler in a ref refreshed by an effect,
    * and that ref is not guaranteed fresh when a NATIVE listener fires: a
    * passive effect runs after the commit, and this listener is outside React's
@@ -313,7 +320,7 @@ export function ColorPicker<TValue = string>({
    * nothing here runs and the draft dies with the surface, which is what a
    * cancel means.
    */
-  React.useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const root = rootRef.current;
     if (root === null) return;
     const onPointerDown = (event: Event): void => {
@@ -346,6 +353,33 @@ export function ColorPicker<TValue = string>({
       // of doing so, and the blur below declines to report one while focus is
       // moving within this picker.
       if (inside) return;
+      /*
+       * A TOUCH press is not yet a tap. It may become a scroll or a long press,
+       * and a dismissable layer waits for the resulting click before dismissing
+       * for exactly that reason — so finishing here would publish a draft while
+       * the picker stays open and the field is still being edited. The click
+       * that follows a completed tap is what finishes it; a scroll produces
+       * none, and the listener is discarded with the effect.
+       */
+      /*
+       * Read off the event rather than narrowed by `instanceof PointerEvent`,
+       * which is realm-bound for the same reason the node test above avoids it.
+       * A listener registered for `pointerdown` receives a pointer event; the
+       * property is absent only where the environment does not implement them,
+       * and an absent type is not a touch.
+       */
+      const pointerType = (event as Partial<PointerEvent>).pointerType;
+      if (pointerType === "touch") {
+        const onClick = (): void => {
+          owner.removeEventListener("click", onClick, true);
+          commitDraft();
+        };
+        owner.addEventListener("click", onClick, true);
+        pendingTap.current = () => {
+          owner.removeEventListener("click", onClick, true);
+        };
+        return;
+      }
       commitDraft();
     };
     /*
@@ -359,6 +393,8 @@ export function ColorPicker<TValue = string>({
     owner.addEventListener("pointerdown", onPointerDown, true);
     return () => {
       owner.removeEventListener("pointerdown", onPointerDown, true);
+      pendingTap.current?.();
+      pendingTap.current = null;
     };
   });
 
@@ -438,7 +474,30 @@ export function ColorPicker<TValue = string>({
   };
 
   return (
-    <div ref={rootRef} className={cn("w-64 space-y-3", className)}>
+    <div
+      ref={rootRef}
+      className={cn("w-64 space-y-3", className)}
+      /*
+       * The finish that focus can express, watched at the PICKER rather than at
+       * the field. `onBlur` is delivered from the bubbling `focusout`, so this
+       * sees focus leaving any descendant.
+       *
+       * At the field alone it missed the keyboard route entirely: tab from the
+       * field to a preset and then out without activating it, and the field's
+       * own blur was declined — focus had moved to something inside — while
+       * nothing watched the boundary the focus actually crossed. The pointer
+       * listener cannot cover it either, since no pointer was involved.
+       *
+       * `relatedTarget` names where focus is going, and is null when it leaves
+       * the document entirely, which is also a finish.
+       */
+      onBlur={event => {
+        const next = event.relatedTarget;
+        const root = rootRef.current;
+        if (root !== null && isNode(next) && root.contains(next)) return;
+        commitDraft();
+      }}
+    >
       <div
         ref={surfaceRef}
         role="application"
@@ -559,22 +618,6 @@ export function ColorPicker<TValue = string>({
             // Kept off the surrounding form, which may have a submit of its own:
             // finishing a colour is not submitting whatever contains it.
             event.preventDefault();
-            commitDraft();
-          }}
-          onBlur={event => {
-            /*
-             * Focus moving WITHIN the picker is not a finish. Pressing a
-             * preset, a recent colour or the eyedropper blurs this field before
-             * that press becomes a click, so reporting here would publish the
-             * typed literal first and the replacement second — two edits for
-             * the one the author made.
-             *
-             * `relatedTarget` is what the focus is moving TO, and it is null
-             * when focus leaves the document entirely, which IS a finish.
-             */
-            const next = event.relatedTarget;
-            const root = rootRef.current;
-            if (root !== null && isNode(next) && root.contains(next)) return;
             commitDraft();
           }}
         />

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -325,6 +325,15 @@ export function ColorPicker<TValue = string>({
     if (root === null) return;
     const onPointerDown = (event: Event): void => {
       /*
+       * Any new press ENDS whatever the last one was waiting for. A touch that
+       * became a scroll produces no click, so its pending completion would
+       * otherwise sit installed and be finished by the next unrelated click
+       * anywhere — including a press on the hex field to move the caret, which
+       * would publish text still being edited.
+       */
+      pendingTap.current?.();
+      pendingTap.current = null;
+      /*
        * A press INSIDE is not a dismissal — a swatch, a slider, the field
        * itself — and committing there would report a draft the press is about
        * to replace.
@@ -390,9 +399,19 @@ export function ColorPicker<TValue = string>({
      * goes with it.
      */
     const owner = root.ownerDocument;
+    /*
+     * A cancelled gesture ends the wait too, and is the signal the platform
+     * gives when a press becomes a scroll rather than a tap.
+     */
+    const onPointerCancel = (): void => {
+      pendingTap.current?.();
+      pendingTap.current = null;
+    };
     owner.addEventListener("pointerdown", onPointerDown, true);
+    owner.addEventListener("pointercancel", onPointerCancel, true);
     return () => {
       owner.removeEventListener("pointerdown", onPointerDown, true);
+      owner.removeEventListener("pointercancel", onPointerCancel, true);
       pendingTap.current?.();
       pendingTap.current = null;
     };
@@ -647,12 +666,20 @@ export function ColorPicker<TValue = string>({
                 className="size-6 rounded border shadow-sm"
                 style={{ backgroundColor: swatch.color }}
                 onClick={() => {
-                  // The swatch REPLACES what was being typed, so the draft goes
-                  // with it. The other replacement paths drop it inside
-                  // `commit`; this one reports through the host instead and has
-                  // to say so itself.
+                  /*
+                   * The swatch REPLACES what was being typed, so the draft goes
+                   * with it — but only where the host can actually perform the
+                   * replacement. `onSwatchSelect` is optional and the type
+                   * permits swatches without it, and dropping a draft for a
+                   * callback that does nothing loses the typed colour and puts
+                   * nothing in its place.
+                   *
+                   * The other replacement paths drop it inside `commit`; this
+                   * one reports through the host and has to say so itself.
+                   */
+                  if (onSwatchSelect === undefined) return;
                   dropDraft();
-                  onSwatchSelect?.(swatch);
+                  onSwatchSelect(swatch);
                 }}
               />
             ))}

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -192,6 +192,41 @@ export function ColorPicker<TValue = string>({
     }
   }, [color, rendered, showAlpha]);
 
+  /*
+   * A typed colour is reported when the author FINISHES it, never per
+   * keystroke.
+   *
+   * `parseHex` accepts 3, 4, 6 and 8 digits, so a PREFIX of a valid colour is
+   * itself a valid colour: typing `#123456` passes through `#123` and `#1234`
+   * on the way. Reporting each of those made the last one stick whenever the
+   * author paused or the surface went away — `#12345` left the host holding
+   * `#11223344`, a colour nobody typed, silently replacing the stored one.
+   *
+   * So the field holds a draft and this is the only thing that publishes it:
+   * Enter, and leaving the field. Dragging is untouched and still reports
+   * continuously, which is what its coalescing exists for — a drag has no
+   * finish to wait for, and typing does.
+   *
+   * DISMISSAL IS NOT A FINISH, deliberately. Escape means cancel, so a draft
+   * dying with the surface is the conventional answer rather than a loss; and
+   * clicking away moves focus out of the field first, so that path commits
+   * through the blur below. Reporting from an unmount instead would arrive
+   * after a host that coalesces a gesture on close has already decided what to
+   * write, which is a value published into nothing.
+   */
+  const commitDraft = (text: string | null): void => {
+    setDraftHex(null);
+    if (text === null) return;
+    const parsed = parseHex(text);
+    // An unfinishable draft is DISCARDED rather than reported. The field
+    // returns to the colour that is actually stored, so what is shown and what
+    // is saved agree — which they did not when a stale intermediate stood in
+    // for the text on screen.
+    if (!parsed) return;
+    setHsva(prev => hsvaFrom(parsed, parsed.alpha, prev.h));
+    onColorChange(toHex(parsed, showAlpha ? parsed.alpha : 1));
+  };
+
   const commit = (next: Hsva): void => {
     setHsva(next);
     setDraftHex(null);
@@ -366,19 +401,21 @@ export function ColorPicker<TValue = string>({
           id={`${fieldId}-hex`}
           className="font-mono"
           value={draftHex ?? rendered}
-          onChange={event => {
-            const text = event.target.value;
-            setDraftHex(text);
-            const parsed = parseHex(text);
-            // Only a value that IS a colour is published. A field mid-typing is
-            // the ordinary state of one, and reporting `#ab` as a colour would
-            // repaint the surface black under the person typing it.
-            if (parsed) {
-              setHsva(hsvaFrom(parsed, parsed.alpha, hsva.h));
-              onColorChange(toHex(parsed, showAlpha ? parsed.alpha : 1));
-            }
+          /*
+           * A keystroke moves the DRAFT and nothing else — not the surface, not
+           * the host. Moving the surface here would also fight the re-seeding
+           * effect above, which compares the rendered hex against the host's
+           * prop and would pull a half-typed value straight back.
+           */
+          onChange={event => setDraftHex(event.target.value)}
+          onKeyDown={event => {
+            if (event.key !== "Enter") return;
+            // Kept off the surrounding form, which may have a submit of its own:
+            // finishing a colour is not submitting whatever contains it.
+            event.preventDefault();
+            commitDraft(event.currentTarget.value);
           }}
-          onBlur={() => setDraftHex(null)}
+          onBlur={event => commitDraft(event.target.value)}
         />
         {canPickFromScreen && (
           <Button

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -190,6 +190,12 @@ export function ColorPicker<TValue = string>({
    * blur carrying no destination can be told from focus genuinely leaving.
    */
   const insidePress = React.useRef(false);
+  /**
+   * Whether a finish was DEFERRED rather than declined: a blur carrying no
+   * destination arrived during an inside press, so the press's own action was
+   * given the chance to supersede the draft instead.
+   */
+  const owedFinish = React.useRef(false);
   /** Undoes a touch press that is waiting to see whether it becomes a tap. */
   const pendingTap = React.useRef<(() => void) | null>(null);
   /**
@@ -224,7 +230,13 @@ export function ColorPicker<TValue = string>({
   // colour has several spellings, and `#FFF` arriving back as `#ffffff` would
   // otherwise reset the surface on every change.
   const rendered = toHexString(hsva, showAlpha);
-  React.useEffect(() => {
+  /*
+   * At LAYOUT timing, matching the listener below. A passive effect leaves the
+   * stale draft readable for a moment the native capture listener is already
+   * refreshed for, so an outside press arriving in between publishes the old
+   * text over the colour the host has just supplied.
+   */
+  useIsomorphicLayoutEffect(() => {
     const incoming = parseHex(color);
     if (
       incoming &&
@@ -274,11 +286,13 @@ export function ColorPicker<TValue = string>({
    * blur that has already been queued will read it before React renders.
    */
   const dropDraft = (): void => {
+    owedFinish.current = false;
     draftRef.current = null;
     setDraftHex(null);
   };
 
   const commitDraft = (): void => {
+    owedFinish.current = false;
     const text = draftRef.current;
     // Taken BEFORE anything else, so a second caller in this same dispatch
     // finds nothing to report rather than the value this one is publishing.
@@ -440,13 +454,36 @@ export function ColorPicker<TValue = string>({
     const onPointerUp = (): void => {
       insidePress.current = false;
     };
+    /*
+     * The finish a null-destination blur DEFERRED rather than cancelled.
+     *
+     * On engines that do not focus a button when it is pressed, the field's
+     * blur is skipped so the press's own action can supersede the draft. Where
+     * that action replaces nothing — a swatch with no handler, a cancelled
+     * sample — the draft would otherwise sit pending with focus already outside
+     * the picker, and no further blur is coming to finish it.
+     *
+     * BUBBLE phase, so the action has already run: a swatch that did replace
+     * the value has dropped the draft by now and there is nothing left to
+     * report. Only a draft that survived its own press, with focus outside,
+     * finishes here.
+     */
+    const onClickResolve = (): void => {
+      // Only a finish that was actually deferred. Reading focus alone would
+      // finish on any click that happens to land while focus is elsewhere,
+      // including one this picker had no part in.
+      if (!owedFinish.current) return;
+      latestCommit.current();
+    };
     owner.addEventListener("pointerdown", onPointerDown, true);
     owner.addEventListener("pointercancel", onPointerCancel, true);
     owner.addEventListener("pointerup", onPointerUp, true);
+    owner.addEventListener("click", onClickResolve, false);
     return () => {
       owner.removeEventListener("pointerdown", onPointerDown, true);
       owner.removeEventListener("pointercancel", onPointerCancel, true);
       owner.removeEventListener("pointerup", onPointerUp, true);
+      owner.removeEventListener("click", onClickResolve, false);
     };
   });
 
@@ -568,7 +605,10 @@ export function ColorPicker<TValue = string>({
         // A blur with NO destination during a press that began inside is that
         // press, not a departure: some engines do not focus a button when it is
         // pressed, and finishing here would beat the click that supersedes it.
-        if (next === null && insidePress.current) return;
+        if (next === null && insidePress.current) {
+          owedFinish.current = true;
+          return;
+        }
         commitDraft();
       }}
     >

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -182,8 +182,13 @@ export function ColorPicker<TValue = string>({
   className,
 }: ColorPickerProps<TValue>) {
   const fieldId = React.useId();
+  /** The picker's own subtree, for telling a press inside it from a dismissal. */
   const rootRef = React.useRef<HTMLDivElement>(null);
-  const fieldRef = React.useRef<HTMLInputElement>(null);
+  /**
+   * The saturation area, whose BOX is what turns a pointer position into a
+   * saturation and brightness pair — the mapping needs the rectangle, not the
+   * element.
+   */
   const surfaceRef = React.useRef<HTMLDivElement>(null);
   const [hsva, setHsva] = React.useState<Hsva>(() => toHsva(color));
   // What the hex field shows while it is being typed into. A half-typed value
@@ -334,23 +339,13 @@ export function ColorPicker<TValue = string>({
       const inside =
         path.includes(root) ||
         (isNode(event.target) && root.contains(event.target));
-      if (inside) {
-        /*
-         * A press inside that is NOT the field replaces the value: a preset, a
-         * recent colour, the surface. The browser blurs the field before that
-         * press becomes a click, so leaving the draft would have the blur
-         * publish the typed literal first and the replacement second — two
-         * edits recorded for one the author made, and for a preset an
-         * `onColorChange` beside the `onSwatchSelect` that was the point.
-         */
-        const field = fieldRef.current;
-        const inField =
-          field !== null &&
-          (path.includes(field) ||
-            (isNode(event.target) && field.contains(event.target)));
-        if (!inField) dropDraft();
-        return;
-      }
+      // A press inside decides NOTHING about the draft. Whether it becomes a
+      // replacement is not knowable here — the eyedropper's button is inside
+      // and its sampling can be cancelled, leaving nothing to replace with —
+      // so each path that actually replaces the value drops the draft as part
+      // of doing so, and the blur below declines to report one while focus is
+      // moving within this picker.
+      if (inside) return;
       commitDraft();
     };
     /*
@@ -539,7 +534,6 @@ export function ColorPicker<TValue = string>({
         </label>
         <Input
           id={`${fieldId}-hex`}
-          ref={fieldRef}
           className="font-mono"
           value={draftHex ?? rendered}
           /*
@@ -567,7 +561,22 @@ export function ColorPicker<TValue = string>({
             event.preventDefault();
             commitDraft();
           }}
-          onBlur={() => commitDraft()}
+          onBlur={event => {
+            /*
+             * Focus moving WITHIN the picker is not a finish. Pressing a
+             * preset, a recent colour or the eyedropper blurs this field before
+             * that press becomes a click, so reporting here would publish the
+             * typed literal first and the replacement second — two edits for
+             * the one the author made.
+             *
+             * `relatedTarget` is what the focus is moving TO, and it is null
+             * when focus leaves the document entirely, which IS a finish.
+             */
+            const next = event.relatedTarget;
+            const root = rootRef.current;
+            if (root !== null && isNode(next) && root.contains(next)) return;
+            commitDraft();
+          }}
         />
         {canPickFromScreen && (
           <Button
@@ -594,7 +603,14 @@ export function ColorPicker<TValue = string>({
                 aria-label={swatch.label}
                 className="size-6 rounded border shadow-sm"
                 style={{ backgroundColor: swatch.color }}
-                onClick={() => onSwatchSelect?.(swatch)}
+                onClick={() => {
+                  // The swatch REPLACES what was being typed, so the draft goes
+                  // with it. The other replacement paths drop it inside
+                  // `commit`; this one reports through the host instead and has
+                  // to say so itself.
+                  dropDraft();
+                  onSwatchSelect?.(swatch);
+                }}
               />
             ))}
           </div>

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -188,6 +188,12 @@ export function ColorPicker<TValue = string>({
   /** Undoes a touch press that is waiting to see whether it becomes a tap. */
   const pendingTap = React.useRef<(() => void) | null>(null);
   /**
+   * The current way to finish a draft, for a deferred tap whose wait may span a
+   * render. Refreshed where the listeners are registered, at layout timing, so
+   * it is settled before any later native event can read it.
+   */
+  const latestCommit = React.useRef<() => void>(() => undefined);
+  /**
    * The saturation area, whose BOX is what turns a pointer position into a
    * saturation and brightness pair — the mapping needs the rectangle, not the
    * element.
@@ -323,6 +329,7 @@ export function ColorPicker<TValue = string>({
   useIsomorphicLayoutEffect(() => {
     const root = rootRef.current;
     if (root === null) return;
+    latestCommit.current = commitDraft;
     const onPointerDown = (event: Event): void => {
       /*
        * Any new press ENDS whatever the last one was waiting for. A touch that
@@ -381,7 +388,13 @@ export function ColorPicker<TValue = string>({
       if (pointerType === "touch") {
         const onClick = (): void => {
           owner.removeEventListener("click", onClick, true);
-          commitDraft();
+          pendingTap.current = null;
+          // The CURRENT commit, not this render's: a wait that spans a rerender
+          // would otherwise report through the closure it was created in — an
+          // old alpha, or a consumer no longer current. The ref is refreshed in
+          // the same layout effect that registers these listeners, so it is
+          // settled before any later native event.
+          latestCommit.current();
         };
         owner.addEventListener("click", onClick, true);
         pendingTap.current = () => {
@@ -412,10 +425,26 @@ export function ColorPicker<TValue = string>({
     return () => {
       owner.removeEventListener("pointerdown", onPointerDown, true);
       owner.removeEventListener("pointercancel", onPointerCancel, true);
-      pendingTap.current?.();
-      pendingTap.current = null;
     };
   });
+
+  /*
+   * A pending tap outlives an ordinary RERENDER and dies with the component.
+   *
+   * The effect above re-runs on every render so its closures stay current, and
+   * ending the wait in its cleanup killed a legitimate one: an outside target
+   * that sets state from its own `pointerdown` rerenders this picker before the
+   * click arrives, so the completion was removed and a finished colour never
+   * reached the host. What ends a wait is a new press, a cancelled gesture, or
+   * this component going away — never a render.
+   */
+  useIsomorphicLayoutEffect(
+    () => () => {
+      pendingTap.current?.();
+      pendingTap.current = null;
+    },
+    []
+  );
 
   const commit = (next: Hsva): void => {
     setHsva(next);

--- a/packages/ui/src/components/color-picker.tsx
+++ b/packages/ui/src/components/color-picker.tsx
@@ -249,30 +249,42 @@ export function ColorPicker<TValue = string>({
    * and removed — a host that coalesces a picker gesture on close has already
    * decided what to write by then.
    *
+   * RE-REGISTERED every render, with no dependency list, which is deliberate.
+   * The obvious alternative keeps the handler in a ref refreshed by an effect,
+   * and that ref is not guaranteed fresh when a NATIVE listener fires: a
+   * passive effect runs after the commit, and this listener is outside React's
+   * event system, so an outside press arriving in between would call the
+   * previous closure and discard the draft it was holding. Swapping one
+   * listener per render costs nothing measurable and has no such window.
+   *
    * Escape is untouched and still cancels: it dismisses without a pointer, so
    * nothing here runs and the draft dies with the surface, which is what a
    * cancel means.
    */
-  const latestCommit = React.useRef(commitDraft);
   React.useEffect(() => {
-    latestCommit.current = commitDraft;
-  });
-  React.useEffect(() => {
-    const onPointerDown = (event: PointerEvent): void => {
-      const root = rootRef.current;
-      if (root === null) return;
+    const root = rootRef.current;
+    if (root === null) return;
+    const onPointerDown = (event: Event): void => {
       const target = event.target;
       // A press INSIDE is not a dismissal — a swatch, a slider, the field
       // itself — and committing there would report a draft the press is about
       // to replace.
       if (target instanceof Node && root.contains(target)) return;
-      latestCommit.current();
+      commitDraft();
     };
-    document.addEventListener("pointerdown", onPointerDown, true);
+    /*
+     * The picker's OWN document, not the global one. Rendered into an iframe or
+     * a pop-out window this component's presses happen in a different document
+     * entirely, and a listener on the parent global would never see them —
+     * which is the case where a dismiss layer unmounts the picker and the draft
+     * goes with it.
+     */
+    const owner = root.ownerDocument;
+    owner.addEventListener("pointerdown", onPointerDown, true);
     return () => {
-      document.removeEventListener("pointerdown", onPointerDown, true);
+      owner.removeEventListener("pointerdown", onPointerDown, true);
     };
-  }, []);
+  });
 
   const commit = (next: Hsva): void => {
     setHsva(next);

--- a/packages/ui/src/lib/isomorphic-layout-effect.ts
+++ b/packages/ui/src/lib/isomorphic-layout-effect.ts
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+/**
+ * A layout effect in the browser, a plain effect where there is no DOM.
+ *
+ * These components are client code, but a consumer may still PRERENDER them,
+ * and React warns that `useLayoutEffect` does nothing on the server. Layout
+ * timing is what the browser needs wherever an effect has to be settled before
+ * anything else can observe it — a registration that must exist before the
+ * first frame, or a native listener that must be the current one before the
+ * next event reaches it. Neither effect runs during a server render, so
+ * choosing between them by environment loses nothing and silences a warning
+ * that reports no real problem.
+ *
+ * Published rather than kept beside its first caller, because a second one
+ * arrived: two spellings of this choice would drift the first time either
+ * learned something about a new environment.
+ */
+export const useIsomorphicLayoutEffect =
+  typeof document === "undefined" ? React.useEffect : React.useLayoutEffect;

--- a/packages/ui/src/lib/shortcuts/react.tsx
+++ b/packages/ui/src/lib/shortcuts/react.tsx
@@ -49,6 +49,7 @@
 import * as React from "react";
 
 import { devWarnOnce } from "../dev-warn";
+import { useIsomorphicLayoutEffect } from "../isomorphic-layout-effect";
 
 import {
   createShortcutManager,
@@ -111,18 +112,6 @@ interface TargetOwner {
  * hold across them.
  */
 const ownersByTarget = new WeakMap<object, TargetOwner>();
-
-/**
- * A layout effect in the browser, a plain effect where there is no DOM.
- *
- * These components are client code, but a consumer may still PRERENDER them, and React warns that
- * `useLayoutEffect` does nothing on the server. Layout timing is what the browser needs:
- * registration has to be settled before paint, or a keystroke arriving in the first frame after
- * mount meets an empty stack. Neither effect runs during a server render, so choosing between
- * them by environment loses nothing and silences a warning that reports no real problem.
- */
-const useIsomorphicLayoutEffect =
-  typeof document === "undefined" ? React.useEffect : React.useLayoutEffect;
 
 /**
  * The options that change how a manager behaves, as a comparable string.


### PR DESCRIPTION
Closes `task:ui-picker-draft-contract`. The founder chose this contract over
the two the task proposed; the reasoning is below because it changes what the
component promises.

## The defect

`parseHex` accepts 3, 4, 6 and 8 digits, so a PREFIX of a valid colour is
itself a valid colour. Typing `#123456` passes through `#123` and `#1234` on
the way, and the picker published each one. Stop at `#12345` and the last valid
intermediate is what the host keeps: `#11223344`, a 20%-alpha colour nobody
typed, silently replacing the stored value.

Every hand-typed six-digit colour crosses two such intermediates, so this is
the ordinary path rather than an edge case. No host could defend against it —
`ColorPickerProps` publishes seven fields, none carrying a draft, a validity
signal or an open state, verified by grep (`onOpenChange`: 0 occurrences).

## The contract

A keystroke moves the draft and nothing else. Enter and blur publish it; an
unfinished draft is discarded, so what the field shows and what is stored agree
again.

**Dragging is untouched** and still reports continuously — that is what its
coalescing exists for. A drag has no finish to wait for; typing does.

**Dismissal is deliberately not a finish.** Escape means cancel, and clicking
away moves focus out of the field first, so that path commits through the blur.

## Two candidates the task named, and why neither was taken

*Discard the draft when the surface goes away* repeats a mistake this
repository already fixed. `advanced-panel.tsx` records it: unmounting "took the
draft with it, and took the explanation beside a refused row with it too… the
author never learned why." It also leaves the wrong value already committed and
merely hides the evidence.

*Report an invalid draft so the host can decline* is what the codebase does
elsewhere and is opt-in — every existing caller must be updated, and one that
ignores the signal keeps today's bug.

Not publishing an unfinished value removes the defect instead of reporting it,
and no caller has to do anything.

## An unmount commit was tried and removed

It looked strictly better — it would save a complete colour typed and then
dismissed. It is wrong: a host that coalesces a picker gesture on close has
already decided what to write by then, so the value is published into nothing.
`style-colour-panel` writes once on close and saw **zero**. Escape-as-cancel is
both conventional and the only version that does not fight that host.

## A stand-in that stopped standing in

`style-colour-panel.test.tsx` drove the picker through its hex field,
documented as standing in for a drag "because it reaches the same
`onColorChange` the surface and sliders do". That is no longer true, so those
assertions would have gone on passing while saying nothing about a drag. The
gesture case now drives the saturation surface, which is the path it names.

## Evidence

Break-verified: restoring per-keystroke publishing fails four cases including
the measured sequence; removing the finish fails the Enter and blur cases.

The defect case asserts the CALL COUNT, not just the value — a version that
published the right final colour after two wrong ones would satisfy a
value-only assertion while the harm (what a host commits when the author stops
early) was still live.

Local gates: ui 1145/1145, builder 2595/2595, lint, check-types, design lint,
comment convention, `fallow audit` and `changeset status` all clean.

## Unrelated red you may see

`main` is currently red on `class-manager-panel.test.tsx` timing out, and
`Lint / Typecheck / Test / Build` will fail here for that inherited reason
until #1372 merges. Separately, `packages/admin`'s `system-resources-parity`
suite fails on main with four cases — core declares a `background-jobs` system
resource that four admin lists do not carry. Both measured as pre-existing with
this branch's files stashed, and both recorded as findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Hex colour values are applied when finished with Enter, leaving the field, or clicking outside the picker.
  * Incomplete colour entries no longer trigger updates and are safely discarded when cancelled or the picker closes.
  * Escape cancels an in-progress edit without changing the selected colour.
  * Clicking away preserves completed colour entries without duplicate updates.
  * Colour editing behaves consistently across embedded picker contexts, keyboard interactions, touch dismissal, and shadow-root environments.
  * Picker interactions now remain reliable during rerenders and cancelled eyedropper actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->