### PR TITLE
fix(admin): give the document title one source instead of two copies

### DIFF
--- a/.changeset/one-title-one-source.md
+++ b/.changeset/one-title-one-source.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Make the document title one value rather than two copies of it. The entry header kept its own copy of the title, so a rename made anywhere else never reached it — and a takeover field can now do exactly that: renaming a page in the builder's settings panel left the header behind the editor showing the old name, and the next keystroke there saved the old name back over the rename. The header's title moves into `EntryTitleInput`, which reads the form rather than holding a copy, and is a control the header's other surfaces can reuse. Separately, the settings panel no longer counts a group whose every child is conditioned away: those children render nothing, so counting them offered the panel with a heading over an empty group. Conditions on nested fields are now read at the qualified path the renderer resolves them against.

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -39,6 +39,7 @@ import { AutoSaveIndicator } from "./AutoSaveIndicator";
 import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
 import { DocumentStatusLive } from "./DocumentStatusLive";
 import { effectiveEntryStatus } from "./entry-address";
+import { EntryTitleInput } from "./EntryTitleInput";
 import { PreviewActions } from "./PreviewActions";
 import { ShowJSONDialog } from "./ShowJSONDialog";
 import { TOOLBAR_CONTAINER, ToolbarLabel } from "./toolbar-density";
