### PR TITLE
feat(nextly): make a content release something you can actually create

### DIFF
--- a/.changeset/a-release-can-be-made.md
+++ b/.changeset/a-release-can-be-made.md
@@ -26,4 +26,4 @@
 "@nextlyhq/ui": patch
 ---
 
-Make content releases reachable: a `nextly.releases.*` Direct API namespace over a service that finally enforces the three release permissions, refusing to schedule a document the caller could not publish themselves.
+Honour the declared null-ordering control in the Drizzle adapter, which was read nowhere, and make content releases reachable: a `nextly.releases.*` Direct API namespace over a service that finally enforces the three release permissions, refusing to schedule a document the caller could not publish themselves.

--- a/.changeset/a-release-can-be-made.md
+++ b/.changeset/a-release-can-be-made.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Make content releases reachable: a `nextly.releases.*` Direct API namespace over a service that finally enforces the three release permissions, refusing to schedule a document the caller could not publish themselves.

--- a/packages/adapter-drizzle/src/__tests__/drizzle-order.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/drizzle-order.test.ts
@@ -1,0 +1,82 @@
+import { PgDialect, pgTable, text, timestamp } from "drizzle-orm/pg-core";
+import { describe, expect, it } from "vitest";
+
+import { buildDrizzleOrderBy } from "../drizzle-order";
+
+/**
+ * Every assertion here compiles the clause to SQL TEXT rather than checking that
+ * a clause came back.
+ *
+ * That distinction is the whole reason this file exists. `OrderBySpec.nulls` was
+ * declared on a published type and documented as "can be explicitly controlled",
+ * and the adapter read it nowhere — so every caller that set it got the dialect
+ * default in silence. A test asserting "an order clause was produced" would have
+ * passed against that implementation, and so would one asserting the spec object
+ * was accepted. Only the rendered SQL can tell a honoured option from an ignored
+ * one.
+ *
+ * Compiled through `PgDialect` to fix one rendering for comparison; the builder
+ * composes drizzle helpers and never emits engine-specific text.
+ */
+const table = pgTable("releases", {
+  id: text("id"),
+  scheduledAt: timestamp("scheduled_at"),
+});
+
+function render(orderBy: Parameters<typeof buildDrizzleOrderBy>[1]): string {
+  const clauses = buildDrizzleOrderBy(
+    { id: table.id, scheduledAt: table.scheduledAt },
+    orderBy
+  );
+  if (clauses.length === 0) return "";
+  const dialect = new PgDialect();
+  return clauses.map(c => dialect.sqlToQuery(c).sql).join(", ");
+}
+
+describe("buildDrizzleOrderBy", () => {
+  it("emits a plain direction when null placement is not asked for", () => {
+    // The control for every case below: with no `nulls`, nothing extra appears,
+    // so an implementation that always emitted a nullness key would fail here.
+    expect(render([{ column: "scheduledAt", direction: "desc" }])).toBe(
+      '"releases"."scheduled_at" desc'
+    );
+  });
+
+  it("puts nulls LAST by sorting on nullness first", () => {
+    // `NULLS LAST` is not portable — MySQL rejects it — so the placement is a
+    // leading sort key on `col is null`, which all three engines evaluate.
+    const sql = render([
+      { column: "scheduledAt", direction: "desc", nulls: "last" },
+    ]);
+    expect(sql).toBe(
+      '"releases"."scheduled_at" is null asc, "releases"."scheduled_at" desc'
+    );
+  });
+
+  it("puts nulls FIRST by inverting that key, not by dropping it", () => {
+    const sql = render([
+      { column: "scheduledAt", direction: "asc", nulls: "first" },
+    ]);
+    expect(sql).toBe(
+      '"releases"."scheduled_at" is null desc, "releases"."scheduled_at" asc'
+    );
+  });
+
+  it("keeps the caller's key order across several columns", () => {
+    // A flatMap that expanded one spec into two clauses could reorder the rest;
+    // the tie-breaker must still come after the primary key.
+    const sql = render([
+      { column: "scheduledAt", direction: "desc", nulls: "last" },
+      { column: "id", direction: "desc" },
+    ]);
+    expect(sql).toBe(
+      '"releases"."scheduled_at" is null asc, "releases"."scheduled_at" desc, "releases"."id" desc'
+    );
+  });
+
+  it("skips an unknown column rather than failing the query", () => {
+    // Ordering is a refinement. A caller naming a column that is not there
+    // should get an unordered answer, not a failed statement.
+    expect(render([{ column: "nope", direction: "desc" }])).toBe("");
+  });
+});

--- a/packages/adapter-drizzle/src/adapter.ts
+++ b/packages/adapter-drizzle/src/adapter.ts
@@ -11,9 +11,10 @@
  * @packageDocumentation
  */
 
-import { asc, desc, getColumns } from "drizzle-orm";
+import { getColumns } from "drizzle-orm";
 import type { AnyRelations, SQL } from "drizzle-orm";
 
