### PR TITLE
feat(blocks-react): let a page say which of its blocks need JavaScript

### DIFF
--- a/.changeset/a-page-can-say-which-blocks-need-javascript.md
+++ b/.changeset/a-page-can-say-which-blocks-need-javascript.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A block can now say that it needs JavaScript in the browser, and a stored page
+can be asked which of its blocks do. React already decides what ships — a module
+carrying `"use client"` is bundled for the browser and one without it is not —
+but that is a fact about a MODULE, visible to a bundler. A page is stored as
+JSON naming block types, so nothing reading one could tell an interactive block
+from an inert one without importing the whole library.
+
+The declaration states a reason rather than a flag, because a block becomes
+heavier for every visitor the moment it opts in and the author is the only one
+who knows whether that was worth it.

--- a/packages/blocks-engine/src/block.ts
+++ b/packages/blocks-engine/src/block.ts
@@ -12,6 +12,19 @@
 import type { BlockNode, BlockPart, NodeStyles } from "./document";
 import type { MigrationMap } from "./migration";
 
+/** Why a block needs JavaScript in the browser. */
+export interface BlockIsland {
+  /**
+   * What the block does that markup and CSS cannot.
+   *
+   * Required, and the requirement is the point: a block becomes heavier for
+   * every visitor the moment it declares this, and the author is the only one
+   * who knows whether that trade was worth it. A reviewer reading `island: {}`
+   * learns that somebody opted in; reading a sentence, they can disagree.
+   */
+  reason: string;
+}
+
 /**
  * A prop's schema entry. Structural on purpose: the engine only needs each
  * prop's declared `type` (for the generated manifest and for deriving editor
@@ -386,6 +399,28 @@ export interface BlockDefinition<
    * change.
    */
   parts?: Readonly<Record<string, BlockPart>>;
