### PR TITLE
refactor(nextly): compose an email once, for sending and for preview

### DIFF
--- a/.changeset/an-email-previews-as-it-will-be-sent.md
+++ b/.changeset/an-email-previews-as-it-will-be-sent.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An email template preview now shows exactly what will be sent.
+
+Previewing a template and sending it were composed separately, and had drifted:
+the preview left out the hidden preheader line, rendered a layout's own
+`{{year}}` and `{{appName}}` as blanks — so a layout footer previewed empty —
+escaped a subject that is delivered as plain text, and never showed the
+plain-text part of the message at all. Both now go through one composition, so
+they cannot disagree.
+
+Previews also work before a template is saved. A new
+`POST /api/email-templates/preview` renders template fields directly, which the
+existing per-template preview route cannot do: it reads the stored row, so it
+shows nothing of what is being typed and has no row to read at all while a
+template is being created.

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -131,6 +131,10 @@
       "types": "./dist/api/email-templates-preview.d.ts",
       "import": "./dist/api/email-templates-preview.mjs"
     },
+    "./api/email-templates-draft-preview": {
+      "types": "./dist/api/email-templates-draft-preview.d.ts",
+      "import": "./dist/api/email-templates-draft-preview.mjs"
+    },
     "./api/email-send": {
       "types": "./dist/api/email-send.d.ts",
       "import": "./dist/api/email-send.mjs"

--- a/packages/nextly/src/api/__tests__/email-templates-draft-preview.test.ts
+++ b/packages/nextly/src/api/__tests__/email-templates-draft-preview.test.ts
@@ -1,0 +1,157 @@
+// The draft-preview route renders fields that were never saved, and gates on the
+// same permissions as the saved-template preview.
+//
+// The permission half is asserted by OBSERVING the call the route makes, not by
+// sending an unauthenticated request: this harness mocks `route-auth`, so a
+// request that "fails to authenticate" here would be failing against the mock.
+// Asserting the arguments the real guard receives is the property that survives
+// someone editing the route — a reconstructed permission list in the test would
+// keep passing after the route stopped asking for it.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Typed to the real signatures, so `mock.calls` carries the argument types and
+// the assertions below read them rather than casting a value they assumed.
+const previewDraft =
+  vi.fn<
+    (
+      fields: Record<string, unknown>,
+      data: Record<string, unknown>
+    ) => Promise<unknown>
+  >();
+const requireRouteAnyPermission =
+  vi.fn<
+    (
+      request: Request,
+      permissions: Array<{ action: string; resource: string }>
+    ) => Promise<void>
+  >();
+
+vi.mock("../../di", () => ({
+  container: { get: vi.fn(() => ({ previewDraft })) },
+  isServicesRegistered: vi.fn(() => true),
+}));
+
+vi.mock("../../init", () => ({
+  getCachedNextly: vi.fn(async () => undefined),
+}));
+
+vi.mock("../route-auth", () => ({
+  requireRouteAnyPermission: (
+    request: Request,
+    permissions: Array<{ action: string; resource: string }>
+  ) => requireRouteAnyPermission(request, permissions),
+}));
+
+function post(body: unknown): Request {
+  return new Request("http://localhost/api/email-templates/preview", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const draft = {
+  subject: "Hi {{name}}",
+  htmlContent: "<p>{{name}}</p>",
+  useLayout: false,
+  kind: "template" as const,
+};
+
+describe("the draft email-template preview route", () => {
+  beforeEach(() => {
+    previewDraft.mockReset();
+    requireRouteAnyPermission.mockClear();
+    requireRouteAnyPermission.mockResolvedValue(undefined);
+    previewDraft.mockResolvedValue({
+      subject: "Hi Priya",
+      html: "<p>Priya</p>",
+      text: "Priya",
+    });
+  });
+
+  it("renders fields that were never saved", async () => {
+    const { POST } = await import("../email-templates-draft-preview");
+
+    const res = await POST(post({ template: draft, data: { name: "Priya" } }));
+    const body: unknown = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body).toEqual({
+      subject: "Hi Priya",
+      html: "<p>Priya</p>",
+      text: "Priya",
+    });
+  });
+
+  it("hands the service the fields and the data it was given", async () => {
+    const { POST } = await import("../email-templates-draft-preview");
+
+    await POST(post({ template: draft, data: { name: "Priya" } }));
+
+    expect(previewDraft).toHaveBeenCalledTimes(1);
+    const [fields, data] = previewDraft.mock.calls[0];
+    expect(fields.subject).toBe("Hi {{name}}");
+    expect(fields.htmlContent).toBe("<p>{{name}}</p>");
+    expect(data).toEqual({ name: "Priya" });
+  });
+
+  it("defaults the optional fields rather than passing them undefined", async () => {
+    const { POST } = await import("../email-templates-draft-preview");
+
+    await POST(post({ template: draft, data: {} }));
+
+    const [fields] = previewDraft.mock.calls[0];
+    expect(fields.plainTextContent).toBeNull();
+    expect(fields.preheader).toBeNull();
+    expect(fields.layoutId).toBeNull();
+  });
+
+  it("gates on the same permissions as the saved-template preview", async () => {
+    const { POST } = await import("../email-templates-draft-preview");
+
+    await POST(post({ template: draft, data: {} }));
+
+    expect(requireRouteAnyPermission).toHaveBeenCalledTimes(1);
+    const [, permissions] = requireRouteAnyPermission.mock.calls[0];
+    expect(permissions).toEqual([
+      { action: "create", resource: "email-templates" },
+      { action: "manage", resource: "email-templates" },
+    ]);
+  });
+
+  it("authorizes BEFORE it renders", async () => {
+    const { POST } = await import("../email-templates-draft-preview");
+    const order: string[] = [];
+    requireRouteAnyPermission.mockImplementationOnce(async () => {
+      order.push("authorize");
+    });
+    previewDraft.mockImplementationOnce(() => {
+      order.push("render");
+      return Promise.resolve({ subject: "", html: "", text: "" });
+    });
+
+    await POST(post({ template: draft, data: {} }));
+
+    expect(order).toEqual(["authorize", "render"]);
+  });
+
+  it("rejects a body carrying no template", async () => {
+    const { POST } = await import("../email-templates-draft-preview");
+
+    const res = await POST(post({ data: {} }));
+
+    expect(res.status).toBe(400);
+    expect(previewDraft).not.toHaveBeenCalled();
+  });
+
+  it("rejects a template whose kind is not one this renderer knows", async () => {
+    const { POST } = await import("../email-templates-draft-preview");
+
+    const res = await POST(
+      post({ template: { ...draft, kind: "banner" }, data: {} })
+    );
+
+    expect(res.status).toBe(400);
+    expect(previewDraft).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/api/email-templates-draft-preview.ts
+++ b/packages/nextly/src/api/email-templates-draft-preview.ts
@@ -1,0 +1,109 @@
+/**
+ * Email Template Draft Preview API Route Handler for Next.js
+ *
+ * Renders template FIELDS with sample data, without requiring the template to
+ * have been saved. Re-export in your Next.js application at
+ * /api/email-templates/preview.
+ *
+ * @example
+ * ```typescript
+ * // In your Next.js app: app/api/email-templates/preview/route.ts
+ * export { POST } from 'nextly/api/email-templates-draft-preview';
+ * ```
+ *
+ * Separate from `/api/email-templates/[id]/preview` because that one reads the
+ * STORED row: it cannot show unsaved edits, and while a template is being
+ * created there is no row to address. Both render through the same composition,
+ * so the two previews cannot disagree with each other or with what is sent.
+ *
+ * The rendered subject/html/text stay JSON-encoded (no raw HTML response); the
+ * admin renders the preview inside a sandboxed iframe.
+ *
+ * @module api/email-templates-draft-preview
+ */
+
+import { z } from "zod";
+
+import { container } from "../di";
+import { getCachedNextly } from "../init";
+import type { EmailTemplateService } from "../services/email/email-template-service";
+
+import { readJsonBody } from "./read-json-body";
+import { respondData } from "./response-shapes";
+import { requireRouteAnyPermission } from "./route-auth";
+import { withErrorHandler } from "./with-error-handler";
+import { nextlyValidationFromZod } from "./zod-to-nextly-error";
+
+async function getEmailTemplateService(): Promise<EmailTemplateService> {
+  await getCachedNextly();
+  return container.get<EmailTemplateService>("emailTemplateService");
+}
+
+/**
+ * The fields a render needs, and nothing else.
+ *
+ * Deliberately not the full template shape: a preview never writes, so
+ * accepting a name, a slug or an id would take input it has no use for.
+ */
+const draftPreviewSchema = z.object({
+  template: z.object({
+    subject: z.string(),
+    htmlContent: z.string(),
+    plainTextContent: z.string().nullable().default(null),
+    preheader: z.string().nullable().default(null),
+    useLayout: z.boolean(),
+    kind: z.enum(["template", "layout", "partial"]),
+    layoutId: z.string().nullable().default(null),
+  }),
+  data: z.record(z.string(), z.unknown()),
+});
+
+/**
+ * POST handler for previewing unsaved email template fields.
+ *
+ * Renders the supplied fields by replacing `{{variable}}` placeholders with
+ * values from `data`, wrapping in the resolved layout when `useLayout` is set,
+ * prepending the hidden preheader, and deriving the plain-text alternative —
+ * the same composition the send path uses.
+ *
+ * Requires authentication. Gated on the same permissions as the saved-template
+ * preview: previewing a draft reveals no more than previewing a stored row.
+ *
+ * Request Body:
+ * - template: the fields to render (required)
+ * - data: key-value pairs for variable interpolation (required)
+ *
+ * Response Codes:
+ * - 200 OK: Preview rendered successfully
+ * - 400 Bad Request: Invalid input
+ * - 401 Unauthorized: Authentication required
+ * - 500 Internal Server Error: Preview failed
+ *
+ * Response: `{ "subject": string, "html": string, "text": string }`
+ */
+export const POST = withErrorHandler(
+  async (request: Request): Promise<Response> => {
+    await requireRouteAnyPermission(request, [
+      { action: "create", resource: "email-templates" },
+      { action: "manage", resource: "email-templates" },
+    ]);
+
+    const service = await getEmailTemplateService();
+    const body = await readJsonBody(request);
+
+    let validated: z.infer<typeof draftPreviewSchema>;
+    try {
+      validated = draftPreviewSchema.parse(body);
+    } catch (err) {
+      if (err instanceof z.ZodError) throw nextlyValidationFromZod(err);
+      throw err;
+    }
+
+    const preview = await service.previewDraft(
+      validated.template,
+      validated.data
+    );
+
+    return respondData(preview);
+  }
+);

--- a/packages/nextly/src/di/registrations/register-email.ts
+++ b/packages/nextly/src/di/registrations/register-email.ts
@@ -89,7 +89,7 @@ export function registerEmailServices(ctx: RegistrationContext): void {
   // EmailTemplateService — CRUD for email templates
   container.registerSingleton<EmailTemplateService>(
     "emailTemplateService",
-    () => new EmailTemplateService(adapter, logger)
+    () => new EmailTemplateService(adapter, logger, config.email?.appName)
   );
 
   // EmailService — orchestration layer for email sending. Depends on

--- a/packages/nextly/src/domains/email/__tests__/delivery-result-reaches-callers.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/delivery-result-reaches-callers.test.ts
@@ -43,7 +43,6 @@ function makeTemplateService() {
   return {
     getTemplateBySlug: vi.fn().mockResolvedValue(null),
     getLayoutFor: vi.fn().mockResolvedValue(null),
-    renderWithLayout: vi.fn(),
   };
 }
 

--- a/packages/nextly/src/domains/email/__tests__/email-template-service.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/email-template-service.test.ts
@@ -692,6 +692,68 @@ describe("EmailTemplateService", () => {
       expect(preview.html).toBe("<p>Bare</p>");
     });
 
+    /*
+     * The three properties below are what a preview must share with a send.
+     * Each one previously differed: the preview dropped the preheader, left a
+     * layout's own `{{year}}`/`{{appName}}` blank when the caller did not pass
+     * them, and HTML-escaped a subject that is delivered as plain text.
+     */
+    it("carries the hidden preheader the send path prepends", async () => {
+      const template = await service.createTemplate({
+        name: "With Preheader",
+        slug: "with-preheader",
+        subject: "Subject",
+        preheader: "Your account is ready",
+        htmlContent: "<p>Body</p>",
+        useLayout: false,
+      });
+
+      const preview = await service.previewTemplate(template.id, {});
+
+      expect(preview.html).toContain("Your account is ready");
+      expect(preview.html.startsWith('<div style="display:none;')).toBe(true);
+    });
+
+    it("fills a layout's year and appName when the caller omits them", async () => {
+      await service.createTemplate({
+        name: "Default Layout",
+        slug: "default-layout",
+        kind: "layout",
+        subject: "",
+        htmlContent: "{{content}}<footer>{{appName}} {{year}}</footer>",
+        useLayout: false,
+      });
+
+      const template = await service.createTemplate({
+        name: "Needs Layout Defaults",
+        slug: "needs-layout-defaults",
+        subject: "Subject",
+        htmlContent: "<p>Body</p>",
+        useLayout: true,
+      });
+
+      const preview = await service.previewTemplate(template.id, {});
+
+      expect(preview.html).toContain("Nextly");
+      expect(preview.html).toMatch(/\d{4}/);
+    });
+
+    it("does not HTML-escape the subject, which is delivered as plain text", async () => {
+      const template = await service.createTemplate({
+        name: "Ampersand Subject",
+        slug: "ampersand-subject",
+        subject: "{{co}} & you",
+        htmlContent: "<p>Body</p>",
+        useLayout: false,
+      });
+
+      const preview = await service.previewTemplate(template.id, {
+        co: "Ben & Jerry",
+      });
+
+      expect(preview.subject).toBe("Ben & Jerry & you");
+    });
+
     it("throws NOT_FOUND for a nonexistent template ID", async () => {
       await expect(
         service.previewTemplate("nonexistent-id", {})

--- a/packages/nextly/src/domains/email/__tests__/render-template.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/render-template.test.ts
@@ -1,103 +1,72 @@
 /**
  * The composition an email recipient actually receives.
  *
- * `sendTemplate` composes a template into subject, HTML and text inline, and
- * `previewTemplate` composes a narrower artifact of its own. The two agreed
- * when they were written and no longer do. These tests pin the SEND path's
- * behaviour — the one users observe in their inbox — so that collapsing both
- * into a single function is provably behaviour-preserving rather than
- * hopefully so.
+ * `sendTemplate` composed a template into subject, HTML and text inline, and
+ * `previewTemplate` composed a narrower artifact of its own. The two agreed
+ * when they were written and had drifted on six properties by the time they
+ * were unified. These tests pin the SEND path's behaviour — the one users
+ * observe in their inbox — against the extracted renderer that now serves both.
  *
- * `composeAsSendDoesToday` is the oracle: it is a transcription of
- * `email-service.ts`, and it is replaced by a call to the extracted function
- * once that exists. Every assertion below must hold across that replacement.
+ * Every assertion calls `renderTemplate` itself. An earlier revision asserted
+ * against a transcription of the old inline composition, which passed whether
+ * or not the extracted renderer was correct: breaking subject escaping in
+ * production left all eleven green. A test that cannot fail for its own reason
+ * is worse than no test, because the next reader takes the green as coverage.
  */
 import { describe, expect, it } from "vitest";
 
-import { htmlToText, interpolateTemplate } from "../services/template-engine";
-
-interface OracleTemplate {
-  subject: string;
-  htmlContent: string;
-  plainTextContent: string | null;
-  preheader: string | null;
-  useLayout: boolean;
-}
+import {
+  renderTemplate,
+  type TemplateFields,
+} from "../services/render-template";
 
 const CONTENT_MARKER = "{{content}}";
 
 /** The default `appName` the send path supplies when configuration has none. */
 const APP_NAME = "Nextly";
 
-function composeAsSendDoesToday(
-  t: OracleTemplate,
+/**
+ * Calls the renderer under test, supplying only the `appName` option.
+ *
+ * A thin argument-shaping helper, deliberately not a second composition: it
+ * makes no decision the renderer would otherwise make.
+ */
+function render(
+  template: TemplateFields,
   layout: { htmlContent: string } | null,
-  vars: Record<string, unknown>
-): { subject: string; html: string; text: string } {
-  const subject = interpolateTemplate(t.subject, vars, { escapeHtml: false });
-  let html = interpolateTemplate(t.htmlContent, vars);
-
-  const text = t.plainTextContent?.trim()
-    ? interpolateTemplate(t.plainTextContent, vars, { escapeHtml: false })
-    : htmlToText(html);
-
-  if (t.preheader?.trim()) {
-    const preheader = interpolateTemplate(t.preheader, vars);
-    html = `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>${html}`;
-  }
-
-  if (t.useLayout && layout) {
-    const layoutVars: Record<string, unknown> = {
-      ...vars,
-      year: vars.year ?? new Date().getFullYear().toString(),
-      appName: vars.appName ?? APP_NAME,
-    };
-    const at = layout.htmlContent.indexOf(CONTENT_MARKER);
-    html =
-      at === -1
-        ? interpolateTemplate(layout.htmlContent, layoutVars) + html
-        : interpolateTemplate(layout.htmlContent.slice(0, at), layoutVars) +
-          html +
-          interpolateTemplate(
-            layout.htmlContent.slice(at + CONTENT_MARKER.length),
-            layoutVars
-          );
-  }
-
-  return { subject, html, text };
+  data: Record<string, unknown>
+) {
+  return renderTemplate(template, layout, data, { appName: APP_NAME });
 }
 
-const base: OracleTemplate = {
+const base: TemplateFields = {
   subject: "Welcome to {{appName}}",
   htmlContent: "<p>Hello {{userName}}</p>",
   plainTextContent: null,
   preheader: null,
   useLayout: false,
+  kind: "template",
 };
 
 describe("the composition recipients receive", () => {
   it("does NOT html-escape the subject", () => {
-    const out = composeAsSendDoesToday(
-      { ...base, subject: "{{co}} & you" },
-      null,
-      { co: "Ben & Jerry" }
-    );
+    const out = render({ ...base, subject: "{{co}} & you" }, null, {
+      co: "Ben & Jerry",
+    });
     expect(out.subject).toBe("Ben & Jerry & you");
     expect(out.subject).not.toContain("&amp;");
   });
 
   it("DOES html-escape values interpolated into the body", () => {
-    const out = composeAsSendDoesToday(
-      { ...base, htmlContent: "<p>{{bio}}</p>" },
-      null,
-      { bio: "<script>alert(1)</script>" }
-    );
+    const out = render({ ...base, htmlContent: "<p>{{bio}}</p>" }, null, {
+      bio: "<script>alert(1)</script>",
+    });
     expect(out.html).toContain("&lt;script&gt;");
     expect(out.html).not.toContain("<script>");
   });
 
   it("prepends a hidden preheader div when one is authored", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, preheader: "Your account is ready" },
       null,
       {}
@@ -107,7 +76,7 @@ describe("the composition recipients receive", () => {
   });
 
   it("uses the authored plain text when there is one", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, plainTextContent: "Hello {{userName}}, welcome." },
       null,
       { userName: "Priya" }
@@ -116,7 +85,7 @@ describe("the composition recipients receive", () => {
   });
 
   it("derives the text part from the body when none is authored", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, htmlContent: "<h1>Hi</h1><p>Visit us</p>" },
       null,
       {}
@@ -126,17 +95,13 @@ describe("the composition recipients receive", () => {
   });
 
   it("derives the text part BEFORE the preheader, so it never leaks in", () => {
-    const out = composeAsSendDoesToday(
-      { ...base, preheader: "SECRET-PREVIEW-LINE" },
-      null,
-      {}
-    );
+    const out = render({ ...base, preheader: "SECRET-PREVIEW-LINE" }, null, {});
     expect(out.html).toContain("SECRET-PREVIEW-LINE");
     expect(out.text).not.toContain("SECRET-PREVIEW-LINE");
   });
 
   it("supplies year and appName to the layout when the caller omits them", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, useLayout: true },
       { htmlContent: `<footer>{{appName}} {{year}}</footer>${CONTENT_MARKER}` },
       {}
@@ -146,7 +111,7 @@ describe("the composition recipients receive", () => {
   });
 
   it("lets the caller's own year and appName win over the defaults", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, useLayout: true },
       { htmlContent: `<footer>{{appName}} {{year}}</footer>${CONTENT_MARKER}` },
       { appName: "Northwind", year: "1999" }
@@ -155,7 +120,7 @@ describe("the composition recipients receive", () => {
   });
 
   it("splices the body at the layout's {{content}} marker", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, useLayout: true },
       { htmlContent: `<header>H</header>${CONTENT_MARKER}<footer>F</footer>` },
       { userName: "Priya" }
@@ -169,7 +134,7 @@ describe("the composition recipients receive", () => {
   });
 
   it("appends the body after a layout with NO marker, dropping nothing", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, useLayout: true },
       { htmlContent: "<header>only</header>" },
       { userName: "Priya" }
@@ -178,8 +143,37 @@ describe("the composition recipients receive", () => {
     expect(out.html).toContain("Hello Priya");
   });
 
+  /*
+   * New behaviour rather than characterised behaviour: `sendTemplate` never
+   * sends a layout row, so the send path had no such guard and the assertions
+   * above cannot cover this. `previewTemplate` did make the distinction, and
+   * the unified renderer has to keep it.
+   */
+  it("renders a layout ROW as its own wrapper, never nested in another", () => {
+    const out = render(
+      {
+        subject: "s",
+        htmlContent: `<html>${CONTENT_MARKER}</html>`,
+        plainTextContent: null,
+        preheader: null,
+        useLayout: true,
+        kind: "layout",
+      },
+      { htmlContent: `<other>${CONTENT_MARKER}</other>` },
+      {}
+    );
+    // Its own wrapper, and no trace of the other one — the property under test.
+    expect(out.html).toBe("<html></html>");
+    expect(out.html).not.toContain("<other>");
+    // The row's own `{{content}}` is consumed as an unbound variable, exactly
+    // as `previewTemplate` did before the unification. Asserted so that the
+    // slot disappearing is recorded as preserved behaviour rather than being
+    // mistaken later for a splice that went wrong.
+    expect(out.html).not.toContain(CONTENT_MARKER);
+  });
+
   it("does not wrap when useLayout is false, even with a layout to hand", () => {
-    const out = composeAsSendDoesToday(
+    const out = render(
       { ...base, useLayout: false },
       { htmlContent: `<header>H</header>${CONTENT_MARKER}` },
       { userName: "Priya" }

--- a/packages/nextly/src/domains/email/__tests__/render-template.test.ts
+++ b/packages/nextly/src/domains/email/__tests__/render-template.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The composition an email recipient actually receives.
+ *
+ * `sendTemplate` composes a template into subject, HTML and text inline, and
+ * `previewTemplate` composes a narrower artifact of its own. The two agreed
+ * when they were written and no longer do. These tests pin the SEND path's
+ * behaviour — the one users observe in their inbox — so that collapsing both
+ * into a single function is provably behaviour-preserving rather than
+ * hopefully so.
+ *
+ * `composeAsSendDoesToday` is the oracle: it is a transcription of
+ * `email-service.ts`, and it is replaced by a call to the extracted function
+ * once that exists. Every assertion below must hold across that replacement.
+ */
+import { describe, expect, it } from "vitest";
+
+import { htmlToText, interpolateTemplate } from "../services/template-engine";
+
+interface OracleTemplate {
+  subject: string;
+  htmlContent: string;
+  plainTextContent: string | null;
+  preheader: string | null;
+  useLayout: boolean;
+}
+
+const CONTENT_MARKER = "{{content}}";
+
+/** The default `appName` the send path supplies when configuration has none. */
+const APP_NAME = "Nextly";
+
+function composeAsSendDoesToday(
+  t: OracleTemplate,
+  layout: { htmlContent: string } | null,
+  vars: Record<string, unknown>
+): { subject: string; html: string; text: string } {
+  const subject = interpolateTemplate(t.subject, vars, { escapeHtml: false });
+  let html = interpolateTemplate(t.htmlContent, vars);
+
+  const text = t.plainTextContent?.trim()
+    ? interpolateTemplate(t.plainTextContent, vars, { escapeHtml: false })
+    : htmlToText(html);
+
+  if (t.preheader?.trim()) {
+    const preheader = interpolateTemplate(t.preheader, vars);
+    html = `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>${html}`;
+  }
+
+  if (t.useLayout && layout) {
+    const layoutVars: Record<string, unknown> = {
+      ...vars,
+      year: vars.year ?? new Date().getFullYear().toString(),
+      appName: vars.appName ?? APP_NAME,
+    };
+    const at = layout.htmlContent.indexOf(CONTENT_MARKER);
+    html =
+      at === -1
+        ? interpolateTemplate(layout.htmlContent, layoutVars) + html
+        : interpolateTemplate(layout.htmlContent.slice(0, at), layoutVars) +
+          html +
+          interpolateTemplate(
+            layout.htmlContent.slice(at + CONTENT_MARKER.length),
+            layoutVars
+          );
+  }
+
+  return { subject, html, text };
+}
+
+const base: OracleTemplate = {
+  subject: "Welcome to {{appName}}",
+  htmlContent: "<p>Hello {{userName}}</p>",
+  plainTextContent: null,
+  preheader: null,
+  useLayout: false,
+};
+
+describe("the composition recipients receive", () => {
+  it("does NOT html-escape the subject", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, subject: "{{co}} & you" },
+      null,
+      { co: "Ben & Jerry" }
+    );
+    expect(out.subject).toBe("Ben & Jerry & you");
+    expect(out.subject).not.toContain("&amp;");
+  });
+
+  it("DOES html-escape values interpolated into the body", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, htmlContent: "<p>{{bio}}</p>" },
+      null,
+      { bio: "<script>alert(1)</script>" }
+    );
+    expect(out.html).toContain("&lt;script&gt;");
+    expect(out.html).not.toContain("<script>");
+  });
+
+  it("prepends a hidden preheader div when one is authored", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, preheader: "Your account is ready" },
+      null,
+      {}
+    );
+    expect(out.html.startsWith('<div style="display:none;')).toBe(true);
+    expect(out.html).toContain("Your account is ready");
+  });
+
+  it("uses the authored plain text when there is one", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, plainTextContent: "Hello {{userName}}, welcome." },
+      null,
+      { userName: "Priya" }
+    );
+    expect(out.text).toBe("Hello Priya, welcome.");
+  });
+
+  it("derives the text part from the body when none is authored", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, htmlContent: "<h1>Hi</h1><p>Visit us</p>" },
+      null,
+      {}
+    );
+    expect(out.text).toContain("Hi");
+    expect(out.text).not.toContain("<h1>");
+  });
+
+  it("derives the text part BEFORE the preheader, so it never leaks in", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, preheader: "SECRET-PREVIEW-LINE" },
+      null,
+      {}
+    );
+    expect(out.html).toContain("SECRET-PREVIEW-LINE");
+    expect(out.text).not.toContain("SECRET-PREVIEW-LINE");
+  });
+
+  it("supplies year and appName to the layout when the caller omits them", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, useLayout: true },
+      { htmlContent: `<footer>{{appName}} {{year}}</footer>${CONTENT_MARKER}` },
+      {}
+    );
+    expect(out.html).toContain(APP_NAME);
+    expect(out.html).toMatch(/\d{4}/);
+  });
+
+  it("lets the caller's own year and appName win over the defaults", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, useLayout: true },
+      { htmlContent: `<footer>{{appName}} {{year}}</footer>${CONTENT_MARKER}` },
+      { appName: "Northwind", year: "1999" }
+    );
+    expect(out.html).toContain("Northwind 1999");
+  });
+
+  it("splices the body at the layout's {{content}} marker", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, useLayout: true },
+      { htmlContent: `<header>H</header>${CONTENT_MARKER}<footer>F</footer>` },
+      { userName: "Priya" }
+    );
+    expect(out.html.indexOf("<header>H</header>")).toBeLessThan(
+      out.html.indexOf("Hello Priya")
+    );
+    expect(out.html.indexOf("Hello Priya")).toBeLessThan(
+      out.html.indexOf("<footer>F</footer>")
+    );
+  });
+
+  it("appends the body after a layout with NO marker, dropping nothing", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, useLayout: true },
+      { htmlContent: "<header>only</header>" },
+      { userName: "Priya" }
+    );
+    expect(out.html).toContain("<header>only</header>");
+    expect(out.html).toContain("Hello Priya");
+  });
+
+  it("does not wrap when useLayout is false, even with a layout to hand", () => {
+    const out = composeAsSendDoesToday(
+      { ...base, useLayout: false },
+      { htmlContent: `<header>H</header>${CONTENT_MARKER}` },
+      { userName: "Priya" }
+    );
+    expect(out.html).toBe("<p>Hello Priya</p>");
+  });
+});

