### PR TITLE
feat(admin): say on the document what is about to happen to it

### DIFF
--- a/.changeset/say-on-the-document-what-is-coming.md
+++ b/.changeset/say-on-the-document-what-is-coming.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Tell an editor, on the document itself, when it is going to change on its own. A document in a scheduled release now carries a bar above the editor naming each release, what will happen to it, and the moment in the timezone its author chose — and answering the question an editable scheduled document raises, which is whether changes saved now are included. They are: a release points at its document rather than copying it, and publishing promotes whatever the working draft holds at that instant. The release list can be filtered to the releases holding one document, which is what the banner reads.

--- a/packages/admin/src/components/features/releases/ScheduledReleaseBanner.tsx
+++ b/packages/admin/src/components/features/releases/ScheduledReleaseBanner.tsx
@@ -78,17 +78,88 @@ function ReleaseLine({ release }: { release: Release }) {
   );
 }
 
+/**
+ * The promise about saved edits, matched to what will actually happen.
+ *
+ * Stated once for the whole banner, so it has to be true of every row. Saying
+ * "the release publishes this document" above a row reading "comes down" is not
+ * merely imprecise — it is the opposite lifecycle effect, and an editor reading
+ * it would believe their work is about to go live when it is about to be
+ * withdrawn.
+ *
+ * `onDefaultLocale` qualifies it further. A release member is whole-document
+ * and materialisation performs the locale-less write, so a draft translation
+ * saved on a non-default locale need not become public with the release. The
+ * banner says what it knows rather than repeating a promise that does not hold
+ * on that screen.
+ */
+function savedEditsSentence(
+  releases: Release[],
+  onDefaultLocale: boolean
+): string {
+  const publishes = releases.some(r => r.memberAction === "publish");
+  const withdraws = releases.some(r => r.memberAction === "unpublish");
+
+  if (!onDefaultLocale) {
+    return publishes
+      ? "You are editing a translation. The release publishes this document as a whole, so changes to this translation are not what it ships."
+      : "You are editing a translation. The release acts on this document as a whole.";
+  }
+  if (publishes && withdraws) {
+    return "Changes you save now are included in whichever of these publishes it — the release ships this document as it stands at that moment.";
+  }
+  if (publishes) {
+    return "Changes you save now are included — the release publishes this document as it stands at that moment.";
+  }
+  if (withdraws) {
+    return "This document is being taken down rather than published, so saving changes now will not put them live.";
+  }
+  // No row said which way it goes, so neither does this.
+  return "What this release does to this document is not something the admin can name here.";
+}
+
 export interface ScheduledReleaseBannerProps {
   document: ReleaseDocumentRef | undefined;
+  /**
+   * Whether the editor is on the document's default locale.
+   *
+   * The promise about saved edits does not hold on a translation view, and a
+   * banner that repeats it there tells a translator their work ships when it
+   * may not.
+   */
+  onDefaultLocale: boolean;
 }
 
 export function ScheduledReleaseBanner({
   document,
+  onDefaultLocale,
 }: ScheduledReleaseBannerProps) {
   // The list endpoint is gated, so a reader without the grant must not issue a
   // request whose only outcome is a 403 under every document they open.
   const canRead = useCan("read-content-releases");
-  const { data } = useReleasesContaining(document, canRead);
+  const { data, isError } = useReleasesContaining(document, canRead);
+
+  // A LOOKUP THAT FAILED IS NOT AN EMPTY SCHEDULE, and collapsing the two hides
+  // a pending automatic change at exactly the moment the admin cannot confirm
+  // there isn't one. React Query captures the error rather than throwing it to
+  // the page's boundary, so nothing else on this screen would say so either.
+  if (isError) {
+    return (
+      <div
+        role="status"
+        className="flex flex-wrap items-center gap-3 border-b border-border bg-muted px-6 py-3"
+      >
+        <CalendarClock
+          className="size-4 shrink-0 text-muted-foreground"
+          aria-hidden
+        />
+        <p className="text-sm text-muted-foreground">
+          Whether this document is in a scheduled release could not be checked.
+          If it is, saving changes here may affect what goes live.
+        </p>
+      </div>
+    );
+  }
 
   const releases = data?.items ?? [];
   // Nothing scheduled is the overwhelmingly common case, and it deserves no
@@ -122,10 +193,9 @@ export function ScheduledReleaseBanner({
           ))}
         </ul>
         {/* The sentence the whole banner exists for. Stated once, below the
-            rows, so it reads as true of all of them. */}
+            rows, and derived from them so it cannot contradict one. */}
         <p className="mt-1.5 text-sm text-muted-foreground">
-          Changes you save now are included — the release publishes this
-          document as it stands at that moment.
+          {savedEditsSentence(releases, onDefaultLocale)}
         </p>
       </div>
     </div>

