### PR TITLE
fix(admin): stop the email editor refusing a save in silence

### DIFF
--- a/.changeset/the-email-editor-stops-refusing-in-silence.md
+++ b/.changeset/the-email-editor-stops-refusing-in-silence.md
@@ -1,0 +1,42 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Fixes four problems in the email template editor.
+
+Save no longer appears to do nothing. If a declared variable was missing its
+name and you had closed Settings, saving was refused with no message anywhere,
+because the only place that message appears is inside Settings. Saving now
+reopens the panel that holds whatever needs fixing.
+
+On a phone the editor's action bar now wraps instead of pushing Save off the
+side of the screen, and the variable strip above the code can no longer grow
+until there is no room left to write in.
+
+And the settings menu, while it steps aside during editing, no longer leaves its
+links reachable by keyboard — tabbing could previously carry you out of the
+editor through a menu you could not see.

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
@@ -58,7 +58,11 @@ export function BodyEditor({
 }) {
   return (
     <>
-      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-border px-3 py-2">
+      {/* Bounded and scrollable. The strip is `shrink-0` and the editor is the
+          only child that can give way, so an unbounded strip takes the pane one
+          declared variable at a time — and a template with enough of them
+          leaves no editor at all. */}
+      <div className="flex max-h-24 shrink-0 flex-wrap items-center gap-2 overflow-y-auto border-b border-border px-3 py-2">
         <Segmented<"html" | "text">
           value={editorTab}
           onChange={onEditorTabChange}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
@@ -23,7 +23,7 @@
  */
 import type { EditorView } from "@codemirror/view";
 import { Suspense, lazy } from "react";
-import type { useForm } from "react-hook-form";
+import { useFormState, type useForm } from "react-hook-form";
 
 import { FormField } from "@admin/components/ui/form";
 
@@ -37,6 +37,42 @@ const CodeMirrorEditor = lazy(() =>
     "@admin/components/features/entries/fields/text/CodeMirrorEditor"
   ).then(m => ({ default: m.CodeMirrorEditor }))
 );
+
+/**
+ * Why a save was refused, for the two body fields.
+ *
+ * Rendered in the toolbar rather than beside the editor because the editor
+ * scrolls: a message under a long template is a message the author has to go
+ * looking for, and the refusal they are trying to understand is the reason they
+ * cannot save.
+ *
+ * It also names the OTHER tab when that is where the problem is. The two bodies
+ * share one toggle, so an author on the plain-text tab can be blocked by the
+ * HTML one with nothing on screen belonging to it.
+ */
+function BodyRefusal({
+  control,
+  editorTab,
+}: {
+  control: ReturnType<typeof useForm<TemplateFormValues>>["control"];
+  editorTab: "html" | "text";
+}) {
+  const { errors } = useFormState({ control });
+  const html = errors.htmlContent?.message;
+  const text = errors.plainTextContent?.message;
+
+  const active = editorTab === "html" ? html : text;
+  const other = editorTab === "html" ? text : html;
+  const otherLabel = editorTab === "html" ? "Plain text" : "HTML";
+
+  if (!active && !other) return null;
+
+  return (
+    <p className="ml-auto text-xs text-destructive" role="alert">
+      {active ?? `${otherLabel}: ${String(other)}`}
+    </p>
+  );
+}
 
 export function BodyEditor({
   control,
@@ -72,6 +108,7 @@ export function BodyEditor({
           ]}
         />
         {chips}
+        <BodyRefusal control={control} editorTab={editorTab} />
       </div>
       {/* Editor body */}
       <div

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/EditorBar.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/EditorBar.tsx
@@ -12,7 +12,12 @@ import { Badge, Button } from "@nextlyhq/ui";
 import type { useForm } from "react-hook-form";
 
 import { Loader2, Send, Settings } from "@admin/components/icons";
-import { FormField } from "@admin/components/ui/form";
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@admin/components/ui/form";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
 
@@ -49,14 +54,26 @@ export function EditorBar({
           control={control}
           name="name"
           render={({ field }) => (
-            <input
-              {...field}
-              onChange={e => onNameChange(e.target.value, field.onChange)}
-              disabled={isPending}
-              placeholder="Untitled template"
-              aria-label="Template name"
-              className="w-full max-w-md truncate bg-transparent text-lg font-semibold text-foreground outline-none placeholder:text-muted-foreground"
-            />
+            /*
+             * The message is not decoration. A refused save reopens whichever
+             * region owns the offending field, and this field's region is
+             * always on screen — so without somewhere to render the message,
+             * a rejection on the name produces no visible reason and Save
+             * reads as a dead control.
+             */
+            <FormItem className="space-y-0.5">
+              <FormControl>
+                <input
+                  {...field}
+                  onChange={e => onNameChange(e.target.value, field.onChange)}
+                  disabled={isPending}
+                  placeholder="Untitled template"
+                  aria-label="Template name"
+                  className="w-full max-w-md truncate bg-transparent text-lg font-semibold text-foreground outline-none placeholder:text-muted-foreground"
+                />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
           )}
         />
         <div className="font-mono text-xs text-muted-foreground">

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/EditorBar.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/EditorBar.tsx
@@ -40,8 +40,11 @@ export function EditorBar({
   onOpenSettings: () => void;
 }) {
   return (
-    <div className="flex w-full items-center gap-3">
-      <div className="min-w-0 flex-1">
+    /* Wraps rather than overflowing. Unwrapped, the six controls exceed the
+       space beside the shell's back button on a phone and push Save off-screen,
+       reachable only by horizontal panning nobody discovers. */
+    <div className="flex w-full flex-wrap items-center gap-x-3 gap-y-2">
+      <div className="min-w-0 flex-1 basis-full sm:basis-auto">
         <FormField
           control={control}
           name="name"

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/EmailTemplateForm.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/EmailTemplateForm.tsx
@@ -18,6 +18,7 @@ import { type EmailTemplateRecord } from "@admin/services/emailTemplateApi";
 import { BodyEditor } from "./BodyEditor";
 import { EditorBar } from "./EditorBar";
 import { EnvelopeBar } from "./EnvelopeBar";
+import { regionsForRefusal } from "./refusal-routing";
 import {
   DEFAULT_VALUES,
   EMAIL_TEMPLATE_FORM_ID,
@@ -165,7 +166,17 @@ export function EmailTemplateForm({
       <form
         id={EMAIL_TEMPLATE_FORM_ID}
         onSubmit={e => {
-          void form.handleSubmit(onSubmit)(e);
+          /*
+           * The second argument is what stops a refusal being silent. The
+           * inspector is summoned, so a field it owns can be invalid while the
+           * only message for it is unmounted — `handleSubmit` then declines and
+           * nothing appears, which reads as a Save button that does nothing.
+           */
+          void form.handleSubmit(onSubmit, errors => {
+            if (regionsForRefusal(Object.keys(errors)).inspector) {
+              setInspectorOpen(true);
+            }
+          })(e);
         }}
         className="h-full min-h-0"
         aria-busy={isPending}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-is-visible.test.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-is-visible.test.tsx
@@ -1,11 +1,11 @@
 /**
  * A refused save must SAY something, wherever the offending field lives.
  *
- * `regionsForRefusal` decides which summoned region to reopen, and a test of
- * that helper alone stays green while a field whose region is already on screen
- * has nowhere to render its message — which is how `htmlContent` and `name`
- * stayed silent after the first fix. These assert the outcome: a message in the
- * DOM, reached through the real component.
+ * `regionsForRefusal` decides which summoned region to reopen. A test of that
+ * helper alone cannot see whether anything then renders the message: a field
+ * whose region is already on screen needs no region opened, and will still be
+ * silent if it has nowhere to put the text. These assert the outcome instead —
+ * the message in the DOM, reached through the real component.
  */
 import { cleanup, render, screen } from "@testing-library/react";
 import { useForm } from "react-hook-form";

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-is-visible.test.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-is-visible.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * A refused save must SAY something, wherever the offending field lives.
+ *
+ * `regionsForRefusal` decides which summoned region to reopen, and a test of
+ * that helper alone stays green while a field whose region is already on screen
+ * has nowhere to render its message — which is how `htmlContent` and `name`
+ * stayed silent after the first fix. These assert the outcome: a message in the
+ * DOM, reached through the real component.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { useForm } from "react-hook-form";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { Form } from "@admin/components/ui/form";
+
+import { BodyEditor } from "../BodyEditor";
+import { EditorBar } from "../EditorBar";
+import { DEFAULT_VALUES, type TemplateFormValues } from "../schema";
+
+afterEach(cleanup);
+
+/** Mounts a region with one field already rejected, as a refused save leaves it. */
+function WithError({
+  field,
+  message,
+  children,
+}: {
+  field: keyof TemplateFormValues;
+  message: string;
+  children: (
+    form: ReturnType<typeof useForm<TemplateFormValues>>
+  ) => React.ReactNode;
+}) {
+  const form = useForm<TemplateFormValues>({ defaultValues: DEFAULT_VALUES });
+  form.setError(field, { type: "manual", message });
+  return <Form {...form}>{children(form)}</Form>;
+}
+
+describe("a refusal is visible where the field is", () => {
+  it("reports a rejected template name in the bar", () => {
+    render(
+      <WithError field="name" message="Template name is required">
+        {form => (
+          <EditorBar
+            control={form.control}
+            isEdit={false}
+            isPending={false}
+            isActive
+            isDirty={false}
+            slug="welcome"
+            onNameChange={(v, onChange) => onChange(v)}
+            onSendTest={() => {}}
+            onOpenSettings={() => {}}
+          />
+        )}
+      </WithError>
+    );
+
+    expect(screen.getByText("Template name is required")).toBeDefined();
+  });
+
+  it("reports a rejected HTML body in the editor toolbar", () => {
+    render(
+      <WithError field="htmlContent" message="HTML content is required">
+        {form => (
+          <BodyEditor
+            control={form.control}
+            editorTab="html"
+            onEditorTabChange={() => {}}
+            isPending={false}
+            editorWrapRef={{ current: null }}
+            htmlEditorViewRef={{ current: null }}
+          />
+        )}
+      </WithError>
+    );
+
+    expect(screen.getByText("HTML content is required")).toBeDefined();
+  });
+
+  it("names the other tab when that is where the refusal is", () => {
+    // An author on the plain-text tab is blocked by the HTML body, which has
+    // nothing on screen belonging to it. Without naming the tab, the message
+    // describes a field the author cannot see.
+    render(
+      <WithError field="htmlContent" message="HTML content is required">
+        {form => (
+          <BodyEditor
+            control={form.control}
+            editorTab="text"
+            onEditorTabChange={() => {}}
+            isPending={false}
+            editorWrapRef={{ current: null }}
+            htmlEditorViewRef={{ current: null }}
+          />
+        )}
+      </WithError>
+    );
+
+    expect(screen.getByText("HTML: HTML content is required")).toBeDefined();
+  });
+
+  it("says nothing when nothing was rejected", () => {
+    // The control. Without it, a component that rendered its message
+    // unconditionally would pass all three tests above.
+    render(
+      <WithError field="name" message="">
+        {form => (
+          <BodyEditor
+            control={form.control}
+            editorTab="html"
+            onEditorTabChange={() => {}}
+            isPending={false}
+            editorWrapRef={{ current: null }}
+            htmlEditorViewRef={{ current: null }}
+          />
+        )}
+      </WithError>
+    );
+
+    expect(screen.queryByRole("alert")).toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-routing.test.ts
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-routing.test.ts
@@ -11,7 +11,8 @@ import { regionsForRefusal } from "../refusal-routing";
 
 describe("regionsForRefusal", () => {
   it("opens the inspector for a field whose message only renders there", () => {
-    // The reported case: a declared variable left without a name.
+    // A declared variable left without a name: rejected by the schema, and
+    // its message renders only inside the inspector.
     expect(regionsForRefusal(["variables"]).inspector).toBe(true);
   });
 

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-routing.test.ts
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-routing.test.ts
@@ -1,0 +1,33 @@
+/**
+ * A refusal that opens nothing is a Save button that does nothing.
+ *
+ * The inspector is summoned, so the message for a field it owns does not exist
+ * in the DOM while it is closed. `handleSubmit` still refuses, and the author
+ * sees no error and no reason.
+ */
+import { describe, expect, it } from "vitest";
+
+import { regionsForRefusal } from "../refusal-routing";
+
+describe("regionsForRefusal", () => {
+  it("opens the inspector for a field whose message only renders there", () => {
+    // The reported case: a declared variable left without a name.
+    expect(regionsForRefusal(["variables"]).inspector).toBe(true);
+  });
+
+  it("leaves it closed for a field the envelope already shows", () => {
+    // The control. Without it, a router that opened the inspector on ANY
+    // refusal would pass the test above just as well — and would then open a
+    // settings panel over the subject the author actually has to fix.
+    expect(regionsForRefusal(["subject"]).inspector).toBe(false);
+    expect(regionsForRefusal(["htmlContent"]).inspector).toBe(false);
+  });
+
+  it("opens it when a refusal names both, since only one of them is visible", () => {
+    expect(regionsForRefusal(["subject", "variables"]).inspector).toBe(true);
+  });
+
+  it("opens nothing when nothing was rejected", () => {
+    expect(regionsForRefusal([]).inspector).toBe(false);
+  });
+});

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/refusal-routing.ts
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/refusal-routing.ts
@@ -1,0 +1,38 @@
+/**
+ * Where a rejected save has to send the author.
+ *
+ * The editor's regions are summoned, so a field can be invalid while the region
+ * that renders its message is unmounted. When that happens `handleSubmit`
+ * refuses and nothing appears anywhere: Save reads as a dead button. The
+ * refusal has to reopen whichever region owns the offending field.
+ *
+ * Declared as data rather than as a condition per field, so adding a field to a
+ * region is one edit here instead of a branch someone has to remember to add.
+ */
+
+/** Fields whose only message lives inside the summoned inspector. */
+const INSPECTOR_FIELDS = new Set([
+  "variables",
+  "slug",
+  "providerId",
+  "useLayout",
+  "layoutId",
+  "isActive",
+  "attachments",
+]);
+
+/**
+ * Which regions a refusal must open, given the names react-hook-form rejected.
+ *
+ * Takes the error KEYS rather than the error object: nested field arrays report
+ * as `variables` at the top level, which is the granularity a region needs, and
+ * a helper that walked the whole tree would be deciding something it is not
+ * asked to decide.
+ */
+export function regionsForRefusal(errorKeys: readonly string[]): {
+  inspector: boolean;
+} {
+  return {
+    inspector: errorKeys.some(key => INSPECTOR_FIELDS.has(key)),
+  };
+}

--- a/packages/admin/src/components/layout/sidebar/SubSidebarPanel.tsx
+++ b/packages/admin/src/components/layout/sidebar/SubSidebarPanel.tsx
@@ -73,9 +73,19 @@ export function SubSidebarPanel({
         </span>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
-        <SubSidebarContent {...content} />
-      </div>
+      {/*
+        Not rendered while closed, rather than hidden. Zero width, zero opacity
+        and `pointer-events-none` remove a subtree from SIGHT and from the
+        mouse, and leave every link in the tab order — so a keyboard user tabs
+        through an invisible menu and is navigated out of the editor by a link
+        they cannot see. `inert` would express this directly, but it is a
+        boolean prop only from React 19 and this package supports 18 as well.
+      */}
+      {hasSubSidebar ? (
+        <div className="flex-1 overflow-y-auto">
+          <SubSidebarContent {...content} />
+        </div>
+      ) : null}
     </aside>
   );
 }

--- a/packages/admin/src/components/layout/sidebar/__tests__/sub-sidebar-panel.test.tsx
+++ b/packages/admin/src/components/layout/sidebar/__tests__/sub-sidebar-panel.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * A collapsed panel must not keep its links reachable by keyboard.
+ *
+ * The panel is hidden with zero width, zero opacity and `pointer-events-none`.
+ * None of those removes a subtree from the TAB ORDER, so while an immersive
+ * editor suppressed the panel a keyboard user could tab through an invisible
+ * menu and be navigated out of the editor by a link they never saw.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  ChromeSuppressionProvider,
+  useSuppressAdminChrome,
+} from "../../ChromeSuppression";
+
+import { SubSidebarPanel } from "../SubSidebarPanel";
+
+vi.mock("../SubSidebarContent", () => ({
+  SubSidebarContent: () => <a href="/admin/settings/api-keys">API Keys</a>,
+}));
+
+afterEach(cleanup);
+
+/** Suppresses the panel for as long as it is mounted, as the editor does. */
+function Suppressor() {
+  useSuppressAdminChrome({ layers: ["subSidebar"], canExit: true });
+  return null;
+}
+
+function renderPanel({ suppress }: { suppress: boolean }) {
+  return render(
+    <ChromeSuppressionProvider>
+      {suppress ? <Suppressor /> : null}
+      <SubSidebarPanel
+        isMobile={false}
+        selectedMain="settings"
+        visibleMenuItemIds={["settings"]}
+        isFolderTreeVisible={false}
+        standaloneLabel=""
+        content={{} as never}
+      />
+    </ChromeSuppressionProvider>
+  );
+}
+
+describe("SubSidebarPanel", () => {
+  it("holds no focusable link while a surface has suppressed it", () => {
+    renderPanel({ suppress: true });
+
+    expect(screen.queryByRole("link", { name: "API Keys" })).toBeNull();
+  });
+
+  it("renders the links when nothing suppressed it", () => {
+    // The control. Without it, a panel that never rendered its content would
+    // pass the test above just as well.
+    renderPanel({ suppress: false });
+
+    expect(screen.getByRole("link", { name: "API Keys" })).toBeDefined();
+  });
+});


### PR DESCRIPTION
Follow-up to #1411, which merged while Codex was mid-review. Four findings arrived on the merged head; all four are genuine and three are consequences of that layout change.

## 1. Save refused in silence (P1 in effect, reported P2)

The worst of the four, because it makes the primary action look broken.

The inspector is summoned, so a field it owns can be invalid while the only `FormMessage` for it is unmounted. Declare a variable, leave its name blank, close Settings, press Save: `handleSubmit` refuses, `onSubmit` is never called, and **nothing appears anywhere**. Verified against the code — `VariablesRail`'s messages are the only rendering of that error, and `VariablesRail` exists only inside `TemplateInspector`.

Fixed with `handleSubmit`'s second argument, routed through a small declarative module:

```ts
export function regionsForRefusal(errorKeys: readonly string[]): { inspector: boolean }
```

A rejected save reopens whichever region owns the offending field. Declared as a `Set` rather than a condition per field, so adding a field to a region is one edit rather than a branch someone must remember.

Four tests, and **the second is the control**: a refusal on `subject` or `htmlContent` must NOT open the inspector — without it, a router that opened it on any refusal would pass the first test and then throw a settings panel over the subject line the author actually has to fix. Break-verified both ways.

## 2. The action bar pushed Save off a phone

One non-wrapping row held the name, status, Settings, Send test, Cancel and Save. Below the shell's back button there was not room, so Save left the viewport and was reachable only by horizontal panning nobody discovers.

Now wraps, with the identity taking its own line on narrow. Measured at a 420px viewport: the bar is 161px tall and **Save sits at x=250 inside 420** — on screen.

## 3. The variable strip could eat the editor

The chip strip is `shrink-0` and the editor is the only child able to give way, so the strip grew by a row per declared variable and took the pane one variable at a time. Bounded to about two rows with its own scroll.

## 4. The collapsed settings menu kept its links in the tab order

`w-0`, `opacity-0` and `pointer-events-none` remove a subtree from sight and from the mouse. They do **not** remove it from the tab order — so while the editor suppressed the panel, a keyboard user could tab through an invisible menu and be navigated out of the editor by a link they never saw.

The panel's content is now not rendered while it is closed. `inert` would say this directly, but it is a boolean prop only from React 19 and this package supports 18 as well, so not rendering is the version-independent answer.

Two tests with a control (suppressed → no link; not suppressed → the link is there, otherwise a panel that never rendered anything would pass). Both break-verified.

## Verified in a real browser, not only in jsdom

```
desktop 1280   primary 604 · secondary 604 · subSidebar 0 · focusable in collapsed panel: 0
narrow  420    bar 161px tall · Save visible at x=250 within 420
/admin/settings (a control)  subSidebar 256 — suppression is scoped to the editor, not global
```

That last line matters: it shows the suppression did not leak into the rest of the admin.

## Gates

`pnpm build` 0 · `check-types` 0 · `lint` 0 · `lint:design` 0 · `comment convention` 0 · admin suite **356 files, 3463 tests** · `fallow` **pass — 0 introduced dead code, complexity and duplication**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Email template validation errors now appear clearly in the relevant fields and editor tabs.
  * Failed saves automatically reopen the editor area containing invalid settings.
  * Email editor controls wrap properly on narrow screens, and long error or chip lists scroll without obscuring content.
  * Hidden sidebar links are no longer reachable by keyboard when the sidebar is collapsed.

* **Tests**
  * Added coverage for validation visibility, error routing, and sidebar accessibility behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->