### PR TITLE
fix(builder): centre the canvas at every scale an author can choose

### DIFF
--- a/.changeset/a-canvas-stays-where-the-author-left-it.md
+++ b/.changeset/a-canvas-stays-where-the-author-left-it.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Keep the page-builder canvas centred whenever an author chooses a zoom level. Choosing a scale used to move the page against the left edge of the canvas — not only when zooming out, but at 100% too on any breakpoint narrower than the region, so a mobile preview sat hard left while the same tier was centred before the zoom control was touched. Centring now travels with the width the canvas is given rather than being restated at each branch that sets one, so the box is centred at every scale it can be drawn at, and above 100% it overflows and scrolls from the left edge exactly as before.

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -1195,6 +1195,100 @@ describe("what the canvas reports about the box it got", () => {
     });
   });
 
+  describe("where in the region a box narrower than it sits", () => {
+    /*
+     * Every case here asserts `marginInline`, and it is the whole subject
+     * rather than an incidental of one: measured in a browser, a 912px region
+     * leaves a half-scale box 228px of free space on each side WITH the margin
+     * and 456px on one side without it. The alignment is the only thing that
+     * differs, so nothing else in these cases can carry the assertion.
+     *
+     * The control is not here. "Previewing with no width" — in the box suite
+     * above — requires `marginInline` to be EMPTY, because a box that fills its
+     * region has no free space to distribute and a margin governing nothing
+     * misleads whoever reads the canvas root. That case and these are the two
+     * halves of the same rule, and a change that makes all of them agree has
+     * broken one of them.
+     */
+    it("centres a tier at the scale its author chose, not only where it fits", () => {
+      /*
+       * The tier is 600px in a 912px region either way. FITTING, the canvas
+       * centres it; the moment a scale is chosen the same tier took the branch
+       * below, which set a width and no margin — so touching the zoom control
+       * moved the page to the left edge without changing what it was showing.
+       *
+       * Asserted at 1 deliberately. A defect reported as "zooming out breaks
+       * centring" is really "choosing a scale breaks it", and 1 is the value
+       * that separates the two: at 1 nothing is magnified or shrunk, so a fix
+       * addressing only scales below 1 leaves this case exactly as it was.
+       */
+      const { container } = atWidth(600, { kind: "fixed", scale: 1 });
+      region(912);
+
+      const root = rootOf(container);
+      expect(root.style.width).toBe("600px");
+      expect(root.style.marginInline).toBe("auto");
+    });
+
+    it("keeps that tier centred at a scale below 1", () => {
+      // The reported case. Separate from the one above rather than a second
+      // assertion inside it, because they fail independently: the branch is
+      // shared but a fix guarded on `scale < 1` passes here and not there.
+      const { container } = atWidth(600, { kind: "fixed", scale: 0.5 });
+      region(912);
+
+      const root = rootOf(container);
+      expect(root.style.width).toBe("600px");
+      expect(root.style.marginInline).toBe("auto");
+    });
+
+    it("centres the widest tier when an author zooms out of it", () => {
+      /*
+       * The widest tier requests no width, so the box IS the region — until a
+       * scale is chosen, which pins the width and paints it smaller. That is
+       * the state the editor opens in, so it is where the zoom control is used
+       * most, and it reached a different branch from the case above.
+       */
+      const { container } = render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={PREVIEWABLE}
+          preview={{ container: "nx-preview-viewport" }}
+          zoom={{ kind: "fixed", scale: 0.5 }}
+        />
+      );
+
+      expect(rootOf(container).style.marginInline).toBe("auto");
+    });
+
+    it("centres a site that previews no viewport at all", () => {
+      // No container name and no declared tiers is the DEFAULT configuration,
+      // so this is the branch most sites take. It carries no preview object at
+      // all, which is why it is reached separately from every case above.
+      const { container } = render(
+        <Canvas
+          document={
+            {
+              formatVersion: 1,
+              kind: "page",
+              nodes: [{ id: "a", type: "acme/leaf", version: 1, props: {} }],
+            } as never
+          }
+          siteStyles={{ css: "", classes: {} } as never}
+          zoom={{ kind: "fixed", scale: 0.5 }}
+        />
+      );
+
+      expect(rootOf(container).style.marginInline).toBe("auto");
+    });
+  });
+
   /** A canvas previewing, with a reporter the test can read. */
   function measured(onMeasured: (width: number | undefined) => void) {
     return render(

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -472,6 +472,40 @@ export function canvasScale(
   return Math.min(1, region / requested);
 }
 
+/** A width the box is given, in whichever of the two forms it is given in. */
+type BoxWidth = { width: string } | { maxWidth: string };
+
+/**
+ * A width, and the centring that travels with it.
+ *
+ * The centring is not a property of any one of the shapes below — it is a
+ * property of HAVING a width. A box told how wide to be is narrower than the
+ * region it sits in, and a narrow box parked against the left edge reads as a
+ * layout that has broken rather than as a viewport being simulated.
+ *
+ * Stated here rather than at each `return` because it was previously stated at
+ * one of them. The other three set a width and omitted the margin, so the
+ * canvas centred while fitting and jumped to the left edge the moment an author
+ * chose a scale — the same tier, the same width, alignment deciding itself on
+ * which branch produced it. Taking a width only through this function is what
+ * makes that disagreement unspellable rather than merely fixed.
+ *
+ * The one branch that sets NO width does not call this, and must not: a box
+ * with no width fills the region, so there is no free space, and an author
+ * reading the canvas root would find a margin that governs nothing.
+ *
+ * `marginInline` rather than a flex or grid alignment on the region, because
+ * the margin resolves against whatever free space exists at the time. Measured
+ * across the range this canvas paints at: at half scale a 912px region gives
+ * 228px each side, and above 1 the box is wider than the region, the free space
+ * is negative, and the margins resolve to zero — so the overflow scrolls from
+ * the left edge with nothing clipped, which is what an author magnifying to
+ * inspect something needs. No branch on the scale is required to get both.
+ */
+function centred(width: BoxWidth): React.CSSProperties {
+  return { ...width, marginInline: "auto" };
+}
+
 /**
  * The canvas root's own style: the container the sheet queries, the width the
  * box is asked to show, and the scale that makes that width fit.
@@ -479,10 +513,8 @@ export function canvasScale(
  * Two shapes, because a request that fits and a request that does not are
  * different situations rather than one with a parameter.
  *
- * WHERE IT FITS, the width is a MAXIMUM with an auto inline margin. Centred
- * rather than left-aligned, which is what every builder surveyed does and is
- * not merely cosmetic: an off-centre narrow box reads as a layout that has
- * broken rather than as a viewport being simulated.
+ * WHERE IT FITS, the width is a MAXIMUM. Every width here is centred — see
+ * `centred` above for why that belongs to the width rather than to the branch.
  *
  * WHERE IT DOES NOT, the width is EXACT and a transform shrinks the box until
  * it does. That is the only way the widest tier stays editable at all: the
@@ -528,7 +560,9 @@ function previewBoxStyle(
    * property of whether a viewport is being simulated.
    */
   if (preview === undefined) {
-    return chosen ? { width: `calc(100% * ${scale})`, zoom: scale } : {};
+    return chosen
+      ? { ...centred({ width: `calc(100% * ${scale})` }), zoom: scale }
+      : {};
   }
   const container = previewContainerStyle(preview.container);
   /*
@@ -564,7 +598,7 @@ function previewBoxStyle(
       // it back restores the width the box had, and the scale then paints it
       // larger without moving what the queries resolve against. No measurement
       // is involved, so there is no observer to disagree with the layout.
-      width: `calc(100% * ${scale})`,
+      ...centred({ width: `calc(100% * ${scale})` }),
       zoom: scale,
     };
   }
@@ -578,13 +612,22 @@ function previewBoxStyle(
    * anything above 1 there is no reading of `maxWidth` that magnifies.
    */
   if (!chosen && scale >= 1) {
-    return {
-      ...container,
-      maxWidth: `${preview.width}px`,
-      marginInline: "auto",
-    };
+    return { ...container, ...centred({ maxWidth: `${preview.width}px` }) };
   }
-  return { ...container, width: `${preview.width}px`, zoom: scale };
+  /*
+   * Reached two ways, and only one of them has slack to centre.
+   *
+   * FITTING, the scale is derived from the region, so the box paints at exactly
+   * the region's width and the margins resolve to zero — measured, 912px into
+   * 912px. CHOSEN, the scale is the author's and owes the region nothing: a
+   * 375px tier at any scale at all paints narrower than the region it sits in,
+   * which is the case that was left against the left edge.
+   */
+  return {
+    ...container,
+    ...centred({ width: `${preview.width}px` }),
+    zoom: scale,
+  };
 }
 
 /**


### PR DESCRIPTION
## What

Choosing a zoom level in the page builder moved the page against the **left edge** of the canvas instead of leaving it centred.

## The defect is wider than "zooming out"

`previewBoxStyle` has five returns. Four declare a width; only one carried `marginInline: "auto"`. So the canvas centred a tier while *fitting* and stopped centring it the moment a scale was chosen — **including at 100%**, where nothing is magnified or shrunk at all. Same tier, same width, alignment deciding itself on which branch produced it.

Reproduced in a browser, painted gaps in a 912px region:

| case | painted | left gap | right gap |
| --- | --- | --- | --- |
| chosen 50%, before | 456 | **0** | **456** |
| chosen 50%, after | 456 | 228 | 228 |
| 375px tier at 100%, before | 375 | **0** | **537** |
| 375px tier at 100%, after | 375 | 269 | 269 |
| chosen 200%, after | 1824 | 0 | overflows, scrolls |

## The fix

Not `marginInline` added to three more branches — that restates the invariant in four places, which is the drift that produced this. Centring is bound to the act of declaring a width:

```ts
type BoxWidth = { width: string } | { maxWidth: string };
function centred(width: BoxWidth): React.CSSProperties
```

Every branch that declares a width takes it from there. The one branch that declares none does not call it, and must not — a box that fills its region has no free space, and a margin governing nothing misleads whoever reads the canvas root.

## Two risks closed by measurement, not by reasoning

- **Above 100%** the free space is negative, so the margins resolve to `0`: the box overflows and scrolls from the left edge with nothing clipped. No branch on the scale is needed to get both behaviours.
- **An absolutely positioned child** — the drop indicator, which is the reason `.nx-canvas` is `position: relative` — keeps its exact offset from the canvas in every case. Drag chrome is unmoved.

`zoom` (not `transform`) is what makes this work: it participates in layout, so auto margins see real free space. The generic "auto margins don't centre scaled elements" advice is about `transform`, where the layout box stays unscaled.

## Evidence

- Four new tests, one per branch. Under a break removing the centring, **all four die by name** plus the two pre-existing centring assertions — 6 failed / 69 passed, file count unchanged at 75.
- Under a second break uncentring **only** the tier-with-width branch, **exactly the two tier tests die** and the other two survive — so the four exercise four distinct branches rather than all riding one path.
- `canvas.test.tsx:672` asserts `marginInline` is empty for "previewing with no width" and **stays green under both breaks**. That case is correct: the box fills the region, so there is nothing to centre. It was not widened.
- Builder suite: 92 files, 2612 tests, all passing. `check-types`, `lint`, and `fallow audit --base origin/main` (`pass`, 2 changed files) clean.
