### PR TITLE
feat(blocks-react): adopt block parts in quote, image and form

### DIFF
--- a/.changeset/a-quote-stops-moving-when-you-name-the-speaker.md
+++ b/.changeset/a-quote-stops-moving-when-you-name-the-speaker.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Typing an attribution on a quote moved the quotation. A user agent indents a
+`<blockquote>` about 40px, and in the attributed shape that margin sat inside
+the block's own indent and added to it — so the same quote drew at 24px bare and
+64px attributed, in any site without a CSS reset. Both now draw at 24px.
+
+An image's caption drew at the body's own size directly beneath the picture, so
+it read as another paragraph that happened to follow an image rather than as a
+caption.

--- a/.changeset/a-quote-stops-moving-when-you-name-the-speaker.md
+++ b/.changeset/a-quote-stops-moving-when-you-name-the-speaker.md
@@ -34,3 +34,9 @@ the block's own indent and added to it — so the same quote drew at 24px bare a
 An image's caption drew at the body's own size directly beneath the picture, so
 it read as another paragraph that happened to follow an image rather than as a
 caption.
+
+A form's fields did not group. One even gap separated a label from the control
+it names and one question from the next, so nothing read as belonging together —
+a label sat as far from its own input as from the next field entirely. The gap
+is now the distance from a label to its control, and the control states the
+distance to the next field.

--- a/packages/blocks-react/src/blocks/accordion.test.tsx
+++ b/packages/blocks-react/src/blocks/accordion.test.tsx
@@ -25,6 +25,8 @@ function args(props: Record<string, unknown>, slot = "BODY") {
     props,
     node: { id: "n1", type: ACCORDION_ITEM_BLOCK, version: 1, props },
     className: "cls",
+    // Required by the render contract; these fixtures declare no parts.
+    partClass: () => "",
     renderSlot: (name: string) => (name === "children" ? slot : null),
   } as never;
 }

--- a/packages/blocks-react/src/blocks/adopted-parts.test.tsx
+++ b/packages/blocks-react/src/blocks/adopted-parts.test.tsx
@@ -69,20 +69,45 @@ describe("core/quote, once it can style the quotation inside its figure", () => 
     expect(bare).not.toContain(blockPartClassName("core/quote", "quotation"));
   });
 
-  it("zeroes that blockquote's inline margin in the compiled sheet", () => {
+  it("zeroes that blockquote's own margin in the compiled sheet", () => {
     // The measured defect: a user agent indents a `<blockquote>` about 40px,
     // and inside the figure that ADDED to the block's own padding — so the same
     // quote sat at 24px bare and 64px attributed. Typing an attribution moved
     // the text.
     const css = sheetFor("core/quote");
     expect(css).toContain(blockPartClassName("core/quote", "quotation"));
-    expect(css).toContain("margin-inline-start: 0");
+    // ALL FOUR sides, not the one the measurement happened to be about. A user
+    // agent gives this element a margin on every side, the figure around it
+    // already states the block ones, and a test naming a single side lets the
+    // other three come back while staying green.
+    for (const side of [
+      "margin-block-start: 0",
+      "margin-block-end: 0",
+      "margin-inline-start: 0",
+      "margin-inline-end: 0",
+    ]) {
+      expect(css).toContain(side);
+    }
+  });
+
+  it("MARKS the attribution element", () => {
+    // Asserted on the markup, separately from the sheet, because the two halves
+    // fail independently: a rule for a mark nobody wears reaches no element,
+    // and the stylesheet looks perfectly correct while it happens. Removing the
+    // mark left every other assertion in this file green.
+    expect(markup("Ada")).toContain(
+      `<figcaption class="${blockPartClassName("core/quote", "attribution")}"`
+    );
   });
 
   it("sets the attribution apart from the quotation it follows", () => {
     const css = sheetFor("core/quote");
     expect(css).toContain(blockPartClassName("core/quote", "attribution"));
     expect(css).toContain("font-size: 0.875em");
+    // BOTH declarations, because the part states two things and a test naming
+    // only one lets the other regress while staying green — the attribution
+    // could run straight into the quotation above it and nothing would say so.
+    expect(css).toContain("margin-block-start: 0.75em");
   });
 });
 