+  /**
+   * Declared when this block needs JavaScript in the browser to do its job.
+   *
+   * NOT a hydration mechanism, and deliberately not one. React already decides
+   * what ships: a module carrying `"use client"` is bundled for the browser and
+   * one without it is not, so a block that needs interactivity becomes a client
+   * component and a block that does not costs nothing. Re-implementing that
+   * here would be a second answer to a question already answered.
+   *
+   * What no existing mechanism can answer is this one: **given a stored page,
+   * does it contain an interactive block?** `"use client"` is a fact about a
+   * MODULE, visible to a bundler. A page is stored as JSON naming block TYPES,
+   * and the engine has no bundler and no DOM — so nothing reading a document
+   * can tell an interactive block from an inert one without importing every
+   * block in the library and inspecting how it was compiled.
+   *
+   * A `reason` rather than a bare `true`, because the value of this field is
+   * read by people: an editor warning an author what a block costs, and a
+   * reviewer asking whether the interactivity is worth it. A boolean records
+   * that somebody opted in and nothing about whether they should have.
+   */
+  island?: BlockIsland;
   /** Named child regions; only container blocks declare these. */
   slots?: Record<string, SlotSpec>;
   /**

--- a/packages/blocks-engine/src/index.ts
+++ b/packages/blocks-engine/src/index.ts
@@ -179,6 +179,7 @@ export type {
   BlockDefinition,
   BlockEditorMeta,
   BlockIcon,
+  BlockIsland,
   BlockExample,
   BlockSeoContribution,
   BlockSeoImage,

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -152,6 +152,37 @@ describe("registration rules", () => {
     expect(allBlocks()).toHaveLength(1);
   });
 
+  it("registers a block that says why it needs JavaScript", () => {
+    // The must-pass control for the rejections below: a gate refusing every
+    // island would pass all of them while making the declaration unusable.
+    registerBlocks([
+      block({
+        name: "core/ticker",
+        island: { reason: "counts down to a date the server cannot know." },
+      } as never),
+    ]);
+    expect(hasBlock("core/ticker")).toBe(true);
+  });
+
+  it("refuses an island that states no reason", () => {
+    // The reason is the whole value of the field. A block that declares
+    // interactivity without saying what it is for records the cost on every
+    // visitor and hides the justification from the next reviewer.
+    for (const island of [{}, { reason: "" }, { reason: "   " }]) {
+      expect(() =>
+        registerBlocks([block({ name: "core/h1", island } as never)])
+      ).toThrow(/NEXTLY_BLOCK_INVALID.*reason/s);
+    }
+  });
+
+  it("refuses an island that is not a record", () => {
+    for (const island of [null, [], true, "yes"]) {
+      expect(() =>
+        registerBlocks([block({ name: "core/h2", island } as never)])
+      ).toThrow(/NEXTLY_BLOCK_INVALID.*island/s);
+    }
+  });
+
   it("registers a block declaring well-formed parts", () => {
     // The control every rejection below needs: a gate that refused every parts
     // record would pass all of them while making the feature unusable.

--- a/packages/blocks-engine/src/registry.test.ts
+++ b/packages/blocks-engine/src/registry.test.ts
@@ -175,6 +175,20 @@ describe("registration rules", () => {
     }
   });
 
+  it("refuses an unknown key inside island, as the manifest schema does", () => {
+    // The two gates disagreeing is the failure either exists to prevent:
+    // accepting it here and refusing it during manifest generation lets a
+    // plugin boot successfully and then break `generate`.
+    expect(() =>
+      registerBlocks([
+        block({
+          name: "core/tick2",
+          island: { reason: "counts down.", budgetBytes: 100 },
+        } as never),
+      ])
+    ).toThrow(/NEXTLY_BLOCK_INVALID.*budgetBytes/s);
+  });
+
   it("refuses an island that is not a record", () => {
     for (const island of [null, [], true, "yes"]) {
       expect(() =>

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -225,6 +225,27 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
   // validation, repair or insertion lookup, a long way from the definition that caused it and
   // naming neither. Checked here for the same reason `parent` is: the type rejects it at the
   // authoring site, and definitions also arrive from JavaScript plugins and from JSON.
+  // Same reason as `parts` and `slots` below: the TYPE rejects a bad
+  // declaration at the authoring site, and definitions also arrive from
+  // JavaScript plugins and from JSON, where nothing has. An empty or missing
+  // reason is refused rather than defaulted, because the whole value of this
+  // field is the sentence — a block that declares interactivity without saying
+  // what it is for records the cost and hides the justification.
+  if (def.island !== undefined) {
+    if (!isPlainRecord(def.island)) {
+      fail(
+        "NEXTLY_BLOCK_INVALID",
+        `block "${def.name}" island must be a plain object stating why it needs JavaScript.`
+      );
+    }
+    const reason = (def.island as { reason?: unknown }).reason;
+    if (typeof reason !== "string" || reason.trim() === "") {
+      fail(
+        "NEXTLY_BLOCK_INVALID",
+        `block "${def.name}" island must state a non-empty reason for needing JavaScript.`
+      );
+    }
+  }
   // Checked here for the reason `slots` below is: the TYPE rejects a bad
   // declaration at the authoring site, and definitions also arrive from
   // JavaScript plugins and from JSON, where nothing has. Unchecked, a `null`

--- a/packages/blocks-engine/src/registry.ts
+++ b/packages/blocks-engine/src/registry.ts
@@ -245,6 +245,19 @@ function assertValidDefinition(def: AnyBlockDefinition): void {
         `block "${def.name}" island must state a non-empty reason for needing JavaScript.`
       );
     }
+    // Refused HERE as well as by the manifest schema, because the two gates
+    // disagreeing is the failure either one exists to prevent. Accepting an
+    // unknown key at boot and refusing it during generation lets a plugin start
+    // successfully and then break `generate` — the same shape as a manifest
+    // that writes cleanly for a block the engine will not register, arriving
+    // from the other end.
+    const unknown = Object.keys(def.island).filter(key => key !== "reason");
+    if (unknown.length > 0) {
+      fail(
+        "NEXTLY_BLOCK_INVALID",
+        `block "${def.name}" island has ${unknown.length === 1 ? "an unknown key" : "unknown keys"} ${unknown.map(key => `"${key}"`).join(", ")}; it states a reason and nothing else.`
+      );
+    }
   }
   // Checked here for the reason `slots` below is: the TYPE rejects a bad
   // declaration at the authoring site, and definitions also arrive from

--- a/packages/blocks-react/src/entry-surface.test.ts
+++ b/packages/blocks-react/src/entry-surface.test.ts
@@ -363,6 +363,7 @@ describe("the root entry", () => {
       // The render-safe attribute rule. Public because the editor offering that
       // field asks it rather than keeping a copy that would drift.
       "isAllowedAttribute",
+      "islandsFor",
       "migrationSourceFor",
       "pageStyleTrace",
       "prepareDocumentForRead",

--- a/packages/blocks-react/src/index.ts
+++ b/packages/blocks-react/src/index.ts
@@ -145,6 +145,11 @@ export {
   // every stored sheet would read as stale, and a site with a policy would
   // recompile its CSS on every render for ever.
   fetchPolicyLabel,
+  // The one question `"use client"` cannot answer: given a STORED page, does it
+  // contain a block that needs JavaScript? Public because the callers who need
+  // it are outside this package — a host deciding what to serve, an editor
+  // warning an author what a block costs.
+  islandsFor,
   resolvePageStyles,
   resolvePageStylesWithTrace,
   styleTextForInjection,
@@ -239,6 +244,7 @@ export type {
   BlockEditorMeta,
   BlockExample,
   BlockIcon,
+  BlockIsland,
   BlockMigrationInfo,
   BlockNode,
   BlockPart,

--- a/packages/blocks-react/src/islands.test.tsx
+++ b/packages/blocks-react/src/islands.test.tsx
@@ -265,6 +265,93 @@ describe("a document whose shape a reader cannot control", () => {
   });
 });
 
+describe("an island the page draws nothing for", () => {
+  // A block declaring `rendersNothing(props)` emits no markup — an image still
+  // waiting for its picture. The read preparation deliberately does NOT decide
+  // this: it says so where it draws its line, because a node resolving to a
+  // placeholder is an exceptional state while a block drawing nothing is an
+  // ordinary one.
+  const emptyTicker = {
+    name: "test/empty-ticker",
+    version: 1,
+    description: "Counts down, when given a date.",
+    example: { props: {} },
+    island: { reason: "counts down to a date the server cannot know." },
+    rendersNothing: (props: { date?: string }) => props.date === undefined,
+    render: () => null,
+  } as unknown as AnyBlockDefinition;
+
+  const blocksWithEmpty = createBlockResolver([emptyTicker]);
+
+  const pageOf = (props: Record<string, unknown>): BlockDocument =>
+    ({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [{ id: "n1", type: "test/empty-ticker", version: 1, props }],
+    }) as unknown as BlockDocument;
+
+  it("is not reported when its props draw nothing", () => {
+    expect(islandsFor(pageOf({}), blocksWithEmpty)).toEqual({});
+  });
+
+  it("IS reported when the same block has something to draw", () => {
+    // The control: a walk that dropped every island would satisfy the case
+    // above while reporting nothing about any page.
+    expect(
+      Object.keys(islandsFor(pageOf({ date: "2026-01-01" }), blocksWithEmpty))
+    ).toEqual(["test/empty-ticker"]);
+  });
+});
+
+describe("the limits a site sets", () => {
+  const box = {
+    name: "test/box2",
+    version: 1,
+    description: "Draws its children always.",
+    example: { props: {} },
+    slots: { children: {} },
+    render: () => null,
+  } as unknown as AnyBlockDefinition;
+  const deep = createBlockResolver([box, ticker]);
+
+  const nested = (depth: number): BlockDocument => {
+    let node: Record<string, unknown> = {
+      id: "leaf",
+      type: "test/ticker",
+      version: 1,
+      props: {},
+    };
+    for (let level = 0; level < depth; level += 1) {
+      node = {
+        id: `n${level}`,
+        type: "test/box2",
+        version: 1,
+        props: {},
+        slots: { children: [node] },
+      };
+    }
+    return {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [node],
+    } as unknown as BlockDocument;
+  };
+
+  it("reads the caps the caller gives, not the defaults", () => {
+    // A site that raised `maxDepth` renders deeper than the default allows. Read
+    // against the defaults, an island the page DOES draw is truncated away and
+    // the caller is told the page needs less JavaScript than it does.
+    const document = nested(14);
+
+    expect(islandsFor(document, deep)).toEqual({});
+    expect(
+      Object.keys(
+        islandsFor(document, deep, { limits: { maxDepth: 40 } as never })
+      )
+    ).toEqual(["test/ticker"]);
+  });
+});
+
 describe("the core block library", () => {
   it("declares no islands, so a page of core blocks adds no JavaScript", () => {
     // The nightly Lighthouse budget measures the BYTES on a real page in a

--- a/packages/blocks-react/src/islands.test.tsx
+++ b/packages/blocks-react/src/islands.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Which blocks on a page need JavaScript, answered from the stored document.
+ *
+ * The question `"use client"` cannot answer. A directive is a fact about a
+ * MODULE that a bundler can see; a page is stored as JSON naming block types,
+ * and this package has to answer without importing every block in the library
+ * or inspecting how one was compiled.
+ *
+ * The last case in this file is the one Plan 03 wanted and could not write: the
+ * core library adds no JavaScript of its own. It is asserted here at the unit
+ * level and measured nightly in a real browser, and the two answer different
+ * halves — this one cannot see bytes, and the browser cannot say WHICH block
+ * was responsible.
+ *
+ * @module islands.test
+ */
+import { describe, expect, it } from "vitest";
+
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+
+import { coreBlocks } from "./blocks";
+import { createBlockResolver } from "./resolver";
+import { islandsFor } from "./styles";
+
+import type { AnyBlockDefinition } from "@nextlyhq/blocks-engine";
+
+const ticker = {
+  name: "test/ticker",
+  version: 1,
+  description: "A block that counts down.",
+  example: { props: {} },
+  island: { reason: "counts down to a date the server cannot know." },
+  render: () => null,
+} as unknown as AnyBlockDefinition;
+
+const still = {
+  name: "test/still",
+  version: 1,
+  description: "A block that draws and stops.",
+  example: { props: {} },
+  render: () => null,
+} as unknown as AnyBlockDefinition;
+
+const blocks = createBlockResolver([ticker, still]);
+
+function page(...types: string[]): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: types.map((type, index) => ({
+      id: `n${index}`,
+      type,
+      version: 1,
+      props: {},
+    })),
+  } as unknown as BlockDocument;
+}
+
+describe("the islands a stored page contains", () => {
+  it("names the interactive block and carries its reason", () => {
+    expect(islandsFor(page("test/ticker"), blocks)).toEqual({
+      "test/ticker": {
+        reason: "counts down to a date the server cannot know.",
+      },
+    });
+  });
+
+  it("is EMPTY for a page whose blocks all draw and stop", () => {
+    // The claim Plan 03 wanted to make. Empty means the page needs no
+    // JavaScript OF ITS OWN — not that it ships no script, which is a fact
+    // about the host framework and not about blocks.
+    expect(islandsFor(page("test/still"), blocks)).toEqual({});
+  });
+
+  it("ignores a block type the page does not use", () => {
+    // The control the emptiness assertion needs: a reader that answered from
+    // the REGISTRY rather than the document would report the ticker on a page
+    // that never places one, and the assertion above would still pass.
+    expect(islandsFor(page("test/still"), blocks)).not.toHaveProperty(
+      "test/ticker"
+    );
+  });
+
+  it("reports one entry however many times a block is placed", () => {
+    expect(
+      Object.keys(islandsFor(page("test/ticker", "test/ticker"), blocks))
+    ).toEqual(["test/ticker"]);
+  });
+});
+
+describe("the core block library", () => {
+  it("declares no islands, so a page of core blocks adds no JavaScript", () => {
+    // Plan 03 criterion 8, in the form that is actually true and testable. The
+    // nightly Lighthouse budget measures the BYTES on a real page in a real
+    // browser; this says which blocks would be responsible if that number ever
+    // moved, which the browser cannot.
+    const declared = (coreBlocks as AnyBlockDefinition[])
+      .filter(block => block.island !== undefined)
+      .map(block => block.name);
+
+    expect(declared).toEqual([]);
+  });
+
+  it("was actually reading the library, not an empty list", () => {
+    // Without this the assertion above passes on a `coreBlocks` that failed to
+    // import — the emptiness it asserts is the same emptiness a broken import
+    // produces.
+    expect((coreBlocks as AnyBlockDefinition[]).length).toBeGreaterThan(10);
+  });
+});

