### PR TITLE
fix(nextly): let the instance's access configuration reach releases

### DIFF
--- a/.changeset/an-instance-that-asks-for-checks-gets-them.md
+++ b/.changeset/an-instance-that-asks-for-checks-gets-them.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Honour a Nextly instance's own access configuration in `nextly.releases.*`, so an instance built with `overrideAccess: false` has its release operations checked instead of silently trusted.

--- a/packages/nextly/src/di/__tests__/register-releases.test.ts
+++ b/packages/nextly/src/di/__tests__/register-releases.test.ts
@@ -105,3 +105,86 @@ describe("registerReleaseServices", () => {
     vi.doUnmock("../../services/lib/permissions");
   });
 });
+
+describe("registerReleaseServices document authority", () => {
+  afterEach(() => {
+    vi.doUnmock("../container");
+    vi.doUnmock("../../services/lib/permissions");
+    vi.resetModules();
+  });
+
+  /**
+   * Build the service with a permission store that ALLOWS the owner, so the
+   * only thing that can refuse below is the key's own scope.
+   */
+  async function withOwnerAllowed(scopePermissions: string[]) {
+    const singletons = new Map<string, unknown>();
+    vi.resetModules();
+    vi.doMock("../../services/lib/permissions", () => ({
+      hasPermission: async () => true,
+    }));
+    vi.doMock("../container", () => ({
+      container: {
+        registerSingleton: (name: string, factory: () => unknown) => {
+          singletons.set(name, factory());
+        },
+        has: (name: string) => name === "rbacAccessControlService",
+        get: () => ({
+          // The OWNER is allowed on the document. If the key's own grants were
+          // ignored, this is the answer that would come back.
+          checkAccess: async () => true,
+          getRegisteredAccess: () => undefined,
+        }),
+      },
+    }));
+    const { registerReleaseServices } = await import(
+      "../registrations/register-releases"
+    );
+    registerReleaseServices({ adapter: { select: async () => [] } } as never);
+    return {
+      svc: singletons.get("releasesService") as {
+        addMember: (r: string, m: unknown, a: unknown) => Promise<unknown>;
+      },
+      actor: {
+        userId: "owner",
+        overrideAccess: false,
+        authenticatedScope: {
+          actorType: "apiKey" as const,
+          permissions: scopePermissions,
+        },
+      },
+    };
+  }
+
+  const MEMBER = {
+    scopeKind: "collection",
+    scopeSlug: "posts",
+    entryId: "e1",
+    locale: null,
+    action: "publish",
+  };
+
+  it("refuses a key without the document grant, however privileged its owner", async () => {
+    // THE case the release-resource check alone does not cover: a key holding
+    // create-content-releases but not publish-posts, owned by someone who CAN
+    // publish posts. Resolving the document from the owner inserts the member
+    // and materialises it later as that privileged person.
+    const { svc, actor } = await withOwnerAllowed(["create-content-releases"]);
+    await expect(svc.addMember("r1", MEMBER, actor)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("admits a key that holds the document grant", async () => {
+    // The control: the key path must not deny everything, which would make a
+    // properly scoped key unusable and still pass the case above. It gets past
+    // the document check and fails later on the fixture adapter instead.
+    const { svc, actor } = await withOwnerAllowed([
+      "create-content-releases",
+      "publish-posts",
+    ]);
+    await expect(svc.addMember("r1", MEMBER, actor)).rejects.not.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+});

--- a/packages/nextly/src/di/__tests__/register-releases.test.ts
+++ b/packages/nextly/src/di/__tests__/register-releases.test.ts
@@ -182,8 +182,115 @@ describe("registerReleaseServices document authority", () => {
     const { svc, actor } = await withOwnerAllowed([
       "create-content-releases",
       "publish-posts",
+      // The base write grant too: an ordinary lifecycle write needs `update`
+      // alongside the verb, so a key holding only `publish-posts` cannot
+      // perform one.
+      "update-posts",
     ]);
     await expect(svc.addMember("r1", MEMBER, actor)).rejects.not.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+});
+
+describe("registerReleaseServices lifecycle grants", () => {
+  afterEach(() => {
+    vi.doUnmock("../container");
+    vi.doUnmock("../../services/lib/permissions");
+    vi.resetModules();
+  });
+
+  async function build(opts: {
+    scopePermissions?: string[];
+    ownerAllows?: (operation: string) => boolean;
+  }) {
+    const singletons = new Map<string, unknown>();
+    vi.resetModules();
+    vi.doMock("../../services/lib/permissions", () => ({
+      hasPermission: async () => true,
+    }));
+    vi.doMock("../container", () => ({
+      container: {
+        registerSingleton: (name: string, factory: () => unknown) => {
+          singletons.set(name, factory());
+        },
+        has: (name: string) => name === "rbacAccessControlService",
+        get: () => ({
+          checkAccess: async ({ operation }: { operation: string }) =>
+            opts.ownerAllows ? opts.ownerAllows(operation) : true,
+          getRegisteredAccess: () => undefined,
+        }),
+      },
+    }));
+    const { registerReleaseServices } = await import(
+      "../registrations/register-releases"
+    );
+    registerReleaseServices({ adapter: { select: async () => [] } } as never);
+    return {
+      svc: singletons.get("releasesService") as {
+        addMember: (r: string, m: unknown, a: unknown) => Promise<unknown>;
+      },
+      actor: {
+        userId: "owner",
+        overrideAccess: false,
+        ...(opts.scopePermissions
+          ? {
+              authenticatedScope: {
+                actorType: "apiKey" as const,
+                permissions: opts.scopePermissions,
+              },
+            }
+          : {}),
+      },
+    };
+  }
+
+  const MEMBER = {
+    scopeKind: "collection",
+    scopeSlug: "posts",
+    entryId: "e1",
+    locale: null,
+    action: "publish",
+  };
+
+  it("refuses a key holding the lifecycle verb but not the base update grant", async () => {
+    // An ordinary lifecycle write requires `update-posts` as well as
+    // `publish-posts`. Asking only about the verb admits a key that may publish
+    // but may not write the document — and the drain then executes as the
+    // owner, turning a release into a way around the missing grant.
+    const { svc, actor } = await build({
+      scopePermissions: ["create-content-releases", "publish-posts"],
+    });
+    await expect(svc.addMember("r1", MEMBER, actor)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("refuses when the AUTHOR cannot perform the action, however scoped the key", async () => {
+    // The author is who executes: `createJobContentApi` strips `actor`, so the
+    // key's scope is gone at materialisation. A member admitted on the key's
+    // authority alone is one the drain refuses forever, leaving the release
+    // scheduled and the content absent.
+    const { svc, actor } = await build({
+      scopePermissions: [
+        "create-content-releases",
+        "publish-posts",
+        "update-posts",
+      ],
+      ownerAllows: operation => operation !== "publish",
+    });
+    await expect(svc.addMember("r1", MEMBER, actor)).rejects.toMatchObject({
+      code: "FORBIDDEN",
+    });
+  });
+
+  it("refuses a session caller who lacks the base update grant", async () => {
+    // Not a key-only rule: an ordinary user scheduling a publish must be able
+    // to write the document too.
+    const { svc, actor } = await build({
+      ownerAllows: operation => operation !== "update",
+    });
+    await expect(svc.addMember("r1", MEMBER, actor)).rejects.toMatchObject({
       code: "FORBIDDEN",
     });
   });

--- a/packages/nextly/src/di/registrations/register-releases.ts
+++ b/packages/nextly/src/di/registrations/register-releases.ts
@@ -81,30 +81,52 @@ export function registerReleaseServices({
             "rbacAccessControlService"
           );
 
-          // A scoped API key is judged by its OWN grants, and by the full
-          // question the ordinary write path asks: the `{action}-{slug}` grant
-          // AND the code-defined access rule, evaluated against the key rather
-          // than its owner. Checking only the permission slug here would be a
-          // partial answer that reads like a complete one — and resolving from
-          // the owner at all is how a narrow key ends up scheduling a publish
-          // it was never granted, materialised later as a privileged person.
+          // TWO questions, because two different principals are involved.
           //
-          // `null` means the caller is not a key, so the ordinary resolution
-          // below applies.
-          const byKey = await apiKeyWriteAllowed(
+          // The AUTHOR is who performs the write later. `createJobContentApi`
+          // strips `actor` from every bound call, so the key's scope is GONE at
+          // materialisation and the recorded author's own grants are the only
+          // thing that can authorize it. A member admitted on a key's authority
+          // alone is one the drain will refuse forever, leaving the release
+          // scheduled with content that never appears.
+          //
+          // An ordinary lifecycle write needs the base `update` grant as well as
+          // the lifecycle verb, so both are asked. Checking only `publish` would
+          // admit a caller who may publish but may not write the document.
+          const authorMay =
+            (await rbac.checkAccess({
+              userId,
+              operation: "update",
+              resource: scopeSlug,
+            })) &&
+            (await rbac.checkAccess({
+              userId,
+              operation: action,
+              resource: scopeSlug,
+            }));
+          if (!authorMay) return false;
+
+          // And a scoped API key must hold the grants ITSELF, or a narrow key
+          // borrows the owner's authority to schedule a write it was never
+          // given. `null` means the caller is not a key, and the author check
+          // above is then the whole answer.
+          const asUser = { id: userId, roles: userRoles };
+          const keyMayAct = await apiKeyWriteAllowed(
             authenticatedScope,
             action,
             scopeSlug,
-            { id: userId, roles: userRoles },
+            asUser,
             rbac
           );
-          if (byKey !== null) return byKey;
-
-          return rbac.checkAccess({
-            userId,
-            operation: action,
-            resource: scopeSlug,
-          });
+          if (keyMayAct === null) return true;
+          const keyMayUpdate = await apiKeyWriteAllowed(
+            authenticatedScope,
+            "update",
+            scopeSlug,
+            asUser,
+            rbac
+          );
+          return keyMayAct && keyMayUpdate === true;
         },
       })
   );

--- a/packages/nextly/src/di/registrations/register-releases.ts
+++ b/packages/nextly/src/di/registrations/register-releases.ts
@@ -15,6 +15,7 @@
  * @module di/registrations/register-releases
  */
 
+import { apiKeyWriteAllowed } from "../../auth/authenticated-scope";
 import type { RBACAccessControlService } from "../../domains/auth/services/rbac-access-control-service";
 import { ReleasesRepository } from "../../domains/releases/releases-repository";
 import {
@@ -63,7 +64,13 @@ export function registerReleaseServices({
         // `register-auth`, and resolving at registration time would make this
         // depend on an ordering between two registrations rather than on the
         // container — the first reordering would break it silently.
-        canActOnDocument: async (userId, scopeSlug, action) => {
+        canActOnDocument: async ({
+          userId,
+          scopeSlug,
+          action,
+          authenticatedScope,
+          userRoles,
+        }) => {
           if (!container.has("rbacAccessControlService")) {
             // No permission store means no basis for saying yes. A minimal boot
             // without RBAC can still construct this service; it simply cannot
@@ -73,6 +80,26 @@ export function registerReleaseServices({
           const rbac = container.get<RBACAccessControlService>(
             "rbacAccessControlService"
           );
+
+          // A scoped API key is judged by its OWN grants, and by the full
+          // question the ordinary write path asks: the `{action}-{slug}` grant
+          // AND the code-defined access rule, evaluated against the key rather
+          // than its owner. Checking only the permission slug here would be a
+          // partial answer that reads like a complete one — and resolving from
+          // the owner at all is how a narrow key ends up scheduling a publish
+          // it was never granted, materialised later as a privileged person.
+          //
+          // `null` means the caller is not a key, so the ordinary resolution
+          // below applies.
+          const byKey = await apiKeyWriteAllowed(
+            authenticatedScope,
+            action,
+            scopeSlug,
+            { id: userId, roles: userRoles },
+            rbac
+          );
+          if (byKey !== null) return byKey;
+
           return rbac.checkAccess({
             userId,
             operation: action,

--- a/packages/nextly/src/direct-api/namespaces/__tests__/releases-namespace.test.ts
+++ b/packages/nextly/src/direct-api/namespaces/__tests__/releases-namespace.test.ts
@@ -45,7 +45,7 @@ describe("releases namespace access defaults", () => {
     await releases.find();
     expect(service.find).toHaveBeenCalledWith(
       {},
-      { userId: "u1", overrideAccess: false }
+      expect.objectContaining({ userId: "u1", overrideAccess: false })
     );
   });
 
@@ -56,7 +56,7 @@ describe("releases namespace access defaults", () => {
     await releases.find();
     expect(service.find).toHaveBeenCalledWith(
       {},
-      { userId: null, overrideAccess: true }
+      expect.objectContaining({ userId: null, overrideAccess: true })
     );
   });
 
@@ -69,7 +69,7 @@ describe("releases namespace access defaults", () => {
     await releases.create({ title: "Launch", userId: "u2" });
     expect(service.create).toHaveBeenCalledWith(
       { title: "Launch", description: undefined },
-      { userId: "u2", overrideAccess: false }
+      expect.objectContaining({ userId: "u2", overrideAccess: false })
     );
   });
 
@@ -90,7 +90,56 @@ describe("releases namespace access defaults", () => {
     expect(service.addMember).toHaveBeenCalledWith(
       "r1",
       expect.objectContaining({ scopeSlug: "posts" }),
-      { userId: "u1", overrideAccess: false }
+      expect.objectContaining({ userId: "u1", overrideAccess: false })
+    );
+  });
+});
+
+describe("releases namespace identity", () => {
+  it("keeps an EXPLICIT null as anonymous, rather than falling back to the instance user", async () => {
+    // A route that turns an absent session into `userId: null` is saying "act as
+    // nobody". Treating that as "not supplied" hands it the instance's
+    // configured user and, with it, that person's release permissions — the
+    // caller asked to be refused and would be authorized instead.
+    const releases = createReleasesNamespace(
+      instance({ overrideAccess: false, user: { id: "u1" } })
+    );
+    await releases.find({ userId: null });
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ userId: null, overrideAccess: false })
+    );
+  });
+
+  it("still falls back to the instance user when userId is OMITTED", async () => {
+    // The control: omitted and present-but-null are different questions, and a
+    // fix answering both as "anonymous" would break every configured instance
+    // while passing the case above.
+    const releases = createReleasesNamespace(
+      instance({ overrideAccess: false, user: { id: "u1" } })
+    );
+    await releases.find();
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ userId: "u1" })
+    );
+  });
+
+  it("forwards a scoped API key's own grants", async () => {
+    // Release authority must resolve from the KEY, not its owner: otherwise a
+    // restricted key inherits authority it was never granted, and a key granted
+    // release authority is denied when its owner lacks it.
+    const scope = {
+      actorType: "apiKey",
+      permissions: ["read-content-releases"],
+    };
+    const releases = createReleasesNamespace(
+      instance({ overrideAccess: false, user: { id: "u1" }, actor: scope })
+    );
+    await releases.find();
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({ authenticatedScope: scope })
     );
   });
 });

--- a/packages/nextly/src/direct-api/namespaces/__tests__/releases-namespace.test.ts
+++ b/packages/nextly/src/direct-api/namespaces/__tests__/releases-namespace.test.ts
@@ -1,0 +1,96 @@
+/**
+ * That `nextly.releases.*` honours the INSTANCE's access configuration.
+ *
+ * An instance built with `getNextly({ overrideAccess: false, user })` is asking
+ * for every operation on it to be checked. A namespace that defaulted to `true`
+ * on its own bypasses that in silence — which is the one failure where a caller
+ * has explicitly asked for enforcement and been given none, and no error appears
+ * anywhere to say so.
+ *
+ * Asserted on what the SERVICE was handed, because that is what decides whether
+ * the checks run. A test that only asserted the call succeeded would pass
+ * against the bypass.
+ *
+ * @module direct-api/namespaces/__tests__/releases-namespace.test
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createReleasesNamespace } from "../releases";
+import type { NextlyContext } from "../context";
+
+const service = {
+  find: vi.fn(async () => []),
+  create: vi.fn(async () => ({ id: "r1" })),
+  addMember: vi.fn(async () => ({ id: "m1" })),
+};
+
+vi.mock("../../../di/container", () => ({
+  container: { has: () => true, get: () => service },
+}));
+
+/** An instance configured the way the docblock's example configures one. */
+function instance(defaultConfig: Record<string, unknown>): NextlyContext {
+  return { defaultConfig } as unknown as NextlyContext;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("releases namespace access defaults", () => {
+  it("enforces when the INSTANCE asked for enforcement", async () => {
+    const releases = createReleasesNamespace(
+      instance({ overrideAccess: false, user: { id: "u1" } })
+    );
+    await releases.find();
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      { userId: "u1", overrideAccess: false }
+    );
+  });
+
+  it("stays trusted when the instance says nothing", async () => {
+    // The control on the case above: the default is still trusted, so the fix
+    // cannot be "always enforce", which would break every in-process caller.
+    const releases = createReleasesNamespace(instance({}));
+    await releases.find();
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      { userId: null, overrideAccess: true }
+    );
+  });
+
+  it("lets one call override the instance, not the reverse", async () => {
+    // Per-call config wins, matching `mergeConfig` and every other namespace, so
+    // a single call can act as someone without reconfiguring the instance.
+    const releases = createReleasesNamespace(
+      instance({ overrideAccess: false, user: { id: "u1" } })
+    );
+    await releases.create({ title: "Launch", userId: "u2" });
+    expect(service.create).toHaveBeenCalledWith(
+      { title: "Launch", description: undefined },
+      { userId: "u2", overrideAccess: false }
+    );
+  });
+
+  it("carries the instance identity into a member add", async () => {
+    // addMember is the operation where a missing identity is worst: the member
+    // records its author, and an authorless one can never materialise.
+    const releases = createReleasesNamespace(
+      instance({ overrideAccess: false, user: { id: "u1" } })
+    );
+    await releases.addMember({
+      releaseId: "r1",
+      scopeKind: "collection",
+      scopeSlug: "posts",
+      entryId: "e1",
+      locale: null,
+      action: "publish",
+    });
+    expect(service.addMember).toHaveBeenCalledWith(
+      "r1",
+      expect.objectContaining({ scopeSlug: "posts" }),
+      { userId: "u1", overrideAccess: false }
+    );
+  });
+});

--- a/packages/nextly/src/direct-api/namespaces/__tests__/releases-namespace.test.ts
+++ b/packages/nextly/src/direct-api/namespaces/__tests__/releases-namespace.test.ts
@@ -143,3 +143,76 @@ describe("releases namespace identity", () => {
     );
   });
 });
+
+describe("releases namespace credential lifetime", () => {
+  it("does not carry the instance's key scope onto an overridden identity", async () => {
+    // The instance's key authorizes the instance's user. A call that names
+    // somebody else — or nobody — must not keep it: `authorize` checks the key
+    // scope BEFORE the anonymous guard, so an inherited scope authorizes
+    // `userId: null` outright.
+    const releases = createReleasesNamespace(
+      instance({
+        overrideAccess: false,
+        user: { id: "u1", roles: ["editor"] },
+        actor: { actorType: "apiKey", permissions: ["read-content-releases"] },
+      })
+    );
+    await releases.find({ userId: null });
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        userId: null,
+        authenticatedScope: undefined,
+        userRoles: undefined,
+      })
+    );
+  });
+
+  it("keeps the instance's credentials when the identity is NOT overridden", async () => {
+    // The control: clearing them unconditionally would strip the scope from
+    // every ordinary call on a key-configured instance and pass the case above.
+    const scope = {
+      actorType: "apiKey",
+      permissions: ["read-content-releases"],
+    };
+    const releases = createReleasesNamespace(
+      instance({
+        overrideAccess: false,
+        user: { id: "u1", roles: ["editor"] },
+        actor: scope,
+      })
+    );
+    await releases.find();
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        userId: "u1",
+        authenticatedScope: scope,
+        userRoles: ["editor"],
+      })
+    );
+  });
+
+  it("lets a transport supply the scope for the identity it is serving", async () => {
+    // A REST request resolves the key for the request it is handling; that wins
+    // over anything the instance was built with.
+    const requestScope = {
+      actorType: "apiKey" as const,
+      permissions: ["publish-content-releases"],
+    };
+    const releases = createReleasesNamespace(
+      instance({
+        overrideAccess: false,
+        actor: { actorType: "apiKey", permissions: ["read-content-releases"] },
+      })
+    );
+    await releases.find({ userId: "u2", authenticatedScope: requestScope });
+    expect(service.find).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        userId: "u2",
+        authenticatedScope: requestScope,
+      })
+    );
+  });
+});

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -139,42 +139,61 @@ function actorOf(ctx: NextlyContext, args: ReleaseCallerArgs) {
   );
 
   return {
-    // An explicit `userId` wins; otherwise the instance's configured `user` is
-    // the acting identity, which is how the rest of the Direct API reads it.
-    userId: args.userId ?? access.user?.id ?? null,
+    // `"userId" in args` rather than `??`, because an explicit `null` MEANS
+    // anonymous and must survive. A route that turns an absent session into
+    // `userId: null` would otherwise be handed the instance's configured user
+    // and receive that person's release permissions — the caller asked to be
+    // refused and would be authorized instead. Omitted and present-but-null are
+    // different questions.
+    userId:
+      "userId" in args ? (args.userId ?? null) : (access.user?.id ?? null),
     overrideAccess: access.overrideAccess ?? true,
+    // Carried, not dropped. Without it release authority resolves from the KEY
+    // OWNER's grants: a restricted key inherits authority it was never given,
+    // and a key granted release authority is denied when its owner lacks it.
+    authenticatedScope: access.authenticatedScope,
   };
 }
 
 export function createReleasesNamespace(ctx: NextlyContext): ReleasesNamespace {
+  // Every operation hands `actorOf` the ORIGINAL argument bag, never a
+  // reconstructed one. Destructuring `{ userId }` out of a call that omitted it
+  // creates the key with value `undefined`, and `"userId" in args` is then true
+  // — so a rebuilt object turns "omitted" into "explicitly nobody" and loses the
+  // instance identity. The same present-but-undefined trap the merge below
+  // guards against, one layer up.
   return {
-    create: ({ title, description, ...caller }) =>
-      service().create({ title, description }, actorOf(ctx, caller)),
+    create: args =>
+      service().create(
+        { title: args.title, description: args.description },
+        actorOf(ctx, args)
+      ),
 
     find: (args = {}) => {
       const { userId, overrideAccess, ...query } = args;
-      return service().find(query, actorOf(ctx, { userId, overrideAccess }));
+      void userId;
+      void overrideAccess;
+      return service().find(query, actorOf(ctx, args));
     },
 
-    findByID: ({ id, ...caller }) =>
-      service().findByID(id, actorOf(ctx, caller)),
+    findByID: args => service().findByID(args.id, actorOf(ctx, args)),
 
-    addMember: ({ releaseId, userId, overrideAccess, ...member }) =>
-      service().addMember(
-        releaseId,
-        member,
-        actorOf(ctx, { userId, overrideAccess })
-      ),
+    addMember: args => {
+      const { releaseId, userId, overrideAccess, ...member } = args;
+      void userId;
+      void overrideAccess;
+      return service().addMember(releaseId, member, actorOf(ctx, args));
+    },
 
-    removeMember: ({ memberId, ...caller }) =>
-      service().removeMember(memberId, actorOf(ctx, caller)),
+    removeMember: args =>
+      service().removeMember(args.memberId, actorOf(ctx, args)),
 
-    listMembers: ({ releaseId, ...caller }) =>
-      service().listMembers(releaseId, actorOf(ctx, caller)),
+    listMembers: args =>
+      service().listMembers(args.releaseId, actorOf(ctx, args)),
 
-    schedule: ({ id, at, timezone, ...caller }) =>
-      service().schedule(id, at, timezone, actorOf(ctx, caller)),
+    schedule: args =>
+      service().schedule(args.id, args.at, args.timezone, actorOf(ctx, args)),
 
-    cancel: ({ id, ...caller }) => service().cancel(id, actorOf(ctx, caller)),
+    cancel: args => service().cancel(args.id, actorOf(ctx, args)),
   };
 }

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -24,6 +24,7 @@
  * @module direct-api/namespaces/releases
  */
 
