### PR TITLE
feat(admin): draw a list widget from the fields its query selected

### DIFF
--- a/.changeset/a-list-widget-draws-its-rows.md
+++ b/.changeset/a-list-widget-draws-its-rows.md
@@ -1,0 +1,50 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The `list` archetype is drawn by the host. A plugin can declare a list widget with no UI code of its own:
+
+```ts
+{
+  id: "acme/recent",
+  title: "Recent posts",
+  archetype: "list",
+  defaultSize: "md",
+  query: {
+    source: "collection:posts",
+    op: "list",
+    select: ["title", "slug"],
+    limit: 5,
+  },
+}
+```
+
+Which field each row shows is taken from the query's `select`, in order: the first selected field is the row's label, and the second — where there is one — is the muted line beneath it. Derived from `select` rather than declared again, because the author has already said which fields the widget is about and a second declaration could disagree with it; it also means a card cannot display a field it never asked the server for.
+
+A `list` whose query selects nothing is refused by name in its own card rather than guessed at. Without `select` the rows carry whatever the collection happens to hold, so core would be picking a key out of a document it knows nothing about — and the key it picked would change the day someone added a column.
+
+A cell that is not printable is left out rather than stringified. A relationship, a repeater or a localized value arrives as an object, and `String(value)` renders "[object Object]", which reads as data rather than as a defect; the row still holds its place so the number of rows matches the number of results. `0` and `false` are printed, since only `null`, `undefined` and blank strings are absences. An empty result says so instead of drawing an empty list, and a card shows at most five rows.

--- a/docs/plugins/admin-ui.mdx
+++ b/docs/plugins/admin-ui.mdx
@@ -189,11 +189,16 @@ A widget is drawn one of two ways, and you pick by what you declare.
 Declare an `archetype` and the `query` it is drawn from, and ship no UI code. The host
 runs the query for the signed-in user and renders the card.
 
-> **What the host draws today: `metric`, and only `metric`.**
-> `table`, `list`, `text` and `actions` are accepted by the contract but have no
-> renderer yet, so a widget declaring one shows "the … archetype is not rendered yet"
-> in its card unless it also ships a `component` to draw the body itself. Declare
-> those archetypes only with a component fallback until this note says otherwise.
+> **What the host draws today: `metric` and `list`.**
+> `table`, `text` and `actions` are accepted by the contract but have no renderer
+> yet, so a widget declaring one shows "the … archetype is not rendered yet" in its
+> card unless it also ships a `component` to draw the body itself. Declare those
+> archetypes only with a component fallback until this note says otherwise.
+>
+> A `list` widget draws one row per result. Its query's `select` decides what each
+> row shows, in order: the first field is the row's label and the second, if there
+> is one, is the muted line under it. A `list` that selects nothing says so rather
+> than guessing at a field.
 
 ```ts
 contributes: {
@@ -213,8 +218,8 @@ contributes: {
 ```
 
 `text` and `actions` are drawn without data, so they take no `query` — declaring one is
-a type error. Every other archetype requires it. (Neither has a renderer yet; see the
-note above.)
+a type error. Every other archetype requires it. (Neither of those two has a renderer
+yet; see the note above.)
 
 ### Draw it yourself
 

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -14,6 +14,7 @@ import {
 } from "@admin/lib/plugins/component-registry";
 import type { AdminBranding } from "@admin/types/branding";
 
+import { coreDrawsArchetype } from "../outcome";
 import { WidgetGrid } from "../WidgetGrid";
 
 let mockBranding: AdminBranding | undefined;
@@ -46,6 +47,32 @@ function renderGrid() {
   );
   return { client, ...render(<WidgetGrid />, { wrapper: Wrapper }) };
 }