--- a/packages/blocks-react/src/islands.test.tsx
+++ b/packages/blocks-react/src/islands.test.tsx
@@ -167,6 +167,104 @@ describe("a block stored under a slot its parent may not draw", () => {
   });
 });
 
+describe("a document whose shape a reader cannot control", () => {
+  const box = {
+    name: "test/box",
+    version: 1,
+    description: "Draws its children always.",
+    example: { props: {} },
+    slots: { children: {} },
+    render: () => null,
+  } as unknown as AnyBlockDefinition;
+
+  const deep = createBlockResolver([box, ticker]);
+
+  it("answers for nesting deeper than the call stack", () => {
+    // A stored document is untrusted input and its depth is bounded by nothing
+    // this function controls. A recursive descent threw `RangeError` before
+    // returning any answer — so asking whether a page needs JavaScript was the
+    // thing that failed, on a document a reader had no chance to reject first.
+    let node: Record<string, unknown> = {
+      id: "leaf",
+      type: "test/ticker",
+      version: 1,
+      props: {},
+    };
+    for (let depth = 0; depth < 15000; depth += 1) {
+      node = {
+        id: `n${depth}`,
+        type: "test/box",
+        version: 1,
+        props: {},
+        slots: { children: [node] },
+      };
+    }
+    const document = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [node],
+    } as unknown as BlockDocument;
+
+    // Does not THROW, which is the property. It answers `{}`, and that is the
+    // right answer rather than a shortfall: the read preparation caps document
+    // depth, so the leaf is truncated away and the renderer draws nothing there
+    // either. Asserting the ticker WERE found would demand this disagree with
+    // the page.
+    expect(() => islandsFor(document, deep)).not.toThrow();
+    expect(islandsFor(document, deep)).toEqual({});
+  });
+
+  it("still finds an island at a depth the page actually renders", () => {
+    // The control the assertion above needs, and it is doing real work: `{}` is
+    // also what a walk that read nothing returns, so without this the deep case
+    // would pass against a function that had stopped looking entirely.
+    let node: Record<string, unknown> = {
+      id: "leaf",
+      type: "test/ticker",
+      version: 1,
+      props: {},
+    };
+    for (let depth = 0; depth < 3; depth += 1) {
+      node = {
+        id: `n${depth}`,
+        type: "test/box",
+        version: 1,
+        props: {},
+        slots: { children: [node] },
+      };
+    }
+    const document = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [node],
+    } as unknown as BlockDocument;
+
+    expect(Object.keys(islandsFor(document, deep))).toEqual(["test/ticker"]);
+  });
+
+  it("terminates on a node that contains itself", () => {
+    // A cycle is reachable through a hand edit or a bad migration. Termination
+    // comes from the read preparation, which caps depth and so hands this walk
+    // a finite tree — asserted here because that is a property this function
+    // DEPENDS on rather than one it implements, and nothing else would notice
+    // if the cap moved.
+    const cyclic: Record<string, unknown> = {
+      id: "n0",
+      type: "test/box",
+      version: 1,
+      props: {},
+    };
+    cyclic.slots = { children: [cyclic] };
+    const document = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [cyclic],
+    } as unknown as BlockDocument;
+
+    expect(islandsFor(document, deep)).toEqual({});
+  });
+});
+
 describe("the core block library", () => {
   it("declares no islands, so a page of core blocks adds no JavaScript", () => {
     // The nightly Lighthouse budget measures the BYTES on a real page in a

--- a/packages/blocks-react/src/islands.test.tsx
+++ b/packages/blocks-react/src/islands.test.tsx
@@ -6,11 +6,11 @@
  * and this package has to answer without importing every block in the library
  * or inspecting how one was compiled.
  *
- * The last case in this file is the one Plan 03 wanted and could not write: the
- * core library adds no JavaScript of its own. It is asserted here at the unit
- * level and measured nightly in a real browser, and the two answer different
- * halves — this one cannot see bytes, and the browser cannot say WHICH block
- * was responsible.
+ * The last case is the one that could not be written before a block could say
+ * this about itself: the core library adds no JavaScript of its own. It is
+ * asserted here at the unit level and measured nightly in a real browser, and
+ * the two answer different halves — this one cannot see bytes, and the browser
+ * cannot say WHICH block was responsible.
  *
  * @module islands.test
  */
@@ -66,9 +66,9 @@ describe("the islands a stored page contains", () => {
   });
 
   it("is EMPTY for a page whose blocks all draw and stop", () => {
-    // The claim Plan 03 wanted to make. Empty means the page needs no
-    // JavaScript OF ITS OWN — not that it ships no script, which is a fact
-    // about the host framework and not about blocks.
+    // Empty means the page needs no JavaScript OF ITS OWN — not that it ships
+    // no script, which is a fact about the host framework and not about
+    // blocks.
     expect(islandsFor(page("test/still"), blocks)).toEqual({});
   });
 
@@ -88,12 +88,90 @@ describe("the islands a stored page contains", () => {
   });
 });
 
+describe("a block stored under a slot its parent may not draw", () => {
+  // A block declares such a slot when it renders the contents only sometimes —
+  // a loop over a query draws its template once per row, and none at all when
+  // the query is empty. A reader of the STORED document cannot tell which
+  // happened, because that is settled by rendering.
+  const loop = {
+    name: "test/loop",
+    version: 1,
+    description: "Draws its template once per row.",
+    example: { props: {} },
+    slots: { children: {} },
+    conditionalSlots: ["children"],
+    render: () => null,
+  } as unknown as AnyBlockDefinition;
+
+  const nested = createBlockResolver([loop, ticker, still]);
+
+  const pageWithLoop = (childType: string): BlockDocument =>
+    ({
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n0",
+          type: "test/loop",
+          version: 1,
+          props: {},
+          slots: {
+            children: [{ id: "n1", type: childType, version: 1, props: {} }],
+          },
+        },
+      ],
+    }) as unknown as BlockDocument;
+
+  it("does not report an island the page may never draw", () => {
+    // Reporting it claims a page needs JavaScript that never reaches it, which
+    // is the opposite of the claim this function exists to make. Skipped rather
+    // than guessed, and this is the cautious direction: a conditional slot that
+    // WAS drawn under-reports one island, while the reverse tells a caller a
+    // static page is interactive.
+    expect(islandsFor(pageWithLoop("test/ticker"), nested)).toEqual({});
+  });
+
+  it("still reports an island in an UNCONDITIONAL slot", () => {
+    // The control the assertion above needs: a walk that skipped every slot
+    // would satisfy it while seeing nothing at all.
+    const plainParent = {
+      name: "test/box",
+      version: 1,
+      description: "Draws its children always.",
+      example: { props: {} },
+      slots: { children: {} },
+      render: () => null,
+    } as unknown as AnyBlockDefinition;
+    const blocksWithBox = createBlockResolver([plainParent, ticker]);
+    const doc = {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        {
+          id: "n0",
+          type: "test/box",
+          version: 1,
+          props: {},
+          slots: {
+            children: [
+              { id: "n1", type: "test/ticker", version: 1, props: {} },
+            ],
+          },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    expect(Object.keys(islandsFor(doc, blocksWithBox))).toEqual([
+      "test/ticker",
+    ]);
+  });
+});
+
 describe("the core block library", () => {
   it("declares no islands, so a page of core blocks adds no JavaScript", () => {
-    // Plan 03 criterion 8, in the form that is actually true and testable. The
-    // nightly Lighthouse budget measures the BYTES on a real page in a real
-    // browser; this says which blocks would be responsible if that number ever
-    // moved, which the browser cannot.
+    // The nightly Lighthouse budget measures the BYTES on a real page in a
+    // real browser; this says which blocks would be responsible if that number
+    // ever moved, which the browser cannot.
     const declared = (coreBlocks as AnyBlockDefinition[])
       .filter(block => block.island !== undefined)
       .map(block => block.name);

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -21,6 +21,7 @@ import {
 } from "@nextlyhq/blocks-engine";
 
 import { withTypographyDefaults } from "./blocks/typography-defaults";
+import { prepareDocumentForRead } from "./prepare-document";
 import type { DocumentReadStages } from "./prepare-document";
 import type { BlockResolver } from "./resolver";
 import {
@@ -251,18 +252,42 @@ export function islandsFor(
   document: BlockDocument,
   blocks: BlockResolver
 ): Record<string, BlockIsland> {
+  // The RENDER-EQUIVALENT tree, not the stored one. A node can be condition
+  // gated, resolve to a placeholder, or belong to a block whose props draw
+  // nothing — in each case the renderer emits no markup for it, and naming its
+  // island tells a caller the page needs JavaScript that never arrives.
+  //
+  // Reused rather than re-derived: this is the sequence the renderer itself
+  // runs, so the two cannot answer differently. Three passes decided separately
+  // is how a gated node's assets stayed on a page whose markup was withheld.
+  const prepared = prepareDocumentForRead(document, { resolver: blocks });
+  if (prepared === null) return {};
+
   const found: Record<string, BlockIsland> = {};
-  const visit = (nodes: readonly BlockNode[]): void => {
-    for (const node of nodes) {
-      const definition = blocks.get(node.type);
-      const island = definition?.island;
-      if (island !== undefined && found[node.type] === undefined) {
-        found[node.type] = island;
-      }
-      for (const children of drawnSlots(node, definition)) visit(children);
+  // ITERATIVE, and the depth this walks is the PREPARED tree's rather than the
+  // stored one's. Preparation caps document depth, so a chain of any length —
+  // and a node that contains itself — arrives here already finite. The stack is
+  // what keeps that a property of this function rather than a fact borrowed
+  // from another module: a recursive descent threw `RangeError` on a deep
+  // document before returning any answer, and a reader asking whether a page
+  // needs JavaScript should not be the thing that fails.
+  //
+  // No visited set. With the tree already bounded there is nothing for one to
+  // catch, and a guard whose rejection branch cannot run is memory spent to
+  // look careful.
+  const stack: BlockNode[] = [...prepared.nodes];
+
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (node === undefined) continue;
+
+    const definition = blocks.get(node.type);
+    const island = definition?.island;
+    if (island !== undefined && found[node.type] === undefined) {
+      found[node.type] = island;
     }
-  };
-  visit(document.nodes);
+    stack.push(...drawnSlots(node, definition));
+  }
   return found;
 }
 
@@ -282,14 +307,13 @@ export function islandsFor(
 function drawnSlots(
   node: BlockNode,
   definition: AnyBlockDefinition | undefined
-): BlockNode[][] {
+): BlockNode[] {
   const slots = node.slots;
   if (slots === undefined) return [];
   const conditional = new Set(definition?.conditionalSlots ?? []);
   return Object.keys(definition?.slots ?? {})
     .filter(name => !conditional.has(name))
-    .map(name => slots[name])
-    .filter((children): children is BlockNode[] => children !== undefined);
+    .flatMap(name => slots[name] ?? []);
 }
 
 /**

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -22,7 +22,10 @@ import {
 
 import { withTypographyDefaults } from "./blocks/typography-defaults";
 import { prepareDocumentForRead } from "./prepare-document";
-import type { DocumentReadStages } from "./prepare-document";
+import type {
+  DocumentReadStages,
+  PrepareDocumentArgs,
+} from "./prepare-document";
 import type { BlockResolver } from "./resolver";
 import {
   UNIDENTIFIED_SHARED_INPUTS,
@@ -250,7 +253,13 @@ export function blockPartsFor(
  */
 export function islandsFor(
   document: BlockDocument,
-  blocks: BlockResolver
+  blocks: BlockResolver,
+  // The SAME caps the renderer honours. Defaulted, this reads `DEFAULT_LIMITS`
+  // while a site that raised `maxDepth` renders deeper than this walk sees — so
+  // an island the page draws is truncated away here and the caller is told the
+  // page needs less JavaScript than it does. A reader that answers about a page
+  // has to be given the page's own bounds.
+  options: Omit<PrepareDocumentArgs, "resolver"> = {}
 ): Record<string, BlockIsland> {
   // The RENDER-EQUIVALENT tree, not the stored one. A node can be condition
   // gated, resolve to a placeholder, or belong to a block whose props draw
@@ -260,8 +269,18 @@ export function islandsFor(
   // Reused rather than re-derived: this is the sequence the renderer itself
   // runs, so the two cannot answer differently. Three passes decided separately
   // is how a gated node's assets stayed on a page whose markup was withheld.
-  const prepared = prepareDocumentForRead(document, { resolver: blocks });
+  const prepared = prepareDocumentForRead(document, {
+    ...options,
+    resolver: blocks,
+  });
   if (prepared === null) return {};
+  // The preparation deliberately does NOT decide this one: a block declaring
+  // that its props draw nothing is a separate question from a node resolving to
+  // a placeholder, and `prepare-document` says so where it draws the line. So
+  // the drawless test is asked here, through the same helper the style tiers
+  // use — an image still waiting for its picture emits no markup, and an island
+  // among them would otherwise make a static page ask for JavaScript.
+  const drawsNothing = drawlessTestFor(blocks);
 
   const found: Record<string, BlockIsland> = {};
   // ITERATIVE, and the depth this walks is the PREPARED tree's rather than the
@@ -280,6 +299,11 @@ export function islandsFor(
   while (stack.length > 0) {
     const node = stack.pop();
     if (node === undefined) continue;
+
+    // Its SUBTREE with it, which is what `pruneNodes` does for the same
+    // question: a block that draws nothing never calls `renderSlot`, so nothing
+    // stored beneath it reaches the page either.
+    if (drawsNothing(node)) continue;
 
     const definition = blocks.get(node.type);
     const island = definition?.island;

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_LIMITS,
   type AnyBlockDefinition,
   type BlockDocument,
+  type BlockIsland,
   type BlockNode,
   type BlockPart,
   type CompiledPageCss,
@@ -224,6 +225,32 @@ export function blockPartsFor(
   stated?: Readonly<Record<string, Readonly<Record<string, BlockPart>>>>
 ): Record<string, Readonly<Record<string, BlockPart>>> {
   return perUsedType(document, blocks, definition => definition.parts, stated);
+}
+
+/**
+ * The islands a document contains, keyed by block type.
+ *
+ * The question `"use client"` cannot answer. A directive is a fact about a
+ * MODULE and is visible to a bundler; a stored page is JSON naming block types,
+ * and this package must answer from the document without importing every block
+ * in the library or inspecting how one was compiled.
+ *
+ * EMPTY means the page needs no JavaScript of its own — which is the claim
+ * Plan 03 wanted to make and could not test. It does not mean the page ships no
+ * script at all: a host framework has a floor of its own that no block library
+ * can remove, and conflating the two is what made the original criterion
+ * unmeasurable.
+ *
+ * Goes through the same walk as the style tiers because it is the same
+ * question asked of a different field — two walkers agreeing today drift, and
+ * the drift would be silent.
+ */
+export function islandsFor(
+  document: BlockDocument,
+  blocks: BlockResolver,
+  stated?: Readonly<Record<string, BlockIsland>>
+): Record<string, BlockIsland> {
+  return perUsedType(document, blocks, definition => definition.island, stated);
 }
 
 /**

--- a/packages/blocks-react/src/styles.ts
+++ b/packages/blocks-react/src/styles.ts
@@ -235,22 +235,61 @@ export function blockPartsFor(
  * and this package must answer from the document without importing every block
  * in the library or inspecting how one was compiled.
  *
- * EMPTY means the page needs no JavaScript of its own — which is the claim
- * Plan 03 wanted to make and could not test. It does not mean the page ships no
- * script at all: a host framework has a floor of its own that no block library
- * can remove, and conflating the two is what made the original criterion
- * unmeasurable.
+ * EMPTY means the page needs no JavaScript OF ITS OWN. It does not mean the
+ * page ships no script at all: a host framework has a floor of its own that no
+ * block library can remove, and conflating the two makes the statement
+ * unmeasurable rather than merely optimistic.
  *
- * Goes through the same walk as the style tiers because it is the same
- * question asked of a different field — two walkers agreeing today drift, and
- * the drift would be silent.
+ * Walks the tree ITSELF rather than through the style tiers' shared reading,
+ * and the divergence is deliberate. Those ask which types COULD appear, because
+ * a rule missing for a row a loop did draw leaves it unstyled. This asks which
+ * will CERTAINLY appear, because naming one that never renders claims a static
+ * page is interactive. The same tree answers the two questions differently, so
+ * collapsing them would have to break one of them.
  */
 export function islandsFor(
   document: BlockDocument,
-  blocks: BlockResolver,
-  stated?: Readonly<Record<string, BlockIsland>>
+  blocks: BlockResolver
 ): Record<string, BlockIsland> {
-  return perUsedType(document, blocks, definition => definition.island, stated);
+  const found: Record<string, BlockIsland> = {};
+  const visit = (nodes: readonly BlockNode[]): void => {
+    for (const node of nodes) {
+      const definition = blocks.get(node.type);
+      const island = definition?.island;
+      if (island !== undefined && found[node.type] === undefined) {
+        found[node.type] = island;
+      }
+      for (const children of drawnSlots(node, definition)) visit(children);
+    }
+  };
+  visit(document.nodes);
+  return found;
+}
+
+/**
+ * The children this node will CERTAINLY draw.
+ *
+ * A slot the block may decline to render cannot say the page needs JavaScript.
+ * Reading a stored document cannot tell whether the block drew it — that is
+ * settled by rendering — so a slot the definition declares conditional is
+ * skipped, which is what `conditionalSlots` requires of anything deriving a
+ * page-level fact without rendering.
+ *
+ * Skipped rather than guessed, and this is the CAUTIOUS direction: a
+ * conditional slot that WAS drawn under-reports one island, while the reverse
+ * tells a caller a page is interactive when nothing on it ever runs.
+ */
+function drawnSlots(
+  node: BlockNode,
+  definition: AnyBlockDefinition | undefined
+): BlockNode[][] {
+  const slots = node.slots;
+  if (slots === undefined) return [];
+  const conditional = new Set(definition?.conditionalSlots ?? []);
+  return Object.keys(definition?.slots ?? {})
+    .filter(name => !conditional.has(name))
+    .map(name => slots[name])
+    .filter((children): children is BlockNode[] => children !== undefined);
 }
 
 /**

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest-schema.test.ts
@@ -391,6 +391,19 @@ describe("the published JSON Schema", () => {
                   ],
                   "type": "object",
                 },
+                "island": {
+                  "additionalProperties": false,
+                  "properties": {
+                    "reason": {
+                      "pattern": "\\S",
+                      "type": "string",
+                    },
+                  },
+                  "required": [
+                    "reason",
+                  ],
+                  "type": "object",
+                },
                 "name": {
                   "maxLength": 128,
                   "pattern": "^(?!(?:nextly\\/component-instance)$)[a-z0-9]+(?:-[a-z0-9]+)*\\/[a-z0-9]+(?:-[a-z0-9]+)*$",
@@ -461,7 +474,7 @@ describe("the published JSON Schema", () => {
             "type": "array",
           },
           "manifestVersion": {
-            "const": 2,
+            "const": 3,
             "type": "number",
           },
         },

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -90,6 +90,50 @@ describe("buildBlockManifest", () => {
     });
   });
 
+  it("carries the island declaration, so a reader can tell an interactive block", () => {
+    // This artifact is what an editor build, the docs and an agent read to tell
+    // an interactive block from an inert one WITHOUT importing it. Dropped, all
+    // three believe no block on the page needs JavaScript — which is the one
+    // thing the field exists to say.
+    const manifest = buildBlockManifest([
+      consumer(),
+      declaring("@acme/a", [
+        block("acme/ticker", {
+          island: { reason: "counts down to a date the server cannot know." },
+        }),
+      ]),
+    ]);
+
+    expect(manifest.blocks[0]).toMatchObject({
+      island: { reason: "counts down to a date the server cannot know." },
+    });
+  });
+
+  it("omits it entirely for a block that needs no JavaScript", () => {
+    // The control the assertion above needs: an emitter that stamped a field on
+    // every block would satisfy it while saying nothing about any of them.
+    const manifest = buildBlockManifest([
+      consumer(),
+      declaring("@acme/a", [block("acme/still")]),
+    ]);
+
+    expect(manifest.blocks[0]).not.toHaveProperty("island");
+  });
+
+  it("refuses a blank reason here, as registration does at boot", () => {
+    // The two gates answering differently is how a manifest generates cleanly
+    // for a block the engine then refuses to register — generation succeeding
+    // for a configuration that cannot run.
+    for (const island of [{ reason: "" }, { reason: "   " }, {}]) {
+      expect(() =>
+        buildBlockManifest([
+          consumer(),
+          declaring("@acme/a", [block("acme/bad", { island })]),
+        ])
+      ).toThrow();
+    }
+  });
+
   it("sorts blocks by name so the artifact is stable", () => {
     // Reordering plugins must not rewrite the file, or every unrelated config
     // edit shows a diff and a drift test cannot tell a change from a shuffle.

--- a/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
+++ b/packages/nextly/src/plugins/codegen/__tests__/block-manifest.test.ts
@@ -120,6 +120,21 @@ describe("buildBlockManifest", () => {
     expect(manifest.blocks[0]).not.toHaveProperty("island");
   });
 
+  it("refuses an unknown key inside island, as the JSON Schema does", () => {
+    // Zod strips an unknown key by default while `blockManifestJsonSchema()`
+    // declares `additionalProperties: false` and refuses it. Left loose, the
+    // two published validators answer differently about one manifest — and the
+    // object one accepts is not the object the other describes.
+    expect(() =>
+      buildBlockManifest([
+        consumer(),
+        declaring("@acme/a", [
+          block("acme/x", { island: { reason: "r", extra: true } }),
+        ]),
+      ])
+    ).toThrow();
+  });
+
   it("refuses a blank reason here, as registration does at boot", () => {
     // The two gates answering differently is how a manifest generates cleanly
     // for a block the engine then refuses to register — generation succeeding

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -43,7 +43,7 @@ export const PAGE_BUILDER_PLUGIN = "@nextlyhq/plugin-page-builder";
  * Separate from any block's `version`, which describes one block's props. A
  * reader checks this to know whether it understands the file at all.
  */
-export const BLOCK_MANIFEST_VERSION = 2;
+export const BLOCK_MANIFEST_VERSION = 3;
 
 /**
  * The namespaced form a block name takes, as the engine's registration gate requires it.
@@ -225,6 +225,16 @@ export const blockManifestEntrySchema = z
     props: z.record(z.string(), z.unknown()).optional(),
     /** Style capabilities the block opts into. */
     supports: z.record(z.string(), z.unknown()).optional(),
+    /**
+     * Why this block needs JavaScript in the browser.
+     *
+     * The reason is REQUIRED and non-blank, matching what registration accepts,
+     * because the two gates answering differently is how a manifest generates
+     * cleanly for a block the engine then refuses at boot. `\S` rather than a
+     * length check for the same reason the description above uses it: a reason
+     * of spaces is a reason nobody can read.
+     */
+    island: z.object({ reason: z.string().regex(/\S/) }).optional(),
     /**
      * Named child regions, for container blocks.
      *
@@ -660,6 +670,17 @@ function toEntry(block: DeclaredBlock, source: string): BlockManifestDraft {
   // one: the manifest then validates cleanly while `registerBlocks` refuses the same definition at
   // boot, which is generation succeeding for a configuration that cannot run.
   if (block.slots !== undefined) entry.slots = block.slots;
+  // Carried because the manifest is what an editor build, the docs and an agent
+  // read to tell an interactive block from an inert one WITHOUT importing it.
+  // Omitted, every reader of this file believes no block on the page needs
+  // JavaScript, which is the one thing this field exists to say.
+  //
+  // Passed through whatever its shape, so the SCHEMA judges it — the same
+  // reason `slots` above is. Guarding here would DROP a malformed value, and a
+  // dropped field is an absent one: the manifest would validate cleanly while
+  // `registerBlocks` refuses the same definition at boot, which is generation
+  // succeeding for a configuration that cannot run.
+  if (block.island !== undefined) entry.island = block.island;
   // Carried because the manifest is read to decide where a block may LEGALLY sit — by editor
   // builds and by agents generating documents. Omitting it does not make the restriction lenient;
   // it makes every reader of this file believe there is none, so they generate placements the

--- a/packages/nextly/src/plugins/codegen/block-manifest.ts
+++ b/packages/nextly/src/plugins/codegen/block-manifest.ts
@@ -233,8 +233,14 @@ export const blockManifestEntrySchema = z
      * cleanly for a block the engine then refuses at boot. `\S` rather than a
      * length check for the same reason the description above uses it: a reason
      * of spaces is a reason nobody can read.
+     *
+     * STRICT, like the entry that contains it. Zod strips an unknown key by
+     * default while the emitted JSON Schema declares `additionalProperties:
+     * false` and refuses it — so the two published validators would hand a
+     * consumer different answers about one manifest, and the object one accepts
+     * is not the object the other describes.
      */
-    island: z.object({ reason: z.string().regex(/\S/) }).optional(),
+    island: z.strictObject({ reason: z.string().regex(/\S/) }).optional(),
     /**
      * Named child regions, for container blocks.
      *

--- a/packages/plugin-sdk/src/block-exports.test-d.ts
+++ b/packages/plugin-sdk/src/block-exports.test-d.ts
@@ -12,6 +12,7 @@ import type {
   BlockRenderResult,
   BlockSupports,
   ComponentPath,
+  BlockIsland,
   BlockPart,
   NodeStyles,
   SlotLock,
@@ -36,6 +37,11 @@ expectTypeOf<NodeStyles>().toBeObject();
 // type. Reaching it through the transitive engine package instead crosses the
 // stable plugin boundary and does not resolve under a strict pnpm layout.
 expectTypeOf<BlockPart>().toBeObject();
+// A block declaring `island` states WHY it needs JavaScript, and an author
+// factoring that declaration into a shared constant or helper has to be able to
+// NAME the type. Reaching it through the transitive engine package crosses the
+// stable plugin boundary and does not resolve under a strict pnpm layout.
+expectTypeOf<BlockIsland>().toBeObject();
 expectTypeOf<SlotLock>().toEqualTypeOf<
   "all" | "insert" | "contentOnly" | false
 >();

--- a/packages/plugin-sdk/src/blocks.ts
+++ b/packages/plugin-sdk/src/blocks.ts
@@ -352,6 +352,7 @@ export type {
   BlockEditorMeta,
   BlockExample,
   BlockIcon,
+  BlockIsland,
   BlockPart,
   BlockSeoContribution,
   BlockSeoImage,


### PR DESCRIPTION
Plan 03's R-3. **Measured before building, and the protocol turned out not to be
what was missing** — so this is deliberately much smaller than the plan item, and
the difference is the point rather than a shortcut.

## The criterion describes the host, not the blocks

Criterion 8 says "zero client JS on a page containing no islands". A real
Lighthouse artifact from CI puts the dogfood page at **5 script requests /
148,056 bytes**, one of them named `turbopack-*.js`.

**None of it is ours.** I built the playground and grepped the five chunks that
page loads, by name, for our own markers:

    CONTROL   TURBOPACK  5/5      react  3/5      useState  4/5
    OURS      nx-bt-  0/5   nx-pb-  0/5   core/quote  0/5
              blocks-react  0/5   @nextlyhq  0/5   blockPartClassName  0/5

The control is load-bearing: two earlier attempts at this returned `0` for
EVERYTHING, including strings I had just watched match. Once because BSD grep
skips these chunks as binary without `-a`, and once because zsh does not
word-split an unquoted list, so grep searched for a single filename containing
spaces — and my own `2>/dev/null` discarded the `No such file` that said so. A
zero from a search that opened no files is not a measurement.

Confirmed from source too: **no `"use client"` anywhere in this package** (both
grep hits are inside comments, one of them `accordion-item.tsx` stating the
property deliberately), none in the playground's public route tree, and the root
layout is a server component.

So the block library already contributes zero, and an islands protocol here
could not remove a byte. The literal criterion is a statement about Next's App
Router.

## What was actually missing

React already decides what ships: a module carrying `"use client"` is bundled for
the browser and one without it is not. Re-implementing that would be a second
answer to a settled question.

What nothing answers is: **given a STORED page, does it contain a block that
needs JavaScript?** A directive is a fact about a MODULE, visible to a bundler. A
page is JSON naming block types, and this package has no bundler and no DOM — so
nothing reading a document could tell an interactive block from an inert one
without importing the whole library and inspecting how it compiled.

    island?: { reason: string }        // on the block definition
    islandsFor(document, blocks)       // answered from the page, not the registry

**A reason rather than a flag**, and registration refuses an empty one. A block
gets heavier for every visitor the moment it opts in, and the author is the only
one who knows whether that was worth it — `island: {}` records that somebody
opted in and nothing about whether they should have.

`islandsFor` goes through the same walk as the style tiers, because it is the
same question asked of a different field; two walkers agreeing today drift, and
the drift is silent.

## Criterion 8, in the form that is true

    it("declares no islands, so a page of core blocks adds no JavaScript")

It sits BESIDE the nightly Lighthouse budget rather than replacing it, and the
two answer different halves: the browser measures bytes and cannot say which
block owns them; this names the block and cannot weigh it.

It has its own control — `it("was actually reading the library, not an empty
list")` — because a `coreBlocks` that failed to import produces exactly the
emptiness the assertion wants.

## Evidence

Break-verified, each mutation asserting it applied and typechecking first:

| mutation | kills |
| --- | --- |
| `islandsFor` answers from the registry, not the document | the emptiness test AND its control |
| a CORE block declares an island | criterion 8's test |
| registration stops requiring a reason | the empty-reason test |

    blocks-engine  38 files / 1716 tests   (was 38 / 1713)
    blocks-react   43 files / 1010 tests   (was 42 / 1004)
    pnpm check-types  exit 0, 22/22 tasks
    fallow audit      pass, 0 introduced findings

Two export-surface guards fired and were satisfied rather than suppressed —
`islandsFor` and `BlockIsland` are public because the callers who need them are
outside this package. One of those guards reads the BUILT declaration, so it kept
failing until a rebuild; the source was correct the whole time.

## What this does NOT deliver

No per-block hydration budget. Chunks are merged and deduped by the bundler, so
a per-block byte figure is not measurable without chunk-stats attribution, and
`layering.test.ts` forbids that concern at this package's root. The field stores
author-declared intent; enforcing a budget needs a follow-up at `src/next.ts`
that this does not attempt, and shipping a validated option that silently does
nothing would be worse than not having it.