--- a/packages/nextly/src/domains/email/services/email-service.ts
+++ b/packages/nextly/src/domains/email/services/email-service.ts
@@ -52,12 +52,9 @@ import { getEmailProviderRegistry } from "./email-provider-registry";
 import type { EmailProviderService } from "./email-provider-service";
 import type { EmailTemplateService } from "./email-template-service";
 import { LOG_PROVIDER_TYPE } from "./providers/log-provider";
+import { DEFAULT_APP_NAME, renderTemplate } from "./render-template";
 import { mergeTemplateAttachments } from "./template-attachment-merge";
-import {
-  htmlToText,
-  interpolateTemplate,
-  validateTemplateVariables,
-} from "./template-engine";
+import { htmlToText, validateTemplateVariables } from "./template-engine";
 
 /**
  * Dependencies needed to resolve attachments from the media library.
@@ -253,34 +250,20 @@ export class EmailService extends BaseService {
         );
       }
 
-      // Interpolate subject (no HTML escaping — plain text)
-      const subject = interpolateTemplate(dbTemplate.subject, variables, {
-        escapeHtml: false,
+      // One composition, shared with every preview surface. Resolving WHICH
+      // layout wraps this template needs the database; composing with it does
+      // not, so only the resolution stays here.
+      const layout = dbTemplate.useLayout
+        ? await this.templateService.getLayoutFor(dbTemplate)
+        : null;
+
+      const {
+        subject,
+        html,
+        text: plainText,
+      } = renderTemplate(dbTemplate, layout, variables, {
+        appName: this.getAppName(),
       });
-
-      // Interpolate body (HTML escaping for injected values)
-      let html = interpolateTemplate(dbTemplate.htmlContent, variables);
-
-      // Plain-text alternative: use the template's own text if authored
-      // (interpolated, no HTML escaping); otherwise derive it from the body
-      // BEFORE the preheader/layout are spliced in, so the hidden preheader div
-      // never leaks into the text mail as duplicated preview text.
-      const plainText = dbTemplate.plainTextContent?.trim()
-        ? interpolateTemplate(dbTemplate.plainTextContent, variables, {
-            escapeHtml: false,
-          })
-        : htmlToText(html);
-
-      // Prepend a hidden preheader (inbox preview line) when authored.
-      if (dbTemplate.preheader?.trim()) {
-        const preheader = interpolateTemplate(dbTemplate.preheader, variables);
-        html = `<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">${preheader}</div>${html}`;
-      }
-
-      // Compose with layout if enabled
-      if (dbTemplate.useLayout) {
-        html = await this.composeWithLayout(dbTemplate, html, variables);
-      }
 
       // Merge template-default attachments with per-send attachments.
       // Dedupe by mediaId — per-send entries win on conflict.
@@ -1021,39 +1004,6 @@ export class EmailService extends BaseService {
   }
 
   // ============================================================
-  // Private: Template Layout Composition
-  // ============================================================
-
-  /**
-   * Compose the final HTML by injecting the interpolated template body
-   * into its resolved layout at the `{{content}}` placeholder. The
-   * layout's own `{{year}}` / `{{appName}}` placeholders are filled;
-   * the body is spliced in verbatim. Returns the body unchanged when
-   * no layout exists.
-   */
-  private async composeWithLayout(
-    template: EmailTemplateRecord,
-    interpolatedBody: string,
-    variables: Record<string, unknown>
-  ): Promise<string> {
-    const layout = await this.templateService.getLayoutFor(template);
-    if (!layout) return interpolatedBody;
-
-    // Ensure common layout variables are always available
-    const layoutVars: Record<string, unknown> = {
-      ...variables,
-      year: variables.year ?? new Date().getFullYear().toString(),
-      appName: variables.appName ?? this.getAppName(),
-    };
-
-    return this.templateService.renderWithLayout(
-      layout,
-      interpolatedBody,
-      layoutVars
-    );
-  }
-
-  // ============================================================
   // Private: Adapter Factories
   // ============================================================
 
