### PR TITLE
feat(blocks-engine): let a block state styles for the elements it draws

### DIFF
--- a/.changeset/a-block-can-style-what-it-draws.md
+++ b/.changeset/a-block-can-style-what-it-draws.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A block that draws more than one element could only style one of them. Its
+default styles are keyed by block type, so they compile to a single rule on a
+single class — the figure wrapping an image and its caption, or the list
+wrapping its items, share one class and everything not wearing it is
+unreachable. `core/form` had already flattened its own markup to work around
+this, at the documented cost that a label sits as far from its own control as
+from the next field.
+
+A block can now name the elements it renders and state styles for each. The
+names are a closed set the block publishes rather than open selectors, so a
+block may change what it draws without invalidating styles addressed to it.

--- a/packages/blocks-engine/docs/override-contract.md
+++ b/packages/blocks-engine/docs/override-contract.md
@@ -112,16 +112,17 @@ Not every builder rule weighs the same. Specificity is written the way devtools
 shows it: (ids, classes, types), where a pseudo-class such as `:hover` counts in
 the middle column.
 
-| What it styles                    | Selector                                        | Specificity |
-| --------------------------------- | ----------------------------------------------- | ----------- |
-| A heading or paragraph's baseline | `.nx-pb-page :where(h1)`                        | 0-1-0       |
-| A block type's defaults           | `.nx-pb-page :where(.nx-bt-core--section)`      | 0-1-0       |
-| Page-wide settings                | `.nx-pb-page.nx-pb-page`                        | 0-2-0       |
-| Links inside the page             | `.nx-pb-page.nx-pb-page a`                      | 0-2-1       |
-| One node's own styles             | `.nx-pb-page.nx-pb-page .nx-pb-a1b2`            | 0-3-0       |
-| Links inside a node               | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a`          | 0-3-1       |
-| Hovered links inside a node       | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a:hover`    | 0-4-1       |
-| Hiding a node at a breakpoint     | `.nx-pb-page.nx-pb-page .nx-pb-a1b2.nx-pb-a1b2` | 0-4-0       |
+| What it styles                         | Selector                                            | Specificity |
+| -------------------------------------- | --------------------------------------------------- | ----------- |
+| A heading or paragraph's baseline      | `.nx-pb-page :where(h1)`                            | 0-1-0       |
+| A block type's defaults                | `.nx-pb-page :where(.nx-bt-core--section)`          | 0-1-0       |
+| An element a block draws inside itself | `.nx-pb-page :where(.nx-bt-core--image figcaption)` | 0-1-0       |
+| Page-wide settings                     | `.nx-pb-page.nx-pb-page`                            | 0-2-0       |
+| Links inside the page                  | `.nx-pb-page.nx-pb-page a`                          | 0-2-1       |
+| One node's own styles                  | `.nx-pb-page.nx-pb-page .nx-pb-a1b2`                | 0-3-0       |
+| Links inside a node                    | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a`              | 0-3-1       |
+| Hovered links inside a node            | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a:hover`        | 0-4-1       |
+| Hiding a node at a breakpoint          | `.nx-pb-page.nx-pb-page .nx-pb-a1b2.nx-pb-a1b2`     | 0-4-0       |
 
 The rule behind the table, which matters more than the rows: **a property that
 styles something inside the element adds that thing's own weight.** Link colour
@@ -131,8 +132,8 @@ a new exception, so read the table as worked examples of the rule.
 
 Three of the rows are deliberate rather than incidental.
 
-**The two DEFAULT rows weigh one class, and the doubling is deliberately
-withheld from them.** Everything else in the table is something a person chose
+**The DEFAULT rows weigh one class, and the doubling is deliberately withheld
+from them.** Everything else in the table is something a person chose
 in the builder, and the repeated class exists so those choices outrank your
 site's CSS. A default is not a choice — nobody asked for it, it is what the
 block library supplies when nobody has said anything — so it is anchored to a
@@ -142,8 +143,16 @@ and it stays below your own `.content h1` at 0-1-1. If your stylesheet has an
 opinion about headings, your opinion wins; if it does not, a heading still looks
 like a heading.
 
-That is the whole contract for these two tiers: **a default is something your
+That is the whole contract for those tiers: **a default is something your
 site can override with ordinary CSS, and an authored value is not.**
+
+**An element a block draws inside itself weighs the same as the block's own
+default**, because it is the same tier: `figcaption` sits inside the `:where()`
+and adds nothing. That is the opposite of the descendant rule two paragraphs up,
+and deliberately so — that rule is about a value somebody CHOSE, and the reason a
+choice picks up the descendant's weight is that it should outrank your
+stylesheet. Nobody chose a block's defaults, so they keep the floor wherever they
+land: your `.content figcaption` still wins.
 
 **Page settings weigh less** than a node's own styles because they are the
 outermost element's own styles, and everything inside should be able to say
@@ -165,7 +174,7 @@ the node, and the table's rule about descendants applies to it as written.
 
 **A scope adds one class to the authored rows and nothing to the default rows.**
 Rendering a document under a scope constrains every selector to that document,
-but on the two default tiers the scope class is emitted inside `:where()` — so a
+but on the default tiers the scope class is emitted inside `:where()` — so a
 scoped document's defaults weigh exactly what an unscoped document's do. Without
 that, scoping a document would quietly push its defaults above your `.content
 h1`, and the same page would be overridable in one embedding and not in

--- a/packages/blocks-engine/docs/override-contract.md
+++ b/packages/blocks-engine/docs/override-contract.md
@@ -112,17 +112,17 @@ Not every builder rule weighs the same. Specificity is written the way devtools
 shows it: (ids, classes, types), where a pseudo-class such as `:hover` counts in
 the middle column.
 
