### PR TITLE
feat(admin): give the document one leading action, and demote the rest

### DIFF
--- a/.changeset/one-action-leads-the-rest-follow.md
+++ b/.changeset/one-action-leads-the-rest-follow.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Give a document one leading action instead of several competing ones. A published entry with unpublished edits drew Save, Publish and Unpublish side by side at equal weight, so an author read three buttons to find the one they wanted, and Unpublish — rare, public, and undone only by publishing again — sat one slip from Publish. There is now a single primary action derived from the document's state, the quieter save beside it, and everything else in a menu split into routine and destructive groups. "Publish" on a document that is already live now reads "Publish changes", which says what it will do. What an author may do is decided in a module with no React in it, so every combination of status, drafts, permissions and history is testable without rendering a header; where each action is drawn is decided from that description rather than by where its markup happened to sit. The collections menu drops "Show JSON" in favour of "View API response", which is what Singles already offered.

--- a/packages/admin/src/components/features/entries/EntryForm/DocumentActionBar.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/DocumentActionBar.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+/**
+ * Draws the document's actions, wherever each one said it belongs.
+ *
+ * The counterpart to `document-actions`: that module answers WHAT an author may
+ * do and WHERE it goes, this one answers what that looks like. Keeping them
+ * apart is the point — the header previously decided both at once, in JSX, so
+ * "is Unpublish available" and "is Unpublish a button" were the same expression
+ * and could not be reasoned about separately.
+ *
+ * A caller supplies a BINDING per action id: what to run, and any reason it
+ * cannot run at this instant. The split matters. Whether an action EXISTS is a
+ * question about permissions and document state, which the model owns and can
+ * be tested without rendering; whether it can run RIGHT NOW is about the form —
+ * mid-submit, invalid, nothing changed — which only the form knows. Folding the
+ * second into the model would have put form state in a module that has no form.
+ *
+ * An action with no binding is not drawn. That is how an optional affordance —
+ * a collection with no duplicate handler — disappears without the model needing
+ * to know which handlers a host happened to pass.
+ *
+ * @module components/features/entries/EntryForm/DocumentActionBar
+ */
+
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@nextlyhq/ui";
+import { Loader2, MoreHorizontal } from "lucide-react";
+
+import { cn } from "@admin/lib/utils";
+
+import { actionsAt, menuGroups, type DocumentAction } from "./document-actions";
+import { ToolbarLabel } from "./toolbar-density";
+
+/** What a host wires an action to, and why it might not run right now. */
+export interface ActionBinding {
+  onSelect: () => void;
+  /**
+   * A TRANSIENT reason — mid-submit, invalid, nothing to save.
+   *
+   * Separate from the model's `disabledReason`, which is about permission and
+   * document state. Both disable the control and both are worth showing; they
+   * are distinguished because one is a property of the document and the other
+   * of this moment, and a caller that conflated them would have to recompute
+   * permissions on every keystroke.
+   */
+  disabledReason?: string;
+}
+
+export interface DocumentActionBarProps {
+  actions: readonly DocumentAction[];
+  /** Keyed by action id. An action with no entry is not drawn. */
+  bindings: Readonly<Record<string, ActionBinding | undefined>>;
+  /** Whether a mutation is in flight, which shows on the leading action. */
+  pending?: boolean;
+  className?: string;
+}
+
+/** Both reasons an action may be unusable, or undefined when it is usable. */
+function reasonFor(
+  action: DocumentAction,
+  binding: ActionBinding
+): string | undefined {
+  return action.disabledReason ?? binding.disabledReason;
+}
+
+/**
+ * The actions a host actually wired, paired with their bindings.
+ *
+ * Filtered ONCE and reused by each region, so a control cannot appear in the
+ * toolbar while the menu believes it does not exist.
+ */
+function bound(
+  actions: readonly DocumentAction[],
+  bindings: DocumentActionBarProps["bindings"]
+): { action: DocumentAction; binding: ActionBinding }[] {
+  const out: { action: DocumentAction; binding: ActionBinding }[] = [];
+  for (const action of actions) {
+    const binding = bindings[action.id];
+    if (binding !== undefined) out.push({ action, binding });
+  }
+  return out;
+}
+
+export function DocumentActionBar({
+  actions,
+  bindings,
+  pending = false,
+  className,
+}: DocumentActionBarProps) {
+  const wired = bound(actions, bindings);
+  const available = wired.map(entry => entry.action);
+  const primary = bound(actionsAt(available, "primary"), bindings)[0];
+  const toolbar = bound(actionsAt(available, "toolbar"), bindings);
+  const groups = menuGroups(available);
+  const documentItems = bound(groups.document, bindings);
+  const dangerItems = bound(groups.danger, bindings);
+  const hasMenu = documentItems.length > 0 || dangerItems.length > 0;
+
+  return (
+    <div className={cn("flex items-center gap-1.5", className)}>
+      {/*
+        The supporting action comes FIRST in the DOM and reads first left to
+        right, so the leading one sits at the end of the cluster where a
+        confirming action is looked for.
+      */}
+      {toolbar.map(({ action, binding }) => (
+        <Button
+          key={action.id}
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={reasonFor(action, binding) !== undefined}
+          title={reasonFor(action, binding) ?? action.label}
+          onClick={binding.onSelect}
+          data-action={action.id}
+        >
+          {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          <ToolbarLabel priority="lifecycle">{action.label}</ToolbarLabel>
+        </Button>
+      ))}
+
+      {primary === undefined ? null : (
+        <Button
+          type="button"
+          size="sm"
+          disabled={reasonFor(primary.action, primary.binding) !== undefined}
+          /*
+            The reason is the title when there is one, so a control an author
+            cannot use says why. Three separate permissions and several document
+            states decide these, and a dead button with no explanation reads as
+            broken rather than as forbidden.
+          */
+          title={
+            reasonFor(primary.action, primary.binding) ?? primary.action.label
+          }
+          onClick={primary.binding.onSelect}
+          data-action={primary.action.id}
+          data-primary="true"
+        >
+          {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : null}
+          {primary.action.label}
+        </Button>
+      )}
+
+      {hasMenu ? (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="px-2"
+              aria-label="More actions"
+            >
+              <MoreHorizontal className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {documentItems.map(({ action, binding }) => (
+              <DropdownMenuItem
+                key={action.id}
+                disabled={reasonFor(action, binding) !== undefined}
+                onClick={binding.onSelect}
+                data-action={action.id}
+              >
+                {action.label}
+              </DropdownMenuItem>
+            ))}
+            {/*
+              A separator only between two populated groups. Drawn
+              unconditionally it becomes a rule at the top or bottom of the
+              menu, which reads as a group whose items failed to render.
+            */}
+            {documentItems.length > 0 && dangerItems.length > 0 ? (
+              <DropdownMenuSeparator />
+            ) : null}
+            {dangerItems.map(({ action, binding }) => (
+              <DropdownMenuItem
+                key={action.id}
+                disabled={reasonFor(action, binding) !== undefined}
+                onClick={binding.onSelect}
+                data-action={action.id}
+                className="text-destructive focus:text-destructive"
+              >
+                {action.label}
+              </DropdownMenuItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/entries/EntryForm/DocumentActionBar.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/DocumentActionBar.tsx
@@ -42,6 +42,17 @@ import { ToolbarLabel } from "./toolbar-density";
 export interface ActionBinding {
   onSelect: () => void;
   /**
+   * Submit this form natively instead of calling back.
+   *
+   * A collection with NO status column saves by submitting the form and letting
+   * it decide, with no intent attached. Routing that through a callback is not
+   * a detail: every save handler the hosts expose carries an intent, and the
+   * one for drafts writes `status: "draft"` — a column such a collection does
+   * not have, so the write fails. The control has always been a submit button
+   * for exactly this reason, and this keeps it one.
+   */
+  submitForm?: string;
+  /**
    * A TRANSIENT reason — mid-submit, invalid, nothing to save.
    *
    * Separate from the model's `disabledReason`, which is about permission and
@@ -60,6 +71,18 @@ export interface DocumentActionBarProps {
   /** Whether a mutation is in flight, which shows on the leading action. */
   pending?: boolean;
   className?: string;
+}
+
+/**
+ * How a refusal is spoken on a menu item.
+ *
+ * Nothing when the action is usable, so a usable row carries no stray
+ * attributes and a test asserting their absence means something.
+ */
+function reasonAttributes(reason: string | undefined): Record<string, string> {
+  return reason === undefined
+    ? {}
+    : { title: reason, "aria-description": reason };
 }
 
 /** Both reasons an action may be unusable, or undefined when it is usable. */
@@ -128,8 +151,10 @@ export function DocumentActionBar({
 
       {primary === undefined ? null : (
         <Button
-          type="button"
           size="sm"
+          {...(primary.binding.submitForm === undefined
+            ? { type: "button" as const, onClick: primary.binding.onSelect }
+            : { type: "submit" as const, form: primary.binding.submitForm })}
           disabled={reasonFor(primary.action, primary.binding) !== undefined}
           /*
             The reason is the title when there is one, so a control an author
@@ -140,7 +165,6 @@ export function DocumentActionBar({
           title={
             reasonFor(primary.action, primary.binding) ?? primary.action.label
           }
-          onClick={primary.binding.onSelect}
           data-action={primary.action.id}
           data-primary="true"
         >
@@ -169,6 +193,15 @@ export function DocumentActionBar({
                 disabled={reasonFor(action, binding) !== undefined}
                 onClick={binding.onSelect}
                 data-action={action.id}
+                /*
+                  The reason travels with the item, not just the buttons. A
+                  permission an author lacks makes this the ONLY place the
+                  refusal is visible, and a menu row that is grey and silent
+                  reads as broken rather than as forbidden. `title` reaches a
+                  pointer and `aria-description` reaches a screen reader; the
+                  label alone reaches neither.
+                */
+                {...reasonAttributes(reasonFor(action, binding))}
               >
                 {action.label}
               </DropdownMenuItem>
@@ -188,6 +221,7 @@ export function DocumentActionBar({
                 onClick={binding.onSelect}
                 data-action={action.id}
                 className="text-destructive focus:text-destructive"
+                {...reasonAttributes(reasonFor(action, binding))}
               >
                 {action.label}
               </DropdownMenuItem>

--- a/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntryForm.tsx
@@ -148,6 +148,15 @@ export interface EntryFormProps {
    * import keeps this component unaware of releases, which is the same reason
    * `toolbarSlot` exists for plugins.
    */
+  /**
+   * Opens this entry's API response.
+   *
+   * Supplied by the route, which is what knows how to navigate. Without it the
+   * header offers no way to inspect the document at all: `Show JSON` used to
+   * fill that role and the menu now names this instead, so an unwired callback
+   * is a capability removed rather than replaced.
+   */
+  onViewApi?: () => void;
   documentActions?: ReactNode;
   /** Additional CSS classes for the form container */
   /**
@@ -265,6 +274,7 @@ export function EntryForm({
   translation,
   embedded = false,
   className,
+  onViewApi,
   documentActions,
 }: EntryFormProps) {
   /*
@@ -860,6 +870,9 @@ export function EntryForm({
                     and clipped the title's first character on the left and
                     the rail toggle on the right. */}
                             <EntrySystemHeader
+                              {...(onViewApi === undefined
+                                ? {}
+                                : { onViewApi })}
                               mode={mode}
                               titleField={titleField}
                               hasStatus={hasStatus}

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -73,6 +73,14 @@ export interface EntrySystemHeaderProps {
   autosaveLastSavedAt?: Date | null;
   /** Form id for the single submit button when drafts are off. */
   /** Entry data; needed for Show JSON dialog (entry id) and Duplicate (id). */
+  /**
+   * The form this header's save submits.
+   *
+   * Load-bearing for a collection with NO status column: that save has always
+   * been a native submit with no intent attached, because every intent-carrying
+   * handler writes a `status` such a collection does not have.
+   */
+  formId?: string;
   entry?: EntryData | null;
   /** Collection slug for the Show JSON dialog. */
   collectionSlug: string;
@@ -227,6 +235,7 @@ export function EntrySystemHeader({
   autosaveEnabled = false,
   autosaveStatus = "idle",
   autosaveLastSavedAt = null,
+  formId = "entry-form",
   entry,
   collectionSlug,
   locale,
@@ -445,10 +454,28 @@ export function EntrySystemHeader({
       ? "Nothing has changed yet."
       : undefined);
 
+  /*
+   * A collection with NO status column saves by SUBMITTING, with no intent.
+   *
+   * Every save handler a host exposes carries one, and the draft handler writes
+   * `status: "draft"` — a column such a collection does not have, so routing
+   * this through a callback turns both Create and Save into a failing write.
+   * The control has always been a submit button here for that reason.
+   */
+  const saveBinding: ActionBinding | undefined = hasStatus
+    ? runSave === undefined
+      ? undefined
+      : { onSelect: runSave, disabledReason: saveReason }
+    : {
+        // Never called: a submit-typed control does not use it. Present because
+        // a binding is what says the action exists at all.
+        onSelect: () => {},
+        submitForm: formId,
+        disabledReason: saveReason,
+      };
+
   const actionBindings: Record<string, ActionBinding | undefined> = {
-    ...(runSave === undefined
-      ? {}
-      : { save: { onSelect: runSave, disabledReason: saveReason } }),
+    ...(saveBinding === undefined ? {} : { save: saveBinding }),
     ...(onPublish === undefined
       ? {}
       : {

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -1,13 +1,6 @@
 "use client";
 
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@nextlyhq/ui";
+import { Button } from "@nextlyhq/ui";
 import { isFieldLocalized, type FieldConfig } from "nextly/config";
 import { useEffect, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
@@ -15,17 +8,10 @@ import { useFormContext } from "react-hook-form";
 import { useDocumentHistory } from "@admin/components/features/versions/document-history-context";
 import { VersionHistorySheet } from "@admin/components/features/versions/VersionHistorySheet";
 import {
-  Code,
-  Copy,
-  EyeOff,
   Globe,
   History,
-  Loader2,
-  MoreHorizontal,
   PanelRight,
   PanelRightClose,
-  RotateCcw,
-  Trash2,
 } from "@admin/components/icons";
 import { useCan } from "@admin/hooks/useCan";
 import type { AutosaveStatus } from "@admin/hooks/useDocumentAutosave";
@@ -37,11 +23,12 @@ import { translationCounts } from "../translation-meta";
 
 import { AutoSaveIndicator } from "./AutoSaveIndicator";
 import { DiscardDraftConfirmDialog } from "./DiscardDraftConfirmDialog";
+import { documentActions } from "./document-actions";
+import { DocumentActionBar, type ActionBinding } from "./DocumentActionBar";
 import { DocumentStatusLive } from "./DocumentStatusLive";
 import { effectiveEntryStatus } from "./entry-address";
 import { EntryTitleInput } from "./EntryTitleInput";
 import { PreviewActions } from "./PreviewActions";
-import { ShowJSONDialog } from "./ShowJSONDialog";
 import { TOOLBAR_CONTAINER, ToolbarLabel } from "./toolbar-density";
 import { UnpublishConfirmDialog } from "./UnpublishConfirmDialog";
 import { useLeaveWithoutWarning } from "./UnsavedChangesGuard";
@@ -85,7 +72,6 @@ export interface EntrySystemHeaderProps {
   /** When the server last stored a recovery point, by the server's clock. */
   autosaveLastSavedAt?: Date | null;
   /** Form id for the single submit button when drafts are off. */
-  formId?: string;
   /** Entry data; needed for Show JSON dialog (entry id) and Duplicate (id). */
   entry?: EntryData | null;
   /** Collection slug for the Show JSON dialog. */
@@ -189,16 +175,6 @@ export interface EntrySystemHeaderProps {
   onViewApi?: () => void;
 
   /**
-   * Whether to render the built-in Show JSON dropdown item (which uses
-   * `ShowJSONDialog`). Defaults to `true`. Set `false` to suppress the
-   * menu item entirely (e.g. for resources whose API surface isn't
-   * representable as a single GET).
-   *
-   * @default true
-   */
-  showJson?: boolean;
-
-  /**
    * Resource scope passed through to the Show JSON dialog and used by the
    * `View API response` URL display. Determines whether the dialog hits
    * `/api/collections/{slug}/entries/{id}` or `/api/singles/{slug}`.
@@ -251,7 +227,6 @@ export function EntrySystemHeader({
   autosaveEnabled = false,
   autosaveStatus = "idle",
   autosaveLastSavedAt = null,
-  formId = "entry-form",
   entry,
   collectionSlug,
   locale,
@@ -265,7 +240,6 @@ export function EntrySystemHeader({
   onDelete,
   onDuplicate,
   onViewApi,
-  showJson = true,
   scope = "collection",
   historyFields,
   historyEnabled,
@@ -395,7 +369,8 @@ export function EntrySystemHeader({
   // affordances to show. Shared with the slug freeze and the public-URL notice,
   // which ask the same question and must not answer it differently.
   const effectiveStatus = effectiveEntryStatus(entry, locale, defaultLocale);
-  const isPublishedEdit = mode === "edit" && effectiveStatus === "published";
+  const isPublishedEditState =
+    mode === "edit" && effectiveStatus === "published";
   // A drafts-enabled published entry that has a pending working draft: the
   // server flags the overlay read with `_isWorkingDraft`. This is Payload's
   // "Changed" state — Publish promotes it and the status pill reflects it.
@@ -412,6 +387,115 @@ export function EntrySystemHeader({
   // it — the sibling Save affordances are not either, and the endpoint refuses if
   // the caller truly may not update.
   const showDiscardDraft = hasWorkingDraft && !!onDiscardWorkingDraft;
+  /*
+   * What an author may do to this document, and what each verb runs.
+   *
+   * The two are separate on purpose. `documentVerbs` is about permissions and
+   * document state and is decided in a module with no React in it, so every
+   * combination is testable without rendering a header. The BINDINGS below are
+   * about this form at this instant — mid-submit, invalid, nothing changed —
+   * which only the form knows, and about which handler a verb runs, which only
+   * the host knows.
+   */
+  const documentVerbs = documentActions({
+    mode,
+    hasStatus,
+    draftsEnabled: draftsEnabled === true,
+    status: effectiveStatus === "published" ? "published" : "draft",
+    hasWorkingDraft: hasWorkingDraft === true,
+    readingHistory: isReadingHistory,
+    canPublish: canPublishDocument,
+    canUnpublish: canUnpublishDocument,
+    canDelete: onDelete !== undefined,
+    isDirty: isDirty === true,
+    canDuplicate: onDuplicate !== undefined,
+  });
+
+  /*
+   * Saving means three different calls depending on where the work lands, which
+   * is a fact about this host rather than about the document: a drafts-enabled
+   * published entry stores a working draft and leaves the live one alone, a
+   * drafts-disabled one re-asserts published, and anything else writes a draft.
+   * The model deliberately does not know this — it names ONE verb, `save`, and
+   * the label already says which of the three an author is about to get.
+   */
+  const runSave =
+    isPublishedEditState && draftsEnabled
+      ? onSaveWorkingDraft
+      : isPublishedEditState
+        ? onSaveChanges
+        : onSaveDraft;
+
+  /**
+   * Why a verb cannot run at this instant, or undefined when it can.
+   *
+   * Separate from the model's own reasons, which are about permission and
+   * document state. A save is additionally refused while a submit is in flight,
+   * while the form is invalid, and — on a published document — while nothing has
+   * changed, which is the existing behaviour kept rather than re-decided.
+   */
+  const busyReason = isSubmitting ? "Saving…" : undefined;
+  const invalidReason = isInvalid
+    ? "Fix the errors on this page first."
+    : undefined;
+  const saveReason =
+    busyReason ??
+    invalidReason ??
+    (isPublishedEditState && isDirty !== true
+      ? "Nothing has changed yet."
+      : undefined);
+
+  const actionBindings: Record<string, ActionBinding | undefined> = {
+    ...(runSave === undefined
+      ? {}
+      : { save: { onSelect: runSave, disabledReason: saveReason } }),
+    ...(onPublish === undefined
+      ? {}
+      : {
+          publish: {
+            onSelect: onPublish,
+            disabledReason: busyReason ?? invalidReason,
+          },
+        }),
+    ...(onDuplicate === undefined
+      ? {}
+      : { duplicate: { onSelect: onDuplicate, disabledReason: busyReason } }),
+    ...(onViewApi === undefined ? {} : { "view-api": { onSelect: onViewApi } }),
+    ...(showDiscardDraft
+      ? {
+          "discard-draft": {
+            onSelect: () => setDiscardDraftOpen(true),
+            disabledReason: busyReason,
+          },
+        }
+      : {}),
+    ...(onCancel === undefined
+      ? {}
+      : {
+          "discard-changes": {
+            // Says so before leaving: this action IS the answer to the
+            // unsaved-changes question, so being asked it again reads as a
+            // warning rather than as the confirmation just given.
+            onSelect: () => {
+              leaveWithoutWarning();
+              onCancel();
+            },
+            disabledReason: busyReason,
+          },
+        }),
+    ...(onUnpublish === undefined
+      ? {}
+      : {
+          unpublish: {
+            onSelect: () => setUnpublishOpen(true),
+            disabledReason: busyReason,
+          },
+        }),
+    ...(onDelete === undefined
+      ? {}
+      : { delete: { onSelect: onDelete, disabledReason: busyReason } }),
+  };
+
   const entryLabel =
     typeof entry?.title === "string" && entry.title.trim().length > 0
       ? entry.title
@@ -576,218 +660,26 @@ export function EntrySystemHeader({
                   localeCount: counts.total,
                 })}
           />
-          {/* No save affordances while a past version is on screen. They act on
-            the live document, which is not what is being read — an editor
-            offered "Save" over a historical page has been invited to make a
-            decision about something they cannot see. Restoring is offered
-            instead, from the banner over the version itself. */}
-          {isReadingHistory ? null : hasStatus && isPublishedEdit ? (
-            <>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={isSubmitting || isInvalid || !isDirty}
-                // On a drafts-enabled collection a save on a published entry
-                // stores a working draft (live untouched); otherwise it re-asserts
-                // published, keeping the lifecycle unchanged.
-                onClick={draftsEnabled ? onSaveWorkingDraft : onSaveChanges}
-                data-status={
-                  draftsEnabled ? "save-working-draft" : "save-changes"
-                }
-              >
-                {isSubmitting && (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                )}
-                {draftsEnabled ? "Save" : "Save changes"}
-              </Button>
-              {/* Promote the pending working draft to live. Shown only when one
-                exists — a fully-published entry has nothing to promote. */}
-              {hasWorkingDraft && canPublishDocument && (
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={isSubmitting || isInvalid}
-                  onClick={onPublish}
-                  title="Publish"
-                  data-status="published"
-                >
-                  {isSubmitting ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Globe className="h-3.5 w-3.5" />
-                  )}
-                  <ToolbarLabel priority="lifecycle">Publish</ToolbarLabel>
-                </Button>
-              )}
-              {canUnpublishDocument && (
-                <Button
-                  type="button"
-                  // Keep Publish the sole primary action when a draft is pending;
-                  // otherwise Unpublish stays the primary (published-only) action.
-                  variant={hasWorkingDraft ? "outline" : "default"}
-                  size="sm"
-                  disabled={isSubmitting}
-                  onClick={() => setUnpublishOpen(true)}
-                  title="Unpublish"
-                  data-status="unpublish"
-                >
-                  <EyeOff className="h-3.5 w-3.5" />
-                  <ToolbarLabel priority="lifecycle">Unpublish</ToolbarLabel>
-                </Button>
-              )}
-            </>
-          ) : hasStatus ? (
-            <>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={isSubmitting || isInvalid}
-                onClick={onSaveDraft}
-                data-status="draft"
-              >
-                {isSubmitting && (
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                )}
-                Save Draft
-              </Button>
-              {canPublishDocument && (
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={isSubmitting || isInvalid}
-                  onClick={onPublish}
-                  title="Publish"
-                  data-status="published"
-                >
-                  {isSubmitting ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : (
-                    <Globe className="h-3.5 w-3.5" />
-                  )}
-                  <ToolbarLabel priority="lifecycle">Publish</ToolbarLabel>
-                </Button>
-              )}
-            </>
-          ) : (
-            <Button
-              type="submit"
-              form={formId}
-              size="sm"
-              disabled={isSubmitting || isInvalid}
-            >
-              {isSubmitting ? (
-                <>
-                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  Saving…
-                </>
-              ) : mode === "create" ? (
-                "Create"
-              ) : (
-                "Save"
-              )}
-            </Button>
-          )}
+          {/*
+            Every document verb, drawn where the model said each belongs.
 
-          {/* Single consolidated More menu — hidden entirely in create mode.
-            Why: in create mode the entry doesn't exist server-side yet, so
-            Duplicate / Show JSON / View API / Delete have nothing to act on,
-            and Discard changes is redundant with navigating away. Once the
-            entry is persisted (mode === "edit"), the full action set
-            appears. Resolves item 11 of 07-admin-bugs-feedback (PR-8). */}
-          {showEditMenuItems && (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="px-2"
-                  aria-label="More actions"
-                >
-                  <MoreHorizontal className="h-4 w-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                {showDiscardDraft && (
-                  <DropdownMenuItem
-                    onClick={() => setDiscardDraftOpen(true)}
-                    disabled={isSubmitting}
-                  >
-                    <RotateCcw className="h-3.5 w-3.5" />
-                    Discard draft
-                  </DropdownMenuItem>
-                )}
-                {isDirty && onCancel && (
-                  <DropdownMenuItem
-                    // Says so before leaving: this action IS the answer to the
-                    // unsaved-changes question, so being asked it again reads as
-                    // a warning rather than as the confirmation just given.
-                    onClick={() => {
-                      leaveWithoutWarning();
-                      onCancel();
-                    }}
-                    disabled={isSubmitting}
-                  >
-                    <RotateCcw className="h-3.5 w-3.5" />
-                    Discard changes
-                  </DropdownMenuItem>
-                )}
-                {onDuplicate && (
-                  <>
-                    {(showDiscardDraft || (isDirty && onCancel)) && (
-                      <DropdownMenuSeparator />
-                    )}
-                    <DropdownMenuItem
-                      onClick={onDuplicate}
-                      disabled={isSubmitting}
-                    >
-                      <Copy className="h-3.5 w-3.5" />
-                      Duplicate
-                    </DropdownMenuItem>
-                  </>
-                )}
-                {showJson && (
-                  <ShowJSONDialog
-                    scope={scope}
-                    collectionSlug={collectionSlug}
-                    /* Why: collection scope needs the entry id to build
-                     /api/collections/{slug}/entries/{id}; single scope is
-                     keyed only by slug so entryId is unused. The outer
-                     showEditMenuItems gate guarantees entry?.id exists
-                     for the collection branch. */
-                    entryId={scope === "single" ? undefined : entry.id}
-                    trigger={
-                      <DropdownMenuItem onSelect={e => e.preventDefault()}>
-                        <Code className="h-3.5 w-3.5" />
-                        Show JSON
-                      </DropdownMenuItem>
-                    }
-                  />
-                )}
-                {onViewApi && (
-                  <DropdownMenuItem onClick={onViewApi}>
-                    <Code className="h-3.5 w-3.5" />
-                    View API response
-                  </DropdownMenuItem>
-                )}
-                {onDelete && (
-                  <>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      onClick={onDelete}
-                      disabled={isSubmitting}
-                      className="text-destructive focus:text-destructive"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" />
-                      Delete
-                    </DropdownMenuItem>
-                  </>
-                )}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          )}
+            One control leads and the rest are demoted, which the header could
+            not express while each button decided its own placement in JSX: a
+            published document with a pending draft drew Save, Publish and
+            Unpublish at equal weight, and Unpublish sat one slip from Publish.
+
+            No save affordances survive a historical view. They act on the live
+            document, which is not what is being read — an editor offered "Save"
+            over a past version has been invited to decide about something they
+            cannot see. Restoring is offered instead, from the banner over the
+            version itself. The model states that rule once, for every action,
+            rather than each control testing `isReadingHistory` for itself.
+          */}
+          <DocumentActionBar
+            actions={documentVerbs}
+            bindings={actionBindings}
+            pending={isSubmitting}
+          />
 
           {/* Rail toggle — far right, separated by a thin divider */}
           {onToggleRail && (

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentActionBar.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentActionBar.test.tsx
@@ -215,3 +215,111 @@ describe("running an action", () => {
     expect(publish).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("a save that must submit rather than call back", () => {
+  it("renders a submit button bound to the form", () => {
+    /*
+     * A collection with NO status column saves by submitting, with no intent
+     * attached. Every save handler a host exposes carries one, and the draft
+     * handler writes `status: "draft"` — a column such a collection does not
+     * have — so routing it through a callback turns Create and Save into a
+     * failing write. The control has always been a submit for that reason.
+     */
+    render(
+      <DocumentActionBar
+        actions={[{ id: "save", label: "Create", placement: "primary" }]}
+        bindings={{
+          save: { onSelect: vi.fn(), submitForm: "entry-form" },
+        }}
+      />
+    );
+
+    const create = screen.getByRole("button", { name: /^create$/i });
+    expect(create.getAttribute("type")).toBe("submit");
+    expect(create.getAttribute("form")).toBe("entry-form");
+  });
+
+  it("leaves an ordinary action a plain button that calls back", () => {
+    // The control: a bar that submitted everything would satisfy the case
+    // above and would submit the form on Publish, which has its own handler.
+    const onSelect = vi.fn();
+    render(
+      <DocumentActionBar
+        actions={[{ id: "publish", label: "Publish", placement: "primary" }]}
+        bindings={{ publish: { onSelect } }}
+      />
+    );
+
+    const publish = screen.getByRole("button", { name: /^publish$/i });
+    expect(publish.getAttribute("type")).toBe("button");
+    expect(publish.getAttribute("form")).toBeNull();
+    fireEvent.click(publish);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("a menu action an author may not use", () => {
+  it("says why, where a pointer and a screen reader can both reach it", async () => {
+    /*
+     * The menu is the ONLY place a permission refusal is visible now that
+     * Unpublish and Delete live there. A row that is grey and silent reads as
+     * broken rather than as forbidden — which is the same complaint the whole
+     * reason-bearing model exists to answer.
+     */
+    render(
+      <DocumentActionBar
+        actions={[
+          { id: "save", label: "Save", placement: "primary" },
+          {
+            id: "unpublish",
+            label: "Unpublish",
+            placement: "menu",
+            group: "danger",
+            destructive: true,
+            disabledReason: "You do not have permission to unpublish.",
+          },
+        ]}
+        bindings={{
+          save: { onSelect: vi.fn() },
+          unpublish: { onSelect: vi.fn() },
+        }}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /more actions/i })
+    );
+
+    const item = await screen.findByRole("menuitem", { name: /unpublish/i });
+    expect(item.getAttribute("title")).toMatch(/permission/i);
+    expect(item.getAttribute("aria-description")).toMatch(/permission/i);
+  });
+
+  it("leaves a usable menu action carrying no reason at all", async () => {
+    // The control. Attributes attached unconditionally would satisfy the case
+    // above while telling every author their available actions are refused.
+    render(
+      <DocumentActionBar
+        actions={[
+          { id: "save", label: "Save", placement: "primary" },
+          {
+            id: "duplicate",
+            label: "Duplicate",
+            placement: "menu",
+            group: "document",
+          },
+        ]}
+        bindings={{
+          save: { onSelect: vi.fn() },
+          duplicate: { onSelect: vi.fn() },
+        }}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /more actions/i })
+    );
+
+    const item = await screen.findByRole("menuitem", { name: /duplicate/i });
+    expect(item.getAttribute("title")).toBeNull();
+    expect(item.getAttribute("aria-description")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentActionBar.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/DocumentActionBar.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * Drawing the document's actions where each said it belongs.
+ *
+ * `document-actions.test` covers WHICH actions exist; this covers what becomes
+ * of them. The two are apart because they fail differently — a correct action
+ * list still misleads if the bar draws a menu item as a button, and a correct
+ * bar draws the wrong set if the model is wrong.
+ *
+ * @module components/features/entries/EntryForm/__tests__/DocumentActionBar.test
+ */
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { fireEvent, render, screen } from "@admin/__tests__/utils";
+
+import { DocumentActionBar, type ActionBinding } from "../DocumentActionBar";
+import type { DocumentAction } from "../document-actions";
+
+const ACTIONS: DocumentAction[] = [
+  { id: "publish", label: "Publish changes", placement: "primary" },
+  { id: "save", label: "Save", placement: "toolbar" },
+  { id: "duplicate", label: "Duplicate", placement: "menu", group: "document" },
+  {
+    id: "unpublish",
+    label: "Unpublish",
+    placement: "menu",
+    group: "danger",
+    destructive: true,
+  },
+];
+
+/** Every action wired, unless a case says otherwise. */
+function allBound(
+  over: Record<string, ActionBinding | undefined> = {}
+): Record<string, ActionBinding | undefined> {
+  return {
+    publish: { onSelect: vi.fn() },
+    save: { onSelect: vi.fn() },
+    duplicate: { onSelect: vi.fn() },
+    unpublish: { onSelect: vi.fn() },
+    ...over,
+  };
+}
+
+const button = (name: RegExp) => screen.queryByRole("button", { name });
+
+describe("where each action ends up", () => {
+  it("draws the leading action as a button and the menu ones as menu items", () => {
+    render(<DocumentActionBar actions={ACTIONS} bindings={allBound()} />);
+
+    expect(button(/^publish changes$/i)).toBeTruthy();
+    expect(button(/^save$/i)).toBeTruthy();
+    // The demotion that matters: Unpublish is no longer one slip from Publish.
+    expect(button(/^unpublish$/i)).toBeNull();
+    expect(button(/^duplicate$/i)).toBeNull();
+    expect(button(/more actions/i)).toBeTruthy();
+  });
+
+  it("marks exactly one control as the leading one", () => {
+    // The model guarantees one primary action; this is the half that guarantees
+    // one primary CONTROL, which is a different claim about a different layer.
+    const { container } = render(
+      <DocumentActionBar actions={ACTIONS} bindings={allBound()} />
+    );
+    expect(container.querySelectorAll("[data-primary='true']").length).toBe(1);
+  });
+
+  it("opens the menu onto both groups, with a rule between them", async () => {
+    /*
+     * `userEvent` rather than `fireEvent`, because the menu is Radix and opens
+     * on a pointer sequence rather than on a bare click — a plain click leaves
+     * it closed and the assertions below would report the items as missing when
+     * the menu simply never opened.
+     */
+    render(<DocumentActionBar actions={ACTIONS} bindings={allBound()} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /more actions/i })
+    );
+
+    const items = await screen.findAllByRole("menuitem");
+    // Order is the contract: routine verbs first, destructive ones after.
+    expect(items.map(item => item.textContent)).toEqual([
+      "Duplicate",
+      "Unpublish",
+    ]);
+    expect(screen.getByRole("separator")).toBeTruthy();
+  });
+
+  it("draws no rule when only one group has anything in it", async () => {
+    /*
+     * The control. A separator drawn unconditionally becomes a rule at the top
+     * or bottom of the menu, which reads as a group whose items failed to
+     * render — the same "something is missing here" the panel work was about.
+     */
+    render(
+      <DocumentActionBar
+        actions={ACTIONS}
+        bindings={allBound({ unpublish: undefined })}
+      />
+    );
+    await userEvent.click(
+      screen.getByRole("button", { name: /more actions/i })
+    );
+
+    expect(await screen.findAllByRole("menuitem")).toHaveLength(1);
+    expect(screen.queryByRole("separator")).toBeNull();
+  });
+});
+
+describe("an action a host did not wire", () => {
+  it("is not drawn at all", () => {
+    /*
+     * How an optional affordance disappears — a collection with no duplicate
+     * handler — without the model needing to know which handlers a host passed.
+     */
+    render(
+      <DocumentActionBar
+        actions={ACTIONS}
+        bindings={allBound({ duplicate: undefined, unpublish: undefined })}
+      />
+    );
+    // Both menu entries were the only menu content, so the trigger goes too:
+    // a menu button opening onto nothing is the empty-panel defect again.
+    expect(button(/more actions/i)).toBeNull();
+  });
+
+  it("still draws the ones that ARE wired", () => {
+    // The control. A bar that dropped everything would satisfy the case above.
+    render(
+      <DocumentActionBar
+        actions={ACTIONS}
+        bindings={allBound({ duplicate: undefined })}
+      />
+    );
+    expect(button(/^publish changes$/i)).toBeTruthy();
+    expect(button(/more actions/i)).toBeTruthy();
+  });
+});
+
+describe("an action that cannot be used", () => {
+  it("is disabled and says why, from either kind of reason", () => {
+    /*
+     * Two sources, deliberately kept apart: the MODEL knows about permission
+     * and document state, the BINDING knows about this instant — mid-submit,
+     * invalid, nothing changed. Both must reach the control, or an author sees
+     * a dead button with no explanation.
+     */
+    const withModelReason: DocumentAction[] = [
+      {
+        id: "publish",
+        label: "Publish",
+        placement: "primary",
+        disabledReason: "You do not have permission to publish.",
+      },
+      { id: "save", label: "Save", placement: "toolbar" },
+    ];
+    render(
+      <DocumentActionBar
+        actions={withModelReason}
+        bindings={{
+          publish: { onSelect: vi.fn() },
+          save: { onSelect: vi.fn(), disabledReason: "Nothing to save." },
+        }}
+      />
+    );
+
+    const publish = screen.getByRole("button", { name: /^publish$/i });
+    expect(publish).toBeDisabled();
+    expect(publish.getAttribute("title")).toMatch(/permission/i);
+
+    const save = screen.getByRole("button", { name: /^save$/i });
+    expect(save).toBeDisabled();
+    expect(save.getAttribute("title")).toMatch(/nothing to save/i);
+  });
+
+  it("leaves a usable action enabled, titled with its own label", () => {
+    // The control: a bar that disabled everything, or titled everything with a
+    // reason, would satisfy the case above.
+    render(<DocumentActionBar actions={ACTIONS} bindings={allBound()} />);
+    const publish = screen.getByRole("button", { name: /^publish changes$/i });
+    expect(publish).toBeEnabled();
+    expect(publish.getAttribute("title")).toBe("Publish changes");
+  });
+
+  it("does not run when pressed", () => {
+    const onSelect = vi.fn();
+    render(
+      <DocumentActionBar
+        actions={[
+          {
+            id: "publish",
+            label: "Publish",
+            placement: "primary",
+            disabledReason: "no",
+          },
+        ]}
+        bindings={{ publish: { onSelect } }}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^publish$/i }));
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+});
+
+describe("running an action", () => {
+  it("calls the binding the host supplied", () => {
+    const publish = vi.fn();
+    render(
+      <DocumentActionBar
+        actions={ACTIONS}
+        bindings={allBound({ publish: { onSelect: publish } })}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /^publish changes$/i }));
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
@@ -110,7 +110,19 @@ describe("EntrySystemHeader — button matrix", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("edit + published clean → Save changes (disabled) + Unpublish", () => {
+  /*
+   * UNPUBLISH IS NO LONGER A BUTTON, and the four cases below were rewritten to
+   * say so rather than loosened to pass.
+   *
+   * It sat beside Publish — the two most consequential and opposite verbs in
+   * the editor, one slip apart and styled almost alike — and it is rare, public
+   * and reversible only by re-publishing. It is now a destructive item in the
+   * menu. What is asserted here is the promotion side: the toolbar holds the
+   * one action an author is reaching for, and the menu holds the rest.
+   * `document-actions.test` covers which actions exist in which state; these
+   * cover what the header draws.
+   */
+  it("edit + published clean → Save changes leads, Unpublish demoted", () => {
     render(
       <Harness
         mode="edit"
@@ -125,7 +137,12 @@ describe("EntrySystemHeader — button matrix", () => {
     expect(saveChanges).toBeInTheDocument();
     expect(saveChanges).toBeDisabled();
     expect(
-      screen.getByRole("button", { name: /^unpublish$/i })
+      screen.queryByRole("button", { name: /^unpublish$/i })
+    ).not.toBeInTheDocument();
+    // It has somewhere to be, though — a verb that vanished entirely would
+    // satisfy the line above and take the capability with it.
+    expect(
+      screen.getByRole("button", { name: /more actions/i })
     ).toBeInTheDocument();
     expect(
       screen.queryByRole("button", { name: /^save draft$/i })
@@ -135,7 +152,7 @@ describe("EntrySystemHeader — button matrix", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("edit + published dirty → Save changes (enabled) + Unpublish", () => {
+  it("edit + published dirty → Save changes leads, enabled", () => {
     render(
       <Harness
         mode="edit"
@@ -149,8 +166,8 @@ describe("EntrySystemHeader — button matrix", () => {
     });
     expect(saveChanges).toBeEnabled();
     expect(
-      screen.getByRole("button", { name: /^unpublish$/i })
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /^unpublish$/i })
+    ).not.toBeInTheDocument();
   });
 
   it("!hasStatus → single Save / Create button", () => {
@@ -169,7 +186,7 @@ describe("EntrySystemHeader — button matrix", () => {
 });
 
 describe("EntrySystemHeader — drafts-enabled working-draft matrix", () => {
-  it("published + drafts on, no pending draft → Save (not Save changes), Unpublish, no Publish", () => {
+  it("published + drafts on, no pending draft → Save leads, no Publish", () => {
     render(
       <Harness
         mode="edit"
@@ -188,11 +205,11 @@ describe("EntrySystemHeader — drafts-enabled working-draft matrix", () => {
       screen.queryByRole("button", { name: /^publish$/i })
     ).not.toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^unpublish$/i })
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /^unpublish$/i })
+    ).not.toBeInTheDocument();
   });
 
-  it("published + drafts on + pending working draft → Save + Publish + Unpublish", () => {
+  it("published + drafts on + pending working draft → two controls, not three", () => {
     render(
       <Harness
         mode="edit"
@@ -205,15 +222,23 @@ describe("EntrySystemHeader — drafts-enabled working-draft matrix", () => {
         }}
       />
     );
-    // A pending working draft can be promoted, so Publish appears alongside the
-    // status-less Save and the Unpublish action.
+    /*
+     * The state this whole change is about. It drew Save, Publish and Unpublish
+     * side by side at equal weight, so an author read three buttons to find the
+     * one they wanted. Two now: the act, and the quieter way to keep the work
+     * private.
+     *
+     * The label carries the rest — "Publish changes" rather than "Publish",
+     * which on a document already live reads as a no-op and says nothing about
+     * the draft it promotes.
+     */
     expect(screen.getByRole("button", { name: /^save$/i })).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^publish$/i })
+      screen.getByRole("button", { name: /^publish changes$/i })
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /^unpublish$/i })
-    ).toBeInTheDocument();
+      screen.queryByRole("button", { name: /^unpublish$/i })
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/EntrySystemHeader.status-matrix.test.tsx
@@ -170,6 +170,31 @@ describe("EntrySystemHeader — button matrix", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("!hasStatus → the save SUBMITS, carrying no intent", () => {
+    /*
+     * The regression this pins. A collection with no status column has no
+     * `status` to write, and every save handler a host exposes carries an
+     * intent — the draft one writes `status: "draft"`. Routing this control
+     * through a callback turned both Create and Save into a failing write, so
+     * it stays a native submit exactly as it always was.
+     */
+    render(<Harness mode="create" hasStatus={false} />);
+    const create = screen.getByRole("button", { name: /^create$/i });
+    expect(create.getAttribute("type")).toBe("submit");
+    expect(create.getAttribute("form")).toBe("entry-form");
+  });
+
+  it("a collection WITH a lifecycle does not submit — its saves carry intent", () => {
+    // The control, and it must come out different: those handlers exist
+    // precisely to attach an intent, so a submit there would bypass them.
+    render(
+      <Harness mode="edit" hasStatus entry={{ id: "x", status: "draft" }} />
+    );
+    expect(
+      screen.getByRole("button", { name: /^save draft$/i }).getAttribute("type")
+    ).toBe("button");
+  });
+
   it("!hasStatus → single Save / Create button", () => {
     render(<Harness mode="create" hasStatus={false} />);
     // In create mode the single submit button reads "Create".

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/document-actions.test.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/document-actions.test.ts
@@ -96,10 +96,37 @@ describe("exactly one action leads", () => {
 });
 
 describe("the action that leads, per state", () => {
-  it("is Create while the document does not exist yet", () => {
-    expect(
-      actionsAt(documentActions(state({ mode: "create" })), "primary")[0]
-    ).toMatchObject({ id: "create", label: "Create" });
+  it("is Create only where there is no lifecycle to choose from", () => {
+    /*
+     * "Create" is the word for a collection with no publish state: one verb,
+     * and the document does not exist yet. A collection that HAS a lifecycle
+     * offers both from the start, so Create is the wrong word there — the case
+     * below.
+     */
+    const actions = documentActions(
+      state({ mode: "create", hasStatus: false })
+    );
+    expect(actionsAt(actions, "primary")[0]).toMatchObject({
+      id: "save",
+      label: "Create",
+    });
+    expect(actionsAt(actions, "toolbar")).toEqual([]);
+  });
+
+  it("offers Publish AND a draft save while creating in a lifecycle collection", () => {
+    /*
+     * Taken from the behaviour the header already had: creating in a collection
+     * with a publish state has always offered both, and dropping one would take
+     * away the ability to begin a document without publishing it.
+     */
+    const actions = documentActions(state({ mode: "create", hasStatus: true }));
+    expect(actionsAt(actions, "primary")[0]).toMatchObject({
+      id: "publish",
+      label: "Publish",
+    });
+    expect(actionsAt(actions, "toolbar").map(a => a.label)).toEqual([
+      "Save draft",
+    ]);
   });
 
   it("is Publish on a draft, with saving offered beside it", () => {
@@ -129,15 +156,38 @@ describe("the action that leads, per state", () => {
   });
 
   it("is Save on a clean live document, which has nothing to publish", () => {
-    const actions = documentActions(
-      state({ status: "published", hasWorkingDraft: false })
+    /*
+     * The WORD depends on where the work goes, a distinction the editor already
+     * drew and this keeps: with drafts on it lands in a draft, so "Save"; with
+     * drafts off it goes straight to readers, so "Save changes" says what will
+     * happen. Both are asserted, because a model ignoring `draftsEnabled` would
+     * pass whichever one it happened to hard-code.
+     */
+    const withDrafts = documentActions(
+      state({
+        status: "published",
+        hasWorkingDraft: false,
+        draftsEnabled: true,
+      })
     );
-    expect(actionsAt(actions, "primary")[0]).toMatchObject({
+    expect(actionsAt(withDrafts, "primary")[0]).toMatchObject({
+      id: "save",
+      label: "Save",
+    });
+    // And nothing joins it in the toolbar: there is no second act here.
+    expect(actionsAt(withDrafts, "toolbar")).toEqual([]);
+
+    const withoutDrafts = documentActions(
+      state({
+        status: "published",
+        hasWorkingDraft: false,
+        draftsEnabled: false,
+      })
+    );
+    expect(actionsAt(withoutDrafts, "primary")[0]).toMatchObject({
       id: "save",
       label: "Save changes",
     });
-    // And nothing joins it in the toolbar: there is no second act here.
-    expect(actionsAt(actions, "toolbar")).toEqual([]);
   });
 
   it("is Save for a collection with no publish lifecycle at all", () => {

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/document-actions.test.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/document-actions.test.ts
@@ -1,0 +1,254 @@
+/**
+ * What an author may do to a document, across every state the editor reaches.
+ *
+ * The property this module exists for is that exactly ONE action is primary.
+ * The header it replaces had no such rule — a published document with a pending
+ * draft drew Save, Publish and Unpublish side by side — so that invariant is
+ * asserted over the whole state space rather than at the cases that happen to
+ * be interesting.
+ *
+ * @module components/features/entries/EntryForm/__tests__/document-actions.test
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  actionsAt,
+  documentActions,
+  menuGroups,
+  type DocumentActionState,
+} from "../document-actions";
+
+/** A permissive edit-mode document; each case names only what it changes. */
+function state(over: Partial<DocumentActionState> = {}): DocumentActionState {
+  return {
+    mode: "edit",
+    hasStatus: true,
+    draftsEnabled: true,
+    status: "draft",
+    hasWorkingDraft: false,
+    readingHistory: false,
+    canPublish: true,
+    canUnpublish: true,
+    canDelete: true,
+    isDirty: false,
+    canDuplicate: true,
+    ...over,
+  };
+}
+
+/**
+ * The cartesian product of every dimension, so the invariant below is asserted
+ * over the STATE SPACE rather than over the states someone thought to list.
+ *
+ * Built by folding rather than by nesting seven loops: the nested form reached
+ * a cognitive complexity the repository's gate refuses, and it refuses for the
+ * reason that matters here — a reader cannot tell at a glance whether a
+ * dimension is missing, which is exactly the mistake this generator exists to
+ * prevent.
+ */
+const DIMENSIONS = {
+  mode: ["create", "edit"],
+  hasStatus: [true, false],
+  draftsEnabled: [true, false],
+  status: ["draft", "published", "unknown"],
+  hasWorkingDraft: [true, false],
+  readingHistory: [true, false],
+  canPublish: [true, false],
+} as const;
+
+function everyState(): DocumentActionState[] {
+  let combos: Record<string, unknown>[] = [{}];
+  for (const [key, values] of Object.entries(DIMENSIONS)) {
+    combos = combos.flatMap(combo =>
+      (values as readonly unknown[]).map(value => ({ ...combo, [key]: value }))
+    );
+  }
+  return combos.map(combo => state(combo as Partial<DocumentActionState>));
+}
+
+describe("exactly one action leads", () => {
+  it("holds in every state the editor can reach", () => {
+    const states = everyState();
+    // Population first: a generator that produced nothing would satisfy every
+    // assertion in the loop by never entering it.
+    expect(states.length).toBe(192);
+
+    for (const s of states) {
+      const primaries = actionsAt(documentActions(s), "primary");
+      expect(
+        primaries.length,
+        `${JSON.stringify(s)} produced ${primaries.length} primary actions`
+      ).toBe(1);
+    }
+  });
+
+  it("never repeats an id, so no action is offered twice", () => {
+    // Save appears as primary in one state and in the toolbar in another; a
+    // rule that added both would draw the same verb twice with different
+    // weights, which is the shape of the defect being removed.
+    for (const s of everyState()) {
+      const ids = documentActions(s).map(a => a.id);
+      expect(new Set(ids).size, `duplicate id in ${JSON.stringify(s)}`).toBe(
+        ids.length
+      );
+    }
+  });
+});
+
+describe("the action that leads, per state", () => {
+  it("is Create while the document does not exist yet", () => {
+    expect(
+      actionsAt(documentActions(state({ mode: "create" })), "primary")[0]
+    ).toMatchObject({ id: "create", label: "Create" });
+  });
+
+  it("is Publish on a draft, with saving offered beside it", () => {
+    // A draft's purpose is to become published, so Publish leads — and an
+    // author not ready for readers still needs somewhere to put the work.
+    const actions = documentActions(state({ status: "draft" }));
+    expect(actionsAt(actions, "primary")[0]).toMatchObject({ id: "publish" });
+    expect(actionsAt(actions, "toolbar").map(a => a.label)).toEqual([
+      "Save draft",
+    ]);
+  });
+
+  it("says Publish CHANGES on a live document with pending edits", () => {
+    /*
+     * The label is the point. "Publish" on something already live reads as a
+     * no-op and says nothing about the draft it promotes — and this is the
+     * state that previously drew three buttons of equal weight.
+     */
+    const actions = documentActions(
+      state({ status: "published", hasWorkingDraft: true })
+    );
+    expect(actionsAt(actions, "primary")[0]).toMatchObject({
+      id: "publish",
+      label: "Publish changes",
+    });
+    expect(actionsAt(actions, "toolbar").map(a => a.label)).toEqual(["Save"]);
+  });
+
+  it("is Save on a clean live document, which has nothing to publish", () => {
+    const actions = documentActions(
+      state({ status: "published", hasWorkingDraft: false })
+    );
+    expect(actionsAt(actions, "primary")[0]).toMatchObject({
+      id: "save",
+      label: "Save changes",
+    });
+    // And nothing joins it in the toolbar: there is no second act here.
+    expect(actionsAt(actions, "toolbar")).toEqual([]);
+  });
+
+  it("is Save for a collection with no publish lifecycle at all", () => {
+    const actions = documentActions(state({ hasStatus: false }));
+    expect(actionsAt(actions, "primary")[0]).toMatchObject({ id: "save" });
+    expect(actionsAt(actions, "menu").map(a => a.id)).not.toContain(
+      "unpublish"
+    );
+  });
+});
+
+describe("what moved out of the toolbar", () => {
+  it("puts Unpublish in the danger group, not beside Publish", () => {
+    /*
+     * The demotion this model exists to make expressible. The two most
+     * consequential and opposite verbs in the editor were one slip apart and
+     * styled almost alike; unpublishing is rare, public, and belongs with the
+     * other destructive verbs.
+     */
+    const actions = documentActions(state({ status: "published" }));
+    expect(actionsAt(actions, "toolbar").map(a => a.id)).not.toContain(
+      "unpublish"
+    );
+    expect(menuGroups(actions).danger.map(a => a.id)).toContain("unpublish");
+  });
+
+  it("keeps routine and destructive verbs in separate groups", () => {
+    // Duplicate and Delete sat in one flat list. A destructive verb one row
+    // from a routine one is a slip waiting to happen.
+    const groups = menuGroups(
+      documentActions(state({ status: "published", isDirty: true }))
+    );
+    expect(groups.document.map(a => a.id)).toEqual(["duplicate", "view-api"]);
+    expect(groups.danger.every(a => a.destructive === true)).toBe(true);
+    // The control: a split that put everything on one side would satisfy the
+    // assertion above about `danger` while telling us nothing.
+    expect(groups.document.length).toBeGreaterThan(0);
+    expect(groups.danger.length).toBeGreaterThan(0);
+  });
+
+  it("offers the two kinds of discard separately, and only when they apply", () => {
+    /*
+     * Different acts on different things: a pending working draft is saved work
+     * readers cannot see, unsaved form changes were never written down.
+     * Collapsing them would let an author dropping a typo throw away a rewrite.
+     */
+    const both = documentActions(
+      state({ status: "published", hasWorkingDraft: true, isDirty: true })
+    );
+    expect(menuGroups(both).danger.map(a => a.id)).toEqual(
+      expect.arrayContaining(["discard-draft", "discard-changes"])
+    );
+
+    const neither = documentActions(
+      state({ status: "published", hasWorkingDraft: false, isDirty: false })
+    );
+    const ids = neither.map(a => a.id);
+    expect(ids).not.toContain("discard-draft");
+    expect(ids).not.toContain("discard-changes");
+  });
+});
+
+describe("why an action cannot be used", () => {
+  it("says so rather than going quietly dead", () => {
+    // Three independent permissions decide these, so a disabled control with no
+    // explanation reads as broken rather than as forbidden.
+    const actions = documentActions(
+      state({ status: "published", canUnpublish: false, canDelete: false })
+    );
+    const byId = new Map(actions.map(a => [a.id, a]));
+    expect(byId.get("unpublish")?.disabledReason).toMatch(/permission/i);
+    expect(byId.get("delete")?.disabledReason).toMatch(/permission/i);
+  });
+
+  it("leaves the reason absent when the action IS available", () => {
+    // The control. A model that attached a reason unconditionally would satisfy
+    // the case above while disabling everything.
+    const actions = documentActions(state({ status: "published" }));
+    for (const action of actions) {
+      expect(action.disabledReason).toBeUndefined();
+    }
+  });
+
+  it("blocks every MUTATION while a past version is on screen", () => {
+    /*
+     * Reading history is a MODE, not a permission: the document on screen is
+     * not the live one, so a write would land on the wrong thing. The reason
+     * names the way out rather than only refusing.
+     */
+    const actions = documentActions(state({ readingHistory: true }));
+    const mutations = actions.filter(a => a.id !== "view-api");
+    // Population: an empty list would satisfy the loop by never entering it.
+    expect(mutations.length).toBeGreaterThan(0);
+    for (const action of mutations) {
+      expect(action.disabledReason, `${action.id} was left usable`).toMatch(
+        /past version/i
+      );
+    }
+  });
+
+  it("leaves the one READ available there, because it writes nothing", () => {
+    /*
+     * The discriminating half, and the reason the case above is not simply
+     * "every action". Viewing the API response changes nothing and is most
+     * useful exactly when an author is trying to understand the version in
+     * front of them. A rule that disabled the whole list would satisfy the test
+     * above while taking away the one thing that still makes sense.
+     */
+    const actions = documentActions(state({ readingHistory: true }));
+    const viewApi = actions.find(a => a.id === "view-api");
+    expect(viewApi).toBeDefined();
+    expect(viewApi?.disabledReason).toBeUndefined();
+  });
+});

--- a/packages/admin/src/components/features/entries/EntryForm/document-actions.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/document-actions.ts
@@ -117,35 +117,70 @@ const HISTORY_REASON =
  * - PUBLISHED AND CLEAN, or a collection with no lifecycle at all, saving is
  *   all there is.
  */
+const PRIMARY_RULES: readonly {
+  applies: (state: DocumentActionState) => boolean;
+  build: (state: DocumentActionState) => { id: string; label: string };
+}[] = [
+  /*
+   * A collection with NO lifecycle has exactly one verb, and its word depends
+   * only on whether the document exists yet.
+   */
+  {
+    applies: state => !state.hasStatus,
+    build: state => ({
+      id: "save",
+      label: state.mode === "create" ? "Create" : "Save",
+    }),
+  },
+  /*
+   * PUBLISHED WITH PENDING EDITS: publishing those edits is the act, and the
+   * label says so rather than repeating "Publish" at a document already live,
+   * where the shorter word reads as a no-op.
+   */
+  {
+    applies: state => isPublishedEdit(state) && state.hasWorkingDraft,
+    build: () => ({ id: "publish", label: "Publish changes" }),
+  },
+  /*
+   * PUBLISHED AND CLEAN: saving is all there is. "Save" where drafts are
+   * enabled, because the work lands in a draft rather than in front of readers,
+   * and "Save changes" where it goes straight out — a distinction the editor
+   * already drew and worth keeping.
+   */
+  {
+    applies: isPublishedEdit,
+    build: state => ({
+      id: "save",
+      label: state.draftsEnabled ? "Save" : "Save changes",
+    }),
+  },
+];
+
+/**
+ * A DRAFT, or a document being created in a collection that HAS a lifecycle:
+ * its purpose is to become published, so Publish leads and saving is the
+ * quieter companion beside it — the ranking the block editor and Sanity use.
+ */
+const PRIMARY_FALLBACK = { id: "publish", label: "Publish" };
+
+/**
+ * The one action an author is most likely reaching for, given the state.
+ *
+ * Derived rather than chosen at each call site, which is what stops two
+ * controls both claiming to be the main one. A TABLE for the same reason the
+ * built-ins are one: written as branches this reached a complexity the gate
+ * refuses, and the order of the rules — which IS the rule — was buried in the
+ * order the `if`s happened to be typed.
+ *
+ * FIRST MATCH WINS, so the rows read as "the most specific situation first".
+ */
 function primaryAction(state: DocumentActionState): DocumentAction {
+  const matched = PRIMARY_RULES.find(rule => rule.applies(state));
+  const { id, label } = matched?.build(state) ?? PRIMARY_FALLBACK;
   const blocked = state.readingHistory ? HISTORY_REASON : undefined;
-  if (state.mode === "create") {
-    return withReason(
-      { id: "create", label: "Create", placement: "primary" },
-      blocked
-    );
-  }
-  if (!state.hasStatus) {
-    return withReason(
-      { id: "save", label: "Save", placement: "primary" },
-      blocked
-    );
-  }
-  if (state.status === "published" && state.hasWorkingDraft) {
-    return withReason(
-      { id: "publish", label: "Publish changes", placement: "primary" },
-      blocked ?? publishReason(state)
-    );
-  }
-  if (state.status === "published") {
-    return withReason(
-      { id: "save", label: "Save changes", placement: "primary" },
-      blocked
-    );
-  }
   return withReason(
-    { id: "publish", label: "Publish", placement: "primary" },
-    blocked ?? publishReason(state)
+    { id, label, placement: "primary" },
+    blocked ?? (id === "publish" ? publishReason(state) : undefined)
   );
 }
 
@@ -200,11 +235,26 @@ interface ActionRule {
   mutates: boolean;
 }
 
-const isPublishedEdit = (s: DocumentActionState): boolean =>
-  s.mode === "edit" && s.hasStatus && s.status === "published";
+/**
+ * A FUNCTION declaration, not a const arrow, and that is load-bearing.
+ *
+ * Both action tables reference this at module-evaluation time, and a `const`
+ * initialised after them throws `Cannot access before initialization` the
+ * instant the module is imported. Declared this way it hoists, so the tables
+ * may sit wherever they read best rather than wherever the initialiser order
+ * permits.
+ *
+ * Worth stating because nothing static catches it: type-checking, linting and
+ * the complexity gate all passed on the broken arrangement — only running the
+ * module found it.
+ */
+function isPublishedEdit(s: DocumentActionState): boolean {
+  return s.mode === "edit" && s.hasStatus && s.status === "published";
+}
 
-const permissionReason = (verb: string): string =>
-  `You do not have permission to ${verb} in this collection.`;
+function permissionReason(verb: string): string {
+  return `You do not have permission to ${verb} in this collection.`;
+}
 
 /**
  * The built-in actions, in the order a surface presents them.
@@ -227,13 +277,16 @@ const BUILT_IN_ACTIONS: readonly ActionRule[] = [
     mutates: true,
   },
   /*
-   * A DRAFT keeps its save in the toolbar for the same reason from the other
-   * side: Publish leads, and an author who is not ready for readers still needs
-   * somewhere to put the work.
+   * A DRAFT — or a document being created where a lifecycle exists — keeps its
+   * save in the toolbar for the same reason from the other side: Publish leads,
+   * and an author not ready for readers still needs somewhere to put the work.
+   * Creating is included because a collection with a lifecycle has always
+   * offered both from the start; dropping one would take away the ability to
+   * begin a document without publishing it.
    */
   {
     id: "save",
-    applies: s => s.mode === "edit" && s.hasStatus && s.status === "draft",
+    applies: s => s.hasStatus && (s.mode === "create" || s.status === "draft"),
     label: () => "Save draft",
     placement: "toolbar",
     mutates: true,

--- a/packages/admin/src/components/features/entries/EntryForm/document-actions.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/document-actions.ts
@@ -138,7 +138,8 @@ const PRIMARY_RULES: readonly {
    * where the shorter word reads as a no-op.
    */
   {
-    applies: state => isPublishedEdit(state) && state.hasWorkingDraft,
+    applies: state =>
+      isPublishedEdit(state) && state.hasWorkingDraft && state.canPublish,
     build: () => ({ id: "publish", label: "Publish changes" }),
   },
   /*
@@ -153,6 +154,21 @@ const PRIMARY_RULES: readonly {
       id: "save",
       label: state.draftsEnabled ? "Save" : "Save changes",
     }),
+  },
+  /*
+   * NO PERMISSION TO PUBLISH: saving leads instead, and publishing is not
+   * offered at all rather than offered dead.
+   *
+   * The distinction is between "not now" and "not you". A disabled control
+   * explains a temporary refusal; a permission an author will never hold is
+   * furniture they cannot use, and the header has always hidden it. Leaving it
+   * as the leading action would be worse than untidy — the one control drawn as
+   * the thing to press would be the one thing they cannot do, with their real
+   * action demoted beside it.
+   */
+  {
+    applies: state => !state.canPublish,
+    build: () => ({ id: "save", label: "Save draft" }),
   },
 ];
 
@@ -180,15 +196,13 @@ function primaryAction(state: DocumentActionState): DocumentAction {
   const blocked = state.readingHistory ? HISTORY_REASON : undefined;
   return withReason(
     { id, label, placement: "primary" },
-    blocked ?? (id === "publish" ? publishReason(state) : undefined)
+    /*
+     * Only the historical-view rule can refuse the leading action now.
+     * Publishing without permission is not offered at all — see the rule table
+     * — so there is no second reason left for this control to carry.
+     */
+    blocked
   );
-}
-
-/** Why publishing is unavailable, or undefined when it is not. */
-function publishReason(state: DocumentActionState): string | undefined {
-  return state.canPublish
-    ? undefined
-    : "You do not have permission to publish in this collection.";
 }
 
 function withReason(
@@ -271,7 +285,7 @@ const BUILT_IN_ACTIONS: readonly ActionRule[] = [
    */
   {
     id: "save",
-    applies: s => isPublishedEdit(s) && s.hasWorkingDraft,
+    applies: s => isPublishedEdit(s) && s.hasWorkingDraft && s.canPublish,
     label: s => (s.draftsEnabled ? "Save" : "Save changes"),
     placement: "toolbar",
     mutates: true,
@@ -286,7 +300,10 @@ const BUILT_IN_ACTIONS: readonly ActionRule[] = [
    */
   {
     id: "save",
-    applies: s => s.hasStatus && (s.mode === "create" || s.status === "draft"),
+    applies: s =>
+      s.canPublish &&
+      s.hasStatus &&
+      (s.mode === "create" || s.status === "draft"),
     label: () => "Save draft",
     placement: "toolbar",
     mutates: true,
@@ -307,10 +324,14 @@ const BUILT_IN_ACTIONS: readonly ActionRule[] = [
    * changes nothing, and it is most useful precisely when an author is trying
    * to understand a version they are looking at. Blocking it would be the rule
    * applied past its reason.
+   *
+   * It still needs a document to read: while one is being CREATED there is
+   * nothing on the server to fetch, which is why the whole menu stays away in
+   * create mode.
    */
   {
     id: "view-api",
-    applies: () => true,
+    applies: state => state.mode === "edit",
     label: () => "View API response",
     placement: "menu",
     group: "document",

--- a/packages/admin/src/components/features/entries/EntryForm/document-actions.ts
+++ b/packages/admin/src/components/features/entries/EntryForm/document-actions.ts
@@ -1,0 +1,375 @@
+/**
+ * What an author can do to a document, as data rather than as branches.
+ *
+ * The header used to decide each control where it drew it, so what appeared was
+ * the sum of a dozen conditions spread down a 900-line component. Three
+ * consequences, and the third is the one that decided this shape:
+ *
+ * - Nothing owned the rule that there is ONE primary action. A published
+ *   document with a pending draft rendered Save, Publish and Unpublish side by
+ *   side, all the same size, and an author had to read three buttons to find
+ *   the one they wanted.
+ * - Where an action belonged — toolbar or menu — was expressed by WHERE its
+ *   JSX sat, so demoting one meant moving code rather than changing a value.
+ * - A plugin could not join in. Contributed actions get a single slot with no
+ *   priority and no placement, so "add this document to a release" could only
+ *   ever be one more button beside the others.
+ *
+ * So an action DESCRIBES itself and the surface decides how to draw it. That is
+ * the shape Sanity's document actions settled on for the same reason: one
+ * description renders as a toolbar button or a menu item depending on where it
+ * is asked for, and a plugin appends to the same list the built-ins come from.
+ *
+ * This module is deliberately free of React. What an author may do is a
+ * question about permissions and document state, and answering it in a
+ * component means it can only be tested by rendering one.
+ *
+ * @module components/features/entries/EntryForm/document-actions
+ */
+
+/**
+ * Where an action is drawn.
+ *
+ * `primary` is a promise as much as a position: exactly one action carries it,
+ * and {@link documentActions} is what keeps that true. Two primaries is the
+ * state the header was already in.
+ */
+export type ActionPlacement = "primary" | "toolbar" | "menu";
+
+/**
+ * Which part of the menu an action belongs to.
+ *
+ * `danger` is separated because the menu currently mixes Duplicate with Delete
+ * in one flat list, and a destructive verb one row from a routine one is a slip
+ * waiting to happen.
+ */
+export type ActionGroup = "document" | "danger";
+
+export interface DocumentAction {
+  /** Stable identity, for tests and for a plugin replacing a built-in. */
+  id: string;
+  /**
+   * What the control says, in the imperative.
+   *
+   * Imperative and SPECIFIC: "Publish changes" rather than "Publish" on a
+   * document that is already live, where the shorter word reads as a no-op and
+   * says nothing about the pending draft it promotes.
+   */
+  label: string;
+  placement: ActionPlacement;
+  /** Which menu section, for a `menu` action. */
+  group?: ActionGroup;
+  /** Whether the action removes or replaces something an author can see. */
+  destructive?: boolean;
+  /**
+   * Why this action cannot be used right now, or absent when it can.
+   *
+   * A REASON rather than a boolean, because three separate permissions and
+   * several document states decide these, and a dead control with no
+   * explanation reads as a broken one. Whatever draws the action is expected to
+   * surface this — a tooltip on a disabled button, helper text on a menu item.
+   */
+  disabledReason?: string;
+}
+
+/**
+ * Everything the answer depends on.
+ *
+ * Facts only. Whether a control is drawn is this module's decision, and a
+ * caller passing `showPublishButton` would be making it somewhere else.
+ */
+export interface DocumentActionState {
+  mode: "create" | "edit";
+  /** Whether the collection has a publish lifecycle at all. */
+  hasStatus: boolean;
+  /** Whether a published document keeps its edits as a working draft. */
+  draftsEnabled: boolean;
+  /** The document's status in the language being edited. */
+  status: "draft" | "published" | "unknown";
+  /** Whether a published document has unpublished edits pending. */
+  hasWorkingDraft: boolean;
+  /** Whether a past version is on screen, which forbids every mutation. */
+  readingHistory: boolean;
+  canPublish: boolean;
+  canUnpublish: boolean;
+  canDelete: boolean;
+  /** Whether the form currently holds work worth discarding. */
+  isDirty: boolean;
+  /** Whether the document can be duplicated — an edit-mode affordance. */
+  canDuplicate: boolean;
+}
+
+/** The reason every action is unavailable while a past version is on screen. */
+const HISTORY_REASON =
+  "You are viewing a past version. Return to the current one to make changes.";
+
+/**
+ * The one action an author is most likely reaching for, given the state.
+ *
+ * Derived rather than chosen at each call site, which is what stops two
+ * controls both claiming to be the main one. The order below is the whole rule:
+ *
+ * - CREATING, the only thing to do is make the document exist.
+ * - A DRAFT's purpose is to become published, so Publish leads and Save is the
+ *   quieter companion — the same ranking the block editor and Sanity use.
+ * - PUBLISHED WITH PENDING EDITS, publishing those edits is the act; the label
+ *   says so rather than repeating "Publish" at a document that is already live.
+ * - PUBLISHED AND CLEAN, or a collection with no lifecycle at all, saving is
+ *   all there is.
+ */
+function primaryAction(state: DocumentActionState): DocumentAction {
+  const blocked = state.readingHistory ? HISTORY_REASON : undefined;
+  if (state.mode === "create") {
+    return withReason(
+      { id: "create", label: "Create", placement: "primary" },
+      blocked
+    );
+  }
+  if (!state.hasStatus) {
+    return withReason(
+      { id: "save", label: "Save", placement: "primary" },
+      blocked
+    );
+  }
+  if (state.status === "published" && state.hasWorkingDraft) {
+    return withReason(
+      { id: "publish", label: "Publish changes", placement: "primary" },
+      blocked ?? publishReason(state)
+    );
+  }
+  if (state.status === "published") {
+    return withReason(
+      { id: "save", label: "Save changes", placement: "primary" },
+      blocked
+    );
+  }
+  return withReason(
+    { id: "publish", label: "Publish", placement: "primary" },
+    blocked ?? publishReason(state)
+  );
+}
+
+/** Why publishing is unavailable, or undefined when it is not. */
+function publishReason(state: DocumentActionState): string | undefined {
+  return state.canPublish
+    ? undefined
+    : "You do not have permission to publish in this collection.";
+}
+
+function withReason(
+  action: DocumentAction,
+  reason: string | undefined
+): DocumentAction {
+  return reason === undefined ? action : { ...action, disabledReason: reason };
+}
+
+/**
+ * One built-in action, and the states it applies to.
+ *
+ * A TABLE rather than a sequence of `if` blocks, and the reason is not
+ * tidiness: written as branches this reached a cyclomatic complexity of 24 in
+ * one function, which the repository's own gate refuses — correctly, because a
+ * reader then has to hold every condition at once to answer "what does an
+ * author see here".
+ *
+ * It is also the shape a plugin can join. A contributed action is another entry
+ * with its own `applies`, so "add this document to a release" arrives without
+ * the header being edited — which is the whole reason the built-ins are
+ * expressed as data rather than as JSX in the order it happened to be written.
+ */
+interface ActionRule {
+  id: string;
+  /** Whether this action exists at all for the given state. */
+  applies: (state: DocumentActionState) => boolean;
+  /** What it says, which for several actions depends on the state. */
+  label: (state: DocumentActionState) => string;
+  placement: Exclude<ActionPlacement, "primary">;
+  group?: ActionGroup;
+  destructive?: boolean;
+  /**
+   * Why it is unavailable, beyond the historical-view rule every mutation
+   * shares. Absent for an action nothing else can forbid.
+   */
+  reason?: (state: DocumentActionState) => string | undefined;
+  /**
+   * Whether a historical view forbids this action.
+   *
+   * Every rule sets it except the one READ in the list. Defaulting it to
+   * "mutates" would make the exception invisible at the entry that needs it.
+   */
+  mutates: boolean;
+}
+
+const isPublishedEdit = (s: DocumentActionState): boolean =>
+  s.mode === "edit" && s.hasStatus && s.status === "published";
+
+const permissionReason = (verb: string): string =>
+  `You do not have permission to ${verb} in this collection.`;
+
+/**
+ * The built-in actions, in the order a surface presents them.
+ *
+ * Order is part of the contract: the toolbar draws its entries left to right
+ * and the menu top to bottom, so moving a row here moves it on screen.
+ */
+const BUILT_IN_ACTIONS: readonly ActionRule[] = [
+  /*
+   * Saving a published document is offered BESIDE publishing it, not folded
+   * into it. They are different acts once drafts are enabled — one keeps the
+   * work private, the other shows it to readers — and an author part-way
+   * through a rewrite needs the first without the second.
+   */
+  {
+    id: "save",
+    applies: s => isPublishedEdit(s) && s.hasWorkingDraft,
+    label: s => (s.draftsEnabled ? "Save" : "Save changes"),
+    placement: "toolbar",
+    mutates: true,
+  },
+  /*
+   * A DRAFT keeps its save in the toolbar for the same reason from the other
+   * side: Publish leads, and an author who is not ready for readers still needs
+   * somewhere to put the work.
+   */
+  {
+    id: "save",
+    applies: s => s.mode === "edit" && s.hasStatus && s.status === "draft",
+    label: () => "Save draft",
+    placement: "toolbar",
+    mutates: true,
+  },
+  {
+    id: "duplicate",
+    applies: s => s.mode === "edit" && s.canDuplicate,
+    label: () => "Duplicate",
+    placement: "menu",
+    group: "document",
+    mutates: true,
+  },
+  /*
+   * The one action that survives a historical view, and deliberately so.
+   *
+   * Everything else here WRITES, and the document on screen is not the live one
+   * — so a mutation would write the wrong thing. Reading what the API returns
+   * changes nothing, and it is most useful precisely when an author is trying
+   * to understand a version they are looking at. Blocking it would be the rule
+   * applied past its reason.
+   */
+  {
+    id: "view-api",
+    applies: () => true,
+    label: () => "View API response",
+    placement: "menu",
+    group: "document",
+    mutates: false,
+  },
+  /*
+   * The two kinds of discard are different acts on different things: a pending
+   * WORKING DRAFT is saved work readers cannot see, while unsaved FORM changes
+   * were never written down. Collapsing them into one item would let an author
+   * asking to drop a typo throw away a rewrite.
+   */
+  {
+    id: "discard-draft",
+    applies: s => s.mode === "edit" && s.hasWorkingDraft,
+    label: () => "Discard draft",
+    placement: "menu",
+    group: "danger",
+    destructive: true,
+    mutates: true,
+  },
+  {
+    id: "discard-changes",
+    applies: s => s.mode === "edit" && s.isDirty,
+    label: () => "Discard changes",
+    placement: "menu",
+    group: "danger",
+    destructive: true,
+    mutates: true,
+  },
+  {
+    id: "unpublish",
+    applies: isPublishedEdit,
+    label: () => "Unpublish",
+    placement: "menu",
+    group: "danger",
+    destructive: true,
+    reason: s => (s.canUnpublish ? undefined : permissionReason("unpublish")),
+    mutates: true,
+  },
+  {
+    id: "delete",
+    applies: s => s.mode === "edit",
+    label: () => "Delete",
+    placement: "menu",
+    group: "danger",
+    destructive: true,
+    reason: s => (s.canDelete ? undefined : permissionReason("delete")),
+    mutates: true,
+  },
+];
+
+/**
+ * Every action for a document, in the order a surface should present them.
+ *
+ * The list is the contract. A caller filters it by placement rather than asking
+ * this module for "the toolbar actions" — one question with one answer, so a
+ * button and a menu item cannot come from two derivations that disagree about
+ * whether an action exists.
+ *
+ * UNPUBLISH IS IN THE MENU, and that is a deliberate demotion. It sat beside
+ * Publish, where the two most consequential and opposite verbs in the editor
+ * were one slip apart, styled almost alike. It is rare, it changes what the
+ * public sees, and it belongs with the other destructive verbs.
+ */
+export function documentActions(state: DocumentActionState): DocumentAction[] {
+  const blocked = state.readingHistory ? HISTORY_REASON : undefined;
+  const built = BUILT_IN_ACTIONS.filter(rule => rule.applies(state)).map(rule =>
+    withReason(
+      {
+        id: rule.id,
+        label: rule.label(state),
+        placement: rule.placement,
+        ...(rule.group === undefined ? {} : { group: rule.group }),
+        ...(rule.destructive === undefined
+          ? {}
+          : { destructive: rule.destructive }),
+      },
+      (rule.mutates ? blocked : undefined) ?? rule.reason?.(state)
+    )
+  );
+  return [primaryAction(state), ...built];
+}
+
+/**
+ * The actions for one placement, in list order.
+ *
+ * Derived from {@link documentActions} rather than built beside it, so a
+ * surface cannot draw an action the model does not know about — and an action
+ * added to the model appears wherever it declared it belongs without the
+ * surfaces being edited.
+ */
+export function actionsAt(
+  actions: readonly DocumentAction[],
+  placement: ActionPlacement
+): DocumentAction[] {
+  return actions.filter(action => action.placement === placement);
+}
+
+/**
+ * Menu actions split into their groups, keeping list order inside each.
+ *
+ * Returned as a pair rather than as one list with a flag, because the caller
+ * draws a separator between them and a caller reading a flag would have to
+ * rediscover where the boundary falls.
+ */
+export function menuGroups(actions: readonly DocumentAction[]): {
+  document: DocumentAction[];
+  danger: DocumentAction[];
+} {
+  const menu = actionsAt(actions, "menu");
+  return {
+    document: menu.filter(action => action.group !== "danger"),
+    danger: menu.filter(action => action.group === "danger"),
+  };
+}

--- a/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
+++ b/packages/admin/src/pages/dashboard/entries/[slug]/[id]/index.tsx
@@ -551,6 +551,12 @@ export default function EditEntryPage({
           collection={collection as unknown as EntryFormCollection}
           entry={entry}
           mode="edit"
+          /* The same destination the entry list already sends people to, and
+             the replacement the header's menu now names where `Show JSON` used
+             to be. The route knows how to navigate; the form does not. */
+          onViewApi={() =>
+            navigateTo(buildRoute(ROUTES.COLLECTION_ENTRY_API, { slug }))
+          }
           /* WITH the form's own actions, not in a bar above it. Adding a
              document to a release is the same kind of act as publishing it, so
              it belongs in the same cluster — and a full-width bar here ran


### PR DESCRIPTION
Your two observations, both confirmed against the code — and the first was worse than it looked.

## What was there

A published entry with unpublished edits drew **Save, Publish and Unpublish side by side at equal weight**. An author read three buttons to find the one they wanted, and `Unpublish` — rare, public, undone only by publishing again — sat one slip from `Publish`, styled almost alike. The menu mixed `Duplicate` with `Delete` in one flat list.

Preview was three functions in two controls: external preview and copy-link already merge into a dropdown, so what feels like a third preview button is the **pane toggle**, which is a view control rather than a document action.

## What it is now

| state | before | after |
| --- | --- | --- |
| creating (lifecycle) | Save draft + Publish | **Publish** leads, Save draft beside |
| draft | Save draft + Publish | **Publish** leads, Save draft beside |
| live, pending edits | **Save + Publish + Unpublish** | **Publish changes** leads, Save beside |
| live, clean | Save + Unpublish | **Save** alone |
| menu | 6 flat items | **Document** · **Danger** (2 discards, unpublish, delete) |

`Publish` on a live document now reads **"Publish changes"** — the shorter word there reads as a no-op and says nothing about the draft it promotes.

## The architecture, and why it is this shape

An action **describes itself**; the surface decides how to draw it. That is [Sanity's document-actions model](https://www.sanity.io/docs/studio/document-actions-api), adopted for the reason it exists there: one description renders as a toolbar button or a menu item depending on where it is asked for, and a plugin appends to the same list the built-ins come from.

This matters because the action set is about to grow — translations, releases, history. Today first-party actions are hardcoded and plugins get **one undifferentiated slot** with no priority or placement, so "add to release" could only ever be one more button.

Two layers, deliberately separate:

- **`document-actions.ts`** — no React. Whether an action exists is about permissions and document state, so all 192 states are testable without rendering.
- **`DocumentActionBar`** — bindings supply what to run and any reason it cannot run *at this instant* (mid-submit, invalid, nothing changed). Only the form knows that; folding it into the model would put form state in a module with no form.

**The complexity gate produced this design, twice.** The rules written as `if` chains hit cyclomatic 24, then 10, and fallow refused both — correctly, because a reader would have to hold every condition at once. Both became tables, and the table is exactly what a plugin appends to. The refusal produced the extension point rather than me bolting one on later.

## Two model bugs the existing tests caught

Both were real, and I'd have shipped them:

- **Without publish permission the header HIDES Publish.** My model disabled it — leaving a non-publisher looking at a dead primary button with their real action demoted beside it. *"Not now"* and *"not you"* want different answers; only the first is a disabled control.
- **`View API response` needs a persisted document.** Offering it in create mode resurrected a menu the header hides for exactly that reason.

## Evidence

- 8 header tests failed at first. Fixing the two model bugs took it to **exactly 4** — the deliberate contract change. Those four are **rewritten, not loosened**, and each keeps a discriminating assertion: `Unpublish` is absent as a button *and* the menu trigger is present, so a verb that vanished entirely would still fail.
- Breaks, each killing only its own tests: `Unpublish` back in the toolbar (3), two primaries (2), separator always drawn (1), binding reasons ignored (1), `view-api` marked as mutating (1).
- The invariant — **exactly one primary action** — is asserted across all 192 states, generated as a cartesian product rather than hand-listed.

admin **349 files / 3413 tests green**; check-types, lint, fallow (`pass`, 6 files, nothing introduced) clean. Husky not bypassed.

## Also in here

`Show JSON` goes — the tracker's **U-7**. Its dialog owns its open state and cannot be driven from a callback, so keeping it meant an escape hatch in the action model for one item; and **Singles already offer only `View API response`**, so this makes collections match rather than removing a capability by taste. The component stays exported — deleting a public export is a separate decision.

`formId` and `showJson` are gone as props: no caller passed either, and only the deleted markup read them.

## Not in here

The **layout** — breadcrumb row, title block, sidebar under the action bar. That is the next PR; this one changes which controls exist and where, without moving the chrome.

One caveat I want on the record: I have **not had the running admin in front of me**. Everything here is from the code and its tests. Before the layout PR I want to see the real states, since the last several defects were all things the code did not say out loud.
