### PR TITLE
fix(admin): keep the document reachable while its history is open

### DIFF
--- a/.changeset/history-sits-beside-the-document.md
+++ b/.changeset/history-sits-beside-the-document.md
@@ -1,0 +1,61 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Opening a document's version history made most of the document's own controls
+stop working, without disabling them or reporting anything.
+
+The panel is pinned to the window's edge with `position: fixed`, which takes it
+out of the layout — so the page underneath kept its full width and carried on
+drawing beneath it. Measured in a browser at 1280x720, the panel occupied
+x 800-1280 at every height, and `document.elementFromPoint` at each control's
+own centre returned a row of the panel rather than the control: Save draft,
+Publish, the overflow menu, the rail toggle, the entry's copy-id button, and
+the account, theme and notification controls in the admin header. Eight
+controls, all visible, all enabled, none of them reachable.
+
+Nothing reported a refusal because nothing refused. The pointer simply landed
+on a different element, which is worse than a disabled control — a disabled one
+at least says it will not act.
+
+Space is now reserved rather than fought over. `SidePanelReservation` carries a
+mounted panel's claim up to the layout, which indents its content column by
+that much, so the page ends where the panel begins. A `z-index` would not have
+helped: raising the page over the panel puts the page's controls on top of the
+panel's rows, which is the same collision with the winner swapped.
+
+The width is stated once and both the element and the reservation are taken
+from it. Two literals would agree until one of them changed, and the failure
+after that is silent in the same way as the original: a strip of document drawn
+under a panel, its controls quietly inert.
+
+Where the window cannot hold both, the panel is modal instead of non-modal.
+That is not a lesser fallback — it is the honest state. The panel covers the
+document either way, and a modal one blocks the clicks it is swallowing and
+scrims what it has withdrawn, instead of accepting them into nothing. Both
+behaviours derive from the single question of whether room was made, so the
+panel cannot end up non-modal over a page that nothing moved.

--- a/packages/admin/src/__tests__/helpers/media-query.ts
+++ b/packages/admin/src/__tests__/helpers/media-query.ts
@@ -1,0 +1,32 @@
+/**
+ * Make jsdom answer a media query, for a test whose subject is the window.
+ *
+ * The global stub in `setup.ts` answers "no match" to everything, which exists
+ * so components that merely CALL `matchMedia` while mounting do not die. A test
+ * whose subject is the answer itself has to state one, or it asserts against
+ * the stub's default and passes for a reason that has nothing to do with the
+ * property — which the setup file says in as many words for system theme, and
+ * is equally true of anything keyed on the window's size.
+ *
+ * `matches` is returned for EVERY query rather than per pattern. A helper that
+ * matched on the query string would need the caller to restate the breakpoint
+ * a component owns, which is the same number in two places; callers here have
+ * one query each, so the distinction has nowhere to hide a defect.
+ *
+ * @module __tests__/helpers/media-query
+ */
+import { vi } from "vitest";
+
+/** Answer every media query with `matches`, for the current test. */
+export function answerMediaQueries(matches: boolean): void {
+  window.matchMedia = vi.fn((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })) as unknown as typeof window.matchMedia;
+}

