### PR TITLE
fix(plugin-sdk): let a block declare the list support the engine already registers

### DIFF
--- a/.changeset/a-list-block-can-say-so.md
+++ b/.changeset/a-list-block-can-say-so.md
@@ -1,0 +1,33 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A block that declares `supports: { list: true }` was rejected by the plugin
+authoring types. The style catalog gained a `list` group, but the authoring
+vocabulary plugin authors compile against was never extended to match, so the
+one capability that lets a block opt into list marker styling could not be
+written down.

--- a/packages/plugin-sdk/src/block-supports.test-d.ts
+++ b/packages/plugin-sdk/src/block-supports.test-d.ts
@@ -27,5 +27,6 @@ export const AUTHORING_SUPPORTS: {
   effects: [],
   position: [],
   container: [],
+  list: [],
   customCss: [],
 };

--- a/packages/plugin-sdk/src/blocks.ts
+++ b/packages/plugin-sdk/src/blocks.ts
@@ -95,6 +95,8 @@ export interface BlockSupportKeys {
   position: never;
   /** Container-query behaviour. */
   container: never;
+  /** Marker style on a list. */
+  list: never;
   /** Author-written CSS on this block. Gates a capability, not a style group. */
   customCss: never;
 }


### PR DESCRIPTION
`main` is red at `067a435c4` on `Lint / Typecheck / Test / Build`, and this
repairs it. The regression is mine, from #1376.

## What broke

#1376 added a `list` group to the style catalog, so `allSupports()` accepts
`supports: { list: true }` at runtime. The authoring vocabulary plugin authors
compile against was never extended to match, and
`packages/plugin-sdk/src/block-supports.test.ts` asserts the two are equal.

The guard fired correctly. A plugin block that renders a list was refused by its
own types while the registry would have honoured it — the one capability that
opts a block into list marker styling could not be written down.

## Why this remedy rather than the other

There were two honest options: declare `list` on the authoring surface, or
remove it from the engine registry as engine-internal. The second would be right
only if no plugin should ever declare it.

`blocks.ts` states the rule itself, in the `BlockSupportKeys` docblock: *the
built-in keys are the style catalog's groups plus the capabilities that have no
catalog group of their own*. `list` is a catalog group — `catalog.ts:681` puts
`listStyleType` in it, one property, no sub-flags — so it belongs in
`BlockSupportKeys` on the merits. Going the other way would remove a capability
the registry already grants.

The catalog settles it more directly still. The comment above `listStyleType`
explains why it was given its own group in the first place:

> Its OWN group, not typography. Group membership is what decides which blocks
> are offered a control, and `typography: true` grants every property in that
> group — so a heading and a button would both be offered a list-marker control
> that cannot change anything they render.

The group exists so that group membership can gate which blocks are offered the
control. That is an authoring-facing purpose by construction, so treating `list`
as engine-internal is not a weaker option — it contradicts the reason the group
was separated at all.

## Evidence

`AUTHORING_SUPPORTS` is exhaustive against `BlockSupportKeys` in both
directions, so the interface member and the constant entry have to move
together. Break-verified both, each mutation asserting it applied first:

| mutation | result |
| --- | --- |
| interface member removed, constant kept | `TS2353` at `block-supports.test-d.ts:30` |
| constant entry removed, interface kept  | `TS2741` at `block-supports.test-d.ts:16` |

Restored tree typechecks at 0 errors. `plugin-sdk` 4 files / 18 tests green.

**Reproducing this locally needs a build first.** The test reads `allSupports()`
from the BUILT engine, so a `dist` predating #1376 leaves both sides of the
comparison stale — they agree, and the guard passes. A drift guard cannot see
drift when one side is an artifact from before the drift. Three sessions hit
that false green today.

```
pnpm --filter @nextlyhq/blocks-engine build
cd packages/plugin-sdk && pnpm vitest run src/block-supports.test.ts
```

## Territory

`packages/plugin-sdk/**` is inside another lane's claim. This was declared as a
coordination note on the ledger before editing rather than taken quietly, with
the commitment that the change is additive only: one interface member, one
constant entry, no existing member, name, order or type altered.

Rebased onto `4e13096b7` and the defect confirmed live from source on that tip
before committing. The branch name predates the diagnosis and describes work
that is not in this PR; it is left alone rather than force-pushed, since a
force-push permanently disqualifies the stranded-commit check.