@@ -113,6 +138,10 @@ describe("core/image, once it can style its caption", () => {
     const css = sheetFor("core/image");
     expect(css).toContain(blockPartClassName("core/image", "caption"));
     expect(css).toContain("font-size: 0.875em");
+    // The part states smaller type AND a distance from the picture. Asserting
+    // the size alone lets the caption regress to sitting flush against the
+    // image while the test claiming to cover its presentation stays green.
+    expect(css).toContain("margin-block-start: 0.5em");
   });
 
   it("does not style the IMG through the caption's rule", () => {

--- a/packages/blocks-react/src/blocks/adopted-parts.test.tsx
+++ b/packages/blocks-react/src/blocks/adopted-parts.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * The two blocks that draw more than one element, and what their parts fix.
+ *
+ * Both defects were the same shape: an element the block renders inside its own
+ * root carried no rule, so it kept whatever a user agent gave it. Asserted here
+ * as the two halves that have to hold together — the block MARKS the element,
+ * and the compiled sheet carries a rule for that mark. Either alone is inert:
+ * a mark nothing styles changes nothing, and a rule for a mark nobody wears
+ * reaches no element.
+ *
+ * @module blocks/adopted-parts.test
+ */
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { blockPartClassName, compilePageCss } from "@nextlyhq/blocks-engine";
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+
+import { image } from "./image";
+import { quote } from "./quote";
+import { blockPartsFor } from "../styles";
+import { createBlockResolver } from "../resolver";
+
+const blocks = createBlockResolver([image, quote] as never);
+
+/** What a published page's stylesheet says, for a document using one block. */
+function sheetFor(type: string): string {
+  const document = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "n1", type, version: 1, props: {} }],
+  } as unknown as BlockDocument;
+  return compilePageCss(document, {
+    breakpoints: { viewport: [{ id: "base", label: "Base" }], container: [] },
+    blockParts: blockPartsFor(document, blocks),
+  } as never).css;
+}
+
+describe("core/quote, once it can style the quotation inside its figure", () => {
+  const markup = (attribution: string) =>
+    renderToStaticMarkup(
+      quote.render({
+        props: { text: "Words", attribution },
+        node: { id: "n1", type: "core/quote", version: 1, props: {} },
+        className: "nx-n1",
+        partClass: (name: string) => blockPartClassName("core/quote", name),
+        ctx: undefined,
+        renderSlot: () => null,
+      } as never) as never
+    );
+
+  it("marks the NESTED blockquote, which is the one that kept a UA margin", () => {
+    expect(markup("Ada")).toContain(
+      `<blockquote class="${blockPartClassName("core/quote", "quotation")}"`
+    );
+  });
+
+  it("leaves the bare branch's blockquote wearing the block's own class", () => {
+    // The same element is a root in one shape and a part in the other. Marking
+    // it in both would apply the block's indent twice, which is the defect the
+    // previous revision had and the reason this is asserted per branch.
+    const bare = markup("");
+    expect(bare).toContain('<blockquote class="nx-n1"');
+    expect(bare).not.toContain(blockPartClassName("core/quote", "quotation"));
+  });
+
+  it("zeroes that blockquote's inline margin in the compiled sheet", () => {
+    // The measured defect: a user agent indents a `<blockquote>` about 40px,
+    // and inside the figure that ADDED to the block's own padding — so the same
+    // quote sat at 24px bare and 64px attributed. Typing an attribution moved
+    // the text.
+    const css = sheetFor("core/quote");
+    expect(css).toContain(blockPartClassName("core/quote", "quotation"));
+    expect(css).toContain("margin-inline-start: 0");
+  });
+
+  it("sets the attribution apart from the quotation it follows", () => {
+    const css = sheetFor("core/quote");
+    expect(css).toContain(blockPartClassName("core/quote", "attribution"));
+    expect(css).toContain("font-size: 0.875em");
+  });
+});
+
+describe("core/image, once it can style its caption", () => {
+  it("MARKS the caption element", async () => {
+    // Asserted separately from the sheet, because the two halves fail
+    // independently: a rule for a mark nobody wears reaches no element, and the
+    // stylesheet looks perfectly correct while it happens. Removing the mark
+    // left every other assertion in this file green.
+    const markup = renderToStaticMarkup(
+      (await image.render({
+        props: { src: "/a.jpg", alt: "", caption: "A view" },
+        node: { id: "n1", type: "core/image", version: 1, props: {} },
+        className: "nx-n1",
+        partClass: (name: string) => blockPartClassName("core/image", name),
+        ctx: { resolveMedia: () => Promise.resolve(null) },
+        renderSlot: () => null,
+      } as never)) as never
+    );
+    expect(markup).toContain(
+      `<figcaption class="${blockPartClassName("core/image", "caption")}"`
+    );
+  });
+
+  it("carries a rule for that mark in the compiled sheet", () => {
+    // Unstyled, the caption drew at the body's own size directly beneath the
+    // picture, so it read as another paragraph that happened to follow an image.
+    const css = sheetFor("core/image");
+    expect(css).toContain(blockPartClassName("core/image", "caption"));
+    expect(css).toContain("font-size: 0.875em");
+  });
+
+  it("does not style the IMG through the caption's rule", () => {
+    // The part is a class the block marks one element with, so a sibling it
+    // also renders cannot pick the rule up — which a `figure figcaption`
+    // descendant could not have promised across a nested block.
+    const css = sheetFor("core/image");
+    expect(css).not.toContain("figcaption");
+    expect(css).not.toContain(" img");
+  });
+});

