### PR TITLE
feat(nextly): stop a release nothing about retrying could fix

### DIFF
--- a/.changeset/stop-a-release-that-cannot-run.md
+++ b/.changeset/stop-a-release-that-cannot-run.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Stop a release that can never run, and say what to fix. A refused release used to stay scheduled and be replanned every tick forever while reading exactly like a healthy one, so nobody learned anything until the launch did not happen. Only permanent refusals stop it — a member with no author, an author who has been deleted or deactivated, a member naming one language — because the transient ones are documented as evidence of nothing and halting on a momentary database error would lose a launch the next pass would have completed. The release page then names each member standing in the way and what resolves it, worked out from the members on every read rather than recorded when it stopped, so it stops naming a cause somebody has already fixed.

--- a/packages/admin/src/components/features/releases/BlockedReleaseNotice.tsx
+++ b/packages/admin/src/components/features/releases/BlockedReleaseNotice.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+/**
+ * Why a release stopped, and what to do about it.
+ *
+ * The state alone is a dead end. "Blocked" tells an operator the launch will
+ * not happen and nothing else — not which document, not why, not whether
+ * waiting helps. It does not help: the drain has already stopped retrying,
+ * because every reason listed here is one that retrying cannot change.
+ *
+ * Each reason names the MEMBER, because the fix is per member — remove that
+ * document, or restore that user — and a release-level "something is wrong"
+ * leaves someone opening every row to find which.
+ *
+ * @module components/features/releases/BlockedReleaseNotice
+ */
+
+import { Card } from "@admin/components/ui";
+import type { ReleaseBlocker } from "@admin/types/releases";
+
+/**
+ * What each reason means, and what resolves it.
+ *
+ * Written as a consequence and a remedy rather than a code, because the reader
+ * is someone who did not schedule this release and is finding out now why a
+ * launch did not happen.
+ */
+const REASON: Record<ReleaseBlocker["reason"], string> = {
+  AUTHOR_GONE:
+    "the person who added it has been deleted or deactivated. A release publishes each document as its author, so there is nobody left to act as. Restore that user, or remove the document and add it again.",
+  NO_AUTHOR:
+    "no author was recorded for it, so there is nobody to publish it as. Remove the document and add it again.",
+  LOCALE_SCOPED:
+    "it names a single language, which releases cannot publish on their own. Remove it and add the document without a language.",
+};
+
+export function BlockedReleaseNotice({
+  blockers,
+}: {
+  blockers: ReleaseBlocker[];
+}) {
+  // A blocked release with nothing to report means the cause has been fixed
+  // since it stopped — which is the point of deriving this rather than storing
+  // it. Saying so beats an empty list, and beats silence.
+  if (blockers.length === 0) {
+    return (
+      <Card className="mb-6 border-warning bg-warning/5 px-4 py-3">
+        <p className="text-sm text-foreground">
+          This release stopped, but nothing is blocking it any more. Schedule it
+          again to let it run.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="mb-6 border-destructive bg-destructive/5 px-4 py-3">
+      <h2 className="text-sm font-medium text-foreground">
+        This release stopped and will not run on its own
+      </h2>
+      <ul className="mt-2 flex list-disc flex-col gap-1 pl-5">
+        {blockers.map(blocker => (
+          <li key={blocker.memberId} className="text-sm text-muted-foreground">
+            One document could not be published: {REASON[blocker.reason]}
+          </li>
+        ))}
+      </ul>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Once it is fixed, schedule the release again.
+      </p>
+    </Card>
+  );
+}

--- a/packages/admin/src/components/features/releases/BlockedReleaseNotice.tsx
+++ b/packages/admin/src/components/features/releases/BlockedReleaseNotice.tsx
@@ -27,11 +27,23 @@ import type { ReleaseBlocker } from "@admin/types/releases";
  */
 const REASON: Record<ReleaseBlocker["reason"], string> = {
   AUTHOR_GONE:
-    "the person who added it has been deleted or deactivated. A release publishes each document as its author, so there is nobody left to act as. Restore that user, or remove the document and add it again.",
+    "the person who added it has been deleted or deactivated. A release acts on each document as its author, so there is nobody left to act as. Restore that user, or remove the document and add it again.",
   NO_AUTHOR:
-    "no author was recorded for it, so there is nobody to publish it as. Remove the document and add it again.",
+    "no author was recorded for it, so there is nobody to act as. Remove the document and add it again.",
   LOCALE_SCOPED:
-    "it names a single language, which releases cannot publish on their own. Remove it and add the document without a language.",
+    "it names a single language, which releases cannot act on by themselves. Remove it and add the document without a language.",
+};
+
+/**
+ * What the member was going to do, said neutrally enough to be true either way.
+ *
+ * The wording used to assume a publish, which states the OPPOSITE of the truth
+ * for a blocked takedown: an operator reading "could not be published" about a
+ * document that was scheduled to come down learns exactly the wrong thing.
+ */
+const ACTION_PHRASE: Record<ReleaseBlocker["action"], string> = {
+  publish: "could not be published",
+  unpublish: "could not be taken down",
 };
 
 export function BlockedReleaseNotice({
@@ -61,7 +73,15 @@ export function BlockedReleaseNotice({
       <ul className="mt-2 flex list-disc flex-col gap-1 pl-5">
         {blockers.map(blocker => (
           <li key={blocker.memberId} className="text-sm text-muted-foreground">
-            One document could not be published: {REASON[blocker.reason]}
+            {/* NAMED, because the fix is per document. An anonymous sentence
+                repeated once per blocker tells an operator that something is
+                wrong and leaves them opening every row to find which. */}
+            <span className="font-medium text-foreground">
+              {blocker.scopeKind === "single"
+                ? blocker.scopeSlug
+                : `${blocker.scopeSlug} / ${blocker.entryId}`}
+            </span>{" "}
+            {ACTION_PHRASE[blocker.action]}: {REASON[blocker.reason]}
           </li>
         ))}
       </ul>

--- a/packages/admin/src/components/features/releases/ReleaseDetail.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseDetail.tsx
@@ -40,6 +40,7 @@ import type {
   ReleaseState,
 } from "@admin/types/releases";
 
+import { BlockedReleaseNotice } from "./BlockedReleaseNotice";
 import { CancelReleaseButton } from "./CancelReleaseButton";
 import { releaseErrorMessage } from "./release-error";
 import { describeRelease, RELEASE_STATE_LABEL } from "./release-schedule";
@@ -327,6 +328,12 @@ export function ReleaseDetail({ id }: { id: string }) {
   return (
     <>
       <Header release={release.data} contentsKnown={contentsKnown} />
+
+      {/* Above the contents, because it changes what the contents MEAN: this
+          is not a list of what will ship, it is a list of what did not. */}
+      {release.data.state === "blocked" ? (
+        <BlockedReleaseNotice blockers={release.data.blockedBy ?? []} />
+      ) : null}
 
       <section aria-labelledby="release-contents">
         <div className="mb-3 flex items-baseline justify-between gap-3">

--- a/packages/admin/src/components/features/releases/ReleaseList.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseList.tsx
@@ -40,12 +40,16 @@ import { describeRelease, RELEASE_STATE_LABEL } from "./release-schedule";
  */
 const STATE_VARIANT: Record<
   ReleaseState,
-  "default" | "outline" | "success" | "warning"
+  "default" | "outline" | "success" | "warning" | "destructive"
 > = {
   draft: "outline",
   scheduled: "warning",
   published: "success",
   cancelled: "outline",
+  // The only state that needs someone to DO something. `cancelled` is quiet
+  // because it is a decision somebody made; this is a launch that will not
+  // happen and nobody has noticed.
+  blocked: "destructive",
 };
 
 /**

--- a/packages/admin/src/components/features/releases/ScheduledReleaseBanner.tsx
+++ b/packages/admin/src/components/features/releases/ScheduledReleaseBanner.tsx
@@ -49,6 +49,29 @@ const ACTION_SENTENCE: Record<string, string> = {
 };
 
 function ReleaseLine({ release }: { release: Release }) {
+  // A release that STOPPED still holds this document, and reads completely
+  // differently: nothing is coming, and somebody has to act. Reported here
+  // rather than by dropping the row, because a row disappearing is exactly what
+  // an editor reads as "resolved".
+  if (release.state === "blocked") {
+    return (
+      <li className="text-sm text-foreground">
+        <Link
+          href={buildRoute(ROUTES.RELEASES_DETAIL, { id: release.id })}
+          className="underline"
+        >
+          {release.title}
+        </Link>{" "}
+        was going to change this document and has{" "}
+        <strong className="font-medium">stopped</strong>. It will not run until
+        somebody fixes it.
+      </li>
+    );
+  }
+  return <ScheduledLine release={release} />;
+}
+
+function ScheduledLine({ release }: { release: Release }) {
   const at = formatScheduledAt(release);
   // An action the admin does not recognise is NAMED as unknown rather than
   // guessed at. Defaulting to "goes live" would state the opposite of the truth
@@ -97,8 +120,16 @@ function savedEditsSentence(
   releases: Release[],
   onDefaultLocale: boolean
 ): string {
-  const publishes = releases.some(r => r.memberAction === "publish");
-  const withdraws = releases.some(r => r.memberAction === "unpublish");
+  // Only the releases still going to happen decide this sentence. A stopped one
+  // makes no promise about saved edits either way, and letting it vote would
+  // have a blocked publish claim that changes are included when nothing is
+  // going to ship them.
+  const pending = releases.filter(r => r.state === "scheduled");
+  if (pending.length === 0) {
+    return "Nothing is scheduled to happen to this document until somebody fixes the release above.";
+  }
+  const publishes = pending.some(r => r.memberAction === "publish");
+  const withdraws = pending.some(r => r.memberAction === "unpublish");
 
   if (!onDefaultLocale) {
     return publishes
@@ -181,11 +212,18 @@ export function ScheduledReleaseBanner({
       />
       <div className="min-w-0 flex-1">
         <div className="mb-1 flex items-center gap-2">
-          <Badge variant="warning">
-            {releases.length === 1
-              ? "Scheduled"
-              : `${releases.length} scheduled`}
-          </Badge>
+          {/* The badge names the WORST state present: a stopped release is the
+              one that needs somebody, and burying it behind a count of
+              scheduled ones is how it gets missed. */}
+          {releases.some(release => release.state === "blocked") ? (
+            <Badge variant="destructive">Stopped</Badge>
+          ) : (
+            <Badge variant="warning">
+              {releases.length === 1
+                ? "Scheduled"
+                : `${releases.length} scheduled`}
+            </Badge>
+          )}
         </div>
         <ul className="flex flex-col gap-0.5">
           {releases.map(release => (

--- a/packages/admin/src/components/features/releases/__tests__/BlockedReleaseNotice.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/BlockedReleaseNotice.test.tsx
@@ -11,17 +11,31 @@
 import { describe, expect, it } from "vitest";
 
 import { render, screen } from "@admin/__tests__/utils";
+import type { ReleaseBlocker } from "@admin/types/releases";
 
 import { BlockedReleaseNotice } from "../BlockedReleaseNotice";
 
 const text = () => document.body.textContent ?? "";
+
+/** A blocker with everything the notice renders, so a case names only its subject. */
+function blocker(over: Partial<ReleaseBlocker> = {}): ReleaseBlocker {
+  return {
+    memberId: "m1",
+    reason: "AUTHOR_GONE",
+    action: "publish",
+    scopeKind: "collection",
+    scopeSlug: "posts",
+    entryId: "e1",
+    ...over,
+  };
+}
 
 describe("it says what to fix", () => {
   it("explains a deleted author, and names the remedy", () => {
     // The commonest way a release becomes unrunnable: somebody left.
     render(
       <BlockedReleaseNotice
-        blockers={[{ memberId: "m1", reason: "AUTHOR_GONE" }]}
+        blockers={[blocker({ memberId: "m1", reason: "AUTHOR_GONE" })]}
       />
     );
     expect(text()).toMatch(/deleted or deactivated/i);
@@ -31,7 +45,7 @@ describe("it says what to fix", () => {
   it("explains a member with no author at all", () => {
     render(
       <BlockedReleaseNotice
-        blockers={[{ memberId: "m1", reason: "NO_AUTHOR" }]}
+        blockers={[blocker({ memberId: "m1", reason: "NO_AUTHOR" })]}
       />
     );
     expect(text()).toMatch(/no author was recorded/i);
@@ -40,7 +54,7 @@ describe("it says what to fix", () => {
   it("explains a language-scoped member", () => {
     render(
       <BlockedReleaseNotice
-        blockers={[{ memberId: "m1", reason: "LOCALE_SCOPED" }]}
+        blockers={[blocker({ memberId: "m1", reason: "LOCALE_SCOPED" })]}
       />
     );
     expect(text()).toMatch(/names a single language/i);
@@ -52,8 +66,8 @@ describe("it says what to fix", () => {
     render(
       <BlockedReleaseNotice
         blockers={[
-          { memberId: "m1", reason: "AUTHOR_GONE" },
-          { memberId: "m2", reason: "LOCALE_SCOPED" },
+          blocker({ memberId: "m1", reason: "AUTHOR_GONE" }),
+          blocker({ memberId: "m2", reason: "LOCALE_SCOPED" }),
         ]}
       />
     );
@@ -65,10 +79,60 @@ describe("it says what to fix", () => {
     // assumes it is still retrying will wait instead of acting.
     render(
       <BlockedReleaseNotice
-        blockers={[{ memberId: "m1", reason: "AUTHOR_GONE" }]}
+        blockers={[blocker({ memberId: "m1", reason: "AUTHOR_GONE" })]}
       />
     );
     expect(text()).toMatch(/will not run on its own/i);
+  });
+});
+
+describe("it does not assume the member was going to be published", () => {
+  it("says a blocked TAKEDOWN could not be taken down", () => {
+    // The wording used to assume a publish, which states the opposite of the
+    // truth here: an operator reading "could not be published" about a document
+    // scheduled to come down learns exactly the wrong thing.
+    render(
+      <BlockedReleaseNotice blockers={[blocker({ action: "unpublish" })]} />
+    );
+    expect(text()).toMatch(/could not be taken down/i);
+    expect(text()).not.toMatch(/could not be published/i);
+  });
+
+  it("still says a blocked publish could not be published", () => {
+    // The control: without it the case above passes against wording that never
+    // mentions publishing at all.
+    render(
+      <BlockedReleaseNotice blockers={[blocker({ action: "publish" })]} />
+    );
+    expect(text()).toMatch(/could not be published/i);
+  });
+});
+
+describe("it names WHICH document", () => {
+  it("identifies a collection entry by slug and id", () => {
+    // The fix is per document. An anonymous sentence repeated once per blocker
+    // tells an operator something is wrong and leaves them opening every row.
+    render(
+      <BlockedReleaseNotice
+        blockers={[blocker({ scopeSlug: "posts", entryId: "e42" })]}
+      />
+    );
+    expect(text()).toMatch(/posts \/ e42/);
+  });
+
+  it("identifies a Single by its slug alone, which is its identity", () => {
+    render(
+      <BlockedReleaseNotice
+        blockers={[
+          blocker({ scopeKind: "single", scopeSlug: "homepage", entryId: "x" }),
+        ]}
+      />
+    );
+    const shown = text();
+    expect(shown).toMatch(/homepage/);
+    // A Single has one document, so pairing its slug with a row id would show
+    // an identifier that means nothing to the reader.
+    expect(shown).not.toMatch(/homepage \/ x/);
   });
 });
 

--- a/packages/admin/src/components/features/releases/__tests__/BlockedReleaseNotice.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/BlockedReleaseNotice.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * What a stopped release tells the person who finds it.
+ *
+ * The state alone is a dead end — it says a launch will not happen and nothing
+ * about which document or why, and waiting does not help because the drain has
+ * already stopped retrying. Every case here is about the notice being
+ * ACTIONABLE rather than merely present.
+ *
+ * @module components/features/releases/__tests__/BlockedReleaseNotice.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+import { BlockedReleaseNotice } from "../BlockedReleaseNotice";
+
+const text = () => document.body.textContent ?? "";
+
+describe("it says what to fix", () => {
+  it("explains a deleted author, and names the remedy", () => {
+    // The commonest way a release becomes unrunnable: somebody left.
+    render(
+      <BlockedReleaseNotice
+        blockers={[{ memberId: "m1", reason: "AUTHOR_GONE" }]}
+      />
+    );
+    expect(text()).toMatch(/deleted or deactivated/i);
+    expect(text()).toMatch(/restore that user/i);
+  });
+
+  it("explains a member with no author at all", () => {
+    render(
+      <BlockedReleaseNotice
+        blockers={[{ memberId: "m1", reason: "NO_AUTHOR" }]}
+      />
+    );
+    expect(text()).toMatch(/no author was recorded/i);
+  });
+
+  it("explains a language-scoped member", () => {
+    render(
+      <BlockedReleaseNotice
+        blockers={[{ memberId: "m1", reason: "LOCALE_SCOPED" }]}
+      />
+    );
+    expect(text()).toMatch(/names a single language/i);
+  });
+
+  it("lists every blocker rather than only the first", () => {
+    // The fix is per member. Reporting one leaves the operator rescheduling,
+    // watching it stop again, and learning the next reason one at a time.
+    render(
+      <BlockedReleaseNotice
+        blockers={[
+          { memberId: "m1", reason: "AUTHOR_GONE" },
+          { memberId: "m2", reason: "LOCALE_SCOPED" },
+        ]}
+      />
+    );
+    expect(screen.getAllByRole("listitem")).toHaveLength(2);
+  });
+
+  it("says the release will not run on its own", () => {
+    // The consequence, which the word "blocked" does not carry. Someone who
+    // assumes it is still retrying will wait instead of acting.
+    render(
+      <BlockedReleaseNotice
+        blockers={[{ memberId: "m1", reason: "AUTHOR_GONE" }]}
+      />
+    );
+    expect(text()).toMatch(/will not run on its own/i);
+  });
+});
+
+describe("when the cause has already been fixed", () => {
+  it("says so instead of showing an empty list", () => {
+    // Reachable BECAUSE the reasons are derived rather than stored: an operator
+    // who restored the user sees the release still stopped and nothing blocking
+    // it, and the only thing left to tell them is to schedule it again. A
+    // stored reason would still be naming the missing author here.
+    render(<BlockedReleaseNotice blockers={[]} />);
+    expect(text()).toMatch(/nothing is blocking it any more/i);
+    expect(text()).toMatch(/schedule it again/i);
+  });
+});

--- a/packages/admin/src/components/features/releases/__tests__/ScheduledReleaseBanner.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/ScheduledReleaseBanner.test.tsx
@@ -195,6 +195,63 @@ describe("when the lookup FAILED", () => {
   });
 });
 
+describe("a release that STOPPED", () => {
+  it("is still reported, rather than vanishing from the banner", () => {
+    // The gap the banner and the blocked state create together. The document is
+    // still in that release and still going nowhere — and a banner that simply
+    // disappears reads as RESOLVED: the editor concludes the release already
+    // ran or was called off, when the launch has actually failed.
+    showing([release({ state: "blocked" })]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).toMatch(/has stopped/i);
+    expect(text).toMatch(/will not run until somebody fixes it/i);
+  });
+
+  it("does not describe it as something that is going to happen", () => {
+    // The control on the case above: rendering a blocked release through the
+    // scheduled wording would say "This document goes live …", which is the
+    // opposite of true and worse than the silence it replaced.
+    showing([release({ state: "blocked" })]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    expect(screen.getByRole("status").textContent).not.toMatch(/goes live/i);
+  });
+
+  it("does not promise that saved edits are included", () => {
+    // Nothing is going to ship them. A stopped release voting on that sentence
+    // is how a banner ends up reassuring an editor about a launch that failed.
+    showing([release({ state: "blocked" })]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    const text = screen.getByRole("status").textContent ?? "";
+    expect(text).not.toMatch(/changes you save now are included/i);
+    expect(text).toMatch(/nothing is scheduled to happen/i);
+  });
+
+  it("badges the STOPPED one even when a scheduled release is also listed", () => {
+    // The worst state present is the one that needs somebody. Burying it behind
+    // a count of scheduled releases is how it gets missed.
+    showing([
+      release({ id: "a", state: "scheduled" }),
+      release({ id: "b", state: "blocked" }),
+    ]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    expect(screen.getByRole("status").textContent).toMatch(/stopped/i);
+  });
+
+  it("still promises inclusion for the scheduled one beside it", () => {
+    // The control: a blocked row must not silence a genuine promise about a
+    // release that IS still going to publish this document.
+    showing([
+      release({ id: "a", state: "scheduled", memberAction: "publish" }),
+      release({ id: "b", state: "blocked" }),
+    ]);
+    render(<ScheduledReleaseBanner document={DOC} onDefaultLocale />);
+    expect(screen.getByRole("status").textContent).toMatch(
+      /changes you save now are included/i
+    );
+  });
+});
+
 describe("when it should say nothing at all", () => {
   it("renders no chrome for a document in no release", () => {
     // The common case by far. A bar reading "not in any release" on every

--- a/packages/admin/src/components/features/releases/release-schedule.ts
+++ b/packages/admin/src/components/features/releases/release-schedule.ts
@@ -19,6 +19,7 @@ export const RELEASE_STATE_LABEL: Record<ReleaseState, string> = {
   scheduled: "Scheduled",
   published: "Published",
   cancelled: "Cancelled",
+  blocked: "Blocked",
 };
 
 /**
@@ -85,6 +86,12 @@ export function describeRelease(release: Release): string {
         : "Published";
     case "cancelled":
       return "Cancelled — nothing will go live";
+    case "blocked":
+      // The one state whose name does not carry its consequence. "Blocked"
+      // alone reads as a warning; what an operator needs is that this will not
+      // happen on its own and that waiting will not help, because the drain has
+      // already stopped retrying it.
+      return "Blocked — it cannot go live until something is fixed";
     case "draft":
       return "Not scheduled yet";
   }

--- a/packages/admin/src/hooks/queries/__tests__/useRelease.polling.test.tsx
+++ b/packages/admin/src/hooks/queries/__tests__/useRelease.polling.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * The detail page has to learn that the launch it is watching stopped.
+ *
+ * This is the screen somebody sits on across a scheduled instant, and the
+ * release settles without any action from this browser: the drain publishes it,
+ * or stops it. With no interval and focus refetching disabled globally, the
+ * page would go on showing `scheduled` until an unrelated mutation or a
+ * remount — so the person most likely to be watching would be the last to find
+ * out. A `staleTime` cannot cover it, because it governs whether a NEW
+ * subscriber refetches and never initiates a request for a mounted query.
+ *
+ * Asserted as the OUTCOME — what the hook reports after the server's answer
+ * changes underneath it — rather than by reading the interval back off the
+ * query, which would pass for any number including one nothing acts on.
+ *
+ * @module hooks/queries/__tests__/useRelease.polling.test
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { fetchReleaseSpy } = vi.hoisted(() => ({ fetchReleaseSpy: vi.fn() }));
+
+vi.mock("@admin/services/releaseApi", () => ({
+  fetchRelease: fetchReleaseSpy,
+  fetchReleases: vi.fn(),
+  fetchReleaseMembers: vi.fn(),
+  createRelease: vi.fn(),
+  scheduleRelease: vi.fn(),
+  cancelRelease: vi.fn(),
+  addReleaseMember: vi.fn(),
+  removeReleaseMember: vi.fn(),
+}));
+
+import { useRelease } from "../useReleases";
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const release = (state: string) => ({
+  id: "r1",
+  title: "Spring launch",
+  description: null,
+  scheduledAt: "2026-09-01T00:00:00.000Z",
+  timezone: "UTC",
+  state,
+  publishedAt: null,
+  ...(state === "blocked"
+    ? { blockedBy: [{ memberId: "m1", reason: "AUTHOR_GONE" }] }
+    : {}),
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+afterEach(() => vi.useRealTimers());
+
+describe("a release detail page held open across the instant", () => {
+  it("learns that the release STOPPED, without anybody touching the page", async () => {
+    // The drain blocks it between two polls. Nothing in this browser wrote
+    // anything, so no mutation invalidates the cache — the only way this page
+    // finds out is by asking again.
+    fetchReleaseSpy
+      .mockResolvedValueOnce(release("scheduled"))
+      .mockResolvedValue(release("blocked"));
+
+    const { result } = renderHook(() => useRelease("r1"), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data?.state).toBe("scheduled");
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    await waitFor(() => expect(result.current.data?.state).toBe("blocked"));
+    // And the reason arrived with it: the blockers ride on this response, so
+    // refreshing the state is also what fills the notice that says what to fix.
+    expect(result.current.data?.blockedBy).toHaveLength(1);
+  });
+
+  it("keeps asking while the release is still scheduled", async () => {
+    // The control for the interval itself. Without it, the case above is
+    // satisfied by a single refetch that happens to fire once.
+    fetchReleaseSpy.mockResolvedValue(release("scheduled"));
+
+    const { result } = renderHook(() => useRelease("r1"), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchReleaseSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    await waitFor(() => expect(fetchReleaseSpy).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(60_000);
+    await waitFor(() => expect(fetchReleaseSpy).toHaveBeenCalledTimes(3));
+  });
+
+  it("does not go silent once the release has settled", async () => {
+    // A settled release is polled SLOWLY, not never. Stopping altogether is
+    // the shape that turns a transient wrong answer into a permanent one: a
+    // row read once as settled would never be corrected, and this page would
+    // hold that claim for as long as it stayed open. It is also wrong on the
+    // facts — another administrator can reschedule a blocked release, and
+    // nothing they do reaches this browser.
+    fetchReleaseSpy.mockResolvedValue(release("blocked"));
+
+    const { result } = renderHook(() => useRelease("r1"), { wrapper });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(fetchReleaseSpy).toHaveBeenCalledTimes(1);
+
+    // Not at the fast cadence...
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(fetchReleaseSpy).toHaveBeenCalledTimes(1);
+
+    // ...but it does come back.
+    await vi.advanceTimersByTimeAsync(240_000);
+    await waitFor(() => expect(fetchReleaseSpy).toHaveBeenCalledTimes(2));
+  });
+});

--- a/packages/admin/src/hooks/queries/useReleases.ts
+++ b/packages/admin/src/hooks/queries/useReleases.ts
@@ -148,6 +148,31 @@ export function useRelease(id: string | undefined) {
     // resolves, and a request for `/releases/undefined` is a 404 the editor
     // would see as "this release is gone".
     enabled: Boolean(id),
+    // Re-asked on the SAME two schedules as the document banner, and for the
+    // same reason: a scheduled release settles by itself, and nothing about
+    // that reaches this browser.
+    //
+    // This page is the one somebody watches a launch on. Held open across the
+    // instant, it would otherwise go on showing `scheduled` however the drain
+    // resolved it — no interval, and the provider disables focus refetching
+    // globally, so nothing would ask again until an unrelated mutation or a
+    // remount. A `staleTime` does not help: it governs whether a NEW subscriber
+    // refetches, and never initiates a request for a query already mounted. So
+    // the person most likely to be watching is the last to learn it stopped.
+    //
+    // The blockers travel on this response, so refreshing it is also what
+    // replaces "scheduled" with the list of what has to be fixed.
+    //
+    // Two SPEEDS rather than an interval and a stop, deliberately. A condition
+    // that halts polling can be satisfied by a wrong answer — a stale row read
+    // once as settled would then never be corrected, and the page would keep
+    // that claim for as long as it stayed open. Slowing down cannot do that.
+    refetchInterval: data =>
+      data.state.data?.state === "scheduled"
+        ? PENDING_RELEASE_POLL_MS
+        : NO_RELEASE_POLL_MS,
+    // And on return to the tab, which is when somebody actually looks.
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/packages/admin/src/types/releases/index.ts
+++ b/packages/admin/src/types/releases/index.ts
@@ -96,6 +96,20 @@ export interface Release {
    * calling it a publish.
    */
   memberAction?: ReleaseMemberAction;
+  /**
+   * What stands between this release and its instant, per member.
+   *
+   * Sent only on a detail read of a BLOCKED release, and derived there rather
+   * than recorded when the drain stopped — so it stops naming a cause somebody
+   * has already fixed, instead of telling an operator their repair did nothing.
+   */
+  blockedBy?: ReleaseBlocker[];
+}
+
+/** One member standing between a release and its instant. */
+export interface ReleaseBlocker {
+  memberId: string;
+  reason: "NO_AUTHOR" | "AUTHOR_GONE" | "LOCALE_SCOPED";
 }
 
 export interface ReleaseMember {

--- a/packages/admin/src/types/releases/index.ts
+++ b/packages/admin/src/types/releases/index.ts
@@ -9,7 +9,11 @@
  * @module types/releases
  */
 
-import type { ReleaseMemberAction, ReleaseState } from "nextly/schemas";
+import type {
+  ReleaseBlockerReason,
+  ReleaseMemberAction,
+  ReleaseState,
+} from "nextly/schemas";
 
 /**
  * The release lifecycle and the member actions, taken from the engine.
@@ -25,7 +29,7 @@ import type { ReleaseMemberAction, ReleaseState } from "nextly/schemas";
  * answer to is a UI that eventually lies. Deriving from the engine is what makes
  * inventing one impossible rather than merely discouraged.
  */
-export type { ReleaseMemberAction, ReleaseState };
+export type { ReleaseBlockerReason, ReleaseMemberAction, ReleaseState };
 
 /**
  * What the server says THIS reader may do to a release.
@@ -106,10 +110,21 @@ export interface Release {
   blockedBy?: ReleaseBlocker[];
 }
 
-/** One member standing between a release and its instant. */
+/**
+ * One member standing between a release and its instant.
+ *
+ * The reason union is taken from the engine, not restated: a cause added there
+ * would otherwise compile everywhere and render as `undefined` in the one
+ * screen that maps it to a sentence.
+ */
 export interface ReleaseBlocker {
   memberId: string;
-  reason: "NO_AUTHOR" | "AUTHOR_GONE" | "LOCALE_SCOPED";
+  reason: ReleaseBlockerReason;
+  /** What this member was going to do — a blocked takedown is not a failed publish. */
+  action: ReleaseMemberAction;
+  scopeKind: "collection" | "single" | "page";
+  scopeSlug: string;
+  entryId: string;
 }
 
 export interface ReleaseMember {

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -98,6 +98,13 @@ function namespace() {
             ])
           )
       ),
+      // Answers a blocker, so a case can assert the detail read ASKED. A stub
+      // returning nothing looks identical to a route that never asked, which is
+      // the failure worth catching: the state says "blocked" and the screen
+      // then has nothing to tell the operator to fix.
+      blockingReasons: vi.fn(async () => [
+        { memberId: "m1", reason: "AUTHOR_GONE" as const },
+      ]),
       schedule: vi.fn(async () => undefined),
       cancel: vi.fn(async () => undefined),
     },
@@ -639,5 +646,38 @@ describe("filtering the list to the releases holding ONE document", () => {
     const { res, query } = await queryFor(search);
     expect(res.status).toBe(400);
     expect(query).toBeUndefined();
+  });
+});
+
+describe("the detail read explains a BLOCKED release", () => {
+  async function detail(state: string) {
+    const api = namespace();
+    api.releases.findByID = vi.fn(async () => ({ id: "r1", state }));
+    getCachedNextly.mockResolvedValue(api);
+    const res = await handleReleaseRequest(
+      new Request("https://example.test/api/releases/r1"),
+      "getRelease",
+      { releaseId: "r1" }
+    );
+    // `respondDoc` sends the document ITSELF — there is no `item` wrapper, and
+    // reading one would make both cases below pass by finding undefined.
+    return { api, body: (await res.json()) as { blockedBy?: unknown } };
+  }
+
+  it("asks WHY, and sends it, when the release is blocked", async () => {
+    // Without this the state is a dead end: it says the launch will not happen
+    // and nothing says which member to fix.
+    const { api, body } = await detail("blocked");
+    expect(api.releases.blockingReasons).toHaveBeenCalled();
+    expect(body.blockedBy).toEqual([{ memberId: "m1", reason: "AUTHOR_GONE" }]);
+  });
+
+  it("does not ask for a release that is fine", async () => {
+    // The control, and a real cost: the question runs an identity lookup over
+    // every member, and asking it on every detail read would pay that to be
+    // told nothing is wrong — which the state already said.
+    const { api, body } = await detail("scheduled");
+    expect(api.releases.blockingReasons).not.toHaveBeenCalled();
+    expect(body.blockedBy).toBeUndefined();
   });
 });

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -550,7 +550,14 @@ const RELEASE_OPERATIONS: Record<
     // The detail read is exactly where the controls are rendered, so this is
     // the one place the extra permission reads are certainly wanted.
     const [item] = await withCapabilities([release], caller, releases);
-    return respondDoc(item);
+    // Only for a release that is actually stopped. Asking otherwise would put
+    // an identity lookup on every detail read to answer "nothing is wrong",
+    // which the state already said.
+    const blockedBy =
+      release.state === "blocked"
+        ? await releases.blockingReasons({ ...caller, releaseId })
+        : undefined;
+    return respondDoc({ ...item, ...(blockedBy ? { blockedBy } : {}) });
   },
 
   createRelease: async ({ request, caller, releases }) => {

--- a/packages/nextly/src/di/__tests__/register-jobs.test.ts
+++ b/packages/nextly/src/di/__tests__/register-jobs.test.ts
@@ -56,6 +56,7 @@ function result(
   return {
     due: 1,
     published: 1,
+    blocked: 0,
     applied: 1,
     failed: 0,
     outcomes: [],
@@ -193,6 +194,7 @@ describe("reportReleasesOutcome", () => {
     reportReleasesOutcome(log, {
       due: 5,
       published: 1,
+      blocked: 0,
       applied: 1,
       failed: 0,
       deferred: 4,
@@ -215,6 +217,7 @@ describe("reportReleasesOutcome", () => {
     reportReleasesOutcome(log, {
       due: 9,
       published: 2,
+      blocked: 0,
       applied: 2,
       failed: 0,
       deferred: 0,
@@ -267,7 +270,10 @@ describe("reportReleasesOutcome", () => {
     // would bury the pass that mattered.
     const log = logger();
 
-    reportReleasesOutcome(log, result({ due: 0, published: 0, applied: 0 }));
+    reportReleasesOutcome(
+      log,
+      result({ due: 0, published: 0, blocked: 0, applied: 0 })
+    );
 
     expect(log.info).not.toHaveBeenCalled();
     expect(log.error).not.toHaveBeenCalled();

--- a/packages/nextly/src/di/__tests__/register-jobs.test.ts
+++ b/packages/nextly/src/di/__tests__/register-jobs.test.ts
@@ -278,4 +278,24 @@ describe("reportReleasesOutcome", () => {
     expect(log.info).not.toHaveBeenCalled();
     expect(log.error).not.toHaveBeenCalled();
   });
+  it("reports the releases this pass STOPPED", () => {
+    // One failed member can stop a whole overlapping component, so the per-
+    // member error below names one release while several were moved. Without
+    // this line the operator reading the log never learns the others stopped.
+    const log = logger();
+    reportReleasesOutcome(log, {
+      due: 2,
+      published: 0,
+      blocked: 2,
+      applied: 0,
+      failed: 1,
+      deferred: 0,
+      undischarged: 0,
+      outcomes: [],
+    });
+    expect(log.info).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ blocked: 2 })
+    );
+  });
 });

--- a/packages/nextly/src/di/registrations/register-jobs.ts
+++ b/packages/nextly/src/di/registrations/register-jobs.ts
@@ -80,6 +80,11 @@ export function reportReleasesOutcome(
     // ACTION, so `deferred` is zero while releases stay scheduled. Without this
     // the one case the finalization bound handles is the one it cannot report.
     undischarged: result.undischarged,
+    // The transitions this pass made that nothing else reports. One failed
+    // member can stop an entire overlapping component, so the error logged
+    // below names ONE release while several were moved to `blocked` — and
+    // without this the operator reading the log has no way to learn that.
+    blocked: result.blocked,
   });
 
   for (const outcome of result.outcomes) {

--- a/packages/nextly/src/direct-api/namespaces/releases.ts
+++ b/packages/nextly/src/direct-api/namespaces/releases.ts
@@ -33,6 +33,7 @@ import type {
 import type {
   AddMemberInput,
   FindReleasesQuery,
+  ReleaseBlocker,
   ReleaseCapabilities,
   ReleasesService,
 } from "../../domains/releases/services/releases-service";
@@ -110,6 +111,15 @@ export interface ReleasesNamespace {
   capabilities(
     args: { releases: readonly ReleaseRow[] } & ReleaseCallerArgs
   ): Promise<Map<string, ReleaseCapabilities>>;
+  /**
+   * What stands between this release and its instant, per member.
+   *
+   * Derived from the members on every call rather than recorded when the drain
+   * stopped, so it stops reporting a cause somebody has fixed.
+   */
+  blockingReasons(
+    args: { releaseId: string } & ReleaseCallerArgs
+  ): Promise<ReleaseBlocker[]>;
   /** Put a document into a release under a lifecycle action. */
   /**
    * Put a document into a release under a lifecycle action.
@@ -278,6 +288,9 @@ export function createReleasesNamespace(ctx: NextlyContext): ReleasesNamespace {
     // permissions for the edit view, not for every read.
     capabilities: args =>
       service().capabilities(args.releases, actorOf(ctx, args)),
+
+    blockingReasons: args =>
+      service().blockingReasons(args.releaseId, actorOf(ctx, args)),
 
     addMember: args => {
       const {

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -67,7 +67,7 @@ function deps(over: {
 }): ApplyDueReleasesDeps {
   const releases = over.releases ?? [release()];
   const members = over.members ?? [member()];
-  const blocked = vi.fn(async (_id: string) => true);
+  const blocked = vi.fn(async (_id: string, _at: Date) => true);
   return {
     // Pinned, so every case below observes a STABLE component order and asserts
     // about the mechanism it names rather than about which rotation came up.
@@ -993,6 +993,18 @@ describe("a release nothing about retrying could fix is STOPPED", () => {
     expect(result.failed).toBeGreaterThan(0);
     expect(blockedBy(d)).toEqual([]);
     expect(result.blocked).toBe(0);
+  });
+
+  it("fences the block on the instant the pass PLANNED against", async () => {
+    // An editor who postpones a due release between the plan and this write
+    // leaves the row in `scheduled`, so a state-only predicate would match and
+    // replace the schedule they just chose with `blocked`. The release would
+    // then never run at the replacement instant, and nothing would say why.
+    const d = deps({ members: [member({ createdBy: null })] });
+    await applyDueReleases(d);
+    const call = vi.mocked(d.repository.blockRelease).mock.calls[0];
+    expect(call?.[1]).toBeInstanceOf(Date);
+    expect(call?.[1]?.getTime()).toBe(release().scheduledAt?.getTime());
   });
 
   it("blocks nothing when every member applies", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -961,6 +961,19 @@ describe("a release nothing about retrying could fix is STOPPED", () => {
     expect(result.blocked).toBe(1);
   });
 
+  it("blocks a member whose author has been DEACTIVATED", async () => {
+    // Found by breaking the classifier: with `AUTHOR_UNAVAILABLE` reclassified
+    // as retryable, the whole suite stayed green — so the commonest permanent
+    // failure of the three had no coverage at all. A departed colleague is the
+    // ordinary way a release becomes unrunnable.
+    const d = deps({
+      runAs: { findUser: async id => ({ id, isActive: false }) },
+    });
+    const result = await applyDueReleases(d);
+    expect(blockedBy(d)).toEqual(["r1"]);
+    expect(result.blocked).toBe(1);
+  });
+
   it("blocks a locale-scoped member", async () => {
     const d = deps({ members: [member({ locale: "de" })] });
     await applyDueReleases(d);

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -944,3 +944,50 @@ describe("applyDueReleases", () => {
     expect(publish).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("a release nothing about retrying could fix is STOPPED", () => {
+  /** The releases this pass moved to `blocked`. */
+  function blockedBy(d: ReturnType<typeof deps>): string[] {
+    return vi.mocked(d.repository.blockRelease).mock.calls.map(call => call[0]);
+  }
+
+  it("blocks a member whose author was never recorded", async () => {
+    // Left scheduled it is replanned every tick forever, and reads as healthy
+    // the whole time — the operator learns nothing until the launch does not
+    // happen.
+    const d = deps({ members: [member({ createdBy: null })] });
+    const result = await applyDueReleases(d);
+    expect(blockedBy(d)).toEqual(["r1"]);
+    expect(result.blocked).toBe(1);
+  });
+
+  it("blocks a locale-scoped member", async () => {
+    const d = deps({ members: [member({ locale: "de" })] });
+    await applyDueReleases(d);
+    expect(blockedBy(d)).toEqual(["r1"]);
+  });
+
+  it("does NOT block when the write merely failed", async () => {
+    // The control that carries the whole design. "Refused or errored" covers a
+    // dropped connection as well as a permission nobody will ever gain, and the
+    // two are indistinguishable here — so a momentary blip must not permanently
+    // halt a launch the next pass would have completed.
+    // The fixture's own way to say the write did not land, per its comment.
+    const d = deps({ mutations: { applied: async () => false } });
+    const result = await applyDueReleases(d);
+    // It still FAILED — the release is held open and retried, which is the
+    // point. It is simply not stopped.
+    expect(result.failed).toBeGreaterThan(0);
+    expect(blockedBy(d)).toEqual([]);
+    expect(result.blocked).toBe(0);
+  });
+
+  it("blocks nothing when every member applies", async () => {
+    // The other control: without it, a pass that blocked everything it touched
+    // would satisfy the two positive cases above.
+    const d = deps({});
+    const result = await applyDueReleases(d);
+    expect(blockedBy(d)).toEqual([]);
+    expect(result.blocked).toBe(0);
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -67,6 +67,7 @@ function deps(over: {
 }): ApplyDueReleasesDeps {
   const releases = over.releases ?? [release()];
   const members = over.members ?? [member()];
+  const blocked = vi.fn(async (_id: string) => true);
   return {
     // Pinned, so every case below observes a STABLE component order and asserts
     // about the mechanism it names rather than about which rotation came up.
@@ -74,6 +75,11 @@ function deps(over: {
     random: () => 0,
     repository: {
       findDueReleases: async () => releases,
+      // A spy, reached through the port with `vi.mocked` so a case can assert
+      // WHICH releases the pass stopped. A stub returning true would let a pass
+      // that blocked the wrong ones — or every one — look identical to a pass
+      // that blocked exactly the hopeless.
+      blockRelease: blocked,
       listMembersOf: async ids =>
         members.filter(m => ids.includes(m.releaseId)),
       isStillDueAt: async (id: string, scheduledAt: Date) =>

--- a/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Why a release cannot proceed, worked out from its members.
+ *
+ * Derived rather than stored, and the tests are shaped by that choice: the
+ * interesting property is that the answer CHANGES when the cause is fixed. A
+ * reason recorded at block time would still name a deleted author after the
+ * operator restored them, and the only way out would be to reschedule and watch
+ * it block again — so "it self-heals" is the behaviour worth pinning, not an
+ * implementation detail.
+ *
+ * @module domains/releases/__tests__/blocking-reasons.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { ReleasesService } from "../services/releases-service";
+import type { ReleasesServiceDeps } from "../services/releases-service";
+
+const ACTOR = { userId: "u1" };
+
+interface M {
+  id: string;
+  createdBy?: string | null;
+  locale?: string | null;
+}
+
+function service(members: M[], liveAuthorIds: string[]) {
+  const listMembers = vi.fn(async () =>
+    members.map(m => ({
+      id: m.id,
+      releaseId: "r1",
+      scopeKind: "collection" as const,
+      scopeSlug: "posts",
+      entryId: `e-${m.id}`,
+      locale: m.locale ?? null,
+      action: "publish" as const,
+      createdBy: m.createdBy === undefined ? "author" : m.createdBy,
+      createdAt: new Date(),
+    }))
+  );
+  const liveAuthors = vi.fn(async () => new Set(liveAuthorIds));
+  const deps = {
+    repository: {
+      listMembers,
+      liveAuthors,
+    } as unknown as ReleasesServiceDeps["repository"],
+    canManageReleases: vi.fn(async () => true),
+    canActOnDocument: vi.fn(async () => true),
+  };
+  return { svc: new ReleasesService(deps), liveAuthors };
+}
+
+describe("what stands between a release and its instant", () => {
+  it("names a member whose author was never recorded", async () => {
+    const { svc } = service([{ id: "m1", createdBy: null }], []);
+    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([
+      { memberId: "m1", reason: "NO_AUTHOR" },
+    ]);
+  });
+
+  it("names a member whose author is gone", async () => {
+    // Deleted or deactivated. The drain performs each member AS its recorded
+    // author, so there is no principal left to act as.
+    const { svc } = service([{ id: "m1", createdBy: "ghost" }], []);
+    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([
+      { memberId: "m1", reason: "AUTHOR_GONE" },
+    ]);
+  });
+
+  it("names a locale-scoped member", async () => {
+    const { svc } = service([{ id: "m1", locale: "de" }], ["author"]);
+    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([
+      { memberId: "m1", reason: "LOCALE_SCOPED" },
+    ]);
+  });
+
+  it("says nothing about a release that can proceed", async () => {
+    // The control. Without it every case above is satisfied by an
+    // implementation that reports a blocker for every member it sees.
+    const { svc } = service([{ id: "m1" }, { id: "m2" }], ["author"]);
+    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([]);
+  });
+
+  it("names each offending member rather than the release", async () => {
+    // The fix is per member — remove that document, restore that user — so a
+    // release-level "something is wrong" leaves an operator opening every row.
+    const { svc } = service(
+      [
+        { id: "ok" },
+        { id: "bad", createdBy: "ghost" },
+        { id: "loc", locale: "fr" },
+      ],
+      ["author"]
+    );
+    const found = await svc.blockingReasons("r1", ACTOR);
+    expect(found).toEqual([
+      { memberId: "bad", reason: "AUTHOR_GONE" },
+      { memberId: "loc", reason: "LOCALE_SCOPED" },
+    ]);
+  });
+});
+
+describe("because it is DERIVED, it changes when the cause is fixed", () => {
+  it("stops reporting an author who has been restored", async () => {
+    // The reason this is computed rather than recorded. A stored reason would
+    // still name the missing author here, and the operator's fix would appear
+    // to have done nothing.
+    const gone = service([{ id: "m1", createdBy: "u9" }], []);
+    expect(await gone.svc.blockingReasons("r1", ACTOR)).toHaveLength(1);
+
+    const restored = service([{ id: "m1", createdBy: "u9" }], ["u9"]);
+    expect(await restored.svc.blockingReasons("r1", ACTOR)).toEqual([]);
+  });
+
+  it("stops reporting a member that was removed", async () => {
+    const withBad = service(
+      [{ id: "m1" }, { id: "bad", createdBy: null }],
+      ["author"]
+    );
+    expect(await withBad.svc.blockingReasons("r1", ACTOR)).toHaveLength(1);
+
+    const fixed = service([{ id: "m1" }], ["author"]);
+    expect(await fixed.svc.blockingReasons("r1", ACTOR)).toEqual([]);
+  });
+});
+
+describe("as an instrument", () => {
+  it("asks for live authors ONCE, not once per member", async () => {
+    // A release of fifty documents must not become fifty identity lookups.
+    const { svc, liveAuthors } = service(
+      Array.from({ length: 12 }, (_, n) => ({ id: `m${n}` })),
+      ["author"]
+    );
+    await svc.blockingReasons("r1", ACTOR);
+    expect(liveAuthors).toHaveBeenCalledTimes(1);
+  });
+
+  it("asks nothing at all about an empty release", async () => {
+    const { svc, liveAuthors } = service([], []);
+    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([]);
+    expect(liveAuthors).not.toHaveBeenCalled();
+  });
+
+  it("refuses a caller who may not read releases", async () => {
+    const deps = {
+      repository: {} as ReleasesServiceDeps["repository"],
+      canManageReleases: vi.fn(async () => false),
+      canActOnDocument: vi.fn(async () => true),
+    };
+    await expect(
+      new ReleasesService(deps).blockingReasons("r1", ACTOR)
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});

--- a/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
@@ -12,6 +12,10 @@
  */
 import { describe, expect, it, vi } from "vitest";
 
+import {
+  RELEASE_SCHEDULABLE_FROM,
+  type ReleaseState,
+} from "../../../schemas/releases/types";
 import { ReleasesService } from "../services/releases-service";
 import type { ReleasesServiceDeps } from "../services/releases-service";
 
@@ -196,5 +200,145 @@ describe("scheduling a blocked release", () => {
     await expect(svc.schedule("r1", AT, "UTC", ACTOR)).resolves.toBeUndefined();
     expect(liveAuthors).not.toHaveBeenCalled();
     expect(scheduleRelease).toHaveBeenCalled();
+  });
+});
+
+describe("the blocker verdict and the write share a fence", () => {
+  const AT = new Date("2026-09-01T00:00:00.000Z");
+
+  /**
+   * A release the DRAIN moves between the service's read and its write.
+   *
+   * The service reads the state, derives blockers from it, and only then
+   * writes — and the drain runs in that window. `scheduleRelease` here models
+   * the repository's conditional UPDATE rather than recording the call: it
+   * answers whether the row's state AT WRITE TIME satisfies the fence the
+   * service passed. Asserting on the argument instead would pass for any list
+   * that merely looked plausible.
+   *
+   * The `from` default is the repository's own, so a service that passes no
+   * fence at all behaves here exactly as it did before this was fixed — which
+   * is what makes the two racing cases below fail on that version.
+   */
+  function racing(atRead: string, atWrite: ReleaseState, live: string[] = []) {
+    const liveAuthors = vi.fn(async () => new Set(live));
+    const scheduleRelease = vi.fn(
+      async (
+        _id: string,
+        _at: Date,
+        _tz: string,
+        from: readonly ReleaseState[] = RELEASE_SCHEDULABLE_FROM
+      ) => from.includes(atWrite)
+    );
+    const deps = {
+      repository: {
+        listMembers: vi.fn(async () => [
+          {
+            id: "m1",
+            releaseId: "r1",
+            scopeKind: "collection" as const,
+            scopeSlug: "posts",
+            entryId: "e1",
+            locale: null,
+            action: "publish" as const,
+            createdBy: "author",
+            createdAt: new Date(),
+          },
+        ]),
+        liveAuthors,
+        findReleases: vi.fn(async () => [{ id: "r1", state: atRead }]),
+        scheduleRelease,
+      } as unknown as ReleasesServiceDeps["repository"],
+      canManageReleases: vi.fn(async () => true),
+      canActOnDocument: vi.fn(async () => true),
+    };
+    return { svc: new ReleasesService(deps), scheduleRelease, liveAuthors };
+  }
+
+  it("REFUSES a release the drain blocked after the state was read", async () => {
+    // The interleaving that made the precondition bypassable. The service saw
+    // `scheduled`, so it examined no blockers; the drain then stopped the
+    // release. A fence spanning every schedulable state accepts `blocked` here
+    // and reschedules a release nobody checked — which reaches its new instant
+    // and stops again, for the same permanent reason.
+    const { svc, liveAuthors } = racing("scheduled", "blocked");
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    // And it was refused for the right reason: no blocker was ever derived,
+    // because at the moment of the read there was nothing to derive.
+    expect(liveAuthors).not.toHaveBeenCalled();
+  });
+
+  it("REFUSES a blocked release that somebody else moved after it was cleared", async () => {
+    // The opposite interleaving. The verdict said "nothing blocks it", and by
+    // the time of the write that release had been cancelled — a decision made
+    // AFTER the verdict, which the write must not silently overwrite.
+    const { svc } = racing("blocked", "cancelled", ["author"]);
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+  });
+
+  it("allows a cleared blocked release that nothing moved", async () => {
+    // The control for the recovery path: without it, a fence that refused
+    // everything would satisfy both cases above.
+    const { svc, scheduleRelease } = racing("blocked", "blocked", ["author"]);
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).resolves.toBeUndefined();
+    expect(scheduleRelease).toHaveBeenCalled();
+  });
+
+  it("allows an ordinary reschedule that nothing moved", async () => {
+    // The control for the common path, which must stay free of all this.
+    const { svc, scheduleRelease } = racing("scheduled", "scheduled");
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).resolves.toBeUndefined();
+    expect(scheduleRelease).toHaveBeenCalled();
+  });
+});
+
+describe("what authority rescheduling actually costs", () => {
+  const AT = new Date("2026-09-01T00:00:00.000Z");
+
+  /** A scoped API key holding exactly the grants it is given, and no others. */
+  function keyHolding(...permissions: string[]) {
+    return {
+      userId: "u1",
+      authenticatedScope: {
+        actorType: "apiKey",
+        permissions,
+      },
+    } as unknown as Parameters<ReleasesService["schedule"]>[3];
+  }
+
+  it("does not demand a READ grant to reschedule a repaired release", async () => {
+    // A key stamped `publish-content-releases` may schedule every release on
+    // the site. Deriving the blockers through the public `blockingReasons`
+    // asked for `read` as well — and for an API key the stamped scope is
+    // authoritative, so the missing grant is refused outright rather than
+    // falling back to publish-implies-read. Such a key could schedule anything
+    // EXCEPT a repaired blocked release, the one case the check exists for.
+    const { svc } = service([{ id: "m1", createdBy: "u9" }], ["u9"]);
+    await expect(
+      svc.schedule("r1", AT, "UTC", keyHolding("publish-content-releases"))
+    ).resolves.toBeUndefined();
+  });
+
+  it("still refuses a key that cannot publish", async () => {
+    // The control. Without it the case above is satisfied by a service that
+    // stopped authorizing scheduling at all.
+    const { svc } = service([{ id: "m1", createdBy: "u9" }], ["u9"]);
+    await expect(
+      svc.schedule("r1", AT, "UTC", keyHolding("read-content-releases"))
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+
+  it("still refuses to READ the blockers without a read grant", async () => {
+    // The authority did not move, it was only taken off the derivation. The
+    // public surface must still demand `read`, or this fix would have widened
+    // who can enumerate a release's members.
+    const { svc } = service([{ id: "m1", createdBy: "u9" }], ["u9"]);
+    await expect(
+      svc.blockingReasons("r1", keyHolding("publish-content-releases"))
+    ).rejects.toMatchObject({ code: "FORBIDDEN" });
   });
 });

--- a/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
@@ -23,7 +23,7 @@ interface M {
   locale?: string | null;
 }
 
-function service(members: M[], liveAuthorIds: string[]) {
+function service(members: M[], liveAuthorIds: string[], state = "blocked") {
   const listMembers = vi.fn(async () =>
     members.map(m => ({
       id: m.id,
@@ -38,21 +38,24 @@ function service(members: M[], liveAuthorIds: string[]) {
     }))
   );
   const liveAuthors = vi.fn(async () => new Set(liveAuthorIds));
+  const scheduleRelease = vi.fn(async () => true);
   const deps = {
     repository: {
       listMembers,
       liveAuthors,
+      findReleases: vi.fn(async () => [{ id: "r1", state }]),
+      scheduleRelease,
     } as unknown as ReleasesServiceDeps["repository"],
     canManageReleases: vi.fn(async () => true),
     canActOnDocument: vi.fn(async () => true),
   };
-  return { svc: new ReleasesService(deps), liveAuthors };
+  return { svc: new ReleasesService(deps), liveAuthors, scheduleRelease };
 }
 
 describe("what stands between a release and its instant", () => {
   it("names a member whose author was never recorded", async () => {
     const { svc } = service([{ id: "m1", createdBy: null }], []);
-    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([
+    expect(await svc.blockingReasons("r1", ACTOR)).toMatchObject([
       { memberId: "m1", reason: "NO_AUTHOR" },
     ]);
   });
@@ -61,14 +64,14 @@ describe("what stands between a release and its instant", () => {
     // Deleted or deactivated. The drain performs each member AS its recorded
     // author, so there is no principal left to act as.
     const { svc } = service([{ id: "m1", createdBy: "ghost" }], []);
-    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([
+    expect(await svc.blockingReasons("r1", ACTOR)).toMatchObject([
       { memberId: "m1", reason: "AUTHOR_GONE" },
     ]);
   });
 
   it("names a locale-scoped member", async () => {
     const { svc } = service([{ id: "m1", locale: "de" }], ["author"]);
-    expect(await svc.blockingReasons("r1", ACTOR)).toEqual([
+    expect(await svc.blockingReasons("r1", ACTOR)).toMatchObject([
       { memberId: "m1", reason: "LOCALE_SCOPED" },
     ]);
   });
@@ -92,7 +95,7 @@ describe("what stands between a release and its instant", () => {
       ["author"]
     );
     const found = await svc.blockingReasons("r1", ACTOR);
-    expect(found).toEqual([
+    expect(found).toMatchObject([
       { memberId: "bad", reason: "AUTHOR_GONE" },
       { memberId: "loc", reason: "LOCALE_SCOPED" },
     ]);
@@ -149,5 +152,49 @@ describe("as an instrument", () => {
     await expect(
       new ReleasesService(deps).blockingReasons("r1", ACTOR)
     ).rejects.toMatchObject({ code: "FORBIDDEN" });
+  });
+});
+
+describe("scheduling a blocked release", () => {
+  const AT = new Date("2026-09-01T00:00:00.000Z");
+
+  it("is REFUSED while what stopped it is still true", async () => {
+    // Scheduling again would reach the instant, hit the same member and stop
+    // again — and the operator would learn that only by waiting for a launch
+    // that does not happen.
+    const { svc, scheduleRelease } = service(
+      [{ id: "m1", createdBy: "ghost" }],
+      []
+    );
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    // And nothing was written: a refusal that arrives after the update is not
+    // a refusal.
+    expect(scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("is allowed once the cause is fixed", async () => {
+    // The control, and the whole point of deriving the blockers: restoring the
+    // author makes the release schedulable with nothing else changing.
+    const { svc, scheduleRelease } = service(
+      [{ id: "m1", createdBy: "u9" }],
+      ["u9"]
+    );
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).resolves.toBeUndefined();
+    expect(scheduleRelease).toHaveBeenCalled();
+  });
+
+  it("does not pay the extra read for a release that is not blocked", async () => {
+    // A draft has nothing to check, and putting the lookup on every schedule
+    // would charge every caller for a question only one state answers yes to.
+    const { svc, liveAuthors, scheduleRelease } = service(
+      [{ id: "m1", createdBy: "ghost" }],
+      [],
+      "draft"
+    );
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).resolves.toBeUndefined();
+    expect(liveAuthors).not.toHaveBeenCalled();
+    expect(scheduleRelease).toHaveBeenCalled();
   });
 });

--- a/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
@@ -31,6 +31,8 @@ interface Row {
   created?: string;
   memberId?: string;
   state?: string;
+  /** A new instant the SECOND read sees, as if somebody rescheduled it. */
+  movedTo?: string;
 }
 
 function service(rows: Row[]) {
@@ -38,6 +40,8 @@ function service(rows: Row[]) {
     memberId: r.memberId ?? `m-${r.id}`,
     releaseId: r.id,
     action: r.action ?? ("publish" as const),
+    // What the FIRST read saw. `movedTo` makes the second read disagree, which
+    // is what happens when somebody reschedules between the two.
     scheduledAt: new Date(r.at),
     createdAt: new Date(r.created ?? r.at),
   }));
@@ -50,7 +54,8 @@ function service(rows: Row[]) {
         id: r.id,
         title: r.id,
         description: null,
-        scheduledAt: new Date(r.at),
+        // What the SECOND read sees.
+        scheduledAt: new Date(r.movedTo ?? r.at),
         timezone: "UTC",
         state: r.state ?? "scheduled",
         publishedAt: null,
@@ -126,6 +131,38 @@ describe("the order the releases are returned in", () => {
   });
 });
 
+describe("a release RESCHEDULED between the two reads", () => {
+  it("is ordered by the instant it now carries, not the one first seen", async () => {
+    // Two reads again. The row that is displayed carries the NEW instant, so
+    // sorting by the old one renders the dates out of chronological order —
+    // and under a limit keeps rows that are no longer the earliest.
+    const svc = service([
+      {
+        id: "was-first",
+        at: "2026-09-01T00:00:00.000Z",
+        movedTo: "2026-10-01T00:00:00.000Z",
+      },
+      { id: "now-first", at: "2026-09-05T00:00:00.000Z" },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
+      "now-first",
+      "was-first",
+    ]);
+  });
+
+  it("orders by the first-read instant when nothing moved", async () => {
+    // The control: without it a comparator reading neither field would pass.
+    const svc = service([
+      { id: "later", at: "2026-10-01T00:00:00.000Z" },
+      { id: "sooner", at: "2026-09-05T00:00:00.000Z" },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
+      "sooner",
+      "later",
+    ]);
+  });
+});
+
 describe("a release the drain settled between the two reads", () => {
   it("is dropped rather than reported as still coming", async () => {
     // Two reads, and the drain runs between them: `findDueMembersFor` selects
@@ -144,6 +181,31 @@ describe("a release the drain settled between the two reads", () => {
     expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
       "still-coming",
     ]);
+  });
+
+  it("KEEPS a release that stopped, because the document is still in it", async () => {
+    // The opposite of the published case, and the reason the filter is a LIST
+    // rather than an equality. A blocked release still holds this document and
+    // is still going nowhere; dropping it makes the document's banner vanish,
+    // and a banner disappearing reads as resolved.
+    const svc = service([
+      { id: "coming", at: "2026-09-01T00:00:00.000Z" },
+      { id: "stopped", at: "2026-09-02T00:00:00.000Z", state: "blocked" },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual([
+      "coming",
+      "stopped",
+    ]);
+  });
+
+  it("still drops a CANCELLED one, which somebody called off on purpose", async () => {
+    // The discrimination: "not published" is not the rule. A cancelled release
+    // is a decision, and reporting it would be telling an editor about history.
+    const svc = service([
+      { id: "coming", at: "2026-09-01T00:00:00.000Z" },
+      { id: "called-off", at: "2026-09-02T00:00:00.000Z", state: "cancelled" },
+    ]);
+    expect(ids(await svc.find({ containing: REF }, ACTOR))).toEqual(["coming"]);
   });
 
   it("keeps the scheduled ones, so the filter is not simply emptying the list", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/find-containing.test.ts
@@ -30,13 +30,22 @@ interface Row {
   /** The MEMBER's creation time, which breaks a tied instant. */
   created?: string;
   memberId?: string;
+  /** The state the SECOND read reports — the release's actual state. */
   state?: string;
+  /**
+   * The state at the FIRST read, when it differs from `state`.
+   *
+   * Only a release the drain settled between the two reads has two states, and
+   * making that explicit is what keeps the re-check honest: the first read has
+   * to hand the row over for the second read to have anything to drop.
+   */
+  stateAtFirstRead?: string;
   /** A new instant the SECOND read sees, as if somebody rescheduled it. */
   movedTo?: string;
 }
 
 function service(rows: Row[]) {
-  const members = rows.map(r => ({
+  const memberOf = (r: Row) => ({
     memberId: r.memberId ?? `m-${r.id}`,
     releaseId: r.id,
     action: r.action ?? ("publish" as const),
@@ -44,10 +53,31 @@ function service(rows: Row[]) {
     // is what happens when somebody reschedules between the two.
     scheduledAt: new Date(r.at),
     createdAt: new Date(r.created ?? r.at),
-  }));
+  });
   const repository = {
+    // HONOURS `states`, because the real query does and a mock that does not
+    // hands the service rows the database would never have returned. That is
+    // not hypothetical: this returned every member regardless, so the case
+    // below asserting a blocked release survives passed while the production
+    // query dropped it one layer down and the banner showed nothing.
     findDueMembersFor: vi.fn(
-      async () => new Map([["collection:posts:e1:", members]])
+      async (
+        _refs: unknown,
+        _now: Date,
+        // The repository's own default, so a caller that names no states gets
+        // the read path's narrow list here too.
+        states: readonly string[] = ["scheduled"]
+      ) =>
+        new Map([
+          [
+            "collection:posts:e1:",
+            rows
+              .filter(r =>
+                states.includes(r.stateAtFirstRead ?? r.state ?? "scheduled")
+              )
+              .map(memberOf),
+          ],
+        ])
     ),
     findReleases: vi.fn(async () =>
       rows.map(r => ({
@@ -175,6 +205,10 @@ describe("a release the drain settled between the two reads", () => {
       {
         id: "already-ran",
         at: "2026-09-02T00:00:00.000Z",
+        // Still scheduled when the members were read, published by the time
+        // the releases were. Without the first-read state the query would
+        // never have returned it and the re-check would have nothing to do.
+        stateAtFirstRead: "scheduled",
         state: "published",
       },
     ]);

--- a/packages/nextly/src/domains/releases/__tests__/release-capabilities.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/release-capabilities.test.ts
@@ -165,7 +165,20 @@ describe("capabilities, as an instrument", () => {
       "scheduled",
       "published",
       "cancelled",
+      "blocked",
     ]);
+  });
+
+  it("treats a BLOCKED release as fixable rather than finished", async () => {
+    // The whole point of the state: an operator removes the member whose author
+    // is gone and reschedules. A blocked release nobody could edit or
+    // reschedule would be a dead end whose only exit is abandoning it.
+    const { svc } = service(ALL);
+    const can = await svc.capabilities([release("blocked")], ACTOR);
+    expect(can.get("r1")?.addMember).toBe(true);
+    expect(can.get("r1")?.removeMember).toBe(true);
+    expect(can.get("r1")?.schedule).toBe(true);
+    expect(can.get("r1")?.cancel).toBe(true);
   });
 });
 

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -20,6 +20,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { deactivate, seedLiveAuthor } from "./helpers/live-author";
 
 import { defineCollection, text } from "../../../config";
+import { RELEASE_STATES_SHOWN_ON_A_DOCUMENT } from "../../../schemas/releases/types";
 import {
   createTestNextly,
   getConfiguredTestDialects,
@@ -204,6 +205,58 @@ describe.each(getConfiguredTestDialects())(
       // due-but-unmaterialised release free.
       const after = await repo.findDueMembersFor([ref("e1")], new Date());
       expect(after.get(documentRefKey(ref("e1"))) ?? []).toEqual([]);
+    });
+
+    it("stops returning a BLOCKED release to the read path", async () => {
+      // The safety half of the state, and the reason the read path may not
+      // simply widen its filter: a release that stopped must stop projecting
+      // its effect onto what a visitor sees, or "stopped" would mean nothing
+      // to a reader.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      await repo.scheduleRelease(release.id, PAST, "UTC");
+      expect(await repo.blockRelease(release.id, PAST)).toBe(true);
+
+      const found = await repo.findDueMembersFor([ref("e1")], new Date());
+      expect(found.get(documentRefKey(ref("e1"))) ?? []).toEqual([]);
+    });
+
+    it("returns a BLOCKED release to a caller that asks for one", async () => {
+      // The half a unit test cannot reach, and the half that was wrong. The
+      // banner widened its own state list one layer ABOVE this query, which
+      // filtered `scheduled` alone — so the row it asked for had already been
+      // dropped and the widening could never fire. Only a real query answers
+      // whether the states a caller names are the states it gets.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+      const release = await repo.createRelease({ title: "Spring launch" });
+      await repo.addMember({
+        releaseId: release.id,
+        ...ref("e1"),
+        action: "publish",
+      });
+      await repo.scheduleRelease(release.id, PAST, "UTC");
+      expect(await repo.blockRelease(release.id, PAST)).toBe(true);
+
+      // The list the document's banner actually passes, imported rather than
+      // spelled again: a test naming its own states would keep passing after
+      // the banner's list changed underneath it.
+      const found = await repo.findDueMembersFor(
+        [ref("e1")],
+        new Date(),
+        RELEASE_STATES_SHOWN_ON_A_DOCUMENT
+      );
+      const members = found.get(documentRefKey(ref("e1"))) ?? [];
+      expect(members).toHaveLength(1);
+      // Still carrying the instant it was going to run at, which is what the
+      // banner orders and dates the row by.
+      expect(members[0]?.scheduledAt.getTime()).toBe(PAST.getTime());
     });
 
     it("keeps each document's members apart", async () => {

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -118,6 +118,13 @@ export interface ApplyDueReleasesDeps {
     listMembersOf(releaseIds: string[]): Promise<ReleaseMemberRow[]>;
     isStillDueAt(releaseId: string, scheduledAt: Date): Promise<boolean>;
     markReleasePublished(id: string, at: Date): Promise<boolean>;
+    /**
+     * Stop a release nothing about retrying could fix.
+     *
+     * Fenced on `scheduled` in the repository, so a release cancelled or
+     * rescheduled while this pass ran keeps the state a person chose.
+     */
+    blockRelease(id: string): Promise<boolean>;
   };
   mutations: ReleaseMutations;
   /** The identity reads, so a member's author can be resolved. */
@@ -187,6 +194,53 @@ export type MaterialisationFailure =
    */
   | "RELEASE_NO_LONGER_SCHEDULED";
 
+/**
+ * Whether retrying could ever change this outcome.
+ *
+ * An exhaustive `Record` rather than a set of the permanent ones, so a failure
+ * kind added later cannot default into either answer: the compiler demands it
+ * be classified, and both defaults are bad. Defaulting to permanent lets a new
+ * transient error permanently stop launches; defaulting to transient puts a
+ * hopeless release back into the retry loop this exists to end.
+ */
+const RETRY_COULD_HELP: Record<MaterialisationFailure, boolean> = {
+  // Nothing about waiting supplies an author, restores a deleted one, or
+  // teaches the engine per-locale releases. These are the ones that leave a
+  // release retrying every tick forever while looking healthy.
+  NO_RECORDED_AUTHOR: false,
+  AUTHOR_UNAVAILABLE: false,
+  LOCALE_SCOPE_UNSUPPORTED: false,
+
+  // Documented at their declarations as evidence of nothing: a lookup that
+  // errored does not mean the user is gone, and a re-read that errored does not
+  // mean the release was cancelled. Blocking on either would let a momentary
+  // database blip permanently halt a launch the next pass would have completed.
+  IDENTITY_LOOKUP_FAILED: true,
+  SCHEDULE_CHECK_FAILED: true,
+
+  // Ambiguous, and resolved toward retrying deliberately. "Refused or errored"
+  // covers both a permission the caller will never gain and a connection that
+  // dropped, and the two are indistinguishable here. Retrying a hopeless write
+  // wastes a tick; blocking a recoverable one loses a launch.
+  WRITE_FAILED: true,
+
+  // Not a failure of this release at all — somebody cancelled or rescheduled it
+  // while the pass was running. Blocking would overwrite their decision with a
+  // state they did not ask for.
+  RELEASE_NO_LONGER_SCHEDULED: true,
+};
+
+/** The releases this pass proved can never be applied as they stand. */
+function permanentlyBrokenReleases(
+  outcomes: readonly MaterialisationOutcome[]
+): Set<string> {
+  return new Set(
+    outcomes
+      .filter(o => o.failure !== null && !RETRY_COULD_HELP[o.failure])
+      .map(o => o.releaseId)
+  );
+}
+
 export interface MaterialisationOutcome {
   ref: DocumentRef;
   memberId: string;
@@ -202,6 +256,11 @@ export interface ApplyDueReleasesResult {
   due: number;
   /** Releases moved to `published` by THIS pass. */
   published: number;
+  /**
+   * Releases moved to `blocked` by THIS pass, because nothing about retrying
+   * them could succeed.
+   */
+  blocked: number;
   applied: number;
   failed: number;
   /**
@@ -235,6 +294,7 @@ export async function applyDueReleases(
     return {
       due: 0,
       published: 0,
+      blocked: 0,
       applied: 0,
       failed: 0,
       deferred: 0,
@@ -283,6 +343,29 @@ export async function applyDueReleases(
     }
   }
 
+  // A release that can NEVER be applied is stopped rather than left scheduled.
+  // Left alone it is replanned every tick forever, and it reads as healthy the
+  // whole time — the operator learns nothing until the launch does not happen.
+  //
+  // Expanded over the overlapping components for the same reason holding open
+  // is: a release sharing a document with a permanently broken one can never
+  // settle either, because the pair is only ever discharged together. Blocking
+  // one and not the other would leave the second retrying forever, which is the
+  // condition this exists to end.
+  const permanent = permanentlyBrokenReleases(outcomes);
+  const toBlock = new Set<string>();
+  if (permanent.size > 0) {
+    for (const group of plan.overlappingReleases) {
+      if (group.some(id => permanent.has(id))) {
+        for (const id of group) toBlock.add(id);
+      }
+    }
+  }
+  let blocked = 0;
+  for (const id of toBlock) {
+    if (await deps.repository.blockRelease(id)) blocked += 1;
+  }
+
   const { published, undischarged } = await dischargeSettledComponents(
     deps,
     plan,
@@ -300,6 +383,7 @@ export async function applyDueReleases(
     failed,
     deferred,
     undischarged,
+    blocked,
     outcomes,
   };
 }

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -121,10 +121,12 @@ export interface ApplyDueReleasesDeps {
     /**
      * Stop a release nothing about retrying could fix.
      *
-     * Fenced on `scheduled` in the repository, so a release cancelled or
-     * rescheduled while this pass ran keeps the state a person chose.
+     * Takes the instant the pass planned against, and the repository fences on
+     * it as well as on the state — the same pair `isStillDueAt` judges by. A
+     * release someone postponed between the plan and this call is left alone,
+     * rather than having the schedule they just chose replaced with `blocked`.
      */
-    blockRelease(id: string): Promise<boolean>;
+    blockRelease(id: string, scheduledAt: Date): Promise<boolean>;
   };
   mutations: ReleaseMutations;
   /** The identity reads, so a member's author can be resolved. */
@@ -229,6 +231,57 @@ const RETRY_COULD_HELP: Record<MaterialisationFailure, boolean> = {
   // state they did not ask for.
   RELEASE_NO_LONGER_SCHEDULED: true,
 };
+
+/**
+ * Stop every release this pass proved can never run, and say how many moved.
+ *
+ * Expanded over the overlapping components for the same reason holding open is:
+ * a release sharing a document with a permanently broken one can never settle
+ * either, because the pair is only ever discharged together. Blocking one and
+ * not the other would leave the second retrying forever, which is the condition
+ * this exists to end.
+ */
+async function stopHopelessReleases(
+  deps: ApplyDueReleasesDeps,
+  plan: ReturnType<typeof planReleaseMaterialisation>,
+  outcomes: readonly MaterialisationOutcome[],
+  plannedInstants: ReadonlyMap<string, Date>
+): Promise<number> {
+  const permanent = permanentlyBrokenReleases(outcomes);
+  if (permanent.size === 0) return 0;
+
+  const toBlock = new Set<string>();
+  for (const group of plan.overlappingReleases) {
+    if (group.some(id => permanent.has(id))) {
+      for (const id of group) toBlock.add(id);
+    }
+  }
+
+  // EARLIEST FIRST, and this ordering is load-bearing rather than tidy. The
+  // component is blocked with one write per release and the port has no
+  // transaction, so a crash or an error partway through leaves it split — and
+  // which half survives decides what the document looks like. Blocking the
+  // earliest first means any prefix that succeeds leaves the LATER releases
+  // still scheduled, and the later one is the winner under the engine's total
+  // order: the document ends in the state the whole component would have left
+  // it in. Blocking the latest first inverts that — the earlier release becomes
+  // the winner and applies the opposite lifecycle action.
+  const ordered = [...toBlock].sort((a, b) => {
+    const at = plannedInstants.get(a)?.getTime() ?? 0;
+    const bt = plannedInstants.get(b)?.getTime() ?? 0;
+    return at - bt;
+  });
+
+  let blocked = 0;
+  for (const id of ordered) {
+    const at = plannedInstants.get(id);
+    // A release with no planned instant was not part of this pass's plan, so
+    // there is nothing to fence against and nothing to stop.
+    if (at === undefined) continue;
+    if (await deps.repository.blockRelease(id, at)) blocked += 1;
+  }
+  return blocked;
+}
 
 /** The releases this pass proved can never be applied as they stand. */
 function permanentlyBrokenReleases(
@@ -352,19 +405,16 @@ export async function applyDueReleases(
   // settle either, because the pair is only ever discharged together. Blocking
   // one and not the other would leave the second retrying forever, which is the
   // condition this exists to end.
-  const permanent = permanentlyBrokenReleases(outcomes);
-  const toBlock = new Set<string>();
-  if (permanent.size > 0) {
-    for (const group of plan.overlappingReleases) {
-      if (group.some(id => permanent.has(id))) {
-        for (const id of group) toBlock.add(id);
-      }
-    }
-  }
-  let blocked = 0;
-  for (const id of toBlock) {
-    if (await deps.repository.blockRelease(id)) blocked += 1;
-  }
+  const blocked = await stopHopelessReleases(
+    deps,
+    plan,
+    outcomes,
+    // The instants THIS pass planned against, so blocking fences on the same
+    // schedule the plan was built from.
+    new Map(
+      releases.flatMap(r => (r.scheduledAt ? [[r.id, r.scheduledAt]] : []))
+    )
+  );
 
   const { published, undischarged } = await dischargeSettledComponents(
     deps,

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -18,6 +18,7 @@ import {
   RELEASE_ASSEMBLABLE_FROM,
   RELEASE_CANCELLABLE_FROM,
   RELEASE_SCHEDULABLE_FROM,
+  RELEASE_STATES_AFFECTING_CONTENT,
   type ReleaseMemberAction,
   type ReleaseState,
 } from "../../schemas/releases/types";
@@ -246,7 +247,8 @@ export class ReleasesRepository {
   async scheduleRelease(
     id: string,
     at: Date,
-    timezone: string
+    timezone: string,
+    from: readonly ReleaseState[] = RELEASE_SCHEDULABLE_FROM
   ): Promise<boolean> {
     const affected = await this.db.updateCount(
       RELEASES,
@@ -262,10 +264,18 @@ export class ReleasesRepository {
           // The fence IS the declaration, not a copy of it: the admin decides
           // which controls to offer from the same list, so a change here cannot
           // leave a button offering a move the database refuses.
+          //
+          // NARROWED BY THE CALLER when it has already formed a judgement about
+          // this release's state. Scheduling a blocked release is a recovery
+          // and is valid only once nothing blocks it, which the service decides
+          // from a read; passing the state that read observed makes this update
+          // a compare-and-set on it. A release blocked between the two simply
+          // fails the fence, rather than being rescheduled with its blockers
+          // never examined.
           {
             column: "state",
             op: "IN",
-            value: [...RELEASE_SCHEDULABLE_FROM],
+            value: [...from],
           },
         ],
       }
@@ -275,21 +285,6 @@ export class ReleasesRepository {
     return true;
   }
 
-  /**
-   * Call a release off.
-   *
-   * Nothing is undone and nothing is written to any document: the read rule
-   * consults only `scheduled` releases, so a cancelled one simply stops being
-   * consulted. That is what makes cancelling a due-but-unmaterialised release
-   * free, and it is why there is no restore path here.
-   */
-  /**
-   * Call a release off, and say whether it moved.
-   *
-   * Fenced away from `published` for the same reason scheduling is: that
-   * release already happened, and marking it cancelled would describe history
-   * that did not occur while leaving the published content in place.
-   */
   /**
    * Stop a release the drain can never apply, and say whether it moved.
    *
@@ -329,6 +324,19 @@ export class ReleasesRepository {
     return true;
   }
 
+  /**
+   * Call a release off, and say whether it moved.
+   *
+   * Nothing is undone and nothing is written to any document: the read rule
+   * consults only the states in `RELEASE_STATES_AFFECTING_CONTENT`, so a
+   * cancelled release simply stops being consulted. That is what makes
+   * cancelling a due-but-unmaterialised release free, and why there is no
+   * restore path here.
+   *
+   * Fenced away from `published` for the same reason scheduling is: that
+   * release already happened, and marking it cancelled would describe history
+   * that did not occur while leaving the published content in place.
+   */
   async cancelRelease(id: string): Promise<boolean> {
     const affected = await this.db.updateCount(
       RELEASES,
@@ -663,8 +671,15 @@ export class ReleasesRepository {
   }
 
   /**
-   * Members of SCHEDULED releases for each of `refs`, in a CONSTANT number of
+   * Members of releases IN `states` for each of `refs`, in a CONSTANT number of
    * queries — two, and never one per document.
+   *
+   * `states` decides which releases count, and it defaults to the read path's
+   * {@link RELEASE_STATES_AFFECTING_CONTENT} because that is the caller which
+   * must never widen by accident: admitting a blocked release here would let a
+   * release that has stopped go on deciding what a visitor sees. A surface that
+   * wants more — a document's banner, which must keep reporting a release that
+   * stopped — asks for it explicitly and says why at the call site.
    *
    * Never call this per row. A listing read resolves its whole result set here
    * and then asks `resolveReleaseEffect` per document, so the database cost
@@ -679,7 +694,8 @@ export class ReleasesRepository {
    */
   async findDueMembersFor(
     refs: DocumentRef[],
-    _now: Date
+    _now: Date,
+    states: readonly ReleaseState[] = RELEASE_STATES_AFFECTING_CONTENT
   ): Promise<Map<string, DueMember[]>> {
     const grouped = new Map<string, DueMember[]>();
     // No refs means no question to ask. Returning early keeps an empty listing
@@ -706,8 +722,9 @@ export class ReleasesRepository {
     // when there are members at all, so the common case — nothing scheduled
     // anywhere — still costs the single query above.
     if (scheduled.length === 0) return grouped;
-    const releases = await this.loadScheduledReleases(
-      scheduled.map(m => m.releaseId)
+    const releases = await this.loadReleasesInStates(
+      scheduled.map(m => m.releaseId),
+      states
     );
 
     const wanted = new Set(refs.map(documentRefKey));
@@ -783,8 +800,11 @@ export class ReleasesRepository {
     });
     if (members.length === 0) return NO_DECISIONS;
 
-    const releases = await this.loadScheduledReleases(
-      members.map(m => m.releaseId)
+    const releases = await this.loadReleasesInStates(
+      members.map(m => m.releaseId),
+      // The READ path, so the narrow list: a blocked release must not decide
+      // what a visitor sees.
+      RELEASE_STATES_AFFECTING_CONTENT
     );
     if (releases.size === 0) return NO_DECISIONS;
 
@@ -910,8 +930,8 @@ export class ReleasesRepository {
   /**
    * Of the given author ids, those whose user still exists and is still active.
    *
-   * A second `IN` query rather than a join, matching {@link loadScheduledReleases}
-   * directly above: the adapter layer is dialect-agnostic and expresses no joins,
+   * A second `IN` query rather than a join, matching {@link loadReleasesInStates}
+   * below: the adapter layer is dialect-agnostic and expresses no joins,
    * and two small keyed reads are the shape this repository already pays on a
    * read that reaches here at all.
    *
@@ -949,8 +969,21 @@ export class ReleasesRepository {
     return new Set(rows.map(r => r.id));
   }
 
-  private async loadScheduledReleases(
-    ids: string[]
+  /**
+   * Of the given releases, those in `states`, keyed by id.
+   *
+   * The states are the CALLER'S, and there is no default. Two callers reach
+   * here wanting different answers — a content read must see only what may
+   * change a page, a document's banner must also see what stopped — and a
+   * shared constant baked in here would silently decide for both. It did once:
+   * this filtered `scheduled` alone, so the banner's wider list sat one layer
+   * above a query that had already dropped every row it named, and the widening
+   * could not fire. Requiring the argument makes that a compile error rather
+   * than a screen that quietly says nothing.
+   */
+  private async loadReleasesInStates(
+    ids: string[],
+    states: readonly ReleaseState[]
   ): Promise<Map<string, { scheduledAt: Date | null }>> {
     const rows = await this.db.select<{
       id: string;
@@ -961,7 +994,9 @@ export class ReleasesRepository {
       where: {
         and: [
           { column: "id", op: "IN", value: [...new Set(ids)] },
-          { column: "state", op: "=", value: "scheduled" },
+          // `IN` even for a single state, so widening the list is a change to
+          // the argument and never to the shape of the query.
+          { column: "state", op: "IN", value: [...states] },
         ],
       },
     });

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -290,6 +290,36 @@ export class ReleasesRepository {
    * release already happened, and marking it cancelled would describe history
    * that did not occur while leaving the published content in place.
    */
+  /**
+   * Stop a release the drain can never apply, and say whether it moved.
+   *
+   * Fenced on `scheduled` alone. Every other state is either a decision
+   * somebody made — cancelled, or rescheduled out from under this pass — or an
+   * outcome already reached, and overwriting any of them with `blocked` would
+   * replace a person's intent with a machine's verdict.
+   *
+   * Deliberately does NOT revalidate. A blocked release is not consulted by the
+   * read rule, exactly as a scheduled one whose instant has not arrived is not
+   * — so nothing a reader can see changes, and a cache bust would be work with
+   * no observable effect.
+   */
+  async blockRelease(id: string): Promise<boolean> {
+    const affected = await this.db.updateCount(
+      RELEASES,
+      {
+        state: "blocked" satisfies ReleaseState,
+        updatedAt: new Date(),
+      },
+      {
+        and: [
+          { column: "id", op: "=", value: id },
+          { column: "state", op: "=", value: "scheduled" },
+        ],
+      }
+    );
+    return affected > 0;
+  }
+
   async cancelRelease(id: string): Promise<boolean> {
     const affected = await this.db.updateCount(
       RELEASES,

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -293,17 +293,21 @@ export class ReleasesRepository {
   /**
    * Stop a release the drain can never apply, and say whether it moved.
    *
-   * Fenced on `scheduled` alone. Every other state is either a decision
-   * somebody made — cancelled, or rescheduled out from under this pass — or an
-   * outcome already reached, and overwriting any of them with `blocked` would
-   * replace a person's intent with a machine's verdict.
+   * Fenced on the state AND on the instant the pass planned against, the same
+   * pair `isStillDueAt` judges by. State alone is not enough: an editor who
+   * postpones a due release between the plan and this write leaves the row in
+   * `scheduled`, so a state-only predicate matches and overwrites the schedule
+   * they just chose. The release would then never run at the replacement
+   * instant, and nothing would say why.
    *
-   * Deliberately does NOT revalidate. A blocked release is not consulted by the
-   * read rule, exactly as a scheduled one whose instant has not arrived is not
-   * — so nothing a reader can see changes, and a cache bust would be work with
-   * no observable effect.
+   * REVALIDATES, and the reason is worth stating because the opposite looks
+   * right: only a DUE release is ever blocked, and a due release is already in
+   * effect for readers — `resolveReleaseEffect` counts every member whose
+   * instant has passed. So its projection is live, and stopping it removes
+   * something a reader can currently see. A scheduled release whose instant has
+   * NOT arrived would indeed need no flush; that is a different release.
    */
-  async blockRelease(id: string): Promise<boolean> {
+  async blockRelease(id: string, scheduledAt: Date): Promise<boolean> {
     const affected = await this.db.updateCount(
       RELEASES,
       {
@@ -314,10 +318,15 @@ export class ReleasesRepository {
         and: [
           { column: "id", op: "=", value: id },
           { column: "state", op: "=", value: "scheduled" },
+          { column: "scheduledAt", op: "=", value: scheduledAt },
         ],
       }
     );
-    return affected > 0;
+    if (affected === 0) return false;
+    // Also drops the shared transition memo, which would otherwise keep
+    // answering `mayHaveDue` for a release that has stopped.
+    await this.revalidateMembersOf(id);
+    return true;
   }
 
   async cancelRelease(id: string): Promise<boolean> {

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -214,6 +214,24 @@ function matchesListQuery(row: ReleaseRow, query: FindReleasesQuery): boolean {
   return true;
 }
 
+/**
+ * One member standing between a release and its instant.
+ *
+ * Named per MEMBER rather than per release, because the fix is per member —
+ * remove that document, or restore that user — and a release-level "something
+ * is wrong" leaves an operator opening every row to find which.
+ */
+export interface ReleaseBlocker {
+  memberId: string;
+  reason:
+    /** The member carries no author, so the drain has nobody to act as. */
+    | "NO_AUTHOR"
+    /** The recorded author has been deleted or deactivated. */
+    | "AUTHOR_GONE"
+    /** The member names one locale, which the engine cannot materialise. */
+    | "LOCALE_SCOPED";
+}
+
 export interface FindReleasesQuery {
   /**
    * Restrict to one lifecycle state.
@@ -539,6 +557,57 @@ export class ReleasesService {
       );
     }
     return this.deps.repository.findReleases(query);
+  }
+
+  /**
+   * Why this release cannot proceed, worked out from its members right now.
+   *
+   * DERIVED rather than stored, and that is the whole design. Every reason a
+   * release blocks is a fact about a member that is still true when the row is
+   * read — no author recorded, an author who is gone, a locale-scoped member —
+   * so recording the reason at block time would create a second copy that goes
+   * stale the moment somebody fixes the cause. An operator who restores the
+   * deleted user would still be told the author is missing, and the only way
+   * out would be to reschedule and watch it block again.
+   *
+   * Answered for any release, not only a blocked one. The same predicate over a
+   * DRAFT is a preview of what would block it, which is the cheaper place to
+   * learn it — and having one implementation means the preview and the verdict
+   * cannot disagree.
+   *
+   * `liveAuthors` is asked ONCE for every author in the release rather than per
+   * member, so a release of fifty documents costs one lookup.
+   */
+  async blockingReasons(
+    releaseId: string,
+    actor: ReleaseActor
+  ): Promise<ReleaseBlocker[]> {
+    await this.authorize(actor, "read");
+    const members = await this.deps.repository.listMembers(releaseId);
+    if (members.length === 0) return [];
+
+    const authors = members
+      .map(member => member.createdBy)
+      .filter((id): id is string => id !== null);
+    const live =
+      authors.length === 0
+        ? new Set<string>()
+        : await this.deps.repository.liveAuthors(authors);
+
+    return members.flatMap<ReleaseBlocker>(member => {
+      // Ordered as the drain checks them, so the reason reported is the one it
+      // would actually stop on rather than whichever this loop noticed first.
+      if (member.locale !== null) {
+        return [{ memberId: member.id, reason: "LOCALE_SCOPED" as const }];
+      }
+      if (member.createdBy === null) {
+        return [{ memberId: member.id, reason: "NO_AUTHOR" as const }];
+      }
+      if (!live.has(member.createdBy)) {
+        return [{ memberId: member.id, reason: "AUTHOR_GONE" as const }];
+      }
+      return [];
+    });
   }
 
   async listMembers(

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -56,9 +56,11 @@ import {
   RELEASE_CANCELLABLE_FROM,
   RELEASE_SCHEDULABLE_FROM,
   isReleaseMemberAction,
+  type ReleaseBlockerReason,
   type ReleaseMemberAction,
   type ReleaseState,
 } from "../../../schemas/releases/types";
+import type { VersionScopeKind } from "../../../schemas/versions/types";
 import { isUniqueViolation } from "../../../shared/lib/unique-violation";
 import { documentRefKey } from "../releases-repository";
 import type {
@@ -181,6 +183,17 @@ export interface ReleasesServiceDeps {
 }
 
 /**
+ * The release states a document's editor needs to be told about.
+ *
+ * `scheduled` because it is about to happen, and `blocked` because it was going
+ * to and now will not — both are facts about this document that nothing else on
+ * the editor's screen carries. Every other state is finished: a published
+ * release already did its work and a cancelled one was called off on purpose,
+ * and reporting either would be telling an editor about history.
+ */
+const VISIBLE_ON_A_DOCUMENT: readonly ReleaseState[] = ["scheduled", "blocked"];
+
+/**
  * The engine's total order over two members, ascending.
  *
  * The same three keys `resolveReleaseEffect` decides a winner with — instant,
@@ -199,6 +212,23 @@ function byEngineOrder(
   const byCreated = a.createdAt.getTime() - b.createdAt.getTime();
   if (byCreated !== 0) return byCreated;
   return a.memberId < b.memberId ? -1 : a.memberId > b.memberId ? 1 : 0;
+}
+
+/**
+ * Why this member cannot be applied, or `null` if it can.
+ *
+ * The order matters and is the drain's: a member that is BOTH locale-scoped and
+ * authorless is reported as the one the drain would actually stop on, rather
+ * than whichever a loop noticed first.
+ */
+function blockerReasonFor(
+  member: ReleaseMemberRow,
+  liveAuthors: ReadonlySet<string>
+): ReleaseBlockerReason | null {
+  if (member.locale !== null) return "LOCALE_SCOPED";
+  if (member.createdBy === null) return "NO_AUTHOR";
+  if (!liveAuthors.has(member.createdBy)) return "AUTHOR_GONE";
+  return null;
 }
 
 /** Whether a row satisfies the qualifiers a list query carries beside `containing`. */
@@ -223,13 +253,24 @@ function matchesListQuery(row: ReleaseRow, query: FindReleasesQuery): boolean {
  */
 export interface ReleaseBlocker {
   memberId: string;
-  reason:
-    /** The member carries no author, so the drain has nobody to act as. */
-    | "NO_AUTHOR"
-    /** The recorded author has been deleted or deactivated. */
-    | "AUTHOR_GONE"
-    /** The member names one locale, which the engine cannot materialise. */
-    | "LOCALE_SCOPED";
+  reason: ReleaseBlockerReason;
+  /**
+   * What this member was going to DO, carried so a reader is not left to guess.
+   *
+   * A blocked takedown is not a failed publish, and a notice that says "could
+   * not be published" about one states the opposite of the truth.
+   */
+  action: ReleaseMemberAction;
+  /**
+   * Which document, so the fix names a row rather than an opaque id.
+   *
+   * `VersionScopeKind` rather than the two values releases accept today: it is
+   * the type the member row actually carries, and narrowing it here would be a
+   * second, quietly smaller vocabulary for the same field.
+   */
+  scopeKind: VersionScopeKind;
+  scopeSlug: string;
+  entryId: string;
 }
 
 export interface FindReleasesQuery {
@@ -509,7 +550,15 @@ export class ReleasesService {
         // been published, and emitting it would report an action that has
         // ALREADY HAPPENED as still coming. A reader polling until nothing is
         // pending would then stop on that row and keep the claim forever.
-        if (release.state !== "scheduled") return [];
+        //
+        // `blocked` is kept for the OPPOSITE reason. A release that stopped
+        // still holds this document and is still going nowhere, so dropping it
+        // makes the document's banner vanish — and a banner disappearing reads
+        // as resolved. The editor concludes the release already ran or was
+        // called off, when in truth the launch has failed and needs somebody to
+        // fix a member. Silence would be worse here than never having shown
+        // anything.
+        if (!VISIBLE_ON_A_DOCUMENT.includes(release.state)) return [];
         return [{ ...release, memberAction: member.action, member }];
       })
       // THE ENGINE'S OWN ORDER, not a simpler one that agrees with it most of
@@ -519,7 +568,19 @@ export class ReleasesService {
       // Sorting on the instant alone leaves those ties in whatever order the
       // database returned, so a reader taking the last row as the final state —
       // which is exactly what this ordering invites — could read the loser.
-      .sort((a, b) => byEngineOrder(a.member, b.member));
+      //
+      // The instant comes from the RE-READ row, not from the member. These are
+      // two reads: a release moved between them carries its new time on the row
+      // that is displayed, and sorting by the old one renders dates out of
+      // order — and, under a limit, keeps rows that are no longer the earliest.
+      // The tie-breakers stay the member's, because that is what the engine
+      // breaks ties on.
+      .sort((a, b) =>
+        byEngineOrder(
+          { ...a.member, scheduledAt: a.scheduledAt ?? a.member.scheduledAt },
+          { ...b.member, scheduledAt: b.scheduledAt ?? b.member.scheduledAt }
+        )
+      );
 
     // The document filter NARROWS the list; it does not replace it. A caller
     // combining it with a window or a limit asked for both, and answering with
@@ -597,16 +658,20 @@ export class ReleasesService {
     return members.flatMap<ReleaseBlocker>(member => {
       // Ordered as the drain checks them, so the reason reported is the one it
       // would actually stop on rather than whichever this loop noticed first.
-      if (member.locale !== null) {
-        return [{ memberId: member.id, reason: "LOCALE_SCOPED" as const }];
-      }
-      if (member.createdBy === null) {
-        return [{ memberId: member.id, reason: "NO_AUTHOR" as const }];
-      }
-      if (!live.has(member.createdBy)) {
-        return [{ memberId: member.id, reason: "AUTHOR_GONE" as const }];
-      }
-      return [];
+      const reason = blockerReasonFor(member, live);
+      if (reason === null) return [];
+      return [
+        {
+          memberId: member.id,
+          reason,
+          // Carried so a reader is not left with an opaque id and a sentence
+          // that assumes a publish: a blocked takedown is not a failed publish.
+          action: member.action,
+          scopeKind: member.scopeKind,
+          scopeSlug: member.scopeSlug,
+          entryId: member.entryId,
+        },
+      ];
     });
   }
 
@@ -873,6 +938,30 @@ export class ReleasesService {
         logContext: { reason: "invalid-timezone", length: timezone.length },
       });
     }
+    // A BLOCKED release is refused while what stopped it is still true.
+    // Scheduling it again would reach the instant, hit the same member, and
+    // stop again — and the operator would learn that only by waiting for a
+    // launch that does not happen. Checked here rather than left to the drain
+    // because this is the moment somebody is asking, and the answer is already
+    // derivable from the members.
+    //
+    // Only for a blocked release: every other state pays no extra read.
+    const [current] = await this.deps.repository.findReleases({ ids: [id] });
+    if (current?.state === "blocked") {
+      const blockers = await this.blockingReasons(id, actor);
+      if (blockers.length > 0) {
+        throw NextlyError.conflict({
+          message:
+            "This release cannot be scheduled until the documents blocking it are fixed or removed.",
+          logContext: {
+            reason: "release-still-blocked",
+            releaseId: id,
+            blockers: blockers.length,
+          },
+        });
+      }
+    }
+
     // The fence answers `false` for a release whose current state forbids the
     // move — a published one, most importantly, because re-scheduling it makes
     // the drain re-apply members against documents that have changed since.

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -55,6 +55,9 @@ import {
   RELEASE_ASSEMBLABLE_WITH_PUBLISH_FROM,
   RELEASE_CANCELLABLE_FROM,
   RELEASE_SCHEDULABLE_FROM,
+  RELEASE_SCHEDULABLE_FROM_BLOCKED,
+  RELEASE_SCHEDULABLE_FROM_UNBLOCKED,
+  RELEASE_STATES_SHOWN_ON_A_DOCUMENT,
   isReleaseMemberAction,
   type ReleaseBlockerReason,
   type ReleaseMemberAction,
@@ -181,17 +184,6 @@ export interface ReleasesServiceDeps {
     userRoles?: string[];
   }) => Promise<boolean>;
 }
-
-/**
- * The release states a document's editor needs to be told about.
- *
- * `scheduled` because it is about to happen, and `blocked` because it was going
- * to and now will not — both are facts about this document that nothing else on
- * the editor's screen carries. Every other state is finished: a published
- * release already did its work and a cancelled one was called off on purpose,
- * and reporting either would be telling an editor about history.
- */
-const VISIBLE_ON_A_DOCUMENT: readonly ReleaseState[] = ["scheduled", "blocked"];
 
 /**
  * The engine's total order over two members, ascending.
@@ -528,7 +520,17 @@ export class ReleasesService {
     now: Date
   ): Promise<Array<ReleaseRow & { memberAction: ReleaseMemberAction }>> {
     const ref = query.containing;
-    const grouped = await this.deps.repository.findDueMembersFor([ref], now);
+    // ASKED FOR, rather than filtered out of the answer afterwards. The
+    // repository's default is the read path's narrow list, so a banner that
+    // did not name its states here would receive scheduled releases only and
+    // its `blocked` case below could never run — which is exactly what this
+    // code did before: the widening sat one layer above the query that had
+    // already dropped the rows.
+    const grouped = await this.deps.repository.findDueMembersFor(
+      [ref],
+      now,
+      RELEASE_STATES_SHOWN_ON_A_DOCUMENT
+    );
     const members = grouped.get(documentRefKey(ref)) ?? [];
     if (members.length === 0) return [];
 
@@ -544,10 +546,11 @@ export class ReleasesService {
         // rather than rendered without its instant: a row saying a document is
         // scheduled, without saying when, is worse than not mentioning it.
         if (release === undefined) return [];
-        // RE-CHECKED, because these are two reads and the drain runs between
-        // them. `findDueMembersFor` selects members of scheduled releases; by
-        // the time the second read fetches those releases one may already have
-        // been published, and emitting it would report an action that has
+        // RE-CHECKED against the SECOND read, and that is all this now does:
+        // the query above already asked for these states, so this is not the
+        // filter but a guard on the window between the two reads. The drain
+        // runs in that window; by the time the second read fetches these
+        // releases one may already have been published, and emitting it would report an action that has
         // ALREADY HAPPENED as still coming. A reader polling until nothing is
         // pending would then stop on that row and keep the claim forever.
         //
@@ -558,7 +561,8 @@ export class ReleasesService {
         // called off, when in truth the launch has failed and needs somebody to
         // fix a member. Silence would be worse here than never having shown
         // anything.
-        if (!VISIBLE_ON_A_DOCUMENT.includes(release.state)) return [];
+        if (!RELEASE_STATES_SHOWN_ON_A_DOCUMENT.includes(release.state))
+          return [];
         return [{ ...release, memberAction: member.action, member }];
       })
       // THE ENGINE'S OWN ORDER, not a simpler one that agrees with it most of
@@ -644,6 +648,25 @@ export class ReleasesService {
     actor: ReleaseActor
   ): Promise<ReleaseBlocker[]> {
     await this.authorize(actor, "read");
+    return this.derivedBlockers(releaseId);
+  }
+
+  /**
+   * The same verdict, for a caller that has ALREADY established its authority.
+   *
+   * Split from {@link blockingReasons} because the read grant belongs to the
+   * public surface and not to the derivation. `schedule` authorizes `publish`
+   * and then needs this answer; routing it through the public method demanded
+   * `read` as well, and an API key scoped to `publish-content-releases` alone
+   * has no such grant — the exact-grant lookup answers before the service's
+   * create-or-publish-implies-read fallback. Such a key could schedule every
+   * release on the site except a repaired one, which is the single case the
+   * check exists for.
+   *
+   * Private, and reachable only after an authorization: the caller has to have
+   * decided already, because nothing here checks.
+   */
+  private async derivedBlockers(releaseId: string): Promise<ReleaseBlocker[]> {
     const members = await this.deps.repository.listMembers(releaseId);
     if (members.length === 0) return [];
 
@@ -947,8 +970,12 @@ export class ReleasesService {
     //
     // Only for a blocked release: every other state pays no extra read.
     const [current] = await this.deps.repository.findReleases({ ids: [id] });
-    if (current?.state === "blocked") {
-      const blockers = await this.blockingReasons(id, actor);
+    const wasBlocked = current?.state === "blocked";
+    if (wasBlocked) {
+      // `derivedBlockers`, not `blockingReasons`: `publish` was authorized
+      // above, and going through the public method would demand `read` as
+      // well — a grant a publish-scoped API key need not hold.
+      const blockers = await this.derivedBlockers(id);
       if (blockers.length > 0) {
         throw NextlyError.conflict({
           message:
@@ -962,12 +989,36 @@ export class ReleasesService {
       }
     }
 
+    // FENCED ON THE STATE THE VERDICT ABOVE WAS FORMED AGAINST, which is what
+    // makes the check and the write one decision rather than two.
+    //
+    // The read and this write are separated by the blocker derivation, and the
+    // drain runs in that window. Both interleavings are refused rather than
+    // silently accepted:
+    //
+    //   - Read `scheduled`, so no blockers were examined; the drain then blocks
+    //     the release. Fencing on the full schedulable list would accept
+    //     `blocked` here and reschedule a release whose permanent blockers
+    //     nobody looked at — it would reach the new instant and stop again.
+    //     Excluding `blocked` makes that update match nothing.
+    //   - Read `blocked` and found it clean; something reschedules or cancels
+    //     it first. Fencing on `blocked` alone refuses, rather than overwriting
+    //     a decision made after the verdict.
+    //
+    // Either way the caller is told, and a retry re-derives against what is
+    // now true. The alternative — a transaction — is not available: the port
+    // exposes no transaction, which is the same constraint the drain's
+    // blocking pass works within.
+    const from = wasBlocked
+      ? RELEASE_SCHEDULABLE_FROM_BLOCKED
+      : RELEASE_SCHEDULABLE_FROM_UNBLOCKED;
+
     // The fence answers `false` for a release whose current state forbids the
     // move — a published one, most importantly, because re-scheduling it makes
     // the drain re-apply members against documents that have changed since.
     // Reported as a CONFLICT rather than swallowed: a caller told nothing would
     // read a no-op as a schedule that took.
-    if (!(await this.deps.repository.scheduleRelease(id, at, timezone))) {
+    if (!(await this.deps.repository.scheduleRelease(id, at, timezone, from))) {
       throw NextlyError.conflict({
         logContext: { reason: "release-not-schedulable", releaseId: id },
       });

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -379,4 +379,8 @@ export * from "./security-config"; // Zod — review in Task 19
 // and must not be able to name one the engine cannot produce, and a second
 // spelling of these unions in a client is how a screen starts describing a
 // state the server has never sent.
-export type { ReleaseState, ReleaseMemberAction } from "./releases/types";
+export type {
+  ReleaseState,
+  ReleaseMemberAction,
+  ReleaseBlockerReason,
+} from "./releases/types";

--- a/packages/nextly/src/schemas/releases/__tests__/parity.test.ts
+++ b/packages/nextly/src/schemas/releases/__tests__/parity.test.ts
@@ -79,6 +79,10 @@ describe("release enums", () => {
       "scheduled",
       "published",
       "cancelled",
+      // A release the drain will never be able to apply. Listed last because
+      // the order is the lifecycle's, and this is the only state reached by
+      // failing rather than by anyone deciding anything.
+      "blocked",
     ]);
     expect([...RELEASE_MEMBER_ACTIONS]).toEqual(["publish", "unpublish"]);
   });

--- a/packages/nextly/src/schemas/releases/types.ts
+++ b/packages/nextly/src/schemas/releases/types.ts
@@ -70,6 +70,26 @@ export function isReleaseMemberAction(v: unknown): v is ReleaseMemberAction {
 }
 
 /**
+ * Why a release cannot be applied, in the vocabulary a CLIENT renders.
+ *
+ * Declared beside the states rather than in the service, so the admin can
+ * `import type` it from the same leaf module it takes `ReleaseState` from. Two
+ * spellings of this union is how a core addition compiles everywhere and then
+ * renders `undefined` in the one screen that maps it to a sentence.
+ *
+ * Deliberately NOT the drain's `MaterialisationFailure`. That names what went
+ * wrong during one pass, transient causes included; this names what is still
+ * true of a stored member and therefore what somebody has to fix.
+ */
+export type ReleaseBlockerReason =
+  /** The member carries no author, so the drain has nobody to act as. */
+  | "NO_AUTHOR"
+  /** The recorded author has been deleted or deactivated. */
+  | "AUTHOR_GONE"
+  /** The member names one locale, which the engine cannot materialise. */
+  | "LOCALE_SCOPED";
+
+/**
  * Which states each lifecycle move may START from.
  *
  * Declared once, here, because three separate places need the same answer and

--- a/packages/nextly/src/schemas/releases/types.ts
+++ b/packages/nextly/src/schemas/releases/types.ts
@@ -13,10 +13,28 @@
  * Lifecycle of a release.
  *
  * Only `scheduled` affects reads. `draft` is still being assembled, `published`
- * has already been materialised into the live rows, and `cancelled` was called
- * off — so a read consults exactly one state and the other three cost nothing.
+ * has already been materialised into the live rows, `cancelled` was called off,
+ * and `blocked` cannot proceed — so a read consults exactly one state and the
+ * other four cost nothing.
+ *
+ * `blocked` is a release the drain will never be able to apply, for a reason
+ * retrying cannot fix: a member with no author, an author who has been deleted
+ * or deactivated, or a locale-scoped member the engine does not support. It
+ * exists because leaving such a release `scheduled` makes it retry every tick
+ * forever while looking exactly like a healthy one — and the operator learns
+ * nothing until the launch does not happen.
+ *
+ * A TRANSIENT failure — a lookup that errored, a re-read that errored — does
+ * NOT block. Those are documented as retry-worthy where they are raised, and
+ * blocking on one would let a momentary database blip permanently stop a launch
+ * that the next pass would have completed.
  */
-export type ReleaseState = "draft" | "scheduled" | "published" | "cancelled";
+export type ReleaseState =
+  | "draft"
+  | "scheduled"
+  | "published"
+  | "cancelled"
+  | "blocked";
 
 /** What a member does to its document when the release takes effect. */
 export type ReleaseMemberAction = "publish" | "unpublish";
@@ -27,6 +45,7 @@ export const RELEASE_STATES: readonly ReleaseState[] = [
   "scheduled",
   "published",
   "cancelled",
+  "blocked",
 ];
 
 /** The member actions, in the order the admin offers them. */
@@ -76,6 +95,9 @@ export const RELEASE_SCHEDULABLE_FROM: readonly ReleaseState[] = [
   "draft",
   "scheduled",
   "cancelled",
+  // A blocked release is fixed and then rescheduled. Excluding it would leave
+  // the operator who has just removed the offending member with nothing to do.
+  "blocked",
 ];
 
 /**
@@ -87,6 +109,8 @@ export const RELEASE_SCHEDULABLE_FROM: readonly ReleaseState[] = [
 export const RELEASE_CANCELLABLE_FROM: readonly ReleaseState[] = [
   "draft",
   "scheduled",
+  // Abandoning a blocked release is the other way out of it.
+  "blocked",
 ];
 
 /**
@@ -98,6 +122,9 @@ export const RELEASE_CANCELLABLE_FROM: readonly ReleaseState[] = [
 export const RELEASE_ASSEMBLABLE_FROM: readonly ReleaseState[] = [
   "draft",
   "cancelled",
+  // Editable BECAUSE it is blocked: the fix is usually to remove the member
+  // whose author is gone, and a release nobody can edit cannot be unblocked.
+  "blocked",
 ];
 
 /**

--- a/packages/nextly/src/schemas/releases/types.ts
+++ b/packages/nextly/src/schemas/releases/types.ts
@@ -156,3 +156,65 @@ export const RELEASE_ASSEMBLABLE_FROM: readonly ReleaseState[] = [
 export const RELEASE_ASSEMBLABLE_WITH_PUBLISH_FROM: readonly ReleaseState[] = [
   "scheduled",
 ];
+
+/**
+ * Which release states a CONTENT read must honour.
+ *
+ * Only `scheduled`. A release projects its effect onto what a visitor sees the
+ * moment its instant passes and before anything is written, so this list is
+ * what decides whether an unpublished document is already public. `blocked` is
+ * absent for exactly that reason and it is the whole point of the state: a
+ * release that stopped must stop projecting, or "stopped" would mean nothing to
+ * a reader.
+ */
+export const RELEASE_STATES_AFFECTING_CONTENT: readonly ReleaseState[] = [
+  "scheduled",
+];
+
+/**
+ * Which release states a DOCUMENT'S EDITOR must be told about.
+ *
+ * Deliberately WIDER than {@link RELEASE_STATES_AFFECTING_CONTENT}, and the two
+ * are declared together so the difference is a decision somebody made rather
+ * than a discrepancy nobody noticed. That is not hypothetical: these two
+ * filters lived in separate layers once, the narrow one ran first, and the
+ * banner's own widening could never be reached.
+ *
+ * `scheduled` because it is about to happen, and `blocked` because it was going
+ * to and now will not — both are facts about this document that nothing else on
+ * the editor's screen carries. A blocked release changes no content, which is
+ * precisely why the editor has to be told: nothing else on the page will
+ * differ, and a banner that vanished would read as resolved.
+ *
+ * Every other state is finished. A published release already did its work and a
+ * cancelled one was called off on purpose, and reporting either would be
+ * telling an editor about history.
+ */
+export const RELEASE_STATES_SHOWN_ON_A_DOCUMENT: readonly ReleaseState[] = [
+  "scheduled",
+  "blocked",
+];
+
+/**
+ * The schedulable states EXCEPT the one that needs repairing first.
+ *
+ * DERIVED from {@link RELEASE_SCHEDULABLE_FROM} rather than spelled again, so a
+ * state added there cannot be silently omitted here.
+ *
+ * This exists because scheduling a blocked release is a different operation
+ * from scheduling any other: it is a recovery, and it is only valid once
+ * nothing is blocking the release any more. That verdict is formed from a read,
+ * and a release can move between that read and the write — so the write fences
+ * on the state the verdict was formed against. A caller that saw a release NOT
+ * blocked uses this list, and is refused if the drain blocked it in the
+ * meantime; a caller that saw it blocked, and checked, fences on `blocked`
+ * alone. Without the split, a release blocked between the two would be
+ * rescheduled with its blockers never examined, and would stop again.
+ */
+export const RELEASE_SCHEDULABLE_FROM_UNBLOCKED: readonly ReleaseState[] =
+  RELEASE_SCHEDULABLE_FROM.filter(state => state !== "blocked");
+
+/** The recovery transition's fence: a blocked release, and nothing else. */
+export const RELEASE_SCHEDULABLE_FROM_BLOCKED: readonly ReleaseState[] = [
+  "blocked",
+];


### PR DESCRIPTION
A refused release stayed `scheduled` and was replanned every tick forever. It read exactly like a healthy one the whole time, so nobody learned anything until the launch did not happen.

## Only PERMANENT refusals stop it

The engine's failure taxonomy already separates the two kinds, in its own docblocks — this change consumes that distinction rather than inventing one:

| stops the release | keeps retrying |
|---|---|
| `NO_RECORDED_AUTHOR` — nobody to act as | `IDENTITY_LOOKUP_FAILED` — *"not evidence that anybody is gone"* |
| `AUTHOR_UNAVAILABLE` — author deleted or deactivated | `SCHEDULE_CHECK_FAILED` — *"not evidence the release was cancelled"* |
| `LOCALE_SCOPE_UNSUPPORTED` — the engine cannot do it | `WRITE_FAILED` — refused *or* errored, and indistinguishable here |
| | `RELEASE_NO_LONGER_SCHEDULED` — somebody's decision, not a failure |

Blocking on a transient one would let a momentary database blip permanently halt a launch the next pass would have completed. The classification is an **exhaustive `Record`**, so a failure kind added later must be classified rather than defaulting into either answer — and both defaults are bad.

Blocking expands over the overlapping components for the same reason holding-open already does: a release sharing a document with a permanently broken one can never settle either, so blocking one and not the other leaves the second retrying forever — the exact condition this ends.

## Two things the audit made smaller than expected

- **No migration.** `state` is `text` / `varchar(32)` with a TypeScript `$type<ReleaseState>()` over it, not a database enum.
- **No reason column.** All three causes are facts still true of a stored row — no author, an author who is not live, a member naming a locale — so the explanation is **derived on every read**. A recorded copy would go stale the moment somebody fixed the cause, telling an operator their repair did nothing. The empty case is reachable for exactly that reason, and says so.

The reasons are asked only for a release that is actually stopped: the question runs one identity lookup over the members, and putting it on every detail read would pay that to be told nothing is wrong, which the state already said.

A blocked release stays schedulable, cancellable and **assemblable** — the fix is usually to remove the member whose author is gone, and a release nobody can edit cannot be unblocked.

## Verification

- nextly **828 files / 10181 tests**; admin **335 / 3208**; typechecks and lints clean on both
- `fallow audit --base origin/main` clean; changeset covers all 25 lockstep packages
- Break-verified in both directions: reclassifying `WRITE_FAILED` as permanent fails the named transient case, and reclassifying `AUTHOR_UNAVAILABLE` as transient fails the deactivated-author case

That second break is worth reporting: it initially failed **nothing** — 167 tests stayed green with a deleted author no longer blocking, so the commonest permanent failure of the three had no coverage at all. The case that now covers it exists because the break exposed the hole.

## Note for whoever merges second

This branch and #1394 both merge cleanly into `main` but conflict with **each other** in five files, where both append to the same regions. Whichever lands second needs a rebase; measured with `git merge-tree`, not assumed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases that cannot be applied due to permanent issues are now marked as **Blocked**.
  * Release details explain each blocking issue, including missing, deleted, or inactive authors and locale restrictions.
  * Blocked releases can be reviewed, corrected, rescheduled, or cancelled.
  * Release lists and details now clearly highlight blocked status and provide actionable guidance.

* **Bug Fixes**
  * Temporary failures remain eligible for retry instead of incorrectly blocking releases.
  * Blocking information updates when the underlying issue is resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->