-| What it styles                         | Selector                                            | Specificity |
-| -------------------------------------- | --------------------------------------------------- | ----------- |
-| A heading or paragraph's baseline      | `.nx-pb-page :where(h1)`                            | 0-1-0       |
-| A block type's defaults                | `.nx-pb-page :where(.nx-bt-core--section)`          | 0-1-0       |
-| An element a block draws inside itself | `.nx-pb-page :where(.nx-bt-core--image figcaption)` | 0-1-0       |
-| Page-wide settings                     | `.nx-pb-page.nx-pb-page`                            | 0-2-0       |
-| Links inside the page                  | `.nx-pb-page.nx-pb-page a`                          | 0-2-1       |
-| One node's own styles                  | `.nx-pb-page.nx-pb-page .nx-pb-a1b2`                | 0-3-0       |
-| Links inside a node                    | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a`              | 0-3-1       |
-| Hovered links inside a node            | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a:hover`        | 0-4-1       |
-| Hiding a node at a breakpoint          | `.nx-pb-page.nx-pb-page .nx-pb-a1b2.nx-pb-a1b2`     | 0-4-0       |
+| What it styles                         | Selector                                          | Specificity |
+| -------------------------------------- | ------------------------------------------------- | ----------- |
+| A heading or paragraph's baseline      | `.nx-pb-page :where(h1)`                          | 0-1-0       |
+| A block type's defaults                | `.nx-pb-page :where(.nx-bt-core--section)`        | 0-1-0       |
+| An element a block draws inside itself | `.nx-pb-page :where(.nx-bp-core--image--caption)` | 0-1-0       |
+| Page-wide settings                     | `.nx-pb-page.nx-pb-page`                          | 0-2-0       |
+| Links inside the page                  | `.nx-pb-page.nx-pb-page a`                        | 0-2-1       |
+| One node's own styles                  | `.nx-pb-page.nx-pb-page .nx-pb-a1b2`              | 0-3-0       |
+| Links inside a node                    | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a`            | 0-3-1       |
+| Hovered links inside a node            | `.nx-pb-page.nx-pb-page .nx-pb-a1b2 a:hover`      | 0-4-1       |
+| Hiding a node at a breakpoint          | `.nx-pb-page.nx-pb-page .nx-pb-a1b2.nx-pb-a1b2`   | 0-4-0       |
 
 The rule behind the table, which matters more than the rows: **a property that
 styles something inside the element adds that thing's own weight.** Link colour
@@ -147,12 +147,16 @@ That is the whole contract for those tiers: **a default is something your
 site can override with ordinary CSS, and an authored value is not.**
 
 **An element a block draws inside itself weighs the same as the block's own
-default**, because it is the same tier: `figcaption` sits inside the `:where()`
-and adds nothing. That is the opposite of the descendant rule two paragraphs up,
-and deliberately so — that rule is about a value somebody CHOSE, and the reason a
-choice picks up the descendant's weight is that it should outrank your
-stylesheet. Nobody chose a block's defaults, so they keep the floor wherever they
-land: your `.content figcaption` still wins.
+default**, because it is the same tier — one class, inside the `:where()`. Your
+`.content figcaption` at 0-1-1 still wins, which is the point: nobody chose a
+block's defaults, so they keep the floor wherever they land.
+
+**It is a CLASS the block marks its element with, not a descendant selector.**
+`.nx-bt-core--form label` would read more naturally and is wrong: it also matches
+a `label` rendered by another block sitting in one of the form's slots, so a
+container would style markup whose structure it does not own, and the deeper the
+page the more it takes. The class carries the owning block type, so it matches
+only elements that block itself marked.
 
 **Page settings weigh less** than a node's own styles because they are the
 outermost element's own styles, and everything inside should be able to say

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -220,10 +220,31 @@ export interface BlockRenderArgs<P, C = unknown> {
   props: P;
   node: BlockNode;
   /**
-   * The generated class the block MUST place on its own root element. Blocks
-   * render a single element and never wrap it, so styles target that element.
+   * The generated class the block MUST place on its own root element.
+   *
+   * Styles for the block's own element target this. A block that draws more
+   * than one element marks the others with {@link partClass} instead — this
+   * one names the root and only the root, so two elements never answer to one
+   * node's identity.
    */
   className: string;
+  /**
+   * The class marking one of the elements this block declares in `parts`.
+   *
+   * Placed on the element the part names: `<figcaption className={partClass("caption")}>`.
+   *
+   * Supplied by the renderer rather than composed by the block, because the
+   * renderer is the only party that already knows which block is rendering. A
+   * block building the class itself would have to repeat its own type, and a
+   * block that repeated a NEIGHBOUR'S type would silently wear another block's
+   * defaults — a mistake nothing could catch, since the result is a valid class
+   * that the compiler happily emits rules for.
+   *
+   * Returns an empty string for a name the block does not declare, so a typo
+   * leaves the element unstyled rather than marked with a class no rule
+   * targets. Both are inert; only one of them is greppable.
+   */
+  partClass: (name: string) => string;
   /**
    * Marks the element that carries a named prop's value, for an editor.
    *

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -9,7 +9,7 @@
  * return type is opaque here and narrowed by the React binding package. That is
  * what keeps this package dependency-free and usable from any runtime.
  */
-import type { BlockNode, NodeStyles } from "./document";
+import type { BlockNode, BlockPart, NodeStyles } from "./document";
 import type { MigrationMap } from "./migration";
 
 /**
@@ -346,6 +346,25 @@ export interface BlockDefinition<
   localized?: (keyof P & string)[];
   /** Shared default styles for every instance of this block type. */
   baseStyles?: NodeStyles;
+  /**
+   * Elements this block renders INSIDE its root, named so a style can reach
+   * one of them.
+   *
+   * {@link baseStyles} is keyed by block TYPE, so it compiles to one rule on
+   * one class. A block that draws more than one element — a figure wrapping an
+   * image and a caption, a list wrapping its items — can put that class on the
+   * root or on one child and has no third option, so every element but the one
+   * holding it is unstyleable. These are the others.
+   *
+   * NAMED rather than written as selectors at the point of use, so a block may
+   * change what it renders without invalidating styles addressed to it: the
+   * name is the contract and the selector is the current implementation of it.
+   * That is the same trade `::part()` makes, and the reason it is a closed set
+   * the block publishes rather than an open selector anyone may write — an open
+   * one couples every stored style to markup the block is otherwise free to
+   * change.
+   */
+  parts?: Readonly<Record<string, BlockPart>>;
   /** Named child regions; only container blocks declare these. */
   slots?: Record<string, SlotSpec>;
   /**

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -528,7 +528,15 @@ export function isPartName(value: unknown): value is string {
   return (
     typeof value === "string" &&
     value.length <= MAX_BLOCK_PART_LENGTH &&
-    BLOCK_PART_NAME_RE.test(value)
+    BLOCK_PART_NAME_RE.test(value) &&
+    // A name `Object.prototype` already owns cannot be stored in a record and
+    // read back: the lookup answers with the inherited member instead of
+    // `undefined`, and assigning it sets the prototype rather than creating an
+    // own property. `constructor` passes the grammar above, which is exactly
+    // why this is asked of the prototype rather than matched against a written
+    // list — the list everyone writes is `__proto__` and `constructor` while
+    // `valueof` behaves identically.
+    !Object.prototype.hasOwnProperty.call(Object.prototype, value)
   );
 }
 

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -394,6 +394,25 @@ export type NodeStyles = Partial<
   Record<StyleState, Partial<Record<BreakpointId, StyleValues>>>
 >;
 
+/** One named element a block renders inside its own root. */
+export interface BlockPart {
+  /**
+   * The element this part names, as a plain HTML tag.
+   *
+   * A tag and nothing else — no class, no combinator, no list. This value
+   * reaches a SELECTOR, and a block definition is code a plugin supplies, so
+   * `"figcaption, body"` would otherwise close the block's rule and open one of
+   * the author's choosing over every `body` on the page. The narrow grammar
+   * refuses that by construction rather than by escaping a wider one, and it
+   * spans what the library actually renders: `figcaption`, `blockquote`,
+   * `cite`, `li`, `label`, `input`. Widening it later is additive; starting
+   * wide and narrowing is not.
+   */
+  selector: string;
+  /** Shared default styles for this part on every instance of the block type. */
+  baseStyles?: NodeStyles;
+}
+
 /** True if a style value is a design-token reference. */
 export function isTokenRef(value: unknown): value is TokenRef {
   // A reference must be a plain record, not merely an object carrying the key.
@@ -489,6 +508,42 @@ export function isBlockType(value: unknown): value is string {
     typeof value === "string" &&
     value.length <= MAX_BLOCK_TYPE_LENGTH &&
     BLOCK_TYPE_RE.test(value)
+  );
+}
+
+/**
+ * The element grammar a {@link BlockPart} selector is held to: an HTML tag.
+ *
+ * Deliberately narrower than what the compiler could emit. This value becomes
+ * part of a SELECTOR and arrives from a block definition, which is code a
+ * plugin supplies, so a value carrying a comma, a brace or a combinator would
+ * let a block close its own rule and open another over elements it does not
+ * render. Every tag reachable this way is inert on its own.
+ *
+ * Not escaped instead, because escaping a wider grammar produces a rule that
+ * matches nothing: `figcaption, body` becomes a class-shaped string no element
+ * carries, which is a style silently missing rather than a declaration refused.
+ * A refusal names the block, the part and the value.
+ */
+const BLOCK_PART_RE = /^[a-z][a-z0-9]*$/;
+
+/**
+ * Longest part selector accepted. A tag longer than this is not one, and the
+ * bound keeps a pathological value out of an issue message.
+ */
+const MAX_BLOCK_PART_LENGTH = 32;
+
+/**
+ * True if a value names an element a block may state a rule for.
+ *
+ * The ONE answer, for the same reason {@link isBlockType} is: a caller that
+ * bounds this where another does not emits a rule its neighbour refuses.
+ */
+export function isPartSelector(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.length <= MAX_BLOCK_PART_LENGTH &&
+    BLOCK_PART_RE.test(value)
   );
 }
 

--- a/packages/blocks-engine/src/document.ts
+++ b/packages/blocks-engine/src/document.ts
@@ -396,19 +396,6 @@ export type NodeStyles = Partial<
 
 /** One named element a block renders inside its own root. */
 export interface BlockPart {
-  /**
-   * The element this part names, as a plain HTML tag.
-   *
-   * A tag and nothing else — no class, no combinator, no list. This value
-   * reaches a SELECTOR, and a block definition is code a plugin supplies, so
-   * `"figcaption, body"` would otherwise close the block's rule and open one of
-   * the author's choosing over every `body` on the page. The narrow grammar
-   * refuses that by construction rather than by escaping a wider one, and it
-   * spans what the library actually renders: `figcaption`, `blockquote`,
-   * `cite`, `li`, `label`, `input`. Widening it later is additive; starting
-   * wide and narrowing is not.
-   */
-  selector: string;
   /** Shared default styles for this part on every instance of the block type. */
   baseStyles?: NodeStyles;
 }
@@ -512,38 +499,36 @@ export function isBlockType(value: unknown): value is string {
 }
 
 /**
- * The element grammar a {@link BlockPart} selector is held to: an HTML tag.
+ * The grammar a part NAME is held to.
  *
- * Deliberately narrower than what the compiler could emit. This value becomes
- * part of a SELECTOR and arrives from a block definition, which is code a
- * plugin supplies, so a value carrying a comma, a brace or a combinator would
- * let a block close its own rule and open another over elements it does not
- * render. Every tag reachable this way is inert on its own.
+ * A part name is compiled into a class, so it reaches a selector — and a block
+ * definition is code a plugin supplies. The same shape a block type's own
+ * segments use, for the same reason: no dot, no bracket, no space can appear,
+ * so nothing here can close a rule and open another.
  *
- * Not escaped instead, because escaping a wider grammar produces a rule that
- * matches nothing: `figcaption, body` becomes a class-shaped string no element
- * carries, which is a style silently missing rather than a declaration refused.
- * A refusal names the block, the part and the value.
+ * Consecutive dashes are excluded deliberately. The class joins the block type
+ * and the part with a DOUBLED dash, so a name containing one would make the
+ * boundary ambiguous and let two different blocks compile to a single class.
  */
-const BLOCK_PART_RE = /^[a-z][a-z0-9]*$/;
+const BLOCK_PART_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 
 /**
- * Longest part selector accepted. A tag longer than this is not one, and the
+ * Longest part name accepted. A name longer than this is not a name, and the
  * bound keeps a pathological value out of an issue message.
  */
 const MAX_BLOCK_PART_LENGTH = 32;
 
 /**
- * True if a value names an element a block may state a rule for.
+ * True if a value names a part a block may state styles for.
  *
  * The ONE answer, for the same reason {@link isBlockType} is: a caller that
- * bounds this where another does not emits a rule its neighbour refuses.
+ * bounds this where another does not emits a class its neighbour refuses.
  */
-export function isPartSelector(value: unknown): value is string {
+export function isPartName(value: unknown): value is string {
   return (
     typeof value === "string" &&
     value.length <= MAX_BLOCK_PART_LENGTH &&
-    BLOCK_PART_RE.test(value)
+    BLOCK_PART_NAME_RE.test(value)
   );
 }
 

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -413,6 +413,7 @@ export type {
   StyleCompileContext,
 } from "./style/compile-page";
 export {
+  blockPartClassName,
   blockTypeClassName,
   // The digest itself, for a caller naming something other than a node from an
   // id — a per-document scope class, say. Exported so that caller reaches for

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -42,6 +42,7 @@ export {
 export type {
   BlockDocument,
   BlockNode,
+  BlockPart,
   Binding,
   BindingSource,
   BindingFormat,

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -152,6 +152,63 @@ describe("registration rules", () => {
     expect(allBlocks()).toHaveLength(1);
   });
 
+  it("registers a block declaring well-formed parts", () => {
+    // The control every rejection below needs: a gate that refused every parts
+    // record would pass all of them while making the feature unusable.
+    registerBlocks([
+      block({
+        name: "core/captioned",
+        parts: { caption: { baseStyles: {} } },
+      } as never),
+    ]);
+    expect(hasBlock("core/captioned")).toBe(true);
+  });
+
+  it("rejects parts that are not a record, at BOOT rather than at render", () => {
+    // Unchecked, a `null` reaches the compile context and `Object.keys` throws
+    // during page-style resolution — a long way from the definition that caused
+    // it, naming neither the block nor the field.
+    expect(() =>
+      registerBlocks([block({ name: "core/d1", parts: null } as never)])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*parts/s);
+    expect(() =>
+      registerBlocks([block({ name: "core/d2", parts: [] } as never)])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*parts/s);
+  });
+
+  it("rejects a part name the compiler would refuse to emit", () => {
+    // Registration and emission ask the SAME predicate. A name accepted here
+    // and refused there registers a block whose part is silently never styled.
+    expect(() =>
+      registerBlocks([
+        block({ name: "core/e1", parts: { "a--b": {} } } as never),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*a--b/s);
+    expect(() =>
+      registerBlocks([
+        block({ name: "core/e2", parts: { Caption: {} } } as never),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*Caption/s);
+  });
+
+  it("rejects a part name Object.prototype already owns", () => {
+    // `constructor` passes the slug grammar, and a record cannot store it and
+    // read it back: the lookup answers with the inherited member.
+    expect(() =>
+      registerBlocks([
+        block({ name: "core/f", parts: { constructor: {} } } as never),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*constructor/s);
+  });
+
+  it("rejects a part whose declaration is not a record", () => {
+    expect(() =>
+      registerBlocks([
+        block({ name: "core/g", parts: { caption: null } } as never),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*caption/s);
+  });
+
   it("rejects a non-namespaced name", () => {
     expect(() => registerBlocks([block({ name: "heading" })])).toThrow(
       /NEXTLY_BLOCK_INVALID/

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -103,6 +103,10 @@ describe("the define-then-register workflow keeps its prop types", () => {
       // call that omits them is not the call a renderer makes.
       renderSlot: () => undefined,
       ctx: undefined,
+      // Required for the same reason: this block declares no parts, so the
+      // answer is empty for every name, and a renderer that could omit it would
+      // leave every block's parts unmarked with nothing to report.
+      partClass: () => "",
     });
     expect(output).toBe("hello reader");
   });

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -10,7 +10,7 @@
  * at boot with a named error rather than producing broken pages later.
  */
 import type { AnyBlockDefinition, BlockSupports } from "./block";
-import { COMPONENT_INSTANCE_TYPE, isBlockType } from "./document";
+import { COMPONENT_INSTANCE_TYPE, isBlockType, isPartName } from "./document";
 import type { MigrationSource } from "./migration";
 import { MAX_MIGRATION_STEPS, findMigrationGaps } from "./migration";
 import type { NestingSource } from "./nesting";
@@ -225,6 +225,42 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
   // validation, repair or insertion lookup, a long way from the definition that caused it and
   // naming neither. Checked here for the same reason `parent` is: the type rejects it at the
   // authoring site, and definitions also arrive from JavaScript plugins and from JSON.
+  // Checked here for the reason `slots` below is: the TYPE rejects a bad
+  // declaration at the authoring site, and definitions also arrive from
+  // JavaScript plugins and from JSON, where nothing has. Unchecked, a `null`
+  // reaches the compile context and `Object.keys` throws during page-style
+  // resolution — a long way from the definition that caused it, naming neither
+  // the block nor the field, and at render time rather than at boot.
+  if (def.parts !== undefined) {
+    if (!isPlainRecord(def.parts)) {
+      fail(
+        "NEXTLY_BLOCK_INVALID",
+        `block "${def.name}" parts must be a plain object keyed by part name.`
+      );
+    }
+    for (const [partName, spec] of Object.entries(def.parts)) {
+      // Bound before the check rather than read after it. `isPartName` narrows
+      // a `string` to `never` on its false branch, so the failure message —
+      // the one place the name has to be readable — would hold a value the
+      // template cannot render.
+      const named = `${partName}`;
+      // The SAME predicate the compiler emits against, so the two gates cannot
+      // answer differently: a name accepted here and refused there registers a
+      // block whose part is silently never styled.
+      if (!isPartName(partName)) {
+        fail(
+          "NEXTLY_BLOCK_INVALID",
+          `block "${def.name}" part "${named}" must be a lowercase slug such as "caption", with no doubled dash.`
+        );
+      }
+      if (!isPlainRecord(spec)) {
+        fail(
+          "NEXTLY_BLOCK_INVALID",
+          `block "${def.name}" part "${named}" must be a plain object.`
+        );
+      }
+    }
+  }
   if (def.slots !== undefined) {
     if (!isPlainRecord(def.slots)) {
       fail(

--- a/packages/blocks-engine/src/style/block-parts.test.ts
+++ b/packages/blocks-engine/src/style/block-parts.test.ts
@@ -190,6 +190,25 @@ describe("a part whose NAME is not a name", () => {
     expect(out.warnings[0]?.message).toContain(TYPE);
   });
 
+  it("refuses a parts value that is not a record, rather than throwing", () => {
+    // Registration refuses this, and registration is not the only door:
+    // `createBlockResolver` stores definitions directly, so a JavaScript caller
+    // can put a `null` on the context. Enumerating it here would throw before a
+    // single block rendered and take the whole page with it — so the compiler
+    // answers for the value it is handed rather than for the value it was
+    // promised.
+    for (const parts of [null, [], 7, "caption"]) {
+      const out = compilePageCss(doc(), {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        blockParts: { [TYPE]: parts },
+      } as unknown as StyleCompileContext);
+      expect(out.css).toBe("");
+      expect(out.warnings.map(issue => issue.code)).toEqual([
+        "invalid-block-part",
+      ]);
+    }
+  });
+
   it("refuses only the bad part, leaving its siblings styled", () => {
     // A block loses one part, not all of them — otherwise a typo in one
     // silently unstyles everything else the block declares.

--- a/packages/blocks-engine/src/style/block-parts.test.ts
+++ b/packages/blocks-engine/src/style/block-parts.test.ts
@@ -1,0 +1,192 @@
+/**
+ * Styles a block states for an element it renders INSIDE its root.
+ *
+ * `blockBases` is keyed by block type and compiles to one rule on one class, so
+ * a block drawing more than one element can reach only the element wearing that
+ * class. These are the others, and the questions here are which element each
+ * rule lands on and what it weighs — a rule emitted correctly against the right
+ * class is still wrong if it attaches to the wrong element, and a default that
+ * outranks the host's own stylesheet is wrong however well it lands.
+ *
+ * @module style/block-parts.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument, BlockNode } from "../document";
+import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
+
+import { compilePageCss } from "./compile-page";
+import type { StyleCompileContext } from "./compile-page";
+import { PAGE_ROOT_CLASS } from "./node-class";
+
+const TYPE = "core/image";
+const TYPE_CLASS = ".nx-bt-core--image";
+/**
+ * What a DEFAULT tier anchors to: ONE page-root class, not the doubled form.
+ * The doubling is what makes an AUTHORED value outrank a host's stylesheet, and
+ * it is deliberately withheld from defaults — so asserting against the doubled
+ * selector here would pass only if block defaults had been promoted above the
+ * CSS they are meant to lose to.
+ */
+const DEFAULTS_ANCHOR = `.${PAGE_ROOT_CLASS}`;
+
+function doc(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "n1", type: TYPE, version: 1, props: {} }],
+  } as unknown as BlockDocument;
+}
+
+function compile(ctx: Partial<StyleCompileContext>) {
+  return compilePageCss(doc(), {
+    breakpoints: FIXTURE_BREAKPOINTS,
+    ...ctx,
+  } as StyleCompileContext);
+}
+
+/** One part named `caption`, carrying whatever styles the case needs. */
+function caption(
+  baseStyles: unknown,
+  selector = "figcaption"
+): StyleCompileContext["blockParts"] {
+  return {
+    [TYPE]: { caption: { selector, baseStyles } },
+  } as StyleCompileContext["blockParts"];
+}
+
+describe("a block's styles for an element it renders", () => {
+  it("lands on that element rather than on the block's root", () => {
+    const out = compile({
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
+    });
+    expect(out.css).toBe(
+      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} figcaption) { font-size: 0.875em }`
+    );
+  });
+
+  it("does not require the block to state root styles as well", () => {
+    // The two tiers are independent: `blockBases` styles the element the
+    // block-type class is on, `blockParts` styles elements it is not, and a
+    // block declaring only the second is ordinary rather than a caller error.
+    const out = compile({
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
+    });
+    expect(out.css).toContain("figcaption");
+    expect(out.warnings).toEqual([]);
+  });
+
+  it("writes the root rule and the part rule against the same block class", () => {
+    const out = compile({
+      blockBases: { [TYPE]: { base: { base: { color: "#111" } } } },
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
+    });
+    expect(out.css).toBe(
+      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS}) { color: #111 }\n` +
+        `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} figcaption) { font-size: 0.875em }`
+    );
+  });
+
+  it("keeps the part inside :where(), so a site's own rule still wins", () => {
+    // The weight question, and the reason it is asked separately from where the
+    // rule lands. A default is not a choice anybody made, so it is anchored to
+    // one page-root class with the rest wrapped: `.content figcaption` at 0-1-1
+    // beats this, and a bare element reset at 0-0-1 does not. Emitting the part
+    // OUTSIDE the wrapper would add its own weight and quietly promote every
+    // block default above the host stylesheet it is meant to defer to.
+    const out = compile({
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
+    });
+    expect(out.css).toContain(":where(");
+    expect(out.css).not.toContain(`:where(${TYPE_CLASS}) figcaption`);
+  });
+
+  it("composes a property's own descendant after the part's element", () => {
+    // `linkColor` carries the catalog's own descendant (`a`). The two are
+    // different questions — one is block-scoped and structural, the other is
+    // property-scoped and crosses every block — so a link inside a caption has
+    // to reach `figcaption a` rather than either one alone.
+    const out = compile({
+      blockParts: caption({ base: { base: { linkColor: "#00f" } } }),
+    });
+    expect(out.css).toBe(
+      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} figcaption a) { color: #00f }`
+    );
+  });
+
+  it("records which element a declaration landed on", () => {
+    const { trace } = compilePageCss(doc(), {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
+      trace: true,
+    } as StyleCompileContext);
+    // Without this the map below runs on `undefined` and the assertion passes
+    // against an absent trace, which is the same green a correct one gives.
+    expect(trace).toBeDefined();
+    expect(trace?.map(entry => entry.descendant)).toEqual([" figcaption"]);
+  });
+});
+
+describe("a part naming something that is not an element", () => {
+  // Every rejection below needs the must-pass control above it to mean
+  // anything: a gate that refuses every selector passes all of these while
+  // styling nothing, and the emitted-rule assertion is what separates the two.
+  const REFUSED = [
+    ["a selector list, which would open a rule of its own", "figcaption, body"],
+    ["a descendant combinator", "figure figcaption"],
+    ["a class", ".caption"],
+    ["a pseudo-element", "figcaption::after"],
+    ["an attribute selector", "figcaption[data-x]"],
+    ["the universal selector", "*"],
+    ["an empty string", ""],
+    ["a value that is not a string", 42],
+  ] as const;
+
+  it.each(REFUSED)("refuses %s", (_why, selector) => {
+    const out = compile({
+      blockParts: caption(
+        { base: { base: { fontSize: "0.875em" } } },
+        selector as string
+      ),
+    });
+    expect(out.css).toBe("");
+    expect(out.warnings.map(issue => issue.code)).toEqual([
+      "invalid-block-part",
+    ]);
+  });
+
+  it("names the block and the part it refused", () => {
+    const out = compile({
+      blockParts: caption(
+        { base: { base: { fontSize: "0.875em" } } },
+        "figcaption, body"
+      ),
+    });
+    expect(out.warnings[0]?.message).toContain("caption");
+    expect(out.warnings[0]?.message).toContain(TYPE);
+    expect(out.warnings[0]?.path).toBe("/blockParts/core~1image/caption");
+  });
+
+  it("refuses only the bad part, leaving its siblings styled", () => {
+    // A block is refused one part, not all of them — otherwise a typo in one
+    // silently unstyles everything else the block declares.
+    const out = compilePageCss(doc(), {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      blockParts: {
+        [TYPE]: {
+          caption: { selector: "figcaption, body", baseStyles: {} },
+          marker: {
+            selector: "li",
+            baseStyles: { base: { base: { fontSize: "1em" } } },
+          },
+        },
+      },
+    } as StyleCompileContext);
+    expect(out.css).toBe(
+      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} li) { font-size: 1em }`
+    );
+    expect(out.warnings.map(issue => issue.code)).toEqual([
+      "invalid-block-part",
+    ]);
+  });
+});

--- a/packages/blocks-engine/src/style/block-parts.test.ts
+++ b/packages/blocks-engine/src/style/block-parts.test.ts
@@ -167,6 +167,9 @@ describe("a part whose NAME is not a name", () => {
     ["a leading dash", "-caption"],
     ["a trailing dash", "caption-"],
     ["an empty string", ""],
+    // Passes the slug grammar and still cannot be stored in a record and read
+    // back, so the compiler refuses it exactly as registration does.
+    ["a name Object.prototype owns", "constructor"],
   ] as const;
 
   it.each(REFUSED)("refuses %s", (_why, name) => {

--- a/packages/blocks-engine/src/style/block-parts.test.ts
+++ b/packages/blocks-engine/src/style/block-parts.test.ts
@@ -3,10 +3,9 @@
  *
  * `blockBases` is keyed by block type and compiles to one rule on one class, so
  * a block drawing more than one element can reach only the element wearing that
- * class. These are the others, and the questions here are which element each
- * rule lands on and what it weighs — a rule emitted correctly against the right
- * class is still wrong if it attaches to the wrong element, and a default that
- * outranks the host's own stylesheet is wrong however well it lands.
+ * class. These are the others, and three questions decide whether they work:
+ * which element each rule lands on, what it weighs, and — the one a descendant
+ * selector gets wrong — whether it stops at the block that declared it.
  *
  * @module style/block-parts.test
  */
@@ -17,104 +16,118 @@ import { FIXTURE_BREAKPOINTS } from "../validation.fixtures";
 
 import { compilePageCss } from "./compile-page";
 import type { StyleCompileContext } from "./compile-page";
-import { PAGE_ROOT_CLASS } from "./node-class";
+import { blockPartClassName, PAGE_ROOT_CLASS } from "./node-class";
 
 const TYPE = "core/image";
-const TYPE_CLASS = ".nx-bt-core--image";
+const PART_CLASS = `.${blockPartClassName(TYPE, "caption")}`;
+
 /**
  * What a DEFAULT tier anchors to: ONE page-root class, not the doubled form.
- * The doubling is what makes an AUTHORED value outrank a host's stylesheet, and
- * it is deliberately withheld from defaults — so asserting against the doubled
- * selector here would pass only if block defaults had been promoted above the
- * CSS they are meant to lose to.
+ * The doubling is what makes an AUTHORED value outrank a host's stylesheet and
+ * is deliberately withheld from defaults — so asserting against the doubled
+ * selector would pass only if block defaults had been promoted above the CSS
+ * they are meant to lose to.
  */
 const DEFAULTS_ANCHOR = `.${PAGE_ROOT_CLASS}`;
 
-function doc(): BlockDocument {
+function doc(type = TYPE): BlockDocument {
   return {
     formatVersion: 1,
     kind: "page",
-    nodes: [{ id: "n1", type: TYPE, version: 1, props: {} }],
+    nodes: [{ id: "n1", type, version: 1, props: {} } as BlockNode],
   } as unknown as BlockDocument;
 }
 
-function compile(ctx: Partial<StyleCompileContext>) {
-  return compilePageCss(doc(), {
+function compile(ctx: Partial<StyleCompileContext>, type = TYPE) {
+  return compilePageCss(doc(type), {
     breakpoints: FIXTURE_BREAKPOINTS,
     ...ctx,
   } as StyleCompileContext);
 }
 
 /** One part named `caption`, carrying whatever styles the case needs. */
-function caption(
-  baseStyles: unknown,
-  selector = "figcaption"
-): StyleCompileContext["blockParts"] {
+function caption(baseStyles: unknown, name = "caption") {
   return {
-    [TYPE]: { caption: { selector, baseStyles } },
+    [TYPE]: { [name]: { baseStyles } },
   } as StyleCompileContext["blockParts"];
 }
 
 describe("a block's styles for an element it renders", () => {
-  it("lands on that element rather than on the block's root", () => {
+  it("lands on the class marking that element", () => {
     const out = compile({
       blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
     });
     expect(out.css).toBe(
-      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} figcaption) { font-size: 0.875em }`
+      `${DEFAULTS_ANCHOR} :where(${PART_CLASS}) { font-size: 0.875em }`
     );
   });
 
