### PR TITLE
test(ci): prove three of Plan 05's exit criteria instead of assuming them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -766,8 +766,11 @@ jobs:
   #
   # POST-MERGE ONLY, which is the whole design of this job. It needs `next build`
   # before `next start`, and that is not a variation on the dev-server suite
-  # above — it is the environment the suite exists for, since task 179's
-  # 500-on-every-path reproduced only under a production build and never in dev.
+  # above — it is the environment the suite exists for. A production build
+  # resolves modules, bundles and prerenders differently enough that a route can
+  # answer 500 on every path there while serving correctly under `next dev`, so
+  # a suite that boots a dev server certifies the one environment in which that
+  # class of failure cannot appear.
   #
   # Running it on every pull request would roughly double the most expensive job
   # in this pipeline: `Browser tests` already spends 10.8-14.7 minutes against a
@@ -848,12 +851,15 @@ jobs:
       - name: Run production browser tests
         run: pnpm --filter @nextlyhq/e2e test:e2e:prod
 
+      # Its own folder, matching the port and database this config already keeps
+      # separate: run both suites on one machine and a shared folder means
+      # whichever finished last is the only report either of them has.
       - name: Upload report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report-production
-          path: e2e/.playwright/report
+          path: e2e/.playwright/report-production
           retention-days: 7
 
       - name: Save Turbo cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,6 +762,107 @@ jobs:
           path: .turbo
           key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
 
+  # The exit demo, against a PRODUCTION build.
+  #
+  # POST-MERGE ONLY, which is the whole design of this job. It needs `next build`
+  # before `next start`, and that is not a variation on the dev-server suite
+  # above — it is the environment the suite exists for, since task 179's
+  # 500-on-every-path reproduced only under a production build and never in dev.
+  #
+  # Running it on every pull request would roughly double the most expensive job
+  # in this pipeline: `Browser tests` already spends 10.8-14.7 minutes against a
+  # 20-minute budget, and a production build lands on top of that. The tiered
+  # arrangement this follows is the ordinary one — a fast subset on the pull
+  # request, the full suite as a gate on merge — and it fits how this repository
+  # already reads verdicts: only one check blocks a merge, so a job reporting on
+  # `main`'s health is worth more here than a fourth check on a branch.
+  #
+  # `needs: [ci]` keeps it behind the fast tests. A production build is a poor
+  # way to discover a type error.
+  e2e-production:
+    name: Production browser tests
+    needs: [ci]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    # Higher than `Browser tests` because the build is inside the budget rather
+    # than done for it. The suite itself is two specs.
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Nothing here pushes; keep the token out of git config.
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      # Scoped to this job for the reason the job above documents at length: six
+      # jobs cache `.turbo` on one commit and build different filter sets, so a
+      # key without `github.job` hands a reader someone else's `dist`.
+      - name: Restore Turbo cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+          restore-keys: |
+            turbo-v2-${{ runner.os }}-${{ github.job }}-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Chromium and its system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: pnpm --filter @nextlyhq/e2e exec playwright install --with-deps chromium
+
+      - name: Install Chromium's system dependencies
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 8
+        run: pnpm --filter @nextlyhq/e2e exec playwright install-deps chromium
+
+      # The playground loads the admin and the plugins from their built output,
+      # so a stale dist is a stale test — and here it would be a stale test of
+      # the one thing this job exists to check.
+      - name: Build packages
+        run: pnpm turbo build --filter='./packages/*'
+        env:
+          TURBO_CACHE_DIR: .turbo
+
+      # The config runs `next build` then `next start` itself, on its own port
+      # and its own database, so nothing here has to arrange that.
+      - name: Run production browser tests
+        run: pnpm --filter @nextlyhq/e2e test:e2e:prod
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: playwright-report-production
+          path: e2e/.playwright/report
+          retention-days: 7
+
+      - name: Save Turbo cache
+        if: success()
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: turbo-v2-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
+
   # Cross-platform smoke test for the scaffolder. Catches Windows path
   # separator bugs and macOS-specific issues that only surface in fresh
   # installs. Runs after the main `ci` job to avoid wasting minutes when

