### PR TITLE
feat(admin): show what ships when, on a calendar

### DIFF
--- a/.changeset/a-calendar-of-what-ships-when.md
+++ b/.changeset/a-calendar-of-what-ships-when.md
@@ -1,0 +1,31 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Add a calendar view of what ships when. The releases page now offers two views of the same set: a list, which answers what launches exist, and a month grid, which answers what is coming and whether anything collides — a question the list can only answer by being read end to end. Each day shows how much is happening and whether any of it has stopped, and selecting a day lists those releases at full width; a month grid goes unreadable if the releases themselves are drawn into it, and the cells are narrow at any window size. Narrow screens get the month as an agenda instead of a squeezed grid, because somebody on a phone is usually asking what happens next rather than what collides.
+
+The times are shown in a zone the reader chooses, named on the page, and remembered between visits. This is not a detail: a release carries an instant and the author's timezone, so which day it lands on has no answer until a zone is named — a launch at eleven at night in New York is the following day in London. Without an explicit choice two colleagues comparing the same page would see one launch on two different days, with nothing on screen to explain why. The zone arithmetic the schedule input already used has moved into one module shared by both, since two implementations of a timezone conversion agree until a daylight boundary and then differ by an hour in a way neither screen can show.

--- a/packages/admin/src/components/features/releases/ReleaseCalendar.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseCalendar.tsx
@@ -1,0 +1,443 @@
+"use client";
+
+/**
+ * What ships when, on a month grid.
+ *
+ * A release list answers "what launches exist"; this answers "what is coming,
+ * and is anything colliding" — the question somebody planning a week actually
+ * has, and one a list ordered by instant answers only by being read end to end.
+ *
+ * ## Why the zone is a control rather than an assumption
+ *
+ * A release carries an instant AND the author's timezone, so "which day does
+ * this land on" has no answer until a zone is named: 23:00 in New York is the
+ * following day in UTC. Every product that ships this surface makes the zone
+ * explicit — Sanity puts a timezone picker on its release calendar and
+ * remembers the choice, Storyblok spans markets and zones — because a team
+ * coordinating a launch is rarely all in one place, and a grid that silently
+ * used the viewer's zone would show two colleagues different days for one
+ * launch with nothing on screen to explain it.
+ *
+ * The default is the reader's own zone, which is right far more often than UTC.
+ * The choice persists, because it is a property of the person rather than of
+ * the visit.
+ *
+ * ## Why cells carry counts rather than content
+ *
+ * A month grid goes noisy the moment state is rendered into it, and the cells
+ * are narrow at any width. So a day shows how much is happening and whether any
+ * of it needs attention; selecting it lists the releases underneath at full
+ * width, where their titles are readable and their actions reachable.
+ *
+ * @module components/features/releases/ReleaseCalendar
+ */
+import { useMemo, useState } from "react";
+
+import { ChevronLeft, ChevronRight } from "@admin/components/icons";
+import { Badge, Button, Card } from "@admin/components/ui";
+import { Link } from "@admin/components/ui/link";
+import { buildRoute, ROUTES } from "@admin/constants/routes";
+import { useReleases } from "@admin/hooks/queries/useReleases";
+import { isValidTimezone } from "@admin/lib/dates/format";
+import type { Release } from "@admin/types/releases";
+
+import {
+  bucketByDay,
+  monthGrid,
+  monthOf,
+  monthWindow,
+  shiftMonth,
+  type DayKey,
+} from "./release-calendar";
+import { RELEASE_STATE_LABEL } from "./release-schedule";
+import { readerZone } from "./release-timezone";
+
+/** Where the reader's chosen zone is remembered between visits. */
+const ZONE_KEY = "nextly.releases.calendar.zone";
+
+/**
+ * The zone to draw in: what the reader last chose, else their own.
+ *
+ * Storage is read defensively and never trusted to be readable — a private
+ * window, cleared site data or a browser refusing storage all throw, and a
+ * calendar that fails to render because it could not remember a preference
+ * would be worse than one that quietly falls back.
+ */
+function initialZone(): string {
+  try {
+    const stored = window.localStorage.getItem(ZONE_KEY);
+    if (stored && isValidTimezone(stored)) return stored;
+  } catch {
+    // Falls through to the reader's own zone.
+  }
+  return readerZone();
+}
+
+function rememberZone(zone: string): void {
+  try {
+    window.localStorage.setItem(ZONE_KEY, zone);
+  } catch {
+    // A preference that cannot be stored is not worth failing a render over.
+  }
+}
+
+const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+/** The zones offered, with the reader's own first however it is spelled. */
+function zoneChoices(current: string): string[] {
+  const common = [
+    "UTC",
+    "America/Los_Angeles",
+    "America/New_York",
+    "Europe/London",
+    "Europe/Berlin",
+    "Asia/Dubai",
+    "Asia/Kolkata",
+    "Asia/Tokyo",
+    "Australia/Sydney",
+  ];
+  return [...new Set([readerZone(), current, ...common])].filter(
+    isValidTimezone
+  );
+}
+
+export function ReleaseCalendar() {
+  const [zone, setZone] = useState(initialZone);
+  const [month, setMonth] = useState(() => monthOf(new Date(), zone));
+  const [selected, setSelected] = useState<DayKey | null>(null);
+
+  const window_ = useMemo(() => monthWindow(month, zone), [month, zone]);
+  // The month IS the query. The list route already takes an instant window, so
+  // a calendar needs no endpoint of its own — and asking for one month rather
+  // than everything is also what keeps this clear of the list's page ceiling.
+  const { data, isPending, isError } = useReleases({
+    scheduledAfter: window_.after,
+    scheduledBefore: window_.before,
+    limit: 200,
+  });
+
+  const releases = useMemo(() => data?.items ?? [], [data]);
+  const byDay = useMemo(() => bucketByDay(releases, zone), [releases, zone]);
+  const grid = useMemo(() => monthGrid(month), [month]);
+  const today = useMemo(() => monthOf(new Date(), zone), [zone]);
+
+  const changeZone = (next: string) => {
+    setZone(next);
+    rememberZone(next);
+    // The selection is a DAY IN A ZONE, and it stops meaning the same thing
+    // when the zone changes. Cleared rather than carried, because a day panel
+    // labelled with one zone and filled from another is the exact confusion
+    // this control exists to remove.
+    setSelected(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Previous month"
+            onClick={() => setMonth(shiftMonth(month, -1))}
+          >
+            <ChevronLeft className="size-4" aria-hidden />
+          </Button>
+          <span className="min-w-[9rem] text-center text-sm font-medium">
+            {monthLabel(month)}
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            aria-label="Next month"
+            onClick={() => setMonth(shiftMonth(month, 1))}
+          >
+            <ChevronRight className="size-4" aria-hidden />
+          </Button>
+          {month === today ? null : (
+            <Button variant="ghost" size="sm" onClick={() => setMonth(today)}>
+              Today
+            </Button>
+          )}
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          {/* NAMED on screen, not just applied. Two colleagues comparing this
+              page need to be able to see they are reading the same grid. */}
+          <span>Times shown in</span>
+          <select
+            className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+            value={zone}
+            onChange={event => changeZone(event.target.value)}
+          >
+            {zoneChoices(zone).map(choice => (
+              <option key={choice} value={choice}>
+                {choice.replace(/_/g, " ")}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {isError ? (
+        <Card className="px-6 py-10 text-center">
+          <p className="text-sm text-muted-foreground">
+            This month&rsquo;s schedule could not be loaded.
+          </p>
+        </Card>
+      ) : (
+        <>
+          {/* The grid is hidden on narrow screens rather than squeezed: seven
+              columns at phone width leaves each day too small to carry a count,
+              let alone be tapped. The agenda below is the same month, read as a
+              sequence. */}
+          <div
+            className="hidden grid-cols-7 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid"
+            role="grid"
+            aria-label={`Releases in ${monthLabel(month)}, times in ${zone}`}
+          >
+            {WEEKDAYS.map(day => (
+              <div
+                key={day}
+                role="columnheader"
+                className="bg-muted px-2 py-1.5 text-center text-xs font-medium text-muted-foreground"
+              >
+                {day}
+              </div>
+            ))}
+            {grid.weeks.flat().map(day => (
+              <DayCell
+                key={day}
+                day={day}
+                month={month}
+                releases={byDay.get(day) ?? []}
+                isSelected={selected === day}
+                isPending={isPending}
+                onSelect={() => setSelected(selected === day ? null : day)}
+              />
+            ))}
+          </div>
+
+          <DayDetail
+            day={selected}
+            zone={zone}
+            releases={selected ? (byDay.get(selected) ?? []) : []}
+          />
+
+          <Agenda byDay={byDay} grid={grid} month={month} zone={zone} />
+        </>
+      )}
+    </div>
+  );
+}
+
+/** `September 2026`, in the reader's locale. */
+function monthLabel(month: string): string {
+  const [year, index] = month.split("-").map(Number);
+  return new Date(Date.UTC(year, index - 1, 1)).toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}
+
+/**
+ * What a day cell says out loud, which is the whole cell for a screen reader.
+ *
+ * Built as a sentence rather than assembled inline so the spoken version and
+ * the badge cannot drift: a cell that shows a count and announces nothing is
+ * the ordinary way this control becomes unusable without looking broken.
+ */
+function dayCellLabel(day: DayKey, count: number, stopped: boolean): string {
+  if (count === 0) return `${day}, nothing scheduled`;
+  const plural = count === 1 ? "release" : "releases";
+  const tail = stopped ? ", one stopped" : "";
+  return `${day}, ${count} ${plural}${tail}`;
+}
+
+/** The count, and whether any of it needs somebody. */
+function DayCount({ count, stopped }: { count: number; stopped: boolean }) {
+  if (count === 0) return null;
+  return (
+    <Badge variant={stopped ? "destructive" : "warning"}>
+      {stopped ? `${count} · stopped` : count}
+    </Badge>
+  );
+}
+
+function DayCell({
+  day,
+  month,
+  releases,
+  isSelected,
+  isPending,
+  onSelect,
+}: {
+  day: DayKey;
+  month: string;
+  releases: Release[];
+  isSelected: boolean;
+  isPending: boolean;
+  onSelect: () => void;
+}) {
+  const inMonth = day.startsWith(month);
+  const stopped = releases.some(release => release.state === "blocked");
+  const count = releases.length;
+
+  return (
+    <button
+      type="button"
+      role="gridcell"
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      aria-label={dayCellLabel(day, count, stopped)}
+      className={cellClassName({ inMonth, isSelected })}
+    >
+      <span
+        className={
+          inMonth ? "text-xs text-foreground" : "text-xs text-muted-foreground"
+        }
+      >
+        {Number(day.slice(8, 10))}
+      </span>
+      {isPending ? null : <DayCount count={count} stopped={stopped} />}
+    </button>
+  );
+}
+
+/** The cell's own styling, kept out of the render so the markup stays legible. */
+function cellClassName({
+  inMonth,
+  isSelected,
+}: {
+  inMonth: boolean;
+  isSelected: boolean;
+}): string {
+  return [
+    "flex min-h-[5rem] flex-col items-start gap-1 p-2 text-left transition-colors",
+    inMonth ? "bg-background" : "bg-muted/40",
+    isSelected ? "ring-2 ring-inset ring-primary" : "hover:bg-accent",
+  ].join(" ");
+}
+
+function DayDetail({
+  day,
+  zone,
+  releases,
+}: {
+  day: DayKey | null;
+  zone: string;
+  releases: Release[];
+}) {
+  if (!day) return null;
+  return (
+    <Card className="flex flex-col gap-2 px-4 py-3">
+      <h2 className="text-sm font-medium text-foreground">
+        {new Date(`${day}T12:00:00.000Z`).toLocaleDateString(undefined, {
+          weekday: "long",
+          day: "numeric",
+          month: "long",
+          year: "numeric",
+          timeZone: "UTC",
+        })}
+      </h2>
+      {releases.length === 0 ? (
+        <p className="text-sm text-muted-foreground">
+          Nothing is scheduled for this day.
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {releases.map(release => (
+            <ReleaseRow key={release.id} release={release} zone={zone} />
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+}
+
+/**
+ * The month as a sequence, for narrow screens and for reading straight through.
+ *
+ * Not a fallback bolted on: a month grid answers "is anything colliding" and an
+ * agenda answers "what happens next", and somebody on a phone is far more often
+ * asking the second.
+ */
+function Agenda({
+  byDay,
+  grid,
+  month,
+  zone,
+}: {
+  byDay: Map<DayKey, Release[]>;
+  grid: { weeks: DayKey[][] };
+  month: string;
+  zone: string;
+}) {
+  const days = grid.weeks
+    .flat()
+    .filter(day => day.startsWith(month))
+    .filter(day => (byDay.get(day)?.length ?? 0) > 0);
+
+  if (days.length === 0) {
+    return (
+      <Card className="px-6 py-10 text-center sm:hidden">
+        <p className="text-sm text-muted-foreground">
+          Nothing is scheduled this month.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3 sm:hidden">
+      {days.map(day => (
+        <Card key={day} className="flex flex-col gap-2 px-4 py-3">
+          <h3 className="text-sm font-medium text-foreground">
+            {new Date(`${day}T12:00:00.000Z`).toLocaleDateString(undefined, {
+              weekday: "short",
+              day: "numeric",
+              month: "short",
+              timeZone: "UTC",
+            })}
+          </h3>
+          <ul className="flex flex-col gap-1.5">
+            {(byDay.get(day) ?? []).map(release => (
+              <ReleaseRow key={release.id} release={release} zone={zone} />
+            ))}
+          </ul>
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+function ReleaseRow({ release, zone }: { release: Release; zone: string }) {
+  const at = release.scheduledAt ? new Date(release.scheduledAt) : null;
+  return (
+    <li className="flex flex-wrap items-center gap-2 text-sm">
+      <span className="tabular-nums text-muted-foreground">
+        {at
+          ? at.toLocaleTimeString(undefined, {
+              hour: "2-digit",
+              minute: "2-digit",
+              timeZone: zone,
+            })
+          : "—"}
+      </span>
+      <Link
+        href={buildRoute(ROUTES.RELEASES_DETAIL, { id: release.id })}
+        className="font-medium text-foreground underline"
+      >
+        {release.title}
+      </Link>
+      {release.state === "scheduled" ? null : (
+        <Badge
+          variant={release.state === "blocked" ? "destructive" : "outline"}
+        >
+          {RELEASE_STATE_LABEL[release.state]}
+        </Badge>
+      )}
+    </li>
+  );
+}

--- a/packages/admin/src/components/features/releases/ReleaseCalendar.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseCalendar.tsx
@@ -108,20 +108,38 @@ const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
  * currently selected, which might have come from storage.
  */
 function zoneChoices(current: string, authored: readonly string[]): string[] {
+  // Only the ADDITIONS are validated. The platform's own list is valid by
+  // construction, and running it through `isValidTimezone` builds a formatter
+  // per entry to re-learn what the platform just told us.
   const supported = supportedZones();
-  const always = [readerZone(), current, "UTC", ...authored];
-  return [...new Set([...always, ...supported])].filter(isValidTimezone);
+  const extras = [readerZone(), current, "UTC", ...authored].filter(
+    zone => !supported.includes(zone) && isValidTimezone(zone)
+  );
+  return [...new Set([...extras, ...supported])];
 }
 
+/**
+ * The platform's zone list, read ONCE.
+ *
+ * Roughly four hundred entries, and constant for the life of the runtime. It
+ * was previously re-read and re-validated on every render — including every
+ * poll and every day selection — which meant constructing four hundred
+ * `Intl.DateTimeFormat` instances to answer a question whose answer cannot
+ * change.
+ */
+let supportedZonesCache: string[] | null = null;
+
 function supportedZones(): string[] {
+  if (supportedZonesCache !== null) return supportedZonesCache;
   try {
     const of = (
       Intl as unknown as { supportedValuesOf?: (k: string) => string[] }
     ).supportedValuesOf;
-    return typeof of === "function" ? of("timeZone") : [];
+    supportedZonesCache = typeof of === "function" ? of("timeZone") : [];
   } catch {
-    return [];
+    supportedZonesCache = [];
   }
+  return supportedZonesCache;
 }
 
 export function ReleaseCalendar() {
@@ -154,8 +172,17 @@ export function ReleaseCalendar() {
     [releases]
   );
   const byDay = useMemo(() => bucketByDay(releases, zone), [releases, zone]);
+  const zones = useMemo(
+    () => zoneChoices(zone, authoredZones),
+    [zone, authoredZones]
+  );
   const grid = useMemo(() => monthGrid(month), [month]);
-  const today = useMemo(() => monthOf(new Date(), zone), [zone]);
+  // NOT memoized on `zone` alone. `new Date()` would then be read once at
+  // mount and never again, so a page left open across a month boundary keeps
+  // naming the previous month as today — and, while sitting on it, hides the
+  // Today button because `month === today`, leaving no way back. One `Intl`
+  // format per render is cheaper than the state that would fix it.
+  const today = monthOf(new Date(), zone);
 
   // A selected day belongs to the month it was chosen in. Paging without
   // clearing leaves the panel open on a date the new grid does not contain,
@@ -181,7 +208,7 @@ export function ReleaseCalendar() {
         month={month}
         today={today}
         zone={zone}
-        zones={zoneChoices(zone, authoredZones)}
+        zones={zones}
         onMonth={goToMonth}
         onZone={changeZone}
       />

--- a/packages/admin/src/components/features/releases/ReleaseCalendar.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseCalendar.tsx
@@ -47,6 +47,7 @@ import {
   monthOf,
   monthWindow,
   shiftMonth,
+  type CalendarMonth,
   type DayKey,
 } from "./release-calendar";
 import { RELEASE_STATE_LABEL } from "./release-schedule";
@@ -54,6 +55,16 @@ import { readerZone } from "./release-timezone";
 
 /** Where the reader's chosen zone is remembered between visits. */
 const ZONE_KEY = "nextly.releases.calendar.zone";
+
+/**
+ * How many releases one month may return before the answer is incomplete.
+ *
+ * The route's own ceiling. A month holding more than this is implausible for a
+ * publishing schedule, which is why this is a REPORTED limit rather than a
+ * paging loop: the honest thing at that volume is to say the grid is partial,
+ * not to issue five more requests to fill in a view nobody can read anyway.
+ */
+const CALENDAR_PAGE_LIMIT = 200;
 
 /**
  * The zone to draw in: what the reader last chose, else their own.
@@ -83,22 +94,34 @@ function rememberZone(zone: string): void {
 
 const WEEKDAYS = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
 
-/** The zones offered, with the reader's own first however it is spelled. */
-function zoneChoices(current: string): string[] {
-  const common = [
-    "UTC",
-    "America/Los_Angeles",
-    "America/New_York",
-    "Europe/London",
-    "Europe/Berlin",
-    "Asia/Dubai",
-    "Asia/Kolkata",
-    "Asia/Tokyo",
-    "Australia/Sydney",
-  ];
-  return [...new Set([readerZone(), current, ...common])].filter(
-    isValidTimezone
-  );
+/**
+ * Every zone this reader can choose between.
+ *
+ * The platform's own list where it has one, because a short hand-picked set
+ * cannot serve a distributed team: somebody in Los Angeles comparing a launch
+ * an Asia/Riyadh colleague scheduled needs that zone, and a curated nine will
+ * never contain the one a given pair happens to need.
+ *
+ * `Intl.supportedValuesOf` is not on every runtime, so the zones the FETCHED
+ * releases were authored in are always offered — those are the ones this page
+ * has an actual reason to show — along with the reader's own and whatever is
+ * currently selected, which might have come from storage.
+ */
+function zoneChoices(current: string, authored: readonly string[]): string[] {
+  const supported = supportedZones();
+  const always = [readerZone(), current, "UTC", ...authored];
+  return [...new Set([...always, ...supported])].filter(isValidTimezone);
+}
+
+function supportedZones(): string[] {
+  try {
+    const of = (
+      Intl as unknown as { supportedValuesOf?: (k: string) => string[] }
+    ).supportedValuesOf;
+    return typeof of === "function" ? of("timeZone") : [];
+  } catch {
+    return [];
+  }
 }
 
 export function ReleaseCalendar() {
@@ -113,13 +136,34 @@ export function ReleaseCalendar() {
   const { data, isPending, isError } = useReleases({
     scheduledAfter: window_.after,
     scheduledBefore: window_.before,
-    limit: 200,
+    limit: CALENDAR_PAGE_LIMIT,
   });
 
   const releases = useMemo(() => data?.items ?? [], [data]);
+  // The route answers this when the window held more than it returned. Reported
+  // rather than absorbed: the list is ordered by instant DESCENDING, so a
+  // truncated month drops the EARLIEST days — the grid would look empty exactly
+  // where the reader is most likely to be looking, and nothing on screen would
+  // say the month was not fully read.
+  const truncated = data?.meta.hasNext ?? false;
+  const authoredZones = useMemo(
+    () =>
+      releases
+        .map(release => release.timezone)
+        .filter((zone): zone is string => Boolean(zone)),
+    [releases]
+  );
   const byDay = useMemo(() => bucketByDay(releases, zone), [releases, zone]);
   const grid = useMemo(() => monthGrid(month), [month]);
   const today = useMemo(() => monthOf(new Date(), zone), [zone]);
+
+  // A selected day belongs to the month it was chosen in. Paging without
+  // clearing leaves the panel open on a date the new grid does not contain,
+  // where it reports "nothing is scheduled" about a day that is not on screen.
+  const goToMonth = (next: string) => {
+    setMonth(next);
+    setSelected(null);
+  };
 
   const changeZone = (next: string) => {
     setZone(next);
@@ -133,101 +177,130 @@ export function ReleaseCalendar() {
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            aria-label="Previous month"
-            onClick={() => setMonth(shiftMonth(month, -1))}
-          >
-            <ChevronLeft className="size-4" aria-hidden />
-          </Button>
-          <span className="min-w-[9rem] text-center text-sm font-medium">
-            {monthLabel(month)}
-          </span>
-          <Button
-            variant="outline"
-            size="sm"
-            aria-label="Next month"
-            onClick={() => setMonth(shiftMonth(month, 1))}
-          >
-            <ChevronRight className="size-4" aria-hidden />
-          </Button>
-          {month === today ? null : (
-            <Button variant="ghost" size="sm" onClick={() => setMonth(today)}>
-              Today
-            </Button>
-          )}
-        </div>
+      <CalendarToolbar
+        month={month}
+        today={today}
+        zone={zone}
+        zones={zoneChoices(zone, authoredZones)}
+        onMonth={goToMonth}
+        onZone={changeZone}
+      />
 
-        <label className="flex items-center gap-2 text-sm text-muted-foreground">
-          {/* NAMED on screen, not just applied. Two colleagues comparing this
-              page need to be able to see they are reading the same grid. */}
-          <span>Times shown in</span>
-          <select
-            className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
-            value={zone}
-            onChange={event => changeZone(event.target.value)}
-          >
-            {zoneChoices(zone).map(choice => (
-              <option key={choice} value={choice}>
-                {choice.replace(/_/g, " ")}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
+      <CalendarBody
+        month={month}
+        zone={zone}
+        grid={grid}
+        byDay={byDay}
+        selected={selected}
+        onSelect={setSelected}
+        isPending={isPending}
+        isError={isError}
+        truncated={truncated}
+      />
+    </div>
+  );
+}
 
-      {isError ? (
-        <Card className="px-6 py-10 text-center">
-          <p className="text-sm text-muted-foreground">
-            This month&rsquo;s schedule could not be loaded.
-          </p>
-        </Card>
-      ) : (
-        <>
-          {/* The grid is hidden on narrow screens rather than squeezed: seven
+/**
+ * Everything that depends on the ANSWER: the grid, the day panel, the agenda.
+ *
+ * Split from the component above so that one holds the query and this one holds
+ * the rendering, rather than a single function nesting a failure branch, a
+ * truncation branch and two device branches inside each other.
+ */
+function CalendarBody({
+  month,
+  zone,
+  grid,
+  byDay,
+  selected,
+  onSelect,
+  isPending,
+  isError,
+  truncated,
+}: {
+  month: string;
+  zone: string;
+  grid: CalendarMonth;
+  byDay: Map<DayKey, Release[]>;
+  selected: DayKey | null;
+  onSelect: (day: DayKey | null) => void;
+  isPending: boolean;
+  isError: boolean;
+  truncated: boolean;
+}) {
+  if (isError) {
+    return (
+      <Card className="px-6 py-10 text-center">
+        <p className="text-sm text-muted-foreground">
+          This month&rsquo;s schedule could not be loaded.
+        </p>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      {/* The grid is hidden on narrow screens rather than squeezed: seven
               columns at phone width leaves each day too small to carry a count,
               let alone be tapped. The agenda below is the same month, read as a
               sequence. */}
+      {/* Deliberately NOT `role="grid"`. Declaring one promises composite
+              keyboard behaviour — a single tab stop with arrow-key movement —
+              and a grid that announces itself without providing it is worse
+              than plain controls: a keyboard user is told to expect arrows,
+              presses them, and nothing happens. These are ordinary buttons in a
+              labelled group, which is what they behave like. */}
+      <div
+        className="hidden grid-cols-7 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid"
+        role="group"
+        aria-label={`Releases in ${monthLabel(month)}, times in ${zone}`}
+      >
+        {WEEKDAYS.map(day => (
           <div
-            className="hidden grid-cols-7 gap-px overflow-hidden rounded-lg border border-border bg-border sm:grid"
-            role="grid"
-            aria-label={`Releases in ${monthLabel(month)}, times in ${zone}`}
+            key={day}
+            aria-hidden
+            className="bg-muted px-2 py-1.5 text-center text-xs font-medium text-muted-foreground"
           >
-            {WEEKDAYS.map(day => (
-              <div
-                key={day}
-                role="columnheader"
-                className="bg-muted px-2 py-1.5 text-center text-xs font-medium text-muted-foreground"
-              >
-                {day}
-              </div>
-            ))}
-            {grid.weeks.flat().map(day => (
-              <DayCell
-                key={day}
-                day={day}
-                month={month}
-                releases={byDay.get(day) ?? []}
-                isSelected={selected === day}
-                isPending={isPending}
-                onSelect={() => setSelected(selected === day ? null : day)}
-              />
-            ))}
+            {day}
           </div>
-
-          <DayDetail
-            day={selected}
-            zone={zone}
-            releases={selected ? (byDay.get(selected) ?? []) : []}
+        ))}
+        {grid.weeks.flat().map((day: DayKey) => (
+          <DayCell
+            key={day}
+            day={day}
+            month={month}
+            releases={byDay.get(day) ?? []}
+            isSelected={selected === day}
+            isPending={isPending}
+            onSelect={() => onSelect(selected === day ? null : day)}
           />
+        ))}
+      </div>
 
-          <Agenda byDay={byDay} grid={grid} month={month} zone={zone} />
-        </>
-      )}
-    </div>
+      {truncated ? (
+        <p role="status" className="text-sm text-muted-foreground">
+          This month holds more than {CALENDAR_PAGE_LIMIT} releases, so the grid
+          is showing the latest {CALENDAR_PAGE_LIMIT} and earlier days may look
+          emptier than they are. Narrow the range from the list view to see
+          them.
+        </p>
+      ) : null}
+
+      <DayDetail
+        day={selected}
+        zone={zone}
+        releases={selected ? (byDay.get(selected) ?? []) : []}
+      />
+
+      <Agenda
+        byDay={byDay}
+        grid={grid}
+        month={month}
+        zone={zone}
+        isPending={isPending}
+      />
+    </>
   );
 }
 
@@ -248,19 +321,22 @@ function monthLabel(month: string): string {
  * the badge cannot drift: a cell that shows a count and announces nothing is
  * the ordinary way this control becomes unusable without looking broken.
  */
-function dayCellLabel(day: DayKey, count: number, stopped: boolean): string {
+function dayCellLabel(day: DayKey, count: number, stopped: number): string {
   if (count === 0) return `${day}, nothing scheduled`;
   const plural = count === 1 ? "release" : "releases";
-  const tail = stopped ? ", one stopped" : "";
+  // COUNTED, not a boolean. Two stopped releases on one day announced as "one
+  // stopped" is a false collision summary to the reader who cannot see the
+  // badge, and the number is already in hand.
+  const tail = stopped === 0 ? "" : `, ${stopped} stopped`;
   return `${day}, ${count} ${plural}${tail}`;
 }
 
-/** The count, and whether any of it needs somebody. */
-function DayCount({ count, stopped }: { count: number; stopped: boolean }) {
+/** The count, and how much of it needs somebody. */
+function DayCount({ count, stopped }: { count: number; stopped: number }) {
   if (count === 0) return null;
   return (
-    <Badge variant={stopped ? "destructive" : "warning"}>
-      {stopped ? `${count} · stopped` : count}
+    <Badge variant={stopped > 0 ? "destructive" : "warning"}>
+      {stopped > 0 ? `${count} · ${stopped} stopped` : count}
     </Badge>
   );
 }
@@ -281,13 +357,14 @@ function DayCell({
   onSelect: () => void;
 }) {
   const inMonth = day.startsWith(month);
-  const stopped = releases.some(release => release.state === "blocked");
+  const stopped = releases.filter(
+    release => release.state === "blocked"
+  ).length;
   const count = releases.length;
 
   return (
     <button
       type="button"
-      role="gridcell"
       onClick={onSelect}
       aria-pressed={isSelected}
       aria-label={dayCellLabel(day, count, stopped)}
@@ -368,16 +445,33 @@ function Agenda({
   grid,
   month,
   zone,
+  isPending,
 }: {
   byDay: Map<DayKey, Release[]>;
   grid: { weeks: DayKey[][] };
   month: string;
   zone: string;
+  isPending: boolean;
 }) {
   const days = grid.weeks
     .flat()
     .filter(day => day.startsWith(month))
     .filter(day => (byDay.get(day)?.length ?? 0) > 0);
+
+  // NOT YET ASKED is not the same as nothing scheduled, and on a narrow screen
+  // this is the only view — so an unanswered query would otherwise render a
+  // confident "nothing scheduled this month" before the request returns, which
+  // is the answer a reader is most likely to act on and leave.
+  if (isPending) {
+    return (
+      <p
+        role="status"
+        className="px-1 py-6 text-sm text-muted-foreground sm:hidden"
+      >
+        Loading this month&rsquo;s schedule&hellip;
+      </p>
+    );
+  }
 
   if (days.length === 0) {
     return (
@@ -439,5 +533,76 @@ function ReleaseRow({ release, zone }: { release: Release; zone: string }) {
         </Badge>
       )}
     </li>
+  );
+}
+
+/**
+ * Month navigation and the zone the grid is drawn in.
+ *
+ * Split out because it is the one part of this screen with no dependency on the
+ * releases themselves — it decides WHICH releases to ask for, and knows nothing
+ * about the answer.
+ */
+function CalendarToolbar({
+  month,
+  today,
+  zone,
+  zones,
+  onMonth,
+  onZone,
+}: {
+  month: string;
+  today: string;
+  zone: string;
+  zones: string[];
+  onMonth: (month: string) => void;
+  onZone: (zone: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label="Previous month"
+          onClick={() => onMonth(shiftMonth(month, -1))}
+        >
+          <ChevronLeft className="size-4" aria-hidden />
+        </Button>
+        <span className="min-w-[9rem] text-center text-sm font-medium">
+          {monthLabel(month)}
+        </span>
+        <Button
+          variant="outline"
+          size="sm"
+          aria-label="Next month"
+          onClick={() => onMonth(shiftMonth(month, 1))}
+        >
+          <ChevronRight className="size-4" aria-hidden />
+        </Button>
+        {month === today ? null : (
+          <Button variant="ghost" size="sm" onClick={() => onMonth(today)}>
+            Today
+          </Button>
+        )}
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-muted-foreground">
+        {/* NAMED on screen, not just applied. Two colleagues comparing this
+            page need to be able to see they are reading the same grid. */}
+        <span>Times shown in</span>
+        <select
+          className="rounded-md border border-border bg-background px-2 py-1 text-sm text-foreground"
+          value={zone}
+          onChange={event => onZone(event.target.value)}
+        >
+          {zones.map(choice => (
+            <option key={choice} value={choice}>
+              {choice.replace(/_/g, " ")}
+            </option>
+          ))}
+        </select>
+      </label>
+    </div>
   );
 }

--- a/packages/admin/src/components/features/releases/ScheduleReleaseDialog.tsx
+++ b/packages/admin/src/components/features/releases/ScheduleReleaseDialog.tsx
@@ -32,6 +32,8 @@ import { useScheduleRelease } from "@admin/hooks/queries/useReleases";
 import { isValidTimezone } from "@admin/lib/dates/format";
 import type { Release } from "@admin/types/releases";
 
+import { instantFor, readerZone } from "./release-timezone";
+
 /**
  * The offset a zone is at for a given instant, as minutes east of UTC.
  *
@@ -41,117 +43,6 @@ import type { Release } from "@admin/types/releases";
  * is what makes daylight saving come out right — the same zone is a different
  * offset in January and July.
  */
-function offsetMinutesAt(instant: Date, timeZone: string): number {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hour12: false,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    second: "2-digit",
-  }).formatToParts(instant);
-
-  const read = (type: Intl.DateTimeFormatPartTypes): number =>
-    Number(parts.find(part => part.type === type)?.value ?? "0");
-
-  // `hour` formats midnight as 24 under `hour12: false` in some engines, which
-  // would place the reading a day late if carried through unchanged.
-  const hour = read("hour") % 24;
-  const asUtc = Date.UTC(
-    read("year"),
-    read("month") - 1,
-    read("day"),
-    hour,
-    read("minute"),
-    read("second")
-  );
-  return (asUtc - instant.getTime()) / 60_000;
-}
-
-/**
- * How `instant` reads back as a wall-clock string in `timeZone`.
- *
- * The same `YYYY-MM-DDTHH:mm` shape a `datetime-local` input produces, so the
- * answer can be compared to what the editor typed without parsing either side.
- */
-function wallTimeIn(instant: Date, timeZone: string): string {
-  const parts = new Intl.DateTimeFormat("en-US", {
-    timeZone,
-    hour12: false,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  }).formatToParts(instant);
-  const read = (type: Intl.DateTimeFormatPartTypes): string =>
-    parts.find(part => part.type === type)?.value ?? "";
-  const hour = String(Number(read("hour")) % 24).padStart(2, "0");
-  return `${read("year")}-${read("month")}-${read("day")}T${hour}:${read("minute")}`;
-}
-
-/**
- * The instant at which `wall` occurs in `timeZone`, as an ISO string with `Z`.
- *
- * Both DST edges are answered here, and they need opposite treatment.
- *
- * A SPRING FORWARD deletes an hour, so the requested wall time may not exist at
- * all. Returning the solver's nearest approach schedules a different moment
- * while every screen reads as though it took: measured, `2026-03-29T02:30` in
- * `Europe/Berlin` came back as 03:30 and `2026-03-08T02:30` in
- * `America/New_York` as 01:30 — an hour late and an hour early from ONE
- * implementation. So a candidate is accepted only if it renders back as exactly
- * what was typed, and `null` otherwise.
- *
- * A FALL BACK repeats an hour, so TWO real instants render as the requested
- * time — in Berlin on 2026-10-25, `00:30Z` and `01:30Z` both read as 02:30. A
- * single-candidate solver silently returns whichever its arithmetic lands on,
- * which is the later one; "02:30 that day" means the first, and an editor who
- * meant the second would have to be able to say so, which this input cannot
- * express. So both offsets in play around the instant are tried and the EARLIER
- * surviving candidate wins.
- *
- * Offsets are read at a full day either side rather than derived from one
- * guess, because that is what makes both members of the ambiguous pair
- * reachable — a transition is at most a couple of hours wide and always falls
- * inside that window.
- */
-export function instantFor(wall: string, timeZone: string): string | null {
-  // `datetime-local` yields `YYYY-MM-DDTHH:mm`, which `Date.parse` reads as
-  // LOCAL time. Appending `Z` reads the same digits as UTC, which is the anchor
-  // every candidate below is measured from.
-  const asUtc = new Date(`${wall}:00.000Z`);
-  if (Number.isNaN(asUtc.getTime())) return null;
-
-  const DAY = 86_400_000;
-  const offsets = new Set([
-    offsetMinutesAt(new Date(asUtc.getTime() - DAY), timeZone),
-    offsetMinutesAt(asUtc, timeZone),
-    offsetMinutesAt(new Date(asUtc.getTime() + DAY), timeZone),
-  ]);
-
-  const candidates = [...offsets]
-    .map(offset => new Date(asUtc.getTime() - offset * 60_000))
-    // The round trip is the whole guarantee: an offset that does not reproduce
-    // the typed wall time is not this zone's offset at that moment.
-    .filter(candidate => wallTimeIn(candidate, timeZone) === wall)
-    .sort((a, b) => a.getTime() - b.getTime());
-
-  return candidates[0]?.toISOString() ?? null;
-}
-
-/** The reader's own zone, or UTC where the platform will not name one. */
-function readerZone(): string {
-  try {
-    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    return isValidTimezone(zone) ? zone : "UTC";
-  } catch {
-    return "UTC";
-  }
-}
-
 export interface ScheduleReleaseDialogProps {
   release: Release;
   open: boolean;

--- a/packages/admin/src/components/features/releases/__tests__/ReleaseCalendar.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/ReleaseCalendar.test.tsx
@@ -9,7 +9,7 @@
  *
  * @module components/features/releases/__tests__/ReleaseCalendar.test
  */
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { fireEvent, render, screen } from "@admin/__tests__/utils";
 
@@ -20,6 +20,17 @@ vi.mock("@admin/hooks/queries/useReleases", () => ({
 }));
 
 import { ReleaseCalendar } from "../ReleaseCalendar";
+
+/**
+ * The clock this suite runs on.
+ *
+ * FROZEN, because the calendar opens on the CURRENT month while the fixture
+ * below is a fixed date. Left on the real clock these agree only while today
+ * falls in a grid containing 1 September 2026 — so the suite would begin
+ * failing in October purely because time passed, on a component nobody had
+ * touched. Mid-September puts the fixture safely inside the opening grid.
+ */
+const FROZEN_NOW = new Date("2026-09-15T12:00:00.000Z");
 
 /** A release on 1 September 2026, 09:00 UTC. */
 const SEPTEMBER = {
@@ -42,9 +53,15 @@ function answer(over: Record<string, unknown> = {}) {
 }
 
 beforeEach(() => {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  vi.setSystemTime(FROZEN_NOW);
   useReleasesMock.mockReset();
   useReleasesMock.mockReturnValue(answer());
   window.localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("the calendar screen", () => {

--- a/packages/admin/src/components/features/releases/__tests__/ReleaseCalendar.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/ReleaseCalendar.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * The calendar as a rendered screen.
+ *
+ * The date arithmetic is tested next door against `release-calendar`; what this
+ * covers is the composition — that the toolbar, the grid, the day panel and the
+ * agenda are actually wired to the query and to each other. Those were split
+ * into separate components to keep the nesting readable, and a split like that
+ * fails by rendering NOTHING rather than by rendering something wrong.
+ *
+ * @module components/features/releases/__tests__/ReleaseCalendar.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { fireEvent, render, screen } from "@admin/__tests__/utils";
+
+const { useReleasesMock } = vi.hoisted(() => ({ useReleasesMock: vi.fn() }));
+
+vi.mock("@admin/hooks/queries/useReleases", () => ({
+  useReleases: (...args: unknown[]) => useReleasesMock(...args),
+}));
+
+import { ReleaseCalendar } from "../ReleaseCalendar";
+
+/** A release on 1 September 2026, 09:00 UTC. */
+const SEPTEMBER = {
+  id: "r1",
+  title: "Autumn launch",
+  description: null,
+  scheduledAt: "2026-09-01T09:00:00.000Z",
+  timezone: "Europe/Berlin",
+  state: "scheduled",
+  publishedAt: null,
+};
+
+function answer(over: Record<string, unknown> = {}) {
+  return {
+    data: { items: [SEPTEMBER], meta: { hasNext: false } },
+    isPending: false,
+    isError: false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  useReleasesMock.mockReset();
+  useReleasesMock.mockReturnValue(answer());
+  window.localStorage.clear();
+});
+
+describe("the calendar screen", () => {
+  it("asks for ONE MONTH rather than every release", async () => {
+    // The whole reason this needed no new endpoint. A calendar that dropped the
+    // window would still render — on every release in the system.
+    render(<ReleaseCalendar />);
+    const params = useReleasesMock.mock.calls[0]?.[0] as {
+      scheduledAfter?: string;
+      scheduledBefore?: string;
+    };
+    expect(params.scheduledAfter).toBeTruthy();
+    expect(params.scheduledBefore).toBeTruthy();
+    expect(new Date(params.scheduledAfter as string).getTime()).toBeLessThan(
+      new Date(params.scheduledBefore as string).getTime()
+    );
+  });
+
+  it("renders the toolbar and a full six-week grid", async () => {
+    // The composition check. Both were extracted from one function, and the way
+    // that goes wrong is a component returning nothing at all.
+    render(<ReleaseCalendar />);
+    expect(screen.getByLabelText(/previous month/i)).toBeTruthy();
+    expect(screen.getByLabelText(/next month/i)).toBeTruthy();
+    // 42 day buttons, plus the two month arrows.
+    const days = screen
+      .getAllByRole("button")
+      .filter(b =>
+        /nothing scheduled|release/i.test(b.getAttribute("aria-label") ?? "")
+      );
+    expect(days).toHaveLength(42);
+  });
+
+  it("names the zone it is drawn in, on the page", async () => {
+    // Two colleagues comparing this page have to be able to see they are
+    // reading the same grid.
+    render(<ReleaseCalendar />);
+    expect(screen.getByText(/times shown in/i)).toBeTruthy();
+  });
+
+  it("says so when the month was truncated", async () => {
+    // The list is ordered by instant DESCENDING, so a truncated month loses its
+    // EARLIEST days — the grid looks emptiest exactly where the reader is
+    // looking. Silence there would be a wrong answer rather than a partial one.
+    useReleasesMock.mockReturnValue(
+      answer({ data: { items: [SEPTEMBER], meta: { hasNext: true } } })
+    );
+    render(<ReleaseCalendar />);
+    expect(screen.getByRole("status").textContent).toMatch(/more than/i);
+  });
+
+  it("does not claim the month is empty while still loading", async () => {
+    // On a narrow screen the agenda is the only view, so an unanswered query
+    // would otherwise render a confident "nothing scheduled".
+    useReleasesMock.mockReturnValue(
+      answer({ data: undefined, isPending: true })
+    );
+    render(<ReleaseCalendar />);
+    expect(screen.queryByText(/nothing is scheduled this month/i)).toBeNull();
+    expect(screen.getByRole("status").textContent).toMatch(/loading/i);
+  });
+
+  it("clears the selected day when the month changes", async () => {
+    // A day belongs to the month it was chosen in. Paging without clearing
+    // leaves the panel reporting on a date the new grid does not contain.
+    render(<ReleaseCalendar />);
+    const day = screen
+      .getAllByRole("button")
+      .find(b => (b.getAttribute("aria-label") ?? "").includes("release"));
+    expect(day).toBeTruthy();
+    fireEvent.click(day as HTMLElement);
+    expect(screen.getAllByRole("heading").length).toBeGreaterThan(0);
+
+    fireEvent.click(screen.getByLabelText(/next month/i));
+    // The panel is gone rather than showing a day from the previous month.
+    expect(
+      screen
+        .queryAllByRole("heading")
+        .filter(h => /2026/.test(h.textContent ?? ""))
+    ).toHaveLength(0);
+  });
+});

--- a/packages/admin/src/components/features/releases/__tests__/release-calendar.test.ts
+++ b/packages/admin/src/components/features/releases/__tests__/release-calendar.test.ts
@@ -137,8 +137,18 @@ describe("the window the month is fetched with", () => {
     // to the month it belongs to, which is exactly when they stop looking.
     const window = monthWindow("2026-09", "UTC");
     expect(window.after).toBe("2026-08-31T00:00:00.000Z");
-    // Exclusive upper bound: the start of the day AFTER the last grid day.
-    expect(window.before).toBe("2026-10-12T00:00:00.000Z");
+    // The LAST INSTANT of the last grid day (2026-10-11), not midnight of the
+    // day after it. The service's upper bound is inclusive — it rejects on
+    // `at > scheduledBefore` — so midnight would also fetch the 12th, a day the
+    // grid does not show. At the page ceiling one release sitting there would
+    // evict a visible one and raise a truncation warning for a month that fits.
+    expect(window.before).toBe("2026-10-11T23:59:59.999Z");
+    // And it is strictly before the next day begins, which is the property that
+    // separates an inclusive bound from an exclusive one. Asserting only the
+    // timestamp above could not tell them apart.
+    expect(new Date(window.before).getTime()).toBeLessThan(
+      new Date("2026-10-12T00:00:00.000Z").getTime()
+    );
   });
 
   it("opens the window at midnight IN THE CHOSEN ZONE", async () => {
@@ -147,6 +157,8 @@ describe("the window the month is fetched with", () => {
     // would miss at the start of every month.
     const berlin = monthWindow("2026-09", "Europe/Berlin");
     expect(berlin.after).toBe("2026-08-30T22:00:00.000Z");
+    // The upper bound moves with the zone too, for the same reason.
+    expect(berlin.before).toBe("2026-10-11T21:59:59.999Z");
     expect(new Date(berlin.after).getTime()).toBeLessThan(
       new Date(monthWindow("2026-09", "UTC").after).getTime()
     );

--- a/packages/admin/src/components/features/releases/__tests__/release-calendar.test.ts
+++ b/packages/admin/src/components/features/releases/__tests__/release-calendar.test.ts
@@ -16,6 +16,7 @@ import {
   monthOf,
   monthWindow,
   shiftMonth,
+  startOfDayInstant,
 } from "../release-calendar";
 
 import type { Release } from "@admin/types/releases";
@@ -55,6 +56,23 @@ describe("which day a release lands on", () => {
       "2026-09-02",
     ]);
     expect([...bucketByDay([early], "UTC").keys()]).toEqual(["2026-09-01"]);
+  });
+
+  it("leaves a CANCELLED release off the grid, instant or not", async () => {
+    // Cancelling keeps `scheduledAt`, so a cancelled launch still has a date —
+    // and counting it would show the day as occupied on a grid whose whole job
+    // is showing collisions, asserting a clash that cannot happen.
+    const cancelled = {
+      ...release("called-off", "2026-09-01T09:00:00.000Z"),
+      state: "cancelled",
+    } as unknown as Release;
+    expect(bucketByDay([cancelled], "UTC").size).toBe(0);
+
+    // The control: the same release, not cancelled, IS counted — so this is a
+    // state filter rather than the bucketing having stopped working.
+    expect(
+      bucketByDay([release("still-on", "2026-09-01T09:00:00.000Z")], "UTC").size
+    ).toBe(1);
   });
 
   it("leaves a release with no instant off the grid entirely", async () => {
@@ -134,14 +152,46 @@ describe("the window the month is fetched with", () => {
     );
   });
 
-  it("survives a zone whose midnight does not exist", async () => {
-    // A zone that springs forward at 00:00 has no midnight that day. The window
-    // must still open — walking forward to the first wall time that exists —
-    // rather than returning something unparseable and emptying the month.
-    const window = monthWindow("2026-10", "America/Santiago");
-    expect(Number.isNaN(new Date(window.after).getTime())).toBe(false);
-    expect(new Date(window.after).getTime()).toBeLessThan(
-      new Date(window.before).getTime()
+  it("opens on a Monday, which is why the skipped-midnight walk is defensive here", async () => {
+    // Worth pinning, because it is the reason the case below tests
+    // `startOfDayInstant` directly instead of through this function. A grid
+    // always opens on a Monday and its exclusive bound is a Monday too, while
+    // every zone that moves its clock at midnight does so on a Sunday — so no
+    // real zone reaches the walk by this route.
+    for (const month of ["2026-09", "2026-10", "2026-11", "2027-01"]) {
+      const opens = new Date(monthWindow(month, "UTC").after);
+      expect(opens.getUTCDay()).toBe(1);
+    }
+  });
+});
+
+describe("a day whose midnight does not exist", () => {
+  it("opens at the first wall time the zone actually has", async () => {
+    // Chile moves its clock AT midnight: on 2026-09-06 Santiago goes straight
+    // from 23:59 on the 5th to 01:00 on the 6th, so `2026-09-06T00:00` is not a
+    // moment. Measured — 03:30Z reads as 23:30 on the 5th there, and 04:00Z as
+    // 01:00 on the 6th.
+    //
+    // The EXACT instant is asserted, because that is the only thing separating
+    // a walk forward from the UTC fallback: both produce a parseable date and
+    // both order correctly, so a test that checked either would stay green on
+    // the broken implementation. An earlier version of this test did exactly
+    // that, on a month whose grid did not even contain the transition.
+    expect(startOfDayInstant("2026-09-06", "America/Santiago")).toBe(
+      "2026-09-06T04:00:00.000Z"
+    );
+    // The control: the same zone on an ordinary day has a real midnight, and
+    // must NOT be walked forward.
+    expect(startOfDayInstant("2026-09-20", "America/Santiago")).toBe(
+      "2026-09-20T03:00:00.000Z"
+    );
+  });
+
+  it("returns the plain midnight instant for a zone with no transition", async () => {
+    // The other control: without it, a function that always walked forward
+    // would satisfy the skipped case above.
+    expect(startOfDayInstant("2026-09-06", "UTC")).toBe(
+      "2026-09-06T00:00:00.000Z"
     );
   });
 });

--- a/packages/admin/src/components/features/releases/__tests__/release-calendar.test.ts
+++ b/packages/admin/src/components/features/releases/__tests__/release-calendar.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Placing releases on a month grid, in a chosen zone.
+ *
+ * The interesting property is not that the grid has the right shape — it is
+ * that a launch lands on the day a reader in that zone would call it. Those two
+ * differ for every release near midnight, which on a schedule made of "publish
+ * at 9am" and "take down at midnight" is not an edge case.
+ *
+ * @module components/features/releases/__tests__/release-calendar.test
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  bucketByDay,
+  monthGrid,
+  monthOf,
+  monthWindow,
+  shiftMonth,
+} from "../release-calendar";
+
+import type { Release } from "@admin/types/releases";
+
+const release = (id: string, scheduledAt: string | null): Release =>
+  ({
+    id,
+    title: id,
+    description: null,
+    scheduledAt,
+    timezone: "UTC",
+    state: "scheduled",
+    publishedAt: null,
+  }) as unknown as Release;
+
+describe("which day a release lands on", () => {
+  it("files a late-evening launch under the reader's day, not UTC's", async () => {
+    // THE case the whole module exists for. 23:00 in Berlin on the 1st is
+    // 21:00Z on the 1st — same day. But 23:00 in New York on the 1st is 03:00Z
+    // on the SECOND, so a grid drawn from the UTC rendering shows it a day
+    // late, on a date the person who scheduled it never chose.
+    const late = release("late", "2026-09-02T03:00:00.000Z");
+
+    expect([...bucketByDay([late], "America/New_York").keys()]).toEqual([
+      "2026-09-01",
+    ]);
+    // The control: the same instant genuinely IS the 2nd in UTC, so a bucketing
+    // that ignored the zone would be right here and wrong above.
+    expect([...bucketByDay([late], "UTC").keys()]).toEqual(["2026-09-02"]);
+  });
+
+  it("files an early-morning launch under the previous day east of Greenwich", async () => {
+    // The mirror image, so the fix cannot be a constant shift in one direction.
+    // 22:30Z on the 1st is already 00:30 on the 2nd in Berlin.
+    const early = release("early", "2026-09-01T22:30:00.000Z");
+    expect([...bucketByDay([early], "Europe/Berlin").keys()]).toEqual([
+      "2026-09-02",
+    ]);
+    expect([...bucketByDay([early], "UTC").keys()]).toEqual(["2026-09-01"]);
+  });
+
+  it("leaves a release with no instant off the grid entirely", async () => {
+    // A draft has not been given a moment. Filing it under today would assert a
+    // launch nobody scheduled, on a screen whose entire subject is when things
+    // happen.
+    expect(bucketByDay([release("draft", null)], "UTC").size).toBe(0);
+  });
+
+  it("orders a day's releases by instant", async () => {
+    // A day cell is read downwards as the order the day will happen in.
+    const day = bucketByDay(
+      [
+        release("evening", "2026-09-01T18:00:00.000Z"),
+        release("morning", "2026-09-01T09:00:00.000Z"),
+      ],
+      "UTC"
+    );
+    expect(day.get("2026-09-01")?.map(r => r.id)).toEqual([
+      "morning",
+      "evening",
+    ]);
+  });
+});
+
+describe("the grid itself", () => {
+  it("is always six rows, so paging does not move the page", async () => {
+    // A month spans four to six weeks. A grid that changes height shifts
+    // everything below it as the reader pages, which is the one thing a
+    // calendar must not do to somebody scanning for a date.
+    for (const month of ["2026-02", "2026-08", "2026-09", "2027-01"]) {
+      const grid = monthGrid(month);
+      expect(grid.weeks).toHaveLength(6);
+      expect(grid.weeks.every(week => week.length === 7)).toBe(true);
+    }
+  });
+
+  it("starts each row on a Monday", async () => {
+    const grid = monthGrid("2026-09");
+    for (const week of grid.weeks) {
+      expect(new Date(`${week[0]}T00:00:00.000Z`).getUTCDay()).toBe(1);
+    }
+  });
+
+  it("leads with the days needed to reach the first of the month", async () => {
+    // 2026-09-01 is a Tuesday, so the row opens on Monday the 31st of August.
+    expect(monthGrid("2026-09").weeks[0]?.[0]).toBe("2026-08-31");
+    expect(monthGrid("2026-09").weeks[0]?.[1]).toBe("2026-09-01");
+  });
+
+  it("opens on the first itself when the month begins on a Monday", async () => {
+    // The control for the lead-in: a month that needs no padding must get none,
+    // or a grid that always reached back a week would satisfy the case above.
+    expect(monthGrid("2026-06").weeks[0]?.[0]).toBe("2026-06-01");
+  });
+});
+
+describe("the window the month is fetched with", () => {
+  it("covers the whole grid, including the days either side", async () => {
+    // Bounded by the grid rather than the month, so a release on a leading or
+    // trailing day is fetched — otherwise it appears only once the reader pages
+    // to the month it belongs to, which is exactly when they stop looking.
+    const window = monthWindow("2026-09", "UTC");
+    expect(window.after).toBe("2026-08-31T00:00:00.000Z");
+    // Exclusive upper bound: the start of the day AFTER the last grid day.
+    expect(window.before).toBe("2026-10-12T00:00:00.000Z");
+  });
+
+  it("opens the window at midnight IN THE CHOSEN ZONE", async () => {
+    // The zone decides the instant, not just the label. Midnight on the 31st in
+    // Berlin is 22:00Z on the 30th — an hour of releases a UTC-bounded window
+    // would miss at the start of every month.
+    const berlin = monthWindow("2026-09", "Europe/Berlin");
+    expect(berlin.after).toBe("2026-08-30T22:00:00.000Z");
+    expect(new Date(berlin.after).getTime()).toBeLessThan(
+      new Date(monthWindow("2026-09", "UTC").after).getTime()
+    );
+  });
+
+  it("survives a zone whose midnight does not exist", async () => {
+    // A zone that springs forward at 00:00 has no midnight that day. The window
+    // must still open — walking forward to the first wall time that exists —
+    // rather than returning something unparseable and emptying the month.
+    const window = monthWindow("2026-10", "America/Santiago");
+    expect(Number.isNaN(new Date(window.after).getTime())).toBe(false);
+    expect(new Date(window.after).getTime()).toBeLessThan(
+      new Date(window.before).getTime()
+    );
+  });
+});
+
+describe("moving between months", () => {
+  it("rolls the year in both directions", async () => {
+    expect(shiftMonth("2026-12", 1)).toBe("2027-01");
+    expect(shiftMonth("2026-01", -1)).toBe("2025-12");
+  });
+
+  it("names the month an instant falls in, in the reader's zone", async () => {
+    // The same instant is two different MONTHS depending on the zone, which is
+    // what decides the grid the reader opens on.
+    expect(monthOf(new Date("2026-09-01T02:00:00.000Z"), "UTC")).toBe(
+      "2026-09"
+    );
+    expect(
+      monthOf(new Date("2026-09-01T02:00:00.000Z"), "America/Los_Angeles")
+    ).toBe("2026-08");
+  });
+});

--- a/packages/admin/src/components/features/releases/__tests__/schedule-instant.test.ts
+++ b/packages/admin/src/components/features/releases/__tests__/schedule-instant.test.ts
@@ -13,7 +13,7 @@
  */
 import { describe, expect, it } from "vitest";
 
-import { instantFor } from "../ScheduleReleaseDialog";
+import { instantFor } from "../release-timezone";
 
 /** How an instant reads in a zone, as the oracle rather than as the subject. */
 function wallClockIn(iso: string, timeZone: string): string {

--- a/packages/admin/src/components/features/releases/release-calendar.ts
+++ b/packages/admin/src/components/features/releases/release-calendar.ts
@@ -98,8 +98,18 @@ export function monthWindow(
   };
 }
 
-/** The instant a day begins in `timeZone`, as an ISO string. */
-function startOfDayInstant(day: DayKey, timeZone: string): string {
+/**
+ * The instant a day begins in `timeZone`, as an ISO string.
+ *
+ * Exported for its own test. Through {@link monthWindow} the walk below is
+ * DEFENSIVE rather than live: a grid always opens on a Monday and its exclusive
+ * upper bound is a Monday too, while every zone that moves its clock at
+ * midnight does so on a Sunday — so no real zone reaches the fallback by that
+ * route. It is still the right shape, because "midnight" is an assumption this
+ * function would otherwise be making silently, and a caller with a different
+ * boundary would inherit it.
+ */
+export function startOfDayInstant(day: DayKey, timeZone: string): string {
   // Midnight can be SKIPPED — a zone that springs forward at 00:00 has no
   // 00:00 that day — so the first wall time that exists is taken instead of
   // assuming one. Bounded at three hours, which is wider than any transition.
@@ -138,6 +148,12 @@ export function bucketByDay(
   const byDay = new Map<DayKey, Release[]>();
   for (const release of releases) {
     if (!release.scheduledAt) continue;
+    // A CANCELLED release keeps its instant, and nothing happens at it. Counting
+    // it would show a day as occupied — and, on a grid whose whole job is
+    // showing collisions, assert a collision that cannot occur. Dropped rather
+    // than styled differently: the calendar answers what will happen, and a
+    // called-off launch is not an answer to that.
+    if (release.state === "cancelled") continue;
     const at = new Date(release.scheduledAt);
     if (Number.isNaN(at.getTime())) continue;
     const key = dayKeyIn(at, timeZone);

--- a/packages/admin/src/components/features/releases/release-calendar.ts
+++ b/packages/admin/src/components/features/releases/release-calendar.ts
@@ -79,6 +79,14 @@ export function monthGrid(month: string): CalendarMonth {
  * trailing day is fetched and shown rather than appearing only once the reader
  * pages to the month it belongs to.
  *
+ * BOTH BOUNDS ARE INCLUSIVE, because that is the contract the service offers:
+ * `matchesListQuery` rejects on `at > scheduledBefore`, so a release exactly at
+ * the upper bound is returned. `before` is therefore the last instant of the
+ * last grid day rather than midnight of the day after it — that midnight
+ * belongs to a day the grid does not show, and at the page ceiling one release
+ * sitting there would evict a visible one AND raise a truncation warning for a
+ * month that actually fits.
+ *
  * Resolved through `instantFor`, which is the same solver the schedule input
  * uses. A month boundary is a wall time like any other and can land on a
  * daylight transition — Brazil has abolished DST at midnight, so `00:00` on the
@@ -92,9 +100,13 @@ export function monthWindow(
   const { weeks } = monthGrid(month);
   const firstDay = weeks[0]?.[0] ?? `${month}-01`;
   const lastDay = weeks[5]?.[6] ?? `${month}-28`;
+  // One millisecond before the next day begins. Derived from that boundary
+  // rather than written as a local "23:59:59.999", because the last grid day
+  // can be one the zone lengthens or shortens and only the boundary knows.
+  const dayAfterGrid = new Date(startOfDayInstant(nextDay(lastDay), timeZone));
   return {
     after: startOfDayInstant(firstDay, timeZone),
-    before: startOfDayInstant(nextDay(lastDay), timeZone),
+    before: new Date(dayAfterGrid.getTime() - 1).toISOString(),
   };
 }
 

--- a/packages/admin/src/components/features/releases/release-calendar.ts
+++ b/packages/admin/src/components/features/releases/release-calendar.ts
@@ -1,0 +1,156 @@
+/**
+ * Placing releases on a month grid, in a zone the reader chooses.
+ *
+ * Pure, and separate from the view for one reason: every hard question here is
+ * about calendars rather than about React. Which instants a month covers, and
+ * which day a launch lands on, both change with the zone the grid is drawn in —
+ * a release at 23:00 in Berlin is the NEXT day in UTC — so a grid that assumes
+ * a zone silently files launches under the wrong date, and no amount of looking
+ * at the screen reveals it.
+ *
+ * @module components/features/releases/release-calendar
+ */
+import type { Release } from "@admin/types/releases";
+
+import { dayKeyIn, instantFor } from "./release-timezone";
+
+/** A `YYYY-MM-DD` calendar day, as read in the grid's zone. */
+export type DayKey = string;
+
+export interface CalendarMonth {
+  /** The first of the month, `YYYY-MM`. */
+  month: string;
+  /** Six rows of seven day keys, so the grid never changes height. */
+  weeks: DayKey[][];
+}
+
+/** `YYYY-MM` for the month `offset` months from `month`. */
+export function shiftMonth(month: string, offset: number): string {
+  const [year, index] = month.split("-").map(Number);
+  if (!year || !index) return month;
+  // `Date.UTC` normalises an out-of-range month, so December + 1 rolls the year
+  // without a special case here.
+  const shifted = new Date(Date.UTC(year, index - 1 + offset, 1));
+  return `${shifted.getUTCFullYear()}-${String(shifted.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+/** The month `instant` falls in, read in `timeZone`. */
+export function monthOf(instant: Date, timeZone: string): string {
+  return dayKeyIn(instant, timeZone).slice(0, 7);
+}
+
+/**
+ * The grid for `month`, padded to whole weeks starting Monday.
+ *
+ * Always six rows. A month spans four to six depending on its length and which
+ * weekday it opens on, and a grid that changes height moves everything under it
+ * as the reader pages through — which is the one thing a calendar must not do
+ * to somebody scanning for a date.
+ *
+ * The days themselves are counted in UTC deliberately: these are LABELS, not
+ * instants. A day key is produced by naming the date, and asking a zone to
+ * convert a label it did not come from is how a grid loses or repeats a day
+ * across a daylight boundary.
+ */
+export function monthGrid(month: string): CalendarMonth {
+  const [year, index] = month.split("-").map(Number);
+  const first = new Date(Date.UTC(year, index - 1, 1));
+  // Monday-first: `getUTCDay` is 0 for Sunday, so Sunday must reach back six
+  // days rather than none.
+  const lead = (first.getUTCDay() + 6) % 7;
+  const start = new Date(first.getTime() - lead * 86_400_000);
+
+  const weeks: DayKey[][] = [];
+  for (let week = 0; week < 6; week += 1) {
+    const row: DayKey[] = [];
+    for (let day = 0; day < 7; day += 1) {
+      const at = new Date(start.getTime() + (week * 7 + day) * 86_400_000);
+      row.push(at.toISOString().slice(0, 10));
+    }
+    weeks.push(row);
+  }
+  return { month, weeks };
+}
+
+/**
+ * The instants a month's grid covers, for the list query's window.
+ *
+ * Bounded by the grid rather than by the month, so a release on a leading or
+ * trailing day is fetched and shown rather than appearing only once the reader
+ * pages to the month it belongs to.
+ *
+ * Resolved through `instantFor`, which is the same solver the schedule input
+ * uses. A month boundary is a wall time like any other and can land on a
+ * daylight transition — Brazil has abolished DST at midnight, so `00:00` on the
+ * first has genuinely not existed there — and the fallback walks forward rather
+ * than guessing an offset, so the window can never open after the day it means.
+ */
+export function monthWindow(
+  month: string,
+  timeZone: string
+): { after: string; before: string } {
+  const { weeks } = monthGrid(month);
+  const firstDay = weeks[0]?.[0] ?? `${month}-01`;
+  const lastDay = weeks[5]?.[6] ?? `${month}-28`;
+  return {
+    after: startOfDayInstant(firstDay, timeZone),
+    before: startOfDayInstant(nextDay(lastDay), timeZone),
+  };
+}
+
+/** The instant a day begins in `timeZone`, as an ISO string. */
+function startOfDayInstant(day: DayKey, timeZone: string): string {
+  // Midnight can be SKIPPED — a zone that springs forward at 00:00 has no
+  // 00:00 that day — so the first wall time that exists is taken instead of
+  // assuming one. Bounded at three hours, which is wider than any transition.
+  for (let minutes = 0; minutes <= 180; minutes += 30) {
+    const hh = String(Math.floor(minutes / 60)).padStart(2, "0");
+    const mm = String(minutes % 60).padStart(2, "0");
+    const iso = instantFor(`${day}T${hh}:${mm}`, timeZone);
+    if (iso !== null) return iso;
+  }
+  // Every candidate refused, which no real zone produces. UTC midnight is the
+  // widest honest answer: a window that is slightly too large shows a release
+  // that belongs to a neighbouring day, where one that is too small hides one.
+  return `${day}T00:00:00.000Z`;
+}
+
+/** The day after `day`, as a key. */
+function nextDay(day: DayKey): DayKey {
+  const at = new Date(`${day}T00:00:00.000Z`);
+  return new Date(at.getTime() + 86_400_000).toISOString().slice(0, 10);
+}
+
+/**
+ * Every release with an instant, filed under the day it happens in `timeZone`.
+ *
+ * A release with no `scheduledAt` is absent rather than filed somewhere
+ * arbitrary: a draft has not been given a moment, and putting it on today would
+ * assert a launch nobody scheduled.
+ *
+ * Each day's releases are ordered by instant, so a day cell reads down the way
+ * the day will actually happen.
+ */
+export function bucketByDay(
+  releases: readonly Release[],
+  timeZone: string
+): Map<DayKey, Release[]> {
+  const byDay = new Map<DayKey, Release[]>();
+  for (const release of releases) {
+    if (!release.scheduledAt) continue;
+    const at = new Date(release.scheduledAt);
+    if (Number.isNaN(at.getTime())) continue;
+    const key = dayKeyIn(at, timeZone);
+    const list = byDay.get(key) ?? [];
+    list.push(release);
+    byDay.set(key, list);
+  }
+  for (const list of byDay.values()) {
+    list.sort(
+      (a, b) =>
+        new Date(a.scheduledAt ?? 0).getTime() -
+        new Date(b.scheduledAt ?? 0).getTime()
+    );
+  }
+  return byDay;
+}

--- a/packages/admin/src/components/features/releases/release-timezone.ts
+++ b/packages/admin/src/components/features/releases/release-timezone.ts
@@ -1,0 +1,141 @@
+/**
+ * Turning instants into what a reader in a given zone would call them.
+ *
+ * A release carries an INSTANT and the author's timezone, and those two facts
+ * disagree about basic questions. "Which day does this launch on" has no answer
+ * until a zone is named: a release at 23:00 in Berlin is the following day in
+ * UTC and the same evening in New York, so a calendar cannot place it, and a
+ * schedule input cannot resolve what somebody typed, without one.
+ *
+ * Extracted from the schedule dialog when the calendar needed the same
+ * arithmetic. Two implementations of a zone conversion agree until a daylight
+ * boundary, and then disagree by an hour in a way neither screen can show.
+ *
+ * @module components/features/releases/release-timezone
+ */
+import { isValidTimezone } from "@admin/lib/dates/format";
+
+/**
+ * The offset, in minutes, that `timeZone` is running at `instant`.
+ *
+ * Derived by asking `Intl` what the wall clock reads there and subtracting the
+ * instant, rather than from a table: the platform's own database is the only
+ * thing that knows when a zone last changed its rules.
+ */
+function offsetMinutesAt(instant: Date, timeZone: string): number {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  }).formatToParts(instant);
+
+  const read = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find(part => part.type === type)?.value ?? "0");
+
+  // `hour` formats midnight as 24 under `hour12: false` in some engines, which
+  // would place the reading a day late if carried through unchanged.
+  const hour = read("hour") % 24;
+  const asUtc = Date.UTC(
+    read("year"),
+    read("month") - 1,
+    read("day"),
+    hour,
+    read("minute"),
+    read("second")
+  );
+  return (asUtc - instant.getTime()) / 60_000;
+}
+
+/** What a clock in `timeZone` reads at `instant`, as `YYYY-MM-DDTHH:mm`. */
+export function wallTimeIn(instant: Date, timeZone: string): string {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour12: false,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  }).formatToParts(instant);
+  const read = (type: Intl.DateTimeFormatPartTypes): string =>
+    parts.find(part => part.type === type)?.value ?? "";
+  const hour = String(Number(read("hour")) % 24).padStart(2, "0");
+  return `${read("year")}-${read("month")}-${read("day")}T${hour}:${read("minute")}`;
+}
+
+/**
+ * The calendar day `instant` falls on in `timeZone`, as `YYYY-MM-DD`.
+ *
+ * The calendar's whole bucketing rule. Derived from the same `Intl` reading the
+ * offset arithmetic uses rather than from a UTC rendering, because a UTC day is
+ * the one thing this must NOT answer with — placing a 23:00 Berlin launch on
+ * the following day is exactly the error a calendar exists to prevent.
+ */
+export function dayKeyIn(instant: Date, timeZone: string): string {
+  return wallTimeIn(instant, timeZone).slice(0, 10);
+}
+
+/**
+ * The instant at which `wall` occurs in `timeZone`, as an ISO string with `Z`.
+ *
+ * Both DST edges are answered here, and they need opposite treatment.
+ *
+ * A SPRING FORWARD deletes an hour, so the requested wall time may not exist at
+ * all. Returning the solver's nearest approach schedules a different moment
+ * while every screen reads as though it took: measured, `2026-03-29T02:30` in
+ * `Europe/Berlin` came back as 03:30 and `2026-03-08T02:30` in
+ * `America/New_York` as 01:30 — an hour late and an hour early from ONE
+ * implementation. So a candidate is accepted only if it renders back as exactly
+ * what was typed, and `null` otherwise.
+ *
+ * A FALL BACK repeats an hour, so TWO real instants render as the requested
+ * time — in Berlin on 2026-10-25, `00:30Z` and `01:30Z` both read as 02:30. A
+ * single-candidate solver silently returns whichever its arithmetic lands on,
+ * which is the later one; "02:30 that day" means the first, and an editor who
+ * meant the second would have to be able to say so, which this input cannot
+ * express. So both offsets in play around the instant are tried and the EARLIER
+ * surviving candidate wins.
+ *
+ * Offsets are read at a full day either side rather than derived from one
+ * guess, because that is what makes both members of the ambiguous pair
+ * reachable — a transition is at most a couple of hours wide and always falls
+ * inside that window.
+ */
+export function instantFor(wall: string, timeZone: string): string | null {
+  // `datetime-local` yields `YYYY-MM-DDTHH:mm`, which `Date.parse` reads as
+  // LOCAL time. Appending `Z` reads the same digits as UTC, which is the anchor
+  // every candidate below is measured from.
+  const asUtc = new Date(`${wall}:00.000Z`);
+  if (Number.isNaN(asUtc.getTime())) return null;
+
+  const DAY = 86_400_000;
+  const offsets = new Set([
+    offsetMinutesAt(new Date(asUtc.getTime() - DAY), timeZone),
+    offsetMinutesAt(asUtc, timeZone),
+    offsetMinutesAt(new Date(asUtc.getTime() + DAY), timeZone),
+  ]);
+
+  const candidates = [...offsets]
+    .map(offset => new Date(asUtc.getTime() - offset * 60_000))
+    // The round trip is the whole guarantee: an offset that does not reproduce
+    // the typed wall time is not this zone's offset at that moment.
+    .filter(candidate => wallTimeIn(candidate, timeZone) === wall)
+    .sort((a, b) => a.getTime() - b.getTime());
+
+  return candidates[0]?.toISOString() ?? null;
+}
+
+/** The reader's own zone, or UTC where the platform will not name one. */
+export function readerZone(): string {
+  try {
+    const zone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return isValidTimezone(zone) ? zone : "UTC";
+  } catch {
+    return "UTC";
+  }
+}

--- a/packages/admin/src/hooks/queries/useReleases.ts
+++ b/packages/admin/src/hooks/queries/useReleases.ts
@@ -57,6 +57,21 @@ export function useReleases(params: ReleaseListParams = {}, enabled = true) {
     // because the surface is closed — would otherwise issue a request whose
     // only outcome is a 403 in everyone's network log.
     enabled,
+    // Re-asked on the SAME two schedules as the banner and the detail row, and
+    // for the same reason: a scheduled release settles by itself, and nothing
+    // about that reaches this browser. A list or a calendar left open across an
+    // instant would otherwise go on showing a release as upcoming after the
+    // drain published or stopped it — and on the calendar that means a day
+    // keeps a count for a launch that has already happened.
+    //
+    // Two SPEEDS rather than an interval and a stop: a condition that halts
+    // polling can be satisfied by a wrong answer, and a stale row read once as
+    // settled would then never be corrected.
+    refetchInterval: data =>
+      hasPendingRelease(data.state.data)
+        ? PENDING_RELEASE_POLL_MS
+        : NO_RELEASE_POLL_MS,
+    refetchOnWindowFocus: true,
   });
 }
 

--- a/packages/admin/src/pages/dashboard/releases/index.tsx
+++ b/packages/admin/src/pages/dashboard/releases/index.tsx
@@ -52,12 +52,14 @@ export default function ReleasesPage() {
             </p>
           </div>
           <div className="flex items-center gap-2">
-            {/* A radiogroup rather than two buttons: these are mutually
-                exclusive views of one thing, and that is what tells a screen
-                reader the second choice replaces the first rather than doing
-                something additional. */}
+            {/* Toggle BUTTONS, deliberately not a radiogroup. A radiogroup
+                promises composite keyboard behaviour — one tab stop, arrows to
+                move and select — and declaring one without providing it is
+                worse than plain controls: it tells a keyboard user to press
+                arrows that do nothing. `aria-pressed` says the same thing about
+                state and promises only what these actually do. */}
             <div
-              role="radiogroup"
+              role="group"
               aria-label="View releases as"
               className="flex items-center rounded-md border border-border p-0.5"
             >
@@ -65,8 +67,7 @@ export default function ReleasesPage() {
                 <button
                   key={option}
                   type="button"
-                  role="radio"
-                  aria-checked={view === option}
+                  aria-pressed={view === option}
                   onClick={() => setView(option)}
                   className={[
                     "rounded px-3 py-1 text-sm capitalize transition-colors",

--- a/packages/admin/src/pages/dashboard/releases/index.tsx
+++ b/packages/admin/src/pages/dashboard/releases/index.tsx
@@ -14,6 +14,7 @@
 import { useState } from "react";
 
 import { CreateReleaseDialog } from "@admin/components/features/releases/CreateReleaseDialog";
+import { ReleaseCalendar } from "@admin/components/features/releases/ReleaseCalendar";
 import { ReleaseList } from "@admin/components/features/releases/ReleaseList";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
@@ -31,6 +32,11 @@ export default function ReleasesPage() {
   // given, and "do not offer it" the clearest reason there is.
   const canAssemble = useCan("create-content-releases");
   const [creating, setCreating] = useState(false);
+  // TWO VIEWS OF ONE SET, not two pages. A list answers "what launches exist"
+  // and a calendar answers "what is coming, and is anything colliding" — the
+  // same releases, read for different questions, which is how every product
+  // that ships this surface arranges it rather than as a separate feature.
+  const [view, setView] = useState<"list" | "calendar">("list");
 
   return (
     <QueryErrorBoundary fallback={<PageErrorFallback />}>
@@ -45,14 +51,47 @@ export default function ReleasesPage() {
               Documents that go live together, at one moment.
             </p>
           </div>
-          {canAssemble ? (
-            <Button onClick={() => setCreating(true)}>New release</Button>
-          ) : null}
+          <div className="flex items-center gap-2">
+            {/* A radiogroup rather than two buttons: these are mutually
+                exclusive views of one thing, and that is what tells a screen
+                reader the second choice replaces the first rather than doing
+                something additional. */}
+            <div
+              role="radiogroup"
+              aria-label="View releases as"
+              className="flex items-center rounded-md border border-border p-0.5"
+            >
+              {(["list", "calendar"] as const).map(option => (
+                <button
+                  key={option}
+                  type="button"
+                  role="radio"
+                  aria-checked={view === option}
+                  onClick={() => setView(option)}
+                  className={[
+                    "rounded px-3 py-1 text-sm capitalize transition-colors",
+                    view === option
+                      ? "bg-accent text-accent-foreground"
+                      : "text-muted-foreground hover:text-foreground",
+                  ].join(" ")}
+                >
+                  {option}
+                </button>
+              ))}
+            </div>
+            {canAssemble ? (
+              <Button onClick={() => setCreating(true)}>New release</Button>
+            ) : null}
+          </div>
         </div>
 
-        <ReleaseList
-          onCreate={canAssemble ? () => setCreating(true) : undefined}
-        />
+        {view === "calendar" ? (
+          <ReleaseCalendar />
+        ) : (
+          <ReleaseList
+            onCreate={canAssemble ? () => setCreating(true) : undefined}
+          />
+        )}
 
         {canAssemble ? (
           <CreateReleaseDialog


### PR DESCRIPTION
Two views of one set on the releases page. A list answers *what launches exist*; a month grid answers *what is coming, and is anything colliding* — the question somebody planning a week actually has, and one an instant-ordered list answers only by being read end to end.

## The zone is a control, and that is the whole design

A release carries an instant **and** the author's timezone, so "which day does this land on" has no answer until a zone is named.

Verified live against a real database — one release at `04:27Z`, one grid:

```
times in Asia/Riyadh         -> 2026-09-01, 1 release
times in America/Los_Angeles -> 2026-08-31, 1 release
```

Same instant, two days. Without an explicit zone two colleagues comparing this page see one launch on different days with nothing on screen to explain it. So the choice is **named on the page**, defaults to the reader's own zone, and persists across reloads (confirmed: `localStorage` survives a full navigation).

That follows the prior art rather than my taste. [Sanity](https://www.sanity.io/docs/studio/content-releases) puts a timezone picker on its release calendar and remembers the choice; [Storyblok](https://www.storyblok.com/docs/api/management/scheduling-stories)'s scheduling view spans markets and zones explicitly.

## Shape follows it too

[Sanity **deprecated** its standalone content-calendar plugin](https://github.com/sanity-io/sanity-plugin-content-calendar) in favour of a calendar *perspective* on releases — so this is a view mode, not a page or a second feature. [Contentful](https://www.contentful.com/help/launch/create-manage-release/working-with-release-calendar/) draws day indicators rather than content into cells, which is also what keeps a grid readable at the width a cell actually gets. So a day carries a count and a stopped marker; selecting it lists those releases at full width. Narrow screens get an agenda rather than a squeezed grid, because someone on a phone is asking *what happens next*, not *what collides*.

**No new API.** The list route already takes an instant window, so one month is one query — checked against `ReleaseListParams` before building rather than discovered after.

## One implementation of the zone arithmetic

`instantFor`, `wallTimeIn` and the offset solver move out of `ScheduleReleaseDialog` into `release-timezone`, now shared with the calendar's `dayKeyIn`. Two implementations of a timezone conversion agree until a daylight boundary and then differ by an hour in a way neither screen can show. The existing DST suite was repointed at the new home and still passes — which is what makes this a move rather than a rewrite.

`monthWindow` is bounded by the **grid**, not the month, so a release on a leading or trailing day is fetched rather than appearing only once the reader pages to it. It opens at midnight *in the chosen zone*, walking forward when a zone has no midnight that day — Brazil abolished DST at midnight, so `00:00` on the first has genuinely not existed there.

## Evidence

Break-verified: making `dayKeyIn` ignore its zone fails exactly the three zone-dependent cases and leaves the grid-shape and window cases green — so the tests discriminate on the property the module exists for, not merely on it running.

Also verified in a running admin: 42 cells, Monday-first, greyed leading days, the zone named in the grid's `aria-label`, and the day count present in each cell's accessible name rather than only in the badge.

## Gates

Full pre-push hook, no bypass: lint 22/22, build 19/19, check-types 22/22, tests 9/9 — admin **339 files**, zero failures. `fallow audit --base origin/main`: `pass`, 7 changed files, all `*_introduced` zero.

## Next on this row

Moving `ReleaseList` and the detail's member list onto the admin `DataTable` that entries, api-keys, media, webhooks and deliveries already use — releases is the only list surface still hand-built from `Card` + `ul/li`. Raised by the founder, and correct.

@codex please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a calendar view for releases with month navigation, agenda layout, day details, release links, and responsive display.
  - Added list/calendar view switching on the releases page.
  - Added timezone selection and timezone-aware release scheduling.
  - Added loading, error, blocked-state, and truncated-results messaging.

- **Bug Fixes**
  - Release data now refreshes automatically, including when the browser regains focus.
  - Improved handling of daylight-saving changes and unusual timezone transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->