+import type { AuthenticatedScope } from "../../auth/authenticated-scope";
 import { container } from "../../di/container";
 import type {
   ReleaseMemberRow,
@@ -59,6 +60,14 @@ export interface ReleaseCallerArgs {
   userId?: string | null;
   /** Defaults to the instance's setting, which itself defaults to `true`. */
   overrideAccess?: boolean;
+  /**
+   * The scoped API key's own grants, when the TRANSPORT already resolved them.
+   *
+   * A REST request authenticates before this layer and holds the key's stamped
+   * permissions; the instance config does not. Supplied explicitly it wins,
+   * because it is the scope of the request actually being served.
+   */
+  authenticatedScope?: AuthenticatedScope;
 }
 
 export interface ReleasesNamespace {
@@ -138,6 +147,13 @@ function actorOf(ctx: NextlyContext, args: ReleaseCallerArgs) {
     mergeConfig(ctx.defaultConfig, supplied as never)
   );
 
+  // An explicit identity REPLACES the instance's, and the credentials that
+  // belong to it go with it. Keeping the instance's key scope while swapping the
+  // user leaves a call made as somebody else — or as nobody — still authorized
+  // by a key that was never theirs: `find({ userId: null })` passes the scope
+  // check before the anonymous guard is ever reached.
+  const overridesIdentity = "userId" in args;
+
   return {
     // `"userId" in args` rather than `??`, because an explicit `null` MEANS
     // anonymous and must survive. A route that turns an absent session into
@@ -145,17 +161,20 @@ function actorOf(ctx: NextlyContext, args: ReleaseCallerArgs) {
     // and receive that person's release permissions — the caller asked to be
     // refused and would be authorized instead. Omitted and present-but-null are
     // different questions.
-    userId:
-      "userId" in args ? (args.userId ?? null) : (access.user?.id ?? null),
+    userId: overridesIdentity
+      ? (args.userId ?? null)
+      : (access.user?.id ?? null),
     overrideAccess: access.overrideAccess ?? true,
-    // Carried, not dropped. Without it release authority resolves from the KEY
-    // OWNER's grants: a restricted key inherits authority it was never given,
-    // and a key granted release authority is denied when its owner lacks it.
-    authenticatedScope: access.authenticatedScope,
-    // Forwarded so code-defined access rules evaluate against the real user
-    // rather than an empty role set, which would deny a rule that names a role
-    // the caller actually holds.
-    userRoles: access.user?.roles,
+    // A scope supplied WITH the call belongs to that call and always wins: a
+    // REST request resolved it for the identity it is serving. An inherited one
+    // travels only while the identity does.
+    authenticatedScope:
+      args.authenticatedScope ??
+      (overridesIdentity ? undefined : access.authenticatedScope),
+    // Roles describe the instance's user, so they follow the same rule — a rule
+    // evaluated against someone else's roles is worse than one evaluated
+    // against none.
+    userRoles: overridesIdentity ? undefined : access.user?.roles,
   };
 }
 
@@ -174,18 +193,30 @@ export function createReleasesNamespace(ctx: NextlyContext): ReleasesNamespace {
       ),
 
     find: (args = {}) => {
-      const { userId, overrideAccess, ...query } = args;
+      // Caller keys are stripped from the QUERY as well as read for the actor.
+      // Leaving them in sends `authenticatedScope` to the repository as a filter
+      // column, which is a query nobody wrote and a credential in a place it
+      // does not belong.
+      const { userId, overrideAccess, authenticatedScope, ...query } = args;
       void userId;
       void overrideAccess;
+      void authenticatedScope;
       return service().find(query, actorOf(ctx, args));
     },
 
     findByID: args => service().findByID(args.id, actorOf(ctx, args)),
 
     addMember: args => {
-      const { releaseId, userId, overrideAccess, ...member } = args;
+      const {
+        releaseId,
+        userId,
+        overrideAccess,
+        authenticatedScope,
+        ...member
+      } = args;
       void userId;
       void overrideAccess;
+      void authenticatedScope;
       return service().addMember(releaseId, member, actorOf(ctx, args));
     },
 

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -152,6 +152,10 @@ function actorOf(ctx: NextlyContext, args: ReleaseCallerArgs) {
     // OWNER's grants: a restricted key inherits authority it was never given,
     // and a key granted release authority is denied when its owner lacks it.
     authenticatedScope: access.authenticatedScope,
+    // Forwarded so code-defined access rules evaluate against the real user
+    // rather than an empty role set, which would deny a rule that names a role
+    // the caller actually holds.
+    userRoles: access.user?.roles,
   };
 }
 

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -36,14 +36,28 @@ import type {
 } from "../../domains/releases/services/releases-service";
 import { NextlyError } from "../../errors/nextly-error";
 
-/** Who the call acts as, and whether its permissions are checked. */
+import type { NextlyContext } from "./context";
+import { accessOptions, mergeConfig } from "./helpers";
+
+/**
+ * Who the call acts as, and whether its permissions are checked.
+ *
+ * Both fields fall back to the INSTANCE configuration, not to a constant. An
+ * instance built with `getNextly({ overrideAccess: false, user })` is asking for
+ * every operation on it to be checked, and a namespace that defaulted to `true`
+ * on its own would bypass that silently — the one failure where a caller has
+ * asked for enforcement and been given none.
+ *
+ * `user` is read from the same `DirectAPIConfig.user` every other namespace
+ * uses, so an instance configured once acts consistently across all of them.
+ */
 export interface ReleaseCallerArgs {
   /**
    * The acting identity. Required whenever `overrideAccess` is `false`, because
    * a checked call with nobody to check is a call that can only be refused.
    */
   userId?: string | null;
-  /** Defaults to `true`: the Direct API is trusted. */
+  /** Defaults to the instance's setting, which itself defaults to `true`. */
   overrideAccess?: boolean;
 }
 
@@ -97,44 +111,70 @@ function service(): ReleasesService {
   return container.get<ReleasesService>("releasesService");
 }
 
-/** Split the caller identity out of an argument bag. */
-function actorOf(args: ReleaseCallerArgs) {
+/**
+ * Split the caller identity out of an argument bag, over the instance defaults.
+ *
+ * Per-call config wins over the instance default, matching `mergeConfig` and
+ * every other namespace, so one call can act as someone without reconfiguring
+ * the instance — and an instance that asked for enforcement keeps it when the
+ * call says nothing.
+ */
+function actorOf(ctx: NextlyContext, args: ReleaseCallerArgs) {
+  // Absent keys are DROPPED before merging, not passed as `undefined`.
+  // `mergeConfig` is a spread and a present-but-undefined key wins it, so
+  // forwarding `{ overrideAccess: undefined }` from a call that said nothing
+  // would erase an instance's configured `false` and silently restore trust.
+  // The same trap the jobs content API documents, arriving from the other side.
+  const supplied: Record<string, unknown> = {};
+  if (args.overrideAccess !== undefined) {
+    supplied.overrideAccess = args.overrideAccess;
+  }
+
+  // Read through `accessOptions` rather than off the merged config directly.
+  // The access fields travel together, and `access-options-seam.test.ts` fails
+  // the build for a namespace that picks at them inline — because an operation
+  // forwarding one and not another compiles, runs, and authorizes wrongly.
+  const access = accessOptions(
+    mergeConfig(ctx.defaultConfig, supplied as never)
+  );
+
   return {
-    userId: args.userId ?? null,
-    // Trusted by default, like every other Direct API operation. A caller
-    // asking for checks says so explicitly.
-    overrideAccess: args.overrideAccess ?? true,
+    // An explicit `userId` wins; otherwise the instance's configured `user` is
+    // the acting identity, which is how the rest of the Direct API reads it.
+    userId: args.userId ?? access.user?.id ?? null,
+    overrideAccess: access.overrideAccess ?? true,
   };
 }
 
-export function createReleasesNamespace(): ReleasesNamespace {
+export function createReleasesNamespace(ctx: NextlyContext): ReleasesNamespace {
   return {
     create: ({ title, description, ...caller }) =>
-      service().create({ title, description }, actorOf(caller)),
+      service().create({ title, description }, actorOf(ctx, caller)),
 
     find: (args = {}) => {
       const { userId, overrideAccess, ...query } = args;
-      return service().find(query, actorOf({ userId, overrideAccess }));
+      return service().find(query, actorOf(ctx, { userId, overrideAccess }));
     },
 
-    findByID: ({ id, ...caller }) => service().findByID(id, actorOf(caller)),
+    findByID: ({ id, ...caller }) =>
+      service().findByID(id, actorOf(ctx, caller)),
 
     addMember: ({ releaseId, userId, overrideAccess, ...member }) =>
       service().addMember(
         releaseId,
         member,
-        actorOf({ userId, overrideAccess })
+        actorOf(ctx, { userId, overrideAccess })
       ),
 
     removeMember: ({ memberId, ...caller }) =>
-      service().removeMember(memberId, actorOf(caller)),
+      service().removeMember(memberId, actorOf(ctx, caller)),
 
     listMembers: ({ releaseId, ...caller }) =>
-      service().listMembers(releaseId, actorOf(caller)),
+      service().listMembers(releaseId, actorOf(ctx, caller)),
 
     schedule: ({ id, at, timezone, ...caller }) =>
-      service().schedule(id, at, timezone, actorOf(caller)),
+      service().schedule(id, at, timezone, actorOf(ctx, caller)),
 
-    cancel: ({ id, ...caller }) => service().cancel(id, actorOf(caller)),
+    cancel: ({ id, ...caller }) => service().cancel(id, actorOf(ctx, caller)),
   };
 }

--- a/packages/nextly/src/direct-api/nextly.ts
+++ b/packages/nextly/src/direct-api/nextly.ts
@@ -282,7 +282,7 @@ export class Nextly implements NextlyContext {
     this.access = createAccessNamespace(this);
     this.apiKeys = createApiKeysNamespace(this);
     this.jobs = createJobsNamespace();
-    this.releases = createReleasesNamespace();
+    this.releases = createReleasesNamespace(this);
   }
 
   /**

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -53,7 +53,14 @@ function service(over?: {
     canManageReleases: vi.fn(async (_id: string, a: ReleaseAuthority) =>
       held.has(a)
     ),
-    canActOnDocument: vi.fn(async () => over?.mayActOnDocument !== false),
+    canActOnDocument: vi.fn(
+      async (_params: {
+        userId: string;
+        scopeSlug: string;
+        action: string;
+        authenticatedScope?: unknown;
+      }) => over?.mayActOnDocument !== false
+    ),
   };
   return { svc: new ReleasesService(deps), repo, deps };
 }
@@ -149,9 +156,11 @@ describe("ReleasesService add-time document check", () => {
     const { svc, deps } = service({ holds: ["create"] });
     await svc.addMember("r1", { ...MEMBER, action: "unpublish" }, ADMIN);
     expect(deps.canActOnDocument).toHaveBeenCalledWith(
-      "u1",
-      "posts",
-      "unpublish"
+      expect.objectContaining({
+        userId: "u1",
+        scopeSlug: "posts",
+        action: "unpublish",
+      })
     );
   });
 
@@ -456,5 +465,47 @@ describe("ReleasesService honours a scoped API key over its owner", () => {
       svc.schedule("r1", new Date(), "UTC", KEY(["read-content-releases"]))
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(repo.scheduleRelease).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReleasesService carries the key scope into the DOCUMENT check", () => {
+  it("hands the scope to the document check, not just the release check", async () => {
+    // The gap this closes: honouring the key for the release resource and then
+    // resolving the DOCUMENT from the owner admits a key that holds
+    // create-content-releases but not publish-posts, whose owner can publish
+    // posts. The member is inserted and later materialised AS that privileged
+    // owner — a narrow key scheduling a publish it was never granted.
+    const scope = {
+      actorType: "apiKey" as const,
+      permissions: ["create-content-releases"],
+    };
+    const { svc, deps } = service({ holds: [] });
+    await svc.addMember("r1", MEMBER, {
+      userId: "owner",
+      overrideAccess: false,
+      authenticatedScope: scope,
+      userRoles: ["editor"],
+    });
+    expect(deps.canActOnDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticatedScope: scope,
+        userRoles: ["editor"],
+      })
+    );
+  });
+
+  it("refuses when the document check denies the key, however privileged the owner", async () => {
+    const { svc, repo } = service({ holds: [], mayActOnDocument: false });
+    await expect(
+      svc.addMember("r1", MEMBER, {
+        userId: "owner",
+        overrideAccess: false,
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["create-content-releases"],
+        },
+      })
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(repo.addMember).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -430,3 +430,31 @@ describe("ReleasesService refuses input the database would answer differently", 
     expect(repo.findReleases).not.toHaveBeenCalled();
   });
 });
+
+describe("ReleasesService honours a scoped API key over its owner", () => {
+  const KEY = (permissions: string[]) => ({
+    userId: "owner",
+    overrideAccess: false,
+    authenticatedScope: { actorType: "apiKey" as const, permissions },
+  });
+
+  it("allows a key holding the grant even when its owner does not", async () => {
+    // The stamped scope is authoritative in BOTH directions. Resolving from the
+    // owner instead would deny a key that was explicitly granted the authority.
+    const { svc, repo, deps } = service({ holds: [] });
+    await svc.find({}, KEY(["read-content-releases"]));
+    expect(repo.findReleases).toHaveBeenCalled();
+    // The owner's grants are never consulted for a scoped key.
+    expect(deps.canManageReleases).not.toHaveBeenCalled();
+  });
+
+  it("denies a key without the grant however privileged its owner", async () => {
+    // The direction that matters more: a key scoped to read content must not
+    // inherit the power to schedule a publish from the person who created it.
+    const { svc, repo } = service({ holds: ["read", "create", "publish"] });
+    await expect(
+      svc.schedule("r1", new Date(), "UTC", KEY(["read-content-releases"]))
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+    expect(repo.scheduleRelease).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -111,6 +111,11 @@ export interface ReleaseActor {
    * up able to schedule a publish.
    */
   authenticatedScope?: AuthenticatedScope;
+  /**
+   * The caller's role set, forwarded so code-defined access rules evaluate
+   * against the real user rather than against an empty list.
+   */
+  userRoles?: string[];
 }
 
 export interface ReleasesServiceDeps {
@@ -133,11 +138,21 @@ export interface ReleasesServiceDeps {
    * The same question the ordinary write path asks (`publish-<slug>` /
    * `unpublish-<slug>`), asked here at add time. Injected for the same reason.
    */
-  canActOnDocument: (
-    userId: string,
-    scopeSlug: string,
-    action: ReleaseMemberAction
-  ) => Promise<boolean>;
+  canActOnDocument: (params: {
+    userId: string;
+    scopeSlug: string;
+    action: ReleaseMemberAction;
+    /**
+     * The scoped API key's own grants, when the caller is one.
+     *
+     * Passed through rather than resolved here. The document verdict is the
+     * permission slug AND the code-defined access rule, and only the wiring
+     * holds both — checking the slug alone in the domain would be a partial
+     * answer that reads like a complete one.
+     */
+    authenticatedScope?: AuthenticatedScope;
+    userRoles?: string[];
+  }) => Promise<boolean>;
 }
 
 export interface FindReleasesQuery {
@@ -543,7 +558,15 @@ export class ReleasesService {
         logContext: { reason: "anonymous", action, scopeSlug },
       });
     }
-    if (await this.deps.canActOnDocument(actor.userId, scopeSlug, action)) {
+    if (
+      await this.deps.canActOnDocument({
+        userId: actor.userId,
+        scopeSlug,
+        action,
+        authenticatedScope: actor.authenticatedScope,
+        userRoles: actor.userRoles,
+      })
+    ) {
       return;
     }
     // Logged as the DOCUMENT authority, not the release one. The two refusals

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -45,6 +45,10 @@
  * @module domains/releases/services/releases-service
  */
 
+import {
+  apiKeyScopeAllows,
+  type AuthenticatedScope,
+} from "../../../auth/authenticated-scope";
 import { NextlyError } from "../../../errors";
 import {
   isReleaseMemberAction,
@@ -97,6 +101,16 @@ export const MAX_RELEASE_TIMEZONE_LENGTH = 64;
 export interface ReleaseActor {
   userId: string | null;
   overrideAccess?: boolean;
+  /**
+   * The scoped API key's OWN grants, when the caller is one.
+   *
+   * Authoritative in BOTH directions and checked before the owner's database
+   * permissions: a key without the grant is denied however privileged its owner,
+   * and a key with it is allowed however unprivileged. Resolving release
+   * authority from the owner instead is how a key scoped to read content ends
+   * up able to schedule a publish.
+   */
+  authenticatedScope?: AuthenticatedScope;
 }
 
 export interface ReleasesServiceDeps {
@@ -190,6 +204,26 @@ export class ReleasesService {
     authority: ReleaseAuthority
   ): Promise<void> {
     if (actor.overrideAccess === true) return;
+
+    // The KEY's stamped scope wins over the owner's grants, in both directions.
+    // `null` means the caller is not a scoped key, so the ordinary resolution
+    // below applies.
+    const byKey = apiKeyScopeAllows(
+      actor.authenticatedScope,
+      authority,
+      RELEASES_RESOURCE
+    );
+    if (byKey === true) return;
+    if (byKey === false) {
+      throw NextlyError.forbidden({
+        logContext: {
+          reason: "api-key-scope-lacks-release-authority",
+          authority,
+          resource: RELEASES_RESOURCE,
+        },
+      });
+    }
+
     // An anonymous caller holds no permissions, and asking the store about a
     // null user would be a lookup whose only possible answer is "no".
     if (actor.userId === null) {
@@ -417,6 +451,12 @@ export class ReleasesService {
     authority: ReleaseAuthority
   ): Promise<boolean> {
     if (actor.overrideAccess === true) return true;
+    const byKey = apiKeyScopeAllows(
+      actor.authenticatedScope,
+      authority,
+      RELEASES_RESOURCE
+    );
+    if (byKey !== null) return byKey;
     if (actor.userId === null) return false;
     return this.deps.canManageReleases(actor.userId, authority);
   }


### PR DESCRIPTION
## Why this is a separate PR

This commit was pushed to #1383 **three minutes after that PR's merge was computed**, so it is not on `main`. #1383 reads MERGED and complete, and this fix is not in it.

    #1383 merged at   2026-08-30T09:48:11Z
    commit pushed at  2026-08-30T09:51:32Z
    git merge-base --is-ancestor d71a21e77 origin/main  →  not an ancestor

Caught by checking the merge **by content** rather than by the PR's state — `touchIfAssemblable` from the previous round is on `main`, `accessOptions` from this one is not.

## The defect

An instance built with `getNextly({ overrideAccess: false, user })` is asking for every operation on it to be checked. `nextly.releases.*` hardcoded its own default, so release operations ran **trusted** on an instance that had explicitly asked for enforcement — a caller requesting checks and being given none, with nothing anywhere reporting it.

The namespace now takes `NextlyContext` like its siblings and reads the merged config through `accessOptions`.

## Two guards caught the first attempt, and both are the point

**`access-options-seam.test.ts`** failed because I read the access fields inline off the merged config. That guard exists because an operation forwarding `user` but not `authenticatedScope` compiles, runs, and authorizes a key as its owner. Now read through the seam.

**My own test caught the subtler one.** Absent keys must be dropped before merging, not forwarded as `undefined`: `mergeConfig` is a spread and a present-but-undefined key wins it, so `{ overrideAccess: undefined }` from a call that said nothing **erased the instance's configured `false`** and silently restored trust. That is the trap `job-content-api` documents from the other side.

It was caught only because the test asserts *what the service was handed* rather than that the call succeeded. A test asserting "it worked" is green against the bypass — which is how a fix that does nothing ships.

## Tests

Four cases, each with its control:
- enforces when the instance asked for enforcement
- **stays trusted when the instance says nothing** — the control, so the fix cannot be "always enforce", which would break every in-process caller
- one call overrides the instance, not the reverse
- the instance identity reaches `addMember`, where a missing author is worst: an authorless member can never materialise

Break-verified: hardcoding the default fails 3 of 4 by name; forwarding `undefined` into the merge fails 2.

## Verification

- `check-types` — 22/22
- `lint` — 24/24
- `pnpm --filter nextly test src/direct-api/` — 19 files, 204 passed
- changeset covers all 25 lockstep packages

Note: `check-types` first failed in `@nextlyhq/blocks-react` on `blockPartClassName` and `parts`. That was a stale `dist` predating the blocks-engine work that landed while this branch was cut, not this diff — this branch touches three files, all under `direct-api`. A `blocks-engine` rebuild cleared it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Access Control**
  - Release operations now honor scoped API key permissions alongside account permissions.
  - Release document actions require the appropriate update and lifecycle permissions.
  - Unauthorized keys, members, and sessions are correctly denied.

- **API Behavior**
  - Release API methods now respect instance-level and per-call identity, role, scope, and access settings.
  - Anonymous requests remain distinguishable from requests using the configured instance identity.
  - API key grants and roles are consistently applied when managing release members.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->