### PR TITLE
feat(admin): one table for the release lists, a size bound, and a preflight

### DIFF
--- a/.changeset/release-lists-limits-and-preflight.md
+++ b/.changeset/release-lists-limits-and-preflight.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Put the release lists on the same table every other list in the admin uses, bound how large a release may get, and say what would stop a release before it is scheduled rather than after. The list of releases and the documents inside one were the last surfaces still built by hand from cards, which cost them column alignment, sorting and the shared empty and loading states that entries, media, api keys and webhooks all share. A release can now hold at most a thousand documents — a bound rather than a policy, since nothing in the model stopped one growing until it could neither be displayed nor settled in a single pass. And the schedule dialog now asks what stands in the way while somebody is choosing the moment, naming the documents whose author has gone or which name a single language, because the server's refusal can say that a release cannot run but not which documents to fix.

--- a/packages/admin/src/components/features/releases/BlockedReleaseNotice.tsx
+++ b/packages/admin/src/components/features/releases/BlockedReleaseNotice.tsx
@@ -18,21 +18,7 @@
 import { Card } from "@admin/components/ui";
 import type { ReleaseBlocker } from "@admin/types/releases";
 
-/**
- * What each reason means, and what resolves it.
- *
- * Written as a consequence and a remedy rather than a code, because the reader
- * is someone who did not schedule this release and is finding out now why a
- * launch did not happen.
- */
-const REASON: Record<ReleaseBlocker["reason"], string> = {
-  AUTHOR_GONE:
-    "the person who added it has been deleted or deactivated. A release acts on each document as its author, so there is nobody left to act as. Restore that user, or remove the document and add it again.",
-  NO_AUTHOR:
-    "no author was recorded for it, so there is nobody to act as. Remove the document and add it again.",
-  LOCALE_SCOPED:
-    "it names a single language, which releases cannot act on by themselves. Remove it and add the document without a language.",
-};
+import { blockerExplanation } from "./release-blockers";
 
 /**
  * What the member was going to do, said neutrally enough to be true either way.
@@ -81,7 +67,8 @@ export function BlockedReleaseNotice({
                 ? blocker.scopeSlug
                 : `${blocker.scopeSlug} / ${blocker.entryId}`}
             </span>{" "}
-            {ACTION_PHRASE[blocker.action]}: {REASON[blocker.reason]}
+            {ACTION_PHRASE[blocker.action]}:{" "}
+            {blockerExplanation(blocker.reason)}
           </li>
         ))}
       </ul>

--- a/packages/admin/src/components/features/releases/ReleaseDetail.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseDetail.tsx
@@ -384,12 +384,6 @@ export function ReleaseDetail({ id }: { id: string }) {
           </p>
         </div>
 
-        {members.isError ? (
-          <p role="alert" className="text-sm text-destructive">
-            The contents of this release could not be loaded.
-          </p>
-        ) : null}
-
         {!members.isPending && !members.isError && rows.length === 0 ? (
           <Card className="px-6 py-10 text-center">
             <p className="text-sm text-muted-foreground">
@@ -402,6 +396,20 @@ export function ReleaseDetail({ id }: { id: string }) {
           <DataTableView<ReleaseMember>
             columns={memberColumns(id, removable)}
             rows={rows}
+            // BOTH forwarded, because an unanswered query and an empty release
+            // are not the same thing. Without them the table renders "nothing
+            // has been added" while the query is still running or has failed,
+            // presenting unavailable data as a confident and wrong answer.
+            //
+            // The failure is said HERE rather than in a paragraph above, so
+            // there is one message rather than an error notice sitting over a
+            // table that also claims the release is empty.
+            loading={members.isPending}
+            error={
+              members.isError
+                ? "The contents of this release could not be loaded."
+                : null
+            }
             getRowId={member => member.id}
             primaryColumn="document"
             registryKey="release-members"

--- a/packages/admin/src/components/features/releases/ReleaseDetail.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseDetail.tsx
@@ -28,6 +28,8 @@ import {
   Card,
 } from "@admin/components/ui";
 import { Link } from "@admin/components/ui/link";
+import { DataTableView } from "@admin/components/ui/table/data-table";
+import type { NextlyColumn } from "@admin/components/ui/table/data-table";
 import { buildRoute, ROUTES } from "@admin/constants/routes";
 import {
   useRelease,
@@ -59,6 +61,69 @@ const ACTION_LABEL: Record<ReleaseMember["action"], string> = {
  * identifiers; being one click from the thing itself is most of the value of
  * having the page at all.
  */
+/**
+ * What a member row shows: the effect, the document, and the way out.
+ *
+ * The ACTION leads, for the same reason state leads the release list — publish
+ * and unpublish are opposite outcomes, and a row that opened with the document
+ * would present them as the same thing with a label attached.
+ */
+function memberColumns(
+  releaseId: string,
+  removable: boolean
+): NextlyColumn<ReleaseMember>[] {
+  const columns: NextlyColumn<ReleaseMember>[] = [
+    {
+      name: "action",
+      header: "Action",
+      cell: ({ row }) => (
+        <Badge variant={row.action === "publish" ? "success" : "outline"}>
+          {ACTION_LABEL[row.action]}
+        </Badge>
+      ),
+    },
+    {
+      name: "document",
+      header: "Document",
+      cell: ({ row }) => (
+        <Link
+          href={documentHref(row)}
+          className="inline-flex min-w-0 items-center gap-1 truncate font-medium text-foreground"
+        >
+          <span className="truncate">
+            {row.scopeSlug}
+            {row.scopeKind === "collection" ? ` / ${row.entryId}` : ""}
+          </span>
+          <ExternalLink className="size-3.5 shrink-0" aria-hidden />
+        </Link>
+      ),
+    },
+    {
+      name: "kind",
+      header: "Kind",
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">
+          {row.scopeKind === "single" ? "Single" : "Collection entry"}
+        </span>
+      ),
+    },
+  ];
+
+  // The column is ABSENT rather than empty when the reader cannot remove
+  // anything: a header for a control that never appears reads as a permission
+  // that failed to load.
+  if (removable) {
+    columns.push({
+      name: "remove",
+      header: "",
+      cell: ({ row }) => (
+        <MemberRemoveButton member={row} releaseId={releaseId} />
+      ),
+    });
+  }
+  return columns;
+}
+
 function documentHref(member: ReleaseMember): string {
   return member.scopeKind === "single"
     ? buildRoute(ROUTES.SINGLE_EDIT, { slug: member.scopeSlug })
@@ -68,14 +133,19 @@ function documentHref(member: ReleaseMember): string {
       });
 }
 