--- a/e2e/playwright.production.config.ts
+++ b/e2e/playwright.production.config.ts
@@ -15,19 +15,20 @@ const BASE_URL = `http://localhost:${PORT}`;
 const E2E_DB_RELATIVE = "file:./data/e2e-prod.db";
 
 /**
- * The phase's exit demo, and the only suite here that runs a PRODUCTION build.
+ * The only suite here that runs a PRODUCTION build.
  *
  * A separate config rather than a project inside the dev one, because the two
  * cannot share a `webServer`: this needs `next build` before `next start`, and
- * the difference is the entire point. Task 179's 500-on-every-path reproduced
- * only in a production build and never in `next dev`, so a suite that boots the
- * dev server certifies the phase's exit criterion against the one environment
- * the failure could not appear in.
+ * the difference is the entire point. A production build resolves modules,
+ * bundles and prerenders differently enough that a route can answer 500 on
+ * every path there while serving correctly under `next dev` — so a suite that
+ * boots the dev server certifies the one environment in which that class of
+ * failure cannot appear.
  *
  * Dev auto-login is correctly hard-blocked here, so the spec signs in through
- * the real form with the seeded credentials. That is not incidental — an exit
- * demo that authenticated by a dev-only shortcut would prove a path no visitor
- * or editor ever takes.
+ * the real form with the seeded credentials. That is not incidental: a suite
+ * that authenticated by a dev-only shortcut would prove a path no visitor or
+ * editor ever takes.
  *
  * @module playwright.production.config
  */
