### PR TITLE
feat(admin): give the email template editor the window

### DIFF
--- a/.changeset/the-email-editor-gets-the-window.md
+++ b/.changeset/the-email-editor-gets-the-window.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The email template editor now gets the window.
+
+Editing a template used to leave roughly half the screen to navigation: the
+settings menu stayed open beside a fixed panel of variables and settings, and
+the code and the preview shared what was left. On a 1280px screen that was
+316px each — too narrow to read a line of the template or to see the email at
+its real width.
+
+The settings menu now steps aside while you edit, and the two panes you are
+actually working in take the space, with a handle between them so you can give
+whichever one you need more room. Everything that addresses the mail — From,
+Reply-to, Subject and the preheader — sits together at the top instead of being
+split between the editor and a settings tab, and the variables you insert are
+beside the cursor rather than a panel away. Settings open over the preview when
+you want them and leave the code where it was.

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
@@ -3,6 +3,14 @@
 /**
  * Region 03 — the body being authored.
  *
+ * The editor FILLS its pane and scrolls inside it, with no minimum height. It
+ * previously carried a 380px floor, which the old layout paired with an outer
+ * `overflow-y-auto` so a short viewport scrolled the whole page. The shell gives
+ * each pane a definite height and clips it, so a floor taller than the pane
+ * makes the editor overflow a box that hides the overflow — and CodeMirror then
+ * measures a viewport larger than anything on screen, and will put the caret in
+ * the clipped part. Stacked on a laptop, that is the common case, not the edge.
+ *
  * Two editors behind one toggle, and the pair carries two invariants that are
  * easy to lose and have no visible symptom when lost:
  *
@@ -64,7 +72,7 @@ export function BodyEditor({
       {/* Editor body */}
       <div
         ref={editorWrapRef}