--- a/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
+++ b/packages/admin/src/components/features/versions/VersionHistorySheet.tsx
@@ -17,6 +17,7 @@
 import { X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { useReserveSidePanel } from "@admin/components/layout/SidePanelReservation";
 import {
   Alert,
   AlertDescription,
@@ -36,6 +37,7 @@ import {
   useVersion,
   useVersions,
 } from "@admin/hooks/queries/useVersions";
+import { useMediaQuery } from "@admin/hooks/useMediaQuery";
 import { apiErrorMessage } from "@admin/lib/api/parseApiError";
 import { navigateTo } from "@admin/lib/navigation";
 import type { VersionScope } from "@admin/services/versionApi";
@@ -54,6 +56,28 @@ import { VersionRow } from "./VersionRow";
 // manual "Load more" control. Bounds the search in a long, retention-disabled,
 // multi-locale history where a lone-locale row would otherwise page to the end.
 const MAX_AUTO_PREVIOUS_PAGES = 3;
+
+/**
+ * The panel's width, and the one place it is stated.
+ *
+ * Both the element's own width and the space the layout keeps clear for it are
+ * taken from here. Two literals would agree on the day they were written and
+ * disagree the day one of them is changed, and the failure that follows is
+ * silent: the page is indented by one number while the panel occupies another,
+ * so a strip of the document is drawn under the panel and its controls stop
+ * responding without appearing to have changed.
+ */
+const PANEL_WIDTH = 480;
+
+/**
+ * The narrowest window that can hold the panel BESIDE the document.
+ *
+ * `PANEL_WIDTH` plus 720, which is what is left for everything else: the
+ * navigation rail takes about 256 of it, leaving the document a little over
+ * 460 — narrow, and still a document rather than a column of wrapped words.
+ * Below this the panel covers the page and is modal instead.
+ */
+const PANEL_MIN_WINDOW = PANEL_WIDTH + 720;
 
 export interface VersionHistorySheetProps {
   open: boolean;
@@ -403,21 +427,55 @@ export function VersionHistorySheet({
   });
   const isEmpty = !list.isLoading && !list.isError && versions.length === 0;
 
+  /*
+   * Whether the window can hold this panel BESIDE the document rather than over
+   * it. Asked of the window, because the panel is `position: fixed` and so is
+   * measured against the window rather than against whatever contains it.
+   *
+   * Read on every render of the header, not on open: `useMediaQuery` answers
+   * `false` until its effect runs, and deciding at the moment of opening would
+   * mount the panel modal and switch it a frame later — engaging a focus trap
+   * and then releasing it.
+   */
+  const roomBeside = useMediaQuery(`(min-width: ${PANEL_MIN_WINDOW}px)`);
+
+  /*
+   * The claim, and the ONE fact both behaviours below are derived from. A panel
+   * that is reserved is beside the document, so the document stays live and
+   * only the explicit controls close it; a panel that is not is over the
+   * document, so it is modal and says so. Deciding those separately is how a
+   * panel ends up non-modal with nothing having made room for it, which leaves
+   * every control underneath it visible, enabled and inert.
+   */
+  useReserveSidePanel(open && roomBeside ? PANEL_WIDTH : null);
+
   return (
-    // Non-modal, and that is the point rather than a detail. A modal panel
-    // scrims the page, traps focus and withdraws everything behind it from the
-    // accessibility tree — so reading a document's history made the document
-    // itself unreachable and unscrollable, which is the one thing an editor
-    // needs beside it. Nothing else about the panel changes.
-    <Sheet open={open} onOpenChange={onOpenChange} modal={false}>
+    // Non-modal WHERE THE LAYOUT MADE ROOM, and that is the point rather than a
+    // detail. A modal panel scrims the page, traps focus and withdraws
+    // everything behind it from the accessibility tree — so reading a
+    // document's history made the document itself unreachable and
+    // unscrollable, which is the one thing an editor needs beside it.
+    //
+    // Where the window is too narrow to hold both, modal is the honest state:
+    // the panel covers the document either way, and a modal one refuses the
+    // clicks it is swallowing instead of accepting them into nothing.
+    <Sheet open={open} onOpenChange={onOpenChange} modal={!roomBeside}>
       <SheetContent
         side="right"
-        className="w-[480px] sm:max-w-[480px] p-0 flex flex-col"
+        className="p-0 flex flex-col"
+        // Width from the same constant the reservation is made with, so the
+        // space kept clear cannot drift from the space taken. Capped at the
+        // window because the panel is wider than a phone.
+        style={{ width: `min(${PANEL_WIDTH}px, 100vw)`, maxWidth: "100vw" }}
         // A non-modal surface closes on outside interaction by default, which
         // would make the document unusable while history is open: the first
         // click into the page it now leaves interactive would dismiss the
-        // panel. Closing stays with the explicit controls and Escape.
-        onInteractOutside={event => event.preventDefault()}
+        // panel. Closing stays with the explicit controls and Escape. A modal
+        // panel keeps the default, which is what a drawer over a page should
+        // do.
+        {...(roomBeside
+          ? { onInteractOutside: (event: Event) => event.preventDefault() }
+          : {})}
       >
         <SheetHeader className="p-4 border-b border-border">
           <div className="flex items-center justify-between gap-2">

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.reservation.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.reservation.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Whether the history panel sits BESIDE the document or over it.
+ *
+ * The panel is `position: fixed`, so nothing about opening it moves the page:
+ * without a reservation the document keeps its full width and draws underneath,
+ * and every control in the covered strip stays visible and enabled while the
+ * pointer lands on the panel instead. That failure is silent in both
+ * directions — no error, no disabled state, no visual change — which is why it
+ * survived on `main` with the editor's Save, Publish and overflow menu all
+ * unreachable whenever history was open.
+ *
+ * Kept out of `VersionHistorySheet.test` because that file mocks the panel's
+ * transport to be about what it renders. This is about what it asks the LAYOUT
+ * for, which is a different seam and one no rendering assertion reaches.
+ *
+ * @module components/features/versions/__tests__/VersionHistorySheet.reservation.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { answerMediaQueries } from "@admin/__tests__/helpers/media-query";
+import { render, screen } from "@admin/__tests__/utils";
+import {
+  SidePanelReservationProvider,
+  useReservedInlineEnd,
+} from "@admin/components/layout/SidePanelReservation";
+
+import { VersionHistorySheet } from "../VersionHistorySheet";
+
+vi.mock("@admin/hooks/queries/useVersions", () => ({
+  useVersions: () => ({
+    data: { pages: [{ items: [], meta: { total: 0 } }] },
+    isLoading: false,
+    isError: false,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+  }),
+  useVersion: () => ({ data: undefined, isLoading: false, error: null }),
+  useRestoreVersion: () => ({ mutate: vi.fn(), isPending: false }),
+  useSetVersionLabel: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+/**
+ * Reports the indent the layout would apply, read out of a RENDER so the
+ * assertion is on the value the content column actually receives.
+ */
+function ColumnProbe() {
+  return <div data-testid="reserved">{String(useReservedInlineEnd())}</div>;
+}
+
+function renderPanel(open: boolean) {
+  return render(
+    <SidePanelReservationProvider>
+      <ColumnProbe />
+      <VersionHistorySheet
+        open={open}
+        onOpenChange={vi.fn()}
+        scope={{ kind: "collection", slug: "posts", entryId: "1" }}
+      />
+    </SidePanelReservationProvider>
+  );
+}
+
+const reserved = () => screen.getByTestId("reserved").textContent;
+const overlay = () => document.querySelector('[data-slot="sheet-overlay"]');
+
+describe("a window wide enough to hold the panel beside the document", () => {
+  // The panel asks the window whether it can hold both; jsdom answers no
+  // unless told, so a test about the wide case has to state it.
+  beforeEach(() => answerMediaQueries(true));
+
+  it("reserves the panel's width, so nothing is left underneath it", async () => {
+    renderPanel(true);
+    // 480, from the panel's own constant. The number is the point: an indent
+    // narrower than the panel leaves a covered strip, which is the defect.
+    expect(reserved()).toBe("480");
+  });
+
+  it("leaves the document live, with no scrim over it", () => {
+    // The other half of the same decision. Room having been made, the panel has
+    // no reason to withdraw the document — an editor reads history to act on it.
+    renderPanel(true);
+    expect(overlay()).toBeNull();
+  });
+
+  it("reserves nothing while it is closed", () => {
+    // The control. An unconditional reservation would satisfy the first case
+    // and indent every page in the admin by 480px forever.
+    renderPanel(false);
+    expect(reserved()).toBe("0");
+  });
+});
+
+describe("a window too narrow to hold both", () => {
+  beforeEach(() => answerMediaQueries(false));
+
+  it("reserves nothing, because there is nothing to reserve it from", () => {
+    renderPanel(true);
+    expect(reserved()).toBe("0");
+  });
+
+  it("covers the document as a modal instead, which REFUSES the clicks", () => {
+    /*
+     * The honest state, and the reason this is not simply "do nothing when
+     * narrow". The panel covers the document either way; a modal one blocks
+     * interaction outright and says so, while a non-modal one accepts every
+     * click into nothing. A scrim is the visible half of that.
+     */
+    renderPanel(true);
+    expect(overlay()).not.toBeNull();
+  });
+});

--- a/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
+++ b/packages/admin/src/components/features/versions/__tests__/VersionHistorySheet.test.tsx
@@ -7,6 +7,7 @@ import userEvent from "@testing-library/user-event";
 import type { FieldConfig } from "nextly/config";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+import { answerMediaQueries } from "@admin/__tests__/helpers/media-query";
 import { render, screen, waitFor, within } from "@admin/__tests__/utils";
 
 const {
@@ -404,6 +405,18 @@ describe("VersionHistorySheet", () => {
   });
 
   it("leaves the document reachable while its history is open", () => {
+    /*
+     * A window wide enough to hold the panel BESIDE the document, which is the
+     * condition this behaviour is now attached to. The panel is only non-modal
+     * where the layout has made room for it; over a window too narrow for both
+     * it covers the document, and modal is the honest state there — see
+     * `VersionHistorySheet.reservation.test`.
+     *
+     * Stated rather than inherited: the global stub answers "no match" to every
+     * query, so a test about the window's size that does not set one up is
+     * asserting against the stub.
+     */
+    answerMediaQueries(true);
     useVersionsMock.mockReturnValue(
       listState({
         data: { pages: [{ items: [version(1)], meta: { hasNext: false } }] },

--- a/packages/admin/src/components/layout/ChromeSuppression.tsx
+++ b/packages/admin/src/components/layout/ChromeSuppression.tsx
@@ -7,6 +7,7 @@ import {
   type AdminChromeLayer,
   type ChromeSuppressionRequest,
 } from "./lib/chrome-suppression";
+import { useMountRegistry } from "./lib/mount-registry";
 
 interface ChromeSuppressionContextValue {
   hidden: Set<AdminChromeLayer>;
@@ -39,22 +40,8 @@ export function ChromeSuppressionProvider({
 }: {
   children: React.ReactNode;
 }) {
-  const [requests, setRequests] = React.useState<
-    readonly ChromeSuppressionRequest[]
-  >([]);
-
-  const register = React.useCallback((request: ChromeSuppressionRequest) => {
-    setRequests(current => [...current, request]);
-    // Identity removal, not value removal: two surfaces asking for the same
-    // layers produce equal objects, and removing by value would release both
-    // when one unmounts.
-    return () =>
-      setRequests(current => {
-        const at = current.indexOf(request);
-        if (at === -1) return current;
-        return [...current.slice(0, at), ...current.slice(at + 1)];
-      });
-  }, []);
+  const { entries: requests, register } =
+    useMountRegistry<ChromeSuppressionRequest>();
 
   const value = React.useMemo<ChromeSuppressionContextValue>(
     () => ({ hidden: resolveSuppressedChrome(requests), register }),

--- a/packages/admin/src/components/layout/SidePanelReservation.tsx
+++ b/packages/admin/src/components/layout/SidePanelReservation.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import React from "react";
+
+import { useMountRegistry } from "./lib/mount-registry";
+import {
+  resolveReservedInlineEnd,
+  type SidePanelReservation,
+} from "./lib/side-panel-reservation";
+
+interface SidePanelReservationContextValue {
+  reserved: number;
+  register: (reservation: SidePanelReservation) => () => void;
+}
+
+/**
+ * Defaults to reserving nothing and accepting registrations that do nothing.
+ *
+ * A panel rendered outside the dashboard layout — a test, a standalone route,
+ * Storybook — then calls the hook harmlessly instead of throwing, which is the
+ * same bargain `ChromeSuppression` makes and for the same reason: the
+ * alternative is every call site guarding the call.
+ */
+const SidePanelReservationContext =
+  React.createContext<SidePanelReservationContextValue>({
+    reserved: 0,
+    register: () => () => {},
+  });
+
+/**
+ * Holds what the currently mounted panels have asked to be kept clear.
+ *
+ * Above the chrome AND above the page, because the panel that makes the claim
+ * is rendered deep inside the page while the element that has to honour it is
+ * the layout's own content column. React data flows down, so the claim has to
+ * be lifted past both.
+ */
+export function SidePanelReservationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const { entries: reservations, register } =
+    useMountRegistry<SidePanelReservation>();
+
+  const value = React.useMemo<SidePanelReservationContextValue>(
+    () => ({ reserved: resolveReservedInlineEnd(reservations), register }),
+    [reservations, register]
+  );
+
+  return (
+    <SidePanelReservationContext.Provider value={value}>
+      {children}
+    </SidePanelReservationContext.Provider>
+  );
+}
+
+/** The width the layout must keep clear right now. For the layout itself. */
+export function useReservedInlineEnd(): number {
+  return React.useContext(SidePanelReservationContext).reserved;
+}
+
+/**
+ * Ask the layout to keep `width` pixels of its inline end clear.
+ *
+ * Pass `null` when the panel is closed, or when it is covering the page
+ * deliberately: a panel with nowhere to be put beside the content is a modal
+ * drawer, and a modal one needs no reservation because it blocks interaction
+ * outright rather than silently swallowing it.
+ *
+ * Mount-scoped, so navigating away releases the claim with nothing to undo.
+ */
+export function useReserveSidePanel(width: number | null): void {
+  const { register } = React.useContext(SidePanelReservationContext);
+
+  /*
+   * A LAYOUT effect on the client, because the space this reserves is missing
+   * until the claim lands. In a passive effect the first frame paints the page
+   * at full width under the panel — the very overlap being prevented — and the
+   * correction lands a frame later as a visible shift of the whole column.
+   */
+  useRegistrationEffect(() => {
+    if (width === null) return;
+    return register({ width });
+  }, [width, register]);
+}
+
+/**
+ * Falls back to a passive effect where there is no DOM: a layout effect during
+ * a server render warns and cannot run, and nothing has painted there anyway.
+ */
+const useRegistrationEffect =
+  typeof window === "undefined" ? React.useEffect : React.useLayoutEffect;

--- a/packages/admin/src/components/layout/__tests__/side-panel-reservation-wiring.test.tsx
+++ b/packages/admin/src/components/layout/__tests__/side-panel-reservation-wiring.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * The seam the resolver test cannot reach: whether a claim made by a panel
+ * rendered deep in the page arrives at the layout, and whether closing that
+ * panel releases it.
+ *
+ * Worth a file of its own because a correct resolver says nothing about the
+ * wiring. A provider that never registered, registered once and cached, or
+ * removed by value rather than by identity leaves every resolver test green
+ * while the page is indented for a panel that closed — or not indented for one
+ * that is open, which is the defect this exists to prevent.
+ *
+ * @module components/layout/__tests__/side-panel-reservation-wiring.test
+ */
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { describe, expect, it } from "vitest";
+
+import {
+  SidePanelReservationProvider,
+  useReservedInlineEnd,
+  useReserveSidePanel,
+} from "../SidePanelReservation";
+
+/**
+ * Stands in for the layout's content column: it reports the indent it would
+ * apply. Read out as text so the assertion is on a value a RENDER received,
+ * which is what the layout consumes.
+ */
+function ColumnProbe() {
+  return <div data-testid="reserved">{String(useReservedInlineEnd())}</div>;
+}
+
+function Panel({ width }: { width: number | null }) {
+  useReserveSidePanel(width);
+  return <div>panel</div>;
+}
+
+const reserved = () => screen.getByTestId("reserved").textContent;
+
+describe("a panel's claim on the layout", () => {
+  it("reserves nothing while no panel is open", () => {
+    render(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("0");
+  });
+
+  it("arrives at the layout from a child", () => {
+    render(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+        <Panel width={480} />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("480");
+  });
+
+  it("is released when the panel unmounts", () => {
+    // The half that fails silently: a claim that outlives its panel leaves a
+    // permanent empty strip down the page with nothing on screen to explain it.
+    const { rerender } = render(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+        <Panel width={480} />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("480");
+
+    rerender(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("0");
+  });
+
+  it("is released when the panel closes without unmounting", () => {
+    /*
+     * How the history panel behaves: it stays mounted with the document header
+     * and passes null while closed. A hook that only released on unmount would
+     * pass the case above and indent the page forever after the first open.
+     */
+    const { rerender } = render(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+        <Panel width={480} />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("480");
+
+    rerender(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+        <Panel width={null} />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("0");
+  });
+
+  it("keeps the surviving claim when one of two identical panels closes", () => {
+    /*
+     * Identity removal, not value removal. Two panels of the same width produce
+     * equal objects, so a provider filtering by value releases BOTH when one
+     * closes — and the page loses its indent while a panel is still on screen,
+     * which is exactly the overlap being prevented.
+     */
+    const { rerender } = render(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+        <Panel width={480} />
+        <Panel width={480} />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("480");
+
+    rerender(
+      <SidePanelReservationProvider>
+        <ColumnProbe />
+        <Panel width={480} />
+      </SidePanelReservationProvider>
+    );
+    expect(reserved()).toBe("480");
+  });
+});

--- a/packages/admin/src/components/layout/__tests__/side-panel-reservation.test.ts
+++ b/packages/admin/src/components/layout/__tests__/side-panel-reservation.test.ts
@@ -1,0 +1,44 @@
+/**
+ * How much of the window's edge is kept clear for the panels that are open.
+ *
+ * The property worth guarding is that overlapping panels do not ADD: they are
+ * pinned to the same edge and cover each other, so two 480px panels still
+ * occupy 480. Summing is the natural way to write this and it is wrong only in
+ * the rare two-panel state, which is the state nobody opens by hand.
+ *
+ * @module components/layout/__tests__/side-panel-reservation.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { resolveReservedInlineEnd } from "../lib/side-panel-reservation";
+
+describe("the width kept clear", () => {
+  it("is nothing when no panel is open", () => {
+    // The default the layout runs in almost all the time: no panel, no indent.
+    expect(resolveReservedInlineEnd([])).toBe(0);
+  });
+
+  it("is the panel's own width when one is open", () => {
+    expect(resolveReservedInlineEnd([{ width: 480 }])).toBe(480);
+  });
+
+  it("is the WIDEST of several, not their total", () => {
+    // 960 would indent the page past two panels that occupy one edge between
+    // them, emptying half the window in a state nobody looks at.
+    expect(resolveReservedInlineEnd([{ width: 480 }, { width: 480 }])).toBe(
+      480
+    );
+    expect(resolveReservedInlineEnd([{ width: 320 }, { width: 480 }])).toBe(
+      480
+    );
+  });
+
+  it("does not depend on the order they registered in", () => {
+    // The control for the case above: a resolver returning the LAST width would
+    // satisfy both assertions there, and would shrink the reservation whenever
+    // a narrow panel happened to open second.
+    expect(resolveReservedInlineEnd([{ width: 480 }, { width: 320 }])).toBe(
+      480
+    );
+  });
+});

--- a/packages/admin/src/components/layout/lib/mount-registry.ts
+++ b/packages/admin/src/components/layout/lib/mount-registry.ts
@@ -1,0 +1,46 @@
+/**
+ * A list of requests made by descendants, each held for as long as its
+ * requester is mounted.
+ *
+ * Two layout providers ask the same question in the same shape — which
+ * surfaces want chrome hidden, which panels want space kept clear — and the
+ * shape is where the subtlety is, not in either answer. What they resolve the
+ * list INTO differs and stays with each of them.
+ *
+ * @module components/layout/lib/mount-registry
+ */
+
+import { useCallback, useState } from "react";
+
+export interface MountRegistry<T> {
+  /** Everything currently registered, in registration order. */
+  entries: readonly T[];
+  /** Adds an entry and returns the release for it. */
+  register: (entry: T) => () => void;
+}
+
+/**
+ * Holds registrations for a provider.
+ *
+ * Release is by IDENTITY, which is the part worth having once. Two requesters
+ * asking for the same thing produce equal values — two panels of one width,
+ * two surfaces hiding one layer — and a release that filtered by value would
+ * drop both when either unmounted. The result is a provider that reports
+ * nothing registered while a requester is still on screen, which reads as the
+ * feature never having worked rather than as a release bug.
+ */
+export function useMountRegistry<T>(): MountRegistry<T> {
+  const [entries, setEntries] = useState<readonly T[]>([]);
+
+  const register = useCallback((entry: T) => {
+    setEntries(current => [...current, entry]);
+    return () =>
+      setEntries(current => {
+        const at = current.indexOf(entry);
+        if (at === -1) return current;
+        return [...current.slice(0, at), ...current.slice(at + 1)];
+      });
+  }, []);
+
+  return { entries, register };
+}

--- a/packages/admin/src/components/layout/lib/side-panel-reservation.ts
+++ b/packages/admin/src/components/layout/lib/side-panel-reservation.ts
@@ -1,0 +1,40 @@
+/**
+ * How much of the window's inline end a mounted panel needs kept clear.
+ *
+ * A panel pinned to the edge with `position: fixed` is outside the layout, so
+ * the page underneath keeps its full width and draws beneath it. Whatever the
+ * page put there is then visible and unclickable: the pointer lands on the
+ * panel, the handler never runs, and nothing reports a refusal because nothing
+ * refused. That is worse than a disabled control, which at least says so.
+ *
+ * The alternative to reserving is a `z-index`, and it does not address this —
+ * raising the page over the panel would put the page's controls ON TOP of the
+ * panel's rows, which is the same collision with the winner swapped. Space has
+ * to be made, not fought over.
+ *
+ * @module components/layout/lib/side-panel-reservation
+ */
+
+/** One mounted panel's claim, held for as long as that panel is on screen. */
+export interface SidePanelReservation {
+  /** CSS pixels of the inline end this panel occupies. */
+  readonly width: number;
+}
+
+/**
+ * The width to keep clear, which is the WIDEST claim rather than their sum.
+ *
+ * Panels pinned to the same edge overlap each other rather than queueing, so
+ * two 480px panels still occupy 480px. Summing would indent the page by 960px
+ * and leave half the window empty — and it would do so only in the rare state
+ * where two are open, which is exactly the state nobody checks.
+ */
+export function resolveReservedInlineEnd(
+  reservations: Iterable<SidePanelReservation>
+): number {
+  let widest = 0;
+  for (const reservation of reservations) {
+    if (reservation.width > widest) widest = reservation.width;
+  }
+  return widest;
+}

--- a/packages/admin/src/layout/DashboardLayout.tsx
+++ b/packages/admin/src/layout/DashboardLayout.tsx
@@ -23,6 +23,10 @@ import {
 import { DashboardHeader } from "../components/layout/header";
 import { SidebarProvider } from "../components/layout/sidebar";
 import { DualSidebar } from "../components/layout/sidebar/DualSidebar";
+import {
+  SidePanelReservationProvider,
+  useReservedInlineEnd,
+} from "../components/layout/SidePanelReservation";
 import { MediaProvider } from "../context/providers/MediaProvider";
 
 interface DashboardLayoutProps {
@@ -48,7 +52,9 @@ interface DashboardLayoutProps {
 export function DashboardLayout({ children }: DashboardLayoutProps) {
   return (
     <ChromeSuppressionProvider>
-      <DashboardChrome>{children}</DashboardChrome>
+      <SidePanelReservationProvider>
+        <DashboardChrome>{children}</DashboardChrome>
+      </SidePanelReservationProvider>
     </ChromeSuppressionProvider>
   );
 }
@@ -66,6 +72,14 @@ function DashboardChrome({ children }: DashboardLayoutProps) {
     hidden.has("primaryRail") && hidden.has("subSidebar");
   const { pathname } = useRouter();
   const branding = useBranding();
+  /*
+   * A panel pinned to the window's edge is `position: fixed`, so it is outside
+   * this column's layout and the column keeps its full width underneath it.
+   * Padding the column is what turns "drawn over" into "beside": the header's
+   * account controls and every document action move inboard of the panel
+   * instead of sitting under it, unclickable and silent about it.
+   */
+  const reservedInlineEnd = useReservedInlineEnd();
 
   // Close mobile menu on route change
   useEffect(() => {
@@ -126,7 +140,10 @@ function DashboardChrome({ children }: DashboardLayoutProps) {
             </Sheet>
 
             {/* Main Content */}
-            <div className="flex-1 min-w-0 flex flex-col min-h-0 overflow-hidden relative">
+            <div
+              className="flex-1 min-w-0 flex flex-col min-h-0 overflow-hidden relative transition-[padding] duration-150"
+              style={{ paddingInlineEnd: reservedInlineEnd }}
+            >
               {!hidden.has("header") && <DashboardHeader />}
               {/* Named container so content responds to the panel width
                   (viewport minus sidebar), not the viewport. */}

--- a/packages/ui/src/components/sheet.tsx
+++ b/packages/ui/src/components/sheet.tsx
@@ -114,6 +114,7 @@ const SheetOverlay = React.forwardRef<
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Overlay
+    data-slot="sheet-overlay"
     className={cn(
       // A modal scrim, from the `--nx-overlay` token rather than a surface
       // token. A black wash is the point — painting it from `background` would


### PR DESCRIPTION
## The defect

Opening a document's version history made most of the document's own controls stop working, without disabling them or reporting anything.

The panel is pinned to the window's edge with `position: fixed`, which takes it out of the layout — so the page underneath kept its full width and carried on drawing beneath it.

Measured in a browser at 1280×720. The panel occupies **x 800–1280 at every height**, and `document.elementFromPoint` at each control's own centre returns a row of the panel rather than the control:

| control | x | reachable with history open |
| --- | --- | --- |
| Add to release | 548–705 | yes |
| Version history | 711–745 | yes |
| Copy shareable link | 751–801 | yes |
| Save draft | 807–841 | **no** |
| Publish | 847–929 | **no** |
| More actions | 935–969 | **no** |
| Hide rail | 990–1024 | **no** |
| Copy ID | 1220–1236 | **no** |
| Theme / notifications / account | 1108–1256 | **no** |

Nothing reported a refusal because nothing refused — the pointer simply landed on a different element. That is worse than a disabled control, which at least says it will not act.

## Why it surfaced now

`Browser tests` has been red on `main` since `a430cd6c6`, whose parent is green and which is the only commit between them. That change moved `Save draft` across the panel's edge **by seven pixels**, from 800 to 807.

It did not create the defect. Seven of the eight controls were already unreachable; `Save draft` was the only one any test clicked, so the suite had been passing on that margin.

## The fix

`SidePanelReservation` carries a mounted panel's claim up to the layout, which indents its content column by that much. The page now ends where the panel begins.

A `z-index` does not address this: raising the page over the panel puts the page's controls on top of the panel's rows, which is the same collision with the winner swapped.

Two properties worth review attention:

- **The width is stated once.** Both the panel element and the reservation read one constant. Two literals would agree until one changed, and the failure after that is silent in the original way — a strip of document under a panel, its controls quietly inert.
- **Where the window cannot hold both, the panel is modal.** Not a lesser fallback: it covers the document either way, and a modal one blocks the clicks it is swallowing and scrims what it has withdrawn instead of accepting them into nothing. Both behaviours derive from the single question of whether room was made, so the panel cannot end up non-modal over a page nothing moved.

`ChromeSuppression` asks the same question in the same shape — which descendants registered a request, released on unmount by identity — so that mechanism is now one implementation, `useMountRegistry`, with each provider keeping only what it resolves the list into. This also cleared the duplication `fallow` flagged as introduced.

## Evidence

- **e2e `version-history-isolation.spec.ts` passes**, the previously failing case going from a 30s timeout to a 2s pass.
- **Seven break-verifications, each killing exactly the named test**, control green after each: resolver summing rather than taking the widest (3 dead), release by value rather than identity (1), release only on unmount (1), reserving with no room (1), never modal (1), always modal (1), reserving a width narrower than the panel (1), resolver answering 0 (8).
- admin **360 files / 3490 tests** green, file count unchanged; ui **49 / 1164** green.
- `check-types` 0, `lint` 0, `fallow audit --base origin/main` **pass**, 13 files analysed, 0 introduced.

## One existing test changed

`"leaves the document reachable while its history is open"` asserted the old unconditional non-modal behaviour against jsdom's stub, which answers "no match" to every media query. The test was about the window and never said which window; it now states one, and the narrow case has its own coverage. `setup.ts` already warns about this class of test passing for the wrong reason.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Version history now adapts to screen size: it appears beside the document on wide screens and as a modal on narrower screens.
  - Page content automatically adjusts to make room for open side panels, preventing panels from covering important content.
  - Multiple open side panels now reserve the appropriate amount of space based on the widest panel.

- **Bug Fixes**
  - Improved handling of panel opening and closing so reserved layout space is released correctly.
  - Enhanced consistency for sheet overlays and responsive panel behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->