+import { buildDrizzleOrderBy } from "./drizzle-order";
 import { buildDrizzleWhere } from "./drizzle-where";
 import {
   createTransactionForwarders,
@@ -23,7 +24,6 @@ import type {
   SupportedDialect,
   SqlParam,
   WhereClause,
-  OrderBySpec,
   SelectOptions,
   InsertOptions,
   UpdateOptions,
@@ -1085,15 +1085,14 @@ export abstract class DrizzleAdapter {
           }
         }
 
+        // Guarded, so `getColumns` is not reached for a select that does not
+        // order. Hoisting it out of this check ran it on every select and broke
+        // callers whose table handle cannot answer it.
         if (options?.orderBy?.length) {
-          const columns = getColumns(tableObj as never);
-          const orderClauses = options.orderBy
-            .map((o: OrderBySpec) => {
-              const col = columns[o.column];
-              if (!col) return undefined;
-              return o.direction === "desc" ? desc(col) : asc(col);
-            })
-            .filter(Boolean);
+          const orderClauses = buildDrizzleOrderBy(
+            getColumns(tableObj as never),
+            options.orderBy
+          );
           if (orderClauses.length) {
             query = query.orderBy(...orderClauses);
           }

--- a/packages/adapter-drizzle/src/drizzle-order.ts
+++ b/packages/adapter-drizzle/src/drizzle-order.ts
@@ -1,0 +1,47 @@
+import { asc, desc, sql } from "drizzle-orm";
+import type { AnyColumn, SQL } from "drizzle-orm";
+
+import type { OrderBySpec } from "./types";
+
+/**
+ * Turn order specifications into drizzle order clauses.
+ *
+ * Extracted from `DrizzleAdapter.select` so the rendered SQL can be asserted
+ * directly. That matters more than it looks: `OrderBySpec.nulls` was declared,
+ * documented as "can be explicitly controlled", and read NOWHERE — every caller
+ * that set it silently got the dialect default instead, and no test could have
+ * caught that while the mapping lived inline in a method that needs a database.
+ *
+ * ## Why null placement is a leading sort key, not `NULLS FIRST/LAST`
+ *
+ * That clause is not portable: PostgreSQL and SQLite accept it, MySQL does not.
+ * `col IS NULL` is a boolean expression all three evaluate, and sorting on it
+ * ascending puts non-null rows first — which is `NULLS LAST` by another name,
+ * spelled in something every supported engine understands.
+ *
+ * The defaults genuinely disagree, which is why the control exists at all:
+ * PostgreSQL treats NULL as largest and puts it FIRST on a descending order,
+ * while MySQL and SQLite treat it as smallest and put it last. A "newest
+ * scheduled first" list containing undated drafts therefore returns different
+ * rows per engine, and under a limit it can return only drafts.
+ */
+export function buildDrizzleOrderBy(
+  columns: Record<string, AnyColumn>,
+  orderBy: OrderBySpec[] | undefined
+): SQL[] {
+  if (!orderBy?.length) return [];
+
+  return orderBy.flatMap((spec): SQL[] => {
+    const col = columns[spec.column];
+    // An unknown column is skipped rather than thrown on: ordering is a
+    // refinement, and a caller naming a column that is not there should get an
+    // unordered answer rather than a failed query.
+    if (!col) return [];
+
+    const direction = spec.direction === "desc" ? desc(col) : asc(col);
+    if (spec.nulls === undefined) return [direction];
+
+    const isNull = sql`${col} is null`;
+    return [spec.nulls === "last" ? asc(isNull) : desc(isNull), direction];
+  });
+}

--- a/packages/nextly/src/di/__tests__/register-releases.test.ts
+++ b/packages/nextly/src/di/__tests__/register-releases.test.ts
@@ -1,0 +1,107 @@
+/**
+ * That the releases service is actually REGISTERED, and what its checks answer.
+ *
+ * A service that exists and is registered nowhere is the exact shape the whole
+ * R-6 product layer was in: complete, tested, and reachable by nothing. The
+ * namespace resolves this from the container by name, so a missing registration
+ * is a runtime 500 on the first call and nothing earlier catches it.
+ *
+ * @module di/__tests__/register-releases.test
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("registerReleaseServices", () => {
+  afterEach(() => {
+    vi.doUnmock("../container");
+    vi.resetModules();
+  });
+
+  it("registers releasesService, so the namespace can resolve it", async () => {
+    const singletons = new Map<string, unknown>();
+    vi.resetModules();
+    vi.doMock("../container", () => ({
+      container: {
+        registerSingleton: (name: string, factory: () => unknown) => {
+          singletons.set(name, factory());
+        },
+        has: () => false,
+        get: () => ({}),
+      },
+    }));
+
+    const { registerReleaseServices } = await import(
+      "../registrations/register-releases"
+    );
+    const { ReleasesService } = await import(
+      "../../domains/releases/services/releases-service"
+    );
+
+    registerReleaseServices({ adapter: { select: async () => [] } } as never);
+
+    // Imported INSIDE the reset module graph, so `instanceof` compares one class
+    // against itself rather than across two copies.
+    expect(singletons.get("releasesService")).toBeInstanceOf(ReleasesService);
+  });
+
+  it("refuses a document action when no permission store is registered", async () => {
+    // A minimal boot without RBAC can still construct the service. It must not
+    // be able to authorize anyone INTO a release: no permission store is no
+    // basis for saying yes, and defaulting the other way would make a stripped
+    // deployment the most permissive one.
+    //
+    // `hasPermission` is stubbed TRUE so the release-authority check cannot be
+    // what refuses. Without that this case passes while never reaching the
+    // document check at all — the earlier gate would refuse first and the test
+    // would be green about a mechanism it never ran.
+    const singletons = new Map<string, unknown>();
+    vi.resetModules();
+    vi.doMock("../../services/lib/permissions", () => ({
+      hasPermission: async () => true,
+    }));
+    vi.doMock("../container", () => ({
+      container: {
+        registerSingleton: (name: string, factory: () => unknown) => {
+          singletons.set(name, factory());
+        },
+        has: (name: string) => name !== "rbacAccessControlService",
+        get: () => ({}),
+      },
+    }));
+
+    const { registerReleaseServices } = await import(
+      "../registrations/register-releases"
+    );
+    registerReleaseServices({ adapter: { select: async () => [] } } as never);
+
+    const svc = singletons.get("releasesService") as {
+      addMember: (r: string, m: unknown, a: unknown) => Promise<unknown>;
+      find: (q: unknown, a: unknown) => Promise<unknown>;
+    };
+    const checked = { userId: "u1", overrideAccess: false };
+
+    // THE CONTROL. With `hasPermission` true, a release-authority operation
+    // succeeds — which proves the stub took effect and that what refuses below
+    // is the document check and nothing upstream of it.
+    await expect(svc.find({}, checked)).resolves.toBeDefined();
+
+    // Asserted on the CODE, not on "it threw". With the check disabled this
+    // call still throws — it reaches a fixture adapter that has no `insert` —
+    // so `toThrow()` alone is satisfied by an incidental crash and stays green
+    // against the exact defect this case exists to catch. Measured: it did.
+    await expect(
+      svc.addMember(
+        "r1",
+        {
+          scopeKind: "collection",
+          scopeSlug: "posts",
+          entryId: "e1",
+          locale: null,
+          action: "publish",
+        },
+        checked
+      )
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+
+    vi.doUnmock("../../services/lib/permissions");
+  });
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -63,6 +63,7 @@ import type { JobDefinition } from "../domains/jobs/job-registry";
 import type { MetaService } from "../domains/meta";
 import type { PreviewConfig } from "../domains/preview/route-config";
 import { resolvePreviewRoute } from "../domains/preview/route-config";
+import type { ReleasesService } from "../domains/releases/services/releases-service";
 import { publishRetentionPolicies } from "../domains/retention/published-policies";
 import {
   clearFieldTypes,
@@ -198,6 +199,7 @@ import {
   registerDashboardServices,
   registerEmailServices,
   registerJobServices,
+  registerReleaseServices,
   registerMediaServices,
   registerMetaServices,
   registerRevalidationServices,
@@ -413,6 +415,8 @@ export interface ServiceMap {
   userFieldDefinitionService: UserFieldDefinitionService;
   permissionSeedService: PermissionSeedService;
   rbacAccessControlService: RBACAccessControlService;
+  /** Content releases: the authorization boundary the Direct API namespace reaches. */
+  releasesService: ReleasesService;
   apiKeyService: ApiKeyService;
   /** Webhook endpoint management, resolved by the webhooks REST handlers. */
   webhookEndpointService: WebhookEndpointService;
@@ -1072,6 +1076,11 @@ export async function registerServices(
   // it anyway keeps the reason a fact about this file rather than a property of
   // the container that a future refactor could remove without noticing.
   registerJobServices(ctx);
+  // After the jobs registration, which registers the drain that materialises
+  // what this service schedules. Order is not load-bearing — both resolve their
+  // dependencies from the container — but keeping them adjacent means a reader
+  // meets the two halves of releases together.
+  registerReleaseServices(ctx);
 
   // ----------------------------------------
   // Layer 4: Sync Code-First Collections

--- a/packages/nextly/src/di/registrations/index.ts
+++ b/packages/nextly/src/di/registrations/index.ts
@@ -11,6 +11,7 @@ export { registerComponentServices } from "./register-components";
 export { registerDashboardServices } from "./register-dashboard";
 export { registerEmailServices } from "./register-email";
 export { registerJobServices } from "./register-jobs";
+export { registerReleaseServices } from "./register-releases";
 export { registerMediaServices } from "./register-media";
 export { registerMetaServices } from "./register-meta";
 export { registerRevalidationServices } from "./register-revalidation";

--- a/packages/nextly/src/di/registrations/register-releases.ts
+++ b/packages/nextly/src/di/registrations/register-releases.ts
@@ -21,6 +21,7 @@ import {
   RELEASES_RESOURCE,
   ReleasesService,
 } from "../../domains/releases/services/releases-service";
+import type { CacheRevalidator } from "../../revalidation/types";
 import { hasPermission } from "../../services/lib/permissions";
 import { container } from "../container";
 
@@ -33,7 +34,18 @@ export function registerReleaseServices({
     "releasesService",
     () =>
       new ReleasesService({
-        repository: new ReleasesRepository(adapter),
+        // WITH the registered revalidator. Without it, scheduling clears only
+        // the in-process transition memo and never flushes the affected
+        // document tags — so a page rendered before the release was scheduled
+        // stays cached with no transition bound and keeps serving pre-release
+        // content past the instant. The repository takes it optionally, which is
+        // exactly why omitting it here would have been silent.
+        repository: new ReleasesRepository(
+          adapter,
+          container.has("cacheRevalidator")
+            ? container.get<CacheRevalidator>("cacheRevalidator")
+            : undefined
+        ),
 
         // The system resource, whose three authorities are seeded by
         // `permission-seed-service`. `hasPermission` fails CLOSED — it returns

--- a/packages/nextly/src/di/registrations/register-releases.ts
+++ b/packages/nextly/src/di/registrations/register-releases.ts
@@ -1,0 +1,72 @@
+/**
+ * The content-releases service, and the two permission questions it asks.
+ *
+ * The releases domain has had a repository, a materialisation pass and a
+ * registered drain since #1323, and no way for anything outside the server
+ * process to reach them. Registering the service is what turns the three seeded
+ * permissions from a vocabulary the admin displays into checks the server runs.
+ *
+ * Both checks are injected rather than imported by the domain. The domain owns
+ * WHICH authority each operation requires; where the answer comes from is a
+ * wiring decision, and keeping it here is what lets the boundary be tested
+ * exhaustively without a permission store — the cases worth covering are the
+ * refusals, and a refusal test that needs RBAC seeded tends not to be written.
+ *
+ * @module di/registrations/register-releases
+ */
+
+import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
+import { ReleasesRepository } from "../../domains/releases/releases-repository";
+import {
+  RELEASES_RESOURCE,
+  ReleasesService,
+} from "../../domains/releases/services/releases-service";
+import { hasPermission } from "../../services/lib/permissions";
+import { container } from "../container";
+
+import type { RegistrationContext } from "./types";
+
+export function registerReleaseServices({
+  adapter,
+}: RegistrationContext): void {
+  container.registerSingleton<ReleasesService>(
+    "releasesService",
+    () =>
+      new ReleasesService({
+        repository: new ReleasesRepository(adapter),
+
+        // The system resource, whose three authorities are seeded by
+        // `permission-seed-service`. `hasPermission` fails CLOSED — it returns
+        // false on any error rather than throwing — which is the behaviour a
+        // gate wants: an unreachable permission store must not read as consent.
+        canManageReleases: (userId, authority) =>
+          hasPermission(userId, authority, RELEASES_RESOURCE),
+
+        // The document's OWN authority, asked with the same operation the
+        // ordinary write path uses. Adding a document to a release is a deferred
+        // publish of it, so this is the check that stops a release from becoming
+        // a way to perform a write the caller could not perform now.
+        //
+        // Resolved lazily, per call. The RBAC service is registered by
+        // `register-auth`, and resolving at registration time would make this
+        // depend on an ordering between two registrations rather than on the
+        // container — the first reordering would break it silently.
+        canActOnDocument: async (userId, scopeSlug, action) => {
+          if (!container.has("rbacAccessControlService")) {
+            // No permission store means no basis for saying yes. A minimal boot
+            // without RBAC can still construct this service; it simply cannot
+            // authorize anyone into a release.
+            return false;
+          }
+          const rbac = container.get<RBACAccessControlService>(
+            "rbacAccessControlService"
+          );
+          return rbac.checkAccess({
+            userId,
+            operation: action,
+            resource: scopeSlug,
+          });
+        },
+      })
+  );
+}

--- a/packages/nextly/src/direct-api/namespaces/index.ts
+++ b/packages/nextly/src/direct-api/namespaces/index.ts
@@ -45,3 +45,8 @@ export {
   type RolesNamespace,
 } from "./rbac";
 export { createJobsNamespace, type JobsNamespace } from "./jobs";
+export {
+  createReleasesNamespace,
+  type ReleaseCallerArgs,
+  type ReleasesNamespace,
+} from "./releases";

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -1,0 +1,140 @@
+/**
+ * Direct API `nextly.releases.*` — batching content to go live at one instant.
+ *
+ * The releases engine has been complete since #1323 and reachable only from
+ * inside the server process: no namespace, no HTTP surface, and no product
+ * caller of `addMember`. Nothing could create a release, which is why every
+ * remaining correctness gap in the feature was unreachable — and why the three
+ * seeded permissions were enforced nowhere.
+ *
+ * This is the reach. Thin on purpose, in the shape of `namespaces/jobs`: the
+ * repository owns the writes and `ReleasesService` owns the authorization, and a
+ * facade that re-derived either would be a second answer to a question already
+ * answered.
+ *
+ * ## What `overrideAccess` means here
+ *
+ * The Direct API is a trusted in-process caller and defaults to
+ * `overrideAccess: true`, exactly as the rest of this package does. A caller
+ * that wants the permission checks — a route handler acting for a person — passes
+ * `overrideAccess: false` with the acting `userId`. Trusted and anonymous are
+ * separate fields rather than one inferred from the other, because folding them
+ * together is how an unauthenticated request acquires system authority.
+ *
+ * @module direct-api/namespaces/releases
+ */
+
+import { container } from "../../di/container";
+import type {
+  ReleaseMemberRow,
+  ReleaseRow,
+} from "../../domains/releases/releases-repository";
+import type {
+  AddMemberInput,
+  FindReleasesQuery,
+  ReleasesService,
+} from "../../domains/releases/services/releases-service";
+import { NextlyError } from "../../errors/nextly-error";
+
+/** Who the call acts as, and whether its permissions are checked. */
+export interface ReleaseCallerArgs {
+  /**
+   * The acting identity. Required whenever `overrideAccess` is `false`, because
+   * a checked call with nobody to check is a call that can only be refused.
+   */
+  userId?: string | null;
+  /** Defaults to `true`: the Direct API is trusted. */
+  overrideAccess?: boolean;
+}
+
+export interface ReleasesNamespace {
+  create(
+    args: { title: string; description?: string | null } & ReleaseCallerArgs
+  ): Promise<ReleaseRow>;
+  /** Releases in a window, newest scheduled instant first. */
+  find(args?: FindReleasesQuery & ReleaseCallerArgs): Promise<ReleaseRow[]>;
+  findByID(
+    args: { id: string } & ReleaseCallerArgs
+  ): Promise<ReleaseRow | null>;
+  /** Put a document into a release under a lifecycle action. */
+  addMember(
+    args: { releaseId: string } & AddMemberInput & ReleaseCallerArgs
+  ): Promise<ReleaseMemberRow>;
+  removeMember(args: { memberId: string } & ReleaseCallerArgs): Promise<void>;
+  listMembers(
+    args: { releaseId: string } & ReleaseCallerArgs
+  ): Promise<ReleaseMemberRow[]>;
+  /**
+   * Commit a release to an instant.
+   *
+   * `timezone` is the authoring intent and travels beside the instant rather
+   * than being folded into it: "9am Berlin time" survives a daylight-saving
+   * boundary as a statement, where a UTC instant alone does not, and the admin
+   * needs it to render what the author actually chose.
+   */
+  schedule(
+    args: { id: string; at: Date; timezone: string } & ReleaseCallerArgs
+  ): Promise<void>;
+  cancel(args: { id: string } & ReleaseCallerArgs): Promise<void>;
+}
+
+/**
+ * The service, resolved from the container rather than constructed here.
+ *
+ * The registration owns a single instance. Building one per call would work, but
+ * it would also be a second place deciding what a service is built from, and the
+ * first divergence between them would be silent.
+ */
+function service(): ReleasesService {
+  if (!container.has("releasesService")) {
+    // The public message stays the uniform internal-error sentence; the reason
+    // an operator needs goes to the log, which is where this package puts
+    // diagnostics rather than in a body a client reads.
+    throw NextlyError.internal({
+      logContext: { reason: "releases-service-unregistered" },
+    });
+  }
+  return container.get<ReleasesService>("releasesService");
+}
+
+/** Split the caller identity out of an argument bag. */
+function actorOf(args: ReleaseCallerArgs) {
+  return {
+    userId: args.userId ?? null,
+    // Trusted by default, like every other Direct API operation. A caller
+    // asking for checks says so explicitly.
+    overrideAccess: args.overrideAccess ?? true,
+  };
+}
+
+export function createReleasesNamespace(): ReleasesNamespace {
+  return {
+    create: ({ title, description, ...caller }) =>
+      service().create({ title, description }, actorOf(caller)),
+
+    find: (args = {}) => {
+      const { userId, overrideAccess, ...query } = args;
+      return service().find(query, actorOf({ userId, overrideAccess }));
+    },
+
+    findByID: ({ id, ...caller }) => service().findByID(id, actorOf(caller)),
+
+    addMember: ({ releaseId, userId, overrideAccess, ...member }) =>
+      service().addMember(
+        releaseId,
+        member,
+        actorOf({ userId, overrideAccess })
+      ),
+
+    removeMember: ({ memberId, ...caller }) =>
+      service().removeMember(memberId, actorOf(caller)),
+
+    listMembers: ({ releaseId, ...caller }) =>
+      service().listMembers(releaseId, actorOf(caller)),
+
+    schedule: ({ id, at, timezone, ...caller }) =>
+      service().schedule(id, at, timezone, actorOf(caller)),
+
+    cancel: ({ id, ...caller }) => service().cancel(id, actorOf(caller)),
+  };
+}

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -82,6 +82,7 @@ import {
   createAccessNamespace,
   createApiKeysNamespace,
   createJobsNamespace,
+  createReleasesNamespace,
   createFieldGroupsNamespace,
   createEmailNamespace,
   createEmailProvidersNamespace,
@@ -95,6 +96,7 @@ import {
   type AccessNamespace,
   type ApiKeysNamespace,
   type JobsNamespace,
+  type ReleasesNamespace,
   type FieldGroupsNamespace,
   type EmailNamespace,
   type EmailProvidersNamespace,
@@ -254,6 +256,7 @@ export class Nextly implements NextlyContext {
   public readonly access: AccessNamespace;
   public readonly apiKeys: ApiKeysNamespace;
   public readonly jobs: JobsNamespace;
+  public readonly releases: ReleasesNamespace;
 
   /**
    * Create a new Nextly instance.
@@ -279,6 +282,7 @@ export class Nextly implements NextlyContext {
     this.access = createAccessNamespace(this);
     this.apiKeys = createApiKeysNamespace(this);
     this.jobs = createJobsNamespace();
+    this.releases = createReleasesNamespace();
   }
 
   /**
@@ -788,6 +792,25 @@ export const nextly = {
   jobs: {
     queue: <TTask extends JobSlug>(args: QueueJobArgs<TTask>) =>
       getNextly().jobs.queue(args),
+  },
+
+  releases: {
+    create: (args: Parameters<ReleasesNamespace["create"]>[0]) =>
+      getNextly().releases.create(args),
+    find: (args?: Parameters<ReleasesNamespace["find"]>[0]) =>
+      getNextly().releases.find(args),
+    findByID: (args: Parameters<ReleasesNamespace["findByID"]>[0]) =>
+      getNextly().releases.findByID(args),
+    addMember: (args: Parameters<ReleasesNamespace["addMember"]>[0]) =>
+      getNextly().releases.addMember(args),
+    removeMember: (args: Parameters<ReleasesNamespace["removeMember"]>[0]) =>
+      getNextly().releases.removeMember(args),
+    listMembers: (args: Parameters<ReleasesNamespace["listMembers"]>[0]) =>
+      getNextly().releases.listMembers(args),
+    schedule: (args: Parameters<ReleasesNamespace["schedule"]>[0]) =>
+      getNextly().releases.schedule(args),
+    cancel: (args: Parameters<ReleasesNamespace["cancel"]>[0]) =>
+      getNextly().releases.cancel(args),
   },
 
   users: {

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -24,12 +24,13 @@ const ANON = { userId: null };
 function repository() {
   return {
     createRelease: vi.fn(async () => ({ id: "r1" })),
+    scheduleReleaseOk: true,
     findReleases: vi.fn(async () => []),
     listMembers: vi.fn(async () => []),
     addMember: vi.fn(async () => ({ id: "m1" })),
     removeMember: vi.fn(async () => undefined),
-    scheduleRelease: vi.fn(async () => undefined),
-    cancelRelease: vi.fn(async () => undefined),
+    scheduleRelease: vi.fn(async () => true),
+    cancelRelease: vi.fn(async () => true),
   };
 }
 
@@ -180,5 +181,53 @@ describe("ReleasesService add-time document check", () => {
     expect(repo.createRelease).toHaveBeenCalledWith(
       expect.objectContaining({ createdBy: "u1" })
     );
+  });
+});
+
+describe("ReleasesService refuses members the drain could never perform", () => {
+  it("refuses a member with no author, rather than persisting an unrunnable one", async () => {
+    // `resolveActionAuthor` returns NO_RECORDED_AUTHOR for `createdBy: null` and
+    // the pass refuses to fall back to a privileged principal — correctly, or
+    // scheduling would become a way to act as the system. So an authorless
+    // member produces a release that can NEVER publish, and the trusted Direct
+    // API default is exactly the call that would create one.
+    const { svc, repo } = service({ holds: ["create"] });
+    await expect(
+      svc.addMember("r1", MEMBER, { userId: null, overrideAccess: true })
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("refuses a locale-scoped member at add time, where applyOne says it belongs", async () => {
+    // `applyOne` refuses any member carrying a locale and its comment names
+    // schedule time as where that refusal belongs once a write surface exists.
+    // This is that surface. Accepting one would persist a member guaranteed to
+    // fail at the scheduled instant, silently.
+    const { svc, repo } = service({ holds: ["create"] });
+    await expect(
+      svc.addMember("r1", { ...MEMBER, locale: "de" }, ADMIN)
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReleasesService lifecycle fences", () => {
+  it("reports a conflict when the schedule fence refuses the move", async () => {
+    // The fence excludes a `published` release: re-scheduling one makes the
+    // drain re-apply members against documents that have changed since. A
+    // caller told nothing would read the no-op as a schedule that took.
+    const { svc, repo } = service({ holds: ["publish"] });
+    repo.scheduleRelease.mockResolvedValueOnce(false);
+    await expect(
+      svc.schedule("r1", new Date(), "UTC", ADMIN)
+    ).rejects.toMatchObject({ code: "CONFLICT" });
+  });
+
+  it("reports a conflict when the cancel fence refuses the move", async () => {
+    const { svc, repo } = service({ holds: ["publish"] });
+    repo.cancelRelease.mockResolvedValueOnce(false);
+    await expect(svc.cancel("r1", ADMIN)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
   });
 });

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -290,3 +290,53 @@ describe("ReleasesService refuses members that would act on nothing", () => {
     );
   });
 });
+
+describe("ReleasesService protects a committed release", () => {
+  it("requires publish authority to add to a SCHEDULED release", async () => {
+    // The drain reads membership at the scheduled instant, not at scheduling
+    // time. So `create` alone would let a caller append content to a launch a
+    // publisher already committed to — the escalation the publish authority
+    // exists to prevent, arriving after the decision instead of before it.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.findReleases.mockResolvedValueOnce([{ id: "r1", state: "scheduled" }]);
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("lets a publisher add to a scheduled release", async () => {
+    // The control on the case above: the refusal must be about the AUTHORITY,
+    // not about the state. Without this, freezing membership outright would
+    // pass the test above and be wrong.
+    const { svc, repo } = service({ holds: ["create", "publish"] });
+    repo.findReleases.mockResolvedValueOnce([{ id: "r1", state: "scheduled" }]);
+    await svc.addMember("r1", MEMBER, ADMIN);
+    expect(repo.addMember).toHaveBeenCalled();
+  });
+
+  it("refuses an unusable schedule instant before touching the release", async () => {
+    // A NaN date reaches timestamp encoding and fails differently per dialect,
+    // so the caller's mistake arrives as an opaque driver error rather than the
+    // sentence naming it.
+    const { svc, repo } = service({ holds: ["publish"] });
+    await expect(
+      svc.schedule("r1", new Date("not a date"), "UTC", ADMIN)
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("applies one title limit, so the narrowest dialect defines the contract", async () => {
+    // `title` is varchar(255) on MySQL and unbounded text elsewhere. Left to the
+    // database, the same call succeeds on two engines and truncates on the
+    // third — returning a row that disagrees with what is stored.
+    const { svc, repo } = service({ holds: ["create"] });
+    await expect(
+      svc.create({ title: "x".repeat(256) }, ADMIN)
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.createRelease).not.toHaveBeenCalled();
+
+    await svc.create({ title: "x".repeat(255) }, ADMIN);
+    expect(repo.createRelease).toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -29,6 +29,14 @@ function repository() {
     listMembers: vi.fn(async () => []),
     addMember: vi.fn(async () => ({ id: "m1" })),
     removeMember: vi.fn(async () => undefined),
+    touchIfAssemblable: vi.fn(async () => true),
+    findMember: vi.fn(
+      async (): Promise<{ id: string; releaseId: string } | undefined> => ({
+        id: "m1",
+        releaseId: "r1",
+      })
+    ),
+    liveAuthors: vi.fn(async (ids: string[]) => new Set(ids)),
     scheduleRelease: vi.fn(async () => true),
     cancelRelease: vi.fn(async () => true),
   };
@@ -250,6 +258,7 @@ describe("ReleasesService refuses members that would act on nothing", () => {
     // mistyped id would insert a row no drain can ever find: a 201 for a member
     // that belongs to nothing.
     const { svc, repo } = service({ holds: ["create"] });
+    repo.touchIfAssemblable.mockResolvedValueOnce(false);
     repo.findReleases.mockResolvedValueOnce([]);
     await expect(svc.addMember("nope", MEMBER, ADMIN)).rejects.toMatchObject({
       code: "NOT_FOUND",
@@ -259,6 +268,7 @@ describe("ReleasesService refuses members that would act on nothing", () => {
 
   it("refuses a member on a release that will never run again", async () => {
     const { svc, repo } = service({ holds: ["create"] });
+    repo.touchIfAssemblable.mockResolvedValueOnce(false);
     repo.findReleases.mockResolvedValueOnce([{ id: "r1", state: "published" }]);
     await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
       code: "CONFLICT",
@@ -298,6 +308,7 @@ describe("ReleasesService protects a committed release", () => {
     // publisher already committed to — the escalation the publish authority
     // exists to prevent, arriving after the decision instead of before it.
     const { svc, repo } = service({ holds: ["create"] });
+    repo.touchIfAssemblable.mockResolvedValueOnce(false);
     repo.findReleases.mockResolvedValueOnce([{ id: "r1", state: "scheduled" }]);
     await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
       code: "FORBIDDEN",
@@ -310,6 +321,7 @@ describe("ReleasesService protects a committed release", () => {
     // not about the state. Without this, freezing membership outright would
     // pass the test above and be wrong.
     const { svc, repo } = service({ holds: ["create", "publish"] });
+    repo.touchIfAssemblable.mockResolvedValueOnce(false);
     repo.findReleases.mockResolvedValueOnce([{ id: "r1", state: "scheduled" }]);
     await svc.addMember("r1", MEMBER, ADMIN);
     expect(repo.addMember).toHaveBeenCalled();
@@ -338,5 +350,83 @@ describe("ReleasesService protects a committed release", () => {
 
     await svc.create({ title: "x".repeat(255) }, ADMIN);
     expect(repo.createRelease).toHaveBeenCalled();
+  });
+});
+
+describe("ReleasesService closes the window around a committed release", () => {
+  it("undoes the member when the release is scheduled during the insert", async () => {
+    // The claim cannot cover the insert itself: a publisher can schedule
+    // between the two, and the drain reads membership at the instant. Detected
+    // after the write and COMPENSATED — a member that should not be there is
+    // removable, while a publish that already happened is not.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.touchIfAssemblable
+      .mockResolvedValueOnce(true) // the claim succeeds: still a draft
+      .mockResolvedValueOnce(false); // scheduled while we were inserting
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    expect(repo.removeMember).toHaveBeenCalledWith("m1");
+  });
+
+  it("does not re-check for a caller who may publish", async () => {
+    // For them adding to a scheduled release is allowed, so there is nothing to
+    // undo — and a second fence call would refuse a legitimate write.
+    const { svc, repo } = service({ holds: ["create", "publish"] });
+    await svc.addMember("r1", MEMBER, ADMIN);
+    expect(repo.touchIfAssemblable).toHaveBeenCalledTimes(1);
+    expect(repo.removeMember).not.toHaveBeenCalled();
+  });
+
+  it("requires publish authority to remove a member from a scheduled release", async () => {
+    // Removing an `unpublish` member CANCELS a committed takedown and leaves
+    // content live. The earlier reasoning — that removal can only make less go
+    // live — was wrong in exactly that direction.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.touchIfAssemblable.mockResolvedValueOnce(false);
+    repo.findReleases.mockResolvedValueOnce([{ id: "r1", state: "scheduled" }]);
+    await expect(svc.removeMember("m1", ADMIN)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(repo.removeMember).not.toHaveBeenCalled();
+  });
+
+  it("treats removing an already-gone member as done, not as an error", async () => {
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.findMember.mockResolvedValueOnce(undefined);
+    await expect(svc.removeMember("gone", ADMIN)).resolves.toBeUndefined();
+    expect(repo.removeMember).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReleasesService refuses input the database would answer differently", () => {
+  it("refuses an author who cannot act, rather than scheduling a pass that always fails", async () => {
+    // Non-null is not enough: a deleted or deactivated author yields
+    // AUTHOR_UNAVAILABLE on every drain, and the only symptom is content that
+    // never appeared.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.liveAuthors.mockResolvedValueOnce(new Set<string>());
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+    });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("refuses a timezone longer than the narrowest dialect stores", async () => {
+    const { svc, repo } = service({ holds: ["publish"] });
+    await expect(
+      svc.schedule("r1", new Date(), "x".repeat(65), ADMIN)
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("refuses a negative limit, which SQLite reads as NO limit", async () => {
+    // `LIMIT -1` on SQLite means unbounded, so a query documented as "at most N"
+    // would return every release.
+    const { svc, repo } = service({ holds: ["read"] });
+    await expect(svc.find({ limit: -1 }, ADMIN)).rejects.toMatchObject({
+      code: "INVALID_INPUT",
+    });
+    expect(repo.findReleases).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -1,0 +1,184 @@
+/**
+ * The authorization boundary for content releases.
+ *
+ * The cases exercised exhaustively are the REFUSALS. A happy-path test passes
+ * against a service with no checks at all, so it can only ever confirm that the
+ * repository was reached — which was never in doubt. Each case below therefore
+ * asserts both that the call is refused AND that the repository was not touched,
+ * because a write that authorizes after the fact has already happened.
+ *
+ * @module domains/releases/__tests__/releases-service.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { ReleasesService } from "../services/releases-service";
+import type {
+  ReleaseAuthority,
+  ReleasesServiceDeps,
+} from "../services/releases-service";
+
+const ADMIN = { userId: "u1" };
+const ANON = { userId: null };
+
+/** Every repository method the service can reach, all spies. */
+function repository() {
+  return {
+    createRelease: vi.fn(async () => ({ id: "r1" })),
+    findReleases: vi.fn(async () => []),
+    listMembers: vi.fn(async () => []),
+    addMember: vi.fn(async () => ({ id: "m1" })),
+    removeMember: vi.fn(async () => undefined),
+    scheduleRelease: vi.fn(async () => undefined),
+    cancelRelease: vi.fn(async () => undefined),
+  };
+}
+
+function service(over?: {
+  holds?: ReleaseAuthority[];
+  mayActOnDocument?: boolean;
+}) {
+  const repo = repository();
+  const held = new Set(over?.holds ?? []);
+  const deps = {
+    repository: repo as unknown as ReleasesServiceDeps["repository"],
+    canManageReleases: vi.fn(async (_id: string, a: ReleaseAuthority) =>
+      held.has(a)
+    ),
+    canActOnDocument: vi.fn(async () => over?.mayActOnDocument !== false),
+  };
+  return { svc: new ReleasesService(deps), repo, deps };
+}
+
+const MEMBER = {
+  scopeKind: "collection" as const,
+  scopeSlug: "posts",
+  entryId: "e1",
+  locale: null,
+  action: "publish" as const,
+};
+
+describe("ReleasesService authorization", () => {
+  it("refuses to create a release without create authority, and writes nothing", async () => {
+    const { svc, repo } = service({ holds: ["read", "publish"] });
+    await expect(svc.create({ title: "Launch" }, ADMIN)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    // The ordering assertion. A refusal that arrives after the insert is not a
+    // refusal — nothing can un-write the row.
+    expect(repo.createRelease).not.toHaveBeenCalled();
+  });
+
+  it("refuses to read releases without read authority", async () => {
+    const { svc, repo } = service({ holds: ["create", "publish"] });
+    await expect(svc.find({}, ADMIN)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(repo.findReleases).not.toHaveBeenCalled();
+  });
+
+  it("refuses to schedule with only create authority, because committing is a separate power", async () => {
+    // The split the seed states: assembling a release changes nothing a reader
+    // can see, and scheduling is the act that puts content live later. A service
+    // that gated both on one permission would silently merge the two.
+    const { svc, repo } = service({ holds: ["create", "read"] });
+    await expect(
+      svc.schedule("r1", new Date(), "UTC", ADMIN)
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(repo.scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("refuses to cancel with only create authority", async () => {
+    // Cancelling needs the same authority as scheduling. Someone who could
+    // cancel but not schedule could still silently stop a launch.
+    const { svc, repo } = service({ holds: ["create", "read"] });
+    await expect(svc.cancel("r1", ADMIN)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(repo.cancelRelease).not.toHaveBeenCalled();
+  });
+
+  it("refuses an anonymous caller without asking the permission store", async () => {
+    const { svc, repo, deps } = service({ holds: ["read"] });
+    await expect(svc.find({}, ANON)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    // Asking about a null user is a lookup whose only possible answer is no, and
+    // a store that answered anything else would be granting authority to nobody.
+    expect(deps.canManageReleases).not.toHaveBeenCalled();
+    expect(repo.findReleases).not.toHaveBeenCalled();
+  });
+
+  it("lets a trusted in-process caller through without a permission store", async () => {
+    // `overrideAccess` is what the Direct API is, and it must NOT be inferred
+    // from a null user: anonymous and trusted are different things.
+    const { svc, repo, deps } = service({ holds: [] });
+    await svc.find({}, { userId: null, overrideAccess: true });
+    expect(deps.canManageReleases).not.toHaveBeenCalled();
+    expect(repo.findReleases).toHaveBeenCalled();
+  });
+});
+
+describe("ReleasesService add-time document check", () => {
+  it("refuses to add a document the caller may not publish", async () => {
+    // The escalation this closes: holding `create-content-releases` says you may
+    // ASSEMBLE a release, never that you may publish what you put in it. A
+    // release is a deferred publish, so without this the permission becomes a
+    // way to perform a write you could not perform now, with a delay on it.
+    const { svc, repo } = service({
+      holds: ["create"],
+      mayActOnDocument: false,
+    });
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("asks about the document's own scope and action, not the release", async () => {
+    // A check that asked about the wrong subject would pass for a caller who may
+    // publish something else entirely.
+    const { svc, deps } = service({ holds: ["create"] });
+    await svc.addMember("r1", { ...MEMBER, action: "unpublish" }, ADMIN);
+    expect(deps.canActOnDocument).toHaveBeenCalledWith(
+      "u1",
+      "posts",
+      "unpublish"
+    );
+  });
+
+  it("still requires release authority even when the document is permitted", async () => {
+    // Both questions, not either. A caller who may publish a post but holds no
+    // release authority must not be able to create scheduled work.
+    const { svc, repo } = service({ holds: [], mayActOnDocument: true });
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("records the actor as the member's author, never a caller-supplied one", async () => {
+    // Materialisation performs each member as its recorded author, so an author
+    // a caller could name would be an identity they could borrow at a future
+    // instant.
+    const { svc, repo } = service({ holds: ["create"] });
+    await svc.addMember(
+      "r1",
+      { ...MEMBER, createdBy: "someone-else" } as never,
+      ADMIN
+    );
+    expect(repo.addMember).toHaveBeenCalledWith(
+      expect.objectContaining({ createdBy: "u1", releaseId: "r1" })
+    );
+  });
+
+  it("records the actor as the release's author on create", async () => {
+    const { svc, repo } = service({ holds: ["create"] });
+    await svc.create(
+      { title: "Launch", createdBy: "someone-else" } as never,
+      ADMIN
+    );
+    expect(repo.createRelease).toHaveBeenCalledWith(
+      expect.objectContaining({ createdBy: "u1" })
+    );
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -25,7 +25,7 @@ function repository() {
   return {
     createRelease: vi.fn(async () => ({ id: "r1" })),
     scheduleReleaseOk: true,
-    findReleases: vi.fn(async () => []),
+    findReleases: vi.fn(async () => [{ id: "r1", state: "draft" }]),
     listMembers: vi.fn(async () => []),
     addMember: vi.fn(async () => ({ id: "m1" })),
     removeMember: vi.fn(async () => undefined),
@@ -229,5 +229,64 @@ describe("ReleasesService lifecycle fences", () => {
     await expect(svc.cancel("r1", ADMIN)).rejects.toMatchObject({
       code: "CONFLICT",
     });
+  });
+});
+
+describe("ReleasesService refuses members that would act on nothing", () => {
+  it("refuses an action outside the union, which would WITHDRAW content", async () => {
+    // The Drizzle `$type` annotation is compile-time only, and the applier
+    // treats every effect that is not exactly "publish" as an unpublish. So a
+    // typo from an untyped caller does not fail — it takes the document down at
+    // the scheduled instant.
+    const { svc, repo } = service({ holds: ["create"] });
+    await expect(
+      svc.addMember("r1", { ...MEMBER, action: "publsih" as never }, ADMIN)
+    ).rejects.toMatchObject({ code: "INVALID_INPUT" });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("refuses a member whose release does not exist", async () => {
+    // No dialect declares a foreign key from a member to its release, so a
+    // mistyped id would insert a row no drain can ever find: a 201 for a member
+    // that belongs to nothing.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.findReleases.mockResolvedValueOnce([]);
+    await expect(svc.addMember("nope", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("refuses a member on a release that will never run again", async () => {
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.findReleases.mockResolvedValueOnce([{ id: "r1", state: "published" }]);
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    expect(repo.addMember).not.toHaveBeenCalled();
+  });
+
+  it("translates a duplicate member into the package's own error", async () => {
+    // The memberKey unique index is what stops one document being scheduled
+    // twice in a release. Callers should meet NextlyError, not the adapter's
+    // DatabaseError.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.addMember.mockRejectedValueOnce(
+      Object.assign(new Error("UNIQUE constraint failed"), { code: "23505" })
+    );
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toMatchObject({
+      code: "DUPLICATE",
+    });
+  });
+
+  it("lets an unexpected database failure through rather than calling it a duplicate", async () => {
+    // The control on the case above: narrow translation only. A connection
+    // fault reported as "already exists" would send an operator hunting for a
+    // row that is not there.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.addMember.mockRejectedValueOnce(new Error("connection reset"));
+    await expect(svc.addMember("r1", MEMBER, ADMIN)).rejects.toThrow(
+      "connection reset"
+    );
   });
 });

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -335,6 +335,55 @@ export class ReleasesRepository {
    * case for a coordinated launch, and an unstable order there makes a paged
    * list skip and repeat rows.
    */
+  /**
+   * Touch a release ONLY if it is still assemblable, and say whether it was.
+   *
+   * One conditional UPDATE rather than a read followed by a decision. A caller
+   * that reads `draft`, decides, and then writes can be overtaken by a publisher
+   * scheduling in between — and the write then lands on a committed launch
+   * without ever passing the publish gate. Folding the check into the statement
+   * removes that window from the check itself; see `addMember` in the service
+   * for how the remaining window around the member write is closed.
+   *
+   * `updateCount` rather than `update({ returning })` for the reason
+   * `markReleasePublished` gives: MySQL has no RETURNING and the adapter
+   * emulates it by re-selecting on a predicate the write invalidates.
+   */
+  async touchIfAssemblable(id: string): Promise<boolean> {
+    const affected = await this.db.updateCount(
+      RELEASES,
+      { updatedAt: new Date() },
+      {
+        and: [
+          { column: "id", op: "=", value: id },
+          { column: "state", op: "IN", value: ["draft", "cancelled"] },
+        ],
+      }
+    );
+    return affected > 0;
+  }
+
+  /** One member by id, so a caller can learn which release it belongs to. */
+  async findMember(memberId: string): Promise<ReleaseMemberRow | undefined> {
+    const rows = await this.db.select<ReleaseMemberRow>(MEMBERS, {
+      where: { and: [{ column: "id", op: "=", value: memberId }] },
+    });
+    return rows[0];
+  }
+
+  /**
+   * Whether these author ids resolve to users who can still act.
+   *
+   * Public because the WRITE path needs the same question the read path asks. A
+   * member whose author is deleted or deactivated is recorded, scheduled, and
+   * then fails on every drain with `AUTHOR_UNAVAILABLE`, leaving the release
+   * scheduled forever — a failure that only ever shows up as content that did
+   * not appear.
+   */
+  async liveAuthors(ids: string[]): Promise<ReadonlySet<string>> {
+    return this.liveAuthorIds(ids);
+  }
+
   async findReleases(query: {
     ids?: string[];
     state?: string;

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -227,8 +227,25 @@ export class ReleasesRepository {
   }
 
   /** Move a release to `scheduled`, which is what makes reads consult it. */
-  async scheduleRelease(id: string, at: Date, timezone: string): Promise<void> {
-    await this.db.update(
+  /**
+   * Commit a release to an instant, and say whether it moved.
+   *
+   * FENCED on the states a schedule may legally leave. A `published` release is
+   * excluded: moving one back to `scheduled` makes the drain re-apply members
+   * whose documents have changed since, republishing or re-withdrawing content
+   * nobody asked it to touch. `draft` and `cancelled` are both legitimate
+   * sources — the second is how a called-off launch is put back on.
+   *
+   * Answering `false` rather than throwing follows `markReleasePublished`: the
+   * repository reports what the fence did, and the caller decides whether a
+   * refusal is a conflict for its transport.
+   */
+  async scheduleRelease(
+    id: string,
+    at: Date,
+    timezone: string
+  ): Promise<boolean> {
+    const affected = await this.db.updateCount(
       RELEASES,
       {
         scheduledAt: at,
@@ -236,9 +253,20 @@ export class ReleasesRepository {
         state: "scheduled" satisfies ReleaseState,
         updatedAt: new Date(),
       },
-      { and: [{ column: "id", op: "=", value: id }] }
+      {
+        and: [
+          { column: "id", op: "=", value: id },
+          {
+            column: "state",
+            op: "IN",
+            value: ["draft", "scheduled", "cancelled"],
+          },
+        ],
+      }
     );
+    if (affected === 0) return false;
     await this.revalidateMembersOf(id);
+    return true;
   }
 
   /**
@@ -249,19 +277,33 @@ export class ReleasesRepository {
    * consulted. That is what makes cancelling a due-but-unmaterialised release
    * free, and it is why there is no restore path here.
    */
-  async cancelRelease(id: string): Promise<void> {
-    await this.db.update(
+  /**
+   * Call a release off, and say whether it moved.
+   *
+   * Fenced away from `published` for the same reason scheduling is: that
+   * release already happened, and marking it cancelled would describe history
+   * that did not occur while leaving the published content in place.
+   */
+  async cancelRelease(id: string): Promise<boolean> {
+    const affected = await this.db.updateCount(
       RELEASES,
       {
         state: "cancelled" satisfies ReleaseState,
         updatedAt: new Date(),
       },
-      { and: [{ column: "id", op: "=", value: id }] }
+      {
+        and: [
+          { column: "id", op: "=", value: id },
+          { column: "state", op: "IN", value: ["draft", "scheduled"] },
+        ],
+      }
     );
+    if (affected === 0) return false;
     // Cancelling changes what a read returns just as scheduling does: a page
     // cached with a lifetime derived from this release is now bounded by an
     // instant that will never arrive.
     await this.revalidateMembersOf(id);
+    return true;
   }
 
   /**
@@ -332,7 +374,11 @@ export class ReleasesRepository {
     return this.db.select<ReleaseRow>(RELEASES, {
       where: conditions.length > 0 ? { and: conditions } : undefined,
       orderBy: [
-        { column: "scheduledAt", direction: "desc" },
+        // NULLS LAST, stated rather than defaulted. An unscheduled draft has a
+        // null instant, and the default differs per dialect — on PostgreSQL a
+        // descending order puts nulls first, so a limited "what ships next"
+        // query would return drafts and omit every scheduled release.
+        { column: "scheduledAt", direction: "desc", nulls: "last" },
         { column: "createdAt", direction: "desc" },
       ],
       limit: query.limit,

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -19,7 +19,11 @@ import type {
   ReleaseState,
 } from "../../schemas/releases/types";
 import type { VersionScopeKind } from "../../schemas/versions/types";
-import type { VersionsDbApi, VersionsWhere } from "../versions/db-api";
+import type {
+  VersionsDbApi,
+  VersionsWhere,
+  VersionsWhereCondition,
+} from "../versions/db-api";
 
 import { releaseMemberKey } from "./release-member-key";
 import { releaseRevalidationIntent } from "./release-revalidation";
@@ -270,6 +274,71 @@ export class ReleasesRepository {
    * 09:00 is in effect AT 09:00, not from the first request after it — to be
    * got wrong, and the two would disagree silently.
    */
+  /**
+   * Releases matching a window and a state, newest scheduled instant first.
+   *
+   * The product read, as opposed to {@link findDueReleases}, which answers the
+   * drain's question and nothing else. Two shapes ask this with different
+   * bounds — a release index wants a page of everything, a dashboard widget
+   * wants the next seven days — so the caller supplies the window and the limit
+   * rather than receiving fixed ones. Fixing either here is what forces the
+   * second caller to grow a second query.
+   *
+   * The bounds are pushed to the database rather than filtered in JS. The window
+   * is the whole point of the query, so discarding rows in memory would mean
+   * reading every release on the site to answer "what ships this week".
+   *
+   * Ordered by `scheduledAt` DESCENDING with `createdAt` breaking ties, so the
+   * order is total: several releases scheduled for one instant is the ordinary
+   * case for a coordinated launch, and an unstable order there makes a paged
+   * list skip and repeat rows.
+   */
+  async findReleases(query: {
+    ids?: string[];
+    state?: string;
+    scheduledAfter?: Date;
+    scheduledBefore?: Date;
+    limit?: number;
+  }): Promise<ReleaseRow[]> {
+    const conditions: VersionsWhereCondition[] = [];
+    // An explicitly EMPTY id list means "none of them", which is not the same
+    // question as "no id filter" — answering it with every release would be the
+    // widest possible wrong answer.
+    if (query.ids !== undefined) {
+      if (query.ids.length === 0) return [];
+      conditions.push({
+        column: "id",
+        op: "IN",
+        value: [...new Set(query.ids)],
+      });
+    }
+    if (query.state !== undefined) {
+      conditions.push({ column: "state", op: "=", value: query.state });
+    }
+    if (query.scheduledAfter !== undefined) {
+      conditions.push({
+        column: "scheduledAt",
+        op: ">=",
+        value: query.scheduledAfter,
+      });
+    }
+    if (query.scheduledBefore !== undefined) {
+      conditions.push({
+        column: "scheduledAt",
+        op: "<=",
+        value: query.scheduledBefore,
+      });
+    }
+    return this.db.select<ReleaseRow>(RELEASES, {
+      where: conditions.length > 0 ? { and: conditions } : undefined,
+      orderBy: [
+        { column: "scheduledAt", direction: "desc" },
+        { column: "createdAt", direction: "desc" },
+      ],
+      limit: query.limit,
+    });
+  }
+
   async findDueReleases(now: Date): Promise<ReleaseRow[]> {
     const rows = await this.db.select<ReleaseRow>(RELEASES, {
       where: {

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -380,6 +380,12 @@ export class ReleasesRepository {
         // query would return drafts and omit every scheduled release.
         { column: "scheduledAt", direction: "desc", nulls: "last" },
         { column: "createdAt", direction: "desc" },
+        // `id` last, so the order is actually total. `createdAt` is not unique
+        // and is stored coarsely enough for concurrent releases to tie —
+        // especially on SQLite — and two drafts tie on a null `scheduledAt` as
+        // well, so without this a limited page can return different rows across
+        // query plans and dialects.
+        { column: "id", direction: "desc" },
       ],
       limit: query.limit,
     });

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -76,6 +76,16 @@ export const RELEASES_RESOURCE = "content-releases";
 export const MAX_RELEASE_TITLE_LENGTH = 255;
 
 /**
+ * The longest timezone every supported dialect can store.
+ *
+ * `nextly_releases.timezone` is `varchar(64)` on MySQL and unbounded `text` on
+ * PostgreSQL and SQLite. Comfortably above every IANA zone name — the longest in
+ * the database is around 32 characters — so the limit refuses nonsense rather
+ * than constraining a real caller.
+ */
+export const MAX_RELEASE_TIMEZONE_LENGTH = 64;
+
+/**
  * Who is asking, and whether to ask at all.
  *
  * `overrideAccess` matches every other service in this package: the Direct API
@@ -135,7 +145,7 @@ export interface FindReleasesQuery {
   scheduledAfter?: Date;
   scheduledBefore?: Date;
   /**
-   * How many rows at most.
+   * How many rows at most. Must be a non-negative integer when given.
    *
    * There is no `offset`: the select port this reads through exposes `where`,
    * `orderBy` and `limit` and nothing else, so offset paging would mean widening
@@ -245,6 +255,18 @@ export class ReleasesService {
     actor: ReleaseActor
   ): Promise<ReleaseRow[]> {
     await this.authorize(actor, "read");
+    // A negative limit is not a smaller page — on SQLite `LIMIT -1` means NO
+    // limit, so a query documented as returning "at most" N would return every
+    // release and turn a bounded dashboard read into a full table scan.
+    if (
+      query.limit !== undefined &&
+      (!Number.isInteger(query.limit) || query.limit < 0)
+    ) {
+      throw NextlyError.invalidInput({
+        message: "`limit` must be a non-negative integer.",
+        logContext: { reason: "invalid-limit", limit: query.limit },
+      });
+    }
     return this.deps.repository.findReleases(query);
   }
 
@@ -272,41 +294,12 @@ export class ReleasesService {
     await this.authorizeDocumentAction(actor, input.scopeSlug, input.action);
     requireRunnableMember(input, actor);
 
-    // The parent must EXIST. No dialect declares a foreign key from a member to
-    // its release, so a mistyped id inserts a row no drain will ever find:
-    // the API answers 201 with a member that belongs to nothing, and the
-    // release it names is not scheduled because it does not exist.
-    const [parent] = await this.deps.repository.findReleases({
-      ids: [releaseId],
-    });
-    if (parent === undefined) {
-      throw NextlyError.notFound({
-        logContext: { reason: "release-not-found", releaseId },
-      });
-    }
-    // A published or cancelled release will never be materialised again, so a
-    // member added to one is work that cannot happen.
-    if (parent.state === "published" || parent.state === "cancelled") {
-      throw NextlyError.conflict({
-        logContext: {
-          reason: "release-not-mutable",
-          releaseId,
-          state: parent.state,
-        },
-      });
-    }
-    // Once a release is SCHEDULED, changing what is in it changes what goes
-    // live at an instant a publisher already committed to. The drain reads
-    // membership at the instant, not at scheduling time, so `create` alone
-    // would let a caller append content to a committed launch without ever
-    // passing the publish gate — the escalation this authority exists to
-    // prevent, arriving after the decision rather than before it.
-    if (parent.state === "scheduled") {
-      await this.authorize(actor, "publish");
-    }
+    // Claimed ATOMICALLY, and the author checked, before anything is written.
+    await this.claimAssemblable(releaseId, actor);
+    await this.requireLiveAuthor(actor.userId);
 
     try {
-      return await this.deps.repository.addMember({
+      const member = await this.deps.repository.addMember({
         ...input,
         releaseId,
         // Never a caller-supplied author. Materialisation performs each member
@@ -314,6 +307,29 @@ export class ReleasesService {
         // identity they could borrow at a future instant.
         createdBy: actor.userId,
       });
+
+      // The window the claim above cannot cover on its own: a publisher may
+      // schedule the release between the claim and this insert, and the drain
+      // reads membership at the instant, so the member would join a committed
+      // launch. Re-checked after the write and COMPENSATED, because a member
+      // that should not be there is removable while a publish that already
+      // happened is not.
+      //
+      // Skipped for a caller who holds `publish`: for them, adding to a
+      // scheduled release is allowed, so there is nothing to undo.
+      if (!(await this.holds(actor, "publish"))) {
+        if (!(await this.deps.repository.touchIfAssemblable(releaseId))) {
+          await this.deps.repository.removeMember(member.id);
+          throw NextlyError.conflict({
+            logContext: {
+              reason: "release-scheduled-during-add",
+              releaseId,
+              memberId: member.id,
+            },
+          });
+        }
+      }
+      return member;
     } catch (error) {
       // The `memberKey` unique index is what stops one document being scheduled
       // twice in one release. Translated here so callers meet this package's
@@ -334,10 +350,94 @@ export class ReleasesService {
   }
 
   async removeMember(memberId: string, actor: ReleaseActor): Promise<void> {
-    // `create`, not `publish`: taking a document out of a release un-does part
-    // of assembling it, and it can only ever make less content go live.
     await this.authorize(actor, "create");
+
+    // An earlier version of this method reasoned that removing a member "can
+    // only ever make less content go live" and needed no publish authority.
+    // That is FALSE for an `unpublish` member: removing one cancels a committed
+    // takedown and leaves content live. So a create-only caller could undo a
+    // publisher's decision in the direction that keeps content up, which is the
+    // direction that matters.
+    const member = await this.deps.repository.findMember(memberId);
+    // Already gone. Idempotent rather than a 404: the caller's intent is
+    // satisfied, and answering not-found for a member somebody else removed
+    // makes a retry look like a failure.
+    if (member === undefined) return;
+
+    await this.claimAssemblable(member.releaseId, actor);
     await this.deps.repository.removeMember(memberId);
+  }
+
+  /**
+   * Take the release as assemblable, or require the authority to change a
+   * committed one.
+   *
+   * The claim is a single conditional statement, so it cannot be overtaken
+   * between deciding and acting the way a read-then-write can. Only when it
+   * fails is the row read, and only to say WHY: a release that does not exist,
+   * one that will never run again, or one a publisher has already committed.
+   */
+  private async claimAssemblable(
+    releaseId: string,
+    actor: ReleaseActor
+  ): Promise<void> {
+    if (await this.deps.repository.touchIfAssemblable(releaseId)) return;
+
+    const [parent] = await this.deps.repository.findReleases({
+      ids: [releaseId],
+    });
+    // No dialect declares a foreign key from a member to its release, so a
+    // mistyped id would otherwise insert a row no drain will ever find.
+    if (parent === undefined) {
+      throw NextlyError.notFound({
+        logContext: { reason: "release-not-found", releaseId },
+      });
+    }
+    if (parent.state === "scheduled") {
+      // Changing what is in a scheduled release changes what goes live at an
+      // instant a publisher committed to. The drain reads membership at the
+      // instant, not at scheduling time.
+      await this.authorize(actor, "publish");
+      return;
+    }
+    // Published or cancelled: never materialised again, so this is work that
+    // cannot happen rather than work someone is not allowed to do.
+    throw NextlyError.conflict({
+      logContext: {
+        reason: "release-not-mutable",
+        releaseId,
+        state: parent.state,
+      },
+    });
+  }
+
+  /** Whether the actor holds an authority, without throwing. */
+  private async holds(
+    actor: ReleaseActor,
+    authority: ReleaseAuthority
+  ): Promise<boolean> {
+    if (actor.overrideAccess === true) return true;
+    if (actor.userId === null) return false;
+    return this.deps.canManageReleases(actor.userId, authority);
+  }
+
+  /**
+   * Refuse an author the drain will not be able to act as.
+   *
+   * Non-null is not enough. A trusted call naming a deleted or deactivated user
+   * persists that id, and `resolveActionAuthor` then returns
+   * `AUTHOR_UNAVAILABLE` on every pass — the release stays scheduled forever and
+   * the only symptom is content that never appeared.
+   */
+  private async requireLiveAuthor(userId: string | null): Promise<void> {
+    if (userId === null) return;
+    const live = await this.deps.repository.liveAuthors([userId]);
+    if (live.has(userId)) return;
+    throw NextlyError.invalidInput({
+      message:
+        "The author for this release member cannot act: the user is missing or deactivated.",
+      logContext: { reason: "author-not-runnable", userId },
+    });
   }
 
   async schedule(
@@ -355,6 +455,17 @@ export class ReleasesService {
       throw NextlyError.invalidInput({
         message: "`at` is not a valid instant.",
         logContext: { reason: "invalid-schedule-instant", releaseId: id },
+      });
+    }
+    // Same reason the title has a limit: the narrowest dialect defines the
+    // contract, or the call succeeds on two engines and truncates on the third.
+    if (
+      timezone.length === 0 ||
+      timezone.length > MAX_RELEASE_TIMEZONE_LENGTH
+    ) {
+      throw NextlyError.invalidInput({
+        message: `\`timezone\` must be between 1 and ${MAX_RELEASE_TIMEZONE_LENGTH} characters.`,
+        logContext: { reason: "invalid-timezone", length: timezone.length },
       });
     }
     // The fence answers `false` for a release whose current state forbids the

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -1,0 +1,289 @@
+/**
+ * The authorization boundary for content releases.
+ *
+ * The releases engine — repository, materialisation, the periodic drain — was
+ * complete and reachable only from inside the server process. Its three
+ * permissions were seeded and enforced NOWHERE, because there was no service in
+ * which to enforce them. This is that service, and it is the layer that makes
+ * the feature safe to expose.
+ *
+ * ## Three authorities, not a CRUD set
+ *
+ * `permission-seed-service` states the split and this honours it rather than
+ * restating it: assembling a release changes nothing a reader can see, while
+ * scheduling it is the act that puts content live later.
+ *
+ *     read     → view releases and their members
+ *     create   → create a release and choose what goes in it
+ *     publish  → schedule or cancel, which is what makes content go live
+ *
+ * `update` and `delete` are deliberately NOT seeded, and so are deliberately
+ * absent here. Renaming is filed under `create` because it is part of assembling
+ * a release; destroying one is a different power and waits for its own
+ * permission to arrive with the surface that checks it. Inventing either here
+ * would teach the admin a vocabulary the server ignores.
+ *
+ * ## Why adding a member asks TWO questions
+ *
+ * Holding `create-content-releases` says you may assemble a release. It does not
+ * say you may publish the document you are putting into one — and a release is a
+ * deferred publish, so allowing that would be a privilege escalation with a delay
+ * on it.
+ *
+ * Materialisation is already safe without this check: `createJobContentApi`
+ * forces `overrideAccess: false`, binds the member's own author, and strips a
+ * caller-supplied override, so a member whose author may not publish simply
+ * fails when the release fires. This check exists because failing THEN is a bad
+ * product: the editor learns at the scheduled instant, with nobody watching,
+ * that their release did not go out. Refusing at add time is the same verdict
+ * delivered while it can still be acted on.
+ *
+ * The check can still go stale — access revoked between adding and firing — which
+ * is exactly why the materialisation-time authorization is not removed. Two
+ * checks, because they answer the question at two different instants.
+ *
+ * @module domains/releases/services/releases-service
+ */
+
+import { NextlyError } from "../../../errors";
+import type { ReleaseMemberAction } from "../../../schemas/releases/types";
+import type {
+  DocumentRef,
+  NewRelease,
+  ReleaseMemberRow,
+  ReleaseRow,
+  ReleasesRepository,
+} from "../releases-repository";
+
+/** The system-resource authorities a release operation can require. */
+export type ReleaseAuthority = "read" | "create" | "publish";
+
+/** The system resource the three permissions are seeded under. */
+export const RELEASES_RESOURCE = "content-releases";
+
+/**
+ * Who is asking, and whether to ask at all.
+ *
+ * `overrideAccess` matches every other service in this package: the Direct API
+ * is a trusted in-process caller and the HTTP layer is not. It is a separate
+ * field from `userId` rather than inferred from its absence — an anonymous
+ * caller and a trusted one are different things, and folding them together is
+ * how an unauthenticated request acquires system authority.
+ */
+export interface ReleaseActor {
+  userId: string | null;
+  overrideAccess?: boolean;
+}
+
+export interface ReleasesServiceDeps {
+  repository: ReleasesRepository;
+  /**
+   * Whether this user holds one of the three release authorities.
+   *
+   * Injected rather than imported so the boundary is testable without a database
+   * and without a permission store — the cases worth exercising exhaustively are
+   * the refusals, and a test that needs RBAC seeded to assert one tends not to
+   * be written.
+   */
+  canManageReleases: (
+    userId: string,
+    authority: ReleaseAuthority
+  ) => Promise<boolean>;
+  /**
+   * Whether this user may perform this lifecycle action on this scope.
+   *
+   * The same question the ordinary write path asks (`publish-<slug>` /
+   * `unpublish-<slug>`), asked here at add time. Injected for the same reason.
+   */
+  canActOnDocument: (
+    userId: string,
+    scopeSlug: string,
+    action: ReleaseMemberAction
+  ) => Promise<boolean>;
+}
+
+export interface FindReleasesQuery {
+  /** Restrict to one lifecycle state. */
+  state?: string;
+  /**
+   * Window on the scheduled instant, both bounds optional and independent.
+   *
+   * A caller supplies the window rather than receiving a fixed one: an index
+   * page wants a page of everything, while a dashboard widget wants "the next
+   * seven days". Fixing it here forces the second caller to grow its own query.
+   */
+  scheduledAfter?: Date;
+  scheduledBefore?: Date;
+  /**
+   * How many rows at most.
+   *
+   * There is no `offset`: the select port this reads through exposes `where`,
+   * `orderBy` and `limit` and nothing else, so offset paging would mean widening
+   * it for a caller that does not exist yet. The index page brings its own
+   * paging question when it is built, and keyset paging over `scheduledAt` is
+   * the shape that will suit it — an offset would drift under a list whose rows
+   * move as releases publish.
+   */
+  limit?: number;
+}
+
+/** What a member add asks for, minus the release it joins. */
+export interface AddMemberInput extends DocumentRef {
+  action: ReleaseMemberAction;
+}
+
+export class ReleasesService {
+  constructor(private readonly deps: ReleasesServiceDeps) {}
+
+  /**
+   * Refuse unless the caller holds `authority` on `content-releases`.
+   *
+   * Called BEFORE every write, never after. A write that authorizes afterwards
+   * has already happened, and no refusal can un-happen it — which is the one
+   * ordering a partial-failure path cannot repair.
+   */
+  private async authorize(
+    actor: ReleaseActor,
+    authority: ReleaseAuthority
+  ): Promise<void> {
+    if (actor.overrideAccess === true) return;
+    // An anonymous caller holds no permissions, and asking the store about a
+    // null user would be a lookup whose only possible answer is "no".
+    if (actor.userId === null) {
+      throw NextlyError.forbidden({
+        logContext: {
+          reason: "anonymous",
+          authority,
+          resource: RELEASES_RESOURCE,
+        },
+      });
+    }
+    if (await this.deps.canManageReleases(actor.userId, authority)) return;
+    // The public message is FIXED by `forbidden`, and deliberately so: a
+    // response that named the missing permission would tell an unauthorized
+    // caller the shape of the authority model. The detail an operator needs goes
+    // to the log instead. The admin surface does not depend on reading it back —
+    // it knows the caller's capabilities already, and the better product is to
+    // not offer an action the person cannot take rather than to explain the
+    // refusal afterwards.
+    throw NextlyError.forbidden({
+      logContext: {
+        reason: "missing-release-authority",
+        authority,
+        resource: RELEASES_RESOURCE,
+        userId: actor.userId,
+      },
+    });
+  }
+
+  async create(
+    input: Omit<NewRelease, "createdBy">,
+    actor: ReleaseActor
+  ): Promise<ReleaseRow> {
+    await this.authorize(actor, "create");
+    // `createdBy` comes from the ACTOR, never from the input. Materialisation
+    // performs each member as its recorded author, so an author a caller could
+    // name would be an identity they could borrow at a future instant.
+    return this.deps.repository.createRelease({
+      ...input,
+      createdBy: actor.userId,
+    });
+  }
+
+  async findByID(id: string, actor: ReleaseActor): Promise<ReleaseRow | null> {
+    await this.authorize(actor, "read");
+    const releases = await this.deps.repository.findReleases({ ids: [id] });
+    return releases[0] ?? null;
+  }
+
+  async find(
+    query: FindReleasesQuery,
+    actor: ReleaseActor
+  ): Promise<ReleaseRow[]> {
+    await this.authorize(actor, "read");
+    return this.deps.repository.findReleases(query);
+  }
+
+  async listMembers(
+    releaseId: string,
+    actor: ReleaseActor
+  ): Promise<ReleaseMemberRow[]> {
+    await this.authorize(actor, "read");
+    return this.deps.repository.listMembers(releaseId);
+  }
+
+  /**
+   * Put a document into a release, under a lifecycle action.
+   *
+   * Two authorities, for the reason in the module docblock: `create` to assemble
+   * the release, and the document's own `publish`/`unpublish` so that scheduling
+   * cannot become a way to perform a write the caller could not perform now.
+   */
+  async addMember(
+    releaseId: string,
+    input: AddMemberInput,
+    actor: ReleaseActor
+  ): Promise<ReleaseMemberRow> {
+    await this.authorize(actor, "create");
+    await this.authorizeDocumentAction(actor, input.scopeSlug, input.action);
+    return this.deps.repository.addMember({
+      ...input,
+      releaseId,
+      createdBy: actor.userId,
+    });
+  }
+
+  async removeMember(memberId: string, actor: ReleaseActor): Promise<void> {
+    // `create`, not `publish`: taking a document out of a release un-does part
+    // of assembling it, and it can only ever make less content go live.
+    await this.authorize(actor, "create");
+    await this.deps.repository.removeMember(memberId);
+  }
+
+  async schedule(
+    id: string,
+    at: Date,
+    timezone: string,
+    actor: ReleaseActor
+  ): Promise<void> {
+    await this.authorize(actor, "publish");
+    await this.deps.repository.scheduleRelease(id, at, timezone);
+  }
+
+  async cancel(id: string, actor: ReleaseActor): Promise<void> {
+    // Cancelling needs the same authority as scheduling, and the seed says so
+    // outright: `publish-content-releases` is "schedule or cancel". Someone who
+    // could cancel but not schedule could still silently stop a launch.
+    await this.authorize(actor, "publish");
+    await this.deps.repository.cancelRelease(id);
+  }
+
+  private async authorizeDocumentAction(
+    actor: ReleaseActor,
+    scopeSlug: string,
+    action: ReleaseMemberAction
+  ): Promise<void> {
+    if (actor.overrideAccess === true) return;
+    if (actor.userId === null) {
+      throw NextlyError.forbidden({
+        logContext: { reason: "anonymous", action, scopeSlug },
+      });
+    }
+    if (await this.deps.canActOnDocument(actor.userId, scopeSlug, action)) {
+      return;
+    }
+    // Logged as the DOCUMENT authority, not the release one. The two refusals
+    // are indistinguishable in the response by design, so the log is the only
+    // place that can tell an operator whether the caller was short of
+    // `create-content-releases` or of `publish-<slug>` — and sending them to
+    // grant the wrong one is the failure this field prevents.
+    throw NextlyError.forbidden({
+      logContext: {
+        reason: "missing-document-authority",
+        action,
+        scopeSlug,
+        userId: actor.userId,
+      },
+    });
+  }
+}

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -46,7 +46,12 @@
  */
 
 import { NextlyError } from "../../../errors";
-import type { ReleaseMemberAction } from "../../../schemas/releases/types";
+import {
+  isReleaseMemberAction,
+  type ReleaseMemberAction,
+  type ReleaseState,
+} from "../../../schemas/releases/types";
+import { isUniqueViolation } from "../../../shared/lib/unique-violation";
 import type {
   DocumentRef,
   NewRelease,
@@ -103,8 +108,14 @@ export interface ReleasesServiceDeps {
 }
 
 export interface FindReleasesQuery {
-  /** Restrict to one lifecycle state. */
-  state?: string;
+  /**
+   * Restrict to one lifecycle state.
+   *
+   * Typed as the exhaustive union rather than `string`: a typo like
+   * `"schedule"` would otherwise be accepted and answered with an empty list and
+   * no diagnostic, which reads exactly like "nothing is scheduled".
+   */
+  state?: ReleaseState;
   /**
    * Window on the scheduled instant, both bounds optional and independent.
    *
@@ -127,8 +138,21 @@ export interface FindReleasesQuery {
   limit?: number;
 }
 
+/**
+ * The document scopes a release can actually materialise.
+ *
+ * `VersionScopeKind` also admits `"page"`, and this input deliberately does NOT.
+ * `release-mutations` routes every non-single scope through the collection API,
+ * so a page member either fails every drain and holds the release scheduled
+ * forever, or targets an unrelated collection that happens to share the slug.
+ * Narrowing the public input is how a scope that cannot be performed stops being
+ * expressible.
+ */
+export type ReleaseScopeKind = "collection" | "single";
+
 /** What a member add asks for, minus the release it joins. */
-export interface AddMemberInput extends DocumentRef {
+export interface AddMemberInput extends Omit<DocumentRef, "scopeKind"> {
+  scopeKind: ReleaseScopeKind;
   action: ReleaseMemberAction;
 }
 
@@ -227,14 +251,57 @@ export class ReleasesService {
     await this.authorize(actor, "create");
     await this.authorizeDocumentAction(actor, input.scopeSlug, input.action);
     requireRunnableMember(input, actor);
-    return this.deps.repository.addMember({
-      ...input,
-      releaseId,
-      // Never a caller-supplied author. Materialisation performs each member as
-      // its recorded author, so an author a caller could name would be an
-      // identity they could borrow at a future instant.
-      createdBy: actor.userId,
+
+    // The parent must EXIST. No dialect declares a foreign key from a member to
+    // its release, so a mistyped id inserts a row no drain will ever find:
+    // the API answers 201 with a member that belongs to nothing, and the
+    // release it names is not scheduled because it does not exist.
+    const [parent] = await this.deps.repository.findReleases({
+      ids: [releaseId],
     });
+    if (parent === undefined) {
+      throw NextlyError.notFound({
+        logContext: { reason: "release-not-found", releaseId },
+      });
+    }
+    // A published or cancelled release will never be materialised again, so a
+    // member added to one is work that cannot happen.
+    if (parent.state === "published" || parent.state === "cancelled") {
+      throw NextlyError.conflict({
+        logContext: {
+          reason: "release-not-mutable",
+          releaseId,
+          state: parent.state,
+        },
+      });
+    }
+
+    try {
+      return await this.deps.repository.addMember({
+        ...input,
+        releaseId,
+        // Never a caller-supplied author. Materialisation performs each member
+        // as its recorded author, so an author a caller could name would be an
+        // identity they could borrow at a future instant.
+        createdBy: actor.userId,
+      });
+    } catch (error) {
+      // The `memberKey` unique index is what stops one document being scheduled
+      // twice in one release. Translated here so callers meet this package's
+      // stable error contract rather than the adapter's DatabaseError — and
+      // narrowly, so an unexpected database failure still propagates.
+      if (isUniqueViolation(error)) {
+        throw NextlyError.duplicate({
+          logContext: {
+            reason: "member-already-in-release",
+            releaseId,
+            scopeSlug: input.scopeSlug,
+            entryId: input.entryId,
+          },
+        });
+      }
+      throw error;
+    }
   }
 
   async removeMember(memberId: string, actor: ReleaseActor): Promise<void> {
@@ -326,6 +393,17 @@ function requireRunnableMember(
   // scheduling would become a way to act as the system. So a member added by a
   // trusted call that named nobody produces a release that can never publish,
   // and the default Direct API path is exactly that call.
+  // An action outside the union is DANGEROUS, not merely invalid. The Drizzle
+  // `$type` annotation is compile-time only, and the applier treats every effect
+  // that is not exactly `"publish"` as an unpublish — so `"publsih"` from an
+  // untyped caller WITHDRAWS the document at the scheduled instant.
+  if (!isReleaseMemberAction(input.action)) {
+    throw NextlyError.invalidInput({
+      message: "`action` must be `publish` or `unpublish`.",
+      logContext: { reason: "unknown-member-action", action: input.action },
+    });
+  }
+
   if (actor.userId === null) {
     throw NextlyError.invalidInput({
       message:

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -226,9 +226,13 @@ export class ReleasesService {
   ): Promise<ReleaseMemberRow> {
     await this.authorize(actor, "create");
     await this.authorizeDocumentAction(actor, input.scopeSlug, input.action);
+    requireRunnableMember(input, actor);
     return this.deps.repository.addMember({
       ...input,
       releaseId,
+      // Never a caller-supplied author. Materialisation performs each member as
+      // its recorded author, so an author a caller could name would be an
+      // identity they could borrow at a future instant.
       createdBy: actor.userId,
     });
   }
@@ -247,7 +251,16 @@ export class ReleasesService {
     actor: ReleaseActor
   ): Promise<void> {
     await this.authorize(actor, "publish");
-    await this.deps.repository.scheduleRelease(id, at, timezone);
+    // The fence answers `false` for a release whose current state forbids the
+    // move — a published one, most importantly, because re-scheduling it makes
+    // the drain re-apply members against documents that have changed since.
+    // Reported as a CONFLICT rather than swallowed: a caller told nothing would
+    // read a no-op as a schedule that took.
+    if (!(await this.deps.repository.scheduleRelease(id, at, timezone))) {
+      throw NextlyError.conflict({
+        logContext: { reason: "release-not-schedulable", releaseId: id },
+      });
+    }
   }
 
   async cancel(id: string, actor: ReleaseActor): Promise<void> {
@@ -255,7 +268,11 @@ export class ReleasesService {
     // outright: `publish-content-releases` is "schedule or cancel". Someone who
     // could cancel but not schedule could still silently stop a launch.
     await this.authorize(actor, "publish");
-    await this.deps.repository.cancelRelease(id);
+    if (!(await this.deps.repository.cancelRelease(id))) {
+      throw NextlyError.conflict({
+        logContext: { reason: "release-not-cancellable", releaseId: id },
+      });
+    }
   }
 
   private async authorizeDocumentAction(
@@ -283,6 +300,55 @@ export class ReleasesService {
         action,
         scopeSlug,
         userId: actor.userId,
+      },
+    });
+  }
+}
+
+/**
+ * Refuse a member the drain could never perform.
+ *
+ * Both refusals are `invalidInput` rather than `forbidden`: nothing is being
+ * denied to this caller, the member simply cannot be materialised, and the
+ * sentence naming why is the whole value of the error. They are stated HERE
+ * rather than left to the drain because a member that fails at the scheduled
+ * instant fails silently — the release stays `scheduled`, the failure is one
+ * recorded outcome, and the editor finds out by noticing content that never
+ * went live.
+ */
+function requireRunnableMember(
+  input: AddMemberInput,
+  actor: ReleaseActor
+): void {
+  // An authorless member is UNRUNNABLE, not merely unattributed.
+  // `resolveActionAuthor` returns `NO_RECORDED_AUTHOR` for `createdBy: null`
+  // and the pass refuses to fall back to a privileged principal — correctly, or
+  // scheduling would become a way to act as the system. So a member added by a
+  // trusted call that named nobody produces a release that can never publish,
+  // and the default Direct API path is exactly that call.
+  if (actor.userId === null) {
+    throw NextlyError.invalidInput({
+      message:
+        "A release member needs an author: pass `userId` for the person this publish acts as.",
+      logContext: {
+        reason: "member-without-author",
+        scopeSlug: input.scopeSlug,
+      },
+    });
+  }
+
+  // Per-locale release visibility is not built. `applyOne` refuses any member
+  // carrying a locale and its comment names schedule time as where that refusal
+  // belongs once a write surface exists — this is that surface, so this is that
+  // refusal. Accepting one here would persist a member guaranteed to fail.
+  if (input.locale !== null && input.locale !== undefined) {
+    throw NextlyError.invalidInput({
+      message:
+        "Per-locale releases are not supported: omit `locale` to schedule the whole document.",
+      logContext: {
+        reason: "locale-scoped-member",
+        scopeSlug: input.scopeSlug,
+        locale: input.locale,
       },
     });
   }

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -67,6 +67,15 @@ export type ReleaseAuthority = "read" | "create" | "publish";
 export const RELEASES_RESOURCE = "content-releases";
 
 /**
+ * The longest title every supported dialect can store.
+ *
+ * MySQL holds it in `varchar(255)`; PostgreSQL and SQLite use unbounded `text`.
+ * Stated once and enforced above the database so the narrowest engine defines
+ * the contract, rather than the contract depending on which engine is running.
+ */
+export const MAX_RELEASE_TITLE_LENGTH = 255;
+
+/**
  * Who is asking, and whether to ask at all.
  *
  * `overrideAccess` matches every other service in this package: the Direct API
@@ -205,6 +214,17 @@ export class ReleasesService {
     actor: ReleaseActor
   ): Promise<ReleaseRow> {
     await this.authorize(actor, "create");
+    // ONE limit, applied before the write, because the column is not one shape:
+    // `nextly_releases.title` is `varchar(255)` on MySQL and unbounded `text` on
+    // PostgreSQL and SQLite. Left to the database, the same call succeeds on two
+    // engines and either errors or silently TRUNCATES on the third — and a
+    // truncating write returns a row that disagrees with what is stored.
+    if (input.title.length > MAX_RELEASE_TITLE_LENGTH) {
+      throw NextlyError.invalidInput({
+        message: `\`title\` must be ${MAX_RELEASE_TITLE_LENGTH} characters or fewer.`,
+        logContext: { reason: "title-too-long", length: input.title.length },
+      });
+    }
     // `createdBy` comes from the ACTOR, never from the input. Materialisation
     // performs each member as its recorded author, so an author a caller could
     // name would be an identity they could borrow at a future instant.
@@ -275,6 +295,15 @@ export class ReleasesService {
         },
       });
     }
+    // Once a release is SCHEDULED, changing what is in it changes what goes
+    // live at an instant a publisher already committed to. The drain reads
+    // membership at the instant, not at scheduling time, so `create` alone
+    // would let a caller append content to a committed launch without ever
+    // passing the publish gate — the escalation this authority exists to
+    // prevent, arriving after the decision rather than before it.
+    if (parent.state === "scheduled") {
+      await this.authorize(actor, "publish");
+    }
 
     try {
       return await this.deps.repository.addMember({
@@ -318,6 +347,16 @@ export class ReleasesService {
     actor: ReleaseActor
   ): Promise<void> {
     await this.authorize(actor, "publish");
+    // An unusable instant is refused HERE rather than at the driver. A NaN date
+    // reaches timestamp encoding and fails differently per dialect, so the
+    // caller's mistake arrives as an opaque database error instead of the
+    // sentence naming it.
+    if (Number.isNaN(at.getTime())) {
+      throw NextlyError.invalidInput({
+        message: "`at` is not a valid instant.",
+        logContext: { reason: "invalid-schedule-instant", releaseId: id },
+      });
+    }
     // The fence answers `false` for a release whose current state forbids the
     // move — a published one, most importantly, because re-scheduling it makes
     // the drain re-apply members against documents that have changed since.

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -52,7 +52,19 @@ export interface VersionsWhere {
 export interface VersionsSelectOptions {
   columns?: string[];
   where?: VersionsWhere;
-  orderBy?: { column: string; direction?: "asc" | "desc" }[];
+  /**
+   * `nulls` is exposed because DEFAULT null ordering is dialect-dependent:
+   * PostgreSQL sorts nulls FIRST on a descending order while MySQL and SQLite
+   * sort them last. A "newest scheduled first" list containing unscheduled
+   * drafts therefore returns different rows per engine, and under a limit it can
+   * return only drafts and omit every scheduled release. The adapter has
+   * supported the control since it was written.
+   */
+  orderBy?: {
+    column: string;
+    direction?: "asc" | "desc";
+    nulls?: "first" | "last";
+  }[];
   limit?: number;
 }
 

--- a/packages/nextly/src/domains/versions/db-api.ts
+++ b/packages/nextly/src/domains/versions/db-api.ts
@@ -22,7 +22,15 @@ export interface VersionsWhereCondition {
   // the working draft (a non-autosave row with no version number) from reads
   // that assume a non-autosave row carries a sequence number. The adapter's
   // WhereOperator spells the set operator uppercase.
-  op: "=" | "!=" | "<" | "IN" | "IS NULL" | "IS NOT NULL";
+  // `>=` and `<=` power the releases window query — "scheduled between these
+  // two instants" — which a dashboard widget and a release index both ask with
+  // different bounds. Added rather than filtered in memory: the alternative is
+  // selecting every release and discarding most of it in JS, which is what
+  // `findDueReleases` does and is only tolerable there because it is already
+  // narrowed to `state = "scheduled"`. The adapter has supported both since
+  // `WHERE_OPERATORS` was written; this union was simply narrower than what it
+  // fronts, and widening a subset keeps the adapter assignable to this port.
+  op: "=" | "!=" | "<" | ">=" | "<=" | "IN" | "IS NULL" | "IS NOT NULL";
   // Matches the adapter's WhereCondition.value so the adapter and the
   // transaction context both structurally satisfy VersionsDbApi (a looser
   // `unknown` here breaks that assignability under method-parameter variance).


### PR DESCRIPTION
## The measurement this PR exists for

The releases engine has been complete since #1323 and reachable **only from inside the server process**. Measured on `main`, each with a control:

| | |
|---|---|
| Direct API namespaces | 11, **none for releases** |
| Dispatcher handlers | 10, **none for releases** |
| Route-parser references | **0** |
| Product callers of `addMember` | **0** (6 files match, all domain or its own tests) |
| Admin release UI files | **0** |

Nothing could create a release. That is why every remaining correctness gap in R-6 was unreachable — and it is one layer earlier than "the admin surfaces", which is where the plan had it.

**The permissions are the sharper version of the same problem.** `read-content-releases`, `create-content-releases` and `publish-content-releases` are seeded at `permission-seed-service.ts:286-303` and registered as a system resource — and are checked **nowhere**, because there was no service in which to check them. A permission with no surface is not a half-built feature; it is an invisible one.

## Three authorities, honoured rather than restated

The seed already states the split and `ReleasesService` follows it:

    read     → view releases and their members
    create   → create a release and choose what goes in it
    publish  → schedule or cancel, which is what makes content go live

`update` and `delete` are deliberately unseeded, so they are deliberately **absent** here. Renaming is filed under `create` because it is part of assembling a release; destroying one is a different power and waits for its own permission to arrive with the surface that checks it. Inventing either would teach the admin a vocabulary the server ignores.

Cancelling requires `publish`, not `create` — the seed says "schedule or cancel" outright, and someone who could cancel but not schedule could still silently stop a launch.

## Adding a document asks TWO questions

Holding `create-content-releases` says you may **assemble** a release. It never says you may publish the document you put into one — and a release is a deferred publish, so allowing that would be a privilege escalation with a delay on it.

Materialisation is already safe without this: `createJobContentApi` forces `overrideAccess: false`, binds the member's own author, and strips a caller-supplied override, so a member whose author may not publish simply fails when the release fires. **This check exists because failing *then* is a bad product** — the editor learns at the scheduled instant, with nobody watching, that their release did not go out. Refusing at add time is the same verdict delivered while it can still be acted on.

Both checks stay. They answer the question at two different instants, and the add-time one can go stale if access is revoked in between.

## Ordering, and what the tests assert

**Every write authorizes before it writes.** Each refusal test asserts both that the call is refused *and that the repository was never reached* — a refusal arriving after the insert is not a refusal, and nothing can un-write the row. That ordering is the one thing a partial-failure path cannot repair.

Assertions are on the error **code**, not on "it threw". That is not stylistic: one case here passed against a deliberately broken implementation because the call also throws for an unrelated reason (a fixture adapter with no `insert`). Measured, then tightened, then re-broken to confirm it now discriminates.

Break-verified:
- `authorize()` always allowing → 6 cases fail by name
- dropping only the document check → exactly the 2 document cases fail
- no-RBAC defaulting to allow instead of deny → the fail-closed case fails

## Two smaller things worth review attention

**`findReleases` is new.** The repository could find *due* releases and nothing else, so there was no way to list them at all. The caller supplies the window and the limit, because an index page and a dashboard widget ask the same question with different bounds — a second consumer has already asked for exactly that shape. `scheduledAt` is returned as a real `Date`, never a formatted string.

**`VersionsWhereCondition` gains `>=` and `<=`.** Additive, and the adapter has supported both since `WHERE_OPERATORS` was written — this union was simply narrower than what it fronts. The alternative was selecting every release and discarding most of it in JS, which is only tolerable in `findDueReleases` because that is already narrowed to `state = "scheduled"`.

There is no `offset`: the select port exposes `where`, `orderBy` and `limit`, and adding paging for a caller that does not exist yet would be guesswork. Keyset paging over `scheduledAt` is the shape the index page will want.

## Refusals are generic on purpose

`NextlyError.forbidden` has a fixed public message so a response cannot leak the shape of the authority model. The detail goes to `logContext`, distinguishing a missing *release* authority from a missing *document* one — otherwise an operator is sent to grant the wrong permission. The admin surface does not need to read the reason back: it knows the caller's capabilities, and the better product is to not offer an action the person cannot take.

## Verification

- `check-types` — 22/22
- `lint` — 24/24
- `pnpm --filter nextly test` — 811 files, 9968 passed, 42 skipped
- `fallow audit --gate new-only` — **verdict pass, 0 introduced** in all four categories
- changeset covers all 25 lockstep packages

Next in this sequence: the HTTP surface (dispatcher + route parser), then the admin surfaces.
