### PR TITLE
fix(admin): decide drawability from the declaration, not the archetype

### DIFF
--- a/.changeset/drawability-is-a-property-of-the-declaration.md
+++ b/.changeset/drawability-is-a-property-of-the-declaration.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Whether core can draw a widget is now a question about the DECLARATION, not just its archetype.
+
+An archetype having a renderer says nothing about whether that renderer can draw a particular widget: a `list` needs its query to `select` the fields each row shows, and the same renderer that claims the archetype refuses a declaration without them. Treating those as one question cost two things.
+
+A list widget that selects nothing had its query batched anyway. The refusal arrived only after the request came back, so the server performed an unprojected read, shipped every accessible document to the browser, and the card discarded them to print "selects no fields" — on every mount and every window-focus refetch. The declaration is refused before the batch is built now, so the card says the same thing without a database read.
+
+And a widget declared through both channels lost its plugin component. The contributed component is the fallback for a widget core cannot draw, and core reported that it could — so a registration naming `list` without `select` replaced a working plugin card with an error. The fallback now asks whether this declaration is drawable, so the component stays.
+
+An archetype states its own precondition beside its body, and returns the reason rather than a boolean, so the card explains what is missing in the words of the archetype that knows.

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -30,7 +30,7 @@ import {
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { cn } from "@admin/lib/utils";
 
-import { coreDrawsArchetype, resolveWidgetOutcome } from "./outcome";
+import { coreDraws, resolveWidgetOutcome } from "./outcome";
 import { resolveDashboardWidgets } from "./resolve-widgets";
 import { widgetSpanClass } from "./sizes";
 import { WidgetRenderer } from "./WidgetRenderer";
@@ -99,10 +99,12 @@ export function WidgetGrid() {
         // on arrival. `custom` always draws, because the plugin's component
         // decides what to do with the slot.
         //
-        // Asked of `coreDrawsArchetype` rather than listed here, so the read
-        // starts happening on its own the day core learns to draw one.
-        widget.query &&
-        (widget.archetype === "custom" || coreDrawsArchetype(widget.archetype))
+        // Asked of `coreDraws` rather than listed here, so the read starts
+        // happening on its own the day core learns to draw one -- and asked of
+        // the whole DECLARATION, not just the archetype, because a renderer
+        // that will refuse this particular widget makes the read just as
+        // wasted as no renderer at all.
+        widget.query && (widget.archetype === "custom" || coreDraws(widget))
           ? [{ widgetId: widget.id, query: widget.query }]
           : []
       ),

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "@admin/lib/plugins/component-registry";
 import type { AdminBranding } from "@admin/types/branding";
 
-import { coreDrawsArchetype } from "../outcome";
+import { coreDraws } from "../outcome";
 import { WidgetGrid } from "../WidgetGrid";
 
 let mockBranding: AdminBranding | undefined;
@@ -65,7 +65,10 @@ function renderGrid() {
 const HOST_DRAWN_ARCHETYPES = ["metric", "table", "list", "text", "actions"];
 
 const UNDRAWABLE = HOST_DRAWN_ARCHETYPES.find(
-  archetype => !coreDrawsArchetype(archetype)
+  // A declaration carrying a query, so what is being asked is "can core draw
+  // this archetype at all", not "is this particular widget under-declared".
+  archetype =>
+    !coreDraws({ archetype, query: { select: ["title"], op: "list" } })
 );
 
 it("has an archetype core cannot draw, which several cases below need", () => {
@@ -331,6 +334,67 @@ describe("WidgetGrid — collection and gating", () => {
 
     await waitFor(() => expect(protectedApi.post).toHaveBeenCalledTimes(1));
     expect(screen.getByText("recent body")).toBeInTheDocument();
+  });
+
+  it("spends no query on a list that selects nothing", async () => {
+    // The declaration is refused by the archetype itself, so the card can never
+    // be drawn -- but the refusal used to arrive only after the query ran. The
+    // grid batched it because `list` had a renderer, the server performed an
+    // UNPROJECTED read and shipped whole documents to the browser, and the card
+    // threw them away to print the refusal. On every mount and every focus.
+    mockBranding = brandingWith([
+      {
+        id: "acme/recent",
+        title: "Recent posts",
+        archetype: "list",
+        query: { source: "collection:posts", op: "list" },
+      },
+    ]);
+
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-acme/recent")).toBeInTheDocument()
+    );
+    expect(screen.getByText(/selects no fields/i)).toBeInTheDocument();
+    expect(protectedApi.post).not.toHaveBeenCalled();
+  });
+
+  it("keeps a contributed component when the registered list is under-declared", async () => {
+    // A widget declared through BOTH channels. The registration names `list`
+    // and omits `select`, so core cannot draw it -- and the contributed
+    // component is the only thing that can. The fallback fires when core cannot
+    // draw, and core reported that it could purely because `list` had an entry
+    // in the renderer table.
+    registerComponents({ "@acme/admin#Recent": () => <div>plugin rows</div> });
+    mockBranding = {
+      plugins: [
+        {
+          name: "@acme",
+          collections: [],
+          widgets: [{ id: "shared", component: "@acme/admin#Recent" }],
+        },
+      ],
+      widgets: [
+        {
+          id: "shared",
+          title: "Shared",
+          archetype: "list",
+          defaultSize: "md",
+          query: { source: "collection:posts", op: "list" },
+        },
+      ],
+    } as unknown as AdminBranding;
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [{ ok: true, result: { op: "list", items: [] } }],
+    });
+
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getByText("plugin rows")).toBeInTheDocument()
+    );
+    expect(screen.queryByText(/selects no fields/i)).not.toBeInTheDocument();
   });
 
   it("draws a LIST widget end to end, from declaration to rows", async () => {

--- a/packages/admin/src/components/features/widgets/archetypes/list.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/list.tsx
@@ -20,7 +20,7 @@
  * @module components/features/widgets/archetypes/list
  */
 
-import type { ArchetypeBody } from "./types";
+import type { ArchetypeAccepts, ArchetypeBody } from "./types";
 
 /** How many rows a card of this size can show without becoming a table. */
 const MAX_ROWS = 5;
@@ -47,6 +47,22 @@ function asText(value: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * A list needs to know which field heads each row, and only `select` says.
+ *
+ * Judged from the DECLARATION, before any request is made. The same refusal
+ * used to arrive only after the query had run: the grid batched the widget
+ * because its archetype had a renderer, the server performed an unprojected
+ * read and shipped whole documents to the browser, and the card then threw them
+ * away to print this sentence -- on every mount and every window focus.
+ */
+export const listAccepts: ArchetypeAccepts = definition => {
+  const select = definition.query?.select ?? [];
+  if (select.length > 0) return undefined;
+  const name = definition.title ?? "This list widget";
+  return `"${name}" is a list widget whose query selects no fields, so there is nothing to show in each row.`;
+};
+
 export const listBody: ArchetypeBody = (result, definition) => {
   if (result.op !== "list") {
     return {
@@ -58,10 +74,11 @@ export const listBody: ArchetypeBody = (result, definition) => {
   const select = definition.query?.select ?? [];
   const [labelField, detailField] = select;
   if (!labelField) {
-    return {
-      ok: false,
-      message: `"${definition.title}" is a list widget whose query selects no fields, so there is nothing to show in each row.`,
-    };
+    // Unreachable through the grid, which declines this declaration before it
+    // batches. Kept because a body must be safe to call on its own -- a test,
+    // or a future caller that has a result in hand -- and because the sentence
+    // is one thing said in one place.
+    return { ok: false, message: listAccepts(definition) ?? "" };
   }
 
   if (result.items.length === 0) {

--- a/packages/admin/src/components/features/widgets/archetypes/types.ts
+++ b/packages/admin/src/components/features/widgets/archetypes/types.ts
@@ -26,3 +26,45 @@ export type ArchetypeBody = (
   result: WidgetResult,
   definition: DashboardWidget
 ) => ArchetypeOutcome;
+
+/**
+ * The part of a declaration an archetype can judge BEFORE any query runs.
+ *
+ * Deliberately narrower than `DashboardWidget`: the two callers that ask this
+ * question hold different objects. `resolve-widgets` is still deciding what the
+ * widget IS, so it has a declaration rather than a resolved one, and asking for
+ * the full shape there would mean building it twice.
+ */
+export interface DeclaredWidget {
+  archetype?: string;
+  title?: string;
+  query?: { select?: string[]; op?: string };
+}
+
+/**
+ * What an archetype needs a declaration to carry, judged without data.
+ *
+ * SEPARATE from the body, because the two answer different questions at
+ * different times. "Does this widget declare what I need to draw it?" is
+ * knowable from the declaration alone, before a request exists. "Is this
+ * payload the op I asked for?" is only knowable once one arrives.
+ *
+ * Keeping them apart is what lets the grid decline to spend a query on a widget
+ * that can never be drawn, and lets a contributed component stay the body for a
+ * declaration core would refuse — both of which were wrong when drawability was
+ * a property of the ARCHETYPE rather than of the archetype and the declaration
+ * together.
+ *
+ * Returning the REASON rather than a boolean, so the card can say what is
+ * missing in the words of the archetype that knows.
+ */
+export type ArchetypeAccepts = (
+  definition: DeclaredWidget
+) => string | undefined;
+
+/** An archetype core can draw: its precondition, and its body. */
+export interface ArchetypeRenderer {
+  /** Absent when the archetype needs nothing beyond its result. */
+  accepts?: ArchetypeAccepts;
+  body: ArchetypeBody;
+}

--- a/packages/admin/src/components/features/widgets/outcome.ts
+++ b/packages/admin/src/components/features/widgets/outcome.ts
@@ -31,9 +31,9 @@ import type {
   WidgetSlot,
 } from "@admin/types/dashboard/widgets";
 
-import { listBody } from "./archetypes/list";
+import { listAccepts, listBody } from "./archetypes/list";
 import { metricBody } from "./archetypes/metric";
-import type { ArchetypeBody } from "./archetypes/types";
+import type { ArchetypeRenderer, DeclaredWidget } from "./archetypes/types";
 
 /**
  * The archetypes core draws from a query result.
@@ -42,9 +42,9 @@ import type { ArchetypeBody } from "./archetypes/types";
  * render, and the card says so by name rather than coming up blank. `custom`
  * is deliberately absent — it is not drawn from a result at all.
  */
-const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeBody>> = {
-  metric: metricBody,
-  list: listBody,
+const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeRenderer>> = {
+  metric: { body: metricBody },
+  list: { accepts: listAccepts, body: listBody },
 };
 
 /**
@@ -63,7 +63,7 @@ const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeBody>> = {
  *
  * `Object.hasOwn` asks the question that was meant.
  */
-function archetypeBody(archetype: string): ArchetypeBody | undefined {
+function archetypeRenderer(archetype: string): ArchetypeRenderer | undefined {
   return Object.hasOwn(ARCHETYPE_BODIES, archetype)
     ? ARCHETYPE_BODIES[archetype as WidgetArchetype]
     : undefined;
@@ -78,8 +78,39 @@ function archetypeBody(archetype: string): ArchetypeBody | undefined {
  * the table above -- not a second list that has to be remembered when an
  * archetype lands here.
  */
-export function coreDrawsArchetype(archetype: string): boolean {
-  return archetypeBody(archetype) !== undefined;
+/**
+ * Why core cannot draw this DECLARATION, or `undefined` when it can.
+ *
+ * The question every caller actually has, and the one `coreDrawsArchetype` --
+ * "is there an entry in the table?" -- only approximated. An archetype having a
+ * renderer says nothing about whether that renderer can draw a particular
+ * widget: a `list` needs `select`, and a declaration without one is refused by
+ * the same renderer that claims the archetype.
+ *
+ * Treating those as the same question cost two things. The grid batched a query
+ * for a widget that could never be drawn, spending an unprojected read and one
+ * of the batch's slots on documents thrown away on arrival. And a widget
+ * declared through both channels lost its contributed component -- the
+ * fallback fires when core cannot draw, and core reported that it could.
+ *
+ * `custom` is not asked about here: it is drawn by the plugin, and its
+ * declaration is judged where the component is resolved.
+ */
+export function coreCannotDraw(definition: DeclaredWidget): string | undefined {
+  const archetype = definition.archetype;
+  if (typeof archetype !== "string" || archetype === "custom") return undefined;
+
+  const renderer = archetypeRenderer(archetype);
+  if (!renderer) {
+    return `The "${archetype}" widget archetype is not rendered yet.`;
+  }
+
+  return renderer.accepts?.(definition);
+}
+
+/** Whether core can draw this declaration at all. */
+export function coreDraws(definition: DeclaredWidget): boolean {
+  return coreCannotDraw(definition) === undefined;
 }
 
 /**
@@ -103,8 +134,18 @@ export function resolveWidgetOutcome(
   // The escape hatch. A plugin component owns its own body and its own states.
   if (definition.archetype === "custom") return { state: "self-drawn" };
 
-  const body = archetypeBody(definition.archetype);
-  if (!body) {
+  // Everything knowable WITHOUT a payload, decided first: an archetype with no
+  // renderer, and a declaration the renderer refuses. Both are settled before
+  // the slot is consulted, so a card that can never be drawn says why on the
+  // first render instead of waiting for a request the grid does not make.
+  const refusal = coreCannotDraw(definition);
+  if (refusal !== undefined) return { state: "failed", message: refusal };
+
+  const renderer = archetypeRenderer(definition.archetype);
+  // Unreachable: `coreCannotDraw` returned nothing, which for a non-`custom`
+  // archetype means the table held a renderer. Narrowing rather than asserting,
+  // so a future archetype that answers differently cannot walk past this.
+  if (!renderer) {
     return {
       state: "failed",
       message: `The "${definition.archetype}" widget archetype is not rendered yet.`,
@@ -129,7 +170,7 @@ export function resolveWidgetOutcome(
 
   if (!slot.ok) return { state: "failed", message: slot.error };
 
-  const drawn = body(slot.result, definition);
+  const drawn = renderer.body(slot.result, definition);
   return drawn.ok
     ? { state: "ready", node: drawn.node }
     : { state: "failed", message: drawn.message };

--- a/packages/admin/src/components/features/widgets/resolve-widgets.ts
+++ b/packages/admin/src/components/features/widgets/resolve-widgets.ts
@@ -19,7 +19,7 @@ import type {
 } from "@admin/types/branding";
 import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
-import { coreDrawsArchetype } from "./outcome";
+import { coreDraws } from "./outcome";
 import { legacySizeToWidgetSize } from "./sizes";
 
 /**
@@ -91,14 +91,17 @@ export interface ReadableWidgetDeclaration {
  * `text` and `actions` are declarable today and none of them has a renderer, so
  * a widget naming one had its component discarded in favour of the sentence
  * "the list widget archetype is not rendered yet" -- an error where a working
- * card was available. Asked of `coreDrawsArchetype` rather than listed here, so
- * the fallback stops applying on its own the day core learns to draw one.
+ * card was available. Asked of `coreDraws` rather than listed here, so the
+ * fallback stops applying on its own the day core learns to draw one -- and
+ * asked of the whole DECLARATION, because a renderer that refuses this
+ * particular widget leaves the contributed component the only thing that can
+ * draw it, exactly as a missing renderer does.
  */
 function resolveArchetype(
   meta: ReadableWidgetDeclaration
 ): DashboardWidget["archetype"] | undefined {
   if (meta.archetype) {
-    const undrawable = !meta.query || !coreDrawsArchetype(meta.archetype);
+    const undrawable = !meta.query || !coreDraws(meta);
     if (meta.archetype !== "custom" && undrawable && meta.component) {
       return "custom";
     }


### PR DESCRIPTION
Fixes both findings raised against #1424 after it merged. They had **one cause**.

`coreDrawsArchetype` answered *"is there an entry in the renderer table?"*, while every caller needed *"can core draw **this widget**?"* — and those diverge the moment an archetype has a precondition. `list` needs its query to `select` the fields each row shows, and the same renderer that claims the archetype refuses a declaration without them.

## What that cost

**A fieldless list still ran its query.** The refusal lived in the body, so it arrived only after the response came back: the grid batched the widget because `list` had a renderer, the server performed an unprojected read, shipped every accessible document to the browser, and the card discarded them to print "selects no fields" — on every mount and every window-focus refetch. The declaration is judged before the batch is built now, so the card says the same thing without a database read.

**A widget declared through both channels lost its plugin component.** The contributed component is the fallback for a widget core cannot draw, and core reported that it could — so a registration naming `list` and omitting `select` replaced a working plugin card with an error sentence. That fallback now asks about the declaration, so the component stays.

## The shape

An archetype states its precondition beside its body:

```ts
const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeRenderer>> = {
  metric: { body: metricBody },
  list: { accepts: listAccepts, body: listBody },
};
```

Separate from the body because they answer different questions at different times. *"Does this widget declare what I need to draw it?"* is knowable from the declaration alone, before a request exists. *"Is this payload the op I asked for?"* is only knowable once one arrives. Keeping them apart is what lets the grid decline to spend a query, and lets a contributed component stay the body for a declaration core would refuse.

`accepts` returns the **reason** rather than a boolean, so the card explains what is missing in the words of the archetype that knows. The body keeps its own copy of the check for callers that already hold a result — a test, or a future caller — and defers to the same sentence, so it is said in one place.

`coreCannotDraw(definition)` replaces `coreDrawsArchetype(archetype)` at all three call sites: the outcome resolver, the grid's batching decision, and the contributed-component fallback in `resolve-widgets`.

## Verification

- Break-verified: restoring drawability-by-archetype (`accepts` ignored) fails exactly the two new cases and nothing else.
- `spends no query on a list that selects nothing` asserts both halves — the card explains itself AND `protectedApi.post` was never called.
- `keeps a contributed component when the registered list is under-declared` asserts the plugin's body renders and the refusal does not.
- Admin suite 363 files / 3,519 tests; `check-types` and lint clean.

## Note

`table` is deliberately not in this PR. It needs the column labels from #1425, and it would have inherited this exact bug had it been built first — adding `table` to the dispatch table with a `select` precondition repeats the shape precisely.