-        className="html-code-editor min-h-[380px] flex-1 overflow-auto bg-background xl:min-h-0"
+        className="html-code-editor min-h-0 flex-1 overflow-auto bg-background"
       >
         {editorTab === "html" ? (
           <FormField
@@ -78,7 +86,7 @@ export function BodyEditor({
             render={({ field }) => (
               <Suspense
                 fallback={
-                  <div className="min-h-[380px] w-full animate-pulse bg-muted/30" />
+                  <div className="h-full w-full animate-pulse bg-muted/30" />
                 }
               >
                 <CodeMirrorEditor
@@ -112,7 +120,7 @@ export function BodyEditor({
                 value={field.value ?? ""}
                 disabled={isPending}
                 placeholder="Plain-text fallback sent alongside the HTML…"
-                className="h-full min-h-[380px] w-full resize-none bg-background p-3.5 font-mono text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground xl:min-h-full"
+                className="h-full w-full resize-none bg-background p-3.5 font-mono text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground"
               />
             )}
           />

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+/**
+ * Region 03 — the body being authored.
+ *
+ * Two editors behind one toggle, and the pair carries two invariants that are
+ * easy to lose and have no visible symptom when lost:
+ *
+ * Each tab gets a DISTINCT `key`, so React mounts a fresh Controller per tab.
+ * Sharing one, whose `name` flips between `htmlContent` and `plainTextContent`,
+ * makes react-hook-form leak and then blank the values after a few toggles.
+ *
+ * Variable insertion targets whichever body is mounted — see
+ * `useVariableInsertion`, which owns that rule.
+ */
+import type { EditorView } from "@codemirror/view";
+import { Suspense, lazy } from "react";
+import type { useForm } from "react-hook-form";
+
+import { FormField } from "@admin/components/ui/form";
+
+import type { TemplateFormValues } from "./schema";
+import { Segmented } from "./Segmented";
+
+// CodeMirror reaches for browser globals on import, so it loads on demand
+// rather than during SSR.
+const CodeMirrorEditor = lazy(() =>
+  import(
+    "@admin/components/features/entries/fields/text/CodeMirrorEditor"
+  ).then(m => ({ default: m.CodeMirrorEditor }))
+);
+
+export function BodyEditor({
+  control,
+  editorTab,
+  onEditorTabChange,
+  isPending,
+  editorWrapRef,
+  htmlEditorViewRef,
+  chips,
+}: {
+  control: ReturnType<typeof useForm<TemplateFormValues>>["control"];
+  editorTab: "html" | "text";
+  onEditorTabChange: (tab: "html" | "text") => void;
+  isPending: boolean;
+  editorWrapRef: React.RefObject<HTMLDivElement | null>;
+  htmlEditorViewRef: React.RefObject<EditorView | null>;
+  /** The variable chips, rendered beside the tab toggle. */
+  chips?: React.ReactNode;
+}) {
+  return (
+    <>
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+        <Segmented<"html" | "text">
+          value={editorTab}
+          onChange={onEditorTabChange}
+          options={[
+            { value: "html", label: "HTML" },
+            { value: "text", label: "Plain text" },
+          ]}
+        />
+        {chips}
+      </div>
+      {/* Editor body */}
+      <div
+        ref={editorWrapRef}
+        className="html-code-editor min-h-[380px] flex-1 overflow-auto bg-background xl:min-h-0"
+      >
+        {editorTab === "html" ? (
+          <FormField
+            // Distinct key so React mounts a fresh Controller per tab.
+            // Without it, one Controller's `name` would flip between
+            // htmlContent/plainTextContent on toggle and react-hook-form
+            // leaks/blanks the values after repeated switches.
+            key="editor-html"
+            control={control}
+            name="htmlContent"
+            render={({ field }) => (
+              <Suspense
+                fallback={
+                  <div className="min-h-[380px] w-full animate-pulse bg-muted/30" />
+                }
+              >
+                <CodeMirrorEditor
+                  value={field.value ?? ""}
+                  onChange={val => {
+                    if (!isPending) field.onChange(val);
+                  }}
+                  onCreateEditor={view => {
+                    htmlEditorViewRef.current = view;
+                  }}
+                  language="html"
+                  disabled={isPending}
+                  readOnly={false}
+                  minHeight={380}
+                  editorOptions={{ tabSize: 2 }}
+                  placeholder={
+                    "<h1>Hello {{userName}}</h1>\n<p>Welcome to {{appName}}.</p>"
+                  }
+                />
+              </Suspense>
+            )}
+          />
+        ) : (
+          <FormField
+            key="editor-text"
+            control={control}
+            name="plainTextContent"
+            render={({ field }) => (
+              <textarea
+                {...field}
+                value={field.value ?? ""}
+                disabled={isPending}
+                placeholder="Plain-text fallback sent alongside the HTML…"
+                className="h-full min-h-[380px] w-full resize-none bg-background p-3.5 font-mono text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground xl:min-h-full"
+              />
+            )}
+          />
+        )}
+      </div>
+    </>
+  );
+}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/EditorBar.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/EditorBar.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+/**
+ * Region 01 — who this template is, and the acts that leave the page.
+ *
+ * The exit itself is NOT here: the shell renders it, because the shell derives
+ * its claim to hide the admin's navigation from having drawn a way back, and a
+ * claim made by whatever happens to be passed in as content is not a claim the
+ * resolver can trust.
+ */
+import { Badge, Button } from "@nextlyhq/ui";
+import type { useForm } from "react-hook-form";
+
+import { Loader2, Send, Settings } from "@admin/components/icons";
+import { FormField } from "@admin/components/ui/form";
+import { Link } from "@admin/components/ui/link";
+import { ROUTES } from "@admin/constants/routes";
+
+import type { TemplateFormValues } from "./schema";
+
+export function EditorBar({
+  control,
+  isEdit,
+  isPending,
+  isActive,
+  isDirty,
+  slug,
+  onNameChange,
+  onSendTest,
+  onOpenSettings,
+}: {
+  control: ReturnType<typeof useForm<TemplateFormValues>>["control"];
+  isEdit: boolean;
+  isPending: boolean;
+  isActive: boolean;
+  isDirty: boolean;
+  slug: string;
+  onNameChange: (value: string, onChange: (v: string) => void) => void;
+  onSendTest: () => void;
+  onOpenSettings: () => void;
+}) {
+  return (
+    <div className="flex w-full items-center gap-3">
+      <div className="min-w-0 flex-1">
+        <FormField
+          control={control}
+          name="name"
+          render={({ field }) => (
+            <input
+              {...field}
+              onChange={e => onNameChange(e.target.value, field.onChange)}
+              disabled={isPending}
+              placeholder="Untitled template"
+              aria-label="Template name"
+              className="w-full max-w-md truncate bg-transparent text-lg font-semibold text-foreground outline-none placeholder:text-muted-foreground"
+            />
+          )}
+        />
+        <div className="font-mono text-xs text-muted-foreground">
+          {slug || "no-slug"}
+        </div>
+      </div>
+
+      <Badge variant={isActive ? "default" : "outline"} className="shrink-0">
+        {isActive ? "Active" : "Inactive"}
+      </Badge>
+      {isDirty ? (
+        <span
+          className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning"
+          title="Unsaved changes"
+          aria-label="Unsaved changes"
+        />
+      ) : null}
+
+      <Button
+        type="button"
+        variant="outline"
+        onClick={onOpenSettings}
+        disabled={isPending}
+      >
+        <Settings className="h-4 w-4" />
+        Settings
+      </Button>
+      {isEdit && (
+        <Button
+          type="button"
+          variant="outline"
+          disabled={isPending}
+          onClick={onSendTest}
+        >
+          <Send className="h-4 w-4" />
+          Send test
+        </Button>
+      )}
+      <Link href={ROUTES.SETTINGS_EMAIL_TEMPLATES}>
+        <Button type="button" variant="outline" disabled={isPending}>
+          Cancel
+        </Button>
+      </Link>
+      <Button type="submit" disabled={isPending}>
+        {isPending ? (
+          <>
+            <Loader2 className="h-4 w-4 animate-spin" />
+            {isEdit ? "Saving…" : "Creating…"}
+          </>
+        ) : isEdit ? (
+          "Save"
+        ) : (
+          "Create template"
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/EmailTemplateForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/EmailTemplateForm.tsx
@@ -2,44 +2,22 @@
 
 import { type EditorView } from "@codemirror/view";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Badge, Button } from "@nextlyhq/ui";
-import {
-  lazy,
-  Suspense,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useForm, type Resolver, type SubmitHandler } from "react-hook-form";
 
-import {
-  ArrowLeft,
-  Braces,
-  Code,
-  Loader2,
-  PanelLeftClose,
-  PanelLeftOpen,
-  Send,
-  Settings,
-} from "@admin/components/icons";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from "@admin/components/ui/form";
-import { Link } from "@admin/components/ui/link";
+import { ImmersiveShell } from "@admin/components/layout/immersive-shell";
+import { Form } from "@admin/components/ui/form";
 import { ROUTES } from "@admin/constants/routes";
 import { useEmailProviders } from "@admin/hooks/queries/useEmailProviders";
 import { useEmailTemplates } from "@admin/hooks/queries/useEmailTemplates";
+import { useMediaQuery } from "@admin/hooks/useMediaQuery";
 import { generateSlug } from "@admin/lib/fields";
-import { cn } from "@admin/lib/utils";
+import { navigateTo } from "@admin/lib/navigation";
 import { type EmailTemplateRecord } from "@admin/services/emailTemplateApi";
 
-import { DataRail } from "./DataRail";
+import { BodyEditor } from "./BodyEditor";
+import { EditorBar } from "./EditorBar";
+import { EnvelopeBar } from "./EnvelopeBar";
 import {
   DEFAULT_VALUES,
   EMAIL_TEMPLATE_FORM_ID,
@@ -47,27 +25,17 @@ import {
   templateToFormValues,
   type TemplateFormValues,
 } from "./schema";
-import { Segmented, type SegOption } from "./Segmented";
 import { SendTestDialog } from "./SendTestDialog";
-import { SettingsRail } from "./SettingsRail";
+import { TemplateDrawer } from "./TemplateDrawer";
+import { TemplateInspector } from "./TemplateInspector";
 import { PreviewPane } from "./TemplatePreview";
 import { useDerivedTemplateState } from "./useDerivedTemplateState";
 import { useVariableInsertion } from "./useVariableInsertion";
-import { VariablesRail } from "./VariablesRail";
-
-// CodeMirror reaches for browser globals on import, so it loads on demand
-// rather than during SSR.
-const CodeMirrorEditor = lazy(() =>
-  import(
-    "@admin/components/features/entries/fields/text/CodeMirrorEditor"
-  ).then(m => ({ default: m.CodeMirrorEditor }))
-);
+import { VariableChips } from "./VariablesRail";
 
 // ============================================================
 // EmailTemplateForm — three-pane workbench
 // ============================================================
-
-type RailTab = "variables" | "data" | "settings";
 
 export interface EmailTemplateFormProps {
   mode: "create" | "edit";
@@ -89,9 +57,16 @@ export function EmailTemplateForm({
   const editorWrapRef = useRef<HTMLDivElement>(null);
   const htmlEditorViewRef = useRef<EditorView | null>(null);
 
-  const [railTab, setRailTab] = useState<RailTab>("variables");
-  const [railOpen, setRailOpen] = useState(true);
   const [editorTab, setEditorTab] = useState<"html" | "text">("html");
+  const [inspectorOpen, setInspectorOpen] = useState(false);
+  const [drawerOpen, setDrawerOpen] = useState(false);
+
+  /*
+   * Below this the two panes stack. `xl` is where the previous grid switched to
+   * columns, and it is the width at which a 600px email and a code column stop
+   * both fitting.
+   */
+  const isNarrow = !useMediaQuery("(min-width: 1280px)");
   const [sampleOverride, setSampleOverride] = useState<string | null>(null);
   const [sendTestOpen, setSendTestOpen] = useState(false);
 
@@ -184,19 +159,6 @@ export function EmailTemplateForm({
     activeLayout,
     isLayoutRow,
   });
-  const railTabs: SegOption<RailTab>[] = [
-    {
-      value: "variables",
-      icon: <Braces className="h-3.5 w-3.5" />,
-      label: "Variables",
-    },
-    { value: "data", icon: <Code className="h-3.5 w-3.5" />, label: "Data" },
-    {
-      value: "settings",
-      icon: <Settings className="h-3.5 w-3.5" />,
-      label: "Settings",
-    },
-  ];
 
   return (
     <Form {...form}>
@@ -205,84 +167,100 @@ export function EmailTemplateForm({
         onSubmit={e => {
           void form.handleSubmit(onSubmit)(e);
         }}
-        className="flex h-full min-h-0 flex-col bg-background"
+        className="h-full min-h-0"
         aria-busy={isPending}
       >
-        {/* ── Top bar ─────────────────────────────────────────── */}
-        <header className="flex shrink-0 items-center gap-3 border-b border-border px-4 py-2.5">
-          <Link
-            href={ROUTES.SETTINGS_EMAIL_TEMPLATES}
-            className="flex h-8 w-8 items-center justify-center rounded-md border border-input text-muted-foreground transition-colors hover:text-foreground"
-            aria-label="Back to templates"
-          >
-            <ArrowLeft className="h-4 w-4" />
-          </Link>
-
-          <div className="min-w-0 flex-1">
-            <FormField
+        <ImmersiveShell
+          /*
+           * `subSidebar` is the settings navigation, which is 256px of
+           * destinations an author mid-template is not going to. `pageFrame` is
+           * the container's padding, which a full-bleed editor reads as a
+           * mistake rather than as a margin. The primary rail STAYS: hiding the
+           * whole of the admin's navigation is a bigger claim than this screen
+           * needs, and the founder asked for the settings sidebar specifically.
+           */
+          suppress={["subSidebar", "pageFrame"]}
+          onExit={() => navigateTo(ROUTES.SETTINGS_EMAIL_TEMPLATES)}
+          exitLabel="Back to templates"
+          splitLabel="Editor and preview"
+          /*
+           * Side by side on a phone gives two columns too narrow to author in
+           * or to judge from, so the panes stack. The breakpoint lives here
+           * rather than in the shell because only this screen knows what its
+           * own panes cost at a width.
+           */
+          orientation={isNarrow ? "vertical" : "horizontal"}
+          bar={
+            <EditorBar
               control={form.control}
-              name="name"
-              render={({ field }) => (
-                <input
-                  {...field}
-                  onChange={e =>
-                    handleNameChange(e.target.value, field.onChange)
-                  }
-                  disabled={isPending}
-                  placeholder="Untitled template"
-                  aria-label="Template name"
-                  className="w-full max-w-md truncate bg-transparent text-lg font-semibold text-foreground outline-none placeholder:text-muted-foreground"
+              isEdit={isEdit}
+              isPending={isPending}
+              isActive={isActive}
+              isDirty={isDirty}
+              slug={slug}
+              onNameChange={handleNameChange}
+              onSendTest={() => setSendTestOpen(true)}
+              onOpenSettings={() => setInspectorOpen(true)}
+            />
+          }
+          band={
+            <EnvelopeBar
+              control={form.control}
+              isPending={isPending}
+              isLayoutRow={isLayoutRow}
+            />
+          }
+          primary={
+            <BodyEditor
+              control={form.control}
+              editorTab={editorTab}
+              onEditorTabChange={setEditorTab}
+              isPending={isPending}
+              editorWrapRef={editorWrapRef}
+              htmlEditorViewRef={htmlEditorViewRef}
+              chips={
+                <VariableChips
+                  declared={variables ?? []}
+                  onInsert={insertVariable}
                 />
-              )}
+              }
             />
-            <div className="font-mono text-xs text-muted-foreground">
-              {slug || "no-slug"}
-            </div>
-          </div>
-
-          <Badge
-            variant={isActive ? "default" : "outline"}
-            className="shrink-0"
-          >
-            {isActive ? "Active" : "Inactive"}
-          </Badge>
-          {isDirty ? (
-            <span
-              className="h-1.5 w-1.5 shrink-0 rounded-full bg-warning"
-              title="Unsaved changes"
-              aria-label="Unsaved changes"
+          }
+          secondary={
+            <PreviewPane
+              html={previewHtml}
+              text={previewText}
+              subject={previewSubject}
+              format={editorTab}
             />
-          ) : null}
-
-          {isEdit && (
-            <Button
-              type="button"
-              variant="outline"
-              disabled={isPending}
-              onClick={() => setSendTestOpen(true)}
-            >
-              <Send className="h-4 w-4" />
-              Send test
-            </Button>
-          )}
-          <Link href={ROUTES.SETTINGS_EMAIL_TEMPLATES}>
-            <Button type="button" variant="outline" disabled={isPending}>
-              Cancel
-            </Button>
-          </Link>
-          <Button type="submit" disabled={isPending}>
-            {isPending ? (
-              <>
-                <Loader2 className="h-4 w-4 animate-spin" />
-                {isEdit ? "Saving…" : "Creating…"}
-              </>
-            ) : isEdit ? (
-              "Save"
-            ) : (
-              "Create template"
-            )}
-          </Button>
-        </header>
+          }
+          inspector={
+            inspectorOpen ? (
+              <TemplateInspector
+                control={form.control}
+                isEdit={isEdit}
+                isPending={isPending}
+                isLayoutRow={isLayoutRow}
+                providers={providers}
+                layouts={layouts}
+                declared={variables ?? []}
+                onInsert={insertVariable}
+                onClose={() => setInspectorOpen(false)}
+              />
+            ) : undefined
+          }
+          drawer={
+            <TemplateDrawer
+              open={drawerOpen}
+              onOpenChange={setDrawerOpen}
+              sampleText={sampleText}
+              onSampleChange={setSampleOverride}
+              onReset={() => setSampleOverride(null)}
+              sampleError={sampleError}
+              unknownVariables={unknownVariables}
+            />
+          }
+        />
 
         {isEdit && (
           <SendTestDialog
@@ -293,222 +271,6 @@ export function EmailTemplateForm({
             sampleData={sampleData}
           />
         )}
-
-        {/* ── Body: three panes (fixed rail + two equal panes) ── */}
-        {/*
-         * `auto-rows-min` is what makes the stacked layout scroll instead of
-         * overlap, and it is load-bearing below `xl`.
-         *
-         * Stacked, the panes are rows of a grid whose own height is definite
-         * (`flex-1` inside a fixed-height column). Default `auto` rows in a
-         * definite-height grid are STRETCHED to fill it, so three rows share
-         * the height and each lands near 250px — while the editor and preview
-         * carry `min-h-[380px]` and `min-h-[420px]` floors. A row shorter than
-         * its content would normally scroll, but each pane also carries
-         * `min-h-0` and its overflow is only hidden at `xl`, so the content
-         * spilled out of its own row and drew on top of the pane below it.
-         *
-         * Sizing the rows to their content instead lets `overflow-y-auto` on
-         * this container do the scrolling, which is what it was there for.
-         *
-         * Reset at `xl`, where the panes become side-by-side columns that must
-         * FILL the viewport height rather than shrink to their content —
-         * `min-content` there leaves a dead band below them.
-         */}
-        <div
-          className={cn(
-            "grid min-h-0 flex-1 auto-rows-min grid-cols-1 overflow-y-auto xl:auto-rows-auto xl:overflow-hidden",
-            railOpen ? "xl:grid-cols-[320px_1fr_1fr]" : "xl:grid-cols-[1fr_1fr]"
-          )}
-        >
-          {/* Left rail */}
-          <aside
-            className={cn(
-              "flex min-h-0 min-w-0 flex-col border-b border-border xl:border-b-0 xl:border-r xl:overflow-hidden",
-              !railOpen && "hidden"
-            )}
-          >
-            <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border p-2">
-              <Segmented<RailTab>
-                value={railTab}
-                onChange={setRailTab}
-                options={railTabs}
-              />
-              <button
-                type="button"
-                onClick={() => setRailOpen(false)}
-                aria-label="Hide panel"
-                title="Hide panel"
-                className="flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground"
-              >
-                <PanelLeftClose className="h-4 w-4" />
-              </button>
-            </div>
-            <div className="min-h-0 flex-1 overflow-y-auto p-4">
-              {railTab === "variables" && (
-                <VariablesRail
-                  control={form.control}
-                  declared={variables ?? []}
-                  onInsert={insertVariable}
-                />
-              )}
-              {railTab === "data" && (
-                <DataRail
-                  sampleText={sampleText}
-                  onSampleChange={setSampleOverride}
-                  onReset={() => setSampleOverride(null)}
-                  sampleError={sampleError}
-                  unknownVariables={unknownVariables}
-                />
-              )}
-              {railTab === "settings" && (
-                <SettingsRail
-                  control={form.control}
-                  isEdit={isEdit}
-                  isPending={isPending}
-                  isLayoutRow={isLayoutRow}
-                  providers={providers}
-                  layouts={layouts}
-                />
-              )}
-            </div>
-          </aside>
-
-          {/* Center: envelope + editor */}
-          <section className="flex min-h-0 min-w-0 flex-col border-b border-border xl:border-b-0 xl:border-r xl:overflow-hidden">
-            {/* Envelope */}
-            <div className="shrink-0 border-b border-border p-3">
-              <FormField
-                control={form.control}
-                name="subject"
-                render={({ field }) => (
-                  <FormItem className="space-y-1">
-                    <div className="flex items-center gap-2">
-                      <span className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                        Subject
-                      </span>
-                      <FormControl>
-                        <input
-                          {...field}
-                          disabled={isPending}
-                          placeholder="Welcome to {{appName}}"
-                          className="w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
-                        />
-                      </FormControl>
-                    </div>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-
-            {/* Editor toolbar */}
-            <div className="flex shrink-0 items-center gap-2 border-b border-border px-3 py-2">
-              {!railOpen ? (
-                <button
-                  type="button"
-                  onClick={() => setRailOpen(true)}
-                  aria-label="Show panel"
-                  title="Show panel"
-                  className="flex h-7 w-7 items-center justify-center rounded-md border border-input text-muted-foreground transition-colors hover:text-foreground"
-                >
-                  <PanelLeftOpen className="h-4 w-4" />
-                </button>
-              ) : null}
-              <Segmented<"html" | "text">
-                value={editorTab}
-                onChange={setEditorTab}
-                options={[
-                  { value: "html", label: "HTML" },
-                  { value: "text", label: "Plain text" },
-                ]}
-              />
-              {unknownVariables.length > 0 ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setRailOpen(true);
-                    setRailTab("data");
-                  }}
-                  className="ml-auto text-xs text-warning hover:underline"
-                >
-                  {unknownVariables.length} unknown variable
-                  {unknownVariables.length === 1 ? "" : "s"}
-                </button>
-              ) : null}
-            </div>
-
-            {/* Editor body */}
-            <div
-              ref={editorWrapRef}
-              className="html-code-editor min-h-[380px] flex-1 overflow-auto bg-background xl:min-h-0"
-            >
-              {editorTab === "html" ? (
-                <FormField
-                  // Distinct key so React mounts a fresh Controller per tab.
-                  // Without it, one Controller's `name` would flip between
-                  // htmlContent/plainTextContent on toggle and react-hook-form
-                  // leaks/blanks the values after repeated switches.
-                  key="editor-html"
-                  control={form.control}
-                  name="htmlContent"
-                  render={({ field }) => (
-                    <Suspense
-                      fallback={
-                        <div className="min-h-[380px] w-full animate-pulse bg-muted/30" />
-                      }
-                    >
-                      <CodeMirrorEditor
-                        value={field.value ?? ""}
-                        onChange={val => {
-                          if (!isPending) field.onChange(val);
-                        }}
-                        onCreateEditor={view => {
-                          htmlEditorViewRef.current = view;
-                        }}
-                        language="html"
-                        disabled={isPending}
-                        readOnly={false}
-                        minHeight={380}
-                        editorOptions={{ tabSize: 2 }}
-                        placeholder={
-                          "<h1>Hello {{userName}}</h1>\n<p>Welcome to {{appName}}.</p>"
-                        }
-                      />
-                    </Suspense>
-                  )}
-                />
-              ) : (
-                <FormField
-                  key="editor-text"
-                  control={form.control}
-                  name="plainTextContent"
-                  render={({ field }) => (
-                    <textarea
-                      {...field}
-                      value={field.value ?? ""}
-                      disabled={isPending}
-                      placeholder="Plain-text fallback sent alongside the HTML…"
-                      className="h-full min-h-[380px] w-full resize-none bg-background p-3.5 font-mono text-sm leading-relaxed text-foreground outline-none placeholder:text-muted-foreground xl:min-h-full"
-                    />
-                  )}
-                />
-              )}
-            </div>
-          </section>
-
-          {/* Right: preview */}
-          <section className="flex min-h-0 min-w-0 flex-col xl:overflow-hidden">
-            <div className="min-h-[420px] flex-1 xl:min-h-0">
-              <PreviewPane
-                html={previewHtml}
-                text={previewText}
-                subject={previewSubject}
-                format={editorTab}
-              />
-            </div>
-          </section>
-        </div>
       </form>
     </Form>
   );

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/EmailTemplateForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/EmailTemplateForm.tsx
@@ -21,7 +21,7 @@ import { EnvelopeBar } from "./EnvelopeBar";
 import {
   DEFAULT_VALUES,
   EMAIL_TEMPLATE_FORM_ID,
-  templateSchema,
+  templateSchemaFor,
   templateToFormValues,
   type TemplateFormValues,
 } from "./schema";
@@ -70,9 +70,13 @@ export function EmailTemplateForm({
   const [sampleOverride, setSampleOverride] = useState<string | null>(null);
   const [sendTestOpen, setSendTestOpen] = useState(false);
 
+  // The row being edited keeps its kind; layouts are wrappers, not bodies.
+  const currentKind = template?.kind ?? "template";
+  const isLayoutRow = currentKind === "layout";
+
   const form = useForm<TemplateFormValues>({
     resolver: zodResolver(
-      templateSchema
+      templateSchemaFor(isLayoutRow)
     ) as unknown as Resolver<TemplateFormValues>,
     defaultValues:
       initialValues ??
@@ -84,10 +88,6 @@ export function EmailTemplateForm({
     { staleTime: 60_000 }
   );
   const providers = providersData?.data ?? [];
-
-  // The row being edited keeps its kind; layouts are wrappers, not bodies.
-  const currentKind = template?.kind ?? "template";
-  const isLayoutRow = currentKind === "layout";
 
   const { data: allTemplates } = useEmailTemplates();
   const layouts = useMemo(
@@ -172,12 +172,12 @@ export function EmailTemplateForm({
       >
         <ImmersiveShell
           /*
-           * `subSidebar` is the settings navigation, which is 256px of
-           * destinations an author mid-template is not going to. `pageFrame` is
-           * the container's padding, which a full-bleed editor reads as a
-           * mistake rather than as a margin. The primary rail STAYS: hiding the
-           * whole of the admin's navigation is a bigger claim than this screen
-           * needs, and the founder asked for the settings sidebar specifically.
+           * `subSidebar` is the settings navigation — 256px of destinations
+           * nobody editing a template is heading to. `pageFrame` is the
+           * container's padding, which a full-bleed surface reads as a mistake
+           * rather than as a margin. The primary rail STAYS: it is the whole of
+           * the admin's navigation, and taking it is a larger claim than a
+           * width problem justifies.
            */
           suppress={["subSidebar", "pageFrame"]}
           onExit={() => navigateTo(ROUTES.SETTINGS_EMAIL_TEMPLATES)}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/EnvelopeBar.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/EnvelopeBar.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+/**
+ * Everything that ADDRESSES the mail, in one strip.
+ *
+ * From, Reply-to, Subject and Preheader answer one question — who receives
+ * this and what do they see before opening it — and they were split across two
+ * places: Subject sat above the editor while the other three were three clicks
+ * away behind a Settings tab. An author writing a subject line and an author
+ * setting the preheader are the same person in the same moment, and the
+ * preheader is literally the text that follows the subject in an inbox.
+ *
+ * Kept as a band above the panes rather than inside the inspector because all
+ * four change what the preview renders, and a field whose effect is visible
+ * belongs where its effect is.
+ *
+ * A LAYOUT row addresses nothing — it is a wrapper other templates are poured
+ * into — so it gets the `{{content}}` guidance in this space instead.
+ */
+import { Input } from "@nextlyhq/ui";
+import type { useForm } from "react-hook-form";
+
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@admin/components/ui/form";
+
+import type { TemplateFormValues } from "./schema";
+
+/** One labelled field in the strip, laid out inline so the band stays shallow. */
+function EnvelopeField({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex min-w-0 flex-1 items-baseline gap-2">
+      <label
+        htmlFor={htmlFor}
+        className="shrink-0 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+      >
+        {label}
+      </label>
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
+  );
+}
+
+export function EnvelopeBar({
+  control,
+  isPending,
+  isLayoutRow,
+}: {
+  control: ReturnType<typeof useForm<TemplateFormValues>>["control"];
+  isPending: boolean;
+  isLayoutRow: boolean;
+}) {
+  if (isLayoutRow) {
+    return (
+      <div className="border-b border-border bg-muted/40 px-4 py-2.5">
+        <p className="text-xs text-muted-foreground">
+          This is a layout. Place{" "}
+          <code className="font-mono text-foreground">{"{{content}}"}</code>{" "}
+          where each email body should be injected.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2 border-b border-border px-4 py-2.5">
+      <FormField
+        control={control}
+        name="subject"
+        render={({ field }) => (
+          <FormItem className="space-y-1">
+            <EnvelopeField label="Subject" htmlFor="envelope-subject">
+              <FormControl>
+                <input
+                  {...field}
+                  id="envelope-subject"
+                  disabled={isPending}
+                  placeholder="Welcome to {{appName}}"
+                  className="w-full bg-transparent text-sm font-medium text-foreground outline-none placeholder:text-muted-foreground"
+                />
+              </FormControl>
+            </EnvelopeField>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      {/* The inbox preview line — the text that follows the subject, which is
+          why it sits under it rather than in a settings panel. */}
+      <FormField
+        control={control}
+        name="preheader"
+        render={({ field }) => (
+          <FormItem className="space-y-1">
+            <EnvelopeField label="Preheader" htmlFor="envelope-preheader">
+              <FormControl>
+                <input
+                  {...field}
+                  id="envelope-preheader"
+                  disabled={isPending}
+                  placeholder="Preview line shown after the subject"
+                  className="w-full bg-transparent text-sm text-muted-foreground outline-none placeholder:text-muted-foreground"
+                />
+              </FormControl>
+            </EnvelopeField>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2 border-t border-border pt-2">
+        <FormField
+          control={control}
+          name="fromOverride"
+          render={({ field }) => (
+            <FormItem className="min-w-0 flex-1 space-y-1">
+              <EnvelopeField label="From" htmlFor="envelope-from">
+                <FormControl>
+                  <Input
+                    {...field}
+                    id="envelope-from"
+                    disabled={isPending}
+                    placeholder="Provider default"
+                    className="h-7 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
+                  />
+                </FormControl>
+              </EnvelopeField>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={control}
+          name="replyTo"
+          render={({ field }) => (
+            <FormItem className="min-w-0 flex-1 space-y-1">
+              <EnvelopeField label="Reply-to" htmlFor="envelope-reply-to">
+                <FormControl>
+                  <Input
+                    {...field}
+                    id="envelope-reply-to"
+                    disabled={isPending}
+                    placeholder="replies@example.com"
+                    className="h-7 border-0 bg-transparent px-0 text-sm shadow-none focus-visible:ring-0"
+                  />
+                </FormControl>
+              </EnvelopeField>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/SettingsRail.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/SettingsRail.tsx
@@ -128,6 +128,22 @@ function AttachmentsField({
   );
 }
 
+/**
+ * What the settings surface needs, named once.
+ *
+ * The inspector wraps this rail and takes the same six values, so a second
+ * spelling of the shape is a second thing to keep in step — and the two drift
+ * silently, because both compile.
+ */
+export interface TemplateSettingsProps {
+  control: ReturnType<typeof useForm<TemplateFormValues>>["control"];
+  isEdit: boolean;
+  isPending: boolean;
+  isLayoutRow: boolean;
+  providers: { id: string; name: string; isDefault?: boolean }[];
+  layouts: { id: string; name: string; slug: string }[];
+}
+
 export function SettingsRail({
   control,
   isEdit,
@@ -135,14 +151,7 @@ export function SettingsRail({
   isLayoutRow,
   providers,
   layouts,
-}: {
-  control: ReturnType<typeof useForm<TemplateFormValues>>["control"];
-  isEdit: boolean;
-  isPending: boolean;
-  isLayoutRow: boolean;
-  providers: { id: string; name: string; isDefault?: boolean }[];
-  layouts: { id: string; name: string; slug: string }[];
-}) {
+}: TemplateSettingsProps) {
   return (
     <div className="space-y-5">
       {isLayoutRow && (
@@ -181,32 +190,6 @@ export function SettingsRail({
       {!isLayoutRow && (
         <FormField
           control={control}
-          name="preheader"
-          render={({ field }) => (
-            <FormItem className="space-y-1.5">
-              <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Preheader
-              </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="Preview line shown after the subject"
-                  className="h-8 text-sm"
-                  disabled={isPending}
-                  {...field}
-                />
-              </FormControl>
-              <p className="text-xs text-muted-foreground">
-                The inbox preview snippet. Supports {"{{variables}}"}.
-              </p>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      )}
-
-      {!isLayoutRow && (
-        <FormField
-          control={control}
           name="providerId"
           render={({ field }) => (
             <FormItem className="space-y-1.5">
@@ -240,55 +223,6 @@ export function SettingsRail({
               <p className="text-xs text-muted-foreground">
                 Override the default sending provider for this template.
               </p>
-            </FormItem>
-          )}
-        />
-      )}
-
-      {!isLayoutRow && (
-        <FormField
-          control={control}
-          name="fromOverride"
-          render={({ field }) => (
-            <FormItem className="space-y-1.5">
-              <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                From override
-              </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="Support &lt;help@example.com&gt;"
-                  className="h-8 text-sm"
-                  disabled={isPending}
-                  {...field}
-                />
-              </FormControl>
-              <p className="text-xs text-muted-foreground">
-                Leave blank to use the provider&apos;s From address.
-              </p>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-      )}
-
-      {!isLayoutRow && (
-        <FormField
-          control={control}
-          name="replyTo"
-          render={({ field }) => (
-            <FormItem className="space-y-1.5">
-              <FormLabel className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
-                Reply-To
-              </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="replies@example.com"
-                  className="h-8 text-sm"
-                  disabled={isPending}
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
             </FormItem>
           )}
         />

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/TemplateDrawer.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/TemplateDrawer.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Region 06 — instruments, not settings.
+ *
+ * Sample data is not configuration: it is never saved with the template and
+ * exists only to exercise the preview. Grouping it with the delivery settings,
+ * as the old rail did, put a throwaway JSON blob beside the provider a real
+ * message will be sent through.
+ *
+ * Collapsed it costs one strip, so the panes keep the height. Open, the JSON
+ * gets the full width of the editor rather than a 320px column — which is what
+ * a nested object needed and never had.
+ */
+import { Button } from "@nextlyhq/ui";
+
+import { ChevronDown, ChevronUp } from "@admin/components/icons";
+import { cn } from "@admin/lib/utils";
+
+import { DataRail } from "./DataRail";
+
+export function TemplateDrawer({
+  open,
+  onOpenChange,
+  sampleText,
+  onSampleChange,
+  onReset,
+  sampleError,
+  unknownVariables,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sampleText: string;
+  onSampleChange: (v: string) => void;
+  onReset: () => void;
+  sampleError: string | null;
+  unknownVariables: string[];
+}) {
+  return (
+    <div className={cn("flex flex-col", open && "max-h-[45vh]")}>
+      <div className="flex shrink-0 items-center gap-3 px-4 py-1.5">
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1.5 px-2 text-xs"
+          onClick={() => onOpenChange(!open)}
+          aria-expanded={open}
+        >
+          {open ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronUp className="h-3.5 w-3.5" />
+          )}
+          Sample data
+        </Button>
+        {unknownVariables.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => onOpenChange(true)}
+            className="text-xs text-warning hover:underline"
+          >
+            {unknownVariables.length} unknown variable
+            {unknownVariables.length === 1 ? "" : "s"}
+          </button>
+        ) : null}
+        {sampleError ? (
+          <span className="text-xs text-destructive">Invalid JSON</span>
+        ) : null}
+      </div>
+      {open ? (
+        <div className="min-h-0 flex-1 overflow-y-auto border-t border-border p-4">
+          <DataRail
+            sampleText={sampleText}
+            onSampleChange={onSampleChange}
+            onReset={onReset}
+            sampleError={sampleError}
+            unknownVariables={unknownVariables}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/TemplateInspector.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/TemplateInspector.tsx
@@ -37,7 +37,10 @@ export function TemplateInspector({
   onClose: () => void;
 }) {
   return (
-    <div className="flex h-full w-[360px] max-w-[85vw] flex-col">
+    // Bounded by the PANE, not by the viewport: the splitter allows the preview
+    // down to 25% — around 300px at 1280 — and the shell clips the pane, so a
+    // viewport-relative maximum lets the inspector's left edge disappear.
+    <div className="flex h-full w-[360px] max-w-full flex-col">
       <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-4 py-2.5">
         <h2 className="text-sm font-semibold text-foreground">Settings</h2>
         <Button

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/TemplateInspector.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/TemplateInspector.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+/**
+ * Region 05 — configuration that is not the content.
+ *
+ * Summoned rather than resident. The rail it replaces was a permanent 320px
+ * column holding three unrelated things, which is why nine controls competed
+ * for the space and the layout picker was hard to find; here the same controls
+ * get the full height of the pane and are grouped by the question they answer.
+ *
+ * Variables live here rather than in the drawer because DECLARING one is
+ * configuration — it is a statement about what this template expects — while
+ * the sample values that exercise them are an instrument, and those are in the
+ * drawer.
+ */
+import { Button } from "@nextlyhq/ui";
+
+import { X } from "@admin/components/icons";
+
+import type { TemplateFormVariable } from "./schema";
+import { SettingsRail, type TemplateSettingsProps } from "./SettingsRail";
+import { VariablesRail } from "./VariablesRail";
+
+export function TemplateInspector({
+  control,
+  isEdit,
+  isPending,
+  isLayoutRow,
+  providers,
+  layouts,
+  declared,
+  onInsert,
+  onClose,
+}: TemplateSettingsProps & {
+  declared: TemplateFormVariable[];
+  onInsert: (name: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="flex h-full w-[360px] max-w-[85vw] flex-col">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border px-4 py-2.5">
+        <h2 className="text-sm font-semibold text-foreground">Settings</h2>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={onClose}
+          aria-label="Close settings"
+        >
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <div className="min-h-0 flex-1 space-y-6 overflow-y-auto p-4">
+        <SettingsRail
+          control={control}
+          isEdit={isEdit}
+          isPending={isPending}
+          isLayoutRow={isLayoutRow}
+          providers={providers}
+          layouts={layouts}
+        />
+        {!isLayoutRow && (
+          <VariablesRail
+            control={control}
+            declared={declared}
+            onInsert={onInsert}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/VariablesRail.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/VariablesRail.tsx
@@ -41,6 +41,38 @@ function VariableChip({
   );
 }
 
+/**
+ * The insertable variables, as a strip for the editor's toolbar.
+ *
+ * Beside the caret rather than a column away: inserting a variable is something
+ * done WHILE typing, and the previous placement made it a trip to a rail and
+ * back. Declaring and describing variables is a different act and stays in the
+ * inspector.
+ */
+export function VariableChips({
+  declared,
+  onInsert,
+}: {
+  declared: TemplateFormVariable[];
+  onInsert: (name: string) => void;
+}) {
+  const builtInNames = new Set(BUILT_IN_VARIABLES.map(v => v.name));
+  const declaredNames = declared
+    .map(v => v.name)
+    .filter(n => n && !builtInNames.has(n));
+
+  return (
+    <div className="flex flex-wrap items-center gap-1.5">
+      {BUILT_IN_VARIABLES.map(v => (
+        <VariableChip key={v.name} name={v.name} onInsert={onInsert} />
+      ))}
+      {declaredNames.map(n => (
+        <VariableChip key={n} name={n} onInsert={onInsert} />
+      ))}
+    </div>
+  );
+}
+
 export function VariablesRail({
   control,
   declared,
@@ -54,11 +86,6 @@ export function VariablesRail({
     control,
     name: "variables",
   });
-  const builtInNames = new Set(BUILT_IN_VARIABLES.map(v => v.name));
-  const declaredNames = declared
-    .map(v => v.name)
-    .filter(n => n && !builtInNames.has(n));
-
   return (
     <div className="space-y-5">
       <div>
@@ -69,14 +96,7 @@ export function VariablesRail({
           Click to insert at the cursor. Built-in variables are always
           available.
         </p>
-        <div className="flex flex-wrap gap-1.5">
-          {BUILT_IN_VARIABLES.map(v => (
-            <VariableChip key={v.name} name={v.name} onInsert={onInsert} />
-          ))}
-          {declaredNames.map(n => (
-            <VariableChip key={n} name={n} onInsert={onInsert} />
-          ))}
-        </div>
+        <VariableChips declared={declared} onInsert={onInsert} />
       </div>
 
       <div>

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/template-schema.test.ts
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/template-schema.test.ts
@@ -1,0 +1,47 @@
+/**
+ * A layout row has no subject, and the shipped default layout is seeded with an
+ * empty one (`domains/email/services/templates/default-layout.ts`).
+ *
+ * Requiring a subject of every row therefore made that layout unsaveable — and
+ * silently, because the layout editor renders no subject field for the message
+ * to attach to. The rule has to know which kind it is validating.
+ */
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_VALUES, templateSchemaFor } from "../schema";
+
+/** A row that is valid apart from the field under test. */
+const base = {
+  ...DEFAULT_VALUES,
+  name: "Default Layout",
+  slug: "default-layout",
+  htmlContent: "<html>{{content}}</html>",
+};
+
+describe("templateSchemaFor", () => {
+  it("accepts a layout row with the empty subject it is seeded with", () => {
+    const result = templateSchemaFor(true).safeParse({ ...base, subject: "" });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("still requires a subject of a message, which is the point of the rule", () => {
+    // The control. Without it, a schema that dropped the requirement entirely
+    // would pass the test above just as well.
+    const result = templateSchemaFor(false).safeParse({ ...base, subject: "" });
+
+    expect(result.success).toBe(false);
+    expect(
+      result.success ? [] : result.error.issues.map(i => i.message)
+    ).toContain("Email subject is required");
+  });
+
+  it("still caps a layout's subject, rather than dropping the field's rules", () => {
+    const result = templateSchemaFor(true).safeParse({
+      ...base,
+      subject: "x".repeat(501),
+    });
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/schema.ts
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/schema.ts
@@ -70,7 +70,25 @@ const templateAttachmentSchema = z.object({
   mimeType: z.string().optional(),
 });
 
-export const templateSchema = z.object({
+/**
+ * A LAYOUT row has no subject, and the built-in default layout is seeded with
+ * an empty one. Requiring a subject of every row therefore makes the shipped
+ * default layout permanently unsaveable — and silently, because the layout
+ * editor has no subject field to attach the message to.
+ *
+ * A factory rather than one schema with a conditional: the caller already knows
+ * which kind it is editing, and a `superRefine` that reads a `kind` field the
+ * form does not carry would be inventing one to interrogate.
+ */
+export function templateSchemaFor(isLayoutRow: boolean) {
+  return templateSchema.extend({
+    subject: isLayoutRow
+      ? z.string().max(500)
+      : z.string().min(1, "Email subject is required").max(500),
+  });
+}
+
+const templateSchema = z.object({
   name: z.string().min(1, "Template name is required").max(255),
   slug: z
     .string()

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -29,13 +29,12 @@ import type { ApiCollection } from "@admin/types/entities";
 import { useSuppressedChrome } from "../ChromeSuppression";
 
 import { hasPluginsSection } from "./lib/has-plugins-section";
-import { isSubSidebarCategory, isSubSidebarOpen } from "./lib/has-sub-sidebar";
+import { isSubSidebarCategory } from "./lib/has-sub-sidebar";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
 import { resolveActiveSection } from "./lib/resolve-section";
-import { subSidebarBorderClass } from "./lib/sub-sidebar-classes";
 import type { MainMenuCategory, MainMenuItem } from "./sidebar-types";
 import { getFilteredMenuItems } from "./sidebar-types";
-import { SubSidebarContent } from "./SubSidebarContent";
+import { SubSidebarPanel } from "./SubSidebarPanel";
 
 interface DualSidebarProps {
   isMobile?: boolean;
@@ -359,16 +358,10 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     return filterCollectionItems(visible, capabilities);
   }, [collectionsData, capabilities]);
 
+  const suppressedChrome = useSuppressedChrome();
+
   const hasSubSidebarCategory = (id: string) =>
     isSubSidebarCategory(id, isFolderTreeVisible);
-
-  const suppressed = useSuppressedChrome();
-  const hasSubSidebar = isSubSidebarOpen(
-    selectedMain,
-    visibleMenuItems.map(item => item.id),
-    isFolderTreeVisible,
-    suppressed
-  );
 
   // The Settings icon lands on the first subpage the user can actually OPEN —
   // gated on each route's own guard, not the broader "can see the link" flag, so
@@ -455,7 +448,16 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
             const Icon = item.icon;
             const isSelected = selectedMain === item.id;
             const href = resolveItemHref(item);
-            const stayOnPageMobile = isMobile && hasSubSidebarCategory(item.id);
+            /*
+             * On mobile a category normally stays put and opens the panel
+             * instead of navigating. With the panel SUPPRESSED there is no
+             * panel to open, so staying put does nothing at all and the drawer
+             * stops navigating — the tap only moves a selection nobody can see.
+             */
+            const stayOnPageMobile =
+              isMobile &&
+              hasSubSidebarCategory(item.id) &&
+              !suppressedChrome.has("subSidebar");
             const renderAsLink = href !== "#" && !stayOnPageMobile;
 
             // Unselected items use muted foreground so the resting icon meets contrast; a faint primary alpha did not.
@@ -514,52 +516,29 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
       </aside>
 
       {/* 2. Sub Sidebar (Detail Menu) */}
-      <aside
-        className={cn(
-          "flex flex-col bg-background overflow-hidden shrink-0",
-          isMobile
-            ? "relative flex"
-            : "fixed inset-y-0 left-[72px] z-45 lg:static lg:flex", // Absolute on tablet, static on desktop
-          subSidebarBorderClass({ isMobile, hasSubSidebar }),
-          hasSubSidebar
-            ? "w-64 opacity-100 translate-x-0"
-            : "w-0 opacity-0 -translate-x-full pointer-events-none lg:w-0 lg:-translate-x-0",
-          !isMobile && "lg:translate-x-0 lg:opacity-100" // Reset for desktop
-        )}
-      >
-        {/* Sub Sidebar Header */}
-        <div className="h-16 px-6 flex items-center  border-b border-border">
-          <span className="font-bold text-base tracking-tight capitalize text-foreground">
-            {selectedMain.startsWith("standalone-")
-              ? standaloneLabel
-              : selectedMain === "media"
-                ? "Media Library"
-                : selectedMain === "builders"
-                  ? "Builders"
-                  : selectedMain}
-          </span>
-        </div>
-
-        {/* Sub Sidebar Content */}
-        <div className="flex-1 overflow-y-auto">
-          <SubSidebarContent
-            selectedMain={selectedMain}
-            standaloneLabel={standaloneLabel}
-            collectionSearch={collectionSearch}
-            onCollectionSearchChange={setCollectionSearch}
-            singleSearch={singleSearch}
-            onSingleSearchChange={setSingleSearch}
-            pluginSearch={pluginSearch}
-            onPluginSearchChange={setPluginSearch}
-            isActive={isActive}
-            hasPermission={hasPermission}
-            canAccessApiKeys={canAccessApiKeys}
-            canAccessWebhooks={canAccessWebhooks}
-            pluginCollectionsForSection={pluginCollectionsForSection}
-            showBuilder={showBuilder}
-          />
-        </div>
-      </aside>
+      <SubSidebarPanel
+        isMobile={Boolean(isMobile)}
+        selectedMain={selectedMain}
+        visibleMenuItemIds={visibleMenuItems.map(item => item.id)}
+        isFolderTreeVisible={isFolderTreeVisible}
+        standaloneLabel={standaloneLabel}
+        content={{
+          selectedMain,
+          standaloneLabel,
+          collectionSearch,
+          onCollectionSearchChange: setCollectionSearch,
+          singleSearch,
+          onSingleSearchChange: setSingleSearch,
+          pluginSearch,
+          onPluginSearchChange: setPluginSearch,
+          isActive,
+          hasPermission,
+          canAccessApiKeys,
+          canAccessWebhooks,
+          pluginCollectionsForSection,
+          showBuilder,
+        }}
+      />
     </div>
   );
 }

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -26,6 +26,8 @@ import { resolvePluginIcon } from "@admin/lib/plugins/resolve-plugin-icon";
 import { cn } from "@admin/lib/utils";
 import type { ApiCollection } from "@admin/types/entities";
 
+import { useSuppressedChrome } from "../ChromeSuppression";
+
 import { hasPluginsSection } from "./lib/has-plugins-section";
 import { isSubSidebarCategory, isSubSidebarOpen } from "./lib/has-sub-sidebar";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
@@ -360,10 +362,12 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const hasSubSidebarCategory = (id: string) =>
     isSubSidebarCategory(id, isFolderTreeVisible);
 
+  const suppressed = useSuppressedChrome();
   const hasSubSidebar = isSubSidebarOpen(
     selectedMain,
     visibleMenuItems.map(item => item.id),
-    isFolderTreeVisible
+    isFolderTreeVisible,
+    suppressed
   );
 
   // The Settings icon lands on the first subpage the user can actually OPEN —

--- a/packages/admin/src/components/layout/sidebar/SubSidebarPanel.tsx
+++ b/packages/admin/src/components/layout/sidebar/SubSidebarPanel.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+/**
+ * The secondary panel: the detail menu beside the icon rail.
+ *
+ * Its own component because it owns one question — whether the panel is showing
+ * at all — and that question has three inputs: the rail's selection, whether
+ * the selection is a category that HAS a panel, and whether a mounted surface
+ * has asked for the panel to go. Answering it inside the sidebar meant a
+ * 500-line component grew another branch every time one of those changed.
+ *
+ * The suppression is read here rather than passed in, because this is the
+ * component the answer is about: an immersive editor asking for `subSidebar`
+ * wants the width back, and the layout above only drops the whole sidebar
+ * COLUMN when the primary rail is surrendered too.
+ */
+import { cn } from "@admin/lib/utils";
+
+import { useSuppressedChrome } from "../ChromeSuppression";
+
+import { isSubSidebarOpen } from "./lib/has-sub-sidebar";
+import { subSidebarBorderClass } from "./lib/sub-sidebar-classes";
+import { SubSidebarContent } from "./SubSidebarContent";
+
+/** The panel's own title, which is the selection's name unless it has one. */
+function panelTitle(selectedMain: string, standaloneLabel: string): string {
+  if (selectedMain.startsWith("standalone-")) return standaloneLabel;
+  if (selectedMain === "media") return "Media Library";
+  if (selectedMain === "builders") return "Builders";
+  return selectedMain;
+}
+
+export function SubSidebarPanel({
+  isMobile,
+  selectedMain,
+  visibleMenuItemIds,
+  isFolderTreeVisible,
+  standaloneLabel,
+  content,
+}: {
+  isMobile: boolean;
+  selectedMain: string;
+  visibleMenuItemIds: readonly string[];
+  isFolderTreeVisible: boolean;
+  standaloneLabel: string;
+  /** Everything `SubSidebarContent` needs, passed through unread. */
+  content: React.ComponentProps<typeof SubSidebarContent>;
+}) {
+  const hasSubSidebar = isSubSidebarOpen(
+    selectedMain,
+    visibleMenuItemIds,
+    isFolderTreeVisible,
+    useSuppressedChrome()
+  );
+
+  return (
+    <aside
+      className={cn(
+        "flex flex-col bg-background overflow-hidden shrink-0",
+        isMobile
+          ? "relative flex"
+          : "fixed inset-y-0 left-[72px] z-45 lg:static lg:flex", // Absolute on tablet, static on desktop
+        subSidebarBorderClass({ isMobile, hasSubSidebar }),
+        hasSubSidebar
+          ? "w-64 opacity-100 translate-x-0"
+          : "w-0 opacity-0 -translate-x-full pointer-events-none lg:w-0 lg:-translate-x-0",
+        !isMobile && "lg:translate-x-0 lg:opacity-100" // Reset for desktop
+      )}
+    >
+      <div className="h-16 px-6 flex items-center  border-b border-border">
+        <span className="font-bold text-base tracking-tight capitalize text-foreground">
+          {panelTitle(selectedMain, standaloneLabel)}
+        </span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto">
+        <SubSidebarContent {...content} />
+      </div>
+    </aside>
+  );
+}

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-sub-sidebar.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-sub-sidebar.test.ts
@@ -10,6 +10,33 @@ import { isSubSidebarCategory, isSubSidebarOpen } from "../lib/has-sub-sidebar";
 const ALL = ["collections", "singles", "media", "plugins", "settings"];
 
 describe("isSubSidebarOpen", () => {
+  it("refuses the panel when a surface suppressed it, even where it would open", () => {
+    /*
+     * The layer was declared in `AdminChromeLayer` and resolved by
+     * `resolveSuppressedChrome`, and nothing implemented it: the layout only
+     * drops the sidebar COLUMN when `primaryRail` is surrendered as well, so a
+     * surface asking for the panel alone got the panel anyway. Both existing
+     * consumers suppress all four layers or only `pageFrame`, so the isolated
+     * case had never been exercised.
+     */
+    expect(
+      isSubSidebarOpen("settings", ALL, false, new Set(["subSidebar"]))
+    ).toBe(false);
+  });
+
+  it("opens where the same input suppresses something ELSE", () => {
+    // The control. Without it, an implementation that refused on ANY non-empty
+    // suppression set would pass the test above just as well.
+    expect(
+      isSubSidebarOpen("settings", ALL, false, new Set(["pageFrame"]))
+    ).toBe(true);
+  });
+
+  it("opens when nothing is suppressed, which is every existing caller", () => {
+    expect(isSubSidebarOpen("settings", ALL, false, new Set())).toBe(true);
+    expect(isSubSidebarOpen("settings", ALL, false)).toBe(true);
+  });
+
   it("opens the panel for a category the rail is showing", () => {
     expect(isSubSidebarOpen("plugins", ALL, false)).toBe(true);
   });

--- a/packages/admin/src/components/layout/sidebar/lib/has-sub-sidebar.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-sub-sidebar.ts
@@ -44,8 +44,19 @@ export function isSubSidebarCategory(
 export function isSubSidebarOpen(
   selectedMain: string,
   visibleMenuItemIds: readonly string[],
-  isFolderTreeVisible: boolean
+  isFolderTreeVisible: boolean,
+  suppressed: ReadonlySet<string> = new Set()
 ): boolean {
+  // An immersive surface may ask for the panel to go while keeping the rail: a
+  // full-bleed editor wants the width back, not the whole of the admin's
+  // navigation. The layout above only drops the sidebar COLUMN when the rail is
+  // surrendered too, so without this the `subSidebar` layer is declared,
+  // resolved by `resolveSuppressedChrome`, and implemented by nothing.
+  //
+  // Defaulted to an empty set so every existing caller keeps its behaviour and
+  // the parameter is opt-in rather than a change to what "open" means.
+  if (suppressed.has("subSidebar")) return false;
+
   return (
     isSubSidebarCategory(selectedMain, isFolderTreeVisible) &&
     visibleMenuItemIds.includes(selectedMain)


### PR DESCRIPTION
## What and why

R-15's complaint was that this page is cluttered. Measured on `main` at a 1280px viewport, it was worse than cluttered — **half the window was navigation**:

| | before | after | |
| --- | --- | --- | --- |
| chrome | 72 + 256 + 320 = **648px (51%)** | **72px** | icon rail only |
| editor | 316px | **604px** | |
| preview | 316px | **604px** | a 600px email now fits |

Both numbers are read from the DOM of the running app, before and after.

The editor now renders into the `ImmersiveShell` from #1404, with its six regions filled:

- **Bar** — name, slug, status, Settings, Send test, Cancel, Save. The exit control is rendered by the *shell*, because the shell derives its right to hide admin chrome from having drawn a way back.
- **Envelope** — From, Reply-to, Subject and Preheader, together. They answer one question and were split across two places: Subject sat above the editor while the other three were three clicks away behind a Settings tab, even though the preheader is literally the text that follows the subject in an inbox.
- **Primary** — the HTML / plain-text editor, with the variable chips **beside the caret** rather than a column away.
- **Secondary** — the preview, draggable against the editor.
- **Inspector** — slug, provider, layout, active, attachments, and variable declarations. Summoned, and it overlays the preview only.
- **Drawer** — sample data, collapsed to a strip until wanted.

Below 1280 the panes stack rather than becoming two unreadable columns. The breakpoint lives in this screen, not in the shell: only the caller knows what its own panes cost at a width.

## A declared chrome layer that nothing implemented

Adopting the shell surfaced a real gap. `useSuppressAdminChrome({ layers: ["subSidebar"] })` did **nothing**:

- `subSidebar` is in the `AdminChromeLayer` union and handled by `resolveSuppressedChrome`.
- The only consumers of the resolved set were `MeasuredPageFrame` (reads `pageFrame`) and `DashboardLayout`, whose gate is `hidden.has("primaryRail") && hidden.has("subSidebar")` — **both**, or nothing.
- `DualSidebar`, which actually renders the panel, never read the set at all: `grep -c useSuppressedChrome DualSidebar.tsx` → 0.

Its two existing consumers suppress all four layers or only `pageFrame`, so the isolated case had never been exercised. Validated, resolved, and implemented by nothing — and I was its first user.

Fixed at the decision rather than at the call site: `isSubSidebarOpen` now takes the suppressed set, defaulted to empty so every existing caller is unchanged. Three tests, and **the second is the control**:

- suppressing `subSidebar` closes the panel where it would otherwise open;
- suppressing **`pageFrame`** leaves it open — without this, an implementation refusing on *any* non-empty set would pass the first test too;
- an empty set, and the no-argument call, both still open.

Break-verified: deleting the guard fails the first, and refusing on `suppressed.size > 0` fails the control.

## Verified in a real browser, not only in jsdom

The overlay design's whole point is that opening settings must not reflow the document being edited, and jsdom computes no layout, so the unit test could only assert containment. Measured live at 1280:

```
inspectorOpen: true
inspectorTop: 251   barBottom: 129   coversBar: false
insideSecondary: true
primaryStillWide: 604      ← unchanged while the inspector is open
```

So the inspector sits below the bar (Save and Cancel stay clickable), inside the preview pane, and the editor does not move. That is the Codex P1 from #1404 confirmed against real geometry.

Console clean — no errors or warnings on load or on opening the inspector.

## Test plan

- `pnpm build` 0 · `check-types` 0 · `lint` 0 · `lint:design` 0
- Admin suite **347 files, 3392 tests, all passing**
- `fallow`: **dead code introduced 0, duplication introduced 0** — the two things the `Changed files` CI job gates on

`fallow` found 3 introduced duplications on the first pass and both of the ones that were mine are fixed at the cause: `VariablesRail` now *uses* `VariableChips` instead of repeating the chip-building, and the settings props are one exported `TemplateSettingsProps` rather than a shape spelled twice. The remaining clone family (`DynamicPluginNav` + `DynamicPluginSectionItems` + `DualSidebar`) is pre-existing and correctly attributed as inherited.

`complexity_introduced` is 4 and is the same attribution artifact written up in `findings/R-15-fallow-cannot-see-through-a-file-split.md`: every function in a new file counts as introduced. CI does not gate on complexity.

## Notes for the reviewer

- **The preview still renders client-side and still disagrees with what is sent.** Deliberately out of scope here — #1399 established the six divergences and shipped `POST /api/email-templates/preview`; wiring it up, with the real 600/375 device model, is the next PR. This one is layout.
- **`primaryRail` is deliberately kept.** The founder asked for the settings sidebar specifically; taking the whole of the admin's navigation is a bigger claim than this screen needs.
- Changeset added: **yes (patch)**, written for the person who noticed the clutter rather than for the diff.
