### PR TITLE
feat(nextly): hold a lease on the document being edited

### DIFF
--- a/.changeset/a-lease-on-the-document-being-edited.md
+++ b/.changeset/a-lease-on-the-document-being-edited.md
@@ -26,12 +26,14 @@
 "@nextlyhq/ui": patch
 ---
 
-Add the document soft lock's server half: a lease on one entry, its heartbeat, and its expiry.
+Add the document soft lock's server half: a lease on one entry, its heartbeat, its expiry and its sweep.
 
-Two authors opening the same entry previously overwrote each other in silence — there was no lock and no `updatedAt` precondition, so the second save won and neither author was told. This adds the mechanism that makes that visible: `nextly_document_lock` holds one row per document being edited, and `acquireDocumentLock`, `renewDocumentLock`, `releaseDocumentLock` and `readDocumentLock` take, keep, give up and observe a claim.
+Two authors opening the same entry previously overwrote each other in silence — there was no lock and no `updatedAt` precondition, so the second save won and neither author was told. `nextly_document_lock` now holds one row per document being edited, and `acquireDocumentLock`, `renewDocumentLock`, `releaseDocumentLock`, `readDocumentLock` and `sweepExpiredDocumentLocks` take, keep, give up, observe and collect a claim.
 
 Every liveness comparison is a SQL expression the database evaluates itself, on its own clock. Contenders sit on different instances whose clocks disagree, so a claim written from one clock and judged against another is decided by that skew rather than by who holds the lock.
 
-A lease lasts 150 seconds and its holder confirms every 15, both derived from one TTL so the two cannot drift apart. A claim whose holder crashed, closed the tab or went offline becomes takeable on expiry alone, and a person may deliberately take over a live one.
+A claim identifies an ACQUISITION rather than a person: each carries a token minted when it was taken, and every heartbeat and release must present it. One author with the document open in two tabs holds two claims under one user id, and a release from the closed tab must not free the claim the other tab is still editing under.
+
+A lease lasts 150 seconds and its holder confirms every 15, both derived from one TTL. Expiry alone releases a claim, so a holder that crashed or went offline does not lock a document indefinitely, and a person may deliberately take over a live one.
 
 The HTTP surface that exposes this is not included, so no behaviour changes for a user yet.

--- a/.changeset/a-lease-on-the-document-being-edited.md
+++ b/.changeset/a-lease-on-the-document-being-edited.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Add the document soft lock's server half: a lease on one entry, its heartbeat, and its expiry.
+
+Two authors opening the same entry previously overwrote each other in silence — there was no lock and no `updatedAt` precondition, so the second save won and neither author was told. This adds the mechanism that makes that visible: `nextly_document_lock` holds one row per document being edited, and `acquireDocumentLock`, `renewDocumentLock`, `releaseDocumentLock` and `readDocumentLock` take, keep, give up and observe a claim.
+
+Every liveness comparison is a SQL expression the database evaluates itself, on its own clock. Contenders sit on different instances whose clocks disagree, so a claim written from one clock and judged against another is decided by that skew rather than by who holds the lock.
+
+A lease lasts 150 seconds and its holder confirms every 15, both derived from one TTL so the two cannot drift apart. A claim whose holder crashed, closed the tab or went offline becomes takeable on expiry alone, and a person may deliberately take over a live one.
+
+The HTTP surface that exposes this is not included, so no behaviour changes for a user yet.

--- a/packages/nextly/src/database/lease-clock.ts
+++ b/packages/nextly/src/database/lease-clock.ts
@@ -59,6 +59,35 @@ export function futureExpression(
   return sql`clock_timestamp() + make_interval(secs => ${seconds})`;
 }
 
