### PR TITLE
feat(admin): one shell for editors that take the window

### DIFF
--- a/.changeset/one-shell-for-editors-that-take-the-window.md
+++ b/.changeset/one-shell-for-editors-that-take-the-window.md
@@ -1,0 +1,36 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Editors that take over the admin window now share one shell.
+
+Four surfaces already built the same arrangement by hand — hiding the admin's
+navigation, a bar across the top, and a draggable split down the middle — and
+each built it slightly differently. The shell names that arrangement once, with
+its regions declared, so an editor says which parts it has instead of arranging
+them itself. Nothing changes on screen yet; the email template editor is its
+first user in a following change.

--- a/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.test.tsx
+++ b/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * The composition four admin surfaces already build by hand.
+ *
+ * `APIPlayground`, `PreviewSplit`, `TranslationPanes` and the page builder's
+ * shell each assemble the same three ingredients — suppress the admin's
+ * furniture, put a bar on top, split the body with a draggable handle — and
+ * each assembles them differently. This component is that composition named
+ * once, with the regions declared rather than arranged ad hoc.
+ *
+ * The email template editor is its first consumer. The other four are
+ * deliberately NOT converted here: migrating every caller in the change that
+ * extracts a primitive is how a reviewable diff stops being reviewable.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  ChromeSuppressionProvider,
+  useSuppressedChrome,
+} from "../ChromeSuppression";
+
+import { ImmersiveShell } from "./ImmersiveShell";
+
+afterEach(cleanup);
+
+/** Reports what the provider currently hides, so a test can read it. */
+function ChromeProbe() {
+  const hidden = useSuppressedChrome();
+  return <span data-testid="hidden">{[...hidden].sort().join(",")}</span>;
+}
+
+function renderShell(
+  props: Partial<Parameters<typeof ImmersiveShell>[0]> = {}
+) {
+  return render(
+    <ChromeSuppressionProvider>
+      <ChromeProbe />
+      <ImmersiveShell
+        bar={<h1>Welcome Email</h1>}
+        primary={<div>the body being authored</div>}
+        secondary={<div>what it will look like</div>}
+        splitLabel="Editor and preview"
+        {...props}
+      />
+    </ChromeSuppressionProvider>
+  );
+}
+
+describe("ImmersiveShell", () => {
+  it("renders the regions it was given", () => {
+    renderShell({ band: <div>envelope</div> });
+
+    expect(screen.getByText("Welcome Email")).toBeDefined();
+    expect(screen.getByText("envelope")).toBeDefined();
+    expect(screen.getByText("the body being authored")).toBeDefined();
+    expect(screen.getByText("what it will look like")).toBeDefined();
+  });
+
+  it("omits the optional regions rather than rendering empty containers", () => {
+    renderShell();
+
+    expect(screen.queryByTestId("shell-band")).toBeNull();
+    expect(screen.queryByTestId("shell-drawer")).toBeNull();
+    expect(screen.queryByTestId("shell-inspector")).toBeNull();
+  });
+
+  it("asks for the chrome layers it was given", () => {
+    renderShell({ suppress: ["subSidebar", "pageFrame"] });
+
+    expect(screen.getByTestId("hidden").textContent).toBe(
+      "pageFrame,subSidebar"
+    );
+  });
+
+  it("releases the chrome when it unmounts", () => {
+    const view = renderShell({ suppress: ["subSidebar", "pageFrame"] });
+    expect(screen.getByTestId("hidden").textContent).toBe(
+      "pageFrame,subSidebar"
+    );
+
+    // Re-render with the shell gone but the provider and probe still mounted:
+    // unmounting the whole tree would remove the probe too, and prove nothing.
+    view.rerender(
+      <ChromeSuppressionProvider>
+        <ChromeProbe />
+      </ChromeSuppressionProvider>
+    );
+
+    expect(screen.getByTestId("hidden").textContent).toBe("");
+  });
+
+  it("hides nothing when asked to suppress nothing", () => {
+    renderShell();
+
+    expect(screen.getByTestId("hidden").textContent).toBe("");
+  });
+
+  it("names the split for a keyboard user, since a separator without a name announces only a number", () => {
+    renderShell();
+
+    expect(
+      screen.getByRole("separator", { name: "Editor and preview" })
+    ).toBeDefined();
+  });
+
+  it("keeps the secondary region mounted while the inspector is open", () => {
+    // The inspector OVERLAYS rather than displaces, so the code being edited
+    // never reflows when a setting changes. jsdom cannot observe stacking
+    // order, so the assertion is on RETENTION — displacing would unmount or
+    // replace the region — and the overlay's own positioning is a style
+    // contract asserted separately below.
+    renderShell({ inspector: <div>settings</div> });
+
+    expect(screen.getByText("settings")).toBeDefined();
+    expect(screen.getByText("what it will look like")).toBeDefined();
+    expect(screen.getByText("the body being authored")).toBeDefined();
+  });
+
+  it("positions the inspector out of the flow, so it cannot displace the panes", () => {
+    renderShell({ inspector: <div>settings</div> });
+
+    // Asserted on the class contract rather than on geometry: jsdom computes no
+    // layout, so a test that read positions would pass whatever the value was.
+    expect(screen.getByTestId("shell-inspector").className).toContain(
+      "absolute"
+    );
+  });
+
+  it("renders the drawer when given one", () => {
+    renderShell({ drawer: <div>sample data</div> });
+
+    expect(screen.getByTestId("shell-drawer")).toBeDefined();
+    expect(screen.getByText("sample data")).toBeDefined();
+  });
+
+  it("persists on the SETTLED event, never on every frame of the drag", () => {
+    /*
+     * The two handler names differ by one letter and by a write per frame:
+     * `onLayoutChange` fires continuously while the pointer moves,
+     * `onLayoutChanged` once the drag settles. jsdom computes no layout, so a
+     * synthesised drag would exercise the library rather than this wiring, and
+     * a mock that is never called cannot tell the two apart — it stays green
+     * under both. Reading the source is the only instrument that can see which
+     * name is used, and the property is worth a guard because the kit's own
+     * docblock names it as easy to get wrong in both directions.
+     */
+    // Repo-relative from the package root vitest runs in, matching
+    // `layout/__tests__/content-measure-wiring.test.ts`.
+    const source = readFileSync(
+      join(
+        process.cwd(),
+        "src/components/layout/immersive-shell/ImmersiveShell.tsx"
+      ),
+      "utf8"
+    );
+
+    // Positive control FIRST. `not.toMatch` is satisfied by an empty string, so
+    // a path that resolved to nothing would certify the property without having
+    // read the file.
+    expect(source).toContain("ResizablePanelGroup");
+    expect(source).toContain("onLayoutChanged");
+    expect(source).not.toMatch(/onLayoutChange[^d]/);
+  });
+});

