### PR TITLE
fix(nextly): scope the admin dashboard to what the caller may read

### DIFF
--- a/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
+++ b/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
@@ -65,7 +65,11 @@ Two behaviour changes are worth planning for:
   `admin.useAsTitle`) is now labelled with its id instead of rendering as
   `[object Object]`. An empty, boolean or date-valued title field falls through
   to the next candidate field and then to the id, where before it rendered as an
-  empty or nonsensical heading.
+  empty or nonsensical heading. That fallback chain now actually runs: the
+  recent-entries read selects the fallback fields (`title`, `name`) alongside
+  the collection's configured title field, where before they were silently
+  dropped by the projection and the chain could never do anything but return
+  the id.
 - The draft/published breakdown on `/stats` is now read through the same
   access-enforced count as the per-collection totals beside it, instead of a
   raw query over the whole table. A collection with an owner-only or custom

--- a/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
+++ b/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
@@ -66,6 +66,18 @@ Two behaviour changes are worth planning for:
   `[object Object]`. An empty, boolean or date-valued title field falls through
   to the next candidate field and then to the id, where before it rendered as an
   empty or nonsensical heading.
+- The draft/published breakdown on `/stats` is now read through the same
+  access-enforced count as the per-collection totals beside it, instead of a
+  raw query over the whole table. A collection with an owner-only or custom
+  stored read rule previously reported every author's draft/published split to
+  every reader who could open it at all, and that number disagreed with
+  `content.totalEntries` sitting next to it in the same response; the two now
+  always agree (`totalEntries === status.published + status.draft`). This also
+  fixes the breakdown never actually running for a collection with the
+  Draft/Published lifecycle enabled: it identified such a collection by
+  scanning its fields for one literally named `status`, but a field with that
+  name is REJECTED by config validation while the lifecycle is on, so every
+  lifecycle collection was silently treated as having no status at all.
 
 One failure mode is deliberately visible as an empty dashboard: if the
 permission lookup itself fails transiently, the dashboard answers HTTP 200 with

--- a/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
+++ b/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
@@ -45,7 +45,36 @@ whoever minted them. A deliberately narrowed key issued by a super-admin
 previously inherited that super-admin's reach on the dashboard endpoints; it
 now sees only the collections it was actually granted.
 
+What a caller may read is now decided by the ACCESS LAYER rather than inferred
+from the permission table's rows. A collection whose `access.read` rule refuses
+the caller is excluded even when a permission row would have admitted it — the
+dashboard now agrees with what `GET /api/collections/{slug}` answers. A
+collection authorized entirely in code, with no permission row at all, is
+included for the same reason. Per-collection entry counts are read with access
+enforced, so a collection with an owner-only or custom read rule now reports the
+number of rows the caller may actually see rather than every row in the table.
+
+Two behaviour changes are worth planning for:
+
+- A super-admin's activity feed is now bounded by the collections and settings
+  resources that currently exist. Activity rows naming a collection that has
+  since been removed from the config are no longer listed, and no longer
+  counted in the 24-hour figure.
+- A recently-edited entry whose title field holds a structured value (a `json`,
+  `group`, `repeater`, `component` or `chips` field named by
+  `admin.useAsTitle`) is now labelled with its id instead of rendering as
+  `[object Object]`. An empty, boolean or date-valued title field falls through
+  to the next candidate field and then to the id, where before it rendered as an
+  empty or nonsensical heading.
+
 One failure mode is deliberately visible as an empty dashboard: if the
 permission lookup itself fails transiently, the dashboard answers HTTP 200 with
 nothing in it rather than falling back to showing everything. An empty
 dashboard that should not be empty is worth investigating in the server logs.
+
+For anyone calling the Direct API: `nextly.count()` accepts a `status` option
+(`"published" | "draft" | "all"`), matching `nextly.find()`. Its absence is
+unchanged — an access-enforced count still defaults to published-only on a
+collection with the draft/publish lifecycle — but a caller that wants the same
+rows a `find({ status: "all" })` would return can now ask for them, and the two
+totals agree.

--- a/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
+++ b/.changeset/narrow-the-dashboard-to-what-the-caller-may-read.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The admin dashboard now shows only what the signed-in caller is permitted to
+read. Previously a caller holding NO read permissions was treated as having no
+filter at all, so the least-privileged account saw every collection; the
+activity feed applied no permission filter of any kind; and recent entries were
+read with hand-built SQL that bypassed access control entirely.
+
+Operators should expect restricted users to report an EMPTIER dashboard than
+before, and that is the fix rather than a regression. A user without read
+permission on a collection no longer sees its entry count, its draft/published
+breakdown, its recently-edited entries, or its activity-feed rows — including
+the entry titles, author names and author emails those rows carry. The
+"changes in the last 24 hours" figure is now counted over the same permitted
+collections instead of over every collection.
+
+API keys are judged on their OWN stamped grant rather than on the roles of
+whoever minted them. A deliberately narrowed key issued by a super-admin
+previously inherited that super-admin's reach on the dashboard endpoints; it
+now sees only the collections it was actually granted.
+
+One failure mode is deliberately visible as an empty dashboard: if the
+permission lookup itself fails transiently, the dashboard answers HTTP 200 with
+nothing in it rather than falling back to showing everything. An empty
+dashboard that should not be empty is worth investigating in the server logs.

--- a/docs/plugins/admin-ui.mdx
+++ b/docs/plugins/admin-ui.mdx
@@ -10,8 +10,9 @@ A plugin can extend the Nextly admin in two complementary ways:
 - **`admin`** (on the plugin definition) — *placement & appearance*: where the
   plugin's items sit in the sidebar and how they look (D20).
 
-Both are `@public`. Admin **dashboard widgets** (`PluginAdminWidget`, D22) are reserved
-but not yet rendered — they remain [`@experimental`](/docs/plugins/stability) until M8.
+Both are `@public`. Admin **dashboard widgets** (`PluginAdminWidget`, D22) are rendered
+on the admin dashboard today, but the contract remains
+[`@experimental`](/docs/plugins/stability) while its shape settles.
 
 ## Component paths
 
@@ -179,12 +180,7 @@ contributes: {
 [Permissions](/docs/plugins/permissions)). View override slots are `list`, `edit`,
 `beforeList`, `afterList`, `beforeEdit`, `afterEdit`.
 
-## Dashboard widgets (reserved)
-
-`contributes.admin.widgets` (D22) is a **forward-looking contract**: the `PluginAdminWidget`
-shape is published so plugin authors can design against it, but **widget rendering and the
-dashboard grid are deferred to a later milestone (M8)** — declaring widgets has **no effect
-yet**. It stays [`@experimental`](/docs/plugins/stability) until the dashboard ships.
+## Dashboard widgets
 
 ```ts
 contributes: {
@@ -201,8 +197,19 @@ contributes: {
 }
 ```
 
