### PR TITLE
feat(admin): draw a table headed by the columns the server described

### DIFF
--- a/.changeset/a-table-widget-heads-its-own-columns.md
+++ b/.changeset/a-table-widget-heads-its-own-columns.md
@@ -1,0 +1,52 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The `table` archetype is drawn by the host. A plugin declares a table widget with no UI code of its own:
+
+```ts
+{
+  id: "acme/posts",
+  title: "Recent posts",
+  archetype: "table",
+  defaultSize: "lg",
+  query: {
+    source: "collection:posts",
+    op: "list",
+    select: ["title", "publishedAt"],
+    limit: 5,
+  },
+}
+```
+
+Each column is headed by that field's label from the collection, so a heading reads "Published at" rather than `publishedAt` — the same string the entry form puts above the field, agreeing by construction rather than through a second declaration that could drift. Where a source has no label the field name is used, which is a poor heading but a true one.
+
+The columns come from what the SERVER returned, not from `select`, and that is the difference that matters. A field carrying an `access.read` rule denying the viewer is stripped from every row before selection runs, so heading the table from the declaration would draw a column no row can fill and print the label of a field this reader may not see. Rows that arrive with no column descriptions are refused by name rather than falling back to `select`, because that fallback is exactly the one that would undo the server's filtering.
+
+A table that selects nothing says so without running a query, an empty result says "Nothing yet." instead of drawing an empty table, and a card shows at most five rows with the footer link as the way to the rest. A cell holding an object is left blank rather than rendered as "[object Object]"; `0` and `false` are printed, since only null, undefined and blank are absences.
+
+The cell reading shared with `list` now lives in one module, so "what does this cell say" has one answer rather than two that drift the first time either is corrected.

--- a/docs/plugins/admin-ui.mdx
+++ b/docs/plugins/admin-ui.mdx
@@ -189,16 +189,24 @@ A widget is drawn one of two ways, and you pick by what you declare.
 Declare an `archetype` and the `query` it is drawn from, and ship no UI code. The host
 runs the query for the signed-in user and renders the card.
 
-> **What the host draws today: `metric` and `list`.**
-> `table`, `text` and `actions` are accepted by the contract but have no renderer
-> yet, so a widget declaring one shows "the … archetype is not rendered yet" in its
-> card unless it also ships a `component` to draw the body itself. Declare those
-> archetypes only with a component fallback until this note says otherwise.
+> **What the host draws today: `metric`, `list` and `table`.**
+> `text` and `actions` are accepted by the contract but have no renderer yet, so a
+> widget declaring one shows "the … archetype is not rendered yet" in its card
+> unless it also ships a `component` to draw the body itself. Declare those two
+> only with a component fallback until this note says otherwise.
 >
 > A `list` widget draws one row per result. Its query's `select` decides what each
 > row shows, in order: the first field is the row's label and the second, if there