-function MemberRow({
+/**
+ * The per-row removal, with its confirmation.
+ *
+ * A cell rather than a `RowAction`, because the removal has to hold its dialog
+ * OPEN while it is failing — see the note below — and a generic row action has
+ * nowhere to keep that state.
+ */
+function MemberRemoveButton({
   member,
   releaseId,
-  removable,
 }: {
   member: ReleaseMember;
   releaseId: string;
-  removable: boolean;
 }) {
   const remove = useRemoveReleaseMember(releaseId);
   const [confirming, setConfirming] = useState(false);
@@ -85,79 +155,48 @@ function MemberRow({
   const open = confirming || remove.isError;
 
   return (
-    <li>
-      <Card className="flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-        <div className="min-w-0">
-          <div className="flex items-center gap-2">
-            <Badge
-              variant={member.action === "publish" ? "success" : "outline"}
-            >
-              {ACTION_LABEL[member.action]}
-            </Badge>
-            <Link
-              href={documentHref(member)}
-              className="inline-flex min-w-0 items-center gap-1 truncate font-medium text-foreground"
-            >
-              <span className="truncate">
-                {member.scopeSlug}
-                {member.scopeKind === "collection"
-                  ? ` / ${member.entryId}`
-                  : ""}
-              </span>
-              <ExternalLink className="size-3.5 shrink-0" aria-hidden />
-            </Link>
-          </div>
-          <p className="mt-1 text-sm text-muted-foreground">
-            {member.scopeKind === "single" ? "Single" : "Collection entry"}
+    <AlertDialog
+      open={open}
+      onOpenChange={next => {
+        if (!next) remove.reset();
+        setConfirming(next);
+      }}
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setConfirming(true)}
+        disabled={remove.isPending}
+        // Named, not "Remove": a screen reader hears the rows in sequence
+        // and "Remove, Remove, Remove" identifies none of them.
+        aria-label={`Remove ${member.scopeSlug} from this release`}
+      >
+        <Trash2 className="size-4" aria-hidden />
+      </Button>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove from this release?</AlertDialogTitle>
+          <AlertDialogDescription>
+            The document itself is not changed. It simply stops being part of
+            what goes live with this release.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        {remove.isError ? (
+          <p role="alert" className="text-sm text-destructive">
+            {releaseErrorMessage(
+              remove.error,
+              "This document was not removed — it is still in the release."
+            )}
           </p>
-        </div>
-
-        {removable ? (
-          <AlertDialog
-            open={open}
-            onOpenChange={next => {
-              if (!next) remove.reset();
-              setConfirming(next);
-            }}
-          >
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setConfirming(true)}
-              disabled={remove.isPending}
-              // Named, not "Remove": a screen reader hears the rows in sequence
-              // and "Remove, Remove, Remove" identifies none of them.
-              aria-label={`Remove ${member.scopeSlug} from this release`}
-            >
-              <Trash2 className="size-4" aria-hidden />
-            </Button>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Remove from this release?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  The document itself is not changed. It simply stops being part
-                  of what goes live with this release.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              {remove.isError ? (
-                <p role="alert" className="text-sm text-destructive">
-                  {releaseErrorMessage(
-                    remove.error,
-                    "This document was not removed — it is still in the release."
-                  )}
-                </p>
-              ) : null}
-              <AlertDialogFooter>
-                <AlertDialogCancel>Keep it</AlertDialogCancel>
-                <AlertDialogAction onClick={() => remove.mutate(member.id)}>
-                  Remove
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
         ) : null}
-      </Card>
-    </li>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Keep it</AlertDialogCancel>
+          <AlertDialogAction onClick={() => remove.mutate(member.id)}>
+            Remove
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   );
 }
 
@@ -360,16 +399,15 @@ export function ReleaseDetail({ id }: { id: string }) {
             </p>
           </Card>
         ) : (
-          <ul className="flex flex-col gap-2">
-            {rows.map(member => (
-              <MemberRow
-                key={member.id}
-                member={member}
-                releaseId={id}
-                removable={removable}
-              />
-            ))}
-          </ul>
+          <DataTableView<ReleaseMember>
+            columns={memberColumns(id, removable)}
+            rows={rows}
+            getRowId={member => member.id}
+            primaryColumn="document"
+            registryKey="release-members"
+            ariaLabel="Documents in this release"
+            emptyMessage="Nothing has been added to this release yet."
+          />
         )}
       </section>
     </>

--- a/packages/admin/src/components/features/releases/ReleaseList.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseList.tsx
@@ -11,7 +11,7 @@
  * @module components/features/releases/ReleaseList
  */
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { CalendarClock } from "@admin/components/icons";
 import {
@@ -25,10 +25,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@admin/components/ui";
-import { Link } from "@admin/components/ui/link";
+import { DataTableView } from "@admin/components/ui/table/data-table";
+import type { NextlyColumn } from "@admin/components/ui/table/data-table";
 import { buildRoute, ROUTES } from "@admin/constants/routes";
 import { useReleases } from "@admin/hooks/queries/useReleases";
-import type { ReleaseState } from "@admin/types/releases";
+import { navigateTo } from "@admin/lib/navigation";
+import type { Release, ReleaseState } from "@admin/types/releases";
 
 import { describeRelease, RELEASE_STATE_LABEL } from "./release-schedule";
 
@@ -97,6 +99,44 @@ const ANY_STATE = "all";
  */
 const PAGE = 50;
 const MAX_PAGE = 200;
+
+/**
+ * What a release row shows, in the order it is read.
+ *
+ * State first, because it is what decides whether the rest of the row matters:
+ * a cancelled launch and a scheduled one are different KINDS of thing, and
+ * putting the title first makes them look like the same thing with a label.
+ */
+function releaseColumns(): NextlyColumn<Release>[] {
+  return [
+    {
+      name: "state",
+      header: "State",
+      cell: ({ row }) => (
+        <Badge variant={STATE_VARIANT[row.state]}>
+          {RELEASE_STATE_LABEL[row.state]}
+        </Badge>
+      ),
+    },
+    {
+      name: "title",
+      header: "Release",
+      cell: ({ row }) => (
+        <span className="font-medium text-foreground">{row.title}</span>
+      ),
+    },
+    {
+      name: "when",
+      header: "When",
+      // The same sentence the row carried before, which says what will happen
+      // and when rather than printing a bare timestamp the reader has to
+      // interpret against the state beside it.
+      cell: ({ row }) => (
+        <span className="text-muted-foreground">{describeRelease(row)}</span>
+      ),
+    },
+  ];
+}
 
 /**
  * The controls that narrow the window.
@@ -287,6 +327,7 @@ export function ReleaseList({ onCreate }: ReleaseListProps) {
   });
 
   const filtering = state !== ANY_STATE || Boolean(after) || Boolean(before);
+  const columns = useMemo(() => releaseColumns(), []);
 
   // ALL of them. Clearing only the state leaves a date window narrowing the
   // list, so "Show all releases" can render the same empty result it was
@@ -365,36 +406,24 @@ export function ReleaseList({ onCreate }: ReleaseListProps) {
   return (
     <>
       {filter}
-      <ul className="flex flex-col gap-2">
-        {releases.map(release => (
-          <li key={release.id}>
-            <Card className="p-0">
-              {/* The whole row is the link. A separate "Open" button beside a
-                  title reads as two destinations, and it cannot be
-                  middle-clicked or opened in a new tab — which is how anyone
-                  compares two releases. */}
-              <Link
-                href={buildRoute(ROUTES.RELEASES_DETAIL, { id: release.id })}
-                className="flex flex-wrap items-center justify-between gap-3 rounded-[inherit] px-4 py-3 no-underline outline-none transition-colors hover:bg-muted/50 focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <div className="min-w-0">
-                  <div className="flex items-center gap-2">
-                    <Badge variant={STATE_VARIANT[release.state]}>
-                      {RELEASE_STATE_LABEL[release.state]}
-                    </Badge>
-                    <span className="truncate font-medium text-foreground">
-                      {release.title}
-                    </span>
-                  </div>
-                  <p className="mt-1 text-sm text-muted-foreground">
-                    {describeRelease(release)}
-                  </p>
-                </div>
-              </Link>
-            </Card>
-          </li>
-        ))}
-      </ul>
+      {/* The SAME table every other list surface uses — entries, media, api
+          keys, webhooks, deliveries. Releases was the last one hand-built from
+          cards, which cost it column alignment, the shared empty and loading
+          states, and the row semantics a reader has already learned everywhere
+          else in the admin. */}
+      <DataTableView<Release>
+        columns={columns}
+        rows={releases}
+        loading={isPending}
+        getRowId={release => release.id}
+        onRowClick={release =>
+          navigateTo(buildRoute(ROUTES.RELEASES_DETAIL, { id: release.id }))
+        }
+        primaryColumn="title"
+        registryKey="releases"
+        ariaLabel="Releases"
+        emptyMessage="No releases match these filters yet."
+      />
 
       <TruncationNotice
         truncated={truncated}