--- a/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.test.tsx
+++ b/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.test.tsx
@@ -11,10 +11,10 @@
  * deliberately NOT converted here: migrating every caller in the change that
  * extracts a primitive is how a reviewable diff stops being reviewable.
  */
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   ChromeSuppressionProvider,
@@ -118,14 +118,76 @@ describe("ImmersiveShell", () => {
     expect(screen.getByText("the body being authored")).toBeDefined();
   });
 
-  it("positions the inspector out of the flow, so it cannot displace the panes", () => {
+  it("scopes the inspector to the secondary pane, not the whole shell", () => {
+    /*
+     * Containment is the discriminating assertion. `absolute` alone passes
+     * whether the overlay is positioned against the secondary pane or against
+     * the shell's outer box — and against the outer box it spans the bar and
+     * the drawer too, so a right-hand inspector covers the save and exit
+     * controls. Being a DESCENDANT of the secondary region is true of exactly
+     * one of those, and the nearest positioned ancestor is what decides it.
+     */
     renderShell({ inspector: <div>settings</div> });
 
-    // Asserted on the class contract rather than on geometry: jsdom computes no
-    // layout, so a test that read positions would pass whatever the value was.
-    expect(screen.getByTestId("shell-inspector").className).toContain(
-      "absolute"
+    const secondary = screen.getByTestId("shell-secondary");
+    const inspector = screen.getByTestId("shell-inspector");
+
+    expect(secondary.contains(inspector)).toBe(true);
+    expect(screen.getByTestId("shell-bar").contains(inspector)).toBe(false);
+    // The containing block itself: without `relative` here the overlay resolves
+    // against some ancestor further out while still being a descendant, so
+    // containment alone is necessary and not sufficient.
+    expect(secondary.className).toContain("relative");
+    expect(inspector.className).toContain("absolute");
+  });
+
+  it("refuses the primary rail to a surface with no way back", () => {
+    /*
+     * The rail is the admin's entire navigation. `bar` is a ReactNode and may
+     * carry no exit at all, so the presence of the slot proves nothing; the
+     * resolver withholds `primaryRail` from a request whose `canExit` is false,
+     * and this asserts the shell answers that question from the affordance.
+     */
+    renderShell({ suppress: ["primaryRail", "pageFrame"] });
+
+    expect(screen.getByTestId("hidden").textContent).toBe("pageFrame");
+  });
+
+  it("grants the primary rail once it renders an exit", () => {
+    // The positive control for the test above: without it, a shell that
+    // withheld the rail unconditionally would pass just as well.
+    renderShell({ suppress: ["primaryRail", "pageFrame"], onExit: () => {} });
+
+    expect(screen.getByTestId("hidden").textContent).toBe(
+      "pageFrame,primaryRail"
     );
+  });
+
+  it("renders the exit control it derives that grant from", () => {
+    const onExit = vi.fn();
+    renderShell({ onExit, exitLabel: "Back to templates" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Back to templates" }));
+
+    expect(onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders no exit control when it was given no way back", () => {
+    renderShell();
+
+    expect(screen.queryByRole("button", { name: "Back" })).toBeNull();
+  });
+
+  it("stacks the panes when asked to, for a viewport too narrow to split", () => {
+    renderShell({ orientation: "vertical" });
+
+    // The separator carries the orientation the library derived, and it is what
+    // a screen reader announces. A stacked group separates along the horizontal.
+    expect(
+      screen
+        .getByRole("separator", { name: "Editor and preview" })
+        .getAttribute("aria-orientation")
+    ).toBe("horizontal");
   });
 
   it("renders the drawer when given one", () => {

--- a/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.tsx
+++ b/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+/**
+ * The shell an immersive editor renders into, with its regions declared.
+ *
+ * Four admin surfaces already compose the same three ingredients by hand —
+ * suppress the admin's furniture, put a bar on top, split the body with a
+ * draggable handle — and each composes them differently. Naming the composition
+ * once means a surface declares WHICH regions it has rather than arranging them,
+ * and the two questions a shell answers badly when spread across call sites —
+ * what may be hidden, and what may be resized — are answered in one place.
+ *
+ * The regions, and why each exists as its own slot:
+ *
+ * - `bar`        identity and the acts that leave the page. Always rendered.
+ * - `band`       an optional strip under the bar for fields that address the
+ *                work rather than being it — an email's envelope, say.
+ * - `primary`    the thing being authored.
+ * - `secondary`  its consequence, rendered beside it. Draggable against
+ *                `primary`, because which of the two deserves the width is the
+ *                author's judgement and changes minute to minute.
+ * - `inspector`  configuration that is not the content. Summoned, and OVERLAYS
+ *                `secondary` rather than displacing it, so the thing being
+ *                edited does not reflow while a setting is changed.
+ * - `drawer`     instruments rather than settings — sample data, problems,
+ *                validation. Collapsible, along the bottom.
+ *
+ * `primary` and `secondary` are the invariant: everything else may be absent,
+ * and those two are always on screen. That is the property every comparable
+ * product holds, and the reason the inspector overlays instead of taking a
+ * column of its own.
+ *
+ * @module components/layout/immersive-shell
+ */
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from "@nextlyhq/ui";
+import type React from "react";
+
+import { useSuppressAdminChrome } from "../ChromeSuppression";
+import type { AdminChromeLayer } from "../lib/chrome-suppression";
+
+/**
+ * Panel ids. Exported because `defaultLayout` and `onLayoutChanged` are keyed by
+ * them, and a caller persisting a layout needs the same spelling this file uses.
+ */
+export const SHELL_PRIMARY = "primary";
+export const SHELL_SECONDARY = "secondary";
+
+export interface ImmersiveShellProps {
+  /** Region 01 — identity, and the controls that leave the page. */
+  bar: React.ReactNode;
+  /** Region 02 — an optional strip beneath the bar. */
+  band?: React.ReactNode;
+  /** Region 03 — the thing being authored. */
+  primary: React.ReactNode;
+  /** Region 04 — its consequence, beside it. */
+  secondary: React.ReactNode;
+  /** Region 05 — summoned configuration, overlaying region 04. */
+  inspector?: React.ReactNode;
+  /** Region 06 — collapsible instruments along the bottom. */
+  drawer?: React.ReactNode;
+  /**
+   * Accessible name for the split.
+   *
+   * Required rather than defaulted: the library supplies a separator's position
+   * but not its name, so an unnamed one announces a bare percentage and leaves
+   * a keyboard user to guess what is on either side. Only the caller knows.
+   */
+  splitLabel: string;
+  /**
+   * Which admin furniture to hide for as long as this shell is mounted.
+   *
+   * Empty by default, so a shell that says nothing takes nothing. The request is
+   * mount-scoped: navigating away restores the chrome with nothing to undo.
+   */
+  suppress?: readonly AdminChromeLayer[];
+  /** Relative weights for the two panes, conventionally summing to 100. */
+  defaultLayout?: Record<string, number>;
+  /**
+   * Called once a drag has SETTLED, never per frame — persisting on every frame
+   * of a drag is a write per frame to whatever is behind the caller's store.
+   */
+  onLayoutChanged?: (layout: Record<string, number>) => void;
+}
+
+export function ImmersiveShell({
+  bar,
+  band,
+  primary,
+  secondary,
+  inspector,
+  drawer,
+  splitLabel,
+  suppress = [],
+  defaultLayout = { [SHELL_PRIMARY]: 50, [SHELL_SECONDARY]: 50 },
+  onLayoutChanged,
+}: ImmersiveShellProps) {
+  /*
+   * `canExit` is true because region 01 always renders and is where a surface
+   * puts its way back. It is a claim the resolver cannot check — it can only
+   * withhold the primary rail from a surface that answers false — so it is made
+   * here, where the bar's presence is guaranteed by the type, rather than left
+   * to each caller to assert about itself.
+   */
+  useSuppressAdminChrome({ layers: suppress, canExit: true });
+
+  return (
+    <div className="relative flex h-full min-h-0 flex-col bg-background">
+      <div data-testid="shell-bar" className="shrink-0">
+        {bar}
+      </div>
+
+      {band ? (
+        <div data-testid="shell-band" className="shrink-0">
+          {band}
+        </div>
+      ) : null}
+
+      <ResizablePanelGroup
+        orientation="horizontal"
+        defaultLayout={defaultLayout}
+        onLayoutChanged={onLayoutChanged}
+        className="min-h-0 flex-1"
+      >
+        {/* Percentage strings, not numbers: this library reads a bare number as
+            PIXELS, so `minSize={25}` is a 25-pixel floor rather than a quarter
+            of the group. */}
+        <ResizablePanel id={SHELL_PRIMARY} minSize="25%">
+          <div
+            data-testid="shell-primary"
+            className="flex h-full min-h-0 flex-col overflow-hidden"
+          >
+            {primary}
+          </div>
+        </ResizablePanel>
+
+        <ResizableHandle withGrip aria-label={splitLabel} />
+
+        <ResizablePanel id={SHELL_SECONDARY} minSize="25%">
+          <div
+            data-testid="shell-secondary"
+            className="flex h-full min-h-0 flex-col overflow-hidden"
+          >
+            {secondary}
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+
+      {drawer ? (
+        <div
+          data-testid="shell-drawer"
+          className="shrink-0 border-t border-border"
+        >
+          {drawer}
+        </div>
+      ) : null}
+
+      {/* Out of the flow on purpose. In the flow it would take width from the
+          panes, so opening it would reflow the document being edited — the one
+          thing a settings panel must not do to an author mid-sentence. */}
+      {inspector ? (
+        <div
+          data-testid="shell-inspector"
+          className="absolute inset-y-0 right-0 z-20 overflow-y-auto border-l border-border bg-background shadow-lg"
+        >
+          {inspector}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.tsx
+++ b/packages/admin/src/components/layout/immersive-shell/ImmersiveShell.tsx
@@ -19,9 +19,8 @@
  * - `secondary`  its consequence, rendered beside it. Draggable against
  *                `primary`, because which of the two deserves the width is the
  *                author's judgement and changes minute to minute.
- * - `inspector`  configuration that is not the content. Summoned, and OVERLAYS
- *                `secondary` rather than displacing it, so the thing being
- *                edited does not reflow while a setting is changed.
+ * - `inspector`  configuration that is not the content. Summoned, and rendered
+ *                INSIDE `secondary` so it overlays that pane and nothing else.
  * - `drawer`     instruments rather than settings — sample data, problems,
  *                validation. Collapsible, along the bottom.
  *
@@ -39,6 +38,8 @@ import {
 } from "@nextlyhq/ui";
 import type React from "react";
 
+import { ArrowLeft } from "@admin/components/icons";
+
 import { useSuppressAdminChrome } from "../ChromeSuppression";
 import type { AdminChromeLayer } from "../lib/chrome-suppression";
 
@@ -49,6 +50,35 @@ import type { AdminChromeLayer } from "../lib/chrome-suppression";
 export const SHELL_PRIMARY = "primary";
 export const SHELL_SECONDARY = "secondary";
 
+/**
+ * A layout for exactly the two panels this shell has.
+ *
+ * Keyed by the constants rather than by `string`: a misspelled, missing or extra
+ * key type-checks against a loose record, and the panel library then cannot
+ * restore the map and silently falls back to a different layout — a persisted
+ * preference that appears to work and does not.
+ */
+export type ShellLayout = Record<
+  typeof SHELL_PRIMARY | typeof SHELL_SECONDARY,
+  number
+>;
+
+/**
+ * The group's own settled-layout callback, DERIVED from the component rather
+ * than restated.
+ *
+ * Restating it as a one-argument function drops the `meta`, and the `meta` is
+ * load-bearing: the group reports the MOUNT pass as well as user drags, and the
+ * mount pass arrives BEFORE a restored layout takes effect. A consumer that
+ * cannot read `meta.isUserInteraction` writes the freshly measured default over
+ * the layout it was restoring, so widths reset on every reload while appearing
+ * to persist within a session. `APIPlayground` filters on exactly that, and a
+ * narrowed type here would have made that filter impossible to write.
+ */
+export type ShellLayoutChanged = NonNullable<
+  React.ComponentProps<typeof ResizablePanelGroup>["onLayoutChanged"]
+>;
+
 export interface ImmersiveShellProps {
   /** Region 01 — identity, and the controls that leave the page. */
   bar: React.ReactNode;
@@ -58,7 +88,7 @@ export interface ImmersiveShellProps {
   primary: React.ReactNode;
   /** Region 04 — its consequence, beside it. */
   secondary: React.ReactNode;
-  /** Region 05 — summoned configuration, overlaying region 04. */
+  /** Region 05 — summoned configuration, overlaying region 04 only. */
   inspector?: React.ReactNode;
   /** Region 06 — collapsible instruments along the bottom. */
   drawer?: React.ReactNode;
@@ -71,19 +101,42 @@ export interface ImmersiveShellProps {
    */
   splitLabel: string;
   /**
+   * Leaves this surface. Rendered by the SHELL, as a control in region 01.
+   *
+   * The shell renders it rather than trusting a caller to, because `canExit` is
+   * derived from it. A surface may only take the admin's primary rail — its
+   * whole navigation — when a way back demonstrably exists, and `bar` is a
+   * `ReactNode` that may be a title, a heading, or nothing at all. Treating the
+   * presence of a slot as proof of an exit is how an author holding unsaved
+   * work is left with no route anywhere except the browser's URL bar.
+   */
+  onExit?: () => void;
+  /** Accessible name for the exit control. */
+  exitLabel?: string;
+  /**
    * Which admin furniture to hide for as long as this shell is mounted.
    *
    * Empty by default, so a shell that says nothing takes nothing. The request is
    * mount-scoped: navigating away restores the chrome with nothing to undo.
+   * `primaryRail` is granted only alongside `onExit` — see above.
    */
   suppress?: readonly AdminChromeLayer[];
+  /**
+   * How the two panes divide the body.
+   *
+   * `vertical` stacks them, which is what a narrow viewport needs: side by side
+   * on a phone leaves two columns too thin to author in or to judge from. The
+   * caller decides, because only it knows what its own panes cost at a width.
+   */
+  orientation?: "horizontal" | "vertical";
   /** Relative weights for the two panes, conventionally summing to 100. */
-  defaultLayout?: Record<string, number>;
+  defaultLayout?: ShellLayout;
   /**
    * Called once a drag has SETTLED, never per frame — persisting on every frame
    * of a drag is a write per frame to whatever is behind the caller's store.
+   * Receives the group's `meta`; read `ShellLayoutChanged` before ignoring it.
    */
-  onLayoutChanged?: (layout: Record<string, number>) => void;
+  onLayoutChanged?: ShellLayoutChanged;
 }
 
 export function ImmersiveShell({
@@ -94,23 +147,39 @@ export function ImmersiveShell({
   inspector,
   drawer,
   splitLabel,
+  onExit,
+  exitLabel = "Back",
   suppress = [],
+  orientation = "horizontal",
   defaultLayout = { [SHELL_PRIMARY]: 50, [SHELL_SECONDARY]: 50 },
   onLayoutChanged,
 }: ImmersiveShellProps) {
   /*
-   * `canExit` is true because region 01 always renders and is where a surface
-   * puts its way back. It is a claim the resolver cannot check — it can only
-   * withhold the primary rail from a surface that answers false — so it is made
-   * here, where the bar's presence is guaranteed by the type, rather than left
-   * to each caller to assert about itself.
+   * DERIVED from the affordance, never declared beside it. The resolver cannot
+   * check a `canExit` claim — it can only withhold the primary rail from a
+   * surface that answers false — so the only honest answer is whether this
+   * shell actually rendered a way back, which it knows because it renders it.
    */
-  useSuppressAdminChrome({ layers: suppress, canExit: true });
+  const canExit = Boolean(onExit);
+  useSuppressAdminChrome({ layers: suppress, canExit });
 
   return (
-    <div className="relative flex h-full min-h-0 flex-col bg-background">
-      <div data-testid="shell-bar" className="shrink-0">
-        {bar}
+    <div className="flex h-full min-h-0 flex-col bg-background">
+      <div
+        data-testid="shell-bar"
+        className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2.5"
+      >
+        {onExit ? (
+          <button
+            type="button"
+            onClick={onExit}
+            aria-label={exitLabel}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-input text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+        ) : null}
+        <div className="min-w-0 flex-1">{bar}</div>
       </div>
 
       {band ? (
@@ -120,7 +189,7 @@ export function ImmersiveShell({
       ) : null}
 
       <ResizablePanelGroup
-        orientation="horizontal"
+        orientation={orientation}
         defaultLayout={defaultLayout}
         onLayoutChanged={onLayoutChanged}
         className="min-h-0 flex-1"
@@ -140,11 +209,23 @@ export function ImmersiveShell({
         <ResizableHandle withGrip aria-label={splitLabel} />
 
         <ResizablePanel id={SHELL_SECONDARY} minSize="25%">
+          {/* `relative` HERE is what scopes the inspector. Positioned against
+              the shell's outer box instead, it spans the bar and the drawer as
+              well, and a right-hand inspector then covers the save and exit
+              controls it is meant to sit beside. */}
           <div
             data-testid="shell-secondary"
-            className="flex h-full min-h-0 flex-col overflow-hidden"
+            className="relative flex h-full min-h-0 flex-col overflow-hidden"
           >
             {secondary}
+            {inspector ? (
+              <div
+                data-testid="shell-inspector"
+                className="absolute inset-y-0 right-0 z-20 overflow-y-auto border-l border-border bg-background shadow-lg"
+              >
+                {inspector}
+              </div>
+            ) : null}
           </div>
         </ResizablePanel>
       </ResizablePanelGroup>
@@ -155,18 +236,6 @@ export function ImmersiveShell({
           className="shrink-0 border-t border-border"
         >
           {drawer}
-        </div>
-      ) : null}
-
-      {/* Out of the flow on purpose. In the flow it would take width from the
-          panes, so opening it would reflow the document being edited — the one
-          thing a settings panel must not do to an author mid-sentence. */}
-      {inspector ? (
-        <div
-          data-testid="shell-inspector"
-          className="absolute inset-y-0 right-0 z-20 overflow-y-auto border-l border-border bg-background shadow-lg"
-        >
-          {inspector}
         </div>
       ) : null}
     </div>

--- a/packages/admin/src/components/layout/immersive-shell/index.ts
+++ b/packages/admin/src/components/layout/immersive-shell/index.ts
@@ -1,0 +1,6 @@
+export {
+  ImmersiveShell,
+  SHELL_PRIMARY,
+  SHELL_SECONDARY,
+  type ImmersiveShellProps,
+} from "./ImmersiveShell";


### PR DESCRIPTION
## What and why

Four admin surfaces already compose the same three ingredients by hand, and each composes them differently:

| surface | chrome suppression | resizable split |
| --- | --- | --- |
| `APIPlayground` | — | yes |
| `PreviewSplit` / `PreviewPanes` | yes | yes |
| `TranslationPanes` | yes | yes |
| `builder-shell` | — | yes |
| `EmailTemplateForm` | **no** | **no — a raw CSS grid** |

The email template editor is the fifth of that shape and the only one using neither primitive, which is why it cannot resize and cannot reclaim its width. `@nextlyhq/ui`'s own resizable docblock names the target directly: *"An editor shell is exactly this: a rail, a canvas and an inspector."*

This names the composition once, with **regions declared rather than arranged**:

- **`bar`** — identity and the acts that leave the page. Always rendered.
- **`band`** — optional strip beneath the bar, for fields that *address* the work rather than being it.
- **`primary`** — the thing being authored.
- **`secondary`** — its consequence, draggable against `primary`.
- **`inspector`** — summoned configuration that **overlays** `secondary` rather than displacing it, so the document being edited never reflows while a setting changes.
- **`drawer`** — instruments rather than settings, along the bottom.

`primary` and `secondary` are the invariant: everything else may be absent and those two are always on screen. That is the property every comparable product holds — Customer.io states it outright, that you may hide any piece *"and you'll always see your code and the corresponding preview no matter what you hide"* — and it is the reason the inspector overlays instead of taking a column.

`canExit: true` is asserted **here** rather than by each caller, because the type guarantees `bar` renders and that is where a surface puts its way back. The resolver cannot check that claim; it can only withhold the primary rail from a surface that answers false.

## Test plan

10 tests, **each break-verified individually** against the component — a suite going green says nothing about whether any single test can fail:

| mutation | test |
| --- | --- |
| drop the `band` slot | renders the regions it was given |
| render optional regions unconditionally | omits the optional regions |
| pass `[]` to the suppression hook | asks for the chrome layers it was given |
| pin the layers to a constant | releases the chrome when it unmounts |
| default `suppress` to a non-empty list | hides nothing when asked to suppress nothing |
| hardcode the separator's name | names the split for a keyboard user |
| drop `secondary` while the inspector is open | keeps the secondary region mounted |
| remove `absolute` from the inspector | positions the inspector out of the flow |
| delete the drawer branch | renders the drawer when given one |
| swap `onLayoutChanged` for `onLayoutChange` | persists on the SETTLED event |

All ten fail.

Two of them are asserted deliberately indirectly, and the files say why:

- **The overlay.** jsdom computes no layout, so a test reading positions would pass whatever the value was. Retention is asserted instead — displacing would unmount or replace the region — with the `absolute` class contract asserted separately.
- **The settled-vs-per-frame handler.** The two names differ by one letter and by a write per frame. A mock that is never called stays green under both, and a synthesised drag would exercise the library rather than this wiring. The source is the only instrument that can see which name is used, following the pattern already in `layout/__tests__/content-measure-wiring.test.ts`. It carries a **positive control first**, because `not.toMatch` is satisfied by an empty string and a mis-resolved path would otherwise certify the property without reading the file.

**Gates:** `pnpm build` 0 · `check-types` 0 · `lint` 0 · `fallow audit` pass (3 files, 0 introduced). `src/components/layout` — **17 files, 137 tests, all passing.**

## Notes for the reviewer

- **The shell has no product consumer in this PR, deliberately.** The email template editor adopts it in the next one. Landing the primitive and migrating every caller in one change is how a reviewable diff stops being reviewable — and the other four surfaces above are explicitly **not** converted here either; that is a separate follow-up.
- `minSize` is a **percentage string**, not a number: this library reads a bare number as pixels, so `minSize={25}` would be a 25-pixel floor rather than a quarter of the group. The trap is documented in `TranslationPanes` and now guarded by comment here.
- Changeset added: **yes (patch)**. The component is not exported from the package index, so nothing changes on screen yet — the entry says so.



---

## Review round 1 — five findings, all valid, all fixed in `e507d78eb`

Two P1 and three P2 from Codex. Nothing was waved through; each is answered on its own thread with the mechanism and its break-verification.

| # | finding | fix |
| --- | --- | --- |
| P1 | `canExit` was hardcoded `true`, so a caller passing `primaryRail` could remove the admin's whole navigation on the strength of a slot existing | the shell now **renders the exit itself** (`onExit`), and derives `canExit = Boolean(onExit)` |
| P1 | the inspector's `absolute` resolved against the shell's outer box, spanning the bar and drawer — a right-hand inspector covered the save and exit controls | the inspector renders **inside** the secondary panel, and `relative` moved onto that pane |
| P2 | narrowing `onLayoutChanged` to one argument made the mount-pass filter impossible, so every consumer would overwrite its restored layout | the type is **derived** from the component, so it carries `meta` by construction |
| P2 | a fixed horizontal split would have regressed the mobile editor on adoption | `orientation` prop; the breakpoint stays with the consumer, which is the only thing that knows what its panes cost |
| P2 | `Record<string, number>` accepted a misspelled layout key, which the library then cannot restore | `ShellLayout`, keyed by the two exported constants |

**One of these was a defect in my own test, and it is the one worth reading.** The overlay assertion checked that the class list contained `absolute` — which is true whether the overlay is scoped to the pane or to the whole shell. It certified the placement it was named for while being unable to observe it. It now asserts containment, which is true of exactly one of the two placements, plus the `relative` containing block, since containment alone is necessary and not sufficient.

Tests: **10 → 15**, and the new ones are break-verified individually — inspector out of the pane, `relative` removed, `canExit` pinned true, pinned false, exit handler detached, exit rendered unconditionally, orientation pinned horizontal. All seven fail. The typed layout was verified in both directions too: a misspelled key produces `TS2561`, and the control compiles clean.

Gates at `e507d78eb`: `pnpm build` 0 · `check-types` 0 · `lint` 0 · `lint:design` 0 · `fallow` pass (2 files, 0 introduced) · `src/components/layout` **17 files, 142 tests**.