-> is one, is the muted line under it. A `list` that selects nothing says so rather
-> than guessing at a field.
+> is one, is the muted line under it.
+>
+> A `table` widget draws a column per selected field, headed by that field's label
+> from your collection — so a heading reads "Published at", not `publishedAt`. The
+> columns come from what the SERVER returned, not from `select`: a field carrying
+> an `access.read` rule that denies the viewer is absent from their rows, and its
+> column and heading are absent with it.
+>
+> A `list` or `table` that selects nothing says so rather than guessing at a field,
+> and says it without running a query.
 
 ```ts
 contributes: {

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -451,6 +451,55 @@ describe("WidgetGrid — collection and gating", () => {
     });
   });
 
+  it("draws a TABLE end to end, headed by the columns the server described", async () => {
+    // The whole path for the third host-drawn archetype: a declaration with no
+    // component, its query batched, the `list` arm validated with its column
+    // descriptions intact, and the headings taken from those rather than from
+    // `select` -- which is what keeps a field the reader may not see out of the
+    // header row.
+    mockBranding = brandingWith([
+      {
+        id: "acme/posts",
+        title: "Recent posts",
+        archetype: "table",
+        defaultSize: "lg",
+        query: {
+          source: "collection:posts",
+          op: "list",
+          select: ["title", "publishedAt"],
+          limit: 5,
+        },
+      },
+    ]);
+    vi.mocked(protectedApi.post).mockResolvedValue({
+      results: [
+        {
+          ok: true,
+          result: {
+            op: "list",
+            items: [{ title: "First post", publishedAt: "yesterday" }],
+            fields: [
+              { name: "title", label: "Title" },
+              { name: "publishedAt", label: "Published at" },
+            ],
+          },
+        },
+      ],
+    });
+
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-table")).toBeInTheDocument()
+    );
+    expect(screen.getByText("Published at")).toBeInTheDocument();
+    expect(screen.getByText("First post")).toBeInTheDocument();
+    // The label reached the browser through the batch parser, which rebuilds a
+    // list result from the fields it names -- so this also proves the
+    // descriptions survive that boundary.
+    expect(screen.queryByText("publishedAt")).not.toBeInTheDocument();
+  });
+
   it("puts a registered widget's query in the same batch as a contributed one", async () => {
     mockBranding = {
       plugins: [

--- a/packages/admin/src/components/features/widgets/archetypes/__tests__/table.test.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/__tests__/table.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * What a `table` card shows, and where its column headings come from.
+ *
+ * The headings are the point of this archetype's tests. They come from the
+ * RESULT, because the server strips fields a reader may not see before it
+ * answers — so a table headed from the declaration would name a column no row
+ * can fill and print the label of a field this reader was denied.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import type {
+  DashboardWidget,
+  WidgetResult,
+} from "@admin/types/dashboard/widgets";
+
+import { tableAccepts, tableBody } from "../table";
+
+const widget = (select?: string[]): DashboardWidget =>
+  ({
+    id: "acme/posts",
+    title: "Recent posts",
+    archetype: "table",
+    size: "lg",
+    query: {
+      source: "collection:posts",
+      op: "list",
+      ...(select && { select }),
+    },
+  }) as DashboardWidget;
+
+const listOf = (
+  items: Record<string, unknown>[],
+  fields?: { name: string; label?: string }[]
+): WidgetResult => ({ op: "list", items, ...(fields && { fields }) });
+
+function draw(result: WidgetResult, definition: DashboardWidget) {
+  const outcome = tableBody(result, definition);
+  if (!outcome.ok) throw new Error(`expected a body, got: ${outcome.message}`);
+  render(<>{outcome.node}</>);
+}
+
+describe("the table archetype", () => {
+  it("heads each column with the source's label", () => {
+    draw(
+      listOf(
+        [{ title: "Hello", publishedAt: "yesterday" }],
+        [
+          { name: "title", label: "Title" },
+          { name: "publishedAt", label: "Published at" },
+        ]
+      ),
+      widget(["title", "publishedAt"])
+    );
+    expect(screen.getByText("Published at")).toBeInTheDocument();
+    // The storage name is NOT what a reader sees when a label exists.
+    expect(screen.queryByText("publishedAt")).not.toBeInTheDocument();
+  });
+
+  it("falls back to the field name when the source has no label", () => {
+    // A field name is a poor heading, but it is true — which an invented one
+    // derived from the identifier would not be.
+    draw(listOf([{ slug: "hello" }], [{ name: "slug" }]), widget(["slug"]));
+    expect(screen.getByText("slug")).toBeInTheDocument();
+  });
+
+  it("draws only the columns the SERVER described, not those selected", () => {
+    // The access case. `select` asked for two fields; the server answered with
+    // one, because the other carries a read rule denying this caller. Heading
+    // the table from the declaration would print "Salary" above a column every
+    // row leaves empty.
+    draw(
+      listOf([{ title: "Hello" }], [{ name: "title", label: "Title" }]),
+      widget(["title", "salary"])
+    );
+    expect(screen.getByText("Title")).toBeInTheDocument();
+    expect(screen.queryByText(/salary/i)).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("widget-table-heading")).toHaveLength(1);
+  });
+
+  it("refuses rows the server did not describe rather than reading select", () => {
+    // The tempting fallback is the one thing that must not happen: heading the
+    // table from `query.select` would undo the server's access filtering.
+    const outcome = tableBody(
+      listOf([{ title: "Hello" }]),
+      widget(["title", "salary"])
+    );
+    expect(outcome.ok).toBe(false);
+    expect(outcome.ok === false && outcome.message).toMatch(
+      /did not describe/i
+    );
+  });
+
+  it("refuses a count payload, naming both ops", () => {
+    const outcome = tableBody({ op: "count", total: 3 }, widget(["title"]));
+    expect(outcome.ok).toBe(false);
+    expect(outcome.ok === false && outcome.message).toMatch(
+      /expected a table/i
+    );
+    expect(outcome.ok === false && outcome.message).toMatch(/count/);
+  });
+
+  it("says nothing is there rather than drawing an empty table", () => {
+    draw(listOf([]), widget(["title"]));
+    expect(screen.getByTestId("widget-table-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("widget-table")).not.toBeInTheDocument();
+  });
+
+  it("caps the rows it draws", () => {
+    const many = Array.from({ length: 12 }, (_, i) => ({ title: `Row ${i}` }));
+    draw(listOf(many, [{ name: "title" }]), widget(["title"]));
+    expect(screen.getAllByTestId("widget-table-row")).toHaveLength(5);
+  });
+
+  it("does NOT stringify an object cell into [object Object]", () => {
+    draw(
+      listOf([{ title: { en: "Localised" } }], [{ name: "title" }]),
+      widget(["title"])
+    );
+    expect(screen.queryByText(/object Object/)).not.toBeInTheDocument();
+    expect(screen.getAllByTestId("widget-table-row")).toHaveLength(1);
+  });
+
+  it("prints a zero rather than dropping it", () => {
+    draw(listOf([{ views: 0 }], [{ name: "views" }]), widget(["views"]));
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("refuses a declaration that selects nothing, before any query runs", () => {
+    expect(tableAccepts(widget())).toMatch(/selects no fields/i);
+    expect(tableAccepts(widget(["title"]))).toBeUndefined();
+  });
+});

--- a/packages/admin/src/components/features/widgets/archetypes/cell-text.ts
+++ b/packages/admin/src/components/features/widgets/archetypes/cell-text.ts
@@ -1,0 +1,49 @@
+/**
+ * Turning one value from a widget row into text a card can print.
+ *
+ * Shared by every archetype that draws rows, because "what does this cell say"
+ * is one question and two answers would drift the first time either was
+ * corrected. `list` learned this reading first; `table` needs exactly the same
+ * one.
+ *
+ * @module components/features/widgets/archetypes/cell-text
+ */
+
+/**
+ * One cell as text, or `undefined` when it is not something to print.
+ *
+ * Objects and arrays are DROPPED rather than stringified. `String({})` is
+ * "[object Object]", which is not a defect a reader can act on — it looks like
+ * data. A relationship, a repeater or a rich-text value all arrive here as
+ * objects, and no row-drawing archetype can render any of them; saying nothing
+ * is better than saying that. The same reading `RecentEntriesWidget` had to be
+ * taught when its titles came back as objects.
+ *
+ * `null` and `undefined` are absent values, not text. `0` and `false` ARE text:
+ * a count of zero is a real answer and dropping it would make the row lie.
+ */
+export function asText(value: unknown): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string") return value.trim() === "" ? undefined : value;
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return undefined;
+}
+
+/**
+ * The refusal an archetype gives when its query selects nothing.
+ *
+ * Both row-drawing archetypes need this and each names its own unit — a list
+ * has rows, a table has columns — so the sentence is built rather than copied.
+ * Judged from the DECLARATION, before any request is made, which is what keeps
+ * the grid from spending an unprojected read on a card that can never draw.
+ */
+export function selectsNothing(
+  title: string | undefined,
+  archetype: string,
+  unit: string
+): string {
+  const name = title ?? `This ${archetype} widget`;
+  return `"${name}" is a ${archetype} widget whose query selects no fields, so there is nothing to show in each ${unit}.`;
+}

--- a/packages/admin/src/components/features/widgets/archetypes/list.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/list.tsx
@@ -20,32 +20,11 @@
  * @module components/features/widgets/archetypes/list
  */
 
+import { asText, selectsNothing } from "./cell-text";
 import type { ArchetypeAccepts, ArchetypeBody } from "./types";
 
 /** How many rows a card of this size can show without becoming a table. */
 const MAX_ROWS = 5;
-
-/**
- * One cell as text, or `undefined` when it is not something to print.
- *
- * Objects and arrays are DROPPED rather than stringified. `String({})` is
- * "[object Object]", which is not a defect a reader can act on — it looks like
- * data. A relationship, a repeater or a rich-text value all arrive here as
- * objects, and this widget cannot draw any of them; saying nothing is better
- * than saying that. The same reading `RecentEntriesWidget` had to be taught
- * when its titles came back as objects.
- *
- * `null` and `undefined` are absent values, not text. `0` and `false` ARE text:
- * a count of zero is a real answer and dropping it would make the row lie.
- */
-function asText(value: unknown): string | undefined {
-  if (value === null || value === undefined) return undefined;
-  if (typeof value === "string") return value.trim() === "" ? undefined : value;
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value);
-  }
-  return undefined;
-}
 
 /**
  * A list needs to know which field heads each row, and only `select` says.
@@ -59,8 +38,7 @@ function asText(value: unknown): string | undefined {
 export const listAccepts: ArchetypeAccepts = definition => {
   const select = definition.query?.select ?? [];
   if (select.length > 0) return undefined;
-  const name = definition.title ?? "This list widget";
-  return `"${name}" is a list widget whose query selects no fields, so there is nothing to show in each row.`;
+  return selectsNothing(definition.title, "list", "row");
 };
 
 export const listBody: ArchetypeBody = (result, definition) => {

--- a/packages/admin/src/components/features/widgets/archetypes/table.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/table.tsx
@@ -1,0 +1,132 @@
+/**
+ * The `table` archetype: a few rows across named columns.
+ *
+ * The COLUMNS come from the result, not from the declaration, and that is the
+ * whole difference between this archetype and reading `select` directly. A
+ * field can carry its own `access.read` rule, and the server strips a denied
+ * field from every row before selection runs — so it answers with the columns
+ * that actually survived the read (`WidgetResult.fields`). Heading a table from
+ * `query.select` would draw a column no row can fill and print the label of a
+ * field this reader may not see.
+ *
+ * Each heading is the source's own label for the field, falling back to the
+ * field name. `publishedAt` is a poor heading and "Published at" is the string
+ * the entry form already puts above that field, so the two agree by
+ * construction rather than by a second declaration that could drift.
+ *
+ * @module components/features/widgets/archetypes/table
+ */
+
+import { asText, selectsNothing } from "./cell-text";
+import type { ArchetypeAccepts, ArchetypeBody } from "./types";
+
+/**
+ * How many rows a card of this size can show before it stops being a glance.
+ *
+ * Lower than a list's, because each row here is wider and a table that scrolls
+ * inside a dashboard card is a table nobody reads. The footer link is how a
+ * reader gets to the rest.
+ */
+const MAX_ROWS = 5;
+
+/** A table is drawn from selected fields, exactly as a list is. */
+export const tableAccepts: ArchetypeAccepts = definition => {
+  const select = definition.query?.select ?? [];
+  if (select.length > 0) return undefined;
+  return selectsNothing(definition.title, "table", "column");
+};
+
+export const tableBody: ArchetypeBody = (result, definition) => {
+  if (result.op !== "list") {
+    return {
+      ok: false,
+      message: `"${definition.title}" expected a table of rows, but the query returned a ${result.op}.`,
+    };
+  }
+
+  if (result.items.length === 0) {
+    return {
+      ok: true,
+      node: (
+        <p
+          data-testid="widget-table-empty"
+          className="text-sm text-muted-foreground"
+        >
+          Nothing yet.
+        </p>
+      ),
+    };
+  }
+
+  const columns = result.fields ?? [];
+  if (columns.length === 0) {
+    // Rows arrived and nothing described them. A declaration with no `select`
+    // never reaches here -- `tableAccepts` refuses it before the query runs --
+    // so this is a server that answered without column descriptions, and the
+    // tempting fallback is the one thing that must not happen: heading the
+    // table from `query.select` would undo the access filtering the server
+    // applied and print the labels of fields this reader may not see.
+    return {
+      ok: false,
+      message: `"${definition.title}" received rows the server did not describe, so its columns cannot be named.`,
+    };
+  }
+
+  const rows = result.items.slice(0, MAX_ROWS);
+
+  return {
+    ok: true,
+    node: (
+      // Scrolls in its own container rather than widening the card: a dashboard
+      // grid cell has a fixed span, and a table that pushes past it takes the
+      // whole row's layout with it.
+      <div className="min-w-0 overflow-x-auto">
+        <table data-testid="widget-table" className="w-full text-sm">
+          <thead>
+            <tr className="border-b border-border">
+              {columns.map(column => (
+                <th
+                  key={column.name}
+                  scope="col"
+                  data-testid="widget-table-heading"
+                  className="whitespace-nowrap pb-1 pr-4 text-left text-xs font-medium text-muted-foreground last:pr-0"
+                >
+                  {/* The source's label when it has one. A field name is a
+                      poor heading, but it is true, which an invented one
+                      would not be. */}
+                  {column.label ?? column.name}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((item, index) => (
+              <tr
+                // The index, because a widget's rows have no identity core can
+                // rely on: `select` need not include a key, and two rows may be
+                // identical in the fields it did select. The body is replaced
+                // wholesale on every refetch and nothing in it is stateful, so
+                // there is no state for a wrong key to strand.
+                key={index}
+                data-testid="widget-table-row"
+                className="border-b border-border/50 last:border-0"
+              >
+                {columns.map(column => (
+                  <td
+                    key={column.name}
+                    className="max-w-[12rem] truncate py-1 pr-4 text-foreground last:pr-0"
+                  >
+                    {/* An em dash rather than an empty cell, so the grid of
+                        cells stays legible and a missing value is visibly a
+                        missing value. */}
+                    {asText(item[column.name]) ?? "—"}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    ),
+  };
+};

--- a/packages/admin/src/components/features/widgets/outcome.ts
+++ b/packages/admin/src/components/features/widgets/outcome.ts
@@ -33,6 +33,7 @@ import type {
 
 import { listAccepts, listBody } from "./archetypes/list";
 import { metricBody } from "./archetypes/metric";
+import { tableAccepts, tableBody } from "./archetypes/table";
 import type { ArchetypeRenderer, DeclaredWidget } from "./archetypes/types";
 
 /**
@@ -45,6 +46,7 @@ import type { ArchetypeRenderer, DeclaredWidget } from "./archetypes/types";
 const ARCHETYPE_BODIES: Partial<Record<WidgetArchetype, ArchetypeRenderer>> = {
   metric: { body: metricBody },
   list: { accepts: listAccepts, body: listBody },
+  table: { accepts: tableAccepts, body: tableBody },
 };
 
 /**


### PR DESCRIPTION
The third host-drawn archetype, and the one #1425 existed to make possible. A plugin declares a table widget with no UI code of its own:

```ts
{
  id: "acme/posts",
  title: "Recent posts",
  archetype: "table",
  defaultSize: "lg",
  query: { source: "collection:posts", op: "list", select: ["title", "publishedAt"], limit: 5 },
}
```

## Columns come from the RESULT, never from `select`

This is the whole difference between this archetype and reading the declaration, and it is only correct because of #1425.

A field can carry its own `access.read` rule, and the server strips a denied field from every row *before* selection runs. Heading the table from `query.select` would therefore draw a column no row can fill **and** print the human label of a field this reader may not see. The server answers with the columns that actually survived, and the table heads itself from those.

Rows arriving with **no** column descriptions are refused by name rather than falling back to `select`. A declaration with no `select` never reaches that branch — `tableAccepts` refuses it before any query runs — so it can only mean a server that answered without descriptions, and the tempting fallback there is precisely the one that would undo the filtering.

## Headings

Each column is headed by that field's label from the collection, so a heading reads "Published at" rather than `publishedAt` — the same string the entry form puts above the field. The two agree by construction rather than through a second declaration free to drift.

Where a source has no label, the field name is used. A poor heading, but a true one, and better than prose derived from an identifier that guesses at capitalisation and word breaks.

## Shared cell reading

`asText` moves into its own module, shared with `list`. "What does this cell say" is one question, and two copies drift the first time either is corrected: an object is left blank rather than rendered as `[object Object]`, and `0`/`false` are printed because only `null`, `undefined` and blank are absences.

## Verification

- Break-verified: heading from `query.select` fails `refuses rows the server did not describe rather than reading select`; preferring the field name over the label fails both heading cases. Each break fails only its own tests.
- `draws only the columns the SERVER described, not those selected` is the access case: `select` asks for two fields, the server answers with one, and the denied field's heading is absent along with its column.
- An end-to-end case in `WidgetGrid.test.tsx` proves the descriptions survive the batch parser — which rebuilds a list result from the fields it names, so this also guards the boundary that silently dropped them once already.
- Admin suite 364 files / 3,547 tests; `check-types` and lint clean.

## Remaining

`text` and `actions` are still undrawn, and their note in the docs says so. They need a content model in core — `WidgetDefinition` has no field either could render from — plus a dispatch fix, since `resolveWidgetOutcome` currently reads a queryless archetype's absent slot as a failure.