### PR TITLE
fix(nextly): close the widget findings left open on #1393

### DIFF
--- a/.changeset/an-accepted-widget-query-is-one-that-runs.md
+++ b/.changeset/an-accepted-widget-query-is-one-that-runs.md
@@ -1,0 +1,52 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The dashboard widget contract promised that an accepted query is one the
+executor will run, and three ways of accepting a query that could not run, or
+that ran differently from what it said, are closed.
+
+A geographic `count` was accepted and then refused at execution: geo predicates
+are evaluated over rows a count never fetches, so validation now refuses the
+combination rather than letting it fail in its batch slot. An explicitly empty
+`select` read as "no fields" and produced a full document, because a selection
+is applied only when it has keys; it is now refused, the way an empty `where`
+combinator already was. And a plugin `setup` transformer could contribute an
+admin widget carrying a value JSON cannot encode: the resolver validated only
+the list it was handed, so the widget reached `/api/admin-meta/workspace` and
+failed that request for every admin.
+
+Rebuilding the collection sources is also all-or-nothing now. Two fields that
+flatten to one name -- which an unnamed layout group can produce without its
+author writing a duplicate -- used to abort the rebuild after the previous
+sources had already been deleted, leaving widgets that had worked a moment
+earlier answering "unavailable source". Duplicates are resolved to the first
+declaration, and a rebuild that fails anywhere leaves the previous set standing.
+
+The admin's `PluginWidgetMeta` is derived from the server's declaration through
+`nextly/config` rather than restated, so the two can no longer describe the same
+payload differently.

--- a/followup-report.md
+++ b/followup-report.md
@@ -1,0 +1,197 @@
+# PR #1393 follow-up — six review findings
+
+Branch `fix/widget-followup`, from merged main at `36d6ab2a1`. One commit per
+finding, one changeset for the PR. Not pushed.
+
+| #   | commit      | finding                                                     |
+| --- | ----------- | ----------------------------------------------------------- |
+| A   | `db7bac834` | setup transformers bypassed widget validation               |
+| B   | `f5c2f6f7d` | geo predicates accepted for `count`, rejected at execution  |
+| C   | `4274a5fe7` | `select: []` returned every field instead of none           |
+| D   | `f132b318d` | duplicate field names aborted the source rebuild mid-flight |
+| E   | `42c371c42` | admin widget metadata type was stale                        |
+| F   | `6ad5a7f5d` | the type test could not detect a widened contract           |
+
+All six findings were verified against the code before being acted on. None was
+mistaken.
+
+## A — where the second validation went, and why
+
+`registerServices` calls `resolvePlugins` (which runs `assertAdminWidgets`)
+before `applyPluginConfigTransformers`, then revalidates only slugs on
+`setupConfig.plugins`. Reproduced: a transformer adding a plugin whose widget
+carries `where: { id: 1n }` booted past every check and failed on the adapter,
+not on the widget.
+
+`assertAdminWidgets` now runs a second time on the transformed list, beside the
+`validatePluginSlugs` call already there — and the same in the CLI's
+`config-loader.ts`, which has the identical shape for the identical reason.
+
+**Validating twice rather than once, deliberately.** The ordering does allow a
+single post-transformer check for the runtime path: nothing between the two
+points reads a widget. But `resolvePlugins` has three callers —
+`di/register.ts`, `cli/utils/config-loader.ts` and
+`plugins/plugin-introspection.ts` — and only the first two apply transformers.
+Moving the check out would take it away from the third and from any future
+caller, and would leave the resolver's own contract ("a config this resolver
+accepted is deliverable") false. `validatePluginSlugs` already carries exactly
+this duplication for exactly this reason, so widgets are now validated the same
+way slugs are rather than differently.
+
+Cost of the duplication: a transformer cannot REPAIR a widget its plugin
+declared badly. That is consistent with slugs, and the CLI would refuse such a
+config regardless.
+
+## B — the claim was checked before acting on it
+
+`collection-query-service.ts` `countEntries` refuses a geo filter
+unconditionally (right after `resolveReadWhere`, before the locale chain):
+`extractGeoFilters` finds them and it throws `NextlyError.invalidInput`. So a
+well-formed `near`/`within` under `op: "count"` passed the contract and failed
+its batch slot.
+
+The `where` walk now carries the op alongside the source and its declared field
+names (one `WhereScope` rather than four parallel parameters), so the refusal
+reaches every nesting depth a combinator can hide a geo operator at. Keyed on
+`GEO_OPERATORS`, not on a hand-kept list of ops.
+
+## C — chose to REJECT `select: []`
+
+Confirmed both halves: `copySelectOrUndefined` preserves `[]` (it is truthy, so
+the conditional spread keeps it), `toSelect` maps it back to `undefined`, and
+`listEntries` applies a selection only when
+`Object.keys(params.select).length > 0`. So "select nothing" became "select
+everything".
+
+Rejected at validation rather than given preserving semantics in the executor:
+
+1. The validator already refuses every construct in the same family — `where`
+   conditions that are `null` or `{}`, and `and`/`or` with an empty array — on
+   exactly this argument: an accepted query that silently widens is the failure
+   the gate exists to close. An empty `select` is that family's projection-side
+   member.
+2. The keys-required rule belongs to the read path and is shared by every caller
+   of `nextly.find`. Teaching the widget seam its own reading of `[]` would be a
+   second implementation of field selection, not a fix — and the Direct API has
+   no representation for "no fields" to preserve.
+3. A widget that genuinely wants no fields back asks for `op: "count"`.
+
+## D — yes, the swap was made atomic
+
+Both halves shipped; the second was contained.
+
+- `exposedFields` deduplicates on name, keeping the first declaration. The
+  duplicate is real and not author-written: `readableFields` flattens unnamed
+  presentational groups into the level they sit in, so a top-level `title` and a
+  `title` inside a layout group arrive as two entries with one name.
+- `replaceSourcesOfKind` now validates and detaches every member into a staging
+  map BEFORE deleting anything, then performs a swap that cannot fail. A refused
+  rebuild leaves the previous set standing — the same reading
+  `refreshCollectionSources` already takes of a registry it could not reach.
+
+`registerSource` and the staging pass share one `preparedSource`
+validate-and-detach step, so they cannot come to disagree about what a usable
+source is; only which ids count as taken differs, and a source of the kind being
+replaced deliberately does not claim its own id (that is what keeps a rebuild
+idempotent).
+
+## E — the `nextly/config` derivation WORKED
+
+`PluginWidgetMeta` is now `export type PluginWidgetMeta = PluginAdminWidget`,
+imported from `nextly/config`. `packages/admin` typechecks clean.
+
+Why it is reachable there and not through `"nextly"`: the admin tsconfig maps
+only the BARE specifier to `../nextly/src`. Subpaths are not covered by that
+mapping, so `nextly/config` resolves through the export map to
+`dist/config.d.ts` exactly as a consumer's would — and admin already imports
+`SinglePreviewConfig` from it.
+
+`src/config.ts` now re-exports `PluginAdminWidget`, `ComponentPath`,
+`HeaderButtonId` and the widget vocabulary. Types only, and taken from the leaf
+modules (`domains/widgets/definition`, `/query`, `/sources`) rather than the
+`domains/widgets` barrel, which also carries `executeWidgetQuery` and through it
+the Direct API — the weight that entry point exists to keep out of a
+`nextly.config.ts`. Nothing is added to the runtime bundle.
+
+Divergence is now impossible by construction rather than by convention, and the
+docblock says so instead of asserting a synchrony nothing enforced.
+`branding.test-d.ts` pins the alias (`toEqualTypeOf<PluginAdminWidget>`) plus the
+serialized field set as a `Pick`. Control: flipping one value type in that
+assertion fails `tsc` with the expected diagnostic, so the file is genuinely
+being checked.
+
+## F — evaluated assertions, in a new `.test-d.ts`
+
+The file the finding named (`widget-exports.test-d.ts`) did not exist; the
+passive assertions live in `src/__tests__/export-contract.test.ts`
+("publishes every contract a widget definition names"). That test is in
+`tsconfig.tests.json`'s include, so it IS compiled — its assertions simply
+cannot detect a widening, which is the finding.
+
+New `src/domains/widgets/widget-exports.test-d.ts`, reusing the `Exact<A,B>` /
+`assertType<T extends true>` pair from `shared/addressable-fields.test-d.ts`
+(restated locally, the way `field-groups-public-surface.test-d.ts` does, rather
+than exported from a type-test file). Each union is compared member for member
+in both directions, and each carries the three claims a closed union makes as
+one tuple: a valid member assignable, `string` NOT assignable, a plausible
+near-miss NOT assignable. The refusals need the acceptance beside them, since a
+narrowing to `never` refuses everything and would satisfy them alone.
+
+Two things worth recording:
+
+- The file caught a wrong assumption of mine on its first run: I wrote
+  `WidgetArchetype` as `"metric" | "chart" | "table" | "list" | "activity" |
+"custom"`; the real union is `"metric" | "table" | "list" | "text" |
+"actions" | "custom"`.
+- The obvious generic helper `ClosedUnion<T, Accepted, NearMiss>` is NOT sound
+  here. Inside a generic alias these conditionals are deferred and it evaluated
+  to `false` for a HEALTHY union — an instrument that fails on correct code,
+  whose obvious remedy is deleting the assertions it broke. Reproduced in
+  isolation; the assertions are instantiated directly instead.
+
+Imported through the ROOT entry point, not the domain modules: there is no
+`nextly/widgets` subpath, so the root is where a plugin author reaches these, and
+a name that stops being re-exported is part of what this catches.
+
+## Break-verifications
+
+| finding    | break                                                                                 | result                                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| A          | remove the post-transform `assertAdminWidgets`                                        | the new boot test fails; nothing else in `src/di src/plugins src/cli` moves                                         |
+| C          | remove the empty-`select` guard                                                       | exactly 2 tests fail (both new) out of 500 in `src/domains/widgets src/api`                                         |
+| D (dedup)  | drop the `taken.has` skip                                                             | exactly the 2 new built-in-sources tests fail                                                                       |
+| D (atomic) | restore delete-then-register                                                          | exactly the 1 new sources test fails                                                                                |
+| F          | widen `WidgetHeight`, `WidgetSize`, `WidgetArchetype`, `WidgetOp` to `string` in turn | 2 assertions fail in the new file for each; `export-contract.test.ts`'s example assignment is untouched by all four |
+
+B was not on the break-verify list; its five tests were written first and three
+failed before the fix, two (the controls) passed.
+
+## Test counts
+
+| suite                                                 | result                                                              | baseline                                      |
+| ----------------------------------------------------- | ------------------------------------------------------------------- | --------------------------------------------- |
+| `packages/nextly` `pnpm test`                         | **841 files, 10386 passed, 42 skipped, 0 failed**                   | 840 / 10370                                   |
+| `packages/admin` `pnpm test`                          | **335 files, 3201 passed, 7 failed**                                | 7 failures all in `BrandingProvider.test.tsx` |
+| root `pnpm check-types`                               | 22/22 successful                                                    | —                                             |
+| root `pnpm test:integration:sqlite`                   | 19/19 tasks; `nextly` 239 files, 1440 passed, 213 skipped, 0 failed | —                                             |
+| `turbo lint --filter=nextly --filter=@nextlyhq/admin` | 2/2 successful, `--max-warnings 0`                                  | —                                             |
+
+`packages/nextly` gains one file (the new boot test; the `.test-d.ts` is not
+collected by vitest) and 16 tests: A 2, B 5, C 4, D 5.
+
+The admin failures are the known-red `BrandingProvider.test.tsx` this work was
+told to ignore. The E change to that package is types-only — an interface
+becoming a type alias, plus a type-only import — so the emitted JavaScript is
+unchanged and cannot reach a runtime test.
+
+## fallow
+
+`fallow audit --base origin/main --gate-marker agent`: **pass**, 14 changed
+files, 0 introduced findings of any kind (36 dead-code / 8 complexity / 9
+duplication all inherited).
+
+Two intermediate `warn` verdicts were resolved rather than waved through: both
+were `duplication_introduced` on the boilerplate shape of consecutive
+`expectTypeOf` / `assertType` lines, and both were fixed by collapsing several
+one-field assertions into one assertion over the whole set — which reads better
+anyway.

