### PR TITLE
fix(admin): show every kind of title a document can hold

### DIFF
--- a/.changeset/a-title-shows-what-it-holds.md
+++ b/.changeset/a-title-shows-what-it-holds.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Show every kind of title a document can hold. `title` is an ownable system column and a code-first schema may redefine it with any field type, so the value reaching the entry header can be a number or a boolean as well as a string. The header's controlled input accepted only strings and numbers, so a document whose title is a checkbox read as "Untitled" over its saved value. The accepted types are now a set rather than a chain of comparisons, because this list has grown twice and each omission read as a deliberate narrowing rather than a case nobody had listed.

--- a/packages/admin/src/components/features/entries/EntryForm/EntryTitleInput.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryTitleInput.tsx
@@ -28,6 +28,31 @@ import { useController, type Control } from "react-hook-form";
 
 import { cn } from "@admin/lib/utils";
 
+/**
+ * The value types a text box can show, which is every primitive it can be
+ * handed.
+ *
+ * A SET rather than a chain of `typeof` comparisons, because this list grew by
+ * one TWICE — numbers, then booleans — and each omission read as a deliberate
+ * narrowing rather than a case nobody had listed. The shape was the defect: a
+ * chain invites adding the type in front of you, a set invites asking which
+ * types exist.
+ *
+ * Measured against the registered input this replaced, which is the parity
+ * being kept: handed `true` it displayed `true`, handed `42` it displayed
+ * `42`. Anything refused here shows as "Untitled" over saved content, which
+ * lies about the document — strictly worse than showing an odd value.
+ *
+ * `symbol` and `function` are absent deliberately rather than forgotten:
+ * neither survives the API round trip, and `String(Symbol())` throws.
+ */
+const PRIMITIVE_TITLES: ReadonlySet<string> = new Set([
+  "string",
+  "number",
+  "bigint",
+  "boolean",
+]);
+
 export interface EntryTitleInputProps {
   /** The form field holding the title. */
   name: string;
@@ -69,8 +94,9 @@ export function EntryTitleInput({
    * PRIMITIVES ARE SHOWN, not just strings.
    *
    * `title` is an ownable system column and a code-first schema may redefine
-   * it: core covers a required NUMBER title, and a document holding `42` must
-   * read `42` here. Accepting only strings would show such a title as
+   * it with any field type: core covers a required NUMBER title, and a
+   * `checkbox` owning the column reaches this as a boolean. A document holding
+   * `42` must read `42` here, and one holding `true` must read `true`. Accepting only strings would show such a title as
    * "Untitled" while the form held its real value — the author would see an
    * empty box over saved content, which is the reverse of the defect this
    * control was extracted to fix. The registered input this replaced rendered
@@ -88,12 +114,7 @@ export function EntryTitleInput({
    * different change from this one.
    */
   const raw: unknown = field.value;
-  const value =
-    typeof raw === "string" ||
-    typeof raw === "number" ||
-    typeof raw === "bigint"
-      ? String(raw)
-      : "";
+  const value = PRIMITIVE_TITLES.has(typeof raw) ? String(raw) : "";
 
   return (
     <input

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.title-sync.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.title-sync.test.tsx
@@ -133,6 +133,38 @@ describe("the header's title and another surface editing the same field", () => 
     expect(headerTitle().value).toBe("42");
   });
 
+  it("shows a BOOLEAN title, which a checkbox owning the column produces", () => {
+    /*
+     * The second omission of the same shape, which is why the accepted types
+     * are now a set rather than a chain. A `checkbox` field may own `title`,
+     * and the registered input this replaced displayed `true` — measured, not
+     * assumed. Refusing it shows "Untitled" over a saved value, which lies
+     * about the document.
+     */
+    function BooleanHarness() {
+      const methods = useForm({ defaultValues: { title: true } });
+      return (
+        <FormProvider {...methods}>
+          <EntrySystemHeader
+            mode="edit"
+            hasStatus
+            entry={{ id: "b", status: "draft" }}
+            collectionSlug="pages"
+            scope="single"
+            onSaveDraft={vi.fn()}
+            onPublish={vi.fn()}
+            onSaveChanges={vi.fn()}
+            onUnpublish={vi.fn()}
+            onCancel={vi.fn()}
+          />
+        </FormProvider>
+      );
+    }
+
+    render(<BooleanHarness />);
+    expect(headerTitle().value).toBe("true");
+  });
+
   it("still shows nothing for a value no text input can draw", () => {
     // The control for the case above. Widening to "any primitive" must not
     // widen to "anything": an object would render as `[object Object]`, which


### PR DESCRIPTION
Follow-up to #1405. Codex raised this on its final commit, so it merged and is live on `main`.

## The defect

`title` is an ownable system column and a code-first schema may redefine it **with any field type**. So the value reaching the header can be a number or a boolean, not just a string. A `checkbox` owning the column read as **"Untitled" over its saved value** — the header lying about the document, which is worse than showing an odd value.

I checked the premise rather than taking it. The registered input this replaced, given each value:

```
boolean true → displayed 'true'
number 42    → displayed '42'
```

So the parity claim is exact, and my coercion regressed it.

## The fix is the shape, not the type

The accepted types are a **set** now rather than a chain of `typeof` comparisons.

That's the actual point. This list has grown **twice** — numbers in #1405, booleans here — and each omission read as a deliberate narrowing rather than a case nobody had listed. A chain invites adding the type in front of you; a set invites asking which types exist. Getting the third one by review would have been a process failure, not a coding one.

`symbol` and `function` stay out deliberately, not by oversight: neither survives the API round trip, and `String(Symbol())` throws.

## Evidence

Break: dropping `"boolean"` from the set kills **the boolean test by name**, 1 of 6. The object-valued control still passes on that break, which is what makes it a control — widening to "any primitive" must not widen to "anything".

admin **339 files / 3259 tests green**; check-types, lint, fallow (`pass`, 3 files) clean.

One note on the typecheck: it first failed on `MAX_QUERIES_PER_REQUEST` and `WidgetDefinition` in files I never touched. That was a stale `dist` — main had gained the widgets work — and it cleared after a rebuild, not a code change.

## Still not fixed, and deliberately

The **write** still yields a string whatever the column's type — unchanged from the registered input. Codex has now suggested twice that the title render through its configured field control, and `packages/admin/AGENTS.md` does say entry field rendering goes through `FieldRenderer`. That convention has always been bypassed here, for a reason: the title is a page heading, not a labelled form row.

Reconciling those two is a design change, and it belongs to the entry-header redesign that's already approved and next up — not to a one-line parity fix.