@@ -1117,7 +1067,7 @@ export class EmailService extends BaseService {
    * Get the application name for email templates.
    */
   private getAppName(): string {
-    return this.emailConfig?.appName ?? "Nextly";
+    return this.emailConfig?.appName ?? DEFAULT_APP_NAME;
   }
 
   /**

--- a/packages/nextly/src/domains/email/services/email-template-service.ts
+++ b/packages/nextly/src/domains/email/services/email-template-service.ts
@@ -39,7 +39,7 @@ import {
 } from "../template-activity";
 import type { EmailAttachmentInput } from "../types";
 
-import { interpolateTemplate } from "./template-engine";
+import { DEFAULT_APP_NAME, renderTemplate } from "./render-template";
 import {
   BUILT_IN_TEMPLATES,
   DEFAULT_LAYOUT_SLUG,
@@ -98,8 +98,19 @@ type EmailTemplatesTable =
 export class EmailTemplateService extends BaseService {
   private emailTemplates: EmailTemplatesTable;
 
-  constructor(adapter: DrizzleAdapter, logger: Logger) {
+  /**
+   * Product name a layout's `{{appName}}` falls back to.
+   *
+   * Held here because a preview must fill it exactly as a send does; without
+   * it a configured installation previews its own layouts under the wrong
+   * name, which is the defect this service used to have in a worse form.
+   */
+  private readonly appName: string;
+
+  constructor(adapter: DrizzleAdapter, logger: Logger, appName?: string) {
     super(adapter, logger);
+
+    this.appName = appName ?? DEFAULT_APP_NAME;
 
     switch (this.dialect) {
       case "postgresql":
@@ -420,12 +431,13 @@ export class EmailTemplateService extends BaseService {
   // ============================================================
 
   /**
-   * Preview a template with sample data.
+   * Preview a saved template with sample data.
    *
-   * Replaces `{{variable}}` placeholders with values from `sampleData`.
-   * Supports dot-notation nested variables (`{{user.name}}`), HTML-escapes
-   * values by default to prevent XSS, and wraps with shared layout
-   * (header/footer) when `useLayout` is enabled.
+   * Returns the narrower `{ subject, html }` its published callers expect,
+   * DERIVED from the full render rather than composed separately. Composed
+   * separately it silently dropped the preheader, left a layout's own
+   * `{{year}}`/`{{appName}}` blank, and escaped a subject that is delivered as
+   * plain text — so authors were shown something no recipient would receive.
    *
    * @throws NextlyError NOT_FOUND if template doesn't exist
    */
@@ -434,47 +446,15 @@ export class EmailTemplateService extends BaseService {
     sampleData: Record<string, unknown>
   ): Promise<{ subject: string; html: string }> {
     const template = await this.getTemplate(id);
+    const layout = template.useLayout
+      ? await this.getLayoutFor(template)
+      : null;
 
-    const subject = interpolateTemplate(template.subject, sampleData);
-    const body = interpolateTemplate(template.htmlContent, sampleData);
+    const { subject, html } = renderTemplate(template, layout, sampleData, {
+      appName: this.appName,
+    });
 
-    // Layout rows preview as-is; message bodies wrap in their layout.
-    if (template.kind === "layout" || !template.useLayout) {
-      return { subject, html: body };
-    }
-
-    const layout = await this.getLayoutFor(template);
-    if (!layout) return { subject, html: body };
-
-    return { subject, html: this.renderWithLayout(layout, body, sampleData) };
-  }
-
-  /**
-   * Inject an already-rendered body into a layout wrapper at its
-   * `{{content}}` placeholder. The layout's own `{{variable}}`
-   * placeholders (e.g. `{{year}}`, `{{appName}}`) are interpolated;
-   * the body is spliced in verbatim (never re-escaped).
-   */
-  renderWithLayout(
-    layout: EmailTemplateRecord,
-    body: string,
-    variables: Record<string, unknown>
-  ): string {
-    // A well-formed layout has exactly one `{{content}}` marker (enforced on
-    // save). Be defensive for legacy/malformed rows: use the FIRST marker as the
-    // slot and preserve the rest of the wrapper, and if there is no marker at
-    // all, append the body after the wrapper so nothing is silently dropped.
-    const markerIndex = layout.htmlContent.indexOf(LAYOUT_CONTENT_PLACEHOLDER);
-    if (markerIndex === -1) {
-      return interpolateTemplate(layout.htmlContent, variables) + body;
-    }
-    const before = layout.htmlContent.slice(0, markerIndex);
-    const after = layout.htmlContent.slice(
-      markerIndex + LAYOUT_CONTENT_PLACEHOLDER.length
-    );
-    const head = interpolateTemplate(before, variables);
-    const tail = interpolateTemplate(after, variables);
-    return head + body + tail;
+    return { subject, html };
   }
 
   // ============================================================

--- a/packages/nextly/src/domains/email/services/email-template-service.ts
+++ b/packages/nextly/src/domains/email/services/email-template-service.ts
@@ -39,7 +39,12 @@ import {
 } from "../template-activity";
 import type { EmailAttachmentInput } from "../types";
 
-import { DEFAULT_APP_NAME, renderTemplate } from "./render-template";
+import {
+  DEFAULT_APP_NAME,
+  renderTemplate,
+  type RenderedTemplate,
+  type TemplateFields,
+} from "./render-template";
 import {
   BUILT_IN_TEMPLATES,
   DEFAULT_LAYOUT_SLUG,
@@ -446,15 +451,27 @@ export class EmailTemplateService extends BaseService {
     sampleData: Record<string, unknown>
   ): Promise<{ subject: string; html: string }> {
     const template = await this.getTemplate(id);
-    const layout = template.useLayout
-      ? await this.getLayoutFor(template)
-      : null;
+    const { subject, html } = await this.previewDraft(template, sampleData);
+    return { subject, html };
+  }
 
-    const { subject, html } = renderTemplate(template, layout, sampleData, {
+  /**
+   * Render fields that may never have been saved.
+   *
+   * The authoring surface previews what is being typed, which the id-addressed
+   * preview structurally cannot show: it reads the stored row, and during
+   * creation there is no row at all. Resolving WHICH layout wraps the draft
+   * still needs the database, so that half stays here while the composition is
+   * the shared one — the saved and unsaved paths cannot drift apart.
+   */
+  async previewDraft(
+    draft: TemplateFields & Pick<EmailTemplateRecord, "layoutId">,
+    sampleData: Record<string, unknown>
+  ): Promise<RenderedTemplate> {
+    const layout = draft.useLayout ? await this.getLayoutFor(draft) : null;
+    return renderTemplate(draft, layout, sampleData, {
       appName: this.appName,
     });
-
-    return { subject, html };
   }
 
   // ============================================================
@@ -607,7 +624,7 @@ export class EmailTemplateService extends BaseService {
    * Returns null when no layout exists at all.
    */
   async getLayoutFor(
-    template: EmailTemplateRecord
+    template: Pick<EmailTemplateRecord, "layoutId">
   ): Promise<EmailTemplateRecord | null> {
     if (template.layoutId) {
       try {

--- a/packages/nextly/src/domains/email/services/render-template.ts
+++ b/packages/nextly/src/domains/email/services/render-template.ts
@@ -56,14 +56,20 @@ export interface TemplateFields {
   kind: EmailTemplateKind;
 }
 
-/** The complete artifact: everything the transport is handed. */
-export interface RenderedTemplate {
+/**
+ * The complete artifact: everything the transport is handed.
+ *
+ * A type alias rather than an interface so it carries an implicit index
+ * signature, which is what lets a route hand it straight to `respondData`
+ * without a copy whose fields could fall out of step with these.
+ */
+export type RenderedTemplate = {
   subject: string;
   /** Layout-wrapped, with the preheader prepended. */
   html: string;
   /** The authored plain text, else one derived from the body. */
   text: string;
-}
+};
 
 export interface RenderTemplateOptions {
   /** Value for `{{appName}}` when the caller's data supplies none. */

--- a/packages/nextly/src/domains/email/services/render-template.ts
+++ b/packages/nextly/src/domains/email/services/render-template.ts
@@ -1,0 +1,140 @@
+/**
+ * The one composition of an email template into what a recipient receives.
+ *
+ * Sending and previewing both call this. A narrower view — the preview
+ * surfaces' `{ subject, html }` — is DERIVED from the result rather than
+ * computed alongside it: the two compositions that existed before agreed when
+ * they were written and had drifted on four observable properties by the time
+ * they were unified, each in the flattering direction, because a preview that
+ * omits something looks correct.
+ *
+ * Pure, and layout-INJECTED rather than layout-resolving. Resolving which
+ * layout wraps a template needs the database; composing with it does not, and
+ * only the second half belongs here. That split is what lets an unsaved draft
+ * be rendered through the same code as a saved row.
+ */
+import type {
+  EmailTemplateKind,
+  EmailTemplateRecord,
+} from "../../../schemas/email-templates/types";
+
+import { htmlToText, interpolateTemplate } from "./template-engine";
+
+/** The slot a layout declares for the message body. */
+const CONTENT_MARKER = "{{content}}";
+
+/**
+ * The product name used when nothing is configured.
+ *
+ * Declared once and imported by every caller that needs a fallback: a second
+ * literal is a second answer to the same question, and the two would drift
+ * exactly as the two compositions this module replaced did.
+ */
+export const DEFAULT_APP_NAME = "Nextly";
+
+/**
+ * The wrapper for the inbox preview line.
+ *
+ * Hidden in every client that honours inline styles, so it contributes preview
+ * text without appearing in the rendered body.
+ */
+const PREHEADER_OPEN =
+  '<div style="display:none;max-height:0;overflow:hidden;mso-hide:all;">';
+
+/**
+ * What a render needs from a template, whether or not it has been saved.
+ *
+ * Structurally satisfied by `EmailTemplateRecord`, so a saved row is passed
+ * directly and a draft supplies the same fields.
+ */
+export interface TemplateFields {
+  subject: string;
+  htmlContent: string;
+  plainTextContent: string | null;
+  preheader: string | null;
+  useLayout: boolean;
+  kind: EmailTemplateKind;
+}
+
+/** The complete artifact: everything the transport is handed. */
+export interface RenderedTemplate {
+  subject: string;
+  /** Layout-wrapped, with the preheader prepended. */
+  html: string;
+  /** The authored plain text, else one derived from the body. */
+  text: string;
+}
+
+export interface RenderTemplateOptions {
+  /** Value for `{{appName}}` when the caller's data supplies none. */
+  appName: string;
+}
+
+export function renderTemplate(
+  template: TemplateFields,
+  layout: Pick<EmailTemplateRecord, "htmlContent"> | null,
+  data: Record<string, unknown>,
+  options: RenderTemplateOptions
+): RenderedTemplate {
+  // Mail clients render a subject as plain text, so escaping it would show the
+  // reader `&amp;` where the value contains `&`.
+  const subject = interpolateTemplate(template.subject, data, {
+    escapeHtml: false,
+  });
+
+  let html = interpolateTemplate(template.htmlContent, data);
+
+  // Derived BEFORE the preheader and the layout are spliced in. The preheader
+  // is a hidden preview line, and a text part derived after it would repeat
+  // that line as the message's opening words; the layout's chrome would follow
+  // it into the text part for the same reason.
+  const text = template.plainTextContent?.trim()
+    ? interpolateTemplate(template.plainTextContent, data, {
+        escapeHtml: false,
+      })
+    : htmlToText(html);
+
+  if (template.preheader?.trim()) {
+    const preheader = interpolateTemplate(template.preheader, data);
+    html = `${PREHEADER_OPEN}${preheader}</div>${html}`;
+  }
+
+  // A layout row IS a wrapper, so wrapping it in another would nest two
+  // documents. It renders as itself.
+  if (template.kind !== "layout" && template.useLayout && layout) {
+    html = spliceIntoLayout(layout.htmlContent, html, {
+      ...data,
+      // A layout's own chrome routinely references these, and a caller sending
+      // one specific template has no reason to know that. Supplied here so a
+      // footer never renders blank, and only where the caller said nothing.
+      year: data.year ?? new Date().getFullYear().toString(),
+      appName: data.appName ?? options.appName,
+    });
+  }
+
+  return { subject, html, text };
+}
+
+/**
+ * Inject an already-rendered body at the wrapper's first `{{content}}`.
+ *
+ * The body is spliced verbatim and never re-interpolated or re-escaped: it is
+ * finished HTML, and a second pass would either escape its markup into visible
+ * text or expand a `{{...}}` that legitimately survived from user content.
+ *
+ * A well-formed layout carries exactly one marker. With none, the body is
+ * appended after the wrapper so a malformed layout drops nothing.
+ */
+function spliceIntoLayout(
+  wrapper: string,
+  body: string,
+  variables: Record<string, unknown>
+): string {
+  const at = wrapper.indexOf(CONTENT_MARKER);
+  if (at === -1) return interpolateTemplate(wrapper, variables) + body;
+  return (
+    interpolateTemplate(wrapper.slice(0, at), variables) +
+    body +
+    interpolateTemplate(wrapper.slice(at + CONTENT_MARKER.length), variables)
+  );
+}

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -46,6 +46,7 @@ const serverEntries = [
   "src/api/email-templates.ts",
   "src/api/email-templates-detail.ts",
   "src/api/email-templates-preview.ts",
+  "src/api/email-templates-draft-preview.ts",
   "src/api/email-send.ts",
   "src/api/email-send-template.ts",
   "src/api/storage-upload-url.ts",


### PR DESCRIPTION
## What and why

"What does this email template render to" had **three** implementations. `sendTemplate` composed it inline, `previewTemplate` composed a narrower artifact of its own, and the admin's `EmailTemplateForm` kept a third copy client-side. They agreed when written and had drifted on six properties — every one of them in the flattering direction, because a preview that omits something still looks correct.

Measured on `origin/main`, `sendTemplate` never calls `previewTemplate`:

| # | property | what recipients get | what the API's preview showed |
| --- | --- | --- | --- |
| 1 | subject escaping | `escapeHtml: false` | **escaped** — `Ben & Jerry` previewed as `Ben &amp; Jerry` |
| 2 | preheader | prepends a hidden `<div>` | **absent** |
| 3 | plain-text part | authored, else derived from the body | **not returned at all** |
| 4 | layout variables | injects `year` / `appName` defaults | **absent** |
| 5 | text derivation point | before preheader and layout | n/a |
| 6 | layout resolution | `composeWithLayout` | `getLayoutFor` |

**#4 is a user-visible defect, not a refactor artefact.** A layout footer is conventionally `© {{year}} {{appName}}`, and the observed preview output was `<footer> </footer>` — literally empty — while the sent mail was correct.

This collapses all of it into one `renderTemplate(fields, layout, data, { appName })`. `previewTemplate` keeps its published `{ subject, html }` shape by **narrowing** the richer result, so the REST route, the dispatcher and the Direct API namespace are unchanged.

It also adds `POST /api/email-templates/preview`, which renders template *fields*. The existing `/[id]/preview` reads the stored row, so it can never show unsaved edits and has no row to address at all while a template is being created — it structurally cannot drive an authoring surface. Both routes go through the same composition, so they cannot disagree with each other or with what is sent.

Groundwork for R-15 (the email template page revamp); the admin side follows in later PRs.

## Test plan

- **Characterisation first.** 11 tests pin the send path's behaviour *before* anything moved. Each was **break-verified individually** with its own named mutation — a suite going green says nothing about whether any single test can fail. All 11 failed only for their own reason.
- **The extraction is provably behaviour-preserving.** Those tests call `renderTemplate` itself and are break-verified against it — see the correction below.

> **Correction, `d7b4bb100`.** The first revision of this PR asserted against a *transcription* of the old inline composition rather than against `renderTemplate`, and this line claimed the re-pointing had happened when it had not. Codex caught it (P1). It was not a cosmetic gap: breaking subject escaping in the production renderer left all 11 tests green, so they could not fail for their own reason. Fixed by deleting the transcription, calling `renderTemplate` in every assertion, and re-running the twelve break-verifications against `render-template.ts` itself — all twelve now fail when production is broken. A twelfth test was added at the same time for the layout-row guard, which is new behaviour the send path never had and the characterisation set therefore could not cover.
- **Behaviour-change pins, written first and observed failing.** The 7 existing `previewTemplate` cases would **not** have caught this change — no fixture sets a preheader, the layout case passes `appName`/`year` explicitly, and no subject contains an escapable character. So 3 new tests were written against the unmodified code and watched fail, each naming its own property:
  ```
  expected '<p>Body</p>' to contain 'Your account is ready'        preheader dropped
  expected '<p>Body</p><footer> </footer>' to contain 'Nextly'     layout defaults blank
  expected 'Ben &amp; Jerry & you' to be 'Ben & Jerry & you'       subject escaped
  ```
- **Route tests (7).** Permission and ordering are asserted by **observing the real call's arguments**, not by sending an unauthenticated request: the house harness mocks `route-auth`, so a "401 test" there would be failing against the mock. Break-verified five ways — deleting the guard, moving it after the render, and swapping `create` for `read` each fail the relevant test.
- **Gates:** `pnpm build` 0 · `check-types` 0 · `lint` 0 · `fallow audit` pass (12 files, 0 introduced) · `changeset status` 0.
- **Suites:** `src/domains/email` + `src/api` — **79 files, 974 tests, all passing.**
- **Nothing stopped being collected:** `it`/`test` count in `domains/email` went 571 → 585, exactly the 14 added; files 49 → 50.

## Notes for the reviewer

- **`previewTemplate`'s output changes** — it now carries the preheader and the layout defaults it was dropping. Type-compatible, so nothing fails to compile; the 3 pins above are what make the change visible.
- **`renderWithLayout` is deleted.** It became dead when both product callers went, and it was a byte-identical second copy of the layout splice. **`fallow` did not flag it** — `dead_code_introduced: 0` — because its only surviving references were the declaration and a `vi.fn()` in a mock, and a mock naming a method reads as a caller. Found by grep with a must-be-found control (`getLayoutFor` → 8 hits). Worth knowing: that gate cannot be trusted for a symbol whose remaining references are test doubles.
- **`getLayoutFor` widened** from `EmailTemplateRecord` to `Pick<…, "layoutId">` — it only ever read that field, and widening lets a draft reuse the resolution instead of getting a second copy.
- **`EmailTemplateService` takes an optional `appName`**, supplied by DI from `config.email.appName`. Without it a configured install would preview its own layouts under the wrong name. One default (`DEFAULT_APP_NAME`), imported by both services rather than spelled twice.
- Changeset added: **yes (patch)**, all published packages.
- **Pre-existing conditions observed, not caused by this branch:** `packages/ui` and other siblings have no `dist` on a fresh worktree, so `pnpm --filter nextly... build` is not enough for the pre-push hook — `@nextlyhq/admin#lint` reports 343 `import-x/no-unresolved` errors until `pnpm build` has run. My diff contains zero admin files.