--- a/packages/admin/src/types/branding.test-d.ts
+++ b/packages/admin/src/types/branding.test-d.ts
@@ -1,9 +1,11 @@
+import type { PluginAdminWidget } from "nextly/config";
 import { expectTypeOf } from "vitest";
 
 import type {
   PluginMenuItemMeta,
   PluginMetadata,
   PluginPageMeta,
+  PluginWidgetMeta,
 } from "./branding";
 
 // Menu metadata (D20) — delivered via /admin-meta, one level of children.
@@ -33,3 +35,38 @@ expectTypeOf<PluginPageMeta>().toMatchTypeOf<{
 expectTypeOf<NonNullable<PluginMetadata["settings"]>>().toMatchTypeOf<{
   component: string;
 }>();
+
+// Widget metadata. `buildPluginAdminMeta` copies a contributed widget verbatim
+// into the payload, so the admin's view of it is DERIVED from the server's
+// declaration rather than restated -- which is what this pins. An interface
+// re-declared here would satisfy the property assertions below and fail this
+// one, which is the divergence the alias exists to make impossible.
+expectTypeOf<PluginWidgetMeta>().toEqualTypeOf<PluginAdminWidget>();
+
+// The fields the server actually serializes. Asserted as a `Pick`, which is one
+// evaluated claim about the whole set rather than five about one field each: a
+// name absent from the declaration cannot be picked, so a stale four-field copy
+// fails here, and the value types are compared at the same time.
+expectTypeOf<
+  Pick<PluginWidgetMeta, "title" | "description" | "icon" | "category" | "link">
+>().toEqualTypeOf<{
+  title?: string;
+  description?: string;
+  icon?: string;
+  category?: string;
+  link?: { label: string; href: string };
+}>();
+
+// `component` stays REQUIRED. A widget without one reaches `PluginSlot` with
+// `path === undefined` and draws an empty cell, so this is the property the
+// two declarations drifted on first.
+expectTypeOf<PluginWidgetMeta>().toMatchTypeOf<{ component: string }>();
+expectTypeOf<{ id: string; component: string }>().toMatchTypeOf<
+  Pick<PluginWidgetMeta, "id" | "component">
+>();
+
+// And the metadata list carries that same shape, which is what a reader of
+// `branding.plugins[].widgets` actually holds.
+expectTypeOf<
+  NonNullable<PluginMetadata["widgets"]>[number]
+>().toEqualTypeOf<PluginWidgetMeta>();

--- a/packages/admin/src/types/branding.ts
+++ b/packages/admin/src/types/branding.ts
@@ -1,3 +1,4 @@
+import type { PluginAdminWidget } from "nextly/config";
 import type {
   FieldStoragePrimitive,
   FieldSurface,
@@ -57,29 +58,28 @@ export interface PluginPageMeta {
 /**
  * A plugin dashboard widget, delivered via `/admin-meta`.
  *
+ * DERIVED from the server's declaration rather than restated beside it.
  * `buildPluginAdminMeta` assigns `contributes.admin.widgets` to the meta
- * verbatim, so this and the server's `PluginAdminWidget` are one shape --
- * declared twice, which is why they were free to drift. They had: the server
- * made `component` OPTIONAL while this kept it required, and nothing compared
- * the two, so a plugin adopting the server's shape reached `PluginSlot` with
- * `path === undefined` and rendered an empty grid cell silently.
+ * verbatim, so the two are one shape -- and while they were one shape declared
+ * twice they drifted twice. First `component`: the server made it optional
+ * while this kept it required, so a plugin adopting the server's shape reached
+ * `PluginSlot` with `path === undefined` and rendered an empty grid cell
+ * silently. Then the declarative half -- `title`, `description`, `icon`,
+ * `category`, `archetype`, `defaultSize`, `minSize`, `maxSize`, `query` and
+ * `link` -- which the server serializes on every contributed widget and this
+ * copy never gained, so admin code reading a property that was PRESENT on the
+ * wire got a type error for it.
  *
- * `component` is required on BOTH sides again, and `admin-contributions.test-d.ts`
- * pins it there -- so widening it in core is now a compile error at the
- * declaration rather than an empty cell at runtime. That is a DECLARED
- * dependency rather than a structural one: deriving this from
- * `PluginAdminWidget` would be better and is not reachable today, because this
- * package's tsconfig maps the bare `nextly` specifier to `../nextly/src` and so
- * shadows the package exports, pulling core's whole source tree in with
- * internal path aliases this project does not carry. Whoever changes either
- * declaration must change both.
+ * An alias makes that a compile error at the one declaration instead of a
+ * convention two files have to keep. It is reachable through `nextly/config`
+ * specifically: this package's tsconfig maps the BARE `nextly` specifier to
+ * `../nextly/src`, so importing from `"nextly"` shadows the package exports and
+ * pulls core's whole source tree in behind internal `@nextly/*` aliases this
+ * project does not declare. Subpaths are not covered by that mapping, so
+ * `nextly/config` resolves through the export map to the built declaration
+ * bundle, exactly as a consumer's would.
  */
-export interface PluginWidgetMeta {
-  id: string;
-  component: string;
-  size?: "full" | "half";
-  requiredPermission?: string;
-}
+export type PluginWidgetMeta = PluginAdminWidget;
 
 /**
  * A plugin's public client configuration, served before a session exists.

--- a/packages/nextly/src/cli/utils/config-loader.ts
+++ b/packages/nextly/src/cli/utils/config-loader.ts
@@ -57,6 +57,7 @@ import {
   finalizeRelationTargets,
   validateCrossPluginRelations,
 } from "../../plugins/schema/validate-relations";
+import { assertAdminWidgets } from "../../plugins/validate-admin-widgets";
 import { validatePluginSlugs } from "../../plugins/validate-slugs";
 
 import { bundleAndRequire } from "./config-bundler";
@@ -581,6 +582,15 @@ async function loadConfigInternal(
       // migration or a db sync accepts and acts on a configuration the
       // deployed app then refuses to start on.
       validatePluginSlugs(transformedConfig.plugins ?? []);
+
+      // The widgets on that same transformed list, and here for the same
+      // reason the runtime checks its own: a transformer can contribute a
+      // widget the resolver's list never held, and a value `JSON.stringify`
+      // cannot carry breaks the whole `/api/admin-meta/workspace` response
+      // rather than the one card. The CLI has to agree with boot, or
+      // `nextly build` accepts a configuration the deployed app refuses to
+      // start on.
+      assertAdminWidgets(transformedConfig.plugins ?? []);
 
       // Fold plugin contributions. Extend targets that aren't code/plugin
       // entities are DEFERRED (candidate Builder/UI-schema targets) rather than

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -170,6 +170,48 @@ export {
 } from "./plugins/plugin-categories";
 export { pluginAdminSlug } from "./plugins/plugin-slug";
 
+// The admin CONTRIBUTION shapes, published so the admin panel can DERIVE its
+// `/admin-meta` types from the declaration the server serializes rather than
+// restating them. `buildPluginAdminMeta` copies a contributed widget verbatim
+// into that payload, so the two were one shape declared twice -- and they
+// drifted, twice: `component` was optional on one side and required on the
+// other, and the whole declarative half (`title`, `archetype`, `defaultSize`,
+// `query`, `link`, ...) was added here and never on the admin's copy, so admin
+// code reading a property that was present on the wire got a type error.
+//
+// This subpath rather than the root, and that is the load-bearing part. The
+// admin's tsconfig maps the bare `nextly` specifier to `../nextly/src`, so
+// importing from `"nextly"` shadows the package exports and pulls core's whole
+// source tree in behind internal `@nextly/*` aliases that project does not
+// declare. `nextly/config` is not covered by that mapping, so it resolves
+// through the export map to the built declaration bundle the way any consumer's
+// would -- which is what makes the derivation reachable at all.
+//
+// Types only: `export type` carries no runtime binding, so nothing here adds a
+// byte to the config entry point's bundle.
+export type {
+  ComponentPath,
+  HeaderButtonId,
+  PluginAdminWidget,
+} from "./plugins/admin-contributions";
+//
+// Taken from the leaf modules rather than from `domains/widgets/index.ts`: that
+// barrel also carries `executeWidgetQuery`, and through it the Direct API, which
+// is exactly the weight this entry point exists to keep out of a
+// `nextly.config.ts`.
+export type {
+  WidgetArchetype,
+  WidgetHeight,
+  WidgetSize,
+} from "./domains/widgets/definition";
+export type { WidgetQuery } from "./domains/widgets/query";
+export type {
+  WidgetOp,
+  WidgetSourceField,
+  WidgetSourceFieldType,
+  WidgetSourceKind,
+} from "./domains/widgets/sources";
+
 // A code-first `preview.url` built from a `{field}` path. Exported because a
 // package that ships a collection in code — the page builder's `pages`, say —
 // can only express its preview as a function, while the path is what its host

--- a/packages/nextly/src/di/__tests__/transformer-widgets-validated-at-boot.test.ts
+++ b/packages/nextly/src/di/__tests__/transformer-widgets-validated-at-boot.test.ts
@@ -1,0 +1,110 @@
+/**
+ * A widget a `setup` transformer introduced is validated too.
+ *
+ * `resolvePlugins` runs `assertAdminWidgets` over the plugin list the CALLER
+ * supplied, and `registerServices` calls it BEFORE `applyPluginConfigTransformers`.
+ * A transformer that adds or replaces `contributes.admin.widgets` therefore
+ * produced widgets nothing had checked -- and the transformed list is the one
+ * `setBootedConfig` publishes and `buildPluginAdminMeta` serializes, so a bigint
+ * introduced there reached `JSON.stringify` and failed
+ * `/api/admin-meta/workspace` for every admin. The same 500 through a second
+ * door.
+ *
+ * Asserted through `registerServices` rather than through `resolvePlugins`,
+ * because the gap is an ORDERING one: a check on the resolver's argument is
+ * correct and still cannot see the list the boot goes on to publish.
+ *
+ * The adapter here cannot connect, which is what makes the positive control
+ * necessary: registration fails either way, so a test asserting only that it
+ * rejects would pass with the validation deleted entirely.
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../../errors/nextly-error";
+import type { PluginDefinition } from "../../plugins/plugin-context";
+
+vi.mock("../../route-handler/auth-handler", () => ({
+  setBootedConfig: () => undefined,
+}));
+
+const { registerServices } = await import("../register");
+
+/** An adapter that fails LATER than the plugin validation under test. */
+const failingAdapter = { connect: () => undefined };
+
+/** A widget whose `query.where` carries a bigint, which JSON cannot encode. */
+const bigintWidget = {
+  id: "acme/revenue",
+  component: "@acme/p/admin#Revenue",
+  query: { source: "collection:posts", op: "count", where: { id: 1n } },
+};
+
+/** A widget that survives the round trip unchanged. */
+const validWidget = {
+  id: "acme/posts",
+  component: "@acme/p/admin#Posts",
+  query: { source: "collection:posts", op: "count" },
+};
+
+/**
+ * A plugin whose `setup` REPLACES the plugin list with one carrying `widget`.
+ *
+ * The transformer speaks for a plugin other than itself, which is the shape the
+ * API permits and the shape the original check cannot see: the widgets it
+ * validated belong to the list the caller passed, and this list did not exist
+ * then.
+ */
+function pluginContributing(widget: unknown): PluginDefinition[] {
+  const contributor = {
+    name: "@acme/p",
+    version: "1.0.0",
+    nextly: "*",
+    contributes: { admin: { widgets: [widget] } },
+  };
+  return [
+    {
+      name: "@acme/transformer",
+      version: "1.0.0",
+      nextly: "*",
+      setup: (config: Record<string, unknown>) => ({
+        ...config,
+        plugins: [...(config.plugins as unknown[]), contributor],
+      }),
+    },
+  ] as unknown as PluginDefinition[];
+}
+
+/** Whatever the boot rejected with, or `undefined` when it got past the adapter. */
+async function bootError(plugins: PluginDefinition[]): Promise<unknown> {
+  try {
+    await registerServices({
+      adapter: failingAdapter,
+      plugins,
+    } as unknown as Parameters<typeof registerServices>[0]);
+  } catch (error) {
+    return error;
+  }
+  return undefined;
+}
+
+/** The failure's code, or the string it turned out to be. */
+function codeOf(error: unknown): string {
+  return NextlyError.is(error) ? error.code : String(error);
+}
+
+describe("widgets a setup transformer introduces", () => {
+  it("refuses a bigint the transformer added, at boot", async () => {
+    expect(codeOf(await bootError(pluginContributing(bigintWidget)))).toBe(
+      "NEXTLY_PLUGIN_ADMIN_WIDGET_INVALID"
+    );
+  });
+
+  // The positive control. Boot fails on the adapter either way, so without this
+  // the refusal above is satisfied by any rejection at all -- including one that
+  // refuses every transformed widget.
+  it("carries a valid widget the transformer added past the check", async () => {
+    expect(codeOf(await bootError(pluginContributing(validWidget)))).not.toBe(
+      "NEXTLY_PLUGIN_ADMIN_WIDGET_INVALID"
+    );
+  });
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -138,6 +138,7 @@ import {
   registerPluginService,
 } from "../plugins/services/plugin-services-registry";
 import { clearPluginSubscriptions } from "../plugins/subscription-tracker";
+import { assertAdminWidgets } from "../plugins/validate-admin-widgets";
 import { validatePluginSlugs } from "../plugins/validate-slugs";
 import { setBootedConfig } from "../route-handler/auth-handler";
 import type {
@@ -504,6 +505,22 @@ export async function registerServices(
   // Boot is where this should fail; without it a transformer-introduced
   // collision would surface on the first admin-meta request instead.
   validatePluginSlugs(setupConfig.plugins ?? []);
+  // And the widgets on that same transformed list, for the same reason one
+  // level in. `resolvePlugins` checks the list the CALLER passed; a transformer
+  // that adds or replaces a plugin contributes widgets that list never held, and
+  // THIS one is what `setBootedConfig` publishes and `buildPluginAdminMeta`
+  // serializes. A bigint under `query.where` there throws inside the single
+  // `JSON.stringify` that builds `/api/admin-meta/workspace`, so the whole
+  // authenticated workspace response answers 500 for every admin — the failure
+  // the resolver's check exists to prevent, reached through a second door.
+  //
+  // Checked in BOTH places rather than moved here, even though nothing between
+  // the two reads a widget. `resolvePlugins` is shared with the CLI config
+  // loader and with `collectPluginInfo`, and neither applies transformers on
+  // this path, so relocating the check would take it away from them; the
+  // duplication is the same one `validatePluginSlugs` above already carries,
+  // for the same reason.
+  assertAdminWidgets(setupConfig.plugins ?? []);
 
   // ----------------------------------------
   // Layer 0c: Fold declarative plugin schema contributions (D3/D12/D50)

--- a/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/built-in-sources.test.ts
@@ -23,6 +23,52 @@ describe("built-in sources", () => {
     expect(source?.supports).toContain("list");
   });
 
+  it("keeps the FIRST declaration when two declared fields share a name", () => {
+    // `readableFields` flattens unnamed presentational groups into the level
+    // they sit in, so a top-level `title` and a `title` inside an unnamed group
+    // arrive as two entries with one name. `validateSourceFields` refuses a
+    // duplicate -- correctly, since a repeated name collapses two fields into
+    // one entry in the query validator's allowlist -- but the refusal aborted
+    // the whole rebuild rather than this one collection. Deduplicated before
+    // the source is built, keeping the first declaration, which is the one an
+    // author reading their config top to bottom means.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        fields: [
+          { name: "title", type: "text" },
+          { name: "title", type: "number" },
+        ],
+        timestamps: false,
+      },
+    ]);
+
+    const fields = getSource("collection:posts")?.fields ?? [];
+    expect(fields.filter(f => f.name === "title")).toHaveLength(1);
+    // The FIRST declaration: `text` maps to `string`, the later `number` to
+    // `number`, so the surviving type says which one was kept.
+    expect(fields.find(f => f.name === "title")?.type).toBe("string");
+  });
+
+  it("does not let one collection's duplicate name unpublish the others", () => {
+    // The consequence the deduplication exists for. `refreshCollectionSources`
+    // rebuilds every collection source in one pass, so a throw on one member
+    // used to take the whole install's sources with it.
+    registerBuiltInSources([
+      {
+        slug: "posts",
+        fields: [
+          { name: "title", type: "text" },
+          { name: "title", type: "text" },
+        ],
+      },
+      { slug: "pages", fields: [{ name: "heading", type: "text" }] },
+    ]);
+
+    expect(getSource("collection:posts")).toBeDefined();
+    expect(getSource("collection:pages")).toBeDefined();
+  });
+
   it("exposes only the collection's own declared fields", () => {
     // No `timestamps` key: an absent flag defaults to ON, the way
     // `defineCollection` normalizes it and the way the registry stores it.

--- a/packages/nextly/src/domains/widgets/__tests__/execute.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/execute.test.ts
@@ -34,6 +34,38 @@ beforeEach(() => {
 });
 
 describe("executeWidgetQuery", () => {
+  it("cannot be reached with an empty selection, which would read every field", async () => {
+    // The composition is the claim. `toSelect` turns `[]` into `undefined` and
+    // the Direct API applies a selection only when it has keys, so an empty
+    // `select` reaching `find` is a FULL-document read -- the widest answer to
+    // the narrowest request. Asserted through `validateWidgetQuery` rather than
+    // by handing `executeWidgetQuery` a literal, because the gate is what has
+    // to hold: nothing composed this way can produce that read.
+    expect(() =>
+      validateWidgetQuery({
+        source: "collection:posts",
+        op: "list",
+        select: [],
+      })
+    ).toThrow(/select is empty/);
+    expect(find).not.toHaveBeenCalled();
+  });
+
+  it("passes a non-empty selection through as one the read path honours", async () => {
+    // The control for the case above, at the seam: a selection with keys is
+    // what `Object.keys(select).length > 0` requires downstream, so this is the
+    // shape that actually narrows the read.
+    const q = validateWidgetQuery({
+      source: "collection:posts",
+      op: "list",
+      select: ["title"],
+    });
+    await executeWidgetQuery(q, caller);
+    expect(find).toHaveBeenCalledWith(
+      expect.objectContaining({ select: { title: true } })
+    );
+  });
+
   it("counts through the access-controlled path", async () => {
     const q = validateWidgetQuery({
       source: "collection:posts",

--- a/packages/nextly/src/domains/widgets/__tests__/query.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/query.test.ts
@@ -119,6 +119,35 @@ describe("validateWidgetQuery", () => {
     ).toThrow(/where references undeclared field "secretScore"/);
   });
 
+  it("refuses an explicitly empty select, which reads as the opposite of what it does", () => {
+    // "Select nothing" is not a projection the read path can express: the
+    // Direct API applies a selection only when it has keys, so an empty one
+    // falls through to an UNSELECTED read and the widget receives the whole
+    // document -- the widest possible answer from the narrowest possible
+    // request. Refused for the same reason `where: { and: [] }` and an empty
+    // condition object are refused: an accepted query that silently widens is
+    // exactly what this validator exists to prevent. A widget that wants no
+    // fields asks for `op: "count"`.
+    expect(() =>
+      validateWidgetQuery({
+        source: "collection:posts",
+        op: "list",
+        select: [],
+      })
+    ).toThrow(/select is empty/);
+  });
+
+  it("still accepts a select naming one declared field", () => {
+    // The control: without it the refusal above is satisfied by a validator
+    // that refuses every `select`.
+    const q = validateWidgetQuery({
+      source: "collection:posts",
+      op: "list",
+      select: ["title"],
+    });
+    expect(q.select).toEqual(["title"]);
+  });
+
   it("refuses a select naming an undeclared field", () => {
     expect(() =>
       validateWidgetQuery({

--- a/packages/nextly/src/domains/widgets/__tests__/query.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/query.test.ts
@@ -670,3 +670,63 @@ describe("a geo filter means what it says or is refused", () => {
     ).toThrow(/is not a valid near filter/);
   });
 });
+
+describe("a geo filter cannot be counted", () => {
+  // `countEntries` refuses a geo predicate unconditionally: it evaluates them in
+  // memory over rows a count never fetches, and `buildWhereClause` emits no SQL
+  // for them, so a total that ignored one would describe every candidate the
+  // filter was meant to exclude. A VALID geo value therefore used to pass this
+  // validator and fail its batch slot at execution -- the contract's promise is
+  // that an accepted query is one the executor will run, so the refusal belongs
+  // here.
+  beforeEach(() => {
+    registerSource({
+      id: "collection:places",
+      label: "Places",
+      kind: "collection",
+      supports: ["count", "list"],
+      fields: [{ name: "location", type: "string" }],
+    });
+  });
+
+  const counting = (where: unknown) => () =>
+    validateWidgetQuery({
+      source: "collection:places",
+      op: "count",
+      where,
+    });
+
+  it("refuses a valid near filter under count", () => {
+    expect(counting({ location: { near: "-74.006,40.7128,10000" } })).toThrow(
+      /where operator "near" on field "location" cannot be counted/
+    );
+  });
+
+  it("refuses a valid within filter under count", () => {
+    expect(counting({ location: { within: "-74.006,40.7128,5000" } })).toThrow(
+      /where operator "within" on field "location" cannot be counted/
+    );
+  });
+
+  it("refuses a geo filter a combinator hides under count", () => {
+    expect(
+      counting({ and: [{ location: { near: "-74.006,40.7128,10000" } }] })
+    ).toThrow(/cannot be counted/);
+  });
+
+  // The controls. Without them the refusals above are satisfied by a validator
+  // that refuses every geo operator, or every `count`.
+  it("still accepts the same geo filter under list", () => {
+    expect(() =>
+      validateWidgetQuery({
+        source: "collection:places",
+        op: "list",
+        where: { location: { near: "-74.006,40.7128,10000" } },
+      })
+    ).not.toThrow();
+  });
+
+  it("still accepts a non-geo filter under count", () => {
+    expect(counting({ location: { equals: "here" } })).not.toThrow();
+  });
+});

--- a/packages/nextly/src/domains/widgets/__tests__/sources.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/sources.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import { NextlyError } from "../../../errors/nextly-error";
 import {
   clearSources,
   getSource,
@@ -220,6 +221,88 @@ describe("a source id's namespace and its kind are one fact", () => {
       replaceSourcesOfKind("collection", [VALID_SOURCE])
     ).not.toThrow();
     expect(getSource("collection:posts")?.label).toBe("Posts");
+  });
+});
+
+describe("replacing a kind is all-or-nothing", () => {
+  // `refreshCollectionSources` runs once per dashboard batch, before any slot,
+  // and rebuilds EVERY collection source from the live registry. Deleting the
+  // previous set and then registering the new one entry by entry meant a single
+  // malformed member -- one collection with a duplicate field name, one slug a
+  // plugin had squatted -- aborted the pass partway and left the store holding
+  // whatever had been registered before the throw. Sources that worked a moment
+  // earlier were then simply gone, and every widget addressing one answered
+  // "unavailable source" until a later refresh happened to succeed.
+  const goodPosts: WidgetSource = {
+    id: "collection:posts",
+    label: "Posts",
+    kind: "collection",
+    supports: ["count"],
+    fields: [{ name: "title", type: "string" }],
+  };
+
+  /** Malformed in a way `validateWidgetSource` refuses: no fields at all. */
+  const malformed = {
+    id: "collection:pages",
+    label: "Pages",
+    kind: "collection",
+    supports: ["count"],
+    fields: [],
+  } as unknown as WidgetSource;
+
+  beforeEach(() => {
+    clearSources();
+    replaceSourcesOfKind("collection", [goodPosts]);
+    registerSource({
+      id: "plugin:acme/revenue",
+      label: "Revenue",
+      kind: "plugin",
+      supports: ["count"],
+      fields: [{ name: "total", type: "number" }],
+    });
+  });
+
+  it("leaves the PREVIOUS set standing when a later member is refused", () => {
+    // `collection:tags` is ordered BEFORE the malformed entry, so a
+    // delete-then-register pass has already published it when the throw lands.
+    const tags: WidgetSource = {
+      id: "collection:tags",
+      label: "Tags",
+      kind: "collection",
+      supports: ["count"],
+      fields: [{ name: "name", type: "string" }],
+    };
+
+    expect(() => replaceSourcesOfKind("collection", [tags, malformed])).toThrow(
+      NextlyError
+    );
+
+    // The old set, intact: the refused pass published nothing.
+    expect(getSource("collection:posts")?.label).toBe("Posts");
+    expect(getSource("collection:tags")).toBeUndefined();
+    expect(getSource("collection:pages")).toBeUndefined();
+  });
+
+  it("still leaves the other kinds alone", () => {
+    expect(() => replaceSourcesOfKind("collection", [malformed])).toThrow();
+    expect(getSource("plugin:acme/revenue")?.label).toBe("Revenue");
+  });
+
+  // The control. Without it the two refusals above are satisfied by a
+  // `replaceSourcesOfKind` that publishes nothing at all.
+  it("publishes the whole set when every member is usable", () => {
+    const tags: WidgetSource = {
+      id: "collection:tags",
+      label: "Tags",
+      kind: "collection",
+      supports: ["count"],
+      fields: [{ name: "name", type: "string" }],
+    };
+    replaceSourcesOfKind("collection", [tags]);
+    // Replaced, not merged: a collection that left the registry loses its
+    // source, which is the direction that matters.
+    expect(getSource("collection:tags")?.label).toBe("Tags");
+    expect(getSource("collection:posts")).toBeUndefined();
   });
 });
 

--- a/packages/nextly/src/domains/widgets/built-in-sources.ts
+++ b/packages/nextly/src/domains/widgets/built-in-sources.ts
@@ -80,13 +80,35 @@ function toSourceType(fieldType: string): WidgetSourceField["type"] {
   }
 }
 
-/** The declared fields a collection exposes to widgets, minus anything unreadable. */
+/**
+ * The declared fields a collection exposes to widgets, minus anything
+ * unreadable and minus any repeat of a name already taken.
+ *
+ * Deduplicated HERE rather than left to `validateSourceFields` to refuse,
+ * because a collection can produce a duplicate without its author writing one:
+ * `readableFields` flattens unnamed presentational groups into the level they
+ * sit in, so a top-level `title` and a `title` inside a layout group arrive as
+ * two entries carrying one name. Refusing that is right for a source declared
+ * by hand and wrong for one DERIVED from a collection -- and the blast radius
+ * is the whole install, since `refreshCollectionSources` rebuilds every
+ * collection source in one pass.
+ *
+ * The FIRST declaration wins, which is the one an author reading their own
+ * config from the top means: a layout group appended below cannot displace the
+ * field it shadows.
+ */
 function exposedFields(
   fields: Array<{ name: string; type: string }>
 ): WidgetSourceField[] {
-  return fields
-    .filter(field => !NEVER_EXPOSED_FIELD_TYPES.has(field.type))
-    .map(field => ({ name: field.name, type: toSourceType(field.type) }));
+  const taken = new Set<string>();
+  const exposed: WidgetSourceField[] = [];
+  for (const field of fields) {
+    if (NEVER_EXPOSED_FIELD_TYPES.has(field.type)) continue;
+    if (taken.has(field.name)) continue;
+    taken.add(field.name);
+    exposed.push({ name: field.name, type: toSourceType(field.type) });
+  }
+  return exposed;
 }
 
 /** One collection, in the shape a widget source is built from. */

--- a/packages/nextly/src/domains/widgets/query.ts
+++ b/packages/nextly/src/domains/widgets/query.ts
@@ -490,10 +490,27 @@ function assertWhereClauseUsable(
  * The same reasoning as `cloneWhereOrUndefined`, one level down: validating
  * the caller's array and then spreading it into the result is two reads of
  * every index, and an index can be an accessor too.
+ *
+ * An EMPTY array is refused, for the reason `where: { and: [] }` and an empty
+ * condition object are refused one field over: it reads as the narrowest
+ * possible request and produces the widest possible answer. "Select nothing"
+ * is not a projection the read path can express -- `listEntries` applies a
+ * selection only when it has keys (`Object.keys(params.select).length > 0`),
+ * so an empty one falls through to an UNSELECTED read and the whole document
+ * reaches a widget that asked for none of it.
+ *
+ * Refused here rather than given a second meaning in the executor. The
+ * keys-required rule is the framework's, shared by every caller of
+ * `nextly.find`, so teaching the widget seam its own reading of `[]` would be
+ * a second implementation of field selection rather than a fix. A widget that
+ * genuinely wants no fields back asks for `op: "count"`.
  */
 function copySelectOrUndefined(select: unknown): string[] | undefined {
   if (select === undefined) return undefined;
   if (!Array.isArray(select)) fail("select must be an array of field names");
+  if (select.length === 0) {
+    fail("select is empty, which reads every field rather than none");
+  }
   return [...(select as unknown[])] as string[];
 }
 

--- a/packages/nextly/src/domains/widgets/query.ts
+++ b/packages/nextly/src/domains/widgets/query.ts
@@ -288,17 +288,71 @@ function assertGeoOperatorValue(
 }
 
 /**
- * Confirms a single field's condition value cannot smuggle in an operator or
- * a field name the earlier checks never see, and cannot silently compile to
- * no condition at all (see `assertFieldConditionUsable`).
+ * The facts every level of the `where` walk needs, carried once instead of
+ * threaded as four parallel parameters.
+ *
+ * `op` is in here because a geo predicate's legality depends on it: the same
+ * clause is executable under `list` and refused under `count` (see
+ * {@link assertGeoOperatorCountable}), so the walk cannot decide a condition
+ * without knowing which operation it is being validated for.
  */
-function assertFieldConditionShape(field: string, value: unknown): void {
+interface WhereScope {
+  source: WidgetSource;
+  declared: ReadonlySet<string>;
+  op: WidgetOp;
+}
+
+/**
+ * Confirms the requested OPERATION can carry this geo operator at all.
+ *
+ * `countEntries` refuses a geo predicate unconditionally, and correctly:
+ * `extractGeoFilters` lifts `near`/`within` out of the `where` and
+ * `applyGeoFilters` evaluates them in memory over the rows `listEntries`
+ * fetched, of which a count has none -- and `buildWhereClause` emits no SQL for
+ * them, so a total that simply ignored one would describe every candidate the
+ * filter was meant to exclude.
+ *
+ * So a geographic `count` is not a query that runs badly; it is one the
+ * executor rejects. Accepting it here and letting it fail in its batch slot
+ * breaks the promise this validator exists to keep -- that an accepted query is
+ * one the executor will run -- and it breaks it at the least useful moment,
+ * with the reason attached to a widget's result rather than to the query that
+ * asked for it.
+ *
+ * Keyed on `GEO_OPERATORS` rather than on a list of ops that "need rows", so a
+ * geo operator added to that vocabulary is refused here without a second edit.
+ */
+function assertGeoOperatorCountable(
+  op: WidgetOp,
+  field: string,
+  operator: string
+): void {
+  if (op !== "count" || !GEO_OPERATORS.has(operator)) return;
+  fail(
+    `where operator "${operator}" on field "${field}" cannot be counted. ` +
+      `Geo predicates are evaluated over fetched rows, so they apply to a ` +
+      `list but not to a count`
+  );
+}
+
+/**
+ * Confirms a single field's condition value cannot smuggle in an operator or
+ * a field name the earlier checks never see, cannot silently compile to
+ * no condition at all (see `assertFieldConditionUsable`), and names no operator
+ * the requested op cannot execute.
+ */
+function assertFieldConditionShape(
+  field: string,
+  value: unknown,
+  op: WidgetOp
+): void {
   const entries = assertFieldConditionUsable(field, value);
   if (!entries) return;
   for (const [operator, operatorValue] of entries) {
     assertOperatorAllowed(field, operator);
     assertOperatorValueShape(field, operator, operatorValue);
     assertGeoOperatorValue(field, operator, operatorValue);
+    assertGeoOperatorCountable(op, field, operator);
   }
 }
 
@@ -353,8 +407,7 @@ function assertCombinatorBranches(
 function walkWhereClause(
   where: Record<string, unknown>,
   depth: number,
-  source: WidgetSource,
-  declared: ReadonlySet<string>
+  scope: WhereScope
 ): void {
   if (depth > MAX_WHERE_DEPTH) {
     fail(`where clause is nested too deeply (max ${MAX_WHERE_DEPTH})`);
@@ -363,19 +416,16 @@ function walkWhereClause(
     if (key === "and" || key === "or") {
       const branches = assertCombinatorBranches(key, value);
       for (const branch of branches) {
-        walkWhereClause(
-          branch as Record<string, unknown>,
-          depth + 1,
-          source,
-          declared
-        );
+        walkWhereClause(branch as Record<string, unknown>, depth + 1, scope);
       }
       continue;
     }
-    if (!declared.has(key)) {
-      fail(`where references undeclared field "${key}" on "${source.id}"`);
+    if (!scope.declared.has(key)) {
+      fail(
+        `where references undeclared field "${key}" on "${scope.source.id}"`
+      );
     }
-    assertFieldConditionShape(key, value);
+    assertFieldConditionShape(key, value, scope.op);
   }
 }
 
@@ -421,14 +471,16 @@ function cloneWhereOrUndefined(
   }
 }
 
-/** Confirms every field named in `where` was declared, at every nesting depth. */
-function assertWhereFieldsDeclared(
-  source: WidgetSource,
+/**
+ * Confirms every field named in `where` was declared, at every nesting depth,
+ * and that every operator it names is one the requested op can execute.
+ */
+function assertWhereClauseUsable(
   where: Record<string, unknown> | undefined,
-  declared: ReadonlySet<string>
+  scope: WhereScope
 ): void {
   if (where === undefined) return;
-  walkWhereClause(where, 0, source, declared);
+  walkWhereClause(where, 0, scope);
 }
 
 /**
@@ -564,7 +616,7 @@ export function validateReadWidgetQuery(
   const where = cloneWhereOrUndefined(raw.where);
   const select = copySelectOrUndefined(raw.select);
 
-  assertWhereFieldsDeclared(source, where, declared);
+  assertWhereClauseUsable(where, { source, declared, op });
   assertSelectFieldsDeclared(source, select, declared);
   const sort = assertSortFieldDeclared(source, raw.sort, declared);
   const status = assertValidStatus(raw.status);

--- a/packages/nextly/src/domains/widgets/sources.ts
+++ b/packages/nextly/src/domains/widgets/sources.ts
@@ -253,16 +253,31 @@ function snapshot(source: WidgetSource): WidgetSource {
   );
 }
 
-/** Register a source. Throws if it is malformed, or if the id is already taken. */
-export function registerSource(source: WidgetSource): void {
+/**
+ * Validates `source` and returns the detached copy the store would hold,
+ * refusing when `isTaken` says its id is already spoken for.
+ *
+ * Separated from the write so a caller replacing a whole KIND can prepare every
+ * member before publishing any of them. Both callers ask the same two
+ * questions in the same order; only WHICH ids count as taken differs.
+ */
+function preparedSource(
+  source: WidgetSource,
+  isTaken: (id: string) => boolean
+): WidgetSource {
   validateWidgetSource(source);
-  const existing = store().get(source.id);
-  if (existing) {
+  if (isTaken(source.id)) {
     throw NextlyError.conflict({
       message: `Widget source "${source.id}" is already registered.`,
     });
   }
-  store().set(source.id, snapshot(source));
+  return snapshot(source);
+}
+
+/** Register a source. Throws if it is malformed, or if the id is already taken. */
+export function registerSource(source: WidgetSource): void {
+  const prepared = preparedSource(source, id => store().has(id));
+  store().set(prepared.id, prepared);
 }
 
 export function getSource(id: string): WidgetSource | undefined {
@@ -291,10 +306,36 @@ export function replaceSourcesOfKind(
   next: readonly WidgetSource[]
 ): void {
   const map = store();
-  for (const [id, source] of map) {
+
+  // Every member is validated and detached BEFORE anything is deleted, and the
+  // swap that follows cannot fail. Deleting first and registering one at a time
+  // meant a single refused member left the store holding a partial rebuild:
+  // `refreshCollectionSources` runs once per dashboard batch over EVERY
+  // collection, so one malformed source unpublished the sources beside it and
+  // every widget addressing one answered "unavailable source" until a later
+  // refresh happened to succeed. A failed rebuild now leaves the previous set
+  // standing, which is the same reading `refreshCollectionSources` already
+  // takes of an unreachable registry.
+  const staged = new Map<string, WidgetSource>();
+  // A source of the KIND being replaced is on its way out, so it does not claim
+  // its own id against the incoming set -- that is what makes a rebuild
+  // idempotent. A source of ANY OTHER kind does claim it, and so does an id this
+  // same pass has already staged: a duplicate inside one pass is a real mistake
+  // and stays refused.
+  const isTaken = (id: string): boolean => {
+    if (staged.has(id)) return true;
+    const existing = map.get(id);
+    return existing !== undefined && existing.kind !== kind;
+  };
+  for (const source of next) {
+    const prepared = preparedSource(source, isTaken);
+    staged.set(prepared.id, prepared);
+  }
+
+  for (const [id, source] of [...map]) {
     if (source.kind === kind) map.delete(id);
   }
-  for (const source of next) registerSource(source);
+  for (const [id, source] of staged) map.set(id, source);
 }
 
 /**

--- a/packages/nextly/src/domains/widgets/widget-exports.test-d.ts
+++ b/packages/nextly/src/domains/widgets/widget-exports.test-d.ts
@@ -1,0 +1,149 @@
+/**
+ * What the published widget vocabulary IS, asserted so the checker evaluates it.
+ *
+ * `__tests__/export-contract.test.ts` proves these names are exported and that
+ * example values are assignable to them. Neither claim survives a WIDENING:
+ * `type WidgetHeight = string` exports the same name and accepts `"tall"`
+ * happily, so both assertions stay green while every plugin author loses the
+ * only thing the type was for -- a typo becoming a compile error instead of a
+ * card that silently draws at the wrong height.
+ *
+ * In a `.test-d.ts` rather than a `.test.ts` for the reason
+ * `shared/addressable-fields.test-d.ts` states: a passive annotation in a
+ * runtime test is transpiled away and checks nothing about the type. It is
+ * compiled by `pnpm check-types` through `tsconfig.tests.json`.
+ *
+ * Read through the ROOT entry point, never through the domain modules. There is
+ * no `nextly/widgets` subpath, so the root is the only place a plugin author can
+ * reach these -- and a name that stops being re-exported is exactly the
+ * regression this file exists to catch, which importing from `./definition`
+ * would hide.
+ *
+ * The `Exact` / `assertType` pair is the one
+ * `shared/addressable-fields.test-d.ts` and
+ * `direct-api/types/field-groups-public-surface.test-d.ts` already use, restated
+ * locally the way those do rather than shared: a `.test-d.ts` exporting a helper
+ * would be imported by files that are not type tests.
+ */
+import type {
+  WidgetArchetype,
+  WidgetHeight,
+  WidgetOp,
+  WidgetSize,
+  WidgetSourceField,
+  WidgetSourceFieldType,
+  WidgetSourceKind,
+} from "../../index";
+
+/** `Exact<A, B>` is `false` when the two types differ in either direction. */
+type Exact<A, B> = [A] extends [B] ? ([B] extends [A] ? true : false) : false;
+
+declare function assertType<T extends true>(proof: T): void;
+
+/** Whether `A` is assignable to `B`, as a value the checker EVALUATES. */
+type AssignableTo<A, B> = [A] extends [B] ? true : false;
+
+// The unions, member for member. `toMatchTypeOf`-style containment would be
+// satisfied by a widened alias; equality in BOTH directions is what refuses one.
+assertType<Exact<WidgetHeight, "short" | "tall">>(true);
+assertType<Exact<WidgetSize, "sm" | "md" | "lg" | "xl" | "full">>(true);
+assertType<Exact<WidgetOp, "count" | "list" | "groupBy" | "timeseries">>(true);
+assertType<
+  Exact<WidgetSourceKind, "collection" | "single" | "system" | "plugin">
+>(true);
+assertType<
+  Exact<WidgetSourceFieldType, "string" | "number" | "boolean" | "date">
+>(true);
+assertType<
+  Exact<
+    WidgetArchetype,
+    "metric" | "table" | "list" | "text" | "actions" | "custom"
+  >
+>(true);
+
+// The three claims a closed string union makes, stated together per type: the
+// valid member is assignable, and `string` and a plausible near-miss are not.
+// None of them is sufficient alone -- the refusals are satisfied by a union
+// narrowed to `never`, which would leave an author unable to write a valid value
+// at all, and the acceptance is satisfied by a widening to `string`, which is
+// the regression this file exists for. The near-miss is the value an author
+// actually mistypes, so a union that quietly GAINED a member fails here where
+// `string` alone would not.
+//
+// Written out per type rather than through a generic `ClosedUnion<T, ...>`
+// helper, and that is deliberate: inside a generic alias these conditionals are
+// deferred, and the wrapper evaluated to `false` for a HEALTHY union -- a helper
+// that fails on correct code and would have been "fixed" by deleting the
+// assertions it broke. Instantiated directly, they resolve.
+assertType<
+  Exact<
+    [
+      AssignableTo<"tall", WidgetHeight>,
+      AssignableTo<string, WidgetHeight>,
+      AssignableTo<"long", WidgetHeight>,
+    ],
+    [true, false, false]
+  >
+>(true);
+assertType<
+  Exact<
+    [
+      AssignableTo<"lg", WidgetSize>,
+      AssignableTo<string, WidgetSize>,
+      AssignableTo<"medium", WidgetSize>,
+    ],
+    [true, false, false]
+  >
+>(true);
+assertType<
+  Exact<
+    [
+      AssignableTo<"count", WidgetOp>,
+      AssignableTo<string, WidgetOp>,
+      AssignableTo<"sum", WidgetOp>,
+    ],
+    [true, false, false]
+  >
+>(true);
+assertType<
+  Exact<
+    [
+      AssignableTo<"metric", WidgetArchetype>,
+      AssignableTo<string, WidgetArchetype>,
+      AssignableTo<"chart", WidgetArchetype>,
+    ],
+    [true, false, false]
+  >
+>(true);
+assertType<
+  Exact<
+    [
+      AssignableTo<"collection", WidgetSourceKind>,
+      AssignableTo<string, WidgetSourceKind>,
+      AssignableTo<"table", WidgetSourceKind>,
+    ],
+    [true, false, false]
+  >
+>(true);
+assertType<
+  Exact<
+    [
+      AssignableTo<"date", WidgetSourceFieldType>,
+      AssignableTo<string, WidgetSourceFieldType>,
+      AssignableTo<"text", WidgetSourceFieldType>,
+    ],
+    [true, false, false]
+  >
+>(true);
+
+// `WidgetSource` is built out of this, so its shape is part of the published
+// contract too -- and `type` carrying the closed vocabulary rather than `string`
+// is the whole reason a source declaration can be checked at all.
+assertType<Exact<WidgetSourceField["name"], string>>(true);
+assertType<Exact<WidgetSourceField["type"], WidgetSourceFieldType>>(true);
+assertType<
+  Exact<AssignableTo<{ name: string; type: "text" }, WidgetSourceField>, false>
+>(true);
+assertType<
+  Exact<AssignableTo<{ name: string; type: "string" }, WidgetSourceField>, true>
+>(true);


### PR DESCRIPTION
Six findings left open on #1393 when it merged. Three of them are the second half of repairs made earlier in that PR — a hole closed on one path and left open on another.

## The two that mattered

**A setup transformer could still 500 the whole admin.** #1393 added `validatedAdminWidgets` so a plugin contributing a non-JSON value (a bigint in a widget `where`, say) is refused at boot rather than making `/api/admin-meta/workspace` throw on `JSON.stringify` and return 500 to every admin user.

That covered only the original plugin list. `registerServices` calls `resolvePlugins` *before* `applyPluginConfigTransformers` and then revalidates only slugs, so a `setup` transformer that adds or replaces `contributes.admin.widgets` produced widgets nothing validated — and the transformed list is what gets published. Same failure, second door.

**A widget source rebuild could leave the set half-registered.** `replaceSourcesOfKind` deleted the existing collection sources before registering the new ones, so a single duplicate field name — which unnamed presentational groups can produce — aborted `refreshCollectionSources` partway and left sources that used to work missing. It now stages every validated member before deleting anything: all-or-nothing.

## The rest

- **Geo predicates were accepted for `count`**, then rejected at execution because `count` cannot apply a filter needing fetched rows. Refused at validation now, so an accepted query is one the executor will actually run.
- **`select: []` returned every field.** An explicit empty selection became `undefined`, and the Direct API only applies selection when the object has keys — so "select nothing" silently meant "select everything", sending full documents to a widget that asked for none. Refused, consistent with how the validator already treats `null`, `{}` and empty `and`/`or`.
- **`PluginWidgetMeta` is now derived, not duplicated.** The server serializes ten fields; the admin declared four, and the docblock claimed the two were "one shape" when nothing enforced it. `PluginWidgetMeta = PluginAdminWidget` via the `nextly/config` subpath, so divergence is a compile error.
- **The type test now evaluates.** `widget-exports.test-d.ts` proved only that names exist and accept examples — it would not have caught `WidgetHeight = string`. It uses the repo's existing `Exact`/`assertType` pattern and includes cases that must remain *rejected*.

## On the derived type

The obvious route does not work and was reproduced before being abandoned: `import type { PluginAdminWidget } from "nextly"` in the admin produces ~112 `TS2307` errors, because admin's tsconfig maps the bare `nextly` specifier to `../nextly/src` and pulls core's whole source in with internal aliases admin does not define.

`nextly/config` works precisely because only the *bare* specifier is mapped — subpaths fall through to the export map and the built declaration bundle.

## Verification

- `packages/nextly` 841 files / 10386 tests (baseline 840 / 10370)
- `packages/admin` 335 / 3208; typecheck 22/22; sqlite integration green; `fallow` pass, 0 introduced
- A, C, D and F each break-verified: fix reverted, the specific test observed failing, restored

## Two notes on the implementation

Finding A validates **twice** rather than once. `resolvePlugins` has three callers and only two apply transformers, so moving the check downstream would strip it from `plugin-introspection` and any future caller — `validatePluginSlugs` already carries the same duplication for the same reason.

Finding F's obvious generic helper is unsound: inside a generic alias the conditionals defer, and it evaluated `false` for a healthy union. Reproduced in isolation and written out per type instead.