### PR TITLE
fix(nextly): stop a group of releases as one indivisible step

### DIFF
--- a/.changeset/block-a-release-group-atomically.md
+++ b/.changeset/block-a-release-group-atomically.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Stop a group of releases as one indivisible step, and refuse to schedule a release that cannot run. Releases that share a document are only ever discharged together, and stopping them one write at a time left the group split whenever a process died partway — the survivor then became the winner on every shared document and could take the opposite lifecycle action to the one the whole group would have produced. Ordering the writes was not enough and could not be made enough: two releases scheduled for the same instant are separated per document by when each member was added, so each can win a different document of the same group, and no ordering of releases preserves a winner chosen per member. The group now moves inside one transaction, so a partial transition cannot be represented at all. Scheduling also now refuses a release with a member nothing can run — a deleted author, no recorded author, a member naming one language — from every state rather than only from a release already marked as stopped, because a colleague leaving does not wait for a background pass and the person scheduling cannot see whether one has run.

--- a/packages/adapter-drizzle/src/__tests__/transaction-forwarders.test.ts
+++ b/packages/adapter-drizzle/src/__tests__/transaction-forwarders.test.ts
@@ -21,6 +21,7 @@ describe("createTransactionForwarders", () => {
       update: vi.fn(),
       delete: vi.fn(),
       upsert: vi.fn(),
+      updateCount: vi.fn(),
     };
 
     const forwarders = createTransactionForwarders(
@@ -48,6 +49,7 @@ describe("createTransactionForwarders", () => {
       update: vi.fn(),
       delete: vi.fn(),
       upsert: vi.fn(),
+      updateCount: vi.fn(),
     };
 
     const forwarders = createTransactionForwarders(
@@ -75,6 +77,7 @@ describe("createTransactionForwarders", () => {
       update: vi.fn().mockResolvedValue([{ id: "1", name: "Bob" }]),
       delete: vi.fn(),
       upsert: vi.fn(),
+      updateCount: vi.fn(),
     };
 
     const forwarders = createTransactionForwarders(
@@ -108,6 +111,7 @@ describe("createTransactionForwarders", () => {
       update: vi.fn(),
       delete: vi.fn().mockResolvedValue(1),
       upsert: vi.fn(),
+      updateCount: vi.fn(),
     };
 
     const forwarders = createTransactionForwarders(
@@ -139,6 +143,7 @@ describe("createTransactionForwarders", () => {
       update: vi.fn(),
       delete: vi.fn(),
       upsert: vi.fn().mockResolvedValue({ id: "1", email: "test@example.com" }),
+      updateCount: vi.fn(),
     };
 
     const forwarders = createTransactionForwarders(
@@ -168,6 +173,7 @@ describe("createTransactionForwarders", () => {
       update: vi.fn(),
       delete: vi.fn(),
       upsert: vi.fn(),
+      updateCount: vi.fn(),
     };
 
     const forwarders = createTransactionForwarders(
@@ -177,5 +183,50 @@ describe("createTransactionForwarders", () => {
 
     const drizzleInstance = forwarders.getDrizzle();
     expect(drizzleInstance).toBe(mockExecutor);
+  });
+});
+
+describe("createTransactionForwarders — updateCount", () => {
+  it("forwards updateCount with the transaction executor", async () => {
+    // The fenced compare-and-set, and the reason it has to be here at all: a
+    // conditional UPDATE that reports how many rows it matched is the only
+    // statement that can transition a set of rows atomically. `update` cannot
+    // stand in — on a dialect without RETURNING it re-SELECTs on the same
+    // WHERE, so an update whose own write falsifies its predicate reads back
+    // zero rows and a write that landed reports as unmatched.
+    const mockExecutor = { name: "tx-executor" };
+    const mockDelegator: TransactionCrudDelegator = {
+      select: vi.fn(),
+      selectOne: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      upsert: vi.fn(),
+      updateCount: vi.fn().mockResolvedValue(1),
+    };
+
+    const forwarders = createTransactionForwarders(
+      mockDelegator,
+      () => mockExecutor
+    );
+    const where: WhereClause = {
+      and: [{ column: "state", op: "=", value: "scheduled" }],
+    };
+
+    const result = await forwarders.updateCount(
+      "releases",
+      { state: "blocked" },
+      where
+    );
+
+    expect(result).toBe(1);
+    // The EXECUTOR is the point. Forwarded without it the statement runs on the
+    // pool, outside the transaction — so it would commit on its own and could
+    // not be rolled back with the rest of the component.
+    expect(mockDelegator.updateCount).toHaveBeenCalledWith(
+      "releases",
+      { state: "blocked" },
+      where,
+      mockExecutor
+    );
   });
 });

--- a/packages/adapter-drizzle/src/transaction-forwarders.ts
+++ b/packages/adapter-drizzle/src/transaction-forwarders.ts
@@ -39,6 +39,12 @@ export interface TransactionCrudDelegator {
     options?: UpdateOptions,
     executor?: unknown
   ): Promise<T[]>;
+  updateCount(
+    table: string,
+    data: Record<string, unknown>,
+    where: WhereClause,
+    executor?: unknown
+  ): Promise<number>;
   delete(
     table: string,
     where: WhereClause,
@@ -58,7 +64,17 @@ export interface TransactionCrudDelegator {
  */
 export type TransactionCrudForwarders = Pick<
   TransactionContext,
-  "select" | "selectOne" | "update" | "delete" | "upsert" | "getDrizzle"
+  | "select"
+  | "selectOne"
+  | "update"
+  // The fenced compare-and-set. Listed explicitly like every other key here:
+  // the type is DERIVED from `TransactionContext` in the sense that its
+  // signatures come from there, but the key set is enumerated, so a method
+  // added to the context is not forwarded until it is named here too.
+  | "updateCount"
+  | "delete"
+  | "upsert"
+  | "getDrizzle"
 >;
 
 /**
@@ -99,6 +115,14 @@ export function createTransactionForwarders(
       options?: UpdateOptions
     ): Promise<T[]> => {
       return delegator.update<T>(table, data, where, options, txDb());
+    },
+
+    updateCount: async (
+      table: string,
+      data: Record<string, unknown>,
+      where: WhereClause
+    ): Promise<number> => {
+      return delegator.updateCount(table, data, where, txDb());
     },
 
     delete: async (

--- a/packages/adapter-drizzle/src/types/transaction.ts
+++ b/packages/adapter-drizzle/src/types/transaction.ts
@@ -204,6 +204,36 @@ export interface TransactionContext {
   ): Promise<T[]>;
 
   /**
+   * Update records and report how many rows the statement affected.
+   *
+   * @remarks
+   * The transactional half of the adapter's `updateCount`, and the only way to
+   * perform a fenced compare-and-set inside a transaction. `update` cannot
+   * answer this: without `returning` it discards the driver's count, and WITH
+   * `returning` on a dialect that lacks RETURNING it re-SELECTs using the same
+   * WHERE — so a conditional update whose own write falsifies its predicate
+   * reads back zero rows, and a write that landed reports as unmatched.
+   *
+   * 🔴 Inherits the adapter's MySQL caveat: MySQL counts CHANGED rows rather
+   * than matched ones, so a caller using this as a compare-and-set must write
+   * at least one column the update always moves — a state transition, a version
+   * bump, a timestamp of sufficient resolution. Postgres (`rowCount`) and
+   * SQLite (`changes`) count matched rows and do not need the precaution, which
+   * is exactly why it cannot be dropped: the dialect where the distinction
+   * exists is the one with no RETURNING to fall back on.
+   *
+   * @param table - Table name
+   * @param data - Column values to write
+   * @param where - Conditions the update must match
+   * @returns Number of rows the statement affected
+   */
+  updateCount(
+    table: string,
+    data: Record<string, unknown>,
+    where: WhereClause
+  ): Promise<number>;
+
+  /**
    * Delete records.
    *
    * @param table - Table name

--- a/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/apply-due-releases.test.ts
@@ -67,7 +67,13 @@ function deps(over: {
 }): ApplyDueReleasesDeps {
   const releases = over.releases ?? [release()];
   const members = over.members ?? [member()];
-  const blocked = vi.fn(async (_id: string, _at: Date) => true);
+  // Answers with the ids it was given, which is what the repository does on a
+  // component that transitioned whole. A stub returning a constant would let a
+  // pass that blocked a DIFFERENT set look identical to a correct one.
+  const blocked = vi.fn(
+    async (entries: readonly { id: string; scheduledAt: Date }[]) =>
+      entries.map(entry => entry.id)
+  );
   return {
     // Pinned, so every case below observes a STABLE component order and asserts
     // about the mechanism it names rather than about which rotation came up.
@@ -79,7 +85,7 @@ function deps(over: {
       // WHICH releases the pass stopped. A stub returning true would let a pass
       // that blocked the wrong ones — or every one — look identical to a pass
       // that blocked exactly the hopeless.
-      blockRelease: blocked,
+      blockReleases: blocked,
       listMembersOf: async ids =>
         members.filter(m => ids.includes(m.releaseId)),
       isStillDueAt: async (id: string, scheduledAt: Date) =>
@@ -948,7 +954,9 @@ describe("applyDueReleases", () => {
 describe("a release nothing about retrying could fix is STOPPED", () => {
   /** The releases this pass moved to `blocked`. */
   function blockedBy(d: ReturnType<typeof deps>): string[] {
-    return vi.mocked(d.repository.blockRelease).mock.calls.map(call => call[0]);
+    return vi
+      .mocked(d.repository.blockReleases)
+      .mock.calls.flatMap(call => call[0].map(entry => entry.id));
   }
 
   it("blocks a member whose author was never recorded", async () => {
@@ -1002,9 +1010,61 @@ describe("a release nothing about retrying could fix is STOPPED", () => {
     // then never run at the replacement instant, and nothing would say why.
     const d = deps({ members: [member({ createdBy: null })] });
     await applyDueReleases(d);
-    const call = vi.mocked(d.repository.blockRelease).mock.calls[0];
-    expect(call?.[1]).toBeInstanceOf(Date);
-    expect(call?.[1]?.getTime()).toBe(release().scheduledAt?.getTime());
+    const entry = vi.mocked(d.repository.blockReleases).mock.calls[0]?.[0]?.[0];
+    expect(entry?.scheduledAt).toBeInstanceOf(Date);
+    expect(entry?.scheduledAt.getTime()).toBe(release().scheduledAt?.getTime());
+  });
+
+  it("hands a whole overlapping COMPONENT over in ONE call", async () => {
+    // The structural property atomicity rests on. Two releases sharing a
+    // document are discharged together or not at all, so the repository has to
+    // receive them as one set — issued as two calls there is no transaction
+    // that could cover both, whatever the repository does internally.
+    //
+    // TIED INSTANTS deliberately, because that is the case no ordering can
+    // rescue: the engine breaks a tie on the MEMBER's creation time, per
+    // document, so each of these releases can win a different document and
+    // blocking either one first corrupts the other.
+    const d = deps({
+      releases: [release({ id: "r1" }), release({ id: "r2" })],
+      members: [
+        // Both name the SAME document, so only the winner acts — and on a tied
+        // instant and a tied creation time the winner is the higher member id,
+        // which is the one constructed second. So the broken member has to be
+        // that one, or the pass never reaches a permanent failure at all.
+        member({ releaseId: "r1", entryId: "e1" }),
+        member({ releaseId: "r2", entryId: "e1", createdBy: null }),
+      ],
+    });
+    await applyDueReleases(d);
+
+    const calls = vi.mocked(d.repository.blockReleases).mock.calls;
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.[0].map(entry => entry.id).sort()).toEqual(["r1", "r2"]);
+  });
+
+  it("skips a component it cannot fence COMPLETELY", async () => {
+    // A release with no planned instant cannot be fenced, so it cannot be
+    // blocked — and blocking the rest of its component is exactly the split
+    // this pass exists to prevent. Nothing moves, and the next pass re-plans
+    // against a set it can fence whole.
+    //
+    // `scheduledAt: null` is how a release reaches the pass without one.
+    const d = deps({
+      releases: [
+        release({ id: "r1" }),
+        release({ id: "r2", scheduledAt: null }),
+      ],
+      members: [
+        member({ releaseId: "r1", entryId: "e1" }),
+        // The winner, and unrunnable — see the note in the case above.
+        member({ releaseId: "r2", entryId: "e1", createdBy: null }),
+      ],
+    });
+    const result = await applyDueReleases(d);
+
+    expect(blockedBy(d)).toEqual([]);
+    expect(result.blocked).toBe(0);
   });
 
   it("blocks nothing when every member applies", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
@@ -42,7 +42,19 @@ function service(members: M[], liveAuthorIds: string[], state = "blocked") {
     }))
   );
   const liveAuthors = vi.fn(async () => new Set(liveAuthorIds));
-  const scheduleRelease = vi.fn(async () => true);
+  // HONOURS the fence it is standing in for: the repository accepts the write
+  // only when the release's current state is in the list the service passed.
+  // A stub answering `true` unconditionally would let a terminal release — a
+  // published one — appear to reschedule, and the case below could not tell
+  // the fence's refusal from the blocker precondition's.
+  const scheduleRelease = vi.fn(
+    async (
+      _id: string,
+      _at: Date,
+      _tz: string,
+      from: readonly ReleaseState[] = RELEASE_SCHEDULABLE_FROM
+    ) => from.includes(state as ReleaseState)
+  );
   const deps = {
     repository: {
       listMembers,
@@ -208,6 +220,30 @@ describe("scheduling a blocked release", () => {
     // Refused BEFORE the write, not after it: a precondition that runs late is
     // not a precondition.
     expect(scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("does not offer an impossible recovery for a PUBLISHED release", async () => {
+    // A published release is terminal: the fence refuses it whatever its
+    // members look like, and it is not assemblable, so `removeMember` will not
+    // let anybody act on the advice either. Deriving blockers first would
+    // answer "fix or remove the documents blocking it" — a recovery that does
+    // not exist — instead of saying the release has already happened.
+    //
+    // The author is deleted here, so the blocker precondition WOULD fire if it
+    // ran. That is what makes this case discriminate.
+    const { svc, liveAuthors, scheduleRelease } = service(
+      [{ id: "m1", createdBy: "ghost" }],
+      [],
+      "published"
+    );
+
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    // Refused by the FENCE, which is the honest answer, and reached because no
+    // blocker was derived on the way.
+    expect(scheduleRelease).toHaveBeenCalled();
+    expect(liveAuthors).not.toHaveBeenCalled();
   });
 
   it("still schedules a release whose members are all runnable", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/blocking-reasons.test.ts
@@ -189,16 +189,36 @@ describe("scheduling a blocked release", () => {
     expect(scheduleRelease).toHaveBeenCalled();
   });
 
-  it("does not pay the extra read for a release that is not blocked", async () => {
-    // A draft has nothing to check, and putting the lookup on every schedule
-    // would charge every caller for a question only one state answers yes to.
-    const { svc, liveAuthors, scheduleRelease } = service(
+  it("is refused from ANY schedulable state, not only from `blocked`", async () => {
+    // Replaces a case that asserted the opposite — that a release which was not
+    // already `blocked` skipped the check to save a read. That made the rule
+    // depend on whether the drain had run yet: the same release with the same
+    // deleted author was refused once labelled and accepted before, which is
+    // not a distinction the person scheduling can see.
+    //
+    // A DRAFT here, the state furthest from `blocked`.
+    const { svc, scheduleRelease } = service(
       [{ id: "m1", createdBy: "ghost" }],
       [],
       "draft"
     );
+    await expect(svc.schedule("r1", AT, "UTC", ACTOR)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    // Refused BEFORE the write, not after it: a precondition that runs late is
+    // not a precondition.
+    expect(scheduleRelease).not.toHaveBeenCalled();
+  });
+
+  it("still schedules a release whose members are all runnable", async () => {
+    // The control for the case above. Without it, a precondition that refused
+    // every schedule would satisfy it perfectly.
+    const { svc, scheduleRelease } = service(
+      [{ id: "m1", createdBy: "u9" }],
+      ["u9"],
+      "draft"
+    );
     await expect(svc.schedule("r1", AT, "UTC", ACTOR)).resolves.toBeUndefined();
-    expect(liveAuthors).not.toHaveBeenCalled();
     expect(scheduleRelease).toHaveBeenCalled();
   });
 });
@@ -220,7 +240,15 @@ describe("the blocker verdict and the write share a fence", () => {
    * fence at all behaves here exactly as it did before this was fixed — which
    * is what makes the two racing cases below fail on that version.
    */
-  function racing(atRead: string, atWrite: ReleaseState, live: string[] = []) {
+  function racing(
+    atRead: string,
+    atWrite: ReleaseState,
+    // CLEAN by default, so the only thing that can refuse these cases is the
+    // fence. A fixture whose author is missing would be refused by the blocker
+    // precondition instead, and every case below would pass without the fence
+    // existing at all.
+    live: string[] = ["author"]
+  ) {
     const liveAuthors = vi.fn(async () => new Set(live));
     const scheduleRelease = vi.fn(
       async (
@@ -261,13 +289,14 @@ describe("the blocker verdict and the write share a fence", () => {
     // release. A fence spanning every schedulable state accepts `blocked` here
     // and reschedules a release nobody checked — which reaches its new instant
     // and stops again, for the same permanent reason.
-    const { svc, liveAuthors } = racing("scheduled", "blocked");
+    const { svc, scheduleRelease } = racing("scheduled", "blocked");
     await expect(svc.schedule("r1", AT, "UTC", ACTOR)).rejects.toMatchObject({
       code: "CONFLICT",
     });
-    // And it was refused for the right reason: no blocker was ever derived,
-    // because at the moment of the read there was nothing to derive.
-    expect(liveAuthors).not.toHaveBeenCalled();
+    // And it was refused by the FENCE rather than by the blocker precondition:
+    // this release has a live author, so there is nothing for that precondition
+    // to object to. The write was attempted and the fence turned it away.
+    expect(scheduleRelease).toHaveBeenCalled();
   });
 
   it("REFUSES a blocked release that somebody else moved after it was cleared", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/releases-repository.integration.test.ts
@@ -221,7 +221,9 @@ describe.each(getConfiguredTestDialects())(
         action: "publish",
       });
       await repo.scheduleRelease(release.id, PAST, "UTC");
-      expect(await repo.blockRelease(release.id, PAST)).toBe(true);
+      expect(
+        await repo.blockReleases([{ id: release.id, scheduledAt: PAST }])
+      ).toEqual([release.id]);
 
       const found = await repo.findDueMembersFor([ref("e1")], new Date());
       expect(found.get(documentRefKey(ref("e1"))) ?? []).toEqual([]);
@@ -242,7 +244,9 @@ describe.each(getConfiguredTestDialects())(
         action: "publish",
       });
       await repo.scheduleRelease(release.id, PAST, "UTC");
-      expect(await repo.blockRelease(release.id, PAST)).toBe(true);
+      expect(
+        await repo.blockReleases([{ id: release.id, scheduledAt: PAST }])
+      ).toEqual([release.id]);
 
       // The list the document's banner actually passes, imported rather than
       // spelled again: a test naming its own states would keep passing after
@@ -257,6 +261,76 @@ describe.each(getConfiguredTestDialects())(
       // Still carrying the instant it was going to run at, which is what the
       // banner orders and dates the row by.
       expect(members[0]?.scheduledAt.getTime()).toBe(PAST.getTime());
+    });
+
+    it("blocks a whole component ATOMICALLY, or not at all", async () => {
+      // The property no ordering of separate writes can give. Two releases
+      // sharing a document must move together: if one is blocked and the other
+      // is not, the survivor becomes the winner on that document and can apply
+      // the OPPOSITE lifecycle action to the one the component would have
+      // produced.
+      //
+      // The second entry's fence is made to miss, exactly as it would for a
+      // release someone postponed between the plan and this write. The first
+      // entry's UPDATE has already run by then, so the assertion below is a
+      // real test of the rollback rather than of a statement never issued.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+
+      const first = await repo.createRelease({ title: "Launch" });
+      const second = await repo.createRelease({ title: "Takedown" });
+      for (const release of [first, second]) {
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+        await repo.scheduleRelease(release.id, PAST, "UTC");
+      }
+
+      // The repository writes in id order, so the id that sorts LATER is the
+      // one to fail — otherwise the failing statement runs first, nothing has
+      // been written yet, and a rollback that does nothing would pass.
+      const [early, late] = [first.id, second.id].sort();
+      const rows = await repo.blockReleases([
+        { id: early as string, scheduledAt: PAST },
+        // Not the instant this release carries, so its fence matches nothing.
+        { id: late as string, scheduledAt: FUTURE },
+      ]);
+
+      expect(rows).toEqual([]);
+      const after = await repo.findReleases({ ids: [first.id, second.id] });
+      expect(after.map(r => r.state).sort()).toEqual([
+        "scheduled",
+        "scheduled",
+      ]);
+    });
+
+    it("blocks every release in the component when each fence matches", async () => {
+      // The control. Without it, a `blockReleases` that refused everything
+      // would satisfy the case above perfectly.
+      const app = await boot(dialect);
+      const repo = new ReleasesRepository(app.adapter);
+
+      const first = await repo.createRelease({ title: "Launch" });
+      const second = await repo.createRelease({ title: "Takedown" });
+      for (const release of [first, second]) {
+        await repo.addMember({
+          releaseId: release.id,
+          ...ref("e1"),
+          action: "publish",
+        });
+        await repo.scheduleRelease(release.id, PAST, "UTC");
+      }
+
+      const rows = await repo.blockReleases([
+        { id: first.id, scheduledAt: PAST },
+        { id: second.id, scheduledAt: PAST },
+      ]);
+
+      expect([...rows].sort()).toEqual([first.id, second.id].sort());
+      const after = await repo.findReleases({ ids: [first.id, second.id] });
+      expect(after.map(r => r.state)).toEqual(["blocked", "blocked"]);
     });
 
     it("keeps each document's members apart", async () => {

--- a/packages/nextly/src/domains/releases/apply-due-releases.ts
+++ b/packages/nextly/src/domains/releases/apply-due-releases.ts
@@ -119,14 +119,23 @@ export interface ApplyDueReleasesDeps {
     isStillDueAt(releaseId: string, scheduledAt: Date): Promise<boolean>;
     markReleasePublished(id: string, at: Date): Promise<boolean>;
     /**
-     * Stop a release nothing about retrying could fix.
+     * Stop a COMPONENT of releases nothing about retrying could fix, atomically.
      *
-     * Takes the instant the pass planned against, and the repository fences on
-     * it as well as on the state — the same pair `isStillDueAt` judges by. A
-     * release someone postponed between the plan and this call is left alone,
-     * rather than having the schedule they just chose replaced with `blocked`.
+     * Takes the whole set rather than one release, because the set sharing a
+     * document is the unit that has to move together — see the repository's own
+     * note on why no ordering of individual writes can substitute for that.
+     *
+     * Each entry carries the instant the pass planned against, and the
+     * repository fences on it as well as on the state — the same pair
+     * `isStillDueAt` judges by. A release someone postponed between the plan
+     * and this call fails its fence, and the whole component is then left
+     * alone rather than half-transitioned.
+     *
+     * @returns the ids actually blocked: every entry, or none.
      */
-    blockRelease(id: string, scheduledAt: Date): Promise<boolean>;
+    blockReleases(
+      entries: readonly { id: string; scheduledAt: Date }[]
+    ): Promise<readonly string[]>;
   };
   mutations: ReleaseMutations;
   /** The identity reads, so a member's author can be resolved. */
@@ -240,6 +249,13 @@ const RETRY_COULD_HELP: Record<MaterialisationFailure, boolean> = {
  * either, because the pair is only ever discharged together. Blocking one and
  * not the other would leave the second retrying forever, which is the condition
  * this exists to end.
+ *
+ * Each component is handed over WHOLE, so the transition is all-or-nothing. An
+ * earlier version issued one write per release and ordered them earliest-first
+ * so that any surviving prefix was safe; that argument does not survive two
+ * releases sharing an instant, because the engine breaks such a tie per
+ * document on the member's creation time, and each release can therefore win a
+ * different document of the same component.
  */
 async function stopHopelessReleases(
   deps: ApplyDueReleasesDeps,
@@ -250,35 +266,34 @@ async function stopHopelessReleases(
   const permanent = permanentlyBrokenReleases(outcomes);
   if (permanent.size === 0) return 0;
 
-  const toBlock = new Set<string>();
-  for (const group of plan.overlappingReleases) {
-    if (group.some(id => permanent.has(id))) {
-      for (const id of group) toBlock.add(id);
-    }
-  }
-
-  // EARLIEST FIRST, and this ordering is load-bearing rather than tidy. The
-  // component is blocked with one write per release and the port has no
-  // transaction, so a crash or an error partway through leaves it split — and
-  // which half survives decides what the document looks like. Blocking the
-  // earliest first means any prefix that succeeds leaves the LATER releases
-  // still scheduled, and the later one is the winner under the engine's total
-  // order: the document ends in the state the whole component would have left
-  // it in. Blocking the latest first inverts that — the earlier release becomes
-  // the winner and applies the opposite lifecycle action.
-  const ordered = [...toBlock].sort((a, b) => {
-    const at = plannedInstants.get(a)?.getTime() ?? 0;
-    const bt = plannedInstants.get(b)?.getTime() ?? 0;
-    return at - bt;
-  });
-
+  // ONE CALL PER COMPONENT, and the component is the unit of atomicity. The
+  // groups are a partition — union-find over shared documents — so no release
+  // is offered twice and a release sharing nothing appears in a set of one.
+  //
+  // Per component rather than one transaction over all of them: components are
+  // independent by construction, so a single wide transaction would hold locks
+  // across releases that have nothing to do with each other, and one bad
+  // component would roll back every good one beside it.
   let blocked = 0;
-  for (const id of ordered) {
-    const at = plannedInstants.get(id);
-    // A release with no planned instant was not part of this pass's plan, so
-    // there is nothing to fence against and nothing to stop.
-    if (at === undefined) continue;
-    if (await deps.repository.blockRelease(id, at)) blocked += 1;
+  for (const group of plan.overlappingReleases) {
+    if (!group.some(id => permanent.has(id))) continue;
+
+    const entries: { id: string; scheduledAt: Date }[] = [];
+    for (const id of group) {
+      const at = plannedInstants.get(id);
+      // A release with no planned instant was not part of this pass's plan, so
+      // there is nothing to fence against. The WHOLE component is then skipped
+      // rather than the one release: blocking the rest is precisely the split
+      // this pass exists to avoid, and the next pass re-plans against a set it
+      // can fence completely.
+      if (at === undefined) {
+        entries.length = 0;
+        break;
+      }
+      entries.push({ id, scheduledAt: at });
+    }
+
+    blocked += (await deps.repository.blockReleases(entries)).length;
   }
   return blocked;
 }

--- a/packages/nextly/src/domains/releases/releases-repository.ts
+++ b/packages/nextly/src/domains/releases/releases-repository.ts
@@ -13,6 +13,7 @@
  *
  * @module domains/releases/releases-repository
  */
+import { NextlyError } from "../../errors";
 import type { CacheRevalidator } from "../../revalidation/types";
 import {
   RELEASE_ASSEMBLABLE_FROM,
@@ -60,7 +61,35 @@ export type ReleasesDbApi = VersionsDbApi & {
     data: Record<string, unknown>,
     where: VersionsWhere
   ): Promise<number>;
+  /**
+   * Run `work` so that either all of its writes land or none do.
+   *
+   * REQUIRED rather than optional, which is safe for a reason worth stating:
+   * the transaction context cannot satisfy `ReleasesDbApi` in the first place,
+   * because it carries no `updateCount` of the adapter's shape — so the only
+   * thing that ever satisfies this port is the adapter itself, and the adapter
+   * always has a transaction. An optional member would buy nothing and would
+   * hand every caller a silent non-atomic fallback to forget about.
+   */
+  transaction<T>(work: (tx: ReleasesTxApi) => Promise<T>): Promise<T>;
 };
+
+/**
+ * The database surface a release transition needs INSIDE a transaction.
+ *
+ * One method, because the atomic path performs exactly one kind of statement: a
+ * fenced compare-and-set. Kept separate from {@link ReleasesDbApi} rather than
+ * reusing it, because a transaction context genuinely cannot do everything the
+ * adapter can — declaring the wider type here would promise a caller reads and
+ * revalidation that are either unavailable or actively wrong before the commit.
+ */
+export interface ReleasesTxApi {
+  updateCount(
+    table: string,
+    data: Record<string, unknown>,
+    where: VersionsWhere
+  ): Promise<number>;
+}
 
 const RELEASES = "nextly_releases";
 const MEMBERS = "nextly_release_members";
@@ -71,6 +100,12 @@ const MEMBERS = "nextly_release_members";
  * in `pending-transition-cache` exists to avoid.
  */
 const USERS = "users";
+
+/** One release to stop, with the instant the pass planned against. */
+export interface BlockRequest {
+  id: string;
+  scheduledAt: Date;
+}
 
 /** The document a member points at. */
 export interface DocumentRef {
@@ -286,7 +321,32 @@ export class ReleasesRepository {
   }
 
   /**
-   * Stop a release the drain can never apply, and say whether it moved.
+   * Stop a whole component of releases the drain can never apply, ATOMICALLY.
+   *
+   * Takes a SET rather than one release, because the unit that has to move
+   * together is the set of releases sharing a document. Blocking them one
+   * statement at a time leaves the component split whenever the process dies
+   * partway — and a split component is not a smaller version of the right
+   * answer, it is a different one: the surviving release becomes the winner on
+   * every document it shares, and can apply the OPPOSITE lifecycle action to
+   * the one the whole component would have produced.
+   *
+   * ## Why ordering cannot substitute for a transaction
+   *
+   * The previous version blocked earliest-first, reasoning that any surviving
+   * prefix leaves the later — and therefore winning — release scheduled. That
+   * argument fails for tied instants, and not repairably. `resolveReleaseEffect`
+   * breaks a tie on the MEMBER's creation time and then its id, and it does so
+   * per document; two releases naming one instant can therefore each win on a
+   * different document of the same component. No ordering of RELEASES can
+   * preserve a winner that is chosen per member, so there is no comparator that
+   * fixes this and the guarantee has to come from atomicity.
+   *
+   * Fenced on the state AND on the instant the pass planned against, the same
+   * pair `isStillDueAt` judges by. State alone is not enough: an editor who
+   * postpones a due release between the plan and this write leaves the row in
+   * `scheduled`, so a state-only predicate matches and overwrites the schedule
+   * they just chose.
    *
    * Fenced on the state AND on the instant the pass planned against, the same
    * pair `isStillDueAt` judges by. State alone is not enough: an editor who
@@ -301,27 +361,78 @@ export class ReleasesRepository {
    * instant has passed. So its projection is live, and stopping it removes
    * something a reader can currently see. A scheduled release whose instant has
    * NOT arrived would indeed need no flush; that is a different release.
+   *
+   * @returns the ids actually blocked — every id given, or none at all.
    */
-  async blockRelease(id: string, scheduledAt: Date): Promise<boolean> {
-    const affected = await this.db.updateCount(
-      RELEASES,
-      {
-        state: "blocked" satisfies ReleaseState,
-        updatedAt: new Date(),
-      },
-      {
-        and: [
-          { column: "id", op: "=", value: id },
-          { column: "state", op: "=", value: "scheduled" },
-          { column: "scheduledAt", op: "=", value: scheduledAt },
-        ],
-      }
+  async blockReleases(
+    entries: readonly BlockRequest[]
+  ): Promise<readonly string[]> {
+    if (entries.length === 0) return [];
+
+    // ORDERED BY ID, and the reason is no longer the one the previous version
+    // gave. Correctness under partial failure now belongs to the transaction,
+    // so this order cannot affect the outcome; it exists so two drains racing
+    // on overlapping components take the same row locks in the same sequence
+    // and cannot deadlock against each other.
+    const ordered = [...entries].sort((a, b) =>
+      a.id < b.id ? -1 : a.id > b.id ? 1 : 0
     );
-    if (affected === 0) return false;
-    // Also drops the shared transition memo, which would otherwise keep
-    // answering `mayHaveDue` for a release that has stopped.
-    await this.revalidateMembersOf(id);
-    return true;
+
+    // Distinguishes a fence that legitimately matched nothing from a database
+    // failure. Both leave the transaction rolled back, and only the first is an
+    // ordinary outcome the drain should absorb — so the flag decides, rather
+    // than the shape of the error, which a caught-and-rethrown driver error
+    // could imitate.
+    let fenceMissed = false;
+    try {
+      await this.db.transaction(async tx => {
+        for (const entry of ordered) {
+          const affected = await tx.updateCount(
+            RELEASES,
+            {
+              state: "blocked" satisfies ReleaseState,
+              // Always moves, which MySQL requires of a compare-and-set: it
+              // counts CHANGED rows rather than matched ones. `state` moves
+              // here too, so this is belt and braces rather than the only
+              // thing keeping the fence honest.
+              updatedAt: new Date(),
+            },
+            {
+              and: [
+                { column: "id", op: "=", value: entry.id },
+                { column: "state", op: "=", value: "scheduled" },
+                { column: "scheduledAt", op: "=", value: entry.scheduledAt },
+              ],
+            }
+          );
+          if (affected === 0) {
+            fenceMissed = true;
+            throw NextlyError.conflict({
+              logContext: {
+                reason: "release-component-moved",
+                releaseId: entry.id,
+              },
+            });
+          }
+        }
+      });
+    } catch (error) {
+      // A member of the component moved between the plan and this write, so
+      // the component is no longer the one that was judged. NOTHING is blocked
+      // rather than the remainder: a partial transition is the defect this
+      // method exists to make unrepresentable, and the next pass re-plans
+      // against what is now true — which terminates, because a release that
+      // moved is no longer due and drops out of the next plan.
+      if (fenceMissed) return [];
+      throw error;
+    }
+
+    // AFTER THE COMMIT, never inside it. Revalidation makes a change visible to
+    // readers and drops the shared transition memo, and doing that from inside
+    // the transaction would announce a transition that can still roll back —
+    // the reader would then see a release stopped that is still scheduled.
+    for (const entry of ordered) await this.revalidateMembersOf(entry.id);
+    return ordered.map(entry => entry.id);
   }
 
   /**

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -961,32 +961,40 @@ export class ReleasesService {
         logContext: { reason: "invalid-timezone", length: timezone.length },
       });
     }
-    // A BLOCKED release is refused while what stopped it is still true.
-    // Scheduling it again would reach the instant, hit the same member, and
-    // stop again — and the operator would learn that only by waiting for a
-    // launch that does not happen. Checked here rather than left to the drain
-    // because this is the moment somebody is asking, and the answer is already
-    // derivable from the members.
+    // A release is refused while anything that would stop it is still true,
+    // WHATEVER state it is scheduled from. Scheduling it would reach the
+    // instant, hit the same member and stop — and the operator would learn
+    // that only by waiting for a launch that does not happen.
     //
-    // Only for a blocked release: every other state pays no extra read.
+    // For EVERY schedulable state, not only `blocked`, and the symmetry is the
+    // point. A release whose author was deleted while it sat `scheduled` is the
+    // same broken release as one the drain has already labelled, and it becomes
+    // the labelled one at its instant; refusing the first while accepting the
+    // second makes the rule depend on whether a background pass happened to
+    // have run yet, which is not something the person scheduling can see. The
+    // ordinary postponement after a colleague leaves is exactly this case.
+    //
+    // The cost is bounded and falls on a human action rather than a read path:
+    // one query for the members, and a second for their authors only when
+    // there are any. Scheduling is not a hot path, and the alternative is
+    // spending it at the instant instead, when nobody is watching.
     const [current] = await this.deps.repository.findReleases({ ids: [id] });
     const wasBlocked = current?.state === "blocked";
-    if (wasBlocked) {
-      // `derivedBlockers`, not `blockingReasons`: `publish` was authorized
-      // above, and going through the public method would demand `read` as
-      // well — a grant a publish-scoped API key need not hold.
-      const blockers = await this.derivedBlockers(id);
-      if (blockers.length > 0) {
-        throw NextlyError.conflict({
-          message:
-            "This release cannot be scheduled until the documents blocking it are fixed or removed.",
-          logContext: {
-            reason: "release-still-blocked",
-            releaseId: id,
-            blockers: blockers.length,
-          },
-        });
-      }
+    // `derivedBlockers`, not `blockingReasons`: `publish` was authorized above,
+    // and going through the public method would demand `read` as well — a grant
+    // a publish-scoped API key need not hold.
+    const blockers = await this.derivedBlockers(id);
+    if (blockers.length > 0) {
+      throw NextlyError.conflict({
+        message:
+          "This release cannot be scheduled until the documents blocking it are fixed or removed.",
+        logContext: {
+          reason: "release-still-blocked",
+          releaseId: id,
+          blockers: blockers.length,
+          state: current?.state,
+        },
+      });
     }
 
     // FENCED ON THE STATE THE VERDICT ABOVE WAS FORMED AGAINST, which is what

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -207,6 +207,30 @@ function byEngineOrder(
 }
 
 /**
+ * Refuse a schedule the driver could not store, before it reaches the driver.
+ *
+ * A NaN date reaches timestamp encoding and fails differently per dialect, so
+ * the caller's mistake would arrive as an opaque database error instead of the
+ * sentence naming it. The timezone limit is the narrowest dialect's, for the
+ * same reason the title has one: otherwise the call succeeds on two engines
+ * and truncates on the third.
+ */
+function assertUsableSchedule(id: string, at: Date, timezone: string): void {
+  if (Number.isNaN(at.getTime())) {
+    throw NextlyError.invalidInput({
+      message: "`at` is not a valid instant.",
+      logContext: { reason: "invalid-schedule-instant", releaseId: id },
+    });
+  }
+  if (timezone.length === 0 || timezone.length > MAX_RELEASE_TIMEZONE_LENGTH) {
+    throw NextlyError.invalidInput({
+      message: `\`timezone\` must be between 1 and ${MAX_RELEASE_TIMEZONE_LENGTH} characters.`,
+      logContext: { reason: "invalid-timezone", length: timezone.length },
+    });
+  }
+}
+
+/**
  * Why this member cannot be applied, or `null` if it can.
  *
  * The order matters and is the drain's: a member that is BOTH locale-scoped and
@@ -940,27 +964,7 @@ export class ReleasesService {
     actor: ReleaseActor
   ): Promise<void> {
     await this.authorize(actor, "publish");
-    // An unusable instant is refused HERE rather than at the driver. A NaN date
-    // reaches timestamp encoding and fails differently per dialect, so the
-    // caller's mistake arrives as an opaque database error instead of the
-    // sentence naming it.
-    if (Number.isNaN(at.getTime())) {
-      throw NextlyError.invalidInput({
-        message: "`at` is not a valid instant.",
-        logContext: { reason: "invalid-schedule-instant", releaseId: id },
-      });
-    }
-    // Same reason the title has a limit: the narrowest dialect defines the
-    // contract, or the call succeeds on two engines and truncates on the third.
-    if (
-      timezone.length === 0 ||
-      timezone.length > MAX_RELEASE_TIMEZONE_LENGTH
-    ) {
-      throw NextlyError.invalidInput({
-        message: `\`timezone\` must be between 1 and ${MAX_RELEASE_TIMEZONE_LENGTH} characters.`,
-        logContext: { reason: "invalid-timezone", length: timezone.length },
-      });
-    }
+    assertUsableSchedule(id, at, timezone);
     // A release is refused while anything that would stop it is still true,
     // WHATEVER state it is scheduled from. Scheduling it would reach the
     // instant, hit the same member and stop — and the operator would learn
@@ -980,22 +984,7 @@ export class ReleasesService {
     // spending it at the instant instead, when nobody is watching.
     const [current] = await this.deps.repository.findReleases({ ids: [id] });
     const wasBlocked = current?.state === "blocked";
-    // `derivedBlockers`, not `blockingReasons`: `publish` was authorized above,
-    // and going through the public method would demand `read` as well — a grant
-    // a publish-scoped API key need not hold.
-    const blockers = await this.derivedBlockers(id);
-    if (blockers.length > 0) {
-      throw NextlyError.conflict({
-        message:
-          "This release cannot be scheduled until the documents blocking it are fixed or removed.",
-        logContext: {
-          reason: "release-still-blocked",
-          releaseId: id,
-          blockers: blockers.length,
-          state: current?.state,
-        },
-      });
-    }
+    await this.assertNothingBlocks(id, current?.state);
 
     // FENCED ON THE STATE THE VERDICT ABOVE WAS FORMED AGAINST, which is what
     // makes the check and the write one decision rather than two.
@@ -1014,9 +1003,16 @@ export class ReleasesService {
     //     a decision made after the verdict.
     //
     // Either way the caller is told, and a retry re-derives against what is
-    // now true. The alternative — a transaction — is not available: the port
-    // exposes no transaction, which is the same constraint the drain's
-    // blocking pass works within.
+    // now true.
+    //
+    // A compare-and-set rather than a transaction, and that is now a choice
+    // rather than a constraint — the port gained one for the drain's blocking
+    // pass. It is the right choice here: a transaction would have to span the
+    // read, an identity lookup for the blockers and the write, holding row
+    // locks across a query that touches another table entirely, to buy a
+    // guarantee this single fenced UPDATE already provides. The blocking pass
+    // needs a transaction because it writes to SEVERAL rows that must move
+    // together; this writes to one.
     const from = wasBlocked
       ? RELEASE_SCHEDULABLE_FROM_BLOCKED
       : RELEASE_SCHEDULABLE_FROM_UNBLOCKED;
@@ -1031,6 +1027,46 @@ export class ReleasesService {
         logContext: { reason: "release-not-schedulable", releaseId: id },
       });
     }
+  }
+
+  /**
+   * Refuse a release whose members carry something nothing can run.
+   *
+   * Only for a state the fence could actually accept. A terminal state —
+   * `published` above all — is refused by the fence whatever its members look
+   * like, and deriving blockers first would answer with the wrong sentence:
+   * "fix or remove the documents blocking it" describes a recovery that does
+   * not exist there, because `RELEASE_ASSEMBLABLE_FROM` excludes `published`
+   * and `removeMember` refuses. An operator would be sent to do something the
+   * product will not let them do, instead of being told the release has
+   * already happened.
+   *
+   * A release that is not there at all takes the same path: there is nothing
+   * to derive blockers from, and the fence reports it as unschedulable.
+   *
+   * `derivedBlockers`, not `blockingReasons`: the caller has authorized
+   * `publish` already, and the public method would demand `read` as well — a
+   * grant a publish-scoped API key need not hold.
+   */
+  private async assertNothingBlocks(
+    id: string,
+    state: ReleaseState | undefined
+  ): Promise<void> {
+    if (state === undefined || !RELEASE_SCHEDULABLE_FROM.includes(state)) {
+      return;
+    }
+    const blockers = await this.derivedBlockers(id);
+    if (blockers.length === 0) return;
+    throw NextlyError.conflict({
+      message:
+        "This release cannot be scheduled until the documents blocking it are fixed or removed.",
+      logContext: {
+        reason: "release-still-blocked",
+        releaseId: id,
+        blockers: blockers.length,
+        state,
+      },
+    });
   }
 
   async cancel(id: string, actor: ReleaseActor): Promise<void> {


### PR DESCRIPTION
Follow-up to #1395, working the two findings raised at its merged head.

The first of them **retired a fix rather than extending it**, and that is the substance of this PR.

## [P1] Block tied overlapping releases atomically

Releases sharing a document form a component that is only ever discharged together. The blocking pass moved them one write at a time, so a process dying partway left the component split — and a split component is not a smaller version of the right answer: the survivor becomes the winner on every shared document and can apply the **opposite** lifecycle action to the one the whole component would have produced.

**The previous mitigation cannot be repaired, and I checked before trying.** It ordered the writes earliest-first, reasoning that any surviving prefix leaves the winning release scheduled. `resolveReleaseEffect` breaks a tie on the MEMBER's creation time and then its id, and it does so **per document** — so two releases naming one instant can each win a different document of the same component:

```
D1: memberA(created 10:00), memberB(created 11:00)  → B wins
D2: memberA(created 12:00), memberB(created 09:00)  → A wins
```

Blocking either first corrupts the other document. No ordering of RELEASES can preserve a winner chosen per MEMBER, so a better comparator would read as a fix and still be wrong. The ordering that remains is only a lock-ordering discipline against concurrent drains; the guarantee comes from a transaction, and a partial transition is no longer representable.

Each component gets its own transaction rather than one wide one: components are independent by construction, so a single transaction would hold locks across unrelated releases and let one bad component roll back every good one beside it.

## The adapter change, and why it is needed

`TransactionContext` forwarded five CRUD verbs but not `updateCount` — the only statement that can perform a fenced compare-and-set inside a transaction. `update` cannot stand in, and the adapter's own docblock says why:

> RETURNING it re-SELECTs using the same WHERE — so a conditional update that just changed a column named in that WHERE reads back zero rows and a write that landed reports as unmatched.

The fence sets `state` scheduled→blocked and `state` is in the WHERE, so `update` + RETURNING would report a successful transition as a failed one. That is a correctness requirement, not a preference.

`adapter.updateCount(table, data, where, executor?)` **already accepts a transaction executor**, so this exposes an existing capability rather than adding one. I could find **no reason** for the omission and I am not claiming it was incidental: it predates the forwarder by eight days, and two refactors that day passed over it. If someone knows why, that is worth hearing before this merges.

⚠️ The forwarder's docblock now carries the inherited MySQL trap: MySQL counts CHANGED rows rather than matched, so any tx-bound compare-and-set must write a column that always moves. This fence moves `state` and `updatedAt`.

## [P2] Validate blockers for every schedulable state

Scheduling derived blockers only for a release the drain had already marked `blocked`. The asymmetry made the rule depend on whether a background pass had run yet: the same release with the same deleted author was refused once labelled and accepted before — not a distinction the person scheduling can see, and the ordinary postponement after a colleague leaves is exactly this case.

Cost measured before choosing: one query for the members, and a second for their authors only when there are any — on a human action, not a read path. The alternative is paying it at the instant instead, when nobody is watching.

**This is a deliberate behaviour change**: a release with an unrunnable member is now refused from `draft`, `scheduled` and `cancelled` too, where it previously scheduled and then stopped at its instant. A test that pinned the old behaviour was replaced rather than deleted, and the replacement says what it replaced.

## Evidence

Five break-verifications, each failing exactly the named test:

| break | test that failed |
|---|---|
| writes run outside a transaction | `blocks a whole component ATOMICALLY, or not at all` |
| one call per release, not per component | `hands a whole overlapping COMPONENT over in ONE call` |
| skip only the unfencable release | `skips a component it cannot fence COMPLETELY` |
| forward without the tx executor | `forwards updateCount with the transaction executor` |
| validate only when already blocked | `is refused from ANY schedulable state` |

The first reproduces the defect itself against a real database: without the transaction the component comes back `['blocked', 'scheduled']`. Its control — every fence matching — stays green under that break, so the test discriminates rather than merely reddening.

The integration case orders the failing fence **second** on purpose: the first UPDATE has already run by then, so it tests the rollback rather than a statement never issued.

## Gates

Full pre-push hook, no bypass: lint 22/22, build 19/19, `check-types` 22/22, tests 8/8 — nextly **841 files**, adapter-drizzle **9 files**, zero failures. `fallow audit --base origin/main`: `pass`, 10 changed files, all `*_introduced` zero.

@codex please review