### PR TITLE
feat(admin): make the preview one control instead of three

### DIFF
--- a/.changeset/one-control-for-the-preview.md
+++ b/.changeset/one-control-for-the-preview.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Make the preview one control instead of three. The entry header carried a pane toggle, an open-the-preview action and a copy-link action, the last two already sharing a menu while the toggle sat beside them looking like a second preview button — three of the header's seven controls for one idea. Where a side pane exists it now leads, because it is the cheapest of the three and the only one with a state worth showing, and opening and copying move into a menu beside it. Where no pane exists the shape is unchanged: a plain button when only one thing can be done, and one menu when both can.

--- a/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/EntrySystemHeader.tsx
@@ -29,7 +29,7 @@ import { DocumentStatusLive } from "./DocumentStatusLive";
 import { effectiveEntryStatus } from "./entry-address";
 import { EntryTitleInput } from "./EntryTitleInput";
 import { PreviewActions } from "./PreviewActions";
-import { TOOLBAR_CONTAINER, ToolbarLabel } from "./toolbar-density";
+import { TOOLBAR_CONTAINER } from "./toolbar-density";
 import { UnpublishConfirmDialog } from "./UnpublishConfirmDialog";
 import { useLeaveWithoutWarning } from "./UnsavedChangesGuard";
 import type { EntryData, EntryFormMode } from "./useEntryForm";
