### PR TITLE
fix(nextly): bound the releases drain by the pass it runs in

### DIFF
--- a/.changeset/a-drain-fits-the-pass-it-runs-in.md
+++ b/.changeset/a-drain-fits-the-pass-it-runs-in.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Bound the content-releases drain by the deadline its runner supplies rather than a budget of its own, so a pass that starts late fits inside what is left of the tick instead of overrunning it.

--- a/.changeset/a-drain-fits-the-pass-it-runs-in.md
+++ b/.changeset/a-drain-fits-the-pass-it-runs-in.md
@@ -26,4 +26,4 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-Bound the content-releases drain by the deadline its runner supplies rather than a budget of its own, so a pass that starts late fits inside what is left of the tick instead of overrunning it.
+Bound the content-releases drain by the deadline its runner supplies rather than a budget of its own, so a pass that starts late fits inside what is left of the tick instead of overrunning it, and measure the remaining pass from the runner's own clock in both built-in drains so an injected clock no longer starves one or overruns the other.

--- a/packages/nextly/src/di/registrations/register-jobs.ts
+++ b/packages/nextly/src/di/registrations/register-jobs.ts
@@ -58,14 +58,6 @@ import type { RegistrationContext } from "./types";
  * required parameter rather than an optional one, and a reporter whose only
  * guard is a comment is a guarantee nobody can prove still holds.
  */
-/**
- * How long a `releases:drain` pass may spend starting releases.
- *
- * Under the shortest serverless limit this trigger runs behind, with room left
- * for the pass to discharge the releases it did finish. A pass that runs out
- * defers the rest to the next tick rather than being killed part-way.
- */
-const RELEASES_DRAIN_BUDGET_MS = 10_000;
 
 export function reportReleasesOutcome(
   logger: Logger,
@@ -181,13 +173,6 @@ export function registerJobServices(ctx: RegistrationContext): void {
         // handler binds each call to the member's own resolved identity.
         contentApi: nextly,
         runAs: databaseRunAs(adapter),
-        // How long one pass may spend starting releases. Chosen here because
-        // this is the only place that knows what runs the tick: the domain
-        // cannot invent a tick length, and leaving it optional would have kept
-        // the unbounded behaviour for exactly the callers who do not know they
-        // need it. Ten seconds sits under the shortest serverless limit this
-        // runs behind while leaving room for the pass to discharge what it did.
-        budgetMs: RELEASES_DRAIN_BUDGET_MS,
         onOutcome: result => reportReleasesOutcome(logger, result),
       })
     );

--- a/packages/nextly/src/domains/jobs/__tests__/remaining-pass.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/remaining-pass.test.ts
@@ -1,0 +1,71 @@
+/**
+ * The one answer to "how long has this handler got".
+ *
+ * The cases worth stating are the ones where an injected runner clock and wall
+ * time disagree, because that is the only condition under which a wrong
+ * implementation is observably wrong — and it is reachable through the
+ * documented `now` option on `runJobsPass`/`runJobs`.
+ *
+ * @module domains/jobs/__tests__/remaining-pass.test
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { remainingPassMs } from "../remaining-pass";
+
+/** A context shaped the way `runJobs` builds one: both fields, one clock. */
+function context(runnerNow: Date, msLeft: number) {
+  return { now: runnerNow, deadline: new Date(runnerNow.getTime() + msLeft) };
+}
+
+describe("remainingPassMs", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("measures between the runner's own two fields, not against wall time", () => {
+    vi.useFakeTimers();
+    // Wall time years AHEAD of the runner's clock. Anchoring to `Date.now()`
+    // makes the span negative here, clamps it to zero, and the handler starts
+    // nothing on every pass while reporting a clean empty run.
+    vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z"));
+
+    expect(
+      remainingPassMs(context(new Date("2020-01-01T00:00:00.000Z"), 9_000))
+    ).toBe(9_000);
+  });
+
+  it("does not inflate the span when wall time runs behind the runner's clock", () => {
+    vi.useFakeTimers();
+    // The opposite skew, and the dangerous one: a `Date.now()` anchor returns
+    // far MORE than the pass has, so the handler keeps starting work after the
+    // invocation should have ended and is killed part-way.
+    vi.setSystemTime(new Date("2020-01-01T00:00:00.000Z"));
+
+    expect(
+      remainingPassMs(context(new Date("2026-06-01T12:00:00.000Z"), 9_000))
+    ).toBe(9_000);
+  });
+
+  it("yields zero rather than a negative span for a pass already past its deadline", () => {
+    // Zero reads as "start nothing more". A negative value would be read as a
+    // deadline in the past by some callers and as no limit at all by others.
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    expect(
+      remainingPassMs({ now, deadline: new Date(now.getTime() - 5_000) })
+    ).toBe(0);
+  });
+
+  it("is unaffected by real time passing, because it reads two fixed instants", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-01T12:00:00.000Z"));
+    const ctx = context(new Date("2026-06-01T12:00:00.000Z"), 9_000);
+
+    const before = remainingPassMs(ctx);
+    vi.setSystemTime(new Date("2026-06-01T12:00:07.000Z"));
+
+    // The span is a property of the context, not of when it is asked. Callers
+    // measure their own elapsed time; conflating the two is what the wall-clock
+    // anchor did.
+    expect(remainingPassMs(ctx)).toBe(before);
+  });
+});

