### PR TITLE
feat(admin): render dashboard widgets from the batched query endpoint

### DIFF
--- a/.changeset/a-dashboard-widget-draws-itself.md
+++ b/.changeset/a-dashboard-widget-draws-itself.md
@@ -1,0 +1,48 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The dashboard now draws widgets. The server half — the registry, the query
+contract and `POST /api/dashboard/query` — has been merged and unused, with
+nothing on the client asking it anything.
+
+Widgets share one anatomy: a header, a body, and an optional footer carrying a
+freshness line and at most one link. Core draws that frame for declarative
+archetypes and plugin components alike, so a plugin contributes a body and
+inherits the loading, error and accessibility behaviour rather than deciding it
+again. Loading marks the body busy instead of replacing it with a spinner, so a
+refresh does not discard the number already on screen, and a widget that fails
+keeps its title — an anonymous error box does not say which card broke.
+
+Every visible widget's query goes out in a single request, and a widget the
+current user may not see contributes no query at all. Sizes are named steps on a
+twelve-column grid; below the `md` breakpoint every widget is full width, which
+the previous plugin grid got wrong.
+
+Only the `metric` archetype renders in this release. The rest report themselves
+as not yet drawn rather than coming up blank, and a payload that does not match
+its archetype says so rather than being silently coerced into a number.

--- a/packages/admin/src/components/features/widgets/WidgetCard.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetCard.tsx
@@ -22,6 +22,14 @@
  * dashboard of ten cards does not tell the user which widget broke, which is
  * the only thing they need in order to do anything about it.
  *
+ * And it is ordinary content, NOT a live region. `role="alert"` is assertive by
+ * definition, so a card that used it became its own interrupting announcer:
+ * five widgets failing at once produced five announcements that spoke over each
+ * other and over the grid's single polite one. The grid owns announcing for the
+ * whole batch, following `EntryForm/DocumentStatusLive`, and the card's job is
+ * to be findable afterwards -- which the region landmark and its title already
+ * do.
+ *
  * Colour comes from the `--nx-*` token scale through its semantic Tailwind
  * classes (`bg-card`, `text-muted-foreground`, `text-destructive`), which are
  * defined for light and dark alike. No hex values.
