### PR TITLE
fix(admin,nextly): derive the draft-preview payload from its schema

### DIFF
--- a/.changeset/derive-the-draft-preview-payload.md
+++ b/.changeset/derive-the-draft-preview-payload.md
@@ -40,3 +40,9 @@ types-only entry point, so a consumer building the request derives its payload
 and its result from the canonical schema and the renderer's own output type. It
 pulls zod and nothing else — no DI container, no route handler — so a type-only
 import costs a browser bundle nothing.
+
+The published request type is the schema's INPUT rather than its output. The
+three fields that default to null are optional on the wire and required after
+parsing, so exporting the parsed shape as the request contract would reject
+payloads the endpoint accepts. Both are exposed: `DraftPreviewRequest` for a
+caller building a body, `DraftPreviewParsed` for a handler reading one.

--- a/.changeset/derive-the-draft-preview-payload.md
+++ b/.changeset/derive-the-draft-preview-payload.md
@@ -1,0 +1,42 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The admin derives its email draft-preview payload from the schema the server
+validates against, instead of restating it.
+
+The client type was a hand-written mirror of the endpoint's zod schema, so the
+wire contract had two definitions. Adding a required field on the server left
+the admin compiling cleanly while every preview request was rejected at
+runtime — a failure that only shows up in a browser, on a surface whose whole
+point is telling an author the truth about what they are sending.
+
+`nextly/api/email-template-preview-types` now exposes the contract as a
+types-only entry point, so a consumer building the request derives its payload
+and its result from the canonical schema and the renderer's own output type. It
+pulls zod and nothing else — no DI container, no route handler — so a type-only
+import costs a browser bundle nothing.