--- a/packages/nextly/src/domains/jobs/index.ts
+++ b/packages/nextly/src/domains/jobs/index.ts
@@ -35,7 +35,6 @@ export {
   type RunAsResult,
   type RunAsUser,
 } from "../../shared/lib/resolve-run-as";
-export { remainingPassMs } from "./remaining-pass";
 export {
   DEFAULT_BATCH_SIZE,
   DEFAULT_MAX_DURATION_MS,

--- a/packages/nextly/src/domains/jobs/index.ts
+++ b/packages/nextly/src/domains/jobs/index.ts
@@ -35,6 +35,7 @@ export {
   type RunAsResult,
   type RunAsUser,
 } from "../../shared/lib/resolve-run-as";
+export { remainingPassMs } from "./remaining-pass";
 export {
   DEFAULT_BATCH_SIZE,
   DEFAULT_MAX_DURATION_MS,

--- a/packages/nextly/src/domains/jobs/remaining-pass.ts
+++ b/packages/nextly/src/domains/jobs/remaining-pass.ts
@@ -1,0 +1,44 @@
+/**
+ * How much of the current pass a handler has left.
+ *
+ * Asked by every handler that walks an unbounded set — every due release, every
+ * undelivered webhook — because `JobContext.deadline` states when the pass
+ * intends to stop but not how far away that is. Stated once here rather than in
+ * each drain: the two built-in drains previously computed it separately, and a
+ * change to runner deadline semantics would have silently made them enforce
+ * different pass boundaries.
+ *
+ * ## Both fields, never the wall clock
+ *
+ * `runJobs` resolves ONE clock — `deps.now ?? (() => new Date())` — and derives
+ * both values from it: `deadline` from the pass's start instant, and each
+ * handler's `context.now` from a fresh call as its job begins. The two are
+ * therefore always on the same timebase, whatever clock the runner was handed.
+ *
+ * Anchoring to `Date.now()` instead subtracts two different ORIGINS whenever a
+ * caller supplies the documented `now` option. A clock behind wall time collapses
+ * the result to zero and the handler starts nothing on every pass; one ahead
+ * grants a budget wider than the pass and the handler overruns the invocation it
+ * was bounded to fit. Both fields come from the runner, so both are used.
+ *
+ * The result is a DURATION, which is why it survives being applied to a handler's
+ * own clock: only the origins differ between the runner's timebase and wall time,
+ * and a span is the same length in both.
+ *
+ * @module domains/jobs/remaining-pass
+ */
+
+import type { JobContext } from "./job-registry";
+
+/**
+ * Milliseconds left in the pass running this handler.
+ *
+ * Never negative. A pass at or past its deadline yields zero, which a bounded
+ * handler reads as "start nothing more" — and which is different from not
+ * knowing, so callers do not have to treat an exhausted budget as unbounded.
+ */
+export function remainingPassMs(
+  context: Pick<JobContext, "now" | "deadline">
+): number {
+  return Math.max(0, context.deadline.getTime() - context.now.getTime());
+}

--- a/packages/nextly/src/domains/releases/__tests__/releases-drain-job.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-drain-job.test.ts
@@ -39,10 +39,11 @@ const REAL_START = new Date("2026-06-01T12:00:00.000Z");
 /**
  * The instant the RUNNER is treating as now, deliberately years from wall time.
  *
- * `JobContext.now` is injected so a job is testable, so the two clocks are not
- * required to agree — and an implementation that mixes them is only wrong when
- * they differ. Pinning them together would make both cases below pass against
- * the defect they exist to catch.
+ * `runJobs` resolves ONE clock (`deps.now ?? (() => new Date())`) and derives
+ * both `context.now` and `context.deadline` from it, so a caller supplying the
+ * documented `now` option moves BOTH away from wall time together. The gap here
+ * is what makes an implementation anchored to `Date.now()` observably wrong;
+ * pinning this to wall time would let that defect pass every case below.
  */
 const CONTEXT_NOW = new Date("2020-01-01T00:00:00.000Z");
 
@@ -52,8 +53,14 @@ const CONTEXT_NOW = new Date("2020-01-01T00:00:00.000Z");
  * `msLeftInPass` is what the RUNNER has left, which is what the drain must fit
  * inside — not a budget of the job's own.
  */
-async function runHandler(msLeftInPass: number): Promise<ApplyDueReleasesDeps> {
-  vi.setSystemTime(REAL_START);
+let wallStart = REAL_START;
+
+async function runHandler(
+  msLeftInPass: number,
+  wallClockAtEntry: Date = REAL_START
+): Promise<ApplyDueReleasesDeps> {
+  wallStart = wallClockAtEntry;
+  vi.setSystemTime(wallClockAtEntry);
   let captured: ApplyDueReleasesDeps | undefined;
   applyMock.mockImplementation(async (deps: ApplyDueReleasesDeps) => {
     captured = deps;
@@ -71,7 +78,11 @@ async function runHandler(msLeftInPass: number): Promise<ApplyDueReleasesDeps> {
     user: null,
     now: CONTEXT_NOW,
     content: {} as never,
-    deadline: new Date(REAL_START.getTime() + msLeftInPass),
+    // Derived from CONTEXT_NOW, because that is the only context `runJobs` can
+    // emit: it builds the deadline from the same clock it builds `now` from. A
+    // fixture pairing an injected `now` with a wall-time deadline pins an input
+    // the runner cannot produce, and leaves the reachable one unasserted.
+    deadline: new Date(CONTEXT_NOW.getTime() + msLeftInPass),
   });
 
   if (captured === undefined) throw new Error("the pass never ran");
@@ -80,7 +91,7 @@ async function runHandler(msLeftInPass: number): Promise<ApplyDueReleasesDeps> {
 
 /** What the pass asks itself before starting more work. */
 function passWouldStop(deps: ApplyDueReleasesDeps, atRealMs: number): boolean {
-  vi.setSystemTime(new Date(REAL_START.getTime() + atRealMs));
+  vi.setSystemTime(new Date(wallStart.getTime() + atRealMs));
   const now = deps.now?.() ?? new Date();
   return now.getTime() >= (deps.deadline?.getTime() ?? Infinity);
 }
@@ -95,10 +106,10 @@ describe("createReleasesDrainJob", () => {
     vi.useFakeTimers();
     const deps = await runHandler(4_000);
 
-    // The runner's clock and wall time are years apart here. `deadline` is a
-    // REAL instant and `now()` is virtual, so an implementation that hands
-    // `context.deadline` straight through compares 2026 against 2020 and the
-    // pass never stops at all.
+    // The runner's clock is years behind wall time, which is the case an
+    // implementation anchored to `Date.now()` gets wrong: the remaining span
+    // collapses to zero and the drain starts nothing on any pass. Both fields
+    // come from the runner, so the span must be measured between them.
     expect(passWouldStop(deps, 3_000)).toBe(false);
     expect(passWouldStop(deps, 4_000)).toBe(true);
   });
@@ -115,12 +126,34 @@ describe("createReleasesDrainJob", () => {
     expect(passWouldStop(deps, 2_000)).toBe(true);
   });
 
-  it("starts nothing when the pass is already at its deadline", async () => {
+  it("grants no budget when the pass is already spent, rather than a negative one", async () => {
     vi.useFakeTimers();
-    // Never a negative budget, which would read as a deadline in the past on the
-    // virtual clock and defer every component including ones this pass applied.
+    // Deliberately NOT titled "starts nothing". `applyWithinBudget` exempts the
+    // first component from the deadline, so an exhausted budget still performs
+    // one component's mutations — which is correct and is not something this
+    // case can observe, because the pass is mocked here. Skipping the pass
+    // outright instead would report a clean empty drain while work was
+    // deferred, which is the failure #1360 exists to prevent.
     const deps = await runHandler(0);
 
     expect(passWouldStop(deps, 0)).toBe(true);
+  });
+
+  it("does not grant more than the pass has, when the runner's clock runs ahead", async () => {
+    vi.useFakeTimers();
+    // The overrun direction, and the more dangerous one: a span measured against
+    // wall time from a runner clock AHEAD of it is longer than the pass, so the
+    // drain keeps starting content mutations after the invocation should have
+    // ended. Both fields move together, so the span must not.
+    // Wall time an hour BEHIND the runner's clock, which is the same thing as
+    // the runner's clock running ahead. Passed in, because the fixture pins wall
+    // time on entry and setting it beforehand would simply be overwritten.
+    const deps = await runHandler(
+      3_000,
+      new Date(CONTEXT_NOW.getTime() - 60 * 60 * 1000)
+    );
+
+    expect(passWouldStop(deps, 2_500)).toBe(false);
+    expect(passWouldStop(deps, 3_000)).toBe(true);
   });
 });

--- a/packages/nextly/src/domains/releases/__tests__/releases-drain-job.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-drain-job.test.ts
@@ -1,0 +1,126 @@
+/**
+ * The drain job's one real decision: how long it may run for.
+ *
+ * Everything else here is assembly — a repository, mutations, a reporter. What
+ * is worth testing is the budget, because getting it wrong is invisible: a pass
+ * that overruns its invocation is killed after doing partial work, and a pass
+ * that never stops looks exactly like a pass with nothing to do.
+ *
+ * The assertions below are about the STOPPING PREDICATE the pass evaluates —
+ * `now() >= deadline` — rather than about the deadline value handed over. A
+ * value assertion passes for an implementation that computes the right number on
+ * the wrong clock, which is the specific defect these guard.
+ *
+ * @module domains/releases/__tests__/releases-drain-job.test
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { ApplyDueReleasesDeps } from "../apply-due-releases";
+
+const { applyMock } = vi.hoisted(() => ({ applyMock: vi.fn() }));
+vi.mock("../apply-due-releases", () => ({ applyDueReleases: applyMock }));
+
+const { createReleasesDrainJob } = await import("../releases-drain-job");
+
+/** A pass that did nothing; these cases never inspect the report. */
+const NOTHING_DUE = {
+  due: 0,
+  published: 0,
+  applied: 0,
+  failed: 0,
+  deferred: 0,
+  undischarged: 0,
+  outcomes: [],
+};
+
+/** Wall time when the handler is entered. */
+const REAL_START = new Date("2026-06-01T12:00:00.000Z");
+
+/**
+ * The instant the RUNNER is treating as now, deliberately years from wall time.
+ *
+ * `JobContext.now` is injected so a job is testable, so the two clocks are not
+ * required to agree — and an implementation that mixes them is only wrong when
+ * they differ. Pinning them together would make both cases below pass against
+ * the defect they exist to catch.
+ */
+const CONTEXT_NOW = new Date("2020-01-01T00:00:00.000Z");
+
+/**
+ * Run the handler at {@link REAL_START} and return the deps the pass received.
+ *
+ * `msLeftInPass` is what the RUNNER has left, which is what the drain must fit
+ * inside — not a budget of the job's own.
+ */
+async function runHandler(msLeftInPass: number): Promise<ApplyDueReleasesDeps> {
+  vi.setSystemTime(REAL_START);
+  let captured: ApplyDueReleasesDeps | undefined;
+  applyMock.mockImplementation(async (deps: ApplyDueReleasesDeps) => {
+    captured = deps;
+    return NOTHING_DUE;
+  });
+
+  const job = createReleasesDrainJob({
+    db: {} as never,
+    contentApi: {} as never,
+    runAs: {} as never,
+    onOutcome: () => {},
+  });
+
+  await job.handler(null as never, {
+    user: null,
+    now: CONTEXT_NOW,
+    content: {} as never,
+    deadline: new Date(REAL_START.getTime() + msLeftInPass),
+  });
+
+  if (captured === undefined) throw new Error("the pass never ran");
+  return captured;
+}
+
+/** What the pass asks itself before starting more work. */
+function passWouldStop(deps: ApplyDueReleasesDeps, atRealMs: number): boolean {
+  vi.setSystemTime(new Date(REAL_START.getTime() + atRealMs));
+  const now = deps.now?.() ?? new Date();
+  return now.getTime() >= (deps.deadline?.getTime() ?? Infinity);
+}
+
+describe("createReleasesDrainJob", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    applyMock.mockReset();
+  });
+
+  it("stops when the runner's deadline arrives, on the same clock the pass reads", async () => {
+    vi.useFakeTimers();
+    const deps = await runHandler(4_000);
+
+    // The runner's clock and wall time are years apart here. `deadline` is a
+    // REAL instant and `now()` is virtual, so an implementation that hands
+    // `context.deadline` straight through compares 2026 against 2020 and the
+    // pass never stops at all.
+    expect(passWouldStop(deps, 3_000)).toBe(false);
+    expect(passWouldStop(deps, 4_000)).toBe(true);
+  });
+
+  it("takes what is LEFT of the pass, so a drain starting late cannot overrun it", async () => {
+    vi.useFakeTimers();
+    // A pass most of the way through its tick: an earlier job overran and left
+    // this one two seconds. A fixed budget cannot know that, and the drain would
+    // keep starting content mutations long after the invocation should have
+    // ended — being killed part-way rather than deferring cleanly.
+    const deps = await runHandler(2_000);
+
+    expect(passWouldStop(deps, 1_500)).toBe(false);
+    expect(passWouldStop(deps, 2_000)).toBe(true);
+  });
+
+  it("starts nothing when the pass is already at its deadline", async () => {
+    vi.useFakeTimers();
+    // Never a negative budget, which would read as a deadline in the past on the
+    // virtual clock and defer every component including ones this pass applied.
+    const deps = await runHandler(0);
+
+    expect(passWouldStop(deps, 0)).toBe(true);
+  });
+});

--- a/packages/nextly/src/domains/releases/releases-drain-job.ts
+++ b/packages/nextly/src/domains/releases/releases-drain-job.ts
@@ -61,28 +61,6 @@ export function createReleasesDrainJob(deps: {
    * than defaulted to silence.
    */
   onOutcome: (result: ApplyDueReleasesResult) => void | Promise<void>;
-  /**
-   * How long one pass may spend STARTING content mutations.
-   *
-   * A drain runs behind a serverless cron tick as often as on a long-lived
-   * process, and a platform kills a tick at a fixed limit. The runner cannot
-   * bound this — `maxDurationMs` is checked before each CLAIM, so it bounds how
-   * many JOBS a pass starts, not how long one handler takes — and `run-jobs`
-   * names the handler being written to fit a tick as what bounds it instead.
-   *
-   * Taken here rather than read from `JobContext`, which carries `user`, `now`
-   * and `content` but no deadline: a handler is asked to fit a tick and told
-   * nothing about how long one is. Wiring a budget per job is the smaller
-   * change; giving every handler its run's deadline is the better one, and it
-   * belongs to the jobs domain rather than here.
-   *
-   * REQUIRED, for the same reason `onOutcome` is: optional, every existing
-   * wiring site keeps the unbounded behaviour this exists to remove, and the
-   * fix is opt-in for exactly the callers who do not know they need it. A
-   * default would be a number invented here for a tick length only the wiring
-   * site knows.
-   */
-  budgetMs: number;
 }): JobDefinition {
   return defineJob({
     slug: RELEASES_DRAIN_JOB,
@@ -93,6 +71,15 @@ export function createReleasesDrainJob(deps: {
     sweep: true,
     handler: async (_input, context) => {
       const startedAt = Date.now();
+      // What is LEFT of the pass, never a fixed budget of this job's own.
+      // `runJobs` checks its budget before starting a handler and cannot
+      // interrupt a running one, so a drain that begins late has less pass
+      // remaining than any constant could know: an earlier job that overran
+      // leaves this one starting with seconds rather than a whole tick. Taking a
+      // full budget anyway means outliving the invocation and being killed
+      // part-way. The webhook drain fits itself inside the same field the same
+      // way, so the two answer "how long have I got" identically.
+      const remainingMs = Math.max(0, context.deadline.getTime() - startedAt);
       const result = await applyDueReleases({
         // ONE clock for both halves. The deadline is derived from the runner's
         // `context.now`, so the comparison has to read the same source — left to
@@ -105,7 +92,14 @@ export function createReleasesDrainJob(deps: {
         // offset by the difference. That keeps a virtual clock authoritative for
         // WHEN the pass thinks it is, without making the budget unmeasurable.
         now: () => new Date(context.now.getTime() + (Date.now() - startedAt)),
-        deadline: new Date(context.now.getTime() + deps.budgetMs),
+        // The remaining pass expressed on THAT clock, rather than passed
+        // through. `context.deadline` is a REAL instant — `runJobs` derives it
+        // from the wall clock at the start of the pass — while `now` above is
+        // virtual, `context.now` offset by elapsed time. Handing the field
+        // across unchanged would compare two timebases: a runner clock behind
+        // wall time would stop the pass after the first release, and one ahead
+        // would never stop it at all.
+        deadline: new Date(context.now.getTime() + remainingMs),
         repository: new ReleasesRepository(deps.db),
         mutations: createReleaseMutations({ contentApi: deps.contentApi }),
         runAs: deps.runAs,

--- a/packages/nextly/src/domains/releases/releases-drain-job.ts
+++ b/packages/nextly/src/domains/releases/releases-drain-job.ts
@@ -30,6 +30,7 @@ import type { RunAsDeps } from "../../shared/lib/resolve-run-as";
 import type { JobContentSource } from "../jobs/job-content-api";
 import { defineJob } from "../jobs/job-registry";
 import type { JobDefinition } from "../jobs/job-registry";
+import { remainingPassMs } from "../jobs/remaining-pass";
 
 import { applyDueReleases } from "./apply-due-releases";
 import type { ApplyDueReleasesResult } from "./apply-due-releases";
@@ -77,9 +78,9 @@ export function createReleasesDrainJob(deps: {
       // remaining than any constant could know: an earlier job that overran
       // leaves this one starting with seconds rather than a whole tick. Taking a
       // full budget anyway means outliving the invocation and being killed
-      // part-way. The webhook drain fits itself inside the same field the same
-      // way, so the two answer "how long have I got" identically.
-      const remainingMs = Math.max(0, context.deadline.getTime() - startedAt);
+      // part-way. Shared with the webhook drain, so the two answer "how long
+      // have I got" with one implementation rather than two that agree today.
+      const remainingMs = remainingPassMs(context);
       const result = await applyDueReleases({
         // ONE clock for both halves. The deadline is derived from the runner's
         // `context.now`, so the comparison has to read the same source — left to
@@ -92,13 +93,12 @@ export function createReleasesDrainJob(deps: {
         // offset by the difference. That keeps a virtual clock authoritative for
         // WHEN the pass thinks it is, without making the budget unmeasurable.
         now: () => new Date(context.now.getTime() + (Date.now() - startedAt)),
-        // The remaining pass expressed on THAT clock, rather than passed
-        // through. `context.deadline` is a REAL instant — `runJobs` derives it
-        // from the wall clock at the start of the pass — while `now` above is
-        // virtual, `context.now` offset by elapsed time. Handing the field
-        // across unchanged would compare two timebases: a runner clock behind
-        // wall time would stop the pass after the first release, and one ahead
-        // would never stop it at all.
+        // The remaining SPAN re-anchored to this handler's clock, rather than
+        // `context.deadline` passed through. The clock above advances with real
+        // elapsed time from `context.now`, so a deadline must share that origin
+        // to be comparable — and `context.deadline`'s origin is the runner's
+        // clock, which a caller may have injected. Re-anchoring keeps the two
+        // sides of `now() >= deadline` on one timebase whether or not it was.
         deadline: new Date(context.now.getTime() + remainingMs),
         repository: new ReleasesRepository(deps.db),
         mutations: createReleaseMutations({ contentApi: deps.contentApi }),

--- a/packages/nextly/src/domains/releases/releases-drain-job.ts
+++ b/packages/nextly/src/domains/releases/releases-drain-job.ts
@@ -30,7 +30,6 @@ import type { RunAsDeps } from "../../shared/lib/resolve-run-as";
 import type { JobContentSource } from "../jobs/job-content-api";
 import { defineJob } from "../jobs/job-registry";
 import type { JobDefinition } from "../jobs/job-registry";
-import { remainingPassMs } from "../jobs/remaining-pass";
 
 import { applyDueReleases } from "./apply-due-releases";
 import type { ApplyDueReleasesResult } from "./apply-due-releases";
@@ -72,34 +71,26 @@ export function createReleasesDrainJob(deps: {
     sweep: true,
     handler: async (_input, context) => {
       const startedAt = Date.now();
-      // What is LEFT of the pass, never a fixed budget of this job's own.
-      // `runJobs` checks its budget before starting a handler and cannot
-      // interrupt a running one, so a drain that begins late has less pass
-      // remaining than any constant could know: an earlier job that overran
-      // leaves this one starting with seconds rather than a whole tick. Taking a
-      // full budget anyway means outliving the invocation and being killed
-      // part-way. Shared with the webhook drain, so the two answer "how long
-      // have I got" with one implementation rather than two that agree today.
-      const remainingMs = remainingPassMs(context);
       const result = await applyDueReleases({
-        // ONE clock for both halves. The deadline is derived from the runner's
-        // `context.now`, so the comparison has to read the same source — left to
-        // its default, `applyDueReleases` compares a virtual deadline against
-        // real wall time, and a runner clock behind wall time stops after the
-        // first release while one ahead never stops at all.
-        //
-        // `context.now` is the instant the runner is treating as now, so it does
-        // not advance during the pass; elapsed time comes from the real clock
-        // offset by the difference. That keeps a virtual clock authoritative for
-        // WHEN the pass thinks it is, without making the budget unmeasurable.
+        // ONE origin for both sides of the pass's `now() >= deadline` test.
+        // `context.now` is the instant the runner is treating as now and does
+        // not advance during the pass, so elapsed time comes from the real clock
+        // offset by the difference: a virtual clock stays authoritative for WHEN
+        // the pass thinks it is, without making the budget unmeasurable.
         now: () => new Date(context.now.getTime() + (Date.now() - startedAt)),
-        // The remaining SPAN re-anchored to this handler's clock, rather than
-        // `context.deadline` passed through. The clock above advances with real
-        // elapsed time from `context.now`, so a deadline must share that origin
-        // to be comparable — and `context.deadline`'s origin is the runner's
-        // clock, which a caller may have injected. Re-anchoring keeps the two
-        // sides of `now() >= deadline` on one timebase whether or not it was.
-        deadline: new Date(context.now.getTime() + remainingMs),
+        // The runner's own deadline, passed through. It needs no arithmetic:
+        // `runJobs` derives it and `context.now` from one clock, and the clock
+        // above is anchored to `context.now`, so the two sides already share an
+        // origin. Re-expressing it as `context.now + (deadline - context.now)`
+        // would cancel to this exact value — a no-op that reads as load-bearing.
+        //
+        // What this DOES replace is a budget of the job's own. `runJobs` checks
+        // its budget before starting a handler and cannot interrupt a running
+        // one, so a drain that begins late has less pass left than any constant
+        // could know: an earlier job that overran leaves this one with seconds
+        // rather than a whole tick, and taking a fixed budget anyway means
+        // outliving the invocation and being killed part-way.
+        deadline: context.deadline,
         repository: new ReleasesRepository(deps.db),
         mutations: createReleaseMutations({ contentApi: deps.contentApi }),
         runAs: deps.runAs,

--- a/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
+++ b/packages/nextly/src/domains/webhooks/webhook-drain-job.ts
@@ -32,7 +32,12 @@
  * @module domains/webhooks/webhook-drain-job
  */
 
-import { defineJob, type JobDefinition } from "../jobs/job-registry";
+import {
+  defineJob,
+  type JobContext,
+  type JobDefinition,
+} from "../jobs/job-registry";
+import { remainingPassMs } from "../jobs/remaining-pass";
 
 import {
   IN_PASS_DRAIN_BOUNDS,
@@ -53,20 +58,23 @@ import type { RunDrainResult } from "./run-drain";
  * drain then means outliving the invocation and being killed before the row is
  * finalized — the sweep retries having done partial work.
  *
- * The deadline the runner supplies is the only value that knows the answer.
- * Reserved against it is one in-flight request: the budget bounds when the drain
- * stops STARTING deliveries, not when the last one returns.
+ * The pass context is the only thing that knows the answer, and it takes BOTH
+ * of the fields the runner derived from its one clock — measuring against
+ * `Date.now()` instead subtracts two different origins whenever a caller
+ * supplies the documented `now` option. Reserved against the remainder is one
+ * in-flight request: the budget bounds when the drain stops STARTING
+ * deliveries, not when the last one returns.
  *
  * A caller's explicit `maxDurationMs` still wins — a trigger that owns its whole
  * invocation, rather than sharing a pass, is entitled to say so.
  */
 function boundsWithin(
-  deadline: Date,
+  context: Pick<JobContext, "now" | "deadline">,
   options?: RunWebhookDrainOptions
 ): Pick<RunWebhookDrainOptions, "maxDurationMs" | "requestTimeoutMs"> {
   if (options?.maxDurationMs !== undefined) return {};
 
-  const remaining = Math.max(0, deadline.getTime() - Date.now());
+  const remaining = remainingPassMs(context);
 
   // The per-request timeout shrinks with the remaining time, and does not simply
   // sit at its default. With little of the pass left, a request allowed the full
@@ -140,7 +148,7 @@ export function createWebhookDrainJob(
     handler: async (_input, context) => {
       const result = await runWebhookDrain(adapter, registry, {
         ...options,
-        ...boundsWithin(context.deadline, options),
+        ...boundsWithin(context, options),
       });
       await onOutcome?.(result);
     },


### PR DESCRIPTION
## The defect

The releases drain derived its own deadline from a `budgetMs` constant wired in at registration. A pass that starts late in a tick therefore awarded itself a full fresh budget: an earlier job that overran leaves this one beginning with seconds, and it would keep starting content mutations long after the invocation should have ended — killed part-way rather than deferring cleanly.

`JobContext.deadline` (#1366) carries the runner's own stopping point, so the number no longer has to be wired in from a site guessing at a tick length. `budgetMs` and `RELEASES_DRAIN_BUDGET_MS` are both gone.

The webhook drain already fits itself inside that field via `boundsWithin`. This makes the two drains answer "how long have I got" the same way.

## Why the remaining time is translated rather than passed through

`context.deadline` is a **real** instant — `runJobs` derives it from the wall clock at the start of the pass. The releases pass instead reads a **virtual** clock: `context.now` offset by elapsed time, so a runner treating some other instant as "now" stays authoritative for *when* the pass thinks it is.

Handing `context.deadline` straight to `applyDueReleases` would compare those two timebases. With a runner clock behind wall time the pass stops after the first release; with one ahead it never stops at all. So the handler takes the remaining span and expresses it on its own clock:

```ts
const remainingMs = Math.max(0, context.deadline.getTime() - startedAt);
// ...
deadline: new Date(context.now.getTime() + remainingMs),
```

## Why no headroom is reserved for the discharge phase

I intended to reserve a slice for `dischargeSettledComponents`, mirroring the webhook drain's reservation of one in-flight request. Reading the guard showed that would be wrong: it exempts components this pass applied — *"always discharged, whatever the clock says"* — so the deadline only bounds components the pass never touched. Reserving would have shrunk the work actually started while protecting nothing.

## Tests

Three cases in a new `releases-drain-job.test.ts`. They assert the **stopping predicate** the pass evaluates (`now() >= deadline`) rather than the deadline value handed over, because a value assertion passes for an implementation that computes the right number on the wrong clock — the specific defect here. The fixture deliberately sets the runner's clock years from wall time, since an implementation that mixes them is only wrong when they differ.

Break-verified: each case fails by name against both a mixed-timebase implementation and a regression to a fixed constant.

## Verification

- `pnpm run check-types` — 22/22
- `pnpm run lint` — 24/24
- `pnpm --filter nextly test` — 808 files, 9941 passed, 42 skipped
- `node scripts/release/check-changesets.mjs .changeset/a-drain-fits-the-pass-it-runs-in.md` — covers all 25 lockstep packages

Note for reviewers: this worktree's `dist` was stale, which made `check-types` blame `plugin-sdk` and `plugin-page-builder` for missing exports unrelated to this change. A full `pnpm run build` cleared it; the failures were not from these four files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release processing now respects the available time remaining in each pass.
  * Prevented release processing from running beyond its deadline.
  * Ensured processing does not start when a pass has already reached its deadline.

* **Tests**
  * Added coverage for deadline handling, late starts, and clock differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->