--- a/packages/blocks-react/src/blocks/adopted-parts.test.tsx
+++ b/packages/blocks-react/src/blocks/adopted-parts.test.tsx
@@ -16,12 +16,13 @@ import { describe, expect, it } from "vitest";
 import { blockPartClassName, compilePageCss } from "@nextlyhq/blocks-engine";
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
 
+import { form } from "./form";
 import { image } from "./image";
 import { quote } from "./quote";
-import { blockPartsFor } from "../styles";
+import { blockBasesFor, blockPartsFor } from "../styles";
 import { createBlockResolver } from "../resolver";
 
-const blocks = createBlockResolver([image, quote] as never);
+const blocks = createBlockResolver([form, image, quote] as never);
 
 /** What a published page's stylesheet says, for a document using one block. */
 function sheetFor(type: string): string {
@@ -32,6 +33,10 @@ function sheetFor(type: string): string {
   } as unknown as BlockDocument;
   return compilePageCss(document, {
     breakpoints: { viewport: [{ id: "base", label: "Base" }], container: [] },
+    // BOTH tiers, because a real page compiles both and the question here is
+    // how they divide the work: the gap is the block's own, the field
+    // separation is the part's. A sheet carrying one of them cannot answer it.
+    blockBases: blockBasesFor(document, blocks),
     blockParts: blockPartsFor(document, blocks),
   } as never).css;
 }
