### PR TITLE
feat(nextly): give content releases a front door at /api/releases

### DIFF
--- a/.changeset/a-release-has-a-front-door.md
+++ b/.changeset/a-release-has-a-front-door.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Give content releases a REST surface at `/api/releases`, where scheduling and cancelling demand the publish authority that assembling a release does not.

--- a/packages/nextly/src/__tests__/init.test.ts
+++ b/packages/nextly/src/__tests__/init.test.ts
@@ -183,6 +183,7 @@ describe("init - Nextly API", () => {
       "meta",
       "permissions",
       "register",
+      "releases",
       "resetPassword",
       "roles",
       "shutdown",

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Which authority each release route demands.
+ *
+ * This is the security-bearing half of the HTTP surface. The route table names
+ * dispatcher operations — list, single, create, update, delete — which cannot
+ * express `publish`, so the mapping from method to release authority lives in
+ * the handler. A mapping that quietly said `create` for scheduling would hand
+ * everyone who can assemble a release the power to ship it, and every route
+ * would still work, so nothing else would notice.
+ *
+ * Asserted on WHAT WAS ASKED of the permission gate rather than on the response,
+ * because a refusal and a wrong-permission grant can produce the same status.
+ *
+ * @module api/__tests__/releases-route-authority.test
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { requireAnyPermission, isErrorResponse, getCachedNextly } = vi.hoisted(
+  () => ({
+    requireAnyPermission: vi.fn(),
+    isErrorResponse: vi.fn(() => false),
+    getCachedNextly: vi.fn(),
+  })
+);
+
+vi.mock("../../auth/middleware", () => ({
+  requireAnyPermission,
+  isErrorResponse,
+}));
+vi.mock("../../auth/middleware/to-nextly-error", () => ({
+  toNextlyAuthError: (e: unknown) => e,
+}));
+vi.mock("../../init", () => ({ getCachedNextly }));
+
+const { handleReleaseRequest } = await import("../releases");
+
+/** Every namespace call the handler can make, all inert. */
+function namespace() {
+  return {
+    releases: {
+      find: vi.fn(async () => []),
+      findByID: vi.fn(async () => ({ id: "r1" })),
+      create: vi.fn(async () => ({ id: "r1" })),
+      addMember: vi.fn(async () => ({ id: "m1" })),
+      removeMember: vi.fn(async () => undefined),
+      listMembers: vi.fn(async () => []),
+      schedule: vi.fn(async () => undefined),
+      cancel: vi.fn(async () => undefined),
+    },
+  };
+}
+
+let api: ReturnType<typeof namespace>;
+
+beforeEach(() => {
+  api = namespace();
+  getCachedNextly.mockResolvedValue(api);
+  requireAnyPermission.mockResolvedValue({ userId: "u1" });
+  isErrorResponse.mockReturnValue(false);
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+/** The single permission the handler demanded for this call. */
+async function authorityFor(
+  method: string,
+  init?: { body?: unknown; params?: Record<string, string> }
+): Promise<{ action: string; resource: string }> {
+  const req = new Request("https://example.test/api/releases?limit=5", {
+    method: init?.body === undefined ? "GET" : "POST",
+    ...(init?.body === undefined
+      ? {}
+      : {
+          body: JSON.stringify(init.body),
+          headers: { "Content-Type": "application/json" },
+        }),
+  });
+  await handleReleaseRequest(req, method, init?.params ?? { releaseId: "r1" });
+  const asked = requireAnyPermission.mock.calls[0]?.[1] as {
+    action: string;
+    resource: string;
+  }[];
+  return asked[0];
+}
+
+describe("release route authority", () => {
+  it("demands publish to schedule, not create", async () => {
+    // THE case. Scheduling is the act that puts content live later; the seed
+    // defines `publish-content-releases` as "schedule or cancel" precisely so it
+    // can be withheld from someone allowed to assemble a release.
+    expect(
+      await authorityFor("scheduleRelease", {
+        body: { at: "2026-09-01T09:00:00Z", timezone: "Europe/Berlin" },
+      })
+    ).toEqual({ action: "publish", resource: "content-releases" });
+  });
+
+  it("demands publish to cancel", async () => {
+    // Someone who could cancel but not schedule could still silently stop a
+    // launch, so the two share one authority.
+    expect(await authorityFor("cancelRelease", { body: {} })).toEqual({
+      action: "publish",
+      resource: "content-releases",
+    });
+  });
+
+  it("demands create to assemble, never publish", async () => {
+    for (const [method, body] of [
+      ["createRelease", { title: "Launch" }],
+      [
+        "addReleaseMember",
+        {
+          scopeKind: "collection",
+          scopeSlug: "posts",
+          entryId: "e1",
+          action: "publish",
+        },
+      ],
+    ] as const) {
+      vi.clearAllMocks();
+      requireAnyPermission.mockResolvedValue({ userId: "u1" });
+      isErrorResponse.mockReturnValue(false);
+      getCachedNextly.mockResolvedValue(api);
+      expect(await authorityFor(method, { body })).toEqual({
+        action: "create",
+        resource: "content-releases",
+      });
+    }
+  });
+
+  it("demands only read to look", async () => {
+    expect(await authorityFor("listReleases")).toEqual({
+      action: "read",
+      resource: "content-releases",
+    });
+  });
+
+  it("turns the service's checks ON rather than trusting the route gate", async () => {
+    // The route can only express the SYSTEM authority. Whether this caller may
+    // publish the document they are adding is a question only the service can
+    // ask, and it asks it only when `overrideAccess` is false.
+    await authorityFor("addReleaseMember", {
+      body: {
+        scopeKind: "collection",
+        scopeSlug: "posts",
+        entryId: "e1",
+        action: "publish",
+      },
+    });
+    expect(api.releases.addMember).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: "u1", overrideAccess: false })
+    );
+  });
+
+  it("refuses an unmapped method before authenticating", async () => {
+    // A route added without an entry in the authority table would otherwise run
+    // unauthorized. Refusing first makes the omission a 400, not a hole.
+    const res = await handleReleaseRequest(
+      new Request("https://example.test/api/releases"),
+      "totallyNewRoute",
+      {}
+    );
+    expect(res.status).toBe(400);
+    expect(requireAnyPermission).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -37,6 +37,13 @@ const { handleReleaseRequest } = await import("../releases");
 /** Every namespace call the handler can make, all inert. */
 function namespace() {
   return {
+    // The member add resolves its target document before accepting it, so the
+    // fake has to answer that read. Present rather than absent: a missing
+    // reader would make the case fail for a reason unrelated to authority.
+    findByID: vi.fn(async (): Promise<{ id: string } | null> => ({ id: "e1" })),
+    findSingle: vi.fn(
+      async (): Promise<{ id: string } | null> => ({ id: "e1" })
+    ),
     releases: {
       find: vi.fn(async () => []),
       findByID: vi.fn(async () => ({ id: "r1" })),
@@ -192,6 +199,167 @@ describe("release route input at the untyped boundary", () => {
     );
     expect(api.releases.find).toHaveBeenCalledWith(
       expect.objectContaining({ state: "scheduled" })
+    );
+  });
+});
+
+describe("release route input validation", () => {
+  async function post(
+    method: string,
+    body: unknown,
+    params = { releaseId: "r1" }
+  ) {
+    return handleReleaseRequest(
+      new Request("https://example.test/api/releases", {
+        method: "POST",
+        body: JSON.stringify(body),
+        headers: { "Content-Type": "application/json" },
+      }),
+      method,
+      params
+    );
+  }
+
+  it("refuses an instant that parses but is not ISO 8601", async () => {
+    // `new Date("1")` is 2001-01-01 and `new Date("09/01/2026")` is
+    // locale-dependent. Both are valid Dates at an instant the author never
+    // chose — and a release publishes at it.
+    for (const at of ["1", "09/01/2026", "next friday"]) {
+      const res = await post("scheduleRelease", { at, timezone: "UTC" });
+      expect(res.status, `accepted ${at}`).toBe(400);
+    }
+    expect(api.releases.schedule).not.toHaveBeenCalled();
+  });
+
+  it("refuses an instant with no zone, which the server would resolve in its own", async () => {
+    // The case only the SHAPE check catches. "2026-09-01T09:00:00" parses, and
+    // round-trips to the same calendar day, so every other guard admits it —
+    // but it carries no zone, so the server resolves it locally and the same
+    // request schedules different instants on two deployments.
+    //
+    // Added after a break-verify: disabling the shape check left the other
+    // cases green, which meant the suite proved the round-trip guard and said
+    // nothing about the shape one.
+    const res = await post("scheduleRelease", {
+      at: "2026-09-01T09:00:00",
+      timezone: "UTC",
+    });
+    expect(res.status).toBe(400);
+    expect(api.releases.schedule).not.toHaveBeenCalled();
+  });
+
+  it("refuses a date that does not exist", async () => {
+    // 2026-02-30 is well-formed and normalises silently to March 2.
+    const res = await post("scheduleRelease", {
+      at: "2026-02-30T09:00:00Z",
+      timezone: "UTC",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a real ISO instant", async () => {
+    // The control: the guard must not refuse every instant, which would make
+    // scheduling impossible and still pass the cases above.
+    const res = await post("scheduleRelease", {
+      at: "2026-09-01T09:00:00Z",
+      timezone: "Europe/Berlin",
+    });
+    expect(res.status).toBe(200);
+    expect(api.releases.schedule).toHaveBeenCalled();
+  });
+
+  it("refuses a timezone the platform cannot format in", async () => {
+    // A length check accepts `Europe/Berln`, which is stored, shown back to the
+    // author as their intent, and throws whenever anything formats with it.
+    const res = await post("scheduleRelease", {
+      at: "2026-09-01T09:00:00Z",
+      timezone: "Europe/Berln",
+    });
+    expect(res.status).toBe(400);
+    expect(api.releases.schedule).not.toHaveBeenCalled();
+  });
+
+  it("refuses a non-string locale rather than widening the member", async () => {
+    // Coercing a numeric locale id to `null` silently widens the member from
+    // one language to the WHOLE document — the opposite of the request, and
+    // indistinguishable downstream from a legitimate document-wide member.
+    const res = await post("addReleaseMember", {
+      scopeKind: "collection",
+      scopeSlug: "posts",
+      entryId: "e1",
+      action: "publish",
+      locale: 42,
+    });
+    expect(res.status).toBe(400);
+    expect(api.releases.addMember).not.toHaveBeenCalled();
+  });
+
+  it("refuses a member whose target document is not there", async () => {
+    // Nothing joins a member to a document, so a typo is accepted by the write
+    // path and fails at the scheduled instant instead — holding the release
+    // open and reporting a failure nobody is watching for.
+    api.findByID.mockResolvedValueOnce(null);
+    const res = await post("addReleaseMember", {
+      scopeKind: "collection",
+      scopeSlug: "posts",
+      entryId: "gone",
+      action: "publish",
+    });
+    expect(res.status).toBe(404);
+    expect(api.releases.addMember).not.toHaveBeenCalled();
+  });
+
+  it("binds a member removal to the release in the path", async () => {
+    await handleReleaseRequest(
+      new Request("https://example.test/api/releases/r1/members/m1", {
+        method: "DELETE",
+      }),
+      "removeReleaseMember",
+      { releaseId: "r1", memberId: "m1" }
+    );
+    // Without the releaseId, `/releases/A/members/B` removes B even when it
+    // belongs to release C, and the response says it worked.
+    expect(api.releases.removeMember).toHaveBeenCalledWith(
+      expect.objectContaining({ memberId: "m1", releaseId: "r1" })
+    );
+  });
+
+  it("forwards an API key's own grants rather than its owner's", async () => {
+    requireAnyPermission.mockResolvedValueOnce({
+      userId: "owner",
+      authMethod: "api-key",
+      permissions: ["read-content-releases"],
+    });
+    await handleReleaseRequest(
+      new Request("https://example.test/api/releases"),
+      "listReleases",
+      {}
+    );
+    expect(api.releases.find).toHaveBeenCalledWith(
+      expect.objectContaining({
+        authenticatedScope: {
+          actorType: "apiKey",
+          permissions: ["read-content-releases"],
+        },
+      })
+    );
+  });
+
+  it("carries no scope for a session, so ordinary RBAC applies", async () => {
+    // The control: stamping a scope on a session request would make every
+    // session resolve against an empty permission list and be refused.
+    requireAnyPermission.mockResolvedValueOnce({
+      userId: "u1",
+      authMethod: "session",
+      permissions: [],
+    });
+    await handleReleaseRequest(
+      new Request("https://example.test/api/releases"),
+      "listReleases",
+      {}
+    );
+    expect(api.releases.find).toHaveBeenCalledWith(
+      expect.objectContaining({ authenticatedScope: undefined })
     );
   });
 });

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -166,3 +166,32 @@ describe("release route authority", () => {
     expect(requireAnyPermission).not.toHaveBeenCalled();
   });
 });
+
+describe("release route input at the untyped boundary", () => {
+  it("refuses an unrecognised state rather than widening the query", async () => {
+    // A query string is whatever was sent. Dropping an unrecognised filter
+    // WIDENS the request — the caller asked for one state and would receive
+    // every release — and a client paging through what it believes is a
+    // filtered list has no way to notice.
+    const res = await handleReleaseRequest(
+      new Request("https://example.test/api/releases?state=schedule"),
+      "listReleases",
+      {}
+    );
+    expect(res.status).toBe(400);
+    expect(api.releases.find).not.toHaveBeenCalled();
+  });
+
+  it("passes a recognised state through", async () => {
+    // The control: the guard must not refuse every state, which would make the
+    // filter unusable and still pass the case above.
+    await handleReleaseRequest(
+      new Request("https://example.test/api/releases?state=scheduled"),
+      "listReleases",
+      {}
+    );
+    expect(api.releases.find).toHaveBeenCalledWith(
+      expect.objectContaining({ state: "scheduled" })
+    );
+  });
+});

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -40,12 +40,20 @@ function namespace() {
     // The member add resolves its target document before accepting it, so the
     // fake has to answer that read. Present rather than absent: a missing
     // reader would make the case fail for a reason unrelated to authority.
-    findByID: vi.fn(async (): Promise<{ id: string } | null> => ({ id: "e1" })),
+    findByID: vi.fn(
+      async (): Promise<{ id: string; status?: string } | null> => ({
+        id: "e1",
+        status: "draft",
+      })
+    ),
     findSingle: vi.fn(
-      async (): Promise<{ id: string } | null> => ({ id: "e1" })
+      async (): Promise<{ id: string; status?: string } | null> => ({
+        id: "single-real-id",
+        status: "draft",
+      })
     ),
     releases: {
-      find: vi.fn(async () => []),
+      find: vi.fn(async (): Promise<{ id: string }[]> => []),
       findByID: vi.fn(async () => ({ id: "r1" })),
       create: vi.fn(async () => ({ id: "r1" })),
       addMember: vi.fn(async () => ({ id: "m1" })),
@@ -361,5 +369,113 @@ describe("release route input validation", () => {
     expect(api.releases.find).toHaveBeenCalledWith(
       expect.objectContaining({ authenticatedScope: undefined })
     );
+  });
+});
+
+describe("release member targets", () => {
+  async function addMember(body: Record<string, unknown>) {
+    return handleReleaseRequest(
+      new Request("https://example.test/api/releases", {
+        method: "POST",
+        body: JSON.stringify({
+          scopeKind: "collection",
+          scopeSlug: "posts",
+          entryId: "e1",
+          action: "publish",
+          ...body,
+        }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      "addReleaseMember",
+      { releaseId: "r1" }
+    );
+  }
+
+  it("looks the target up across ALL lifecycle states", async () => {
+    // The document a release exists to publish is usually a DRAFT. An untrusted
+    // read defaults to `published`, so without this the ordinary
+    // draft-to-launch flow 404s at the moment it is assembled — the one case
+    // this check must not break.
+    await addMember({});
+    expect(api.findByID).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "all" })
+    );
+  });
+
+  it("refuses a target with no draft/published lifecycle", async () => {
+    // Materialisation works by writing the status field. With the lifecycle
+    // disabled the write produces no observable state, the drain records a
+    // failed action, and the release stays scheduled and retries forever.
+    api.findByID.mockResolvedValueOnce({ id: "e1" });
+    const res = await addMember({});
+    expect(res.status).toBe(400);
+    expect(api.releases.addMember).not.toHaveBeenCalled();
+  });
+
+  it("stores a Single's own id, not the one the caller sent", async () => {
+    // A Single is addressed by slug, so any id is accepted — but release
+    // visibility compares stored decisions against the row's real id, and a
+    // member carrying a stale one is invisible to reads until a drain runs.
+    await addMember({
+      scopeKind: "single",
+      scopeSlug: "homepage",
+      entryId: "stale",
+    });
+    expect(api.releases.addMember).toHaveBeenCalledWith(
+      expect.objectContaining({ entryId: "single-real-id" })
+    );
+  });
+});
+
+describe("release list windowing", () => {
+  it("reports truncation rather than presenting a partial schedule as whole", async () => {
+    // Without over-fetching, a page of two is reported as `total: 2,
+    // hasNext: false` whether two releases exist or two hundred do.
+    api.releases.find.mockResolvedValueOnce([
+      { id: "a" },
+      { id: "b" },
+      { id: "c" },
+    ]);
+    const res = await handleReleaseRequest(
+      new Request("https://example.test/api/releases?limit=2"),
+      "listReleases",
+      {}
+    );
+    const body = (await res.json()) as {
+      items: unknown[];
+      meta: { hasNext: boolean };
+    };
+    expect(body.items).toHaveLength(2);
+    expect(body.meta.hasNext).toBe(true);
+    // The over-fetch is what makes truncation observable at all.
+    expect(api.releases.find).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 3 })
+    );
+  });
+
+  it("refuses a window bound that is not a real ISO instant", async () => {
+    // Held to the same contract as a scheduling instant. Two parsers for one
+    // concept is how they drift: this one accepted `1` and normalised it into a
+    // query bound nobody asked for.
+    const res = await handleReleaseRequest(
+      new Request("https://example.test/api/releases?scheduledAfter=1"),
+      "listReleases",
+      {}
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts an instant at an offset that crosses midnight in UTC", async () => {
+    // 2026-09-01T00:30:00+02:00 is August 31 in UTC and entirely valid.
+    // Comparing the calendar day against the UTC rendering refused it — a real
+    // instant rejected for every caller east of Greenwich.
+    const res = await handleReleaseRequest(
+      new Request(
+        "https://example.test/api/releases?scheduledAfter=2026-09-01T00:30:00%2B02:00"
+      ),
+      "listReleases",
+      {}
+    );
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -31,6 +31,20 @@ vi.mock("../../auth/middleware/to-nextly-error", () => ({
   toNextlyAuthError: (e: unknown) => e,
 }));
 vi.mock("../../init", () => ({ getCachedNextly }));
+vi.mock("../../di", () => ({
+  container: {
+    has: () => true,
+    // The registry answers what the SCHEMA declared. Default: the lifecycle is
+    // on, because that is the ordinary collection a release targets.
+    get: () => ({
+      getCollectionBySlug: async () => lifecycleRecord,
+      getSingleBySlug: async () => lifecycleRecord,
+    }),
+  },
+}));
+
+/** Swapped per case, so a target without a lifecycle can be expressed. */
+let lifecycleRecord: { status?: boolean } | null = { status: true };
 
 const { handleReleaseRequest } = await import("../releases");
 
@@ -68,6 +82,7 @@ function namespace() {
 let api: ReturnType<typeof namespace>;
 
 beforeEach(() => {
+  lifecycleRecord = { status: true };
   api = namespace();
   getCachedNextly.mockResolvedValue(api);
   requireAnyPermission.mockResolvedValue({ userId: "u1" });
@@ -402,11 +417,13 @@ describe("release member targets", () => {
     );
   });
 
-  it("refuses a target with no draft/published lifecycle", async () => {
-    // Materialisation works by writing the status field. With the lifecycle
-    // disabled the write produces no observable state, the drain records a
-    // failed action, and the release stays scheduled and retries forever.
-    api.findByID.mockResolvedValueOnce({ id: "e1" });
+  it("refuses a target whose SCHEMA declares no lifecycle", async () => {
+    // Read from the schema, not probed on the row. The `status` name is
+    // reserved only when the lifecycle is enabled, so a collection with it
+    // DISABLED may legally define an ordinary field called `status` — and a row
+    // probe would admit it, after which materialisation overwrites that
+    // author's field with "published" and reports the release complete.
+    lifecycleRecord = { status: false };
     const res = await addMember({});
     expect(res.status).toBe(400);
     expect(api.releases.addMember).not.toHaveBeenCalled();
@@ -477,5 +494,66 @@ describe("release list windowing", () => {
       {}
     );
     expect(res.status).toBe(200);
+  });
+});
+
+describe("release route paging and body validation", () => {
+  it("bounds an unlimited list rather than serialising the table", async () => {
+    // `GET /api/releases` with no limit used to select every release. On an
+    // installation with a real history that is an ordinary authenticated
+    // request turned into an unbounded read.
+    await handleReleaseRequest(
+      new Request("https://example.test/api/releases"),
+      "listReleases",
+      {}
+    );
+    expect(api.releases.find).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 51 })
+    );
+  });
+
+  it("refuses a page larger than the maximum", async () => {
+    const res = await handleReleaseRequest(
+      new Request("https://example.test/api/releases?limit=100000"),
+      "listReleases",
+      {}
+    );
+    expect(res.status).toBe(400);
+    expect(api.releases.find).not.toHaveBeenCalled();
+  });
+
+  it("refuses a description that is present but not a string", async () => {
+    // Coercing it to null turns a malformed request into silent data loss,
+    // where every other bad field here answers 400.
+    const res = await handleReleaseRequest(
+      new Request("https://example.test/api/releases", {
+        method: "POST",
+        body: JSON.stringify({ title: "Launch", description: 42 }),
+        headers: { "Content-Type": "application/json" },
+      }),
+      "createRelease",
+      {}
+    );
+    expect(res.status).toBe(400);
+    expect(api.releases.create).not.toHaveBeenCalled();
+  });
+
+  it("forwards the authenticated roles, which code-defined rules evaluate", async () => {
+    requireAnyPermission.mockResolvedValueOnce({
+      userId: "u1",
+      authMethod: "api-key",
+      permissions: ["read-content-releases"],
+      roles: ["editor"],
+    });
+    await handleReleaseRequest(
+      new Request("https://example.test/api/releases"),
+      "listReleases",
+      {}
+    );
+    // With `roles: []` a role-positive rule rejects a valid key, and an
+    // absence-based rule admits one it should refuse.
+    expect(api.releases.find).toHaveBeenCalledWith(
+      expect.objectContaining({ userRoles: ["editor"] })
+    );
   });
 });

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -1,0 +1,313 @@
+/**
+ * `/api/releases` — the HTTP surface for content releases.
+ *
+ * Owns its own authorization and body parsing, like the API-key, webhook and
+ * jobs handlers beside it, which is why `routeHandler` dispatches here before
+ * the shared body read.
+ *
+ * ## Two gates, and why neither is redundant
+ *
+ * The route checks the SYSTEM authority — read, create or publish on
+ * `content-releases` — because that is what produces a proper 401 or 403 for an
+ * unauthenticated or unauthorized caller, and it stops a request before any
+ * service work happens.
+ *
+ * The service is then called with `overrideAccess: false` and the authenticated
+ * user, so its own checks still run. That is not the same question asked twice:
+ * the route can only express the system authority, while the service also asks
+ * whether this caller may publish the DOCUMENT they are putting into a release.
+ * A route gate cannot know that, because the document is in the body.
+ *
+ * @module api/releases
+ */
+
+import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
+import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+import { RELEASES_RESOURCE } from "../domains/releases/services/releases-service";
+import { getCachedNextly } from "../init";
+
+import { withErrorHandler } from "./with-error-handler";
+
+/**
+ * The release authority each method needs, declared once.
+ *
+ * Kept here rather than on the parsed route because `OperationType` is the
+ * dispatcher's shared vocabulary — list, single, create, update, delete — and
+ * `publish` is not a member of it. Widening a type every service shares to
+ * describe one of them would be the wrong trade; this table is the same
+ * information in the place that enforces it.
+ *
+ * The split that matters: scheduling and cancelling need `publish`, NOT the
+ * `create` that assembling a release needs. Committing a release to an instant
+ * is the act that puts content live, and the seed keeps the two apart —
+ * "publish-content-releases" is defined as "schedule or cancel".
+ */
+const RELEASE_AUTHORITY: Record<string, "read" | "create" | "publish"> = {
+  listReleases: "read",
+  getRelease: "read",
+  listReleaseMembers: "read",
+  createRelease: "create",
+  addReleaseMember: "create",
+  // Removing a member un-does part of assembling a release and can only ever
+  // make LESS content go live, so it is `create` rather than `publish`.
+  removeReleaseMember: "create",
+  scheduleRelease: "publish",
+  cancelRelease: "publish",
+};
+
+/**
+ * Reject a body that is not a JSON object.
+ *
+ * Returned as a refusal rather than coerced: `null` and `[]` are both valid JSON
+ * and neither carries the fields these routes read, so accepting them would turn
+ * a caller's mistake into a confusing failure further in.
+ */
+async function jsonObject(req: Request): Promise<Record<string, unknown>> {
+  let parsed: unknown;
+  try {
+    parsed = await req.json();
+  } catch {
+    throw new ReleaseRequestError("A JSON body is required.");
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new ReleaseRequestError("A JSON object body is required.");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+/** A caller-fixable problem with the request itself. */
+class ReleaseRequestError extends Error {}
+
+function requireString(body: Record<string, unknown>, key: string): string {
+  const value = body[key];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new ReleaseRequestError(`\`${key}\` is required.`);
+  }
+  return value;
+}
+
+/**
+ * An instant supplied by a caller.
+ *
+ * Refused rather than defaulted when unparseable. A release whose scheduled
+ * instant silently became "now" would publish immediately, which is the one
+ * outcome an author scheduling something for later cannot recover from.
+ */
+function requireInstant(body: Record<string, unknown>, key: string): Date {
+  const raw = body[key];
+  if (typeof raw !== "string") {
+    throw new ReleaseRequestError(`\`${key}\` must be an ISO 8601 string.`);
+  }
+  const at = new Date(raw);
+  if (Number.isNaN(at.getTime())) {
+    throw new ReleaseRequestError(`\`${key}\` is not a valid instant.`);
+  }
+  return at;
+}
+
+/** Optional positive integer from a query string. */
+function optionalCount(value: string | null): number | undefined {
+  if (value === null) return undefined;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new ReleaseRequestError("`limit` must be a positive integer.");
+  }
+  return n;
+}
+
+function optionalInstant(value: string | null, key: string): Date | undefined {
+  if (value === null) return undefined;
+  const at = new Date(value);
+  if (Number.isNaN(at.getTime())) {
+    throw new ReleaseRequestError(`\`${key}\` is not a valid instant.`);
+  }
+  return at;
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/**
+ * What every release operation is handed.
+ *
+ * `caller` carries `overrideAccess: false`, which is what turns the service's
+ * own checks ON. The route can only ask the SYSTEM question — may this person
+ * touch releases at all — while the service also asks whether they may publish
+ * the DOCUMENT they are putting into one, which is in the body and therefore
+ * invisible to any route gate.
+ */
+interface ReleaseContext {
+  request: Request;
+  caller: { userId: string; overrideAccess: false };
+  releases: Awaited<ReturnType<typeof getCachedNextly>>["releases"];
+  releaseId: string;
+  memberId: string;
+}
+
+/**
+ * One function per operation, keyed by the method the route table named.
+ *
+ * A map rather than a switch: eight cases in one function is twenty-three paths
+ * through it, and each case is independent of the others — nothing falls
+ * through, nothing shares a local. Splitting them means each reads as the small
+ * thing it is, and the authority table above stays the single place that says
+ * what each one needs.
+ */
+const RELEASE_OPERATIONS: Record<
+  string,
+  (ctx: ReleaseContext) => Promise<Response>
+> = {
+  listReleases: async ({ request, caller, releases }) => {
+    const params = new URL(request.url).searchParams;
+    return json({
+      releases: await releases.find({
+        ...caller,
+        state: params.get("state") ?? undefined,
+        scheduledAfter: optionalInstant(
+          params.get("scheduledAfter"),
+          "scheduledAfter"
+        ),
+        scheduledBefore: optionalInstant(
+          params.get("scheduledBefore"),
+          "scheduledBefore"
+        ),
+        limit: optionalCount(params.get("limit")),
+      }),
+    });
+  },
+
+  getRelease: async ({ caller, releases, releaseId }) => {
+    const release = await releases.findByID({ ...caller, id: releaseId });
+    // A caller who may not read releases never reaches here — the authority
+    // gate refused them — so answering 404 cannot leak whether a release exists.
+    if (release === null) return json({ error: "Release not found." }, 404);
+    return json({ release });
+  },
+
+  createRelease: async ({ request, caller, releases }) => {
+    const body = await jsonObject(request);
+    const description = body.description;
+    return json(
+      {
+        release: await releases.create({
+          ...caller,
+          title: requireString(body, "title"),
+          description: typeof description === "string" ? description : null,
+        }),
+      },
+      201
+    );
+  },
+
+  listReleaseMembers: async ({ caller, releases, releaseId }) =>
+    json({ members: await releases.listMembers({ ...caller, releaseId }) }),
+
+  addReleaseMember: async ({ request, caller, releases, releaseId }) => {
+    const body = await jsonObject(request);
+    const action = body.action;
+    if (action !== "publish" && action !== "unpublish") {
+      throw new ReleaseRequestError(
+        "`action` must be `publish` or `unpublish`."
+      );
+    }
+    const scopeKind = body.scopeKind;
+    if (scopeKind !== "collection" && scopeKind !== "single") {
+      throw new ReleaseRequestError(
+        "`scopeKind` must be `collection` or `single`."
+      );
+    }
+    const locale = body.locale;
+    return json(
+      {
+        member: await releases.addMember({
+          ...caller,
+          releaseId,
+          scopeKind,
+          scopeSlug: requireString(body, "scopeSlug"),
+          entryId: requireString(body, "entryId"),
+          // `null` means the document itself rather than one language of it.
+          locale: typeof locale === "string" ? locale : null,
+          action,
+        }),
+      },
+      201
+    );
+  },
+
+  removeReleaseMember: async ({ caller, releases, memberId }) => {
+    await releases.removeMember({ ...caller, memberId });
+    return json({ removed: true });
+  },
+
+  scheduleRelease: async ({ request, caller, releases, releaseId }) => {
+    const body = await jsonObject(request);
+    await releases.schedule({
+      ...caller,
+      id: releaseId,
+      at: requireInstant(body, "at"),
+      // Required, never defaulted to UTC. The timezone is the author's INTENT —
+      // "9am Berlin" survives a daylight-saving boundary as a statement where a
+      // UTC instant alone does not — and guessing it puts content live an hour
+      // early twice a year.
+      timezone: requireString(body, "timezone"),
+    });
+    return json({ scheduled: true });
+  },
+
+  cancelRelease: async ({ caller, releases, releaseId }) => {
+    await releases.cancel({ ...caller, id: releaseId });
+    return json({ cancelled: true });
+  },
+};
+
+/**
+ * Route a parsed release operation to the Direct API namespace.
+ *
+ * The authority is looked up BEFORE authenticating, so a route added without an
+ * entry in {@link RELEASE_AUTHORITY} is refused rather than running unguarded.
+ */
+export async function handleReleaseRequest(
+  req: Request,
+  method: string,
+  routeParams: Record<string, string> = {}
+): Promise<Response> {
+  return withErrorHandler(async (request: Request): Promise<Response> => {
+    const authority = RELEASE_AUTHORITY[method];
+    const operation = RELEASE_OPERATIONS[method];
+    if (authority === undefined || operation === undefined) {
+      return json({ error: "Unknown release operation" }, 400);
+    }
+
+    const auth = await requireAnyPermission(request, [
+      { action: authority, resource: RELEASES_RESOURCE },
+    ]);
+    // Thrown, not returned: `withErrorHandler` turns a NextlyError into the
+    // canonical envelope every other 401/403 in this API ships, and returning
+    // the raw refusal would give release routes a shape of their own.
+    if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+    const nextly = await getCachedNextly();
+
+    try {
+      return await operation({
+        request,
+        caller: { userId: auth.userId, overrideAccess: false },
+        releases: nextly.releases,
+        releaseId: routeParams.releaseId ?? "",
+        memberId: routeParams.memberId ?? "",
+      });
+    } catch (error) {
+      // Caller-fixable request problems answer 400 with the sentence that names
+      // the mistake. Everything else falls through to `withErrorHandler`, which
+      // keeps a service refusal a 403 and an unexpected fault a 500.
+      if (error instanceof ReleaseRequestError) {
+        return json({ error: error.message }, 400);
+      }
+      throw error;
+    }
+  })(req);
+}

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -137,13 +137,35 @@ function requireInstant(body: Record<string, unknown>, key: string): Date {
     throw badRequest(`\`${key}\` is not a valid instant.`, { value: raw });
   }
   // A well-formed but impossible date — 2026-02-30 — parses and normalises
-  // silently. Round-tripping the calendar fields is what catches it.
-  if (!raw.startsWith(at.toISOString().slice(0, 10))) {
+  // silently. Caught by re-reading the calendar fields IN THE STATED OFFSET,
+  // never against the UTC rendering: `2026-09-01T00:30:00+02:00` is August 31
+  // in UTC and perfectly valid, so comparing to `toISOString()` would refuse a
+  // legitimate instant for every caller east of Greenwich.
+  if (!statesTheSameDay(raw, at)) {
     throw badRequest(`\`${key}\` names a date that does not exist.`, {
       value: raw,
     });
   }
   return at;
+}
+
+/**
+ * Whether the parsed instant still names the calendar day the caller wrote.
+ *
+ * Compared in the offset the STRING states, by shifting the instant by that
+ * offset before reading its date parts. An impossible date normalises to a
+ * different day and is caught; a real one at an offset boundary is not, because
+ * its UTC rendering is irrelevant to what the author wrote.
+ */
+function statesTheSameDay(raw: string, at: Date): boolean {
+  const offset = raw.slice(19);
+  const minutes =
+    offset === "" || offset === "Z"
+      ? 0
+      : (offset.startsWith("-") ? -1 : 1) *
+        (Number(offset.slice(1, 3)) * 60 + Number(offset.slice(4, 6)));
+  const local = new Date(at.getTime() + minutes * 60_000);
+  return raw.startsWith(local.toISOString().slice(0, 10));
 }
 
 /**
@@ -204,13 +226,16 @@ function optionalCount(value: string | null): number | undefined {
   return n;
 }
 
+/**
+ * A window bound, held to the SAME contract as a scheduling instant.
+ *
+ * Two parsers for one concept is how they drift: this one accepted `1`,
+ * `2026-02-30` and locale-dependent forms and normalised them into query bounds
+ * nobody asked for, silently returning the wrong page of releases.
+ */
 function optionalInstant(value: string | null, key: string): Date | undefined {
   if (value === null) return undefined;
-  const at = new Date(value);
-  if (Number.isNaN(at.getTime())) {
-    throw badRequest(`\`${key}\` is not a valid instant.`);
-  }
-  return at;
+  return requireInstant({ [key]: value }, key);
 }
 
 /**
@@ -228,27 +253,34 @@ function optionalInstant(value: string | null, key: string): Date | undefined {
  * reader into the service, and this moves there so the Direct API path gets it
  * too.
  */
-async function requireTargetExists(
+async function resolveTarget(
   ctx: ReleaseContext,
   scopeKind: "collection" | "single",
   scopeSlug: string,
   entryId: string
-): Promise<void> {
-  const found =
-    scopeKind === "single"
-      ? await ctx.nextly.findSingle({
-          slug: scopeSlug as never,
-          overrideAccess: false,
-          user: { id: ctx.caller.userId },
-        })
-      : await ctx.nextly.findByID({
-          collection: scopeSlug as never,
-          id: entryId,
-          overrideAccess: false,
-          user: { id: ctx.caller.userId },
-        });
+): Promise<string> {
+  // `status: "all"` is REQUIRED, not incidental. An untrusted read defaults to
+  // `published`, and the document a release most often exists to publish is a
+  // DRAFT — so the ordinary draft-to-launch flow would 404 at the moment it is
+  // assembled, which is the one case this check must not break.
+  const found = (await (scopeKind === "single"
+    ? ctx.nextly.findSingle({
+        slug: scopeSlug as never,
+        overrideAccess: false,
+        user: { id: ctx.caller.userId } as never,
+        status: "all",
+      } as never)
+    : ctx.nextly.findByID({
+        collection: scopeSlug as never,
+        id: entryId,
+        overrideAccess: false,
+        user: { id: ctx.caller.userId } as never,
+        status: "all",
+      } as never))) as { id?: string; status?: unknown } | null | undefined;
 
   if (found === null || found === undefined) {
+    // Read AS the caller, so a document they may not see and one that is not
+    // there are the same answer and this cannot be used to probe for ids.
     throw NextlyError.notFound({
       logContext: {
         reason: "release-member-target-missing",
@@ -258,6 +290,36 @@ async function requireTargetExists(
       },
     });
   }
+
+  // A target with no publish lifecycle can never satisfy the member.
+  // Materialisation works by writing the status field; a collection with the
+  // lifecycle disabled has none, so the write produces no observable published
+  // or draft state, the drain records a failed action, and the release stays
+  // scheduled and retries forever.
+  //
+  // Probed on the ROW rather than read from configuration: the row is what the
+  // write will touch, and a schema that declares a lifecycle its table does not
+  // carry is a state this codebase has met before.
+  if (!("status" in found)) {
+    throw badRequest(
+      `\`${scopeSlug}\` has no draft/published lifecycle, so it cannot be scheduled in a release.`,
+      { reason: "target-without-lifecycle", scopeKind, scopeSlug }
+    );
+  }
+
+  // The SINGLE's own id, not the one the caller sent. A Single is addressed by
+  // slug, so any id is accepted here — but release visibility compares stored
+  // decisions against the row's real id, and a member carrying a stale one is
+  // invisible to reads until a background drain happens to run.
+  if (scopeKind === "single") {
+    if (typeof found.id !== "string") {
+      throw NextlyError.internal({
+        logContext: { reason: "single-without-id", scopeSlug },
+      });
+    }
+    return found.id;
+  }
+  return entryId;
 }
 
 /**
@@ -307,6 +369,10 @@ const RELEASE_OPERATIONS: Record<
   listReleases: async ({ request, caller, releases }) => {
     const params = new URL(request.url).searchParams;
     const limit = optionalCount(params.get("limit"));
+    // ONE row past the limit, so truncation is observable. Without it a page of
+    // five is reported as `total: 5, hasNext: false` whether five releases exist
+    // or five hundred do, and a client renders an incomplete schedule as the
+    // whole one.
     const found = await releases.find({
       ...caller,
       // The runtime guard belongs HERE, at the untyped boundary. The service
@@ -322,18 +388,24 @@ const RELEASE_OPERATIONS: Record<
         params.get("scheduledBefore"),
         "scheduledBefore"
       ),
-      limit,
+      limit: limit === undefined ? undefined : limit + 1,
     });
+    const page = limit === undefined ? found : found.slice(0, limit);
+    const hasNext = limit !== undefined && found.length > limit;
     // The canonical list envelope, so shared client tooling reads this like
     // every other list. The meta is synthetic because the query is windowed
     // rather than paged — `total` is what this page holds, and a second query
     // to count the whole table would be a read nobody asked for.
-    return respondList(found, {
-      total: found.length,
+    return respondList(page, {
+      // `total` is what this window holds, not a count of the table: the query
+      // is windowed rather than paged, and a second COUNT would be a read
+      // nobody asked for. `hasNext` is the honest part — it says whether more
+      // matched than were returned.
+      total: page.length,
       page: 1,
-      limit: limit ?? found.length,
-      totalPages: 1,
-      hasNext: false,
+      limit: limit ?? page.length,
+      totalPages: hasNext ? 2 : 1,
+      hasNext,
       hasPrev: false,
     });
   },
@@ -401,7 +473,9 @@ const RELEASE_OPERATIONS: Record<
       });
     }
 
-    await requireTargetExists(ctx, scopeKind, scopeSlug, entryId);
+    // Returns the id the member must carry, which for a Single is the row's
+    // own rather than whatever the caller sent.
+    const targetId = await resolveTarget(ctx, scopeKind, scopeSlug, entryId);
 
     return respondMutation(
       "Added to release.",
@@ -410,7 +484,7 @@ const RELEASE_OPERATIONS: Record<
         releaseId,
         scopeKind,
         scopeSlug,
-        entryId,
+        entryId: targetId,
         locale,
         action,
       }),

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -21,9 +21,11 @@
  * @module api/releases
  */
 
+import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { RELEASES_RESOURCE } from "../domains/releases/services/releases-service";
+import { NextlyError } from "../errors";
 import { getCachedNextly } from "../init";
 import {
   isReleaseState,
@@ -31,6 +33,12 @@ import {
   type ReleaseState,
 } from "../schemas/releases/types";
 
+import {
+  respondAction,
+  respondDoc,
+  respondList,
+  respondMutation,
+} from "./response-shapes";
 import { withErrorHandler } from "./with-error-handler";
 
 /**
@@ -72,21 +80,31 @@ async function jsonObject(req: Request): Promise<Record<string, unknown>> {
   try {
     parsed = await req.json();
   } catch {
-    throw new ReleaseRequestError("A JSON body is required.");
+    throw badRequest("A JSON body is required.");
   }
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-    throw new ReleaseRequestError("A JSON object body is required.");
+    throw badRequest("A JSON object body is required.");
   }
   return parsed as Record<string, unknown>;
 }
 
-/** A caller-fixable problem with the request itself. */
-class ReleaseRequestError extends Error {}
+/**
+ * A caller-fixable problem with the request.
+ *
+ * `NextlyError.invalidInput` rather than a bare `Error` rendered by hand:
+ * `withErrorHandler` turns it into the canonical envelope every other 400 in
+ * this API ships, with its code and request id. A hand-rolled `{ error }` body
+ * is a second response shape for one class of failure, and the client tooling
+ * that reads the canonical one cannot see it.
+ */
+function badRequest(message: string, logContext: Record<string, unknown> = {}) {
+  return NextlyError.invalidInput({ message, logContext });
+}
 
 function requireString(body: Record<string, unknown>, key: string): string {
   const value = body[key];
   if (typeof value !== "string" || value.length === 0) {
-    throw new ReleaseRequestError(`\`${key}\` is required.`);
+    throw badRequest(`\`${key}\` is required.`);
   }
   return value;
 }
@@ -101,13 +119,64 @@ function requireString(body: Record<string, unknown>, key: string): string {
 function requireInstant(body: Record<string, unknown>, key: string): Date {
   const raw = body[key];
   if (typeof raw !== "string") {
-    throw new ReleaseRequestError(`\`${key}\` must be an ISO 8601 string.`);
+    throw badRequest(`\`${key}\` must be an ISO 8601 string.`);
+  }
+  // Parseability is NOT the contract. `new Date` accepts "1" as 2001-01-01,
+  // normalises "2026-02-30" to March 2, and reads "09/01/2026" differently by
+  // locale — each of which yields a perfectly valid Date at an instant the
+  // author never chose, and a release publishes at it. The shape is checked
+  // first so only genuine ISO 8601 reaches the parser.
+  if (!ISO_INSTANT.test(raw)) {
+    throw badRequest(
+      `\`${key}\` must be an ISO 8601 instant, for example 2026-09-01T09:00:00Z.`,
+      { value: raw }
+    );
   }
   const at = new Date(raw);
   if (Number.isNaN(at.getTime())) {
-    throw new ReleaseRequestError(`\`${key}\` is not a valid instant.`);
+    throw badRequest(`\`${key}\` is not a valid instant.`, { value: raw });
+  }
+  // A well-formed but impossible date — 2026-02-30 — parses and normalises
+  // silently. Round-tripping the calendar fields is what catches it.
+  if (!raw.startsWith(at.toISOString().slice(0, 10))) {
+    throw badRequest(`\`${key}\` names a date that does not exist.`, {
+      value: raw,
+    });
   }
   return at;
+}
+
+/**
+ * ISO 8601 with an explicit offset or `Z`.
+ *
+ * A local-time string carries no zone, so the server would resolve it in its
+ * own — the same request scheduling different instants on two deployments.
+ * `timezone` states the author's intent separately and does not make the
+ * instant ambiguous.
+ */
+const ISO_INSTANT =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d{1,3})?)?(Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * A timezone the platform can actually format in.
+ *
+ * A length check accepts `Europe/Berln`, which is stored, shown to an author as
+ * their intent, and then throws whenever anything formats with it. `Intl` is the
+ * only authority on what this runtime supports, so it is asked directly.
+ */
+function requireTimezone(body: Record<string, unknown>): string {
+  const zone = requireString(body, "timezone");
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: zone });
+  } catch {
+    throw badRequest(
+      "`timezone` must be an IANA time zone, such as Europe/Berlin.",
+      {
+        value: zone,
+      }
+    );
+  }
+  return zone;
 }
 
 /** Optional positive integer from a query string. */
@@ -121,9 +190,7 @@ function requireInstant(body: Record<string, unknown>, key: string): Date {
 function releaseStateParam(value: string | null): ReleaseState | undefined {
   if (value === null) return undefined;
   if (!isReleaseState(value)) {
-    throw new ReleaseRequestError(
-      `\`state\` must be one of: ${RELEASE_STATES.join(", ")}.`
-    );
+    throw badRequest(`\`state\` must be one of: ${RELEASE_STATES.join(", ")}.`);
   }
   return value;
 }
@@ -132,7 +199,7 @@ function optionalCount(value: string | null): number | undefined {
   if (value === null) return undefined;
   const n = Number(value);
   if (!Number.isInteger(n) || n <= 0) {
-    throw new ReleaseRequestError("`limit` must be a positive integer.");
+    throw badRequest("`limit` must be a positive integer.");
   }
   return n;
 }
@@ -141,16 +208,56 @@ function optionalInstant(value: string | null, key: string): Date | undefined {
   if (value === null) return undefined;
   const at = new Date(value);
   if (Number.isNaN(at.getTime())) {
-    throw new ReleaseRequestError(`\`${key}\` is not a valid instant.`);
+    throw badRequest(`\`${key}\` is not a valid instant.`);
   }
   return at;
 }
 
-function json(body: unknown, status = 200): Response {
-  return new Response(JSON.stringify(body), {
-    status,
-    headers: { "Content-Type": "application/json" },
-  });
+/**
+ * Refuse a member whose target document is not there.
+ *
+ * A typo or a stale id is accepted happily by the write path — nothing joins a
+ * member to a document — and then fails at the scheduled instant with
+ * not-found, holding the release open and reporting a failure nobody is
+ * watching for. Resolved as the CALLER, so a document they may not read is
+ * indistinguishable from one that does not exist and this cannot be used to
+ * probe for ids.
+ *
+ * Placed at this boundary because it is where a content reader is available.
+ * When the add-time document-rule check lands in the wiring it will carry the
+ * reader into the service, and this moves there so the Direct API path gets it
+ * too.
+ */
+async function requireTargetExists(
+  ctx: ReleaseContext,
+  scopeKind: "collection" | "single",
+  scopeSlug: string,
+  entryId: string
+): Promise<void> {
+  const found =
+    scopeKind === "single"
+      ? await ctx.nextly.findSingle({
+          slug: scopeSlug as never,
+          overrideAccess: false,
+          user: { id: ctx.caller.userId },
+        })
+      : await ctx.nextly.findByID({
+          collection: scopeSlug as never,
+          id: entryId,
+          overrideAccess: false,
+          user: { id: ctx.caller.userId },
+        });
+
+  if (found === null || found === undefined) {
+    throw NextlyError.notFound({
+      logContext: {
+        reason: "release-member-target-missing",
+        scopeKind,
+        scopeSlug,
+        entryId,
+      },
+    });
+  }
 }
 
 /**
@@ -164,7 +271,21 @@ function json(body: unknown, status = 200): Response {
  */
 interface ReleaseContext {
   request: Request;
-  caller: { userId: string; overrideAccess: false };
+  caller: {
+    userId: string;
+    overrideAccess: false;
+    /**
+     * The KEY's own grants when this request authenticated as one.
+     *
+     * Reducing an API-key request to its owner's `userId` makes the service
+     * resolve release authority from the OWNER's database permissions, and both
+     * directions are wrong: a key scoped narrowly inherits authority it was
+     * never granted, and a key granted release authority is denied when its
+     * owner lacks it. `auth.permissions` is the stamped scope; it travels.
+     */
+    authenticatedScope?: AuthenticatedScope;
+  };
+  nextly: Awaited<ReturnType<typeof getCachedNextly>>;
   releases: Awaited<ReturnType<typeof getCachedNextly>>["releases"];
   releaseId: string;
   memberId: string;
@@ -185,24 +306,35 @@ const RELEASE_OPERATIONS: Record<
 > = {
   listReleases: async ({ request, caller, releases }) => {
     const params = new URL(request.url).searchParams;
-    return json({
-      releases: await releases.find({
-        ...caller,
-        // The runtime guard belongs HERE, at the untyped boundary. The service
-        // takes `ReleaseState` so a typed caller cannot pass a typo, but a query
-        // string is whatever was sent — and an unrecognised state answered with
-        // an empty list reads exactly like "nothing is scheduled".
-        state: releaseStateParam(params.get("state")),
-        scheduledAfter: optionalInstant(
-          params.get("scheduledAfter"),
-          "scheduledAfter"
-        ),
-        scheduledBefore: optionalInstant(
-          params.get("scheduledBefore"),
-          "scheduledBefore"
-        ),
-        limit: optionalCount(params.get("limit")),
-      }),
+    const limit = optionalCount(params.get("limit"));
+    const found = await releases.find({
+      ...caller,
+      // The runtime guard belongs HERE, at the untyped boundary. The service
+      // takes `ReleaseState` so a typed caller cannot pass a typo, but a query
+      // string is whatever was sent — and an unrecognised state answered with
+      // an empty list reads exactly like "nothing is scheduled".
+      state: releaseStateParam(params.get("state")),
+      scheduledAfter: optionalInstant(
+        params.get("scheduledAfter"),
+        "scheduledAfter"
+      ),
+      scheduledBefore: optionalInstant(
+        params.get("scheduledBefore"),
+        "scheduledBefore"
+      ),
+      limit,
+    });
+    // The canonical list envelope, so shared client tooling reads this like
+    // every other list. The meta is synthetic because the query is windowed
+    // rather than paged — `total` is what this page holds, and a second query
+    // to count the whole table would be a read nobody asked for.
+    return respondList(found, {
+      total: found.length,
+      page: 1,
+      limit: limit ?? found.length,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
     });
   },
 
@@ -210,63 +342,89 @@ const RELEASE_OPERATIONS: Record<
     const release = await releases.findByID({ ...caller, id: releaseId });
     // A caller who may not read releases never reaches here — the authority
     // gate refused them — so answering 404 cannot leak whether a release exists.
-    if (release === null) return json({ error: "Release not found." }, 404);
-    return json({ release });
+    if (release === null) {
+      throw NextlyError.notFound({
+        logContext: { reason: "release-not-found", releaseId },
+      });
+    }
+    return respondDoc(release);
   },
 
   createRelease: async ({ request, caller, releases }) => {
     const body = await jsonObject(request);
     const description = body.description;
-    return json(
-      {
-        release: await releases.create({
-          ...caller,
-          title: requireString(body, "title"),
-          description: typeof description === "string" ? description : null,
-        }),
-      },
-      201
+    return respondMutation(
+      "Release created.",
+      await releases.create({
+        ...caller,
+        title: requireString(body, "title"),
+        description: typeof description === "string" ? description : null,
+      }),
+      { status: 201 }
     );
   },
 
-  listReleaseMembers: async ({ caller, releases, releaseId }) =>
-    json({ members: await releases.listMembers({ ...caller, releaseId }) }),
+  listReleaseMembers: async ({ caller, releases, releaseId }) => {
+    const members = await releases.listMembers({ ...caller, releaseId });
+    return respondList(members, {
+      total: members.length,
+      page: 1,
+      limit: members.length,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
+  },
 
-  addReleaseMember: async ({ request, caller, releases, releaseId }) => {
+  addReleaseMember: async ctx => {
+    const { request, caller, releases, releaseId } = ctx;
     const body = await jsonObject(request);
     const action = body.action;
     if (action !== "publish" && action !== "unpublish") {
-      throw new ReleaseRequestError(
-        "`action` must be `publish` or `unpublish`."
-      );
+      throw badRequest("`action` must be `publish` or `unpublish`.");
     }
     const scopeKind = body.scopeKind;
     if (scopeKind !== "collection" && scopeKind !== "single") {
-      throw new ReleaseRequestError(
-        "`scopeKind` must be `collection` or `single`."
-      );
+      throw badRequest("`scopeKind` must be `collection` or `single`.");
     }
-    const locale = body.locale;
-    return json(
-      {
-        member: await releases.addMember({
-          ...caller,
-          releaseId,
-          scopeKind,
-          scopeSlug: requireString(body, "scopeSlug"),
-          entryId: requireString(body, "entryId"),
-          // `null` means the document itself rather than one language of it.
-          locale: typeof locale === "string" ? locale : null,
-          action,
-        }),
-      },
-      201
+    const scopeSlug = requireString(body, "scopeSlug");
+    const entryId = requireString(body, "entryId");
+    // Neither a string nor null is REFUSED, never coerced. Coercing a numeric
+    // locale id from a mismatched client schema to `null` silently WIDENS the
+    // member from one language to the whole document — the opposite of what the
+    // caller asked for, and the service cannot tell the difference because by
+    // then it is a legitimate document-wide member.
+    const locale = "locale" in body ? body.locale : null;
+    if (locale !== null && typeof locale !== "string") {
+      throw badRequest("`locale` must be a string or null.", {
+        received: typeof locale,
+      });
+    }
+
+    await requireTargetExists(ctx, scopeKind, scopeSlug, entryId);
+
+    return respondMutation(
+      "Added to release.",
+      await releases.addMember({
+        ...caller,
+        releaseId,
+        scopeKind,
+        scopeSlug,
+        entryId,
+        locale,
+        action,
+      }),
+      { status: 201 }
     );
   },
 
-  removeReleaseMember: async ({ caller, releases, memberId }) => {
-    await releases.removeMember({ ...caller, memberId });
-    return json({ removed: true });
+  removeReleaseMember: async ({ caller, releases, releaseId, memberId }) => {
+    // Bound to the release in the PATH. Deleting by member id alone means
+    // `/api/releases/A/members/B` removes B even when B belongs to release C —
+    // a stale client URL then quietly edits a release the caller never named,
+    // and the response says it worked.
+    await releases.removeMember({ ...caller, memberId, releaseId });
+    return respondAction("Removed from release.", { memberId, releaseId });
   },
 
   scheduleRelease: async ({ request, caller, releases, releaseId }) => {
@@ -279,14 +437,16 @@ const RELEASE_OPERATIONS: Record<
       // "9am Berlin" survives a daylight-saving boundary as a statement where a
       // UTC instant alone does not — and guessing it puts content live an hour
       // early twice a year.
-      timezone: requireString(body, "timezone"),
+      timezone: requireTimezone(body),
     });
-    return json({ scheduled: true });
+    return respondAction("Release scheduled.", { releaseId });
   },
 
   cancelRelease: async ({ caller, releases, releaseId }) => {
     await releases.cancel({ ...caller, id: releaseId });
-    return json({ cancelled: true });
+    // Not `{ cancelled: true }`: the response-shape contract refuses
+    // boolean-only bodies, because a caller cannot grow against them.
+    return respondAction("Release cancelled.", { releaseId });
   },
 };
 
@@ -305,7 +465,7 @@ export async function handleReleaseRequest(
     const authority = RELEASE_AUTHORITY[method];
     const operation = RELEASE_OPERATIONS[method];
     if (authority === undefined || operation === undefined) {
-      return json({ error: "Unknown release operation" }, 400);
+      throw badRequest("Unknown release operation.", { method });
     }
 
     const auth = await requireAnyPermission(request, [
@@ -318,22 +478,20 @@ export async function handleReleaseRequest(
 
     const nextly = await getCachedNextly();
 
-    try {
-      return await operation({
-        request,
-        caller: { userId: auth.userId, overrideAccess: false },
-        releases: nextly.releases,
-        releaseId: routeParams.releaseId ?? "",
-        memberId: routeParams.memberId ?? "",
-      });
-    } catch (error) {
-      // Caller-fixable request problems answer 400 with the sentence that names
-      // the mistake. Everything else falls through to `withErrorHandler`, which
-      // keeps a service refusal a 403 and an unexpected fault a 500.
-      if (error instanceof ReleaseRequestError) {
-        return json({ error: error.message }, 400);
-      }
-      throw error;
-    }
+    return operation({
+      request,
+      caller: {
+        userId: auth.userId,
+        overrideAccess: false,
+        authenticatedScope:
+          auth.authMethod === "api-key"
+            ? { actorType: "apiKey", permissions: auth.permissions }
+            : undefined,
+      },
+      nextly,
+      releases: nextly.releases,
+      releaseId: routeParams.releaseId ?? "",
+      memberId: routeParams.memberId ?? "",
+    });
   })(req);
 }

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -25,6 +25,11 @@ import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { RELEASES_RESOURCE } from "../domains/releases/services/releases-service";
 import { getCachedNextly } from "../init";
+import {
+  isReleaseState,
+  RELEASE_STATES,
+  type ReleaseState,
+} from "../schemas/releases/types";
 
 import { withErrorHandler } from "./with-error-handler";
 
@@ -106,6 +111,23 @@ function requireInstant(body: Record<string, unknown>, key: string): Date {
 }
 
 /** Optional positive integer from a query string. */
+/**
+ * A lifecycle state from a query string, or a refusal.
+ *
+ * Refused rather than ignored. Dropping an unrecognised filter widens the query
+ * — the caller asked for one state and receives every release — and a client
+ * paging through what it believes is a filtered list has no way to notice.
+ */
+function releaseStateParam(value: string | null): ReleaseState | undefined {
+  if (value === null) return undefined;
+  if (!isReleaseState(value)) {
+    throw new ReleaseRequestError(
+      `\`state\` must be one of: ${RELEASE_STATES.join(", ")}.`
+    );
+  }
+  return value;
+}
+
 function optionalCount(value: string | null): number | undefined {
   if (value === null) return undefined;
   const n = Number(value);
@@ -166,7 +188,11 @@ const RELEASE_OPERATIONS: Record<
     return json({
       releases: await releases.find({
         ...caller,
-        state: params.get("state") ?? undefined,
+        // The runtime guard belongs HERE, at the untyped boundary. The service
+        // takes `ReleaseState` so a typed caller cannot pass a typo, but a query
+        // string is whatever was sent — and an unrecognised state answered with
+        // an empty list reads exactly like "nothing is scheduled".
+        state: releaseStateParam(params.get("state")),
         scheduledAfter: optionalInstant(
           params.get("scheduledAfter"),
           "scheduledAfter"

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -24,6 +24,7 @@
 import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+import { container } from "../di";
 import { RELEASES_RESOURCE } from "../domains/releases/services/releases-service";
 import { NextlyError } from "../errors";
 import { getCachedNextly } from "../init";
@@ -217,11 +218,27 @@ function releaseStateParam(value: string | null): ReleaseState | undefined {
   return value;
 }
 
-function optionalCount(value: string | null): number | undefined {
-  if (value === null) return undefined;
+/**
+ * The page size, always bounded.
+ *
+ * An omitted limit used to mean "no limit", so `GET /api/releases` selected and
+ * serialised the entire table — an ordinary authenticated request turned into an
+ * unbounded read on any installation with a real release history. A supplied one
+ * was accepted at any size, which is the same read asked for explicitly.
+ */
+const DEFAULT_RELEASE_PAGE = 50;
+const MAX_RELEASE_PAGE = 200;
+
+function pageSize(value: string | null): number {
+  if (value === null) return DEFAULT_RELEASE_PAGE;
   const n = Number(value);
   if (!Number.isInteger(n) || n <= 0) {
     throw badRequest("`limit` must be a positive integer.");
+  }
+  if (n > MAX_RELEASE_PAGE) {
+    throw badRequest(`\`limit\` may be at most ${MAX_RELEASE_PAGE}.`, {
+      requested: n,
+    });
   }
   return n;
 }
@@ -236,6 +253,36 @@ function optionalCount(value: string | null): number | undefined {
 function optionalInstant(value: string | null, key: string): Date | undefined {
   if (value === null) return undefined;
   return requireInstant({ [key]: value }, key);
+}
+
+/**
+ * Whether this scope declares a Draft/Published lifecycle.
+ *
+ * Asked of the registry, which holds what the schema declared. Answering `false`
+ * when the registry cannot be reached is deliberate: a member whose lifecycle
+ * support is unknown is one the drain may not be able to perform, and admitting
+ * it on an unavailable answer trades a clear refusal now for a release that
+ * silently never publishes.
+ */
+async function declaresLifecycle(
+  scopeKind: "collection" | "single",
+  scopeSlug: string
+): Promise<boolean> {
+  const key =
+    scopeKind === "single"
+      ? "singleRegistryService"
+      : "collectionRegistryService";
+  if (!container.has(key)) return false;
+  const registry = container.get<{
+    getCollectionBySlug?: (
+      slug: string
+    ) => Promise<{ status?: boolean } | null>;
+    getSingleBySlug?: (slug: string) => Promise<{ status?: boolean } | null>;
+  }>(key);
+  const record = await (scopeKind === "single"
+    ? registry.getSingleBySlug?.(scopeSlug)
+    : registry.getCollectionBySlug?.(scopeSlug));
+  return record?.status === true;
 }
 
 /**
@@ -292,15 +339,17 @@ async function resolveTarget(
   }
 
   // A target with no publish lifecycle can never satisfy the member.
-  // Materialisation works by writing the status field; a collection with the
-  // lifecycle disabled has none, so the write produces no observable published
-  // or draft state, the drain records a failed action, and the release stays
-  // scheduled and retries forever.
+  // Materialisation works by writing the status field, so with the lifecycle
+  // disabled the write produces no observable published or draft state, the
+  // drain records a failed action, and the release stays scheduled forever.
   //
-  // Probed on the ROW rather than read from configuration: the row is what the
-  // write will touch, and a schema that declares a lifecycle its table does not
-  // carry is a state this codebase has met before.
-  if (!("status" in found)) {
+  // Read from the SCHEMA, not probed on the row. An earlier version checked
+  // whether the row carried a `status` property, which is wrong in the
+  // dangerous direction: the name is reserved only when the lifecycle is
+  // enabled, so a collection with it DISABLED may legally define an ordinary
+  // field called `status` — and materialisation would then overwrite that
+  // author's field with "published" and report the release complete.
+  if (!(await declaresLifecycle(scopeKind, scopeSlug))) {
     throw badRequest(
       `\`${scopeSlug}\` has no draft/published lifecycle, so it cannot be scheduled in a release.`,
       { reason: "target-without-lifecycle", scopeKind, scopeSlug }
@@ -346,6 +395,8 @@ interface ReleaseContext {
      * owner lacks it. `auth.permissions` is the stamped scope; it travels.
      */
     authenticatedScope?: AuthenticatedScope;
+    /** The authenticated roles, which code-defined access rules are evaluated against. */
+    userRoles?: string[];
   };
   nextly: Awaited<ReturnType<typeof getCachedNextly>>;
   releases: Awaited<ReturnType<typeof getCachedNextly>>["releases"];
@@ -368,7 +419,7 @@ const RELEASE_OPERATIONS: Record<
 > = {
   listReleases: async ({ request, caller, releases }) => {
     const params = new URL(request.url).searchParams;
-    const limit = optionalCount(params.get("limit"));
+    const limit = pageSize(params.get("limit"));
     // ONE row past the limit, so truncation is observable. Without it a page of
     // five is reported as `total: 5, hasNext: false` whether five releases exist
     // or five hundred do, and a client renders an incomplete schedule as the
@@ -388,10 +439,10 @@ const RELEASE_OPERATIONS: Record<
         params.get("scheduledBefore"),
         "scheduledBefore"
       ),
-      limit: limit === undefined ? undefined : limit + 1,
+      limit: limit + 1,
     });
-    const page = limit === undefined ? found : found.slice(0, limit);
-    const hasNext = limit !== undefined && found.length > limit;
+    const page = found.slice(0, limit);
+    const hasNext = found.length > limit;
     // The canonical list envelope, so shared client tooling reads this like
     // every other list. The meta is synthetic because the query is windowed
     // rather than paged — `total` is what this page holds, and a second query
@@ -403,7 +454,7 @@ const RELEASE_OPERATIONS: Record<
       // matched than were returned.
       total: page.length,
       page: 1,
-      limit: limit ?? page.length,
+      limit,
       totalPages: hasNext ? 2 : 1,
       hasNext,
       hasPrev: false,
@@ -424,13 +475,21 @@ const RELEASE_OPERATIONS: Record<
 
   createRelease: async ({ request, caller, releases }) => {
     const body = await jsonObject(request);
-    const description = body.description;
+    // Present-but-wrong is REFUSED, not nulled. Coercing a client's numeric or
+    // object description to `null` turns a malformed request into silent data
+    // loss, where every other bad field here answers 400.
+    const description = "description" in body ? body.description : null;
+    if (description !== null && typeof description !== "string") {
+      throw badRequest("`description` must be a string or null.", {
+        received: typeof description,
+      });
+    }
     return respondMutation(
       "Release created.",
       await releases.create({
         ...caller,
         title: requireString(body, "title"),
-        description: typeof description === "string" ? description : null,
+        description,
       }),
       { status: 201 }
     );
@@ -561,6 +620,12 @@ export async function handleReleaseRequest(
           auth.authMethod === "api-key"
             ? { actorType: "apiKey", permissions: auth.permissions }
             : undefined,
+        // The authenticated role set. `apiKeyWriteAllowed` evaluates
+        // code-defined publish rules against it, so dropping it makes every
+        // rule see `roles: []` — a role-positive rule then rejects a valid key,
+        // and an absence-based one ("not a contractor") admits one it should
+        // refuse.
+        userRoles: auth.roles,
       },
       nextly,
       releases: nextly.releases,

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -231,7 +231,10 @@ export function createReleasesNamespace(ctx: NextlyContext): ReleasesNamespace {
     },
 
     removeMember: args =>
-      service().removeMember(args.memberId, actorOf(ctx, args)),
+      // `releaseId` FORWARDED, not folded into the caller bag. It was declared
+      // on the interface and dropped here — a parameter the type advertised and
+      // the implementation ignored, so the mismatch guard it enables never ran.
+      service().removeMember(args.memberId, actorOf(ctx, args), args.releaseId),
 
     listMembers: args =>
       service().listMembers(args.releaseId, actorOf(ctx, args)),

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -68,6 +68,14 @@ export interface ReleaseCallerArgs {
    * because it is the scope of the request actually being served.
    */
   authenticatedScope?: AuthenticatedScope;
+  /**
+   * The caller's resolved roles, when the TRANSPORT already has them.
+   *
+   * Travels with `authenticatedScope` and for the same reason: code-defined
+   * publish rules are evaluated against a role set, and an overridden identity
+   * must bring its own rather than inherit the instance's.
+   */
+  userRoles?: string[];
 }
 
 export interface ReleasesNamespace {
@@ -80,6 +88,22 @@ export interface ReleasesNamespace {
     args: { id: string } & ReleaseCallerArgs
   ): Promise<ReleaseRow | null>;
   /** Put a document into a release under a lifecycle action. */
+  /**
+   * Put a document into a release under a lifecycle action.
+   *
+   * An AUTHOR is required, and it may come from either place: `userId` on the
+   * call, or the `user` an instance was configured with. The drain performs
+   * each member as its recorded author, so a member with none returns
+   * `NO_RECORDED_AUTHOR` on every pass and the release can never publish — even
+   * on a trusted call, which is the one case where "trusted" does not mean
+   * "as anybody".
+   *
+   * Not narrowed to a required `userId` in the type, deliberately: that would
+   * refuse the legitimate flow where an instance built with a `user` supplies
+   * the author for every call on it. The refusal is at runtime because only
+   * runtime knows whether either source produced one, and its message names the
+   * field to pass.
+   */
   addMember(
     args: { releaseId: string } & AddMemberInput & ReleaseCallerArgs
   ): Promise<ReleaseMemberRow>;
@@ -184,7 +208,8 @@ function actorOf(ctx: NextlyContext, args: ReleaseCallerArgs) {
     // Roles describe the instance's user, so they follow the same rule — a rule
     // evaluated against someone else's roles is worse than one evaluated
     // against none.
-    userRoles: overridesIdentity ? undefined : access.user?.roles,
+    userRoles:
+      args.userRoles ?? (overridesIdentity ? undefined : access.user?.roles),
   };
 }
 
@@ -207,10 +232,17 @@ export function createReleasesNamespace(ctx: NextlyContext): ReleasesNamespace {
       // Leaving them in sends `authenticatedScope` to the repository as a filter
       // column, which is a query nobody wrote and a credential in a place it
       // does not belong.
-      const { userId, overrideAccess, authenticatedScope, ...query } = args;
+      const {
+        userId,
+        overrideAccess,
+        authenticatedScope,
+        userRoles,
+        ...query
+      } = args;
       void userId;
       void overrideAccess;
       void authenticatedScope;
+      void userRoles;
       return service().find(query, actorOf(ctx, args));
     },
 
@@ -222,11 +254,13 @@ export function createReleasesNamespace(ctx: NextlyContext): ReleasesNamespace {
         userId,
         overrideAccess,
         authenticatedScope,
+        userRoles,
         ...member
       } = args;
       void userId;
       void overrideAccess;
       void authenticatedScope;
+      void userRoles;
       return service().addMember(releaseId, member, actorOf(ctx, args));
     },
 

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -83,7 +83,17 @@ export interface ReleasesNamespace {
   addMember(
     args: { releaseId: string } & AddMemberInput & ReleaseCallerArgs
   ): Promise<ReleaseMemberRow>;
-  removeMember(args: { memberId: string } & ReleaseCallerArgs): Promise<void>;
+  /**
+   * Take a document back out of a release.
+   *
+   * `releaseId` is optional but SHOULD be supplied by any caller that knows it —
+   * a transport addressing `/releases/A/members/B` knows which release it meant,
+   * and passing it turns a stale or crafted member id into a refusal instead of
+   * a silent edit to a different release.
+   */
+  removeMember(
+    args: { memberId: string; releaseId?: string } & ReleaseCallerArgs
+  ): Promise<void>;
   listMembers(
     args: { releaseId: string } & ReleaseCallerArgs
   ): Promise<ReleaseMemberRow[]>;

--- a/packages/nextly/src/dispatcher/types.ts
+++ b/packages/nextly/src/dispatcher/types.ts
@@ -11,6 +11,7 @@ import type { NextlyError } from "../errors/nextly-error";
 
 export type ServiceType =
   | "users"
+  | "releases"
   | "rbac"
   | "auth"
   | "posts"

--- a/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-service.test.ts
@@ -30,6 +30,7 @@ function repository() {
     addMember: vi.fn(async () => ({ id: "m1" })),
     removeMember: vi.fn(async () => undefined),
     touchIfAssemblable: vi.fn(async () => true),
+    restoreMember: vi.fn(async () => undefined),
     findMember: vi.fn(
       async (): Promise<{ id: string; releaseId: string } | undefined> => ({
         id: "m1",
@@ -507,5 +508,32 @@ describe("ReleasesService carries the key scope into the DOCUMENT check", () => 
       })
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
     expect(repo.addMember).not.toHaveBeenCalled();
+  });
+});
+
+describe("ReleasesService closes the window around a REMOVAL too", () => {
+  it("puts the member back when the release is scheduled during the delete", async () => {
+    // Removing an `unpublish` member cancels a committed takedown, so a
+    // publisher scheduling between the claim and the delete would have their
+    // decision undone by a caller who never passed the publish gate.
+    const { svc, repo } = service({ holds: ["create"] });
+    repo.touchIfAssemblable
+      .mockResolvedValueOnce(true) // the claim succeeds
+      .mockResolvedValueOnce(false); // scheduled while we were deleting
+    await expect(svc.removeMember("m1", ADMIN)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    // Restored with the ORIGINAL row, so the undo is invisible to anything
+    // holding that id.
+    expect(repo.restoreMember).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "m1" })
+    );
+  });
+
+  it("does not re-check for a caller who may publish", async () => {
+    const { svc, repo } = service({ holds: ["create", "publish"] });
+    await svc.removeMember("m1", ADMIN);
+    expect(repo.touchIfAssemblable).toHaveBeenCalledTimes(1);
+    expect(repo.restoreMember).not.toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -580,6 +580,19 @@ export class ReleasesRepository {
     return row;
   }
 
+  /**
+   * Put a removed member back, exactly as it was.
+   *
+   * The compensating half of a bounded removal. Restoring with the ORIGINAL row
+   * — same id, same `createdAt`, same recorded author — is what makes the undo
+   * invisible: a caller that retries sees the member it expected rather than a
+   * new one, and anything holding the old id still resolves.
+   */
+  async restoreMember(row: ReleaseMemberRow): Promise<void> {
+    await this.db.insert(MEMBERS, { ...row }, { returning: [] });
+    await this.revalidateMembersOf(row.releaseId);
+  }
+
   async removeMember(memberId: string): Promise<void> {
     // The row is read BEFORE the delete: afterwards there is nothing left to
     // say which document's tags to flush, and the projection that release was

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -438,6 +438,26 @@ export class ReleasesService {
 
     await this.claimAssemblable(member.releaseId, actor);
     await this.deps.repository.removeMember(memberId);
+
+    // The same window the member ADD closes, and it matters more here: removing
+    // an `unpublish` member cancels a committed takedown, so a publisher
+    // scheduling between the claim and the delete would have their decision
+    // undone by a caller who never passed the publish gate.
+    //
+    // Compensated by restoring the ORIGINAL row — same id, same author, same
+    // timestamp — so the undo is invisible to anything holding that id.
+    if (!(await this.holds(actor, "publish"))) {
+      if (!(await this.deps.repository.touchIfAssemblable(member.releaseId))) {
+        await this.deps.repository.restoreMember(member);
+        throw NextlyError.conflict({
+          logContext: {
+            reason: "release-scheduled-during-remove",
+            releaseId: member.releaseId,
+            memberId,
+          },
+        });
+      }
+    }
   }
 
   /**

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -398,7 +398,12 @@ export class ReleasesService {
     }
   }
 
-  async removeMember(memberId: string, actor: ReleaseActor): Promise<void> {
+  async removeMember(
+    memberId: string,
+    actor: ReleaseActor,
+    /** The release the caller believes this member belongs to, when it knows. */
+    expectedReleaseId?: string
+  ): Promise<void> {
     await this.authorize(actor, "create");
 
     // An earlier version of this method reasoned that removing a member "can
@@ -412,6 +417,24 @@ export class ReleasesService {
     // satisfied, and answering not-found for a member somebody else removed
     // makes a retry look like a failure.
     if (member === undefined) return;
+
+    // A member id that belongs to a DIFFERENT release than the caller named is
+    // refused, not followed. Nothing joins the two in the path, so a stale
+    // client URL would otherwise edit a release the caller never addressed and
+    // be told it worked.
+    if (
+      expectedReleaseId !== undefined &&
+      member.releaseId !== expectedReleaseId
+    ) {
+      throw NextlyError.notFound({
+        logContext: {
+          reason: "member-belongs-to-another-release",
+          memberId,
+          expectedReleaseId,
+          actualReleaseId: member.releaseId,
+        },
+      });
+    }
 
     await this.claimAssemblable(member.releaseId, actor);
     await this.deps.repository.removeMember(memberId);

--- a/packages/nextly/src/init.ts
+++ b/packages/nextly/src/init.ts
@@ -168,6 +168,11 @@ function buildNextlyInstance(
     // `await getNextly()` path.
     jobs: directAPI.jobs,
 
+    // Content releases. Forwarded for the reason stated above: a namespace that
+    // stops at the class is absent from the documented `await getNextly()`
+    // path, which is the one the REST handlers use.
+    releases: directAPI.releases,
+
     // RBAC namespaces
     roles: directAPI.roles,
     permissions: directAPI.permissions,

--- a/packages/nextly/src/init/nextly-instance.ts
+++ b/packages/nextly/src/init/nextly-instance.ts
@@ -882,9 +882,13 @@ export interface Nextly {
    *
    * @example
    * ```typescript
+   * // `userId` is REQUIRED for a member even on a trusted call: the drain
+   * // performs each member as its recorded author, and a member with none can
+   * // never be materialised.
    * const release = await nextly.releases.create({ title: "Spring launch" });
    * await nextly.releases.addMember({
    *   releaseId: release.id,
+   *   userId: editor.id,
    *   scopeKind: "collection",
    *   scopeSlug: "posts",
    *   entryId: post.id,

--- a/packages/nextly/src/init/nextly-instance.ts
+++ b/packages/nextly/src/init/nextly-instance.ts
@@ -16,6 +16,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 import type { ServiceMap } from "../di/register";
 import type { FieldGroupsNamespace } from "../direct-api/namespaces/index";
 import type { JobsNamespace } from "../direct-api/namespaces/jobs";
+import type { ReleasesNamespace } from "../direct-api/namespaces/releases";
 import type {
   AuthResult,
   BulkDeleteArgs,
@@ -871,6 +872,33 @@ export interface Nextly {
    * ```
    */
   jobs: JobsNamespace;
+
+  /**
+   * Content releases — batch documents and put them live at one instant.
+   *
+   * Every operation authorizes: pass `overrideAccess: false` with the acting
+   * `userId` for a call made on a person's behalf. Left at its default the call
+   * is trusted, like the rest of the Direct API.
+   *
+   * @example
+   * ```typescript
+   * const release = await nextly.releases.create({ title: "Spring launch" });
+   * await nextly.releases.addMember({
+   *   releaseId: release.id,
+   *   scopeKind: "collection",
+   *   scopeSlug: "posts",
+   *   entryId: post.id,
+   *   locale: null,
+   *   action: "publish",
+   * });
+   * await nextly.releases.schedule({
+   *   id: release.id,
+   *   at: new Date("2026-09-01T09:00:00Z"),
+   *   timezone: "Europe/Berlin",
+   * });
+   * ```
+   */
+  releases: ReleasesNamespace;
 
   roles: {
     find: (args?: FindRolesArgs) => Promise<ListResult<Role>>;

--- a/packages/nextly/src/route-handler/__tests__/route-parser.releases.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.releases.test.ts
@@ -1,0 +1,103 @@
+/**
+ * `/api/releases` — a top-level surface for a first-class object.
+ *
+ * A release is not a sub-resource of the documents it batches: it has its own
+ * lifecycle, and it is the only shape that answers "what is going live on
+ * Friday?" without starting from a document. So the risks are the ones a new
+ * top-level branch carries — that it claims paths belonging to neighbours, that
+ * the verb gates are real, and that a deeper path silently matches a shorter
+ * route and ignores the tail.
+ *
+ * @module route-handler/__tests__/route-parser.releases.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseRestRoute } from "../route-parser";
+
+describe("releases routes", () => {
+  it("lists and creates at the collection root", () => {
+    expect(parseRestRoute(["releases"], "GET")).toMatchObject({
+      service: "releases",
+      method: "listReleases",
+    });
+    expect(parseRestRoute(["releases"], "POST")).toMatchObject({
+      service: "releases",
+      method: "createRelease",
+    });
+  });
+
+  it("reads one release by id", () => {
+    expect(parseRestRoute(["releases", "r1"], "GET")).toMatchObject({
+      service: "releases",
+      method: "getRelease",
+      routeParams: { releaseId: "r1" },
+    });
+  });
+
+  it("separates schedule from cancel, and both from assembling", () => {
+    // The distinction the seed makes and this surface must preserve: putting a
+    // document into a release changes nothing a reader can see, while
+    // committing it to an instant is what puts content live.
+    expect(parseRestRoute(["releases", "r1", "schedule"], "POST").method).toBe(
+      "scheduleRelease"
+    );
+    expect(parseRestRoute(["releases", "r1", "cancel"], "POST").method).toBe(
+      "cancelRelease"
+    );
+    expect(parseRestRoute(["releases", "r1", "members"], "POST").method).toBe(
+      "addReleaseMember"
+    );
+  });
+
+  it("routes members by verb, and one member by id", () => {
+    expect(parseRestRoute(["releases", "r1", "members"], "GET")).toMatchObject({
+      method: "listReleaseMembers",
+      routeParams: { releaseId: "r1" },
+    });
+    expect(
+      parseRestRoute(["releases", "r1", "members", "m1"], "DELETE")
+    ).toMatchObject({
+      method: "removeReleaseMember",
+      routeParams: { releaseId: "r1", memberId: "m1" },
+    });
+  });
+
+  it("claims only the verb each route declares", () => {
+    // A branch that ignored the verb would turn a read into a schedule, or let
+    // a GET remove a member. Each case below is a route that must NOT match.
+    expect(
+      parseRestRoute(["releases", "r1", "schedule"], "GET").method
+    ).not.toBe("scheduleRelease");
+    expect(parseRestRoute(["releases", "r1", "cancel"], "GET").method).not.toBe(
+      "cancelRelease"
+    );
+    expect(
+      parseRestRoute(["releases", "r1", "members", "m1"], "GET").method
+    ).not.toBe("removeReleaseMember");
+    expect(parseRestRoute(["releases", "r1"], "DELETE").method).not.toBe(
+      "getRelease"
+    );
+  });
+
+  it("claims nothing deeper than the routes it declares", () => {
+    // Unlike the entry publish-all branch, this surface guards its depth: a
+    // longer path 404s rather than matching a shorter route and ignoring the
+    // tail, which would make `.../schedule/tomorrow` schedule the release.
+    expect(
+      parseRestRoute(["releases", "r1", "schedule", "tomorrow"], "POST").method
+    ).not.toBe("scheduleRelease");
+    expect(
+      parseRestRoute(["releases", "r1", "members", "m1", "extra"], "DELETE")
+        .method
+    ).not.toBe("removeReleaseMember");
+  });
+
+  it("does not claim a collection named releases", () => {
+    // The reason the permission resource is `content-releases` and not
+    // `releases`: "press releases" is a collection real sites have. A site's own
+    // collection lives under /api/collections/releases and must be untouched.
+    expect(
+      parseRestRoute(["collections", "releases", "entries"], "GET").service
+    ).toBe("collections");
+  });
+});

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2027,6 +2027,147 @@ function parseApiKeyRoutes(
 }
 
 /**
+ * The `/api/releases` route table.
+ *
+ * Declared as data rather than as a branch per route. Eight routes written as
+ * eight `if` blocks is one function with twenty-five paths through it, and the
+ * shape they all match on — id, subresource, sub-id, verb — is identical, so the
+ * branches differ only in their values. Stating the values once means a new
+ * route is a row, and means the depth guard and the verb gate cannot be
+ * forgotten for one of them.
+ *
+ * `operation` is the dispatcher's shared vocabulary — list, single, create,
+ * update, delete — and deliberately does NOT carry the release authority. The
+ * three seeded permissions are read / create / publish, and `publish` has no
+ * member in that union; widening a type every service shares to describe one of
+ * them would be the wrong trade. The authority each method needs is declared in
+ * `api/releases`, beside the handler that enforces it.
+ */
+interface ReleaseRoute {
+  /** Whether the path carries a release id. */
+  id: boolean;
+  /** The segment after the id, or `null` for none. */
+  subresource: string | null;
+  /** Whether the path carries a fourth segment, such as a member id. */
+  subId: boolean;
+  verb: string;
+  operation: OperationType;
+  method: string;
+}
+
+const RELEASE_ROUTES: ReleaseRoute[] = [
+  {
+    id: false,
+    subresource: null,
+    subId: false,
+    verb: "GET",
+    operation: "list",
+    method: "listReleases",
+  },
+  {
+    id: false,
+    subresource: null,
+    subId: false,
+    verb: "POST",
+    operation: "create",
+    method: "createRelease",
+  },
+  {
+    id: true,
+    subresource: null,
+    subId: false,
+    verb: "GET",
+    operation: "single",
+    method: "getRelease",
+  },
+  {
+    id: true,
+    subresource: "members",
+    subId: false,
+    verb: "GET",
+    operation: "list",
+    method: "listReleaseMembers",
+  },
+  {
+    id: true,
+    subresource: "members",
+    subId: false,
+    verb: "POST",
+    operation: "create",
+    method: "addReleaseMember",
+  },
+  {
+    id: true,
+    subresource: "members",
+    subId: true,
+    verb: "DELETE",
+    operation: "delete",
+    method: "removeReleaseMember",
+  },
+  // Scheduling and cancelling are separate routes rather than one `PATCH` with a
+  // state in the body: they are the two directions of the authority the seed
+  // calls "schedule or cancel", and a body field is not something a route table
+  // or an audit log can see.
+  {
+    id: true,
+    subresource: "schedule",
+    subId: false,
+    verb: "POST",
+    operation: "update",
+    method: "scheduleRelease",
+  },
+  {
+    id: true,
+    subresource: "cancel",
+    subId: false,
+    verb: "POST",
+    operation: "update",
+    method: "cancelRelease",
+  },
+];
+
+/**
+ * `/api/releases` — the content-release surface.
+ *
+ * A release is a first-class object with its own lifecycle rather than a
+ * sub-resource of the documents it batches, so it gets a top-level route. That
+ * is the shape Contentful, Strapi and Sanity all give it, and the only one that
+ * answers "what is going live on Friday?" without starting from a document.
+ */
+function parseReleaseRoutes(
+  id: string | undefined,
+  subresource: string | undefined,
+  subId: string | undefined,
+  additionalParams: string[],
+  httpMethod: string,
+  routeParams: Record<string, string>
+): ParsedRoute | null {
+  // Nothing deeper than the table exists. Guarded once, so a longer path 404s
+  // instead of matching a shorter route and silently ignoring the tail — which
+  // would make `.../schedule/tomorrow` schedule the release.
+  if (additionalParams.length > 0) return null;
+
+  const route = RELEASE_ROUTES.find(
+    candidate =>
+      candidate.id === Boolean(id) &&
+      candidate.subresource === (subresource ?? null) &&
+      candidate.subId === Boolean(subId) &&
+      candidate.verb === httpMethod
+  );
+  if (!route) return null;
+
+  if (id) routeParams.releaseId = id;
+  if (subId) routeParams.memberId = subId;
+
+  return {
+    service: "releases",
+    operation: route.operation,
+    method: route.method,
+    routeParams,
+  };
+}
+
+/**
  * GET or POST /api/jobs/run → run one background job pass.
  *
  * `run` is the only path under `jobs`, and it is an operation rather than an
@@ -2633,6 +2774,19 @@ export function parseRestRoute(
   // Handle API Keys endpoints
   if (resource === "api-keys") {
     const result = parseApiKeyRoutes(id, httpMethod, routeParams);
+    if (result) return result;
+  }
+
+  // Handle content releases
+  if (resource === "releases") {
+    const result = parseReleaseRoutes(
+      id,
+      subresource,
+      subId,
+      additionalParams,
+      httpMethod,
+      routeParams
+    );
     if (result) return result;
   }
 

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -57,6 +57,7 @@ import {
 import { runJobsRoute } from "./api/jobs-run-route";
 import { mintPreviewLink, revokePreviewLinks } from "./api/preview-links";
 import { resolveEntryPreviewUrl } from "./api/preview-url";
+import { handleReleaseRequest } from "./api/releases";
 import { readOrGenerateRequestId, withRequestIdHeader } from "./api/request-id";
 // canonical respondX wire shapes (spec §5.1) instead of the
 // hand-rolled `{ data: <payload> }` envelope.
@@ -342,6 +343,7 @@ async function handleApiKeyRequest(
 const DIRECT_DISPATCH_SERVICES = new Set<string>([
   "apiKeys",
   "webhooks",
+  "releases",
   "jobs",
   "generalSettings",
   "previewLinks",
@@ -1021,6 +1023,14 @@ async function handleServiceRequest(
   // before they can read it.
   if (service === "webhooks") {
     return handleWebhookRequest(req, method, routeParams);
+  }
+
+  // ==================== CONTENT RELEASES DIRECT DISPATCH ====================
+  // Beside the handlers above and for the same reason: it owns its auth and
+  // parses its own JSON, so it must stay above the shared body read below or
+  // the stream reaches it consumed.
+  if (service === "releases") {
+    return handleReleaseRequest(req, method, routeParams);
   }
 
   // ==================== JOBS DIRECT DISPATCH ====================


### PR DESCRIPTION
Second of three. #1383 made releases reachable in-process; this makes them reachable over HTTP. The admin surfaces follow.

## Why a top-level route

A release is a first-class object with its own lifecycle, not a sub-resource of the documents it batches. That is the shape Contentful, Strapi and Sanity all give it, and it is the only one that answers *"what is going live on Friday?"* without starting from a document.

    GET    /api/releases                          list, windowed
    POST   /api/releases                          create
    GET    /api/releases/:id                      one release
    GET    /api/releases/:id/members              its contents
    POST   /api/releases/:id/members              add a document
    DELETE /api/releases/:id/members/:memberId    take one out
    POST   /api/releases/:id/schedule             commit it to an instant
    POST   /api/releases/:id/cancel               call it off

## The security-bearing part: which authority each route demands

**Scheduling and cancelling need `publish`. Assembling needs `create`.** The seed defines `publish-content-releases` as "schedule or cancel" precisely so it can be withheld from someone allowed to build a release, and a table mapping POST to `create` uniformly would have merged the two — handing everyone who can assemble a release the power to ship it.

That mapping lives beside the handler rather than on the parsed route, because `OperationType` is the dispatcher's shared vocabulary (list/single/create/update/delete) and has **no `publish` member**. Widening a type every service shares to describe one of them would be the wrong trade.

The authority is looked up **before** authenticating, so a route added without an entry in the table is refused rather than running unguarded. Break-verified: removing that line fails exactly that case.

## Two gates, neither redundant

The route checks the **system** authority — that is what produces a proper 401/403 and stops a request before any service work. The service is then called with `overrideAccess: false`, so it still asks whether this caller may publish the **document** they are adding. No route gate can ask that: the document is in the body.

Break-verified: making the handler trust the route gate fails the case that asserts it.

## Both layers are tables, because the gate said so

The first version mirrored branch-per-route and `fallow` called both the parser (CC 25) and the handler switch (CC 23) **critical**, attributed as introduced. It was right — eight routes written as eight `if` blocks differ only in their values.

Now a route table and a handler map. Depth is guarded once, so `.../schedule/tomorrow` 404s instead of matching a shorter route and ignoring the tail — a property the older entry publish-all branch does not have, and its test says so rather than pretending otherwise.

## Input refused at the boundary, not ignored

Rebasing onto main surfaced a real gap: the service now types `state` as `ReleaseState`, so a query string no longer type-checks. That is the type change doing its job, and the HTTP route is exactly the untyped boundary the runtime guard was meant for.

An unrecognised state is **refused**, because dropping it widens the query — the caller asked for one state and would receive every release, and a client paging through what it believes is a filtered list has no way to notice. There is a control asserting a valid state still passes, so the guard cannot be "refuse everything".

`timezone` is required rather than defaulted to UTC: it is the author's intent, and guessing it puts content live an hour early twice a year.

## Tests

- **7** route-parser cases, including that a site's own `releases` collection under `/api/collections/releases` is untouched — the reason the permission resource is `content-releases` and not `releases` is that "press releases" is a collection real sites have
- **8** authority cases, asserting **what was asked of the permission gate** rather than the response status, because a refusal and a wrong-permission grant can produce the same status

Break-verified by name: authorizing `schedule` as `create` fails the escalation case; trusting the route gate fails the override case; dropping the depth guard fails the depth case.

## Verification

- `check-types` — 22/22
- `lint` — 24/24
- `pnpm --filter nextly test` — 816 files, 10018 passed
- `fallow audit --gate new-only` — **pass**, 0 introduced in all four categories
- changeset covers all 25 lockstep packages

Depends on #1389, which carries a fix that missed #1383's merge window by three minutes.
