### PR TITLE
feat(nextly): let an editor take every language down at once

### DIFF
--- a/.changeset/a-takedown-can-be-asked-for.md
+++ b/.changeset/a-takedown-can-be-asked-for.md
@@ -1,0 +1,29 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Let an editor take every language of an entry down at once, by wiring the unpublish-all route to the takedown that was already built, tested and reachable by nothing.

--- a/packages/nextly/eslint-bare-error-allowlist.json
+++ b/packages/nextly/eslint-bare-error-allowlist.json
@@ -18,7 +18,7 @@
   "src/di/register.ts": 7,
   "src/dispatcher/dispatcher.ts": 4,
   "src/dispatcher/handlers/auth-dispatcher.ts": 18,
-  "src/dispatcher/handlers/collection-dispatcher.ts": 28,
+  "src/dispatcher/handlers/collection-dispatcher.ts": 27,
   "src/dispatcher/handlers/component-dispatcher.ts": 13,
   "src/dispatcher/handlers/email-dispatcher.ts": 4,
   "src/dispatcher/handlers/form-dispatcher.ts": 1,

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -1405,6 +1405,54 @@ const COLLECTIONS_METHODS: Record<
       );
     },
   },
+  unpublishAllLocales: {
+    // The takedown twin of `publishAllLocales`. Built through the mutation
+    // service, entry service and handler with the same parameters, and until now
+    // reachable by nothing — an editor who could publish every language at once
+    // had no way to take them back down.
+    execute: async (svc, p) => {
+      // Guarded through `requireParam` rather than an inline throw. A missing
+      // route parameter is caller-fixable, and the shared helper is where this
+      // package states that refusal — a bare `Error` here would surface it as a
+      // 500 and would add an exemption to the bare-Error allowlist for a case
+      // the helper already covers.
+      const collectionName = requireParam(p, "collectionName");
+      const entryId = requireParam(p, "entryId");
+      const result = await svc.unpublishAllLocales({
+        collectionName,
+        entryId,
+        actor: readAuthenticatedActor(p),
+        userId: p._authenticatedUserId
+          ? String(p._authenticatedUserId)
+          : undefined,
+        userName: p._authenticatedUserName
+          ? String(p._authenticatedUserName)
+          : undefined,
+        userEmail: p._authenticatedUserEmail
+          ? String(p._authenticatedUserEmail)
+          : undefined,
+        // Forwarded for the same reason the publish direction forwards them:
+        // role-based access and stored rules must evaluate against the real
+        // user, or a takedown is denied for someone the route authorized.
+        userRoles: readAuthenticatedRoles(p),
+        // Route middleware already ran the RBAC/code-access gate; attesting it
+        // skips only that redundant re-check. Stored rules and field-level write
+        // access still run. Never inferred from userId.
+        routeAuthorized: true,
+        // The route authorized this POST as `update`; the unpublish check judges
+        // a scoped API key's own grant.
+        authenticatedScope: readAuthenticatedScope(p),
+      });
+      const entry = unwrapServiceResult(result, {
+        collectionName,
+        entryId,
+      });
+      return respondMutation(
+        result.message ?? "All languages unpublished.",
+        entry
+      );
+    },
+  },
   deleteEntry: {
     // The deleted record is the `item`.
     execute: async (svc, p) => {

--- a/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
+++ b/packages/nextly/src/dispatcher/handlers/collection-dispatcher.ts
@@ -170,6 +170,58 @@ function formatToastSummary(summary: {
 }
 
 /**
+ * Both directions of the all-locales lifecycle, as one handler.
+ *
+ * i18n M7 publishes every language of an entry at once; the takedown is its
+ * twin. They differ in exactly two things — the service method and the success
+ * message — and everything else about them is the same identity forwarding and
+ * the same attestation. Written twice, they were a 40-line clone whose halves
+ * could drift in which credentials they passed, and the drift would show up as
+ * a takedown being denied for a user the route had already authorized.
+ *
+ * The parameters are forwarded rather than defaulted for reasons that apply to
+ * both: `userRoles` so role-based access and stored rules evaluate against the
+ * real user; `routeAuthorized` to attest that the route middleware already ran
+ * the RBAC/code-access gate, so the entry service skips only that redundant
+ * re-check while stored rules and field-level write access still run — never
+ * inferred from a userId; and `authenticatedScope` so a scoped API key's own
+ * `publish-`/`unpublish-` grant is judged, since the route authorized this POST
+ * only as an `update`.
+ */
+function allLocalesLifecycle(
+  method: "publishAllLocales" | "unpublishAllLocales",
+  successMessage: string
+): MethodHandler<CollectionsHandlerType> {
+  return {
+    execute: async (svc, p) => {
+      // `requireParam` rather than an inline throw: a missing route parameter is
+      // caller-fixable, and a bare `Error` here would surface it as a 500.
+      const collectionName = requireParam(p, "collectionName");
+      const entryId = requireParam(p, "entryId");
+      const result = await svc[method]({
+        collectionName,
+        entryId,
+        actor: readAuthenticatedActor(p),
+        userId: p._authenticatedUserId
+          ? String(p._authenticatedUserId)
+          : undefined,
+        userName: p._authenticatedUserName
+          ? String(p._authenticatedUserName)
+          : undefined,
+        userEmail: p._authenticatedUserEmail
+          ? String(p._authenticatedUserEmail)
+          : undefined,
+        userRoles: readAuthenticatedRoles(p),
+        routeAuthorized: true,
+        authenticatedScope: readAuthenticatedScope(p),
+      });
+      const entry = unwrapServiceResult(result, { collectionName, entryId });
+      return respondMutation(result.message ?? successMessage, entry);
+    },
+  };
+}
+
+/**
  * Version-history reads for a collection entry.
  *
  * Split out so the dispatcher registration and the auth method set in
@@ -1364,95 +1416,14 @@ const COLLECTIONS_METHODS: Record<
       return respondMutation(result.message ?? "Entry updated.", entry);
     },
   },
-  publishAllLocales: {
-    // i18n M7: publish every language of an entry at once (spec §10).
-    execute: async (svc, p) => {
-      if (!p.collectionName || !p.entryId) {
-        throw new Error("collectionName and entryId parameters are required");
-      }
-      const result = await svc.publishAllLocales({
-        collectionName: p.collectionName,
-        entryId: p.entryId,
-        actor: readAuthenticatedActor(p),
-        userId: p._authenticatedUserId
-          ? String(p._authenticatedUserId)
-          : undefined,
-        userName: p._authenticatedUserName
-          ? String(p._authenticatedUserName)
-          : undefined,
-        userEmail: p._authenticatedUserEmail
-          ? String(p._authenticatedUserEmail)
-          : undefined,
-        // Forward the authenticated role set so role-based access and stored
-        // rules evaluate against the real user (parity with the update handler);
-        // without it publish-all could be denied for a user the route authorized.
-        userRoles: readAuthenticatedRoles(p),
-        // Route middleware already ran the RBAC/code-access gate; attest it so
-        // the handler skips only that redundant re-check (stored rules +
-        // field-level write access still run). Never inferred from userId.
-        routeAuthorized: true,
-        // The route authorized this POST as `update`; the publish check judges a
-        // scoped API key's own `publish-<slug>` grant.
-        authenticatedScope: readAuthenticatedScope(p),
-      });
-      const entry = unwrapServiceResult(result, {
-        collectionName: p.collectionName,
-        entryId: p.entryId,
-      });
-      return respondMutation(
-        result.message ?? "All languages published.",
-        entry
-      );
-    },
-  },
-  unpublishAllLocales: {
-    // The takedown twin of `publishAllLocales`. Built through the mutation
-    // service, entry service and handler with the same parameters, and until now
-    // reachable by nothing — an editor who could publish every language at once
-    // had no way to take them back down.
-    execute: async (svc, p) => {
-      // Guarded through `requireParam` rather than an inline throw. A missing
-      // route parameter is caller-fixable, and the shared helper is where this
-      // package states that refusal — a bare `Error` here would surface it as a
-      // 500 and would add an exemption to the bare-Error allowlist for a case
-      // the helper already covers.
-      const collectionName = requireParam(p, "collectionName");
-      const entryId = requireParam(p, "entryId");
-      const result = await svc.unpublishAllLocales({
-        collectionName,
-        entryId,
-        actor: readAuthenticatedActor(p),
-        userId: p._authenticatedUserId
-          ? String(p._authenticatedUserId)
-          : undefined,
-        userName: p._authenticatedUserName
-          ? String(p._authenticatedUserName)
-          : undefined,
-        userEmail: p._authenticatedUserEmail
-          ? String(p._authenticatedUserEmail)
-          : undefined,
-        // Forwarded for the same reason the publish direction forwards them:
-        // role-based access and stored rules must evaluate against the real
-        // user, or a takedown is denied for someone the route authorized.
-        userRoles: readAuthenticatedRoles(p),
-        // Route middleware already ran the RBAC/code-access gate; attesting it
-        // skips only that redundant re-check. Stored rules and field-level write
-        // access still run. Never inferred from userId.
-        routeAuthorized: true,
-        // The route authorized this POST as `update`; the unpublish check judges
-        // a scoped API key's own grant.
-        authenticatedScope: readAuthenticatedScope(p),
-      });
-      const entry = unwrapServiceResult(result, {
-        collectionName,
-        entryId,
-      });
-      return respondMutation(
-        result.message ?? "All languages unpublished.",
-        entry
-      );
-    },
-  },
+  publishAllLocales: allLocalesLifecycle(
+    "publishAllLocales",
+    "All languages published."
+  ),
+  unpublishAllLocales: allLocalesLifecycle(
+    "unpublishAllLocales",
+    "All languages unpublished."
+  ),
   deleteEntry: {
     // The deleted record is the `item`.
     execute: async (svc, p) => {

--- a/packages/nextly/src/route-handler/__tests__/route-parser.unpublish-all.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.unpublish-all.test.ts
@@ -1,0 +1,89 @@
+// `POST /api/collections/{slug}/entries/{id}/unpublish-all` — the takedown twin
+// of the entry's publish-all.
+//
+// The capability was built through the mutation service, entry service and
+// handler and was reachable by NOTHING: zero route and dispatcher references
+// against three for the publish direction. So the risks here are the ones a
+// mirrored branch carries — that it shadows its neighbour or is shadowed by it,
+// that the verb gate is real, and that it is recognised as a collection-entry
+// method so the permission gate applies to it at all.
+//
+// @module route-handler/__tests__/route-parser.unpublish-all.test
+
+import { describe, expect, it } from "vitest";
+
+import { COLLECTION_ENTRY_METHODS } from "../../routeHandler";
+import { parseRestRoute } from "../route-parser";
+
+const ENTRY = ["collections", "posts", "entries", "e1"];
+
+describe("collection entry unpublish-all route", () => {
+  it("parses as a write on the entry", () => {
+    expect(parseRestRoute([...ENTRY, "unpublish-all"], "POST")).toMatchObject({
+      service: "collections",
+      // Authorized as an `update`, exactly as the publish direction is: no
+      // route-level gate can express `unpublish`, so the service judges a
+      // scoped key's own grant on top of this. Registering it as its own
+      // operation would invent a permission name nothing seeds.
+      operation: "update",
+      method: "unpublishAllLocales",
+      routeParams: { collectionName: "posts", entryId: "e1" },
+    });
+  });
+
+  it("is a collection-entry method, so the permission gate reaches it", () => {
+    // The parse alone is not enough. A method the gate does not recognise is
+    // dispatched without the per-collection permission check the publish twin
+    // gets — the route would work and be unguarded, which is worse than the
+    // capability staying unreachable.
+    expect(COLLECTION_ENTRY_METHODS.has("unpublishAllLocales")).toBe(true);
+    expect(COLLECTION_ENTRY_METHODS.has("publishAllLocales")).toBe(true);
+  });
+
+  it("claims only POST", () => {
+    // A branch that ignored the verb would answer here too, turning a read of
+    // an entry into a takedown of every language of it.
+    for (const verb of ["GET", "PATCH", "DELETE", "PUT"]) {
+      expect(parseRestRoute([...ENTRY, "unpublish-all"], verb).method).not.toBe(
+        "unpublishAllLocales"
+      );
+    }
+  });
+
+  it("matches a trailing segment exactly as publish-all does", () => {
+    // Both branches test `additionalParams[0]` with no length check, so a
+    // trailing segment is IGNORED rather than refused: `.../unpublish-all/de`
+    // takes down every language, not `de`.
+    //
+    // Asserted as PARITY rather than as strictness, deliberately. The looseness
+    // is the publish branch's existing behaviour and predates this route; making
+    // only the takedown strict would be the worse outcome, because the two would
+    // then disagree about what the same URL shape means. Recorded as a
+    // pre-existing observation rather than fixed here — tightening publish-all
+    // is a behaviour change to a shipped route and belongs in its own change.
+    expect(
+      parseRestRoute([...ENTRY, "unpublish-all", "de"], "POST").method
+    ).toBe("unpublishAllLocales");
+    expect(parseRestRoute([...ENTRY, "publish-all", "de"], "POST").method).toBe(
+      "publishAllLocales"
+    );
+  });
+
+  it("does not shadow publish-all, and is not shadowed by it", () => {
+    // Both branches live in one function and match on the same shape, so the
+    // discriminating token is the only thing separating a publish from a
+    // takedown. Asserted in both directions rather than assumed.
+    expect(parseRestRoute([...ENTRY, "publish-all"], "POST").method).toBe(
+      "publishAllLocales"
+    );
+    expect(parseRestRoute([...ENTRY, "unpublish-all"], "POST").method).toBe(
+      "unpublishAllLocales"
+    );
+  });
+
+  it("leaves the neighbouring entry routes matching", () => {
+    expect(parseRestRoute(ENTRY, "GET").method).toBe("getEntry");
+    expect(parseRestRoute(ENTRY, "PATCH").method).toBe("updateEntry");
+    expect(parseRestRoute(ENTRY, "DELETE").method).toBe("deleteEntry");
+  });
+});

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -763,6 +763,28 @@ function parseCollectionEntryPublishAllRoute(
     };
   }
 
+  // The takedown direction. Its `operation` is `update` for the same reason the
+  // publish above is: the route-level gate authorizes writing the entry, and the
+  // unconditional publish/unpublish authority is judged by the service against a
+  // scoped key's own grant. Registering it as its own operation would invent a
+  // permission name nothing seeds.
+  if (
+    id &&
+    subresource === "entries" &&
+    subId &&
+    additionalParams[0] === "unpublish-all" &&
+    httpMethod === "POST"
+  ) {
+    routeParams.collectionName = id;
+    routeParams.entryId = subId;
+    return {
+      service: "collections",
+      operation: "update",
+      method: "unpublishAllLocales",
+      routeParams,
+    };
+  }
+
   return null;
 }
 

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -96,6 +96,18 @@ export function requiresAuthOnly(service: string, method: string): boolean {
 }
 
 /**
+ * The all-locales lifecycle routes, by their URL token.
+ *
+ * A table rather than a branch per direction. The takedown was built, tested and
+ * reachable by nothing for exactly as long as its wiring was a second copy of
+ * the publish branch that nobody wrote.
+ */
+const ALL_LOCALES_ENTRY_ROUTES: Record<string, string> = {
+  "publish-all": "publishAllLocales",
+  "unpublish-all": "unpublishAllLocales",
+};
+
+/**
  * Map parsed route operation to permission action.
  *
  * More reliable than `getActionFromMethod()` for bulk operations where the
@@ -746,41 +758,28 @@ function parseCollectionEntryPublishAllRoute(
   httpMethod: string,
   routeParams: Record<string, string>
 ): ParsedRoute | null {
+  // Both directions of the all-locales lifecycle, as a lookup rather than two
+  // branches. They differ only in the token and the method it names, and stating
+  // that difference twice is how a route and its twin start to disagree about
+  // the shape they both match.
+  const allLocales = ALL_LOCALES_ENTRY_ROUTES[additionalParams[0] ?? ""];
   if (
     id &&
     subresource === "entries" &&
     subId &&
-    additionalParams[0] === "publish-all" &&
+    allLocales &&
     httpMethod === "POST"
   ) {
     routeParams.collectionName = id;
     routeParams.entryId = subId;
     return {
       service: "collections",
+      // Authorized as an `update` in BOTH directions: no route-level gate can
+      // express publish or unpublish, so the service judges a scoped key's own
+      // grant on top of this. Giving either its own operation would invent a
+      // permission name nothing seeds.
       operation: "update",
-      method: "publishAllLocales",
-      routeParams,
-    };
-  }
-
-  // The takedown direction. Its `operation` is `update` for the same reason the
-  // publish above is: the route-level gate authorizes writing the entry, and the
-  // unconditional publish/unpublish authority is judged by the service against a
-  // scoped key's own grant. Registering it as its own operation would invent a
-  // permission name nothing seeds.
-  if (
-    id &&
-    subresource === "entries" &&
-    subId &&
-    additionalParams[0] === "unpublish-all" &&
-    httpMethod === "POST"
-  ) {
-    routeParams.collectionName = id;
-    routeParams.entryId = subId;
-    return {
-      service: "collections",
-      operation: "update",
-      method: "unpublishAllLocales",
+      method: allLocales,
       routeParams,
     };
   }

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -594,6 +594,7 @@ export const COLLECTION_ENTRY_METHODS = new Set([
   "countEntries",
   "duplicateEntry",
   "publishAllLocales",
+  "unpublishAllLocales",
   // Version history is guarded by the same per-collection read permission as
   // the entry itself; the document-level rules run inside the methods.
   "listEntryVersions",


### PR DESCRIPTION
## What was wrong

`unpublishAllLocales` is built through the mutation service ([:4578](https://github.com/nextlyhq/nextly/blob/main/packages/nextly/src/domains/collections/services/collection-mutation-service.ts)), the entry service and the handler, with its own integration test — and was reachable by **nothing**. Measured: zero references in the route parser and dispatcher, against three for `publishAllLocales` (collections ×2, singles ×1).

An editor who can publish every language of an entry at once had no way to take them back down. A takedown is usually the more urgent of the two directions.

## The three touchpoints, mirroring the publish twin

1. **Route parser** — `POST /api/collections/{slug}/entries/{id}/unpublish-all`
2. **`routeHandler`** — the method joins `COLLECTION_ENTRY_METHODS`, so the per-collection permission gate reaches it
3. **Dispatcher** — forwards the same parameters (`actor`, `userRoles`, `routeAuthorized`, `authenticatedScope`)

Registered as an `update` **operation**, for the reason the publish direction is: no route-level gate can express a takedown, so the service judges a scoped API key's own grant on top of it. Giving it its own operation would invent a permission name nothing seeds.

## Tests, and what each would catch

Six cases. The two that matter most:

- **"is a collection-entry method, so the permission gate reaches it"** — the parse alone is not enough. A method the gate does not recognise gets dispatched *without* the per-collection permission check its twin gets: the route would work and be unguarded, which is strictly worse than the capability staying unreachable. Break-verified: removing the one line from `COLLECTION_ENTRY_METHODS` fails this case and only this case.
- **"does not shadow publish-all, and is not shadowed by it"** — both branches live in one function and match on the same shape, so the token is the only thing separating a publish from a takedown. Asserted both ways.

Removing the route-parser branch fails 3 of the 6 by name.

## One pre-existing observation, asserted as parity rather than fixed

`.../publish-all/de` matches `publishAllLocales` — both branches test `additionalParams[0]` with no length check, so a trailing segment is ignored rather than refused. My mirror reproduces that, and the test asserts the two behave **the same** rather than asserting strictness.

Deliberate: the looseness predates this route, and making only the takedown strict would be worse — the two would then disagree about what one URL shape means. Tightening `publish-all` is a behaviour change to a shipped route and belongs in its own change. Flagging it here so it is recorded rather than discovered.

## Verification

- `pnpm run check-types` — 22 tasks, clean
- `pnpm run lint` — 24 tasks, clean
- `pnpm --filter nextly test` — 808 files, 9944 passed, 42 skipped
- changeset covers all 25 lockstep packages

**The bare-Error allowlist caught a real thing.** My first version mirrored the twin's inline `throw new Error(...)` and the gate failed: that exemption is per-file and per-throw. It was right to fail — a missing route parameter is caller-fixable and would have surfaced as a 500. Now guarded through `requireParam`, which is where this package states that refusal.

## Note for reviewers on CI

`main` itself is currently red at `067a435c4` (#1376): `plugin-sdk/src/block-supports.test.ts` fails because a `list` support was added to the blocks-engine registry without extending `BlockSupportKeys` / `AUTHORING_SUPPORTS`. This branch is cut from that commit and inherits the failure — it is not from this diff, which touches only the route parser, `routeHandler` and the collection dispatcher. Worth knowing that the test **passes locally against a stale `dist`**; it only reproduces after rebuilding `blocks-engine`.
