### PR TITLE
fix(admin): let the preview keep its name and show its progress

### DIFF
--- a/.changeset/the-preview-says-who-it-is.md
+++ b/.changeset/the-preview-says-who-it-is.md
@@ -1,0 +1,29 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Let the preview control keep its name and show its progress. Its menu trigger carried a fixed accessible name, which overrode the label a collection had declared — so a control reading "View page" on screen answered to "Preview options" and to nothing a voice-control user could see. And once copying a link moved into that menu, choosing it closed the menu and took the only spinner with it, leaving a slow mint with no sign it had started. The trigger is now named after the control it belongs to, and it carries the copying state itself.

--- a/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/PreviewActions.tsx
@@ -134,11 +134,22 @@ function SplitControl({
   options,
   size,
   disabled,
+  optionsLabel,
+  copying,
 }: {
   press: ReactElement;
   options: ReactElement[];
   size: "default" | "sm";
   disabled: boolean;
+  /**
+   * What this chevron opens, named after the control it belongs to.
+   *
+   * The chevron carries no visible text, so its `aria-label` IS its name, and a
+   * fixed one detaches it from a press whose label the collection chose.
+   */
+  optionsLabel: string;
+  /** Whether a link is being minted, which only this control can still show. */
+  copying: boolean;
 }) {
   if (options.length === 0) return press;
   return (
@@ -152,10 +163,20 @@ function SplitControl({
             size={size}
             disabled={disabled}
             className="rounded-l-none px-1.5"
-            aria-label="Preview options"
-            title="Preview options"
+            aria-label={optionsLabel}
+            title={optionsLabel}
           >
-            <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            {/*
+              Progress belongs on the control that STAYS. Choosing to copy
+              closes the menu, so the item that showed the spinner is gone the
+              instant it would start — a slow mint then looks like nothing
+              happened at all.
+            */}
+            {copying ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <ChevronDown className="h-4 w-4" aria-hidden="true" />
+            )}
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">{options}</DropdownMenuContent>
@@ -236,6 +257,8 @@ export function PreviewActions({
         size={size}
         disabled={disabled}
         options={options}
+        optionsLabel={`${labels.pane} options`}
+        copying={isCopyingLink}
         press={
           <Button
             type="button"
@@ -305,11 +328,27 @@ export function PreviewActions({
           variant="outline"
           size={size}
           disabled={disabled}
-          aria-label="Preview options"
-          title="Preview options"
+          /*
+            Derived from the VISIBLE text, not fixed. A collection naming its
+            preview "View page" renders that word, and a hardcoded name here
+            overrides it — so a voice-control user saying what they can see
+            addresses nothing, and a screen reader announces a name the screen
+            does not show.
+          */
+          aria-label={`${labels.menuTrigger} options`}
+          title={`${labels.menuTrigger} options`}
           data-preview-lead="menu"
         >
-          <Eye className="h-4 w-4" aria-hidden="true" />
+          {/*
+            Progress belongs on the control that STAYS: choosing to copy closes
+            the menu, so the item that would show the spinner is gone the
+            instant it starts.
+          */}
+          {isCopyingLink ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Eye className="h-4 w-4" aria-hidden="true" />
+          )}
           <ToolbarLabel priority="secondary">{labels.menuTrigger}</ToolbarLabel>
           <ChevronDown className="h-4 w-4" aria-hidden="true" />
         </Button>

--- a/packages/admin/src/components/features/entries/EntryForm/__tests__/PreviewActions.test.tsx
+++ b/packages/admin/src/components/features/entries/EntryForm/__tests__/PreviewActions.test.tsx
@@ -128,7 +128,9 @@ describe("where a pane exists, it leads and the rest follow", () => {
     // replaces, so the count is the assertion.
     expect(buttons).toHaveLength(2);
     expect(buttons[0]).toHaveAttribute("data-preview-lead", "pane");
-    expect(buttons[1]).toHaveAttribute("aria-label", "Preview options");
+    // Named after the press it belongs to, not fixed: the chevron carries no
+    // visible text, so its label IS its name.
+    expect(buttons[1]).toHaveAttribute("aria-label", "Show preview options");
   });
 
   it("reports the pane's state on the press, which a menu item cannot", () => {
@@ -150,7 +152,9 @@ describe("where a pane exists, it leads and the rest follow", () => {
     const user = userEvent.setup();
     render(<PreviewActions {...withPane} />);
 
-    await user.click(screen.getByRole("button", { name: "Preview options" }));
+    await user.click(
+      screen.getByRole("button", { name: "Show preview options" })
+    );
 
     // "Open in new tab" rather than "Preview": a menu item repeating the press's
     // word would give an author two ways to preview and no way to tell them
@@ -172,5 +176,78 @@ describe("where a pane exists, it leads and the rest follow", () => {
     const buttons = screen.getAllByRole("button");
     expect(buttons).toHaveLength(1);
     expect(buttons[0]).toHaveAttribute("data-preview-lead", "pane");
+  });
+});
+
+describe("the control keeps saying who it is, and what it is doing", () => {
+  it("names the chevron after a label the collection declared", () => {
+    /*
+     * A fixed `aria-label` overrides the visible text. A collection naming its
+     * preview "View page" renders that word, so a voice-control user saying
+     * what they can see addresses nothing, and a screen reader announces a name
+     * the screen does not show.
+     */
+    render(
+      <PreviewActions
+        previewLabel="View page"
+        onTogglePreviewPane={vi.fn()}
+        isLinkAvailable
+        onCopyLink={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "View page options" })
+    ).toBeInTheDocument();
+  });
+
+  it("names the menu trigger after its own visible text", () => {
+    // The other surface with the same defect: this one HAS visible text, so a
+    // fixed name is a direct contradiction of what is on screen.
+    render(
+      <PreviewActions
+        previewLabel="View page"
+        isPreviewAvailable
+        onPreview={vi.fn()}
+        isLinkAvailable
+        onCopyLink={vi.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole("button", { name: "View page options" })
+    ).toBeInTheDocument();
+  });
+
+  it("shows copying on the control that STAYS after the menu closes", () => {
+    /*
+     * Choosing "Copy shareable link" closes the menu, so the item that carried
+     * the spinner is gone the instant it would start spinning. Without this a
+     * slow mint looks like nothing happened.
+     */
+    const { container } = render(
+      <PreviewActions
+        onTogglePreviewPane={vi.fn()}
+        isLinkAvailable
+        onCopyLink={vi.fn()}
+        isCopyingLink
+      />
+    );
+
+    expect(container.querySelector(".animate-spin")).not.toBeNull();
+  });
+
+  it("shows nothing spinning when no link is being minted", () => {
+    // The control: a spinner rendered unconditionally would satisfy the case
+    // above while telling every author something is always in flight.
+    const { container } = render(
+      <PreviewActions
+        onTogglePreviewPane={vi.fn()}
+        isLinkAvailable
+        onCopyLink={vi.fn()}
+      />
+    );
+
+    expect(container.querySelector(".animate-spin")).toBeNull();
   });
 });


### PR DESCRIPTION
The two findings Codex left on #1414's final commit. It merged before I could act on them, so both are live on `main`.

Both are regressions from folding three preview controls into one, and both were on surfaces my own tests already reached.

## 1 · The trigger overrode its own visible name

A collection naming its preview `"View page"` renders that word — and `aria-label="Preview options"` replaced it. A screen reader announced a name the screen does not show, and a voice-control user saying what they could see addressed nothing. The previous implementation produced `${previewLabel} options`.

Both triggers are now named after the control they belong to: the split chevron takes the press's label, and the menu trigger takes its own visible text.

## 2 · Copying lost its progress

Once copy moved into the menu, choosing it **closes the menu** — so the item carrying the spinner is gone the instant it would start spinning. The persistent control showed only its chevron, and a slow mint looked like nothing had happened.

Progress now sits on the control that stays.

## Why my tests missed both

Worth stating, because it is the transferable part: my tests asserted **which control appears** and **what it says on screen**. Neither is the same question as what it is called to a screen reader, or what it looks like mid-flight. A component can pass every "is the right button there" assertion while being unusable by voice and silent under load.

## Evidence

- Break: hardcoding the chevron's name again kills **3 by name**, including the new declared-label test.
- Break: removing the spinner from the persistent control kills **1 by name**.
- The spinner test has a control that must **not** fail on that break — nothing spins when no link is being minted, so a spinner rendered unconditionally would satisfy the first assertion while telling every author something is permanently in flight.

admin **357 files / 3476 tests green**; check-types, lint, fallow (`pass`) clean.

## Unrelated, and worth flagging

`Browser tests` is **red on `main`, and was already red before any of my merges** — same spec, same line (`version-history-isolation.spec.ts:138`), on at least 8 consecutive commits. The failure is a click on "Save draft" being intercepted by the version-history sheet, not a missing control. I verified it is not mine before writing this rather than assuming; it needs an owner.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility**
  - Improved accessible labels and tooltips for preview controls using the visible action text.
- **User Experience**
  - Preview actions now show a loading indicator while a link is being copied or generated.
  - Updated preview option labels provide clearer context across pane and menu views.
- **Tests**
  - Added coverage for accessible naming and loading-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->