@@ -365,13 +366,6 @@ export function EntrySystemHeader({
   const titleLabel =
     (titleField as { label?: string } | undefined)?.label ?? "Title";
 
-  const { ref: rhfRef, ...rhfRegister } = form.register(titleName, {
-    required:
-      !lockIdentity && !isReadingHistory && titleRequired
-        ? "Title is required"
-        : false,
-  });
-
   // the title input bypasses FieldWrapper, so apply the same per-field RTL rule here —
   // flip to RTL only when the title is a translatable field AND the active locale is RTL (a
   // shared/LTR title stays LTR). Uses the same classifier as FieldWrapper for consistency.
@@ -450,29 +444,21 @@ export function EntrySystemHeader({
           window widths that was nothing. It now keeps a readable minimum and the
           actions collapse around it (see `toolbar-density`). */}
         <div className="flex-1 min-w-[10rem] @max-lg/toolbar:basis-full">
-          <input
-            {...rhfRegister}
-            ref={el => {
-              rhfRef(el);
+          {/* The title is part of the document, so reading a past version
+            locks it with everything else. Left editable it would mutate the
+            LIVE document while the banner says the page cannot be edited — and
+            go to autosave as unsaved work nobody typed on purpose. */}
+          <EntryTitleInput
+            name={titleName}
+            control={form.control}
+            label={titleLabel}
+            required={titleRequired && !isReadingHistory}
+            locked={lockIdentity || isReadingHistory}
+            submitting={isSubmitting}
+            rtl={titleRtl}
+            inputRef={(el: HTMLInputElement | null) => {
               inputRef.current = el;
             }}
-            type="text"
-            placeholder="Untitled"
-            aria-label={titleLabel}
-            disabled={isSubmitting}
-            // The title is part of the document, so reading a past version locks
-            // it with everything else. Left editable it would mutate the LIVE
-            // document while the banner says the page cannot be edited — and go
-            // to autosave as unsaved work nobody typed on purpose.
-            readOnly={lockIdentity || isReadingHistory}
-            // RTL for a translatable title edited in an RTL language.
-            {...(titleRtl ? { dir: "rtl" as const } : {})}
-            className={cn(
-              "w-full text-xl font-semibold tracking-tight text-foreground",
-              "bg-transparent outline-none placeholder:text-muted-foreground",
-              isSubmitting && "opacity-60 cursor-not-allowed",
-              lockIdentity && "cursor-default text-foreground/80"
-            )}
           />
         </div>
 

--- a/packages/admin/src/components/features/entries/EntryForm/EntryTitleInput.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryTitleInput.tsx
@@ -66,13 +66,34 @@ export function EntryTitleInput({
   });
 
   /*
-   * A title is text, and anything else is a schema this control cannot draw.
-   * Coerced rather than passed through, so a misconfigured field cannot put
-   * `[object Object]` on screen or hand React a value it refuses — and an
-   * empty string keeps the input controlled and editable, where `undefined`
-   * would silently make it uncontrolled again and reintroduce the private copy.
+   * PRIMITIVES ARE SHOWN, not just strings.
+   *
+   * `title` is an ownable system column and a code-first schema may redefine
+   * it: core covers a required NUMBER title, and a document holding `42` must
+   * read `42` here. Accepting only strings would show such a title as
+   * "Untitled" while the form held its real value — the author would see an
+   * empty box over saved content, which is the reverse of the defect this
+   * control was extracted to fix. The registered input this replaced rendered
+   * primitives natively, so this keeps what it displayed.
+   *
+   * Anything else — an object, an array, null — becomes empty rather than
+   * `[object Object]`, and an empty string keeps the input controlled, where
+   * `undefined` would make it uncontrolled again and reintroduce the private
+   * copy.
+   *
+   * What this does NOT change is the write. A text input yields a string
+   * whatever the column's type, exactly as it did before, so editing a numeric
+   * title still produces a string its schema will refuse. Drawing the title
+   * through its own configured field control is the fix for that, and it is a
+   * different change from this one.
    */
-  const value = typeof field.value === "string" ? field.value : "";
+  const raw: unknown = field.value;
+  const value =
+    typeof raw === "string" ||
+    typeof raw === "number" ||
+    typeof raw === "bigint"
+      ? String(raw)
+      : "";
 
   return (
     <input

--- a/packages/admin/src/components/features/entries/EntryForm/EntryTitleInput.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryTitleInput.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+/**
+ * The document's title, as one control that reads the form rather than a copy.
+ *
+ * Its own component for two reasons, and the first is a hard requirement. The
+ * header returns early when it is rendered outside a form — a legitimate
+ * arrangement — and a hook cannot sit after that return. Registering the input
+ * was not a hook and could; reading the form's value IS one, so the control
+ * moves to where it is only ever mounted with a form around it and its hook
+ * runs unconditionally.
+ *
+ * The second is that the title is about to be drawn somewhere other than the
+ * header, and a second copy of this would be the exact defect it was extracted
+ * to fix.
+ *
+ * CONTROLLED, deliberately. Registered, the input kept a private copy of the
+ * value: React Hook Form seeds the DOM once and an edit made through any other
+ * surface never reaches it. That became real the moment a takeover field could
+ * rename the document — the page builder's settings panel renames a page, this
+ * input goes on showing the old name behind the editor, and the author's next
+ * keystroke saves the old name back over the rename.
+ *
+ * @module components/features/entries/EntryForm/EntryTitleInput
+ */
+
+import { useController, type Control } from "react-hook-form";
+
+import { cn } from "@admin/lib/utils";
+
+export interface EntryTitleInputProps {
+  /** The form field holding the title. */
+  name: string;
+  /** The form this title belongs to. */
+  control: Control<Record<string, unknown>>;
+  /** Accessible name, from the field's own label. */
+  label: string;
+  /** Whether an empty title should be refused. */
+  required: boolean;
+  /** Whether the document's identity is fixed — a Single's, for instance. */
+  locked: boolean;
+  /** Whether the form is mid-submit. */
+  submitting: boolean;
+  /** Whether this title is being edited in a right-to-left language. */
+  rtl: boolean;
+  /** Published so the header can focus it when creating. */
+  inputRef?: (element: HTMLInputElement | null) => void;
+  className?: string;
+}
+
+export function EntryTitleInput({
+  name,
+  control,
+  label,
+  required,
+  locked,
+  submitting,
+  rtl,
+  inputRef,
+  className,
+}: EntryTitleInputProps) {
+  const { field } = useController({
+    control,
+    name,
+    rules: { required: required && !locked ? "Title is required" : false },
+  });
+
+  /*
+   * A title is text, and anything else is a schema this control cannot draw.
+   * Coerced rather than passed through, so a misconfigured field cannot put
+   * `[object Object]` on screen or hand React a value it refuses — and an
+   * empty string keeps the input controlled and editable, where `undefined`
+   * would silently make it uncontrolled again and reintroduce the private copy.
+   */
+  const value = typeof field.value === "string" ? field.value : "";
+
+  return (
+    <input
+      name={field.name}
+      value={value}
+      onChange={field.onChange}
+      onBlur={field.onBlur}
+      ref={element => {
+        field.ref(element);
+        inputRef?.(element);
+      }}
+      type="text"
+      placeholder="Untitled"
+      aria-label={label}
+      disabled={submitting}
+      readOnly={locked}
+      {...(rtl ? { dir: "rtl" as const } : {})}
+      className={cn(
+        "w-full text-xl font-semibold tracking-tight text-foreground",
+        "bg-transparent outline-none placeholder:text-muted-foreground",
+        submitting && "opacity-60 cursor-not-allowed",
+        locked && "cursor-default text-foreground/80",
+        className
+      )}
+    />
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.title-sync.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.title-sync.test.tsx
@@ -100,4 +100,66 @@ describe("the header's title and another surface editing the same field", () => 
 
     expect(headerTitle().value).toBe("");
   });
+
+  it("shows a NUMERIC title, which a code-first schema may legitimately declare", () => {
+    /*
+     * `title` is an ownable system column and core covers a required number
+     * one, so a document may hold `42` here. Accepting only strings showed such
+     * a title as "Untitled" over saved content — an empty box where the form
+     * held a real value, which is the reverse of the defect this control exists
+     * to fix.
+     */
+    function NumericHarness() {
+      const methods = useForm({ defaultValues: { title: 42 } });
+      return (
+        <FormProvider {...methods}>
+          <EntrySystemHeader
+            mode="edit"
+            hasStatus
+            entry={{ id: "n", status: "draft", title: 42 }}
+            collectionSlug="pages"
+            scope="single"
+            onSaveDraft={vi.fn()}
+            onPublish={vi.fn()}
+            onSaveChanges={vi.fn()}
+            onUnpublish={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </FormProvider>
+      );
+    }
+
+    render(<NumericHarness />);
+    expect(headerTitle().value).toBe("42");
+  });
+
+  it("still shows nothing for a value no text input can draw", () => {
+    // The control for the case above. Widening to "any primitive" must not
+    // widen to "anything": an object would render as `[object Object]`, which
+    // is worse than empty because it looks like content.
+    function ObjectHarness() {
+      const methods = useForm({
+        defaultValues: { title: { nested: "value" } as unknown },
+      });
+      return (
+        <FormProvider {...methods}>
+          <EntrySystemHeader
+            mode="edit"
+            hasStatus
+            entry={{ id: "o", status: "draft" }}
+            collectionSlug="pages"
+            scope="single"
+            onSaveDraft={vi.fn()}
+            onPublish={vi.fn()}
+            onSaveChanges={vi.fn()}
+            onUnpublish={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </FormProvider>
+      );
+    }
+
+    render(<ObjectHarness />);
+    expect(headerTitle().value).toBe("");
+  });
 });

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.title-sync.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.title-sync.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * The header's title shows what the FORM holds, not a copy it keeps itself.
+ *
+ * A takeover surface — the page builder — covers this header while editing, and
+ * its settings panel can rename the document. The header stays mounted behind
+ * it. While this input kept its own copy of the value, a rename made through
+ * that panel never reached it: the author left the editor, saw the old name,
+ * and the next keystroke here saved the old name back over the rename.
+ *
+ * Two surfaces render one field, so the property under test is that they cannot
+ * disagree. The other surface is stood in for by a plain controlled input on
+ * the same form rather than by mounting the whole page builder — what matters
+ * is that the edit arrives through the form rather than through this input, and
+ * a second control is the smallest thing that does that faithfully.
+ *
+ * @module components/features/entries/EntryForm/__tests__/EntrySystemHeader.title-sync.test
+ */
+import { useForm, FormProvider, Controller } from "react-hook-form";
+import { describe, it, expect, vi } from "vitest";
+
+import { fireEvent, render, screen } from "@admin/__tests__/utils";
+
+import { EntrySystemHeader } from "../EntrySystemHeader";
+
+/** The header, plus a second surface editing the same field through the form. */
+function Harness() {
+  const methods = useForm({ defaultValues: { title: "About Us" } });
+  return (
+    <FormProvider {...methods}>
+      <EntrySystemHeader
+        mode="edit"
+        hasStatus
+        entry={{ id: "about", status: "draft", title: "About Us" }}
+        collectionSlug="pages"
+        scope="single"
+        onSaveDraft={vi.fn()}
+        onPublish={vi.fn()}
+        onSaveChanges={vi.fn()}
+        onUnpublish={vi.fn()}
+        onCancel={vi.fn()}
+      />
+      <Controller
+        name="title"
+        control={methods.control}
+        render={({ field }) => (
+          <input
+            aria-label="settings panel title"
+            value={typeof field.value === "string" ? field.value : ""}
+            onChange={event => field.onChange(event.target.value)}
+          />
+        )}
+      />
+    </FormProvider>
+  );
+}
+
+const headerTitle = () => screen.getByLabelText("Title") as HTMLInputElement;
+
+describe("the header's title and another surface editing the same field", () => {
+  it("shows a rename made through the OTHER surface", () => {
+    /*
+     * The defect, stated as the property it violated. Before this input read
+     * from the form, it answered `About Us` here — the value it was seeded
+     * with — while the form already held the new one.
+     */
+    render(<Harness />);
+    expect(headerTitle().value).toBe("About Us");
+
+    fireEvent.change(screen.getByLabelText("settings panel title"), {
+      target: { value: "Our Story" },
+    });
+
+    expect(headerTitle().value).toBe("Our Story");
+  });
+
+  it("sends its own edits the other way", () => {
+    /*
+     * The control, and it has to come out different or the case above says only
+     * that both inputs render the same initial value. An input that read the
+     * form but never wrote to it would satisfy the first test completely.
+     */
+    render(<Harness />);
+    const other = screen.getByLabelText(
+      "settings panel title"
+    ) as HTMLInputElement;
+
+    fireEvent.change(headerTitle(), { target: { value: "Renamed Here" } });
+
+    expect(other.value).toBe("Renamed Here");
+    expect(headerTitle().value).toBe("Renamed Here");
+  });
+
+  it("still reports an empty title as empty rather than as the seeded value", () => {
+    // Clearing is an edit like any other, and a controlled input that fell back
+    // to its default when handed an empty string would refuse to be cleared —
+    // the failure mode a `value ?? initial` fallback produces.
+    render(<Harness />);
+
+    fireEvent.change(headerTitle(), { target: { value: "" } });
+
+    expect(headerTitle().value).toBe("");
+  });
+});

--- a/packages/admin/src/lib/builder/takeoverLayout.test.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.test.ts
@@ -326,3 +326,57 @@ describe("fields nested inside a group", () => {
     expect(out.content.map(f => f.name)).toEqual(["faqs"]);
   });
 });
+
+describe("a group holding a hidden controller", () => {
+  /*
+   * The realistic shape, and the one the first version of this rule counted as
+   * content. A group carries the field its own controls are conditioned on, and
+   * that field is `admin.hidden` because a toolbar drives it rather than the
+   * form. `FieldWrapper` returns null for a hidden field, so it draws nothing —
+   * but it is not conditioned away, so a visibility rule that only asks about
+   * conditions finds it "visible" and keeps the whole group alive.
+   */
+  const withHiddenController = [
+    { name: "body", type: "blocks" },
+    {
+      name: "seo",
+      type: "group",
+      fields: [
+        { name: "mode", type: "select", admin: { hidden: true } },
+        {
+          name: "legacyMeta",
+          type: "text",
+          admin: { condition: { field: "mode", equals: "classic" } },
+        },
+      ],
+    },
+  ];
+
+  it("hides the group when its only DRAWN child is conditioned away", () => {
+    const out = computeFieldsBeside(withHiddenController, "body", {
+      "seo.mode": "builder",
+    });
+    expect(out.content.map(f => f.name)).toEqual([]);
+  });
+
+  it("keeps it when that child can render", () => {
+    // The control: the hidden controller is unchanged between the two, so a
+    // rule that simply dropped every group would pass the case above and fail
+    // here.
+    const out = computeFieldsBeside(withHiddenController, "body", {
+      "seo.mode": "classic",
+    });
+    expect(out.content.map(f => f.name)).toEqual(["seo"]);
+  });
+
+  it("still WATCHES the hidden controller, which is what decides the rest", () => {
+    /*
+     * The two questions are different and it matters that they stay so. A
+     * hidden field draws nothing, so it cannot keep a group alive — but it is
+     * exactly the field whose value the other children read, so it must still
+     * be subscribed to. Filtering hidden fields out of the name walk would
+     * leave the condition above evaluated against a value nobody watched.
+     */
+    expect(conditionFieldNames(withHiddenController)).toEqual(["seo.mode"]);
+  });
+});

--- a/packages/admin/src/lib/builder/takeoverLayout.test.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   computeMainFields,
   computeFieldsBeside,
+  conditionFieldNames,
   takeoverControllerNames,
   takeoverTypesFromBranding,
 } from "./takeoverLayout";
@@ -243,5 +244,85 @@ describe("computeFieldsBeside", () => {
     // This fixture declares no title or slug, so the identity group is empty
     // and the collection's own field is the whole of what is offered.
     expect(offered(codeFirstFields, "content")).toEqual(["summary"]);
+  });
+});
+
+describe("fields nested inside a group", () => {
+  /** A group whose single child renders only in the classic editor. */
+  const grouped = [
+    { name: "title", type: "text" },
+    { name: "slug", type: "text" },
+    { name: "body", type: "blocks" },
+    {
+      name: "seo",
+      type: "group",
+      fields: [
+        {
+          name: "legacy",
+          type: "text",
+          admin: { condition: { field: "mode", equals: "classic" } },
+        },
+      ],
+    },
+  ];
+
+  it("watches the child's condition at its QUALIFIED path, not its bare name", () => {
+    /*
+     * `FieldRenderer` resolves a nested condition against the field's own base,
+     * so this child watches `seo.mode`. Collecting the bare `mode` would
+     * subscribe to a top-level field that does not exist, and every lookup
+     * against it would read `undefined` — which this rule treats as "not
+     * watched" and therefore visible, hiding nothing and fixing nothing.
+     */
+    expect(conditionFieldNames(grouped)).toEqual(["seo.mode"]);
+  });
+
+  it("hides a group whose every child is conditioned away", () => {
+    // The reported case: the group's OWN condition passes — it has none — so
+    // counting it left the panel offered with a `Fields` heading over a group
+    // that draws its label and nothing else.
+    const out = computeFieldsBeside(grouped, "body", { "seo.mode": "builder" });
+    expect(out.content.map(f => f.name)).toEqual([]);
+  });
+
+  it("keeps that group once any child can render", () => {
+    // The control. A rule that dropped every group, or every field carrying
+    // children, would satisfy the case above without being right.
+    const out = computeFieldsBeside(grouped, "body", { "seo.mode": "classic" });
+    expect(out.content.map(f => f.name)).toEqual(["seo"]);
+  });
+
+  it("leaves a group alone when nothing has told it about the value", () => {
+    // An unwatched name reads as `undefined`, and hiding content on the
+    // strength of a value nobody supplied would withhold a panel that has
+    // something in it — the failure in the direction that loses work.
+    const out = computeFieldsBeside(grouped, "body", {});
+    expect(out.content.map(f => f.name)).toEqual(["seo"]);
+  });
+
+  it("does NOT walk into a repeater, whose fields are a row template", () => {
+    /*
+     * A repeater's children describe what each ROW holds; their conditions are
+     * evaluated per row against that row's values, and the repeater renders its
+     * add control whether or not it has any rows. Treating an all-conditional
+     * row template as an empty repeater would hide a control that works.
+     */
+    const withRepeater = [
+      { name: "body", type: "blocks" },
+      {
+        name: "faqs",
+        type: "repeater",
+        fields: [
+          {
+            name: "answer",
+            type: "text",
+            admin: { condition: { field: "kind", equals: "long" } },
+          },
+        ],
+      },
+    ];
+    expect(conditionFieldNames(withRepeater)).toEqual([]);
+    const out = computeFieldsBeside(withRepeater, "body", {});
+    expect(out.content.map(f => f.name)).toEqual(["faqs"]);
   });
 });

--- a/packages/admin/src/lib/builder/takeoverLayout.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.ts
@@ -121,7 +121,21 @@ function isConditionallyVisible(
   if (base === null || f.fields === undefined || f.fields.length === 0) {
     return true;
   }
-  return f.fields.some(child => isConditionallyVisible(child, values, base));
+  /*
+   * A HIDDEN child counts for nothing, the same way a hidden field does at the
+   * top level. `FieldWrapper` returns null for one, so it draws nothing — and a
+   * group's commonest shape is exactly the trap: a hidden controller field
+   * beside the controls whose conditions read it. Counting the controller kept
+   * such a group alive with every visible control conditioned away, which is
+   * the blank panel this rule exists to prevent.
+   *
+   * Filtering here rather than inside the walk above, because the two questions
+   * differ: the walk collects the names a condition WATCHES, and a hidden
+   * controller is precisely the field that must still be watched.
+   */
+  return f.fields.some(
+    child => !isHidden(child) && isConditionallyVisible(child, values, base)
+  );
 }
 
 /**

--- a/packages/admin/src/lib/builder/takeoverLayout.ts
+++ b/packages/admin/src/lib/builder/takeoverLayout.ts
@@ -31,6 +31,13 @@ export interface TakeoverType {
 export interface LayoutField {
   name?: string;
   type?: string;
+  /**
+   * A structured field's children, when it has any.
+   *
+   * Loose for the same reason `admin` is: every field-config shape must stay
+   * assignable to this, and only the traversal below reads it.
+   */
+  fields?: readonly LayoutField[];
   // Loose on purpose: any field config (FieldConfig, ManifestField, …) must be
   // assignable to LayoutField so the generic `T` binds to the caller's type. The
   // condition is cast to FieldCondition where it's actually evaluated.
@@ -88,13 +95,33 @@ function controllerName(f: LayoutField): string | undefined {
  */
 function isConditionallyVisible(
   f: LayoutField,
-  values: Record<string, unknown>
+  values: Record<string, unknown>,
+  basePath = ""
 ): boolean {
   const condition = f.admin?.condition as FieldCondition | undefined;
-  const watches = condition?.field;
-  if (condition === undefined || watches === undefined) return true;
-  if (!(watches in values)) return true;
-  return evaluateCondition(condition, values[watches]);
+  const watches = watchedName(f, basePath);
+  if (condition !== undefined && watches !== undefined) {
+    if (watches in values && !evaluateCondition(condition, values[watches])) {
+      return false;
+    }
+  }
+  /*
+   * A GROUP is only as visible as its contents. Its own condition passing says
+   * the group may render; it does not say anything will be inside it, and
+   * `GroupInput` sends each child through `FieldRenderer`, which answers null
+   * for a condition that is false. A group whose every child is hidden draws
+   * its label and its gutter over nothing — which, counted as content, offers
+   * a panel with a heading and no control in it.
+   *
+   * An EMPTY `fields` list is left visible rather than hidden: a group that
+   * declares no children is a schema the author wrote on purpose, and this is
+   * not the place to decide it was a mistake.
+   */
+  const base = childBase(f, basePath);
+  if (base === null || f.fields === undefined || f.fields.length === 0) {
+    return true;
+  }
+  return f.fields.some(child => isConditionallyVisible(child, values, base));
 }
 
 /**
@@ -105,14 +132,60 @@ function isConditionallyVisible(
  * beside the rule that consumes it so the two cannot name different sets.
  */
 export function conditionFieldNames<T extends LayoutField>(
-  fields: T[]
+  fields: readonly T[]
 ): string[] {
   const names = new Set<string>();
-  for (const f of fields) {
-    const watches = (f.admin?.condition as FieldCondition | undefined)?.field;
-    if (watches !== undefined) names.add(watches);
-  }
+  collectConditionNames(fields, "", names);
   return [...names];
+}
+
+/**
+ * The qualified name a field's condition watches, or undefined for no condition.
+ *
+ * QUALIFIED BY THE PATH, because `FieldRenderer` resolves a nested condition
+ * against the field's own base — a child of the `seo` group watching `mode`
+ * watches `seo.mode`. Collecting the bare name would subscribe to a top-level
+ * field that usually does not exist, and judging visibility against it would
+ * read `undefined` for a condition that is really satisfied.
+ */
+function watchedName(f: LayoutField, basePath: string): string | undefined {
+  const watches = (f.admin?.condition as FieldCondition | undefined)?.field;
+  if (watches === undefined) return undefined;
+  return basePath === "" ? watches : `${basePath}.${watches}`;
+}
+
+/**
+ * The path a structured field's children are addressed under, or null when this
+ * field's children are not addressed from the form root at all.
+ *
+ * A GROUP's children render directly and their values live at
+ * `group.child`, so the walk continues into them. A REPEATER's `fields` are a
+ * ROW TEMPLATE — they describe what each row contains, their conditions are
+ * evaluated per row against that row's values, and the repeater itself renders
+ * its add control whether or not it holds any. Walking into one would collect
+ * names that address nothing and could hide a repeater that draws perfectly
+ * well, so it deliberately stops here.
+ */
+function childBase(f: LayoutField, basePath: string): string | null {
+  if (f.type !== "group" || f.fields === undefined) return null;
+  const own = f.name ?? "";
+  if (own === "") return basePath;
+  return basePath === "" ? own : `${basePath}.${own}`;
+}
+
+function collectConditionNames(
+  fields: readonly LayoutField[],
+  basePath: string,
+  into: Set<string>
+): void {
+  for (const f of fields) {
+    const watches = watchedName(f, basePath);
+    if (watches !== undefined) into.add(watches);
+    const base = childBase(f, basePath);
+    if (base !== null && f.fields !== undefined) {
+      collectConditionNames(f.fields, base, into);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Two defects that both come from counting something that isn't there. Both were reported on the final commit of #1397, after it had merged, so both are live on `main`.

## 1 · The title was written down twice

The header's title input held its own copy. React Hook Form seeds a registered input once, so an edit made through any **other** surface never reaches it — and a takeover field is now such a surface.

Rename a page in the builder's Settings panel → leave the editor → the header behind it still reads the old name → the next keystroke there **saves the old name back over the rename.**

Measured before fixing, with both mounted:

```
AssertionError: expected 'old' to be 'renamed'
```

The input moves into **`EntryTitleInput`**, which reads the form rather than copying it.

Its own component for a reason that isn't taste: the header returns early when rendered outside a form, and **a hook cannot sit after that return** — `register` was not a hook and could. Leaving it inline produced a genuine `rules-of-hooks` violation, not a lint nit. It is also the control the header's other surfaces will draw, and a second copy of it would be the defect it was extracted to fix.

## 2 · A group whose children are all conditioned away

`GroupInput` sends each child through `FieldRenderer`, which answers `null` for a false condition. So a group whose every child is hidden draws its label and gutter over nothing — and counted as content, that offered the Settings panel with a `Fields` heading and no control in it. The same defect the panel exists to prevent, one level in.

**Nested conditions are read at the path the renderer resolves them against.** A child of `seo` watching `mode` watches `seo.mode` — `FieldRenderer` builds `${basePath}.${condition.field}`. Collecting the bare name subscribes to a top-level field that usually doesn't exist, so every lookup reads `undefined`, which this rule treats as "not watched" and therefore visible: it would have fixed nothing while looking correct.

**A repeater is deliberately not walked.** Its `fields` are a *row template*, evaluated per row against that row's values, and the repeater renders its add control whatever they say. Treating an all-conditional template as an empty repeater would hide a control that works.

## Evidence

Four breaks, each killing only its own tests by name:

| break | dies |
| --- | --- |
| controlled → uncontrolled title | the sync test — **1 of 205** |
| stop recursing into a group's children | the group-hidden test |
| collect the bare name, not the qualified path | the path test + the group test |

The title suite carries two deliberate controls that must **not** fail on that break — "sends its own edits the other way" and "still reports an empty title as empty". An uncontrolled input satisfies both, which is what makes them controls rather than a second copy of the first assertion.

admin **339 files / 3253 tests green**; plugin-page-builder 49 / 519; `check-types`, `lint`, `fallow` (`pass`, 5 files) clean. Husky not bypassed.

## Not in this PR

The entry-header redesign is approved and comes next, on an action-descriptor model — the header's action set is about to grow (translation, releases, history), and today first-party actions are hardcoded while plugins get one undifferentiated slot with no priority or placement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated entry title editing for more reliable synchronization across the entry form.
  * Titles now correctly display and update when changed through different form controls.
  * Improved handling of empty and non-text title values.

* **Bug Fixes**
  * Conditional fields within grouped layouts now evaluate correctly using their full field paths.
  * Groups with no visible child fields are now hidden appropriately, while unaffected groups remain visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->