-  it("does not require the block to state root styles as well", () => {
-    // The two tiers are independent: `blockBases` styles the element the
-    // block-type class is on, `blockParts` styles elements it is not, and a
-    // block declaring only the second is ordinary rather than a caller error.
+  it("does not reach elements a NESTED block renders", () => {
+    // The defect a descendant selector has and a marker class cannot: written
+    // as `.nx-bt-core--image figcaption`, a container's default also matches a
+    // `figcaption` produced by another block sitting in one of its slots, so a
+    // parent styles markup whose structure it does not own. The class carries
+    // the owning type, so only elements the block itself marked can match.
     const out = compile({
       blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
     });
-    expect(out.css).toContain("figcaption");
-    expect(out.warnings).toEqual([]);
+    expect(out.css).not.toContain("figcaption");
+    expect(out.css).not.toContain(" li");
+    expect(out.css).toContain(blockPartClassName(TYPE, "caption"));
   });
 
-  it("writes the root rule and the part rule against the same block class", () => {
+  it("names the block that owns the part, so two blocks cannot collide", () => {
+    expect(blockPartClassName("core/image", "caption")).not.toBe(
+      blockPartClassName("core/quote", "caption")
+    );
+    // The doubled dash is the boundary, and a part name may not contain one —
+    // otherwise these two would spell the same class.
+    expect(blockPartClassName("core/image", "caption-wide")).not.toBe(
+      blockPartClassName("core/image-caption", "wide")
+    );
+  });
+
+  it("puts an interaction state on the PART, not on the block root", () => {
+    // Focus does not propagate from a focused descendant to its ancestor, so a
+    // state written onto the block root leaves a focusable part's `focus`
+    // envelope unreachable: the input is focused and the rule waits for the
+    // form to be.
+    const out = compile({
+      blockParts: caption({ focus: { base: { color: "#222" } } }),
+    });
+    expect(out.css).toContain(`${PART_CLASS}:where(:focus-visible)`);
+    expect(out.css).not.toContain(":where(:focus-visible) ");
+  });
+
+  it("keeps the part inside :where(), so a site's own rule still wins", () => {
+    // A default is not a choice anybody made, so it is anchored to one
+    // page-root class with the rest wrapped: `.content .nx-bp-…` at 0-2-0 beats
+    // this, and a bare element reset at 0-0-1 does not.
+    const out = compile({
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
+    });
+    expect(out.css.startsWith(`${DEFAULTS_ANCHOR} :where(`)).toBe(true);
+    expect(out.css).not.toContain(`${DEFAULTS_ANCHOR}${DEFAULTS_ANCHOR}`);
+  });
+
+  it("writes the root rule and the part rule for one block together", () => {
     const out = compile({
       blockBases: { [TYPE]: { base: { base: { color: "#111" } } } },
       blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
     });
-    expect(out.css).toBe(
-      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS}) { color: #111 }\n` +
-        `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} figcaption) { font-size: 0.875em }`
-    );
+    expect(out.css).toContain("color: #111");
+    expect(out.css).toContain("font-size: 0.875em");
   });
 
-  it("keeps the part inside :where(), so a site's own rule still wins", () => {
-    // The weight question, and the reason it is asked separately from where the
-    // rule lands. A default is not a choice anybody made, so it is anchored to
-    // one page-root class with the rest wrapped: `.content figcaption` at 0-1-1
-    // beats this, and a bare element reset at 0-0-1 does not. Emitting the part
-    // OUTSIDE the wrapper would add its own weight and quietly promote every
-    // block default above the host stylesheet it is meant to defer to.
+  it("does not require the block to state root styles as well", () => {
     const out = compile({
       blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
     });
-    expect(out.css).toContain(":where(");
-    expect(out.css).not.toContain(`:where(${TYPE_CLASS}) figcaption`);
+    expect(out.css).toContain("font-size: 0.875em");
+    expect(out.warnings).toEqual([]);
   });
 
-  it("composes a property's own descendant after the part's element", () => {
-    // `linkColor` carries the catalog's own descendant (`a`). The two are
-    // different questions — one is block-scoped and structural, the other is
-    // property-scoped and crosses every block — so a link inside a caption has
-    // to reach `figcaption a` rather than either one alone.
-    const out = compile({
-      blockParts: caption({ base: { base: { linkColor: "#00f" } } }),
-    });
-    expect(out.css).toBe(
-      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} figcaption a) { color: #00f }`
-    );
-  });
-
-  it("records which element a declaration landed on", () => {
+  it("records WHICH element a declaration landed on", () => {
     const { trace } = compilePageCss(doc(), {
       breakpoints: FIXTURE_BREAKPOINTS,
       blockParts: caption({ base: { base: { fontSize: "0.875em" } } }),
@@ -123,31 +136,42 @@ describe("a block's styles for an element it renders", () => {
     // Without this the map below runs on `undefined` and the assertion passes
     // against an absent trace, which is the same green a correct one gives.
     expect(trace).toBeDefined();
-    expect(trace?.map(entry => entry.descendant)).toEqual([" figcaption"]);
+    expect(trace?.map(entry => entry.origin)).toEqual([
+      { kind: "blockType", type: TYPE, part: "caption" },
+    ]);
+  });
+
+  it("leaves a block's own root rule reporting no part", () => {
+    // The control for the assertion above: an origin that always carried a part
+    // would satisfy it while telling a reader nothing.
+    const { trace } = compilePageCss(doc(), {
+      breakpoints: FIXTURE_BREAKPOINTS,
+      blockBases: { [TYPE]: { base: { base: { color: "#111" } } } },
+      trace: true,
+    } as StyleCompileContext);
+    expect(trace).toBeDefined();
+    expect(trace?.map(entry => entry.origin)).toEqual([
+      { kind: "blockType", type: TYPE },
+    ]);
   });
 });
 
-describe("a part naming something that is not an element", () => {
-  // Every rejection below needs the must-pass control above it to mean
-  // anything: a gate that refuses every selector passes all of these while
-  // styling nothing, and the emitted-rule assertion is what separates the two.
+describe("a part whose NAME is not a name", () => {
+  // Every rejection needs the must-pass cases above it to mean anything: a gate
+  // that refuses every name passes all of these while styling nothing.
   const REFUSED = [
-    ["a selector list, which would open a rule of its own", "figcaption, body"],
-    ["a descendant combinator", "figure figcaption"],
-    ["a class", ".caption"],
-    ["a pseudo-element", "figcaption::after"],
-    ["an attribute selector", "figcaption[data-x]"],
-    ["the universal selector", "*"],
+    ["a doubled dash, which would make the class boundary ambiguous", "a--b"],
+    ["an uppercase letter", "Caption"],
+    ["a space", "my caption"],
+    ["a dot", "caption.x"],
+    ["a leading dash", "-caption"],
+    ["a trailing dash", "caption-"],
     ["an empty string", ""],
-    ["a value that is not a string", 42],
   ] as const;
 
-  it.each(REFUSED)("refuses %s", (_why, selector) => {
+  it.each(REFUSED)("refuses %s", (_why, name) => {
     const out = compile({
-      blockParts: caption(
-        { base: { base: { fontSize: "0.875em" } } },
-        selector as string
-      ),
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }, name),
     });
     expect(out.css).toBe("");
     expect(out.warnings.map(issue => issue.code)).toEqual([
@@ -157,33 +181,26 @@ describe("a part naming something that is not an element", () => {
 
   it("names the block and the part it refused", () => {
     const out = compile({
-      blockParts: caption(
-        { base: { base: { fontSize: "0.875em" } } },
-        "figcaption, body"
-      ),
+      blockParts: caption({ base: { base: { fontSize: "0.875em" } } }, "a--b"),
     });
-    expect(out.warnings[0]?.message).toContain("caption");
+    expect(out.warnings[0]?.message).toContain("a--b");
     expect(out.warnings[0]?.message).toContain(TYPE);
-    expect(out.warnings[0]?.path).toBe("/blockParts/core~1image/caption");
   });
 
   it("refuses only the bad part, leaving its siblings styled", () => {
-    // A block is refused one part, not all of them — otherwise a typo in one
+    // A block loses one part, not all of them — otherwise a typo in one
     // silently unstyles everything else the block declares.
     const out = compilePageCss(doc(), {
       breakpoints: FIXTURE_BREAKPOINTS,
       blockParts: {
         [TYPE]: {
-          caption: { selector: "figcaption, body", baseStyles: {} },
-          marker: {
-            selector: "li",
-            baseStyles: { base: { base: { fontSize: "1em" } } },
-          },
+          "a--b": { baseStyles: { base: { base: { color: "#111" } } } },
+          marker: { baseStyles: { base: { base: { fontSize: "1em" } } } },
         },
       },
     } as StyleCompileContext);
     expect(out.css).toBe(
-      `${DEFAULTS_ANCHOR} :where(${TYPE_CLASS} li) { font-size: 1em }`
+      `${DEFAULTS_ANCHOR} :where(.${blockPartClassName(TYPE, "marker")}) { font-size: 1em }`
     );
     expect(out.warnings.map(issue => issue.code)).toEqual([
       "invalid-block-part",

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -1919,6 +1919,22 @@ export function compilePageCss(
       );
     if (!hasParts) continue;
     const parts = partsByType[type];
+    // Registration refuses a malformed record, and registration is NOT the only
+    // door: `createBlockResolver` stores definitions directly, so a JavaScript
+    // caller reaches this with whatever it was given. Enumerating a `null` here
+    // throws before a single block renders and takes the whole page with it —
+    // so this answers for the value it is HANDED rather than for the value the
+    // type promised, exactly as the node-type check above does.
+    if (!isPlainRecord(parts)) {
+      pushBoundedWarning(warningAllowance, warnings, {
+        path: pointer("/blockParts", type),
+        code: "invalid-block-part",
+        severity: "warning",
+        message: `"${describeValue(parts)}" is not a set of parts, so no part of "${type}" was styled.`,
+        suggestion: "Use a plain object keyed by part name.",
+      });
+      continue;
+    }
     // Sorted so one document always serializes the same way, exactly as the
     // type loop above and `groupByDescendant` below both do.
     for (const name of Object.keys(parts).sort()) {

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -20,6 +20,7 @@
 import type {
   BlockDocument,
   BlockNode,
+  BlockPart,
   BreakpointDef,
   BreakpointSet,
   NodeStyles,
@@ -32,6 +33,7 @@ import {
   MAX_NAMED_CLASSES,
   STYLE_STATES,
   isBlockType,
+  isPartSelector,
 } from "../document";
 import { describeValue, pointer } from "../issue-text";
 import { DEFAULT_LIMITS } from "../limits";
@@ -144,6 +146,22 @@ export interface StyleCompileContext {
    * improving a block's default look reaches pages that already exist.
    */
   blockBases?: Readonly<Record<string, NodeStyles>>;
+  /**
+   * Base styles for the elements a block renders inside its root, keyed by
+   * block name and then by part name.
+   *
+   * A sibling of {@link blockBases} rather than a richer value inside it,
+   * matching how {@link elementBases} and the named-class tier already sit
+   * beside it. The two answer different questions — one styles the element the
+   * block-type class is ON, the other styles elements it is not — and a block
+   * declaring neither, one, or both are all ordinary.
+   *
+   * The selector travels with the styles because this package holds no
+   * registry: it cannot look a part's element up from its name, so the caller
+   * that does hold the definitions resolves both together, the same way
+   * `drawsNothing` answers from a registry this compiler cannot see.
+   */
+  blockParts?: Readonly<Record<string, Readonly<Record<string, BlockPart>>>>;
 
   /**
    * Typographic defaults per HTML element, keyed by tag name.
@@ -1198,6 +1216,16 @@ function unknownBreakpointWarnings(
 /** What one envelope is, and what may be written from it. */
 interface EnvelopeContext {
   origin: StyleOrigin;
+  /**
+   * An element INSIDE the envelope's own, which every rule from it attaches to.
+   *
+   * Prepended to each declaration's own `descendant` rather than folded into
+   * the selector string, so the two reach the cascade by one path: a rule for a
+   * part gets the part's weight added exactly as a link colour inside a node
+   * already does, and the provenance trace records which element a declaration
+   * landed on instead of reporting the block's root for all of them.
+   */
+  part?: string;
   /** Appended to as declarations are emitted; absent when no caller asked for a trace. */
   trace?: StyleTraceEntry[];
   /** Which hosts this site will fetch from; unasked when absent. */
@@ -1270,6 +1298,10 @@ function envelopeRules(
   // disagree between a node's base rule and its hover one.
   const stateSelectors =
     previewStates === true ? PREVIEW_STATE_SELECTORS : STATE_SELECTORS;
+  // Same reasoning as `stateSelectors` above: a property of the envelope, read
+  // once, so a base rule and a hover rule cannot disagree about which element
+  // they are for.
+  const partStep = about.part === undefined ? "" : ` ${about.part}`;
   if (styles === undefined) return [];
   // A stored envelope that is not an object — `[]`, a string, `null` — styles
   // nothing, and this compiler reads persisted data whether or not a caller
@@ -1361,8 +1393,8 @@ function envelopeRules(
           // the only part that weighs.
           selector:
             weightlessAnchor === undefined
-              ? `${selector}${stateSelectors[state]}${rule.descendant}`
-              : `${weightlessAnchor} :where(${selector}${stateSelectors[state]}${rule.descendant})`,
+              ? `${selector}${stateSelectors[state]}${partStep}${rule.descendant}`
+              : `${weightlessAnchor} :where(${selector}${stateSelectors[state]}${partStep}${rule.descendant})`,
           declarations: rule.declarations,
         });
         // Recorded here, from the same declarations that were just emitted, in the same loop.
@@ -1374,7 +1406,9 @@ function envelopeRules(
             origin,
             property: declaration.property,
             value: declaration.value,
-            ...(rule.descendant === "" ? {} : { descendant: rule.descendant }),
+            ...(partStep + rule.descendant === ""
+              ? {}
+              : { descendant: partStep + rule.descendant }),
             state,
             breakpoint: context.id,
             ...(context.atRule === undefined ? {} : { atRule: context.atRule }),
@@ -1844,8 +1878,15 @@ export function compilePageCss(
     if (typeof node.type === "string") usedTypes.add(node.type);
   }
   const bases = ctx.blockBases ?? {};
+  const partsByType = ctx.blockParts ?? {};
   for (const type of [...usedTypes].sort()) {
-    if (!Object.hasOwn(bases, type)) continue;
+    // Own properties only, and for the same reason the caller narrowing these
+    // records checks the same thing: a record reached through a polluted
+    // prototype answers this lookup with an inherited value, which would emit a
+    // rule against a selector built from a node type nobody declared.
+    const hasBase = Object.hasOwn(bases, type);
+    const hasParts = Object.hasOwn(partsByType, type);
+    if (!hasBase && !hasParts) continue;
     // A node type reaches a SELECTOR, and this compiler reads persisted data
     // whether or not a caller validated it. Unchecked, `"evil/x, body"` emits
     // `.nx-pb-page .nx-bt-evil--x, body { … }` — a second selector of the
@@ -1866,29 +1907,73 @@ export function compilePageCss(
       });
       continue;
     }
-    rules.push(
-      ...envelopeRules(
-        bases[type],
-        // Escaped as well as refused above. The check is what makes this safe;
-        // escaping is what keeps it safe if the check is ever loosened, and it
-        // changes nothing for a type that passed, whose characters are all
-        // legal in a class already.
-        `.${escapeIdentifier(blockTypeClassName(type))}`,
-        pointer("/blockBases", type),
-        contexts,
-        tokenPrefix,
-        warnings,
-        budget,
-        warningAllowance,
-        {
-          origin: { kind: "blockType", type },
-          previewStates,
-          trace,
-          mayFetchUrl,
-          weightlessAnchor: defaultsAnchor,
-        }
-      )
-    );
+    // Escaped as well as refused above. The check is what makes this safe;
+    // escaping is what keeps it safe if the check is ever loosened, and it
+    // changes nothing for a type that passed, whose characters are all legal in
+    // a class already. Built once because both tiers below anchor to it.
+    const typeClass = `.${escapeIdentifier(blockTypeClassName(type))}`;
+    if (hasBase)
+      rules.push(
+        ...envelopeRules(
+          bases[type],
+          typeClass,
+          pointer("/blockBases", type),
+          contexts,
+          tokenPrefix,
+          warnings,
+          budget,
+          warningAllowance,
+          {
+            origin: { kind: "blockType", type },
+            previewStates,
+            trace,
+            mayFetchUrl,
+            weightlessAnchor: defaultsAnchor,
+          }
+        )
+      );
+    if (!hasParts) continue;
+    const parts = partsByType[type];
+    // Sorted so one document always serializes the same way, exactly as the
+    // type loop above and `groupByDescendant` below both do.
+    for (const name of Object.keys(parts).sort()) {
+      const part = parts[name];
+      // A part's selector reaches a SELECTOR, and a block definition is code a
+      // plugin supplies. Held to a bare tag rather than escaped into something
+      // safe: escaping would let `figcaption, body` through as a class-shaped
+      // string that matches no element, which is a rule nobody can find rather
+      // than a rule nobody wrote. Refusing says so.
+      if (!isPartSelector(part?.selector)) {
+        pushBoundedWarning(warningAllowance, warnings, {
+          path: pointer(pointer("/blockParts", type), name),
+          code: "invalid-block-part",
+          severity: "warning",
+          message: `"${describeValue(part?.selector)}" is not an element name, so the "${name}" part of "${type}" was not styled.`,
+          suggestion: 'Name the element as a plain tag, such as "figcaption".',
+        });
+        continue;
+      }
+      rules.push(
+        ...envelopeRules(
+          part.baseStyles,
+          typeClass,
+          pointer(pointer("/blockParts", type), name),
+          contexts,
+          tokenPrefix,
+          warnings,
+          budget,
+          warningAllowance,
+          {
+            origin: { kind: "blockType", type },
+            part: part.selector,
+            previewStates,
+            trace,
+            mayFetchUrl,
+            weightlessAnchor: defaultsAnchor,
+          }
+        )
+      );
+    }
   }
 
   // The named classes, in library order — the tier between a block's defaults and a node's own

--- a/packages/blocks-engine/src/style/compile-page.ts
+++ b/packages/blocks-engine/src/style/compile-page.ts
@@ -33,7 +33,7 @@ import {
   MAX_NAMED_CLASSES,
   STYLE_STATES,
   isBlockType,
-  isPartSelector,
+  isPartName,
 } from "../document";
 import { describeValue, pointer } from "../issue-text";
 import { DEFAULT_LIMITS } from "../limits";
@@ -60,6 +60,7 @@ import {
   NAMED_CLASS_SLUG_RE,
 } from "./named-class";
 import {
+  blockPartClassName,
   blockTypeClassName,
   nodeClassNames,
   PAGE_ROOT_CLASS,
@@ -1216,16 +1217,6 @@ function unknownBreakpointWarnings(
 /** What one envelope is, and what may be written from it. */
 interface EnvelopeContext {
   origin: StyleOrigin;
-  /**
-   * An element INSIDE the envelope's own, which every rule from it attaches to.
-   *
-   * Prepended to each declaration's own `descendant` rather than folded into
-   * the selector string, so the two reach the cascade by one path: a rule for a
-   * part gets the part's weight added exactly as a link colour inside a node
-   * already does, and the provenance trace records which element a declaration
-   * landed on instead of reporting the block's root for all of them.
-   */
-  part?: string;
   /** Appended to as declarations are emitted; absent when no caller asked for a trace. */
   trace?: StyleTraceEntry[];
   /** Which hosts this site will fetch from; unasked when absent. */
@@ -1298,10 +1289,6 @@ function envelopeRules(
   // disagree between a node's base rule and its hover one.
   const stateSelectors =
     previewStates === true ? PREVIEW_STATE_SELECTORS : STATE_SELECTORS;
-  // Same reasoning as `stateSelectors` above: a property of the envelope, read
-  // once, so a base rule and a hover rule cannot disagree about which element
-  // they are for.
-  const partStep = about.part === undefined ? "" : ` ${about.part}`;
   if (styles === undefined) return [];
   // A stored envelope that is not an object — `[]`, a string, `null` — styles
   // nothing, and this compiler reads persisted data whether or not a caller
@@ -1393,8 +1380,8 @@ function envelopeRules(
           // the only part that weighs.
           selector:
             weightlessAnchor === undefined
-              ? `${selector}${stateSelectors[state]}${partStep}${rule.descendant}`
-              : `${weightlessAnchor} :where(${selector}${stateSelectors[state]}${partStep}${rule.descendant})`,
+              ? `${selector}${stateSelectors[state]}${rule.descendant}`
+              : `${weightlessAnchor} :where(${selector}${stateSelectors[state]}${rule.descendant})`,
           declarations: rule.declarations,
         });
         // Recorded here, from the same declarations that were just emitted, in the same loop.
@@ -1406,9 +1393,7 @@ function envelopeRules(
             origin,
             property: declaration.property,
             value: declaration.value,
-            ...(partStep + rule.descendant === ""
-              ? {}
-              : { descendant: partStep + rule.descendant }),
+            ...(rule.descendant === "" ? {} : { descendant: rule.descendant }),
             state,
             breakpoint: context.id,
             ...(context.atRule === undefined ? {} : { atRule: context.atRule }),
@@ -1937,26 +1922,30 @@ export function compilePageCss(
     // Sorted so one document always serializes the same way, exactly as the
     // type loop above and `groupByDescendant` below both do.
     for (const name of Object.keys(parts).sort()) {
-      const part = parts[name];
-      // A part's selector reaches a SELECTOR, and a block definition is code a
-      // plugin supplies. Held to a bare tag rather than escaped into something
-      // safe: escaping would let `figcaption, body` through as a class-shaped
-      // string that matches no element, which is a rule nobody can find rather
-      // than a rule nobody wrote. Refusing says so.
-      if (!isPartSelector(part?.selector)) {
+      // A part name is compiled INTO a class, so it reaches a selector, and a
+      // block definition is code a plugin supplies. Refused rather than escaped
+      // for the reason the block type above is: escaping produces a class no
+      // renderer will ever write, which is a style silently missing rather than
+      // a value reported.
+      if (!isPartName(name)) {
         pushBoundedWarning(warningAllowance, warnings, {
           path: pointer(pointer("/blockParts", type), name),
           code: "invalid-block-part",
           severity: "warning",
-          message: `"${describeValue(part?.selector)}" is not an element name, so the "${name}" part of "${type}" was not styled.`,
-          suggestion: 'Name the element as a plain tag, such as "figcaption".',
+          message: `"${describeValue(name)}" is not a part name, so that part of "${type}" was not styled.`,
+          suggestion: 'Use a lowercase slug such as "caption".',
         });
         continue;
       }
       rules.push(
         ...envelopeRules(
-          part.baseStyles,
-          typeClass,
+          parts[name]?.baseStyles,
+          // The block type is encoded in the class rather than left as an
+          // ancestor. `.nx-bt-core--form label` would also match labels a CHILD
+          // block renders into one of the form's slots, so a container's
+          // defaults would reach markup it does not own; a single class matches
+          // only what the block itself marked.
+          `.${escapeIdentifier(blockPartClassName(type, name))}`,
           pointer(pointer("/blockParts", type), name),
           contexts,
           tokenPrefix,
@@ -1964,8 +1953,10 @@ export function compilePageCss(
           budget,
           warningAllowance,
           {
-            origin: { kind: "blockType", type },
-            part: part.selector,
+            // The part travels with the origin so a provenance reader can say
+            // WHICH element a declaration landed on. Without it two rules from
+            // one block report the same source and differ only by property.
+            origin: { kind: "blockType", type, part: name },
             previewStates,
             trace,
             mayFetchUrl,

--- a/packages/blocks-engine/src/style/node-class.ts
+++ b/packages/blocks-engine/src/style/node-class.ts
@@ -43,6 +43,16 @@ export const PAGE_ROOT_SELECTOR = `.${PAGE_ROOT_CLASS}.${PAGE_ROOT_CLASS}`;
 export const BLOCK_TYPE_CLASS_PREFIX = "nx-bt-";
 
 /**
+ * What a class marking one of a block's own rendered elements starts with.
+ *
+ * Separate from the block-type prefix because the two answer different
+ * questions — which block this element belongs to, versus which element of it
+ * this is — and a reader scanning a rendered page can tell them apart without
+ * knowing the vocabulary.
+ */
+export const BLOCK_PART_CLASS_PREFIX = "nx-bp-";
+
+/**
  * The class an element wears to opt into the site's content width.
  *
  * Here rather than beside the container block that applies it, because the rule
@@ -166,4 +176,26 @@ export function nodeClassName(id: string): string {
  */
 export function blockTypeClassName(type: string): string {
   return BLOCK_TYPE_CLASS_PREFIX + type.replace(/\//g, "--");
+}
+
+/**
+ * The class marking one element a block renders inside its own root.
+ *
+ * The block type is encoded INTO the class rather than left as an ancestor
+ * selector, and that is the whole point rather than a shortening. A rule
+ * written as `.nx-bt-core--form label` matches every `label` beneath the form,
+ * including labels rendered by other blocks sitting in its slots — so a
+ * container's defaults reach markup it does not own, and the deeper the tree
+ * the more it takes. A single class matches exactly the elements the block
+ * itself marked, whatever is nested inside it.
+ *
+ * Both separators are the doubled dash for the reason
+ * {@link blockTypeClassName} gives: a part name is
+ * `[a-z0-9]+(-[a-z0-9]+)*`, so a doubled dash cannot occur inside one and is
+ * free to mean a boundary. Without that, `core/image` + `caption-wide` and
+ * `core/image-caption` + `wide` would both spell `core--image-caption-wide`
+ * and one block's defaults would silently apply to another's element.
+ */
+export function blockPartClassName(type: string, part: string): string {
+  return `${BLOCK_PART_CLASS_PREFIX}${type.replace(/\//g, "--")}--${part}`;
 }

--- a/packages/blocks-engine/src/style/override-contract.doc.test.ts
+++ b/packages/blocks-engine/src/style/override-contract.doc.test.ts
@@ -63,6 +63,17 @@ function contractCss(): string {
           },
         },
       },
+      {
+        // Carries the row for an element a block draws inside itself. A second
+        // node rather than a part bolted onto the section above, because the
+        // table is read as a worked example and a section does not draw a
+        // caption — a row nobody could meet in a real document teaches the
+        // wrong thing even while the compiler emits it.
+        id: "n2",
+        type: "core/image",
+        version: 1,
+        props: {},
+      },
     ],
     settings: {
       styles: { base: { base: { color: "#111", linkColor: "#222" } } },
@@ -74,6 +85,14 @@ function contractCss(): string {
     elementBases: { h1: { base: { base: { fontSize: "2.25rem" } } } },
     blockBases: {
       "core/section": { base: { base: { backgroundColor: "#eee" } } },
+    },
+    blockParts: {
+      "core/image": {
+        caption: {
+          selector: "figcaption",
+          baseStyles: { base: { base: { fontSize: "0.875em" } } },
+        },
+      },
     },
   });
 

--- a/packages/blocks-engine/src/style/override-contract.doc.test.ts
+++ b/packages/blocks-engine/src/style/override-contract.doc.test.ts
@@ -88,10 +88,7 @@ function contractCss(): string {
     },
     blockParts: {
       "core/image": {
-        caption: {
-          selector: "figcaption",
-          baseStyles: { base: { base: { fontSize: "0.875em" } } },
-        },
+        caption: { baseStyles: { base: { base: { fontSize: "0.875em" } } } },
       },
     },
   });

--- a/packages/blocks-engine/src/style/style-origin.test.ts
+++ b/packages/blocks-engine/src/style/style-origin.test.ts
@@ -399,3 +399,56 @@ describe("the typographic baseline's origin", () => {
     expect(styleOrigin(elementTrace(), box, askFontSize)).toBeUndefined();
   });
 });
+
+describe("a rule for an element the block draws inside itself", () => {
+  /** A trace carrying one part rule and, optionally, a page value under it. */
+  function partTrace(pageColour?: string): readonly StyleTraceEntry[] {
+    const { trace } = compilePageCss(
+      page(
+        [node({})],
+        pageColour === undefined
+          ? undefined
+          : { styles: styles({ color: pageColour }) }
+      ),
+      {
+        breakpoints: FIXTURE_BREAKPOINTS,
+        blockParts: {
+          "core/box": { caption: { baseStyles: styles({ color: "green" }) } },
+        },
+        trace: true,
+      } as never
+    );
+    expect(trace).toBeDefined();
+    return trace ?? [];
+  }
+
+  it("is not what the NODE is showing for that property", () => {
+    // The part's rule lands on an element the block marks inside its root, so
+    // the node's own box never wears it. Attributed to the node, a style
+    // inspector offers a control that reports a value the browser applies
+    // somewhere else — and editing it would appear to do nothing.
+    const showing = styleOrigin(partTrace(), box, atBase);
+
+    expect(showing).toBeUndefined();
+  });
+
+  it("does not outrank a value that DOES reach the node", () => {
+    // The sharper form: with a page value present, attributing the part would
+    // not merely add a phantom entry, it would replace the true answer.
+    const showing = styleOrigin(partTrace("black"), box, atBase);
+
+    expect(showing?.origin).toEqual({ kind: "page" });
+  });
+
+  it("still reports a block's ROOT default, which does reach the node", () => {
+    // The control both assertions above need. A `blockType` origin rejected
+    // outright would satisfy them while hiding every block default there is.
+    const trace = traceOf(page([node({})]), [], {
+      "core/box": styles({ color: "green" }),
+    });
+
+    const showing = styleOrigin(trace, box, atBase);
+
+    expect(showing?.origin).toEqual({ kind: "blockType", type: "core/box" });
+  });
+});

--- a/packages/blocks-engine/src/style/style-origin.ts
+++ b/packages/blocks-engine/src/style/style-origin.ts
@@ -188,8 +188,15 @@ function reachesNode(entry: StyleTraceEntry, subject: StyleSubject): boolean {
       return true;
     case "node":
       return origin.id === subject.nodeId;
+    // A rule for one of the block's PARTS lands on an element the block marks
+    // inside its root, never on the node's own box — so it does not compete for
+    // the node's value, and reporting it would offer a control over a value the
+    // browser applies somewhere else. Refused rather than matched against a part
+    // the subject names, because a subject has no way to say which part it is:
+    // the answer would have to be guessed, and the quiet answer is the one this
+    // module already gives a caller that cannot state its tag.
     case "blockType":
-      return origin.type === subject.blockType;
+      return origin.part === undefined && origin.type === subject.blockType;
     case "class":
       return (subject.classIds ?? []).includes(origin.id);
     // The baseline lands on the ELEMENT, so only a node rendering that element

--- a/packages/blocks-engine/src/style/style-trace.ts
+++ b/packages/blocks-engine/src/style/style-trace.ts
@@ -25,7 +25,17 @@ export type StyleOrigin =
   /** The page's own settings, on the root everything else is anchored to. */
   | { kind: "page" }
   /** A block type's default look, shared by every node of that type. */
-  | { kind: "blockType"; type: string }
+  /**
+   * A block type's default look, shared by every node of that type.
+   *
+   * `part` names one of the elements the block renders inside its own root,
+   * absent when the rule is for the element the block-type class is on. Carried
+   * here rather than left to be read off the selector because a provenance
+   * reader answers "where did this value come from", and two rules from one
+   * block that differ only in which element they landed on are otherwise
+   * indistinguishable.
+   */
+  | { kind: "blockType"; type: string; part?: string }
   /**
    * The typographic baseline for one element, shared by every `h1` on the page.
    *

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -244,7 +244,7 @@ export const ISSUE_CODES = {
   "invalid-scope":
     "The compile scope is not a single class, so the document's rules were not scoped.",
   "invalid-block-part":
-    "A block names an element it renders, and the name is not a plain HTML tag, so that part's default styles were not written.",
+    "A block names an element it renders, and the name is not a lowercase slug, so that part's default styles were not written.",
   // Spelled the same as the `NestingRefusal` members they report, so the code a
   // caller matches on and the reason the rule gave are one string rather than a
   // mapping that has to be kept in step.

--- a/packages/blocks-engine/src/validation.ts
+++ b/packages/blocks-engine/src/validation.ts
@@ -243,6 +243,8 @@ export const ISSUE_CODES = {
     "Some token and class names were not checked against the site, so any that do not resolve are not reported.",
   "invalid-scope":
     "The compile scope is not a single class, so the document's rules were not scoped.",
+  "invalid-block-part":
+    "A block names an element it renders, and the name is not a plain HTML tag, so that part's default styles were not written.",
   // Spelled the same as the `NestingRefusal` members they report, so the code a
   // caller matches on and the reason the rule gave are one string rather than a
   // mapping that has to be kept in step.

--- a/packages/blocks-react/src/block-boundary.tsx
+++ b/packages/blocks-react/src/block-boundary.tsx
@@ -1,4 +1,8 @@
-import { blockTypeClassName, type BlockNode } from "@nextlyhq/blocks-engine";
+import {
+  blockPartClassName,
+  blockTypeClassName,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
 import { Suspense, cloneElement, isValidElement, type ReactNode } from "react";
 
 import type { BlockHostPolicy, PageContext } from "./context";
@@ -986,6 +990,14 @@ export function BlockBoundary({
       props: node.props,
       node,
       className,
+      // Built from the DEFINITION being rendered, so a block cannot name a
+      // neighbour's type and quietly wear its defaults. An undeclared name
+      // returns "" rather than a class, so a typo leaves the element unstyled
+      // instead of marked with a class no rule targets.
+      partClass: (name: string) =>
+        definition.parts !== undefined && Object.hasOwn(definition.parts, name)
+          ? blockPartClassName(definition.name, name)
+          : "",
       ctx: context,
       // Undefined rather than a no-op function when this is not an editor
       // render, so `markProp?.("text")` spreads nothing and a published page

--- a/packages/blocks-react/src/block-parts.test.tsx
+++ b/packages/blocks-react/src/block-parts.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * The contract that lets a block style an element it draws inside its root.
+ *
+ * Both halves are asserted together, because either alone is inert and the
+ * failure is silent — the same shape `inline-props.test.tsx` guards. A part
+ * declared but never marked gives the compiled rule no element to land on; an
+ * element marked for a part that was never declared wears a class no rule
+ * targets. Neither shows up as an error, and both render a page that simply
+ * looks wrong.
+ *
+ * @module block-parts.test
+ */
+import { renderToReadableStream } from "react-dom/server";
+import type { ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { PageRenderer } from "./page-renderer";
+import { createBlockResolver } from "./resolver";
+
+import type {
+  AnyBlockDefinition,
+  BlockDocument,
+} from "@nextlyhq/blocks-engine";
+
+async function renderToHtml(element: ReactElement): Promise<string> {
+  const stream = await renderToReadableStream(element, {
+    onError(error) {
+      throw error;
+    },
+  });
+  await stream.allReady;
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let html = "";
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    html += decoder.decode(value, { stream: true });
+  }
+  return html + decoder.decode();
+}
+
+/** A block that draws a caption beside its own content and marks it. */
+const captioned = {
+  name: "test/captioned",
+  version: 1,
+  description: "Draws a figure with a caption inside it.",
+  example: { props: {} },
+  parts: { caption: { baseStyles: { base: { base: { fontSize: "1em" } } } } },
+  render: ({
+    className,
+    partClass,
+  }: {
+    className: string;
+    partClass: (name: string) => string;
+  }) => (
+    <figure className={className}>
+      <figcaption className={partClass("caption")}>A caption</figcaption>
+      {/* A name the block never declared. */}
+      <span className={partClass("nonesuch")}>Undeclared</span>
+    </figure>
+  ),
+} as unknown as AnyBlockDefinition;
+
+async function html(): Promise<string> {
+  return renderToHtml(
+    <PageRenderer
+      document={
+        {
+          formatVersion: 1,
+          kind: "page",
+          nodes: [{ id: "n1", type: "test/captioned", version: 1, props: {} }],
+        } as unknown as BlockDocument
+      }
+      blocks={createBlockResolver([captioned])}
+    />
+  );
+}
+
+describe("the class a block marks one of its own elements with", () => {
+  it("carries the block that owns it, not just the part name", async () => {
+    // A bare `nx-bp-caption` would be worn by every block's caption, so one
+    // block's defaults would land on another's element wherever they nest.
+    expect(await html()).toContain('class="nx-bp-test--captioned--caption"');
+  });
+
+  it("stays off the block's own root, which keeps its own class", async () => {
+    const out = await html();
+    // Two elements answering to one identity is the defect the part mechanism
+    // exists to avoid, not one it may reintroduce.
+    expect(out).toMatch(/<figure class="nx-pb-[^"]*"/);
+    expect(out).not.toMatch(/<figure class="[^"]*nx-bp-/);
+  });
+
+  it("is EMPTY for a name the block never declared", async () => {
+    // The failure this shapes: a typo yields no class rather than a class no
+    // rule targets. Both are inert; only one is greppable.
+    const out = await html();
+    expect(out).toContain('<span class="">');
+    expect(out).not.toContain("nonesuch");
+  });
+});

--- a/packages/blocks-react/src/blocks/library.test.tsx
+++ b/packages/blocks-react/src/blocks/library.test.tsx
@@ -61,6 +61,10 @@ function args<P>(
     props,
     node: NODE,
     className: "nx-n1",
+    // Required by the render contract. These fixtures declare no parts, so the
+    // answer is empty for every name — but a renderer that could omit it would
+    // leave every block's parts unmarked with nothing to report.
+    partClass: () => "",
     ctx,
     drawnWith,
     renderSlot: (_name: string, override?: PageContext) => {

--- a/packages/blocks-react/src/blocks/list-length.test.tsx
+++ b/packages/blocks-react/src/blocks/list-length.test.tsx
@@ -37,6 +37,10 @@ function args<P>(props: P): BlockRenderArgs<P> {
     props,
     node: NODE,
     className: "nx-n1",
+    // Required by the render contract. These fixtures declare no parts, so the
+    // answer is empty for every name — but a renderer that could omit it would
+    // leave every block's parts unmarked with nothing to report.
+    partClass: () => "",
     ctx: context(),
     renderSlot: () => null,
   };

--- a/packages/blocks-react/src/blocks/primitives.test.tsx
+++ b/packages/blocks-react/src/blocks/primitives.test.tsx
@@ -66,6 +66,10 @@ function args<P>(
     props,
     node: NODE,
     className: "nx-n1",
+    // Required by the render contract. These fixtures declare no parts, so the
+    // answer is empty for every name — but a renderer that could omit it would
+    // leave every block's parts unmarked with nothing to report.
+    partClass: () => "",
     ctx,
     renderSlot: () => null,
     ...(hostPolicy === undefined ? {} : { hostPolicy }),

--- a/packages/blocks-react/src/blocks/rich-text.test.tsx
+++ b/packages/blocks-react/src/blocks/rich-text.test.tsx
@@ -47,6 +47,10 @@ function args(
     props,
     node: NODE,
     className: "nx-n1",
+    // Required by the render contract. These fixtures declare no parts, so the
+    // answer is empty for every name — but a renderer that could omit it would
+    // leave every block's parts unmarked with nothing to report.
+    partClass: () => "",
     ctx: context(),
     renderSlot: () => null,
     ...(markProp === undefined ? {} : { markProp }),

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -200,6 +200,11 @@ const SOURCE_MODULES: ReadonlyArray<{
       // would disagree exactly there. It crosses a module boundary inside this
       // package; a consumer states its own through `styleContext.blockBases`.
       "blockBasesFor",
+      // Internal for the same reason and by the same route: it is the same walk
+      // over the same tree, reading a different field of the definition, so a
+      // consumer stating its own answer states it through
+      // `styleContext.blockParts` exactly as it does for the bases.
+      "blockPartsFor",
       "drawlessTestFor",
       "effectiveCompile",
       "gatedEntriesCoverRemovedNodes",

--- a/packages/blocks-react/src/host-fetch-policy.test.tsx
+++ b/packages/blocks-react/src/host-fetch-policy.test.tsx
@@ -53,6 +53,10 @@ function embedArgs<P>(
     props,
     node: { id: "n1", type: "core/embed", version: 1, props: {} },
     className: "nx-n1",
+    // Required by the render contract. These fixtures declare no parts, so the
+    // answer is empty for every name — but a renderer that could omit it would
+    // leave every block's parts unmarked with nothing to report.
+    partClass: () => "",
     ctx: context(),
     renderSlot: () => null,
     ...(hostPolicy === undefined ? {} : { hostPolicy }),
@@ -296,6 +300,8 @@ describe("core/image", () => {
       props,
       node: { id: "n1", type: "core/image", version: 1, props: {} },
       className: "nx-n1",
+      // This block declares no parts; the contract requires the answer anyway.
+      partClass: () => "",
       ctx: {
         ...context(),
         resolveMedia: () =>
@@ -588,6 +594,8 @@ describe("the render and the link preview choose the same image", () => {
       props: both,
       node: { id: "n1", type: "core/image", version: 1, props: {} },
       className: "nx-n1",
+      // This block declares no parts; the contract requires the answer anyway.
+      partClass: () => "",
       ctx: {
         ...context(),
         resolveMedia: () =>
@@ -620,6 +628,8 @@ describe("the render and the link preview choose the same image", () => {
       },
       node: { id: "n1", type: "core/image", version: 1, props: {} },
       className: "nx-n1",
+      // This block declares no parts; the contract requires the answer anyway.
+      partClass: () => "",
       ctx: {
         ...context(),
         resolveMedia: () =>

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -241,6 +241,7 @@ export type {
   BlockIcon,
   BlockMigrationInfo,
   BlockNode,
+  BlockPart,
   BlockRenderResult,
   BlockSeoContribution,
   BlockSeoImage,

--- a/packages/blocks-react/src/shared-input-staleness.test.ts
+++ b/packages/blocks-react/src/shared-input-staleness.test.ts
@@ -316,3 +316,41 @@ describe("an INHERITED block base is not turned into an emitted one", () => {
     expect(css).toContain("#abcdef");
   });
 });
+
+describe("a block that changes one of its own parts", () => {
+  // A block adding or changing a part changes the CSS `compilePageCss` emits.
+  // If the identity cannot see it, the `styles && !untrusted` path reuses the
+  // artifact compiled before the change and the new rules never appear — a
+  // stale sheet served as a fresh one, which nothing downstream can detect.
+  const withPart = (colour: string): StyleCompileContext => ({
+    ...context(),
+    blockParts: {
+      "test/text": {
+        caption: { baseStyles: { base: { base: { color: colour } } } },
+      },
+    },
+  });
+
+  const stampWith = (ctx: StyleCompileContext) =>
+    resolvePageStyles(doc(), undefined, ctx, blocks).sharedInputsId;
+
+  it("moves the identity when a part's value changes", () => {
+    expect(stampWith(withPart("#010101"))).not.toBe(
+      stampWith(withPart("#020202"))
+    );
+  });
+
+  it("moves the identity when a part is added at all", () => {
+    expect(stampWith(context())).not.toBe(stampWith(withPart("#010101")));
+  });
+
+  it("leaves the identity alone when no block declares a part", () => {
+    // The control the two above need. Without it, an identity that changed on
+    // EVERY compile would satisfy both while seeing nothing — and it also pins
+    // the reason the tier is spread rather than slotted: while nothing declares
+    // a part, every artifact already stored keeps its stamp.
+    expect(stampWith(context())).toBe(
+      stampWith({ ...context(), blockParts: { "test/text": {} } })
+    );
+  });
+});

--- a/packages/blocks-react/src/shared-style-inputs.ts
+++ b/packages/blocks-react/src/shared-style-inputs.ts
@@ -82,6 +82,11 @@ export type SharedStyleInputs = Pick<
   | "namedClasses"
   | "tokenPrefix"
   | "blockBases"
+  // The parts tier, for exactly the reason `blockBases` is here: a block
+  // adding or changing a part changes the CSS `compilePageCss` emits, and a
+  // stamp that cannot see it hands back the artifact compiled before the
+  // change. The new rules then never appear until some unrelated input moves.
+  | "blockParts"
   // The typographic baseline is part of the IDENTITY, not merely of the
   // compile. A host replacing it changes what every heading and paragraph
   // renders as, and a stored sheet compiled against the old one is wrong in a
@@ -612,6 +617,16 @@ function labelFor(inputs: SharedStyleInputs, reading: Reading): string {
     // to different stylesheets, and a stamp that cannot see the difference
     // hands the first one's sheet to the second.
     blockBaseParts(inputs.elementBases, reading),
+    // The parts tier. SPREAD rather than held in a fixed slot, the same care
+    // `previewStates` and `previewContainer` take: while no block declares a
+    // part this array's shape is exactly what it was, so every artifact already
+    // stored keeps its stamp. A fixed slot would have invalidated every page on
+    // the site to record a field unset on all of them — and the moment a block
+    // does declare one, the element appears and the stamp moves, which is the
+    // whole point.
+    ...(blockPartsPresent(inputs.blockParts)
+      ? [blockPartsParts(inputs.blockParts, reading)]
+      : []),
     // A preview sheet gives every interaction state a forceable form, so its
     // selectors are not the published ones and the two must not share a stored
     // artifact. Without this, `resolvePageStyles` — exported, and returning a
@@ -625,6 +640,48 @@ function labelFor(inputs: SharedStyleInputs, reading: Reading): string {
     // field that is unset on all of them.
     ...(inputs.previewStates === true ? ["preview-states"] : []),
   ]);
+}
+
+/** True if any block declares any part, so the tier can affect the sheet. */
+function blockPartsPresent(
+  blockParts: SharedStyleInputs["blockParts"]
+): boolean {
+  // A type present with an EMPTY record emits nothing, so it must not move a
+  // stamp — the same reasoning that keeps a discarded breakpoint out of the
+  // identity above.
+  return Object.values(blockParts ?? {}).some(
+    parts => Object.keys(parts ?? {}).length > 0
+  );
+}
+
+/**
+ * Each block's parts, keyed by type and then by part name, reduced as classes
+ * are.
+ *
+ * Both levels sorted for the reason the block tier's single level is: a record
+ * has no meaningful order, and two equal sets must not stamp apart. The part's
+ * envelope goes through the SAME reduction, because it is a style envelope of
+ * the same shape arriving from the same untrusted place.
+ */
+function blockPartsParts(
+  blockParts: SharedStyleInputs["blockParts"],
+  reading: Reading
+): unknown[] {
+  const byType = blockParts ?? {};
+  return Object.keys(byType)
+    .sort()
+    .map(type => {
+      const parts = byType[type] ?? {};
+      return [
+        structural(type, reading),
+        Object.keys(parts)
+          .sort()
+          .map(name => [
+            structural(name, reading),
+            styleEnvelope(parts[name]?.baseStyles, reading),
+          ]),
+      ];
+    });
 }
 
 /** Each block type's defaults, in a fixed key order, reduced as classes are. */

--- a/packages/blocks-react/src/styles.test.ts
+++ b/packages/blocks-react/src/styles.test.ts
@@ -575,10 +575,7 @@ describe("the parts a block declares for elements it renders", () => {
       render: () => null,
       baseStyles: { base: { base: { color: "#111" } } },
       parts: {
-        caption: {
-          selector: "figcaption",
-          baseStyles: { base: { base: { fontSize: "0.875em" } } },
-        },
+        caption: { baseStyles: { base: { base: { fontSize: "0.875em" } } } },
       },
     },
   ] as unknown as Parameters<typeof createBlockResolver>[0]);
@@ -594,7 +591,7 @@ describe("the parts a block declares for elements it renders", () => {
       { breakpoints: { viewport: [], container: [] } },
       captioned
     );
-    expect(css).toContain("figcaption");
+    expect(css).toContain("nx-bp-test--text--caption");
     expect(css).toContain("font-size: 0.875em");
   });
 
@@ -607,6 +604,6 @@ describe("the parts a block declares for elements it renders", () => {
       { breakpoints: { viewport: [], container: [] } },
       blocks
     );
-    expect(css).not.toContain("figcaption");
+    expect(css).not.toContain("nx-bp-");
   });
 });

--- a/packages/blocks-react/src/styles.test.ts
+++ b/packages/blocks-react/src/styles.test.ts
@@ -563,3 +563,50 @@ describe("a preview artifact read back UNDER a context", () => {
     expect(styles.css).toContain("@media (max-width: 991px)");
   });
 });
+
+describe("the parts a block declares for elements it renders", () => {
+  /** A block whose root and caption are styled separately. */
+  const captioned = createBlockResolver([
+    {
+      name: "test/text",
+      version: 1,
+      description: "A block that draws a caption beside its own content.",
+      example: { props: {} },
+      render: () => null,
+      baseStyles: { base: { base: { color: "#111" } } },
+      parts: {
+        caption: {
+          selector: "figcaption",
+          baseStyles: { base: { base: { fontSize: "0.875em" } } },
+        },
+      },
+    },
+  ] as unknown as Parameters<typeof createBlockResolver>[0]);
+
+  it("reaches the sheet without the caller mirroring them into the context", () => {
+    // The coupling this closes is the one `blockBasesFor` already closes for a
+    // block's root styles: the renderer holds the definitions, so a caller
+    // repeating them into the context is a step that is easy to miss and silent
+    // when missed — the element renders and simply has no rule.
+    const { css } = resolvePageStyles(
+      doc(node("n1")),
+      undefined,
+      { breakpoints: { viewport: [], container: [] } },
+      captioned
+    );
+    expect(css).toContain("figcaption");
+    expect(css).toContain("font-size: 0.875em");
+  });
+
+  it("does not invent parts for a block that declares none", () => {
+    // The control the assertion above needs: a resolver that answered
+    // `figcaption` for every block would satisfy it while reading nothing.
+    const { css } = resolvePageStyles(
+      doc(node("n1")),
+      undefined,
+      { breakpoints: { viewport: [], container: [] } },
+      blocks
+    );
+    expect(css).not.toContain("figcaption");
+  });
+});

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -6,8 +6,10 @@ import {
   nodeClassNames,
   walkNodes,
   DEFAULT_LIMITS,
+  type AnyBlockDefinition,
   type BlockDocument,
   type BlockNode,
+  type BlockPart,
   type CompiledPageCss,
   type DocumentLimits,
   type MayFetchUrl,
@@ -199,12 +201,53 @@ export function blockBasesFor(
   blocks: BlockResolver,
   stated?: Readonly<Record<string, NodeStyles>>
 ): Record<string, NodeStyles> {
-  const bases: Record<string, NodeStyles> = {};
+  return perUsedType(
+    document,
+    blocks,
+    definition => definition.baseStyles,
+    stated
+  );
+}
+
+/**
+ * The parts of each block type this document draws, keyed by type.
+ *
+ * The same question as {@link blockBasesFor} asked of a different field, and it
+ * goes through the same walk for that reason: two walkers agreeing today drift
+ * apart later, and the drift would be silent — one tier of a block's styles
+ * would keep reaching the sheet while the other stopped, which reads as the
+ * block having declared nothing.
+ */
+export function blockPartsFor(
+  document: BlockDocument,
+  blocks: BlockResolver,
+  stated?: Readonly<Record<string, Readonly<Record<string, BlockPart>>>>
+): Record<string, Readonly<Record<string, BlockPart>>> {
+  return perUsedType(document, blocks, definition => definition.parts, stated);
+}
+
+/**
+ * One reading of "which block types does this tree use", answered for whichever
+ * field the caller names.
+ *
+ * `stated` narrows a supplied record to this tree instead of reading the
+ * resolver, and it is the same walk because it is the same question.
+ */
+function perUsedType<T>(
+  document: BlockDocument,
+  blocks: BlockResolver,
+  read: (definition: AnyBlockDefinition) => T | undefined,
+  stated?: Readonly<Record<string, T>>
+): Record<string, T> {
+  const found: Record<string, T> = {};
   walkNodes(document.nodes, node => {
-    if (bases[node.type] !== undefined) return;
-    const baseStyles =
+    if (found[node.type] !== undefined) return;
+    const definition = blocks.get(node.type);
+    const value =
       stated === undefined
-        ? blocks.get(node.type)?.baseStyles
+        ? definition === undefined
+          ? undefined
+          : read(definition)
         : // OWN properties only, because that is the boundary `compilePageCss`
           // draws: it emits a base for a used type only when
           // `Object.hasOwn(bases, type)` succeeds. A record reached through
@@ -216,9 +259,9 @@ export function blockBasesFor(
           Object.hasOwn(stated, node.type)
           ? stated[node.type]
           : undefined;
-    if (baseStyles !== undefined) bases[node.type] = baseStyles;
+    if (value !== undefined) found[node.type] = value;
   });
-  return bases;
+  return found;
 }
 
 /**
@@ -268,6 +311,11 @@ function compileContextFor(
       storedDocument ?? document,
       blocks,
       styleContext.blockBases
+    ),
+    blockParts: blockPartsFor(
+      storedDocument ?? document,
+      blocks,
+      styleContext.blockParts
     ),
     drawsNothing,
   });

--- a/packages/plugin-sdk/src/block-exports.test-d.ts
+++ b/packages/plugin-sdk/src/block-exports.test-d.ts
@@ -12,6 +12,7 @@ import type {
   BlockRenderResult,
   BlockSupports,
   ComponentPath,
+  BlockPart,
   NodeStyles,
   SlotLock,
   SlotSpec,
@@ -30,6 +31,11 @@ expectTypeOf<BlockSeoContribution>().toBeObject();
 // construction into a helper needs to spell it without reaching past the SDK.
 expectTypeOf<BlockSeoImage>().not.toBeAny();
 expectTypeOf<NodeStyles>().toBeObject();
+// A block naming an element it renders declares it through this, so an author
+// writing a reusable part declaration or a helper has to be able to NAME the
+// type. Reaching it through the transitive engine package instead crosses the
+// stable plugin boundary and does not resolve under a strict pnpm layout.
+expectTypeOf<BlockPart>().toBeObject();
 expectTypeOf<SlotLock>().toEqualTypeOf<
   "all" | "insert" | "contentOnly" | false
 >();

--- a/packages/plugin-sdk/src/blocks.ts
+++ b/packages/plugin-sdk/src/blocks.ts
@@ -352,6 +352,7 @@ export type {
   BlockEditorMeta,
   BlockExample,
   BlockIcon,
+  BlockPart,
   BlockSeoContribution,
   BlockSeoImage,
   BlockVariation,


### PR DESCRIPTION
The first of three. This one adds the mechanism and adopts it in no block, so
the rendered output of every existing page is unchanged.

## The problem

A block's defaults are keyed by block TYPE, so they compile to one rule on one
class. A block that draws more than one element can put that class on its root
or on one child, and has no third option — everything else is unreachable.

Four blocks are affected, measured by reading their renders rather than by
counting tags (a grep was wrong in both directions: it read alternative render
branches as simultaneous elements, and matched a `<string>` type annotation):

| block | what is unreachable |
| --- | --- |
| `core/form` | markup already flattened to cope; fields do not group |
| `core/quote` | the nested `<blockquote>` — 24px bare against 64px attributed |
| `core/image` | a width lands on the figure or the img depending on the caption |
| `core/list` | the `<li>` items |

`core/form` is the strongest evidence, because it is not a bug report — it is a
receipt. Its docblock says the alternative *"needs a rule on a DESCENDANT ... and
none of them reaches an arbitrary child. Flattening puts the whole layout on the
one selector that exists,"* and records the cost: one gap separates a label from
its own control and one field from the next, so nothing clusters.

## The shape, and why this one

A block names the elements it renders and states styles for each. The names are
a **closed set the block publishes** rather than open selectors, so a block may
change what it draws without invalidating styles addressed to it.

Prior art is in `research:a-block-cannot-state-a-rule-for-an-element-it-renders`.
The decisive evidence against the open-selector alternative is that Gutenberg
took it and has this repository's exact `blockquote`+`cite` shape unresolved for
years, because a globally-shared element mechanism collided with the block's own
selector and lost.

**No new cascade machinery.** The part is prepended to each declaration's own
descendant rather than folded into the selector, so weight is computed by the
path a link colour inside a node already takes, and the provenance trace records
which element a declaration landed on instead of naming the block root for all
of them.

**A part names a plain HTML tag and nothing else.** The value reaches a SELECTOR
and a block definition is code a plugin supplies, so a wider grammar lets
`figcaption, body` close the block's rule and open one over every `body` on the
page. Refused rather than escaped: escaping yields a class-shaped string no
element carries, which is a style silently missing rather than a value reported.
Every part the library needs is a tag — `figcaption`, `blockquote`, `cite`,
`li`, `label`, `input` — so the narrow grammar costs nothing today, and widening
it later is additive where starting wide and narrowing is not.

## Evidence

16 new engine tests, each break-verified by a mutation that removes what its
name promises. Every mutation asserts it applied, and the mutated tree is
typechecked first — a mutation that leaves the file unparseable reports
`Tests no tests` with a non-zero exit, which reads exactly like a caught defect.

| mutation | kills |
| --- | --- |
| the part never reaches the selector | 5 tests |
| the gate accepts every selector | 10 tests |
| the trace forgets the part | the trace test only |
| the part is emitted OUTSIDE `:where()` | the weight test, and 4 more |

No test survives all four. 2 renderer tests prove the wiring end to end and were
re-break-verified after being edited, since a fix to a test is a change to the
experiment.

    blocks-engine   38 files / 1701 tests   (baseline 37 / 1685)
    blocks-react    40 files /  987 tests   (baseline 40 /  985)

`pnpm check-types` clean repo-wide. `fallow audit --base origin/main` passes with
`changed_files_count: 13` and zero introduced findings of any kind.

Two existing guards fired during the work and were satisfied rather than
suppressed: the type surface refused a type reachable from a re-exported one
that a consumer could not name, and the entry surface refused a new module
export that was neither re-exported nor declared internal.

The contract table gains a row, and the doc test verifies it against a selector
the compiler actually emits at the documented weight. The corpus gains a real
captioned-image node rather than a caption bolted onto a section, because a row
nobody could meet in a real document teaches the wrong thing even while the
compiler emits it. Prose that counted "the two DEFAULT rows" is corrected — there
are now three.

## What is NOT in this PR

**No block declares a part yet**, so no rendered page changes. Adoption in the
four blocks above is the next PR, and letting a NODE-level authored override
address a part is the one after — that third one is what fixes the captioned
image, and it is separate because it must not relax the rule that one node
identity means one element, which a passing test currently pins.

**A lint defect I introduced in #1364 and did not fix here.** Linting after a
Lighthouse run reports 14 warnings inside `apps/playground/.next-lighthouse/`,
because that directory was never added to the ignore list beside `.next-e2e/**`,
whose comment describes this exact problem. CI has never seen it — no job builds
there and then lints — and the pre-push hook filters to `./packages/*`. One line,
filed as `finding:lighthouse-build-dir-is-not-lint-ignored`, kept out of this
diff because an unrelated lint-config change inside a feature PR is the kind of
thing that gets waved through and later cannot be attributed.