### PR TITLE
fix(admin): list background jobs among the system resources

### DIFF
--- a/.changeset/grant-permission-over-background-jobs.md
+++ b/.changeset/grant-permission-over-background-jobs.md
@@ -1,0 +1,35 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Background jobs can be granted in the admin again.
+
+`manage-background-jobs` is seeded and enforced, but the admin's permission
+screens did not list the resource — so the row never appeared, and there was no
+way to give anyone that permission without editing the database. It now appears
+in the permissions page, the role matrix and the capability builder, alongside
+webhooks and API keys.

--- a/packages/admin/src/constants/permissions.ts
+++ b/packages/admin/src/constants/permissions.ts
@@ -49,6 +49,10 @@ export const SYSTEM_RESOURCES_IN_DISPLAY_ORDER = [
   "email-templates",
   "api-keys",
   "webhooks",
+  // Operational rather than content: running the background job queue by hand.
+  // Placed after webhooks so the tail of the list stays the machinery an
+  // operator manages rather than the content an editor does.
+  "background-jobs",
 ] as const;
 
 /**


### PR DESCRIPTION
**`main` is red on `packages/admin` and this is my regression.** Small and standalone so it can merge without waiting on my two open feature PRs.

## The red

```
FAIL admin/src/hooks/__tests__/system-resources-parity.test.ts
  × the capability builder covers every system resource
  × the permissions page covers every system resource
  × the permissions page display order covers every system resource
  × the role matrix covers every system resource

expected [ …(10) ] to deeply equal [ 'api-keys', 'background-jobs', …(9) ]
```

#1355 added `background-jobs` to core's `SYSTEM_RESOURCES`. The admin holds its own ordered list and derives the set, the display order and the role matrix from it — so one entry was missing and the guard caught it, exactly as designed.

## The red is the smaller half

`manage-background-jobs` is seeded at boot and the `/api/jobs/run` route enforces it. But the resource never appeared on any permission screen, so **the permission could be held only by super_admin and given to nobody else without writing to the database.**

That is the inverse of the failure the seed file warns about. Its rule is *"a permission nothing enforces teaches the admin a vocabulary the server ignores"* — this was the mirror image: a permission the server **does** enforce and the interface never offers. Both ends of that contract have to be present for the permission to mean anything, and I shipped one of them.

## The fix

One entry, in the one place the admin keeps the list — the set, the display order and the role matrix all derive from it, which is why a single line repairs four cases.

Placed after `webhooks` so the tail of the list stays the machinery an operator manages rather than the content an editor does. No label map was needed: the permissions page derives **Background Jobs** from the slug by title-casing it, the same path `email-providers` takes.

## Verification

| gate | result |
| --- | --- |
| admin suite | **328 files / 3136 tests passed** (was 4 failing) |
| `check-types` | pass |
| `lint` | pass, 0 warnings |
| `fallow --base origin/main` | `verdict: pass`, `changed_files_count: 1`, every `*_introduced` **0** |

## Note on the other red

`packages/builder`'s `class-manager-panel` timeout is unrelated and belongs to another lane — tracked in #1372. Its bisect boundary is `15e531507` (green, and the direct parent) → `b93f9138e` (first red). Peers have since measured that the test does not hang but sits at ~24.5s against a 30s default on an idle machine — three independent readings, 16276ms / 24540ms / 45583ms, against a 30000ms budget.

**Correction to an earlier version of this note:** it said `main` was green at `b1f2b7bce` by luck. That was wrong, and I had relayed it without measuring. `main` has been red on this check on **every commit since `15e531507`**, verified per-sha by taking the latest row for that check name:

```
15e531507  success     <- last green
b93f9138e  failure     <- #1367, first red
db55e6f2c  failure
d283f5311  failure
b1f2b7bce  failure
```

The corrected fact is the stronger one: this check has failed every time it has been asked since #1367, and #1372 — the fix — is still open. Mentioned only so this PR's checks are read against the right cause.