@@ -117,5 +122,53 @@ describe("core/image, once it can style its caption", () => {
     const css = sheetFor("core/image");
     expect(css).not.toContain("figcaption");
     expect(css).not.toContain(" img");
+  });
+});
+
+describe("core/form, once it can space a control apart from its label", () => {
+  it("marks each control, whichever element the field type renders", () => {
+    // A field is an `<input>` or a `<textarea>` depending on its type, and both
+    // are the same part: the thing a label names. Marking only one would leave
+    // every textarea field ungrouped, which no assertion on the stylesheet
+    // could see.
+    const markup = renderToStaticMarkup(
+      form.render({
+        props: {
+          fields: [
+            { name: "a", label: "A", type: "text" },
+            { name: "b", label: "B", type: "textarea" },
+          ],
+        },
+        node: { id: "n1", type: "core/form", version: 1, props: {} },
+        className: "nx-n1",
+        partClass: (name: string) => blockPartClassName("core/form", name),
+        ctx: undefined,
+        renderSlot: () => null,
+      } as never) as never
+    );
+    const marker = blockPartClassName("core/form", "control");
+    expect(markup).toContain(`<input`);
+    expect(markup).toContain(`<textarea`);
+    expect(markup.split(marker).length - 1).toBe(2);
+  });
+
+  it("separates FIELDS with the control, not the grid gap", () => {
+    // The measured defect: one even gap spaced a label as far from its own
+    // input as from the next question, so nothing grouped. The gap is now the
+    // label-to-control distance and the control states the field separation —
+    // which is why the gap shrinks and a margin appears, rather than either
+    // alone.
+    const css = sheetFor("core/form");
+    expect(css).toContain("gap: 0.25rem");
+    expect(css).toContain(blockPartClassName("core/form", "control"));
+    expect(css).toContain("margin-block-end: 0.75rem");
+  });
+
+  it("puts that distance BELOW the control, so the form has no leading gap", () => {
+    // Above each label separates fields equally well and also pushes the FIRST
+    // label down, which reads as padding nobody asked for. Asserted because the
+    // two placements are indistinguishable from the field spacing alone.
+    const css = sheetFor("core/form");
+    expect(css).not.toContain("margin-block-start: 0.75rem");
   });
 });

--- a/packages/blocks-react/src/blocks/form.test.tsx
+++ b/packages/blocks-react/src/blocks/form.test.tsx
@@ -37,6 +37,8 @@ function args(props: FormProps, nodeId = "n1"): BlockRenderArgs<FormProps> {
     props,
     node,
     className: "nx-n1",
+    // Required by the render contract; these fixtures declare no parts.
+    partClass: () => "",
     ctx: context(),
     renderSlot: () => null,
   } as unknown as BlockRenderArgs<FormProps>;

--- a/packages/blocks-react/src/blocks/form.tsx
+++ b/packages/blocks-react/src/blocks/form.tsx
@@ -141,7 +141,33 @@ export const FORM_BASE_STYLES = {
   base: {
     base: {
       display: "grid",
-      gap: "1rem",
+      // The gap is now the distance from a label to the control it names, NOT
+      // the distance between fields. One even gap spaced a label as far from
+      // its own input as from the next question, so nothing grouped; the field
+      // separation is stated by the control instead, which is the only element
+      // that knows a field has ended.
+      gap: "0.25rem",
+    },
+  },
+} as const;
+
+/**
+ * The control a field's label names.
+ *
+ * Carried on the CONTROL rather than the label, and the difference is the whole
+ * reason there is no leading gap inside the form: a margin above each label
+ * separates fields equally well and also pushes the FIRST label down, which
+ * reads as stray padding nobody asked for. Below the control the same distance
+ * falls only between fields and before the submit, where it is wanted.
+ */
+const FORM_PARTS = {
+  control: {
+    baseStyles: {
+      base: {
+        base: {
+          margin: { blockEnd: "0.75rem" },
+        },
+      },
     },
   },
 } as const;
@@ -155,6 +181,7 @@ export function renderForm({
   props,
   node,
   className,
+  partClass,
 }: BlockRenderArgs<FormProps>): ReactElement {
   // A stored array can hold anything: a migration, a hand edit, or an older
   // version of this block can all leave a member that is not a field. Sliced
@@ -198,9 +225,23 @@ export function renderForm({
         {required ? <span aria-hidden="true"> *</span> : null}
       </label>,
       type === "textarea" ? (
-        <textarea key={id} id={id} name={name} required={required} rows={4} />
+        <textarea
+          key={id}
+          id={id}
+          name={name}
+          required={required}
+          rows={4}
+          className={partClass("control")}
+        />
       ) : (
-        <input key={id} id={id} name={name} type={type} required={required} />
+        <input
+          key={id}
+          id={id}
+          name={name}
+          type={type}
+          required={required}
+          className={partClass("control")}
+        />
       )
     );
   });