--- a/packages/admin/src/services/emailTemplateApi.ts
+++ b/packages/admin/src/services/emailTemplateApi.ts
@@ -14,6 +14,11 @@
  * ```
  */
 
+import type {
+  DraftPreviewRequest,
+  RenderedTemplate,
+} from "nextly/api/email-template-preview-types";
+
 import { fetcher } from "../lib/api/fetcher";
 import type {
   ActionResponse,
@@ -202,36 +207,29 @@ export async function previewTemplate(
 }
 
 /**
- * The fields the draft-preview route renders, and nothing more.
+ * The fields the draft-preview route renders — DERIVED from the schema the
+ * server validates against, never restated.
  *
- * Mirrors the route's own zod schema rather than reusing a template payload
- * type: a preview never writes, so sending a name, a slug or an id would hand
- * the endpoint input it has no use for, and widening this later would widen
- * what an unsaved draft can put on the wire.
+ * A hand-written mirror compiles happily while every request is rejected: add
+ * a required field on the server and nothing here fails until runtime. Taking
+ * the type from the canonical schema turns that into a build error, for the
+ * same reason the render itself has only one implementation — a contract with
+ * two definitions is one that drifts.
+ *
+ * A type-only import, so nothing of the server reaches the browser bundle, and
+ * the entry point it comes from pulls zod and nothing else.
  */
-export interface DraftPreviewTemplate {
-  subject: string;
-  htmlContent: string;
-  plainTextContent: string | null;
-  preheader: string | null;
-  useLayout: boolean;
-  kind: EmailTemplateKind;
-  layoutId: string | null;
-}
+export type DraftPreviewTemplate = DraftPreviewRequest["template"];
 
 /**
  * A rendered draft: the complete artifact, including the text part.
  *
+ * The server's own `RenderedTemplate`, so the field the browser-side preview
+ * used to guess at cannot be dropped here without the compiler noticing.
  * Distinct from `EmailTemplatePreviewResult`, which carries no `text` because
- * the saved-row preview predates the unified renderer. Narrowing this to match
- * it would discard the one field that tells an author whether the plain-text
- * alternative recipients receive is the one they wrote.
+ * the saved-row preview predates the unified renderer.
  */
-export interface DraftPreviewResult {
-  subject: string;
-  html: string;
-  text: string;
-}
+export type DraftPreviewResult = RenderedTemplate;
 
 /**
  * Render UNSAVED template fields through the server's composition.

--- a/packages/admin/src/services/emailTemplateApi.ts
+++ b/packages/admin/src/services/emailTemplateApi.ts
@@ -221,6 +221,9 @@ export async function previewTemplate(
  */
 export type DraftPreviewTemplate = DraftPreviewRequest["template"];
 
+/** The variable values a render interpolates, as the schema declares them. */
+export type DraftPreviewData = DraftPreviewRequest["data"];
+
 /**
  * A rendered draft: the complete artifact, including the text part.
  *
@@ -241,11 +244,18 @@ export type DraftPreviewResult = RenderedTemplate;
  */
 export async function previewDraft(
   template: DraftPreviewTemplate,
-  data: Record<string, unknown>
+  data: DraftPreviewData
 ): Promise<DraftPreviewResult> {
+  /*
+   * The WHOLE body is annotated, not just the template inside it. Typing only
+   * the nested field leaves the envelope hand-authored, so a schema that gains
+   * another required top-level property still compiles here and fails as a 400
+   * at runtime — which is the failure this derivation exists to prevent.
+   */
+  const body: DraftPreviewRequest = { template, data };
   return fetcher<DraftPreviewResult>(
     "/email-templates/preview",
-    { method: "POST", body: JSON.stringify({ template, data }) },
+    { method: "POST", body: JSON.stringify(body) },
     true
   );
 }

--- a/packages/admin/src/types/draft-preview-contract.test-d.ts
+++ b/packages/admin/src/types/draft-preview-contract.test-d.ts
@@ -1,0 +1,49 @@
+/**
+ * The draft-preview request contract, asserted at the type level.
+ *
+ * Both properties here are compile-time only, so a runtime test cannot hold
+ * them: nothing throws when the client's idea of the request drifts from the
+ * server's — the request simply starts coming back 400 in a browser. These
+ * fail the build instead, which is the whole point of deriving the payload.
+ *
+ * `include: ["src/**\/*"]` covers this file, so `check-types` enforces it.
+ */
+import type { DraftPreviewRequest } from "nextly/api/email-template-preview-types";
+
+import type {
+  DraftPreviewData,
+  DraftPreviewTemplate,
+} from "@admin/services/emailTemplateApi";
+
+/*
+ * The REQUEST type, not the parsed one. The schema defaults
+ * `plainTextContent`, `preheader` and `layoutId` to null, so a caller may omit
+ * all three and the server fills them in. Typed from `z.infer` — the output —
+ * those fields are required and this assignment is a compile error, which
+ * would reject payloads the endpoint accepts.
+ */
+const omittingDefaultedFields: DraftPreviewRequest = {
+  template: {
+    subject: "Welcome",
+    htmlContent: "<p>Hello</p>",
+    useLayout: false,
+    kind: "template",
+  },
+  data: {},
+};
+
+/*
+ * The WHOLE envelope is derived, not just the template inside it. If this
+ * alias only tracked `["template"]`, a schema gaining another required
+ * top-level property would still compile here and fail as a 400 at runtime.
+ */
+const wholeEnvelope: DraftPreviewRequest = {
+  template: {} as DraftPreviewTemplate,
+  // No assertion: `DraftPreviewData` is the schema's own record type, which an
+  // empty object already satisfies. Asserting it would be noise the linter is
+  // right to reject — and would hide a future narrowing of that field.
+  data: {} satisfies DraftPreviewData,
+};
+
+void omittingDefaultedFields;
+void wholeEnvelope;

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -190,6 +190,10 @@
     "./api/email-provider-types": {
       "types": "./dist/api/email-provider-types.d.ts",
       "import": "./dist/api/email-provider-types.mjs"
+    },
+    "./api/email-template-preview-types": {
+      "types": "./dist/api/email-template-preview-types.d.ts",
+      "import": "./dist/api/email-template-preview-types.mjs"
     }
   },
   "files": [

--- a/packages/nextly/src/api/email-template-preview-types.ts
+++ b/packages/nextly/src/api/email-template-preview-types.ts
@@ -16,5 +16,6 @@
 export {
   draftPreviewSchema,
   type DraftPreviewRequest,
+  type DraftPreviewParsed,
 } from "../domains/email/draft-preview-request";
 export type { RenderedTemplate } from "../domains/email/services/render-template";

--- a/packages/nextly/src/api/email-template-preview-types.ts
+++ b/packages/nextly/src/api/email-template-preview-types.ts
@@ -1,0 +1,20 @@
+/**
+ * The draft-preview wire contract, for the client that has to satisfy it.
+ *
+ * A types-only entry point so an admin — or any consumer building the request
+ * — derives its payload from the schema the server validates against, rather
+ * than mirroring it. A hand-written mirror compiles happily while the server
+ * rejects every call: adding a required field on one side is invisible to the
+ * other until runtime, which is the same failure mode this feature already had
+ * when the preview render existed twice.
+ *
+ * Re-exported from the leaf that declares it, so importing this pulls zod and
+ * nothing else — no DI container, no route handler.
+ *
+ * @module api/email-template-preview-types
+ */
+export {
+  draftPreviewSchema,
+  type DraftPreviewRequest,
+} from "../domains/email/draft-preview-request";
+export type { RenderedTemplate } from "../domains/email/services/render-template";

--- a/packages/nextly/src/domains/email/draft-preview-request.ts
+++ b/packages/nextly/src/domains/email/draft-preview-request.ts
@@ -34,4 +34,21 @@ export const draftPreviewSchema = z.object({
   data: z.record(z.string(), z.unknown()),
 });
 
-export type DraftPreviewRequest = z.infer<typeof draftPreviewSchema>;
+/**
+ * What a CALLER sends — the schema's input, not its output.
+ *
+ * `z.infer` describes the value after parsing, where every `.default(null)`
+ * field has been filled in and is therefore required. Publishing that as the
+ * request contract rejects payloads the server accepts: omitting
+ * `plainTextContent` is valid on the wire and a compile error against the
+ * output type. The two differ precisely BECAUSE the schema has defaults, so
+ * the distinction is load-bearing rather than stylistic.
+ */
+export type DraftPreviewRequest = z.input<typeof draftPreviewSchema>;
+
+/**
+ * What the SERVER holds once the body has been parsed: defaults applied, so
+ * every field is present. Named separately because a handler reading
+ * `template.preheader` needs the guarantee that the caller's type cannot give.
+ */
+export type DraftPreviewParsed = z.output<typeof draftPreviewSchema>;

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -40,6 +40,7 @@ const serverEntries = [
   "src/api/versions-diff.ts",
   "src/api/email-providers.ts",
   "src/api/email-provider-types.ts",
+  "src/api/email-template-preview-types.ts",
   "src/api/email-providers-detail.ts",
   "src/api/email-providers-test.ts",
   "src/api/email-providers-default.ts",


### PR DESCRIPTION
Follow-up to #1419, closing the last review finding on it.

## What was wrong

#1419 removed the duplicated email render and gave the draft-preview endpoint a
single request schema shared by both transports. It left one copy behind: the
admin's `DraftPreviewTemplate` was a **hand-written mirror** of that zod schema.

So the wire contract still had two definitions, one layer further out. Add a
required field on the server and the admin keeps compiling while every preview
request is rejected at runtime — invisible until a browser hits it, on the one
surface whose entire job is telling an author the truth about what they are
sending.

## What changed

`nextly/api/email-template-preview-types` exposes the contract as a **types-only**
entry point, following the existing `./api/email-provider-types` precedent. It
re-exports from the leaf that declares the schema, so it pulls zod and nothing
else — no DI container, no route handler — and the admin's import is
`import type`, erased at compile time, so nothing of the server reaches the
browser bundle.

The admin now derives both halves:

- `DraftPreviewTemplate = DraftPreviewRequest["template"]`
- `DraftPreviewResult = RenderedTemplate` — the renderer's own output type, so
  the `text` field the deleted browser-side preview used to guess at cannot be
  dropped here without the compiler noticing.

## Evidence

The property under test is a **compile-time** one, so the proof is a typecheck
rather than a unit test. Break-verified on this branch:

1. Add `brandId: z.string()` to `draftPreviewSchema` (server side).
2. Rebuild `nextly` — `check-types` reads `dist`, so without a rebuild the old
   `.d.ts` answers and the check passes vacuously.
3. `tsc --noEmit` in `packages/admin` → **2 × TS2741**, naming `brandId` as
   missing in exactly the two places that construct the payload.
4. Restore and rebuild → 0 errors.

Before this change the same mutation produces **zero** admin errors, which is
the defect.

Full `pnpm build`, `check-types` and `lint` all exit 0. Admin 3505 tests across
362 files; nextly 10537 across 849. `fallow audit --gate new-only` reports
**verdict: pass** with every introduced count at zero. Changeset covers all 25
lockstep packages, derived from `.changeset/config.json` and validated with
`check-changesets.mjs` (exit 0).

The pre-push hook first rejected this with eleven ~10s timeouts across unrelated
files. All of them pass in isolation — including `export-contract.test.ts` (96
tests), which was the one plausibly in this change's blast radius given it adds
an export subpath — so they were contention in the concurrent run.