+
+/**
+ * An archetype core cannot draw in THIS release, derived rather than named.
+ *
+ * Several cases below need a widget nothing can render — to prove the grid does
+ * not spend a query on it, does not claim freshness for it, and still counts it
+ * as failed. Naming one (`list`, until it gained a body) makes those cases go
+ * quietly wrong the day that archetype lands: they keep passing while testing
+ * something else entirely. Asking the renderer table keeps them pointed at
+ * whatever is genuinely undrawn.
+ */
+// Listed here rather than imported: `nextly/config` publishes the archetype
+// VOCABULARY as a type only, and is deliberately almost free of runtime values.
+// The names are stable; which of them core can draw is the part that moves, and
+// that is asked of `coreDrawsArchetype` below.
+const HOST_DRAWN_ARCHETYPES = ["metric", "table", "list", "text", "actions"];
+
+const UNDRAWABLE = HOST_DRAWN_ARCHETYPES.find(
+  archetype => !coreDrawsArchetype(archetype)
+);
+
+it("has an archetype core cannot draw, which several cases below need", () => {
+  // Stated as its own case so that when core draws everything, this fails with
+  // a sentence instead of leaving the cases below silently vacuous.
+  expect(UNDRAWABLE).toBeDefined();
+});
 
 function brandingWith(widgets: unknown[]): AdminBranding {
   return {
@@ -228,7 +255,7 @@ describe("WidgetGrid — collection and gating", () => {
       {
         id: "acme/recent",
         title: "Recent posts",
-        archetype: "list",
+        archetype: UNDRAWABLE,
         query: { source: "collection:posts", op: "list" },
       },
     ]);
@@ -254,7 +281,7 @@ describe("WidgetGrid — collection and gating", () => {
       {
         id: "acme/recent",
         title: "Recent posts",
-        archetype: "list",
+        archetype: UNDRAWABLE,
         query: { source: "collection:posts", op: "list" },
       },
       {
@@ -291,7 +318,7 @@ describe("WidgetGrid — collection and gating", () => {
       {
         id: "acme/recent",
         title: "Recent posts",
-        archetype: "list",
+        archetype: UNDRAWABLE,
         component: "@acme/admin#Recent",
         query: { source: "collection:posts", op: "list" },
       },
@@ -304,6 +331,60 @@ describe("WidgetGrid — collection and gating", () => {
 
     await waitFor(() => expect(protectedApi.post).toHaveBeenCalledTimes(1));
     expect(screen.getByText("recent body")).toBeInTheDocument();
+  });
+
+  it("draws a LIST widget end to end, from declaration to rows", async () => {
+    // The second host-drawn archetype, through the whole path: a declarative
+    // contribution with no component, its query batched, the `list` arm of the
+    // response validated, and the rows drawn from the fields it selected.
+    mockBranding = brandingWith([
+      {
+        id: "acme/recent",
+        title: "Recent posts",
+        archetype: "list",
+        defaultSize: "md",
+        query: {
+          source: "collection:posts",
+          op: "list",
+          select: ["title", "slug"],
+          limit: 5,
+        },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        {
+          ok: true,
+          result: {
+            op: "list",
+            items: [
+              { title: "First post", slug: "first-post" },
+              { title: "Second post", slug: "second-post" },
+            ],
+          },
+        },
+      ],
+    });
+
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getAllByTestId("widget-list-row")).toHaveLength(2)
+    );
+    expect(screen.getByText("First post")).toBeInTheDocument();
+    expect(screen.getByText("second-post")).toBeInTheDocument();
+    // And the select reached the server as declared, so the rows are drawn from
+    // fields the query actually asked for.
+    expect(vi.mocked(protectedApi.post).mock.calls[0][1]).toEqual({
+      queries: [
+        {
+          source: "collection:posts",
+          op: "list",
+          select: ["title", "slug"],
+          limit: 5,
+        },
+      ],
+    });
   });
 
   it("puts a registered widget's query in the same batch as a contributed one", async () => {
@@ -793,7 +874,7 @@ describe("WidgetGrid — accessibility", () => {
     mockBranding = brandingWith([
       {
         id: "listy",
-        archetype: "list",
+        archetype: UNDRAWABLE,
         title: "Recent",
         query: { source: "collection:posts", op: "list" },
       },

--- a/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
@@ -91,6 +91,10 @@ describe("resolveDashboardWidgets", () => {
   });
 
   it("keeps the contributed component when the registry names an archetype core cannot draw", () => {
+    // `table` because it has no renderer in this release; the point is an
+    // archetype core cannot draw, not that particular name. When `table` gains
+    // a body this must move to whichever archetype is still undrawn.
+    //
     // The population this resolver reads both channels FOR: an app that
     // registered a widget and also contributed it, which is how it got a card
     // before the registry was published at all. `WidgetDefinition` forbids
@@ -106,7 +110,7 @@ describe("resolveDashboardWidgets", () => {
         {
           id: "acme/recent",
           title: "Recent posts",
-          archetype: "list",
+          archetype: "table",
           defaultSize: "md",
           query: { source: "collection:posts", op: "list", limit: 5 },
         } as unknown as RegisteredWidgetMeta,
@@ -138,7 +142,7 @@ describe("resolveDashboardWidgets", () => {
         {
           id: "acme/recent",
           title: "Recent posts",
-          archetype: "list",
+          archetype: "table",
           defaultSize: "md",
           requiredPermission: "read-secrets",
           query: { source: "collection:posts", op: "list", limit: 5 },

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/list.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/list.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * What a `list` card shows, and what it refuses to guess at.
+ *
+ * Asserted through the body rather than the whole grid, because the decisions
+ * here are about ONE payload and one declaration — which field is the label,
+ * what a non-printable cell becomes, what an empty result reads as.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  DashboardWidget,
+  WidgetResult,
+} from "@admin/types/dashboard/widgets";
+
+import { listBody } from "../list";
+
+const widget = (select?: string[]): DashboardWidget =>
+  ({
+    id: "acme/recent",
+    title: "Recent posts",
+    archetype: "list",
+    size: "md",
+    query: {
+      source: "collection:posts",
+      op: "list",
+      ...(select && { select }),
+    },
+  }) as DashboardWidget;
+
+const listOf = (items: Record<string, unknown>[]): WidgetResult => ({
+  op: "list",
+  items,
+});
+
+/** Renders a successful body, or fails loudly with the refusal's message. */
+function draw(result: WidgetResult, definition: DashboardWidget) {
+  const outcome = listBody(result, definition);
+  if (!outcome.ok) throw new Error(`expected a body, got: ${outcome.message}`);
+  render(<>{outcome.node}</>);
+}
+
+describe("the list archetype", () => {
+  it("takes the row's label from the FIRST selected field", () => {
+    draw(
+      listOf([{ title: "Hello", slug: "hello" }]),
+      widget(["title", "slug"])
+    );
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+  });
+
+  it("shows the second selected field as the line under it", () => {
+    draw(
+      listOf([{ title: "Hello", slug: "hello" }]),
+      widget(["title", "slug"])
+    );
+    expect(screen.getByText("hello")).toBeInTheDocument();
+  });
+
+  it("ignores fields past the second", () => {
+    // Two lines is the card's whole vocabulary. A third would either wrap into
+    // the next row or silently truncate, and neither reads as a list.
+    draw(listOf([{ a: "one", b: "two", c: "three" }]), widget(["a", "b", "c"]));
+    expect(screen.queryByText("three")).not.toBeInTheDocument();
+  });
+
+  it("refuses a list whose query selects nothing, by name", () => {
+    // Without `select` the rows carry whatever the collection holds, so core
+    // would be picking a key out of a document it knows nothing about — and the
+    // key it picked would change the day someone added a column.
+    const outcome = listBody(listOf([{ title: "Hello" }]), widget());
+    expect(outcome.ok).toBe(false);
+    expect(outcome.ok === false && outcome.message).toMatch(/Recent posts/);
+    expect(outcome.ok === false && outcome.message).toMatch(
+      /selects no fields/i
+    );
+  });
+
+  it("refuses a count payload, naming both ops", () => {
+    const outcome = listBody({ op: "count", total: 3 }, widget(["title"]));
+    expect(outcome.ok).toBe(false);
+    expect(outcome.ok === false && outcome.message).toMatch(/expected a list/i);
+    expect(outcome.ok === false && outcome.message).toMatch(/count/);
+  });
+
+  it("says nothing is there rather than drawing an empty list", () => {
+    draw(listOf([]), widget(["title"]));
+    expect(screen.getByTestId("widget-list-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("widget-list-row")).not.toBeInTheDocument();
+  });
+
+  it("caps the rows it draws", () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ title: `Row ${i}` }));
+    draw(listOf(many), widget(["title"]));
+    expect(screen.getAllByTestId("widget-list-row")).toHaveLength(5);
+  });
+
+  it("does NOT stringify an object cell into [object Object]", () => {
+    // The exact defect a sibling widget shipped once: a relationship, repeater
+    // or rich-text value arrives as an object, and `String(value)` renders
+    // "[object Object]" — which looks like data rather than a bug.
+    draw(
+      listOf([{ title: { en: "Localised" }, slug: "x" }]),
+      widget(["title", "slug"])
+    );
+    expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+    // The row still occupies its place, so the count matches the result.
+    expect(screen.getAllByTestId("widget-list-row")).toHaveLength(1);
+  });
+
+  it("prints a zero rather than dropping it", () => {
+    // `0` and `false` are answers; only null/undefined/blank are absences.
+    draw(listOf([{ views: 0 }]), widget(["views"]));
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("leaves the second line off when that field is absent", () => {
+    draw(listOf([{ title: "Hello" }]), widget(["title", "slug"]));
+    const row = screen.getByTestId("widget-list-row");
+    expect(row.textContent).toBe("Hello");
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/list.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/list.tsx
@@ -1,0 +1,118 @@
+/**
+ * The `list` archetype: a few rows, each a line of text.
+ *
+ * WHICH field a row shows is taken from the query's `select`, in order: the
+ * first selected field is the row's label and the second, when there is one, is
+ * the muted line under it. Everything after that is ignored.
+ *
+ * Derived from `select` rather than declared separately, because a second
+ * declaration would be a second answer to one question — the author has already
+ * said which fields this widget is about, and a `list: { primary, secondary }`
+ * block could disagree with it. It also means the widget cannot display a field
+ * it did not ask the server for, which keeps the card honest about its own
+ * query.
+ *
+ * A `list` widget that selects NOTHING is refused by name rather than guessed
+ * at. Without `select` the rows carry whatever the collection happens to hold,
+ * so core would be picking a key out of a document it knows nothing about — and
+ * the field it picked would change the day someone added a column.
+ *
+ * @module components/features/widgets/archetypes/list
+ */
+
+import type { ArchetypeBody } from "./types";
+
+/** How many rows a card of this size can show without becoming a table. */
+const MAX_ROWS = 5;
+
+/**
+ * One cell as text, or `undefined` when it is not something to print.
+ *
+ * Objects and arrays are DROPPED rather than stringified. `String({})` is
+ * "[object Object]", which is not a defect a reader can act on — it looks like
+ * data. A relationship, a repeater or a rich-text value all arrive here as
+ * objects, and this widget cannot draw any of them; saying nothing is better
+ * than saying that. The same reading `RecentEntriesWidget` had to be taught
+ * when its titles came back as objects.
+ *
+ * `null` and `undefined` are absent values, not text. `0` and `false` ARE text:
+ * a count of zero is a real answer and dropping it would make the row lie.
+ */
+function asText(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string") return value.trim() === "" ? undefined : value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return undefined;
+}
+
+export const listBody: ArchetypeBody = (result, definition) => {
+  if (result.op !== "list") {
+    return {
+      ok: false,
+      message: `"${definition.title}" expected a list, but the query returned a ${result.op}.`,
+    };
+  }
+
+  const select = definition.query?.select ?? [];
+  const [labelField, detailField] = select;
+  if (!labelField) {
+    return {
+      ok: false,
+      message: `"${definition.title}" is a list widget whose query selects no fields, so there is nothing to show in each row.`,
+    };
+  }
+
+  if (result.items.length === 0) {
+    return {
+      ok: true,
+      node: (
+        <p
+          data-testid="widget-list-empty"
+          className="text-sm text-muted-foreground"
+        >
+          Nothing yet.
+        </p>
+      ),
+    };
+  }
+
+  const rows = result.items.slice(0, MAX_ROWS);
+
+  return {
+    ok: true,
+    node: (
+      <ul data-testid="widget-list" className="flex flex-col gap-2">
+        {rows.map((item, index) => {
+          const label = asText(item[labelField]);
+          const detail = detailField ? asText(item[detailField]) : undefined;
+          return (
+            <li
+              // The index, because a widget's rows have no identity core can
+              // rely on: `select` need not include a key, and two rows may be
+              // identical in the fields it did select. The list is replaced
+              // wholesale on every refetch and nothing in it is stateful or
+              // reorderable, so there is no state for a wrong key to strand.
+              key={index}
+              data-testid="widget-list-row"
+              className="flex min-w-0 flex-col gap-0.5"
+            >
+              <span className="truncate text-sm text-foreground">
+                {/* An em dash rather than an empty line, so a row whose label
+                    is absent or unprintable still occupies its place and the
+                    count of rows matches the count of results. */}
+                {label ?? "—"}
+              </span>
+              {detail !== undefined && (
+                <span className="truncate text-xs text-muted-foreground">
+                  {detail}
+                </span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    ),
+  };
+};

--- a/packages/admin/src/components/features/widgets/outcome.ts
+++ b/packages/admin/src/components/features/widgets/outcome.ts
@@ -31,6 +31,7 @@ import type {
   WidgetSlot,
 } from "@admin/types/dashboard/widgets";
 
+import { listBody } from "./archetypes/list";
 import { metricBody } from "./archetypes/metric";
 import type { ArchetypeBody } from "./archetypes/types";
 
@@ -43,6 +44,7 @@ import type { ArchetypeBody } from "./archetypes/types";
  */
 const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeBody>> = {
   metric: metricBody,
+  list: listBody,
 };
 
 /**


### PR DESCRIPTION
The second host-drawn archetype. A plugin declares a list widget with no UI code of its own and core renders one row per result:

```ts
{
  id: "acme/recent",
  title: "Recent posts",
  archetype: "list",
  defaultSize: "md",
  query: { source: "collection:posts", op: "list", select: ["title", "slug"], limit: 5 },
}
```

## Which field a row shows

Taken from the query's `select`, in order: the first selected field is the row's label, the second is the muted line under it, and anything after that is ignored — two lines is the card's whole vocabulary.

Derived from `select` rather than declared again. A `list: { primary, secondary }` block would be a second answer to a question the author has already answered, and the two could disagree; deriving also means a card cannot display a field it never asked the server for, which keeps it honest about its own query.

A list whose query selects **nothing** is refused by name in its own card rather than guessed at. Without `select` the rows carry whatever the collection happens to hold, so core would be picking a key out of a document it knows nothing about — and the key it picked would change the day someone added a column.

## What a cell becomes

A cell that is not printable is left out rather than stringified. A relationship, a repeater or a localized value arrives as an object, and `String(value)` renders `[object Object]` — which reads as data rather than as a defect. This is not hypothetical: it is a defect a sibling widget on this same dashboard already shipped once. The row keeps its place, so the number of rows still matches the number of results.

`0` and `false` ARE printed. Only `null`, `undefined` and blank strings are absences, and dropping a zero would make the row lie.

An empty result says "Nothing yet." instead of drawing an empty list, and a card shows at most five rows.

## The grid tests now derive their undrawable archetype

Several cases need a widget nothing can draw — to prove the grid spends no query on it, claims no freshness for it, and still counts it as failed. They named `list`, because `list` was undrawn. That is exactly the kind of pin that goes quietly wrong: those cases would have kept passing while testing something else entirely.

They now ask `coreDrawsArchetype` for whatever is still undrawn, with a case asserting such an archetype exists — so when core eventually draws all five, they fail with a sentence instead of becoming vacuous.

## Verification

- Break-verified twice: stringifying object cells fails `does NOT stringify an object cell into [object Object]`, and guessing the label from the first result's keys instead of refusing fails `refuses a list whose query selects nothing, by name`. Each break fails exactly its own case.
- `list.test.tsx` covers the body directly (10 cases); `WidgetGrid.test.tsx` adds an end-to-end case asserting the declaration reaches the batch with its `select` intact and the rows are drawn from it.
- Admin suite 361 files / 3,509 tests; `check-types` clean.

## One note for whoever edits the docs next

`docs/plugins/admin-ui.mdx` is edited by hand here and deliberately **not** run through prettier. The file is already prettier-dirty on `main`, and prettier's preferred formatting of one of its examples appends a `;` to an object property, turning a copyable snippet into a syntax error — which is how that same example broke on #1421. `lint-staged`'s glob is `*.md` and does not match `.mdx`, so nothing reformats it automatically.