+/**
+ * How many seconds remain until `column`, as an expression the database evaluates itself.
+ *
+ * A DURATION rather than the instant itself, and that is the point. An expiry read back as a value
+ * has to be parsed by the driver, and the three drivers disagree: PostgreSQL hands back a `Date`
+ * from a `timestamptz`, MySQL a zoneless `DATETIME` the driver interprets in ITS session zone, and
+ * SQLite a bare integer of unix seconds that is not a date to anything. Normalising those into one
+ * instant is a per-dialect conversion in the read path, which is the same class of bug the
+ * expressions above exist to remove from the write path.
+ *
+ * A remaining span has no such problem. Both sides of the subtraction happen inside one database,
+ * on one clock, in one statement, and what crosses the boundary is a number of seconds — the same
+ * length in every timebase and on every driver.
+ *
+ * Negative when the instant has passed, which callers are expected to read as expired rather than
+ * clamp: "how long ago" and "not yet" are different answers and only one of them is zero.
+ */
+export function remainingSecondsExpression(
+  dialect: SupportedDialect,
+  column: string
+): SQL {
+  const target = sql.identifier(column);
+  if (dialect === "sqlite") return sql`(${target} - unixepoch())`;
+  if (dialect === "mysql") {
+    return sql`TIMESTAMPDIFF(SECOND, UTC_TIMESTAMP(), ${target})`;
+  }
+  return sql`EXTRACT(EPOCH FROM (${target} - clock_timestamp()))`;
+}
+
 /** Every timing a lease needs, so a caller cannot hold two of them that disagree. */
 export interface LeaseTimings {
   /** How long a confirmation grants. */

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -292,6 +292,22 @@ export function generateSqliteCoreTableStatements(): string[] {
     // interleave with.
     `CREATE UNIQUE INDEX IF NOT EXISTS "nextly_jobs_dedupe_idx"
       ON "nextly_jobs" ("dedupe_key")`,
+    `CREATE TABLE IF NOT EXISTS "nextly_document_lock" (
+      "lock_key" TEXT PRIMARY KEY NOT NULL,
+      "collection" TEXT NOT NULL,
+      "entry_id" TEXT NOT NULL,
+      "owner_id" TEXT NOT NULL,
+      "owner_label" TEXT,
+      "acquired_at" INTEGER NOT NULL,
+      "expires_at" INTEGER NOT NULL
+    )`,
+    // Separate statements for the reason the ones above are: SQLite skips a
+    // CREATE TABLE wholesale once the table exists, so an index folded into it
+    // would never appear on a database built by an earlier boot.
+    `CREATE INDEX IF NOT EXISTS "ndl_expires_at_idx"
+      ON "nextly_document_lock" ("expires_at")`,
+    `CREATE INDEX IF NOT EXISTS "ndl_collection_idx"
+      ON "nextly_document_lock" ("collection")`,
     // No REFERENCES to "email_providers": that table is not bootstrapped here,
     // and SQLite resolves a foreign key at insert time rather than at CREATE,
     // so declaring one would turn every recorded delivery into a failure on a

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -293,10 +293,12 @@ export function generateSqliteCoreTableStatements(): string[] {
     `CREATE UNIQUE INDEX IF NOT EXISTS "nextly_jobs_dedupe_idx"
       ON "nextly_jobs" ("dedupe_key")`,
     `CREATE TABLE IF NOT EXISTS "nextly_document_lock" (
-      "lock_key" TEXT PRIMARY KEY NOT NULL,
-      "collection" TEXT NOT NULL,
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "scope_kind" TEXT NOT NULL,
+      "slug" TEXT NOT NULL,
       "entry_id" TEXT NOT NULL,
       "owner_id" TEXT NOT NULL,
+      "claim_token" TEXT NOT NULL,
       "owner_label" TEXT,
       "acquired_at" INTEGER NOT NULL,
       "expires_at" INTEGER NOT NULL
@@ -306,8 +308,8 @@ export function generateSqliteCoreTableStatements(): string[] {
     // would never appear on a database built by an earlier boot.
     `CREATE INDEX IF NOT EXISTS "ndl_expires_at_idx"
       ON "nextly_document_lock" ("expires_at")`,
-    `CREATE INDEX IF NOT EXISTS "ndl_collection_idx"
-      ON "nextly_document_lock" ("collection")`,
+    `CREATE INDEX IF NOT EXISTS "ndl_scope_idx"
+      ON "nextly_document_lock" ("scope_kind", "slug")`,
     // No REFERENCES to "email_providers": that table is not bootstrapped here,
     // and SQLite resolves a foreign key at insert time rather than at CREATE,
     // so declaring one would turn every recorded delivery into a failure on a

--- a/packages/nextly/src/domains/document-lock/__tests__/document-lock-repository.integration.test.ts
+++ b/packages/nextly/src/domains/document-lock/__tests__/document-lock-repository.integration.test.ts
@@ -1,0 +1,249 @@
+/**
+ * The document soft lock against a REAL database.
+ *
+ * Only an integration test can establish any of this, because every question the
+ * lock answers is answered by the database rather than by this code.
+ *
+ * First, that the table exists at all. It reaches a database through several
+ * separate registries, and a miss in any one of them leaves every unit test
+ * passing against a table no real installation has.
+ *
+ * Second, that expiry actually releases. A claim whose holder crashed is
+ * takeable because a SQL comparison says so — on the database's clock, in the
+ * dialect's own type. A unit test with a mocked transaction cannot tell a
+ * working comparison from one that is `NULL` on one dialect and therefore never
+ * true.
+ *
+ * Third, that the fences hold. A renewal or a release arriving from somebody who
+ * no longer owns the row must change nothing, and that is a property of the
+ * WHERE clause reaching a real row.
+ *
+ * Runs against whichever dialect the integration run configures; CI covers
+ * SQLite, Postgres and MySQL.
+ *
+ * @module domains/document-lock/__tests__/document-lock-repository.integration.test
+ */
+
+import { sql } from "drizzle-orm";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import { futureExpression } from "../../../database/lease-clock";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { DOCUMENT_LOCK_TABLE } from "../../../schemas/document-lock";
+import {
+  acquireDocumentLock,
+  readDocumentLock,
+  releaseDocumentLock,
+  renewDocumentLock,
+} from "../document-lock-repository";
+import { documentLockKey } from "../lock-key";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: "posts",
+        status: true,
+        fields: [text({ name: "title" })],
+      }),
+    ],
+  });
+  return current;
+}
+
+const DOC = { collection: "posts", entryId: "entry-1" } as const;
+const ADA = { ownerId: "user-ada", ownerLabel: "Ada" };
+const GRACE = { ownerId: "user-grace", ownerLabel: "Grace" };
+
+/**
+ * Push a claim's expiry into the past.
+ *
+ * Written with the SAME clock expression the repository writes expiries with,
+ * given a negative offset, rather than a timestamp this test builds itself. A
+ * hand-built instant would have to be correct in three dialects' types and time
+ * zones, which is the exact problem the expression exists to solve — and a test
+ * that solves it a second way can pass while the repository's version is broken.
+ */
+async function expireClaim(app: TestNextly): Promise<void> {
+  const dialect = app.adapter.getCapabilities().dialect;
+  const key = documentLockKey(DOC.collection, DOC.entryId);
+  await app.adapter.transaction(async ctx => {
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          SET ${sql.identifier("expires_at")} = ${futureExpression(dialect, -600)}
+          WHERE ${sql.identifier("lock_key")} = ${key}`
+    );
+  });
+}
+
+/**
+ * Set a claim's remaining lease to a known number of seconds.
+ *
+ * The point is to make a RENEWAL observable. A claim taken a moment ago already
+ * has nearly the full lease, so extending it changes the remaining span by an
+ * amount too small to assert on — and a test that cannot see the extension
+ * cannot tell a fenced heartbeat from an unfenced one.
+ */
+async function setRemaining(app: TestNextly, seconds: number): Promise<void> {
+  const dialect = app.adapter.getCapabilities().dialect;
+  const key = documentLockKey(DOC.collection, DOC.entryId);
+  await app.adapter.transaction(async ctx => {
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          SET ${sql.identifier("expires_at")} = ${futureExpression(dialect, seconds)}
+          WHERE ${sql.identifier("lock_key")} = ${key}`
+    );
+  });
+}
+
+describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
+  it("gives the first author the claim, and says how long it has", async () => {
+    const app = await boot(d);
+    const got = await acquireDocumentLock(app.adapter, DOC, ADA);
+
+    expect(got.status).toBe("acquired");
+    expect(got.holder.ownerId).toBe("user-ada");
+    // A positive remaining span, computed by the database. Zero or negative
+    // here would mean the expiry was written on a clock the comparison does not
+    // read, which is the failure this whole design exists to prevent.
+    expect(got.holder.expiresInSeconds).toBeGreaterThan(0);
+    expect(got.holder.expiresInSeconds).toBeLessThanOrEqual(150);
+  });
+
+  it("refuses a second author and names who is editing", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+
+    const got = await acquireDocumentLock(app.adapter, DOC, GRACE);
+    expect(got.status).toBe("held");
+    // The label is what the interface renders. Returning only an id would make
+    // the refusal unactionable for the person reading it.
+    expect(got.holder.ownerLabel).toBe("Ada");
+    expect(got.holder.ownerId).toBe("user-ada");
+  });
+
+  it("lets the SAME author re-acquire, so reopening a tab is not a conflict", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+
+    const again = await acquireDocumentLock(app.adapter, DOC, ADA);
+    expect(again.status).toBe("acquired");
+  });
+
+  it("hands an EXPIRED claim to the next author without asking for a takeover", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await expireClaim(app);
+
+    // No takeover flag. A holder that crashed, closed the laptop or went
+    // offline never releases, so expiry alone has to be enough — otherwise the
+    // document stays locked by somebody who will never come back.
+    const got = await acquireDocumentLock(app.adapter, DOC, GRACE);
+    expect(got.status).toBe("acquired");
+    expect(got.holder.ownerId).toBe("user-grace");
+  });
+
+  it("reports nobody editing once a claim has expired", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+    expect(await readDocumentLock(app.adapter, DOC)).toBeDefined();
+
+    await expireClaim(app);
+    expect(await readDocumentLock(app.adapter, DOC)).toBeUndefined();
+  });
+
+  it("transfers the document on a deliberate takeover", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+
+    const stolen = await acquireDocumentLock(app.adapter, DOC, GRACE, {
+      takeover: true,
+    });
+    expect(stolen.status).toBe("acquired");
+    expect(stolen.holder.ownerId).toBe("user-grace");
+    expect((await readDocumentLock(app.adapter, DOC))?.ownerLabel).toBe(
+      "Grace"
+    );
+  });
+
+  it("tells the ousted author it lost the claim, and to whom", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await acquireDocumentLock(app.adapter, DOC, GRACE, { takeover: true });
+
+    const beat = await renewDocumentLock(app.adapter, DOC, ADA);
+    expect(beat.status).toBe("lost");
+    // Naming the new holder is what lets the interface say "Grace took over"
+    // rather than only that something happened.
+    expect(beat.holder?.ownerId).toBe("user-grace");
+  });
+
+  it("reports a lapsed claim as lost with NOBODY holding it", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await releaseDocumentLock(app.adapter, DOC, ADA);
+
+    const beat = await renewDocumentLock(app.adapter, DOC, ADA);
+    expect(beat.status).toBe("lost");
+    // Absent rather than present-and-empty. "Nobody has it" leads the editor to
+    // offer resuming; "Grace has it" leads it to offer requesting access, and
+    // collapsing the two makes one of those wrong.
+    expect(beat.holder).toBeUndefined();
+  });
+
+  it("does not let a heartbeat from a non-owner extend the owner's claim", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+    // Wind the lease down first. Asserting on the OWNER after an unfenced
+    // renewal proves nothing — an unfenced UPDATE sets `expires_at` and leaves
+    // `owner_id` alone, so Ada still owns it either way and the defect is
+    // invisible. What an unfenced renewal actually does is extend a lease
+    // Grace does not hold, and only the remaining span shows that.
+    await setRemaining(app, 30);
+
+    const beat = await renewDocumentLock(app.adapter, DOC, GRACE);
+    expect(beat.status).toBe("lost");
+
+    const held = await readDocumentLock(app.adapter, DOC);
+    expect(held?.ownerId).toBe("user-ada");
+    // Still the wound-down lease. Unfenced, this would have jumped back to the
+    // full 150 seconds on a heartbeat from somebody with no claim at all.
+    expect(held?.expiresInSeconds).toBeLessThanOrEqual(30);
+  });
+
+  it("does not let a non-owner release somebody else's claim", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+
+    await releaseDocumentLock(app.adapter, DOC, GRACE);
+    // A late release from a previous holder must not free the document out from
+    // under whoever took it over.
+    expect((await readDocumentLock(app.adapter, DOC))?.ownerId).toBe(
+      "user-ada"
+    );
+  });
+
+  it("frees the document when its owner releases it", async () => {
+    const app = await boot(d);
+    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await releaseDocumentLock(app.adapter, DOC, ADA);
+
+    expect(await readDocumentLock(app.adapter, DOC)).toBeUndefined();
+    const next = await acquireDocumentLock(app.adapter, DOC, GRACE);
+    expect(next.status).toBe("acquired");
+  });
+});

--- a/packages/nextly/src/domains/document-lock/__tests__/document-lock-repository.integration.test.ts
+++ b/packages/nextly/src/domains/document-lock/__tests__/document-lock-repository.integration.test.ts
@@ -41,6 +41,7 @@ import {
   readDocumentLock,
   releaseDocumentLock,
   renewDocumentLock,
+  sweepExpiredDocumentLocks,
 } from "../document-lock-repository";
 import { documentLockKey } from "../lock-key";
 
@@ -65,7 +66,11 @@ async function boot(dialect: TestDialect): Promise<TestNextly> {
   return current;
 }
 
-const DOC = { collection: "posts", entryId: "entry-1" } as const;
+const DOC = {
+  scopeKind: "collection",
+  slug: "posts",
+  entryId: "entry-1",
+} as const;
 const ADA = { ownerId: "user-ada", ownerLabel: "Ada" };
 const GRACE = { ownerId: "user-grace", ownerLabel: "Grace" };
 
@@ -80,12 +85,12 @@ const GRACE = { ownerId: "user-grace", ownerLabel: "Grace" };
  */
 async function expireClaim(app: TestNextly): Promise<void> {
   const dialect = app.adapter.getCapabilities().dialect;
-  const key = documentLockKey(DOC.collection, DOC.entryId);
+  const key = documentLockKey(DOC.scopeKind, DOC.slug, DOC.entryId);
   await app.adapter.transaction(async ctx => {
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
           SET ${sql.identifier("expires_at")} = ${futureExpression(dialect, -600)}
-          WHERE ${sql.identifier("lock_key")} = ${key}`
+          WHERE ${sql.identifier("id")} = ${key}`
     );
   });
 }
@@ -100,17 +105,29 @@ async function expireClaim(app: TestNextly): Promise<void> {
  */
 async function setRemaining(app: TestNextly, seconds: number): Promise<void> {
   const dialect = app.adapter.getCapabilities().dialect;
-  const key = documentLockKey(DOC.collection, DOC.entryId);
+  const key = documentLockKey(DOC.scopeKind, DOC.slug, DOC.entryId);
   await app.adapter.transaction(async ctx => {
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
           SET ${sql.identifier("expires_at")} = ${futureExpression(dialect, seconds)}
-          WHERE ${sql.identifier("lock_key")} = ${key}`
+          WHERE ${sql.identifier("id")} = ${key}`
     );
   });
 }
 
 describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
+  /** Acquire as `who`, failing loudly rather than returning an unusable token. */
+  async function claim(
+    app: TestNextly,
+    who: typeof ADA
+  ): Promise<{ token: string }> {
+    const got = await acquireDocumentLock(app.adapter, DOC, who);
+    if (got.status !== "acquired") {
+      throw new Error(`expected to acquire, got ${got.status}`);
+    }
+    return { token: got.claimToken };
+  }
+
   it("gives the first author the claim, and says how long it has", async () => {
     const app = await boot(d);
     const got = await acquireDocumentLock(app.adapter, DOC, ADA);
@@ -126,7 +143,7 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
 
   it("refuses a second author and names who is editing", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await claim(app, ADA);
 
     const got = await acquireDocumentLock(app.adapter, DOC, GRACE);
     expect(got.status).toBe("held");
@@ -138,15 +155,42 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
 
   it("lets the SAME author re-acquire, so reopening a tab is not a conflict", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await claim(app, ADA);
 
     const again = await acquireDocumentLock(app.adapter, DOC, ADA);
     expect(again.status).toBe("acquired");
   });
 
+  it("does not let one tab's release free the claim its own author holds in another", async () => {
+    const app = await boot(d);
+    const first = await claim(app, ADA);
+    const second = await claim(app, ADA);
+    expect(second.token).not.toBe(first.token);
+
+    // The first tab closes. Fenced on OWNER alone this would delete the row the
+    // second tab is editing under, leaving that tab believing it is protected
+    // while anybody could take the document.
+    await releaseDocumentLock(app.adapter, DOC, first.token);
+
+    expect((await readDocumentLock(app.adapter, DOC))?.ownerId).toBe(
+      "user-ada"
+    );
+    const beat = await renewDocumentLock(app.adapter, DOC, second.token);
+    expect(beat.status).toBe("renewed");
+  });
+
+  it("ignores a heartbeat from a tab whose claim was replaced", async () => {
+    const app = await boot(d);
+    const first = await claim(app, ADA);
+    await claim(app, ADA);
+
+    const stale = await renewDocumentLock(app.adapter, DOC, first.token);
+    expect(stale.status).toBe("lost");
+  });
+
   it("hands an EXPIRED claim to the next author without asking for a takeover", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await claim(app, ADA);
     await expireClaim(app);
 
     // No takeover flag. A holder that crashed, closed the laptop or went
@@ -157,18 +201,63 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
     expect(got.holder.ownerId).toBe("user-grace");
   });
 
+  it("refuses to revive a claim whose lease already expired", async () => {
+    const app = await boot(d);
+    const ada = await claim(app, ADA);
+    await expireClaim(app);
+
+    // A delayed heartbeat arriving after expiry, before anyone else acquired.
+    // Fenced on ownership alone this would extend the row by another full lease
+    // and report success — resurrecting a claim that was already free, and
+    // refusing the author who was about to take it.
+    const beat = await renewDocumentLock(app.adapter, DOC, ada.token);
+    expect(beat.status).toBe("lost");
+
+    const next = await acquireDocumentLock(app.adapter, DOC, GRACE);
+    expect(next.status).toBe("acquired");
+  });
+
   it("reports nobody editing once a claim has expired", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await claim(app, ADA);
     expect(await readDocumentLock(app.adapter, DOC)).toBeDefined();
 
     await expireClaim(app);
     expect(await readDocumentLock(app.adapter, DOC)).toBeUndefined();
   });
 
+  it("deletes lapsed claims when swept, so the table tracks documents open now", async () => {
+    const app = await boot(d);
+    await claim(app, ADA);
+    await expireClaim(app);
+
+    await sweepExpiredDocumentLocks(app.adapter);
+
+    // Gone from the table, not merely hidden by the liveness test. Without the
+    // sweep every document ever opened and abandoned would leave a row forever.
+    const rows = await app.adapter.queryStatement<{ n: unknown }>(
+      sql`SELECT COUNT(*) AS ${sql.identifier("n")}
+          FROM ${sql.identifier(DOCUMENT_LOCK_TABLE)}`
+    );
+    expect(Number(rows[0]?.n)).toBe(0);
+  });
+
+  it("does not sweep a claim that is still live", async () => {
+    const app = await boot(d);
+    await claim(app, ADA);
+
+    await sweepExpiredDocumentLocks(app.adapter);
+
+    // The control for the case above: a sweep that deleted everything would
+    // pass that test while destroying every active editing session.
+    expect((await readDocumentLock(app.adapter, DOC))?.ownerId).toBe(
+      "user-ada"
+    );
+  });
+
   it("transfers the document on a deliberate takeover", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await claim(app, ADA);
 
     const stolen = await acquireDocumentLock(app.adapter, DOC, GRACE, {
       takeover: true,
@@ -182,10 +271,10 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
 
   it("tells the ousted author it lost the claim, and to whom", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    const ada = await claim(app, ADA);
     await acquireDocumentLock(app.adapter, DOC, GRACE, { takeover: true });
 
-    const beat = await renewDocumentLock(app.adapter, DOC, ADA);
+    const beat = await renewDocumentLock(app.adapter, DOC, ada.token);
     expect(beat.status).toBe("lost");
     // Naming the new holder is what lets the interface say "Grace took over"
     // rather than only that something happened.
@@ -194,10 +283,10 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
 
   it("reports a lapsed claim as lost with NOBODY holding it", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
-    await releaseDocumentLock(app.adapter, DOC, ADA);
+    const ada = await claim(app, ADA);
+    await releaseDocumentLock(app.adapter, DOC, ada.token);
 
-    const beat = await renewDocumentLock(app.adapter, DOC, ADA);
+    const beat = await renewDocumentLock(app.adapter, DOC, ada.token);
     expect(beat.status).toBe("lost");
     // Absent rather than present-and-empty. "Nobody has it" leads the editor to
     // offer resuming; "Grace has it" leads it to offer requesting access, and
@@ -207,7 +296,7 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
 
   it("does not let a heartbeat from a non-owner extend the owner's claim", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await claim(app, ADA);
     // Wind the lease down first. Asserting on the OWNER after an unfenced
     // renewal proves nothing — an unfenced UPDATE sets `expires_at` and leaves
     // `owner_id` alone, so Ada still owns it either way and the defect is
@@ -215,7 +304,7 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
     // Grace does not hold, and only the remaining span shows that.
     await setRemaining(app, 30);
 
-    const beat = await renewDocumentLock(app.adapter, DOC, GRACE);
+    const beat = await renewDocumentLock(app.adapter, DOC, "not-a-real-token");
     expect(beat.status).toBe("lost");
 
     const held = await readDocumentLock(app.adapter, DOC);
@@ -227,11 +316,9 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
 
   it("does not let a non-owner release somebody else's claim", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
+    await claim(app, ADA);
 
-    await releaseDocumentLock(app.adapter, DOC, GRACE);
-    // A late release from a previous holder must not free the document out from
-    // under whoever took it over.
+    await releaseDocumentLock(app.adapter, DOC, "not-a-real-token");
     expect((await readDocumentLock(app.adapter, DOC))?.ownerId).toBe(
       "user-ada"
     );
@@ -239,11 +326,26 @@ describe.each(getConfiguredTestDialects())("document soft lock (%s)", d => {
 
   it("frees the document when its owner releases it", async () => {
     const app = await boot(d);
-    await acquireDocumentLock(app.adapter, DOC, ADA);
-    await releaseDocumentLock(app.adapter, DOC, ADA);
+    const ada = await claim(app, ADA);
+    await releaseDocumentLock(app.adapter, DOC, ada.token);
 
     expect(await readDocumentLock(app.adapter, DOC)).toBeUndefined();
     const next = await acquireDocumentLock(app.adapter, DOC, GRACE);
     expect(next.status).toBe("acquired");
+  });
+
+  it("gives the document to exactly one of two simultaneous first claims", async () => {
+    const app = await boot(d);
+
+    // Both find no row and both insert. The loser must not raise: on PostgreSQL
+    // a unique-violation aborts the whole transaction, so a caught constraint
+    // error would leave the read that reports the winner failing with 25P02.
+    const [first, second] = await Promise.all([
+      acquireDocumentLock(app.adapter, DOC, ADA),
+      acquireDocumentLock(app.adapter, DOC, GRACE),
+    ]);
+
+    const outcomes = [first.status, second.status].sort();
+    expect(outcomes).toEqual(["acquired", "held"]);
   });
 });

--- a/packages/nextly/src/domains/document-lock/__tests__/lock-key.test.ts
+++ b/packages/nextly/src/domains/document-lock/__tests__/lock-key.test.ts
@@ -1,0 +1,43 @@
+/**
+ * The key a document's lock row is addressed by.
+ *
+ * Every case here is about a document that CANNOT be locked. The key is derived
+ * in one place precisely so a document that has no representable key is refused
+ * once, loudly, rather than silently colliding with a different document's row —
+ * which would present as one author's lock releasing another author's document.
+ *
+ * @module domains/document-lock/__tests__/lock-key.test
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { MAX_DOCUMENT_LOCK_KEY_LENGTH, documentLockKey } from "../lock-key";
+
+describe("documentLockKey", () => {
+  it("joins a collection and an entry id", () => {
+    expect(documentLockKey("posts", "abc-123")).toBe("posts:abc-123");
+  });
+
+  it("refuses a collection carrying the separator, which would collide with another document", () => {
+    // "a:b" + "c" and "a" + "b:c" both read as "a:b:c". Escaping instead of
+    // refusing would make the key unreadable in the database session where
+    // somebody debugging "who holds this" actually looks.
+    expect(documentLockKey("a:b", "c")).toBeUndefined();
+    expect(documentLockKey("a", "b:c")).toBeUndefined();
+  });
+
+  it("refuses an empty half rather than producing a key with a hole in it", () => {
+    expect(documentLockKey("", "abc")).toBeUndefined();
+    expect(documentLockKey("posts", "")).toBeUndefined();
+  });
+
+  it("refuses a key MySQL could not index, at the boundary", () => {
+    const fits = "e".repeat(MAX_DOCUMENT_LOCK_KEY_LENGTH - "posts:".length);
+    expect(documentLockKey("posts", fits)).toHaveLength(
+      MAX_DOCUMENT_LOCK_KEY_LENGTH
+    );
+    // One character more is refused rather than silently truncated: two entry
+    // ids sharing a 191-character prefix would otherwise share a lock row.
+    expect(documentLockKey("posts", `${fits}e`)).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/domains/document-lock/__tests__/lock-key.test.ts
+++ b/packages/nextly/src/domains/document-lock/__tests__/lock-key.test.ts
@@ -15,29 +15,42 @@ import { MAX_DOCUMENT_LOCK_KEY_LENGTH, documentLockKey } from "../lock-key";
 
 describe("documentLockKey", () => {
   it("joins a collection and an entry id", () => {
-    expect(documentLockKey("posts", "abc-123")).toBe("posts:abc-123");
+    expect(documentLockKey("collection", "posts", "abc-123")).toBe(
+      "collection:posts:abc-123"
+    );
   });
 
   it("refuses a collection carrying the separator, which would collide with another document", () => {
     // "a:b" + "c" and "a" + "b:c" both read as "a:b:c". Escaping instead of
     // refusing would make the key unreadable in the database session where
     // somebody debugging "who holds this" actually looks.
-    expect(documentLockKey("a:b", "c")).toBeUndefined();
-    expect(documentLockKey("a", "b:c")).toBeUndefined();
+    expect(documentLockKey("collection", "a:b", "c")).toBeUndefined();
+    expect(documentLockKey("collection", "a", "b:c")).toBeUndefined();
   });
 
   it("refuses an empty half rather than producing a key with a hole in it", () => {
-    expect(documentLockKey("", "abc")).toBeUndefined();
-    expect(documentLockKey("posts", "")).toBeUndefined();
+    expect(documentLockKey("collection", "", "abc")).toBeUndefined();
+    expect(documentLockKey("collection", "posts", "")).toBeUndefined();
+  });
+
+  it("gives a Single and a collection entry with the same slug DIFFERENT keys", () => {
+    // Their entries live in separate tables, so an id is unique only within its
+    // own kind. One key for both would mean taking over the Single silently
+    // released the collection entry, and each author would be told they held a
+    // document the other was editing.
+    expect(documentLockKey("single", "about", "1")).not.toBe(
+      documentLockKey("collection", "about", "1")
+    );
   });
 
   it("refuses a key MySQL could not index, at the boundary", () => {
-    const fits = "e".repeat(MAX_DOCUMENT_LOCK_KEY_LENGTH - "posts:".length);
-    expect(documentLockKey("posts", fits)).toHaveLength(
+    const prefix = "collection:posts:";
+    const fits = "e".repeat(MAX_DOCUMENT_LOCK_KEY_LENGTH - prefix.length);
+    expect(documentLockKey("collection", "posts", fits)).toHaveLength(
       MAX_DOCUMENT_LOCK_KEY_LENGTH
     );
     // One character more is refused rather than silently truncated: two entry
     // ids sharing a 191-character prefix would otherwise share a lock row.
-    expect(documentLockKey("posts", `${fits}e`)).toBeUndefined();
+    expect(documentLockKey("collection", "posts", `${fits}e`)).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/document-lock/__tests__/timings.test.ts
+++ b/packages/nextly/src/domains/document-lock/__tests__/timings.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The lease timings, and that they are DERIVED rather than written down.
+ *
+ * The derivation is the thing under test. Two numbers chosen side by side agree
+ * on the day they are written and drift afterwards, each looking reasonable
+ * alone — and the drift here is an editor that believes it is protected while
+ * somebody else is already taking the document.
+ *
+ * @module domains/document-lock/__tests__/timings.test
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS,
+  DOCUMENT_LOCK_LOSS_AFTER_MS,
+  DOCUMENT_LOCK_RENEW_MARGIN_SECONDS,
+  DOCUMENT_LOCK_TTL_SECONDS,
+} from "../timings";
+
+describe("document lock timings", () => {
+  it("is the 150-second lease and 15-second heartbeat that were ruled", () => {
+    expect(DOCUMENT_LOCK_TTL_SECONDS).toBe(150);
+    expect(DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS).toBe(15_000);
+  });
+
+  it("tells a holder it is losing the claim while it is still protected", () => {
+    // Two heartbeats of lease remain at the loss deadline. A holder warned at
+    // expiry would be told after it stopped being protected rather than while
+    // it still is, which is too late to save anything.
+    expect(DOCUMENT_LOCK_LOSS_AFTER_MS).toBe(
+      DOCUMENT_LOCK_TTL_SECONDS * 1000 - 2 * DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
+    );
+    expect(DOCUMENT_LOCK_LOSS_AFTER_MS).toBeLessThan(
+      DOCUMENT_LOCK_TTL_SECONDS * 1000
+    );
+  });
+
+  it("requires a renewal to leave more than one heartbeat of lease in hand", () => {
+    // The margin is what "usable" is judged against. Below one heartbeat a
+    // claim could expire before its holder next asks, so a renewal returning
+    // less than this is not a claim anything may rely on.
+    expect(DOCUMENT_LOCK_RENEW_MARGIN_SECONDS * 1000).toBeGreaterThan(
+      DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS
+    );
+    expect(DOCUMENT_LOCK_RENEW_MARGIN_SECONDS).toBe(
+      DOCUMENT_LOCK_LOSS_AFTER_MS / 1000
+    );
+  });
+});

--- a/packages/nextly/src/domains/document-lock/document-lock-repository.ts
+++ b/packages/nextly/src/domains/document-lock/document-lock-repository.ts
@@ -13,14 +13,22 @@
  * lock. Asking the database for both sides puts every comparison in one frame
  * of reference.
  *
+ * ## A claim is an ACQUISITION, not a person
+ *
+ * Every claim carries a token minted when it was taken, and every heartbeat and
+ * release must present it. Ownership alone is not enough: one author with the
+ * document open in two tabs holds two claims under one user id, and a release
+ * from the tab they closed would otherwise delete the claim the other tab is
+ * still editing under — leaving that tab believing it is protected while
+ * somebody else takes the document.
+ *
  * ## Why a takeover is allowed here and refused by the migration lock
  *
  * They share a clock and a TTL derivation, and nothing else. That lock guards
  * DDL, where stealing a live claim means two concurrent migrations corrupting a
  * schema, so it never steals. This one mediates two people, where refusing
  * forever would mean a closed laptop locking a document until its lease runs
- * out with no way to ask for it back. Different questions, different answers,
- * deliberately not shared.
+ * out with no way to ask for it back.
  *
  * ## No flush on takeover
  *
@@ -33,6 +41,8 @@
  *
  * @module domains/document-lock/document-lock-repository
  */
+
+import { randomUUID } from "node:crypto";
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type {
@@ -48,7 +58,6 @@ import {
 } from "../../database/lease-clock";
 import { NextlyError } from "../../errors/nextly-error";
 import { DOCUMENT_LOCK_TABLE } from "../../schemas/document-lock";
-import { isUniqueViolation } from "../../shared/lib/unique-violation";
 
 import { documentLockKey } from "./lock-key";
 import {
@@ -77,13 +86,11 @@ export interface DocumentLockClaimant {
  * before its holder asks again", which is what a claimant needs before it starts
  * editing: a claim shorter than that is live now and gone before anything
  * re-checks it.
- *
- * Both are computed in the same statement as the read, so no caller can hold a
- * holder and a liveness verdict that disagree.
  */
 interface LockRow {
   readonly ownerId: string;
   readonly ownerLabel: string | null;
+  readonly claimToken: string;
   readonly expiresInSeconds: number;
   readonly live: boolean;
   readonly usable: boolean;
@@ -92,6 +99,7 @@ interface LockRow {
 interface RawLockRow {
   readonly owner_id: string | null;
   readonly owner_label: string | null;
+  readonly claim_token: string | null;
   readonly expires_in: unknown;
   readonly live: unknown;
   readonly usable: unknown;
@@ -114,13 +122,14 @@ interface RawLockRow {
 function lockRowQuery(dialect: SupportedDialect, key: string): SQL {
   return sql`SELECT ${sql.identifier("owner_id")},
       ${sql.identifier("owner_label")},
+      ${sql.identifier("claim_token")},
       ${remainingSecondsExpression(dialect, "expires_at")} AS ${sql.identifier("expires_in")},
       CASE WHEN ${sql.identifier("expires_at")} > ${nowExpression(dialect)}
            THEN 1 ELSE 0 END AS ${sql.identifier("live")},
       CASE WHEN ${sql.identifier("expires_at")} > ${futureExpression(dialect, DOCUMENT_LOCK_RENEW_MARGIN_SECONDS)}
            THEN 1 ELSE 0 END AS ${sql.identifier("usable")}
       FROM ${sql.identifier(DOCUMENT_LOCK_TABLE)}
-      WHERE ${sql.identifier("lock_key")} = ${key}`;
+      WHERE ${sql.identifier("id")} = ${key}`;
 }
 
 /** The row, or `undefined` when no claim on this document exists at all. */
@@ -129,9 +138,10 @@ function toLockRow(row: RawLockRow | undefined): LockRow | undefined {
   return {
     ownerId: row.owner_id,
     ownerLabel: row.owner_label,
+    claimToken: row.claim_token ?? "",
     // Every driver reports this differently — a number on SQLite, a string from
     // PostgreSQL's `EXTRACT` on some drivers, a number from MySQL — so it is
-    // coerced once here rather than at each of the three call sites.
+    // coerced once here rather than at each call site.
     expiresInSeconds: Math.trunc(Number(row.expires_in)),
     live: Number(row.live) === 1,
     usable: Number(row.usable) === 1,
@@ -146,33 +156,19 @@ function toHolder(row: LockRow): DocumentLockHolder {
   };
 }
 
-/**
- * The row this claim was just written to is gone.
- *
- * Only a release landing in the same instant produces this. Reported as a
- * conflict the caller may retry rather than as "somebody else is editing",
- * which would be false — nobody holds the document, including us.
- */
-function lockRowVanished(key: string, at: string): never {
-  throw NextlyError.conflict({
-    reason: "state",
-    message: "Could not start editing just now. Please try again.",
-    logContext: { reason: "lock row vanished", at, key },
-  });
-}
-
 /** The key for this document, or a refusal naming why there is not one. */
 function keyFor(ref: DocumentRef): string {
-  const key = documentLockKey(ref.collection, ref.entryId);
+  const key = documentLockKey(ref.scopeKind, ref.slug, ref.entryId);
   if (key !== undefined) return key;
-  // `invalidInput` rather than `internal`: a collection slug or entry id can
-  // reach here from a request, so this is a caller mistake rather than a
-  // programming one, and it must not read as a server fault in the log.
+  // `invalidInput` rather than `internal`: a slug or entry id can reach here
+  // from a request, so this is a caller mistake rather than a programming one,
+  // and it must not read as a server fault in the log.
   throw NextlyError.invalidInput({
     message: "This document cannot be locked for editing.",
     logContext: {
       reason: "document reference does not form a portable lock key",
-      collection: ref.collection,
+      scopeKind: ref.scopeKind,
+      slug: ref.slug,
       entryId: ref.entryId,
     },
   });
@@ -204,6 +200,88 @@ export async function readDocumentLock(
 }
 
 /**
+ * An insert that yields to a concurrent winner instead of raising.
+ *
+ * 🔴 Deliberately NOT a caught unique violation. On PostgreSQL a constraint
+ * error aborts the whole transaction, so catching `23505` leaves a context in
+ * which every later statement fails with `25P02` — the read that was supposed
+ * to report the winner cannot run. Letting the database ignore the conflict
+ * keeps the transaction usable, and the read-back that follows is then the one
+ * thing that decides the outcome.
+ *
+ * MySQL cannot express `ON CONFLICT`, and PostgreSQL and SQLite cannot express
+ * `INSERT IGNORE`; the spelling differs per dialect but the semantics are the
+ * same on all three.
+ */
+function insertIfAbsent(
+  dialect: SupportedDialect,
+  key: string,
+  ref: DocumentRef,
+  claimant: DocumentLockClaimant,
+  claimToken: string
+): SQL {
+  const columns = sql`(${sql.identifier("id")}, ${sql.identifier("scope_kind")},
+      ${sql.identifier("slug")}, ${sql.identifier("entry_id")},
+      ${sql.identifier("owner_id")}, ${sql.identifier("claim_token")},
+      ${sql.identifier("owner_label")}, ${sql.identifier("acquired_at")},
+      ${sql.identifier("expires_at")})`;
+  const values = sql`VALUES (${key}, ${ref.scopeKind}, ${ref.slug}, ${ref.entryId},
+      ${claimant.ownerId}, ${claimToken}, ${claimant.ownerLabel ?? null},
+      ${nowExpression(dialect)},
+      ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)})`;
+
+  if (dialect === "mysql") {
+    return sql`INSERT IGNORE INTO ${sql.identifier(DOCUMENT_LOCK_TABLE)} ${columns} ${values}`;
+  }
+  return sql`INSERT INTO ${sql.identifier(DOCUMENT_LOCK_TABLE)} ${columns} ${values}
+      ON CONFLICT (${sql.identifier("id")}) DO NOTHING`;
+}
+
+/**
+ * The row this claim was just written to is gone.
+ *
+ * Only a release or a sweep landing in the same instant produces this. Reported
+ * as a conflict the caller may retry rather than as "somebody else is editing",
+ * which would be false — nobody holds the document, including us.
+ */
+function lockRowVanished(key: string): never {
+  throw NextlyError.conflict({
+    reason: "state",
+    message: "Could not start editing just now. Please try again.",
+    logContext: { reason: "lock row vanished during acquisition", key },
+  });
+}
+
+/** Whether this existing claim may be replaced by the caller's. */
+function isTakeable(
+  existing: LockRow,
+  claimant: DocumentLockClaimant,
+  takeover: boolean
+): boolean {
+  // Lapsed, ours to renew, or deliberately taken over by a person who was told
+  // who held it.
+  return (
+    !existing.live || existing.ownerId === claimant.ownerId || takeover === true
+  );
+}
+
+/** Replace whatever claim the row carries with this one. */
+function writeClaim(
+  dialect: SupportedDialect,
+  key: string,
+  claimant: DocumentLockClaimant,
+  claimToken: string
+): SQL {
+  return sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+      SET ${sql.identifier("owner_id")} = ${claimant.ownerId},
+          ${sql.identifier("claim_token")} = ${claimToken},
+          ${sql.identifier("owner_label")} = ${claimant.ownerLabel ?? null},
+          ${sql.identifier("acquired_at")} = ${nowExpression(dialect)},
+          ${sql.identifier("expires_at")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)}
+      WHERE ${sql.identifier("id")} = ${key}`;
+}
+
+/**
  * Claim this document for editing.
  *
  * Returns `held` rather than throwing when somebody else has it, because that is
@@ -224,118 +302,63 @@ export async function acquireDocumentLock(
 ): Promise<AcquireDocumentLockOutcome> {
   const dialect = adapter.getCapabilities().dialect;
   const key = keyFor(ref);
-  const label = claimant.ownerLabel ?? null;
+  const claimToken = randomUUID();
 
   return adapter.transaction(async ctx => {
-    // Serializes contenders that find an existing row. A row that does NOT yet
-    // exist cannot be locked, which is why the insert below is written to
-    // survive losing that race rather than to assume it won.
+    // 🔴 INSERT FIRST, then lock. `lockRow` issues `SELECT ... FOR UPDATE`, and
+    // on a row that does not exist yet InnoDB answers that with a GAP lock —
+    // two contenders opening the same fresh document then deadlock, which is a
+    // failed acquisition on a path with no conflict in it. Creating the row
+    // first is atomic on every dialect and needs no prior lock, so by the time
+    // anything is locked the row is a real row and the lock is an ordinary one.
+    await ctx.runStatement(
+      insertIfAbsent(dialect, key, ref, claimant, claimToken)
+    );
     await ctx.lockRow(DOCUMENT_LOCK_TABLE, key);
 
     const existing = await readRow(ctx, dialect, key);
 
-    if (existing === undefined) {
-      const inserted = await insertClaim(ctx, dialect, key, ref, claimant);
-      if (inserted !== undefined) return inserted;
-      // Another contender inserted between our read and our write. Re-reading
-      // rather than reporting failure: they may hold it, or their claim may
-      // already have lapsed, and only the row can say which.
-      const after = await readRow(ctx, dialect, key);
-      if (after === undefined) lockRowVanished(key, "contended-insert");
-      return acquisitionOf(after, claimant);
+    // Ours already: the insert above found no row and wrote this claim. Nothing
+    // to update, and no other outcome is possible for this token.
+    if (existing !== undefined && existing.claimToken === claimToken) {
+      return { status: "acquired", holder: toHolder(existing), claimToken };
     }
 
-    const mine = existing.ownerId === claimant.ownerId;
-    const takeable = !existing.live || mine || options?.takeover === true;
-    if (!takeable) return { status: "held", holder: toHolder(existing) };
+    if (existing === undefined) lockRowVanished(key);
+    if (!isTakeable(existing, claimant, options?.takeover === true)) {
+      return { status: "held", holder: toHolder(existing) };
+    }
 
-    await ctx.runStatement(
-      sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
-          SET ${sql.identifier("owner_id")} = ${claimant.ownerId},
-              ${sql.identifier("owner_label")} = ${label},
-              ${sql.identifier("acquired_at")} = ${nowExpression(dialect)},
-              ${sql.identifier("expires_at")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)}
-          WHERE ${sql.identifier("lock_key")} = ${key}`
-    );
+    await ctx.runStatement(writeClaim(dialect, key, claimant, claimToken));
 
-    // Read back rather than trusting the update's affected-row count, which the
-    // dialects report inconsistently — and which counts a row matched but
-    // unchanged differently again.
+    // Read back rather than trusting an affected-row count, which the dialects
+    // report inconsistently — and which counts a row matched but unchanged
+    // differently again.
     const after = await readRow(ctx, dialect, key);
-    if (after === undefined) lockRowVanished(key, "acquisition");
-    return acquisitionOf(after, claimant);
+    if (after === undefined) lockRowVanished(key);
+
+    // 🔴 The TOKEN decides, not the owner. A concurrent acquisition by the same
+    // author writes a different token, so comparing owners would report both
+    // callers as holders of one claim and let either release the other's.
+    if (after.claimToken !== claimToken || !after.usable) {
+      return { status: "held", holder: toHolder(after) };
+    }
+    return { status: "acquired", holder: toHolder(after), claimToken };
   });
-}
-
-/**
- * Is this row a claim the caller may rely on?
- *
- * 🔴 OWNERSHIP AND USABILITY, never ownership alone. A row can name this
- * claimant and still be spent: a transaction suspended or merely slow between
- * writing the expiry and reading it back can burn more than the TTL inside
- * itself. Reporting success on that hands back a claim a contender may take the
- * instant it commits, while the editor carries on believing it is protected.
- *
- * Returns a boolean rather than an outcome because the two callers name the same
- * verdict differently — acquiring calls it `acquired`/`held`, confirming calls it
- * `renewed`/`lost` — and one function returning both unions could only do it
- * through a cast that erases the difference it exists to preserve.
- */
-function holdsIt(row: LockRow, claimant: DocumentLockClaimant): boolean {
-  return row.ownerId === claimant.ownerId && row.usable;
-}
-
-/** The same verdict, named the way an acquisition names it. */
-function acquisitionOf(
-  row: LockRow,
-  claimant: DocumentLockClaimant
-): AcquireDocumentLockOutcome {
-  return holdsIt(row, claimant)
-    ? { status: "acquired", holder: toHolder(row) }
-    : { status: "held", holder: toHolder(row) };
-}
-
-/** Insert a first claim, or `undefined` when another contender won the race. */
-async function insertClaim(
-  ctx: TransactionContext,
-  dialect: SupportedDialect,
-  key: string,
-  ref: DocumentRef,
-  claimant: DocumentLockClaimant
-): Promise<AcquireDocumentLockOutcome | undefined> {
-  try {
-    await ctx.runStatement(
-      sql`INSERT INTO ${sql.identifier(DOCUMENT_LOCK_TABLE)}
-          (${sql.identifier("lock_key")}, ${sql.identifier("collection")},
-           ${sql.identifier("entry_id")}, ${sql.identifier("owner_id")},
-           ${sql.identifier("owner_label")}, ${sql.identifier("acquired_at")},
-           ${sql.identifier("expires_at")})
-          VALUES (${key}, ${ref.collection}, ${ref.entryId},
-                  ${claimant.ownerId}, ${claimant.ownerLabel ?? null},
-                  ${nowExpression(dialect)},
-                  ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)})`
-    );
-  } catch (error) {
-    // A duplicate key reaches here in several shapes, nested a couple of
-    // wrappers deep; this is the one place that knows all of them.
-    if (!isUniqueViolation(error)) throw error;
-    return undefined;
-  }
-  const after = await readRow(ctx, dialect, key);
-  if (after === undefined) lockRowVanished(key, "insert");
-  return acquisitionOf(after, claimant);
 }
 
 /**
  * Confirm a claim this editor believes it still holds.
  *
- * Fenced on ownership in the statement itself, so a heartbeat that arrives after
- * somebody took the document over extends THEIR claim by nothing.
+ * Fenced in the statement itself on the acquisition token AND on the claim still
+ * being live, so a heartbeat that arrives after somebody took the document over,
+ * from a tab whose claim was replaced, or after the lease already lapsed,
+ * extends nothing.
  */
 export async function renewDocumentLock(
   adapter: DrizzleAdapter,
   ref: DocumentRef,
-  claimant: DocumentLockClaimant
+  claimToken: string
 ): Promise<RenewDocumentLockOutcome> {
   const dialect = adapter.getCapabilities().dialect;
   const key = keyFor(ref);
@@ -345,42 +368,76 @@ export async function renewDocumentLock(
     await ctx.runStatement(
       sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
           SET ${sql.identifier("expires_at")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)}
-          WHERE ${sql.identifier("lock_key")} = ${key}
-            AND ${sql.identifier("owner_id")} = ${claimant.ownerId}`
+          WHERE ${sql.identifier("id")} = ${key}
+            AND ${sql.identifier("claim_token")} = ${claimToken}
+            AND ${sql.identifier("expires_at")} > ${nowExpression(dialect)}`
     );
     const after = await readRow(ctx, dialect, key);
-    // No row at all means the claim lapsed and was cleared, or its holder
+    // No row at all means the claim lapsed and was swept, or its holder
     // released it. Reported as lost WITHOUT a holder, which is a different
     // answer from "somebody else has it" and leads the interface to offer
     // resuming rather than requesting access.
     if (after === undefined) return { status: "lost" };
-    return holdsIt(after, claimant)
-      ? { status: "renewed", holder: toHolder(after) }
-      : { status: "lost", holder: toHolder(after) };
+    // 🔴 Liveness is a PRECONDITION of renewal, not a consequence of it. Without
+    // the clause above, a heartbeat arriving after expiry — but before anyone
+    // else acquired — would revive a claim that was already free for the taking,
+    // and the author who was about to acquire would be refused by a lease that
+    // should not have existed.
+    if (after.claimToken !== claimToken || !after.usable) {
+      return { status: "lost", holder: toHolder(after) };
+    }
+    return { status: "renewed", holder: toHolder(after) };
   });
 }
 
 /**
  * Give up a claim.
  *
- * Fenced on ownership so a late release from a previous holder cannot free the
- * document out from under whoever took it over. Silent when there is nothing to
+ * Fenced on the acquisition token so neither a late release from a previous
+ * holder nor one from the author's own closed second tab can free the document
+ * out from under whoever is editing now. Silent when there is nothing to
  * release: an editor closing a tab whose claim already lapsed has nothing to
- * apologise for, and reporting an error there would be noise on a path nobody
- * is watching.
+ * apologise for, and an error there would be noise on a path nobody watches.
  */
 export async function releaseDocumentLock(
   adapter: DrizzleAdapter,
   ref: DocumentRef,
-  claimant: DocumentLockClaimant
+  claimToken: string
 ): Promise<void> {
   const key = keyFor(ref);
   await adapter.transaction(async ctx => {
     await ctx.lockRow(DOCUMENT_LOCK_TABLE, key);
     await ctx.runStatement(
       sql`DELETE FROM ${sql.identifier(DOCUMENT_LOCK_TABLE)}
-          WHERE ${sql.identifier("lock_key")} = ${key}
-            AND ${sql.identifier("owner_id")} = ${claimant.ownerId}`
+          WHERE ${sql.identifier("id")} = ${key}
+            AND ${sql.identifier("claim_token")} = ${claimToken}`
+    );
+  });
+}
+
+/**
+ * Delete every claim that has lapsed.
+ *
+ * A released claim deletes its own row, so this only ever collects the ones
+ * nobody came back from — a crashed tab, a closed laptop, a lost connection.
+ * Without it the table would keep one row per document ever OPENED rather than
+ * per document open now, and the docblock's bound would be a claim nothing
+ * enforced.
+ *
+ * Bounded by the database's clock like every other comparison here, so a sweep
+ * running on an instance whose clock is behind cannot delete a live claim.
+ *
+ * @returns nothing — a sweep that deletes nothing is the ordinary case, and a
+ * count nobody reads would only invite treating it as a health signal.
+ */
+export async function sweepExpiredDocumentLocks(
+  adapter: DrizzleAdapter
+): Promise<void> {
+  const dialect = adapter.getCapabilities().dialect;
+  await adapter.transaction(async ctx => {
+    await ctx.runStatement(
+      sql`DELETE FROM ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          WHERE ${sql.identifier("expires_at")} <= ${nowExpression(dialect)}`
     );
   });
 }

--- a/packages/nextly/src/domains/document-lock/document-lock-repository.ts
+++ b/packages/nextly/src/domains/document-lock/document-lock-repository.ts
@@ -1,0 +1,386 @@
+/**
+ * One editor's claim on one document: taking it, keeping it, and giving it up.
+ *
+ * Two authors opening the same entry is what this exists for. Without it the
+ * second save silently overwrites the first, and neither author is told.
+ *
+ * ## The claim is decided by the database, never by this process
+ *
+ * Every liveness comparison is a SQL expression the database evaluates itself.
+ * Contenders sit on different machines — under serverless, a different instance
+ * per request — whose clocks disagree, so a claim written from one clock and
+ * judged against another is decided by that skew rather than by who holds the
+ * lock. Asking the database for both sides puts every comparison in one frame
+ * of reference.
+ *
+ * ## Why a takeover is allowed here and refused by the migration lock
+ *
+ * They share a clock and a TTL derivation, and nothing else. That lock guards
+ * DDL, where stealing a live claim means two concurrent migrations corrupting a
+ * schema, so it never steals. This one mediates two people, where refusing
+ * forever would mean a closed laptop locking a document until its lease runs
+ * out with no way to ask for it back. Different questions, different answers,
+ * deliberately not shared.
+ *
+ * ## No flush on takeover
+ *
+ * Taking a claim over does not move the ousted author's unsaved work anywhere.
+ * The editor already writes an autosave into a per-document-per-author row on
+ * its own interval, so that work survives on a path that runs whether or not a
+ * takeover ever happens — including in the cases a lease actually exists for,
+ * where the ousted client is asleep, offline or gone and could not have flushed
+ * anything.
+ *
+ * @module domains/document-lock/document-lock-repository
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type {
+  SupportedDialect,
+  TransactionContext,
+} from "@nextlyhq/adapter-drizzle/types";
+import { sql, type SQL } from "drizzle-orm";
+
+import {
+  futureExpression,
+  nowExpression,
+  remainingSecondsExpression,
+} from "../../database/lease-clock";
+import { NextlyError } from "../../errors/nextly-error";
+import { DOCUMENT_LOCK_TABLE } from "../../schemas/document-lock";
+import { isUniqueViolation } from "../../shared/lib/unique-violation";
+
+import { documentLockKey } from "./lock-key";
+import {
+  DOCUMENT_LOCK_RENEW_MARGIN_SECONDS,
+  DOCUMENT_LOCK_TTL_SECONDS,
+} from "./timings";
+import type {
+  AcquireDocumentLockOutcome,
+  DocumentLockHolder,
+  DocumentRef,
+  RenewDocumentLockOutcome,
+} from "./types";
+
+/** Who is asking, and what the interface should call them. */
+export interface DocumentLockClaimant {
+  readonly ownerId: string;
+  readonly ownerLabel?: string | null;
+}
+
+/**
+ * The row as the database reports it, with every time question already decided
+ * there.
+ *
+ * `live` is "would this claim still exclude a contender right now", which is
+ * what an observer reports. `usable` is the stricter "will it outlast the window
+ * before its holder asks again", which is what a claimant needs before it starts
+ * editing: a claim shorter than that is live now and gone before anything
+ * re-checks it.
+ *
+ * Both are computed in the same statement as the read, so no caller can hold a
+ * holder and a liveness verdict that disagree.
+ */
+interface LockRow {
+  readonly ownerId: string;
+  readonly ownerLabel: string | null;
+  readonly expiresInSeconds: number;
+  readonly live: boolean;
+  readonly usable: boolean;
+}
+
+interface RawLockRow {
+  readonly owner_id: string | null;
+  readonly owner_label: string | null;
+  readonly expires_in: unknown;
+  readonly live: unknown;
+  readonly usable: unknown;
+}
+
+/**
+ * The single statement that reads a lock row and decides both liveness
+ * questions.
+ *
+ * Issued as a raw statement rather than through the typed query builder because
+ * the comparisons have to be the database's own clock expressions, which the
+ * builder has no way to express.
+ *
+ * The two verdicts are `CASE` expressions returning 1 or 0 rather than booleans
+ * because the dialects return booleans differently — `true`, `1` and `"1"` all
+ * occur — and a caller comparing against one of those three is a per-dialect
+ * defect no unit double can see. An integer normalises through `Number()` on
+ * every driver.
+ */
+function lockRowQuery(dialect: SupportedDialect, key: string): SQL {
+  return sql`SELECT ${sql.identifier("owner_id")},
+      ${sql.identifier("owner_label")},
+      ${remainingSecondsExpression(dialect, "expires_at")} AS ${sql.identifier("expires_in")},
+      CASE WHEN ${sql.identifier("expires_at")} > ${nowExpression(dialect)}
+           THEN 1 ELSE 0 END AS ${sql.identifier("live")},
+      CASE WHEN ${sql.identifier("expires_at")} > ${futureExpression(dialect, DOCUMENT_LOCK_RENEW_MARGIN_SECONDS)}
+           THEN 1 ELSE 0 END AS ${sql.identifier("usable")}
+      FROM ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+      WHERE ${sql.identifier("lock_key")} = ${key}`;
+}
+
+/** The row, or `undefined` when no claim on this document exists at all. */
+function toLockRow(row: RawLockRow | undefined): LockRow | undefined {
+  if (row === undefined || row.owner_id === null) return undefined;
+  return {
+    ownerId: row.owner_id,
+    ownerLabel: row.owner_label,
+    // Every driver reports this differently — a number on SQLite, a string from
+    // PostgreSQL's `EXTRACT` on some drivers, a number from MySQL — so it is
+    // coerced once here rather than at each of the three call sites.
+    expiresInSeconds: Math.trunc(Number(row.expires_in)),
+    live: Number(row.live) === 1,
+    usable: Number(row.usable) === 1,
+  };
+}
+
+function toHolder(row: LockRow): DocumentLockHolder {
+  return {
+    ownerId: row.ownerId,
+    ownerLabel: row.ownerLabel,
+    expiresInSeconds: row.expiresInSeconds,
+  };
+}
+
+/**
+ * The row this claim was just written to is gone.
+ *
+ * Only a release landing in the same instant produces this. Reported as a
+ * conflict the caller may retry rather than as "somebody else is editing",
+ * which would be false — nobody holds the document, including us.
+ */
+function lockRowVanished(key: string, at: string): never {
+  throw NextlyError.conflict({
+    reason: "state",
+    message: "Could not start editing just now. Please try again.",
+    logContext: { reason: "lock row vanished", at, key },
+  });
+}
+
+/** The key for this document, or a refusal naming why there is not one. */
+function keyFor(ref: DocumentRef): string {
+  const key = documentLockKey(ref.collection, ref.entryId);
+  if (key !== undefined) return key;
+  // `invalidInput` rather than `internal`: a collection slug or entry id can
+  // reach here from a request, so this is a caller mistake rather than a
+  // programming one, and it must not read as a server fault in the log.
+  throw NextlyError.invalidInput({
+    message: "This document cannot be locked for editing.",
+    logContext: {
+      reason: "document reference does not form a portable lock key",
+      collection: ref.collection,
+      entryId: ref.entryId,
+    },
+  });
+}
+
+async function readRow(
+  ctx: Pick<TransactionContext, "queryStatement">,
+  dialect: SupportedDialect,
+  key: string
+): Promise<LockRow | undefined> {
+  const rows = await ctx.queryStatement<RawLockRow>(lockRowQuery(dialect, key));
+  return toLockRow(rows[0]);
+}
+
+/**
+ * Who holds this document right now, if anybody.
+ *
+ * Read on the adapter's own connection rather than in a transaction: opening one
+ * to read a single row asks for more than the read needs, and this is the call
+ * an editor makes on every poll.
+ */
+export async function readDocumentLock(
+  adapter: DrizzleAdapter,
+  ref: DocumentRef
+): Promise<DocumentLockHolder | undefined> {
+  const dialect = adapter.getCapabilities().dialect;
+  const row = await readRow(adapter, dialect, keyFor(ref));
+  return row !== undefined && row.live ? toHolder(row) : undefined;
+}
+
+/**
+ * Claim this document for editing.
+ *
+ * Returns `held` rather than throwing when somebody else has it, because that is
+ * an ordinary answer with a name and a countdown in it that the interface has to
+ * render.
+ *
+ * `takeover` is the deliberate steal a person asks for after being told who
+ * holds it. It is a separate argument rather than a retry of the same call so
+ * that no caller can take a document over by accident: an editor opening a
+ * document and a person pressing "take over anyway" are different intents and
+ * the server can tell them apart.
+ */
+export async function acquireDocumentLock(
+  adapter: DrizzleAdapter,
+  ref: DocumentRef,
+  claimant: DocumentLockClaimant,
+  options?: { readonly takeover?: boolean }
+): Promise<AcquireDocumentLockOutcome> {
+  const dialect = adapter.getCapabilities().dialect;
+  const key = keyFor(ref);
+  const label = claimant.ownerLabel ?? null;
+
+  return adapter.transaction(async ctx => {
+    // Serializes contenders that find an existing row. A row that does NOT yet
+    // exist cannot be locked, which is why the insert below is written to
+    // survive losing that race rather than to assume it won.
+    await ctx.lockRow(DOCUMENT_LOCK_TABLE, key);
+
+    const existing = await readRow(ctx, dialect, key);
+
+    if (existing === undefined) {
+      const inserted = await insertClaim(ctx, dialect, key, ref, claimant);
+      if (inserted !== undefined) return inserted;
+      // Another contender inserted between our read and our write. Re-reading
+      // rather than reporting failure: they may hold it, or their claim may
+      // already have lapsed, and only the row can say which.
+      const after = await readRow(ctx, dialect, key);
+      if (after === undefined) lockRowVanished(key, "contended-insert");
+      return acquisitionOf(after, claimant);
+    }
+
+    const mine = existing.ownerId === claimant.ownerId;
+    const takeable = !existing.live || mine || options?.takeover === true;
+    if (!takeable) return { status: "held", holder: toHolder(existing) };
+
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          SET ${sql.identifier("owner_id")} = ${claimant.ownerId},
+              ${sql.identifier("owner_label")} = ${label},
+              ${sql.identifier("acquired_at")} = ${nowExpression(dialect)},
+              ${sql.identifier("expires_at")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)}
+          WHERE ${sql.identifier("lock_key")} = ${key}`
+    );
+
+    // Read back rather than trusting the update's affected-row count, which the
+    // dialects report inconsistently — and which counts a row matched but
+    // unchanged differently again.
+    const after = await readRow(ctx, dialect, key);
+    if (after === undefined) lockRowVanished(key, "acquisition");
+    return acquisitionOf(after, claimant);
+  });
+}
+
+/**
+ * Is this row a claim the caller may rely on?
+ *
+ * 🔴 OWNERSHIP AND USABILITY, never ownership alone. A row can name this
+ * claimant and still be spent: a transaction suspended or merely slow between
+ * writing the expiry and reading it back can burn more than the TTL inside
+ * itself. Reporting success on that hands back a claim a contender may take the
+ * instant it commits, while the editor carries on believing it is protected.
+ *
+ * Returns a boolean rather than an outcome because the two callers name the same
+ * verdict differently — acquiring calls it `acquired`/`held`, confirming calls it
+ * `renewed`/`lost` — and one function returning both unions could only do it
+ * through a cast that erases the difference it exists to preserve.
+ */
+function holdsIt(row: LockRow, claimant: DocumentLockClaimant): boolean {
+  return row.ownerId === claimant.ownerId && row.usable;
+}
+
+/** The same verdict, named the way an acquisition names it. */
+function acquisitionOf(
+  row: LockRow,
+  claimant: DocumentLockClaimant
+): AcquireDocumentLockOutcome {
+  return holdsIt(row, claimant)
+    ? { status: "acquired", holder: toHolder(row) }
+    : { status: "held", holder: toHolder(row) };
+}
+
+/** Insert a first claim, or `undefined` when another contender won the race. */
+async function insertClaim(
+  ctx: TransactionContext,
+  dialect: SupportedDialect,
+  key: string,
+  ref: DocumentRef,
+  claimant: DocumentLockClaimant
+): Promise<AcquireDocumentLockOutcome | undefined> {
+  try {
+    await ctx.runStatement(
+      sql`INSERT INTO ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          (${sql.identifier("lock_key")}, ${sql.identifier("collection")},
+           ${sql.identifier("entry_id")}, ${sql.identifier("owner_id")},
+           ${sql.identifier("owner_label")}, ${sql.identifier("acquired_at")},
+           ${sql.identifier("expires_at")})
+          VALUES (${key}, ${ref.collection}, ${ref.entryId},
+                  ${claimant.ownerId}, ${claimant.ownerLabel ?? null},
+                  ${nowExpression(dialect)},
+                  ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)})`
+    );
+  } catch (error) {
+    // A duplicate key reaches here in several shapes, nested a couple of
+    // wrappers deep; this is the one place that knows all of them.
+    if (!isUniqueViolation(error)) throw error;
+    return undefined;
+  }
+  const after = await readRow(ctx, dialect, key);
+  if (after === undefined) lockRowVanished(key, "insert");
+  return acquisitionOf(after, claimant);
+}
+
+/**
+ * Confirm a claim this editor believes it still holds.
+ *
+ * Fenced on ownership in the statement itself, so a heartbeat that arrives after
+ * somebody took the document over extends THEIR claim by nothing.
+ */
+export async function renewDocumentLock(
+  adapter: DrizzleAdapter,
+  ref: DocumentRef,
+  claimant: DocumentLockClaimant
+): Promise<RenewDocumentLockOutcome> {
+  const dialect = adapter.getCapabilities().dialect;
+  const key = keyFor(ref);
+
+  return adapter.transaction(async ctx => {
+    await ctx.lockRow(DOCUMENT_LOCK_TABLE, key);
+    await ctx.runStatement(
+      sql`UPDATE ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          SET ${sql.identifier("expires_at")} = ${futureExpression(dialect, DOCUMENT_LOCK_TTL_SECONDS)}
+          WHERE ${sql.identifier("lock_key")} = ${key}
+            AND ${sql.identifier("owner_id")} = ${claimant.ownerId}`
+    );
+    const after = await readRow(ctx, dialect, key);
+    // No row at all means the claim lapsed and was cleared, or its holder
+    // released it. Reported as lost WITHOUT a holder, which is a different
+    // answer from "somebody else has it" and leads the interface to offer
+    // resuming rather than requesting access.
+    if (after === undefined) return { status: "lost" };
+    return holdsIt(after, claimant)
+      ? { status: "renewed", holder: toHolder(after) }
+      : { status: "lost", holder: toHolder(after) };
+  });
+}
+
+/**
+ * Give up a claim.
+ *
+ * Fenced on ownership so a late release from a previous holder cannot free the
+ * document out from under whoever took it over. Silent when there is nothing to
+ * release: an editor closing a tab whose claim already lapsed has nothing to
+ * apologise for, and reporting an error there would be noise on a path nobody
+ * is watching.
+ */
+export async function releaseDocumentLock(
+  adapter: DrizzleAdapter,
+  ref: DocumentRef,
+  claimant: DocumentLockClaimant
+): Promise<void> {
+  const key = keyFor(ref);
+  await adapter.transaction(async ctx => {
+    await ctx.lockRow(DOCUMENT_LOCK_TABLE, key);
+    await ctx.runStatement(
+      sql`DELETE FROM ${sql.identifier(DOCUMENT_LOCK_TABLE)}
+          WHERE ${sql.identifier("lock_key")} = ${key}
+            AND ${sql.identifier("owner_id")} = ${claimant.ownerId}`
+    );
+  });
+}