@@ -254,6 +295,7 @@ export const form = defineBlock<FormProps, PageContext>({
     },
   },
   baseStyles: FORM_BASE_STYLES,
+  parts: FORM_PARTS,
   supports: {
     typography: true,
     color: true,

--- a/packages/blocks-react/src/blocks/form.tsx
+++ b/packages/blocks-react/src/blocks/form.tsx
@@ -12,18 +12,22 @@
  *
  * **Every element is a DIRECT child of the form, which is the layout.** The
  * root is a grid, so each label and each control becomes its own row and the
- * label sits above the control it names. The alternative — wrapping each pair
- * in a `<label>` — needs a rule on a DESCENDANT to stack them, and the style
- * catalog compiles one selector per node; only a handful of catalog entries
- * (`linkColor` among them) reach inside a block at all, and none of them
- * reaches an arbitrary child. Flattening puts the whole layout on the one
- * selector that exists.
+ * label sits above the control it names. Nothing is wrapped: a `<label>` around
+ * each pair would be a second element per field, and the grouping it exists to
+ * produce is available without one.
  *
- * What that costs is grouping: one `gap` separates a label from its control and
- * one field from the next, so the rows are evenly spaced rather than clustered
- * into fields. It is honest spacing rather than wrong spacing, and a site
- * stylesheet can tighten it. Inline styles are not an option and should not
- * be — see `root-inline-styles.test.tsx` for why a block may not write one.
+ * **The grouping comes from TWO distances rather than one.** A single `gap`
+ * spaced a label from the control it names exactly as far as from the next
+ * question, so nothing read as belonging together. The `gap` is now the smaller
+ * of the two — label to its own control — and each control states the larger one
+ * below itself, which falls between fields and before the submit. Stating it
+ * below the control rather than above the label is what keeps the FIRST label
+ * flush with the top of the form instead of pushed down by a leading margin.
+ *
+ * The control's distance is a PART, which is how a block states a rule for an
+ * element it renders inside its own root. Inline styles are not an option and
+ * should not be — see `root-inline-styles.test.tsx` for why a block may not
+ * write one.
  *
  * **Labels are associated explicitly, not by wrapping.** `htmlFor` and `id` are
  * the association that survives the flattening above, and the id is derived
@@ -129,8 +133,12 @@ const MAX_FIELDS = 100;
  * question, and nothing asks it.**
  *
  * A length is correct until the site stylesheet is wired into the render path.
- * `1rem` because that is what `space.4` itself declares, so the value does not
- * change when this becomes a token again.
+ *
+ * The VALUE is no longer `space.4`, and that is a change of meaning rather than
+ * of taste: this gap once carried the whole of the form's spacing, and now
+ * carries only the distance from a label to the control it names. The field
+ * separation moved to the control's own part, where the two together still come
+ * to `1rem`. So a future token here is a label-to-control token, not `space.4`.
  *
  * Both `display` and `gap` are in `STYLE_CATALOG`. A property that is not is
  * dropped by the compiler rather than passed through, so the test asserts the

--- a/packages/blocks-react/src/blocks/image.test.tsx
+++ b/packages/blocks-react/src/blocks/image.test.tsx
@@ -28,6 +28,8 @@ async function draw(caption: string) {
         ...(caption === "" ? {} : { caption }),
       },
       className: `nx-pb-node1 ${TYPE_CLASS}`,
+      // Required by the render contract; these fixtures declare no parts.
+      partClass: () => "",
     } as never)
   );
   return container;