-Declaring widgets now is safe (it's validated but ignored); they'll light up when the
-dashboard lands. Everything else on this page is `@public` today.
+Widgets declared in `contributes.admin.widgets` are rendered on the admin dashboard by
+`PluginWidgetGrid`, in a 12-column grid, and hidden from users who lack
+`requiredPermission`.
+
+The contract is still `@experimental` and is expected to grow: a title, a declarative
+query, a size beyond `full`/`half`, and a per-instance config schema. Pin your Nextly
+version while it settles.
+
+`requiredPermission` gates whether the widget renders. It does **not** constrain the data
+your widget reads — fetch through the access-controlled API so a viewer only ever sees
+rows they may read.
+
+Everything else on this page is `@public` today.
 
 ## Placement & appearance
 

--- a/docs/plugins/api-reference.mdx
+++ b/docs/plugins/api-reference.mdx
@@ -49,7 +49,7 @@ interface PluginContributions {
     pages?:    PluginAdminPage[];              // { path, component, requiredPermission? }
     settings?: { component: ComponentPath };
     views?:    Record<string, PluginCollectionView>; // list/edit/before*/after* by collection slug
-    // widgets?: RESERVED (M8 / D58) — not rendered yet
+    widgets?:  PluginAdminWidget[];             // rendered on the dashboard; @experimental
   };
 }
 ```

--- a/docs/plugins/stability.mdx
+++ b/docs/plugins/stability.mdx
@@ -51,7 +51,7 @@ These ship today but carry no guarantee yet — use them, but expect change:
 - Filters & actions (D63): `ctx.filters` / `ctx.actions` + seam types
 - Secrets (D37): `secret`, `Secret`, `isSecret`
 - Client UX (`@nextlyhq/plugin-sdk/client`): `useCan`, `<Can>`
-- Admin dashboard widgets (`PluginAdminWidget`, D22 — reserved, not rendered until M8)
+- Admin dashboard widgets (`PluginAdminWidget`, D22 — rendered; shape still settling)
 - `contributes.events`, `dependsOn` / `optionalDependsOn`, `plugin.rename` (D54)
 
 Each graduates once a first-party plugin exercises it.

--- a/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
+++ b/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
@@ -70,6 +70,9 @@ vi.mock("../../services/lib/permissions", () => ({
 
 import { requireAuthentication } from "../../auth/middleware";
 import { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
+import { SETTINGS_ACTIVITY_NAMESPACES } from "../../domains/audit/settings-activity-namespaces";
+import { EMAIL_PROVIDER_ACTIVITY_COLLECTION } from "../../domains/email/provider-activity";
+import { EMAIL_TEMPLATE_ACTIVITY_COLLECTION } from "../../domains/email/template-activity";
 import {
   hasPermission,
   isSuperAdmin,
@@ -248,6 +251,8 @@ describe("the resolver no longer parses permission slugs", () => {
 
     await getDashboardStats(new Request("http://x/api/dashboard/stats"));
 
+    // The two settings namespaces are offered too and refused: the key holds
+    // no `read-email-providers` / `read-email-templates` grant.
     expect(scopeOf(getStats)).toEqual(new Set(["site-settings"]));
   });
 
@@ -280,13 +285,145 @@ describe("a super-admin session", () => {
     await getDashboardStats(new Request("http://x/api/dashboard/stats"));
 
     expect(scopeOf(getStats)).toEqual(
-      new Set(["posts", "pages", "site-settings"])
+      new Set([
+        "posts",
+        "pages",
+        "site-settings",
+        ...SETTINGS_ACTIVITY_NAMESPACES,
+      ])
     );
   });
 });
 
 describe("the resolver fails closed", () => {
-  it("admits nothing when the registries cannot be reached", async () => {
+  it("contributes no CONTENT entity when the registries cannot be reached", async () => {
+    // A degraded container must not widen the scope. The registries supply the
+    // collections and singles, so an unreachable registry costs exactly those;
+    // the settings namespaces are a compiled-in list rather than a registry
+    // read, so they still get a verdict and this caller holds their grants.
+    // An implementation that answered `all` on a registry error -- or that
+    // threw -- fails here.
+    containerGet.mockImplementation((name: string) => {
+      if (name === "dashboardService") return { getStats };
+      if (name === "rbacAccessControlService") return rbac;
+      throw new Error("registry unavailable");
+    });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats)).toEqual(new Set(SETTINGS_ACTIVITY_NAMESPACES));
+  });
+
+  it("admits nothing at all when the caller can be granted nothing", async () => {
+    asMock(hasPermission).mockResolvedValue(false);
+    containerGet.mockImplementation((name: string) => {
+      if (name === "dashboardService") return { getStats };
+      if (name === "rbacAccessControlService") return rbac;
+      throw new Error("registry unavailable");
+    });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats)).toEqual(new Set());
+  });
+});
+
+/**
+ * `activity_log.collection` is WIDER than the content registries.
+ *
+ * The column is a free string by design (`record-settings-activity`'s own
+ * docblock says so), and `recordSettingsActivity` files settings mutations under
+ * names that are neither a collection nor a single. Enumerating candidates from
+ * the two content registries alone therefore filtered those rows out of
+ * `/activity` and out of `recentChanges24h` for EVERY caller, super-admin
+ * included -- because the scope became an `IN (...)` over a list that never
+ * contained them.
+ *
+ * The failure this closes is not hypothetical. Rotating SMTP credentials writes
+ * `collection = "email-providers"` with `changedFields: ["host", "username",
+ * "password"]`, on the rows the audit module describes as holding "the
+ * credentials that send password-reset mail". That entry vanishing from the feed
+ * is a credential-change audit trail nobody can see.
+ *
+ * The decision procedure was never the problem: `canReadEntity("email-providers")`
+ * has a real answer, because `read-email-providers` is a SEEDED permission
+ * (resource `email-providers`, action `read`) that `routeHandler` already
+ * authorizes the provider list with. Only the candidate list was too narrow.
+ */
+describe("settings activity namespaces are offered for a decision", () => {
+  it("admits `email-providers` for a super-admin", async () => {
+    asMock(isSuperAdmin).mockResolvedValue(true);
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats).has(EMAIL_PROVIDER_ACTIVITY_COLLECTION)).toBe(
+      true
+    );
+  });
+
+  it("admits `email-templates` for a super-admin", async () => {
+    asMock(isSuperAdmin).mockResolvedValue(true);
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats).has(EMAIL_TEMPLATE_ACTIVITY_COLLECTION)).toBe(
+      true
+    );
+  });
+
+  it("refuses them for an editor holding no read grant on either", async () => {
+    // The positive control for the two above. Widening the candidate list must
+    // not widen the ANSWER: an implementation that appended the namespaces
+    // unconditionally, rather than offering them to `canReadEntity`, would pass
+    // the super-admin cases and fail here.
+    asMock(hasPermission).mockImplementation(
+      async (_userId: string, _action: string, resource: string) =>
+        !SETTINGS_ACTIVITY_NAMESPACES.includes(
+          resource as (typeof SETTINGS_ACTIVITY_NAMESPACES)[number]
+        )
+    );
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    const scope = scopeOf(getStats);
+    expect(scope.has(EMAIL_PROVIDER_ACTIVITY_COLLECTION)).toBe(false);
+    expect(scope.has(EMAIL_TEMPLATE_ACTIVITY_COLLECTION)).toBe(false);
+    // ...while a content collection the same caller DOES hold a grant on stays.
+    expect(scope.has("posts")).toBe(true);
+  });
+
+  it("admits one and refuses the other -- they are separate resources", async () => {
+    // The feed groups by this column precisely so a template edit and a
+    // credential change do not read as the same kind of event; the two
+    // permissions are seeded separately, so the scope must be able to split
+    // them rather than admitting or refusing the pair.
+    asMock(hasPermission).mockImplementation(
+      async (_userId: string, _action: string, resource: string) =>
+        resource !== EMAIL_TEMPLATE_ACTIVITY_COLLECTION
+    );
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    const scope = scopeOf(getStats);
+    expect(scope.has(EMAIL_PROVIDER_ACTIVITY_COLLECTION)).toBe(true);
+    expect(scope.has(EMAIL_TEMPLATE_ACTIVITY_COLLECTION)).toBe(false);
+  });
+
+  it("bounds /activity by them too -- that is the endpoint they exist for", async () => {
+    asMock(isSuperAdmin).mockResolvedValue(true);
+
+    await getDashboardActivity(new Request("http://x/api/dashboard/activity"));
+
+    expect(
+      scopeOf(getRecentActivity).has(EMAIL_PROVIDER_ACTIVITY_COLLECTION)
+    ).toBe(true);
+  });
+
+  it("still admits nothing when the registries are unreachable", async () => {
+    // Fail-closed is preserved: a settings namespace is a CANDIDATE, not a
+    // standing grant. It is offered for a decision like everything else, and a
+    // caller who can decide nothing gets nothing.
+    asMock(hasPermission).mockResolvedValue(false);
     containerGet.mockImplementation((name: string) => {
       if (name === "dashboardService") return { getStats };
       if (name === "rbacAccessControlService") return rbac;

--- a/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
+++ b/packages/nextly/src/api/__tests__/dashboard-read-scope.test.ts
@@ -1,0 +1,300 @@
+/**
+ * The dashboard's read scope must be the ACCESS LAYER's answer, not a re-read
+ * of the permission table's slugs.
+ *
+ * `api/dashboard.test.ts` covers the SHAPE of the scope — that a write grant
+ * confers no visibility, that an empty grant stays empty, that an API key is
+ * judged on its own stamped scope. Every one of those assertions is satisfied
+ * by a resolver that only ever looks at permission slugs, which is what this
+ * file exists to disprove.
+ *
+ * A collection may be authorized ENTIRELY in code:
+ *
+ *     defineCollection({ slug: "posts", access: { read: ctx => ... } })
+ *
+ * `checkAccess` consults that rule BEFORE it falls back to the stored grants,
+ * so a slug-only resolver answers a different question from the one the row
+ * read answers. Both directions are wrong and only one is visible: a rule that
+ * REFUSES a collection the caller holds `posts:read` for made `/stats` disclose
+ * that collection's count and `/activity` disclose its entry titles, user names
+ * and emails, while `GET /api/collections/posts` correctly returned 403.
+ *
+ * These tests therefore drive a REAL `RBACAccessControlService` with real
+ * registered access rules, and stub only the database reads underneath it.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { containerGet, containerHas, getStats, getRecentActivity } = vi.hoisted(
+  () => ({
+    containerGet: vi.fn(),
+    containerHas: vi.fn(),
+    getStats: vi.fn(),
+    getRecentActivity: vi.fn(),
+  })
+);
+
+// `api/dashboard` reads the container through `../di`, which re-exports it from
+// `../di/container` — the same specifier `auth/entity-read-access` imports. One
+// mock therefore serves both, and it has to: a resolver that consulted a
+// DIFFERENT container from the one the RBAC service is registered in would
+// silently deny everything and still look like a working scope.
+vi.mock("../../di/container", () => ({
+  container: { get: containerGet, has: containerHas },
+}));
+
+vi.mock("../../auth/middleware", () => ({
+  requireAuthentication: vi.fn(),
+  isErrorResponse: vi.fn(() => false),
+}));
+
+vi.mock("../../auth/middleware/to-nextly-error", () => ({
+  toNextlyAuthError: vi.fn((e: unknown) => new Error(String(e))),
+}));
+
+vi.mock("../../init", () => ({
+  getCachedNextly: vi.fn().mockResolvedValue(undefined),
+}));
+
+// The database underneath the access layer. `RBACAccessControlService` calls
+// these directly, so stubbing them is what makes a real service runnable in a
+// unit test — the registered code rules above them are NOT stubbed, because
+// they are the subject.
+vi.mock("../../services/lib/permissions", () => ({
+  isSuperAdmin: vi.fn(),
+  hasPermission: vi.fn(),
+  listEffectivePermissions: vi.fn(),
+  listRoleSlugsForUser: vi.fn(),
+  resolveRoleSlugs: vi.fn(),
+}));
+
+import { requireAuthentication } from "../../auth/middleware";
+import { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
+import {
+  hasPermission,
+  isSuperAdmin,
+  listEffectivePermissions,
+  listRoleSlugsForUser,
+  resolveRoleSlugs,
+} from "../../services/lib/permissions";
+import { getDashboardActivity, getDashboardStats } from "../dashboard";
+
+const asMock = (fn: unknown): ReturnType<typeof vi.fn> =>
+  fn as ReturnType<typeof vi.fn>;
+
+/** Two collections and one single, standing in for a real registry. */
+const COLLECTIONS = [{ slug: "posts" }, { slug: "pages" }];
+const SINGLES = [{ slug: "site-settings" }];
+
+let rbac: RBACAccessControlService;
+
+function scopeOf(spy: ReturnType<typeof vi.fn>): Set<string> {
+  const arg = spy.mock.calls[0]?.[0] as {
+    scope: { kind: string; resources?: Set<string> };
+  };
+  expect(arg.scope.kind).toBe("some");
+  return arg.scope.resources as Set<string>;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  rbac = new RBACAccessControlService();
+
+  containerHas.mockImplementation(
+    (name: string) => name === "rbacAccessControlService"
+  );
+  containerGet.mockImplementation((name: string) => {
+    switch (name) {
+      case "rbacAccessControlService":
+        return rbac;
+      case "collectionRegistryService":
+        return { getAllCollections: vi.fn().mockResolvedValue(COLLECTIONS) };
+      case "singleRegistryService":
+        return { getAllSingles: vi.fn().mockResolvedValue(SINGLES) };
+      case "dashboardService":
+        return { getStats };
+      case "activityLogService":
+        return { getRecentActivity };
+      default:
+        throw new Error(`unexpected container.get("${name}")`);
+    }
+  });
+
+  getStats.mockResolvedValue({});
+  getRecentActivity.mockResolvedValue({
+    activities: [],
+    total: 0,
+    hasMore: false,
+  });
+
+  // An ordinary editor, holding every stored read grant there is. The stored
+  // grants are deliberately PERMISSIVE so that anything this scope excludes was
+  // excluded by a code-defined rule and by nothing else.
+  asMock(requireAuthentication).mockResolvedValue({
+    userId: "alice",
+    authMethod: "session",
+    permissions: [],
+    roles: ["role-7"],
+  });
+  asMock(isSuperAdmin).mockResolvedValue(false);
+  asMock(hasPermission).mockResolvedValue(true);
+  asMock(listEffectivePermissions).mockResolvedValue([
+    "posts:read",
+    "pages:read",
+    "site-settings:read",
+  ]);
+  asMock(listRoleSlugsForUser).mockResolvedValue(["editor"]);
+  asMock(resolveRoleSlugs).mockResolvedValue(["editor"]);
+});
+
+describe("a code-defined access.read rule bounds the dashboard scope", () => {
+  it("excludes a collection the rule REFUSES, though the caller holds its read grant", async () => {
+    // The finding, exactly: `posts` is readable only by an auditor, Alice is an
+    // editor, and the permissions table still carries `posts:read` for her
+    // role. `GET /api/collections/posts` answers 403; `/stats` must agree.
+    rbac.registerCollectionAccess("posts", {
+      read: ctx => ctx.roles.includes("auditor"),
+    });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats).has("posts")).toBe(false);
+  });
+
+  it("keeps a collection the rule ALLOWS — the resolver must not just drop everything guarded", async () => {
+    // The positive control. Without it, an implementation that excluded every
+    // collection carrying any code rule would satisfy the assertion above.
+    rbac.registerCollectionAccess("posts", {
+      read: ctx => ctx.roles.includes("editor"),
+    });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats).has("posts")).toBe(true);
+  });
+
+  it("honours a boolean `read: false` the same way", async () => {
+    rbac.registerCollectionAccess("pages", { read: false });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    const scope = scopeOf(getStats);
+    expect(scope.has("pages")).toBe(false);
+    expect(scope.has("posts")).toBe(true);
+  });
+
+  it("admits a collection authorized ONLY in code, with no stored grant at all", async () => {
+    // The other direction of the same defect. A slug-only resolver drops a
+    // collection whose `read` rule allows it but whose row the permissions
+    // table says nothing about, so the dashboard under-reports what the caller
+    // can actually open.
+    asMock(hasPermission).mockResolvedValue(false);
+    asMock(listEffectivePermissions).mockResolvedValue([]);
+    rbac.registerCollectionAccess("posts", { read: true });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    const scope = scopeOf(getStats);
+    expect(scope.has("posts")).toBe(true);
+    // `pages` has no rule and no grant, so it must still be refused.
+    expect(scope.has("pages")).toBe(false);
+  });
+
+  it("applies the same rule to a SINGLE", async () => {
+    // `getRegisteredAccess` reads the collection and single maps alike, so a
+    // single resolves its own rules with no branch in the resolver.
+    rbac.registerSingleAccess("site-settings", { read: false });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats).has("site-settings")).toBe(false);
+  });
+
+  it("bounds /activity by the same decision", async () => {
+    // The endpoint that discloses entryTitle, userName and userEmail.
+    rbac.registerCollectionAccess("posts", { read: false });
+
+    await getDashboardActivity(new Request("http://x/api/dashboard/activity"));
+
+    expect(scopeOf(getRecentActivity).has("posts")).toBe(false);
+  });
+});
+
+describe("the resolver no longer parses permission slugs", () => {
+  it("does not consult listEffectivePermissions at all", async () => {
+    // `checkAccess` reaches the stored grants through `hasPermission`, which
+    // asks about ONE resource. `listEffectivePermissions` was the slug-parsing
+    // path's own source, and the access layer uses it only to build the context
+    // a code rule reads — never registered here, so it must go unused.
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(listEffectivePermissions).not.toHaveBeenCalled();
+    expect(hasPermission).toHaveBeenCalled();
+  });
+
+  it("keeps a hyphenated resource name whole without splitting anything", async () => {
+    // `read-site-settings` names `site-settings`. The old api-key branch had to
+    // strip the prefix by LENGTH to avoid yielding `site`; asking the access
+    // layer removes the parser and the subtlety together.
+    asMock(requireAuthentication).mockResolvedValue({
+      userId: "owner-1",
+      authMethod: "api-key",
+      permissions: ["read-site-settings"],
+      roles: ["viewer"],
+    });
+    asMock(resolveRoleSlugs).mockResolvedValue(["viewer"]);
+    // The owner is a super-admin. A key exists to carry LESS reach than that.
+    asMock(isSuperAdmin).mockResolvedValue(true);
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats)).toEqual(new Set(["site-settings"]));
+  });
+
+  it("still refuses an API key's slug when a code rule denies it", async () => {
+    asMock(requireAuthentication).mockResolvedValue({
+      userId: "owner-1",
+      authMethod: "api-key",
+      permissions: ["read-posts", "read-pages"],
+      roles: ["viewer"],
+    });
+    asMock(resolveRoleSlugs).mockResolvedValue(["viewer"]);
+    rbac.registerCollectionAccess("posts", {
+      read: ctx => ctx.roles.includes("auditor"),
+    });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats)).toEqual(new Set(["pages"]));
+  });
+});
+
+describe("a super-admin session", () => {
+  it("is granted every registered entity, by the access layer's own bypass", async () => {
+    // `checkAccess` short-circuits on `isSuperAdmin` before it reads any rule,
+    // so the resolver needs no super-admin branch of its own.
+    asMock(isSuperAdmin).mockResolvedValue(true);
+    asMock(hasPermission).mockResolvedValue(false);
+    rbac.registerCollectionAccess("posts", { read: false });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats)).toEqual(
+      new Set(["posts", "pages", "site-settings"])
+    );
+  });
+});
+
+describe("the resolver fails closed", () => {
+  it("admits nothing when the registries cannot be reached", async () => {
+    containerGet.mockImplementation((name: string) => {
+      if (name === "dashboardService") return { getStats };
+      if (name === "rbacAccessControlService") return rbac;
+      throw new Error("registry unavailable");
+    });
+
+    await getDashboardStats(new Request("http://x/api/dashboard/stats"));
+
+    expect(scopeOf(getStats)).toEqual(new Set());
+  });
+});

--- a/packages/nextly/src/api/authenticated-read.test.ts
+++ b/packages/nextly/src/api/authenticated-read.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Coverage for `readCaller`'s API-KEY branch, which had none.
+ *
+ * `readCaller` is the seam that decides whether an access rule judges a request
+ * on the KEY's own stamped grant or on the roles of whoever minted it. The
+ * conditional spread that builds `authenticatedScope` is the whole mechanism,
+ * and it is the kind that fails silently in both directions: dropped, a
+ * narrowly scoped key inherits its owner's reach; emitted for a session, a
+ * session caller is judged against an empty permission list and reads nothing.
+ * Neither raises an error -- the request succeeds and answers as somebody else.
+ *
+ * `resolveRoleSlugs` is mocked because it is a database lookup with nothing to
+ * connect to here; the assertions are about what `readCaller` ASSEMBLES from
+ * the auth context, which is the part that has no other coverage.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/lib/permissions", () => ({
+  resolveRoleSlugs: vi.fn(),
+}));
+
+import type { AuthContext } from "../auth/middleware";
+import { resolveRoleSlugs } from "../services/lib/permissions";
+
+import { readCaller } from "./authenticated-read";
+
+/** An API-key context: the user id is the key's OWNER, not the key. */
+function apiKeyAuth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    userId: "owner-1",
+    userName: "Owner",
+    userEmail: "owner@example.com",
+    permissions: ["read-posts"],
+    roles: ["viewer-of-posts"],
+    authMethod: "api-key",
+    apiKeyId: "key-1",
+    ...overrides,
+  };
+}
+
+function sessionAuth(overrides: Partial<AuthContext> = {}): AuthContext {
+  return {
+    userId: "user-1",
+    userName: "User",
+    userEmail: "user@example.com",
+    permissions: [],
+    roles: ["role-id-abc"],
+    authMethod: "session",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (resolveRoleSlugs as ReturnType<typeof vi.fn>).mockResolvedValue(["editor"]);
+});
+
+describe("readCaller for an API-KEY caller", () => {
+  it("carries the KEY's own stamped grant as `authenticatedScope`", async () => {
+    const caller = await readCaller(apiKeyAuth());
+
+    // `actorType: "apiKey"` is what makes `apiKeyScopeAllows` treat the scope
+    // as authoritative; any other value makes it return null and fall back to
+    // the OWNER's RBAC, which is the inheritance this branch exists to stop.
+    expect(caller.authenticatedScope).toEqual({
+      actorType: "apiKey",
+      permissions: ["read-posts"],
+    });
+  });
+
+  it("forwards the grant verbatim, in the `action-resource` spelling", async () => {
+    // API-key permissions are `permissions.slug` -- `${action}-${resource}` --
+    // not the `${resource}:${action}` form session RBAC builds. `readCaller`
+    // must not translate: `apiKeyScopeAllows` compares against
+    // `permissionSlug(operation, resource)`, which is the hyphen form.
+    const permissions = ["read-posts", "update-posts", "read-site-settings"];
+
+    const caller = await readCaller(apiKeyAuth({ permissions }));
+
+    expect(caller.authenticatedScope?.permissions).toEqual(permissions);
+  });
+
+  it("carries an EMPTY grant rather than omitting the scope", async () => {
+    // A role-based key whose role was deleted resolves to `[]`. Omitting the
+    // scope here would send the decision back to the owner's roles, so the
+    // least-privileged key would be judged as the most privileged owner.
+    const caller = await readCaller(apiKeyAuth({ permissions: [] }));
+
+    expect(caller.authenticatedScope).toEqual({
+      actorType: "apiKey",
+      permissions: [],
+    });
+  });
+
+  it("resolves role SLUGS onto the user rather than forwarding raw ids", async () => {
+    const caller = await readCaller(apiKeyAuth());
+
+    expect(resolveRoleSlugs).toHaveBeenCalledWith(apiKeyAuth());
+    expect(caller.user.roles).toEqual(["editor"]);
+    expect(caller.user.id).toBe("owner-1");
+  });
+});
+
+describe("readCaller for a SESSION caller", () => {
+  it("omits `authenticatedScope` entirely", async () => {
+    const caller = await readCaller(sessionAuth());
+
+    // Present-but-empty would be judged as an api-key with no grants and read
+    // nothing; absent is what sends the decision to the session's own RBAC.
+    expect(caller.authenticatedScope).toBeUndefined();
+    expect("authenticatedScope" in caller).toBe(false);
+  });
+
+  it("still builds the user context, so the caller is not anonymous", async () => {
+    // The control for the assertion above: `authenticatedScope` being absent
+    // must mean the branch declined it, not that `readCaller` returned an
+    // empty object. Without this, a `readCaller` that built nothing at all
+    // would satisfy the undefined check.
+    const caller = await readCaller(sessionAuth());
+
+    expect(caller.user).toMatchObject({
+      id: "user-1",
+      email: "user@example.com",
+      roles: ["editor"],
+      role: "editor",
+    });
+  });
+});

--- a/packages/nextly/src/api/authenticated-read.ts
+++ b/packages/nextly/src/api/authenticated-read.ts
@@ -15,12 +15,11 @@
  * @module api/authenticated-read
  */
 
-import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { buildUserContext } from "../auth/user-context";
-import type { UserContext } from "../domains/collections/services/collection-types";
+import type { ReadCaller } from "../services/dashboard/readable-resources";
 import { resolveRoleSlugs } from "../services/lib/permissions";
 
 /**
@@ -79,13 +78,23 @@ export async function authenticatedRead(
  * rather than on the roles of whoever minted it. Without it a narrowly scoped
  * key issued by a super-admin inherits the owner's reach.
  *
+ * The return type is the NAMED `ReadCaller` rather than an inline literal, and
+ * that annotation is what couples this function to its consumer. An inline
+ * shape only had to be assignable at each call site, and the property that
+ * matters is OPTIONAL: every caller passes the result as a variable rather than
+ * an object literal, so excess-property checking never applies, and renaming
+ * `authenticatedScope` here would compile everywhere. The dashboard service's
+ * conditional spread would then simply stop firing, and every API-key
+ * recent-entries read would be judged by the minter's roles -- the exact silent
+ * drop the `satisfies Pick<FindArgs<string>, "actor">` beside it exists to
+ * prevent. `ReadCaller` is declared in `readable-resources` because that is
+ * where the dashboard service reads it from; one declaration, two importers.
+ *
  * `versions-access` and `preview-links` each grew their own copy of this before
  * there was a shared one; they are left as they are, and new read endpoints
  * should call this.
  */
-export async function readCaller(
-  auth: AuthContext
-): Promise<{ user: UserContext; authenticatedScope?: AuthenticatedScope }> {
+export async function readCaller(auth: AuthContext): Promise<ReadCaller> {
   const roles = await resolveRoleSlugs(auth);
   const user = buildUserContext({
     claims: auth.claims,
@@ -96,13 +105,23 @@ export async function readCaller(
   });
   return {
     user,
+    // `satisfies` makes the field name a COMPILE-TIME boundary, and the
+    // return annotation alone does NOT: TypeScript exempts properties
+    // introduced by a SPREAD from excess-property checking, so
+    // `...(cond ? { authenticatedScopeTypo: ... } : {})` is assignable to
+    // `ReadCaller` and compiles clean. Every consumer then reads
+    // `caller.authenticatedScope` as `undefined` -- an API key silently judged
+    // by its minter's roles, with no error anywhere. `Required<Pick<...>>`
+    // rather than a bare `Pick` so a rename fails twice: once as an excess
+    // property, once as a missing one. `dashboard-service` applies the same
+    // pattern to `find()`'s `actor` for the same reason.
     ...(auth.authMethod === "api-key"
-      ? {
+      ? ({
           authenticatedScope: {
             actorType: "apiKey" as const,
             permissions: auth.permissions,
           },
-        }
+        } satisfies Required<Pick<ReadCaller, "authenticatedScope">>)
       : {}),
   };
 }

--- a/packages/nextly/src/api/authenticated-read.ts
+++ b/packages/nextly/src/api/authenticated-read.ts
@@ -15,6 +15,7 @@
  * @module api/authenticated-read
  */
 
+import type { ReadAccessCaller } from "../auth/entity-read-access";
 import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
@@ -123,5 +124,33 @@ export async function readCaller(auth: AuthContext): Promise<ReadCaller> {
           },
         } satisfies Required<Pick<ReadCaller, "authenticatedScope">>)
       : {}),
+  };
+}
+
+/**
+ * The same caller, in the shape an ENTITY-LEVEL read decision reads.
+ *
+ * Derived from {@link ReadCaller} rather than rebuilt from the `AuthContext`,
+ * and that is the whole point: `readCaller` has already resolved role IDs to
+ * slugs, and resolving them a second time is both an extra database read per
+ * request and a second chance to resolve them differently. One question, one
+ * resolution — the narrower view is derived from the richer one.
+ *
+ * `authenticatedScope` is present only for an API key, so its presence IS the
+ * auth method. Reading `actorType` rather than mere presence keeps that true if
+ * a future actor kind starts carrying a scope: a non-key actor must not be
+ * judged by `canReadEntity`'s api-key branch, which reads
+ * `permissions` as the key's own `{action}-{resource}` grants.
+ */
+export function readAccessCaller(caller: ReadCaller): ReadAccessCaller {
+  const isApiKey = caller.authenticatedScope?.actorType === "apiKey";
+  return {
+    userId: caller.user.id,
+    authMethod: isApiKey ? "api-key" : "session",
+    // A session caller carries none here on purpose: its grants are resolved
+    // from the database by `checkAccess`. Handing it the key vocabulary would
+    // answer "denied" for every check.
+    permissions: isApiKey ? (caller.authenticatedScope?.permissions ?? []) : [],
+    roles: caller.user.roles ?? [],
   };
 }

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -267,6 +267,7 @@ describe("dashboard read scope", () => {
     // appear: the handler carries the verdict, it does not re-decide it.
     expect(getStats).toHaveBeenCalledWith({
       scope: { kind: "some", resources: new Set(["posts"]) },
+      caller: expect.anything(),
     });
   });
 
@@ -283,6 +284,7 @@ describe("dashboard read scope", () => {
     // `some` admits nothing, and that is what must arrive.
     expect(getStats).toHaveBeenCalledWith({
       scope: { kind: "some", resources: new Set() },
+      caller: expect.anything(),
     });
   });
 
@@ -298,7 +300,35 @@ describe("dashboard read scope", () => {
 
     expect(getStats).toHaveBeenCalledWith({
       scope: { kind: "some", resources: new Set(REGISTERED) },
+      caller: expect.anything(),
     });
+  });
+
+  it("hands the service the SAME resolved caller it decided the scope with", async () => {
+    // The per-collection totals are read as this caller, so the scope and the
+    // counts have to describe one identity. Two resolutions would let the
+    // dashboard list a collection under one identity and count it under
+    // another, and nothing in the response would say so.
+    (requireAuthentication as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: "user-1",
+      authMethod: "session",
+      permissions: [],
+      roles: ["role-7"],
+    });
+    (resolveRoleSlugs as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "editor",
+    ]);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    serviceStub = { getStats };
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    expect(getStats).toHaveBeenCalledWith(
+      expect.objectContaining({
+        caller: { user: { id: "user-1", roles: ["editor"], role: "editor" } },
+      })
+    );
   });
 
   it("decides under the caller's RESOLVED identity, not the raw auth context", async () => {
@@ -442,6 +472,7 @@ describe("dashboard read scope for an API-KEY caller", () => {
 
     expect(getStats).toHaveBeenCalledWith({
       scope: { kind: "some", resources: new Set(["site-settings"]) },
+      caller: expect.anything(),
     });
   });
 

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -286,3 +286,137 @@ describe("dashboard activity scope", () => {
     );
   });
 });
+
+/**
+ * The api-key branch of `resolveReadableResources`.
+ *
+ * `auth.userId` for an API-key request is the key's OWNER, so authorizing by
+ * that id judges the key on the owner's roles rather than on the grant the key
+ * was actually minted with. The whole point of a narrowly scoped key is that it
+ * carries LESS reach than its owner, and a super-admin owner is where that gap
+ * is widest -- so every test here makes the owner a super-admin, because a test
+ * with an ordinary owner passes on the broken implementation too.
+ *
+ * The two permission vocabularies are not interchangeable and this is the seam
+ * where they meet. `listEffectivePermissions` (session RBAC) builds
+ * `${resource}:${action}` -- `posts:read`. An API key's `auth.permissions`
+ * carries the `permissions.slug` column, seeded as `${action}-${resource}` --
+ * `read-posts`. Reading either spelling with the other's parser yields an empty
+ * scope, which fails closed and therefore looks like a working deny rather than
+ * a broken read.
+ */
+describe("dashboard read scope for an API-KEY caller", () => {
+  /** A key whose OWNER is a super-admin, bearing the key's own narrow grant. */
+  function authenticateAsApiKey(permissions: string[]): void {
+    (requireAuthentication as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: "owner-1",
+      authMethod: "api-key",
+      permissions,
+      roles: ["viewer-of-posts"],
+      apiKeyId: "key-1",
+    });
+    // The owner really is a super-admin. If the handler authorizes by owner id
+    // this resolves true and the caller gets `all` -- the defect under test.
+    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+  }
+
+  it("scopes /stats to the KEY's grant, not the super-admin owner's roles", async () => {
+    authenticateAsApiKey(["read-posts"]);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set(["posts"]) },
+    });
+    // The owner's RBAC must not be consulted at all for an API key: the key's
+    // resolved set already reflects any super-admin bypass it was entitled to.
+    expect(listEffectivePermissions).not.toHaveBeenCalled();
+  });
+
+  it("scopes /activity to the KEY's grant, not the super-admin owner's roles", async () => {
+    authenticateAsApiKey(["read-posts"]);
+
+    const getRecentActivity = vi
+      .fn()
+      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      getRecentActivity,
+    });
+
+    await getDashboardActivity(
+      makeReq("http://localhost/api/dashboard/activity")
+    );
+
+    // Without this the response carries entryTitle, userName, userEmail and
+    // metadata for every collection the key holds no grant on.
+    expect(getRecentActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { kind: "some", resources: new Set(["posts"]) },
+      })
+    );
+  });
+
+  it("admits only `read-` slugs, so a write grant confers no visibility", async () => {
+    authenticateAsApiKey(["read-posts", "create-pages", "delete-orders"]);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set(["posts"]) },
+    });
+  });
+
+  it("keeps a hyphenated resource name whole", async () => {
+    // `read-site-settings` names the resource `site-settings`. A parser that
+    // splits on "-" and takes index 1 yields `site`, which matches no
+    // collection -- a silent empty dashboard that reads as a working deny.
+    authenticateAsApiKey(["read-site-settings"]);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set(["site-settings"]) },
+    });
+  });
+
+  it("admits nothing for a key whose grant is empty", async () => {
+    // A role-based key whose role was deleted resolves to `[]`. That must
+    // stay empty rather than widening to the owner's reach.
+    authenticateAsApiKey([]);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set() },
+    });
+  });
+
+  it("still grants everything to a SESSION super-admin -- the branch must not over-restrict", async () => {
+    (requireAuthentication as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: "user-1",
+      authMethod: "session",
+      permissions: [],
+      roles: ["super-admin"],
+    });
+    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    expect(getStats).toHaveBeenCalledWith({ scope: { kind: "all" } });
+  });
+});

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -45,6 +45,7 @@ vi.mock("../auth/entity-read-access", () => ({ readableEntities }));
 
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { container } from "../di";
+import { SETTINGS_ACTIVITY_NAMESPACES } from "../domains/audit/settings-activity-namespaces";
 import { resolveRoleSlugs } from "../services/lib/permissions";
 
 import {
@@ -57,8 +58,23 @@ function makeReq(url: string): Request {
   return new Request(url);
 }
 
-/** Two collections and one single, standing in for the real registries. */
-const REGISTERED = ["posts", "pages", "site-settings"];
+/**
+ * Every name the handler offers for a read decision.
+ *
+ * Two collections and one single from the stubbed registries, PLUS the settings
+ * activity namespaces, which are not registry-derived: `activity_log.collection`
+ * is a free string and `recordSettingsActivity` files entries under names that
+ * are neither a collection nor a single. Spliced from the exported list rather
+ * than spelled out, so a new namespace reaches this expectation the moment its
+ * writer registers one -- a literal here would leave the test agreeing with a
+ * handler that had gone stale.
+ */
+const CANDIDATES = [
+  "posts",
+  "pages",
+  "site-settings",
+  ...SETTINGS_ACTIVITY_NAMESPACES,
+];
 
 /**
  * The dashboard service (or activity log service) this test wants back.
@@ -203,7 +219,7 @@ describe("getDashboardRecentEntries", () => {
     // role-guarded collection silently returned zero rows.
     expect(getRecentEntries).toHaveBeenCalledWith(
       5,
-      { kind: "some", resources: new Set(REGISTERED) },
+      { kind: "some", resources: new Set(CANDIDATES) },
       { user: { id: "user-1", roles: ["editor"], role: "editor" } }
     );
   });
@@ -242,7 +258,7 @@ describe("getDashboardActivity", () => {
  * the way to the service.
  */
 describe("dashboard read scope", () => {
-  it("offers every registered entity for a decision -- singles as well as collections", async () => {
+  it("offers every candidate for a decision -- singles and settings namespaces too", async () => {
     // A single is an entity with its own `access` rules, and
     // `getRegisteredAccess` reads both maps. Omitting the single registry here
     // would leave every single permanently invisible on the dashboard, with no
@@ -252,7 +268,7 @@ describe("dashboard read scope", () => {
 
     await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
 
-    expect(offeredSlugs()).toEqual([...REGISTERED].sort());
+    expect(offeredSlugs()).toEqual([...CANDIDATES].sort());
   });
 
   it("forwards exactly what the access layer admitted, and nothing beside it", async () => {
@@ -299,7 +315,7 @@ describe("dashboard read scope", () => {
     await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
 
     expect(getStats).toHaveBeenCalledWith({
-      scope: { kind: "some", resources: new Set(REGISTERED) },
+      scope: { kind: "some", resources: new Set(CANDIDATES) },
       caller: expect.anything(),
     });
   });

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -33,7 +33,10 @@ vi.mock("../services/lib/permissions", () => ({
 
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { container } from "../di";
-import { isSuperAdmin } from "../services/lib/permissions";
+import {
+  isSuperAdmin,
+  listEffectivePermissions,
+} from "../services/lib/permissions";
 
 import {
   getDashboardActivity,
@@ -134,5 +137,56 @@ describe("getDashboardActivity", () => {
     const json = (await res.json()) as Record<string, unknown>;
     expect(json).not.toHaveProperty("data");
     expect(json).toEqual(result);
+  });
+});
+
+describe("dashboard read scope", () => {
+  it("asks the service for nothing when the caller holds no read permissions", async () => {
+    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue(
+      []
+    );
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    // The defect was that an empty permission set reached the service as
+    // "no filter" and returned every collection. The scope must arrive as an
+    // EMPTY `some`, which admits nothing.
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set() },
+    });
+  });
+
+  it("asks the service for everything when the caller is a super-admin", async () => {
+    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    expect(getStats).toHaveBeenCalledWith({ scope: { kind: "all" } });
+  });
+
+  it("passes only the readable resources through", async () => {
+    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "posts:read",
+      "posts:update",
+      "pages:update",
+    ]);
+
+    const getStats = vi.fn().mockResolvedValue({});
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    // `pages` is writable but not readable, so it must not appear.
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set(["posts"]) },
+    });
   });
 });

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -122,6 +122,43 @@ describe("getDashboardRecentEntries", () => {
     expect(json).not.toHaveProperty("data");
     expect(json).toEqual(entries);
   });
+
+  it("builds the caller from readCaller's RESOLVED slugs and forwards it as the third argument", async () => {
+    // Session auth carries role IDS on the auth context; `resolveRoleSlugs`
+    // is what turns those into the SLUGS a role-based access rule matches.
+    // The two are made deliberately different strings ("role-7" vs
+    // "editor") so this assertion can actually tell "the handler forwarded
+    // the resolved caller" apart from "the handler forwarded the raw auth
+    // context" -- if both were "editor" the test could not distinguish them.
+    (requireAuthentication as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: "user-1",
+      roles: ["role-7"],
+    });
+    (resolveRoleSlugs as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "editor",
+    ]);
+
+    const getRecentEntries = vi.fn().mockResolvedValue({ entries: [] });
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      getRecentEntries,
+    });
+
+    await getDashboardRecentEntries(
+      makeReq("http://x/api/dashboard/recent-entries?limit=5")
+    );
+
+    // The seam this task's whole security property runs through: had the
+    // handler built `{ user: { id: auth.userId, roles: auth.roles } }` by
+    // hand instead of calling `readCaller(auth)`, this would observe
+    // `roles: ["role-7"]` (the unresolved id) instead of `["editor"]`, and
+    // every test in the file would otherwise stay green while a
+    // role-guarded collection silently returned zero rows.
+    expect(getRecentEntries).toHaveBeenCalledWith(
+      5,
+      { kind: "all" },
+      { user: { id: "user-1", roles: ["editor"], role: "editor" } }
+    );
+  });
 });
 
 describe("getDashboardActivity", () => {

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -27,21 +27,25 @@ vi.mock("../di", () => ({
 }));
 
 vi.mock("../services/lib/permissions", () => ({
-  isSuperAdmin: vi.fn(),
-  listEffectivePermissions: vi.fn(),
   // `readCaller` (via `authenticated-read.ts`) resolves this to build the
   // caller it hands the dashboard service. Unmocked, it falls through to a
   // real database lookup that has nothing to connect to in this suite.
   resolveRoleSlugs: vi.fn(),
 }));
 
+// The scope's DECISION is `canReadEntity`'s, and
+// `__tests__/dashboard-read-scope.test.ts` drives the real one against a real
+// `RBACAccessControlService`. Stubbed here so these tests can assert the
+// handler's WIRING instead: which slugs it offers for a decision, under whose
+// resolved identity, and that the verdict reaches the service unchanged.
+const { readableEntities } = vi.hoisted(() => ({
+  readableEntities: vi.fn(),
+}));
+vi.mock("../auth/entity-read-access", () => ({ readableEntities }));
+
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { container } from "../di";
-import {
-  isSuperAdmin,
-  listEffectivePermissions,
-  resolveRoleSlugs,
-} from "../services/lib/permissions";
+import { resolveRoleSlugs } from "../services/lib/permissions";
 
 import {
   getDashboardActivity,
@@ -53,15 +57,59 @@ function makeReq(url: string): Request {
   return new Request(url);
 }
 
+/** Two collections and one single, standing in for the real registries. */
+const REGISTERED = ["posts", "pages", "site-settings"];
+
+/**
+ * The dashboard service (or activity log service) this test wants back.
+ *
+ * `container.get` now answers for the two registries as well, because the scope
+ * is resolved from the entities they list. A single `mockReturnValue` would
+ * hand the same object to every lookup, so the registries would answer with a
+ * service and the scope would silently come out empty -- which looks exactly
+ * like a working deny.
+ */
+let serviceStub: unknown = {};
+
+/** The slugs offered for a read decision, in the order they were offered. */
+function offeredSlugs(): string[] {
+  return [...((readableEntities.mock.calls[0]?.[0] as string[]) ?? [])].sort();
+}
+
+/** The identity the read decisions were taken under. */
+function decidingCaller(): Record<string, unknown> {
+  return readableEntities.mock.calls[0]?.[1] as Record<string, unknown>;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  // Default to authenticated super-admin so the success-path tests below
-  // can override only the bits they care about.
+  serviceStub = {};
+  (container.get as ReturnType<typeof vi.fn>).mockImplementation(
+    (name: string) => {
+      if (name === "collectionRegistryService") {
+        return {
+          getAllCollections: vi
+            .fn()
+            .mockResolvedValue([{ slug: "posts" }, { slug: "pages" }]),
+        };
+      }
+      if (name === "singleRegistryService") {
+        return {
+          getAllSingles: vi.fn().mockResolvedValue([{ slug: "site-settings" }]),
+        };
+      }
+      return serviceStub;
+    }
+  );
+  // Admits everything by default, so a test that cares about the scope states
+  // its own verdict and the rest are unaffected by it.
+  readableEntities.mockImplementation(
+    async (slugs: readonly string[]) => new Set(slugs)
+  );
   (requireAuthentication as ReturnType<typeof vi.fn>).mockResolvedValue({
     userId: "user-1",
   });
   (isErrorResponse as ReturnType<typeof vi.fn>).mockReturnValue(false);
-  (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
   (resolveRoleSlugs as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 });
 
@@ -83,9 +131,9 @@ describe("getDashboardStats", () => {
       singles: 0,
       apiKeys: 0,
     };
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+    serviceStub = {
       getStats: vi.fn().mockResolvedValue(stats),
-    });
+    };
 
     const res = await getDashboardStats(
       makeReq("http://x/api/dashboard/stats")
@@ -109,9 +157,9 @@ describe("getDashboardRecentEntries", () => {
         { id: "p1", collection: "posts", updatedAt: "2026-04-29T00:00:00Z" },
       ],
     };
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+    serviceStub = {
       getRecentEntries: vi.fn().mockResolvedValue(entries),
-    });
+    };
 
     const res = await getDashboardRecentEntries(
       makeReq("http://x/api/dashboard/recent-entries?limit=5")
@@ -139,9 +187,9 @@ describe("getDashboardRecentEntries", () => {
     ]);
 
     const getRecentEntries = vi.fn().mockResolvedValue({ entries: [] });
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+    serviceStub = {
       getRecentEntries,
-    });
+    };
 
     await getDashboardRecentEntries(
       makeReq("http://x/api/dashboard/recent-entries?limit=5")
@@ -155,7 +203,7 @@ describe("getDashboardRecentEntries", () => {
     // role-guarded collection silently returned zero rows.
     expect(getRecentEntries).toHaveBeenCalledWith(
       5,
-      { kind: "all" },
+      { kind: "some", resources: new Set(REGISTERED) },
       { user: { id: "user-1", roles: ["editor"], role: "editor" } }
     );
   });
@@ -168,9 +216,9 @@ describe("getDashboardActivity", () => {
       total: 1,
       hasMore: false,
     };
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+    serviceStub = {
       getRecentActivity: vi.fn().mockResolvedValue(result),
-    });
+    };
 
     const res = await getDashboardActivity(
       makeReq("http://x/api/dashboard/activity?limit=5")
@@ -183,77 +231,120 @@ describe("getDashboardActivity", () => {
   });
 });
 
+/**
+ * What the handler does with the access layer's answer.
+ *
+ * The DECISION itself belongs to `canReadEntity` and is driven for real, with a
+ * real `RBACAccessControlService` and real code-defined rules, in
+ * `__tests__/dashboard-read-scope.test.ts`. Everything here is about the wiring
+ * around it, which has its own ways of being wrong: offering the wrong SET of
+ * candidates, offering them under the wrong IDENTITY, or widening the verdict on
+ * the way to the service.
+ */
 describe("dashboard read scope", () => {
-  it("asks the service for nothing when the caller holds no read permissions", async () => {
-    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
-    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue(
-      []
-    );
-
+  it("offers every registered entity for a decision -- singles as well as collections", async () => {
+    // A single is an entity with its own `access` rules, and
+    // `getRegisteredAccess` reads both maps. Omitting the single registry here
+    // would leave every single permanently invisible on the dashboard, with no
+    // error to say so.
     const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+    serviceStub = { getStats };
 
     await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
 
-    // The defect was that an empty permission set reached the service as
-    // "no filter" and returned every collection. The scope must arrive as an
-    // EMPTY `some`, which admits nothing.
+    expect(offeredSlugs()).toEqual([...REGISTERED].sort());
+  });
+
+  it("forwards exactly what the access layer admitted, and nothing beside it", async () => {
+    readableEntities.mockResolvedValue(new Set(["posts"]));
+
+    const getStats = vi.fn().mockResolvedValue({});
+    serviceStub = { getStats };
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    // `pages` and `site-settings` were offered and refused, so they must not
+    // appear: the handler carries the verdict, it does not re-decide it.
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set(["posts"]) },
+    });
+  });
+
+  it("passes an EMPTY `some` through when the access layer admits nothing", async () => {
+    readableEntities.mockResolvedValue(new Set());
+
+    const getStats = vi.fn().mockResolvedValue({});
+    serviceStub = { getStats };
+
+    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+
+    // The original defect was an empty set reaching the service as "no
+    // filter", so the least-privileged caller got the most access. An empty
+    // `some` admits nothing, and that is what must arrive.
     expect(getStats).toHaveBeenCalledWith({
       scope: { kind: "some", resources: new Set() },
     });
   });
 
-  it("asks the service for everything when the caller is a super-admin", async () => {
-    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
-
+  it("never resolves an unbounded `all`, even when everything is admitted", async () => {
+    // The positive control for the two above: an implementation that answered
+    // `all` whenever nothing was refused would satisfy both of them, and would
+    // then let `recentChanges24h` count activity for collections that are no
+    // longer registered at all.
     const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+    serviceStub = { getStats };
 
     await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
 
-    expect(getStats).toHaveBeenCalledWith({ scope: { kind: "all" } });
+    expect(getStats).toHaveBeenCalledWith({
+      scope: { kind: "some", resources: new Set(REGISTERED) },
+    });
   });
 
-  it("passes only the readable resources through", async () => {
-    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
-    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue([
-      "posts:read",
-      "posts:update",
-      "pages:update",
+  it("decides under the caller's RESOLVED identity, not the raw auth context", async () => {
+    // Session auth carries role IDS; a role-based access rule matches SLUGS.
+    // The two strings are deliberately different so this can tell "the handler
+    // asked as the resolved caller" apart from "the handler forwarded the raw
+    // context" -- the second answers no for every role-guarded entity, silently.
+    (requireAuthentication as ReturnType<typeof vi.fn>).mockResolvedValue({
+      userId: "user-1",
+      authMethod: "session",
+      permissions: [],
+      roles: ["role-7"],
+    });
+    (resolveRoleSlugs as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "editor",
     ]);
 
-    const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+    serviceStub = { getStats: vi.fn().mockResolvedValue({}) };
 
     await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
 
-    // `pages` is writable but not readable, so it must not appear.
-    expect(getStats).toHaveBeenCalledWith({
-      scope: { kind: "some", resources: new Set(["posts"]) },
+    expect(decidingCaller()).toEqual({
+      userId: "user-1",
+      authMethod: "session",
+      // A session carries none: its grants are resolved from the database.
+      permissions: [],
+      roles: ["editor"],
     });
   });
 });
 
 describe("dashboard activity scope", () => {
-  it("scopes the activity feed to the caller's readable resources", async () => {
-    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
-    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue([
-      "posts:read",
-    ]);
+  it("scopes the activity feed to the entities the access layer admitted", async () => {
+    readableEntities.mockResolvedValue(new Set(["posts"]));
 
     const getRecentActivity = vi
       .fn()
       .mockResolvedValue({ activities: [], total: 0, hasMore: false });
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
-      getRecentActivity,
-    });
+    serviceStub = { getRecentActivity };
 
     await getDashboardActivity(
       makeReq("http://localhost/api/dashboard/activity")
     );
 
     // The defect was that no scope was passed at all, so every caller saw
-    // every collection's activity.
+    // every collection's activity -- entry titles, user names and emails.
     expect(getRecentActivity).toHaveBeenCalledWith(
       expect.objectContaining({
         scope: { kind: "some", resources: new Set(["posts"]) },
@@ -262,17 +353,12 @@ describe("dashboard activity scope", () => {
   });
 
   it("passes an EMPTY scope through rather than omitting it", async () => {
-    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
-    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue(
-      []
-    );
+    readableEntities.mockResolvedValue(new Set());
 
     const getRecentActivity = vi
       .fn()
       .mockResolvedValue({ activities: [], total: 0, hasMore: false });
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
-      getRecentActivity,
-    });
+    serviceStub = { getRecentActivity };
 
     await getDashboardActivity(
       makeReq("http://localhost/api/dashboard/activity")
@@ -288,22 +374,21 @@ describe("dashboard activity scope", () => {
 });
 
 /**
- * The api-key branch of `resolveReadableResources`.
+ * An API-KEY caller reaches the decision as the KEY, not as its owner.
  *
- * `auth.userId` for an API-key request is the key's OWNER, so authorizing by
- * that id judges the key on the owner's roles rather than on the grant the key
- * was actually minted with. The whole point of a narrowly scoped key is that it
- * carries LESS reach than its owner, and a super-admin owner is where that gap
- * is widest -- so every test here makes the owner a super-admin, because a test
- * with an ordinary owner passes on the broken implementation too.
+ * `auth.userId` for an API-key request is the key's OWNER, so a decision taken
+ * on that id alone judges the key by the owner's roles. The whole point of a
+ * narrowly scoped key is that it carries LESS reach than its owner, and a
+ * super-admin owner is where that gap is widest -- so the tests here make the
+ * owner a super-admin, because a test with an ordinary owner passes on the
+ * broken implementation too.
  *
- * The two permission vocabularies are not interchangeable and this is the seam
- * where they meet. `listEffectivePermissions` (session RBAC) builds
- * `${resource}:${action}` -- `posts:read`. An API key's `auth.permissions`
- * carries the `permissions.slug` column, seeded as `${action}-${resource}` --
- * `read-posts`. Reading either spelling with the other's parser yields an empty
- * scope, which fails closed and therefore looks like a working deny rather than
- * a broken read.
+ * `canReadEntity`'s api-key branch is what enforces it, and it reads
+ * `permissions` in the KEY's vocabulary: the `permissions.slug` column, seeded
+ * as `${action}-${resource}` -- `read-posts`. A session's grants are spelled
+ * `${resource}:${action}` and resolved from the database instead, so handing
+ * either branch the other's list answers "denied" for every check, which fails
+ * closed and reads as a working deny rather than as a broken read.
  */
 describe("dashboard read scope for an API-KEY caller", () => {
   /** A key whose OWNER is a super-admin, bearing the key's own narrow grant. */
@@ -315,71 +400,43 @@ describe("dashboard read scope for an API-KEY caller", () => {
       roles: ["viewer-of-posts"],
       apiKeyId: "key-1",
     });
-    // The owner really is a super-admin. If the handler authorizes by owner id
-    // this resolves true and the caller gets `all` -- the defect under test.
-    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    (resolveRoleSlugs as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "viewer-of-posts",
+    ]);
   }
 
-  it("scopes /stats to the KEY's grant, not the super-admin owner's roles", async () => {
-    authenticateAsApiKey(["read-posts"]);
+  it("takes the decision as the key, carrying the key's OWN stamped grant", async () => {
+    authenticateAsApiKey(["read-posts", "create-pages"]);
 
-    const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
-
-    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
-
-    expect(getStats).toHaveBeenCalledWith({
-      scope: { kind: "some", resources: new Set(["posts"]) },
-    });
-    // The owner's RBAC must not be consulted at all for an API key: the key's
-    // resolved set already reflects any super-admin bypass it was entitled to.
-    expect(listEffectivePermissions).not.toHaveBeenCalled();
-  });
-
-  it("scopes /activity to the KEY's grant, not the super-admin owner's roles", async () => {
-    authenticateAsApiKey(["read-posts"]);
-
-    const getRecentActivity = vi
-      .fn()
-      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
-      getRecentActivity,
-    });
-
-    await getDashboardActivity(
-      makeReq("http://localhost/api/dashboard/activity")
-    );
-
-    // Without this the response carries entryTitle, userName, userEmail and
-    // metadata for every collection the key holds no grant on.
-    expect(getRecentActivity).toHaveBeenCalledWith(
-      expect.objectContaining({
-        scope: { kind: "some", resources: new Set(["posts"]) },
-      })
-    );
-  });
-
-  it("admits only `read-` slugs, so a write grant confers no visibility", async () => {
-    authenticateAsApiKey(["read-posts", "create-pages", "delete-orders"]);
-
-    const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+    serviceStub = { getStats: vi.fn().mockResolvedValue({}) };
 
     await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
 
-    expect(getStats).toHaveBeenCalledWith({
-      scope: { kind: "some", resources: new Set(["posts"]) },
+    expect(decidingCaller()).toEqual({
+      userId: "owner-1",
+      authMethod: "api-key",
+      // Verbatim, unparsed. The prefix stripping that used to happen here is
+      // gone: `canReadEntity` tests membership of `read-{slug}` instead, so a
+      // hyphenated resource name needs no special handling to stay whole.
+      permissions: ["read-posts", "create-pages"],
+      roles: ["viewer-of-posts"],
     });
   });
 
-  it("keeps a hyphenated resource name whole", async () => {
-    // `read-site-settings` names the resource `site-settings`. A parser that
-    // splits on "-" and takes index 1 yields `site`, which matches no
-    // collection -- a silent empty dashboard that reads as a working deny.
+  it("offers a hyphenated slug for decision whole, never split", async () => {
+    // `read-site-settings` names `site-settings`. The old parser split on "-"
+    // and had to strip by LENGTH to avoid yielding `site`, which matches no
+    // entity -- a silent empty dashboard that reads as a working deny.
     authenticateAsApiKey(["read-site-settings"]);
+    readableEntities.mockImplementation(
+      async (slugs: readonly string[], caller: { permissions: string[] }) =>
+        new Set(
+          slugs.filter(slug => caller.permissions.includes(`read-${slug}`))
+        )
+    );
 
     const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+    serviceStub = { getStats };
 
     await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
 
@@ -388,35 +445,23 @@ describe("dashboard read scope for an API-KEY caller", () => {
     });
   });
 
-  it("admits nothing for a key whose grant is empty", async () => {
-    // A role-based key whose role was deleted resolves to `[]`. That must
-    // stay empty rather than widening to the owner's reach.
-    authenticateAsApiKey([]);
+  it("scopes /activity through the same decision", async () => {
+    authenticateAsApiKey(["read-posts"]);
+    readableEntities.mockResolvedValue(new Set(["posts"]));
 
-    const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
+    const getRecentActivity = vi
+      .fn()
+      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
+    serviceStub = { getRecentActivity };
 
-    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
+    await getDashboardActivity(
+      makeReq("http://localhost/api/dashboard/activity")
+    );
 
-    expect(getStats).toHaveBeenCalledWith({
-      scope: { kind: "some", resources: new Set() },
-    });
-  });
-
-  it("still grants everything to a SESSION super-admin -- the branch must not over-restrict", async () => {
-    (requireAuthentication as ReturnType<typeof vi.fn>).mockResolvedValue({
-      userId: "user-1",
-      authMethod: "session",
-      permissions: [],
-      roles: ["super-admin"],
-    });
-    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
-
-    const getStats = vi.fn().mockResolvedValue({});
-    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({ getStats });
-
-    await getDashboardStats(makeReq("http://localhost/api/dashboard/stats"));
-
-    expect(getStats).toHaveBeenCalledWith({ scope: { kind: "all" } });
+    expect(getRecentActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { kind: "some", resources: new Set(["posts"]) },
+      })
+    );
   });
 });

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -29,6 +29,10 @@ vi.mock("../di", () => ({
 vi.mock("../services/lib/permissions", () => ({
   isSuperAdmin: vi.fn(),
   listEffectivePermissions: vi.fn(),
+  // `readCaller` (via `authenticated-read.ts`) resolves this to build the
+  // caller it hands the dashboard service. Unmocked, it falls through to a
+  // real database lookup that has nothing to connect to in this suite.
+  resolveRoleSlugs: vi.fn(),
 }));
 
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
@@ -36,6 +40,7 @@ import { container } from "../di";
 import {
   isSuperAdmin,
   listEffectivePermissions,
+  resolveRoleSlugs,
 } from "../services/lib/permissions";
 
 import {
@@ -57,6 +62,7 @@ beforeEach(() => {
   });
   (isErrorResponse as ReturnType<typeof vi.fn>).mockReturnValue(false);
   (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+  (resolveRoleSlugs as ReturnType<typeof vi.fn>).mockResolvedValue([]);
 });
 
 describe("getDashboardStats", () => {

--- a/packages/nextly/src/api/dashboard.test.ts
+++ b/packages/nextly/src/api/dashboard.test.ts
@@ -190,3 +190,56 @@ describe("dashboard read scope", () => {
     });
   });
 });
+
+describe("dashboard activity scope", () => {
+  it("scopes the activity feed to the caller's readable resources", async () => {
+    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue([
+      "posts:read",
+    ]);
+
+    const getRecentActivity = vi
+      .fn()
+      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      getRecentActivity,
+    });
+
+    await getDashboardActivity(
+      makeReq("http://localhost/api/dashboard/activity")
+    );
+
+    // The defect was that no scope was passed at all, so every caller saw
+    // every collection's activity.
+    expect(getRecentActivity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { kind: "some", resources: new Set(["posts"]) },
+      })
+    );
+  });
+
+  it("passes an EMPTY scope through rather than omitting it", async () => {
+    (isSuperAdmin as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    (listEffectivePermissions as ReturnType<typeof vi.fn>).mockResolvedValue(
+      []
+    );
+
+    const getRecentActivity = vi
+      .fn()
+      .mockResolvedValue({ activities: [], total: 0, hasMore: false });
+    (container.get as ReturnType<typeof vi.fn>).mockReturnValue({
+      getRecentActivity,
+    });
+
+    await getDashboardActivity(
+      makeReq("http://localhost/api/dashboard/activity")
+    );
+
+    // The fail-closed branch. An omitted scope would let the service's own
+    // default decide, and a service default is exactly what went wrong in
+    // dashboard-service. The handler states it.
+    expect(getRecentActivity).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: { kind: "some", resources: new Set() } })
+    );
+  });
+});

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -25,6 +25,11 @@ import { getCachedNextly } from "../init";
 import type { ActivityLogService } from "../services/dashboard/activity-log-service";
 import type { DashboardService } from "../services/dashboard/dashboard-service";
 import {
+  allResources,
+  someResources,
+  type ReadableResources,
+} from "../services/dashboard/readable-resources";
+import {
   isSuperAdmin,
   listEffectivePermissions,
 } from "../services/lib/permissions";
@@ -48,17 +53,19 @@ async function getActivityLogService(): Promise<ActivityLogService> {
 }
 
 /**
- * Resolve the read-allowed resource set for a non-superadmin caller, or
- * `undefined` for a superadmin (which the dashboard service treats as
- * "no resource filter"). Centralized so each handler stays focused on its
- * own service call.
+ * Resolve what this caller may read.
+ *
+ * A super-admin gets `all`. Everyone else gets exactly the resources they hold
+ * a `:read` permission for -- INCLUDING the empty case, which admits nothing.
+ * `listEffectivePermissions` fails closed by returning `[]`, and this function
+ * preserves that rather than inverting it.
  */
 async function resolveReadableResources(
   userId: string
-): Promise<Set<string> | undefined> {
-  if (await isSuperAdmin(userId)) return undefined;
+): Promise<ReadableResources> {
+  if (await isSuperAdmin(userId)) return allResources();
   const permissionPairs = await listEffectivePermissions(userId);
-  return new Set(
+  return someResources(
     permissionPairs
       .filter(pair => pair.endsWith(":read"))
       .map(pair => pair.split(":")[0])
@@ -80,8 +87,8 @@ export const getDashboardStats = withErrorHandler(async (req: Request) => {
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
 
   const service = await getDashboardService();
-  const readableResources = await resolveReadableResources(auth.userId);
-  const stats = await service.getStats({ readableResources });
+  const scope = await resolveReadableResources(auth.userId);
+  const stats = await service.getStats({ scope });
 
   // Bare-object read: stats is the dashboard summary itself; no envelope.
   // Spread into a fresh literal so respondData's `Record<string, unknown>`
@@ -110,8 +117,8 @@ export const getDashboardRecentEntries = withErrorHandler(
       : 5;
 
     const service = await getDashboardService();
-    const readableResources = await resolveReadableResources(auth.userId);
-    const entries = await service.getRecentEntries(limit, readableResources);
+    const scope = await resolveReadableResources(auth.userId);
+    const entries = await service.getRecentEntries(limit, scope);
 
     // Service returns `{ entries: [...] }` (a named-field object). This is a
     // capped non-paginated read (no total / page / limit semantics), so the

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -158,7 +158,8 @@ export const getDashboardActivity = withErrorHandler(async (req: Request) => {
     : 5;
 
   const service = await getActivityLogService();
-  const result = await service.getRecentActivity({ limit });
+  const scope = await resolveReadableResources(auth.userId);
+  const result = await service.getRecentActivity({ limit, scope });
 
   // Cursor-shaped read: keep `hasMore` adjacent to `activities` and `total`.
   // Spread into a fresh literal so the response-shape generic accepts the

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -22,6 +22,7 @@ import { readableEntities } from "../auth/entity-read-access";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
+import { SETTINGS_ACTIVITY_NAMESPACES } from "../domains/audit/settings-activity-namespaces";
 import { getCachedNextly } from "../init";
 import type { ActivityLogService } from "../services/dashboard/activity-log-service";
 import type { DashboardService } from "../services/dashboard/dashboard-service";
@@ -51,16 +52,36 @@ async function getActivityLogService(): Promise<ActivityLogService> {
 }
 
 /**
- * Every entity the dashboard can describe: collections and singles alike.
+ * Every name the dashboard can describe, offered for a read decision.
  *
- * Read from the two registries the dashboard service itself reads, so the set
- * being authorized is the set that would be counted. A registry that cannot be
- * reached yields NOTHING rather than an unbounded list -- an empty scope admits
- * nothing, which is visible and reportable; the alternative is a dashboard that
- * widens when the container is degraded.
+ * Three sources, and the third is the one that is easy to miss. The two content
+ * registries give the collections and singles, so the set being authorized is
+ * the set that would be counted. But the scope also bounds `/activity` and
+ * `recentChanges24h`, which filter `activity_log.collection` -- and that column
+ * is a FREE STRING whose namespace is deliberately wider than the registries.
+ * `recordSettingsActivity` files settings mutations under names that are
+ * neither a collection nor a single, so enumerating from the registries alone
+ * removed every such row from the feed for every caller, super-admin included.
+ * Rotating SMTP credentials is one of those rows. See
+ * {@link SETTINGS_ACTIVITY_NAMESPACES}.
+ *
+ * Widening the CANDIDATES is not widening the answer: each name still goes to
+ * `canReadEntity`, and each settings namespace has a real verdict there because
+ * its `read-{name}` permission is seeded and already authorizes the
+ * corresponding settings route.
+ *
+ * The per-collection COUNTS are unaffected by the third source.
+ * `getRegisteredCollections` filters the registry list BY this scope, and
+ * `filterByResource` can only ever narrow it -- a name that is not in the
+ * registry cannot be added to it by appearing in the scope.
+ *
+ * A registry that cannot be reached contributes NOTHING rather than an
+ * unbounded list -- an empty scope admits nothing, which is visible and
+ * reportable; the alternative is a dashboard that widens when the container is
+ * degraded.
  */
 async function registeredEntitySlugs(): Promise<string[]> {
-  const slugs: string[] = [];
+  const slugs: string[] = [...SETTINGS_ACTIVITY_NAMESPACES];
   try {
     const collections = await container
       .get<{

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -18,6 +18,7 @@
  * @since 1.0.0
  */
 
+import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
@@ -53,19 +54,55 @@ async function getActivityLogService(): Promise<ActivityLogService> {
   return container.get<ActivityLogService>("activityLogService");
 }
 
+/** The `action-resource` prefix an API key's read grant is spelled with. */
+const API_KEY_READ_PREFIX = "read-";
+
 /**
  * Resolve what this caller may read.
  *
- * A super-admin gets `all`. Everyone else gets exactly the resources they hold
- * a `:read` permission for -- INCLUDING the empty case, which admits nothing.
- * `listEffectivePermissions` fails closed by returning `[]`, and this function
- * preserves that rather than inverting it.
+ * The AUTHENTICATION METHOD decides which grant is authoritative, so this takes
+ * the whole auth context rather than a bare user id. For an API key
+ * `auth.userId` is the key's OWNER, and a key exists precisely to carry less
+ * reach than that owner: a super-admin who mints a role-based key bound to a
+ * narrow role and hands it to an integration has deliberately narrowed it.
+ * Authorizing by owner id resolves `isSuperAdmin` to true and returns `all`,
+ * so the key reads every collection it holds no grant on. `collections-schema`
+ * branches the same way, for the same reason.
+ *
+ * The two paths also speak different permission vocabularies, and neither
+ * parser reads the other's spelling:
+ *
+ * - SESSION -- `listEffectivePermissions` builds `${resource}:${action}` from
+ *   the `permissions` table's own columns, so a read grant is `posts:read`.
+ * - API KEY -- `auth.permissions` carries the `permissions.slug` column, which
+ *   is seeded as `${action}-${resource}`, so the same grant is `read-posts`.
+ *
+ * The api-key branch strips the prefix by LENGTH rather than splitting on `-`,
+ * because a resource name may itself contain one: `read-site-settings` names
+ * `site-settings`, and splitting yields `site`, which matches no collection.
+ * That failure is silent -- it fails closed, so it reads as a working deny
+ * rather than as a parser that cannot see the resource.
+ *
+ * Both branches preserve the EMPTY case rather than inverting it into "no
+ * filter": `listEffectivePermissions` returns `[]` on any thrown error, and a
+ * role-based key whose role was deleted resolves to `[]` too.
  */
 async function resolveReadableResources(
-  userId: string
+  auth: AuthContext
 ): Promise<ReadableResources> {
-  if (await isSuperAdmin(userId)) return allResources();
-  const permissionPairs = await listEffectivePermissions(userId);
+  if (auth.authMethod === "api-key") {
+    // The key's own resolved set is the whole bound -- no super-admin bypass,
+    // because any super-admin reach the key was entitled to is already
+    // reflected in the set `resolveApiKeyPermissions` stamped onto it.
+    return someResources(
+      auth.permissions
+        .filter(slug => slug.startsWith(API_KEY_READ_PREFIX))
+        .map(slug => slug.slice(API_KEY_READ_PREFIX.length))
+    );
+  }
+
+  if (await isSuperAdmin(auth.userId)) return allResources();
+  const permissionPairs = await listEffectivePermissions(auth.userId);
   return someResources(
     permissionPairs
       .filter(pair => pair.endsWith(":read"))
@@ -88,7 +125,7 @@ export const getDashboardStats = withErrorHandler(async (req: Request) => {
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
 
   const service = await getDashboardService();
-  const scope = await resolveReadableResources(auth.userId);
+  const scope = await resolveReadableResources(auth);
   const stats = await service.getStats({ scope });
 
   // Bare-object read: stats is the dashboard summary itself; no envelope.
@@ -118,7 +155,7 @@ export const getDashboardRecentEntries = withErrorHandler(
       : 5;
 
     const service = await getDashboardService();
-    const scope = await resolveReadableResources(auth.userId);
+    const scope = await resolveReadableResources(auth);
     // The caller WHOLE, not an id: `readCaller` resolves role IDs to the
     // SLUGS a role-based access rule matches, and carries an API key's own
     // stamped scope separately so it is judged on that rather than on
@@ -164,7 +201,7 @@ export const getDashboardActivity = withErrorHandler(async (req: Request) => {
     : 5;
 
   const service = await getActivityLogService();
-  const scope = await resolveReadableResources(auth.userId);
+  const scope = await resolveReadableResources(auth);
   const result = await service.getRecentActivity({ limit, scope });
 
   // Cursor-shaped read: keep `hasMore` adjacent to `activities` and `total`.

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -138,10 +138,13 @@ export const getDashboardStats = withErrorHandler(async (req: Request) => {
 
   const service = await getDashboardService();
   // The caller WHOLE, not an id. `readCaller` resolves session role IDs to the
-  // SLUGS an access rule matches and carries an API key's own stamped scope.
+  // SLUGS an access rule matches and carries an API key's own stamped scope,
+  // and BOTH consumers read it: the scope resolution asks which entities are in
+  // reach, and the per-collection counts are then read AS this caller so the
+  // numbers describe rows it may actually see.
   const caller = await readCaller(auth);
   const scope = await resolveReadableResources(caller);
-  const stats = await service.getStats({ scope });
+  const stats = await service.getStats({ scope, caller });
 
   // Bare-object read: stats is the dashboard summary itself; no envelope.
   // Spread into a fresh literal so respondData's `Record<string, unknown>`

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -18,7 +18,7 @@
  * @since 1.0.0
  */
 
-import type { AuthContext } from "../auth/middleware";
+import { readableEntities } from "../auth/entity-read-access";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
@@ -26,16 +26,12 @@ import { getCachedNextly } from "../init";
 import type { ActivityLogService } from "../services/dashboard/activity-log-service";
 import type { DashboardService } from "../services/dashboard/dashboard-service";
 import {
-  allResources,
   someResources,
   type ReadableResources,
+  type ReadCaller,
 } from "../services/dashboard/readable-resources";
-import {
-  isSuperAdmin,
-  listEffectivePermissions,
-} from "../services/lib/permissions";
 
-import { readCaller } from "./authenticated-read";
+import { readAccessCaller, readCaller } from "./authenticated-read";
 import { respondData } from "./response-shapes";
 import { withErrorHandler } from "./with-error-handler";
 
@@ -54,60 +50,76 @@ async function getActivityLogService(): Promise<ActivityLogService> {
   return container.get<ActivityLogService>("activityLogService");
 }
 
-/** The `action-resource` prefix an API key's read grant is spelled with. */
-const API_KEY_READ_PREFIX = "read-";
+/**
+ * Every entity the dashboard can describe: collections and singles alike.
+ *
+ * Read from the two registries the dashboard service itself reads, so the set
+ * being authorized is the set that would be counted. A registry that cannot be
+ * reached yields NOTHING rather than an unbounded list -- an empty scope admits
+ * nothing, which is visible and reportable; the alternative is a dashboard that
+ * widens when the container is degraded.
+ */
+async function registeredEntitySlugs(): Promise<string[]> {
+  const slugs: string[] = [];
+  try {
+    const collections = await container
+      .get<{
+        getAllCollections: () => Promise<Array<{ slug: string }>>;
+      }>("collectionRegistryService")
+      .getAllCollections();
+    for (const collection of collections) slugs.push(String(collection.slug));
+  } catch {
+    // Unreachable registry: contribute nothing rather than guess.
+  }
+  try {
+    const singles = await container
+      .get<{
+        getAllSingles: () => Promise<Array<{ slug: string }>>;
+      }>("singleRegistryService")
+      .getAllSingles();
+    for (const single of singles) slugs.push(String(single.slug));
+  } catch {
+    // As above.
+  }
+  return slugs;
+}
 
 /**
- * Resolve what this caller may read.
+ * Resolve what this caller may read, by ASKING the access layer.
  *
- * The AUTHENTICATION METHOD decides which grant is authoritative, so this takes
- * the whole auth context rather than a bare user id. For an API key
- * `auth.userId` is the key's OWNER, and a key exists precisely to carry less
- * reach than that owner: a super-admin who mints a role-based key bound to a
- * narrow role and hands it to an integration has deliberately narrowed it.
- * Authorizing by owner id resolves `isSuperAdmin` to true and returns `all`,
- * so the key reads every collection it holds no grant on. `collections-schema`
- * branches the same way, for the same reason.
+ * The decision is `canReadEntity`'s, taken once per registered entity, because
+ * that is the only answer that agrees with what a row read will give. This used
+ * to derive the set from permission SLUGS -- filtering `read-{slug}` for a key
+ * and `{slug}:read` for a session -- and that is a second implementation of a
+ * decision `checkAccess` already makes, which was more permissive than the
+ * original in one direction and less in the other:
  *
- * The two paths also speak different permission vocabularies, and neither
- * parser reads the other's spelling:
+ * - A collection whose `access.read` REFUSES the caller still has the
+ *   `{slug}:read` row a slug filter admits it on, so `/stats` disclosed its
+ *   count and `/activity` its entry titles, user names and emails, while
+ *   `GET /api/collections/{slug}` correctly answered 403.
+ * - A collection authorized ENTIRELY in code has no permission row to find, so
+ *   a slug filter dropped a collection the caller can actually open.
  *
- * - SESSION -- `listEffectivePermissions` builds `${resource}:${action}` from
- *   the `permissions` table's own columns, so a read grant is `posts:read`.
- * - API KEY -- `auth.permissions` carries the `permissions.slug` column, which
- *   is seeded as `${action}-${resource}`, so the same grant is `read-posts`.
+ * Asking removes both, and with them the two hand-rolled parsers and their
+ * subtleties: there is no prefix to strip by length so that `read-site-settings`
+ * keeps naming `site-settings`, because nothing is parsed. There is no
+ * super-admin branch either -- `checkAccess` short-circuits on `isSuperAdmin`
+ * before it reads any rule, so the bypass arrives through the same call as
+ * everything else.
  *
- * The api-key branch strips the prefix by LENGTH rather than splitting on `-`,
- * because a resource name may itself contain one: `read-site-settings` names
- * `site-settings`, and splitting yields `site`, which matches no collection.
- * That failure is silent -- it fails closed, so it reads as a working deny
- * rather than as a parser that cannot see the resource.
- *
- * Both branches preserve the EMPTY case rather than inverting it into "no
- * filter": `listEffectivePermissions` returns `[]` on any thrown error, and a
- * role-based key whose role was deleted resolves to `[]` too.
+ * One consequence is deliberate and worth naming: a super-admin's scope is now
+ * the ENUMERATED set of registered entities rather than the unbounded `all`, so
+ * an `activity_log` row naming a collection that is no longer registered is
+ * filtered out. An unregistered slug has no rule and no registry entry to
+ * decide against, and admitting what cannot be judged is the inversion this
+ * whole endpoint was fixed to remove.
  */
 async function resolveReadableResources(
-  auth: AuthContext
+  caller: ReadCaller
 ): Promise<ReadableResources> {
-  if (auth.authMethod === "api-key") {
-    // The key's own resolved set is the whole bound -- no super-admin bypass,
-    // because any super-admin reach the key was entitled to is already
-    // reflected in the set `resolveApiKeyPermissions` stamped onto it.
-    return someResources(
-      auth.permissions
-        .filter(slug => slug.startsWith(API_KEY_READ_PREFIX))
-        .map(slug => slug.slice(API_KEY_READ_PREFIX.length))
-    );
-  }
-
-  if (await isSuperAdmin(auth.userId)) return allResources();
-  const permissionPairs = await listEffectivePermissions(auth.userId);
-  return someResources(
-    permissionPairs
-      .filter(pair => pair.endsWith(":read"))
-      .map(pair => pair.split(":")[0])
-  );
+  const slugs = await registeredEntitySlugs();
+  return someResources(await readableEntities(slugs, readAccessCaller(caller)));
 }
 
 /**
@@ -125,7 +137,10 @@ export const getDashboardStats = withErrorHandler(async (req: Request) => {
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
 
   const service = await getDashboardService();
-  const scope = await resolveReadableResources(auth);
+  // The caller WHOLE, not an id. `readCaller` resolves session role IDs to the
+  // SLUGS an access rule matches and carries an API key's own stamped scope.
+  const caller = await readCaller(auth);
+  const scope = await resolveReadableResources(caller);
   const stats = await service.getStats({ scope });
 
   // Bare-object read: stats is the dashboard summary itself; no envelope.
@@ -155,12 +170,12 @@ export const getDashboardRecentEntries = withErrorHandler(
       : 5;
 
     const service = await getDashboardService();
-    const scope = await resolveReadableResources(auth);
     // The caller WHOLE, not an id: `readCaller` resolves role IDs to the
     // SLUGS a role-based access rule matches, and carries an API key's own
     // stamped scope separately so it is judged on that rather than on
     // whoever minted it. See `getRecentFromCollection`'s use of it.
     const caller = await readCaller(auth);
+    const scope = await resolveReadableResources(caller);
     const entries = await service.getRecentEntries(limit, scope, caller);
 
     // Service returns `{ entries: [...] }` (a named-field object). This is a
@@ -201,7 +216,7 @@ export const getDashboardActivity = withErrorHandler(async (req: Request) => {
     : 5;
 
   const service = await getActivityLogService();
-  const scope = await resolveReadableResources(auth);
+  const scope = await resolveReadableResources(await readCaller(auth));
   const result = await service.getRecentActivity({ limit, scope });
 
   // Cursor-shaped read: keep `hasMore` adjacent to `activities` and `total`.

--- a/packages/nextly/src/api/dashboard.ts
+++ b/packages/nextly/src/api/dashboard.ts
@@ -34,6 +34,7 @@ import {
   listEffectivePermissions,
 } from "../services/lib/permissions";
 
+import { readCaller } from "./authenticated-read";
 import { respondData } from "./response-shapes";
 import { withErrorHandler } from "./with-error-handler";
 
@@ -118,7 +119,12 @@ export const getDashboardRecentEntries = withErrorHandler(
 
     const service = await getDashboardService();
     const scope = await resolveReadableResources(auth.userId);
-    const entries = await service.getRecentEntries(limit, scope);
+    // The caller WHOLE, not an id: `readCaller` resolves role IDs to the
+    // SLUGS a role-based access rule matches, and carries an API key's own
+    // stamped scope separately so it is judged on that rather than on
+    // whoever minted it. See `getRecentFromCollection`'s use of it.
+    const caller = await readCaller(auth);
+    const entries = await service.getRecentEntries(limit, scope, caller);
 
     // Service returns `{ entries: [...] }` (a named-field object). This is a
     // capped non-paginated read (no total / page / limit semantics), so the

--- a/packages/nextly/src/auth/entity-read-access.ts
+++ b/packages/nextly/src/auth/entity-read-access.ts
@@ -15,6 +15,7 @@
 
 import { container } from "../di/container";
 import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
+import { NextlyError } from "../errors/nextly-error";
 import type {
   AccessControlContext,
   CollectionAccessControl,
@@ -139,4 +140,97 @@ export async function canReadEntity(
   // the safe direction; the route-level gate has already run for any real
   // request that reaches a dispatcher handler.
   return false;
+}
+
+/**
+ * How many read decisions may be in flight at once.
+ *
+ * This bounds the cheap decision that PRECEDES a query rather than the queries
+ * themselves, and it exists for a different resource. {@link canReadEntity}
+ * resolves a session caller through `isSuperAdmin`, which is a per-user TTL
+ * cache: fired concurrently from a cold cache, every call misses before the
+ * first one populates it, so a site with a hundred entities opens a hundred
+ * simultaneous permission reads to answer one question a hundred times.
+ * Grouping them keeps the pool intact and lets the cache do its job.
+ */
+export const AUTHORIZATION_CONCURRENCY = 8;
+
+/**
+ * The order authorization decisions are taken in: one, then bounded groups.
+ *
+ * The lone first group is not a rounding artefact — it is the warm-up. The
+ * shared per-user caches (`isSuperAdmin`, and the role/permission reads behind
+ * it) are populated by whichever call resolves first, so letting one finish
+ * before the rest fan out converts N cold misses into one miss and N-1 hits.
+ * Fanning out immediately is what makes a cold cache expensive.
+ *
+ * Deliberately NOT a cap on how many entities are authorized. Every candidate
+ * still gets a decision, because one skipped without a verdict cannot be safely
+ * named as unconsulted (naming it discloses that it exists) nor safely omitted
+ * (that is the silent "nothing there" the callers of this exist to prevent).
+ * What is bounded here is concurrency, which is the resource that actually
+ * breaks.
+ */
+export function authorizationGroups(
+  slugs: readonly string[],
+  concurrency: number = AUTHORIZATION_CONCURRENCY
+): string[][] {
+  // A non-positive step never advances `i`, and a negative one walks it
+  // backwards: either spins forever on a non-empty list. Unreachable today —
+  // every caller takes the default — which is precisely what makes the guard
+  // cheap: it reads two values already in hand and its branch never runs.
+  //
+  // It THROWS rather than clamping because `concurrency` is a module constant
+  // no request can reach, so a bad one is a programming error;
+  // `INTERNAL_ERROR` is the honest classification, and the value travels in
+  // `logContext` where an operator can see it without it reaching the response.
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw NextlyError.internal({
+      logContext: {
+        concurrency,
+        reason: "authorization concurrency must be a positive integer",
+      },
+    });
+  }
+  if (slugs.length === 0) return [];
+  const groups: string[][] = [[slugs[0]]];
+  const rest = slugs.slice(1);
+  for (let i = 0; i < rest.length; i += concurrency) {
+    groups.push(rest.slice(i, i + concurrency));
+  }
+  return groups;
+}
+
+/**
+ * Which of `slugs` this caller may read, decided one entity at a time.
+ *
+ * The decision is {@link canReadEntity}'s, taken per entity, because that is
+ * the only thing that agrees with what a row read will answer. Deriving the set
+ * from permission SLUGS instead — filtering `read-{slug}` or `{slug}:read` —
+ * looks equivalent and is not: `checkAccess` resolves a code-defined
+ * `access.read` BEFORE it falls back to the stored grants, so a collection
+ * authorized purely in code has no permission row to find, and one REFUSED in
+ * code still has the row that a slug filter would admit it on.
+ *
+ * Coarse only in WHAT it decides — whether an entity is in reach at all. The
+ * per-row rules of whatever query follows still decide which documents come
+ * back.
+ */
+export async function readableEntities(
+  slugs: readonly string[],
+  caller: ReadAccessCaller
+): Promise<Set<string>> {
+  const allowed = new Set<string>();
+  for (const group of authorizationGroups(slugs)) {
+    const verdicts = await Promise.all(
+      group.map(async slug => ({
+        slug,
+        allowed: await canReadEntity(slug, caller),
+      }))
+    );
+    for (const verdict of verdicts) {
+      if (verdict.allowed) allowed.add(verdict.slug);
+    }
+  }
+  return allowed;
 }

--- a/packages/nextly/src/direct-api/__tests__/collections.test.ts
+++ b/packages/nextly/src/direct-api/__tests__/collections.test.ts
@@ -503,6 +503,25 @@ describe("Direct API - Collection Operations", () => {
       );
     });
 
+    it("should forward the lifecycle scope to the service", async () => {
+      // The option is only worth having if it ARRIVES: an accepted argument
+      // that is dropped between the namespace and the service leaves an
+      // untrusted count silently answering `published` only, while the call
+      // site reads as though it asked for everything.
+      mocks.collectionsHandler.countEntries.mockResolvedValue({
+        success: true,
+        statusCode: 200,
+        message: "OK",
+        data: { totalDocs: 9 },
+      });
+
+      await nextly.count({ collection: "posts", status: "all" });
+
+      expect(mocks.collectionsHandler.countEntries).toHaveBeenCalledWith(
+        expect.objectContaining({ collectionName: "posts", status: "all" })
+      );
+    });
+
     it("should throw on failure", async () => {
       mocks.collectionsHandler.countEntries.mockResolvedValue({
         success: false,

--- a/packages/nextly/src/direct-api/namespaces/collections.ts
+++ b/packages/nextly/src/direct-api/namespaces/collections.ts
@@ -407,6 +407,9 @@ export async function count(
     // From `args`, never `config` -- same reason as `find`: an inheritable
     // exemption would reach nested reads a caller's own `where` travels into.
     frameworkFilter: args.frameworkFilter,
+    // Lifecycle scope, from `args` exactly as `find` takes it, so a count and
+    // the list beside it describe the same rows.
+    status: args.status,
     ...accessOptions(config),
     // i18n M4: parity with find() so locale-scoped counts match.
     locale: config.locale,

--- a/packages/nextly/src/direct-api/types/collections.ts
+++ b/packages/nextly/src/direct-api/types/collections.ts
@@ -395,6 +395,18 @@ export interface CountArgs<TSlug extends CollectionSlug = CollectionSlug>
    * looser.
    */
   frameworkFilter?: true;
+
+  /**
+   * As {@link FindArgs.status}, and present for the same reason a count mirrors
+   * every other one of `find`'s filters: the total has to describe the rows a
+   * list would return. Without it an untrusted count silently answers
+   * `published` only -- `resolveStatusFilter`'s default for a caller that
+   * states nothing -- so `count()` and `find({ status: "all" }).meta.total`
+   * disagree about one collection, and neither says why.
+   *
+   * The query service has always accepted this; only the Direct API dropped it.
+   */
+  status?: "published" | "draft" | "all";
 }
 
 /**

--- a/packages/nextly/src/domains/audit/record-activity.ts
+++ b/packages/nextly/src/domains/audit/record-activity.ts
@@ -17,6 +17,7 @@
 import type { RequestActor } from "../../auth/request-actor";
 import { container } from "../../di/container";
 import type { NextlyServiceConfig } from "../../di/register";
+import { entryHeading } from "../../lib/entry-heading";
 import type {
   ActivityLogAction,
   ActivityLogService,
@@ -92,32 +93,27 @@ function collectionViews(): CollectionViews {
 }
 
 /**
- * The heading shown for an entry in the feed, in descending preference:
- * the collection's configured title field, then a `title` or `name` field,
- * then the id.
+ * The heading recorded for an entry in the feed.
+ *
+ * The WALK is shared with the dashboard's recent-entries list (`lib/entry-heading`)
+ * because both answer the same question about the same fields; only the source
+ * of the title field differs, which is what this resolves. Two walks would
+ * disagree about which entry is which depending on where you read it.
  *
  * Denormalized on purpose. The feed outlives the entry it names, so resolving
  * the heading at read time would leave a deleted entry's row unlabelled — the
  * one entry whose label the reader can no longer recover any other way.
  */
-function entryHeading(
+function feedHeading(
   collection: string,
   data: Record<string, unknown>,
   entryId: string | undefined
 ): string | undefined {
-  const titleField = collectionViews().titleFields.get(collection);
-  const candidates = [
-    titleField ? data[titleField] : undefined,
-    data.title,
-    data.name,
-  ];
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.length > 0) return candidate;
-    if (typeof candidate === "number" || typeof candidate === "bigint") {
-      return String(candidate);
-    }
-  }
-  return entryId;
+  return entryHeading(
+    data,
+    collectionViews().titleFields.get(collection),
+    entryId
+  );
 }
 
 /**
@@ -208,7 +204,7 @@ export async function recordMutationActivity(
     collection: input.collection,
     ...(input.entryId !== undefined ? { entryId: input.entryId } : {}),
     ...(() => {
-      const heading = entryHeading(input.collection, input.data, input.entryId);
+      const heading = feedHeading(input.collection, input.data, input.entryId);
       return heading !== undefined ? { entryTitle: heading } : {};
     })(),
     ...(metadata !== undefined ? { metadata } : {}),

--- a/packages/nextly/src/domains/audit/settings-activity-namespaces.ts
+++ b/packages/nextly/src/domains/audit/settings-activity-namespaces.ts
@@ -1,0 +1,51 @@
+/**
+ * The `activity_log.collection` values that name a SETTINGS resource.
+ *
+ * `activity_log.collection` is a free string, deliberately — see
+ * {@link recordSettingsActivity}, whose docblock explains that a settings
+ * resource gets a name of the same shape as a content collection rather than a
+ * second trail with its own reader. The consequence is that the column's
+ * namespace is WIDER than the union of the collection and single registries,
+ * and anything enumerating candidates from those two registries alone is
+ * enumerating a subset of what the column actually holds.
+ *
+ * That subset is not a safe default. A reader that filters
+ * `collection IN (...)` over it drops every settings entry for every caller,
+ * super-admin included — and these are the entries worth keeping most. Rotating
+ * SMTP credentials records `collection = "email-providers"` with
+ * `changedFields: ["host", "username", "password"]` against the rows that send
+ * password-reset mail. Losing that is losing a credential-change audit trail.
+ *
+ * So the namespaces are named here, once, composed from the constants their own
+ * writers already export rather than restated as literals — a second spelling
+ * of `"email-providers"` is exactly how a reader and a writer drift apart
+ * silently.
+ *
+ * This is a list of CANDIDATES, never of grants. Every consumer still asks
+ * `canReadEntity` per name, and each has a real answer: `read-email-providers`
+ * and `read-email-templates` are seeded permissions (`permission-seed-service`)
+ * that `routeHandler` already authorizes the corresponding settings routes
+ * with. Appending a name here widens what may be CONSIDERED, never what is
+ * allowed.
+ *
+ * A new `recordSettingsActivity` caller belongs in this list. It is deliberately
+ * in the audit domain, beside the writer that creates the namespace, so that a
+ * new writer and the readers of its rows are one file apart.
+ *
+ * @module domains/audit/settings-activity-namespaces
+ */
+
+import { EMAIL_PROVIDER_ACTIVITY_COLLECTION } from "../email/provider-activity";
+import { EMAIL_TEMPLATE_ACTIVITY_COLLECTION } from "../email/template-activity";
+
+/**
+ * Every non-content `activity_log.collection` a production writer emits.
+ *
+ * `as const` so a consumer can narrow against the union rather than against
+ * `string`, and so an accidental mutation is a type error rather than a
+ * scope that grows at runtime.
+ */
+export const SETTINGS_ACTIVITY_NAMESPACES = [
+  EMAIL_PROVIDER_ACTIVITY_COLLECTION,
+  EMAIL_TEMPLATE_ACTIVITY_COLLECTION,
+] as const;

--- a/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
+++ b/packages/nextly/src/domains/i18n/services/translation-worklist-service.ts
@@ -39,7 +39,6 @@
  * @module domains/i18n/services/translation-worklist-service
  */
 
-import { NextlyError } from "../../../errors/nextly-error";
 import { resolveLocalizedFieldNames } from "../classify-fields";
 import type { TranslationFilterState } from "../companion-join";
 
@@ -152,67 +151,17 @@ export function worklistTotalPages(total: number, limit: number): number {
 }
 
 /**
- * How many authorization decisions may be in flight at once.
+ * How many authorization decisions may be in flight at once, and the order they
+ * are taken in.
  *
- * The cap above bounds QUERIES; this bounds the far cheaper decision that
- * precedes them, and it exists for a different resource. `canReadEntity`
- * resolves a session caller through `isSuperAdmin`, which is a per-user TTL
- * cache: fired concurrently from a cold cache, every call misses before the
- * first one populates it, so a site with a hundred localized collections opens
- * a hundred simultaneous permission reads to answer one question a hundred
- * times. Grouping them keeps the pool intact and lets the cache do its job.
+ * Both live beside {@link canReadEntity} — the function whose per-user caches
+ * they exist to protect — and are re-exported here because this fan-out was
+ * their first caller and its tests name them at this path.
  */
-export const AUTHORIZATION_CONCURRENCY = 8;
-
-/**
- * The order authorization decisions are taken in: one, then bounded groups.
- *
- * The lone first group is not a rounding artefact — it is the warm-up. The
- * shared per-user caches (`isSuperAdmin`, and the role/permission reads behind
- * it) are populated by whichever call resolves first, so letting one finish
- * before the rest fan out converts N cold misses into one miss and N-1 hits.
- * Fanning out immediately is what makes a cold cache expensive.
- *
- * Deliberately NOT a cap on how many collections are authorized. Every
- * candidate still gets a decision, because a collection that is skipped without
- * one cannot be safely named as unconsulted (naming it discloses that it
- * exists) nor safely omitted (that is the silent "nothing to do there" this
- * endpoint exists to prevent). What is bounded here is concurrency, which is
- * the resource that actually breaks.
- */
-export function authorizationGroups(
-  slugs: readonly string[],
-  concurrency: number = AUTHORIZATION_CONCURRENCY
-): string[][] {
-  // A non-positive step never advances `i`, and a negative one walks it
-  // backwards: either spins forever on a non-empty list. Unreachable today —
-  // the only caller takes the default — which is precisely what makes the guard
-  // cheap: it reads two values already in hand and its branch never runs.
-  //
-  // It THROWS where `worklistTotalPages` returns a safe value for the same
-  // shape of bad input, and the difference is where the value comes from.
-  // `limit` is a request parameter, clamped upstream, so a caller can put a
-  // zero in front of it and refusing there would be a 500 for a request the
-  // system chose to accept. `concurrency` is a module constant no request can
-  // reach, so a bad one is a programming error — `INTERNAL_ERROR` is the honest
-  // classification, and the value travels in `logContext` where an operator can
-  // see it without it reaching the response.
-  if (!Number.isInteger(concurrency) || concurrency < 1) {
-    throw NextlyError.internal({
-      logContext: {
-        concurrency,
-        reason: "authorization concurrency must be a positive integer",
-      },
-    });
-  }
-  if (slugs.length === 0) return [];
-  const groups: string[][] = [[slugs[0]]];
-  const rest = slugs.slice(1);
-  for (let i = 0; i < rest.length; i += concurrency) {
-    groups.push(rest.slice(i, i + concurrency));
-  }
-  return groups;
-}
+export {
+  AUTHORIZATION_CONCURRENCY,
+  authorizationGroups,
+} from "../../../auth/entity-read-access";
 
 /** One document's outstanding work in one language. */
 export interface TranslationWorkRow {

--- a/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
+++ b/packages/nextly/src/domains/users/__tests__/user-delete-audit-erasure.integration.test.ts
@@ -41,6 +41,7 @@ import {
 } from "../../../schemas/users/sqlite";
 import { nextlyEvents as eventsSqlite } from "../../../schemas/webhooks/sqlite";
 import { ActivityLogService } from "../../../services/dashboard/activity-log-service";
+import { allResources } from "../../../services/dashboard/readable-resources";
 import { UserMutationService } from "../services/user-mutation-service";
 
 const TEST_DB_DIR = join(
@@ -409,8 +410,13 @@ describe("deleting a user erases them from the activity log without erasing the 
       entryTitle: "Before Deletion",
     });
 
+    // This suite exercises the erasure identity mechanism, not permission
+    // scoping, so it asks for every resource explicitly -- an omitted scope
+    // now fails closed and would return nothing, which is the correct
+    // behaviour for a real caller but not what this assertion is about.
     const live = await activity.getRecentActivity({
       userId: String(author.id),
+      scope: allResources(),
     });
     expect(live.activities).toHaveLength(1);
     // The premise: every field the admin renders survives the mapping.
@@ -423,6 +429,7 @@ describe("deleting a user erases them from the activity log without erasing the 
 
     const erased = await activity.getRecentActivity({
       userId: String(author.id),
+      scope: allResources(),
     });
     expect(erased.activities).toHaveLength(1);
     expect(erased.activities[0].userName).toBeNull();
@@ -464,6 +471,7 @@ describe("deleting a user erases them from the activity log without erasing the 
 
     const feed = await activity.getRecentActivity({
       userId: String(author.id),
+      scope: allResources(),
     });
     expect(feed.activities.map(a => a.entryTitle)).toEqual(["newer", "older"]);
     // The count query reads the same filter through its own spelling.

--- a/packages/nextly/src/lib/entry-heading.test.ts
+++ b/packages/nextly/src/lib/entry-heading.test.ts
@@ -1,0 +1,44 @@
+/**
+ * The shared heading walk, at the two boundaries its callers differ on.
+ *
+ * `services/dashboard/__tests__/recent-entries.test.ts` drives it through the
+ * dashboard, where the fallback is always the entry id. The activity feed's
+ * fallback may be `undefined` — a delete row can legitimately have nothing to
+ * call the entry it names — and that case has no other test.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { entryHeading } from "./entry-heading";
+
+describe("entryHeading", () => {
+  it("prefers the configured title field over `title` and `name`", () => {
+    expect(
+      entryHeading({ heading: "H", title: "T", name: "N" }, "heading", "id-1")
+    ).toBe("H");
+  });
+
+  it("starts at `title` when no title field is configured", () => {
+    expect(entryHeading({ title: "T", name: "N" }, null, "id-1")).toBe("T");
+  });
+
+  it("returns `undefined` rather than a placeholder when nothing is usable", () => {
+    // The activity feed's case. A heading it invents is worse than none: the
+    // row would claim a name the entry never had.
+    expect(entryHeading({ title: {} }, null, undefined)).toBeUndefined();
+  });
+
+  it("accepts a bigint, which `typeof` reports separately from `number`", () => {
+    expect(entryHeading({ title: 9007199254740993n }, null, "id-1")).toBe(
+      "9007199254740993"
+    );
+  });
+
+  it("refuses `null`, a boolean and a Date without stringifying any of them", () => {
+    // `String(null)` is "null", `String(false)` is "false", and a Date renders
+    // its whole locale string — three headings that read as data and are not.
+    expect(entryHeading({ title: null }, null, "id-1")).toBe("id-1");
+    expect(entryHeading({ title: false }, null, "id-1")).toBe("id-1");
+    expect(entryHeading({ title: new Date(0) }, null, "id-1")).toBe("id-1");
+  });
+});

--- a/packages/nextly/src/lib/entry-heading.ts
+++ b/packages/nextly/src/lib/entry-heading.ts
@@ -1,0 +1,55 @@
+/**
+ * The label an entry is shown under, from whatever its collection nominated.
+ *
+ * `admin.useAsTitle` names a FIELD, and schema validation checks only that the
+ * field exists -- never that it holds a primitive. `json`, `group`, `repeater`,
+ * `component` and `chips` all arrive here as objects or arrays, and `String()`
+ * on one of those renders `[object Object]`: a heading that says nothing, on
+ * every surface whose job is to name the entry.
+ *
+ * So the candidates are narrowed by `typeof` before anything is stringified,
+ * which is the rule the surrounding code already states -- every branch that
+ * reaches `String()` must already be known to be a real primitive.
+ *
+ * One module rather than one per surface. The activity feed and the dashboard's
+ * recent-entries list answer the same question about the same fields, and two
+ * implementations of it would disagree about which entry is which depending on
+ * where you read it.
+ *
+ * @module lib/entry-heading
+ */
+
+/**
+ * The first candidate that is a usable heading, else `fallback`.
+ *
+ * Candidates, in descending preference: the collection's configured title
+ * field, then a `title` field, then a `name` field. An absent `titleField`
+ * simply starts the walk at `title`.
+ *
+ * An EMPTY string is skipped rather than returned. `??` only skips `null` and
+ * `undefined`, so an untitled draft used to render as no heading at all --
+ * indistinguishable from a row that failed to load.
+ *
+ * `fallback` is generic so a caller supplying a string gets `string` back and
+ * one supplying `undefined` keeps the option of having no heading. The activity
+ * feed needs the second: a delete row outlives the entry it names, and it may
+ * legitimately have nothing to call it.
+ */
+export function entryHeading<TFallback extends string | undefined>(
+  data: Record<string, unknown>,
+  titleField: string | null | undefined,
+  fallback: TFallback
+): string | TFallback {
+  const candidates = [
+    titleField ? data[titleField] : undefined,
+    data.title,
+    data.name,
+  ];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.length > 0) return candidate;
+    if (typeof candidate === "number" || typeof candidate === "bigint") {
+      return String(candidate);
+    }
+  }
+  return fallback;
+}

--- a/packages/nextly/src/plugins/admin-contributions.ts
+++ b/packages/nextly/src/plugins/admin-contributions.ts
@@ -138,9 +138,14 @@ export interface PluginAdminPage {
 /**
  * @experimental A plugin-contributed dashboard widget.
  *
- * RESERVED — the contract is published for forward-compatibility, but
- * widget rendering / the dashboard grid is **deferred** and is NOT
- * built. Declaring widgets has no effect yet.
+ * Rendered by `PluginWidgetGrid` on the admin dashboard and gated on
+ * `requiredPermission`. Still `@experimental`: the shape is expected to grow a
+ * title, an archetype, a declarative query and a config schema before it
+ * graduates (D55 -- graduation needs a first-party plugin exercising it).
+ *
+ * `requiredPermission` decides whether the CARD renders. It does not constrain
+ * the rows a widget's own query returns; a widget is responsible for reading
+ * through the access-controlled path.
  */
 export interface PluginAdminWidget {
   id: string;
@@ -173,8 +178,7 @@ export interface PluginCollectionView {
  * @public Declarative admin-UI contributions. Introspectable
  * by the host without running the plugin.
  *
- * Consumed: `menu`, `pages` + `settings`, `views`.
- * `widgets` is RESERVED — deferred; not rendered.
+ * Consumed: `menu`, `pages` + `settings`, `views`, `widgets`.
  */
 export interface PluginAdminContributions {
   /** Sidebar navigation entries. */

--- a/packages/nextly/src/services/collections/collection-entry-service.ts
+++ b/packages/nextly/src/services/collections/collection-entry-service.ts
@@ -228,6 +228,14 @@ export class CollectionEntryService extends BaseService {
     routeAuthorized?: boolean;
     /** Caller's authenticated scope; a scoped key is judged on its read grant. */
     authenticatedScope?: AuthenticatedScope;
+    /**
+     * Draft/Published filter override (only effective when the collection has
+     * the status lifecycle). Declared rather than merely forwarded: `params`
+     * reaches the query service whole, so an undeclared option travels at
+     * runtime while looking absent to every reader of this signature -- and the
+     * one thing nobody re-checks is an option that appears not to exist.
+     */
+    status?: "published" | "draft" | "all";
   }): Promise<CollectionServiceResult<{ totalDocs: number }>> {
     return this.queryService.countEntries(params);
   }

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.integration.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.integration.test.ts
@@ -1,0 +1,70 @@
+/**
+ * The activity feed's permission scope must exclude BOTH sides of a read: the
+ * rows a caller may not see, and the total that counts them.
+ *
+ * `activity-scope.test.ts` covers this against a mocked adapter, which proves
+ * the arguments `getRecentActivity` builds but never executes the SQL
+ * `countActivities` emits from them. This runs the same property against a
+ * real SQLite database so the IN-clause placeholder/params pairing in
+ * `countActivities` is actually exercised end to end, not merely asserted by
+ * shape.
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import { someResources } from "../readable-resources";
+
+let current: TestNextly | undefined;
+
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+describe("activity feed scope (sqlite integration)", () => {
+  it("excludes an unscoped collection from both the activities list and the total", async () => {
+    current = await createTestNextly({ dialect: "sqlite" });
+
+    // The write path decides identity by checking whether the account still
+    // exists, so a real user row is required -- the same shape
+    // `mutation-activity.integration.test.ts` uses for its actor.
+    const actorId = "scope-actor";
+    await current.adapter.insert("users", {
+      id: actorId,
+      name: "Scope Actor",
+      email: "scope-actor@test.local",
+      is_active: true,
+    });
+
+    const activityLog = current.getService("activityLogService");
+    await activityLog.logActivity({
+      userId: actorId,
+      action: "create",
+      collection: "posts",
+      entryTitle: "Visible Post",
+    });
+    await activityLog.logActivity({
+      userId: actorId,
+      action: "create",
+      collection: "pages",
+      entryTitle: "Hidden Page",
+    });
+
+    const result = await activityLog.getRecentActivity({
+      scope: someResources(["posts"]),
+    });
+
+    expect(result.activities.map(a => a.entryTitle)).toEqual(["Visible Post"]);
+    expect(result.activities.some(a => a.entryTitle === "Hidden Page")).toBe(
+      false
+    );
+    // `total` is what exercises countActivities' own IN-clause SQL end to
+    // end. A placeholder/params mismatch there would leave `activities`
+    // correct (a different code path, `adapter.select`) and only this number
+    // silently wrong -- exactly the failure mode I-1 describes.
+    expect(result.total).toBe(1);
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { ActivityLogService } from "../activity-log-service";
+import { someResources } from "../readable-resources";
+
+function makeService() {
+  const adapter = {
+    select: vi.fn().mockResolvedValue([]),
+    executeQuery: vi.fn().mockResolvedValue([{ count: 0 }]),
+    getDialect: () => "sqlite",
+  } as unknown as ConstructorParameters<typeof ActivityLogService>[0];
+  const logger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  } as unknown as ConstructorParameters<typeof ActivityLogService>[1];
+  return { service: new ActivityLogService(adapter, logger), adapter };
+}
+
+describe("activity feed scope", () => {
+  it("returns nothing WITHOUT querying when the caller may read nothing", async () => {
+    const { service, adapter } = makeService();
+
+    const result = await service.getRecentActivity({
+      limit: 5,
+      scope: someResources([]),
+    });
+
+    expect(result).toEqual({ activities: [], total: 0, hasMore: false });
+    // An empty IN list is a syntax error on some dialects, so the short-circuit
+    // must happen BEFORE the query is built, not inside it.
+    expect(adapter.select).not.toHaveBeenCalled();
+  });
+
+  it("queries with an IN filter when the caller may read some resources", async () => {
+    const { service, adapter } = makeService();
+
+    await service.getRecentActivity({
+      limit: 5,
+      scope: someResources(["posts", "email-providers"]),
+    });
+
+    const call = (adapter.select as ReturnType<typeof vi.fn>).mock.calls[0];
+    const where = (
+      call[1] as { where: { and: Array<Record<string, unknown>> } }
+    ).where;
+    expect(where.and).toContainEqual(
+      expect.objectContaining({ op: "IN", column: "collection" })
+    );
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/activity-scope.test.ts
@@ -3,11 +3,20 @@ import { describe, expect, it, vi } from "vitest";
 import { ActivityLogService } from "../activity-log-service";
 import { someResources } from "../readable-resources";
 
-function makeService() {
+/**
+ * `dialect` defaults to sqlite. The earlier version of this mock exposed a
+ * `getDialect` method that nothing in `ActivityLogService` calls -- the real
+ * getter reads `this.adapter.getCapabilities().dialect` -- so every access to
+ * `this.dialect` threw, was swallowed by `countActivities`' own `catch`, and
+ * silently returned 0. That masked exactly the SQL-emission defect this file
+ * now tests for directly: `getCapabilities` is what has to be mocked for
+ * `filterClause`'s dialect branches to run at all.
+ */
+function makeService(dialect: "postgresql" | "sqlite" = "sqlite") {
   const adapter = {
     select: vi.fn().mockResolvedValue([]),
     executeQuery: vi.fn().mockResolvedValue([{ count: 0 }]),
-    getDialect: () => "sqlite",
+    getCapabilities: () => ({ dialect }),
   } as unknown as ConstructorParameters<typeof ActivityLogService>[0];
   const logger = {
     error: vi.fn(),
@@ -15,7 +24,7 @@ function makeService() {
     debug: vi.fn(),
     info: vi.fn(),
   } as unknown as ConstructorParameters<typeof ActivityLogService>[1];
-  return { service: new ActivityLogService(adapter, logger), adapter };
+  return { service: new ActivityLogService(adapter, logger), adapter, logger };
 }
 
 describe("activity feed scope", () => {
@@ -33,7 +42,7 @@ describe("activity feed scope", () => {
     expect(adapter.select).not.toHaveBeenCalled();
   });
 
-  it("queries with an IN filter when the caller may read some resources", async () => {
+  it("queries with an IN filter over exactly the scope's resources", async () => {
     const { service, adapter } = makeService();
 
     await service.getRecentActivity({
@@ -45,8 +54,87 @@ describe("activity feed scope", () => {
     const where = (
       call[1] as { where: { and: Array<Record<string, unknown>> } }
     ).where;
-    expect(where.and).toContainEqual(
-      expect.objectContaining({ op: "IN", column: "collection" })
+    // Asserting the exact filter object, not `objectContaining({ op, column })`:
+    // a shape-only match passes an implementation that pushes the wrong
+    // `value` (an unrelated array, or the wrong scope entirely) as long as
+    // `op` and `column` are right. `value` is the only field that actually
+    // carries the security property -- which resources the caller may read.
+    expect(where.and).toContainEqual({
+      column: "collection",
+      op: "IN",
+      value: ["posts", "email-providers"],
+    });
+  });
+});
+
+describe("countActivities SQL emission", () => {
+  // `countActivities` is private; its emitted SQL and params are observable
+  // only through what it hands `adapter.executeQuery`. Nothing previously
+  // inspected either -- the mock's `executeQuery` return value was read, but
+  // its call arguments never were -- so a placeholder/params mismatch here
+  // (I-1) would produce a wrong `total`, or a silent 0 through the blanket
+  // catch, with a green suite either way.
+  //
+  // One case per dialect, and one filter of each kind (`=` then `IN`) so the
+  // placeholder numbering is proven across a boundary: if it were derived from
+  // the filter's array index rather than from `params.length` as each value is
+  // pushed, the `IN` filter's own placeholders would be right but everything
+  // would still line up here, because index 1 and `params.length` after one
+  // push agree. What catches the regression is that a WRONG numbering scheme
+  // also has to survive the exact params array asserted below, in the exact
+  // order `filterClause` pushes them.
+  it.each([
+    {
+      dialect: "postgresql" as const,
+      expectedSql:
+        'SELECT COUNT(*) as count FROM activity_log WHERE "user_id" = $1 AND "collection" IN ($2, $3)',
+    },
+    {
+      dialect: "sqlite" as const,
+      expectedSql:
+        "SELECT COUNT(*) as count FROM activity_log WHERE `user_id` = ? AND `collection` IN (?, ?)",
+    },
+  ])(
+    "emits the full parameterised SQL and params, on $dialect",
+    async ({ dialect, expectedSql }) => {
+      const { service, adapter } = makeService(dialect);
+
+      await service.getRecentActivity({
+        userId: "u1",
+        scope: someResources(["posts", "email-providers"]),
+      });
+
+      // Full string and full array, not a substring or a `toContain`: either
+      // of those would pass a query missing a clause, carrying an extra one,
+      // or binding its params out of order.
+      expect(adapter.executeQuery).toHaveBeenCalledWith(expectedSql, [
+        "u1",
+        "posts",
+        "email-providers",
+      ]);
+    }
+  );
+
+  it("logs and returns 0, rather than throwing or reporting silently, when the count query fails", async () => {
+    const { service, adapter, logger } = makeService();
+    (adapter.executeQuery as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("connection reset")
+    );
+
+    const result = await service.getRecentActivity({
+      userId: "u1",
+      scope: someResources(["posts"]),
+    });
+
+    // The rows still come back (a different adapter call, `select`, which
+    // this rejection does not touch) -- only `total` degrades.
+    expect(result.total).toBe(0);
+    // The property M-3 fixes: a bare `catch { return 0 }` here made a
+    // placeholder/params mismatch indistinguishable from a legitimate empty
+    // count, with nothing in the logs to tell them apart.
+    expect(logger.error).toHaveBeenCalledWith(
+      "Failed to count activities",
+      expect.objectContaining({ error: "connection reset" })
     );
   });
 });

--- a/packages/nextly/src/services/dashboard/__tests__/collection-counts.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/collection-counts.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Per-collection totals must be the CALLER's totals.
+ *
+ * `dashboard-scope.test.ts` covers which collections are counted at all, and
+ * every assertion in it is satisfied by a bare `SELECT COUNT(*)` over the
+ * physical table — which is what this used to be. Entity-level scope decides
+ * whether a collection appears; it says nothing about which ROWS inside it the
+ * caller may read. A collection with an owner-only stored read rule therefore
+ * reported every author's row count to every reader who could open it at all:
+ * Alice, allowed to read `posts` but only her own, saw Bob's posts in the
+ * number.
+ *
+ * The fix routes the total through `nextly.count({ overrideAccess: false })`,
+ * which runs `checkCollectionAccess` and then applies
+ * `getAccessQueryConstraint` — the same owner-only WHERE predicate the list
+ * read applies. So the tests here drive the raw table count and the
+ * access-controlled count to DIFFERENT numbers; a test where they agreed could
+ * not tell the two implementations apart.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { count } = vi.hoisted(() => ({ count: vi.fn() }));
+vi.mock("../../../direct-api/nextly", () => ({ getNextly: () => ({ count }) }));
+
+const { containerGet } = vi.hoisted(() => ({ containerGet: vi.fn() }));
+vi.mock("../../../di/container", () => ({ container: { get: containerGet } }));
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { Logger } from "../../shared";
+import { DashboardService } from "../dashboard-service";
+import { someResources, type ReadCaller } from "../readable-resources";
+
+/** Rows physically present in `posts`, of which the caller owns two. */
+const ROWS_IN_TABLE = 7;
+const ROWS_THE_CALLER_MAY_READ = 2;
+
+const COLLECTIONS = [
+  {
+    slug: "posts",
+    tableName: "posts",
+    labels: { plural: "Posts" },
+    fields: [],
+  },
+];
+
+const CALLER: ReadCaller = {
+  user: { id: "alice", roles: ["editor"] },
+};
+
+/** Every raw `COUNT(*)` answers with the WHOLE table, access ignored. */
+function makeAdapter(): DrizzleAdapter {
+  return {
+    getCapabilities: () => ({ dialect: "sqlite" }),
+    executeQuery: vi
+      .fn()
+      .mockImplementation(() => Promise.resolve([{ count: ROWS_IN_TABLE }])),
+  } as unknown as DrizzleAdapter;
+}
+
+function makeLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeService(): DashboardService {
+  return new DashboardService(makeAdapter(), makeLogger());
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  containerGet.mockImplementation((name: string) => {
+    if (name === "collectionRegistryService") {
+      return { getAllCollections: vi.fn().mockResolvedValue(COLLECTIONS) };
+    }
+    if (name === "singleRegistryService") {
+      return { getAllSingles: vi.fn().mockResolvedValue([]) };
+    }
+    throw new Error(`unexpected container.get("${name}")`);
+  });
+  // The stored read rule at work: the access-controlled count sees two rows
+  // where the table holds seven.
+  count.mockResolvedValue({ total: ROWS_THE_CALLER_MAY_READ });
+});
+
+describe("per-collection totals honour the caller's row-level access", () => {
+  it("reports the access-controlled count, not the physical row count", async () => {
+    const stats = await makeService().getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    expect(stats.collectionCounts).toEqual([
+      { slug: "posts", label: "Posts", group: null, count: 2 },
+    ]);
+    // The raw table count is still 7, and a bare `COUNT(*)` would have
+    // reported it. This is the separating assertion: with the two numbers
+    // equal, both implementations pass.
+    expect(stats.collectionCounts[0].count).not.toBe(ROWS_IN_TABLE);
+  });
+
+  it("sums totalEntries from the same access-controlled numbers", async () => {
+    const stats = await makeService().getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    expect(stats.content.totalEntries).toBe(ROWS_THE_CALLER_MAY_READ);
+  });
+
+  it("reads with access ENFORCED and carries the caller", async () => {
+    await makeService().getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    // `overrideAccess: false` plus `user` is what runs both
+    // `checkCollectionAccess` and the owner-only query constraint. Omitting
+    // either makes the count trusted, which is what the raw query already was.
+    expect(count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        overrideAccess: false,
+        user: CALLER.user,
+      })
+    );
+  });
+
+  it("counts every lifecycle state, so the dashboard total does not silently drop drafts", async () => {
+    // `resolveStatusFilter` returns `published` for an untrusted read that
+    // states nothing, so a count without this reports published-only totals —
+    // a number that would no longer agree with the draft/published breakdown
+    // sitting beside it in the same response.
+    await makeService().getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    expect(count).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "all" })
+    );
+  });
+
+  it("judges an API key on its OWN stamped scope, not its minter's roles", async () => {
+    await makeService().getStats({
+      scope: someResources(["posts"]),
+      caller: {
+        user: { id: "owner-1", roles: ["viewer"] },
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["read-posts"],
+        },
+      },
+    });
+
+    // Dropped, the count is judged by whoever minted the key — for a
+    // super-admin owner that is their entire account.
+    expect(count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: { actorType: "apiKey", permissions: ["read-posts"] },
+      })
+    );
+  });
+
+  it("contributes nothing for a collection whose count is refused", async () => {
+    // `countEntries` throws rather than returning zero when collection access
+    // is denied outright. A refusal must cost that collection's number, never
+    // the whole response.
+    count.mockRejectedValue(new Error("access denied"));
+
+    const stats = await makeService().getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    expect(stats.collectionCounts).toEqual([
+      { slug: "posts", label: "Posts", group: null, count: 0 },
+    ]);
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
@@ -64,11 +64,29 @@ const SINGLES = [{ slug: "site-settings" }, { slug: "about" }];
  * query resolves to zero rows/zero count -- the point of these tests is
  * which COLLECTIONS get counted at all, not the counts themselves.
  */
-function makeAdapter(): DrizzleAdapter {
+function makeAdapter(
+  dialect: "postgresql" | "mysql" | "sqlite" = "sqlite"
+): DrizzleAdapter {
   return {
-    getCapabilities: () => ({ dialect: "sqlite" }),
-    executeQuery: vi.fn().mockResolvedValue([{ count: 0 }]),
+    getCapabilities: () => ({ dialect }),
+    // `activity_log` answers with a DISTINCT count so `recentChanges24h` can be
+    // told apart from the zero every other counter returns. A shared 0 would
+    // make "the scope short-circuited the query" and "the query ran and found
+    // nothing" the same observation -- and the first is the property under
+    // test.
+    executeQuery: vi
+      .fn()
+      .mockImplementation((sql: string) =>
+        Promise.resolve([{ count: sql.includes("activity_log") ? 7 : 0 }])
+      ),
   } as unknown as DrizzleAdapter;
+}
+
+/** Every `activity_log` query `getStats` emitted, with its bound params. */
+function activityLogCalls(adapter: DrizzleAdapter): Array<[string, unknown[]]> {
+  const calls = (adapter.executeQuery as unknown as ReturnType<typeof vi.fn>)
+    .mock.calls as Array<[string, unknown[]]>;
+  return calls.filter(([sql]) => sql.includes("activity_log"));
 }
 
 function makeLogger(): Logger {
@@ -140,5 +158,109 @@ describe("DashboardService applies the read scope it is given", () => {
       "posts",
     ]);
     expect(stats.singles).toBe(2);
+  });
+});
+
+/**
+ * `recentChanges24h` reads `activity_log` -- the very table this branch taught
+ * `ActivityLogService` to filter. Left unscoped it made ONE `/stats` response
+ * answer "what may this caller see" two different ways about one table:
+ * `collectionCounts` honoured the scope while `recentChanges24h` counted every
+ * collection's changes, so the number itself disclosed that activity exists
+ * outside the caller's reach.
+ *
+ * The counter is private and its result is a bare number, so a count of 7 and a
+ * count of 7-of-which-some-are-forbidden are indistinguishable from the return
+ * value alone. What separates them is the SQL: these assert the emitted query
+ * and its bound params, the way `activity-scope.test.ts` does for
+ * `countActivities`.
+ *
+ * The other five counters (`media`, `users`, `roles`, `permissions`, active API
+ * keys) are deliberately left unscoped. They are uniformly unscoped rather than
+ * newly inconsistent, and scoping them is a design decision about what a
+ * dashboard admin metric means, not a defect in this table's filter.
+ */
+describe("recentChanges24h honours the read scope", () => {
+  it("counts nothing WITHOUT querying when the caller may read nothing", async () => {
+    const adapter = makeAdapter();
+    const service = new DashboardService(adapter, makeLogger());
+
+    const stats = await service.getStats({ scope: someResources([]) });
+
+    expect(stats.content.recentChanges24h).toBe(0);
+    // An empty `IN ()` is a syntax error on some dialects, so the
+    // short-circuit must happen BEFORE the query is built rather than let the
+    // driver reject it -- the same rule `getRecentActivity` follows.
+    expect(activityLogCalls(adapter)).toEqual([]);
+  });
+
+  it.each([
+    {
+      dialect: "sqlite" as const,
+      expectedSql:
+        'SELECT COUNT(*) as count FROM "activity_log" WHERE "created_at" > ? AND "collection" IN (?, ?)',
+    },
+    {
+      dialect: "postgresql" as const,
+      expectedSql:
+        'SELECT COUNT(*) as count FROM "activity_log" WHERE "created_at" > $1 AND "collection" IN ($2, $3)',
+    },
+    {
+      dialect: "mysql" as const,
+      expectedSql:
+        "SELECT COUNT(*) as count FROM `activity_log` WHERE `created_at` > ? AND `collection` IN (?, ?)",
+    },
+  ])(
+    "restricts the count to the scope's collections, on $dialect",
+    async ({ dialect, expectedSql }) => {
+      const adapter = makeAdapter(dialect);
+      const service = new DashboardService(adapter, makeLogger());
+
+      await service.getStats({
+        scope: someResources(["posts", "email-providers"]),
+      });
+
+      const calls = activityLogCalls(adapter);
+      expect(calls).toHaveLength(1);
+      const [sql, params] = calls[0];
+      // Full string, not a substring: `toContain("IN (")` passes a query that
+      // also dropped the cutoff, and passes one whose placeholders are
+      // numbered wrongly. The cutoff must stay bound at position 1 with the
+      // scope's values after it, in order.
+      expect(sql).toBe(expectedSql);
+      expect(params.slice(1)).toEqual(["posts", "email-providers"]);
+      // Parameterised, never interpolated: no collection name may appear in
+      // the SQL text itself.
+      expect(sql).not.toContain("posts");
+    }
+  );
+
+  it("counts across every collection for a super-admin's `all` scope", async () => {
+    const adapter = makeAdapter();
+    const service = new DashboardService(adapter, makeLogger());
+
+    const stats = await service.getStats({ scope: allResources() });
+
+    const calls = activityLogCalls(adapter);
+    expect(calls).toHaveLength(1);
+    const [sql, params] = calls[0];
+    // The positive control for the two cases above: `all` must NOT narrow, so
+    // an implementation that filtered unconditionally -- which would satisfy
+    // every scoped assertion here -- fails this one.
+    expect(sql).toBe(
+      'SELECT COUNT(*) as count FROM "activity_log" WHERE "created_at" > ?'
+    );
+    expect(params).toHaveLength(1);
+    expect(stats.content.recentChanges24h).toBe(7);
+  });
+
+  it("denies by default when the options object is omitted entirely", async () => {
+    const adapter = makeAdapter();
+    const service = new DashboardService(adapter, makeLogger());
+
+    const stats = await service.getStats();
+
+    expect(stats.content.recentChanges24h).toBe(0);
+    expect(activityLogCalls(adapter)).toEqual([]);
   });
 });

--- a/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
@@ -28,12 +28,23 @@ vi.mock("../../../di/container", () => ({
   container: { get: vi.fn() },
 }));
 
+// The per-collection totals are read through the access-controlled Direct API
+// count. These tests are about WHICH collections get counted, so the number
+// itself is pinned at zero; `collection-counts.test.ts` is where the number
+// being the caller's rather than the table's is asserted.
+const { count } = vi.hoisted(() => ({ count: vi.fn() }));
+vi.mock("../../../direct-api/nextly", () => ({ getNextly: () => ({ count }) }));
+
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { container } from "../../../di/container";
 import type { Logger } from "../../shared";
 import { DashboardService } from "../dashboard-service";
-import { allResources, someResources } from "../readable-resources";
+import {
+  allResources,
+  someResources,
+  type ReadCaller,
+} from "../readable-resources";
 
 /** Three registered collections, standing in for a real registry response. */
 const COLLECTIONS = [
@@ -58,6 +69,9 @@ const COLLECTIONS = [
 ];
 
 const SINGLES = [{ slug: "site-settings" }, { slug: "about" }];
+
+/** Who the counts are read as. Required by `getStats`, so it is stated once. */
+const CALLER: ReadCaller = { user: { id: "user-1", roles: ["editor"] } };
 
 /**
  * Adapter stub for the count fan-out `getStats` performs. Every COUNT(*)
@@ -100,6 +114,7 @@ function makeLogger(): Logger {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  count.mockResolvedValue({ total: 0 });
   (container.get as ReturnType<typeof vi.fn>).mockImplementation(
     (name: string) => {
       if (name === "collectionRegistryService") {
@@ -122,16 +137,22 @@ describe("DashboardService applies the read scope it is given", () => {
   it("admits nothing for an explicit empty scope", async () => {
     const service = new DashboardService(makeAdapter(), makeLogger());
 
-    const stats = await service.getStats({ scope: someResources([]) });
+    const stats = await service.getStats({
+      scope: someResources([]),
+      caller: CALLER,
+    });
 
     expect(stats.collectionCounts).toEqual([]);
     expect(stats.singles).toBe(0);
   });
 
-  it("admits nothing when the options object is omitted entirely -- deny by default", async () => {
+  it("admits nothing when the scope is omitted -- deny by default", async () => {
+    // `caller` is REQUIRED and `scope` is not, so this is the only shape a
+    // caller can still get wrong. It must deny; the old default returned
+    // everything.
     const service = new DashboardService(makeAdapter(), makeLogger());
 
-    const stats = await service.getStats();
+    const stats = await service.getStats({ caller: CALLER });
 
     expect(stats.collectionCounts).toEqual([]);
     expect(stats.singles).toBe(0);
@@ -142,6 +163,7 @@ describe("DashboardService applies the read scope it is given", () => {
 
     const stats = await service.getStats({
       scope: someResources(["posts"]),
+      caller: CALLER,
     });
 
     expect(stats.collectionCounts.map(c => c.slug)).toEqual(["posts"]);
@@ -150,7 +172,10 @@ describe("DashboardService applies the read scope it is given", () => {
   it("admits everything for a super-admin's `all` scope", async () => {
     const service = new DashboardService(makeAdapter(), makeLogger());
 
-    const stats = await service.getStats({ scope: allResources() });
+    const stats = await service.getStats({
+      scope: allResources(),
+      caller: CALLER,
+    });
 
     expect(stats.collectionCounts.map(c => c.slug).sort()).toEqual([
       "orders",
@@ -185,7 +210,10 @@ describe("recentChanges24h honours the read scope", () => {
     const adapter = makeAdapter();
     const service = new DashboardService(adapter, makeLogger());
 
-    const stats = await service.getStats({ scope: someResources([]) });
+    const stats = await service.getStats({
+      scope: someResources([]),
+      caller: CALLER,
+    });
 
     expect(stats.content.recentChanges24h).toBe(0);
     // An empty `IN ()` is a syntax error on some dialects, so the
@@ -218,6 +246,7 @@ describe("recentChanges24h honours the read scope", () => {
 
       await service.getStats({
         scope: someResources(["posts", "email-providers"]),
+        caller: CALLER,
       });
 
       const calls = activityLogCalls(adapter);
@@ -239,7 +268,10 @@ describe("recentChanges24h honours the read scope", () => {
     const adapter = makeAdapter();
     const service = new DashboardService(adapter, makeLogger());
 
-    const stats = await service.getStats({ scope: allResources() });
+    const stats = await service.getStats({
+      scope: allResources(),
+      caller: CALLER,
+    });
 
     const calls = activityLogCalls(adapter);
     expect(calls).toHaveLength(1);
@@ -254,11 +286,11 @@ describe("recentChanges24h honours the read scope", () => {
     expect(stats.content.recentChanges24h).toBe(7);
   });
 
-  it("denies by default when the options object is omitted entirely", async () => {
+  it("denies by default when the scope is omitted", async () => {
     const adapter = makeAdapter();
     const service = new DashboardService(adapter, makeLogger());
 
-    const stats = await service.getStats();
+    const stats = await service.getStats({ caller: CALLER });
 
     expect(stats.content.recentChanges24h).toBe(0);
     expect(activityLogCalls(adapter)).toEqual([]);

--- a/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Regression coverage for the read-scope defect at the level where it lived:
+ * `DashboardService` itself.
+ *
+ * `api/dashboard.test.ts` covers the HANDLER -- that `resolveReadableResources`
+ * computes the right `ReadableResources` and forwards it to the service. It
+ * mocks the service out entirely, so it can never observe whether the service
+ * actually APPLIES the scope it is handed. `readable-resources.test.ts` covers
+ * the `filterByResource`/`someResources` helpers in isolation, never through
+ * the service's own consumption of them.
+ *
+ * Neither of those files would go red if `getRegisteredCollections` /
+ * `getRegisteredSingles` reverted to the old
+ * `if (!scope || scope.resources.size === 0) return mapped;` -- exactly the
+ * fail-open bug this task exists to close. These tests construct a real
+ * `DashboardService` against a stubbed adapter and a stubbed DI container so
+ * that bug has a test that actually exercises the vulnerable code path.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// `DashboardService` reads its registries off the shared DI container
+// (`container.get("collectionRegistryService")` /
+// `container.get("singleRegistryService")`) rather than taking them as
+// constructor arguments, so the container module itself is the seam to mock
+// -- the same shape `api/dashboard.test.ts` uses for `../di`.
+vi.mock("../../../di/container", () => ({
+  container: { get: vi.fn() },
+}));
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import { container } from "../../../di/container";
+import type { Logger } from "../../shared";
+import { DashboardService } from "../dashboard-service";
+import { allResources, someResources } from "../readable-resources";
+
+/** Three registered collections, standing in for a real registry response. */
+const COLLECTIONS = [
+  {
+    slug: "posts",
+    tableName: "posts",
+    labels: { plural: "Posts" },
+    fields: [],
+  },
+  {
+    slug: "pages",
+    tableName: "pages",
+    labels: { plural: "Pages" },
+    fields: [],
+  },
+  {
+    slug: "orders",
+    tableName: "orders",
+    labels: { plural: "Orders" },
+    fields: [],
+  },
+];
+
+const SINGLES = [{ slug: "site-settings" }, { slug: "about" }];
+
+/**
+ * Adapter stub for the count fan-out `getStats` performs. Every COUNT(*)
+ * query resolves to zero rows/zero count -- the point of these tests is
+ * which COLLECTIONS get counted at all, not the counts themselves.
+ */
+function makeAdapter(): DrizzleAdapter {
+  return {
+    getCapabilities: () => ({ dialect: "sqlite" }),
+    executeQuery: vi.fn().mockResolvedValue([{ count: 0 }]),
+  } as unknown as DrizzleAdapter;
+}
+
+function makeLogger(): Logger {
+  return {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (container.get as ReturnType<typeof vi.fn>).mockImplementation(
+    (name: string) => {
+      if (name === "collectionRegistryService") {
+        return { getAllCollections: vi.fn().mockResolvedValue(COLLECTIONS) };
+      }
+      if (name === "singleRegistryService") {
+        return { getAllSingles: vi.fn().mockResolvedValue(SINGLES) };
+      }
+      // `getStats` also fans out to `fieldGroupRegistryService` and reads
+      // `activity_log`/`api_keys` via raw queries; neither is registered
+      // here. Both call sites catch and fall back to zero, which is exactly
+      // what these tests want -- the assertions below are all about
+      // `collectionCounts` and `singles`.
+      throw new Error(`unexpected container.get("${name}") in this test`);
+    }
+  );
+});
+
+describe("DashboardService applies the read scope it is given", () => {
+  it("admits nothing for an explicit empty scope", async () => {
+    const service = new DashboardService(makeAdapter(), makeLogger());
+
+    const stats = await service.getStats({ scope: someResources([]) });
+
+    expect(stats.collectionCounts).toEqual([]);
+    expect(stats.singles).toBe(0);
+  });
+
+  it("admits nothing when the options object is omitted entirely -- deny by default", async () => {
+    const service = new DashboardService(makeAdapter(), makeLogger());
+
+    const stats = await service.getStats();
+
+    expect(stats.collectionCounts).toEqual([]);
+    expect(stats.singles).toBe(0);
+  });
+
+  it("admits only the named resource, not everything registered", async () => {
+    const service = new DashboardService(makeAdapter(), makeLogger());
+
+    const stats = await service.getStats({
+      scope: someResources(["posts"]),
+    });
+
+    expect(stats.collectionCounts.map(c => c.slug)).toEqual(["posts"]);
+  });
+
+  it("admits everything for a super-admin's `all` scope", async () => {
+    const service = new DashboardService(makeAdapter(), makeLogger());
+
+    const stats = await service.getStats({ scope: allResources() });
+
+    expect(stats.collectionCounts.map(c => c.slug).sort()).toEqual([
+      "orders",
+      "pages",
+      "posts",
+    ]);
+    expect(stats.singles).toBe(2);
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/dashboard-scope.test.ts
@@ -296,3 +296,48 @@ describe("recentChanges24h honours the read scope", () => {
     expect(activityLogCalls(adapter)).toEqual([]);
   });
 });
+
+/**
+ * A scope may name something that is not a content collection.
+ *
+ * `activity_log.collection` is a free string, so the read scope carries settings
+ * namespaces (`email-providers`, `email-templates`) alongside collection and
+ * single slugs. Two properties have to hold at once, and they pull in opposite
+ * directions: the name must reach the `activity_log` filter, and it must NOT
+ * become a collection to count. `filterByResource` can only narrow the registry
+ * list, so the second follows from the shape rather than from a guard — this
+ * pins it, because a future `getCollectionCounts` that iterated the SCOPE
+ * instead of the filtered registry would try to count a table that does not
+ * exist and report the failure as a zero.
+ */
+describe("a scope naming a non-content activity namespace", () => {
+  it("reaches the activity_log filter", async () => {
+    const adapter = makeAdapter();
+    const service = new DashboardService(adapter, makeLogger());
+
+    await service.getStats({
+      scope: someResources(["posts", "email-providers"]),
+      caller: CALLER,
+    });
+
+    const calls = activityLogCalls(adapter);
+    expect(calls).toHaveLength(1);
+    const [, params] = calls[0];
+    expect(params.slice(1)).toEqual(["posts", "email-providers"]);
+  });
+
+  it("does not become a collection to count", async () => {
+    const service = new DashboardService(makeAdapter(), makeLogger());
+
+    const stats = await service.getStats({
+      scope: someResources(["posts", "email-providers"]),
+      caller: CALLER,
+    });
+
+    expect(stats.collectionCounts.map(c => c.slug)).toEqual(["posts"]);
+    expect(count).toHaveBeenCalledTimes(1);
+    expect(count).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: "posts" })
+    );
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/readable-resources.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/readable-resources.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  allResources,
+  canRead,
+  filterByResource,
+  someResources,
+} from "../readable-resources";
+
+const items = [
+  { slug: "posts" },
+  { slug: "pages" },
+  { slug: "email-providers" },
+];
+const bySlug = (item: { slug: string }) => item.slug;
+
+describe("readable resources", () => {
+  it("lets a super-admin read every resource", () => {
+    const scope = allResources();
+    expect(canRead(scope, "posts")).toBe(true);
+    expect(filterByResource(scope, items, bySlug)).toEqual(items);
+  });
+
+  it("admits only the named resources", () => {
+    const scope = someResources(["posts"]);
+    expect(canRead(scope, "posts")).toBe(true);
+    expect(canRead(scope, "pages")).toBe(false);
+    expect(filterByResource(scope, items, bySlug)).toEqual([{ slug: "posts" }]);
+  });
+
+  // This is the defect. An empty scope means "this caller may read NOTHING" --
+  // it must never be read as "apply no filter". `listEffectivePermissions`
+  // returns [] for a user with no roles AND for any thrown error, so this path
+  // is reachable from a transient database failure, not only from a misconfigured user.
+  it("admits nothing when the scope is empty", () => {
+    const scope = someResources([]);
+    expect(canRead(scope, "posts")).toBe(false);
+    expect(filterByResource(scope, items, bySlug)).toEqual([]);
+  });
+
+  it("treats the scope as read-only data, not a filter toggle", () => {
+    const scope = someResources(["email-providers"]);
+    // System resources share the namespace with collection slugs by construction:
+    // a seeded permission `{ resource: "email-providers", action: "read" }` becomes
+    // the pair `email-providers:read`, and the activity log files rows under the
+    // same string. One scope therefore gates both.
+    expect(filterByResource(scope, items, bySlug)).toEqual([
+      { slug: "email-providers" },
+    ]);
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
@@ -6,6 +6,15 @@ vi.mock("../../../direct-api/nextly", () => ({
   getNextly: () => ({ find }),
 }));
 
+// Backs `getRegisteredCollections`'s real (unstubbed) path -- see "does not
+// query a collection outside the caller's scope" below, which needs the real
+// `filterByResource` call to run rather than a stub that already decided the
+// answer.
+const getAllCollections = vi.fn();
+vi.mock("../../../di/container", () => ({
+  container: { get: () => ({ getAllCollections }) },
+}));
+
 import { DashboardService } from "../dashboard-service";
 import { someResources } from "../readable-resources";
 
@@ -27,6 +36,7 @@ function makeService() {
 beforeEach(() => {
   vi.clearAllMocks();
   find.mockResolvedValue({ items: [] });
+  getAllCollections.mockResolvedValue([]);
 });
 
 describe("recent entries", () => {
@@ -103,34 +113,7 @@ describe("recent entries", () => {
     );
   });
 
-  it("refuses to read at all when it has no caller", async () => {
-    const service = makeService();
-    vi.spyOn(
-      service as unknown as {
-        getRegisteredCollections: (s: unknown) => Promise<unknown[]>;
-      },
-      "getRegisteredCollections"
-    ).mockResolvedValue([
-      {
-        slug: "posts",
-        tableName: "posts",
-        label: "Posts",
-        group: null,
-        useAsTitle: "title",
-        hasStatus: true,
-      },
-    ]);
-
-    // No caller means no access decision can be made. Reading anyway with
-    // `user: undefined` and `overrideAccess: false` is the shape most likely to
-    // be mishandled downstream, so refuse here instead.
-    const result = await service.getRecentEntries(5, someResources(["posts"]));
-
-    expect(find).not.toHaveBeenCalled();
-    expect(result).toEqual({ entries: [] });
-  });
-
-  it("does not query a collection outside the caller's scope", async () => {
+  it("requires a caller at compile time -- there is no optional-parameter fallback", async () => {
     const service = makeService();
     vi.spyOn(
       service as unknown as {
@@ -139,10 +122,56 @@ describe("recent entries", () => {
       "getRegisteredCollections"
     ).mockResolvedValue([]);
 
-    await service.getRecentEntries(5, someResources([]), {
+    // `caller` is a required parameter now (not `caller?`): a handler that
+    // forgets to build one must fail to compile rather than silently return
+    // an empty, unauthenticated-looking feed. This file is NOT in
+    // `tsconfig.tests.json`'s exclude list, so `pnpm check-types` actually
+    // evaluates this directive -- widening `caller` back to optional makes
+    // it unused and the build fails, which is the point.
+    // @ts-expect-error -- omitting `caller` must fail to typecheck.
+    const result = await service.getRecentEntries(5, someResources(["posts"]));
+
+    // Even reached through a type-system bypass, the call must not throw:
+    // with no registered collections there is nothing to read through.
+    expect(result).toEqual({ entries: [] });
+  });
+
+  it("does not query a collection outside the caller's scope", async () => {
+    const service = makeService();
+    // Deliberately NOT stubbing `getRegisteredCollections` here: it is the
+    // function that applies `filterByResource(scope, ...)`
+    // (dashboard-service.ts), so stubbing it is exactly what would let the
+    // scope filter be deleted without this test noticing. The registry
+    // returns three collections; only "posts" is in scope, so only "posts"
+    // may reach `find`.
+    getAllCollections.mockResolvedValue([
+      {
+        slug: "posts",
+        tableName: "posts",
+        labels: { plural: "Posts" },
+        fields: [],
+      },
+      {
+        slug: "pages",
+        tableName: "pages",
+        labels: { plural: "Pages" },
+        fields: [],
+      },
+      {
+        slug: "orders",
+        tableName: "orders",
+        labels: { plural: "Orders" },
+        fields: [],
+      },
+    ]);
+
+    await service.getRecentEntries(5, someResources(["posts"]), {
       user: { id: "user-1" },
     });
 
-    expect(find).not.toHaveBeenCalled();
+    expect(find).toHaveBeenCalledTimes(1);
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({ collection: "posts" })
+    );
   });
 });

--- a/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
@@ -175,3 +175,99 @@ describe("recent entries", () => {
     );
   });
 });
+
+/**
+ * `admin.useAsTitle` may name a field of any type.
+ *
+ * Schema validation checks only that the named field EXISTS, never that it
+ * holds a primitive, so `json`, `group`, `repeater`, `component` and `chips`
+ * all reach this code as objects or arrays. `String()` on one of those renders
+ * `[object Object]` -- a heading that says nothing, in a feed whose whole job
+ * is to name the entry.
+ *
+ * The rule is already written in the comment above this mapping ("narrow by
+ * typeof/instanceof first so every branch that reaches String() is already
+ * known to be a real primitive") and `updatedAt` and `status` beside it obey
+ * it. The title did not.
+ */
+describe("recent entry headings", () => {
+  function collectionWithTitleField(useAsTitle: string) {
+    return {
+      slug: "posts",
+      tableName: "posts",
+      label: "Posts",
+      group: null,
+      useAsTitle,
+      hasStatus: false,
+    };
+  }
+
+  async function headingFor(
+    row: Record<string, unknown>,
+    useAsTitle = "title"
+  ): Promise<string> {
+    const service = makeService();
+    vi.spyOn(
+      service as unknown as {
+        getRegisteredCollections: (s: unknown) => Promise<unknown[]>;
+      },
+      "getRegisteredCollections"
+    ).mockResolvedValue([collectionWithTitleField(useAsTitle)]);
+    find.mockResolvedValue({ items: [row] });
+
+    const result = await service.getRecentEntries(5, someResources(["posts"]), {
+      user: { id: "user-1" },
+    });
+    return result.entries[0].title;
+  }
+
+  it("falls back to the id when the title field holds an object", async () => {
+    expect(
+      await headingFor({ id: "p1", title: { en: "Hello" }, updatedAt: "" })
+    ).toBe("p1");
+  });
+
+  it("falls back to the id when the title field holds an array", async () => {
+    // A `repeater` or `chips` field named by `useAsTitle`.
+    expect(
+      await headingFor({ id: "p2", title: ["a", "b"], updatedAt: "" })
+    ).toBe("p2");
+  });
+
+  it("keeps a numeric title, which is a real primitive", async () => {
+    // The positive control for the two above: an implementation that rejected
+    // everything but a string would satisfy them and would blank out a
+    // numeric title field.
+    expect(await headingFor({ id: "p3", title: 2026, updatedAt: "" })).toBe(
+      "2026"
+    );
+  });
+
+  it("skips past an EMPTY string to the next candidate", async () => {
+    // An untitled draft. `??` only skips null and undefined, so an empty
+    // string reached the heading and rendered as nothing at all.
+    expect(
+      await headingFor({ id: "p4", title: "", name: "Draft", updatedAt: "" })
+    ).toBe("Draft");
+  });
+
+  it("skips past an object title to the next candidate rather than to the id", async () => {
+    expect(
+      await headingFor(
+        {
+          id: "p5",
+          heading: { en: "Hi" },
+          title: "Fallback title",
+          updatedAt: "",
+        },
+        "heading"
+      )
+    ).toBe("Fallback title");
+  });
+
+  it("keeps an ordinary string title", async () => {
+    expect(
+      await headingFor({ id: "p6", title: "Real title", updatedAt: "" })
+    ).toBe("Real title");
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
@@ -202,6 +202,32 @@ describe("recent entry headings", () => {
     };
   }
 
+  /**
+   * The Direct API's `select` is a REAL projection: `applyFieldSelection`
+   * (collection-query-service.ts) keeps only `id`, the system timestamps, and
+   * whatever key was explicitly asked for -- it does not hand back the whole
+   * row regardless of what was requested. A row fixture passed straight
+   * through to `entryHeading` -- unprojected -- would let its fallback chain
+   * (`data.title`, `data.name`) "work" in a test while being dead code in
+   * production, because a real read only ever carries what `select` named.
+   *
+   * So the mock projects too: a field survives only if `select` asked for it
+   * by name. This is what makes "the fallback candidates are in `select`" an
+   * assertion that can actually fail.
+   */
+  function project(
+    row: Record<string, unknown>,
+    select: Record<string, boolean> | undefined
+  ): Record<string, unknown> {
+    const projected: Record<string, unknown> = {};
+    if (row.id !== undefined) projected.id = row.id;
+    if (!select) return { ...projected };
+    for (const [key, included] of Object.entries(select)) {
+      if (included && row[key] !== undefined) projected[key] = row[key];
+    }
+    return projected;
+  }
+
   async function headingFor(
     row: Record<string, unknown>,
     useAsTitle = "title"
@@ -213,7 +239,11 @@ describe("recent entry headings", () => {
       },
       "getRegisteredCollections"
     ).mockResolvedValue([collectionWithTitleField(useAsTitle)]);
-    find.mockResolvedValue({ items: [row] });
+    find.mockImplementation(
+      async (args: { select?: Record<string, boolean> }) => ({
+        items: [project(row, args.select)],
+      })
+    );
 
     const result = await service.getRecentEntries(5, someResources(["posts"]), {
       user: { id: "user-1" },
@@ -269,5 +299,48 @@ describe("recent entry headings", () => {
     expect(
       await headingFor({ id: "p6", title: "Real title", updatedAt: "" })
     ).toBe("Real title");
+  });
+
+  it("projects entryHeading's fallback candidates, so its chain can actually fire", async () => {
+    // `entryHeading`'s chain is `data[titleField] ?? data.title ?? data.name`.
+    // `applyFieldSelection` keeps only what `select` names, so `title` and
+    // `name` reach a real read ONLY if they are asked for here -- proven by
+    // the two preceding tests failing without this.
+    const service = makeService();
+    vi.spyOn(
+      service as unknown as {
+        getRegisteredCollections: (s: unknown) => Promise<unknown[]>;
+      },
+      "getRegisteredCollections"
+    ).mockResolvedValue([collectionWithTitleField("heading")]);
+
+    await service.getRecentEntries(5, someResources(["posts"]), {
+      user: { id: "user-1" },
+    });
+
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        select: expect.objectContaining({ title: true, name: true }),
+      })
+    );
+  });
+
+  it("resolves a REAL heading through the fallback chain, from a genuinely projected row", async () => {
+    // `useAsTitle` names a field ("heading") this row does not carry -- the
+    // realistic case of a field that is empty, absent, or of a type
+    // `entryHeading` will not render. `title` reaches the resolver only
+    // because the projection above selected it; a select missing the
+    // fallback candidates would drop it here exactly as it does in
+    // production, and this would resolve to the id instead.
+    expect(
+      await headingFor(
+        {
+          id: "p7",
+          title: "Selected through a real projection",
+          updatedAt: "",
+        },
+        "heading"
+      )
+    ).toBe("Selected through a real projection");
   });
 });

--- a/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/recent-entries.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const find = vi.fn();
+
+vi.mock("../../../direct-api/nextly", () => ({
+  getNextly: () => ({ find }),
+}));
+
+import { DashboardService } from "../dashboard-service";
+import { someResources } from "../readable-resources";
+
+function makeService() {
+  const adapter = {
+    executeQuery: vi.fn().mockResolvedValue([]),
+    select: vi.fn().mockResolvedValue([]),
+    getDialect: () => "sqlite",
+  } as unknown as ConstructorParameters<typeof DashboardService>[0];
+  const logger = {
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  } as unknown as ConstructorParameters<typeof DashboardService>[1];
+  return new DashboardService(adapter, logger);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  find.mockResolvedValue({ items: [] });
+});
+
+describe("recent entries", () => {
+  it("reads through the Direct API with access control ENFORCED", async () => {
+    const service = makeService();
+    vi.spyOn(
+      service as unknown as {
+        getRegisteredCollections: (s: unknown) => Promise<unknown[]>;
+      },
+      "getRegisteredCollections"
+    ).mockResolvedValue([
+      {
+        slug: "posts",
+        tableName: "posts",
+        label: "Posts",
+        group: null,
+        useAsTitle: "title",
+        hasStatus: true,
+      },
+    ]);
+
+    const caller = { user: { id: "user-1", roles: ["editor"] } };
+    await service.getRecentEntries(5, someResources(["posts"]), caller);
+
+    // The whole point of the change: the read must NOT be a raw query, and it
+    // must carry the caller so the ordinary access rules apply. A read that
+    // omitted `user` would default to a trusted read and leak exactly what the
+    // raw SQL leaked.
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        overrideAccess: false,
+        user: { id: "user-1", roles: ["editor"] },
+        limit: 5,
+        sort: "-updatedAt",
+      })
+    );
+  });
+
+  it("forwards an API key's own scope so it is not judged by its minter's roles", async () => {
+    const service = makeService();
+    vi.spyOn(
+      service as unknown as {
+        getRegisteredCollections: (s: unknown) => Promise<unknown[]>;
+      },
+      "getRegisteredCollections"
+    ).mockResolvedValue([
+      {
+        slug: "posts",
+        tableName: "posts",
+        label: "Posts",
+        group: null,
+        useAsTitle: "title",
+        hasStatus: true,
+      },
+    ]);
+
+    await service.getRecentEntries(5, someResources(["posts"]), {
+      user: { id: "user-1", roles: ["admin"] },
+      authenticatedScope: { actorType: "apiKey", permissions: ["posts:read"] },
+    });
+
+    // The Direct API's `find` names this option `actor` (it is translated to
+    // `authenticatedScope` further down the call chain -- see
+    // `direct-api/namespaces/helpers.ts`), so that is the key the caller's
+    // `authenticatedScope` must arrive under here.
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actor: {
+          actorType: "apiKey",
+          permissions: ["posts:read"],
+        },
+      })
+    );
+  });
+
+  it("refuses to read at all when it has no caller", async () => {
+    const service = makeService();
+    vi.spyOn(
+      service as unknown as {
+        getRegisteredCollections: (s: unknown) => Promise<unknown[]>;
+      },
+      "getRegisteredCollections"
+    ).mockResolvedValue([
+      {
+        slug: "posts",
+        tableName: "posts",
+        label: "Posts",
+        group: null,
+        useAsTitle: "title",
+        hasStatus: true,
+      },
+    ]);
+
+    // No caller means no access decision can be made. Reading anyway with
+    // `user: undefined` and `overrideAccess: false` is the shape most likely to
+    // be mishandled downstream, so refuse here instead.
+    const result = await service.getRecentEntries(5, someResources(["posts"]));
+
+    expect(find).not.toHaveBeenCalled();
+    expect(result).toEqual({ entries: [] });
+  });
+
+  it("does not query a collection outside the caller's scope", async () => {
+    const service = makeService();
+    vi.spyOn(
+      service as unknown as {
+        getRegisteredCollections: (s: unknown) => Promise<unknown[]>;
+      },
+      "getRegisteredCollections"
+    ).mockResolvedValue([]);
+
+    await service.getRecentEntries(5, someResources([]), {
+      user: { id: "user-1" },
+    });
+
+    expect(find).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/services/dashboard/__tests__/status-breakdown.test.ts
+++ b/packages/nextly/src/services/dashboard/__tests__/status-breakdown.test.ts
@@ -1,0 +1,188 @@
+/**
+ * The draft/published breakdown must be the CALLER's breakdown.
+ *
+ * `getStats` computes `content.totalEntries` from the access-controlled
+ * per-collection counts (`collection-counts.test.ts`), but its sibling
+ * `status` breakdown used to run raw `SELECT ... GROUP BY status` over the
+ * PHYSICAL table -- ignoring both the collection's access rule and its
+ * stored row-level constraint. A collection with an owner-only read rule
+ * therefore reported the WHOLE table's draft/published split to a reader who
+ * could see only a fraction of it: the breakdown both disclosed hidden row
+ * counts and contradicted the total sitting beside it in the same response.
+ *
+ * The fix routes the breakdown through the same access-enforced
+ * `nextly.count({ overrideAccess: false, status })` path as the total, once
+ * for `"published"` and once for `"draft"`. So this file drives the raw
+ * per-status counts and the access-controlled ones to DIFFERENT numbers -- a
+ * test where they agreed could not tell the two implementations apart -- and
+ * asserts `totalEntries === published + draft` for the CALLER, which the raw
+ * path could not have satisfied.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { count } = vi.hoisted(() => ({ count: vi.fn() }));
+vi.mock("../../../direct-api/nextly", () => ({ getNextly: () => ({ count }) }));
+
+const { containerGet } = vi.hoisted(() => ({ containerGet: vi.fn() }));
+vi.mock("../../../di/container", () => ({ container: { get: containerGet } }));
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+
+import type { Logger } from "../../shared";
+import { DashboardService } from "../dashboard-service";
+import { someResources, type ReadCaller } from "../readable-resources";
+
+/**
+ * Table-wide truth: 5 rows, 4 published, 1 draft. A stored owner-only read
+ * rule means Alice may see only her own 1 row, which happens to be published.
+ */
+const RAW_PUBLISHED_EVERYONE = 4;
+const RAW_DRAFT_EVERYONE = 1;
+const ALICE_VISIBLE_TOTAL = 1;
+const ALICE_VISIBLE_PUBLISHED = 1;
+const ALICE_VISIBLE_DRAFT = 0;
+
+/** `status: true` is the collection-level Draft/Published lifecycle flag. */
+const COLLECTIONS = [
+  {
+    slug: "posts",
+    tableName: "posts",
+    labels: { plural: "Posts" },
+    fields: [],
+    status: true,
+  },
+];
+
+const CALLER: ReadCaller = {
+  user: { id: "alice", roles: ["editor"] },
+};
+
+/**
+ * Any raw SQL over `posts` answers with EVERYONE's rows, access ignored --
+ * the wrong number this fix must stop reaching for.
+ */
+function makeAdapter(): DrizzleAdapter {
+  return {
+    getCapabilities: () => ({ dialect: "sqlite" }),
+    executeQuery: vi.fn().mockImplementation((sql: string) => {
+      if (sql.toLowerCase().includes("group by")) {
+        return Promise.resolve([
+          { status: "published", count: RAW_PUBLISHED_EVERYONE },
+          { status: "draft", count: RAW_DRAFT_EVERYONE },
+        ]);
+      }
+      return Promise.resolve([
+        { count: RAW_PUBLISHED_EVERYONE + RAW_DRAFT_EVERYONE },
+      ]);
+    }),
+  } as unknown as DrizzleAdapter;
+}
+
+function makeLogger(): Logger {
+  return { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+}
+
+function makeService(adapter: DrizzleAdapter): DashboardService {
+  return new DashboardService(adapter, makeLogger());
+}
+
+let adapter: DrizzleAdapter;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  adapter = makeAdapter();
+  containerGet.mockImplementation((name: string) => {
+    if (name === "collectionRegistryService") {
+      return { getAllCollections: vi.fn().mockResolvedValue(COLLECTIONS) };
+    }
+    if (name === "singleRegistryService") {
+      return { getAllSingles: vi.fn().mockResolvedValue([]) };
+    }
+    throw new Error(`unexpected container.get("${name}")`);
+  });
+
+  // The access-controlled count answers per the STATUS it was asked for --
+  // Alice's one visible row, split by lifecycle. `status: "all"` is what
+  // `getCollectionCounts` asks for the total.
+  count.mockImplementation(
+    ({ status }: { status?: "all" | "published" | "draft" }) => {
+      if (status === "published") {
+        return Promise.resolve({ total: ALICE_VISIBLE_PUBLISHED });
+      }
+      if (status === "draft") {
+        return Promise.resolve({ total: ALICE_VISIBLE_DRAFT });
+      }
+      return Promise.resolve({ total: ALICE_VISIBLE_TOTAL });
+    }
+  );
+});
+
+describe("the status breakdown honours the caller's row-level access", () => {
+  it("reports the CALLER's published/draft split, not the whole table's", async () => {
+    const stats = await makeService(adapter).getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    expect(stats.status).toEqual({
+      published: ALICE_VISIBLE_PUBLISHED,
+      draft: ALICE_VISIBLE_DRAFT,
+    });
+    // The number a raw, access-blind GROUP BY would have reported -- this is
+    // the separating assertion. With the two numbers equal, both
+    // implementations would pass.
+    expect(stats.status.published).not.toBe(RAW_PUBLISHED_EVERYONE);
+    expect(stats.status.draft).not.toBe(RAW_DRAFT_EVERYONE);
+  });
+
+  it("keeps the breakdown consistent with the total: totalEntries === published + draft", async () => {
+    const stats = await makeService(adapter).getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    expect(stats.content.totalEntries).toBe(ALICE_VISIBLE_TOTAL);
+    expect(stats.content.totalEntries).toBe(
+      stats.status.published + stats.status.draft
+    );
+  });
+
+  it("asks for published and draft through the access-enforced count, per collection", async () => {
+    await makeService(adapter).getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    expect(count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        overrideAccess: false,
+        user: CALLER.user,
+        status: "published",
+      })
+    );
+    expect(count).toHaveBeenCalledWith(
+      expect.objectContaining({
+        collection: "posts",
+        overrideAccess: false,
+        user: CALLER.user,
+        status: "draft",
+      })
+    );
+  });
+
+  it("never falls back to a raw GROUP BY over the physical table", async () => {
+    await makeService(adapter).getStats({
+      scope: someResources(["posts"]),
+      caller: CALLER,
+    });
+
+    const rawCalls = (
+      adapter.executeQuery as unknown as { mock: { calls: unknown[][] } }
+    ).mock.calls;
+    for (const [sql] of rawCalls) {
+      expect(String(sql).toLowerCase()).not.toContain("group by");
+    }
+  });
+});

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -26,6 +26,8 @@ import { NextlyError } from "../../errors";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
 
+import { someResources, type ReadableResources } from "./readable-resources";
+
 /** The three mutation actions tracked in the activity log. */
 export type ActivityLogAction = "create" | "update" | "delete";
 
@@ -95,6 +97,12 @@ export interface ActivityLogQueryOptions {
   offset?: number;
   collection?: string;
   userId?: string;
+  /**
+   * Which resources the caller may read. An omitted scope denies: this feed
+   * exposes entry titles across every collection, so a caller that forgets to
+   * scope it must get nothing rather than everything.
+   */
+  scope?: ReadableResources;
 }
 
 const TABLE = "activity_log";
@@ -145,7 +153,9 @@ interface ActivityFilter {
   property: string;
   /** The physical column, for the count query's SQL. */
   column: string;
-  value: SqlParam;
+  /** `=` for a single value, `IN` for a set. */
+  op: "=" | "IN";
+  value: SqlParam | SqlParam[];
 }
 
 /**
@@ -297,6 +307,11 @@ export class ActivityLogService extends BaseService {
     const limit = Math.min(options?.limit ?? 10, 50);
     const offset = options?.offset ?? 0;
 
+    // Fail-closed default: an omitted scope must deny, not grant. This feed
+    // exposes entry titles across every collection, so a caller that forgets
+    // to pass one gets nothing rather than everything.
+    const scope = options?.scope ?? someResources([]);
+
     try {
       // Each filter carries BOTH spellings because its two consumers disagree
       // by nature: `adapter.select` resolves names against the Drizzle table,
@@ -310,6 +325,7 @@ export class ActivityLogService extends BaseService {
         filters.push({
           property: "collection",
           column: "collection",
+          op: "=",
           value: options.collection,
         });
       }
@@ -317,7 +333,24 @@ export class ActivityLogService extends BaseService {
         filters.push({
           property: "userId",
           column: "user_id",
+          op: "=",
           value: options.userId,
+        });
+      }
+      if (scope.kind === "some") {
+        // An empty scope yields an `IN ()`, which matches nothing -- the
+        // intended answer for a caller who may read nothing. Short-circuit
+        // instead, because an empty IN list is a syntax error on some
+        // dialects, and the short-circuit must happen BEFORE the query is
+        // built rather than let the driver reject it.
+        if (scope.resources.size === 0) {
+          return { activities: [], total: 0, hasMore: false };
+        }
+        filters.push({
+          property: "collection",
+          column: "collection",
+          op: "IN",
+          value: [...scope.resources],
         });
       }
 
@@ -326,7 +359,7 @@ export class ActivityLogService extends BaseService {
           ? {
               and: filters.map(f => ({
                 column: f.property,
-                op: "=" as const,
+                op: f.op,
                 value: f.value,
               })),
             }
@@ -365,13 +398,12 @@ export class ActivityLogService extends BaseService {
       const params: SqlParam[] = [];
 
       if (filters.length > 0) {
-        const clauses = filters.map((c, i) => {
-          params.push(c.value);
-          // Use positional placeholders for PG ($1, $2) and ? for MySQL/SQLite
-          return this.dialect === "postgresql"
-            ? `"${c.column}" = $${i + 1}`
-            : `\`${c.column}\` = ?`;
-        });
+        // Placeholder numbering derives from `params.length` as each value is
+        // pushed, not from the filter's own index: an `IN` filter contributes
+        // several parameters, so `$${i + 1}` -- correct only while every
+        // filter carried exactly one value -- would bind the wrong values
+        // for every filter after the first `IN`.
+        const clauses = filters.map(f => this.filterClause(f, params));
         sql += ` WHERE ${clauses.join(" AND ")}`;
       }
 
