### PR TITLE
test(admin): control the session the branding provider gates on

### DIFF
--- a/packages/admin/src/context/providers/BrandingProvider.test.tsx
+++ b/packages/admin/src/context/providers/BrandingProvider.test.tsx
@@ -21,6 +21,34 @@ vi.mock("@admin/lib/api/protectedApi", () => ({
   protectedApi: { get: (...args: unknown[]) => protectedGet(...args) },
 }));
 
+/**
+ * The provider's THIRD input, and the one the two API mocks above cannot
+ * reach. `BrandingProvider` gates the workspace query on `enabled:
+ * !sessionPending`, so `useAuthSession` decides whether that query is ever
+ * allowed to run — and its real implementation calls `getSession()`, which
+ * issues a genuine `fetch` to `${location.origin}/admin/api/auth/session`
+ * rather than going through `publicApi`. Left unmocked, whether these tests
+ * pass depends on what answers port 3000 on the machine running them: nothing
+ * listening refuses the connection at once and the session settles, while a
+ * dev server that accepts and never answers leaves it pending forever, the
+ * workspace query permanently disabled, and every status here stuck on
+ * `pending`.
+ *
+ * A settled session is supplied so the assertions below are about the two
+ * admin-meta halves, which is what this file covers. The session's own effect
+ * on the status — resolving, signed out, signed in — is covered next door in
+ * `BrandingProvider.session.test.tsx`, which drives it per test.
+ */
+const SETTLED_SESSION = {
+  data: { isSetup: true, isAuthenticated: true },
+  isPending: false,
+};
+
+vi.mock("@admin/hooks/queries/useAuthSession", () => ({
+  useAuthSession: () => SETTLED_SESSION,
+  authSessionKey: ["auth", "session"],
+}));
+
 import {
   BrandingProvider,
   useAppName,


### PR DESCRIPTION
`BrandingProvider.test.tsx` fails 7 of 8 locally on every machine in this workspace while passing in CI. It blocks the pre-push hook for every lane, so it has been costing time across several sessions.

## Why it fails, and why CI never noticed

`BrandingProvider` has three inputs. The test mocked two of them — `publicApi` and `protectedApi` — and never mocked the third: `useAuthSession`, which gates the workspace query through `enabled: !sessionPending`.

Its real implementation reaches `getSession()`, which issues a genuine `fetch` to `http://localhost:3000/admin/api/auth/session`. That call does not go through either mocked API client, so neither mock could intercept it.

- **Locally**, a dev server accepts the connection and never answers. The session query stays pending forever, the workspace query is never enabled, and every status reads `pending`.
- **In CI**, nothing listens on port 3000. The connection is refused instantly, `getSession()` catches it and returns null, and the file passes.

So CI was green by accident of an empty port, not because the test was sound.

## The fix

Mock `@admin/hooks/queries/useAuthSession` with a settled session — exactly as the sibling `BrandingProvider.session.test.tsx` in the same directory already does. That file owns the session-transition coverage; this one only ever needed the session to have answered.

Test-only, 28 insertions, 0 deletions. No assertion touched, no timeout raised. The queries never settled at all, so no timeout would have helped.

## Verification

- Admin package: 335 files / 3208 tests, all passing. Baseline was 334/335 and 3201/3208 — the file count is unchanged, so nothing stopped being discovered.
- `check-types` 22/22.
- Break-verified on two axes rather than one. Forcing `isPending: true` turns 7 red — but that mirrors the original symptom, so it does not discriminate on its own. Forcing `isUnavailable: false` turns exactly the two tests naming `unavailable` red. Both restored clean.

## A larger class this exposes, not fixed here

Measured rather than grepped: wrapping global `fetch` in `setup.ts` for one full suite run and logging every call shows **13 test files reach `localhost:3000`**. This was one. The other twelve pass only because no assertion in them waits on those requests — they are the same latent defect, currently silent.

The durable repair is a boundary rather than twelve patches: make `setup.ts` reject unstubbed `fetch` so a test reaching the network fails loudly instead of hanging or passing by luck. That would turn all twelve red at once and deserves its own change.