--- a/packages/blocks-react/src/blocks/image.tsx
+++ b/packages/blocks-react/src/blocks/image.tsx
@@ -43,6 +43,7 @@ export async function renderImage({
   className,
   ctx,
   hostPolicy,
+  partClass,
 }: BlockRenderArgs<ImageProps>): Promise<ReactElement | null> {
   const mediaId = text(props.mediaId);
   // A resolver that throws must not take the page with it: media lives behind
@@ -132,7 +133,7 @@ export async function renderImage({
   return (
     <figure className={className}>
       {image}
-      <figcaption>{caption}</figcaption>
+      <figcaption className={partClass("caption")}>{caption}</figcaption>
     </figure>
   );
 }
@@ -176,6 +177,26 @@ const IMAGE_BASE_STYLES = {
   },
 } as const;
 
+/**
+ * The caption, which only the captioned branch renders.
+ *
+ * Unstyled, it drew at the body's own size directly beneath the picture, so a
+ * caption read as another paragraph that happened to follow an image. These are
+ * the two things that make it read as a caption instead.
+ */
+const IMAGE_PARTS = {
+  caption: {
+    baseStyles: {
+      base: {
+        base: {
+          fontSize: "0.875em",
+          margin: { blockStart: "0.5em" },
+        },
+      },
+    },
+  },
+} as const;
+
 export const image = defineBlock<ImageProps, PageContext>({
   name: IMAGE_BLOCK,
   version: 1,
@@ -191,6 +212,7 @@ export const image = defineBlock<ImageProps, PageContext>({
     keywords: ["picture", "photo", "img", "media"],
   },
   baseStyles: IMAGE_BASE_STYLES,
+  parts: IMAGE_PARTS,
   props: {
     mediaId: { type: "media" },
     src: { type: "url" },

--- a/packages/blocks-react/src/blocks/primitives.alt.test.tsx
+++ b/packages/blocks-react/src/blocks/primitives.alt.test.tsx
@@ -17,6 +17,8 @@ const args = (props: Record<string, unknown>, alt?: string) =>
   ({
     props,
     className: undefined,
+    // Required by the render contract; these fixtures declare no parts.
+    partClass: () => "",
     ctx: ctxWith(alt),
   }) as never;
 

--- a/packages/blocks-react/src/blocks/primitives.test.tsx
+++ b/packages/blocks-react/src/blocks/primitives.test.tsx
@@ -163,7 +163,10 @@ describe("core/quote", () => {
     // and leaving the inner copy standing when a node-local style overrides
     // the root.
     expect(out).not.toMatch(/<blockquote[^>]*nx-bt-core--quote/);
-    expect(out).toContain("<figcaption>Ada, <cite>A Book</cite></figcaption>");
+    // The figcaption is a PART now, so it carries a class. Asserted on the
+    // content and the element rather than on the exact opening tag, which is
+    // what made this pin markup the block is free to change.
+    expect(out).toContain("Ada, <cite>A Book</cite></figcaption>");
   });
 
   it("is a bare blockquote when there is nothing to attribute", () => {
@@ -404,7 +407,7 @@ describe("core/image", () => {
       await renderImage(args({ src: "/a.jpg", caption: "A view" }))
     );
     expect(out).toContain('<figure class="nx-n1">');
-    expect(out).toContain("<figcaption>A view</figcaption>");
+    expect(out).toContain("A view</figcaption>");
     expect(out).not.toContain('<img class="nx-n1"');
   });
 });
@@ -633,7 +636,7 @@ describe("through the boundary", () => {
 
     expect(html).toContain("<figure");
     expect(html).toContain("nx-node");
-    expect(html).toContain("<figcaption>A view</figcaption>");
+    expect(html).toContain("A view</figcaption>");
   });
 
   it("awaits an async primitive rather than rendering its promise", async () => {

--- a/packages/blocks-react/src/blocks/quote.tsx
+++ b/packages/blocks-react/src/blocks/quote.tsx
@@ -34,6 +34,7 @@ export function renderQuote({
   props,
   className,
   markProp,
+  partClass,
 }: BlockRenderArgs<QuoteProps>): ReactElement {
   const quoted = text(props.text);
   const attribution = text(props.attribution);
@@ -50,19 +51,17 @@ export function renderQuote({
   const markText = markProp?.("text");
   const markSource = markProp?.("source");
 
-  // Deliberately UNCLASSED. The attributed branch wraps this in a `<figure>`
-  // that already takes the block's class, and giving the same class to the
-  // quotation inside it applies the whole default twice — the indent as well as
-  // the reset — so an attributed quote steps in further than a bare one and a
-  // node-local override reaches the figure while the nested copy stays put.
-  //
-  // The cost is that this element keeps whatever inline margin a user agent
-  // gives it in a host with no reset. That is one rule short of correct rather
-  // than two applications of it, and closing it needs a way for a block to
-  // state a rule for an element INSIDE itself, which a block-type default is
-  // not.
+  // Marked as a PART rather than given the block's own class. The attributed
+  // branch wraps this in a `<figure>` that already takes that class, and giving
+  // the same one to the quotation inside applies the whole default twice — the
+  // indent as well as the reset — so an attributed quote would step in further
+  // than a bare one. A part carries only what this element needs, which is the
+  // user-agent margin removed.
   const blockquote = (
-    <blockquote {...(citeUrl === undefined ? {} : { cite: citeUrl })}>
+    <blockquote
+      className={partClass("quotation")}
+      {...(citeUrl === undefined ? {} : { cite: citeUrl })}
+    >
       <p {...markText}>{quoted}</p>
     </blockquote>
   );
@@ -82,7 +81,7 @@ export function renderQuote({
   return (
     <figure className={className}>
       {blockquote}
-      <figcaption>
+      <figcaption className={partClass("attribution")}>
         {attribution}
         {attribution !== "" && source !== "" ? ", " : null}
         {source === "" ? null : <cite {...markSource}>{source}</cite>}
@@ -146,6 +145,48 @@ const QUOTE_BASE_STYLES = {
   },
 } as const;
 
+/**
+ * The elements the attributed branch renders inside its `<figure>`.
+ *
+ * Only that branch has them: with nothing to attribute, the `<blockquote>` IS
+ * the block and wears the block's own class, so the same element is a root in
+ * one shape and a part in the other. The class it carries says which.
+ */
+const QUOTE_PARTS = {
+  quotation: {
+    baseStyles: {
+      base: {
+        base: {
+          // The whole point of the part. A user agent gives `<blockquote>` a
+          // margin of its own — about 40px inline and 1em block — and inside
+          // the figure that ADDS to what the block already states, so in a host
+          // with no reset the same quote sat at 24px bare and 64px attributed.
+          // Typing an attribution moved the text.
+          margin: {
+            blockStart: "0",
+            blockEnd: "0",
+            inlineStart: "0",
+            inlineEnd: "0",
+          },
+        },
+      },
+    },
+  },
+  attribution: {
+    baseStyles: {
+      base: {
+        base: {
+          // A caption for the quotation, not a second paragraph of it. Smaller
+          // and set apart, so the reader can tell the speaker from the speech
+          // without the two running together.
+          fontSize: "0.875em",
+          margin: { blockStart: "0.75em" },
+        },
+      },
+    },
+  },
+} as const;
+
 export const quote = defineBlock<QuoteProps, PageContext>({
   name: QUOTE_BLOCK,
   version: 1,
@@ -161,6 +202,7 @@ export const quote = defineBlock<QuoteProps, PageContext>({
     keywords: ["blockquote", "pull quote", "citation"],
   },
   baseStyles: QUOTE_BASE_STYLES,
+  parts: QUOTE_PARTS,
   props: {
     text: { type: "textarea", inline: true },
     attribution: { type: "text" },

--- a/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/root-inline-styles.test.tsx
@@ -314,6 +314,8 @@ function renderArgs(
     props,
     node: nodeFor(block, props),
     className: classNameFor(block),
+    // Required by the render contract; these fixtures declare no parts.
+    partClass: () => "",
     ctx,
     renderSlot: () => <span>child</span>,
     ...(hostPolicy === undefined ? {} : { hostPolicy }),


### PR DESCRIPTION
The second of the block-parts work. #1382 added the mechanism and adopted it in
no block; this adopts it in the three whose defects were measured, and every
change here is a fix somebody can see on a page.

## What was wrong, and what it looks like now

Each number below was measured in a browser against the COMPILED stylesheet, and
each has a pre-fix control that still reports the old value — so the measurement
discriminates rather than agreeing with the change.

**`core/quote` — typing an attribution moved the quotation.**

    before   bare 24px   attributed 64px
    after    bare 24px   attributed 24px

A user agent indents a `<blockquote>` about 40px. The attributed shape nests one
inside a `<figure>` that already carries the block's own indent, so the two
added: the same quote sat in two different places depending on whether you had
named the speaker.

**`core/form` — nothing grouped.**

    before   label to its own control 16px   field to field 16px   to submit 16px
    after    label to its own control  4px   field to field 16px   to submit 16px

One even gap separated a label from the control it names and one question from
the next, so a label sat as far from its own input as from the next field
entirely.

**`core/image` — a caption read as another paragraph.** Unstyled, it drew at the
body's own size directly beneath the picture. It is now smaller and set apart.

## Two decisions worth review

**The quote's nested `<blockquote>` is a PART, not the block's own class.** Giving
it that class applies the whole default twice — the indent as well as the reset —
which an earlier revision did, and is why an attributed quote stepped in FURTHER
than a bare one. The same element is a root in one shape and a part in the other,
and the class it wears says which, so both branches are asserted separately.

**The form's field separation sits BELOW the control, not above the label.** Both
group the fields; only one of them also pushes the FIRST label down and gives
every form a leading gap nobody asked for. There is a test for that specifically,
because the two placements are indistinguishable from the field spacing alone.

**No element is added, moved or wrapped anywhere in this PR.** `core/form`'s
docblock describes wrapping each label/control pair, and an earlier reading of
this took that as the only route and reported the fix as a rendered-HTML change
needing a compatibility decision. It is not: redistributing the spacing achieves
the same grouping, and the markup gains a class per control and nothing else — so
a stylesheet written against this block's structure keeps working.

## `core/list` is deliberately not adopted

Its root already restores the two things a reset takes — the markers and the
indent — and its `<li>` has no measured defect. Declaring a part would mean
inventing a spacing opinion and applying it to every list that already exists,
which is a change with a cost and no demonstrated benefit.

## Evidence

Ten tests over the three blocks, each break-verified by a mutation that removes
what its name promises, each asserting the mutation applied and typechecking the
mutated tree first:

| mutation | kills |
| --- | --- |
| the nested blockquote is unmarked | the marking test |
| the quotation part drops its margin reset | the compiled-sheet test |
| the caption is unmarked | the caption marking test |
| only `<input>` is marked, `<textarea>` forgotten | the both-controls test |
| the field distance moves above the label | the placement test AND the sheet test |
| the grid keeps its old even gap | the sheet test |

    blocks-react   42 files / 1003 tests   (baseline 41 / 993)
    blocks-engine  38 files / 1713 tests   (unchanged)
    pnpm check-types  exit 0 per package
    fallow audit      pass, 0 introduced findings

Two things this found in its own tests. Removing the image caption's marking
broke NOTHING at first — the tests asserted the stylesheet and never that the
block marks the element, and a stylesheet can be perfectly correct while reaching
no element at all. And the shared helper compiled only the parts tier, so it was
judging half a sheet; it now compiles both, which is what a real page does.

Several fixtures cast their render arguments, so `partClass` — required by the
contract since #1382 — passed the type checker and failed at run time instead.
Those are updated here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved image caption styling with clearer typography and spacing.
  * Enhanced quoted content with consistent nested-quote spacing and attribution styling.
  * Refined form layouts by separating labels from controls while maintaining comfortable spacing between fields and the submit button.
  * Added consistent styling hooks for block parts, improving customization and visual consistency across supported blocks.

* **Tests**
  * Expanded coverage for image captions, quotations, form controls, and block styling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->