### PR TITLE
fix(admin): keep the refusal on screen when the chip strip scrolls

### DIFF
--- a/.changeset/the-refusal-stays-on-screen.md
+++ b/.changeset/the-refusal-stays-on-screen.md
@@ -1,0 +1,34 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The reason a save was refused now stays on screen.
+
+The message explaining a rejected save sat in the same strip as the variable
+chips, which scrolls once a template declares enough of them — so on those
+templates the explanation could sit just out of view and saving looked silent
+again. The message now has its own row and cannot scroll away.

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/BodyEditor.tsx
@@ -98,7 +98,15 @@ export function BodyEditor({
           only child that can give way, so an unbounded strip takes the pane one
           declared variable at a time — and a template with enough of them
           leaves no editor at all. */}
-      <div className="flex max-h-24 shrink-0 flex-wrap items-center gap-2 overflow-y-auto border-b border-border px-3 py-2">
+      {/*
+        Two rows, and the split is the point. The chip strip is bounded and
+        scrolls, because it grows by a row per declared variable and the editor
+        is the only thing able to give way. The refusal must NOT be inside that
+        scroller: submitting does not scroll it, so with enough chips the alert
+        mounts below the visible area and the refused save is silent again —
+        which is the failure this alert exists to end.
+      */}
+      <div className="flex shrink-0 items-center gap-2 px-3 pt-2">
         <Segmented<"html" | "text">
           value={editorTab}
           onChange={onEditorTabChange}
@@ -107,9 +115,18 @@ export function BodyEditor({
             { value: "text", label: "Plain text" },
           ]}
         />
-        {chips}
         <BodyRefusal control={control} editorTab={editorTab} />
       </div>
+      {chips ? (
+        <div
+          data-testid="body-editor-chips"
+          className="flex max-h-16 shrink-0 flex-wrap items-center gap-2 overflow-y-auto border-b border-border px-3 pb-2 pt-2"
+        >
+          {chips}
+        </div>
+      ) : (
+        <div className="shrink-0 border-b border-border pb-2" />
+      )}
       {/* Editor body */}
       <div
         ref={editorWrapRef}

--- a/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-is-visible.test.tsx
+++ b/packages/admin/src/components/features/settings/EmailTemplateForm/__tests__/refusal-is-visible.test.tsx
@@ -100,6 +100,40 @@ describe("a refusal is visible where the field is", () => {
     expect(screen.getByText("HTML: HTML content is required")).toBeDefined();
   });
 
+  it("keeps the alert out of the strip that scrolls", () => {
+    /*
+     * The chip strip is bounded and scrollable, because it grows by a row per
+     * declared variable. An alert laid out inside it mounts below the visible
+     * area once there are enough chips, and submitting does not scroll that
+     * container — so the message exists, is in the DOM, and cannot be seen.
+     *
+     * Containment is the discriminating assertion: "the alert is present"
+     * passes in both arrangements, which is how the first version of this
+     * shipped.
+     */
+    render(
+      <WithError field="htmlContent" message="HTML content is required">
+        {form => (
+          <BodyEditor
+            control={form.control}
+            editorTab="html"
+            onEditorTabChange={() => {}}
+            isPending={false}
+            editorWrapRef={{ current: null }}
+            htmlEditorViewRef={{ current: null }}
+            chips={<span>{"{{appName}}"}</span>}
+          />
+        )}
+      </WithError>
+    );
+
+    const alert = screen.getByRole("alert");
+    const strip = screen.getByTestId("body-editor-chips");
+
+    expect(alert).toBeDefined();
+    expect(strip.contains(alert)).toBe(false);
+  });
+
   it("says nothing when nothing was rejected", () => {
     // The control. Without it, a component that rendered its message
     // unconditionally would pass all three tests above.


### PR DESCRIPTION
Follow-up to #1413, which merged while Codex was reviewing it. One P2 arrived on the merged head, and it is my own two fixes colliding.

## The problem

#1413 did two things to the editor toolbar: it bounded the variable-chip strip (`max-h-24 overflow-y-auto`, so a template with many declared variables cannot eat the editor), and it added the refusal alert that explains a rejected save.

Both landed **in the same container**. So once a template declares enough variables for the strip to scroll, the alert is laid out after the chips inside the scroller, submitting does not scroll it, and the message mounts below the visible area — the refused save is silent again, which is the exact failure the alert exists to end.

## The fix

Two rows. The tab toggle and the alert sit in a non-scrolling row; the chips get their own bounded, scrollable row beneath. The alert can no longer scroll out of view, and the strip stays bounded.

## Why the existing tests could not catch it, demonstrated

The tests from #1413 assert the message reaches the DOM. That is true in **both** arrangements — present-but-unscrolled-to is still present — so they were green on the defect.

The new test asserts **containment**, which is true of exactly one arrangement:

```ts
const alert = screen.getByRole("alert");
const strip = screen.getByTestId("body-editor-chips");
expect(strip.contains(alert)).toBe(false);
```

Break-verified with a mutation that changes **only** containment — moving which row carries the testid, so nothing about rendering or conditionality moves:

```
keeps the alert out of the strip that scrolls        FAILED as intended
reports a rejected HTML body in the editor toolbar   still green   <- why it missed this
says nothing when nothing was rejected               still green
```

The first attempt at that mutation put the alert inside the `{chips ? …}` branch, which also made it conditional — two changes at once, so the red did not isolate the property and one unrelated test failed with it. Recorded because a break that kills by the wrong route is not evidence.

## Gates

`pnpm build` 0 · `check-types` 0 · `lint` 0 · `lint:design` 0 · `comment convention` 0 · admin suite **357 files, 3468 tests** · `fallow` **pass — 0 introduced** dead code, complexity and duplication.