--- a/packages/nextly/src/domains/document-lock/index.ts
+++ b/packages/nextly/src/domains/document-lock/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Document soft lock — who is editing what, and for how much longer.
+ *
+ * @module domains/document-lock
+ */
+
+export {
+  acquireDocumentLock,
+  readDocumentLock,
+  releaseDocumentLock,
+  renewDocumentLock,
+  type DocumentLockClaimant,
+} from "./document-lock-repository";
+export {
+  DOCUMENT_LOCK_KEY_SEPARATOR,
+  MAX_DOCUMENT_LOCK_KEY_LENGTH,
+  documentLockKey,
+} from "./lock-key";
+export {
+  DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS,
+  DOCUMENT_LOCK_LOSS_AFTER_MS,
+  DOCUMENT_LOCK_RENEW_MARGIN_SECONDS,
+  DOCUMENT_LOCK_TTL_SECONDS,
+} from "./timings";
+export type {
+  AcquireDocumentLockOutcome,
+  DocumentLockHolder,
+  DocumentRef,
+  RenewDocumentLockOutcome,
+} from "./types";

--- a/packages/nextly/src/domains/document-lock/index.ts
+++ b/packages/nextly/src/domains/document-lock/index.ts
@@ -9,12 +9,14 @@ export {
   readDocumentLock,
   releaseDocumentLock,
   renewDocumentLock,
+  sweepExpiredDocumentLocks,
   type DocumentLockClaimant,
 } from "./document-lock-repository";
 export {
   DOCUMENT_LOCK_KEY_SEPARATOR,
   MAX_DOCUMENT_LOCK_KEY_LENGTH,
   documentLockKey,
+  type DocumentScopeKind,
 } from "./lock-key";
 export {
   DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS,

--- a/packages/nextly/src/domains/document-lock/lock-key.ts
+++ b/packages/nextly/src/domains/document-lock/lock-key.ts
@@ -1,0 +1,56 @@
+/**
+ * The key one document's lock row is addressed by, and the bound it is held to.
+ *
+ * A leaf module with no imports, so the repository (which writes the row) and
+ * any caller that needs to name a lock without opening a connection read the
+ * same derivation. Two spellings of "which row is this document's" would agree
+ * on the day they were written and drift into an editor locking one row and
+ * releasing another.
+ *
+ * @module domains/document-lock/lock-key
+ */
+
+/**
+ * What separates the two halves of a key.
+ *
+ * A colon rather than a hyphen or a dot, because collection slugs are kebab-case
+ * and entry ids are uuids: both may contain a hyphen, neither may contain a
+ * colon, so this is the one character that cannot appear inside either half.
+ */
+export const DOCUMENT_LOCK_KEY_SEPARATOR = ":";
+
+/**
+ * The longest key MySQL will index in `varchar(191)` utf8mb4 — the narrowest of
+ * the three dialects, so it is the bound all of them are held to. A key that
+ * worked on two dialects and threw on the third would surface as an editor that
+ * cannot open a document, on one deployment only.
+ */
+export const MAX_DOCUMENT_LOCK_KEY_LENGTH = 191;
+
+/**
+ * The key for one document, or `undefined` when no valid key describes it.
+ *
+ * 🔴 Returns rather than throws, because both answers are ordinary here: the
+ * caller decides whether an unrepresentable document is a bad request or a
+ * programming mistake, and those are different responses. Throwing would make
+ * that choice on the caller's behalf.
+ *
+ * A half containing the separator is refused rather than escaped. Escaping
+ * would make the key non-obvious to read in a database session — which is where
+ * anybody debugging "who holds this lock" actually looks — and no supported
+ * collection slug or entry id can contain one.
+ */
+export function documentLockKey(
+  collection: string,
+  entryId: string
+): string | undefined {
+  if (collection === "" || entryId === "") return undefined;
+  if (
+    collection.includes(DOCUMENT_LOCK_KEY_SEPARATOR) ||
+    entryId.includes(DOCUMENT_LOCK_KEY_SEPARATOR)
+  ) {
+    return undefined;
+  }
+  const key = `${collection}${DOCUMENT_LOCK_KEY_SEPARATOR}${entryId}`;
+  return key.length > MAX_DOCUMENT_LOCK_KEY_LENGTH ? undefined : key;
+}

--- a/packages/nextly/src/domains/document-lock/lock-key.ts
+++ b/packages/nextly/src/domains/document-lock/lock-key.ts
@@ -11,11 +11,23 @@
  */
 
 /**
- * What separates the two halves of a key.
+ * Which kind of thing is being edited.
  *
- * A colon rather than a hyphen or a dot, because collection slugs are kebab-case
- * and entry ids are uuids: both may contain a hyphen, neither may contain a
- * colon, so this is the one character that cannot appear inside either half.
+ * Part of the key rather than a detail beside it: a collection and a Single may
+ * carry the same slug, and their entries live in different tables, so an entry
+ * id is unique only within its own kind. Without this, a Single and a
+ * collection entry sharing both would be ONE lock — taking over the one would
+ * silently release the other, and each author would be told they held a
+ * document the other was editing.
+ */
+export type DocumentScopeKind = "collection" | "single";
+
+/**
+ * What separates the parts of a key.
+ *
+ * A colon rather than a hyphen or a dot, because slugs are kebab-case and entry
+ * ids are uuids: both may contain a hyphen, neither may contain a colon, so
+ * this is the one character that cannot appear inside any part.
  */
 export const DOCUMENT_LOCK_KEY_SEPARATOR = ":";
 
@@ -35,22 +47,23 @@ export const MAX_DOCUMENT_LOCK_KEY_LENGTH = 191;
  * programming mistake, and those are different responses. Throwing would make
  * that choice on the caller's behalf.
  *
- * A half containing the separator is refused rather than escaped. Escaping
+ * A part containing the separator is refused rather than escaped. Escaping
  * would make the key non-obvious to read in a database session — which is where
  * anybody debugging "who holds this lock" actually looks — and no supported
- * collection slug or entry id can contain one.
+ * slug or entry id can contain one.
  */
 export function documentLockKey(
-  collection: string,
+  scopeKind: DocumentScopeKind,
+  slug: string,
   entryId: string
 ): string | undefined {
-  if (collection === "" || entryId === "") return undefined;
+  if (slug === "" || entryId === "") return undefined;
   if (
-    collection.includes(DOCUMENT_LOCK_KEY_SEPARATOR) ||
+    slug.includes(DOCUMENT_LOCK_KEY_SEPARATOR) ||
     entryId.includes(DOCUMENT_LOCK_KEY_SEPARATOR)
   ) {
     return undefined;
   }
-  const key = `${collection}${DOCUMENT_LOCK_KEY_SEPARATOR}${entryId}`;
+  const key = [scopeKind, slug, entryId].join(DOCUMENT_LOCK_KEY_SEPARATOR);
   return key.length > MAX_DOCUMENT_LOCK_KEY_LENGTH ? undefined : key;
 }

--- a/packages/nextly/src/domains/document-lock/timings.ts
+++ b/packages/nextly/src/domains/document-lock/timings.ts
@@ -1,0 +1,67 @@
+/**
+ * How long a document claim lasts, and how often its holder confirms it.
+ *
+ * Derived from one TTL rather than written down side by side, so no two of them
+ * can be chosen independently and drift into a holder that believes it is
+ * protected while a contender is already taking the row.
+ *
+ * ## Why these numbers
+ *
+ * 150 seconds and a 15-second heartbeat are WordPress's shipped constants for
+ * exactly this problem — `wp_check_post_lock_window` defaults to 150, atop the
+ * edit screen's 15-second heartbeat. They are kept because they are the most
+ * battle-tested figures for mediating two humans over one document, not because
+ * of any margin rule: WordPress derives 150 as "lock duration, plus 5 seconds",
+ * and observed ratios elsewhere disagree with each other and with it.
+ *
+ * ## Why they differ from the migration lock's
+ *
+ * That lock guards DDL and refuses to steal a live claim, because two concurrent
+ * migrations corrupt a schema. This one mediates two people and must permit a
+ * takeover. They deliberately share only the clock they are judged against and
+ * the derivation below; their durations answer different questions and are free
+ * to differ.
+ *
+ * @module domains/document-lock/timings
+ */
+
+import { deriveLeaseTimings } from "../../database/lease-clock";
+
+/** How long one confirmation grants a holder. */
+export const DOCUMENT_LOCK_TTL_SECONDS = 150;
+
+/**
+ * How many heartbeats fit in one lease.
+ *
+ * The only free parameter, and it buys tolerance for failure: at ten, a holder
+ * can lose several consecutive heartbeats to a slow query or a brief network
+ * blip and still hold a claim nobody else can take.
+ */
+const DOCUMENT_LOCK_RENEW_DIVISOR = 10;
+
+const TIMINGS = deriveLeaseTimings(
+  DOCUMENT_LOCK_TTL_SECONDS,
+  DOCUMENT_LOCK_RENEW_DIVISOR
+);
+
+/** How often an open editor confirms it is still there. */
+export const DOCUMENT_LOCK_HEARTBEAT_INTERVAL_MS = TIMINGS.renewIntervalMs;
+
+/**
+ * How long an editor may go without a CONFIRMED heartbeat before it must treat
+ * the claim as lost and stop offering to save.
+ *
+ * Deliberately not "how many heartbeats failed". A count reaches its limit at
+ * the moment the lease expires rather than before it, so the editor would be
+ * told after it stopped being protected rather than while it still is.
+ */
+export const DOCUMENT_LOCK_LOSS_AFTER_MS = TIMINGS.lossAfterMs;
+
+/**
+ * How much lease a confirmation must actually grant for a holder to rely on it.
+ *
+ * "Not yet expired" is not the same as "safe to keep editing": a renewal that
+ * leaves almost nothing returns a claim that passes a liveness test with
+ * nothing left in it.
+ */
+export const DOCUMENT_LOCK_RENEW_MARGIN_SECONDS = TIMINGS.renewMarginSeconds;

--- a/packages/nextly/src/domains/document-lock/types.ts
+++ b/packages/nextly/src/domains/document-lock/types.ts
@@ -4,9 +4,13 @@
  * @module domains/document-lock/types
  */
 
+import type { DocumentScopeKind } from "./lock-key";
+
 /** The document a claim is about. */
 export interface DocumentRef {
-  readonly collection: string;
+  /** Whether this is a collection entry or a Single. Part of the identity. */
+  readonly scopeKind: DocumentScopeKind;
+  readonly slug: string;
   readonly entryId: string;
 }
 
@@ -31,9 +35,18 @@ export interface DocumentLockHolder {
  * and a countdown in it — not an exception. The HTTP layer turns `held` into a
  * 409 carrying the same holder; a thrown error would have to smuggle that
  * through log context, which is not public.
+ *
+ * 🔴 `claimToken` is returned ONLY on success, and only to the caller that
+ * succeeded. It identifies this acquisition, and every later heartbeat and
+ * release must present it. Handing it out with a `held` refusal would let the
+ * refused caller act on somebody else's claim.
  */
 export type AcquireDocumentLockOutcome =
-  | { readonly status: "acquired"; readonly holder: DocumentLockHolder }
+  | {
+      readonly status: "acquired";
+      readonly holder: DocumentLockHolder;
+      readonly claimToken: string;
+    }
   | { readonly status: "held"; readonly holder: DocumentLockHolder };
 
 /**

--- a/packages/nextly/src/domains/document-lock/types.ts
+++ b/packages/nextly/src/domains/document-lock/types.ts
@@ -1,0 +1,49 @@
+/**
+ * What a document lock is, and the answers asking for one can produce.
+ *
+ * @module domains/document-lock/types
+ */
+
+/** The document a claim is about. */
+export interface DocumentRef {
+  readonly collection: string;
+  readonly entryId: string;
+}
+
+/** Who holds a claim, and how much of it is left. */
+export interface DocumentLockHolder {
+  readonly ownerId: string;
+  /** The holder's display name as it was when the claim was taken. */
+  readonly ownerLabel: string | null;
+  /**
+   * Seconds until the claim lapses. Negative once it has, which a reader should
+   * treat as expired rather than clamp — "gone 40 seconds ago" and "not yet" are
+   * different facts and only one of them is zero.
+   */
+  readonly expiresInSeconds: number;
+}
+
+/**
+ * The outcome of asking to edit a document.
+ *
+ * A discriminated result rather than a thrown error, because "somebody else is
+ * editing this" is an ordinary answer the interface has to RENDER — with a name
+ * and a countdown in it — not an exception. The HTTP layer turns `held` into a
+ * 409 carrying the same holder; a thrown error would have to smuggle that
+ * through log context, which is not public.
+ */
+export type AcquireDocumentLockOutcome =
+  | { readonly status: "acquired"; readonly holder: DocumentLockHolder }
+  | { readonly status: "held"; readonly holder: DocumentLockHolder };
+
+/**
+ * The outcome of confirming a claim you believe you hold.
+ *
+ * `lost` carries the current holder when there is one, so an editor can say who
+ * took over rather than only that something did. It is absent when the claim
+ * simply lapsed and nobody has taken it — the distinction decides whether the
+ * interface offers "request access" or "resume editing".
+ */
+export type RenewDocumentLockOutcome =
+  | { readonly status: "renewed"; readonly holder: DocumentLockHolder }
+  | { readonly status: "lost"; readonly holder?: DocumentLockHolder };

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -126,6 +126,14 @@ const POST_045_TABLES = [
   // table present in only one of the two is re-proposed on every reconcile
   // instead of round-tripping to silence.
   "nextly_jobs",
+  // The document soft lock, post-0.45 like the tables above: an existing
+  // install gains it on upgrade, so its CREATE TABLE and its two indexes are
+  // legitimate rather than phantom. The pass-2 assertion below is what proves
+  // the declaration round-trips — this table is reached through the core
+  // schema, the dialect bundles AND the SQLite bootstrap DDL, and a shape that
+  // disagrees between any two of them is re-proposed on every reconcile rather
+  // than settling to silence.
+  "nextly_document_lock",
 ];
 
 // The post-045 names are static identifiers, but escape defensively so the

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -16,6 +16,7 @@ export { users, accounts, sessions } from "../users/mysql";
 // `getCoreSchema`, because this bundle is what decides whether the table EXISTS: it is what
 // `reconcileCore` hands drizzle-kit.
 export { nextlyFieldGroupLock } from "../field-group-lock/mysql";
+export { nextlyDocumentLock } from "../document-lock/mysql";
 
 export {
   emailVerificationTokens,

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -31,6 +31,7 @@ export { users, accounts, sessions } from "../users/postgres";
 // `getCoreSchema`, because this bundle is what decides whether the table EXISTS: it is what
 // `reconcileCore` hands drizzle-kit.
 export { nextlyFieldGroupLock } from "../field-group-lock/postgres";
+export { nextlyDocumentLock } from "../document-lock/postgres";
 
 // Auth tokens.
 export {

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -16,6 +16,7 @@ export { users, accounts, sessions } from "../users/sqlite";
 // `getCoreSchema`, because this bundle is what decides whether the table EXISTS: it is what
 // `reconcileCore` hands drizzle-kit.
 export { nextlyFieldGroupLock } from "../field-group-lock/sqlite";
+export { nextlyDocumentLock } from "../document-lock/sqlite";
 
 export {
   emailVerificationTokens,

--- a/packages/nextly/src/schemas/document-lock/index.ts
+++ b/packages/nextly/src/schemas/document-lock/index.ts
@@ -1,0 +1,62 @@
+/**
+ * `nextly_document_lock` — dialect-aware barrel.
+ *
+ * @module schemas/document-lock
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../errors/nextly-error";
+
+import * as my from "./mysql";
+import * as pg from "./postgres";
+import * as sl from "./sqlite";
+
+export { pg, my, sl };
+
+/**
+ * The physical table name, spelled once.
+ *
+ * The repository addresses this table through raw statements rather than the
+ * typed query builder, because liveness has to be decided by SQL the database
+ * evaluates itself. That means the name is written somewhere other than the
+ * declaration, and this is the only place it may be read from.
+ */
+export const DOCUMENT_LOCK_TABLE = "nextly_document_lock";
+
+/**
+ * The ONE place a dialect is turned into a lock table.
+ *
+ * 🔴 A ternary chain ending in a bare `else` would silently assign every future
+ * dialect to whichever branch came last, so adding one to `SupportedDialect`
+ * would compile and hand back another dialect's table. The `never` assignment
+ * below makes the compiler demand a case instead.
+ */
+function lockForDialect(dialect: SupportedDialect) {
+  switch (dialect) {
+    case "postgresql":
+      return pg.nextlyDocumentLock;
+    case "mysql":
+      return my.nextlyDocumentLock;
+    case "sqlite":
+      return sl.nextlyDocumentLock;
+    default: {
+      // Exhaustiveness check — TypeScript flags a missing dialect at compile
+      // time, so reaching here means a dialect was added without a table for
+      // it. `internal` because that is a programming mistake rather than a
+      // state an operator can be in or fix.
+      const _exhaustive: never = dialect;
+      throw NextlyError.internal({
+        logContext: {
+          reason: "no document lock table for this dialect",
+          dialect: String(_exhaustive),
+        },
+      });
+    }
+  }
+}
+
+/** The lock table for the requested dialect, as a schema fragment. */
+export function documentLockTables(dialect: SupportedDialect) {
+  return { nextlyDocumentLock: lockForDialect(dialect) };
+}

--- a/packages/nextly/src/schemas/document-lock/mysql.ts
+++ b/packages/nextly/src/schemas/document-lock/mysql.ts
@@ -1,0 +1,30 @@
+/**
+ * `nextly_document_lock` — one editor's claim on one document, MySQL.
+ *
+ * See `./postgres.ts` for what the table is and why the key is synthetic.
+ *
+ * @module schemas/document-lock/mysql
+ */
+
+import { datetime, index, mysqlTable, varchar } from "drizzle-orm/mysql-core";
+
+export const nextlyDocumentLock = mysqlTable(
+  "nextly_document_lock",
+  {
+    lockKey: varchar("lock_key", { length: 191 }).primaryKey(),
+    collection: varchar("collection", { length: 191 }).notNull(),
+    entryId: varchar("entry_id", { length: 191 }).notNull(),
+    ownerId: varchar("owner_id", { length: 191 }).notNull(),
+    ownerLabel: varchar("owner_label", { length: 191 }),
+    // `datetime` stores no zone, which is why every value written to and read
+    // from these two columns comes from `UTC_TIMESTAMP()` rather than `NOW()`.
+    // A holder whose session is UTC and a contender whose session is UTC+05
+    // would otherwise disagree about when this claim ends by five hours.
+    acquiredAt: datetime("acquired_at").notNull(),
+    expiresAt: datetime("expires_at").notNull(),
+  },
+  t => [
+    index("ndl_expires_at_idx").on(t.expiresAt),
+    index("ndl_collection_idx").on(t.collection),
+  ]
+);

--- a/packages/nextly/src/schemas/document-lock/mysql.ts
+++ b/packages/nextly/src/schemas/document-lock/mysql.ts
@@ -1,7 +1,8 @@
 /**
  * `nextly_document_lock` — one editor's claim on one document, MySQL.
  *
- * See `./postgres.ts` for what the table is and why the key is synthetic.
+ * See `./postgres.ts` for what the table is, why `id` is a composite string and
+ * why the scope kind is part of it.
  *
  * @module schemas/document-lock/mysql
  */
@@ -11,11 +12,13 @@ import { datetime, index, mysqlTable, varchar } from "drizzle-orm/mysql-core";
 export const nextlyDocumentLock = mysqlTable(
   "nextly_document_lock",
   {
-    lockKey: varchar("lock_key", { length: 191 }).primaryKey(),
-    collection: varchar("collection", { length: 191 }).notNull(),
+    id: varchar("id", { length: 191 }).primaryKey(),
+    scopeKind: varchar("scope_kind", { length: 32 }).notNull(),
+    slug: varchar("slug", { length: 191 }).notNull(),
     entryId: varchar("entry_id", { length: 191 }).notNull(),
     ownerId: varchar("owner_id", { length: 191 }).notNull(),
-    ownerLabel: varchar("owner_label", { length: 191 }),
+    claimToken: varchar("claim_token", { length: 36 }).notNull(),
+    ownerLabel: varchar("owner_label", { length: 255 }),
     // `datetime` stores no zone, which is why every value written to and read
     // from these two columns comes from `UTC_TIMESTAMP()` rather than `NOW()`.
     // A holder whose session is UTC and a contender whose session is UTC+05
@@ -25,6 +28,6 @@ export const nextlyDocumentLock = mysqlTable(
   },
   t => [
     index("ndl_expires_at_idx").on(t.expiresAt),
-    index("ndl_collection_idx").on(t.collection),
+    index("ndl_scope_idx").on(t.scopeKind, t.slug),
   ]
 );

--- a/packages/nextly/src/schemas/document-lock/postgres.ts
+++ b/packages/nextly/src/schemas/document-lock/postgres.ts
@@ -1,0 +1,57 @@
+/**
+ * `nextly_document_lock` — one editor's claim on one document, PostgreSQL.
+ *
+ * A row exists only while somebody is editing, and says who and until when. Two
+ * authors opening the same entry is the case this exists for: without it the
+ * second save silently overwrites the first, with nothing recorded anywhere.
+ *
+ * ## Why the key is synthetic
+ *
+ * `lock_key` is `collection:entryId` rather than a composite primary key,
+ * because the row is claimed through `lockRow`, which takes ONE scalar id. A
+ * composite key would need a second way to address the row, and the two would
+ * have to agree forever.
+ *
+ * `collection` and `entry_id` are stored alongside it rather than parsed back
+ * out of the key. A `LIKE` against a synthetic key is not an index the database
+ * can use, and "who is editing in this collection" is the question an operator
+ * actually asks.
+ *
+ * ## Why the row is small and short-lived
+ *
+ * `expires_at` is the whole mechanism: a holder that crashes, closes the tab or
+ * goes offline stops renewing, and the claim becomes takeable without anybody
+ * having to notice it died. Rows are deleted on release and overwritten on
+ * re-acquire, so the table's size is bounded by documents being edited right
+ * now, not by edits over time.
+ *
+ * @module schemas/document-lock/postgres
+ */
+
+import { index, pgTable, timestamp, varchar } from "drizzle-orm/pg-core";
+
+export const nextlyDocumentLock = pgTable(
+  "nextly_document_lock",
+  {
+    // 191 on every dialect, not because PostgreSQL needs it, but because MySQL
+    // will not index a longer utf8mb4 varchar. A key that worked on two
+    // dialects and threw on the third would surface as an editor that cannot
+    // open a document, on one deployment only.
+    lockKey: varchar("lock_key", { length: 191 }).primaryKey(),
+    collection: varchar("collection", { length: 191 }).notNull(),
+    entryId: varchar("entry_id", { length: 191 }).notNull(),
+    ownerId: varchar("owner_id", { length: 191 }).notNull(),
+    // A snapshot of the holder's display name rather than a join to `users`.
+    // The lock is read by every open editor every 15 seconds, so this is a hot
+    // path; and the label has to survive the holder being deleted mid-edit,
+    // which a join does not. Staleness is bounded by the lease — a rename is
+    // visible within one expiry.
+    ownerLabel: varchar("owner_label", { length: 191 }),
+    acquiredAt: timestamp("acquired_at", { withTimezone: true }).notNull(),
+    expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
+  },
+  t => [
+    index("ndl_expires_at_idx").on(t.expiresAt),
+    index("ndl_collection_idx").on(t.collection),
+  ]
+);

--- a/packages/nextly/src/schemas/document-lock/postgres.ts
+++ b/packages/nextly/src/schemas/document-lock/postgres.ts
@@ -1,29 +1,38 @@
 /**
  * `nextly_document_lock` — one editor's claim on one document, PostgreSQL.
  *
- * A row exists only while somebody is editing, and says who and until when. Two
- * authors opening the same entry is the case this exists for: without it the
- * second save silently overwrites the first, with nothing recorded anywhere.
+ * A row exists only while somebody is editing, and says who, under which
+ * acquisition, and until when. Two authors opening the same entry is the case
+ * this exists for: without it the second save silently overwrites the first,
+ * with nothing recorded anywhere.
  *
- * ## Why the key is synthetic
+ * ## Why `id` is a composite string
  *
- * `lock_key` is `collection:entryId` rather than a composite primary key,
- * because the row is claimed through `lockRow`, which takes ONE scalar id. A
- * composite key would need a second way to address the row, and the two would
- * have to agree forever.
+ * `id` holds `scopeKind:slug:entryId` rather than the table carrying a
+ * composite primary key, because the row is claimed through `lockRow`, whose
+ * contract is one scalar keyed on a column literally named `id` — it emits
+ * `SELECT id FROM <table> WHERE id = ? FOR UPDATE`.
  *
- * `collection` and `entry_id` are stored alongside it rather than parsed back
- * out of the key. A `LIKE` against a synthetic key is not an index the database
- * can use, and "who is editing in this collection" is the question an operator
- * actually asks.
+ * 🔴 The column NAME is part of that contract, not a preference. Called
+ * anything else, every claim fails on PostgreSQL and MySQL with
+ * `column "id" does not exist` — and passes on SQLite, whose `lockRow` is a
+ * no-op because `BEGIN IMMEDIATE` already serializes writers. A single-dialect
+ * test run therefore reports this as working.
+ *
+ * ## Why the scope kind is in the key
+ *
+ * A collection and a Single may carry the same slug, and their rows live in
+ * different tables, so an entry id is unique only within its own kind. Keyed on
+ * slug and entry alone, a Single and a collection entry that happened to share
+ * both would be one lock: taking over the one would silently release the other.
  *
  * ## Why the row is small and short-lived
  *
  * `expires_at` is the whole mechanism: a holder that crashes, closes the tab or
  * goes offline stops renewing, and the claim becomes takeable without anybody
- * having to notice it died. Rows are deleted on release and overwritten on
- * re-acquire, so the table's size is bounded by documents being edited right
- * now, not by edits over time.
+ * having to notice it died. Rows are deleted on release, overwritten on
+ * re-acquire, and swept once expired, so the table's size tracks documents open
+ * right now rather than every document ever edited.
  *
  * @module schemas/document-lock/postgres
  */
@@ -37,21 +46,25 @@ export const nextlyDocumentLock = pgTable(
     // will not index a longer utf8mb4 varchar. A key that worked on two
     // dialects and threw on the third would surface as an editor that cannot
     // open a document, on one deployment only.
-    lockKey: varchar("lock_key", { length: 191 }).primaryKey(),
-    collection: varchar("collection", { length: 191 }).notNull(),
+    id: varchar("id", { length: 191 }).primaryKey(),
+    scopeKind: varchar("scope_kind", { length: 32 }).notNull(),
+    slug: varchar("slug", { length: 191 }).notNull(),
     entryId: varchar("entry_id", { length: 191 }).notNull(),
     ownerId: varchar("owner_id", { length: 191 }).notNull(),
-    // A snapshot of the holder's display name rather than a join to `users`.
-    // The lock is read by every open editor every 15 seconds, so this is a hot
-    // path; and the label has to survive the holder being deleted mid-edit,
-    // which a join does not. Staleness is bounded by the lease — a rename is
-    // visible within one expiry.
-    ownerLabel: varchar("owner_label", { length: 191 }),
+    // Identifies the ACQUISITION, not the person. One author with the document
+    // open in two tabs holds two claims under one `owner_id`; without this, a
+    // release from the tab they closed would delete the claim the other tab is
+    // still editing under, and that tab would carry on believing it is
+    // protected while somebody else takes the document.
+    claimToken: varchar("claim_token", { length: 36 }).notNull(),
+    // 255 to match the widest `users.name` any dialect stores, so a valid name
+    // can never fail an acquisition. Not indexed, so the length costs nothing.
+    ownerLabel: varchar("owner_label", { length: 255 }),
     acquiredAt: timestamp("acquired_at", { withTimezone: true }).notNull(),
     expiresAt: timestamp("expires_at", { withTimezone: true }).notNull(),
   },
   t => [
     index("ndl_expires_at_idx").on(t.expiresAt),
-    index("ndl_collection_idx").on(t.collection),
+    index("ndl_scope_idx").on(t.scopeKind, t.slug),
   ]
 );

--- a/packages/nextly/src/schemas/document-lock/sqlite.ts
+++ b/packages/nextly/src/schemas/document-lock/sqlite.ts
@@ -1,7 +1,8 @@
 /**
  * `nextly_document_lock` — one editor's claim on one document, SQLite.
  *
- * See `./postgres.ts` for what the table is and why the key is synthetic.
+ * See `./postgres.ts` for what the table is, why `id` is a composite string and
+ * why the scope kind is part of it.
  *
  * @module schemas/document-lock/sqlite
  */
@@ -11,10 +12,12 @@ import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
 export const nextlyDocumentLock = sqliteTable(
   "nextly_document_lock",
   {
-    lockKey: text("lock_key").primaryKey(),
-    collection: text("collection").notNull(),
+    id: text("id").primaryKey(),
+    scopeKind: text("scope_kind").notNull(),
+    slug: text("slug").notNull(),
     entryId: text("entry_id").notNull(),
     ownerId: text("owner_id").notNull(),
+    claimToken: text("claim_token").notNull(),
     ownerLabel: text("owner_label"),
     // Stored as unix SECONDS, which is what `mode: "timestamp"` means here and
     // why this dialect's clock expressions are integer arithmetic on
@@ -24,6 +27,6 @@ export const nextlyDocumentLock = sqliteTable(
   },
   t => [
     index("ndl_expires_at_idx").on(t.expiresAt),
-    index("ndl_collection_idx").on(t.collection),
+    index("ndl_scope_idx").on(t.scopeKind, t.slug),
   ]
 );

--- a/packages/nextly/src/schemas/document-lock/sqlite.ts
+++ b/packages/nextly/src/schemas/document-lock/sqlite.ts
@@ -1,0 +1,29 @@
+/**
+ * `nextly_document_lock` — one editor's claim on one document, SQLite.
+ *
+ * See `./postgres.ts` for what the table is and why the key is synthetic.
+ *
+ * @module schemas/document-lock/sqlite
+ */
+
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const nextlyDocumentLock = sqliteTable(
+  "nextly_document_lock",
+  {
+    lockKey: text("lock_key").primaryKey(),
+    collection: text("collection").notNull(),
+    entryId: text("entry_id").notNull(),
+    ownerId: text("owner_id").notNull(),
+    ownerLabel: text("owner_label"),
+    // Stored as unix SECONDS, which is what `mode: "timestamp"` means here and
+    // why this dialect's clock expressions are integer arithmetic on
+    // `unixepoch()` rather than interval arithmetic.
+    acquiredAt: integer("acquired_at", { mode: "timestamp" }).notNull(),
+    expiresAt: integer("expires_at", { mode: "timestamp" }).notNull(),
+  },
+  t => [
+    index("ndl_expires_at_idx").on(t.expiresAt),
+    index("ndl_collection_idx").on(t.collection),
+  ]
+);

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -27,6 +27,7 @@ import { drizzleTableToTableSpec } from "./_internal/drizzle-to-tablespec";
 import { apiKeyTables } from "./api-keys";
 import { auditTables } from "./audit";
 import { authTokenTables } from "./auth-tokens";
+import { documentLockTables } from "./document-lock";
 import {
   dynamicCollectionsPg,
   dynamicCollectionsMysql,
@@ -168,6 +169,11 @@ export function getCoreSchema(
     // without this a column could never be added to an existing installation's copy. Same reasoning
     // as `nextly_schema_events` and `nextly_i18n_archive` below.
     ...Object.values(fieldGroupLockTables(dialect)),
+    // `nextly_document_lock` — one row per document being edited right now.
+    // Declared here because it is the set `nextly migrate` pushes: a table
+    // outside it is never created on a real installation, however completely
+    // its own module declares it.
+    ...Object.values(documentLockTables(dialect)),
     ...Object.values(apiKeyTables(dialect)),
     // `nextly_schema_events` (the migration ledger) is a first-class managed
     // table. It is still bootstrapped out-of-band via `getSchemaEventsDdl` so
@@ -277,6 +283,7 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   // Read by live introspection. Absent here, the table is created and then invisible to every
   // snapshot, so the drift check proposes adding it again on every run.
   "nextly_field_group_lock",
+  "nextly_document_lock",
   "dynamic_collections",
   "dynamic_singles",
   STORAGE_FORMAT.registryTable,


### PR DESCRIPTION
Two authors opening the same entry overwrote each other in silence. There was no lock and no `updatedAt` precondition, so the second save won and neither author was told. This is the server half of the soft lock: the lease, its heartbeat, and its expiry.

## What is here

`nextly_document_lock` holds one row per document being edited. `acquireDocumentLock`, `renewDocumentLock`, `releaseDocumentLock` and `readDocumentLock` take, keep, give up and observe a claim.

**The HTTP surface is deliberately not included, so nothing changes for a user yet.** Exposing it needs an authorization design of its own — locking a document you may not edit must be refused, which means resolving per-document update rules rather than the coarse route permission — and it touches `routeHandler.ts` and `dispatcher/types.ts`, two shared files other lanes are working in. That is the next PR, and it unblocks `task:pb-softlock-request-access-ui`.

## Decisions worth a reviewer's attention

**The database decides, never this process.** Every liveness comparison is a SQL expression the database evaluates itself. Contenders sit on different machines — under serverless, a different instance per request — whose clocks disagree, so a claim written from one clock and judged against another is decided by that skew rather than by who holds the lock.

**Nothing reads an instant back.** `remainingSecondsExpression` (new, in `lease-clock.ts`) returns a *duration*. The three drivers disagree about timestamps — PostgreSQL hands back a `Date` from `timestamptz`, MySQL a zoneless `DATETIME` its session interprets, SQLite a bare integer — and normalising those in the read path is the same class of bug the existing clock expressions remove from the write path. A span is the same length in every timebase.

**150s / 15s, derived not chosen.** Both come from `deriveLeaseTimings(150, 10)`, so they cannot drift apart. These are WordPress's shipped constants for exactly this problem (`wp_check_post_lock_window` defaults to 150, atop the 15s edit-screen heartbeat). Kept because they are the most battle-tested figures for mediating two humans, **not** because of a 10x margin rule — WordPress derives 150 as "lock duration, plus 5 seconds", and observed ratios elsewhere (Payload ~30x, k8s ~4x, ZooKeeper ~3x, this repo's own migration lock 8x) agree with neither each other nor it.

**Shared with the migration lock: the clock and the derivation. Nothing else.** That lock guards DDL and never steals a live claim, because two concurrent migrations corrupt a schema. This one mediates two people and must permit a takeover. `lease-clock.ts` already named this consumer in its own docblock before this PR existed.

**No takeover flush.** The founder dropped that clause on 2026-08-20. The editor already autosaves into a per-document-per-author row on its own interval, so an ousted author's work survives on a path that runs regardless — including in the cases a lease actually exists for, where the client is asleep, offline or gone and could not have flushed anything.

**Synthetic key.** `lock_key` is `collection:entryId` because the row is claimed through `lockRow`, which takes one scalar id. `collection` and `entry_id` are stored alongside rather than parsed back out, since a `LIKE` against a synthetic key is not an index the database can use.

**Whole-entry, not per-locale** — a product call by the founder. Reversible without a migration: rows are meaningless 150s after their last heartbeat, so widening the key to include a locale later needs no backfill.

## Evidence

Break-verified — each mutation stated before running, whole file, and it kills only the test whose name promises it:

| mutation | defect introduced | test killed |
|---|---|---|
| remove renew fence | any user's heartbeat extends the holder's lease | *does not let a heartbeat from a non-owner extend the owner's claim* |
| remove release fence | a late release frees a document from under its new holder | *does not let a non-owner release somebody else's claim* |
| `takeable = true` | a second author silently steals a live claim | *refuses a second author and names who is editing* |
| `live` always 1 | a crashed holder locks the document forever | *hands an EXPIRED claim to the next author*, *reports nobody editing once a claim has expired* |

**One of those tests was wrong and is fixed here.** The renew-fence test originally asserted *ownership* after an unfenced renewal — but an unfenced `UPDATE` sets `expires_at` and leaves `owner_id` alone, so the owner is unchanged either way and the mutation killed nothing. It now winds the lease down first and asserts the remaining span, which is what the defect actually moves.

Gates, all after a full `pnpm build` so nothing reads a stale `dist`: `check-types` 22/22 · `lint` 24/24 · nextly suite **811 files / 9954 passed** · document-lock integration 11/11 · comment convention clean · `fallow --base origin/main` exit 0, 17 changed files, introduced dead 0 / complexity 0 / styling 0.

One intermittent failure appeared in a single mid-session run and never recurred across two subsequent full runs at an identical file count of 811. I did not identify it, and I would rather say so than call the suite unqualified green.

`fallow` reports 1 introduced duplication: the three dialect table declarations. Left as is deliberately — every sibling schema feature (`auth-tokens`, `field-group-lock`, `jobs`) triplicates the same way, and deviating from the house pattern for a metric would cost more than it buys.

## Registries

A new core table has to reach several, and a miss in any one leaves every unit test passing against a table no real installation has. Registered in `getCoreSchema`, `CORE_TABLE_NAMES`, the three dialect bundles, and the SQLite bootstrap DDL — that last one caught by the existing `sqlite-core-tables` guard, which is exactly what it is for.

Edits to shared files are **additive only**: three new export lines in the dialect bundles with no existing export altered or reordered; one import, one spread and one name in `schemas/index.ts`; one new exported function in `lease-clock.ts`; one `CREATE TABLE` plus two indexes in the bootstrap DDL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document locking with claim, renewal, release, inspection, and takeover support.
  * Added lock expiration, holder details, ownership-loss reporting, and cleanup of expired locks.
  * Added support across SQLite, MySQL, and PostgreSQL.

* **Bug Fixes**
  * Prevented stale renewals or releases from affecting a newer lock claim.
  * Improved handling of document scopes with distinct lock identities.

* **Tests**
  * Added coverage for contention, expiry, takeover, ownership fencing, key validation, timing, and cross-database behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->