@@ -116,7 +124,6 @@ export function WidgetCard({
       >
         {error !== null ? (
           <p
-            role="alert"
             className="text-sm text-destructive"
             data-testid="widget-card-error"
           >

--- a/packages/admin/src/components/features/widgets/WidgetCard.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetCard.tsx
@@ -30,6 +30,16 @@
  * to be findable afterwards -- which the region landmark and its title already
  * do.
  *
+ * The card is FLAT AND BORDERED, with no internal rules. It sits on a dashboard
+ * beside the Users and Roles stat cards, and a plugin's widget that reads as a
+ * different component is a plugin that looks bolted on. Those neighbours are a
+ * single padded surface: one outer border, the figure large, its label small and
+ * muted, an icon in the top-right corner. So the header divider is off, the
+ * footer is a quiet line inside the card rather than a tinted strip under a
+ * rule, the padding is one step at every level, and the icon moves to the right
+ * where the neighbours put theirs. Two borders and a filled band across the
+ * bottom made a card twice the visual weight of the ones next to it.
+ *
  * Colour comes from the `--nx-*` token scale through its semantic Tailwind
  * classes (`bg-card`, `text-muted-foreground`, `text-destructive`), which are
  * defined for light and dark alike. No hex values.
@@ -82,10 +92,17 @@ export function WidgetCard({
   className,
 }: WidgetCardProps) {
   const titleId = useId();
-  // A broken card offers no "view all": the destination is the thing that just
-  // failed to answer, so the link is an invitation into the same failure.
-  const showLink = link !== undefined && error === null;
-  const showFooter = showLink || updatedAt !== null;
+  // What a card in an error state withholds, decided once.
+  //
+  // It offers no "view all": the destination is the thing that just failed to
+  // answer, so the link is an invitation into the same failure. And it claims
+  // no freshness: the timestamp is when the BATCH landed, which is true of the
+  // request and not of this card -- "Updated just now" printed under "Source
+  // unavailable." tells the reader the opposite of what happened.
+  //
+  // Here rather than at each caller, so an archetype added later inherits both
+  // rather than having to remember them.
+  const settled = error === null;
 
   return (
     <Card
@@ -96,20 +113,12 @@ export function WidgetCard({
       aria-labelledby={titleId}
       className={cn("flex h-full flex-col", className)}
     >
-      <CardHeader className="flex-row items-center gap-2 space-y-0">
-        {icon && (
-          <span className="shrink-0 text-muted-foreground" aria-hidden="true">
-            {icon}
-          </span>
-        )}
-        <CardTitle
-          id={titleId}
-          className="min-w-0 flex-1 truncate text-sm font-semibold"
-        >
-          {title}
-        </CardTitle>
-        {headerAction && <span className="shrink-0">{headerAction}</span>}
-      </CardHeader>
+      <WidgetCardHeader
+        titleId={titleId}
+        title={title}
+        icon={icon}
+        headerAction={headerAction}
+      />
 
       <CardContent
         data-testid="widget-card-body"
@@ -118,7 +127,7 @@ export function WidgetCard({
         // attribute is a weaker signal than one that says "no longer busy".
         aria-busy={isLoading}
         className={cn(
-          "flex flex-1 flex-col justify-center p-4",
+          "flex flex-1 flex-col justify-center px-5 pb-5 pt-2",
           isLoading && "opacity-60 transition-opacity"
         )}
       >
@@ -134,33 +143,107 @@ export function WidgetCard({
         )}
       </CardContent>
 
-      {showFooter && (
-        <CardFooter
-          data-testid="widget-card-footer"
-          className="flex items-center justify-between gap-2 border-t border-border px-4 py-2"
-        >
-          {updatedAt !== null ? (
-            <span
-              data-testid="widget-card-freshness"
-              className="text-xs text-muted-foreground"
-            >
-              Updated {formatRelativeTime(updatedAt.toISOString())}
-            </span>
-          ) : (
-            // Holds the footer's left column so a link-only footer still sits
-            // right, without a second layout branch.
-            <span />
-          )}
-          {showLink && (
-            <Link
-              href={link.href}
-              className="text-xs font-medium text-primary hover:underline focus-visible:underline"
-            >
-              {link.label}
-            </Link>
-          )}
-        </CardFooter>
-      )}
+      <WidgetCardFooter
+        freshness={settled ? updatedAt : null}
+        link={settled ? link : undefined}
+      />
     </Card>
+  );
+}
+
+/**
+ * The card's header, drawn as one row.
+ *
+ * Its own component so `WidgetCard` above stays a description of the card's
+ * STATES rather than of its markup -- which is the part an archetype author
+ * reads.
+ *
+ * The icon sits on the RIGHT, where the Users and Roles stat cards beside this
+ * one put theirs. It is optional and functional rather than decorative: an icon
+ * on every card is noise.
+ */
+function WidgetCardHeader({
+  titleId,
+  title,
+  icon,
+  headerAction,
+}: {
+  titleId: string;
+  title: string;
+  icon?: ReactNode;
+  headerAction?: ReactNode;
+}) {
+  return (
+    <CardHeader
+      // No rule under the header. The stat cards beside this one are a single
+      // padded surface, and a divider is the difference between a card and a
+      // panel.
+      noBorder
+      className="flex-row items-start gap-2 space-y-0 px-5 pb-0 pt-5"
+    >
+      <CardTitle
+        id={titleId}
+        className="min-w-0 flex-1 truncate text-xs font-semibold tracking-tight text-muted-foreground"
+      >
+        {title}
+      </CardTitle>
+      {icon && (
+        <span
+          className="shrink-0 pt-0.5 text-muted-foreground"
+          aria-hidden="true"
+        >
+          {icon}
+        </span>
+      )}
+      {headerAction && <span className="shrink-0">{headerAction}</span>}
+    </CardHeader>
+  );
+}
+
+/**
+ * The freshness line and the single footer link, or nothing at all.
+ *
+ * Both are already resolved by the time they arrive: an error state withholds
+ * each of them, and that decision belongs with the card's other state rules
+ * rather than being taken again here.
+ */
+function WidgetCardFooter({
+  freshness,
+  link,
+}: {
+  freshness: Date | null;
+  link?: { label: string; href: string };
+}) {
+  if (freshness === null && link === undefined) return null;
+
+  return (
+    <CardFooter
+      data-testid="widget-card-footer"
+      // No top rule and no tint. `CardFooter` defaults to both, which draws a
+      // filled strip across the bottom and reads as a separate element attached
+      // to the card rather than as part of it.
+      className="flex items-center justify-between gap-2 border-0 bg-transparent px-5 pb-4 pt-0"
+    >
+      {freshness !== null ? (
+        <span
+          data-testid="widget-card-freshness"
+          className="text-xs text-muted-foreground"
+        >
+          Updated {formatRelativeTime(freshness.toISOString())}
+        </span>
+      ) : (
+        // Holds the footer's left column so a link-only footer still sits
+        // right, without a second layout branch.
+        <span />
+      )}
+      {link !== undefined && (
+        <Link
+          href={link.href}
+          className="text-xs font-medium text-primary hover:underline focus-visible:underline"
+        >
+          {link.label}
+        </Link>
+      )}
+    </CardFooter>
   );
 }

--- a/packages/admin/src/components/features/widgets/WidgetCard.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetCard.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+/**
+ * The one anatomy every dashboard widget wears.
+ *
+ * Header, body, optional footer — drawn by core for declarative archetypes and
+ * for plugin components alike. A plugin contributes a BODY and nothing else,
+ * which is what stops one plugin's card from looking unlike the rest of the
+ * dashboard and what makes the loading, error and accessibility work below
+ * apply to every widget without each author reimplementing it.
+ *
+ * Two decisions that are easy to get backwards:
+ *
+ * Loading marks the body `aria-busy`; it does not swap in a spinner. A spinner
+ * discards the numbers the reader was already looking at on every window-focus
+ * refetch — and this grid refetches on focus by convention — so the card would
+ * flicker between a value and a spinner for data that usually comes back
+ * unchanged. `aria-busy` says the same thing to a screen reader without
+ * destroying the visible state.
+ *
+ * An error replaces the body and KEEPS the title. An anonymous error box on a
+ * dashboard of ten cards does not tell the user which widget broke, which is
+ * the only thing they need in order to do anything about it.
+ *
+ * Colour comes from the `--nx-*` token scale through its semantic Tailwind
+ * classes (`bg-card`, `text-muted-foreground`, `text-destructive`), which are
+ * defined for light and dark alike. No hex values.
+ *
+ * @module components/features/widgets/WidgetCard
+ */
+
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@nextlyhq/ui";
+import { useId, type ReactNode } from "react";
+
+import { Link } from "@admin/components/ui/link";
+import { formatRelativeTime } from "@admin/lib/dashboard";
+import { cn } from "@admin/lib/utils";
+
+export interface WidgetCardProps {
+  /** Always rendered, in every state. */
+  title: string;
+  /** Optional, and functional rather than decorative — an icon per card is noise. */
+  icon?: ReactNode;
+  /** Room for the overflow menu the next slice adds. */
+  headerAction?: ReactNode;
+  /** Marks the body busy. Does not replace it. */
+  isLoading?: boolean;
+  /** Replaces the body. The title stays. */
+  error?: string | null;
+  /** When this widget's data landed, for the footer's freshness line. */
+  updatedAt?: Date | null;
+  /** At most ONE. A footer is not a row of buttons. */
+  link?: { label: string; href: string };
+  /** The archetype's rendering, or the plugin's component. */
+  children: ReactNode;
+  className?: string;
+}
+
+export function WidgetCard({
+  title,
+  icon,
+  headerAction,
+  isLoading = false,
+  error = null,
+  updatedAt = null,
+  link,
+  children,
+  className,
+}: WidgetCardProps) {
+  const titleId = useId();
+  // A broken card offers no "view all": the destination is the thing that just
+  // failed to answer, so the link is an invitation into the same failure.
+  const showLink = link !== undefined && error === null;
+  const showFooter = showLink || updatedAt !== null;
+
+  return (
+    <Card
+      // `region` + the title as its name is what lets a screen-reader user jump
+      // between widgets and know which one they landed on. Without the name a
+      // region is worse than no landmark at all.
+      role="region"
+      aria-labelledby={titleId}
+      className={cn("flex h-full flex-col", className)}
+    >
+      <CardHeader className="flex-row items-center gap-2 space-y-0">
+        {icon && (
+          <span className="shrink-0 text-muted-foreground" aria-hidden="true">
+            {icon}
+          </span>
+        )}
+        <CardTitle
+          id={titleId}
+          className="min-w-0 flex-1 truncate text-sm font-semibold"
+        >
+          {title}
+        </CardTitle>
+        {headerAction && <span className="shrink-0">{headerAction}</span>}
+      </CardHeader>
+
+      <CardContent
+        data-testid="widget-card-body"
+        // Explicitly `false` rather than absent when idle: a reader that saw
+        // `aria-busy="true"` needs the attribute to change back, and an omitted
+        // attribute is a weaker signal than one that says "no longer busy".
+        aria-busy={isLoading}
+        className={cn(
+          "flex flex-1 flex-col justify-center p-4",
+          isLoading && "opacity-60 transition-opacity"
+        )}
+      >
+        {error !== null ? (
+          <p
+            role="alert"
+            className="text-sm text-destructive"
+            data-testid="widget-card-error"
+          >
+            {error}
+          </p>
+        ) : (
+          children
+        )}
+      </CardContent>
+
+      {showFooter && (
+        <CardFooter
+          data-testid="widget-card-footer"
+          className="flex items-center justify-between gap-2 border-t border-border px-4 py-2"
+        >
+          {updatedAt !== null ? (
+            <span
+              data-testid="widget-card-freshness"
+              className="text-xs text-muted-foreground"
+            >
+              Updated {formatRelativeTime(updatedAt.toISOString())}
+            </span>
+          ) : (
+            // Holds the footer's left column so a link-only footer still sits
+            // right, without a second layout branch.
+            <span />
+          )}
+          {showLink && (
+            <Link
+              href={link.href}
+              className="text-xs font-medium text-primary hover:underline focus-visible:underline"
+            >
+              {link.label}
+            </Link>
+          )}
+        </CardFooter>
+      )}
+    </Card>
+  );
+}

--- a/packages/admin/src/components/features/widgets/WidgetCard.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetCard.tsx
@@ -127,7 +127,11 @@ export function WidgetCard({
         // attribute is a weaker signal than one that says "no longer busy".
         aria-busy={isLoading}
         className={cn(
-          "flex flex-1 flex-col justify-center px-5 pb-5 pt-2",
+          // Top-aligned, not centred. Cards in a grid row stretch to the
+          // tallest of them, so centring floats a one-line figure in the middle
+          // of whatever the tallest card in that row happens to be -- while the
+          // stat cards beside it keep their number directly under its label.
+          "flex flex-1 flex-col justify-start px-5 pb-5 pt-2",
           isLoading && "opacity-60 transition-opacity"
         )}
       >

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * The dashboard's widget grid.
+ *
+ * Twelve columns, one cell per visible widget, and ONE request for all of them.
+ * The grid is where the three cross-cutting decisions live, because none of
+ * them can be made correctly by a widget on its own:
+ *
+ * - **Batching.** Every visible widget's query goes out together, so a
+ *   dashboard costs one round trip rather than one per card.
+ * - **Gating.** A widget the user may not see is dropped before its query is
+ *   collected, so a denied card causes no request on their behalf.
+ * - **Announcement.** ONE live region for the whole grid, following
+ *   `EntryForm/DocumentStatusLive`. Ten widgets each announcing their own
+ *   refresh would interrupt each other, and a reader could not tell which
+ *   announcement belonged to what they just did — so the grid speaks once, for
+ *   the batch, and the cards stay silent.
+ *
+ * @module components/features/widgets/WidgetGrid
+ */
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { useBranding } from "@admin/context/providers/BrandingProvider";
+import {
+  useWidgetQueries,
+  type WidgetQueryRequest,
+} from "@admin/hooks/queries/useWidgetQueries";
+import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
+import { cn } from "@admin/lib/utils";
+
+import { resolveDashboardWidgets } from "./resolve-widgets";
+import { widgetSpanClass } from "./sizes";
+import { WidgetRenderer } from "./WidgetRenderer";
+
+/**
+ * What the grid says once a batch settles, or `null` for a state not worth
+ * interrupting a reader for.
+ *
+ * Mid-flight says nothing, for the same reason `DocumentStatusLive` stays quiet
+ * during a save: this grid refetches on every window focus, and announcing the
+ * start of each refresh would speak over the reader every time they came back
+ * to the tab. What matters is where it came to rest.
+ */
+function settledAnnouncement(
+  isLoading: boolean,
+  hasError: boolean,
+  total: number,
+  failed: number
+): string | null {
+  if (total === 0) return null;
+  if (hasError) return "Dashboard widgets could not be updated.";
+  if (isLoading) return null;
+  const loaded = total - failed;
+  const noun = total === 1 ? "widget" : "widgets";
+  return failed > 0
+    ? `${loaded} of ${total} ${noun} updated, ${failed} failed.`
+    : `${loaded} of ${total} ${noun} updated.`;
+}
+
+export function WidgetGrid() {
+  const branding = useBranding();
+  const { hasPermission } = useCurrentUserPermissions();
+
+  const widgets = useMemo(
+    () => resolveDashboardWidgets(branding?.plugins, hasPermission),
+    [branding, hasPermission]
+  );
+
+  // Only the archetypes that ASK for data. A `custom` widget fetches its own,
+  // and putting it in the batch would send a query nothing reads.
+  const requests = useMemo<WidgetQueryRequest[]>(
+    () =>
+      widgets.flatMap(widget =>
+        widget.query ? [{ widgetId: widget.id, query: widget.query }] : []
+      ),
+    [widgets]
+  );
+
+  const { slots, isLoading, error, updatedAt } = useWidgetQueries(requests);
+
+  const failed = useMemo(
+    () => Object.values(slots).filter(slot => !slot.ok).length,
+    [slots]
+  );
+
+  const [announcement, setAnnouncement] = useState("");
+  // What was last spoken, so an unchanged outcome does not re-fire. A ref
+  // rather than state because it must not itself cause a render.
+  const spoken = useRef("");
+  const next = settledAnnouncement(
+    isLoading,
+    error !== null,
+    requests.length,
+    failed
+  );
+
+  useEffect(() => {
+    if (!next || next === spoken.current) return;
+    spoken.current = next;
+    setAnnouncement(next);
+  }, [next]);
+
+  // Nothing to draw. Returned after the hooks above so the hook order is the
+  // same on every render, whatever the branding says.
+  if (widgets.length === 0) return null;
+
+  return (
+    <section aria-label="Dashboard widgets" className="grid grid-cols-12 gap-6">
+      <span
+        role="status"
+        aria-live="polite"
+        className="sr-only"
+        data-testid="widget-grid-live"
+      >
+        {announcement}
+      </span>
+      {widgets.map(widget => (
+        <div
+          key={widget.id}
+          data-testid={`widget-cell-${widget.id}`}
+          className={cn(widgetSpanClass(widget.size))}
+        >
+          <WidgetRenderer
+            definition={widget}
+            slot={slots[widget.id]}
+            updatedAt={widget.query ? updatedAt : null}
+          />
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -91,7 +91,8 @@ export function WidgetGrid() {
     [widgets]
   );
 
-  const { slots, isLoading, error, updatedAt } = useWidgetQueries(requests);
+  const { slots, isLoading, isFetching, error, updatedAt } =
+    useWidgetQueries(requests);
 
   const failed = useMemo(
     () => Object.values(slots).filter(slot => !slot.ok).length,
@@ -139,6 +140,10 @@ export function WidgetGrid() {
             definition={widget}
             slot={slots[widget.id]}
             updatedAt={widget.query ? updatedAt : null}
+            // Only a widget that asked for something can be waiting on an
+            // answer. A card drawn entirely by a plugin component took no part
+            // in the batch, so a refetch says nothing about it.
+            isFetching={widget.query ? isFetching : false}
           />
         </div>
       ))}

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -30,6 +30,7 @@ import {
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { cn } from "@admin/lib/utils";
 
+import { resolveWidgetOutcome } from "./outcome";
 import { resolveDashboardWidgets } from "./resolve-widgets";
 import { widgetSpanClass } from "./sizes";
 import { WidgetRenderer } from "./WidgetRenderer";
@@ -42,15 +43,19 @@ import { WidgetRenderer } from "./WidgetRenderer";
  * during a save: this grid refetches on every window focus, and announcing the
  * start of each refresh would speak over the reader every time they came back
  * to the tab. What matters is where it came to rest.
+ *
+ * `failed` counts CARDS THAT SHOW AN ERROR, not slots the server marked bad,
+ * and the two are different numbers. There is no separate "the whole request
+ * failed" sentence either: a rejected request gives every widget in it a failed
+ * slot, so the counts already say so -- and with the requests partitioned, one
+ * batch failing does not mean the dashboard did.
  */
 function settledAnnouncement(
   isLoading: boolean,
-  hasError: boolean,
   total: number,
   failed: number
 ): string | null {
   if (total === 0) return null;
-  if (hasError) return "Dashboard widgets could not be updated.";
   if (isLoading) return null;
   const loaded = total - failed;
   const noun = total === 1 ? "widget" : "widgets";
@@ -91,24 +96,33 @@ export function WidgetGrid() {
     [widgets]
   );
 
-  const { slots, isLoading, isFetching, error, updatedAt } =
-    useWidgetQueries(requests);
+  const { slots, isFetching, updatedAt } = useWidgetQueries(requests);
 
-  const failed = useMemo(
-    () => Object.values(slots).filter(slot => !slot.ok).length,
-    [slots]
+  // The same answer the cards are drawn from, so the announcement cannot
+  // describe a dashboard other than the one on screen. Counting slots instead
+  // said "3 of 3 widgets updated" while a card read "the list archetype is not
+  // rendered yet": the response was fine and the card was not.
+  //
+  // Only widgets that ASKED are counted, and self-drawn ones are dropped even
+  // when they did. A plugin component decides what it shows from the slot it
+  // was handed, so core cannot say whether it worked, and guessing either way
+  // would put a number in the reader's ear that nothing on screen supports.
+  const counted = useMemo(
+    () =>
+      widgets
+        .filter(widget => widget.query)
+        .map(widget => resolveWidgetOutcome(widget, slots[widget.id]))
+        .filter(outcome => outcome.state !== "self-drawn"),
+    [widgets, slots]
   );
+  const failed = counted.filter(outcome => outcome.state === "failed").length;
+  const settling = counted.some(outcome => outcome.state === "loading");
 
   const [announcement, setAnnouncement] = useState("");
   // What was last spoken, so an unchanged outcome does not re-fire. A ref
   // rather than state because it must not itself cause a render.
   const spoken = useRef("");
-  const next = settledAnnouncement(
-    isLoading,
-    error !== null,
-    requests.length,
-    failed
-  );
+  const next = settledAnnouncement(settling, counted.length, failed);
 
   useEffect(() => {
     if (!next || next === spoken.current) return;

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -76,8 +76,13 @@ export function WidgetGrid() {
     [branding, hasPermission]
   );
 
-  // Only the archetypes that ASK for data. A `custom` widget fetches its own,
-  // and putting it in the batch would send a query nothing reads.
+  // Every widget that DECLARED a query, archetype notwithstanding. `custom` is
+  // included on purpose: core's widget validator puts it in neither the data
+  // set nor the query-less set, because a widget that draws its own body may
+  // still want the host to run its request -- and `WidgetRenderer` hands the
+  // resulting slot to the plugin component. A widget that declares no query
+  // contributes nothing here, which is what keeps a dashboard of plugin
+  // components from issuing a request at all.
   const requests = useMemo<WidgetQueryRequest[]>(
     () =>
       widgets.flatMap(widget =>

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -63,8 +63,16 @@ export function WidgetGrid() {
   const branding = useBranding();
   const { hasPermission } = useCurrentUserPermissions();
 
+  // Both channels a widget can reach the dashboard by: `contributes.admin.widgets`
+  // and the registry `registerWidget` writes to. Reading only the first made the
+  // registry invisible to the renderer built around it.
   const widgets = useMemo(
-    () => resolveDashboardWidgets(branding?.plugins, hasPermission),
+    () =>
+      resolveDashboardWidgets(
+        branding?.plugins,
+        branding?.widgets,
+        hasPermission
+      ),
     [branding, hasPermission]
   );
 

--- a/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
@@ -110,6 +110,22 @@ export function WidgetRenderer({
   }
 
   if (!slot) {
+    // Absent means IN FLIGHT, and only a widget that actually asked for
+    // something can have a request in flight. One with no query never will, so
+    // reading its absent slot as busy leaves the card spinning for the life of
+    // the page -- with nothing on screen, in the live region or in the console
+    // saying why. `resolve-widgets` prefers a contributed component over this,
+    // so reaching here means there was none to prefer.
+    if (!definition.query) {
+      return (
+        <WidgetCard
+          {...shared}
+          error={`The "${definition.archetype}" archetype is drawn from a query, and this widget declares none.`}
+        >
+          {null}
+        </WidgetCard>
+      );
+    }
     return (
       <WidgetCard {...shared} isLoading>
         {null}

--- a/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
@@ -84,14 +84,24 @@ export function WidgetRenderer({
     link: definition.link,
   };
 
-  // The escape hatch. A plugin component owns its own loading and empty states
-  // and never took part in the batch, so the card asserts nothing about either.
+  // The escape hatch. A plugin component draws its own body, so the card
+  // asserts nothing about its loading or empty states -- the component knows
+  // what it is showing and the card does not.
+  //
+  // It DOES receive its slot. `custom` is deliberately allowed to carry a
+  // query: core's own validator puts it in neither the data set nor the
+  // query-less set, because a widget that draws itself may still want the host
+  // to run its request. The grid honours that by putting the query in the
+  // batch, so withholding the answer here would make every such widget pay for
+  // a database read on every mount and every window focus and then fetch the
+  // same data again for itself. `undefined` while the batch is in flight, and
+  // the component decides what that looks like.
   if (definition.archetype === "custom") {
     return (
       <WidgetCard {...shared}>
         <PluginSlot
           path={definition.component}
-          props={{ widgetId: definition.id }}
+          props={{ widgetId: definition.id, slot }}
         />
       </WidgetCard>
     );

--- a/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
@@ -71,12 +71,23 @@ export interface WidgetRendererProps {
   slot: WidgetSlot | undefined;
   /** When the batch this slot came from landed, for the freshness line. */
   updatedAt?: Date | null;
+  /**
+   * Whether a request for this widget is in flight RIGHT NOW, including a
+   * background refetch that is keeping the previous answer on screen.
+   *
+   * Separate from the slot's absence, which is only ever the first load. This
+   * grid refetches on every window focus and the cards deliberately keep their
+   * numbers through it, so without this a reader using a screen reader had no
+   * way to know the dashboard was reading again.
+   */
+  isFetching?: boolean;
 }
 
 export function WidgetRenderer({
   definition,
   slot,
   updatedAt = null,
+  isFetching = false,
 }: WidgetRendererProps) {
   const shared = {
     title: definition.title,
@@ -143,9 +154,18 @@ export function WidgetRenderer({
     );
   }
 
+  // From here down the card is showing an ANSWER, so `isLoading` reports a
+  // refetch rather than a first load -- it marks the body busy and leaves what
+  // is already there alone, which is the whole reason the card marks rather
+  // than replaces.
   if (!slot.ok) {
     return (
-      <WidgetCard {...shared} error={slot.error} updatedAt={updatedAt}>
+      <WidgetCard
+        {...shared}
+        error={slot.error}
+        updatedAt={updatedAt}
+        isLoading={isFetching}
+      >
         {null}
       </WidgetCard>
     );
@@ -154,14 +174,19 @@ export function WidgetRenderer({
   const outcome = body(slot.result, definition);
   if (!outcome.ok) {
     return (
-      <WidgetCard {...shared} error={outcome.message} updatedAt={updatedAt}>
+      <WidgetCard
+        {...shared}
+        error={outcome.message}
+        updatedAt={updatedAt}
+        isLoading={isFetching}
+      >
         {null}
       </WidgetCard>
     );
   }
 
   return (
-    <WidgetCard {...shared} updatedAt={updatedAt}>
+    <WidgetCard {...shared} updatedAt={updatedAt} isLoading={isFetching}>
       {outcome.node}
     </WidgetCard>
   );

--- a/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
@@ -9,6 +9,10 @@
  * of them again. Adding `table`, `list`, `text` and `actions` is one entry in
  * `ARCHETYPE_BODIES` each.
  *
+ * WHICH of those states a widget is in is decided by `resolveWidgetOutcome`
+ * rather than here, because the grid has to count the same answer for its live
+ * region. See `./outcome`.
+ *
  * `custom` is the exception, and it does NOT get a second resolution path: it
  * goes through `PluginSlot`, which already resolves a component path against
  * the registry and already isolates a throw behind `PluginComponentBoundary`.
@@ -18,7 +22,6 @@
  * @module components/features/widgets/WidgetRenderer
  */
 
-import type { WidgetArchetype } from "nextly/config";
 import type { ReactNode } from "react";
 
 import * as Icons from "@admin/components/icons";
@@ -28,20 +31,8 @@ import type {
   WidgetSlot,
 } from "@admin/types/dashboard/widgets";
 
-import { metricBody } from "./archetypes/metric";
-import type { ArchetypeBody } from "./archetypes/types";
+import { resolveWidgetOutcome } from "./outcome";
 import { WidgetCard } from "./WidgetCard";
-
-/**
- * The archetypes core draws from a query result.
- *
- * Partial on purpose: an archetype with no entry is one this release does not
- * render, and the card says so by name rather than coming up blank. `custom`
- * is deliberately absent — it is not drawn from a result at all.
- */
-const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeBody>> = {
-  metric: metricBody,
-};
 
 /**
  * A Lucide icon component for the definition's icon NAME, or nothing.
@@ -95,6 +86,8 @@ export function WidgetRenderer({
     link: definition.link,
   };
 
+  const outcome = resolveWidgetOutcome(definition, slot);
+
   // The escape hatch. A plugin component draws its own body, so the card
   // asserts nothing about its loading or empty states -- the component knows
   // what it is showing and the card does not.
@@ -107,7 +100,7 @@ export function WidgetRenderer({
   // a database read on every mount and every window focus and then fetch the
   // same data again for itself. `undefined` while the batch is in flight, and
   // the component decides what that looks like.
-  if (definition.archetype === "custom") {
+  if (outcome.state === "self-drawn") {
     return (
       <WidgetCard {...shared}>
         <PluginSlot
@@ -118,35 +111,7 @@ export function WidgetRenderer({
     );
   }
 
-  const body = ARCHETYPE_BODIES[definition.archetype];
-  if (!body) {
-    return (
-      <WidgetCard
-        {...shared}
-        error={`The "${definition.archetype}" widget archetype is not rendered yet.`}
-      >
-        {null}
-      </WidgetCard>
-    );
-  }
-
-  if (!slot) {
-    // Absent means IN FLIGHT, and only a widget that actually asked for
-    // something can have a request in flight. One with no query never will, so
-    // reading its absent slot as busy leaves the card spinning for the life of
-    // the page -- with nothing on screen, in the live region or in the console
-    // saying why. `resolve-widgets` prefers a contributed component over this,
-    // so reaching here means there was none to prefer.
-    if (!definition.query) {
-      return (
-        <WidgetCard
-          {...shared}
-          error={`The "${definition.archetype}" archetype is drawn from a query, and this widget declares none.`}
-        >
-          {null}
-        </WidgetCard>
-      );
-    }
+  if (outcome.state === "loading") {
     return (
       <WidgetCard {...shared} isLoading>
         {null}
@@ -158,21 +123,7 @@ export function WidgetRenderer({
   // refetch rather than a first load -- it marks the body busy and leaves what
   // is already there alone, which is the whole reason the card marks rather
   // than replaces.
-  if (!slot.ok) {
-    return (
-      <WidgetCard
-        {...shared}
-        error={slot.error}
-        updatedAt={updatedAt}
-        isLoading={isFetching}
-      >
-        {null}
-      </WidgetCard>
-    );
-  }
-
-  const outcome = body(slot.result, definition);
-  if (!outcome.ok) {
+  if (outcome.state === "failed") {
     return (
       <WidgetCard
         {...shared}

--- a/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetRenderer.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+/**
+ * Dispatches a widget to its archetype body, inside the one card.
+ *
+ * The card is drawn HERE rather than by each archetype, so an archetype added
+ * later contributes a body function and inherits the header, the footer, the
+ * busy state, the error presentation and the region label without deciding any
+ * of them again. Adding `table`, `list`, `text` and `actions` is one entry in
+ * `ARCHETYPE_BODIES` each.
+ *
+ * `custom` is the exception, and it does NOT get a second resolution path: it
+ * goes through `PluginSlot`, which already resolves a component path against
+ * the registry and already isolates a throw behind `PluginComponentBoundary`.
+ * A widget-specific resolver beside it would be a second place for a plugin
+ * component to fail differently.
+ *
+ * @module components/features/widgets/WidgetRenderer
+ */
+
+import type { WidgetArchetype } from "nextly/config";
+import type { ReactNode } from "react";
+
+import * as Icons from "@admin/components/icons";
+import { PluginSlot } from "@admin/components/shared/plugin-slot";
+import type {
+  DashboardWidget,
+  WidgetSlot,
+} from "@admin/types/dashboard/widgets";
+
+import { metricBody } from "./archetypes/metric";
+import type { ArchetypeBody } from "./archetypes/types";
+import { WidgetCard } from "./WidgetCard";
+
+/**
+ * The archetypes core draws from a query result.
+ *
+ * Partial on purpose: an archetype with no entry is one this release does not
+ * render, and the card says so by name rather than coming up blank. `custom`
+ * is deliberately absent — it is not drawn from a result at all.
+ */
+const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeBody>> = {
+  metric: metricBody,
+};
+
+/**
+ * A Lucide icon component for the definition's icon NAME, or nothing.
+ *
+ * Names arrive from a plugin's declaration, so an unknown one is expected
+ * input. It resolves to nothing rather than to a placeholder glyph: an icon is
+ * meant to be functional here, and a stand-in that means nothing is worse than
+ * the header simply not having one.
+ */
+function resolveIcon(name: string | undefined): ReactNode {
+  if (!name) return undefined;
+  const icons = Icons as unknown as Record<
+    string,
+    Icons.LucideIcon | undefined
+  >;
+  const Icon = icons[name];
+  return Icon ? <Icon className="h-4 w-4" /> : undefined;
+}
+
+export interface WidgetRendererProps {
+  definition: DashboardWidget;
+  /**
+   * This widget's slot from the batch. `undefined` means the batch has not
+   * answered yet — which is why a data widget with no slot is BUSY rather than
+   * empty, and a widget that asked for nothing is neither.
+   */
+  slot: WidgetSlot | undefined;
+  /** When the batch this slot came from landed, for the freshness line. */
+  updatedAt?: Date | null;
+}
+
+export function WidgetRenderer({
+  definition,
+  slot,
+  updatedAt = null,
+}: WidgetRendererProps) {
+  const shared = {
+    title: definition.title,
+    icon: resolveIcon(definition.icon),
+    link: definition.link,
+  };
+
+  // The escape hatch. A plugin component owns its own loading and empty states
+  // and never took part in the batch, so the card asserts nothing about either.
+  if (definition.archetype === "custom") {
+    return (
+      <WidgetCard {...shared}>
+        <PluginSlot
+          path={definition.component}
+          props={{ widgetId: definition.id }}
+        />
+      </WidgetCard>
+    );
+  }
+
+  const body = ARCHETYPE_BODIES[definition.archetype];
+  if (!body) {
+    return (
+      <WidgetCard
+        {...shared}
+        error={`The "${definition.archetype}" widget archetype is not rendered yet.`}
+      >
+        {null}
+      </WidgetCard>
+    );
+  }
+
+  if (!slot) {
+    return (
+      <WidgetCard {...shared} isLoading>
+        {null}
+      </WidgetCard>
+    );
+  }
+
+  if (!slot.ok) {
+    return (
+      <WidgetCard {...shared} error={slot.error} updatedAt={updatedAt}>
+        {null}
+      </WidgetCard>
+    );
+  }
+
+  const outcome = body(slot.result, definition);
+  if (!outcome.ok) {
+    return (
+      <WidgetCard {...shared} error={outcome.message} updatedAt={updatedAt}>
+        {null}
+      </WidgetCard>
+    );
+  }
+
+  return (
+    <WidgetCard {...shared} updatedAt={updatedAt}>
+      {outcome.node}
+    </WidgetCard>
+  );
+}

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetCard.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetCard.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * The card is the one anatomy every widget wears, so these assert what a user
+ * or a screen reader can observe about it, not which props were forwarded.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { WidgetCard } from "../WidgetCard";
+
+describe("WidgetCard", () => {
+  it("renders the title and the body it was given", () => {
+    render(
+      <WidgetCard title="Published posts">
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.getByText("Published posts")).toBeInTheDocument();
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("marks the body busy while loading instead of swapping in a spinner", () => {
+    render(
+      <WidgetCard title="Published posts" isLoading>
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    );
+    // The body it already had is still there: loading is a state of the body,
+    // not a replacement for it.
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("does not mark the body busy when it is not loading", () => {
+    render(
+      <WidgetCard title="Published posts">
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "false"
+    );
+  });
+
+  it("keeps the title when the body is an error, so the user knows which widget broke", () => {
+    render(
+      <WidgetCard title="Published posts" error="Source unavailable.">
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.getByText("Published posts")).toBeInTheDocument();
+    expect(screen.getByText("Source unavailable.")).toBeInTheDocument();
+    // The error REPLACES the body rather than sitting beside a stale number.
+    expect(screen.queryByText("42")).not.toBeInTheDocument();
+  });
+
+  it("names the widget in the error's accessible role", () => {
+    render(
+      <WidgetCard title="Published posts" error="Source unavailable.">
+        <p>42</p>
+      </WidgetCard>
+    );
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent("Source unavailable.");
+  });
+
+  it("renders at most one footer link", () => {
+    render(
+      <WidgetCard
+        title="Published posts"
+        link={{ label: "View all", href: "/dashboard/entries/posts" }}
+      >
+        <p>42</p>
+      </WidgetCard>
+    );
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", "/dashboard/entries/posts");
+  });
+
+  it("shows a freshness line when it has been told when the data landed", () => {
+    render(
+      <WidgetCard title="Published posts" updatedAt={new Date()}>
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.getByTestId("widget-card-freshness")).toHaveTextContent(
+      /updated just now/i
+    );
+  });
+
+  it("renders no footer at all when there is neither freshness nor a link", () => {
+    render(
+      <WidgetCard title="Published posts">
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.queryByTestId("widget-card-footer")).not.toBeInTheDocument();
+  });
+
+  it("drops the footer link while showing an error, so a broken card offers no dead end", () => {
+    render(
+      <WidgetCard
+        title="Published posts"
+        error="Source unavailable."
+        link={{ label: "View all", href: "/dashboard/entries/posts" }}
+      >
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("renders the header action beside the title", () => {
+    render(
+      <WidgetCard title="Published posts" headerAction={<button>Menu</button>}>
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(screen.getByRole("button", { name: "Menu" })).toBeInTheDocument();
+  });
+
+  it("labels the card region with its own title", () => {
+    render(
+      <WidgetCard title="Published posts">
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(
+      screen.getByRole("region", { name: "Published posts" })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetCard.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetCard.test.tsx
@@ -57,14 +57,26 @@ describe("WidgetCard", () => {
     expect(screen.queryByText("42")).not.toBeInTheDocument();
   });
 
-  it("names the widget in the error's accessible role", () => {
-    render(
+  it("shows the error as ordinary content, never as its own live region", () => {
+    // `role="alert"` is assertive by definition, so a card that carried one
+    // became its own interrupting announcer -- and a dashboard where five
+    // widgets fail at once then produces five announcements over the top of the
+    // grid's single polite one. The grid owns announcing for the batch.
+    const { container } = render(
       <WidgetCard title="Published posts" error="Source unavailable.">
         <p>42</p>
       </WidgetCard>
     );
-    const alert = screen.getByRole("alert");
-    expect(alert).toHaveTextContent("Source unavailable.");
+    expect(screen.getByTestId("widget-card-error")).toHaveTextContent(
+      "Source unavailable."
+    );
+    expect(
+      container.querySelectorAll('[role="alert"], [role="status"], [aria-live]')
+    ).toHaveLength(0);
+    // Still findable, by the landmark the title names.
+    expect(
+      screen.getByRole("region", { name: "Published posts" })
+    ).toBeInTheDocument();
   });
 
   it("renders at most one footer link", () => {

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetCard.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetCard.test.tsx
@@ -104,6 +104,27 @@ describe("WidgetCard", () => {
     );
   });
 
+  it("does not claim fresh content on a card that is showing an error", () => {
+    // The timestamp is when the BATCH landed, which is true of the request and
+    // not of this card: "Updated just now" under "Source unavailable." tells
+    // the reader the opposite of what happened.
+    render(
+      <WidgetCard
+        title="Published posts"
+        error="Source unavailable."
+        updatedAt={new Date()}
+      >
+        <p>42</p>
+      </WidgetCard>
+    );
+    expect(
+      screen.queryByTestId("widget-card-freshness")
+    ).not.toBeInTheDocument();
+    // Nothing else is left behind either: with no link and no freshness there
+    // is no footer to draw.
+    expect(screen.queryByTestId("widget-card-footer")).not.toBeInTheDocument();
+  });
+
   it("renders no footer at all when there is neither freshness nor a link", () => {
     render(
       <WidgetCard title="Published posts">

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -575,6 +575,87 @@ describe("WidgetGrid — refetching", () => {
 });
 
 describe("WidgetGrid — accessibility", () => {
+  it("keeps ONE live region even when several cards fail at once", async () => {
+    // The earlier version of this counted `[aria-live]` only, which the card's
+    // `role="alert"` does not set -- so five assertive card regions satisfied
+    // "exactly one live region" byte for byte.
+    mockBranding = brandingWith([
+      {
+        id: "one",
+        archetype: "metric",
+        title: "One",
+        query: { source: "collection:a", op: "count" },
+      },
+      {
+        id: "two",
+        archetype: "metric",
+        title: "Two",
+        query: { source: "collection:b", op: "count" },
+      },
+      {
+        id: "three",
+        archetype: "metric",
+        title: "Three",
+        query: { source: "collection:c", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: false, error: "Source unavailable." },
+        { ok: false, error: "Source unavailable." },
+        { ok: false, error: "Source unavailable." },
+      ],
+    });
+
+    const { container } = renderGrid();
+    await waitFor(() =>
+      expect(screen.getAllByTestId("widget-card-error")).toHaveLength(3)
+    );
+    expect(
+      container.querySelectorAll('[aria-live], [role="status"], [role="alert"]')
+    ).toHaveLength(1);
+  });
+
+  it("counts a card that cannot RENDER as failed, not as updated", async () => {
+    // A slot can be `ok` and still unrenderable: this release draws `metric`
+    // and nothing else, and a metric handed a list payload refuses it. Counting
+    // slots said every widget updated while both cards showed an error.
+    mockBranding = brandingWith([
+      {
+        id: "listy",
+        archetype: "list",
+        title: "Recent",
+        query: { source: "collection:posts", op: "list" },
+      },
+      {
+        id: "mismatched",
+        archetype: "metric",
+        title: "Mismatched",
+        query: { source: "collection:posts", op: "count" },
+      },
+      {
+        id: "fine",
+        archetype: "metric",
+        title: "Fine",
+        query: { source: "collection:pages", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "list", items: [] } },
+        { ok: true, result: { op: "list", items: [] } },
+        { ok: true, result: { op: "count", total: 4 } },
+      ],
+    });
+
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-grid-live")).toHaveTextContent(
+        /1 of 3 widgets updated, 2 failed/i
+      )
+    );
+  });
+
   it("has exactly ONE live region for the whole grid", async () => {
     mockBranding = brandingWith([
       {

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -44,7 +44,7 @@ function renderGrid() {
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
-  return render(<WidgetGrid />, { wrapper: Wrapper });
+  return { client, ...render(<WidgetGrid />, { wrapper: Wrapper }) };
 }
 
 function brandingWith(widgets: unknown[]): AdminBranding {
@@ -530,6 +530,47 @@ describe("WidgetGrid — a request that fails outright", () => {
     );
     expect(screen.getByText("Posts")).toBeInTheDocument();
     expect(screen.getByText("Pages")).toBeInTheDocument();
+  });
+});
+
+describe("WidgetGrid — refetching", () => {
+  it("marks a data card busy while it refetches, keeping the number visible", async () => {
+    mockBranding = brandingWith([
+      {
+        id: "posts",
+        archetype: "metric",
+        title: "Posts",
+        query: { source: "collection:posts", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValueOnce({
+      results: [{ ok: true, result: { op: "count", total: 12 } }],
+    });
+
+    const { client } = renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-posts")).toHaveTextContent("12")
+    );
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "false"
+    );
+
+    // A refetch that never settles: exactly the state a window-focus refresh is
+    // in while the request is out.
+    vi.mocked(protectedApi.post).mockImplementation(
+      () => new Promise(() => {})
+    );
+    void client.refetchQueries();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+        "aria-busy",
+        "true"
+      )
+    );
+    // And the reader still has the number they were looking at.
+    expect(screen.getByTestId("widget-cell-posts")).toHaveTextContent("12");
   });
 });
 

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -574,6 +574,42 @@ describe("WidgetGrid — refetching", () => {
   });
 });
 
+describe("WidgetGrid — a malformed response member", () => {
+  it("colours one card and leaves the page and its neighbour standing", async () => {
+    mockBranding = brandingWith([
+      {
+        id: "broken",
+        archetype: "metric",
+        title: "Broken",
+        query: { source: "collection:posts", op: "count" },
+      },
+      {
+        id: "fine",
+        archetype: "metric",
+        title: "Fine",
+        query: { source: "collection:pages", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      // Shaped as a slot, carrying no result: the renderer used to dereference
+      // it and throw into the dashboard's error boundary.
+      results: [{ ok: true }, { ok: true, result: { op: "count", total: 5 } }],
+    });
+
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-fine")).toHaveTextContent("5")
+    );
+    expect(screen.getByTestId("widget-cell-broken")).toHaveTextContent(
+      /unreadable/i
+    );
+    // The grid itself is still on screen, which is the whole point.
+    expect(
+      screen.getByRole("region", { name: /dashboard widgets/i })
+    ).toBeInTheDocument();
+  });
+});
+
 describe("WidgetGrid — accessibility", () => {
   it("keeps ONE live region even when several cards fail at once", async () => {
     // The earlier version of this counted `[aria-live]` only, which the card's

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -271,6 +271,45 @@ describe("WidgetGrid — collection and gating", () => {
     expect(screen.getByText("panel body")).toBeInTheDocument();
   });
 
+  it("draws the contributed component when a data archetype declares no query", () => {
+    // `archetype: "metric"` with no `query` is a legal contribution: the field
+    // is optional and boot requires only `id` and `component`. Core cannot draw
+    // a metric without a result, no request is made for it, and reading the
+    // missing slot as "in flight" left the card busy forever. The component the
+    // author actually shipped is right there.
+    registerComponents({ "@acme/admin#Panel": () => <div>panel body</div> });
+    mockBranding = brandingWith([
+      {
+        id: "queryless",
+        title: "Queryless",
+        archetype: "metric",
+        component: "@acme/admin#Panel",
+      },
+    ]);
+
+    renderGrid();
+    expect(screen.getByText("panel body")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "false"
+    );
+    expect(protectedApi.post).not.toHaveBeenCalled();
+  });
+
+  it("names a blank title's widget instead of drawing an unnamed landmark", () => {
+    // `title: "   "` passes a nullish fallback and leaves the card region's
+    // `aria-labelledby` pointing at an empty heading.
+    registerComponents({ "@acme/admin#Blank": () => <div>blank body</div> });
+    mockBranding = brandingWith([
+      { id: "acme/untitled", title: "   ", component: "@acme/admin#Blank" },
+    ]);
+
+    renderGrid();
+    expect(
+      screen.getByRole("region", { name: "acme/untitled" })
+    ).toBeInTheDocument();
+  });
+
   it("shows a widget that declares no permission at all", () => {
     registerComponents({ "@acme/admin#Open": () => <div>open widget</div> });
     mockBranding = brandingWith([

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -1,0 +1,418 @@
+/**
+ * The grid: what it collects, what it hides, how wide each cell is, and how
+ * much it says out loud.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+import {
+  clearRegistry,
+  registerComponents,
+} from "@admin/lib/plugins/component-registry";
+import type { AdminBranding } from "@admin/types/branding";
+
+import { WidgetGrid } from "../WidgetGrid";
+
+let mockBranding: AdminBranding | undefined;
+let granted: string[] = [];
+
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => mockBranding,
+}));
+vi.mock("@admin/hooks/useCurrentUserPermissions", () => ({
+  useCurrentUserPermissions: () => ({
+    hasPermission: (p: string) => granted.includes(p),
+  }),
+}));
+vi.mock("@admin/lib/api/protectedApi", () => ({
+  protectedApi: { post: vi.fn() },
+}));
+
+function renderGrid() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<WidgetGrid />, { wrapper: Wrapper });
+}
+
+function brandingWith(widgets: unknown[]): AdminBranding {
+  return {
+    plugins: [{ name: "@acme", collections: [], widgets }],
+  } as unknown as AdminBranding;
+}
+
+beforeEach(() => {
+  granted = [];
+  vi.clearAllMocks();
+  vi.mocked(protectedApi.post).mockResolvedValue({ results: [] });
+});
+
+afterEach(() => {
+  clearRegistry();
+  mockBranding = undefined;
+  vi.restoreAllMocks();
+});
+
+describe("WidgetGrid — collection and gating", () => {
+  it("renders nothing when no plugin contributes a widget", () => {
+    mockBranding = {
+      plugins: [{ name: "@acme", collections: [] }],
+    } as unknown as AdminBranding;
+    const { container } = renderGrid();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when every contributed widget is denied", () => {
+    registerComponents({ "@acme/admin#Secret": () => <div>secret</div> });
+    mockBranding = brandingWith([
+      {
+        id: "secret",
+        component: "@acme/admin#Secret",
+        requiredPermission: "manage-secret",
+      },
+    ]);
+    const { container } = renderGrid();
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a permitted widget and hides a denied one", () => {
+    granted = ["read-stats"];
+    registerComponents({
+      "@acme/admin#Stats": () => <div>stats widget</div>,
+      "@acme/admin#Secret": () => <div>secret widget</div>,
+    });
+    mockBranding = brandingWith([
+      {
+        id: "stats",
+        component: "@acme/admin#Stats",
+        requiredPermission: "read-stats",
+      },
+      {
+        id: "secret",
+        component: "@acme/admin#Secret",
+        requiredPermission: "manage-secret",
+      },
+    ]);
+    renderGrid();
+    expect(screen.getByText("stats widget")).toBeInTheDocument();
+    expect(screen.queryByText("secret widget")).not.toBeInTheDocument();
+  });
+
+  it("skips a declaration that describes no body, rather than drawing an empty card", () => {
+    // Neither an archetype nor a component: the plugin half is gone, or the
+    // declaration was never renderable. A titled card with nothing under it
+    // reads as a product bug rather than as a missing plugin.
+    registerComponents({ "@acme/admin#Real": () => <div>real body</div> });
+    mockBranding = brandingWith([
+      { id: "hollow", title: "Hollow" },
+      { id: "real", component: "@acme/admin#Real" },
+    ]);
+    renderGrid();
+    expect(screen.queryByTestId("widget-cell-hollow")).not.toBeInTheDocument();
+    expect(screen.queryByText("Hollow")).not.toBeInTheDocument();
+    // The grid itself survives it.
+    expect(screen.getByText("real body")).toBeInTheDocument();
+  });
+
+  it("keeps one cell when two plugins ship the same widget id", () => {
+    // The id keys a batch result back to its card, so a duplicate would hand
+    // both widgets the same slot and one would show the other's number.
+    registerComponents({
+      "@acme/admin#First": () => <div>first body</div>,
+      "@other/admin#Second": () => <div>second body</div>,
+    });
+    mockBranding = {
+      plugins: [
+        {
+          name: "@acme",
+          collections: [],
+          widgets: [{ id: "shared", component: "@acme/admin#First" }],
+        },
+        {
+          name: "@other",
+          collections: [],
+          widgets: [{ id: "shared", component: "@other/admin#Second" }],
+        },
+      ],
+    } as unknown as AdminBranding;
+    renderGrid();
+    expect(screen.getAllByTestId("widget-cell-shared")).toHaveLength(1);
+    expect(screen.getByText("first body")).toBeInTheDocument();
+    expect(screen.queryByText("second body")).not.toBeInTheDocument();
+  });
+
+  it("shows a widget that declares no permission at all", () => {
+    registerComponents({ "@acme/admin#Open": () => <div>open widget</div> });
+    mockBranding = brandingWith([
+      { id: "open", component: "@acme/admin#Open" },
+    ]);
+    renderGrid();
+    expect(screen.getByText("open widget")).toBeInTheDocument();
+  });
+});
+
+describe("WidgetGrid — sizing", () => {
+  it("gives every cell a full-width base span whatever its size", () => {
+    registerComponents({ "@acme/admin#A": () => <div>a</div> });
+    mockBranding = brandingWith([
+      { id: "small", component: "@acme/admin#A", defaultSize: "sm" },
+      { id: "medium", component: "@acme/admin#A", defaultSize: "md" },
+      { id: "large", component: "@acme/admin#A", defaultSize: "lg" },
+      { id: "xlarge", component: "@acme/admin#A", defaultSize: "xl" },
+      { id: "whole", component: "@acme/admin#A", defaultSize: "full" },
+    ]);
+    renderGrid();
+    for (const id of ["small", "medium", "large", "xlarge", "whole"]) {
+      const cell = screen.getByTestId(`widget-cell-${id}`);
+      expect(cell.className.split(" ")).toContain("col-span-12");
+    }
+  });
+
+  it("narrows a small widget only at md and lg", () => {
+    registerComponents({ "@acme/admin#A": () => <div>a</div> });
+    mockBranding = brandingWith([
+      { id: "small", component: "@acme/admin#A", defaultSize: "sm" },
+    ]);
+    renderGrid();
+    expect(screen.getByTestId("widget-cell-small")).toHaveClass(
+      "col-span-12",
+      "md:col-span-6",
+      "lg:col-span-3"
+    );
+  });
+
+  it("honours the deprecated half alias without half-width phones", () => {
+    registerComponents({ "@acme/admin#A": () => <div>a</div> });
+    mockBranding = brandingWith([
+      { id: "halved", component: "@acme/admin#A", size: "half" },
+    ]);
+    renderGrid();
+    const cell = screen.getByTestId("widget-cell-halved");
+    expect(cell).toHaveClass("col-span-12", "lg:col-span-6");
+    expect(cell.className.split(" ")).not.toContain("col-span-6");
+  });
+
+  it("prefers an explicit defaultSize over the deprecated alias", () => {
+    registerComponents({ "@acme/admin#A": () => <div>a</div> });
+    mockBranding = brandingWith([
+      {
+        id: "both",
+        component: "@acme/admin#A",
+        size: "half",
+        defaultSize: "sm",
+      },
+    ]);
+    renderGrid();
+    expect(screen.getByTestId("widget-cell-both")).toHaveClass("lg:col-span-3");
+  });
+});
+
+describe("WidgetGrid — batching", () => {
+  it("asks for every data widget in a single request", async () => {
+    mockBranding = brandingWith([
+      {
+        id: "posts",
+        archetype: "metric",
+        title: "Posts",
+        query: { source: "collection:posts", op: "count" },
+      },
+      {
+        id: "pages",
+        archetype: "metric",
+        title: "Pages",
+        query: { source: "collection:pages", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "count", total: 12 } },
+        { ok: true, result: { op: "count", total: 34 } },
+      ],
+    });
+
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-posts")).toHaveTextContent("12")
+    );
+    expect(screen.getByTestId("widget-cell-pages")).toHaveTextContent("34");
+    expect(protectedApi.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("issues no request when nothing on the dashboard asks for data", () => {
+    registerComponents({ "@acme/admin#A": () => <div>a</div> });
+    mockBranding = brandingWith([
+      { id: "custom-only", component: "@acme/admin#A" },
+    ]);
+    renderGrid();
+    expect(protectedApi.post).not.toHaveBeenCalled();
+  });
+
+  it("does not ask on behalf of a widget the user may not see", async () => {
+    granted = ["read-posts"];
+    mockBranding = brandingWith([
+      {
+        id: "posts",
+        archetype: "metric",
+        title: "Posts",
+        requiredPermission: "read-posts",
+        query: { source: "collection:posts", op: "count" },
+      },
+      {
+        id: "secrets",
+        archetype: "metric",
+        title: "Secrets",
+        requiredPermission: "read-secrets",
+        query: { source: "collection:secrets", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [{ ok: true, result: { op: "count", total: 1 } }],
+    });
+
+    renderGrid();
+    await waitFor(() => expect(protectedApi.post).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(protectedApi.post).mock.calls[0][1]).toEqual({
+      queries: [{ source: "collection:posts", op: "count" }],
+    });
+  });
+
+  it("shows one widget's failure in its own card and its neighbour's number in theirs", async () => {
+    mockBranding = brandingWith([
+      {
+        id: "broken",
+        archetype: "metric",
+        title: "Broken",
+        query: { source: "collection:gone", op: "count" },
+      },
+      {
+        id: "fine",
+        archetype: "metric",
+        title: "Fine",
+        query: { source: "collection:posts", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: false, error: "Source unavailable." },
+        { ok: true, result: { op: "count", total: 9 } },
+      ],
+    });
+
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-fine")).toHaveTextContent("9")
+    );
+    expect(screen.getByTestId("widget-cell-broken")).toHaveTextContent(
+      "Source unavailable."
+    );
+    expect(screen.getByTestId("widget-cell-broken")).toHaveTextContent(
+      "Broken"
+    );
+  });
+});
+
+describe("WidgetGrid — accessibility", () => {
+  it("has exactly ONE live region for the whole grid", async () => {
+    mockBranding = brandingWith([
+      {
+        id: "posts",
+        archetype: "metric",
+        title: "Posts",
+        query: { source: "collection:posts", op: "count" },
+      },
+      {
+        id: "pages",
+        archetype: "metric",
+        title: "Pages",
+        query: { source: "collection:pages", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "count", total: 1 } },
+        { ok: true, result: { op: "count", total: 2 } },
+      ],
+    });
+
+    const { container } = renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-posts")).toHaveTextContent("1")
+    );
+    expect(container.querySelectorAll("[aria-live]")).toHaveLength(1);
+  });
+
+  it("announces once for the batch, not once per widget", async () => {
+    mockBranding = brandingWith([
+      {
+        id: "posts",
+        archetype: "metric",
+        title: "Posts",
+        query: { source: "collection:posts", op: "count" },
+      },
+      {
+        id: "pages",
+        archetype: "metric",
+        title: "Pages",
+        query: { source: "collection:pages", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "count", total: 1 } },
+        { ok: true, result: { op: "count", total: 2 } },
+      ],
+    });
+
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-grid-live")).toHaveTextContent(
+        /2 of 2 widgets updated/i
+      )
+    );
+  });
+
+  it("names how many widgets failed rather than which one, once", async () => {
+    mockBranding = brandingWith([
+      {
+        id: "broken",
+        archetype: "metric",
+        title: "Broken",
+        query: { source: "collection:gone", op: "count" },
+      },
+      {
+        id: "fine",
+        archetype: "metric",
+        title: "Fine",
+        query: { source: "collection:posts", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: false, error: "Source unavailable." },
+        { ok: true, result: { op: "count", total: 9 } },
+      ],
+    });
+
+    renderGrid();
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-grid-live")).toHaveTextContent(
+        /1 of 2 widgets updated, 1 failed/i
+      )
+    );
+  });
+
+  it("gives the grid an accessible name", () => {
+    registerComponents({ "@acme/admin#A": () => <div>a</div> });
+    mockBranding = brandingWith([{ id: "a", component: "@acme/admin#A" }]);
+    renderGrid();
+    expect(
+      screen.getByRole("region", { name: /dashboard widgets/i })
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -47,6 +47,14 @@ function brandingWith(widgets: unknown[]): AdminBranding {
   } as unknown as AdminBranding;
 }
 
+/** Branding carrying REGISTERED widgets and no plugin contribution at all. */
+function brandingWithRegistered(widgets: unknown[]): AdminBranding {
+  return {
+    plugins: [{ name: "@acme", collections: [] }],
+    widgets,
+  } as unknown as AdminBranding;
+}
+
 beforeEach(() => {
   granted = [];
   vi.clearAllMocks();
@@ -145,6 +153,116 @@ describe("WidgetGrid — collection and gating", () => {
     expect(screen.getAllByTestId("widget-cell-shared")).toHaveLength(1);
     expect(screen.getByText("first body")).toBeInTheDocument();
     expect(screen.queryByText("second body")).not.toBeInTheDocument();
+  });
+
+  it("renders a widget the app only REGISTERED, with no contribution beside it", () => {
+    // The registry is what `registerWidget` writes to, and it is the store this
+    // whole system is built around. A widget that reached it without also being
+    // declared under `contributes.admin.widgets` was invisible to the grid.
+    mockBranding = brandingWithRegistered([
+      {
+        id: "acme/revenue",
+        title: "Revenue",
+        archetype: "metric",
+        defaultSize: "sm",
+        query: { source: "collection:orders", op: "count" },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [{ ok: true, result: { op: "count", total: 42 } }],
+    });
+
+    renderGrid();
+    return waitFor(() => {
+      expect(screen.getByTestId("widget-cell-acme/revenue")).toHaveTextContent(
+        "42"
+      );
+    });
+  });
+
+  it("puts a registered widget's query in the same batch as a contributed one", async () => {
+    mockBranding = {
+      plugins: [
+        {
+          name: "@acme",
+          collections: [],
+          widgets: [
+            {
+              id: "contributed",
+              archetype: "metric",
+              title: "Contributed",
+              query: { source: "collection:posts", op: "count" },
+            },
+          ],
+        },
+      ],
+      widgets: [
+        {
+          id: "acme/registered",
+          title: "Registered",
+          archetype: "metric",
+          defaultSize: "sm",
+          query: { source: "collection:orders", op: "count" },
+        },
+      ],
+    } as unknown as AdminBranding;
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "count", total: 1 } },
+        { ok: true, result: { op: "count", total: 2 } },
+      ],
+    });
+
+    renderGrid();
+    await waitFor(() => expect(protectedApi.post).toHaveBeenCalledTimes(1));
+    expect(vi.mocked(protectedApi.post).mock.calls[0][1]).toEqual({
+      queries: [
+        { source: "collection:posts", op: "count" },
+        { source: "collection:orders", op: "count" },
+      ],
+    });
+  });
+
+  it("gates a registered widget on its permission like any other", () => {
+    mockBranding = brandingWithRegistered([
+      {
+        id: "acme/secret",
+        title: "Secret",
+        archetype: "metric",
+        defaultSize: "sm",
+        requiredPermission: "read-secrets",
+        query: { source: "collection:secrets", op: "count" },
+      },
+    ]);
+    const { container } = renderGrid();
+    expect(container).toBeEmptyDOMElement();
+    expect(protectedApi.post).not.toHaveBeenCalled();
+  });
+
+  it("keeps one cell when a widget is both contributed and registered", () => {
+    registerComponents({ "@acme/admin#Panel": () => <div>panel body</div> });
+    mockBranding = {
+      plugins: [
+        {
+          name: "@acme",
+          collections: [],
+          widgets: [{ id: "shared", component: "@acme/admin#Panel" }],
+        },
+      ],
+      widgets: [
+        {
+          id: "shared",
+          title: "Shared",
+          archetype: "metric",
+          defaultSize: "sm",
+          query: { source: "collection:posts", op: "count" },
+        },
+      ],
+    } as unknown as AdminBranding;
+    renderGrid();
+    expect(screen.getAllByTestId("widget-cell-shared")).toHaveLength(1);
+    // The contribution is what the dashboard already drew, so it keeps winning.
+    expect(screen.getByText("panel body")).toBeInTheDocument();
   });
 
   it("shows a widget that declares no permission at all", () => {

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -33,7 +33,13 @@ vi.mock("@admin/lib/api/protectedApi", () => ({
 
 function renderGrid() {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    // `retry` is a DEFAULT and the hook sets `retry: 2` on the query itself,
+    // which wins -- so turning it off here only makes these tests look like it
+    // had. What is disabled is the BACKOFF, where the seconds go: the attempts
+    // still run, in milliseconds, so a rejected batch settles inside the
+    // default `waitFor` window instead of timing out and reading as a card
+    // that never recovered.
+    defaultOptions: { queries: { retry: false, retryDelay: 0, gcTime: 0 } },
   });
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
@@ -432,6 +438,59 @@ describe("WidgetGrid — batching", () => {
     expect(screen.getByTestId("widget-cell-broken")).toHaveTextContent(
       "Broken"
     );
+  });
+});
+
+describe("WidgetGrid — a request that fails outright", () => {
+  const twoMetrics = () =>
+    brandingWith([
+      {
+        id: "posts",
+        archetype: "metric",
+        title: "Posts",
+        query: { source: "collection:posts", op: "count" },
+      },
+      {
+        id: "pages",
+        archetype: "metric",
+        title: "Pages",
+        query: { source: "collection:pages", op: "count" },
+      },
+    ]);
+
+  it("shows an error on every card rather than leaving them busy forever", async () => {
+    mockBranding = twoMetrics();
+    vi.mocked(protectedApi.post).mockRejectedValue(new Error("network down"));
+
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-posts")).toHaveTextContent(
+        /could not be loaded/i
+      )
+    );
+    expect(screen.getByTestId("widget-cell-pages")).toHaveTextContent(
+      /could not be loaded/i
+    );
+    // And no card is still claiming to be working on it.
+    for (const body of screen.getAllByTestId("widget-card-body")) {
+      expect(body).toHaveAttribute("aria-busy", "false");
+    }
+  });
+
+  it("keeps each failed card named, so the reader knows which widgets are dark", async () => {
+    mockBranding = twoMetrics();
+    vi.mocked(protectedApi.post).mockRejectedValue(new Error("network down"));
+
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-posts")).toHaveTextContent(
+        /could not be loaded/i
+      )
+    );
+    expect(screen.getByText("Posts")).toBeInTheDocument();
+    expect(screen.getByText("Pages")).toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
@@ -71,7 +71,9 @@ describe("WidgetRenderer — metric", () => {
     );
     // Not "1" (the item count), and not blank.
     expect(screen.queryByTestId("widget-metric-value")).not.toBeInTheDocument();
-    expect(screen.getByRole("alert")).toHaveTextContent(/expected a count/i);
+    expect(screen.getByTestId("widget-card-error")).toHaveTextContent(
+      /expected a count/i
+    );
     // The title survives, so the user knows which widget is mismatched.
     expect(screen.getByText("Published posts")).toBeInTheDocument();
   });
@@ -83,7 +85,9 @@ describe("WidgetRenderer — metric", () => {
         slot={{ ok: false, error: "Source unavailable." }}
       />
     );
-    expect(screen.getByRole("alert")).toHaveTextContent("Source unavailable.");
+    expect(screen.getByTestId("widget-card-error")).toHaveTextContent(
+      "Source unavailable."
+    );
     expect(screen.getByText("Published posts")).toBeInTheDocument();
     expect(screen.queryByTestId("widget-metric-value")).not.toBeInTheDocument();
   });
@@ -240,7 +244,7 @@ describe("WidgetRenderer — archetypes not built yet", () => {
         slot={{ ok: true, result: { op: "list", items: [] } }}
       />
     );
-    expect(screen.getByRole("alert")).toHaveTextContent(/list/i);
+    expect(screen.getByTestId("widget-card-error")).toHaveTextContent(/list/i);
     expect(screen.getByText("Recent entries")).toBeInTheDocument();
   });
 });

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
@@ -141,6 +141,41 @@ describe("WidgetRenderer — custom", () => {
   });
 });
 
+describe("WidgetRenderer — a data archetype with nothing to draw from", () => {
+  it("says so rather than staying busy for a slot that will never arrive", () => {
+    render(
+      <WidgetRenderer
+        definition={{
+          id: "acme/queryless",
+          title: "Queryless",
+          archetype: "metric",
+          size: "sm",
+        }}
+        slot={undefined}
+      />
+    );
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "false"
+    );
+    expect(screen.getByTestId("widget-card-error")).toHaveTextContent(
+      /declares none/i
+    );
+    expect(screen.getByText("Queryless")).toBeInTheDocument();
+  });
+
+  it("stays busy for a widget that DID ask and has not been answered", () => {
+    // The control for the case above: absence still means in flight when there
+    // is a request to be in flight.
+    render(<WidgetRenderer definition={metric} slot={undefined} />);
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    );
+    expect(screen.queryByTestId("widget-card-error")).not.toBeInTheDocument();
+  });
+});
+
 describe("WidgetRenderer — archetypes not built yet", () => {
   it("says so, by name, instead of rendering an empty card", () => {
     render(

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
@@ -88,6 +88,29 @@ describe("WidgetRenderer — metric", () => {
     expect(screen.queryByTestId("widget-metric-value")).not.toBeInTheDocument();
   });
 
+  it("says it is busy during a refetch WITHOUT discarding the number on screen", () => {
+    // The card marks the body rather than swapping in a spinner, so the reader
+    // keeps the value while a screen reader is told the dashboard is reading
+    // again. Reporting only the first load left `aria-busy` false for every
+    // window-focus refresh this grid performs.
+    render(
+      <WidgetRenderer definition={metric} slot={countSlot(21)} isFetching />
+    );
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    );
+    expect(screen.getByTestId("widget-metric-value")).toHaveTextContent("21");
+  });
+
+  it("is not busy once a refetch has settled", () => {
+    render(<WidgetRenderer definition={metric} slot={countSlot(21)} />);
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "false"
+    );
+  });
+
   it("renders the definition's single footer link", () => {
     render(
       <WidgetRenderer

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
@@ -131,6 +131,33 @@ describe("WidgetRenderer — custom", () => {
     expect(screen.getByText("Acme panel")).toBeInTheDocument();
   });
 
+  it("hands the plugin component the slot the batch fetched for it", () => {
+    // A `custom` widget may declare a query -- core's validator allows it
+    // deliberately -- and the grid puts that query in the batch. Withholding
+    // the answer here made the dashboard pay for the read and then throw it
+    // away, on every mount and every window focus.
+    registerComponent(
+      "@acme/admin#Panel",
+      ({ slot }: { slot?: WidgetSlot }) => (
+        <div>
+          {slot?.ok === true && slot.result.op === "count"
+            ? `count:${slot.result.total}`
+            : "no slot"}
+        </div>
+      )
+    );
+    render(
+      <WidgetRenderer
+        definition={{
+          ...custom,
+          query: { source: "collection:posts", op: "count" },
+        }}
+        slot={countSlot(7)}
+      />
+    );
+    expect(screen.getByText("count:7")).toBeInTheDocument();
+  });
+
   it("never marks a custom body busy for a batch it did not participate in", () => {
     registerComponent("@acme/admin#Panel", () => <div>acme body</div>);
     render(<WidgetRenderer definition={custom} slot={undefined} />);

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
@@ -195,6 +195,37 @@ describe("WidgetRenderer — custom", () => {
   });
 });
 
+describe("WidgetRenderer — freshness", () => {
+  it("shows when the data landed on a card that has data", () => {
+    render(
+      <WidgetRenderer
+        definition={metric}
+        slot={countSlot(3)}
+        updatedAt={new Date()}
+      />
+    );
+    expect(screen.getByTestId("widget-card-freshness")).toHaveTextContent(
+      /updated just now/i
+    );
+  });
+
+  it("says nothing about freshness on a slot that failed", () => {
+    render(
+      <WidgetRenderer
+        definition={metric}
+        slot={{ ok: false, error: "Source unavailable." }}
+        updatedAt={new Date()}
+      />
+    );
+    expect(
+      screen.queryByTestId("widget-card-freshness")
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("widget-card-error")).toHaveTextContent(
+      "Source unavailable."
+    );
+  });
+});
+
 describe("WidgetRenderer — a data archetype with nothing to draw from", () => {
   it("says so rather than staying busy for a slot that will never arrive", () => {
     render(

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetRenderer.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * The renderer's job is dispatch: the right body inside the one card, and a
+ * refusal rather than a coercion when the payload is not what the archetype
+ * asked for.
+ */
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearRegistry,
+  registerComponent,
+} from "@admin/lib/plugins/component-registry";
+import type {
+  DashboardWidget,
+  WidgetSlot,
+} from "@admin/types/dashboard/widgets";
+
+import { WidgetRenderer } from "../WidgetRenderer";
+
+afterEach(() => {
+  clearRegistry();
+  vi.restoreAllMocks();
+});
+
+const metric: DashboardWidget = {
+  id: "core/published-posts",
+  title: "Published posts",
+  archetype: "metric",
+  size: "sm",
+  query: { source: "collection:posts", op: "count" },
+};
+
+const countSlot = (total: number): WidgetSlot => ({
+  ok: true,
+  result: { op: "count", total },
+});
+
+describe("WidgetRenderer — metric", () => {
+  it("renders a count, formatted for the reader's locale", () => {
+    render(<WidgetRenderer definition={metric} slot={countSlot(1234567)} />);
+    expect(screen.getByTestId("widget-metric-value")).toHaveTextContent(
+      (1234567).toLocaleString()
+    );
+  });
+
+  it("renders zero as zero rather than as an empty state", () => {
+    render(<WidgetRenderer definition={metric} slot={countSlot(0)} />);
+    expect(screen.getByTestId("widget-metric-value")).toHaveTextContent("0");
+  });
+
+  it("wears the shared card anatomy, title and all", () => {
+    render(<WidgetRenderer definition={metric} slot={countSlot(5)} />);
+    expect(screen.getByText("Published posts")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-card-body")).toBeInTheDocument();
+  });
+
+  it("marks the body busy while the batch has not answered for it", () => {
+    render(<WidgetRenderer definition={metric} slot={undefined} />);
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "true"
+    );
+  });
+
+  it("says a list payload is the wrong shape rather than coercing it", () => {
+    render(
+      <WidgetRenderer
+        definition={metric}
+        slot={{ ok: true, result: { op: "list", items: [{ id: 1 }] } }}
+      />
+    );
+    // Not "1" (the item count), and not blank.
+    expect(screen.queryByTestId("widget-metric-value")).not.toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent(/expected a count/i);
+    // The title survives, so the user knows which widget is mismatched.
+    expect(screen.getByText("Published posts")).toBeInTheDocument();
+  });
+
+  it("shows a failed slot's message and keeps the title", () => {
+    render(
+      <WidgetRenderer
+        definition={metric}
+        slot={{ ok: false, error: "Source unavailable." }}
+      />
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Source unavailable.");
+    expect(screen.getByText("Published posts")).toBeInTheDocument();
+    expect(screen.queryByTestId("widget-metric-value")).not.toBeInTheDocument();
+  });
+
+  it("renders the definition's single footer link", () => {
+    render(
+      <WidgetRenderer
+        definition={{
+          ...metric,
+          link: { label: "View all", href: "/dashboard/entries/posts" },
+        }}
+        slot={countSlot(3)}
+      />
+    );
+    const links = screen.getAllByRole("link");
+    expect(links).toHaveLength(1);
+    expect(links[0]).toHaveAttribute("href", "/dashboard/entries/posts");
+  });
+});
+
+describe("WidgetRenderer — custom", () => {
+  const custom: DashboardWidget = {
+    id: "acme/panel",
+    title: "Acme panel",
+    archetype: "custom",
+    size: "lg",
+    component: "@acme/admin#Panel",
+  };
+
+  it("renders the plugin component through the existing PluginSlot", () => {
+    registerComponent("@acme/admin#Panel", () => <div>acme body</div>);
+    render(<WidgetRenderer definition={custom} slot={undefined} />);
+    expect(screen.getByText("acme body")).toBeInTheDocument();
+    expect(screen.getByText("Acme panel")).toBeInTheDocument();
+  });
+
+  it("isolates a throwing plugin component behind the boundary", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    registerComponent("@acme/admin#Panel", () => {
+      throw new Error("boom");
+    });
+    render(<WidgetRenderer definition={custom} slot={undefined} />);
+    expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    // The rest of the card is intact around the isolated body.
+    expect(screen.getByText("Acme panel")).toBeInTheDocument();
+  });
+
+  it("never marks a custom body busy for a batch it did not participate in", () => {
+    registerComponent("@acme/admin#Panel", () => <div>acme body</div>);
+    render(<WidgetRenderer definition={custom} slot={undefined} />);
+    expect(screen.getByTestId("widget-card-body")).toHaveAttribute(
+      "aria-busy",
+      "false"
+    );
+  });
+});
+
+describe("WidgetRenderer — archetypes not built yet", () => {
+  it("says so, by name, instead of rendering an empty card", () => {
+    render(
+      <WidgetRenderer
+        definition={{
+          id: "core/recent",
+          title: "Recent entries",
+          archetype: "list",
+          size: "lg",
+          query: { source: "collection:posts", op: "list" },
+        }}
+        slot={{ ok: true, result: { op: "list", items: [] } }}
+      />
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(/list/i);
+    expect(screen.getByText("Recent entries")).toBeInTheDocument();
+  });
+});

--- a/packages/admin/src/components/features/widgets/__tests__/sizes.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/sizes.test.ts
@@ -1,0 +1,92 @@
+/**
+ * The size -> span map is the only place a widget's width is decided, so these
+ * assert the RENDERED class text rather than a lookup succeeding.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  WIDGET_SPAN_CLASSES,
+  legacySizeToWidgetSize,
+  widgetSpanClass,
+} from "../sizes";
+
+import type { WidgetSize } from "nextly/config";
+
+const ALL_SIZES: WidgetSize[] = ["sm", "md", "lg", "xl", "full"];
+
+describe("widget span classes", () => {
+  it("gives every size a full-width base span, so a phone is one column", () => {
+    for (const size of ALL_SIZES) {
+      const classes = widgetSpanClass(size).split(" ");
+      expect(classes).toContain("col-span-12");
+    }
+  });
+
+  it("never emits an unprefixed span narrower than 12", () => {
+    // The defect in the grid this replaces: `col-span-6` with no breakpoint
+    // prefix, which is half a phone screen.
+    for (const size of ALL_SIZES) {
+      const unprefixed = widgetSpanClass(size)
+        .split(" ")
+        .filter(c => !c.includes(":"));
+      expect(unprefixed).toEqual(["col-span-12"]);
+    }
+  });
+
+  it("narrows only at md and lg, and to the declared column counts", () => {
+    expect(widgetSpanClass("sm")).toBe(
+      "col-span-12 md:col-span-6 lg:col-span-3"
+    );
+    expect(widgetSpanClass("md")).toBe(
+      "col-span-12 md:col-span-6 lg:col-span-4"
+    );
+    expect(widgetSpanClass("lg")).toBe(
+      "col-span-12 md:col-span-12 lg:col-span-6"
+    );
+    expect(widgetSpanClass("xl")).toBe(
+      "col-span-12 md:col-span-12 lg:col-span-8"
+    );
+    expect(widgetSpanClass("full")).toBe("col-span-12");
+  });
+
+  it("uses only md and lg as breakpoints", () => {
+    for (const size of ALL_SIZES) {
+      for (const cls of widgetSpanClass(size).split(" ")) {
+        const [prefix] = cls.split(":");
+        if (cls.includes(":")) expect(["md", "lg"]).toContain(prefix);
+      }
+    }
+  });
+
+  it("writes every class out in full, because Tailwind scans source text", () => {
+    // A `col-span-${n}` template literal produces no class in the built
+    // stylesheet. Assert the map holds literal strings with no interpolation
+    // residue rather than trusting the call site.
+    for (const value of Object.values(WIDGET_SPAN_CLASSES)) {
+      expect(value).not.toMatch(/[$`{}]/);
+      expect(value).toMatch(/^col-span-12( (md|lg):col-span-\d+)*$/);
+    }
+  });
+
+  it("falls back to full width for a size the registry does not know", () => {
+    expect(widgetSpanClass(undefined)).toBe("col-span-12");
+    expect(widgetSpanClass("enormous" as WidgetSize)).toBe("col-span-12");
+  });
+});
+
+describe("legacySizeToWidgetSize", () => {
+  it("maps the deprecated half alias onto the six-column size", () => {
+    expect(legacySizeToWidgetSize("half")).toBe("lg");
+    expect(widgetSpanClass(legacySizeToWidgetSize("half"))).toContain(
+      "lg:col-span-6"
+    );
+  });
+
+  it("maps the deprecated full alias onto full", () => {
+    expect(legacySizeToWidgetSize("full")).toBe("full");
+  });
+
+  it("defaults an undeclared size to full width", () => {
+    expect(legacySizeToWidgetSize(undefined)).toBe("full");
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/metric.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/metric.tsx
@@ -36,7 +36,10 @@ export const metricBody: ArchetypeBody = (result, definition) => {
     node: (
       <p
         data-testid="widget-metric-value"
-        className="text-3xl font-bold leading-none tabular-nums tracking-tight text-foreground"
+        // Sized to the Users and Roles stat cards on the same dashboard rather
+        // than a step above them: a plugin's number that shouts louder than the
+        // core ones reads as a different component, not as a peer.
+        className="text-2xl font-bold leading-none tabular-nums tracking-tight text-foreground"
       >
         {result.total.toLocaleString()}
       </p>

--- a/packages/admin/src/components/features/widgets/archetypes/metric.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/metric.tsx
@@ -1,0 +1,45 @@
+/**
+ * The `metric` archetype: one number, large.
+ *
+ * `tabular-nums` because the grid refetches on window focus and a
+ * proportionally-spaced count visibly reflows every time its digits change —
+ * "1,999" to "2,000" moves the whole number sideways. Fixed-width digits keep
+ * a refresh from reading as a layout jump.
+ *
+ * `toLocaleString()` because an unformatted `1234567` is not a number anyone
+ * reads at a glance, and the grouping separator is the reader's, not ours.
+ *
+ * @module components/features/widgets/archetypes/metric
+ */
+
+import type { ArchetypeBody } from "./types";
+
+/**
+ * Renders a `count` result, and REFUSES anything else.
+ *
+ * The refusal is the point. A `list` result carries `items`, and the tempting
+ * coercion — showing `items.length` — invents a number the query never asked
+ * for: a list capped at 5 rows would display "5" for a collection of ten
+ * thousand, which is not wrong-looking in any way the reader could detect. A
+ * mismatch is a declaration bug in the widget, and it has to look like one.
+ */
+export const metricBody: ArchetypeBody = (result, definition) => {
+  if (result.op !== "count") {
+    return {
+      ok: false,
+      message: `"${definition.title}" expected a count, but the query returned a ${result.op}.`,
+    };
+  }
+
+  return {
+    ok: true,
+    node: (
+      <p
+        data-testid="widget-metric-value"
+        className="text-3xl font-bold leading-none tabular-nums tracking-tight text-foreground"
+      >
+        {result.total.toLocaleString()}
+      </p>
+    ),
+  };
+};

--- a/packages/admin/src/components/features/widgets/archetypes/types.ts
+++ b/packages/admin/src/components/features/widgets/archetypes/types.ts
@@ -1,0 +1,28 @@
+/**
+ * What an archetype body is, as a contract the dispatch table can hold.
+ *
+ * A body returns an OUTCOME rather than a node, because "this payload is not
+ * what I asked for" is a real answer an archetype has to be able to give. A
+ * body that could only return a node would have to render its own error box,
+ * which is how a dashboard ends up with as many error designs as it has
+ * archetypes — and the mismatch has to reach `WidgetCard`, which is the thing
+ * that knows to keep the title.
+ *
+ * @module components/features/widgets/archetypes/types
+ */
+
+import type { ReactNode } from "react";
+
+import type {
+  DashboardWidget,
+  WidgetResult,
+} from "@admin/types/dashboard/widgets";
+
+export type ArchetypeOutcome =
+  | { ok: true; node: ReactNode }
+  | { ok: false; message: string };
+
+export type ArchetypeBody = (
+  result: WidgetResult,
+  definition: DashboardWidget
+) => ArchetypeOutcome;

--- a/packages/admin/src/components/features/widgets/outcome.ts
+++ b/packages/admin/src/components/features/widgets/outcome.ts
@@ -1,0 +1,99 @@
+/**
+ * What a widget's card will actually SHOW, decided once.
+ *
+ * Two callers need this and they must never disagree. `WidgetRenderer` draws
+ * from it, and `WidgetGrid` counts from it for the live region — and the grid
+ * previously counted SLOTS instead, which is a different question. A slot can
+ * be `ok` and still unrenderable: a `list` archetype in a release that draws
+ * only `metric`, or a metric handed a list payload. The grid then announced
+ * "3 of 3 widgets updated" while a card on screen said the archetype is not
+ * rendered yet, and the announcement carried the authority of having been
+ * derived from the response.
+ *
+ * So the transport's verdict is not the card's verdict, and the announcement
+ * has to come from the second. Deriving one view from the other rather than
+ * computing them alongside is what keeps them from drifting the day a new
+ * archetype lands.
+ *
+ * The grid and the renderer each call this, so a body runs twice per render.
+ * That is deliberate and it is the cheap half of the trade: a body returns an
+ * element it does not mount, while the alternative — the grid counting
+ * something adjacent — is the defect above.
+ *
+ * @module components/features/widgets/outcome
+ */
+
+import type { WidgetArchetype } from "nextly/config";
+import type { ReactNode } from "react";
+
+import type {
+  DashboardWidget,
+  WidgetSlot,
+} from "@admin/types/dashboard/widgets";
+
+import { metricBody } from "./archetypes/metric";
+import type { ArchetypeBody } from "./archetypes/types";
+
+/**
+ * The archetypes core draws from a query result.
+ *
+ * Partial on purpose: an archetype with no entry is one this release does not
+ * render, and the card says so by name rather than coming up blank. `custom`
+ * is deliberately absent — it is not drawn from a result at all.
+ */
+const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeBody>> = {
+  metric: metricBody,
+};
+
+/**
+ * What the card is about to be, as four cases the grid can count and the
+ * renderer can draw.
+ *
+ * `self-drawn` is neither success nor failure and must not be counted as
+ * either: the plugin's component decides what it shows, and core has no way to
+ * know whether it worked.
+ */
+export type WidgetOutcome =
+  | { state: "self-drawn" }
+  | { state: "loading" }
+  | { state: "failed"; message: string }
+  | { state: "ready"; node: ReactNode };
+
+export function resolveWidgetOutcome(
+  definition: DashboardWidget,
+  slot: WidgetSlot | undefined
+): WidgetOutcome {
+  // The escape hatch. A plugin component owns its own body and its own states.
+  if (definition.archetype === "custom") return { state: "self-drawn" };
+
+  const body = ARCHETYPE_BODIES[definition.archetype];
+  if (!body) {
+    return {
+      state: "failed",
+      message: `The "${definition.archetype}" widget archetype is not rendered yet.`,
+    };
+  }
+
+  if (!slot) {
+    // Absent means IN FLIGHT, and only a widget that actually asked for
+    // something can have a request in flight. One with no query never will, so
+    // reading its absent slot as busy leaves the card spinning for the life of
+    // the page -- with nothing on screen, in the live region or in the console
+    // saying why. `resolve-widgets` prefers a contributed component over this,
+    // so reaching here means there was none to prefer.
+    if (!definition.query) {
+      return {
+        state: "failed",
+        message: `The "${definition.archetype}" archetype is drawn from a query, and this widget declares none.`,
+      };
+    }
+    return { state: "loading" };
+  }
+
+  if (!slot.ok) return { state: "failed", message: slot.error };
+
+  const drawn = body(slot.result, definition);
+  return drawn.ok
+    ? { state: "ready", node: drawn.node }
+    : { state: "failed", message: drawn.message };
+}

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -11,7 +11,11 @@
  * @module components/features/widgets/resolve-widgets
  */
 
-import type { PluginMetadata, PluginWidgetMeta } from "@admin/types/branding";
+import type {
+  PluginMetadata,
+  PluginWidgetMeta,
+  RegisteredWidgetMeta,
+} from "@admin/types/branding";
 import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
 import { legacySizeToWidgetSize } from "./sizes";
@@ -84,22 +88,87 @@ function resolveOne(
   };
 }
 
-/** The visible widgets, in declaration order, each id appearing once. */
+/**
+ * One REGISTERED widget as the grid renders it, or `undefined` when the user
+ * may not see it.
+ *
+ * Separate from `resolveOne` above rather than folded into it, because the two
+ * inputs are different contracts rather than two spellings of one. A
+ * contribution is almost entirely optional and needs every default that
+ * function supplies; a registered definition passed `validateWidgetDefinition`,
+ * which requires the title, the archetype and the size, requires a query for
+ * every data archetype and a component for `custom`, and forbids each where it
+ * does not belong. Nothing here has a default to invent, and giving it one
+ * would quietly accept a definition the registry would have refused.
+ *
+ * The permission gate IS shared, and deliberately: a denied widget's query must
+ * stay out of the batch whichever channel declared it.
+ */
+function resolveRegistered(
+  meta: RegisteredWidgetMeta,
+  hasPermission: (permission: string) => boolean
+): DashboardWidget | undefined {
+  if (meta.requiredPermission && !hasPermission(meta.requiredPermission)) {
+    return undefined;
+  }
+
+  return {
+    id: meta.id,
+    title: meta.title,
+    description: meta.description,
+    icon: meta.icon,
+    archetype: meta.archetype,
+    size: meta.defaultSize,
+    query: meta.query,
+    component: meta.component,
+    link: meta.link,
+  };
+}
+
+/**
+ * The visible widgets, each id appearing once: contributions in declaration
+ * order, then registrations.
+ *
+ * BOTH channels, because they are two ways into the same grid and neither
+ * subsumes the other. `contributes.admin.widgets` is declarative and travels
+ * with the plugin's config; `registerWidget` is the imperative API the widget
+ * registry exists for. Reading only the first left an app that used the public
+ * registration API invisible to the renderer built around that registry.
+ *
+ * Contributions FIRST, so an id declared in both keeps the card the dashboard
+ * already drew for it. An app that worked around the gap by declaring a
+ * registered widget twice therefore sees no change, and the registry only ever
+ * ADDS what was previously missing.
+ */
 export function resolveDashboardWidgets(
   plugins: PluginMetadata[] | undefined,
+  registered: RegisteredWidgetMeta[] | undefined,
   hasPermission: (permission: string) => boolean
 ): DashboardWidget[] {
-  // Widget ids are plugin-local, so two plugins can ship the same one. The id
-  // is what keys a batch result back to its card, so a duplicate would hand
-  // both widgets the same slot -- one of them showing the other's number, with
-  // nothing visibly wrong. First declaration wins and the rest are dropped.
+  // Widget ids are plugin-local, so two plugins can ship the same one -- and a
+  // registration can collide with a contribution. The id is what keys a batch
+  // result back to its card, so a duplicate would hand both widgets the same
+  // slot -- one of them showing the other's number, with nothing visibly wrong.
+  // First declaration wins and the rest are dropped.
   const seen = new Set<string>();
 
-  return declaredWidgets(plugins).flatMap(meta => {
-    if (seen.has(meta.id)) return [];
-    const widget = resolveOne(meta, hasPermission);
+  const take = (
+    id: string,
+    resolve: () => DashboardWidget | undefined
+  ): DashboardWidget[] => {
+    if (seen.has(id)) return [];
+    const widget = resolve();
     if (!widget) return [];
-    seen.add(meta.id);
+    seen.add(id);
     return [widget];
-  });
+  };
+
+  return [
+    ...declaredWidgets(plugins).flatMap(meta =>
+      take(meta.id, () => resolveOne(meta, hasPermission))
+    ),
+    ...(registered ?? []).flatMap(meta =>
+      take(meta.id, () => resolveRegistered(meta, hasPermission))
+    ),
+  ];
 }

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -29,12 +29,42 @@ import { legacySizeToWidgetSize } from "./sizes";
  * plugin half has gone missing must never break the grid, and a card with a
  * title and nothing under it reads as a product bug rather than as a missing
  * plugin.
+ *
+ * A declared archetype does NOT automatically win, and that is the case worth
+ * reading twice. Every archetype but `custom` is drawn by core FROM A QUERY
+ * RESULT, so one declared without a query describes a body core cannot produce
+ * -- no request is made for it, no slot ever arrives, and the card reads that
+ * absence as "still loading" for the life of the page. `PluginAdminWidget`
+ * makes `query` optional and `component` required, so the declaration is legal
+ * and the component is always there; drawing it is both the better outcome and
+ * the one the author actually shipped.
  */
 function resolveArchetype(
   meta: PluginWidgetMeta
 ): DashboardWidget["archetype"] | undefined {
-  if (meta.archetype) return meta.archetype;
+  if (meta.archetype) {
+    if (meta.archetype !== "custom" && !meta.query && meta.component) {
+      return "custom";
+    }
+    return meta.archetype;
+  }
   return meta.component ? "custom" : undefined;
+}
+
+/**
+ * A title with visible text, falling back to the widget's id.
+ *
+ * TRIMMED, not merely nullish-checked. `title: ""` and `title: "   "` are legal
+ * for a contributed widget -- boot requires only a usable `id` and `component`
+ * -- and both pass a `??`. The title is the card region's `aria-labelledby`
+ * target, so an empty one makes a landmark with no accessible name, which is
+ * worse for a screen-reader user than having no landmark at all. The id is a
+ * poor title and it NAMES the widget, which is the one thing a card in that
+ * state has to be able to do.
+ */
+function resolveTitle(title: string | undefined, id: string): string {
+  const trimmed = title?.trim();
+  return trimmed ? trimmed : id;
 }
 
 /**
@@ -72,9 +102,7 @@ function resolveOne(
 
   return {
     id: meta.id,
-    // The id is a poor title, but it names the widget, which is the one thing
-    // an error card has to be able to do.
-    title: meta.title ?? meta.id,
+    title: resolveTitle(meta.title, meta.id),
     description: meta.description,
     icon: meta.icon,
     archetype,
@@ -114,7 +142,10 @@ function resolveRegistered(
 
   return {
     id: meta.id,
-    title: meta.title,
+    // Through the same helper as a contribution, though `validateWidgetDefinition`
+    // already rejects a blank title: the card must not have two ideas about what
+    // its region is named depending on which channel declared it.
+    title: resolveTitle(meta.title, meta.id),
     description: meta.description,
     icon: meta.icon,
     archetype: meta.archetype,

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -1,0 +1,105 @@
+/**
+ * Turns what plugins DECLARED into what the grid can render.
+ *
+ * A `PluginWidgetMeta` is almost entirely optional — a widget may legally be
+ * nothing but an id and a component path — while `DashboardWidget` is the shape
+ * the renderer works from, with no field it would have to invent a default for.
+ * Closing that gap in ONE function is what keeps the defaults out of the
+ * renderer, where "title ?? id" would end up written once per archetype and
+ * would drift.
+ *
+ * @module components/features/widgets/resolve-widgets
+ */
+
+import type { PluginMetadata, PluginWidgetMeta } from "@admin/types/branding";
+import type { DashboardWidget } from "@admin/types/dashboard/widgets";
+
+import { legacySizeToWidgetSize } from "./sizes";
+
+/**
+ * The archetype a declaration means, or `undefined` when it means nothing
+ * renderable.
+ *
+ * A widget with neither an archetype nor a component describes no body at all.
+ * It is skipped rather than rendered as an empty card: a definition whose
+ * plugin half has gone missing must never break the grid, and a card with a
+ * title and nothing under it reads as a product bug rather than as a missing
+ * plugin.
+ */
+function resolveArchetype(
+  meta: PluginWidgetMeta
+): DashboardWidget["archetype"] | undefined {
+  if (meta.archetype) return meta.archetype;
+  return meta.component ? "custom" : undefined;
+}
+
+/**
+ * Every widget declared by any plugin, flattened, with no filtering.
+ *
+ * Separate from the decisions below so the two `?? []` defaults — a project
+ * with no plugins, a plugin with no widgets — sit in the one place that is
+ * about SHAPE rather than about visibility.
+ */
+function declaredWidgets(
+  plugins: PluginMetadata[] | undefined
+): PluginWidgetMeta[] {
+  return (plugins ?? []).flatMap(plugin => plugin.widgets ?? []);
+}
+
+/**
+ * One declaration as the grid renders it, or `undefined` when it is not
+ * renderable at all.
+ *
+ * `hasPermission` is the `useCurrentUserPermissions` predicate, which is
+ * closed-until-loaded: an undeclared permission renders, a declared one does
+ * not render until the grant is known. Gating HERE rather than inside the card
+ * is what keeps a denied widget's query out of the batch — a card that is never
+ * mounted must not cause a request on the user's behalf.
+ */
+function resolveOne(
+  meta: PluginWidgetMeta,
+  hasPermission: (permission: string) => boolean
+): DashboardWidget | undefined {
+  if (meta.requiredPermission && !hasPermission(meta.requiredPermission)) {
+    return undefined;
+  }
+  const archetype = resolveArchetype(meta);
+  if (!archetype) return undefined;
+
+  return {
+    id: meta.id,
+    // The id is a poor title, but it names the widget, which is the one thing
+    // an error card has to be able to do.
+    title: meta.title ?? meta.id,
+    description: meta.description,
+    icon: meta.icon,
+    archetype,
+    // `defaultSize` is the enum; `size` is the deprecated two-value alias. The
+    // enum wins where both are declared, because a plugin that adopted the new
+    // field meant it.
+    size: meta.defaultSize ?? legacySizeToWidgetSize(meta.size),
+    query: meta.query,
+    component: meta.component,
+    link: meta.link,
+  };
+}
+
+/** The visible widgets, in declaration order, each id appearing once. */
+export function resolveDashboardWidgets(
+  plugins: PluginMetadata[] | undefined,
+  hasPermission: (permission: string) => boolean
+): DashboardWidget[] {
+  // Widget ids are plugin-local, so two plugins can ship the same one. The id
+  // is what keys a batch result back to its card, so a duplicate would hand
+  // both widgets the same slot -- one of them showing the other's number, with
+  // nothing visibly wrong. First declaration wins and the rest are dropped.
+  const seen = new Set<string>();
+
+  return declaredWidgets(plugins).flatMap(meta => {
+    if (seen.has(meta.id)) return [];
+    const widget = resolveOne(meta, hasPermission);
+    if (!widget) return [];
+    seen.add(meta.id);
+    return [widget];
+  });
+}

--- a/packages/admin/src/components/features/widgets/sizes.ts
+++ b/packages/admin/src/components/features/widgets/sizes.ts
@@ -1,0 +1,71 @@
+/**
+ * The one place a widget's width is decided.
+ *
+ * Sizes are named steps on a 12-column grid, and the map below is the design's
+ * responsive table written as class text:
+ *
+ * | size   | < md | md | >= lg |
+ * |--------|------|----|-------|
+ * | `sm`   | 12   | 6  | 3     |
+ * | `md`   | 12   | 6  | 4     |
+ * | `lg`   | 12   | 12 | 6     |
+ * | `xl`   | 12   | 12 | 8     |
+ * | `full` | 12   | 12 | 12    |
+ *
+ * Two properties this file exists to hold.
+ *
+ * The BASE span is 12 for every size, with no exceptions. Below `md` a
+ * dashboard is one column: an unprefixed `col-span-6` is half a phone screen,
+ * which is what the grid this replaces shipped.
+ *
+ * And every class is written out IN FULL. Tailwind resolves utilities by
+ * scanning source TEXT, so a `col-span-${n}` template literal produces a
+ * `className` at runtime that has no rule behind it in the built stylesheet —
+ * the element gets the attribute and no width. The `md:col-span-12` entries are
+ * therefore literal and deliberate even where they restate the base: they make
+ * the map readable as the table it is, and cost one scanned class each.
+ *
+ * @module components/features/widgets/sizes
+ */
+
+import type { WidgetSize } from "nextly/config";
+
+/**
+ * Span classes per size. Frozen because this is the shared map, not a starting
+ * point a caller may edit for one grid.
+ */
+export const WIDGET_SPAN_CLASSES: Readonly<Record<WidgetSize, string>> =
+  Object.freeze({
+    sm: "col-span-12 md:col-span-6 lg:col-span-3",
+    md: "col-span-12 md:col-span-6 lg:col-span-4",
+    lg: "col-span-12 md:col-span-12 lg:col-span-6",
+    xl: "col-span-12 md:col-span-12 lg:col-span-8",
+    full: "col-span-12",
+  });
+
+/**
+ * The span classes for `size`, falling back to full width.
+ *
+ * The fallback is not defensive decoration: `size` reaches here from a plugin's
+ * declaration over the wire, so a value outside the enum is a shape the admin
+ * has to survive. Full width is the safe answer — a widget too wide is legible,
+ * a widget with no span class at all collapses to the grid's implicit one.
+ */
+export function widgetSpanClass(size: WidgetSize | undefined): string {
+  if (!size) return WIDGET_SPAN_CLASSES.full;
+  return WIDGET_SPAN_CLASSES[size] ?? WIDGET_SPAN_CLASSES.full;
+}
+
+/**
+ * The deprecated `size?: "full" | "half"` alias, as a real size.
+ *
+ * Plugin declarations still carry it, and `half` meant "6 of 12" — which is
+ * `lg` in the enum. Mapping it here rather than at the call site is what stops
+ * the old vocabulary reaching the span map, where it would miss and silently
+ * become full width for every half widget on the dashboard.
+ */
+export function legacySizeToWidgetSize(
+  size: "full" | "half" | undefined
+): WidgetSize {
+  return size === "half" ? "lg" : "full";
+}

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -1,0 +1,242 @@
+/**
+ * The batching hook. Every assertion here is about an OUTCOME the dashboard
+ * can observe — how many requests left the browser, and which widget got which
+ * answer — rather than about `protectedApi.post` having been reached.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+
+import { useWidgetQueries } from "./useWidgetQueries";
+
+import type { WidgetQuery } from "nextly/config";
+
+vi.mock("@admin/lib/api/protectedApi", () => ({
+  protectedApi: { post: vi.fn() },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    // `retry` is NOT disabled here. The hook sets `retry: 2` itself, following
+    // `useDashboardStats`, and a query-level option wins over this default — so
+    // turning it off here would only make the tests look like they had. What is
+    // disabled is the BACKOFF, which is where the seconds go: three immediate
+    // attempts exercise the same retry path in milliseconds.
+    defaultOptions: { queries: { retryDelay: 0, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+const countQuery = (source: string): WidgetQuery => ({ source, op: "count" });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useWidgetQueries", () => {
+  it("sends N queries as ONE request", async () => {
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "count", total: 1 } },
+        { ok: true, result: { op: "count", total: 2 } },
+        { ok: true, result: { op: "count", total: 3 } },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/a", query: countQuery("collection:posts") },
+          { widgetId: "core/b", query: countQuery("collection:pages") },
+          { widgetId: "core/c", query: countQuery("collection:media") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() =>
+      expect(Object.keys(result.current.slots)).toHaveLength(3)
+    );
+    expect(protectedApi.post).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(protectedApi.post).mock.calls[0][0]).toBe(
+      "/dashboard/query"
+    );
+    expect(vi.mocked(protectedApi.post).mock.calls[0][1]).toEqual({
+      queries: [
+        countQuery("collection:posts"),
+        countQuery("collection:pages"),
+        countQuery("collection:media"),
+      ],
+    });
+  });
+
+  it("keys positional results back onto their widget ids", async () => {
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "count", total: 11 } },
+        { ok: true, result: { op: "count", total: 22 } },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/posts", query: countQuery("collection:posts") },
+          { widgetId: "core/pages", query: countQuery("collection:pages") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() =>
+      expect(result.current.slots["core/posts"]).toBeDefined()
+    );
+    expect(result.current.slots["core/posts"]).toEqual({
+      ok: true,
+      result: { op: "count", total: 11 },
+    });
+    expect(result.current.slots["core/pages"]).toEqual({
+      ok: true,
+      result: { op: "count", total: 22 },
+    });
+  });
+
+  it("does not blank a neighbour when one slot fails", async () => {
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: false, error: "Source unavailable." },
+        { ok: true, result: { op: "count", total: 7 } },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/broken", query: countQuery("collection:gone") },
+          { widgetId: "core/fine", query: countQuery("collection:posts") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() =>
+      expect(result.current.slots["core/fine"]).toBeDefined()
+    );
+    expect(result.current.slots["core/broken"]).toEqual({
+      ok: false,
+      error: "Source unavailable.",
+    });
+    expect(result.current.slots["core/fine"]).toEqual({
+      ok: true,
+      result: { op: "count", total: 7 },
+    });
+    // A failing slot is data, not a rejected query.
+    expect(result.current.error).toBeNull();
+  });
+
+  it("issues no request at all when there is nothing to ask", async () => {
+    const { result } = renderHook(() => useWidgetQueries([]), { wrapper });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(protectedApi.post).not.toHaveBeenCalled();
+    expect(result.current.slots).toEqual({});
+  });
+
+  it("gives a widget the server answered short an explicit failed slot", async () => {
+    // A server that returns fewer slots than queries would otherwise leave the
+    // trailing widgets in a permanent, silent loading state.
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [{ ok: true, result: { op: "count", total: 5 } }],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/a", query: countQuery("collection:posts") },
+          { widgetId: "core/b", query: countQuery("collection:pages") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.slots["core/b"]).toBeDefined());
+    expect(result.current.slots["core/b"]).toEqual({
+      ok: false,
+      error: expect.stringMatching(/no result/i),
+    });
+  });
+
+  it("surfaces a whole-request failure as error, with no slots", async () => {
+    vi.mocked(protectedApi.post).mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/a", query: countQuery("collection:posts") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("network down");
+    expect(result.current.slots).toEqual({});
+  });
+
+  it("reports loading while the single request is in flight", async () => {
+    vi.mocked(protectedApi.post).mockImplementation(
+      () => new Promise(() => {})
+    );
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/a", query: countQuery("collection:posts") },
+        ]),
+      { wrapper }
+    );
+
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it("refetches through one request, not one per widget", async () => {
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        { ok: true, result: { op: "count", total: 1 } },
+        { ok: true, result: { op: "count", total: 2 } },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/a", query: countQuery("collection:posts") },
+          { widgetId: "core/b", query: countQuery("collection:pages") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.slots["core/b"]).toBeDefined());
+    expect(protectedApi.post).toHaveBeenCalledTimes(1);
+
+    await result.current.refetch();
+    expect(protectedApi.post).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses a body the server did not shape as a results array", async () => {
+    vi.mocked(protectedApi.post).mockResolvedValue({ nope: true });
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/a", query: countQuery("collection:posts") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.slots).toEqual({});
+  });
+});

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -12,7 +12,7 @@ import { protectedApi } from "@admin/lib/api/protectedApi";
 
 import { useWidgetQueries } from "./useWidgetQueries";
 
-import type { WidgetQuery } from "nextly/config";
+import { MAX_QUERIES_PER_REQUEST, type WidgetQuery } from "nextly/config";
 
 vi.mock("@admin/lib/api/protectedApi", () => ({
   protectedApi: { post: vi.fn() },
@@ -248,6 +248,118 @@ describe("useWidgetQueries", () => {
 
     await result.current.refetch();
     expect(protectedApi.post).toHaveBeenCalledTimes(2);
+  });
+
+  it("splits a dashboard past the endpoint's cap into requests it will accept", async () => {
+    // The endpoint REFUSES a body above `MAX_QUERIES_PER_REQUEST`, so one
+    // oversized batch is rejected whole -- every widget on the dashboard dark
+    // at once, over a limit none of them individually crossed.
+    const over = MAX_QUERIES_PER_REQUEST + 1;
+    const requests = Array.from({ length: over }, (_, i) => ({
+      widgetId: `core/${i}`,
+      query: countQuery(`collection:c${i}`),
+    }));
+    vi.mocked(protectedApi.post).mockImplementation(
+      async (_path: string, body: unknown) => ({
+        results: (body as { queries: unknown[] }).queries.map((_q, i) => ({
+          ok: true,
+          result: { op: "count", total: i },
+        })),
+      })
+    );
+
+    const { result } = renderHook(() => useWidgetQueries(requests), {
+      wrapper,
+    });
+
+    await waitFor(() =>
+      expect(Object.keys(result.current.slots)).toHaveLength(over)
+    );
+    // Every widget answered, and no request exceeded the cap.
+    for (const call of vi.mocked(protectedApi.post).mock.calls) {
+      expect(
+        (call[1] as { queries: unknown[] }).queries.length
+      ).toBeLessThanOrEqual(MAX_QUERIES_PER_REQUEST);
+    }
+    // The keying survives the split: the last widget belongs to the second
+    // partition and reads position 0 of ITS response, not position 30.
+    expect(result.current.slots[`core/${over - 1}`]).toEqual({
+      ok: true,
+      result: { op: "count", total: 0 },
+    });
+    expect(result.current.slots["core/0"]).toEqual({
+      ok: true,
+      result: { op: "count", total: 0 },
+    });
+    expect(result.current.slots["core/5"]).toEqual({
+      ok: true,
+      result: { op: "count", total: 5 },
+    });
+  });
+
+  it("keeps one request while the dashboard fits in one", async () => {
+    // The control for the split above: partitioning must not turn the common
+    // case into several round trips.
+    const requests = Array.from(
+      { length: MAX_QUERIES_PER_REQUEST },
+      (_, i) => ({
+        widgetId: `core/${i}`,
+        query: countQuery(`collection:c${i}`),
+      })
+    );
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: requests.map(() => ({
+        ok: true,
+        result: { op: "count", total: 1 },
+      })),
+    });
+
+    const { result } = renderHook(() => useWidgetQueries(requests), {
+      wrapper,
+    });
+
+    await waitFor(() =>
+      expect(Object.keys(result.current.slots)).toHaveLength(
+        MAX_QUERIES_PER_REQUEST
+      )
+    );
+    expect(protectedApi.post).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails only the partition that failed, not the widgets beside it", async () => {
+    const over = MAX_QUERIES_PER_REQUEST + 1;
+    const requests = Array.from({ length: over }, (_, i) => ({
+      widgetId: `core/${i}`,
+      query: countQuery(`collection:c${i}`),
+    }));
+    vi.mocked(protectedApi.post).mockImplementation(
+      async (_path: string, body: unknown) => {
+        const sent = (body as { queries: unknown[] }).queries;
+        if (sent.length === 1) throw new Error("second batch down");
+        return {
+          results: sent.map(() => ({
+            ok: true,
+            result: { op: "count", total: 3 },
+          })),
+        };
+      }
+    );
+
+    const { result } = renderHook(() => useWidgetQueries(requests), {
+      wrapper,
+    });
+
+    await waitFor(() =>
+      expect(result.current.slots[`core/${over - 1}`]).toBeDefined()
+    );
+    expect(result.current.slots[`core/${over - 1}`]).toEqual({
+      ok: false,
+      error: expect.stringMatching(/could not be/i),
+    });
+    expect(result.current.slots["core/0"]).toEqual({
+      ok: true,
+      result: { op: "count", total: 3 },
+    });
   });
 
   it("refuses a body the server did not shape as a results array", async () => {

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -362,6 +362,72 @@ describe("useWidgetQueries", () => {
     });
   });
 
+  describe("a member of results that is not a slot", () => {
+    async function slotFor(member: unknown) {
+      vi.mocked(protectedApi.post).mockResolvedValue({ results: [member] });
+      const { result } = renderHook(
+        () =>
+          useWidgetQueries([
+            { widgetId: "core/a", query: countQuery("collection:posts") },
+          ]),
+        { wrapper }
+      );
+      await waitFor(() => expect(result.current.slots["core/a"]).toBeDefined());
+      return result.current.slots["core/a"];
+    }
+
+    it("isolates an ok slot carrying no result", async () => {
+      // `{ ok: true }` is where this actually bites: the renderer hands
+      // `slot.result` to an archetype body, which reads `result.op` and throws
+      // a TypeError into the dashboard's error boundary -- one malformed entry
+      // replacing the whole page.
+      expect(await slotFor({ ok: true })).toEqual({
+        ok: false,
+        error: expect.stringMatching(/unreadable/i),
+      });
+    });
+
+    it("isolates a primitive where a slot belongs", async () => {
+      // Quieter and no better: `ok` is absent, so the card took the failure
+      // branch with `undefined` for its message and drew a blank body.
+      expect(await slotFor(42)).toEqual({
+        ok: false,
+        error: expect.stringMatching(/unreadable/i),
+      });
+    });
+
+    it("isolates an object with no discriminator", async () => {
+      expect(await slotFor({})).toEqual({
+        ok: false,
+        error: expect.stringMatching(/unreadable/i),
+      });
+    });
+
+    it("isolates a failed slot whose message is missing", async () => {
+      expect(await slotFor({ ok: false })).toEqual({
+        ok: false,
+        error: expect.stringMatching(/unreadable/i),
+      });
+    });
+
+    it("still reads a null member as the server answering short", async () => {
+      // The control: `null` was always handled, and must stay handled with its
+      // own sentence rather than being folded into the malformed case.
+      expect(await slotFor(null)).toEqual({
+        ok: false,
+        error: expect.stringMatching(/no result/i),
+      });
+    });
+
+    it("still passes a well-formed slot through untouched", async () => {
+      // The positive control. A validator that refused everything would satisfy
+      // every assertion above.
+      expect(
+        await slotFor({ ok: true, result: { op: "count", total: 8 } })
+      ).toEqual({ ok: true, result: { op: "count", total: 8 } });
+    });
+  });
+
   it("refuses a body the server did not shape as a results array", async () => {
     vi.mocked(protectedApi.post).mockResolvedValue({ nope: true });
 

--- a/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.test.tsx
@@ -169,8 +169,35 @@ describe("useWidgetQueries", () => {
     });
   });
 
-  it("surfaces a whole-request failure as error, with no slots", async () => {
+  it("gives every widget a FAILED slot when the whole request fails", async () => {
+    // Not an empty `slots`. A widget with no slot is busy by the renderer's
+    // contract, so a settled failure that produced no slots left every card on
+    // the dashboard spinning forever.
     vi.mocked(protectedApi.post).mockRejectedValue(new Error("network down"));
+
+    const { result } = renderHook(
+      () =>
+        useWidgetQueries([
+          { widgetId: "core/a", query: countQuery("collection:posts") },
+          { widgetId: "core/b", query: countQuery("collection:pages") },
+        ]),
+      { wrapper }
+    );
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe("network down");
+    expect(result.current.slots).toEqual({
+      "core/a": { ok: false, error: expect.stringMatching(/could not be/i) },
+      "core/b": { ok: false, error: expect.stringMatching(/could not be/i) },
+    });
+  });
+
+  it("says nothing per widget while the request is still being retried", async () => {
+    // Absent, not failed: the batch has not settled, so the cards are busy
+    // rather than broken.
+    vi.mocked(protectedApi.post).mockImplementation(
+      () => new Promise(() => {})
+    );
 
     const { result } = renderHook(
       () =>
@@ -180,8 +207,6 @@ describe("useWidgetQueries", () => {
       { wrapper }
     );
 
-    await waitFor(() => expect(result.current.error).not.toBeNull());
-    expect(result.current.error?.message).toBe("network down");
     expect(result.current.slots).toEqual({});
   });
 
@@ -237,6 +262,11 @@ describe("useWidgetQueries", () => {
     );
 
     await waitFor(() => expect(result.current.error).not.toBeNull());
-    expect(result.current.slots).toEqual({});
+    // Refused, so it settled by failing -- which the widget hears about in its
+    // own slot rather than by waiting forever.
+    expect(result.current.slots["core/a"]).toEqual({
+      ok: false,
+      error: expect.stringMatching(/could not be/i),
+    });
   });
 });

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -51,6 +51,24 @@ export interface UseWidgetQueriesResult {
 const MISSING_SLOT_ERROR = "The server returned no result for this widget.";
 
 /**
+ * What every widget in a batch is told when the REQUEST itself failed.
+ *
+ * A settled-and-failed request must produce slots, not an absence. A widget
+ * with no slot is BUSY by the renderer's contract -- which is right while the
+ * batch is in flight and wrong once it has failed, and the difference is
+ * invisible from the card: every data widget on the dashboard sat spinning
+ * forever, with only the grid's live region saying anything had gone wrong.
+ *
+ * A fixed sentence rather than the transport's own message. The per-slot errors
+ * the server sends are written to be read by an admin; a rejected request
+ * carries whatever the network, a proxy or a changed envelope produced, and
+ * putting that on ten cards at once turns the card into a channel for text
+ * nobody wrote for it. What actually failed travels in `error`, where the grid
+ * reads it.
+ */
+const BATCH_FAILED_ERROR = "Dashboard data could not be loaded.";
+
+/**
  * Narrows the response body before anything is keyed from it.
  *
  * The alternative — trusting `results` and indexing it — turns a proxy error
@@ -100,21 +118,39 @@ export function useWidgetQueries(
   });
 
   const results = query.data;
+  // `isError` is settled-and-failed: with `retry: 2` the query stays pending
+  // through its attempts, so this is false while there is still hope.
+  const failed = query.isError;
 
   const slots = useMemo<Record<string, WidgetSlot>>(() => {
-    if (!results) return {};
     const keyed: Record<string, WidgetSlot> = {};
-    queries.forEach((entry, index) => {
-      // A short response is the server disagreeing with us about how many
-      // questions were asked. Saying so per widget is what stops the trailing
-      // cards spinning silently forever.
-      keyed[entry.widgetId] = results[index] ?? {
-        ok: false,
-        error: MISSING_SLOT_ERROR,
-      };
-    });
+
+    if (results) {
+      queries.forEach((entry, index) => {
+        // A short response is the server disagreeing with us about how many
+        // questions were asked. Saying so per widget is what stops the trailing
+        // cards spinning silently forever.
+        keyed[entry.widgetId] = results[index] ?? {
+          ok: false,
+          error: MISSING_SLOT_ERROR,
+        };
+      });
+      return keyed;
+    }
+
+    // Answered by failing. Every widget gets its own failed slot, because a
+    // card cannot tell an absent slot from a pending one and renders both as
+    // busy. Data it already holds wins over this branch -- a refetch that
+    // fails on window focus keeps the numbers the reader was looking at,
+    // which is the same reason loading marks the body rather than replacing it.
+    if (failed) {
+      queries.forEach(entry => {
+        keyed[entry.widgetId] = { ok: false, error: BATCH_FAILED_ERROR };
+      });
+    }
+
     return keyed;
-  }, [queries, results]);
+  }, [queries, results, failed]);
 
   return {
     slots,

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -1,0 +1,128 @@
+/**
+ * Every visible widget's data request, in ONE round trip.
+ *
+ * `POST /api/dashboard/query` takes `{ queries: WidgetQuery[] }` and answers
+ * `{ results }` POSITIONALLY — `results[i]` belongs to `queries[i]` and carries
+ * no widget id of its own. Re-keying that back onto widget ids is this hook's
+ * whole job, and it is the reason a dashboard of ten cards costs one request
+ * rather than ten.
+ *
+ * Refresh follows `useDashboardStats` exactly: `staleTime: 0`, refetch on mount
+ * and on window focus, and NO polling interval. The UX evidence is against
+ * aggressive auto-refresh; a dashboard that moves on its own is a dashboard
+ * nobody can read.
+ *
+ * @module hooks/queries/useWidgetQueries
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import type { WidgetQuery } from "nextly/config";
+import { useMemo } from "react";
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+import type {
+  WidgetQueryBatchResponse,
+  WidgetSlot,
+} from "@admin/types/dashboard/widgets";
+
+/** One widget's request: the id to key the answer back to, and what to ask. */
+export interface WidgetQueryRequest {
+  widgetId: string;
+  query: WidgetQuery;
+}
+
+export interface UseWidgetQueriesResult {
+  /** Keyed by `widgetId`. A widget with no answer yet is simply absent. */
+  slots: Record<string, WidgetSlot>;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<unknown>;
+  /**
+   * When this batch landed, or `null` before it has.
+   *
+   * Exposed because the card's freshness line is a property of the BATCH, not
+   * of a widget: every card in one request was answered at the same instant,
+   * and a per-card timestamp would be the same value recomputed n times.
+   */
+  updatedAt: Date | null;
+}
+
+/** What a widget is told when the batch came back shorter than it went out. */
+const MISSING_SLOT_ERROR = "The server returned no result for this widget.";
+
+/**
+ * Narrows the response body before anything is keyed from it.
+ *
+ * The alternative — trusting `results` and indexing it — turns a proxy error
+ * page or a changed envelope into a dashboard of cards stuck loading forever,
+ * with nothing anywhere saying why. Failing the query instead puts the failure
+ * where `error` is read.
+ */
+function readResults(body: unknown): WidgetSlot[] {
+  const results = (body as WidgetQueryBatchResponse | null)?.results;
+  if (!Array.isArray(results)) {
+    throw new Error(
+      "Dashboard query response was not shaped as { results: [] }."
+    );
+  }
+  return results;
+}
+
+/**
+ * Batches `queries` into one request and hands each widget back its own slot.
+ *
+ * `enabled` is `queries.length > 0`: a dashboard with nothing to ask must issue
+ * no request, not an empty one. An empty batch would still cost a round trip,
+ * an authentication check and a log line on every mount and every window focus,
+ * for an answer that is knowable without asking.
+ */
+export function useWidgetQueries(
+  queries: WidgetQueryRequest[]
+): UseWidgetQueriesResult {
+  const query = useQuery<WidgetSlot[], Error>({
+    // The requests themselves are the key. Two dashboards asking for different
+    // widgets are different questions and must not share one cache entry;
+    // TanStack hashes the array deterministically, so a re-render with an
+    // equal-but-new array does not refetch.
+    queryKey: ["dashboard", "widget-queries", queries],
+    queryFn: async () => {
+      const body = await protectedApi.post<unknown>("/dashboard/query", {
+        queries: queries.map(entry => entry.query),
+      });
+      return readResults(body);
+    },
+    enabled: queries.length > 0,
+    staleTime: 0,
+    gcTime: 5 * 60 * 1000,
+    retry: 2,
+    refetchOnMount: "always",
+    refetchOnWindowFocus: true,
+  });
+
+  const results = query.data;
+
+  const slots = useMemo<Record<string, WidgetSlot>>(() => {
+    if (!results) return {};
+    const keyed: Record<string, WidgetSlot> = {};
+    queries.forEach((entry, index) => {
+      // A short response is the server disagreeing with us about how many
+      // questions were asked. Saying so per widget is what stops the trailing
+      // cards spinning silently forever.
+      keyed[entry.widgetId] = results[index] ?? {
+        ok: false,
+        error: MISSING_SLOT_ERROR,
+      };
+    });
+    return keyed;
+  }, [queries, results]);
+
+  return {
+    slots,
+    isLoading: query.isLoading,
+    error: query.error ?? null,
+    refetch: query.refetch,
+    // `dataUpdatedAt` is 0 until the query has resolved once, which is not an
+    // instant in 1970 -- it is the absence of one.
+    updatedAt: query.dataUpdatedAt ? new Date(query.dataUpdatedAt) : null,
+  };
+}

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -32,6 +32,7 @@ import { useMemo } from "react";
 import { protectedApi } from "@admin/lib/api/protectedApi";
 import type {
   WidgetQueryBatchResponse,
+  WidgetResult,
   WidgetSlot,
 } from "@admin/types/dashboard/widgets";
 
@@ -71,6 +72,10 @@ export interface UseWidgetQueriesResult {
 /** What a widget is told when the batch came back shorter than it went out. */
 const MISSING_SLOT_ERROR = "The server returned no result for this widget.";
 
+/** What a widget is told when its entry is not shaped like a slot at all. */
+const MALFORMED_SLOT_ERROR =
+  "The server returned an unreadable result for this widget.";
+
 /**
  * What every widget in a batch is told when the REQUEST itself failed.
  *
@@ -97,6 +102,63 @@ const BATCH_FAILED_ERROR = "Dashboard data could not be loaded.";
  * with nothing anywhere saying why. Failing the query instead puts the failure
  * where `error` is read.
  */
+/**
+ * One member of `results` as a slot, or a failed slot saying it was not one.
+ *
+ * `Array.isArray` says nothing about the MEMBERS, and every one of them is
+ * dereferenced downstream: `WidgetRenderer` reads `slot.ok` and then hands
+ * `slot.result` to an archetype body, which reads `result.op`. So
+ * `{ "results": [{ "ok": true }] }` threw a `TypeError` out of the renderer and
+ * into the dashboard's error boundary -- one malformed entry replacing the
+ * entire page, which is the exact blast radius the per-slot shape exists to
+ * prevent. `{ "results": [42] }` was quieter and no better: `ok` was absent, so
+ * the card took the failure branch with `undefined` where its message goes and
+ * drew a blank body with nothing wrong on it.
+ *
+ * The DISCRIMINATOR is checked before anything branches on it, because a member
+ * carrying neither `true` nor `false` there is not a slot in either direction.
+ * `result` is checked as an OBJECT and no further: an archetype refuses a
+ * payload of the wrong `op` itself and names the widget when it does, and that
+ * refusal is better than this one. What it cannot survive is not being handed
+ * an object at all.
+ */
+function asSlot(value: unknown): WidgetSlot {
+  if (value === undefined || value === null) {
+    return { ok: false, error: MISSING_SLOT_ERROR };
+  }
+  if (!isObject(value)) return malformed();
+
+  const slot = value as { ok?: unknown; error?: unknown; result?: unknown };
+
+  if (slot.ok === false) return refusal(slot.error);
+  if (slot.ok !== true) return malformed();
+  if (!isObject(slot.result)) return malformed();
+
+  return { ok: true, result: slot.result as WidgetResult };
+}
+
+/** Whether a value can be read as the object a slot or a result must be. */
+function isObject(value: unknown): boolean {
+  return typeof value === "object" && value !== null;
+}
+
+/** The refusal a member gets when it is not a slot at all. */
+function malformed(): WidgetSlot {
+  return { ok: false, error: MALFORMED_SLOT_ERROR };
+}
+
+/**
+ * A declared failure, carrying the server's own message.
+ *
+ * A slot that says `ok: false` and supplies no readable message is still a
+ * failure -- refusing to show it would be a second, silent one -- so it falls
+ * back rather than being discarded.
+ */
+function refusal(error: unknown): WidgetSlot {
+  const usable = typeof error === "string" && error.trim() !== "";
+  return { ok: false, error: usable ? error : MALFORMED_SLOT_ERROR };
+}
+
 function readResults(body: unknown): unknown[] {
   const results = (body as WidgetQueryBatchResponse | null)?.results;
   if (!Array.isArray(results)) {
@@ -174,12 +236,11 @@ export function useWidgetQueries(
     if (answer.data) {
       partition.forEach((entry, position) => {
         // A short response is the server disagreeing with us about how many
-        // questions were asked. Saying so per widget is what stops the trailing
-        // cards spinning silently forever.
-        slots[entry.widgetId] = (answer.data[position] as WidgetSlot) ?? {
-          ok: false,
-          error: MISSING_SLOT_ERROR,
-        };
+        // questions were asked, and a member that is not a slot is it
+        // disagreeing about the shape. Saying so per widget is what stops the
+        // trailing cards spinning silently forever -- and what keeps one bad
+        // entry from throwing out of the renderer and taking the page with it.
+        slots[entry.widgetId] = asSlot(answer.data[position]);
       });
       return;
     }

--- a/packages/admin/src/hooks/queries/useWidgetQueries.ts
+++ b/packages/admin/src/hooks/queries/useWidgetQueries.ts
@@ -1,11 +1,21 @@
 /**
- * Every visible widget's data request, in ONE round trip.
+ * Every visible widget's data request, in as few round trips as the endpoint
+ * allows.
  *
  * `POST /api/dashboard/query` takes `{ queries: WidgetQuery[] }` and answers
  * `{ results }` POSITIONALLY — `results[i]` belongs to `queries[i]` and carries
  * no widget id of its own. Re-keying that back onto widget ids is this hook's
  * whole job, and it is the reason a dashboard of ten cards costs one request
  * rather than ten.
+ *
+ * It also REFUSES a body above `MAX_QUERIES_PER_REQUEST`, so "one request for
+ * everything" stops being correct at the thirty-first widget: a single batch
+ * would be rejected whole and every widget on the dashboard would go dark at
+ * once, over a limit none of them individually crossed. The requests are
+ * therefore partitioned to that size, and the partition is a property of the
+ * TRANSPORT rather than of the dashboard — each partition is its own query, its
+ * own retry and its own failure, and a widget's slot comes back from whichever
+ * one carried it.
  *
  * Refresh follows `useDashboardStats` exactly: `staleTime: 0`, refetch on mount
  * and on window focus, and NO polling interval. The UX evidence is against
@@ -15,8 +25,8 @@
  * @module hooks/queries/useWidgetQueries
  */
 
-import { useQuery } from "@tanstack/react-query";
-import type { WidgetQuery } from "nextly/config";
+import { useQueries } from "@tanstack/react-query";
+import { MAX_QUERIES_PER_REQUEST, type WidgetQuery } from "nextly/config";
 import { useMemo } from "react";
 
 import { protectedApi } from "@admin/lib/api/protectedApi";
@@ -35,14 +45,25 @@ export interface UseWidgetQueriesResult {
   /** Keyed by `widgetId`. A widget with no answer yet is simply absent. */
   slots: Record<string, WidgetSlot>;
   isLoading: boolean;
+  /**
+   * Whether any request is in flight, INCLUDING a background refetch that is
+   * keeping its previous answer on screen.
+   *
+   * Distinct from `isLoading`, which is only ever true before there is anything
+   * to show. On window focus this grid refetches while the cards keep their
+   * numbers, and a reader has no way to know that is happening unless the card
+   * says so — which is what `aria-busy` is for.
+   */
+  isFetching: boolean;
   error: Error | null;
   refetch: () => Promise<unknown>;
   /**
-   * When this batch landed, or `null` before it has.
+   * When the data on screen landed, or `null` before all of it has.
    *
-   * Exposed because the card's freshness line is a property of the BATCH, not
-   * of a widget: every card in one request was answered at the same instant,
-   * and a per-card timestamp would be the same value recomputed n times.
+   * The OLDEST partition's answer, not the newest. Every card reads one
+   * freshness line, so it has to be true of every card: taking the newest would
+   * let a partition that answered ten minutes ago sit under a timestamp from a
+   * partition that answered a second ago.
    */
   updatedAt: Date | null;
 }
@@ -76,7 +97,7 @@ const BATCH_FAILED_ERROR = "Dashboard data could not be loaded.";
  * with nothing anywhere saying why. Failing the query instead puts the failure
  * where `error` is read.
  */
-function readResults(body: unknown): WidgetSlot[] {
+function readResults(body: unknown): unknown[] {
   const results = (body as WidgetQueryBatchResponse | null)?.results;
   if (!Array.isArray(results)) {
     throw new Error(
@@ -87,78 +108,112 @@ function readResults(body: unknown): WidgetSlot[] {
 }
 
 /**
- * Batches `queries` into one request and hands each widget back its own slot.
+ * The requests split into batches the endpoint will accept.
  *
- * `enabled` is `queries.length > 0`: a dashboard with nothing to ask must issue
- * no request, not an empty one. An empty batch would still cost a round trip,
- * an authentication check and a log line on every mount and every window focus,
- * for an answer that is knowable without asking.
+ * Chunked in ORDER, so a widget's position inside its partition is what the
+ * positional response is keyed back through, and a dashboard that grows past
+ * the limit does not reshuffle which request its existing widgets travel in.
+ *
+ * An empty input produces NO partitions, which is what keeps a dashboard with
+ * nothing to ask from issuing a request: an empty batch would still cost a
+ * round trip, an authentication check and a log line on every mount and every
+ * window focus, for an answer that is knowable without asking.
+ */
+function partitionRequests(
+  queries: WidgetQueryRequest[]
+): WidgetQueryRequest[][] {
+  const partitions: WidgetQueryRequest[][] = [];
+  for (
+    let start = 0;
+    start < queries.length;
+    start += MAX_QUERIES_PER_REQUEST
+  ) {
+    partitions.push(queries.slice(start, start + MAX_QUERIES_PER_REQUEST));
+  }
+  return partitions;
+}
+
+/**
+ * Batches `queries` into as few requests as the endpoint allows and hands each
+ * widget back its own slot.
  */
 export function useWidgetQueries(
   queries: WidgetQueryRequest[]
 ): UseWidgetQueriesResult {
-  const query = useQuery<WidgetSlot[], Error>({
-    // The requests themselves are the key. Two dashboards asking for different
-    // widgets are different questions and must not share one cache entry;
-    // TanStack hashes the array deterministically, so a re-render with an
-    // equal-but-new array does not refetch.
-    queryKey: ["dashboard", "widget-queries", queries],
-    queryFn: async () => {
-      const body = await protectedApi.post<unknown>("/dashboard/query", {
-        queries: queries.map(entry => entry.query),
-      });
-      return readResults(body);
-    },
-    enabled: queries.length > 0,
-    staleTime: 0,
-    gcTime: 5 * 60 * 1000,
-    retry: 2,
-    refetchOnMount: "always",
-    refetchOnWindowFocus: true,
+  const partitions = useMemo(() => partitionRequests(queries), [queries]);
+
+  const results = useQueries({
+    queries: partitions.map(partition => ({
+      // The partition's own requests are its key. Two dashboards asking for
+      // different widgets are different questions and must not share one cache
+      // entry; TanStack hashes the array deterministically, so a re-render with
+      // an equal-but-new array does not refetch.
+      queryKey: ["dashboard", "widget-queries", partition],
+      queryFn: async () => {
+        const body = await protectedApi.post<unknown>("/dashboard/query", {
+          queries: partition.map(entry => entry.query),
+        });
+        return readResults(body);
+      },
+      staleTime: 0,
+      gcTime: 5 * 60 * 1000,
+      retry: 2,
+      refetchOnMount: "always" as const,
+      refetchOnWindowFocus: true,
+    })),
   });
 
-  const results = query.data;
-  // `isError` is settled-and-failed: with `retry: 2` the query stays pending
-  // through its attempts, so this is false while there is still hope.
-  const failed = query.isError;
+  // Not memoized, and deliberately: `useQueries` builds a fresh result array on
+  // every render, so a memo keyed on it would recompute every render anyway
+  // while reading as though it did not. The walk is one pass over the widgets.
+  const slots: Record<string, WidgetSlot> = {};
+  partitions.forEach((partition, index) => {
+    const answer = results[index];
+    if (!answer) return;
 
-  const slots = useMemo<Record<string, WidgetSlot>>(() => {
-    const keyed: Record<string, WidgetSlot> = {};
-
-    if (results) {
-      queries.forEach((entry, index) => {
+    if (answer.data) {
+      partition.forEach((entry, position) => {
         // A short response is the server disagreeing with us about how many
         // questions were asked. Saying so per widget is what stops the trailing
         // cards spinning silently forever.
-        keyed[entry.widgetId] = results[index] ?? {
+        slots[entry.widgetId] = (answer.data[position] as WidgetSlot) ?? {
           ok: false,
           error: MISSING_SLOT_ERROR,
         };
       });
-      return keyed;
+      return;
     }
 
-    // Answered by failing. Every widget gets its own failed slot, because a
-    // card cannot tell an absent slot from a pending one and renders both as
-    // busy. Data it already holds wins over this branch -- a refetch that
-    // fails on window focus keeps the numbers the reader was looking at,
-    // which is the same reason loading marks the body rather than replacing it.
-    if (failed) {
-      queries.forEach(entry => {
-        keyed[entry.widgetId] = { ok: false, error: BATCH_FAILED_ERROR };
+    // Answered by failing. Every widget in THIS partition gets its own failed
+    // slot, because a card cannot tell an absent slot from a pending one and
+    // renders both as busy — and only this partition's widgets are affected,
+    // which is the point of splitting them. Data already held wins over this
+    // branch, so a refetch that fails on window focus keeps the numbers the
+    // reader was looking at.
+    if (answer.isError) {
+      partition.forEach(entry => {
+        slots[entry.widgetId] = { ok: false, error: BATCH_FAILED_ERROR };
       });
     }
+  });
 
-    return keyed;
-  }, [queries, results, failed]);
+  const settledAt = results.map(answer => answer.dataUpdatedAt);
 
   return {
     slots,
-    isLoading: query.isLoading,
-    error: query.error ?? null,
-    refetch: query.refetch,
-    // `dataUpdatedAt` is 0 until the query has resolved once, which is not an
-    // instant in 1970 -- it is the absence of one.
-    updatedAt: query.dataUpdatedAt ? new Date(query.dataUpdatedAt) : null,
+    isLoading: results.some(answer => answer.isLoading),
+    isFetching: results.some(answer => answer.isFetching),
+    // The FIRST failure, which is enough for the grid: what a reader needs per
+    // widget is already in that widget's slot, and this says only that
+    // something in the batch did not answer.
+    error: results.find(answer => answer.error)?.error ?? null,
+    refetch: () => Promise.all(results.map(answer => answer.refetch())),
+    // `dataUpdatedAt` is 0 until a partition has resolved once, which is not an
+    // instant in 1970 -- it is the absence of one. A single unresolved
+    // partition makes the whole line absent rather than wrong.
+    updatedAt:
+      settledAt.length > 0 && settledAt.every(at => at > 0)
+        ? new Date(Math.min(...settledAt))
+        : null,
   };
 }

--- a/packages/admin/src/pages/dashboard/index.tsx
+++ b/packages/admin/src/pages/dashboard/index.tsx
@@ -13,11 +13,11 @@ import { Alert, AlertDescription, AlertTitle, Button } from "@nextlyhq/ui";
 import type React from "react";
 
 import { CollectionQuickLinks } from "@admin/components/features/dashboard/CollectionQuickLinks";
-import { PluginWidgetGrid } from "@admin/components/features/dashboard/PluginWidgetGrid";
 import { SeedDemoContentCard } from "@admin/components/features/dashboard/SeedDemoContentCard";
 import { SinglesQuickLinks } from "@admin/components/features/dashboard/SinglesQuickLinks";
 import { TeamSummary } from "@admin/components/features/dashboard/TeamSummary";
 import { WelcomeHeader } from "@admin/components/features/dashboard/WelcomeHeader";
+import { WidgetGrid } from "@admin/components/features/widgets/WidgetGrid";
 import { AlertCircle } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { ErrorBoundary } from "@admin/components/shared/error-boundary";
@@ -83,9 +83,16 @@ const DashboardPage: React.FC = () => {
             <TeamSummary />
           </div>
 
-          {/* Plugin-contributed dashboard widgets (D22 / C9). Renders nothing
-              when no plugin contributes a widget the current user may see. */}
-          <PluginWidgetGrid />
+          {/* The widget grid: every contributed widget, permission-gated, in a
+              12-column layout that collapses to one column below `md`, with a
+              single batched request behind all of them. Renders nothing when no
+              plugin contributes a widget the current user may see.
+
+              This replaces `PluginWidgetGrid`, which stays in the tree until the
+              core widget registry lands: it is the only thing that has ever
+              rendered plugin widgets, and removing it before its replacement is
+              wired to the registry would take them off the dashboard. */}
+          <WidgetGrid />
         </div>
       </PageContainer>
     </ErrorBoundary>

--- a/packages/admin/src/types/branding.ts
+++ b/packages/admin/src/types/branding.ts
@@ -1,4 +1,4 @@
-import type { PluginAdminWidget } from "nextly/config";
+import type { PluginAdminWidget, WidgetDefinition } from "nextly/config";
 import type {
   FieldStoragePrimitive,
   FieldSurface,
@@ -80,6 +80,23 @@ export interface PluginPageMeta {
  * bundle, exactly as a consumer's would.
  */
 export type PluginWidgetMeta = PluginAdminWidget;
+
+/**
+ * A widget the running app REGISTERED, as `/admin-meta/workspace` serializes it.
+ *
+ * A different channel from `PluginWidgetMeta` above, not a variant of it. That
+ * one is DECLARED in a plugin's `contributes.admin.widgets` and is almost
+ * entirely optional; this one went through `registerWidget`, whose validator
+ * requires `title`, `archetype` and `defaultSize`, requires a `query` for every
+ * data archetype and a `component` for `custom`, and forbids each where it does
+ * not belong. So a registered widget arrives already complete, and the resolver
+ * has nothing to default for it.
+ *
+ * Aliased from core's own declaration for the same reason `PluginWidgetMeta` is:
+ * the server puts that exact object on the wire, so a second spelling here would
+ * be one contract declared twice.
+ */
+export type RegisteredWidgetMeta = WidgetDefinition;
 
 /**
  * A plugin's public client configuration, served before a session exists.
@@ -257,6 +274,20 @@ export interface AdminBranding {
    * unavailable. Only `usePluginClientConfig` reads this.
    */
   pluginClientConfigs?: PluginClientConfigMeta[];
+
+  /**
+   * Widgets the running app registered through `registerWidget`.
+   *
+   * Beside `plugins`, never inside it: a registration is not a plugin
+   * contribution, and the two reach the dashboard grid by different routes. A
+   * widget may legitimately appear in both -- an app that declares it AND
+   * registers it -- which is why the grid dedupes by id rather than assuming
+   * the lists are disjoint.
+   *
+   * Comes from the session-gated half alone, so its absence means the registry
+   * has not arrived rather than that the app registered nothing.
+   */
+  widgets?: RegisteredWidgetMeta[];
 
   /** Custom sidebar groups created by the user for organizing collections/singles. */
   customGroups?: Array<{ slug: string; name: string; icon?: string }>;

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -1,0 +1,75 @@
+/**
+ * What the admin knows about a dashboard widget and about the data one asked
+ * for.
+ *
+ * The enum vocabulary (`WidgetSize`, `WidgetArchetype`, `WidgetQuery`) is
+ * IMPORTED from core rather than restated, through `nextly/config`: this
+ * package's tsconfig maps the bare `nextly` specifier to `../nextly/src`, so
+ * importing from `"nextly"` shadows the package exports and drags core's whole
+ * source tree in behind internal aliases this project does not declare.
+ * Subpaths escape that mapping and resolve through the export map, exactly as a
+ * consumer's import would.
+ *
+ * Two shapes below are declared here rather than imported, because
+ * `nextly/config` does not re-export them: core's `WidgetDefinition` and
+ * `WidgetResult` live in `domains/widgets`, which the config entry point
+ * deliberately keeps out (its barrel carries `executeWidgetQuery`, and through
+ * it the Direct API). `WidgetResult` is the wire shape of one slot in
+ * `POST /api/dashboard/query`, so it is a client contract regardless of where
+ * the server happens to declare it.
+ *
+ * @module types/dashboard/widgets
+ */
+
+import type { WidgetArchetype, WidgetQuery, WidgetSize } from "nextly/config";
+
+/**
+ * One executed query's payload, as `POST /api/dashboard/query` sends it.
+ *
+ * Discriminated on `op` so a body that asked for a count and a body that asked
+ * for a list cannot be read as each other — a renderer that reaches for
+ * `total` on a list result must fail to compile, not print `undefined`.
+ */
+export type WidgetResult =
+  | { op: "count"; total: number }
+  | { op: "list"; items: Record<string, unknown>[] };
+
+/**
+ * One slot of the batch response, positionally matched to one query.
+ *
+ * A failure is a value here, not a thrown error, because the batch answers 200
+ * with the other widgets' data intact: one widget's failure must colour one
+ * card, not blank the dashboard.
+ */
+export type WidgetSlot =
+  | { ok: true; result: WidgetResult }
+  | { ok: false; error: string };
+
+/** The whole batch response body. */
+export interface WidgetQueryBatchResponse {
+  results: WidgetSlot[];
+}
+
+/**
+ * A widget as the grid renders it: every field the card and the archetype need,
+ * with nothing optional that the renderer would have to invent a default for.
+ *
+ * Plugin contributions arrive as `PluginWidgetMeta`, whose declarative half is
+ * all optional (a widget may still be nothing but a `component`). `resolve`
+ * in `resolve-widgets.ts` is the one place that gap is closed, so the renderer
+ * below it never has to ask whether a title exists.
+ */
+export interface DashboardWidget {
+  id: string;
+  title: string;
+  description?: string;
+  /** Lucide icon name, resolved to a component by the card. */
+  icon?: string;
+  archetype: WidgetArchetype;
+  size: WidgetSize;
+  /** Present for the data archetypes; absent for `text`, `actions`, `custom`. */
+  query?: WidgetQuery;
+  /** Present for `custom`; the path `PluginSlot` resolves. */
+  component?: string;
+  link?: { label: string; href: string };
+}

--- a/packages/nextly/src/__tests__/routeHandler-workspace-widgets.test.ts
+++ b/packages/nextly/src/__tests__/routeHandler-workspace-widgets.test.ts
@@ -1,0 +1,108 @@
+/**
+ * The registry reaching the admin over the wire.
+ *
+ * `publishableWidgets` has its own unit tests; what those cannot see is whether
+ * anything CALLS it, and an unwired projection is indistinguishable from an app
+ * that registered nothing. So this drives the real handler and reads the real
+ * response body.
+ *
+ * The session is the one precondition replaced, because it needs a signed
+ * cookie and a database and has nothing to do with the property under test.
+ * Service initialisation is deliberately NOT replaced: it runs
+ * `resetWidgetRegistries()`, so a widget registered before the first request
+ * would be cleared by the boot that request triggers, and a test that mocked
+ * boot away would pass while the real dashboard showed nothing. Warming boot
+ * first and registering after it is the order a plugin's own registration
+ * happens in.
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { clearWidgets, registerWidget } from "../domains/widgets/registry";
+import { createDynamicHandlers } from "../routeHandler";
+import { sanitizeConfig } from "../shared/types/config";
+
+// By the module's own path rather than by the `@nextly/auth/middleware` alias
+// the handler imports it under. `vi.mock` keys on a resolved id and the alias is
+// rewritten by a Vite plugin rather than by the mock registry, so a factory
+// registered against the alias string is never consulted -- the route then
+// answers 401 with the real middleware, which reads as the test being wrong
+// about authentication rather than about the mock.
+vi.mock("../auth/middleware", async importOriginal => {
+  const actual = await importOriginal<typeof import("../auth/middleware")>();
+  return {
+    ...actual,
+    // A caller with a session, expressed as the shape `isErrorResponse` reads:
+    // no `statusCode` means "authenticated".
+    requireAuthentication: vi.fn(async () => ({ user: { id: "u1" } })),
+  };
+});
+
+const ORIGINAL_DB_DIALECT = process.env.DB_DIALECT;
+// sqlite is the one dialect that needs no connection string.
+process.env.DB_DIALECT = "sqlite";
+
+const handlers = createDynamicHandlers({
+  config: sanitizeConfig({ collections: [] }),
+});
+
+async function workspaceBody(): Promise<Record<string, unknown>> {
+  const response = await handlers.GET(
+    new Request("http://localhost/api/admin-meta/workspace", { method: "GET" }),
+    { params: Promise.resolve({ params: ["admin-meta", "workspace"] }) }
+  );
+  expect(response.status).toBe(200);
+  return (await response.json()) as Record<string, unknown>;
+}
+
+beforeAll(async () => {
+  // The first request boots, and boot empties the registries. Every
+  // registration below therefore happens after it, exactly as a plugin's does.
+  await workspaceBody();
+});
+
+afterEach(() => clearWidgets());
+
+describe("the widget registry over /api/admin-meta/workspace", () => {
+  it("carries a widget the app registered through the public API", async () => {
+    registerWidget(
+      {
+        id: "acme/revenue",
+        title: "Revenue",
+        archetype: "metric",
+        defaultSize: "sm",
+        query: { source: "collection:orders", op: "count" },
+      },
+      { source: "@acme/stripe" }
+    );
+
+    expect(await workspaceBody()).toMatchObject({
+      widgets: [
+        {
+          id: "acme/revenue",
+          title: "Revenue",
+          archetype: "metric",
+          defaultSize: "sm",
+          query: { source: "collection:orders", op: "count" },
+        },
+      ],
+    });
+  });
+
+  it("omits the key entirely when nothing is registered", async () => {
+    expect(await workspaceBody()).not.toHaveProperty("widgets");
+  });
+});
+
+afterAll(() => {
+  if (ORIGINAL_DB_DIALECT === undefined) delete process.env.DB_DIALECT;
+  else process.env.DB_DIALECT = ORIGINAL_DB_DIALECT;
+});

--- a/packages/nextly/src/api/widget-query.ts
+++ b/packages/nextly/src/api/widget-query.ts
@@ -17,6 +17,7 @@
 import { authorizationGroups, canReadEntity } from "../auth/entity-read-access";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+import { MAX_QUERIES_PER_REQUEST } from "../domains/widgets/batch-limit";
 import { refreshCollectionSources } from "../domains/widgets/collection-sources";
 import { executeWidgetQuery } from "../domains/widgets/execute";
 import {
@@ -38,9 +39,6 @@ import { readAccessCaller, readCaller } from "./authenticated-read";
 import { readJsonBody } from "./read-json-body";
 import { respondData } from "./response-shapes";
 import { withErrorHandler } from "./with-error-handler";
-
-/** No dashboard needs more than this many widgets in one round trip. */
-const MAX_QUERIES_PER_REQUEST = 30;
 
 const PRIVATE_NO_STORE_HEADERS = {
   "Cache-Control": "private, no-store",

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -211,6 +211,12 @@ export type {
   WidgetSize,
 } from "./domains/widgets/definition";
 export type { WidgetQuery } from "./domains/widgets/query";
+// A VALUE, and the only one in this block. The admin batches a dashboard's
+// widgets into requests `POST /api/dashboard/query` will accept, so it needs the
+// number that endpoint refuses above -- and a second copy of it on the client
+// would send a batch the server rejects the day the two diverged. Its module has
+// no imports, so taking it here costs a `nextly.config.ts` nothing.
+export { MAX_QUERIES_PER_REQUEST } from "./domains/widgets/batch-limit";
 export type {
   WidgetOp,
   WidgetSourceField,

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -199,8 +199,14 @@ export type {
 // barrel also carries `executeWidgetQuery`, and through it the Direct API, which
 // is exactly the weight this entry point exists to keep out of a
 // `nextly.config.ts`.
+//
+// `WidgetDefinition` is here for the same derivation reason as the contribution
+// shapes above: `/api/admin-meta/workspace` serializes the registry verbatim, so
+// the admin reads exactly this shape off the wire and restating it there would
+// be one contract declared twice.
 export type {
   WidgetArchetype,
+  WidgetDefinition,
   WidgetHeight,
   WidgetSize,
 } from "./domains/widgets/definition";

--- a/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/publish.test.ts
@@ -1,0 +1,88 @@
+/**
+ * What the registry publishes to the admin.
+ *
+ * The assertions are about the PAYLOAD a browser would receive, not about the
+ * round-trip helper having been called: a widget that cannot survive
+ * `JSON.stringify` must cost itself its card and nothing else, because the
+ * alternative -- the workspace response failing for every admin -- is the
+ * failure this projection exists to avoid.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setNextlyLogger } from "../../../observability/logger";
+import type { WidgetDefinition } from "../definition";
+import { publishableWidgets } from "../publish";
+import { clearWidgets, registerWidget } from "../registry";
+
+const def = (
+  id: string,
+  over: Partial<WidgetDefinition> = {}
+): WidgetDefinition => ({
+  id,
+  title: id,
+  archetype: "metric",
+  defaultSize: "sm",
+  query: { source: "collection:posts", op: "count" },
+  ...over,
+});
+
+beforeEach(() => clearWidgets());
+afterEach(() => setNextlyLogger(undefined));
+
+describe("publishableWidgets", () => {
+  it("publishes a widget the app registered through the public API", () => {
+    registerWidget(def("acme/revenue", { title: "Revenue" }), {
+      source: "@acme/stripe",
+    });
+
+    expect(publishableWidgets()).toEqual([
+      {
+        id: "acme/revenue",
+        title: "Revenue",
+        archetype: "metric",
+        defaultSize: "sm",
+        query: { source: "collection:posts", op: "count" },
+      },
+    ]);
+  });
+
+  it("publishes nothing when nothing is registered", () => {
+    expect(publishableWidgets()).toEqual([]);
+  });
+
+  it("drops only the widget JSON cannot carry, and keeps its neighbours", () => {
+    const error = vi.fn();
+    setNextlyLogger({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error,
+    });
+
+    registerWidget(def("acme/before"), { source: "@acme/a" });
+    registerWidget(
+      // A `BigInt` under `where` is type-legal (`Record<string, unknown>`) and
+      // `structuredClone` stores it, so the registry's own gate lets it in.
+      def("acme/bigint", {
+        query: {
+          source: "collection:posts",
+          op: "count",
+          where: { views: { greater_than: 10n } },
+        },
+      } as Partial<WidgetDefinition>),
+      { source: "@acme/b" }
+    );
+    registerWidget(def("acme/after"), { source: "@acme/c" });
+
+    expect(publishableWidgets().map(w => w.id)).toEqual([
+      "acme/before",
+      "acme/after",
+    ]);
+    expect(error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        kind: "widget-not-serializable",
+        widget: "acme/bigint",
+      })
+    );
+  });
+});

--- a/packages/nextly/src/domains/widgets/batch-limit.ts
+++ b/packages/nextly/src/domains/widgets/batch-limit.ts
@@ -1,0 +1,19 @@
+/**
+ * How many widget queries one request may carry.
+ *
+ * Its own module, with NO imports, for the reason `plugins/plugin-slug.ts` is:
+ * the admin has to know this number in order to split a dashboard into requests
+ * the endpoint will accept, and it can only reach it through `nextly/config` --
+ * which must not pull `api/widget-query.ts`, the auth middleware and the query
+ * executor behind it into a `nextly.config.ts`.
+ *
+ * ONE number, because the endpoint REFUSES above it and the client PARTITIONS
+ * below it. Two copies would agree on the day they were written; the day they
+ * stopped, a dashboard would send a batch the server rejects and every widget
+ * in it would go dark at once.
+ *
+ * @module domains/widgets/batch-limit
+ */
+
+/** No dashboard needs more than this many widgets in one round trip. */
+export const MAX_QUERIES_PER_REQUEST = 30;

--- a/packages/nextly/src/domains/widgets/index.ts
+++ b/packages/nextly/src/domains/widgets/index.ts
@@ -50,6 +50,7 @@ export {
   clearWidgets,
   type WidgetPatch,
 } from "./registry";
+export { MAX_QUERIES_PER_REQUEST } from "./batch-limit";
 export { executeWidgetQuery, type WidgetResult } from "./execute";
 export {
   registerBuiltInSources,

--- a/packages/nextly/src/domains/widgets/publish.ts
+++ b/packages/nextly/src/domains/widgets/publish.ts
@@ -1,0 +1,54 @@
+/**
+ * The registered widgets as the admin may receive them.
+ *
+ * The registry is the single place that knows which widgets exist in a running
+ * app, and `registerWidget` is the public API an app or plugin uses to add one.
+ * Nothing carried that store to the browser, so the admin grid could only ever
+ * render `contributes.admin.widgets` -- a plugin that registered a widget and
+ * did not ALSO declare it as a contribution was invisible to its own renderer.
+ * This is the projection that closes that gap.
+ *
+ * Per widget rather than per payload, and that is the whole reason this is a
+ * function rather than a `listWidgets()` call at the call site. A registration
+ * happens in code at boot, so unlike `contributes.admin.widgets` it never passed
+ * `assertAdminWidgets` -- the registry's own gate is `structuredClone`, which
+ * carries a `BigInt` under `WidgetQuery.where` happily where `JSON.stringify`
+ * throws. One such widget would take the whole authenticated workspace payload
+ * down for every admin. Skipping the offender and logging it costs that one
+ * widget its card and leaves the dashboard standing.
+ *
+ * @module domains/widgets/publish
+ */
+
+import { getNextlyLogger } from "../../observability/logger";
+import { jsonOnly, unserializableKeys } from "../../plugins/json-round-trip";
+
+import type { WidgetDefinition } from "./definition";
+import { listWidgets } from "./registry";
+
+/**
+ * Every registered widget that survives the trip to the browser unchanged, in
+ * registration order.
+ *
+ * Returns the DECODED value rather than the stored object, so what is checked is
+ * exactly what ships -- the same reading `validatedAdminWidgets` takes of a
+ * contributed widget, and for the same reason.
+ */
+export function publishableWidgets(): WidgetDefinition[] {
+  const publishable: WidgetDefinition[] = [];
+
+  for (const definition of listWidgets()) {
+    const serializable = jsonOnly(definition);
+    if (serializable === undefined) {
+      getNextlyLogger().error({
+        kind: "widget-not-serializable",
+        widget: definition.id,
+        keys: unserializableKeys(definition),
+      });
+      continue;
+    }
+    publishable.push(serializable as unknown as WidgetDefinition);
+  }
+
+  return publishable;
+}

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -87,6 +87,7 @@ import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
 import { container } from "./di/container";
+import { publishableWidgets } from "./domains/widgets/publish";
 import { NextlyError } from "./errors/nextly-error";
 import {
   currentFlattenedErrors,
@@ -1462,6 +1463,26 @@ async function buildAdminMeta(): Promise<{
     if (publicPlugins.length > 0) {
       branding.pluginClientConfigs = publicPlugins;
     }
+  }
+
+  // The widget REGISTRY, beside the contributions above. The two are different
+  // channels to the same grid and neither subsumes the other: a contribution is
+  // DECLARED in `contributes.admin.widgets` and travels with the plugin's
+  // config, while a registration is an imperative `registerWidget` call made
+  // during boot. Serializing only the first left an app that used the public
+  // registration API invisible to the renderer built around that registry --
+  // its card never drew and its query never entered the batch.
+  //
+  // Only this half of the payload can carry it. The registry is populated
+  // during boot, and `handleAdminMetaWorkspaceRequest` is the caller that
+  // awaits `ensureServicesInitialized()` first; the public branding route is
+  // served without it and would answer from an empty store. That the workspace
+  // half already describes the RUNNING installation rather than the configured
+  // one -- `showBuilder` from the live resolver, `customGroups` from the
+  // database -- is the same property this relies on.
+  const registered = publishableWidgets();
+  if (registered.length > 0) {
+    workspace.widgets = registered;
   }
 
   // Override config branding with DB values when available


### PR DESCRIPTION
The first visible piece of the dashboard widget system. The server contract merged in #1393 and #1400 and nothing consumed it; this renders a card.

## What this adds

- **`sizes.ts`** — one size→span map. Base span is 12 for **every** size, narrowing only at `md` and `lg`. Today's `PluginWidgetGrid` writes `col-span-6` with no breakpoint prefix, so a "half" widget is half-width at 320px.
- **`WidgetCard`** — one anatomy every widget wears: header, body, optional footer. Core renders the frame for declarative archetypes and plugin components alike, so a plugin contributes a body and cannot make its card look unlike the rest of the dashboard. An error replaces the body but keeps the title; an anonymous error box does not say which widget broke.
- **`useWidgetQueries`** — every visible widget's query in **one** request, results keyed back positionally. `staleTime: 0`, refetch on mount and focus, no polling — the convention `useDashboardStats` already sets.
- **`WidgetRenderer` + the `metric` archetype** — dispatch structured so the remaining four archetypes are additive. A payload that does not match its archetype says so rather than being coerced.

`PluginWidgetGrid.tsx` is deliberately **not** deleted. The registry migration is a later task, and removing it now would drop plugin widgets from the dashboard before their replacement exists.

## Verified in a running app, not only in tests

Booted the playground and drove it with a browser. Two metric widgets declared temporarily on the playground's fixture plugin drew live counts — 4 published posts, 2 categories — over exactly **one** `POST /admin/api/dashboard/query`.

Measured cell widths after genuinely resizing the viewport: **342px each at 390px wide** (full width, stacked), 366px at 820px, 308px at 1440px. One `[aria-live]` region reading "2 of 2 widgets updated". Correct in both themes, colours inverting through `--nx-*` tokens.

The error path was exercised against the real server rather than a stub: pointing one widget at a nonexistent source made that card keep its title and show the server's own refusal while its neighbour kept its number. The playground fixture is fully reverted — `git diff -- apps/playground` is empty.

## Five places the design doc did not survive contact with the code

Recorded because they change what the next slice must do:

1. **`WidgetDefinition` and `WidgetResult` are not reachable from `nextly/config`** — only the enum and query types are. Both are declared admin-side for now, which is the duplication #1400 just removed for `PluginWidgetMeta`, reappearing one layer up.
2. **`PluginAdminWidget.component` is required**, so a plugin cannot declare a Tier-1 declarative widget without naming a component core never resolves. **Tier 1 as designed is not expressible through the plugin contract yet** — this is the most consequential of the five.
3. Part 3.10's "one request per widget in v1" is superseded by the merged batch endpoint; built batched.
4. No `defaultHeight` on the plugin contract, so even card heights come from `h-full` plus grid stretch rather than the `short|tall` enum.
5. Plugin widget ids are bare slugs and can collide across plugins. Since the id keys a batch result to a card, a duplicate would show one card's number in another. First declaration wins, with a test.

## Verification

`packages/admin` 342 files / 3284 tests (baseline 337 / 3226). Typecheck clean with admin forced, so the verdict describes work that actually ran. Admin lint clean, `fallow` pass with 0 introduced, e2e `admin-smoke` 6/6.