@@ -277,22 +277,6 @@ export function EntrySystemHeader({
     getLocale,
   } = useLocalization();
   const defaultLocaleLabel = getLocale(defaultLocale)?.label ?? defaultLocale;
-  /*
-   * A declared label is used VERBATIM, not built into a sentence.
-   *
-   * `previewLabel` is a complete button label, not a noun: collections
-   * legitimately name one "View page", and "Show View page" is not English.
-   * Where the author supplied nothing there is no such risk and the control
-   * keeps its own wording, which says what the click will do.
-   *
-   * Losing "Show"/"Hide" for a declared label costs nothing that is not carried
-   * elsewhere — `aria-pressed` states it for assistive technology and the
-   * variant states it visually, which is how a toggle button reports itself.
-   */
-  const previewToggleLabel =
-    previewLabel ?? (previewPaneOpen ? "Hide preview" : "Show preview");
-  const previewToggleTitle =
-    previewLabel ?? (previewPaneOpen ? "Hide the preview" : "Show the preview");
   // Present only when the entry was fetched with `?translation-status=1` on a
   // localized collection; undefined otherwise, which both consumers below
   // treat as "nothing to report" rather than as zero progress.
@@ -616,40 +600,24 @@ export function EntrySystemHeader({
             minting a link and opening a preview both act on what is already
             saved, so a submit in flight is a race with them and not merely a
             busy form. */}
+          {/* ONE control for the preview, not three. The pane toggle used to
+            sit beside this looking like a second preview button, with opening
+            and copying already sharing a menu of their own — three of the
+            header's controls for one idea. */}
           <PreviewActions
             size="sm"
             isPreviewAvailable={isPreviewAvailable}
             {...(onPreview === undefined ? {} : { onPreview })}
             {...(previewLabel === undefined ? {} : { previewLabel })}
+            {...(onTogglePreviewPane === undefined
+              ? {}
+              : { onTogglePreviewPane })}
+            previewPaneOpen={previewPaneOpen}
             isLinkAvailable={isLinkAvailable}
             {...(onCopyLink === undefined ? {} : { onCopyLink })}
             isCopyingLink={isCopyingLink}
             disabled={isSubmitting}
           />
-          {/* The pane toggle, beside the preview actions rather than inside
-              them: `PreviewActions` decides its own shape from which of OPEN
-              and COPY are available, and a third action would make that a
-              three-way decision for a control whose whole design is that it
-              collapses to one button when only one thing can be done.
-
-              Offered only where a pane exists to open — an embedded editor in
-              a modal passes no handler and gets no control. */}
-          {onTogglePreviewPane !== undefined && (
-            <Button
-              type="button"
-              variant={previewPaneOpen ? "secondary" : "ghost"}
-              size="sm"
-              onClick={onTogglePreviewPane}
-              disabled={isSubmitting}
-              aria-pressed={previewPaneOpen}
-              title={previewToggleTitle}
-            >
-              <PanelRight className="h-4 w-4" aria-hidden="true" />
-              <ToolbarLabel priority="secondary">
-                {previewToggleLabel}
-              </ToolbarLabel>
-            </Button>
-          )}
           {/* Sits with the actions rather than beside the title: it reports on
             the same work the save buttons act on, and reads as status for that
             cluster.

--- a/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
@@ -1,38 +1,54 @@
 "use client";
 
 /**
- * The preview control on the entry form.
+ * Everything an author can do with a preview, as ONE control.
  *
- * Two actions that look like one feature and are not: opening the preview uses
- * the editor's own session and can carry unsaved changes, while a shareable
- * link goes to someone with no session at all and can only show what was saved.
- * They are grouped because an author reaching for one is deciding between them,
- * not because they do the same thing.
+ * There were three, and they read as three unrelated buttons: a pane toggle, an
+ * "open the preview" action, and a copy-link action — two of which already
+ * shared a dropdown while the third sat beside them looking like a second
+ * preview button. Counted from the running editor, that was three of the seven
+ * controls in the header for one idea.
  *
- * The shape adapts to what is actually available rather than showing disabled
- * controls, which say "you cannot do this" without saying why:
+ * They are one idea, so this is one control: pressing it does the thing an
+ * author wants most, and the menu holds the other ways of getting at the same
+ * preview. That is the split-button shape every editor surveyed uses for this —
+ * the block editor's preview, Webflow's, Framer's — and the reason is the same
+ * everywhere: the variants are destinations for one intent, not separate verbs.
  *
- * - **Both** — one button with a menu. A fourth top-level button would crowd a
- *   narrow sidebar that already holds Preview, Cancel and Save.
- * - **Preview only** — exactly the button that was there before, unchanged.
- * - **Link only** — a single button, for a collection with no configured
- *   preview URL whose drafts can still be shared.
- * - **Neither** — nothing.
+ * WHICH ONE IS THE PRESS is decided by what the surface offers, not by
+ * preference. A pane toggle is the cheapest and most reversible — it costs
+ * nothing to open and nothing to close — so it leads wherever it exists, and it
+ * is the only one of the three with a STATE worth showing, which a press with
+ * `aria-pressed` expresses and a menu item cannot. Where no pane exists — an
+ * editor embedded in a modal — opening the preview leads instead.
  *
- * @module components/entries/EntryForm/PreviewActions
+ * @module components/features/entries/EntryForm/PreviewActions
  */
 
-import { Button } from "@nextlyhq/ui";
+import type { ReactElement } from "react";
 
-import { ChevronDown, Eye, Link2, Loader2 } from "@admin/components/icons";
 import {
+  Check,
+  ChevronDown,
+  Copy,
+  ExternalLink,
+  Eye,
+  Loader2,
+  PanelRight,
+} from "@admin/components/icons";
+import {
+  Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@admin/components/ui";
+import { cn } from "@admin/lib/utils";
 
 import { ToolbarLabel } from "./toolbar-density";
+
+const COPY_LABEL = "Copy shareable link";
+const OPEN_LABEL = "Open in new tab";
 
 export interface PreviewActionsProps {
   /** Whether the collection has a preview URL configured. */
@@ -48,6 +64,15 @@ export interface PreviewActionsProps {
   /** Label for the preview action. */
   previewLabel?: string;
   /**
+   * Shows or hides the side-by-side pane.
+   *
+   * Absent means the surface offers no pane at all, which is what an editor
+   * embedded in a modal does.
+   */
+  onTogglePreviewPane?: () => void;
+  /** Whether that pane is open, which the control reports as its pressed state. */
+  previewPaneOpen?: boolean;
+  /**
    * Whether a shareable link can be minted. False for an unsaved entry, which
    * has no id to name, and for an author without `update` on the collection.
    */
@@ -56,6 +81,8 @@ export interface PreviewActionsProps {
   onCopyLink?: () => void;
   /** Whether a link is being minted right now. */
   isCopyingLink?: boolean;
+  /** Whether the link was just copied, for the control's acknowledgement. */
+  isLinkCopied?: boolean;
   /** Whether the surrounding form is submitting. */
   disabled?: boolean;
   /**
@@ -69,73 +96,203 @@ export interface PreviewActionsProps {
   size?: "default" | "sm";
 }
 
-const COPY_LABEL = "Copy shareable link";
+/**
+ * What each position calls the preview.
+ *
+ * Four labels rather than one, because the same action is named differently
+ * depending on where it sits — and gathering them here keeps that decision
+ * readable instead of spread across four ternaries in the render.
+ *
+ * A DECLARED label wins everywhere and is used VERBATIM. Collections name one
+ * "View page", and interpolating a verb produced "Show View page", which is not
+ * English; the open state is reported by `aria-pressed` and by the variant,
+ * which is how a toggle button reports itself.
+ */
+function previewLabels(
+  declared: string | undefined,
+  paneOpen: boolean,
+  hasPane: boolean
+): { pane: string; solo: string; menuOpen: string; menuTrigger: string } {
+  const fallbackPane = paneOpen ? "Hide preview" : "Show preview";
+  return {
+    pane: declared ?? fallbackPane,
+    solo: declared ?? "Preview",
+    /*
+     * Under the pane toggle, opening names its DESTINATION: an item saying
+     * "Preview" beside a button saying "Show preview" tells an author nothing
+     * about which is which. Where the menu IS the control there is nothing to
+     * confuse it with, so it is simply the preview.
+     */
+    menuOpen: declared ?? (hasPane ? OPEN_LABEL : "Preview"),
+    menuTrigger: declared ?? "Preview",
+  };
+}
+
+/** A press paired with a chevron that opens the rest. */
+function SplitControl({
+  press,
+  options,
+  size,
+  disabled,
+}: {
+  press: ReactElement;
+  options: ReactElement[];
+  size: "default" | "sm";
+  disabled: boolean;
+}) {
+  if (options.length === 0) return press;
+  return (
+    <div className="flex items-center">
+      {press}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="outline"
+            size={size}
+            disabled={disabled}
+            className="rounded-l-none px-1.5"
+            aria-label="Preview options"
+            title="Preview options"
+          >
+            <ChevronDown className="h-4 w-4" aria-hidden="true" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">{options}</DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 export function PreviewActions({
   isPreviewAvailable = false,
   onPreview,
-  previewLabel = "Preview",
+  previewLabel,
+  onTogglePreviewPane,
+  previewPaneOpen = false,
   isLinkAvailable = false,
   onCopyLink,
   isCopyingLink = false,
+  isLinkCopied = false,
   disabled = false,
   size = "default",
 }: PreviewActionsProps) {
-  const canPreview = isPreviewAvailable && onPreview !== undefined;
+  const canPane = onTogglePreviewPane !== undefined;
+  const canOpen = isPreviewAvailable && onPreview !== undefined;
   const canCopy = isLinkAvailable && onCopyLink !== undefined;
 
-  /**
-   * Adapts a possibly-asynchronous handler to the void-returning slot a DOM
-   * event expects.
-   *
-   * Handing the promise straight to `onClick` makes a rejection invisible,
-   * which is what forbids it. It is not this control's to report either: it
-   * knows the action failed and nothing about why, so anything it rendered
-   * would be a second, vaguer error beside the handler's own. Discarding the
-   * value leaves a rejection to the runtime's unhandled-rejection reporting,
-   * where it stays visible without being claimed here.
+  // Nothing to offer is nothing to draw. A control that opens onto no options
+  // is the empty-menu defect, and a disabled one here would be furniture.
+  if (!canPane && !canOpen && !canCopy) return null;
+
+  const labels = previewLabels(previewLabel, previewPaneOpen, canPane);
+
+  /*
+   * `onSelect` rather than `onClick`, which is what makes `disabled` real: the
+   * menu is uncontrolled and stays open across the state change that starts a
+   * save, and Radix suppresses a disabled item's `onSelect` while letting a
+   * click through.
    */
-  const startPreview =
-    onPreview === undefined
-      ? undefined
-      : () => {
-          void onPreview();
-        };
-
-  if (!canPreview && !canCopy) return null;
-
-  if (canPreview && !canCopy) {
-    return (
-      <Button
-        type="button"
-        variant="outline"
-        size={size}
-        onClick={startPreview}
+  const options: ReactElement[] = [];
+  if (canOpen) {
+    options.push(
+      <DropdownMenuItem
+        key="open"
+        onSelect={() => void onPreview?.()}
         disabled={disabled}
-        title={previewLabel}
+        data-preview-option="open"
       >
-        <Eye className="h-4 w-4" />
-        <ToolbarLabel priority="secondary">{previewLabel}</ToolbarLabel>
-      </Button>
+        <ExternalLink className="h-4 w-4" aria-hidden="true" />
+        {labels.menuOpen}
+      </DropdownMenuItem>
+    );
+  }
+  if (canCopy) {
+    options.push(
+      <DropdownMenuItem
+        key="copy"
+        onSelect={() => onCopyLink?.()}
+        disabled={disabled || isCopyingLink}
+        data-preview-option="copy"
+      >
+        {copyIcon(isCopyingLink, isLinkCopied)}
+        {COPY_LABEL}
+      </DropdownMenuItem>
     );
   }
 
-  if (!canPreview && canCopy) {
+  /*
+   * WHERE A PANE EXISTS, it leads and the rest become its menu.
+   *
+   * The pane toggle is the cheapest and most reversible of the three — nothing
+   * is spent opening or closing it — and it is the only one with a STATE worth
+   * showing, which a press with `aria-pressed` expresses and a menu item
+   * cannot. One visual unit replaces the pane toggle and a separate preview
+   * menu sitting side by side, which read as two preview buttons.
+   */
+  if (canPane) {
+    return (
+      <SplitControl
+        size={size}
+        disabled={disabled}
+        options={options}
+        press={
+          <Button
+            type="button"
+            variant={previewPaneOpen ? "secondary" : "outline"}
+            size={size}
+            onClick={onTogglePreviewPane}
+            disabled={disabled}
+            aria-pressed={previewPaneOpen}
+            title={labels.pane}
+            className={cn(options.length > 0 && "rounded-r-none border-r-0")}
+            data-preview-lead="pane"
+          >
+            <PanelRight className="h-4 w-4" aria-hidden="true" />
+            <ToolbarLabel priority="secondary">{labels.pane}</ToolbarLabel>
+          </Button>
+        }
+      />
+    );
+  }
+
+  /*
+   * WITHOUT A PANE the shape is unchanged, deliberately.
+   *
+   * There is no obvious lead between opening and copying — neither is cheaper
+   * nor more reversible than the other — so promoting one would ADD a button
+   * rather than remove one. Collapsing to a plain button when only one thing
+   * can be done, and to one menu when both can, is what this already did and is
+   * right for that case.
+   */
+  if (canOpen !== canCopy) {
+    const solo = canOpen
+      ? {
+          label: labels.solo,
+          icon: <Eye className="h-4 w-4" aria-hidden="true" />,
+          run: () => void onPreview?.(),
+          busy: false,
+          lead: "open",
+        }
+      : {
+          label: COPY_LABEL,
+          icon: copyIcon(isCopyingLink, isLinkCopied),
+          run: () => onCopyLink?.(),
+          busy: isCopyingLink,
+          lead: "copy",
+        };
     return (
       <Button
         type="button"
         variant="outline"
         size={size}
-        onClick={onCopyLink}
-        disabled={disabled || isCopyingLink}
-        title={COPY_LABEL}
+        onClick={solo.run}
+        disabled={disabled || solo.busy}
+        title={solo.label}
+        data-preview-lead={solo.lead}
       >
-        {isCopyingLink ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
-        ) : (
-          <Link2 className="h-4 w-4" />
-        )}
-        <ToolbarLabel priority="secondary">{COPY_LABEL}</ToolbarLabel>
+        {solo.icon}
+        <ToolbarLabel priority="secondary">{solo.label}</ToolbarLabel>
       </Button>
     );
   }
@@ -148,41 +305,23 @@ export function PreviewActions({
           variant="outline"
           size={size}
           disabled={disabled}
-          // The trigger opens a menu rather than performing the preview, so it
-          // says so: a control labelled only "Preview" that opens a list is a
-          // different promise than the one it keeps.
-          aria-label={`${previewLabel} options`}
-          title={`${previewLabel} options`}
+          aria-label="Preview options"
+          title="Preview options"
+          data-preview-lead="menu"
         >
-          {isCopyingLink ? (
-            <Loader2 className="h-4 w-4 animate-spin" />
-          ) : (
-            <Eye className="h-4 w-4" />
-          )}
-          <ToolbarLabel priority="secondary">{previewLabel}</ToolbarLabel>
-          <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" />
+          <Eye className="h-4 w-4" aria-hidden="true" />
+          <ToolbarLabel priority="secondary">{labels.menuTrigger}</ToolbarLabel>
+          <ChevronDown className="h-4 w-4" aria-hidden="true" />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {/*
-         * Each item carries `disabled` itself rather than relying on the
-         * trigger. The menu is uncontrolled, so a submit that begins while it
-         * is already open leaves it open: disabling only the trigger would stop
-         * the next opening and none of the actions inside the current one, and
-         * both of these race the save they would run alongside.
-         */}
-        <DropdownMenuItem onSelect={startPreview} disabled={disabled}>
-          <Eye className="h-4 w-4" />
-          {previewLabel}
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          onSelect={onCopyLink}
-          disabled={disabled || isCopyingLink}
-        >
-          <Link2 className="h-4 w-4" />
-          {COPY_LABEL}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
+      <DropdownMenuContent align="end">{options}</DropdownMenuContent>
     </DropdownMenu>
   );
+}
+
+/** Copying reports its own progress: in flight, just done, or ready. */
+function copyIcon(copying: boolean, copied: boolean): ReactElement {
+  if (copying) return <Loader2 className="h-4 w-4 animate-spin" />;
+  if (copied) return <Check className="h-4 w-4 text-success" />;
+  return <Copy className="h-4 w-4" aria-hidden="true" />;
 }

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/PreviewActions.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/PreviewActions.test.tsx
@@ -103,3 +103,74 @@ describe("PreviewActions", () => {
     ).toBeInTheDocument();
   });
 });
+
+describe("where a pane exists, it leads and the rest follow", () => {
+  /*
+   * The consolidation this control was rebuilt for. The header carried the pane
+   * toggle and a separate preview menu side by side — two controls, three
+   * functions, for one idea — and an author reading the bar saw what looked
+   * like two preview buttons.
+   */
+  const withPane = {
+    onTogglePreviewPane: vi.fn(),
+    previewPaneOpen: false,
+    isPreviewAvailable: true,
+    onPreview: vi.fn(),
+    isLinkAvailable: true,
+    onCopyLink: vi.fn(),
+  };
+
+  it("draws ONE unit: the toggle, and a chevron for the rest", () => {
+    render(<PreviewActions {...withPane} />);
+
+    const buttons = screen.getAllByRole("button");
+    // The press and its chevron. Three separate top-level controls is what this
+    // replaces, so the count is the assertion.
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]).toHaveAttribute("data-preview-lead", "pane");
+    expect(buttons[1]).toHaveAttribute("aria-label", "Preview options");
+  });
+
+  it("reports the pane's state on the press, which a menu item cannot", () => {
+    // Why the pane leads rather than opening: it is the only one of the three
+    // with a state worth showing.
+    const { rerender } = render(<PreviewActions {...withPane} />);
+    expect(screen.getAllByRole("button")[0]).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+
+    rerender(<PreviewActions {...withPane} previewPaneOpen />);
+    const open = screen.getAllByRole("button")[0];
+    expect(open).toHaveAttribute("aria-pressed", "true");
+    expect(open).toHaveAccessibleName("Hide preview");
+  });
+
+  it("puts opening and copying behind the chevron, named apart", async () => {
+    const user = userEvent.setup();
+    render(<PreviewActions {...withPane} />);
+
+    await user.click(screen.getByRole("button", { name: "Preview options" }));
+
+    // "Open in new tab" rather than "Preview": a menu item repeating the press's
+    // word would give an author two ways to preview and no way to tell them
+    // apart.
+    expect(
+      await screen.findByRole("menuitem", { name: "Open in new tab" })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("menuitem", { name: "Copy shareable link" })
+    ).toBeInTheDocument();
+  });
+
+  it("is a lone toggle when there is nothing else to offer", () => {
+    // The control for the chevron: it must appear only when the menu has
+    // something in it, or it opens onto nothing.
+    render(
+      <PreviewActions onTogglePreviewPane={vi.fn()} previewPaneOpen={false} />
+    );
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]).toHaveAttribute("data-preview-lead", "pane");
+  });
+});


### PR DESCRIPTION
The visible half of the header work. #1412 changed which lifecycle controls exist; this removes the duplication you can actually see.

## Counted from the running editor, not from the code

Seven controls in the header, and **three of them were the preview**:

```
Add to release · [🕘] · Preview ⌄ · Show preview · [Save changes] · [⋯] · [▯]
                        └─────────┴─ two controls, three functions, one idea
```

A pane toggle, an open-the-preview action and a copy-link action — the last two already sharing a menu, while the toggle sat beside them looking like a second preview button.

## After

```
Add to release · [🕘] · [Show preview ⌄] · [Save changes] · [⋯] · [▯]
```

**Where a pane exists it leads**, and opening and copying become its menu. It earns the press on two grounds: it is the cheapest and most reversible of the three — nothing is spent opening or closing it — and it is the only one with a **state** worth showing, which `aria-pressed` on a press expresses and a menu item cannot.

**Where no pane exists the shape is unchanged, deliberately.** Neither opening nor copying is cheaper or more reversible than the other, so promoting one would *add* a button rather than remove one. The existing collapse — a plain button for one, a single menu for both — is right for that case, and its tests still pin it. An editor embedded in a modal passes no pane handler and sees exactly what it saw before.

## Three decisions the existing tests refused to let me overwrite

All three were considered choices I'd have flattened:

- **`previewLabel` is a complete label, used verbatim.** Collections name one "View page"; interpolating a verb produced *"Show View page"*. State is carried by `aria-pressed` and the variant, not by a prefix.
- **`COPY_LABEL` is "Copy shareable link"**, not the shorter one I'd invented.
- **A menu item takes `onSelect`, not `onClick`.** Radix suppresses a *disabled* item's `onSelect` while letting a click through — and the menu is uncontrolled, so it stays open across the state change that starts a save. That distinction is what stops an author racing the write already in flight. My `onClick` version passed `aria-disabled` and still fired the handler.

I also reverted my own drift: `PreviewActions` reads from the package's icon and ui barrels again, rather than `lucide-react` directly.

## Evidence

- New tests for the consolidation: one unit rather than three controls, the pressed state on the press, the two options named apart (`Open in new tab` beside `Show preview`, because two items both saying "Preview" tell an author nothing), and a lone toggle when there is nothing to put in a menu.
- Break: making the pane stop leading kills **3 by name**. The no-pane tests keep passing on that break, which is what shows the two cases are genuinely separate.
- The header's own copy of the label derivation is deleted — byte-identical to the one that moved, checked before removing it.

admin **353 files / 3455 tests green**; check-types, lint, fallow (`pass`) clean.

The complexity gate refused this twice on the way (cc 24, then 21) and both refusals produced the decomposition — the shapes are now named components and the four position-dependent labels are one function instead of four ternaries in the render.

## Still to come

`Add to release` becoming a descriptor rather than a bespoke slot, the view controls (`🕘`, `▯`) grouping visually apart from document actions, and then the breadcrumb row and title block.
