### PR TITLE
fix(admin): put the page in the page builder's settings panel

### DIFF
--- a/.changeset/a-settings-panel-with-the-page-in-it.md
+++ b/.changeset/a-settings-panel-with-the-page-in-it.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Give the page builder's Settings panel something to show. It was offered on the rail and opened blank for the commonest shape a collection takes — a title, a slug and a builder field — because the panel was filled from the entry form's body rule, which strips title and slug on the grounds that the form header already draws them. A builder covering the whole window suppresses that header, so the two fields most worth reaching from inside the editor were the two being withheld, and a document's own name could not be read there at all. The panel now offers them, grouped as Page above the collection's own fields, and it is withheld entirely when a document genuinely has nothing beside its builder field. `useEntryFieldsPanel` takes the asking field's path and answers with the fields drawn, or null — one value for both the decision to offer a panel and what goes in it, so a surface cannot offer a region it renders nothing into.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment jsdom
+
+/**
+ * The decision that withholds the panel, and the grouping it draws when it does
+ * not.
+ *
+ * `takeoverLayout.test` covers which fields come back; this covers what is done
+ * with them. The two are worth keeping apart because only one of them is about
+ * blankness: a correct field list still produced an empty panel for as long as
+ * something rendered it unconditionally.
+ *
+ * @module components/entries/EntryForm/EntryFieldsPanel.test
+ */
+import { render, screen } from "@testing-library/react";
+import type { FieldConfig } from "nextly/config";
+import { describe, expect, it, vi } from "vitest";
+
+/*
+ * The field renderer is replaced, not rendered. What is under test is which
+ * fields reach it and how they are grouped; drawing fifteen real input types
+ * would make this a test of the field renderer, which has its own.
+ */
+vi.mock("./EntryFormContent", () => ({
+  EntryFormContent: ({ fields }: { fields: FieldConfig[] }) => (
+    <span>{fields.map(f => f.name).join(",")}</span>
+  ),
+}));
+
+const { fieldsBesidePanel } = await import("./EntryFieldsPanel");
+
+const field = (name: string, type = "text") => ({ name, type }) as FieldConfig;
+
+/** A collection shaped the way a Pages collection usually is. */
+const minimal = [field("title"), field("slug"), field("body", "blocks")];
+
+describe("the panel a takeover surface offers back", () => {
+  it("answers NULL when the asking field is all there is", () => {
+    /*
+     * The state that must withhold the panel. A collection declaring only the
+     * builder field has nothing to give back — not even an identity, because
+     * this fixture has none — and an element here would be offered, opened and
+     * blank.
+     */
+    expect(fieldsBesidePanel([field("body", "blocks")], "body")).toBeNull();
+  });
+
+  it("answers null outside any field it recognises, rather than an empty shell", () => {
+    // An excludePath naming nothing still has to answer honestly about what is
+    // left. Here that is the whole (empty) list.
+    expect(fieldsBesidePanel([], "body")).toBeNull();
+  });
+
+  it("draws the document's identity, which is what the minimal shape has", () => {
+    /*
+     * The defect, from the other side. Title and slug were stripped as system
+     * fields, so this exact collection produced nothing at all — while being
+     * the shape most Pages collections take, and while the builder covering the
+     * form is what removed the header that draws them.
+     */
+    const panel = fieldsBesidePanel(minimal, "body");
+    expect(panel).not.toBeNull();
+    render(<div data-testid="host">{panel}</div>);
+
+    expect(screen.getByTestId("host").textContent).toContain("title,slug");
+  });
+
+  it("labels the groups rather than running them together", () => {
+    // The grouping is the reason the panel is readable at all: a slug sorted in
+    // among a collection's own relations lands in an order an author cannot
+    // anticipate.
+    render(
+      <div>{fieldsBesidePanel([...minimal, field("summary")], "body")}</div>
+    );
+
+    expect(screen.getByText("Page")).toBeDefined();
+    expect(screen.getByText("Fields")).toBeDefined();
+  });
+
+  it("omits a group that has nothing in it, heading and all", () => {
+    /*
+     * A labelled region containing nothing is the same failure as the panel
+     * itself being blank, one level down — so the heading has to go with its
+     * fields. This collection declares no fields of its own.
+     */
+    render(<div>{fieldsBesidePanel(minimal, "body")}</div>);
+
+    expect(screen.getByText("Page")).toBeDefined();
+    expect(screen.queryByText("Fields")).toBeNull();
+  });
+
+  it("keeps the collection's own fields out of the identity group", () => {
+    // The control for the grouping. One `EntryFormContent` handed every field
+    // would satisfy every assertion above about content being present.
+    render(
+      <div data-testid="host">
+        {fieldsBesidePanel([...minimal, field("summary")], "body")}
+      </div>
+    );
+
+    const text = screen.getByTestId("host").textContent ?? "";
+    expect(text).toContain("title,slug");
+    expect(text).toContain("summary");
+    // Never as one list: that spelling is what a merged panel would produce.
+    expect(text).not.toContain("title,slug,summary");
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.test.tsx
@@ -221,6 +221,52 @@ describe("the panel a takeover surface offers back", () => {
     expect(prevented).toBe(true);
   });
 
+  it("refuses a MODIFIED Enter too, which submits exactly as a bare one does", () => {
+    /*
+     * An earlier version exempted Shift+Enter on the assumption that a modifier
+     * means something other than submit. Measured in a browser: Shift+Enter in
+     * a single-line input submits the enclosing form just as a bare Enter does,
+     * so the exemption left the whole hole open through one extra keystroke.
+     */
+    render(<div>{fieldsBesidePanel(minimal, "body")}</div>);
+    const input = screen.getByLabelText("title input");
+
+    for (const modifier of [
+      { shiftKey: true },
+      { ctrlKey: true },
+      { metaKey: true },
+      { altKey: true },
+    ]) {
+      const prevented = !fireEvent.keyDown(input, {
+        key: "Enter",
+        ...modifier,
+      });
+      expect(prevented).toBe(true);
+    }
+  });
+
+  it("lets a COMPOSING Enter through, which an IME uses to accept a candidate", () => {
+    /*
+     * An author typing Japanese, Chinese or Korean presses Enter to accept the
+     * candidate they are part-way through. That keystroke arrives here with
+     * `isComposing` set, and the browser does not submit on it — so refusing it
+     * protects nothing and makes these fields unusable in those languages.
+     */
+    render(<div>{fieldsBesidePanel(minimal, "body")}</div>);
+    const input = screen.getByLabelText("title input");
+
+    const composing = !fireEvent.keyDown(input, {
+      key: "Enter",
+      isComposing: true,
+    });
+    expect(composing).toBe(false);
+
+    // The legacy spelling of the same state, which is how some engines report
+    // a composition instead of setting the flag.
+    const legacy = !fireEvent.keyDown(input, { key: "Enter", keyCode: 229 });
+    expect(legacy).toBe(false);
+  });
+
   it("leaves Enter alone in a textarea, where it is a newline", () => {
     // The control, and the reason the guard reads the element rather than
     // swallowing every Enter in the panel.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.test.tsx
@@ -11,7 +11,7 @@
  *
  * @module components/entries/EntryForm/EntryFieldsPanel.test
  */
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import type { FieldConfig } from "nextly/config";
 import { describe, expect, it, vi } from "vitest";
 
@@ -22,13 +22,51 @@ import { describe, expect, it, vi } from "vitest";
  */
 vi.mock("./EntryFormContent", () => ({
   EntryFormContent: ({ fields }: { fields: FieldConfig[] }) => (
-    <span>{fields.map(f => f.name).join(",")}</span>
+    <>
+      <span>{fields.map(f => f.name).join(",")}</span>
+      {/*
+        REAL controls, not a text summary. The Enter guard below is about what
+        an implicit submission does, and that is a property of the elements —
+        a mock rendering only text would let the guard's test pass whatever the
+        handler did, which is the shape of a test that proves nothing.
+      */}
+      {fields.map(f => (
+        <span key={f.name}>
+          <input aria-label={`${f.name} input`} />
+          <textarea aria-label={`${f.name} textarea`} />
+        </span>
+      ))}
+    </>
   ),
+}));
+
+/** Props the stubbed notice was rendered with, newest last. */
+const noticeProps: Array<{ slugName: string; active: boolean }> = [];
+
+vi.mock("./PublicUrlChangeNotice", () => ({
+  PublicUrlChangeNotice: (props: { slugName: string; active: boolean }) => {
+    noticeProps.push({ slugName: props.slugName, active: props.active });
+    return <span>url notice</span>;
+  },
 }));
 
 const { fieldsBesidePanel } = await import("./EntryFieldsPanel");
 
-const field = (name: string, type = "text") => ({ name, type }) as FieldConfig;
+/**
+ * A field fixture.
+ *
+ * Cast through `unknown` because `FieldConfig` is the CORE union and the types
+ * that matter here are not in it: `blocks` is contributed by a plugin, and a
+ * bare `admin.condition` is looser than any single member. The panel only ever
+ * reads `name` and `admin`, so a fuller fixture would add nothing an assertion
+ * could see.
+ */
+const field = (name: string, type = "text", admin?: unknown) =>
+  ({
+    name,
+    type,
+    ...(admin === undefined ? {} : { admin }),
+  }) as unknown as FieldConfig;
 
 /** A collection shaped the way a Pages collection usually is. */
 const minimal = [field("title"), field("slug"), field("body", "blocks")];
@@ -102,5 +140,137 @@ describe("the panel a takeover surface offers back", () => {
     expect(text).toContain("summary");
     // Never as one list: that spelling is what a merged panel would produce.
     expect(text).not.toContain("title,slug,summary");
+  });
+
+  it("drops a field whose CONDITION is false, rather than counting a blank row", () => {
+    /*
+     * `FieldRenderer` returns null for a field whose condition is false, so a
+     * field counted here but not drawn puts a heading over blank space and
+     * offers a panel for it — the same defect this file is about, one level in.
+     *
+     * `editorMode` is "builder", so a field shown only in the classic editor
+     * must not be counted. The identity group is what keeps the panel alive.
+     */
+    const withConditional = [
+      ...minimal,
+      field("classicBody", "richText", {
+        condition: { field: "editorMode", equals: "classic" },
+      }),
+    ];
+    render(
+      <div data-testid="host">
+        {fieldsBesidePanel(withConditional, "body", {
+          values: { editorMode: "builder" },
+        })}
+      </div>
+    );
+
+    expect(screen.getByTestId("host").textContent).toContain("title,slug");
+    expect(screen.queryByText("Fields")).toBeNull();
+  });
+
+  it("counts that same field once its condition holds", () => {
+    // The control. Without it, a rule that dropped every conditional field —
+    // or every field at all — would satisfy the case above.
+    render(
+      <div data-testid="host">
+        {fieldsBesidePanel(
+          [
+            ...minimal,
+            field("classicBody", "richText", {
+              condition: { field: "editorMode", equals: "classic" },
+            }),
+          ],
+          "body",
+          { values: { editorMode: "classic" } }
+        )}
+      </div>
+    );
+
+    expect(screen.getByText("Fields")).toBeDefined();
+    expect(screen.getByTestId("host").textContent).toContain("classicBody");
+  });
+
+  it("answers NULL when every remaining field is conditioned away", () => {
+    // The whole panel, not just a group: a document left with nothing visible
+    // must withhold the rail slot exactly as one with nothing declared does.
+    const onlyConditional = [
+      field("body", "blocks"),
+      field("classicBody", "richText", {
+        condition: { field: "editorMode", equals: "classic" },
+      }),
+    ];
+    expect(
+      fieldsBesidePanel(onlyConditional, "body", {
+        values: { editorMode: "builder" },
+      })
+    ).toBeNull();
+  });
+
+  it("refuses Enter in a single-line field, which would submit the form behind it", () => {
+    /*
+     * These inputs sit inside the entry's own form, so Enter is an implicit
+     * submission — and the builder writes its document back on the way out, so
+     * that submit would save the blocks as they were before the editor opened.
+     */
+    render(<div>{fieldsBesidePanel(minimal, "body")}</div>);
+
+    const input = screen.getByLabelText("title input");
+    const prevented = !fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(prevented).toBe(true);
+  });
+
+  it("leaves Enter alone in a textarea, where it is a newline", () => {
+    // The control, and the reason the guard reads the element rather than
+    // swallowing every Enter in the panel.
+    render(<div>{fieldsBesidePanel(minimal, "body")}</div>);
+
+    const area = screen.getByLabelText("title textarea");
+    const prevented = !fireEvent.keyDown(area, { key: "Enter" });
+
+    expect(prevented).toBe(false);
+  });
+
+  it("carries the public-URL warning beside the slug, but only with an address to break", () => {
+    /*
+     * The meta strip that normally shows this is covered by the editor, so
+     * this panel is the only place an author renaming a published page from
+     * inside the builder is told the old URL stops working.
+     *
+     * The notice is stubbed and its PROPS asserted rather than its output: it
+     * reads form state through its own hook and has its own tests, and what
+     * changed here is the wiring. Both directions are asserted from one file
+     * because "absent" is only meaningful beside a case that renders it.
+     */
+    const { unmount } = render(
+      <div>
+        {fieldsBesidePanel(minimal, "body", { hasPublicAddress: true })}
+      </div>
+    );
+    expect(noticeProps).toEqual([{ slugName: "slug", active: true }]);
+    unmount();
+
+    noticeProps.length = 0;
+    render(
+      <div>
+        {fieldsBesidePanel(minimal, "body", { hasPublicAddress: false })}
+      </div>
+    );
+    expect(noticeProps).toEqual([]);
+  });
+
+  it("does not warn when the panel is not offering a slug at all", () => {
+    // A notice pointing at a field this panel does not show would name a
+    // control the author cannot see.
+    noticeProps.length = 0;
+    render(
+      <div>
+        {fieldsBesidePanel([field("title"), field("body", "blocks")], "body", {
+          hasPublicAddress: true,
+        })}
+      </div>
+    );
+    expect(noticeProps).toEqual([]);
   });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.tsx
@@ -1,0 +1,106 @@
+/**
+ * The entry's other fields, drawn for a surface that covers the form.
+ *
+ * A takeover field — the page builder is the one that ships — fills the window,
+ * so every other field on the document becomes unreachable without leaving the
+ * editor and losing its undo history. This is what that surface offers back.
+ *
+ * It draws through `EntryFormContent`, the same component the form body uses,
+ * rather than laying fields out itself. How a field is rendered is the entry
+ * form's contract, and a second renderer here would be a copy that drifts —
+ * silently, because both would look correct.
+ *
+ * The two groups are LABELLED rather than concatenated. A document's identity
+ * and the fields a collection happens to declare answer to different things,
+ * and the surveyed editors agree on presenting them apart: Webflow's page
+ * settings open on name and slug before SEO and custom code, and the block
+ * editor's document sidebar keeps status and permalink above the taxonomies.
+ * Run together, a slug lands between two relations in an order the author has
+ * no way to anticipate.
+ *
+ * @module components/entries/EntryForm/EntryFieldsPanel
+ */
+
+import { FormSection } from "@nextlyhq/ui";
+import type { FieldConfig } from "nextly/config";
+import type * as React from "react";
+
+import { computeFieldsBeside } from "@admin/lib/builder/takeoverLayout";
+
+import { EntryFormContent } from "./EntryFormContent";
+
+export interface EntryFieldsPanelProps {
+  /** The document's identity — title, slug. */
+  page: FieldConfig[];
+  /** Everything else the collection declares. */
+  content: FieldConfig[];
+  /** Whether the surrounding form is mid-submit. */
+  disabled?: boolean;
+  /** Form mode, which write-only fields adjust their affordances for. */
+  mode?: "create" | "edit";
+}
+
+/**
+ * Draws whichever groups have fields, and nothing for a group that has none.
+ *
+ * An EMPTY group is omitted rather than drawn with a heading over blank space:
+ * a labelled region containing nothing reads as a control that has failed,
+ * which is the same thing the panel as a whole is withheld to avoid. Whether
+ * to offer the panel at all is decided before this renders — see
+ * `renderEntryFields` in `EntryForm` — so this component is never asked to draw
+ * two empty groups.
+ */
+export function EntryFieldsPanel({
+  page,
+  content,
+  disabled,
+  mode,
+}: EntryFieldsPanelProps) {
+  return (
+    <div className="space-y-4 p-4">
+      {page.length === 0 ? null : (
+        <FormSection
+          label="Page"
+          description="How this document is identified and addressed."
+        >
+          <EntryFormContent fields={page} disabled={disabled} mode={mode} />
+        </FormSection>
+      )}
+      {content.length === 0 ? null : (
+        <FormSection label="Fields">
+          <EntryFormContent fields={content} disabled={disabled} mode={mode} />
+        </FormSection>
+      )}
+    </div>
+  );
+}
+
+/**
+ * The panel for one asking field, or NULL when it would have nothing in it.
+ *
+ * The whole decision in one place, because it is one decision. A caller reads
+ * the answer twice — once to decide whether to offer a region and once to fill
+ * it — and those must not be able to disagree; returning an element that
+ * happens to render nothing is what reserved width to display blankness.
+ *
+ * Named and exported rather than inlined into the form's callback so the rule
+ * can be exercised without standing up an entire `EntryForm`. What that leaves
+ * uncovered is the form CALLING this, which no test reaches today because
+ * nothing renders `EntryForm` at all.
+ */
+export function fieldsBesidePanel(
+  allFields: FieldConfig[],
+  excludePath: string,
+  options: { disabled?: boolean; mode?: "create" | "edit" } = {}
+): React.ReactNode | null {
+  const beside = computeFieldsBeside(allFields, excludePath);
+  if (beside.page.length === 0 && beside.content.length === 0) return null;
+  return (
+    <EntryFieldsPanel
+      page={beside.page}
+      content={beside.content}
+      disabled={options.disabled}
+      mode={options.mode}
+    />
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.tsx
@@ -66,9 +66,27 @@ export interface EntryFieldsPanelProps {
  * Scoped to what actually submits implicitly. A textarea takes Enter as a
  * newline, and a control that has opened a listbox or a menu is using Enter to
  * choose — intercepting either would break the field to protect the form.
+ *
+ * MODIFIERS ARE NOT AN EXEMPTION. An earlier version let Shift+Enter through on
+ * the assumption that a modified Enter means something other than submit; it
+ * does not. Measured in a browser: Shift+Enter in a single-line input submits
+ * the enclosing form exactly as a bare Enter does, so exempting it left the
+ * whole of this hole open through one extra keystroke.
+ *
+ * A COMPOSING keystroke is exempt, and that one is real. An author using an IME
+ * presses Enter to accept the candidate they are part-way through typing, and
+ * that keystroke reaches here with `isComposing` set. Refusing it would not
+ * protect anything — the browser does not submit on it — while making the title
+ * and slug fields unusable in Japanese, Chinese and Korean.
  */
 function blockImplicitSubmit(event: React.KeyboardEvent<HTMLDivElement>): void {
-  if (event.key !== "Enter" || event.shiftKey) return;
+  if (event.key !== "Enter") return;
+  // Read from the native event: React's synthetic keyboard event does not
+  // carry `isComposing`, and `keyCode === 229` is how the same state reaches
+  // engines that report the composition rather than the flag.
+  if (event.nativeEvent.isComposing || event.nativeEvent.keyCode === 229) {
+    return;
+  }
   const target = event.target;
   if (!(target instanceof HTMLElement)) return;
   if (target.tagName !== "INPUT") return;

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFieldsPanel.tsx
@@ -28,6 +28,7 @@ import type * as React from "react";
 import { computeFieldsBeside } from "@admin/lib/builder/takeoverLayout";
 
 import { EntryFormContent } from "./EntryFormContent";
+import { PublicUrlChangeNotice } from "./PublicUrlChangeNotice";
 
 export interface EntryFieldsPanelProps {
   /** The document's identity — title, slug. */
@@ -38,6 +39,41 @@ export interface EntryFieldsPanelProps {
   disabled?: boolean;
   /** Form mode, which write-only fields adjust their affordances for. */
   mode?: "create" | "edit";
+  /**
+   * The slug field's name, when this panel is offering one and the document
+   * has a public address. Absent means no warning is warranted.
+   */
+  slugName?: string;
+}
+
+/**
+ * Stop a keystroke in this panel from submitting the form behind it.
+ *
+ * These inputs are mounted inside the entry's own `<form>`, so pressing Enter
+ * in a single-line field is an implicit submission. A takeover surface holds
+ * its work privately and writes it back on the way out — the page builder says
+ * so in as many words — and nothing in the form's contract lets it be asked to
+ * flush first. An implicit submit therefore saves the value the field held
+ * BEFORE the editor opened, and in create mode the navigation that follows
+ * unmounts the editor and takes the unwritten work with it.
+ *
+ * Refusing the keystroke rather than teaching the form to flush, deliberately:
+ * a flush-before-submit contract is a real change to how every surface commits
+ * and is not something to introduce from a settings panel. This closes the way
+ * IN that this panel opened; the wider gap is unchanged and still applies to
+ * any save started from a button or a palette.
+ *
+ * Scoped to what actually submits implicitly. A textarea takes Enter as a
+ * newline, and a control that has opened a listbox or a menu is using Enter to
+ * choose — intercepting either would break the field to protect the form.
+ */
+function blockImplicitSubmit(event: React.KeyboardEvent<HTMLDivElement>): void {
+  if (event.key !== "Enter" || event.shiftKey) return;
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return;
+  if (target.tagName !== "INPUT") return;
+  if (target.getAttribute("aria-expanded") === "true") return;
+  event.preventDefault();
 }
 
 /**
@@ -47,23 +83,38 @@ export interface EntryFieldsPanelProps {
  * a labelled region containing nothing reads as a control that has failed,
  * which is the same thing the panel as a whole is withheld to avoid. Whether
  * to offer the panel at all is decided before this renders — see
- * `renderEntryFields` in `EntryForm` — so this component is never asked to draw
- * two empty groups.
+ * `fieldsBesidePanel` below — so this component is never asked to draw two
+ * empty groups.
  */
 export function EntryFieldsPanel({
   page,
   content,
   disabled,
   mode,
+  slugName,
 }: EntryFieldsPanelProps) {
   return (
-    <div className="space-y-4 p-4">
+    <div className="space-y-4 p-4" onKeyDown={blockImplicitSubmit}>
       {page.length === 0 ? null : (
         <FormSection
           label="Page"
           description="How this document is identified and addressed."
         >
           <EntryFormContent fields={page} disabled={disabled} mode={mode} />
+          {/*
+            The same warning the meta strip carries, for the same reason and in
+            the only other place the slug is editable. This editor covers the
+            strip that would otherwise show it, so without this the one surface
+            that hides the notice is also a surface that can rewrite a live
+            address and save it.
+          */}
+          {slugName === undefined ? null : (
+            <PublicUrlChangeNotice
+              slugName={slugName}
+              active
+              className="mt-3 block"
+            />
+          )}
         </FormSection>
       )}
       {content.length === 0 ? null : (
@@ -91,16 +142,36 @@ export function EntryFieldsPanel({
 export function fieldsBesidePanel(
   allFields: FieldConfig[],
   excludePath: string,
-  options: { disabled?: boolean; mode?: "create" | "edit" } = {}
+  options: {
+    disabled?: boolean;
+    mode?: "create" | "edit";
+    /**
+     * The current values of every field a condition watches. Without them a
+     * field whose condition is false is counted here and renders nothing,
+     * which offers the panel and draws a heading over blank space.
+     */
+    values?: Record<string, unknown>;
+    /** Whether the document has a public address the slug decides. */
+    hasPublicAddress?: boolean;
+  } = {}
 ): React.ReactNode | null {
-  const beside = computeFieldsBeside(allFields, excludePath);
+  const beside = computeFieldsBeside(allFields, excludePath, options.values);
   if (beside.page.length === 0 && beside.content.length === 0) return null;
+  // Warned about only where the slug is actually offered AND the document has
+  // an address to break: a notice on a document nobody can reach is noise, and
+  // one beside a field this panel is not showing points at nothing.
+  const slug = beside.page.find(f => f.name === "slug");
   return (
     <EntryFieldsPanel
       page={beside.page}
       content={beside.content}
       disabled={options.disabled}
       mode={options.mode}
+      slugName={
+        options.hasPublicAddress === true && slug !== undefined
+          ? (slug.name ?? "slug")
+          : undefined
+      }
     />
   );
 }

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -40,7 +40,10 @@ import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePreviewLink } from "@admin/hooks/usePreviewLink";
 import { useTakeoverLayout } from "@admin/hooks/useTakeoverLayout";
-import { computeMainFields } from "@admin/lib/builder/takeoverLayout";
+import {
+  computeMainFields,
+  conditionFieldNames,
+} from "@admin/lib/builder/takeoverLayout";
 import { cn } from "@admin/lib/utils";
 
 import { CopyFromLanguageScope } from "../CopyFromLanguageScope";
@@ -402,21 +405,6 @@ export function EntryForm({
    * form submits are one thing. A second `EntryForm` would fork the state and
    * lose the edit made in whichever copy did not save.
    */
-  /*
-   * Delegated whole, including the decision to answer NULL when there is
-   * nothing to draw — which is what withholds the panel rather than opening an
-   * empty one. Kept out of this callback so the rule is reachable by a test
-   * without standing up the entire form.
-   */
-  const renderEntryFields = useCallback(
-    (excludePath: string) =>
-      fieldsBesidePanel(allFields, excludePath, {
-        disabled: isSubmitting,
-        mode,
-      }),
-    [allFields, isSubmitting, mode]
-  );
-
   // Get form errors and submit attempt count. submitCount gates the
   // top-level "Please fix the following errors" toast in FormErrorSummary
   // so it only appears after the user actually clicks Save / Publish, not
@@ -503,6 +491,51 @@ export function EntryForm({
     defaultLocale,
     mutationPending: isSubmitting,
   });
+
+  /*
+   * The values every field CONDITION watches, read through `watch` so the panel
+   * recomputes as an author changes them rather than only when the form
+   * remounts.
+   *
+   * `watch` answers a name list POSITIONALLY, so the result is zipped back onto
+   * the names it was asked for — the same shape `useTakeoverLayout` needs, and
+   * for the same reason: handed the bare array, every condition would be
+   * evaluated against `undefined` and each conditional field would be judged on
+   * a value nobody supplied.
+   */
+  const conditionNames = useMemo(
+    () => conditionFieldNames(allFields),
+    [allFields]
+  );
+  const watchedConditions = form.watch(conditionNames);
+  const conditionValues = useMemo(
+    () =>
+      Object.fromEntries(
+        conditionNames.map((name, i) => [name, watchedConditions[i]])
+      ),
+    [conditionNames, watchedConditions]
+  );
+
+  /*
+   * Delegated whole, including the decision to answer NULL when there is
+   * nothing to draw — which is what withholds the panel rather than opening an
+   * empty one. Kept out of this callback so the rule is reachable by a test
+   * without standing up the entire form.
+   *
+   * Declared here rather than beside the other field derivations because it
+   * needs `hasPublicAddress`: a surface offering the slug has to carry the same
+   * warning the meta strip it covers would have shown.
+   */
+  const renderEntryFields = useCallback(
+    (excludePath: string) =>
+      fieldsBesidePanel(allFields, excludePath, {
+        disabled: isSubmitting,
+        mode,
+        values: conditionValues,
+        hasPublicAddress,
+      }),
+    [allFields, isSubmitting, mode, conditionValues, hasPublicAddress]
+  );
 
   useAutoSlug({
     form,

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -40,10 +40,7 @@ import { useEntryFormShortcuts } from "@admin/hooks/useKeyboardShortcuts";
 import { useLocalization } from "@admin/hooks/useLocalization";
 import { usePreviewLink } from "@admin/hooks/usePreviewLink";
 import { useTakeoverLayout } from "@admin/hooks/useTakeoverLayout";
-import {
-  computeMainFields,
-  computeFieldsBeside,
-} from "@admin/lib/builder/takeoverLayout";
+import { computeMainFields } from "@admin/lib/builder/takeoverLayout";
 import { cn } from "@admin/lib/utils";
 
 import { CopyFromLanguageScope } from "../CopyFromLanguageScope";
@@ -63,6 +60,7 @@ import {
   previewLinkLocale,
   useHasPublicAddress,
 } from "./entry-address";
+import { fieldsBesidePanel } from "./EntryFieldsPanel";
 import { EntryFormActions } from "./EntryFormActions";
 import { EntryFormContent } from "./EntryFormContent";
 import {
@@ -404,14 +402,18 @@ export function EntryForm({
    * form submits are one thing. A second `EntryForm` would fork the state and
    * lose the edit made in whichever copy did not save.
    */
+  /*
+   * Delegated whole, including the decision to answer NULL when there is
+   * nothing to draw — which is what withholds the panel rather than opening an
+   * empty one. Kept out of this callback so the rule is reachable by a test
+   * without standing up the entire form.
+   */
   const renderEntryFields = useCallback(
-    (excludePath: string) => (
-      <EntryFormContent
-        fields={computeFieldsBeside(allFields, excludePath)}
-        disabled={isSubmitting}
-        mode={mode}
-      />
-    ),
+    (excludePath: string) =>
+      fieldsBesidePanel(allFields, excludePath, {
+        disabled: isSubmitting,
+        mode,
+      }),
     [allFields, isSubmitting, mode]
   );
 

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.test.tsx
@@ -12,13 +12,19 @@ import {
  * A field that covers the whole form — the page builder is the one that ships —
  * leaves its author unable to reach the entry's other fields without closing the
  * editor and losing its undo history. `useEntryFieldsPanel` is how that surface
- * offers them back, so the two states it can return are the contract: a renderer,
- * or null.
+ * offers them back, so the two states it can return are the contract: the fields
+ * drawn, or null.
+ *
+ * It answers with the NODE rather than a renderer because a caller makes two
+ * decisions from it — whether to offer a region, and what to put in it — and
+ * those must not be able to disagree. A renderer could only be gated on its own
+ * existence, which is true for every entry form whether or not it draws
+ * anything; that is what put an empty panel on the page builder's rail.
  */
 function Consumer({ exclude }: { exclude: string }) {
-  const render = useEntryFieldsPanel();
-  if (render === null) return <p>no panel</p>;
-  return <div data-testid="panel">{render(exclude)}</div>;
+  const fields = useEntryFieldsPanel(exclude);
+  if (fields === null) return <p>no panel</p>;
+  return <div data-testid="panel">{fields}</div>;
 }
 
 describe("useEntryFieldsPanel", () => {
@@ -31,9 +37,10 @@ describe("useEntryFieldsPanel", () => {
   });
 
   it("returns null when the form supplies no renderer", () => {
-    // The provider is present but this form hides nothing, which must be
-    // distinguishable from "there is a renderer that happens to draw nothing" —
-    // the first means withhold the panel, the second means show an empty one.
+    // The provider is present but this form supplies no renderer at all, which
+    // is a different fact from a form whose renderer finds nothing to draw.
+    // Both now answer null, because a caller does the same thing with either —
+    // offer no panel. Distinguishing them only ever produced an empty one.
     render(
       <EntryFormContextProvider collectionSlug="posts">
         <Consumer exclude="content" />
@@ -42,7 +49,27 @@ describe("useEntryFieldsPanel", () => {
     expect(screen.getByText("no panel")).toBeInTheDocument();
   });
 
-  it("hands back the form's own renderer, and passes the excluded path to it", () => {
+  it("answers null when the form's renderer finds nothing to draw", () => {
+    /*
+     * The defect this shape exists to make unrepresentable. A form whose
+     * renderer returns null for this path has nothing to offer, and the caller
+     * must reach the same conclusion it reaches outside a form entirely —
+     * otherwise it reserves a region and opens it blank. Before this, a caller
+     * could only see that a renderer EXISTED, which every entry form's does.
+     */
+    render(
+      <EntryFormContextProvider
+        collectionSlug="posts"
+        renderEntryFields={() => null}
+      >
+        <Consumer exclude="sections" />
+      </EntryFormContextProvider>
+    );
+    expect(screen.getByText("no panel")).toBeInTheDocument();
+    expect(screen.queryByTestId("panel")).not.toBeInTheDocument();
+  });
+
+  it("draws the form's own fields, and passes the excluded path to it", () => {
     // The path travels to the renderer rather than being resolved here: which
     // field is asking is the CALLER's fact, and a context that guessed it would
     // be wrong for the second takeover surface a collection ever declares.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryFormContext.tsx
@@ -414,22 +414,33 @@ export function useDocumentIdentity(): DocumentIdentity | null {
  * ```
  */
 /**
- * A renderer for the entry's other fields, or null outside an entry form.
+ * The entry's other fields, drawn — or null when there are none to draw.
  *
- * Pass the asking field's path; it is excluded from what comes back. Null means
- * there is no surrounding form to draw from — a preview or a standalone
- * harness — and a caller should offer no panel at all rather than an empty one,
- * because reserving width to show nothing reads as a broken control.
+ * Pass the asking field's path; it is excluded from what comes back. Null has
+ * one meaning for a caller, "offer no panel", and it covers both reasons that
+ * can be true: there is no surrounding form to draw from — a preview, a
+ * standalone harness — or there IS one and it has nothing left once this
+ * field and the system's own are set aside.
+ *
+ * Returns the NODE rather than a renderer, which is the whole point of the
+ * shape. A caller offers a region and then fills it, and those are two
+ * decisions that must not disagree; handed a renderer, the only thing a caller
+ * could gate on was whether the renderer EXISTED, which is true for every entry
+ * form whether or not it draws anything. That is how a settings panel came to
+ * be offered, reserved and opened blank. One value answers both questions, so
+ * the rail and the body cannot say different things.
+ *
+ * Cheap to call unconditionally: this builds an element rather than rendering
+ * one, and a caller that never mounts it has paid for a description nobody
+ * read.
  *
  * Optional-context by construction, like {@link useDocumentIdentity}: a field
- * rendered outside an entry form is a legitimate arrangement (a preview, a
- * standalone harness) and gets null rather than a thrown error.
+ * rendered outside an entry form is a legitimate arrangement and gets null
+ * rather than a thrown error.
  */
-export function useEntryFieldsPanel():
-  | ((excludePath: string) => ReactNode)
-  | null {
+export function useEntryFieldsPanel(excludePath: string): ReactNode | null {
   const context = useOptionalEntryFormContext();
-  return context?.renderEntryFields ?? null;
+  return context?.renderEntryFields?.(excludePath) ?? null;
 }
 
 export function useDocumentStatus(): DocumentStatus | null {

--- a/packages/admin/src/lib/builder/takeoverLayout.test.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.test.ts
@@ -145,47 +145,103 @@ describe("takeoverControllerNames", () => {
 });
 
 describe("computeFieldsBeside", () => {
+  /** Both groups run together, for the assertions that do not care which. */
+  const offered = (fs: typeof fields, exclude: string) => {
+    const out = computeFieldsBeside(fs, exclude);
+    return [...out.page, ...out.content].map(f => f.name);
+  };
+
   it("offers every body field except the one asking and its controller", () => {
-    const out = computeFieldsBeside(fields, "content");
-    expect(out.map(f => f.name)).toEqual(["summary"]);
+    expect(offered(fields, "content")).toEqual(["title", "slug", "summary"]);
   });
 
   it("withholds the field that decides whether the asking field is visible", () => {
     // `content` renders only while `editormode` equals "builder". Offering
     // `editormode` inside `content`'s own panel would let an author un-render
     // the surface they are standing in, from a control that does not say so.
-    expect(
-      computeFieldsBeside(fields, "content").map(f => f.name)
-    ).not.toContain("editormode");
+    expect(offered(fields, "content")).not.toContain("editormode");
   });
 
   it("never offers the asking field back to itself", () => {
     // Rendering `content` inside `content`'s own panel would nest an editor in
     // its own settings.
-    expect(
-      computeFieldsBeside(fields, "content").map(f => f.name)
-    ).not.toContain("content");
+    expect(offered(fields, "content")).not.toContain("content");
   });
 
-  it("omits system fields, which the system header already draws", () => {
-    // A second editor for the title would be a second answer to one value.
-    const names = computeFieldsBeside(fields, "content").map(f => f.name);
-    expect(names).not.toContain("title");
-    expect(names).not.toContain("slug");
+  it("OFFERS the system fields, because the surface asking has hidden them", () => {
+    /*
+     * This replaces a case requiring the opposite, and the reversal is the
+     * point rather than a relaxation. Title and slug were withheld because the
+     * system header draws them, so a second editor would have been a second
+     * answer to one value. A surface that COVERS the form suppresses that
+     * header — the page builder names it in `useSuppressAdminChrome` — so
+     * there is no first editor to compete with, and withholding them left the
+     * commonest collection shape, a title, a slug and a builder field, with an
+     * empty panel and no way to read a document's own name from inside it.
+     */
+    const out = computeFieldsBeside(fields, "content");
+    expect(out.page.map(f => f.name)).toEqual(["title", "slug"]);
+  });
+
+  it("keeps them APART from the fields a collection declares", () => {
+    // The panel labels the two groups, so a slug is never sorted in among a
+    // collection's own relations in an order an author cannot anticipate.
+    const out = computeFieldsBeside(fields, "content");
+    expect(out.content.map(f => f.name)).toEqual(["summary"]);
+    expect(out.content.map(f => f.name)).not.toContain("title");
+  });
+
+  it("gives the minimal collection shape something to show, which it had none of", () => {
+    /*
+     * The shape that produced the defect: title, slug, and the builder field.
+     * Every system field stripped, the asking field excluded, nothing left —
+     * so the panel was offered and opened blank. The identity group is what it
+     * now has, and it is the group an author most needs while the form is
+     * covered.
+     */
+    const minimal = [
+      { name: "title", type: "text" },
+      { name: "slug", type: "text" },
+      { name: "content", type: "blocks" },
+    ];
+    const out = computeFieldsBeside(minimal, "content");
+    expect(out.page.map(f => f.name)).toEqual(["title", "slug"]);
+    expect(out.content).toEqual([]);
+  });
+
+  it("reports BOTH groups empty when the builder is genuinely all there is", () => {
+    /*
+     * The case the caller must still be able to detect, and the reason the
+     * emptiness check reads both groups rather than assuming a document always
+     * has an identity. A collection declaring only the takeover field and its
+     * controller offers nothing at all, and a panel must not be opened for it.
+     */
+    const alone = [
+      { name: "editormode", type: "select" },
+      {
+        name: "content",
+        type: "page-builder",
+        admin: { condition: { field: "editormode", equals: "builder" } },
+      },
+    ];
+    const out = computeFieldsBeside(alone, "content");
+    expect(out.page).toEqual([]);
+    expect(out.content).toEqual([]);
   });
 
   it("does not depend on a takeover being active", () => {
     // `layout: "takeover"` is declared in the branding type and no shipped
     // plugin sets it, so a rule conditioned on an ACTIVE takeover would be
     // permanently inert. The same fields are offered either way.
-    const asIfActive = computeFieldsBeside(fields, "content");
-    const asIfNot = computeFieldsBeside(fields, "content");
-    expect(asIfActive.map(f => f.name)).toEqual(asIfNot.map(f => f.name));
+    const asIfActive = offered(fields, "content");
+    const asIfNot = offered(fields, "content");
+    expect(asIfActive).toEqual(asIfNot);
     expect(asIfActive.length).toBeGreaterThan(0);
   });
 
   it("works for the code-first shape, which is addressed by the same name", () => {
-    const out = computeFieldsBeside(codeFirstFields, "content");
-    expect(out.map(f => f.name)).toEqual(["summary"]);
+    // This fixture declares no title or slug, so the identity group is empty
+    // and the collection's own field is the whole of what is offered.
+    expect(offered(codeFirstFields, "content")).toEqual(["summary"]);
   });
 });

--- a/packages/admin/src/lib/builder/takeoverLayout.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.ts
@@ -151,7 +151,23 @@ export function computeMainFields<T extends LayoutField>(
 }
 
 /**
- * The body fields a surface may offer BESIDE the one it was opened for.
+ * What a takeover surface offers back, split the way its panel presents it.
+ *
+ * Two groups rather than one list, because they are answerable to different
+ * things: `page` is what every document has and what a surface covering the
+ * form takes away, while `content` is whatever this collection happens to
+ * declare. A single list would put a page's slug between two of its own
+ * relations, ordered by nothing an author can predict.
+ */
+export interface FieldsBeside<T> {
+  /** The document's identity — title and slug — in the order declared. */
+  page: T[];
+  /** Everything else the form body would show. */
+  content: T[];
+}
+
+/**
+ * The fields a surface may offer BESIDE the one it was opened for.
  *
  * Everything the form body would show, minus the field at `excludePath` — the
  * field whose own surface is asking. A page builder rendering this inside its
@@ -166,13 +182,22 @@ export function computeMainFields<T extends LayoutField>(
  * and while a full-screen surface covers the body, showing them is the only
  * way an author reaches them without leaving it.
  *
- * System fields are already stripped, so the title and slug drawn by the system
- * header are not offered a second, competing editor here.
+ * TITLE AND SLUG ARE OFFERED HERE, which they were not, and the reason they
+ * were withheld is the reason they now belong: they are drawn by the system
+ * header, so offering them again would have been a second, competing editor.
+ * A surface that COVERS the form suppresses that header — the page builder
+ * names it in `useSuppressAdminChrome` — so there is no second editor to
+ * compete with and no first one to fall back on. Withholding them left the
+ * commonest shape a collection takes, a title, a slug and a builder field,
+ * with nothing to put in the panel at all: it was offered and opened blank,
+ * and a document's own name could not be read from inside the editor.
+ *
+ * They stay grouped rather than merged so the panel can say which is which.
  */
 export function computeFieldsBeside<T extends LayoutField>(
   fields: T[],
   excludePath: string
-): T[] {
+): FieldsBeside<T> {
   /*
    * The field whose value decides whether the asking field is visible at all is
    * withheld too.
@@ -185,13 +210,18 @@ export function computeFieldsBeside<T extends LayoutField>(
    */
   const asking = fields.find(f => (f.name ?? "") === excludePath);
   const controller = asking === undefined ? undefined : controllerName(asking);
-  return fields.filter(
+  const offered = fields.filter(
     f =>
-      !SYSTEM_FIELDS.has(f.name ?? "") &&
       !isHidden(f) &&
       (f.name ?? "") !== excludePath &&
       (f.name ?? "") !== controller
   );
+  // Partitioned from ONE filtered list rather than filtered twice, so a field
+  // cannot land in both groups or in neither if the two predicates ever drift.
+  return {
+    page: offered.filter(f => SYSTEM_FIELDS.has(f.name ?? "")),
+    content: offered.filter(f => !SYSTEM_FIELDS.has(f.name ?? "")),
+  };
 }
 
 /** Resolve the value a field's condition source currently holds. */

--- a/packages/admin/src/lib/builder/takeoverLayout.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.ts
@@ -72,6 +72,50 @@ function controllerName(f: LayoutField): string | undefined {
 }
 
 /**
+ * Whether a field's own condition currently lets it render.
+ *
+ * `FieldRenderer` returns `null` for a field whose condition is false, so a
+ * caller counting fields without asking this counts rows that will not appear —
+ * which is how a panel comes to be offered with a heading over a blank body.
+ * Only the CONDITION is duplicated here, never the verdict: both sides call
+ * `evaluateCondition`, so the semantics have one implementation and this adds
+ * the lookup the renderer does with `useWatch`.
+ *
+ * A field with no condition is visible, and so is one whose condition names a
+ * field this caller did not watch — an unwatched name reads as `undefined`,
+ * and hiding a field on the strength of a value nobody supplied would withhold
+ * a panel that has content in it.
+ */
+function isConditionallyVisible(
+  f: LayoutField,
+  values: Record<string, unknown>
+): boolean {
+  const condition = f.admin?.condition as FieldCondition | undefined;
+  const watches = condition?.field;
+  if (condition === undefined || watches === undefined) return true;
+  if (!(watches in values)) return true;
+  return evaluateCondition(condition, values[watches]);
+}
+
+/**
+ * Every field name a condition on these fields watches.
+ *
+ * The set a caller must observe for {@link computeFieldsBeside} to answer about
+ * the fields as they currently render rather than as they were declared. Kept
+ * beside the rule that consumes it so the two cannot name different sets.
+ */
+export function conditionFieldNames<T extends LayoutField>(
+  fields: T[]
+): string[] {
+  const names = new Set<string>();
+  for (const f of fields) {
+    const watches = (f.admin?.condition as FieldCondition | undefined)?.field;
+    if (watches !== undefined) names.add(watches);
+  }
+  return [...names];
+}
+
+/**
  * Field types flagged `layout: "takeover"` in the admin branding metadata,
  * paired with their editor component path.
  */
@@ -196,7 +240,8 @@ export interface FieldsBeside<T> {
  */
 export function computeFieldsBeside<T extends LayoutField>(
   fields: T[],
-  excludePath: string
+  excludePath: string,
+  values: Record<string, unknown> = {}
 ): FieldsBeside<T> {
   /*
    * The field whose value decides whether the asking field is visible at all is
@@ -213,6 +258,7 @@ export function computeFieldsBeside<T extends LayoutField>(
   const offered = fields.filter(
     f =>
       !isHidden(f) &&
+      isConditionallyVisible(f, values) &&
       (f.name ?? "") !== excludePath &&
       (f.name ?? "") !== controller
   );

--- a/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment jsdom
+
+/**
+ * Whether the Settings panel is OFFERED, and whether what fills it agrees.
+ *
+ * The rail and the panel body are two decisions taken from one question — is
+ * there anything to show — and while they were taken separately they could
+ * disagree. They did: every entry form supplies a field renderer, so a gate on
+ * the renderer's existence was true even for a collection whose only fields are
+ * its title, its slug and the builder field itself. The rail offered Settings,
+ * the region was reserved, and it opened blank.
+ *
+ * So the assertions here are deliberately PAIRED — rail and body, in the same
+ * test, from the same render. Checking either alone is what let them drift: a
+ * body that renders nothing passes any test that only reads the rail, and a
+ * panel nobody offers passes any test that only reads the body.
+ *
+ * Every sibling file in this directory mocks `useEntryFieldsPanel` to `null`,
+ * which is the state where Settings is correctly absent — so the branch where
+ * it IS offered had no coverage anywhere before this file.
+ *
+ * The builder shell is replaced with recorders rather than rendered, as
+ * `BlocksField.fonts.test` does and for its reason: what is under test is which
+ * props this component passes.
+ *
+ * @module admin/BlocksField.settingsPanel.test
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** What the entry-fields hook answers with for the test in hand. */
+let entryFields: React.ReactNode | null;
+/** Every path the hook was asked about, so the exclusion can be asserted. */
+const askedFor: string[] = [];
+
+vi.mock("@nextlyhq/builder/shell", async importOriginal => {
+  const real = await importOriginal<Record<string, unknown>>();
+  const nothing = (): null => null;
+  const passthrough = ({
+    children,
+  }: {
+    children?: React.ReactNode;
+  }): React.JSX.Element => <>{children}</>;
+  return {
+    ...real,
+    /*
+      This shell CALLS `renderPanel` and also reports `availablePanels`, which
+      is what lets one render answer both halves of the question. A shell that
+      exposed only one of them would reproduce the split this file exists to
+      close.
+    */
+    BuilderShell: ({
+      renderPanel,
+      availablePanels,
+    }: {
+      renderPanel?: (panel: string) => React.ReactNode;
+      availablePanels?: readonly string[];
+    }): React.JSX.Element => (
+      <div>
+        <div data-testid="rail">{(availablePanels ?? []).join(",")}</div>
+        <div data-testid="panel">{renderPanel?.("settings")}</div>
+      </div>
+    ),
+    BlockKeyboardActions: passthrough,
+    BlockToolbar: nothing,
+    BreakpointManager: nothing,
+    BreakpointSwitcher: nothing,
+    InspectorPanel: nothing,
+    InsertPanel: nothing,
+    LayersPanel: nothing,
+    TokensStudio: nothing,
+    BlockContextMenu: passthrough,
+  };
+});
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
+  usePluginClientConfig: () => ({}),
+  useDocumentCheckpoint: () => ({ schedule: () => {} }),
+  useEntryFieldsPanel: (excludePath: string) => {
+    askedFor.push(excludePath);
+    return entryFields;
+  },
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  validationIssues: () => [],
+  useSingleDocument: () => ({ data: undefined, isPending: false, error: null }),
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async () => ({ success: true }),
+    isPending: false,
+  }),
+}));
+
+const { BlocksField } = await import("./BlocksField");
+
+function Host(): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: undefined } });
+  return <BlocksField name="body" control={control} />;
+}
+
+function openEditor(): void {
+  render(<Host />);
+  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+}
+
+/** The rail's panel list, as the shell was handed it. */
+const rail = (): string => screen.getByTestId("rail").textContent ?? "";
+
+beforeEach(() => {
+  entryFields = null;
+  askedFor.length = 0;
+});
+
+afterEach(cleanup);
+
+describe("offering the Settings panel", () => {
+  it("withholds it, and renders nothing into it, when there are no fields", () => {
+    /*
+     * The state a document reaches when the builder field is all it has beside
+     * its identity — and the state of every surface outside an entry form.
+     * Both halves are asserted because the defect was that they disagreed:
+     * withholding the rail slot while still rendering a body would be just as
+     * wrong, and no test that read one of them could tell.
+     */
+    entryFields = null;
+    openEditor();
+
+    expect(rail()).not.toContain("settings");
+    const panel = screen.getByTestId("panel");
+    // Both, because they fail differently: a body that rendered an empty
+    // wrapper has no text and is not empty, and it is the wrapper that would
+    // reserve the region.
+    expect(panel.textContent).toBe("");
+    expect(panel.childElementCount).toBe(0);
+  });
+
+  it("offers it AND fills it when the form has fields to give back", () => {
+    // The branch nothing covered. A panel that is offered must have a body, and
+    // this is the pairing that says so from one render.
+    entryFields = <p>the entry&apos;s other fields</p>;
+    openEditor();
+
+    expect(rail()).toContain("settings");
+    expect(screen.getByTestId("panel").textContent).toContain(
+      "the entry's other fields"
+    );
+  });
+
+  it("leaves the OTHER panels alone in both states", () => {
+    /*
+     * The control. `settings` is the only slot this decision governs, so a
+     * change that withheld the whole rail — or that offered every panel
+     * unconditionally — would satisfy the two cases above and be caught only
+     * here.
+     */
+    entryFields = null;
+    openEditor();
+    const withoutSettings = rail();
+    cleanup();
+
+    entryFields = <p>fields</p>;
+    openEditor();
+    const withSettings = rail();
+
+    for (const panel of ["insert", "layers", "tokens", "fonts", "classes"]) {
+      expect(withoutSettings).toContain(panel);
+      expect(withSettings).toContain(panel);
+    }
+    // And the two differ by exactly the one slot under test.
+    expect(withSettings).not.toBe(withoutSettings);
+  });
+
+  it("asks about the builder field's OWN path, so it is never offered itself", () => {
+    // Rendering this editor inside this editor's settings panel would nest an
+    // editor in its own chrome. The exclusion is the caller's to state, and it
+    // can only state it correctly if it passes its own name.
+    entryFields = <p>fields</p>;
+    openEditor();
+
+    expect(askedFor.length).toBeGreaterThan(0);
+    expect(new Set(askedFor)).toEqual(new Set(["body"]));
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
@@ -110,7 +110,7 @@ vi.mock("./DocumentStatusPill", () => ({
 const { BlocksField } = await import("./BlocksField");
 
 function Host(): React.JSX.Element {
-  const { control, register } = useForm({
+  const { control, register, setValue } = useForm({
     defaultValues: { body: undefined, title: "" },
   });
   return (
@@ -119,6 +119,21 @@ function Host(): React.JSX.Element {
           the SAME form, which is what makes it dirty the way that panel's
           fields are. */}
       <input aria-label="title" {...register("title")} />
+      {/* Writes the BLOCKS field the way leaving the editor does: `done`
+          commits the document into the form, which is what makes that field
+          dirty while no editor is mounted. */}
+      <button
+        type="button"
+        onClick={() =>
+          setValue(
+            "body",
+            { formatVersion: 1, kind: "page", nodes: [] } as never,
+            { shouldDirty: true }
+          )
+        }
+      >
+        commit blocks
+      </button>
       <BlocksField name="body" control={control} />
     </>
   );
@@ -233,5 +248,28 @@ describe("offering the Settings panel", () => {
 
     expect(pillDirty.length).toBeGreaterThan(0);
     expect(pillDirty.every(d => d === false)).toBe(true);
+  });
+
+  it("still reports dirty for unsaved BLOCKS after the editor is reopened", () => {
+    /*
+     * The case an earlier version discarded. Leaving the editor commits the
+     * document into the form, so the blocks field is dirty; reopening builds a
+     * fresh editor whose `undoDepth` is zero. Excluding the field from
+     * `dirtyFields` — which that version did, to avoid double-counting the undo
+     * history — removed the only remaining witness, and the pill read clean
+     * over blocks that had never been saved.
+     *
+     * Double-counting cannot matter to a boolean, and the form's baseline is
+     * advanced by the reset on a successful submit, so a dirty blocks field
+     * means genuinely unsaved blocks.
+     */
+    entryFields = <p>fields</p>;
+    render(<Host />);
+
+    // Commit blocks the way leaving the editor does, then open a fresh one.
+    fireEvent.click(screen.getByRole("button", { name: "commit blocks" }));
+    fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+
+    expect(pillDirty.at(-1)).toBe(true);
   });
 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
@@ -54,13 +54,16 @@ vi.mock("@nextlyhq/builder/shell", async importOriginal => {
     BuilderShell: ({
       renderPanel,
       availablePanels,
+      topBar,
     }: {
       renderPanel?: (panel: string) => React.ReactNode;
       availablePanels?: readonly string[];
+      topBar?: React.ReactNode;
     }): React.JSX.Element => (
       <div>
         <div data-testid="rail">{(availablePanels ?? []).join(",")}</div>
         <div data-testid="panel">{renderPanel?.("settings")}</div>
+        <div data-testid="topbar">{topBar}</div>
       </div>
     ),
     BlockKeyboardActions: passthrough,
@@ -94,11 +97,31 @@ vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
   }),
 }));
 
+/** What the status pill was told on the most recent render. */
+const pillDirty: boolean[] = [];
+
+vi.mock("./DocumentStatusPill", () => ({
+  DocumentStatusPill: ({ isDirty }: { isDirty: boolean }) => {
+    pillDirty.push(isDirty);
+    return <span data-testid="pill">{isDirty ? "dirty" : "clean"}</span>;
+  },
+}));
+
 const { BlocksField } = await import("./BlocksField");
 
 function Host(): React.JSX.Element {
-  const { control } = useForm({ defaultValues: { body: undefined } });
-  return <BlocksField name="body" control={control} />;
+  const { control, register } = useForm({
+    defaultValues: { body: undefined, title: "" },
+  });
+  return (
+    <>
+      {/* Stands in for a field the settings panel edits. It is registered on
+          the SAME form, which is what makes it dirty the way that panel's
+          fields are. */}
+      <input aria-label="title" {...register("title")} />
+      <BlocksField name="body" control={control} />
+    </>
+  );
 }
 
 function openEditor(): void {
@@ -112,6 +135,7 @@ const rail = (): string => screen.getByTestId("rail").textContent ?? "";
 beforeEach(() => {
   entryFields = null;
   askedFor.length = 0;
+  pillDirty.length = 0;
 });
 
 afterEach(cleanup);
@@ -182,5 +206,32 @@ describe("offering the Settings panel", () => {
 
     expect(askedFor.length).toBeGreaterThan(0);
     expect(new Set(askedFor)).toEqual(new Set(["body"]));
+  });
+
+  it("reports the document dirty when only a SETTINGS field was edited", () => {
+    /*
+     * The pill read `undoDepth` alone, which is the editor's own history. Once
+     * this panel makes the entry's fields editable, an author can rename the
+     * page, touch no block, and be told the document is saved — two surfaces
+     * writing to one document with the status answering for only one of them.
+     */
+    entryFields = <p>fields</p>;
+    openEditor();
+    expect(pillDirty.at(-1)).toBe(false);
+
+    fireEvent.change(screen.getByLabelText("title"), {
+      target: { value: "Renamed" },
+    });
+
+    expect(pillDirty.at(-1)).toBe(true);
+  });
+
+  it("still reports clean when nothing has been touched at all", () => {
+    // The control. A pill hardwired to dirty would satisfy the case above.
+    entryFields = <p>fields</p>;
+    openEditor();
+
+    expect(pillDirty.length).toBeGreaterThan(0);
+    expect(pillDirty.every(d => d === false)).toBe(true);
   });
 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -123,6 +123,7 @@ import {
 } from "react";
 import {
   useController,
+  useFormState,
   useWatch,
   type Control,
   type FieldValues,
@@ -1235,6 +1236,33 @@ function shownStyleStateFor(
   return switcherIsOnScreen ? editing : "base";
 }
 
+/**
+ * Whether this document holds unsaved work, from EITHER surface that writes it.
+ *
+ * The status pill otherwise reads the editor's `undoDepth` alone, which is its
+ * own history and says nothing about the form — so an author who renamed the
+ * page and touched no block was told the document was saved. Two surfaces now
+ * write to one document, and the pill has to answer for both.
+ *
+ * `dirtyFields` rather than `isDirty`, with this field excluded. The blocks
+ * field belongs to the editor and is committed on the way out, so while the
+ * editor is open it is either clean or dirty from a previous visit; counting it
+ * here would double the undo history or report work that is already saved.
+ *
+ * The editor's own history is taken as an argument rather than combined at the
+ * call site, so "is this document dirty" is answered in one place. It is also
+ * one fewer branch inside the largest component in this package, which the
+ * complexity gate refuses to let grow.
+ */
+function useDocumentDirty<TFieldValues extends FieldValues>(
+  control: Control<TFieldValues>,
+  ownField: string,
+  editorDirty: boolean
+): boolean {
+  const { dirtyFields } = useFormState({ control });
+  return editorDirty || Object.keys(dirtyFields).some(f => f !== ownField);
+}
+
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   initialValue,
   onCommit,
@@ -1387,6 +1415,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    * a collection whose only fields are its title, its slug and this one.
    */
   const entryFields = useEntryFieldsPanel(name);
+
+  const documentDirty = useDocumentDirty(control, name, editor.undoDepth > 0);
 
   /*
    * The getting-started card, and the host's switch for it.
@@ -1999,7 +2029,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         // editor is open, because the document is committed on the way out.
         topBar={
           <>
-            <DocumentStatusPill isDirty={editor.undoDepth > 0} />
+            <DocumentStatusPill isDirty={documentDirty} />
             {/*
              * Gated on the SAME read the canvas and the cascade are gated on.
              * Until the stored style has answered, `canvasSiteStyle` is the

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -1378,10 +1378,15 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   const inline = useInlineEditing(editor, loadInlineRichTextEditor, announce);
 
   /*
-   * The entry's other fields, or null when there is no surrounding form. Null
-   * is what withholds the panel rather than opening an empty one.
+   * The entry's other fields, ALREADY DRAWN, or null when there are none.
+   *
+   * One value feeds both the rail's availability and the panel's body below,
+   * so the two cannot disagree about whether there is anything to show. Asking
+   * separately is what put an empty Settings panel on the rail: every entry
+   * form has a renderer, so a gate on the renderer's existence is true even for
+   * a collection whose only fields are its title, its slug and this one.
    */
-  const renderEntryFields = useEntryFieldsPanel();
+  const entryFields = useEntryFieldsPanel(name);
 
   /*
    * The getting-started card, and the host's switch for it.
@@ -1974,7 +1979,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
       <BuilderShell
         onExit={done}
         availablePanels={
-          renderEntryFields === null
+          entryFields === null
             ? AVAILABLE_PANELS
             : AVAILABLE_PANELS_WITH_SETTINGS
         }
@@ -2223,13 +2228,16 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
               />
             ),
             /*
-              The entry's own fields — SEO, relations, whatever this collection
-              declares — which the takeover removed from the page behind this
-              editor. Rendered by the ADMIN's closure, not reconstructed here:
-              how a field is drawn is the entry form's contract, and a second
-              renderer would drift from it.
+              The document's title and slug, and the entry's own fields — SEO,
+              relations, whatever this collection declares — which this editor
+              covered when it took the window. Drawn by the ADMIN, not
+              reconstructed here: how a field is drawn is the entry form's
+              contract, and a second renderer would drift from it.
+
+              The same value the rail was derived from, so a panel is never
+              offered that this returns nothing for.
             */
-            settings: () => renderEntryFields?.(name) ?? null,
+            settings: () => entryFields,
           };
           return panels[panel]?.() ?? null;
         }}

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -1244,10 +1244,19 @@ function shownStyleStateFor(
  * page and touched no block was told the document was saved. Two surfaces now
  * write to one document, and the pill has to answer for both.
  *
- * `dirtyFields` rather than `isDirty`, with this field excluded. The blocks
- * field belongs to the editor and is committed on the way out, so while the
- * editor is open it is either clean or dirty from a previous visit; counting it
- * here would double the undo history or report work that is already saved.
+ * The blocks field is COUNTED here, and an earlier version excluded it. The
+ * reasoning for excluding it was that the editor owns that field and reports
+ * its own history, so counting it would double the undo depth or report saved
+ * work. Both halves were wrong. Double-counting cannot matter to a boolean, and
+ * the form's baseline advances on a successful submit — `useEntryForm` resets
+ * it — so a dirty blocks field means genuinely unsaved blocks.
+ *
+ * Excluding it lost the one case that has no other witness: an author who edits
+ * blocks, leaves the editor, and opens it again before saving. Leaving commits
+ * the document into the form, so the field is dirty; reopening builds a fresh
+ * editor whose `undoDepth` is zero. With the field excluded, nothing was left
+ * to say the document had unsaved work, and the pill read clean over blocks
+ * that had never been saved.
  *
  * The editor's own history is taken as an argument rather than combined at the
  * call site, so "is this document dirty" is answered in one place. It is also
@@ -1256,11 +1265,10 @@ function shownStyleStateFor(
  */
 function useDocumentDirty<TFieldValues extends FieldValues>(
   control: Control<TFieldValues>,
-  ownField: string,
   editorDirty: boolean
 ): boolean {
   const { dirtyFields } = useFormState({ control });
-  return editorDirty || Object.keys(dirtyFields).some(f => f !== ownField);
+  return editorDirty || Object.keys(dirtyFields).length > 0;
 }
 
 function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
@@ -1416,7 +1424,7 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    */
   const entryFields = useEntryFieldsPanel(name);
 
-  const documentDirty = useDocumentDirty(control, name, editor.undoDepth > 0);
+  const documentDirty = useDocumentDirty(control, editor.undoDepth > 0);
 
   /*
    * The getting-started card, and the host's switch for it.

--- a/packages/plugin-sdk/src/admin.ts
+++ b/packages/plugin-sdk/src/admin.ts
@@ -84,22 +84,41 @@ export {
 export { useReportUnsavedWork } from "@nextlyhq/admin";
 
 /**
- * Render the entry's remaining fields inside a takeover surface (@experimental).
+ * The entry's remaining fields, drawn for a takeover surface (@experimental).
  *
- * A field whose type is registered as a TAKEOVER collapses the form body to
- * itself, so an entry edited through one has its SEO, its relations and its
- * custom fields removed from the page — not merely covered. This returns a
- * renderer for exactly those, so the surface that took the body over can offer
- * them back without the author leaving it.
+ * A field whose type is registered as a TAKEOVER covers the whole form, so an
+ * entry edited through one has its title, its slug, its SEO and its relations
+ * put out of reach. This is how the surface that covered them offers them back
+ * without the author leaving it and losing their undo history.
  *
- * Null when nothing is hidden, which is a different answer from a renderer that
- * draws nothing: the first means offer no panel, the second means offer an
- * empty one. A shell that reserves width to display nothing reads as a broken
- * control rather than an absent feature.
+ * Pass the asking field's path; it is excluded from what comes back, along with
+ * any field whose condition currently hides it. What you get is the fields
+ * ALREADY DRAWN, or `null`.
  *
- * The renderer is built from the FORM'S OWN control, so what the surface draws
- * and what the form submits are one thing. Constructing a second form would
- * fork the state and lose the edit made in whichever copy did not save.
+ * ```tsx
+ * const fields = useEntryFieldsPanel(name);
+ * // One value answers both questions, so a rail and its panel cannot disagree.
+ * const panels = fields === null ? BASE_PANELS : [...BASE_PANELS, "settings"];
+ * // ...and the same value is what fills it.
+ * renderPanel={panel => (panel === "settings" ? fields : null)}
+ * ```
+ *
+ * `null` means OFFER NO PANEL, and it covers both reasons that can be true:
+ * there is no surrounding entry form — a preview, a standalone harness — or
+ * there is one with nothing left to show. A surface that reserves width to
+ * display nothing reads as a broken control rather than an absent feature, so
+ * the two are deliberately not distinguished: a caller does the same thing with
+ * either.
+ *
+ * A NODE rather than a renderer, because a caller makes two decisions from this
+ * — whether to offer a region, and what to put in it — and those must not be
+ * able to disagree. Handed a renderer, the only thing a caller could gate on
+ * was whether the renderer existed, which is true for every entry form whether
+ * or not it draws anything.
+ *
+ * It is built from the FORM'S OWN control, so what the surface draws and what
+ * the form submits are one thing. Constructing a second form would fork the
+ * state and lose the edit made in whichever copy did not save.
  */
 export { useEntryFieldsPanel } from "@nextlyhq/admin";
 


### PR DESCRIPTION
## What

The page builder's **Settings panel was offered on the rail and opened blank.**

Two independent causes. Fixing either alone leaves the other live.

### 1. The rail asked a question it could not fail

`settings` joined the rail when `renderEntryFields !== null`. `EntryForm` builds that closure unconditionally, so it is **never** null inside a form — the gate was true even when the renderer had nothing to draw. The region was reserved and opened empty.

The codebase states the rule against this three times (*"reserving width to display nothing reads as a broken control rather than an absent feature"*). The hook's own test even named the case — *"a renderer that happens to draw nothing"* — and accepted "show an empty one".

`useEntryFieldsPanel(excludePath)` now returns **the fields drawn, or null**. One value serves both the decision to offer a region and what fills it, so the rail and the body cannot disagree.

### 2. The content stripped the two fields that most belonged

`computeFieldsBeside` removed `title` and `slug` as system fields — correct in the form *body*, where the entry header draws them. **A builder covering the window suppresses that header** (`useSuppressAdminChrome({ layers: [… "header" …] })`), so the reason for withholding them was the reason they belonged.

For the commonest shape a collection takes — a title, a slug, a builder field — stripping them left *nothing*, and a document's own name could not be read from inside the editor at all.

Both references put exactly those fields in this panel:

| | contents |
|---|---|
| [Webflow page settings](https://university.webflow.com/lesson/pages-panel) | page name, **slug**, SEO title, meta description, OG, custom code |
| [Gutenberg document sidebar](https://media-studies.com/gutenberg-editor-interface/) | status & visibility, **permalink/slug**, categories, tags |

They are now offered, grouped as **Page** above the collection's own fields.

## Evidence

Coverage first: **no test anywhere asserted that `settings` joins the rail.** Every `BlocksField` test mocks the hook to `() => null`, so the entire non-null branch was uncovered.

- `BlocksField.settingsPanel.test.tsx` (new) asserts the rail **and** the body from one render, deliberately paired — checking either alone is what let them drift.
- Break: reinstating the old always-offer gate kills **2 by name**, including the control that notices the two rails stopped differing.
- Break: removing the null decision originally killed **nothing** — a real gap. The decision moved into `fieldsBesidePanel` so it is reachable, and the same break now kills **2 by name**.
- Break: merging the two groups kills **6 by name** across both suites.
- Suites: admin **336 files / 3218 tests green**; plugin-page-builder **49 / 516 green**; plugin-sdk surface snapshot unchanged. `check-types`, `lint`, `fallow` (`pass`, 9 changed files) clean.

### What is not covered

`EntryForm` **calling** `fieldsBesidePanel`. Nothing renders `EntryForm` in any test — its directory has exactly one test file, for the context — so standing up that harness is its own task rather than a line in this one.

## Second commit: a suite that passed for the wrong reason

`5321e3a6e` is separate and needs its own read. `BrandingProvider.test` left `useAuthSession` unmocked, so the real hook fetched. The workspace query is `enabled: !sessionPending`, so a session that never settles holds it pending and all seven status assertions read `"pending"`.

Where nothing answers that fetch it fails fast and the suite passes — that is a CI runner, which is why this has never been seen here. Where something **is** answering, which on a developer's machine is any dev server on the admin's port, all seven time out at their one-second wait. Reproduced in **two unrelated worktrees on two branches**, deterministically, in isolation and in the full run.

It is included because it blocks `git push` for anyone touching `admin` locally, and husky is not bypassed. Happy to split it out if you'd rather.

## Note

`useEntryFieldsPanel` is exported through `plugin-sdk/admin` and its signature changed. One first-party consumer, alpha, and the surface snapshot is unaffected (it records the name).