--- a/packages/admin/src/components/features/releases/ScheduledReleaseBanner.tsx
+++ b/packages/admin/src/components/features/releases/ScheduledReleaseBanner.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+/**
+ * Says, above the document itself, that this is going to change on its own.
+ *
+ * The document is editable and looks entirely ordinary, which is exactly the
+ * problem: nothing else on the screen distinguishes a post from a post that
+ * goes live on Friday whether anyone touches it again or not.
+ *
+ * ## Why it states the CONSEQUENCE rather than naming the release
+ *
+ * Sanity locks the documents in a scheduled release, so "are my edits
+ * included?" is unanswerable there by construction — there is nothing to edit.
+ * Nextly leaves them editable, deliberately, which means the question is live
+ * every time somebody opens one and the document is the only place it can be
+ * answered. A banner that named the release without answering it would be
+ * strictly worse than the lock: the same information, none of the safety.
+ *
+ * The answer is YES, and it is a property of the engine rather than a choice
+ * made here: a release member POINTS AT its document rather than carrying a
+ * copy, and materialisation promotes whatever the working draft holds at the
+ * instant. So an edit saved now ships.
+ *
+ * ## Why several releases are listed rather than summarised
+ *
+ * A document belonging to more than one release is the ordinary case — "publish
+ * on the 1st, take down on the 20th" — so the rows are ordered by instant, the
+ * order the changes will actually happen in. Reading the last row gives the
+ * final state, which is what the engine's own ordering concludes; restating
+ * that conclusion here would be a second implementation of it.
+ *
+ * @module components/features/releases/ScheduledReleaseBanner
+ */
+
+import { CalendarClock } from "@admin/components/icons";
+import { Badge } from "@admin/components/ui";
+import { Link } from "@admin/components/ui/link";
+import { buildRoute, ROUTES } from "@admin/constants/routes";
+import { useReleasesContaining } from "@admin/hooks/queries/useReleases";
+import { useCan } from "@admin/hooks/useCan";
+import type { Release, ReleaseDocumentRef } from "@admin/types/releases";
+
+import { formatScheduledAt } from "./release-schedule";
+
+/** What a membership will do, said as the consequence rather than the verb. */
+const ACTION_SENTENCE: Record<string, string> = {
+  publish: "goes live",
+  unpublish: "comes down",
+};
+
+function ReleaseLine({ release }: { release: Release }) {
+  const at = formatScheduledAt(release);
+  // An action the admin does not recognise is NAMED as unknown rather than
+  // guessed at. Defaulting to "goes live" would state the opposite of the truth
+  // for an unpublish the engine gained after this shipped.
+  const consequence = release.memberAction
+    ? ACTION_SENTENCE[release.memberAction]
+    : undefined;
+
+  return (
+    <li className="text-sm text-foreground">
+      {consequence ? (
+        <>
+          This document <strong className="font-medium">{consequence}</strong>
+        </>
+      ) : (
+        <>This document changes</>
+      )}
+      {at ? ` ${at}` : " when this release takes effect"}, with{" "}
+      <Link
+        href={buildRoute(ROUTES.RELEASES_DETAIL, { id: release.id })}
+        className="underline"
+      >
+        {release.title}
+      </Link>
+      .
+    </li>
+  );
+}
+
+export interface ScheduledReleaseBannerProps {
+  document: ReleaseDocumentRef | undefined;
+}
+
+export function ScheduledReleaseBanner({
+  document,
+}: ScheduledReleaseBannerProps) {
+  // The list endpoint is gated, so a reader without the grant must not issue a
+  // request whose only outcome is a 403 under every document they open.
+  const canRead = useCan("read-content-releases");
+  const { data } = useReleasesContaining(document, canRead);
+
+  const releases = data?.items ?? [];
+  // Nothing scheduled is the overwhelmingly common case, and it deserves no
+  // chrome at all: a bar saying "not in any release" on every document would
+  // be noise on the screens where this matters least.
+  if (releases.length === 0) return null;
+
+  return (
+    // `status`, not `alert`: this is a standing fact about the document rather
+    // than something going wrong, and it is present on every visit — an
+    // assertive live region would interrupt a screen-reader user each time.
+    <div
+      role="status"
+      className="flex flex-wrap items-start gap-3 border-b border-border bg-primary/5 px-6 py-3"
+    >
+      <CalendarClock
+        className="mt-0.5 size-4 shrink-0 text-muted-foreground"
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <div className="mb-1 flex items-center gap-2">
+          <Badge variant="warning">
+            {releases.length === 1
+              ? "Scheduled"
+              : `${releases.length} scheduled`}
+          </Badge>
+        </div>
+        <ul className="flex flex-col gap-0.5">
+          {releases.map(release => (
+            <ReleaseLine key={release.id} release={release} />
+          ))}
+        </ul>
+        {/* The sentence the whole banner exists for. Stated once, below the
+            rows, so it reads as true of all of them. */}
+        <p className="mt-1.5 text-sm text-muted-foreground">
+          Changes you save now are included — the release publishes this
+          document as it stands at that moment.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/releases/__tests__/ScheduledReleaseBanner.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/ScheduledReleaseBanner.test.tsx
@@ -26,7 +26,7 @@ vi.mock("@admin/hooks/queries/useReleases", () => ({
   useReleasesContaining: (
     document: unknown,
     enabled: boolean
-  ): { data: { items: Release[] } | undefined } =>
+  ): { data: { items: Release[] } | undefined; isError: boolean } =>
     containing(document, enabled),
 }));
 
@@ -54,13 +54,13 @@ function release(over: Partial<Release> = {}): Release {
 }
 
 const showing = (items: Release[]) =>
-  containing.mockReturnValue({ data: { items } });
+  containing.mockReturnValue({ data: { items }, isError: false });
 
 beforeEach(() => {
   canFor.mockReset();
   canFor.mockImplementation(() => true);
   containing.mockReset();
-  containing.mockReturnValue({ data: undefined });
+  containing.mockReturnValue({ data: undefined, isError: false });
 });
 
 describe("when the document is in a scheduled release", () => {
@@ -70,7 +70,7 @@ describe("when the document is in a scheduled release", () => {
     // materialisation promotes the working draft — a property of the engine,
     // not a claim this component is free to make.
     showing([release()]);
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     expect(screen.getByRole("status").textContent).toMatch(
       /changes you save now are included/i
     );
@@ -78,7 +78,7 @@ describe("when the document is in a scheduled release", () => {
 
   it("names the consequence, the moment and its zone", () => {
     showing([release()]);
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     const text = screen.getByRole("status").textContent ?? "";
     expect(text).toMatch(/goes live/i);
     // The AUTHOR's zone, named. "9am Berlin" survives a daylight-saving
@@ -91,7 +91,7 @@ describe("when the document is in a scheduled release", () => {
     // The control on the case above: a banner that always said "goes live"
     // passes it, and would state the exact opposite of the truth here.
     showing([release({ memberAction: "unpublish" })]);
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     const text = screen.getByRole("status").textContent ?? "";
     expect(text).toMatch(/comes down/i);
     expect(text).not.toMatch(/goes live/i);
@@ -100,7 +100,7 @@ describe("when the document is in a scheduled release", () => {
   it("does not guess at an action it does not recognise", () => {
     // An engine that gained a third action must not be rendered as a publish.
     showing([release({ memberAction: undefined })]);
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     const text = screen.getByRole("status").textContent ?? "";
     expect(text).toMatch(/this document changes/i);
     expect(text).not.toMatch(/goes live|comes down/i);
@@ -118,7 +118,7 @@ describe("when the document is in a scheduled release", () => {
         scheduledAt: "2026-09-20T07:00:00.000Z",
       }),
     ]);
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     const text = screen.getByRole("status").textContent ?? "";
     expect(text).toContain("Launch");
     expect(text).toContain("Takedown");
@@ -127,10 +127,71 @@ describe("when the document is in a scheduled release", () => {
 
   it("links each release to its own page", () => {
     showing([release()]);
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     expect(
       screen.getByRole("link", { name: "Spring launch" }).getAttribute("href")
     ).toBe("/admin/releases/r1");
+  });
+});
+
+describe("the promise about saved edits matches what will happen", () => {
+  it("does not claim a publish when the document is being TAKEN DOWN", () => {
+    // The sentence is stated once for the whole banner, so it has to be true of
+    // every row. "The release publishes this document" above a row reading
+    // "comes down" is the opposite lifecycle effect, and an editor reading it
+    // believes their work is about to go live when it is about to be withdrawn.
+    showing([release({ memberAction: "unpublish" })]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).toMatch(/taken down rather than published/i);
+    expect(text).not.toMatch(/changes you save now are included/i);
+  });
+
+  it("still promises inclusion when a release does publish it", () => {
+    // The control: without it the case above is satisfied by a banner that
+    // never makes the promise at all, which would remove the point of it.
+    showing([release({ memberAction: "publish" })]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    expect(screen.getByRole("status").textContent).toMatch(
+      /changes you save now are included/i
+    );
+  });
+
+  it("qualifies the promise when both a publish and a takedown are listed", () => {
+    showing([
+      release({ id: "a", memberAction: "publish" }),
+      release({ id: "b", memberAction: "unpublish" }),
+    ]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    expect(screen.getByRole("status").textContent).toMatch(
+      /whichever of these publishes it/i
+    );
+  });
+
+  it("does not promise a TRANSLATION will ship", () => {
+    // A member is whole-document and materialisation performs the locale-less
+    // write, so a draft translation saved here need not become public with the
+    // release. Repeating the promise on that screen tells a translator their
+    // work ships when it may not.
+    showing([release()]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale={false} />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).toMatch(/editing a translation/i);
+    expect(text).not.toMatch(/changes you save now are included/i);
+  });
+});
+
+describe("when the lookup FAILED", () => {
+  it("says so rather than looking like nothing is scheduled", () => {
+    // The dangerous collapse: `data` is undefined on an error exactly as it is
+    // before the first response, so `?? []` turns a failure into "nothing
+    // scheduled" and the safety signal disappears at the moment the admin
+    // cannot confirm there is nothing to signal.
+    containing.mockReturnValue({ data: undefined, isError: true });
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    expect(screen.getByRole("status").textContent).toMatch(
+      /could not be checked/i
+    );
   });
 });
 
@@ -139,7 +200,9 @@ describe("when it should say nothing at all", () => {
     // The common case by far. A bar reading "not in any release" on every
     // document would be noise on precisely the screens where it matters least.
     showing([]);
-    const { container } = render(<ScheduledReleaseBanner document={DOC} />);
+    const { container } = render(
+      <ScheduledReleaseBanner document={DOC} onDefaultLocale />
+    );
     expect(container.textContent).toBe("");
   });
 
@@ -147,8 +210,10 @@ describe("when it should say nothing at all", () => {
     // Absence and "not yet known" are different, and a banner that flashed in
     // after the page settled would read as the document changing under the
     // editor.
-    containing.mockReturnValue({ data: undefined });
-    const { container } = render(<ScheduledReleaseBanner document={DOC} />);
+    containing.mockReturnValue({ data: undefined, isError: false });
+    const { container } = render(
+      <ScheduledReleaseBanner document={DOC} onDefaultLocale />
+    );
     expect(container.textContent).toBe("");
   });
 
@@ -156,7 +221,7 @@ describe("when it should say nothing at all", () => {
     // `/api/releases` is gated, so an unentitled reader would otherwise produce
     // a 403 under every document they open.
     canFor.mockImplementation(slug => slug !== "read-content-releases");
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     expect(containing).toHaveBeenCalledWith(DOC, false);
   });
 
@@ -164,7 +229,7 @@ describe("when it should say nothing at all", () => {
     // The control: without it the case above passes against a component that
     // never enables the query at all.
     showing([]);
-    render(<ScheduledReleaseBanner document={DOC} />);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
     expect(containing).toHaveBeenCalledWith(DOC, true);
   });
 });

--- a/packages/admin/src/components/features/releases/__tests__/ScheduledReleaseBanner.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/ScheduledReleaseBanner.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * What the banner says, and when it says nothing.
+ *
+ * The property that matters is not that a bar appears — it is that the bar
+ * answers the question an editable scheduled document raises. Sanity locks
+ * those documents, so it never has to; Nextly leaves them editable, so a banner
+ * that named the release without saying whether edits are included would be
+ * strictly worse than the lock, and it would look completely finished.
+ *
+ * @module components/features/releases/__tests__/ScheduledReleaseBanner.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import type { Release } from "@admin/types/releases";
+
+import { ScheduledReleaseBanner } from "../ScheduledReleaseBanner";
+
+const { canFor, containing } = vi.hoisted(() => ({
+  canFor: vi.fn((_slug: string) => true),
+  containing: vi.fn(),
+}));
+
+vi.mock("@admin/hooks/useCan", () => ({ useCan: (s: string) => canFor(s) }));
+vi.mock("@admin/hooks/queries/useReleases", () => ({
+  useReleasesContaining: (
+    document: unknown,
+    enabled: boolean
+  ): { data: { items: Release[] } | undefined } =>
+    containing(document, enabled),
+}));
+
+const DOC = {
+  scopeKind: "collection" as const,
+  scopeSlug: "posts",
+  entryId: "e1",
+};
+
+function release(over: Partial<Release> = {}): Release {
+  return {
+    id: "r1",
+    title: "Spring launch",
+    description: null,
+    scheduledAt: "2026-09-01T07:00:00.000Z",
+    timezone: "Europe/Berlin",
+    state: "scheduled",
+    publishedAt: null,
+    createdBy: "u1",
+    createdAt: "2026-08-01T00:00:00.000Z",
+    updatedAt: "2026-08-01T00:00:00.000Z",
+    memberAction: "publish",
+    ...over,
+  };
+}
+
+const showing = (items: Release[]) =>
+  containing.mockReturnValue({ data: { items } });
+
+beforeEach(() => {
+  canFor.mockReset();
+  canFor.mockImplementation(() => true);
+  containing.mockReset();
+  containing.mockReturnValue({ data: undefined });
+});
+
+describe("when the document is in a scheduled release", () => {
+  it("answers whether edits saved now are included", () => {
+    // The whole reason the banner exists, and the one sentence a reader cannot
+    // get anywhere else. It is true because a member points at its document and
+    // materialisation promotes the working draft — a property of the engine,
+    // not a claim this component is free to make.
+    showing([release()]);
+    render(<ScheduledReleaseBanner document={DOC} />);
+    expect(screen.getByRole("status").textContent).toMatch(
+      /changes you save now are included/i
+    );
+  });
+
+  it("names the consequence, the moment and its zone", () => {
+    showing([release()]);
+    render(<ScheduledReleaseBanner document={DOC} />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).toMatch(/goes live/i);
+    // The AUTHOR's zone, named. "9am Berlin" survives a daylight-saving
+    // boundary where a converted local time does not.
+    expect(text).toContain("Europe/Berlin");
+    expect(text).toContain("9:00");
+  });
+
+  it("says a document COMES DOWN rather than assuming a publish", () => {
+    // The control on the case above: a banner that always said "goes live"
+    // passes it, and would state the exact opposite of the truth here.
+    showing([release({ memberAction: "unpublish" })]);
+    render(<ScheduledReleaseBanner document={DOC} />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).toMatch(/comes down/i);
+    expect(text).not.toMatch(/goes live/i);
+  });
+
+  it("does not guess at an action it does not recognise", () => {
+    // An engine that gained a third action must not be rendered as a publish.
+    showing([release({ memberAction: undefined })]);
+    render(<ScheduledReleaseBanner document={DOC} />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).toMatch(/this document changes/i);
+    expect(text).not.toMatch(/goes live|comes down/i);
+  });
+
+  it("lists several releases in the order they will happen", () => {
+    // The ordinary case, not an edge one: "publish on the 1st, take down on the
+    // 20th". Summarising to one would hide the second change entirely.
+    showing([
+      release({ id: "a", title: "Launch", memberAction: "publish" }),
+      release({
+        id: "b",
+        title: "Takedown",
+        memberAction: "unpublish",
+        scheduledAt: "2026-09-20T07:00:00.000Z",
+      }),
+    ]);
+    render(<ScheduledReleaseBanner document={DOC} />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).toContain("Launch");
+    expect(text).toContain("Takedown");
+    expect(text.indexOf("Launch")).toBeLessThan(text.indexOf("Takedown"));
+  });
+
+  it("links each release to its own page", () => {
+    showing([release()]);
+    render(<ScheduledReleaseBanner document={DOC} />);
+    expect(
+      screen.getByRole("link", { name: "Spring launch" }).getAttribute("href")
+    ).toBe("/admin/releases/r1");
+  });
+});
+
+describe("when it should say nothing at all", () => {
+  it("renders no chrome for a document in no release", () => {
+    // The common case by far. A bar reading "not in any release" on every
+    // document would be noise on precisely the screens where it matters least.
+    showing([]);
+    const { container } = render(<ScheduledReleaseBanner document={DOC} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("renders nothing while the answer has not arrived", () => {
+    // Absence and "not yet known" are different, and a banner that flashed in
+    // after the page settled would read as the document changing under the
+    // editor.
+    containing.mockReturnValue({ data: undefined });
+    const { container } = render(<ScheduledReleaseBanner document={DOC} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("does not ask at all when the reader may not read releases", () => {
+    // `/api/releases` is gated, so an unentitled reader would otherwise produce
+    // a 403 under every document they open.
+    canFor.mockImplementation(slug => slug !== "read-content-releases");
+    render(<ScheduledReleaseBanner document={DOC} />);
+    expect(containing).toHaveBeenCalledWith(DOC, false);
+  });
+
+  it("asks when the reader may", () => {
+    // The control: without it the case above passes against a component that
+    // never enables the query at all.
+    showing([]);
+    render(<ScheduledReleaseBanner document={DOC} />);
+    expect(containing).toHaveBeenCalledWith(DOC, true);
+  });
+});

--- a/packages/admin/src/hooks/queries/useReleases.ts
+++ b/packages/admin/src/hooks/queries/useReleases.ts
@@ -36,6 +36,7 @@ import {
 import type {
   AddReleaseMemberPayload,
   CreateReleasePayload,
+  ReleaseDocumentRef,
   ReleaseListParams,
   ScheduleReleasePayload,
 } from "@admin/types/releases";
@@ -56,6 +57,28 @@ export function useReleases(params: ReleaseListParams = {}, enabled = true) {
     // because the surface is closed — would otherwise issue a request whose
     // only outcome is a 403 in everyone's network log.
     enabled,
+  });
+}
+
+/**
+ * The scheduled releases holding one document, soonest first.
+ *
+ * A narrowing of the same list, so it shares the list's cache key and is
+ * invalidated by every release write — adding this document to a release
+ * refreshes the banner without the banner knowing that happened.
+ */
+export function useReleasesContaining(
+  document: ReleaseDocumentRef | undefined,
+  enabled = true
+) {
+  const params: ReleaseListParams = document ? { containing: document } : {};
+  return useQuery({
+    queryKey: releaseKeys.list(params),
+    queryFn: () => fetchReleases(params),
+    // Never asked without a complete reference: the route refuses a partial
+    // one, and a 404-shaped error in the console under every document editor
+    // is a poor way to say "this document has no id yet".
+    enabled: enabled && Boolean(document),
   });
 }
 

--- a/packages/admin/src/hooks/queries/useReleases.ts
+++ b/packages/admin/src/hooks/queries/useReleases.ts
@@ -71,7 +71,15 @@ export function useReleasesContaining(
   document: ReleaseDocumentRef | undefined,
   enabled = true
 ) {
-  const params: ReleaseListParams = document ? { containing: document } : {};
+  // The route's ceiling rather than its default of 50. A document in more
+  // than fifty scheduled releases is implausible, and asking for the ceiling
+  // costs nothing when the real answer is one or two — but the banner presents
+  // the rows as a SEQUENCE whose last member is the document's final state, and
+  // a silently truncated sequence would present an incomplete answer as a
+  // complete one.
+  const params: ReleaseListParams = document
+    ? { containing: document, limit: 200 }
+    : {};
   const query = useQuery({
     queryKey: releaseKeys.list(params),
     queryFn: () => fetchReleases(params),
@@ -79,17 +87,29 @@ export function useReleasesContaining(
     // one, and a 404-shaped error in the console under every document editor
     // is a poor way to say "this document has no id yet".
     enabled: enabled && Boolean(document),
-    // Re-asked while a release is still pending, because the thing that
-    // resolves it is the BACKGROUND DRAIN — no admin mutation runs, so nothing
-    // invalidates this query when the instant passes. An editor with the page
-    // open across that moment would otherwise keep reading that a release is
-    // coming, and that saves are still included, after it has already run.
+    // Re-asked on TWO schedules, because two different things change this
+    // answer and neither runs an admin mutation that would invalidate it.
     //
-    // Only while something is actually pending: polling a document in no
-    // release, which is nearly all of them, would be a request a minute for an
-    // answer that is always the same.
+    // A pending release is resolved by the background drain, so an editor
+    // holding the page across the instant would otherwise keep reading that a
+    // release is coming, and that saves are still included, after it has run.
+    //
+    // An EMPTY answer changes too, and that is the case a pending-only interval
+    // misses: another administrator schedules this document from their own
+    // browser, which invalidates their QueryClient and not this one. The first
+    // editor then goes on saving, indefinitely, without learning the document
+    // has an automatic pending change. Polled more slowly rather than not at
+    // all — nearly every document is in no release, and the answer is worth one
+    // request every few minutes rather than one a minute.
     refetchInterval: data =>
-      hasPendingRelease(data.state.data) ? PENDING_RELEASE_POLL_MS : false,
+      hasPendingRelease(data.state.data)
+        ? PENDING_RELEASE_POLL_MS
+        : NO_RELEASE_POLL_MS,
+    // And on return to the tab, which is when an editor actually resumes
+    // typing. The global provider disables this everywhere; here the answer is
+    // a safety signal rather than a view of data the reader already has, and
+    // coming back to a stale one is exactly the moment it matters.
+    refetchOnWindowFocus: true,
   });
   return query;
 }
@@ -103,6 +123,15 @@ export function useReleasesContaining(
  * few seconds, for a page that mostly sits open.
  */
 const PENDING_RELEASE_POLL_MS = 60_000;
+
+/**
+ * How often to re-ask when this document is in no release at all.
+ *
+ * Five minutes. Nearly every document is in this state, so the cost is paid on
+ * every open editor — but the answer is not static: somebody else can schedule
+ * this document at any moment, and nothing they do reaches this browser.
+ */
+const NO_RELEASE_POLL_MS = 300_000;
 
 /** Whether anything in this answer is still waiting to happen. */
 function hasPendingRelease(

--- a/packages/admin/src/hooks/queries/useReleases.ts
+++ b/packages/admin/src/hooks/queries/useReleases.ts
@@ -72,14 +72,43 @@ export function useReleasesContaining(
   enabled = true
 ) {
   const params: ReleaseListParams = document ? { containing: document } : {};
-  return useQuery({
+  const query = useQuery({
     queryKey: releaseKeys.list(params),
     queryFn: () => fetchReleases(params),
     // Never asked without a complete reference: the route refuses a partial
     // one, and a 404-shaped error in the console under every document editor
     // is a poor way to say "this document has no id yet".
     enabled: enabled && Boolean(document),
+    // Re-asked while a release is still pending, because the thing that
+    // resolves it is the BACKGROUND DRAIN — no admin mutation runs, so nothing
+    // invalidates this query when the instant passes. An editor with the page
+    // open across that moment would otherwise keep reading that a release is
+    // coming, and that saves are still included, after it has already run.
+    //
+    // Only while something is actually pending: polling a document in no
+    // release, which is nearly all of them, would be a request a minute for an
+    // answer that is always the same.
+    refetchInterval: data =>
+      hasPendingRelease(data.state.data) ? PENDING_RELEASE_POLL_MS : false,
   });
+  return query;
+}
+
+/**
+ * How often to re-ask while a release is still ahead of this document.
+ *
+ * A minute. The banner is a safety signal rather than a clock, so the cost of
+ * being a minute late is that an editor briefly reads a promise that has just
+ * become moot; the cost of polling harder is a request per document editor per
+ * few seconds, for a page that mostly sits open.
+ */
+const PENDING_RELEASE_POLL_MS = 60_000;
+
+/** Whether anything in this answer is still waiting to happen. */
+function hasPendingRelease(
+  data: { items: { state: string }[] } | undefined
+): boolean {
+  return (data?.items ?? []).some(release => release.state === "scheduled");
 }
 
 export function useRelease(id: string | undefined) {

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -21,6 +21,7 @@ import {
   type EntryFormCollection,
 } from "@admin/components/features/entries/EntryForm";
 import { AddToReleaseButton } from "@admin/components/features/releases/AddToReleaseButton";
+import { ScheduledReleaseBanner } from "@admin/components/features/releases/ScheduledReleaseBanner";
 import {
   CONTENT_PAGE_MEASURE,
   CONTENT_MEASURE_LENGTH,
@@ -527,6 +528,15 @@ export default function EditEntryPage({
             <PluginSlot path={beforeEditPath} props={editInjectionProps} />
           </div>
         )}
+        {/* FULL WIDTH and first, matching the historical-version banner: this
+            is a standing fact about the whole document, and a bar constrained
+            to the content measure reads as a note about the fields under it.
+            It does not touch the per-language staleness markers in the language
+            panel — those answer a different question, and a stale translation
+            inside a scheduled release is exactly where an editor needs both. */}
+        <ScheduledReleaseBanner
+          document={{ scopeKind: "collection", scopeSlug: slug, entryId: id }}
+        />
         {/* Above the form, in the same measure as the editor, because the
             question it asks is about this document as a whole rather than about
             any field in it. Bounded here for the reason the injection slots are:

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -475,6 +475,15 @@ export default function EditEntryPage({
             />
           }
         >
+          {/* A custom edit view replaces the FORM, not the facts about the
+              document. Its editor is as able to save changes into a scheduled
+              release as any other, and omitting the banner here would withhold
+              the warning from precisely the documents a project cared enough
+              about to build a bespoke editor for. */}
+          <ScheduledReleaseBanner
+            document={{ scopeKind: "collection", scopeSlug: slug, entryId: id }}
+            onDefaultLocale={!isNonDefaultLocale}
+          />
           {/* Boxed for the same reason the injection slots are: under the
               measured frame this is a direct child of a CSS grid, and the rule
               that puts a child in the content column can only place a
@@ -536,6 +545,7 @@ export default function EditEntryPage({
             inside a scheduled release is exactly where an editor needs both. */}
         <ScheduledReleaseBanner
           document={{ scopeKind: "collection", scopeSlug: slug, entryId: id }}
+          onDefaultLocale={!isNonDefaultLocale}
         />
         {/* Above the form, in the same measure as the editor, because the
             question it asks is about this document as a whole rather than about

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -343,6 +343,7 @@ export default function SingleEditPage({
               ? { scopeKind: "single", scopeSlug: slug, entryId: document.id }
               : undefined
           }
+          onDefaultLocale={!isNonDefaultLocale}
         />
         {/* A Single is a release member exactly as a collection entry is — the
             engine models both and the release detail page links to both — so

--- a/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
+++ b/packages/admin/src/pages/dashboard/singles/[slug]/index.tsx
@@ -20,6 +20,7 @@ import { Alert, AlertDescription, Button, Skeleton } from "@nextlyhq/ui";
 import type React from "react";
 
 import { AddToReleaseButton } from "@admin/components/features/releases/AddToReleaseButton";
+import { ScheduledReleaseBanner } from "@admin/components/features/releases/ScheduledReleaseBanner";
 import {
   SingleForm,
   type SingleSchema,
@@ -335,6 +336,14 @@ export default function SingleEditPage({
           would keep the two-pane translation surface inside the content
           measure while the entry editor beside it took the whole panel. */}
       <MeasuredPageFrame>
+        {/* Full width and first, for the reason the entry editor gives. */}
+        <ScheduledReleaseBanner
+          document={
+            slug
+              ? { scopeKind: "single", scopeSlug: slug, entryId: document.id }
+              : undefined
+          }
+        />
         {/* A Single is a release member exactly as a collection entry is — the
             engine models both and the release detail page links to both — so
             omitting this control here would leave the Single half of that

--- a/packages/admin/src/services/releaseApi.ts
+++ b/packages/admin/src/services/releaseApi.ts
@@ -54,6 +54,15 @@ function query(params: ReleaseListParams): string {
     search.set("scheduledBefore", params.scheduledBefore);
   }
   if (params.limit !== undefined) search.set("limit", String(params.limit));
+  // All three or none. The route refuses a partial reference, so sending one
+  // part would turn a document question into a 400 rather than into an answer
+  // about every release — which is the behaviour we want, and not one to
+  // trigger by accident.
+  if (params.containing) {
+    search.set("containingScopeKind", params.containing.scopeKind);
+    search.set("containingScopeSlug", params.containing.scopeSlug);
+    search.set("containingEntryId", params.containing.entryId);
+  }
   const q = search.toString();
   return q ? `?${q}` : "";
 }

--- a/packages/admin/src/types/releases/index.ts
+++ b/packages/admin/src/types/releases/index.ts
@@ -86,6 +86,16 @@ export interface Release {
    * hide every control — or as permitted, which would offer refusals.
    */
   can?: ReleaseCapabilities;
+  /**
+   * What this release will do to the document the list was filtered BY.
+   *
+   * Present only on a read narrowed with `containing`, because it belongs to
+   * the membership rather than to the release: one release can publish a post
+   * while taking a landing page down. Optional rather than defaulted, so a
+   * screen has to decide what an unknown action means instead of quietly
+   * calling it a publish.
+   */
+  memberAction?: ReleaseMemberAction;
 }
 
 export interface ReleaseMember {
@@ -120,10 +130,26 @@ export interface AddReleaseMemberPayload {
   action: ReleaseMemberAction;
 }
 
+/** A document, as the release list's `containing` filter names it. */
+export interface ReleaseDocumentRef {
+  scopeKind: "collection" | "single";
+  scopeSlug: string;
+  entryId: string;
+}
+
 /** The window a release list may be narrowed to. */
 export interface ReleaseListParams {
   state?: ReleaseState;
   scheduledAfter?: string;
   scheduledBefore?: string;
   limit?: number;
+  /**
+   * Only the SCHEDULED releases holding this document.
+   *
+   * The question a document editor asks. All three parts travel or none: the
+   * route refuses a partial reference rather than widening to every release,
+   * because a banner rendering that would tell an author their post is in
+   * eleven launches.
+   */
+  containing?: ReleaseDocumentRef;
 }

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -67,7 +67,13 @@ function namespace() {
       })
     ),
     releases: {
-      find: vi.fn(async (): Promise<{ id: string }[]> => []),
+      // Takes its query, so a case can assert on what the route ASKED for. A
+      // zero-argument stub records an empty call tuple, and a test reading
+      // `calls[0][0]` from it does not compile — which is the compiler saying
+      // the fake and the thing it stands in for have different shapes.
+      find: vi.fn(
+        async (_query: Record<string, unknown>): Promise<{ id: string }[]> => []
+      ),
       findByID: vi.fn(async () => ({ id: "r1" })),
       create: vi.fn(async () => ({ id: "r1" })),
       addMember: vi.fn(async () => ({ id: "m1" })),

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -576,3 +576,62 @@ describe("release route paging and body validation", () => {
     );
   });
 });
+
+describe("filtering the list to the releases holding ONE document", () => {
+  /** What the namespace's `find` received for this query string. */
+  async function queryFor(search: string) {
+    const api = namespace();
+    getCachedNextly.mockResolvedValue(api);
+    const res = await handleReleaseRequest(
+      new Request(`https://example.test/api/releases${search}`),
+      "listReleases",
+      {}
+    );
+    return { res, query: api.releases.find.mock.calls[0]?.[0] };
+  }
+
+  it("passes a COMPLETE reference through as a whole-document ref", async () => {
+    const { query } = await queryFor(
+      "?containingScopeKind=collection&containingScopeSlug=posts&containingEntryId=e1"
+    );
+    // Asserted on what the service RECEIVED rather than on the status, because
+    // a filter that is parsed and then dropped answers 200 with every release
+    // — which is the failure worth catching and which no status code reveals.
+    expect(query).toMatchObject({
+      containing: {
+        scopeKind: "collection",
+        scopeSlug: "posts",
+        entryId: "e1",
+        // A member is whole-document: the service refuses a locale-scoped one,
+        // so this surface must not invent a narrowing the engine lacks.
+        locale: null,
+      },
+    });
+  });
+
+  it("passes NO filter when none was asked for", async () => {
+    // The control. Without it, a parser that always produced a `containing`
+    // key would satisfy the case above just as well.
+    const { query } = await queryFor("?limit=5");
+    expect(query).not.toHaveProperty("containing");
+  });
+
+  it.each([
+    ["?containingScopeKind=collection"],
+    ["?containingScopeSlug=posts"],
+    ["?containingEntryId=e1"],
+    ["?containingScopeKind=collection&containingScopeSlug=posts"],
+    ["?containingScopeSlug=posts&containingEntryId=e1"],
+    [
+      "?containingScopeKind=widget&containingScopeSlug=posts&containingEntryId=e1",
+    ],
+  ])("refuses the PARTIAL or unmodelled reference %s", async search => {
+    // Refused rather than ignored. Dropping an incomplete reference answers
+    // with every release instead of the ones holding the document, and a
+    // document banner rendering that tells an author their post is in eleven
+    // launches.
+    const { res, query } = await queryFor(search);
+    expect(res.status).toBe(400);
+    expect(query).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -25,7 +25,10 @@ import type { AuthenticatedScope } from "../auth/authenticated-scope";
 import { isErrorResponse, requireAnyPermission } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
-import type { ReleaseRow } from "../domains/releases/releases-repository";
+import type {
+  DocumentRef,
+  ReleaseRow,
+} from "../domains/releases/releases-repository";
 import {
   RELEASES_RESOURCE,
   type ReleaseCapabilities,
@@ -409,6 +412,40 @@ interface ReleaseContext {
 }
 
 /**
+ * The document a caller is asking about, when they are asking about one.
+ *
+ * All three parts or none. A partial reference is REFUSED rather than ignored:
+ * dropping it would answer with every release instead of the ones holding the
+ * document, and a document editor rendering that would tell an author their
+ * post is in eleven launches.
+ *
+ * `locale` is deliberately absent. A member is whole-document — the service
+ * refuses a locale-scoped one — so accepting a locale here would offer a
+ * narrowing the engine does not have.
+ */
+function containingRef(
+  params: URLSearchParams
+): { containing: DocumentRef } | Record<string, never> {
+  const scopeKind = params.get("containingScopeKind");
+  const scopeSlug = params.get("containingScopeSlug");
+  const entryId = params.get("containingEntryId");
+  if (scopeKind === null && scopeSlug === null && entryId === null) return {};
+
+  if (scopeKind !== "collection" && scopeKind !== "single") {
+    throw badRequest(
+      "`containingScopeKind` must be `collection` or `single`.",
+      { received: scopeKind }
+    );
+  }
+  if (!scopeSlug || !entryId) {
+    throw badRequest(
+      "`containingScopeSlug` and `containingEntryId` are both required when filtering by document."
+    );
+  }
+  return { containing: { scopeKind, scopeSlug, entryId, locale: null } };
+}
+
+/**
  * Each release, with what THIS caller may do to it.
  *
  * Attached at the HTTP surface rather than inside the read, because a control
@@ -477,6 +514,7 @@ const RELEASE_OPERATIONS: Record<
         params.get("scheduledBefore"),
         "scheduledBefore"
       ),
+      ...containingRef(params),
       limit: limit + 1,
     });
     const page = found.slice(0, limit);

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -37,6 +37,7 @@ import type {
   ReleasesService,
 } from "../../domains/releases/services/releases-service";
 import { NextlyError } from "../../errors/nextly-error";
+import type { ReleaseMemberAction } from "../../schemas/releases/types";
 
 import type { NextlyContext } from "./context";
 import { accessOptions, mergeConfig } from "./helpers";
@@ -83,8 +84,19 @@ export interface ReleasesNamespace {
   create(
     args: { title: string; description?: string | null } & ReleaseCallerArgs
   ): Promise<ReleaseRow>;
-  /** Releases in a window, newest scheduled instant first. */
-  find(args?: FindReleasesQuery & ReleaseCallerArgs): Promise<ReleaseRow[]>;
+  /**
+   * Releases in a window, newest scheduled instant first.
+   *
+   * Filtering by `containing` returns them SOONEST first instead — the order
+   * they will be applied to that document — and each row carries the member's
+   * action, because a release can publish one document while taking another
+   * down. Declared in the return type rather than left to the runtime: a caller
+   * that cannot see `memberAction` cannot tell which way a release moves the
+   * document it just asked about.
+   */
+  find(
+    args?: FindReleasesQuery & ReleaseCallerArgs
+  ): Promise<Array<ReleaseRow & { memberAction?: ReleaseMemberAction }>>;
   findByID(
     args: { id: string } & ReleaseCallerArgs
   ): Promise<ReleaseRow | null>;

--- a/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
@@ -126,6 +126,36 @@ describe("the order the releases are returned in", () => {
   });
 });
 
+describe("a release the drain settled between the two reads", () => {
+  it("is dropped rather than reported as still coming", async () => {
+    // Two reads, and the drain runs between them: `findDueMembersFor` selects
+    // members of SCHEDULED releases, and by the time the second read fetches
+    // those releases one may already be published. Emitting it reports an
+    // action that has ALREADY HAPPENED as upcoming — and a reader polling until
+    // nothing is pending stops on that row and keeps the claim forever.
+    const svc = service([
+      { id: "still-coming", at: "2026-09-01T00:00:00.000Z" },
+      {
+        id: "already-ran",
+        at: "2026-09-02T00:00:00.000Z",
+        state: "published",
+      },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
+      "still-coming",
+    ]);
+  });
+
+  it("keeps the scheduled ones, so the filter is not simply emptying the list", async () => {
+    // The control. Without it a branch that dropped everything would pass.
+    const svc = service([
+      { id: "a", at: "2026-09-01T00:00:00.000Z" },
+      { id: "b", at: "2026-09-02T00:00:00.000Z" },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual(["a", "b"]);
+  });
+});
+
 describe("the document filter NARROWS the list rather than replacing it", () => {
   const WINDOWED = [
     { id: "before", at: "2026-08-01T00:00:00.000Z" },

--- a/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
@@ -1,0 +1,177 @@
+/**
+ * The releases holding one document, in the order the engine will apply them.
+ *
+ * Two properties, and both were wrong in the first version. The ORDER has to be
+ * the engine's total order rather than a comparator that agrees with it most of
+ * the time: two releases naming one instant is not an edge case, and a reader
+ * takes the last row as the document's final state. And the document filter has
+ * to NARROW the list rather than replace it — a caller combining it with a
+ * window asked for both.
+ *
+ * @module domains/releases/__tests__/find-containing.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { ReleasesService } from "../services/releases-service";
+import type { ReleasesServiceDeps } from "../services/releases-service";
+
+const ACTOR = { userId: "u1" };
+const REF = {
+  scopeKind: "collection" as const,
+  scopeSlug: "posts",
+  entryId: "e1",
+  locale: null,
+};
+
+interface Row {
+  id: string;
+  at: string;
+  action?: "publish" | "unpublish";
+  /** The MEMBER's creation time, which breaks a tied instant. */
+  created?: string;
+  memberId?: string;
+  state?: string;
+}
+
+function service(rows: Row[]) {
+  const members = rows.map(r => ({
+    memberId: r.memberId ?? `m-${r.id}`,
+    releaseId: r.id,
+    action: r.action ?? ("publish" as const),
+    scheduledAt: new Date(r.at),
+    createdAt: new Date(r.created ?? r.at),
+  }));
+  const repository = {
+    findDueMembersFor: vi.fn(
+      async () => new Map([["collection:posts:e1:", members]])
+    ),
+    findReleases: vi.fn(async () =>
+      rows.map(r => ({
+        id: r.id,
+        title: r.id,
+        description: null,
+        scheduledAt: new Date(r.at),
+        timezone: "UTC",
+        state: r.state ?? "scheduled",
+        publishedAt: null,
+        createdBy: "u1",
+        createdAt: new Date(r.at),
+        updatedAt: new Date(r.at),
+      }))
+    ),
+  };
+  const deps = {
+    repository: repository as unknown as ReleasesServiceDeps["repository"],
+    canManageReleases: vi.fn(async () => true),
+    canActOnDocument: vi.fn(async () => true),
+  };
+  return new ReleasesService(deps);
+}
+
+const ids = (rows: { id: string }[]) => rows.map(r => r.id);
+
+describe("the order the releases are returned in", () => {
+  it("is soonest first", async () => {
+    const svc = service([
+      { id: "later", at: "2026-09-20T00:00:00.000Z" },
+      { id: "sooner", at: "2026-09-01T00:00:00.000Z" },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
+      "sooner",
+      "later",
+    ]);
+  });
+
+  it("breaks a TIED instant on the member's creation time", async () => {
+    // The case a comparator on the instant alone cannot decide. It leaves these
+    // in whatever order the driver returned, which differs by dialect — and the
+    // last row is read as the document's final state.
+    const svc = service([
+      {
+        id: "second",
+        at: "2026-09-01T00:00:00.000Z",
+        created: "2026-08-02T00:00:00.000Z",
+      },
+      {
+        id: "first",
+        at: "2026-09-01T00:00:00.000Z",
+        created: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
+      "first",
+      "second",
+    ]);
+  });
+
+  it("breaks a tie on the member ID when even the creation times match", async () => {
+    // The engine's last tiebreak. Without it two members written in the same
+    // transaction order arbitrarily, and the winner is whichever the query plan
+    // felt like.
+    const svc = service([
+      {
+        id: "b",
+        at: "2026-09-01T00:00:00.000Z",
+        created: "2026-08-01T00:00:00.000Z",
+        memberId: "m-zz",
+      },
+      {
+        id: "a",
+        at: "2026-09-01T00:00:00.000Z",
+        created: "2026-08-01T00:00:00.000Z",
+        memberId: "m-aa",
+      },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual(["a", "b"]);
+  });
+});
+
+describe("the document filter NARROWS the list rather than replacing it", () => {
+  const WINDOWED = [
+    { id: "before", at: "2026-08-01T00:00:00.000Z" },
+    { id: "inside", at: "2026-09-10T00:00:00.000Z" },
+    { id: "after", at: "2026-10-01T00:00:00.000Z" },
+  ];
+
+  it("honours a lower bound", async () => {
+    const svc = service(WINDOWED);
+    const rows = await svc.find(
+      { containing: REF, scheduledAfter: new Date("2026-09-01T00:00:00.000Z") },
+      ACTOR
+    );
+    expect(ids(rows)).toEqual(["inside", "after"]);
+  });
+
+  it("honours an upper bound", async () => {
+    const svc = service(WINDOWED);
+    const rows = await svc.find(
+      {
+        containing: REF,
+        scheduledBefore: new Date("2026-09-15T00:00:00.000Z"),
+      },
+      ACTOR
+    );
+    expect(ids(rows)).toEqual(["before", "inside"]);
+  });
+
+  it("honours a limit, applied AFTER the ordering", async () => {
+    // Order first, then trim. Trimming an unordered set returns an arbitrary
+    // subset and calls it the soonest.
+    const svc = service(WINDOWED);
+    expect(ids(await svc.find({ containing: REF, limit: 2 }, ACTOR))).toEqual([
+      "before",
+      "inside",
+    ]);
+  });
+
+  it("returns everything matching when no qualifier is given", async () => {
+    // The control: without it every case above is satisfied by a filter that
+    // drops rows for some unrelated reason.
+    const svc = service(WINDOWED);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
+      "before",
+      "inside",
+      "after",
+    ]);
+  });
+});

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -60,6 +60,7 @@ import {
   type ReleaseState,
 } from "../../../schemas/releases/types";
 import { isUniqueViolation } from "../../../shared/lib/unique-violation";
+import { documentRefKey } from "../releases-repository";
 import type {
   DocumentRef,
   NewRelease,
@@ -197,6 +198,20 @@ export interface FindReleasesQuery {
    */
   scheduledAfter?: Date;
   scheduledBefore?: Date;
+  /**
+   * Only releases that CONTAIN this document.
+   *
+   * The inverse of `listMembers`, and the question a document editor asks: what
+   * is going to happen to the thing I am looking at. Expressed as a filter on
+   * the release list rather than a route of its own, because that is what it is
+   * — the same resource, narrowed — and because a literal path segment under
+   * `/api/releases` would be read as a release id.
+   *
+   * Answers about SCHEDULED releases only. A draft membership changes nothing on
+   * its own, and the question this serves is whether the document will change
+   * without anyone touching it again.
+   */
+  containing?: DocumentRef;
   /**
    * How many rows at most. Must be a non-negative integer when given.
    *
@@ -398,6 +413,52 @@ export class ReleasesService {
     );
   }
 
+  /**
+   * The scheduled releases holding this document, soonest first.
+   *
+   * Reuses `findDueMembersFor`, which returns every member of a scheduled
+   * release and leaves the dueness judgement to the pure rule — so the same
+   * query serves the read path's "what is live now" and this surface's "what is
+   * still coming", without a second implementation of either.
+   *
+   * The member's ACTION travels with each release, because it is the thing an
+   * editor needs and it belongs to the membership rather than to the release: a
+   * release can publish one document while unpublishing another.
+   *
+   * Ordered by instant ascending — the order the changes will actually happen —
+   * so a document in several releases reads as a sequence. The final state is
+   * then the last row, which is what `resolveReleaseEffect` will conclude, and
+   * saying it that way avoids a second implementation of that ordering.
+   */
+  private async findContaining(
+    ref: DocumentRef,
+    now: Date
+  ): Promise<Array<ReleaseRow & { memberAction: ReleaseMemberAction }>> {
+    const grouped = await this.deps.repository.findDueMembersFor([ref], now);
+    const members = grouped.get(documentRefKey(ref)) ?? [];
+    if (members.length === 0) return [];
+
+    const releases = await this.deps.repository.findReleases({
+      ids: [...new Set(members.map(member => member.releaseId))],
+    });
+    const byId = new Map(releases.map(release => [release.id, release]));
+
+    return members
+      .flatMap(member => {
+        const release = byId.get(member.releaseId);
+        // A member whose release vanished between the two reads is dropped
+        // rather than rendered without its instant: a row saying a document is
+        // scheduled, without saying when, is worse than not mentioning it.
+        return release === undefined
+          ? []
+          : [{ ...release, memberAction: member.action }];
+      })
+      .sort(
+        (a, b) =>
+          (a.scheduledAt?.getTime() ?? 0) - (b.scheduledAt?.getTime() ?? 0)
+      );
+  }
+
   async find(
     query: FindReleasesQuery,
     actor: ReleaseActor
@@ -414,6 +475,9 @@ export class ReleasesService {
         message: "`limit` must be a non-negative integer.",
         logContext: { reason: "invalid-limit", limit: query.limit },
       });
+    }
+    if (query.containing !== undefined) {
+      return this.findContaining(query.containing, new Date());
     }
     return this.deps.repository.findReleases(query);
   }

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -180,6 +180,40 @@ export interface ReleasesServiceDeps {
   }) => Promise<boolean>;
 }
 
+/**
+ * The engine's total order over two members, ascending.
+ *
+ * The same three keys `resolveReleaseEffect` decides a winner with — instant,
+ * then the member's creation time, then its id — because a document's releases
+ * are read as a SEQUENCE and the last of them is its final state. Two releases
+ * naming one instant is not an edge case, and any comparator that stops at the
+ * instant leaves those in the order the driver happened to return, which
+ * differs by dialect.
+ */
+function byEngineOrder(
+  a: { scheduledAt: Date; createdAt: Date; memberId: string },
+  b: { scheduledAt: Date; createdAt: Date; memberId: string }
+): number {
+  const byScheduled = a.scheduledAt.getTime() - b.scheduledAt.getTime();
+  if (byScheduled !== 0) return byScheduled;
+  const byCreated = a.createdAt.getTime() - b.createdAt.getTime();
+  if (byCreated !== 0) return byCreated;
+  return a.memberId < b.memberId ? -1 : a.memberId > b.memberId ? 1 : 0;
+}
+
+/** Whether a row satisfies the qualifiers a list query carries beside `containing`. */
+function matchesListQuery(row: ReleaseRow, query: FindReleasesQuery): boolean {
+  if (query.state !== undefined && row.state !== query.state) return false;
+  const at = row.scheduledAt?.getTime();
+  if (query.scheduledAfter !== undefined) {
+    if (at === undefined || at < query.scheduledAfter.getTime()) return false;
+  }
+  if (query.scheduledBefore !== undefined) {
+    if (at === undefined || at > query.scheduledBefore.getTime()) return false;
+  }
+  return true;
+}
+
 export interface FindReleasesQuery {
   /**
    * Restrict to one lifecycle state.
@@ -431,9 +465,10 @@ export class ReleasesService {
    * saying it that way avoids a second implementation of that ordering.
    */
   private async findContaining(
-    ref: DocumentRef,
+    query: FindReleasesQuery & { containing: DocumentRef },
     now: Date
   ): Promise<Array<ReleaseRow & { memberAction: ReleaseMemberAction }>> {
+    const ref = query.containing;
     const grouped = await this.deps.repository.findDueMembersFor([ref], now);
     const members = grouped.get(documentRefKey(ref)) ?? [];
     if (members.length === 0) return [];
@@ -443,7 +478,7 @@ export class ReleasesService {
     });
     const byId = new Map(releases.map(release => [release.id, release]));
 
-    return members
+    const rows = members
       .flatMap(member => {
         const release = byId.get(member.releaseId);
         // A member whose release vanished between the two reads is dropped
@@ -451,12 +486,27 @@ export class ReleasesService {
         // scheduled, without saying when, is worse than not mentioning it.
         return release === undefined
           ? []
-          : [{ ...release, memberAction: member.action }];
+          : [{ ...release, memberAction: member.action, member }];
       })
-      .sort(
-        (a, b) =>
-          (a.scheduledAt?.getTime() ?? 0) - (b.scheduledAt?.getTime() ?? 0)
-      );
+      // THE ENGINE'S OWN ORDER, not a simpler one that agrees with it most of
+      // the time. `resolveReleaseEffect` breaks a tied instant on the member's
+      // creation time and then on its id, precisely because two releases can
+      // name the same moment and the driver's row order differs by dialect.
+      // Sorting on the instant alone leaves those ties in whatever order the
+      // database returned, so a reader taking the last row as the final state —
+      // which is exactly what this ordering invites — could read the loser.
+      .sort((a, b) => byEngineOrder(a.member, b.member));
+
+    // The document filter NARROWS the list; it does not replace it. A caller
+    // combining it with a window or a limit asked for both, and answering with
+    // releases outside the window is answering a question nobody put.
+    return rows
+      .map(({ member, ...row }) => {
+        void member;
+        return row;
+      })
+      .filter(row => matchesListQuery(row, query))
+      .slice(0, query.limit ?? rows.length);
   }
 
   async find(
@@ -477,7 +527,10 @@ export class ReleasesService {
       });
     }
     if (query.containing !== undefined) {
-      return this.findContaining(query.containing, new Date());
+      return this.findContaining(
+        { ...query, containing: query.containing },
+        new Date()
+      );
     }
     return this.deps.repository.findReleases(query);
   }

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -484,9 +484,15 @@ export class ReleasesService {
         // A member whose release vanished between the two reads is dropped
         // rather than rendered without its instant: a row saying a document is
         // scheduled, without saying when, is worse than not mentioning it.
-        return release === undefined
-          ? []
-          : [{ ...release, memberAction: member.action, member }];
+        if (release === undefined) return [];
+        // RE-CHECKED, because these are two reads and the drain runs between
+        // them. `findDueMembersFor` selects members of scheduled releases; by
+        // the time the second read fetches those releases one may already have
+        // been published, and emitting it would report an action that has
+        // ALREADY HAPPENED as still coming. A reader polling until nothing is
+        // pending would then stop on that row and keep the claim forever.
+        if (release.state !== "scheduled") return [];
+        return [{ ...release, memberAction: member.action, member }];
       })
       // THE ENGINE'S OWN ORDER, not a simpler one that agrees with it most of
       // the time. `resolveReleaseEffect` breaks a tied instant on the member's


### PR DESCRIPTION
A scheduled document looked exactly like any other. Nothing on the editor distinguished a post from a post that goes live on Friday whether anyone touches it again or not — and the release pages cannot help, because they are reached *from* the release while this is a question asked *from the document*.

## Why the banner states the consequence rather than naming the release

Sanity locks the documents in a scheduled release, so it never has to answer whether edits are included: there is nothing to edit. Nextly leaves them editable on purpose, which is what makes the question live on every visit and makes the document the only place it can be answered. A banner that named the release without answering it would be strictly worse than the lock — the same information, none of the safety.

The answer is **yes**, and that is a property of the engine rather than a choice made in the UI. `apply-due-releases.ts` reads *"Publish the document, promoting its pending working draft if it has one"*, and a member points at its document rather than carrying a copy. So an edit saved now ships.

## Two things taken from the engine rather than decided here

- **Several releases are listed in the order they will happen.** `plan-release-materialisation.ts` states that belonging to several is the ordinary case — "publish on the 1st, take down on the 20th" — so the final state is the last row. Restating that conclusion would be a second implementation of `resolveReleaseEffect`'s total ordering.
- **An action the admin does not recognise renders as "this document changes"**, never assumed to be a publish. A test fails on the assuming version.

## The read surface is a filter, not a route

`/api/releases/for-document` would be parsed as a release id — `RELEASE_ROUTES` matches on `candidate.id === Boolean(id)` — and "releases containing this document" is the same resource narrowed anyway. It reuses `findDueMembersFor`, which already returns every member of a scheduled release and leaves dueness to the pure rule, so there is no second query.

A **partial** reference is refused rather than ignored: widening it answers with every release, and the banner would tell an author their post is in eleven launches.

## Boundary

`LanguagePanel` is untouched — its blob is identical to main's. The per-language staleness markers and this banner answer different questions, and a stale translation inside a scheduled release is exactly where an editor needs both.

## Verification

- `fallow audit --base origin/main` → **verdict `pass`, 0 introduced** in every category
- admin 335 files / 3203 tests; nextly releases+api+direct-api 63 / 694
- `check-types` and `lint` clean on both packages; both comment gates clean
- changeset covers all 25 lockstep packages
- Break-verified: removing the consequence sentence, hardcoding "goes live", and ignoring a partial reference each fail named tests

## Known limitation, recorded not built

The release list still cannot reach past 200 in one state, and a **draft** cannot be reached by the date filter at all because it has no instant. A keyset cursor *is* expressible through the existing port — the ordering is already total — but the predicate spans three columns and a NULL, and `nulls: "last"` is emulated because MySQL rejects it, so it needs the three dialect legs. Written up in `findings/2026-08-30-release-list-cannot-page.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scheduled release notifications to collection entry and single edit pages.
  * Displays upcoming release actions, scheduled times, time zones, badges, and links to release details.
  * Supports filtering scheduled releases by the document they contain.
  * Includes accessible messaging and a neutral fallback for unrecognized release actions.

* **Bug Fixes**
  * Validates document filters and rejects incomplete or invalid references.
  * Omits the banner when no applicable scheduled releases are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->