@@ -383,6 +415,39 @@ export class ActivityLogService extends BaseService {
     } catch {
       return 0;
     }
+  }
+
+  /**
+   * Render one filter as a parameterised SQL clause, pushing its value(s)
+   * onto `params` as it goes.
+   *
+   * Placeholder numbering derives from `params.length` at the moment each
+   * value is pushed, never from the filter's position in the array: an `IN`
+   * filter contributes several parameters, so a caller numbering from the
+   * filter index (`$${i + 1}`) -- correct only while every filter carried
+   * exactly one value -- would bind the wrong values for every filter that
+   * follows the first `IN`.
+   */
+  private filterClause(filter: ActivityFilter, params: SqlParam[]): string {
+    const quoted =
+      this.dialect === "postgresql"
+        ? `"${filter.column}"`
+        : `\`${filter.column}\``;
+
+    if (filter.op === "IN") {
+      const placeholders = (filter.value as SqlParam[])
+        .map(v => {
+          params.push(v);
+          return this.dialect === "postgresql" ? `$${params.length}` : "?";
+        })
+        .join(", ");
+      return `${quoted} IN (${placeholders})`;
+    }
+
+    params.push(filter.value as SqlParam);
+    return this.dialect === "postgresql"
+      ? `${quoted} = $${params.length}`
+      : `${quoted} = ?`;
   }
 
   private mapRow = (row: Record<string, unknown>): ActivityLogEntry => {

--- a/packages/nextly/src/services/dashboard/activity-log-service.ts
+++ b/packages/nextly/src/services/dashboard/activity-log-service.ts
@@ -147,16 +147,23 @@ interface ActivityWriteTables {
  * wants the schema property; the count query writes SQL and wants the physical
  * column. They are carried together so a filter cannot be added in one
  * spelling and used in the other.
+ *
+ * A discriminated union rather than `op: "=" | "IN"` paired with
+ * `value: SqlParam | SqlParam[]`: those two fields varying independently let
+ * `{ op: "=", value: ["a", "b"] }` type-check, a state `filterClause` cannot
+ * handle. Tying `op` to `value`'s shape makes that state unrepresentable and
+ * lets `filterClause` narrow on `op` without a cast.
  */
-interface ActivityFilter {
+interface ActivityFilterBase {
   /** The Drizzle schema property, for `adapter.select`. */
   property: string;
   /** The physical column, for the count query's SQL. */
   column: string;
-  /** `=` for a single value, `IN` for a set. */
-  op: "=" | "IN";
-  value: SqlParam | SqlParam[];
 }
+
+type ActivityFilter =
+  | (ActivityFilterBase & { op: "="; value: SqlParam })
+  | (ActivityFilterBase & { op: "IN"; value: SqlParam[] });
 
 /**
  * Safely convert an unknown driver-returned value to a nullable string.
@@ -412,7 +419,14 @@ export class ActivityLogService extends BaseService {
       }>(sql, params);
 
       return Number(result[0]?.count ?? 0);
-    } catch {
+    } catch (error) {
+      // Matches the sibling catch in `getRecentActivity`: a placeholder/params
+      // mismatch or a dialect failure here would otherwise surface as a silent
+      // 0 with nothing in the logs to explain it -- the `total` field would be
+      // wrong and nothing would say why.
+      this.logger.error("Failed to count activities", {
+        error: error instanceof Error ? error.message : String(error),
+      });
       return 0;
     }
   }
@@ -434,8 +448,12 @@ export class ActivityLogService extends BaseService {
         ? `"${filter.column}"`
         : `\`${filter.column}\``;
 
+    // The discriminated union on `filter.op` narrows `filter.value` to
+    // `SqlParam[]` in this branch and `SqlParam` below without a cast --
+    // the type itself rules out an `IN` filter carrying a scalar or a `=`
+    // filter carrying an array.
     if (filter.op === "IN") {
-      const placeholders = (filter.value as SqlParam[])
+      const placeholders = filter.value
         .map(v => {
           params.push(v);
           return this.dialect === "postgresql" ? `$${params.length}` : "?";
@@ -444,7 +462,7 @@ export class ActivityLogService extends BaseService {
       return `${quoted} IN (${placeholders})`;
     }
 
-    params.push(filter.value as SqlParam);
+    params.push(filter.value);
     return this.dialect === "postgresql"
       ? `${quoted} = $${params.length}`
       : `${quoted} = ?`;

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -2,9 +2,15 @@
  * Dashboard Service
  *
  * Aggregates content-centric statistics, recent entries across collections,
- * and project-wide metrics for the admin dashboard. Uses the database adapter
- * directly for simple read-only aggregate queries — no hooks, access control,
- * or relationship expansion needed for dashboard stats.
+ * and project-wide metrics for the admin dashboard.
+ *
+ * Anything describing CONTENT goes through the ordinary access-controlled path
+ * — `nextly.find` for the recent-entries feed, `nextly.count` for the
+ * per-collection totals — because a number computed beside the access layer
+ * discloses exactly what the row read withholds. The adapter is used directly
+ * only for the installation-wide admin metrics (`media`, `users`, `roles`,
+ * `permissions`, active API keys), which are uniformly unscoped, and for the
+ * two `activity_log` aggregates, whose scoping is applied to the query itself.
  *
  * @module services/dashboard/dashboard-service
  * @since 1.0.0
@@ -100,8 +106,9 @@ export class DashboardService extends BaseService {
   /**
    * Get aggregated dashboard statistics.
    *
-   * Runs all count queries in parallel for fast response. Uses the database
-   * adapter directly for simple COUNT(*) queries.
+   * Runs all count queries in parallel for fast response. The per-collection
+   * totals go through the access-controlled count; see
+   * {@link countReadableEntries} for why they cannot be a bare `COUNT(*)`.
    */
   async getStats(options: {
     scope?: ReadableResources;

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -125,7 +125,7 @@ export class DashboardService extends BaseService {
     ] = await Promise.all([
       this.getCollectionCounts(collections),
       this.countTable("media"),
-      this.countRecentChanges24h(),
+      this.countRecentChanges24h(scope),
       this.countTable("users"),
       this.countTable("roles"),
       this.countTable("permissions"),
@@ -389,7 +389,31 @@ export class DashboardService extends BaseService {
     }
   }
 
-  private async countRecentChanges24h(): Promise<number> {
+  /**
+   * Count the last 24 hours of `activity_log` rows the caller may READ.
+   *
+   * `activity_log` spans every collection, so an unscoped count answers a
+   * different question from the `collectionCounts` beside it in the same
+   * `/stats` response: one honours the caller's scope and the other does not,
+   * and the number itself then discloses that changes exist outside the
+   * caller's reach. `ActivityLogService.getRecentActivity` filters this table
+   * with an `IN` on `collection`; this is the same filter applied to the count.
+   *
+   * The other counters in `getStats` (`media`, `users`, `roles`, `permissions`,
+   * active API keys) stay unscoped. They are uniformly unscoped rather than
+   * newly inconsistent, and what a scoped admin metric should mean is a design
+   * question rather than a defect in this table's filter.
+   *
+   * @param scope - What the caller may read. An empty `some` returns 0 without
+   *   querying: it admits nothing, and an empty `IN ()` is a syntax error on
+   *   some dialects, so the short-circuit has to happen before the query is
+   *   built rather than as a driver rejection swallowed by the catch below.
+   */
+  private async countRecentChanges24h(
+    scope: ReadableResources
+  ): Promise<number> {
+    if (scope.kind === "some" && scope.resources.size === 0) return 0;
+
     try {
       const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000);
       // Phase A follow-up: same dialect-aware formatter as above. The
@@ -397,15 +421,34 @@ export class DashboardService extends BaseService {
       // SQLite rejects.
       const cutoffParam = this.dateForRawBind(cutoff);
       const q = this.dialect === "mysql" ? "`" : '"';
-      const ph = this.dialect === "postgresql" ? "$1" : "?";
 
-      const sql =
+      // Placeholder numbering derives from `params.length` at the moment each
+      // value is pushed, never from a fixed index: the `IN` list contributes
+      // as many parameters as the scope has resources, so a hardcoded `$1`/`$2`
+      // -- correct only while the query bound exactly one value -- would bind
+      // the cutoff and the collection names to the wrong positions. Every
+      // value goes through here, so no collection name is ever interpolated
+      // into the SQL text.
+      const params: SqlParam[] = [];
+      const bind = (value: SqlParam): string => {
+        params.push(value);
+        return this.dialect === "postgresql" ? `$${params.length}` : "?";
+      };
+
+      let sql =
         `SELECT COUNT(*) as count FROM ${q}activity_log${q} ` +
-        `WHERE ${q}created_at${q} > ${ph}`;
+        `WHERE ${q}created_at${q} > ${bind(cutoffParam)}`;
+
+      if (scope.kind === "some") {
+        const placeholders = [...scope.resources]
+          .map(resource => bind(resource))
+          .join(", ");
+        sql += ` AND ${q}collection${q} IN (${placeholders})`;
+      }
 
       const result = await this.adapter.executeQuery<{
         count: number | string;
-      }>(sql, [cutoffParam]);
+      }>(sql, params);
 
       return Number(result[0]?.count ?? 0);
     } catch (error) {

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -16,6 +16,7 @@ import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 import { container } from "../../di/container";
 import { getNextly } from "../../direct-api/nextly";
 import type { CountArgs, FindArgs } from "../../direct-api/types";
+import { entryHeading } from "../../lib/entry-heading";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
 
@@ -708,13 +709,15 @@ export class DashboardService extends BaseService {
       const rows = result.items ?? [];
 
       return rows.map(row => {
-        const rawTitle = row[titleField] ?? row.title ?? row.name ?? row.id;
         // `??` against an `unknown` value narrows the checked side to `{}`,
         // which still has nothing but `Object.prototype.toString` -- calling
         // `String()` on that renders `[object Object]` instead of failing
         // loudly. Narrow by `typeof`/`instanceof` first so every branch that
         // reaches `String()` (or a bare `.toLowerCase()`) is already known to
-        // be a real primitive.
+        // be a real primitive. `entryHeading` is that narrowing for the title,
+        // and it is the SAME walk the activity feed records its headings with,
+        // so one entry does not get two different names depending on which
+        // surface names it.
         const updatedAt =
           row.updatedAt instanceof Date
             ? row.updatedAt.toISOString()
@@ -727,9 +730,10 @@ export class DashboardService extends BaseService {
           status = row.status.toLowerCase() === "draft" ? "draft" : "published";
         }
 
+        const id = String(row.id);
         return {
-          id: String(row.id),
-          title: String(rawTitle),
+          id,
+          title: entryHeading(row, titleField, id),
           collectionSlug: coll.slug,
           collectionLabel: coll.label,
           status,

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -15,7 +15,7 @@ import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 
 import { container } from "../../di/container";
 import { getNextly } from "../../direct-api/nextly";
-import type { FindArgs } from "../../direct-api/types";
+import type { CountArgs, FindArgs } from "../../direct-api/types";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
 
@@ -102,13 +102,22 @@ export class DashboardService extends BaseService {
    * Runs all count queries in parallel for fast response. Uses the database
    * adapter directly for simple COUNT(*) queries.
    */
-  async getStats(options?: {
+  async getStats(options: {
     scope?: ReadableResources;
+    /**
+     * Who is asking. REQUIRED, not defaulted, for the reason
+     * {@link getRecentEntries} states: the per-collection totals are read with
+     * access ENFORCED, so a caller-less call would have to read with
+     * `user: undefined`, and the only safe meaning of that is zero. Making it a
+     * type error forecloses the shape rather than leaving a runtime guard to
+     * catch it.
+     */
+    caller: ReadCaller;
   }): Promise<DashboardStatsResponse> {
     // An omitted scope denies rather than allows. A caller that forgets to
     // pass one gets an empty dashboard, which is visible and reportable; the
     // old default returned everything, which was not.
-    const scope = options?.scope ?? someResources([]);
+    const scope = options.scope ?? someResources([]);
     const collections = await this.getRegisteredCollections(scope);
     const singles = await this.getRegisteredSingles(scope);
 
@@ -123,7 +132,7 @@ export class DashboardService extends BaseService {
       apiKeyCount,
       statusBreakdown,
     ] = await Promise.all([
-      this.getCollectionCounts(collections),
+      this.getCollectionCounts(collections, options.caller),
       this.countTable("media"),
       this.countRecentChanges24h(scope),
       this.countTable("users"),
@@ -211,8 +220,9 @@ export class DashboardService extends BaseService {
    * Returns an array of stat items for display in the 2×4 grid widget.
    * Reuses the same data sources as `getStats()`.
    */
-  async getProjectStats(options?: {
+  async getProjectStats(options: {
     scope?: ReadableResources;
+    caller: ReadCaller;
   }): Promise<ProjectStatsResponse> {
     const dashStats = await this.getStats(options);
 
@@ -488,20 +498,75 @@ export class DashboardService extends BaseService {
   }
 
   private async getCollectionCounts(
-    collections: CollectionInfo[]
+    collections: CollectionInfo[],
+    caller: ReadCaller
   ): Promise<CollectionCount[]> {
     const results = await Promise.all(
-      collections.map(async coll => {
-        const count = await this.countTable(coll.tableName);
-        return {
-          slug: coll.slug,
-          label: coll.label,
-          group: coll.group,
-          count,
-        };
-      })
+      collections.map(async coll => ({
+        slug: coll.slug,
+        label: coll.label,
+        group: coll.group,
+        count: await this.countReadableEntries(coll, caller),
+      }))
     );
     return results;
+  }
+
+  /**
+   * How many entries of ONE collection this caller may read.
+   *
+   * This used to be `countTable`, a bare `SELECT COUNT(*)` over the physical
+   * table. The read SCOPE decides whether a collection appears here at all; it
+   * says nothing about which rows inside it the caller may read, so a
+   * collection with an owner-only or custom stored read rule reported every
+   * author's rows to every reader who could open it -- the count disclosing
+   * exactly what the row read withholds.
+   *
+   * `overrideAccess: false` plus `user` is what closes it: `countEntries` runs
+   * `checkCollectionAccess` and then applies `getAccessQueryConstraint`, which
+   * is the same WHERE predicate the list read applies. `getRecentEntries` takes
+   * the identical path for the same reason.
+   *
+   * `status: "all"` is the one WIDENING option, and it keeps the number
+   * MEANING what it meant: an untrusted count that states nothing gets
+   * `resolveStatusFilter`'s `published` default, so without it the dashboard's
+   * per-collection totals would quietly exclude drafts and stop agreeing with
+   * the draft/published breakdown beside them. Under `"all"` no status
+   * condition is built at all, for the main row or a localized collection's
+   * per-locale `_status` companion.
+   */
+  private async countReadableEntries(
+    coll: CollectionInfo,
+    caller: ReadCaller
+  ): Promise<number> {
+    try {
+      const result = await getNextly().count({
+        collection: coll.slug,
+        overrideAccess: false,
+        user: caller.user,
+        // `satisfies` makes the field name a COMPILE-TIME boundary: a
+        // conditional spread is exempt from excess-property checking, so a
+        // wrong key here would compile clean and be dropped silently, leaving
+        // an API key counted by its minter's roles. Same pattern as
+        // `getRecentFromCollection`'s `find()` call.
+        ...(caller.authenticatedScope
+          ? ({ actor: caller.authenticatedScope } satisfies Pick<
+              CountArgs<string>,
+              "actor"
+            >)
+          : {}),
+        status: "all",
+      });
+      return result.total;
+    } catch (error) {
+      // A collection whose table is not yet created, or whose read the caller
+      // is refused outright, contributes zero rather than failing the whole
+      // dashboard -- the same posture `getRecentFromCollection` takes.
+      this.logger.debug(`Failed to count entries in ${coll.slug}`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return 0;
+    }
   }
 
   /**

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -15,6 +15,7 @@ import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 
 import { container } from "../../di/container";
 import { getNextly } from "../../direct-api/nextly";
+import type { FindArgs } from "../../direct-api/types";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
 
@@ -163,21 +164,19 @@ export class DashboardService extends BaseService {
    * @param limit - Maximum number of entries to return (default: 5, max: 20)
    * @param scope - What the caller may read. Defaults to nothing rather than
    *   everything -- see {@link getStats}.
-   * @param caller - Who is asking. Required to make an access decision at all:
-   *   see the no-caller guard below, which refuses rather than reading with
-   *   `user: undefined`.
+   * @param caller - Who is asking. REQUIRED, not defaulted: there is exactly
+   *   one production caller (the REST handler, via `readCaller`), and a
+   *   future handler that forgets to build one must fail to compile rather
+   *   than silently return HTTP 200 with an empty, unauthenticated-looking
+   *   feed. Reading with `user: undefined` and `overrideAccess: false` is the
+   *   shape most likely to be mishandled downstream, so the type system
+   *   forecloses it instead of a runtime guard trying to catch it.
    */
   async getRecentEntries(
     limit: number = 5,
     scope: ReadableResources = someResources([]),
-    caller?: ReadCaller
+    caller: ReadCaller
   ): Promise<RecentEntriesResponse> {
-    // No caller, no access decision. Reading anyway with `user: undefined`
-    // and `overrideAccess: false` is the shape most likely to be mishandled
-    // downstream (some paths treat a missing `user` as "trusted"), so refuse
-    // outright rather than hand an ambiguous read on.
-    if (!caller) return { entries: [] };
-
     const clampedLimit = Math.min(Math.max(limit, 1), 20);
     const collections = await this.getRegisteredCollections(scope);
 
@@ -567,12 +566,28 @@ export class DashboardService extends BaseService {
         // Reducing either to an id is how a read silently answers as
         // somebody with different rights.
         user: caller.user,
+        // `satisfies` makes the field name a COMPILE-TIME boundary rather
+        // than a convention: `find()`'s excess-property check is exempt from
+        // a conditional spread (`...(cond ? {x} : {})`), which is exactly
+        // why a wrong key here -- `authenticatedScope`, the name this value
+        // has on `caller` -- would compile clean and be silently dropped by
+        // `find()` instead of failing loudly. Typing the spread's operand
+        // against the real option name closes that gap: rename `actor`
+        // anywhere in `FindArgs` and this line stops compiling.
         ...(caller.authenticatedScope
-          ? { actor: caller.authenticatedScope }
+          ? ({ actor: caller.authenticatedScope } satisfies Pick<
+              FindArgs<string>,
+              "actor"
+            >)
           : {}),
         // The dashboard shows what the editor can act on, drafts included.
-        // The lifecycle filter -- not a `where` on a status column -- is
-        // what makes this correct for localized collections too.
+        // `status: "all"` is the one WIDENING option in this call -- it also
+        // propagates into relationship expansion (see
+        // `status-filter.ts`'s `expansionStatusScope`) -- and under it
+        // `resolveStatusFilter` returns null: no status condition is built
+        // at all, for the main row or its per-locale `_status` companion.
+        // That is not "the lifecycle filter handles locales correctly"; it
+        // is that NO filter is applied, so none can be wrong for either.
         status: "all",
         select: {
           id: true,

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -17,6 +17,13 @@ import { container } from "../../di/container";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
 
+import {
+  filterByResource,
+  someResources,
+  type ReadableResources,
+  type ReadCaller,
+} from "./readable-resources";
+
 /** Content statistics for the hero stats row. */
 export interface ContentStats {
   totalEntries: number;
@@ -94,12 +101,14 @@ export class DashboardService extends BaseService {
    * adapter directly for simple COUNT(*) queries.
    */
   async getStats(options?: {
-    readableResources?: Set<string>;
+    scope?: ReadableResources;
   }): Promise<DashboardStatsResponse> {
-    const collections = await this.getRegisteredCollections(
-      options?.readableResources
-    );
-    const singles = await this.getRegisteredSingles(options?.readableResources);
+    // An omitted scope denies rather than allows. A caller that forgets to
+    // pass one gets an empty dashboard, which is visible and reportable; the
+    // old default returned everything, which was not.
+    const scope = options?.scope ?? someResources([]);
+    const collections = await this.getRegisteredCollections(scope);
+    const singles = await this.getRegisteredSingles(scope);
 
     const [
       collectionCounts,
@@ -151,13 +160,21 @@ export class DashboardService extends BaseService {
    * to prevent excessive DB queries on large installations.
    *
    * @param limit - Maximum number of entries to return (default: 5, max: 20)
+   * @param scope - What the caller may read. Defaults to nothing rather than
+   *   everything -- see {@link getStats}.
+   * @param caller - Unused in this task. Filled in by a follow-up that needs
+   *   to know who is asking rather than only what they may read; declared now
+   *   so the signature settles once instead of widening twice.
    */
   async getRecentEntries(
     limit: number = 5,
-    readableResources?: Set<string>
+    scope: ReadableResources = someResources([]),
+    // `_caller` is intentionally unused today; preserved for a follow-up that
+    // needs to know who is asking (not only what they may read).
+    _caller?: ReadCaller
   ): Promise<RecentEntriesResponse> {
     const clampedLimit = Math.min(Math.max(limit, 1), 20);
-    const collections = await this.getRegisteredCollections(readableResources);
+    const collections = await this.getRegisteredCollections(scope);
 
     let collectionsToQuery = collections;
     if (collections.length > MAX_COLLECTIONS_FOR_RECENT) {
@@ -191,7 +208,7 @@ export class DashboardService extends BaseService {
    * Reuses the same data sources as `getStats()`.
    */
   async getProjectStats(options?: {
-    readableResources?: Set<string>;
+    scope?: ReadableResources;
   }): Promise<ProjectStatsResponse> {
     const dashStats = await this.getStats(options);
 
@@ -226,7 +243,7 @@ export class DashboardService extends BaseService {
   }
 
   private async getRegisteredCollections(
-    readableResources?: Set<string>
+    scope: ReadableResources
   ): Promise<CollectionInfo[]> {
     try {
       const registryService = container.get<{
@@ -252,8 +269,9 @@ export class DashboardService extends BaseService {
           c.fields?.some(f => f.name === "_status" || f.name === "status") ??
           false,
       }));
-      if (!readableResources || readableResources.size === 0) return mapped;
-      return mapped.filter(c => readableResources.has(String(c.slug)));
+      // Derive the readable subset from the shared scope check rather than
+      // re-testing membership here -- see `filterByResource`.
+      return filterByResource(scope, mapped, c => String(c.slug));
     } catch (error) {
       this.logger.error("Failed to get registered collections", {
         error: error instanceof Error ? error.message : String(error),
@@ -263,7 +281,7 @@ export class DashboardService extends BaseService {
   }
 
   private async getRegisteredSingles(
-    readableResources?: Set<string>
+    scope: ReadableResources
   ): Promise<Array<{ slug: string }>> {
     try {
       const singleRegistryService = container.get<{
@@ -271,9 +289,7 @@ export class DashboardService extends BaseService {
       }>("singleRegistryService");
 
       const singles = await singleRegistryService.getAllSingles();
-      if (!readableResources || readableResources.size === 0) return singles;
-
-      return singles.filter(s => readableResources.has(String(s.slug)));
+      return filterByResource(scope, singles, s => String(s.slug));
     } catch (error) {
       this.logger.error("Failed to get registered singles", {
         error: error instanceof Error ? error.message : String(error),

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -14,6 +14,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { SqlParam } from "@nextlyhq/adapter-drizzle/types";
 
 import { container } from "../../di/container";
+import { getNextly } from "../../direct-api/nextly";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
 
@@ -162,17 +163,21 @@ export class DashboardService extends BaseService {
    * @param limit - Maximum number of entries to return (default: 5, max: 20)
    * @param scope - What the caller may read. Defaults to nothing rather than
    *   everything -- see {@link getStats}.
-   * @param caller - Unused in this task. Filled in by a follow-up that needs
-   *   to know who is asking rather than only what they may read; declared now
-   *   so the signature settles once instead of widening twice.
+   * @param caller - Who is asking. Required to make an access decision at all:
+   *   see the no-caller guard below, which refuses rather than reading with
+   *   `user: undefined`.
    */
   async getRecentEntries(
     limit: number = 5,
     scope: ReadableResources = someResources([]),
-    // `_caller` is intentionally unused today; preserved for a follow-up that
-    // needs to know who is asking (not only what they may read).
-    _caller?: ReadCaller
+    caller?: ReadCaller
   ): Promise<RecentEntriesResponse> {
+    // No caller, no access decision. Reading anyway with `user: undefined`
+    // and `overrideAccess: false` is the shape most likely to be mishandled
+    // downstream (some paths treat a missing `user` as "trusted"), so refuse
+    // outright rather than hand an ambiguous read on.
+    if (!caller) return { entries: [] };
+
     const clampedLimit = Math.min(Math.max(limit, 1), 20);
     const collections = await this.getRegisteredCollections(scope);
 
@@ -186,7 +191,7 @@ export class DashboardService extends BaseService {
     }
 
     const entryPromises = collectionsToQuery.map(coll =>
-      this.getRecentFromCollection(coll, clampedLimit)
+      this.getRecentFromCollection(coll, clampedLimit, caller)
     );
     const results = await Promise.all(entryPromises);
 
@@ -529,70 +534,90 @@ export class DashboardService extends BaseService {
     }
   }
 
+  /**
+   * Recent entries from ONE collection, read through the ordinary
+   * access-controlled path.
+   *
+   * This used to be a hand-built `SELECT ... ORDER BY updated_at DESC
+   * LIMIT n` against the physical table. That skipped field-level access
+   * control, the collection's own access `where` constraints, the
+   * draft/publish lifecycle (it string-matched a `status` column, so a
+   * localized collection's per-locale `_status` companion was invisible),
+   * locale scoping and hooks -- and returned the titles of entries the
+   * caller could not read.
+   *
+   * `overrideAccess: false` plus `user` is what enforces all of it, and is
+   * the same path a REST read takes.
+   */
   private async getRecentFromCollection(
     coll: CollectionInfo,
-    limit: number
+    limit: number,
+    caller: ReadCaller
   ): Promise<RecentEntry[]> {
     try {
-      const q = this.dialect === "mysql" ? "`" : '"';
-      const titleCol = coll.useAsTitle ?? "title";
+      const titleField = coll.useAsTitle ?? "title";
+      const result = await getNextly().find({
+        collection: coll.slug,
+        limit,
+        sort: "-updatedAt",
+        overrideAccess: false,
+        // The caller WHOLE: `user` carries resolved role slugs, and `actor`
+        // (translated internally to `authenticatedScope`) keeps an API key
+        // judged on its own stamped grant rather than its minter's roles.
+        // Reducing either to an id is how a read silently answers as
+        // somebody with different rights.
+        user: caller.user,
+        ...(caller.authenticatedScope
+          ? { actor: caller.authenticatedScope }
+          : {}),
+        // The dashboard shows what the editor can act on, drafts included.
+        // The lifecycle filter -- not a `where` on a status column -- is
+        // what makes this correct for localized collections too.
+        status: "all",
+        select: {
+          id: true,
+          updatedAt: true,
+          [titleField]: true,
+          ...(coll.hasStatus ? { status: true } : {}),
+        },
+      });
 
-      const selectCols = [`${q}id${q}`, `${q}updated_at${q}`];
+      const rows = result.items ?? [];
 
-      // Try to select the title column; if it doesn't exist the query
-      // will just return NULL for it — we fall back to the entry ID.
-      selectCols.push(`${q}${titleCol}${q}`);
-
-      if (coll.hasStatus) {
-        selectCols.push(`${q}status${q}`);
-      }
-
-      const sql =
-        `SELECT ${selectCols.join(", ")} ` +
-        `FROM ${q}${coll.tableName}${q} ` +
-        `ORDER BY ${q}updated_at${q} DESC ` +
-        `LIMIT ${limit}`;
-
-      const rows = await this.adapter.executeQuery<Record<string, unknown>>(
-        sql,
-        []
-      );
-
-      /* eslint-disable @typescript-eslint/no-base-to-string */
       return rows.map(row => {
-        const title =
-          row[titleCol] != null
-            ? String(row[titleCol])
-            : row.title != null
-              ? String(row.title)
-              : row.name != null
-                ? String(row.name)
-                : String(row.id);
-
+        const rawTitle = row[titleField] ?? row.title ?? row.name ?? row.id;
+        // `??` against an `unknown` value narrows the checked side to `{}`,
+        // which still has nothing but `Object.prototype.toString` -- calling
+        // `String()` on that renders `[object Object]` instead of failing
+        // loudly. Narrow by `typeof`/`instanceof` first so every branch that
+        // reaches `String()` (or a bare `.toLowerCase()`) is already known to
+        // be a real primitive.
         const updatedAt =
-          row.updated_at instanceof Date
-            ? row.updated_at.toISOString()
-            : String(row.updated_at ?? "");
+          row.updatedAt instanceof Date
+            ? row.updatedAt.toISOString()
+            : typeof row.updatedAt === "string"
+              ? row.updatedAt
+              : "";
 
         let status: "published" | "draft" | "none" = "none";
-        if (coll.hasStatus && row.status != null) {
-          const s = String(row.status).toLowerCase();
-          status = s === "draft" ? "draft" : "published";
+        if (coll.hasStatus && typeof row.status === "string") {
+          status = row.status.toLowerCase() === "draft" ? "draft" : "published";
         }
 
         return {
           id: String(row.id),
-          title,
+          title: String(rawTitle),
           collectionSlug: coll.slug,
           collectionLabel: coll.label,
           status,
           updatedAt,
         };
       });
-      /* eslint-enable @typescript-eslint/no-base-to-string */
     } catch (error) {
-      // Silently skip collections that fail (e.g., table doesn't exist yet)
-      this.logger.debug(`Failed to get recent entries from ${coll.tableName}`, {
+      // A collection whose table is not yet created, or which the caller
+      // may not read at all, contributes nothing rather than failing the
+      // feed.
+      this.logger.debug(`Failed to get recent entries from ${coll.slug}`, {
         error: error instanceof Error ? error.message : String(error),
       });
       return [];

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -724,10 +724,23 @@ export class DashboardService extends BaseService {
         // That is not "the lifecycle filter handles locales correctly"; it
         // is that NO filter is applied, so none can be wrong for either.
         status: "all",
+        // `entryHeading`'s fallback chain is
+        // `data[titleField] ?? data.title ?? data.name`, but the Direct
+        // API's `select` is a real projection (`applyFieldSelection` in
+        // `collection-query-service.ts` keeps only `id`, the system
+        // timestamps, and whatever key is named here) -- so `title` and
+        // `name` reach the resolver only when they are asked for by name.
+        // Without them the fallback candidates are simply absent from every
+        // real read, and the chain can never do anything but return the id:
+        // dead code that only "worked" in a test handing the resolver an
+        // unprojected row. Selecting a field twice when `titleField` already
+        // IS `title` or `name` is harmless -- every value here is `true`.
         select: {
           id: true,
           updatedAt: true,
           [titleField]: true,
+          title: true,
+          name: true,
           ...(coll.hasStatus ? { status: true } : {}),
         },
       });

--- a/packages/nextly/src/services/dashboard/dashboard-service.ts
+++ b/packages/nextly/src/services/dashboard/dashboard-service.ts
@@ -129,8 +129,16 @@ export class DashboardService extends BaseService {
     const collections = await this.getRegisteredCollections(scope);
     const singles = await this.getRegisteredSingles(scope);
 
+    // Computed first, rather than folded into the `Promise.all` below: the
+    // status breakdown reuses these numbers for every collection without the
+    // Draft/Published lifecycle (see `getContentStatusBreakdown`), which
+    // needs the totals in hand before it can decide whether to ask for more.
+    const collectionCounts = await this.getCollectionCounts(
+      collections,
+      options.caller
+    );
+
     const [
-      collectionCounts,
       mediaCount,
       recentChanges,
       userCount,
@@ -140,7 +148,6 @@ export class DashboardService extends BaseService {
       apiKeyCount,
       statusBreakdown,
     ] = await Promise.all([
-      this.getCollectionCounts(collections, options.caller),
       this.countTable("media"),
       this.countRecentChanges24h(scope),
       this.countTable("users"),
@@ -148,7 +155,11 @@ export class DashboardService extends BaseService {
       this.countTable("permissions"),
       this.countRegistryItems("fieldGroupRegistryService"),
       this.countActiveApiKeys(),
-      this.getContentStatusBreakdown(collections),
+      this.getContentStatusBreakdown(
+        collections,
+        collectionCounts,
+        options.caller
+      ),
     ]);
 
     const totalEntries = collectionCounts.reduce((sum, c) => sum + c.count, 0);
@@ -275,7 +286,18 @@ export class DashboardService extends BaseService {
             tableName: string;
             labels: { singular: string; plural: string };
             admin?: { useAsTitle?: string; group?: string };
-            fields: Array<{ name: string; type: string }>;
+            /**
+             * The Draft/Published lifecycle toggle. This is a top-level
+             * column on `dynamic_collections`, entirely separate from
+             * `fields` (the author's own field configs) -- and while the
+             * lifecycle is on, a user field literally named `status` is
+             * REJECTED at config validation as a reserved name (it would
+             * collide with the synthesized lifecycle column). So a lifecycle
+             * collection's `fields` array can never contain a `status`
+             * entry: scanning it for one always answers false, for exactly
+             * the collections this flag exists to identify.
+             */
+            status?: boolean;
           }>
         >;
       }>("collectionRegistryService");
@@ -287,9 +309,7 @@ export class DashboardService extends BaseService {
         label: c.labels?.plural ?? c.labels?.singular ?? c.slug,
         group: c.admin?.group ?? null,
         useAsTitle: c.admin?.useAsTitle ?? null,
-        hasStatus:
-          c.fields?.some(f => f.name === "_status" || f.name === "status") ??
-          false,
+        hasStatus: c.status === true,
       }));
       // Derive the readable subset from the shared scope check rather than
       // re-testing membership here -- see `filterByResource`.
@@ -535,17 +555,25 @@ export class DashboardService extends BaseService {
    * is the same WHERE predicate the list read applies. `getRecentEntries` takes
    * the identical path for the same reason.
    *
-   * `status: "all"` is the one WIDENING option, and it keeps the number
-   * MEANING what it meant: an untrusted count that states nothing gets
-   * `resolveStatusFilter`'s `published` default, so without it the dashboard's
-   * per-collection totals would quietly exclude drafts and stop agreeing with
-   * the draft/published breakdown beside them. Under `"all"` no status
-   * condition is built at all, for the main row or a localized collection's
-   * per-locale `_status` companion.
+   * `status` defaults to `"all"`, the one WIDENING option, and it keeps the
+   * number MEANING what it meant: an untrusted count that states nothing gets
+   * `resolveStatusFilter`'s `published` default, so without it the
+   * dashboard's per-collection totals would quietly exclude drafts and stop
+   * agreeing with the draft/published breakdown beside them. Under `"all"` no
+   * status condition is built at all, for the main row or a localized
+   * collection's per-locale `_status` companion.
+   *
+   * `getContentStatusBreakdown` calls this same method with `"published"` and
+   * `"draft"` explicitly, rather than a second implementation of "how many
+   * rows of this collection can this caller read": one question, one
+   * implementation, so the total and the breakdown cannot silently drift
+   * apart the way a raw `SELECT ... GROUP BY` and this access-controlled
+   * count already had.
    */
   private async countReadableEntries(
     coll: CollectionInfo,
-    caller: ReadCaller
+    caller: ReadCaller,
+    status: "all" | "published" | "draft" = "all"
   ): Promise<number> {
     try {
       const result = await getNextly().count({
@@ -563,7 +591,7 @@ export class DashboardService extends BaseService {
               "actor"
             >)
           : {}),
-        status: "all",
+        status,
       });
       return result.total;
     } catch (error) {
@@ -578,27 +606,57 @@ export class DashboardService extends BaseService {
   }
 
   /**
-   * Get draft vs published content breakdown across all collections.
+   * Draft vs published content breakdown, read through the SAME
+   * access-enforced path as the per-collection totals beside it.
    *
-   * Collections without a `_status` or `status` field count all entries
-   * as published.
+   * This used to be a raw `SELECT ... GROUP BY status` over the physical
+   * table -- ignoring both the collection's access rule and its stored
+   * row-level constraint, so a collection with an owner-only read rule
+   * reported every author's rows split by lifecycle to a reader who could see
+   * only a fraction of them. That number both disclosed rows the read access
+   * withholds and disagreed with `content.totalEntries`, computed beside it
+   * from the access-controlled count.
+   *
+   * A collection WITHOUT the Draft/Published lifecycle has no split to make:
+   * every row this caller may read counts as published. That total is
+   * already sitting in `collectionCounts` -- computed one step before this
+   * call, with the identical access rules -- so it is looked up rather than
+   * asked for again.
+   *
+   * A lifecycle collection's total CANNOT be split into `published` and
+   * `draft` by subtracting one from the other. A due RELEASE adjusts the
+   * `"published"` read alone -- revealing a draft whose scheduled publish has
+   * arrived, or hiding a published row whose scheduled unpublish has arrived
+   * (see `collection-query-service.ts`'s `releaseDecisions`, which only fires
+   * for `status: "published"`) -- while `"draft"` and `"all"` apply no such
+   * adjustment. So the three numbers are not guaranteed to sum, and each is
+   * asked for explicitly rather than derived.
    */
   private async getContentStatusBreakdown(
-    collections: CollectionInfo[]
+    collections: CollectionInfo[],
+    collectionCounts: CollectionCount[],
+    caller: ReadCaller
   ): Promise<ContentStatus> {
+    const totalsBySlug = new Map(
+      collectionCounts.map(c => [c.slug, c.count] as const)
+    );
     let published = 0;
     let draft = 0;
 
     const results = await Promise.all(
       collections.map(async coll => {
         if (!coll.hasStatus) {
-          // No status field — all entries count as published
-          const total = await this.countTable(coll.tableName);
-          return { published: total, draft: 0 };
+          // Same access rules, same rows, already counted for the total
+          // above -- asking again would be a second implementation of the
+          // same question.
+          return { published: totalsBySlug.get(coll.slug) ?? 0, draft: 0 };
         }
 
-        const statusField = coll.hasStatus ? "status" : "_status";
-        return this.countByStatus(coll.tableName, statusField);
+        const [publishedCount, draftCount] = await Promise.all([
+          this.countReadableEntries(coll, caller, "published"),
+          this.countReadableEntries(coll, caller, "draft"),
+        ]);
+        return { published: publishedCount, draft: draftCount };
       })
     );
 
@@ -608,45 +666,6 @@ export class DashboardService extends BaseService {
     }
 
     return { published, draft };
-  }
-
-  private async countByStatus(
-    tableName: string,
-    statusColumn: string
-  ): Promise<{ published: number; draft: number }> {
-    try {
-      const q = this.dialect === "mysql" ? "`" : '"';
-      const sql =
-        `SELECT ${q}${statusColumn}${q} as status, COUNT(*) as count ` +
-        `FROM ${q}${tableName}${q} ` +
-        `GROUP BY ${q}${statusColumn}${q}`;
-
-      const rows = await this.adapter.executeQuery<{
-        status: string | null;
-        count: number | string;
-      }>(sql, []);
-
-      let published = 0;
-      let draft = 0;
-
-      for (const row of rows) {
-        const count = Number(row.count ?? 0);
-        const status = String(row.status ?? "").toLowerCase();
-        if (status === "draft") {
-          draft += count;
-        } else {
-          // "published", null, or any other value counts as published
-          published += count;
-        }
-      }
-
-      return { published, draft };
-    } catch (error) {
-      this.logger.error(`Failed to count by status: ${tableName}`, {
-        error: error instanceof Error ? error.message : String(error),
-      });
-      return { published: 0, draft: 0 };
-    }
   }
 
   /**

--- a/packages/nextly/src/services/dashboard/readable-resources.ts
+++ b/packages/nextly/src/services/dashboard/readable-resources.ts
@@ -22,7 +22,20 @@ export type ReadableResources =
   | { readonly kind: "all" }
   | { readonly kind: "some"; readonly resources: ReadonlySet<string> };
 
-/** Every resource. Super-admins only. */
+/**
+ * Every resource, with no enumeration and no filter.
+ *
+ * No HTTP handler produces this any more. `resolveReadableResources` asks the
+ * access layer per registered entity, and a super-admin's bypass arrives as
+ * every entity being ADMITTED rather than as an unbounded scope -- so an
+ * `activity_log` row naming an entity that is no longer registered cannot be
+ * read by anyone, which is the deny-by-default posture the rest of this module
+ * exists for.
+ *
+ * It remains for a TRUSTED internal caller that legitimately reads across the
+ * whole installation (an account-erasure sweep, say), where narrowing to the
+ * registry would silently skip rows the sweep must reach.
+ */
 export function allResources(): ReadableResources {
   return { kind: "all" };
 }

--- a/packages/nextly/src/services/dashboard/readable-resources.ts
+++ b/packages/nextly/src/services/dashboard/readable-resources.ts
@@ -1,0 +1,66 @@
+/**
+ * What a caller is allowed to read, as a value that cannot be misread.
+ *
+ * This replaces a `Set<string> | undefined` in which `undefined` meant
+ * "super-admin, no filter" and an EMPTY SET meant "this caller may read
+ * nothing". Consumers checked `size === 0` and treated the empty set as
+ * "no filter", so the least-privileged caller was granted the most access.
+ *
+ * `listEffectivePermissions` returns `[]` for a user with no roles, for a
+ * falsy user id, and for ANY thrown error -- on a line whose own comment reads
+ * `// fail-closed`. Making the two cases separate constructors is what stops a
+ * transient database failure from widening disclosure.
+ *
+ * @module services/dashboard/readable-resources
+ */
+
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
+import type { UserContext } from "../../domains/collections/services/collection-types";
+
+/** A caller's read scope. Construct via {@link allResources} or {@link someResources}. */
+export type ReadableResources =
+  | { readonly kind: "all" }
+  | { readonly kind: "some"; readonly resources: ReadonlySet<string> };
+
+/** Every resource. Super-admins only. */
+export function allResources(): ReadableResources {
+  return { kind: "all" };
+}
+
+/**
+ * Exactly the named resources -- and an empty iterable means exactly nothing,
+ * which is the whole point of this module.
+ */
+export function someResources(resources: Iterable<string>): ReadableResources {
+  return { kind: "some", resources: new Set(resources) };
+}
+
+/** Whether `resource` is readable under `scope`. */
+export function canRead(scope: ReadableResources, resource: string): boolean {
+  return scope.kind === "all" || scope.resources.has(resource);
+}
+
+/** Keep only the items whose resource name is readable under `scope`. */
+export function filterByResource<T>(
+  scope: ReadableResources,
+  items: readonly T[],
+  getResource: (item: T) => string
+): T[] {
+  if (scope.kind === "all") return [...items];
+  return items.filter(item => scope.resources.has(getResource(item)));
+}
+
+/**
+ * Who is asking, in the two shapes an access decision reads.
+ *
+ * This is the return shape of `readCaller()` (`api/authenticated-read.ts`),
+ * declared once here so the dashboard service and the API handler that calls
+ * it name the same type instead of each re-deriving it. `authenticatedScope`
+ * is present only for an API-key caller: it carries that key's own stamped
+ * grant, which must be judged on its own terms rather than falling back to
+ * the key's owner's roles.
+ */
+export interface ReadCaller {
+  user: UserContext;
+  authenticatedScope?: AuthenticatedScope;
+}


### PR DESCRIPTION
The canvas never fits. An author who pins a tier wider than the pane edits at the pane's width, with the control still reporting the tier they picked.

Diagnosed by the lane that introduced it (#1316), who handed over the measurement rather than editing a file with an open PR of mine on it. Every link confirmed here independently before taking it.

## What is wrong

`useRegionWidth` reads its region from `box.current.parentElement`. Since the block context menu arrived, that parent is Radix's trigger carrying `display: contents` — deliberately, so a `span` around a block box does not change the layout it is meant to be transparent over.

A boxless element measures zero. **Verified in a browser rather than reasoned about:**

| observed element | reported inline size |
|---|---|
| `display: contents` wrapper inside a 911px container | **0** |
| the 911px container itself | **911** |

`canvasScale` guards `!(region > 0)` by returning the identity, so the fit is `1` forever and `previewBoxStyle` takes its `maxWidth` branch instead of `width` + `zoom`.

## What an author sees

Pin **Tablet (1024)** in a 911px pane, and edit at **911px** — with the zoom control reporting "fitting, 100%" and the tier still shown as selected.

Nothing on screen contradicts it. The width readout that would have said `911px · Tablet` is suppressed because it compares **tiers**, and 911 and 1024 are the same tier. Any authored boundary between the two behaves differently from a real tablet.

**The control that says it is the wrapper and not the observer:** pinning Mobile (640, *narrower* than the region) works correctly — that path needs no scaling. The defect appears only where region-relative fitting is required, which is exactly what a zero region disables.

## The fix

A walk past boxless ancestors, not a check for that one wrapper. The wrapper arrived legitimately and nothing connected it to a measurement two files away; the next one would do the same.

`display: none` is deliberately **not** walked past. It is boxless too, but its children generate no box either — there is no canvas being laid out anywhere, so the hidden ancestor's zero is the honest answer. Skipping it would compute a fit for a canvas nobody can see.

## Verification

Two cases, break-verified in both directions:

- measuring `parentElement` fails the boxless case
- walking past **every** ancestor fails the control that pins an ordinary parent — which is what stops the fit being computed against the window rather than the pane

builder: 2467 tests pass. Lint, typecheck clean. `fallow audit --base origin/main` gives **pass**, zero introduced.

## One thing worth recording

This also disabled the fit that #1335 built on top, so a test asserting the zoom control shows a fit below 100% could never have passed in a browser. That lane recorded it at the time as "could not drive the canvas into a shrunk-fit state — verified at unit level only" and filed it as a coverage gap.

**The gap was this bug.** When a state is reachable in units and not in a browser, the difference between the two is a hypothesis about production, not a limitation of the harness.