@@ -37,7 +38,22 @@ export default defineConfig({
   forbidOnly: Boolean(process.env.CI),
   retries: 0,
   workers: 1,
-  reporter: process.env.CI ? [["github"], ["line"]] : [["line"]],
+  // The HTML reporter is what makes the CI artifact exist. With `github` and
+  // `line` alone the run annotates and prints, writes no report directory, and
+  // an upload step finds nothing — which is worst on the failing run that most
+  // needs the trace. Its own folder rather than the dev suite's, for the reason
+  // the port and the database are its own: on one machine a shared folder
+  // leaves whichever suite finished last as the only report either has.
+  reporter: process.env.CI
+    ? [
+        ["github"],
+        ["line"],
+        [
+          "html",
+          { outputFolder: "./.playwright/report-production", open: "never" },
+        ],
+      ]
+    : [["line"]],
   use: {
     baseURL: BASE_URL,
     trace: "retain-on-failure",

--- a/e2e/tests/site-style.spec.ts
+++ b/e2e/tests/site-style.spec.ts
@@ -203,10 +203,11 @@ test("a stored token reaches the published page's site sheet, both modes", async
 test("a stored font face reaches the published page as a rule a browser would act on", async ({
   request,
 }) => {
-  // The third authorable tier. Tokens and classes are asserted above; a font
-  // is the one the phase's exit criterion names alongside them, and it travels
-  // a different road — it is emitted as an AT-RULE rather than as a custom
-  // property or a class selector, so neither assertion above covers it.
+  // The third authorable tier, and the one neither assertion above reaches. A
+  // token becomes a custom property and a class becomes a selector; a font
+  // becomes an AT-RULE, which is emitted by different code down a different
+  // path, so a break between stored font data and the served sheet shows up
+  // here or nowhere.
   const response = await request.get(`/blocks/${PAGE_SLUG}`);
   await expectOk(response, "fetching the published page");
   const sheet = siteSheetOf(await response.text());

--- a/e2e/tests/site-style.spec.ts
+++ b/e2e/tests/site-style.spec.ts
@@ -48,6 +48,21 @@ const TOKEN_PROPERTY = "--site-color-e2e-accent";
 const TOKEN_LIGHT = "#1b7f5c";
 const TOKEN_DARK = "#8fe3c0";
 
+/**
+ * The stored font face, and the family its `@font-face` declares.
+ *
+ * A family no other tier names, for the reason the token above is named that
+ * way: a family the engine or this app's config already ships would appear in
+ * the sheet whether or not the stored document was read.
+ *
+ * The file need not exist. The claim is that a stored face reaches the served
+ * sheet as a rule a browser would act on — whether the browser then finds the
+ * file is the host's business, and asserting on a real download would make
+ * this a test of static serving instead.
+ */
+const FONT_FAMILY = "E2E Sans";
+const FONT_URL = "/fonts/e2e-sans.woff2";
+
 /** The stored class, and the colour its rule applies. */
 const CLASS_ID = "e2e-accent-class";
 const CLASS_SLUG = "e2e-accent";
@@ -93,6 +108,12 @@ const STORED_STYLE = {
       slug: CLASS_SLUG,
       orderIndex: 0,
       styles: { base: { base: { color: CLASS_COLOR } } },
+    },
+  ],
+  fonts: [
+    {
+      family: FONT_FAMILY,
+      src: [{ url: FONT_URL, format: "woff2" }],
     },
   ],
 };
@@ -177,6 +198,34 @@ test("a stored token reaches the published page's site sheet, both modes", async
   const darkIndex = sheet.indexOf(`${TOKEN_PROPERTY}:${TOKEN_DARK}`);
   expect(darkIndex).toBeGreaterThan(-1);
   expect(sheet.slice(0, darkIndex)).toContain('[data-nx-theme="dark"]');
+});
+
+test("a stored font face reaches the published page as a rule a browser would act on", async ({
+  request,
+}) => {
+  // The third authorable tier. Tokens and classes are asserted above; a font
+  // is the one the phase's exit criterion names alongside them, and it travels
+  // a different road — it is emitted as an AT-RULE rather than as a custom
+  // property or a class selector, so neither assertion above covers it.
+  const response = await request.get(`/blocks/${PAGE_SLUG}`);
+  await expectOk(response, "fetching the published page");
+  const sheet = siteSheetOf(await response.text());
+
+  // The family, quoted as the emitter writes it. A face that failed validation
+  // contributes NOTHING rather than half a rule, so the family appearing at all
+  // means the stored face was read, validated and emitted whole.
+  expect(sheet).toContain(`@font-face`);
+  expect(sheet).toContain(`font-family:"${FONT_FAMILY}"`);
+
+  // The source, with its format. Asserting the url alone would pass on a rule
+  // that named the file and told the browser nothing about how to parse it.
+  expect(sheet).toContain(`url("${FONT_URL}") format("woff2")`);
+
+  // `swap` is the emitter's default and the reason it has one: text stays
+  // readable while the file loads. Its absence would be a face that renders
+  // invisible text on a slow connection, which is a real regression and not a
+  // formatting difference.
+  expect(sheet).toContain("font-display:swap");
 });
 
 test("a stored class is emitted as a rule and applied to a referencing node", async ({

--- a/packages/builder/src/style-inspector-public-block.test.tsx
+++ b/packages/builder/src/style-inspector-public-block.test.tsx
@@ -28,6 +28,7 @@ import {
   defineBlock,
   registerBlocks,
   STYLE_GROUP_DEFS,
+  stylePropertiesForSupports,
   type BlockDocument,
   type BlockNode,
 } from "@nextlyhq/blocks-engine";
@@ -145,16 +146,35 @@ describe("a block declared through the public API", () => {
     expect(groups).toEqual(catalogOrder);
   });
 
-  it("fills each section with controls, so the inspector is complete rather than merely present", () => {
+  it("offers every property the engine says those supports allow, not merely some", () => {
     const sections = inspect("acme/callout").sections;
 
-    // Every section carries at least one property, and every property carries
-    // at least one control. A section list with empty sections is the failure
-    // this separates out: it would satisfy the group assertions above while
-    // presenting an author with three empty accordions.
+    // The expectation is the ENGINE's answer rather than a list written here.
+    // Two reasons, and the second is why a count would not do: a list written
+    // here would agree with itself and stop tracking the catalog, and an
+    // inspector that kept only the FIRST property of each group satisfies
+    // "every section is non-empty" while presenting a partial inspector — the
+    // exact failure the phrase "complete inspector" is about.
+    for (const section of sections) {
+      const offered = section.properties.map(property => property.property);
+      const allowed = stylePropertiesForSupports({
+        [section.group]: true,
+      }).map(entry => entry.property);
+
+      // Membership rather than length: a section that dropped one property and
+      // gained another matches any total compared against.
+      expect(offered).toEqual(allowed);
+    }
+  });
+
+  it("gives every offered property at least one control to edit it with", () => {
+    // Separate from the property set above, because they fail differently: a
+    // property present with no control is a labelled row an author cannot
+    // touch, which reads as a bug in the control rather than in the inspector.
+    const sections = inspect("acme/callout").sections;
+
     expect(sections.length).toBeGreaterThan(0);
     for (const section of sections) {
-      expect(section.properties.length).toBeGreaterThan(0);
       for (const property of section.properties) {
         expect(property.controls.length).toBeGreaterThan(0);
       }

--- a/packages/builder/src/style-inspector-public-block.test.tsx
+++ b/packages/builder/src/style-inspector-public-block.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * A block declared the way a THIRD PARTY declares one gets a full inspector.
+ *
+ * The other inspector suites build their fixtures as object literals passed to
+ * `registerBlocks` through `as never`. That is convenient and it removes the
+ * property this file exists for: the cast is exactly what takes the public
+ * contract out of the path, so those suites prove the inspector derives from a
+ * supports declaration and cannot prove a plugin author can produce one.
+ *
+ * So the fixture below goes through `defineBlock`, which is what the plugin SDK
+ * re-exports to third parties, and is registered WITHOUT A CAST. If the public
+ * definition shape and the registry ever disagree, this file stops compiling —
+ * which is the failure a plugin author would hit, arriving here instead of in
+ * their project.
+ *
+ * "Zero custom editor code" is the other half, and it is asserted by omission
+ * with a control: the definition declares no `editor` and no inspector
+ * components, and the assertions below show the sections and controls appear
+ * anyway. The control is the LAST test, which registers a block supporting
+ * nothing and requires an empty inspector — without it, an `inspectStyle` that
+ * returned every group for every block would satisfy everything above.
+ *
+ * @module style-inspector-public-block.test
+ */
+import {
+  BASE_BREAKPOINT,
+  clearBlocks,
+  defineBlock,
+  registerBlocks,
+  STYLE_GROUP_DEFS,
+  type BlockDocument,
+  type BlockNode,
+} from "@nextlyhq/blocks-engine";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { inspectStyle, type StyleInspection } from "./style-inspector";
+
+interface CalloutProps {
+  /** The callout's body text. */
+  text?: string;
+}
+
+/**
+ * A third-party block: declared through the public API, carrying no editor
+ * code of any kind.
+ *
+ * `supports` names three groups and no properties within them, which is the
+ * ordinary way an author opts in — the properties each group offers are the
+ * catalog's answer, not this definition's.
+ */
+const acmeCallout = defineBlock<CalloutProps>({
+  name: "acme/callout",
+  version: 1,
+  description: "A callout an author can style but not configure.",
+  props: {
+    text: { type: "string", label: "Text" },
+  },
+  defaultProps: { text: "" },
+  example: { props: { text: "Heads up" } },
+  supports: {
+    spacing: true,
+    typography: true,
+    color: true,
+  },
+  render: () => null,
+});
+
+/** A block that opts into nothing, so "everything is offered" cannot pass. */
+const acmeInert = defineBlock<CalloutProps>({
+  name: "acme/inert",
+  version: 1,
+  description: "A block with no style opt-in at all.",
+  props: {
+    text: { type: "string", label: "Text" },
+  },
+  defaultProps: { text: "" },
+  example: { props: { text: "Nothing to style" } },
+  supports: {},
+  render: () => null,
+});
+
+afterEach(() => {
+  clearBlocks();
+});
+
+/** A document holding one node of the given block type. */
+function documentOf(type: string): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "a", type, version: 1, props: {} }] as BlockNode[],
+  } as BlockDocument;
+}
+
+/**
+ * The inspection for one node, refusing rather than returning null.
+ *
+ * `inspectStyle` answers `null` when the selection names no node, and a test
+ * reading `?.sections` on that would report an empty inspector — the same shape
+ * as a block that opts into nothing, which is this file's control. Failing here
+ * keeps the two apart.
+ */
+function inspect(type: string): StyleInspection {
+  registerBlocks([type === "acme/inert" ? acmeInert : acmeCallout], {
+    source: "public-block-test",
+  });
+  const inspection = inspectStyle(documentOf(type), "a", {
+    breakpoint: BASE_BREAKPOINT,
+  });
+  if (inspection === null) {
+    throw new Error(`inspectStyle found no node for ${type}`);
+  }
+  return inspection;
+}
+
+describe("a block declared through the public API", () => {
+  it("registers without a cast, which is the contract a plugin author compiles against", () => {
+    // The assertion is that this line type-checks and does not throw. A
+    // definition the registry refuses at runtime, or a shape `registerBlocks`
+    // will not accept at compile time, both fail here — and both are what a
+    // third party would hit first.
+    expect(() =>
+      registerBlocks([acmeCallout], { source: "public-block-test" })
+    ).not.toThrow();
+  });
+
+  it("gets a section for every group it supports, with no editor code of its own", () => {
+    const groups = inspect("acme/callout").sections.map(s => s.group);
+
+    // Exactly the three it opted into. `toEqual` on a sorted list rather than
+    // three `toContain`s, so a section it did NOT opt into fails here instead
+    // of passing unnoticed.
+    expect([...groups].sort()).toEqual(["color", "spacing", "typography"]);
+  });
+
+  it("orders those sections as the catalog presents them, not as supports lists them", () => {
+    const groups = inspect("acme/callout").sections.map(s => s.group);
+
+    const catalogOrder = STYLE_GROUP_DEFS.map(g => g.key).filter(k =>
+      groups.includes(k)
+    );
+    // The definition lists spacing, typography, color; the catalog's own order
+    // is what an author sees. A block author cannot reorder another block's
+    // inspector by the order they happened to type their supports.
+    expect(groups).toEqual(catalogOrder);
+  });
+
+  it("fills each section with controls, so the inspector is complete rather than merely present", () => {
+    const sections = inspect("acme/callout").sections;
+
+    // Every section carries at least one property, and every property carries
+    // at least one control. A section list with empty sections is the failure
+    // this separates out: it would satisfy the group assertions above while
+    // presenting an author with three empty accordions.
+    expect(sections.length).toBeGreaterThan(0);
+    for (const section of sections) {
+      expect(section.properties.length).toBeGreaterThan(0);
+      for (const property of section.properties) {
+        expect(property.controls.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it("offers nothing for a block that opts into nothing", () => {
+    // The control for all three assertions above. An `inspectStyle` that
+    // ignored `supports` and returned the whole catalog would pass every test
+    // in this file except this one.
+    expect(inspect("acme/inert").sections).toEqual([]);
+  });
+});

--- a/packages/plugin-sdk/src/block-exports.test-d.ts
+++ b/packages/plugin-sdk/src/block-exports.test-d.ts
@@ -3,6 +3,7 @@ import { expectTypeOf } from "vitest";
 
 import { blockSupports, defineBlock } from "@nextlyhq/plugin-sdk/blocks";
 import type {
+  AnyBlockDefinition,
   BlockEditorMeta,
   BlockExample,
   BlockSeoContribution,
@@ -17,6 +18,32 @@ import type {
   SlotLock,
   SlotSpec,
 } from "@nextlyhq/plugin-sdk/blocks";
+
+// A definition written through THIS package's `defineBlock` is something the
+// engine's registry accepts.
+//
+// The two helpers are separate declarations: `BlockDefinition` here extends
+// `EngineBlockDefinition<P, BlockRenderContext>` and narrows the supports keys
+// and the render contract, so an author compiling against the SDK is checked
+// against a different type from the one `registerBlocks` consumes. Nothing
+// previously asserted that the narrower type still satisfies the wider one, and
+// a change to either could separate them while every suite on both sides stayed
+// green — the failure would first appear in somebody's plugin.
+//
+// Assignability is the whole claim, so it is asserted at the type level rather
+// than by registering anything: the registry's runtime checks are the engine's
+// to test, and a value assertion here would re-test those instead.
+const sdkDefined = defineBlock<{ text?: string }>({
+  name: "acme/assignable",
+  version: 1,
+  description: "Declared through the SDK, consumed by the engine's registry.",
+  props: { text: { type: "string", label: "Text" } },
+  defaultProps: { text: "" },
+  example: { props: { text: "Hello" } },
+  supports: { spacing: true },
+  render: () => null,
+});
+expectTypeOf(sdkDefined).toExtend<AnyBlockDefinition>();
 
 // Everything a definition asks an author to fill in is reachable from the SDK,
 // so writing a block never means importing the engine directly.


### PR DESCRIPTION
I verified Plan 05's six exit criteria one at a time — locating each asserting test, running it, and break-verifying that it discriminates. Three had no assertion. This closes them. **No changeset: CI and test only.**

## What the verification found

| # | Criterion | Before |
|---|---|---|
| 1 | Third-party block → complete inspector, *via a fixture declared only through the public Block API* | fixture used `registerBlocks([...] as never)` |
| 2 | Tokens, classes **and fonts** authorable end to end | fonts reached no served page in any test |
| 3 | Shared-sheet delivery on, named classes live | **met** |
| 4 | Control values derive from the catalog, proven by a synthetic catalog change | **met** — break-verified |
| 5 | Every control's value proven on a published page in a browser | production suite ran nowhere |
| 6 | No third colour parser, *asserted by a module-graph test* | see below |

## The three fixes

**The production browser suite ran nowhere.** `test:e2e:prod` and `playwright.production.config.ts` appeared in no workflow. Its two specs are the only ones exercising a `next build`, which is the environment task 179's 500-on-every-path reproduced in and `next dev` never did.

Added as a **post-merge** job (`if: github.event_name == 'push'`), not a per-PR one. That is the ordinary tiered arrangement — a fast subset on the pull request, the full suite as a gate on merge — and it is what the numbers here support: `Browser tests` already spends 10.8–14.7 minutes of a 20-minute budget on the dev server, so a production build on every PR would roughly double the most expensive job in the pipeline for a suite whose value is pre-release confidence. `ci.yml` already triggers on pushes to `main`, so no new workflow. Verified locally first: **2 passed in 44.4s**, so this will not redden `main`.

**A block declared the way a third party declares one had no inspector test.** The existing suites pass object literals through `as never`, and that cast is precisely what removes the public contract from the path — so they prove the inspector derives from a supports declaration and cannot prove a plugin author can produce one. The new fixture goes through `defineBlock` and registers **without a cast**, so a disagreement between the published shape and the registry stops the file compiling rather than reaching somebody's project. It caught one immediately: I spelled a prop schema `kind` where `PropSchema` requires `type`.

**Fonts reached no served page.** Tokens and classes were both asserted on real responses; a font travels a different road — emitted as an at-rule rather than a custom property or a class selector — so neither covered it. The new case reads the family, the source with its `format`, and `font-display`, whose absence renders invisible text on a slow connection rather than a differently-formatted rule.

## Evidence

Break-verified, each mutation stated before running:

| mutation | kills |
|---|---|
| `emitFontFaces` returns `""` | the font case, alone |
| inspector ignores `supports` | 2 of the 5 block cases |

**Honest limit:** that second mutation did *not* kill the file's control (*"offers nothing for a block that opts into nothing"*), so the control's own discriminating power is unproven by this break. It is there because an `inspectStyle` returning the whole catalog would otherwise satisfy every other assertion in the file.

`check-types` 22/22 · builder **92 files / 2607 tests** · `site-style.spec.ts` **4 passed** in a browser · production suite **2 passed** · `fallow --base origin/main` **pass**, exit 0, introduced counts all 0 · comment convention clean.

## Two things left as findings, not fixed here

**Criterion 6 is not met as written, and the test says so itself:**

> *"So this is not the control for 'no third colour parser'. That rule is a design constraint, enforced at review."*

What `style-colour-boundary.test.ts` does enforce — the admin theme's contrast implementation being unreachable from the editor — is real and discriminates: publishing `./styles/contrast/color` as a `ui` subpath killed exactly *"is not published as a subpath, so no import can resolve to it"*. The criterion overstates the test rather than the test underdelivering, so the plan is what should change.

**Criterion 5 is now runnable but still not per-control.** The mechanism is proven on served pages; "*every* control's value" is not, and `D-05.7` is referenced nowhere in the codebase.

**Pre-existing, untouched:** `playground` lint fails on `main` with 1119 errors and 51333 warnings.

@codex review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Production browser tests now run automatically after changes are merged to the main branch.
  * Added end-to-end coverage for published custom fonts, including font source, format, and display behavior.
  * Publicly defined blocks now receive style inspector controls for supported spacing, typography, and color settings.

* **Tests**
  * Added validation that SDK-defined blocks remain compatible with the editor’s block system.
  * Added coverage for blocks without style support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->