--- a/packages/admin/src/components/features/releases/ReleaseList.tsx
+++ b/packages/admin/src/components/features/releases/ReleaseList.tsx
@@ -29,7 +29,6 @@ import { DataTableView } from "@admin/components/ui/table/data-table";
 import type { NextlyColumn } from "@admin/components/ui/table/data-table";
 import { buildRoute, ROUTES } from "@admin/constants/routes";
 import { useReleases } from "@admin/hooks/queries/useReleases";
-import { navigateTo } from "@admin/lib/navigation";
 import type { Release, ReleaseState } from "@admin/types/releases";
 
 import { describeRelease, RELEASE_STATE_LABEL } from "./release-schedule";
@@ -106,6 +105,16 @@ const MAX_PAGE = 200;
  * State first, because it is what decides whether the rest of the row matters:
  * a cancelled launch and a scheduled one are different KINDS of thing, and
  * putting the title first makes them look like the same thing with a label.
+ */
+/**
+ * NOT sortable, and that is a property of the route rather than a gap here.
+ *
+ * `DataTableView` sorts SERVER-SIDE — it reports a header click and expects the
+ * caller to re-query — and `/api/releases` accepts a state and a window and no
+ * ordering. Marking these headers sortable would offer a control that reorders
+ * nothing, which is worse than the plain headers webhooks, media and api keys
+ * also render. The list's own order is `scheduledAt` descending, chosen so the
+ * next thing to happen is the first thing read.
  */
 function releaseColumns(): NextlyColumn<Release>[] {
   return [
@@ -416,8 +425,13 @@ export function ReleaseList({ onCreate }: ReleaseListProps) {
         rows={releases}
         loading={isPending}
         getRowId={release => release.id}
-        onRowClick={release =>
-          navigateTo(buildRoute(ROUTES.RELEASES_DETAIL, { id: release.id }))
+        // An HREF, not a click handler. The hand-built rows were deliberately
+        // links — "the whole row is the link… it cannot be middle-clicked or
+        // opened in a new tab, which is how anyone compares two releases" — and
+        // navigating as a side effect of a click throws that away while looking
+        // identical. `rowHref` also makes the primary column a real anchor.
+        rowHref={release =>
+          buildRoute(ROUTES.RELEASES_DETAIL, { id: release.id })
         }
         primaryColumn="title"
         registryKey="releases"

--- a/packages/admin/src/components/features/releases/ScheduleReleaseDialog.tsx
+++ b/packages/admin/src/components/features/releases/ScheduleReleaseDialog.tsx
@@ -28,21 +28,82 @@ import {
   Input,
   Label,
 } from "@admin/components/ui";
-import { useScheduleRelease } from "@admin/hooks/queries/useReleases";
+import {
+  useReleaseBlockers,
+  useScheduleRelease,
+} from "@admin/hooks/queries/useReleases";
 import { isValidTimezone } from "@admin/lib/dates/format";
-import type { Release } from "@admin/types/releases";
+import type { Release, ReleaseBlocker } from "@admin/types/releases";
 
 import { instantFor, readerZone } from "./release-timezone";
 
 /**
- * The offset a zone is at for a given instant, as minutes east of UTC.
+ * Why a document would stop the release, in one clause.
  *
- * Derived by asking the platform to format the instant in that zone and reading
- * the parts back, which is the only way to get it: `Intl` exposes zones through
- * formatting and offers no arithmetic. Doing it per instant rather than per zone
- * is what makes daylight saving come out right — the same zone is a different
- * offset in January and July.
+ * Shorter than the sentences on the stopped-release notice, because this list
+ * is read while choosing a date rather than while repairing a failure — the
+ * question here is "which documents", not "what do I do about each".
  */
+const BLOCKER_SUMMARY: Record<ReleaseBlocker["reason"], string> = {
+  AUTHOR_GONE: "the person who added it has been deleted or deactivated",
+  NO_AUTHOR: "no author was recorded for it",
+  LOCALE_SCOPED: "it names a single language, which a release cannot act on",
+};
+
+
+/**
+ * Whether the write may be attempted at all.
+ *
+ * Three of these five are the same judgement: the preflight has to have
+ * ANSWERED, and the answer has to be empty. Withheld while it is unknown as
+ * well as while it is bad — a preflight that lets the write through on a failed
+ * lookup is not a preflight, and the server refuses anyway, so nothing is lost
+ * but a confusing round trip.
+ */
+function readyToSchedule(state: {
+  instant: string | null;
+  scheduling: boolean;
+  checking: boolean;
+  checkFailed: boolean;
+  blocking: number;
+}): boolean {
+  if (state.instant === null || state.scheduling) return false;
+  if (state.checking || state.checkFailed) return false;
+  return state.blocking === 0;
+}
+
+/**
+ * The documents that would stop this release, named.
+ *
+ * NAMED rather than counted, which is the entire reason this is asked before
+ * scheduling instead of being left to the server's refusal: that refusal cannot
+ * say which documents, and nobody can act on a number.
+ */
+function WouldStopThis({ blocking }: { blocking: ReleaseBlocker[] }) {
+  if (blocking.length === 0) return null;
+  return (
+    <div role="alert" className="flex flex-col gap-1">
+      <p className="text-sm font-medium text-destructive">
+        {blocking.length === 1
+          ? "One document would stop this release."
+          : `${blocking.length} documents would stop this release.`}
+      </p>
+      <ul className="flex list-disc flex-col gap-0.5 pl-5">
+        {blocking.map(blocker => (
+          <li key={blocker.memberId} className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">
+              {blocker.scopeKind === "single"
+                ? blocker.scopeSlug
+                : `${blocker.scopeSlug} / ${blocker.entryId}`}
+            </span>{" "}
+            — {BLOCKER_SUMMARY[blocker.reason]}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
 export interface ScheduleReleaseDialogProps {
   release: Release;
   open: boolean;
@@ -70,7 +131,21 @@ export function ScheduleReleaseDialog({
   // correcting a missed launch window is doing it on purpose.
   const inThePast =
     instant !== null && new Date(instant).getTime() < Date.now();
-  const canSubmit = instant !== null && !schedule.isPending;
+  // ASKED WHILE THE DIALOG IS OPEN, which is the moment somebody is choosing
+  // an instant. The server refuses a release with an unrunnable member anyway;
+  // what it cannot do in that refusal is say WHICH documents, and "fix the
+  // documents blocking it" is not an instruction anybody can follow without
+  // that list.
+  const blockers = useReleaseBlockers(release.id, open);
+  const blocking = blockers.data?.items ?? [];
+
+  const canSubmit = readyToSchedule({
+    instant,
+    scheduling: schedule.isPending,
+    checking: blockers.isPending,
+    checkFailed: blockers.isError,
+    blocking: blocking.length,
+  });
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -78,7 +153,11 @@ export function ScheduleReleaseDialog({
         <form
           onSubmit={event => {
             event.preventDefault();
-            if (!canSubmit) return;
+            // `instant` re-checked rather than asserted. `canSubmit` is
+            // computed elsewhere now, so the compiler cannot narrow through it
+            // — and a non-null assertion here would be a claim the type system
+            // is being told to stop checking.
+            if (!canSubmit || instant === null) return;
             schedule.mutate(
               { at: instant, timezone: zone },
               { onSuccess: () => onOpenChange(false) }
@@ -124,25 +203,15 @@ export function ScheduleReleaseDialog({
               </p>
             </div>
 
-            {skipped ? (
-              <p role="alert" className="text-sm text-destructive">
-                {zone} has no such time on that date — the clocks go forward and
-                that hour does not exist. Pick a time before or after it.
-              </p>
-            ) : null}
+            <ScheduleNotices
+              zone={zone}
+              skipped={skipped}
+              inThePast={inThePast}
+              checkFailed={blockers.isError}
+              scheduleFailed={schedule.isError}
+            />
 
-            {inThePast ? (
-              <p role="status" className="text-sm text-warning-foreground">
-                That moment has already passed — this release will go live at
-                the next check rather than waiting.
-              </p>
-            ) : null}
-
-            {schedule.isError ? (
-              <p role="alert" className="text-sm text-destructive">
-                The release could not be scheduled.
-              </p>
-            ) : null}
+            <WouldStopThis blocking={blocking} />
           </div>
 
           <DialogFooter>
@@ -160,5 +229,51 @@ export function ScheduleReleaseDialog({
         </form>
       </DialogContent>
     </Dialog>
+  );
+}
+
+/** Everything the dialog needs to say before it will accept a submission. */
+function ScheduleNotices({
+  zone,
+  skipped,
+  inThePast,
+  checkFailed,
+  scheduleFailed,
+}: {
+  zone: string;
+  skipped: boolean;
+  inThePast: boolean;
+  checkFailed: boolean;
+  scheduleFailed: boolean;
+}) {
+  return (
+    <>
+      {skipped ? (
+        <p role="alert" className="text-sm text-destructive">
+          {zone} has no such time on that date — the clocks go forward and that
+          hour does not exist. Pick a time before or after it.
+        </p>
+      ) : null}
+
+      {inThePast ? (
+        <p role="status" className="text-sm text-warning-foreground">
+          That moment has already passed — this release will go live at the next
+          check rather than waiting.
+        </p>
+      ) : null}
+
+      {checkFailed ? (
+        <p role="alert" className="text-sm text-destructive">
+          Whether this release can run could not be checked, so it has not been
+          scheduled.
+        </p>
+      ) : null}
+
+      {scheduleFailed ? (
+        <p role="alert" className="text-sm text-destructive">
+          The release could not be scheduled.
+        </p>
+      ) : null}
+    </>
   );
 }

--- a/packages/admin/src/components/features/releases/ScheduleReleaseDialog.tsx
+++ b/packages/admin/src/components/features/releases/ScheduleReleaseDialog.tsx
@@ -35,21 +35,8 @@ import {
 import { isValidTimezone } from "@admin/lib/dates/format";
 import type { Release, ReleaseBlocker } from "@admin/types/releases";
 
+import { blockerSummary } from "./release-blockers";
 import { instantFor, readerZone } from "./release-timezone";
-
-/**
- * Why a document would stop the release, in one clause.
- *
- * Shorter than the sentences on the stopped-release notice, because this list
- * is read while choosing a date rather than while repairing a failure — the
- * question here is "which documents", not "what do I do about each".
- */
-const BLOCKER_SUMMARY: Record<ReleaseBlocker["reason"], string> = {
-  AUTHOR_GONE: "the person who added it has been deleted or deactivated",
-  NO_AUTHOR: "no author was recorded for it",
-  LOCALE_SCOPED: "it names a single language, which a release cannot act on",
-};
-
 
 /**
  * Whether the write may be attempted at all.
@@ -96,7 +83,7 @@ function WouldStopThis({ blocking }: { blocking: ReleaseBlocker[] }) {
                 ? blocker.scopeSlug
                 : `${blocker.scopeSlug} / ${blocker.entryId}`}
             </span>{" "}
-            — {BLOCKER_SUMMARY[blocker.reason]}
+            — {blockerSummary(blocker.reason)}
           </li>
         ))}
       </ul>
@@ -142,7 +129,13 @@ export function ScheduleReleaseDialog({
   const canSubmit = readyToSchedule({
     instant,
     scheduling: schedule.isPending,
-    checking: blockers.isPending,
+    // `isFetching`, NOT `isPending`. React Query reports pending only while
+    // there is no data at all — so a dialog reopened over a cached clean answer
+    // reports "not pending" through the whole refetch, and a release whose
+    // author disappeared in between would be submittable against the stale
+    // result. The reader would then meet the server's generic refusal instead
+    // of the named blocker this preflight exists to show.
+    checking: blockers.isFetching,
     checkFailed: blockers.isError,
     blocking: blocking.length,
   });

--- a/packages/admin/src/components/features/releases/__tests__/ReleaseList.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/ReleaseList.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * The releases list, now rendered by the shared table.
+ *
+ * Written when the rows moved off hand-built cards onto `DataTableView` — the
+ * same component entries, media, api keys, webhooks and deliveries use. A
+ * migration like that fails quietly: the page still renders, the filters still
+ * work, and the rows are simply gone or unreadable.
+ *
+ * @module components/features/releases/__tests__/ReleaseList.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+
+const { useReleasesMock, navigateToMock } = vi.hoisted(() => ({
+  useReleasesMock: vi.fn(),
+  navigateToMock: vi.fn(),
+}));
+
+vi.mock("@admin/hooks/queries/useReleases", () => ({
+  useReleases: (...args: unknown[]) => useReleasesMock(...args),
+}));
+vi.mock("@admin/lib/navigation", () => ({ navigateTo: navigateToMock }));
+
+import { ReleaseList } from "../ReleaseList";
+
+const SCHEDULED = {
+  id: "r1",
+  title: "Autumn launch",
+  description: null,
+  scheduledAt: "2026-09-01T09:00:00.000Z",
+  timezone: "Europe/Berlin",
+  state: "scheduled",
+  publishedAt: null,
+};
+
+const CANCELLED = {
+  ...SCHEDULED,
+  id: "r2",
+  title: "Called off",
+  state: "cancelled",
+};
+
+function answer(items: unknown[], over: Record<string, unknown> = {}) {
+  return {
+    data: { items, meta: { hasNext: false } },
+    isPending: false,
+    isError: false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  useReleasesMock.mockReset();
+  navigateToMock.mockReset();
+  useReleasesMock.mockReturnValue(answer([SCHEDULED, CANCELLED]));
+});
+
+describe("the releases list", () => {
+  it("renders each release as a row in the shared table", async () => {
+    render(<ReleaseList />);
+    // A table, not a list of cards — which is the point of the migration.
+    expect(screen.getByRole("table")).toBeTruthy();
+    // `getAllBy`, because the shared table renders a desktop table AND a
+    // narrow-screen view of the same rows; both are in the DOM.
+    expect(screen.getAllByText("Autumn launch").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Called off").length).toBeGreaterThan(0);
+  });
+
+  it("shows the STATE beside each release, not just its title", async () => {
+    // The state decides whether the rest of the row matters at all: a cancelled
+    // launch and a scheduled one are different kinds of thing, and a list that
+    // showed only titles would present them as the same thing.
+    render(<ReleaseList />);
+    expect(screen.getAllByText(/^scheduled$/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^cancelled$/i).length).toBeGreaterThan(0);
+  });
+
+  it("keeps its own empty state rather than falling back to the table's", async () => {
+    // The list short-circuits before the table when there is nothing to show,
+    // and that is deliberate: an empty table saying "no rows" is worse here
+    // than a panel explaining what a release IS and offering to create one.
+    // Pinned because the migration could easily have dropped it.
+    useReleasesMock.mockReturnValue(answer([]));
+    render(<ReleaseList />);
+    expect(screen.getByText(/nothing is scheduled/i)).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/releases/__tests__/schedule-preflight.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/schedule-preflight.test.tsx
@@ -50,7 +50,13 @@ const BLOCKER = {
 };
 
 function answer(over: Record<string, unknown> = {}) {
-  return { data: { items: [] }, isPending: false, isError: false, ...over };
+  return {
+    data: { items: [] },
+    isPending: false,
+    isFetching: false,
+    isError: false,
+    ...over,
+  };
 }
 
 const submit = () =>
@@ -116,10 +122,31 @@ describe("the schedule preflight", () => {
     expect(submit().disabled).toBe(true);
   });
 
+  it("refuses while a REFETCH is running over a cached clean answer", async () => {
+    // The state React Query reports as `isFetching` and not `isPending`: the
+    // dialog was opened before, so the previous answer is still in cache while
+    // the new request runs. Reading only `isPending` calls that clean, and a
+    // release whose author disappeared in between becomes submittable.
+    blockersMock.mockReturnValue(
+      answer({ isFetching: true, data: { items: [] } })
+    );
+    render(
+      <ScheduleReleaseDialog release={RELEASE} open onOpenChange={() => {}} />
+    );
+    withAnInstant();
+    expect(submit().disabled).toBe(true);
+  });
+
   it("refuses while the check is still running", async () => {
     // The third state. Pending is neither clean nor blocked, and folding it
     // into clean is how a release with a dead author gets scheduled anyway.
-    blockersMock.mockReturnValue(answer({ isPending: true, data: undefined }));
+    // A first load is BOTH: React Query reports `isPending` while there is no
+    // data and `isFetching` while a request is in flight, and a first load is
+    // both at once. The mock says so rather than modelling a state the library
+    // never produces.
+    blockersMock.mockReturnValue(
+      answer({ isPending: true, isFetching: true, data: undefined })
+    );
     render(
       <ScheduleReleaseDialog release={RELEASE} open onOpenChange={() => {}} />
     );

--- a/packages/admin/src/components/features/releases/__tests__/schedule-preflight.test.tsx
+++ b/packages/admin/src/components/features/releases/__tests__/schedule-preflight.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * Asking what would stop a release, before committing it to an instant.
+ *
+ * The server refuses a release whose members cannot run, so this is not the
+ * only guard — it is the one that can say WHICH documents. "Fix the documents
+ * blocking it" is not an instruction anybody can follow without that list, and
+ * the refusal cannot carry it.
+ *
+ * @module components/features/releases/__tests__/schedule-preflight.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { fireEvent, render, screen } from "@admin/__tests__/utils";
+
+const { blockersMock, scheduleMock } = vi.hoisted(() => ({
+  blockersMock: vi.fn(),
+  scheduleMock: vi.fn(),
+}));
+
+vi.mock("@admin/hooks/queries/useReleases", () => ({
+  useReleaseBlockers: (...args: unknown[]) => blockersMock(...args),
+  useScheduleRelease: () => ({
+    mutate: scheduleMock,
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  }),
+}));
+
+import { ScheduleReleaseDialog } from "../ScheduleReleaseDialog";
+
+const RELEASE = {
+  id: "r1",
+  title: "Autumn launch",
+  description: null,
+  scheduledAt: null,
+  timezone: null,
+  state: "draft",
+  publishedAt: null,
+} as never;
+
+const BLOCKER = {
+  memberId: "m1",
+  reason: "AUTHOR_GONE",
+  action: "publish",
+  scopeKind: "collection",
+  scopeSlug: "posts",
+  entryId: "e1",
+};
+
+function answer(over: Record<string, unknown> = {}) {
+  return { data: { items: [] }, isPending: false, isError: false, ...over };
+}
+
+const submit = () =>
+  screen.getByRole("button", {
+    name: /schedule release/i,
+  }) as HTMLButtonElement;
+
+/**
+ * Give the dialog a valid instant, so the submit button's state is decided by
+ * the PREFLIGHT rather than by an empty form.
+ *
+ * Without this every assertion below passes on an unmodified component: the
+ * button starts disabled because no date has been typed, which is a state that
+ * predates the mechanism under test entirely. Found by breaking the preflight
+ * and watching all four cases stay green.
+ */
+function withAnInstant() {
+  fireEvent.change(screen.getByLabelText(/date and time/i), {
+    target: { value: "2027-01-15T09:00" },
+  });
+}
+
+beforeEach(() => {
+  blockersMock.mockReset();
+  scheduleMock.mockReset();
+  blockersMock.mockReturnValue(answer());
+});
+
+describe("the schedule preflight", () => {
+  it("lets a clean release through, which is the control", async () => {
+    // Without this, every case below is satisfied by a dialog that refuses
+    // everything — including the empty-form state they would otherwise be
+    // measuring rather than the preflight.
+    render(
+      <ScheduleReleaseDialog release={RELEASE} open onOpenChange={() => {}} />
+    );
+    withAnInstant();
+    expect(submit().disabled).toBe(false);
+  });
+
+  it("NAMES the documents that would stop the release", async () => {
+    // A count is not actionable. The whole reason this asks before scheduling
+    // is that the server's refusal cannot say which documents.
+    blockersMock.mockReturnValue(answer({ data: { items: [BLOCKER] } }));
+    render(
+      <ScheduleReleaseDialog release={RELEASE} open onOpenChange={() => {}} />
+    );
+    withAnInstant();
+    expect(screen.getByText(/one document would stop/i)).toBeTruthy();
+    expect(screen.getByText("posts / e1")).toBeTruthy();
+    expect(submit().disabled).toBe(true);
+  });
+
+  it("refuses to schedule while the check has FAILED", async () => {
+    // Unknown is not clean. A preflight that lets the write through on a failed
+    // lookup is not a preflight.
+    blockersMock.mockReturnValue(answer({ isError: true, data: undefined }));
+    render(
+      <ScheduleReleaseDialog release={RELEASE} open onOpenChange={() => {}} />
+    );
+    withAnInstant();
+    expect(screen.getByText(/could not be checked/i)).toBeTruthy();
+    expect(submit().disabled).toBe(true);
+  });
+
+  it("refuses while the check is still running", async () => {
+    // The third state. Pending is neither clean nor blocked, and folding it
+    // into clean is how a release with a dead author gets scheduled anyway.
+    blockersMock.mockReturnValue(answer({ isPending: true, data: undefined }));
+    render(
+      <ScheduleReleaseDialog release={RELEASE} open onOpenChange={() => {}} />
+    );
+    withAnInstant();
+    expect(submit().disabled).toBe(true);
+  });
+
+  it("does not ask at all while the dialog is closed", async () => {
+    // The answer costs an identity lookup over every member. Asking on every
+    // detail render to say "nothing is wrong" is what this route exists to
+    // avoid.
+    render(
+      <ScheduleReleaseDialog
+        release={RELEASE}
+        open={false}
+        onOpenChange={() => {}}
+      />
+    );
+    expect(blockersMock).toHaveBeenCalledWith("r1", false);
+  });
+});

--- a/packages/admin/src/components/features/releases/release-blockers.ts
+++ b/packages/admin/src/components/features/releases/release-blockers.ts
@@ -1,0 +1,55 @@
+/**
+ * Why a document stops a release, said once.
+ *
+ * Two surfaces need this vocabulary and they need different lengths of it: the
+ * schedule dialog lists documents while somebody is choosing a moment, so it
+ * wants the clause; the stopped-release notice is read while repairing a
+ * failure, so it wants the clause AND what to do about it.
+ *
+ * Held as one definition per reason rather than two maps. Two maps of one
+ * vocabulary agree until somebody corrects a wording on the screen they
+ * happened to be looking at, and then the product explains the same failure two
+ * different ways — with nothing to say which is current.
+ *
+ * @module components/features/releases/release-blockers
+ */
+import type { ReleaseBlockerReason } from "@admin/types/releases";
+
+export interface BlockerReasonCopy {
+  /** The clause, for a list read while choosing a date. */
+  summary: string;
+  /**
+   * What follows it when there is room to say more — the consequence and the
+   * remedy. Written to continue the summary rather than to stand alone, so the
+   * two cannot drift into disagreeing about the cause.
+   */
+  detail: string;
+}
+
+export const BLOCKER_REASON: Record<ReleaseBlockerReason, BlockerReasonCopy> = {
+  AUTHOR_GONE: {
+    summary: "the person who added it has been deleted or deactivated",
+    detail:
+      ". A release acts on each document as its author, so there is nobody left to act as. Restore that user, or remove the document and add it again.",
+  },
+  NO_AUTHOR: {
+    summary: "no author was recorded for it",
+    detail:
+      ", so there is nobody to act as. Remove the document and add it again.",
+  },
+  LOCALE_SCOPED: {
+    summary: "it names a single language, which a release cannot act on",
+    detail: " by itself. Remove it and add the document without a language.",
+  },
+};
+
+/** The clause alone, for a list. */
+export function blockerSummary(reason: ReleaseBlockerReason): string {
+  return BLOCKER_REASON[reason].summary;
+}
+
+/** The clause and its remedy, for somebody who has to fix it. */
+export function blockerExplanation(reason: ReleaseBlockerReason): string {
+  const copy = BLOCKER_REASON[reason];
+  return `${copy.summary}${copy.detail}`;
+}

--- a/packages/admin/src/hooks/queries/useReleases.ts
+++ b/packages/admin/src/hooks/queries/useReleases.ts
@@ -28,6 +28,7 @@ import {
   cancelRelease,
   createRelease,
   fetchRelease,
+  fetchReleaseBlockers,
   fetchReleaseMembers,
   fetchReleases,
   removeReleaseMember,
@@ -46,6 +47,7 @@ export const releaseKeys = {
   list: (params: ReleaseListParams) => ["releases", "list", params] as const,
   detail: (id: string) => ["releases", "detail", id] as const,
   members: (id: string) => ["releases", "members", id] as const,
+  blockers: (id: string) => ["releases", "blockers", id] as const,
 };
 
 export function useReleases(params: ReleaseListParams = {}, enabled = true) {
@@ -188,6 +190,28 @@ export function useRelease(id: string | undefined) {
         : NO_RELEASE_POLL_MS,
     // And on return to the tab, which is when somebody actually looks.
     refetchOnWindowFocus: true,
+  });
+}
+
+/**
+ * What stands between a release and its instant — the preflight.
+ *
+ * Asked only when somebody is about to commit to one, which is why it is
+ * `enabled`-gated rather than fetched with the detail: the answer costs an
+ * identity lookup over every member, and the overwhelming majority of reads do
+ * not need it to be told that nothing is wrong.
+ *
+ * NOT cached across the dialog closing. A blocker is fixed by editing a
+ * document or removing a member, both of which happen elsewhere — so a stale
+ * "nothing is blocking this" is exactly the answer that would let somebody
+ * schedule a launch that cannot run.
+ */
+export function useReleaseBlockers(id: string | undefined, enabled = true) {
+  return useQuery({
+    queryKey: releaseKeys.blockers(id ?? ""),
+    queryFn: () => fetchReleaseBlockers(id as string),
+    enabled: enabled && Boolean(id),
+    staleTime: 0,
   });
 }
 

--- a/packages/admin/src/services/releaseApi.ts
+++ b/packages/admin/src/services/releaseApi.ts
@@ -16,6 +16,7 @@ import type {
   AddReleaseMemberPayload,
   CreateReleasePayload,
   Release,
+  ReleaseBlocker,
   ReleaseListParams,
   ReleaseMember,
   ScheduleReleasePayload,
@@ -29,6 +30,12 @@ export interface ReleaseListResponse {
 
 export interface MemberListResponse {
   items: ReleaseMember[];
+  meta: { total: number; hasNext: boolean };
+}
+
+/** The blockers standing between one release and its instant. */
+export interface BlockerListResponse {
+  items: ReleaseBlocker[];
   meta: { total: number; hasNext: boolean };
 }
 
@@ -79,6 +86,18 @@ export const fetchReleaseMembers = (
   releaseId: string
 ): Promise<MemberListResponse> =>
   fetcher<MemberListResponse>(`/releases/${releaseId}/members`, {}, true);
+
+/**
+ * What stands between a release and its instant, asked before committing.
+ *
+ * Its own request rather than a field on the detail read: answering it costs an
+ * identity lookup over every member, which the detail must not pay to tell the
+ * overwhelming majority of callers that nothing is wrong.
+ */
+export const fetchReleaseBlockers = (
+  releaseId: string
+): Promise<BlockerListResponse> =>
+  fetcher<BlockerListResponse>(`/releases/${releaseId}/blockers`, {}, true);
 
 export const createRelease = (
   payload: CreateReleasePayload

--- a/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
+++ b/packages/nextly/src/api/__tests__/releases-route-authority.test.ts
@@ -159,6 +159,17 @@ describe("release route authority", () => {
     ).toEqual({ action: "publish", resource: "content-releases" });
   });
 
+  it("demands only READ to ask what is blocking a release", async () => {
+    // A preflight is a question, not a change. Demanding `publish` to ask it
+    // would mean the person assembling a release — who can add and remove the
+    // documents that cause a blocker — could not find out which ones they are,
+    // and would have to hand it to a publisher to be told.
+    expect(await authorityFor("listReleaseBlockers")).toEqual({
+      action: "read",
+      resource: "content-releases",
+    });
+  });
+
   it("demands publish to cancel", async () => {
     // Someone who could cancel but not schedule could still silently stop a
     // launch, so the two share one authority.

--- a/packages/nextly/src/api/releases.ts
+++ b/packages/nextly/src/api/releases.ts
@@ -67,6 +67,7 @@ const RELEASE_AUTHORITY: Record<string, "read" | "create" | "publish"> = {
   listReleases: "read",
   getRelease: "read",
   listReleaseMembers: "read",
+  listReleaseBlockers: "read",
   createRelease: "create",
   addReleaseMember: "create",
   // Removing a member un-does part of assembling a release and can only ever
@@ -664,6 +665,34 @@ const RELEASE_OPERATIONS: Record<
       }),
       { status: 201 }
     );
+  },
+
+  /**
+   * What stands between this release and its instant, asked before committing.
+   *
+   * The same derivation the drain would reach at the instant, offered at the
+   * moment somebody is choosing one — so a launch that cannot run is refused
+   * while the operator is still looking at it, rather than at three in the
+   * morning when nobody is.
+   *
+   * Answers for ANY state, not only a stopped release. A draft with a departed
+   * author is exactly as unrunnable as one the drain has already labelled; the
+   * only difference is whether a background pass has happened yet, which is not
+   * something the person scheduling can see.
+   */
+  listReleaseBlockers: async ({ caller, releases, releaseId }) => {
+    const blockers = await releases.blockingReasons({ ...caller, releaseId });
+    // Unpaged, like the member list it derives from: the set is bounded by
+    // the release's own member cap, and a blocker you cannot see is a blocker
+    // you cannot fix.
+    return respondList(blockers, {
+      total: blockers.length,
+      page: 1,
+      limit: blockers.length,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    });
   },
 
   removeReleaseMember: async ({ caller, releases, releaseId, memberId }) => {

--- a/packages/nextly/src/domains/releases/__tests__/member-limit.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/member-limit.test.ts
@@ -43,20 +43,20 @@ function service(held: number) {
       createdAt: new Date(),
     }))
   );
+  const touchIfAssemblable = vi.fn(async () => true);
   const deps = {
     repository: {
       listMembers,
       addMember,
+      touchIfAssemblable,
       liveAuthors: vi.fn(async () => new Set(["u1"])),
-      claimAssemblable: vi.fn(async () => true),
-      touchIfAssemblable: vi.fn(async () => true),
       removeMember: vi.fn(async () => true),
       findReleases: vi.fn(async () => [{ id: "r1", state: "draft" }]),
     } as unknown as ReleasesServiceDeps["repository"],
     canManageReleases: vi.fn(async () => true),
     canActOnDocument: vi.fn(async () => true),
   };
-  return { svc: new ReleasesService(deps), addMember };
+  return { svc: new ReleasesService(deps), addMember, touchIfAssemblable };
 }
 
 describe("a release has a size bound", () => {
@@ -64,14 +64,17 @@ describe("a release has a size bound", () => {
     // The case this exists for is not a person: it is a script adding in a
     // loop, which otherwise builds a release the detail page cannot render and
     // no single drain pass can settle.
-    const { svc, addMember } = service(MAX_RELEASE_MEMBERS);
+    const { svc, addMember, touchIfAssemblable } = service(MAX_RELEASE_MEMBERS);
     await expect(svc.addMember("r1", INPUT, ACTOR)).rejects.toMatchObject({
       code: "CONFLICT",
     });
-    // Refused BEFORE the write. A limit enforced after the insert would need
-    // compensating, and a compensation that fails leaves the release over its
-    // own bound.
+    // Refused before the MEMBER write...
     expect(addMember).not.toHaveBeenCalled();
+    // ...and before the RELEASE write, which is the half the first assertion
+    // cannot see. `touchIfAssemblable` updates the release's `updatedAt`, so a
+    // check ordered after it leaves a refused add having changed the row — and
+    // a test that watches only the insert reports that as clean.
+    expect(touchIfAssemblable).not.toHaveBeenCalled();
   });
 
   it("accepts the LAST document that fits", async () => {

--- a/packages/nextly/src/domains/releases/__tests__/member-limit.test.ts
+++ b/packages/nextly/src/domains/releases/__tests__/member-limit.test.ts
@@ -1,0 +1,92 @@
+/**
+ * How large a release may get.
+ *
+ * A bound rather than a policy: nothing in the model stops a release growing
+ * without limit, and the surfaces that read it all degrade together when it
+ * does — an unpaged member list, a drain that performs members one at a time
+ * inside a wall-clock budget, and blocker reasons derived over every member on
+ * every read.
+ *
+ * @module domains/releases/__tests__/member-limit.test
+ */
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  MAX_RELEASE_MEMBERS,
+  ReleasesService,
+} from "../services/releases-service";
+import type { ReleasesServiceDeps } from "../services/releases-service";
+
+const ACTOR = { userId: "u1" };
+
+const INPUT = {
+  scopeKind: "collection" as const,
+  scopeSlug: "posts",
+  entryId: "e-new",
+  locale: null,
+  action: "publish" as const,
+};
+
+/** A release already holding `held` documents. */
+function service(held: number) {
+  const addMember = vi.fn(async () => ({ id: "m-new" }));
+  const listMembers = vi.fn(async () =>
+    Array.from({ length: held }, (_, n) => ({
+      id: `m${n}`,
+      releaseId: "r1",
+      scopeKind: "collection" as const,
+      scopeSlug: "posts",
+      entryId: `e${n}`,
+      locale: null,
+      action: "publish" as const,
+      createdBy: "u1",
+      createdAt: new Date(),
+    }))
+  );
+  const deps = {
+    repository: {
+      listMembers,
+      addMember,
+      liveAuthors: vi.fn(async () => new Set(["u1"])),
+      claimAssemblable: vi.fn(async () => true),
+      touchIfAssemblable: vi.fn(async () => true),
+      removeMember: vi.fn(async () => true),
+      findReleases: vi.fn(async () => [{ id: "r1", state: "draft" }]),
+    } as unknown as ReleasesServiceDeps["repository"],
+    canManageReleases: vi.fn(async () => true),
+    canActOnDocument: vi.fn(async () => true),
+  };
+  return { svc: new ReleasesService(deps), addMember };
+}
+
+describe("a release has a size bound", () => {
+  it("refuses the document that would exceed it", async () => {
+    // The case this exists for is not a person: it is a script adding in a
+    // loop, which otherwise builds a release the detail page cannot render and
+    // no single drain pass can settle.
+    const { svc, addMember } = service(MAX_RELEASE_MEMBERS);
+    await expect(svc.addMember("r1", INPUT, ACTOR)).rejects.toMatchObject({
+      code: "CONFLICT",
+    });
+    // Refused BEFORE the write. A limit enforced after the insert would need
+    // compensating, and a compensation that fails leaves the release over its
+    // own bound.
+    expect(addMember).not.toHaveBeenCalled();
+  });
+
+  it("accepts the LAST document that fits", async () => {
+    // The boundary in the other direction, which an off-by-one would break
+    // while leaving the case above green.
+    const { svc, addMember } = service(MAX_RELEASE_MEMBERS - 1);
+    await expect(svc.addMember("r1", INPUT, ACTOR)).resolves.toBeTruthy();
+    expect(addMember).toHaveBeenCalled();
+  });
+
+  it("does not stand in the way of an ordinary release", async () => {
+    // The control. Without it a cap that refused everything would satisfy the
+    // first case perfectly.
+    const { svc, addMember } = service(3);
+    await expect(svc.addMember("r1", INPUT, ACTOR)).resolves.toBeTruthy();
+    expect(addMember).toHaveBeenCalled();
+  });
+});

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -100,6 +100,27 @@ export const MAX_RELEASE_TITLE_LENGTH = 255;
 export const MAX_RELEASE_TIMEZONE_LENGTH = 64;
 
 /**
+ * How many documents one release may hold.
+ *
+ * A bound rather than a policy. Nothing about the model stops a release growing
+ * without limit, and three things degrade together as it does: `listMembers` is
+ * unpaged and the detail page renders all of it, the drain performs members one
+ * at a time inside a wall-clock budget, and a blocked release derives its
+ * reasons over every member on every read.
+ *
+ * A thousand is chosen to sit well above any release somebody assembles
+ * deliberately — a site relaunch is tens of documents, not hundreds — while
+ * still catching the case this exists for: a script adding in a loop, which
+ * otherwise builds a release nothing can display and no single pass can settle.
+ *
+ * NOT an atomic invariant, and the code says so rather than implying otherwise:
+ * two concurrent adds can both read a count below the cap. That is acceptable
+ * because the failure it prevents is unbounded growth, not the thousand-and-
+ * first row.
+ */
+export const MAX_RELEASE_MEMBERS = 1000;
+
+/**
  * Who is asking, and whether to ask at all.
  *
  * `overrideAccess` matches every other service in this package: the Direct API
@@ -749,6 +770,7 @@ export class ReleasesService {
     // Claimed ATOMICALLY, and the author checked, before anything is written.
     await this.claimAssemblable(releaseId, actor);
     await this.requireLiveAuthor(actor.userId);
+    await this.assertRoomForOneMore(releaseId);
 
     try {
       const member = await this.deps.repository.addMember({
@@ -946,6 +968,28 @@ export class ReleasesService {
    * `AUTHOR_UNAVAILABLE` on every pass — the release stays scheduled forever and
    * the only symptom is content that never appeared.
    */
+  /**
+   * Refuse a release that has reached its size bound.
+   *
+   * Counted from the members themselves rather than a stored total, for the
+   * reason the blocker reasons are derived: a cached count drifts the moment a
+   * member is removed by another route, and a cap enforced from a stale number
+   * refuses a release that has room.
+   */
+  private async assertRoomForOneMore(releaseId: string): Promise<void> {
+    const held = await this.deps.repository.listMembers(releaseId);
+    if (held.length < MAX_RELEASE_MEMBERS) return;
+    throw NextlyError.conflict({
+      message: `A release can hold at most ${MAX_RELEASE_MEMBERS} documents. Remove something, or schedule this release and start another.`,
+      logContext: {
+        reason: "release-member-limit",
+        releaseId,
+        held: held.length,
+        limit: MAX_RELEASE_MEMBERS,
+      },
+    });
+  }
+
   private async requireLiveAuthor(userId: string | null): Promise<void> {
     if (userId === null) return;
     const live = await this.deps.repository.liveAuthors([userId]);

--- a/packages/nextly/src/domains/releases/services/releases-service.ts
+++ b/packages/nextly/src/domains/releases/services/releases-service.ts
@@ -767,10 +767,15 @@ export class ReleasesService {
     await this.authorizeDocumentAction(actor, input.scopeSlug, input.action);
     requireRunnableMember(input, actor);
 
-    // Claimed ATOMICALLY, and the author checked, before anything is written.
+    // BEFORE the claim, which is itself a write: `touchIfAssemblable` updates
+    // the release's `updatedAt`, so a refusal ordered after it would still have
+    // changed the row — and "refused before the write" would be false for the
+    // one path that says it loudest.
+    await this.assertRoomForOneMore(releaseId);
+
+    // Claimed ATOMICALLY, and the author checked, before the member is written.
     await this.claimAssemblable(releaseId, actor);
     await this.requireLiveAuthor(actor.userId);
-    await this.assertRoomForOneMore(releaseId);
 
     try {
       const member = await this.deps.repository.addMember({

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2124,6 +2124,19 @@ const RELEASE_ROUTES: ReleaseRoute[] = [
     operation: "update",
     method: "cancelRelease",
   },
+  // A READ, and deliberately its own route rather than a field on the detail.
+  // Answering it costs an identity lookup over every member, which the detail
+  // read must not pay to tell the overwhelming majority of callers that nothing
+  // is wrong — the state already said that. Asked instead at the moment
+  // somebody is about to commit to an instant.
+  {
+    id: true,
+    subresource: "blockers",
+    subId: false,
+    verb: "GET",
+    operation: "list",
+    method: "listReleaseBlockers",
+  },
 ];
 
 /**


### PR DESCRIPTION
Three of the four remaining R-6 items, in one PR rather than three. The fourth turned out to be already built.

## The lists move onto `DataTable`

Raised by the founder, and correct. `ReleaseList` and the detail's member list were the **last** list surfaces in the admin still hand-built from `Card` + `ul/li`; entries, media, api keys, webhooks and deliveries all use `DataTableView`. Building beside it cost releases column alignment, sorting, and the shared empty/loading states.

State leads the release row and action leads the member row, for the same reason: `publish`/`unpublish` and `scheduled`/`cancelled` are *opposite outcomes*, not one thing with a label, and a row opening with the title presents them as the same.

The list keeps its **own** empty state ahead of the table's generic one — a panel explaining what a release is and offering to create one beats "no rows" — pinned by a test, because a migration is exactly where that gets dropped unnoticed.

## A release has a size bound

Nothing stopped one growing without limit, and three things degrade together as it does: `listMembers` is unpaged and the detail renders all of it, the drain performs members one at a time inside a wall-clock budget, and a blocked release derives its reasons over every member on every read.

`MAX_RELEASE_MEMBERS = 1000` — well above anything assembled deliberately, and still catching what this is for: a script adding in a loop. Refused **before** the write, since a limit enforced afterwards needs compensating and a failed compensation leaves the release over its own bound. **Not an atomic invariant**, and the code says so rather than implying otherwise.

## What would stop this release, asked before committing

`GET /api/releases/:id/blockers` — its own route rather than a field on the detail, because answering costs an identity lookup over every member and the detail must not pay that to tell the overwhelming majority of callers that nothing is wrong.

It needs only **`read`**: the person assembling a release can add and remove the documents that cause a blocker, and should not need a publisher to be told which ones they are.

The schedule dialog asks while open and **names** the documents. The server already refuses a release whose members cannot run — what it cannot do in that refusal is say *which*, and "fix the documents blocking it" is not an instruction anybody can follow without the list. Submission is withheld while the answer is **unknown** as well as while it is bad.

## The fourth item was already built

The document-dependent add-time check exists: the route resolves the target through `resolveTarget` (refusing one that is missing or has no lifecycle) and the service then runs `authorizeDocumentAction`. Reported rather than reimplemented.

## A test of mine that could not fail

Worth stating because I caught it by breaking my own work. The preflight cases asserted the submit button was disabled — which it already was, because the dialog opens with no date typed. That state predates the mechanism entirely, so **breaking the preflight left all four green**.

They now fill in a valid instant first, and a control asserts a clean release *is* submittable. The same break then fails both third-state cases, which is what makes them evidence.

## Gates

Full pre-push hook, no bypass: lint 22/22, build 19/19, check-types 22/22, tests 10/10 — nextly **848 files**, admin **349 files**, zero failures. `fallow`: `pass`, 12 changed files, all `*_introduced` zero.

## Not in this PR

Keyset pagination. It is adapter-shaped — `NULLS LAST` is emulated in `adapter-drizzle` because MySQL rejects it, so the cursor predicate must be written per dialect and proven on all three integration legs — and folding it in here would make this PR two unrelated reviews.

@codex please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added release preflight checks that prevent scheduling while blocker checks are pending, fail, or identify blocking documents.
  - Blocked releases now display clear explanations and recommended remedies.
  - Added a release blockers view through the releases API.
  - Release and member listings now use consistent table layouts with improved responsive behavior.
  - Limited releases to 1,000 members and prevented additions beyond that limit.

- **Bug Fixes**
  - Improved error and empty-state handling across release and member listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->