### PR TITLE
feat(plugin-page-builder): say when the editor is holding unsaved work

### DIFF
--- a/.changeset/the-editor-says-when-work-is-unsaved.md
+++ b/.changeset/the-editor-says-when-work-is-unsaved.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The page builder now says when it is holding work the document does not have.
+
+The editor takes the whole window and asks the admin to hide its chrome, so
+nothing outside it is on screen while an author is editing. Inside it, the only
+reading was the publish pill — and that pill answers a different question,
+"is this page live?", which has no answer on a collection that declares no
+publish lifecycle. There it renders nothing, correctly, and took the only
+indication of unsaved work down with it. An author editing such a page had
+nothing in the toolbar to read at all, while `documentDirty` was already being
+computed a few lines away.
+
+Whether work is outstanding and whether the page is live are two questions, so
+they are now two readings. The dirty state is derived once and both read it, so
+they cannot disagree about it.
+
+The new reading is SILENT when nothing is outstanding, rather than saying
+"Saved". The same `false` is produced by a document that was never saved — a
+blocks field renders inside a create form and inside previews — so a positive
+claim there would tell an author their work was safe on the strength of nothing
+having been typed. That asymmetry is the point: the state worth interrupting
+someone for is the one where leaving loses something.

--- a/packages/admin/src/components/features/widgets/archetypes/table.tsx
+++ b/packages/admin/src/components/features/widgets/archetypes/table.tsx
@@ -109,7 +109,12 @@ export const tableBody: ArchetypeBody = (result, definition) => {
                 // there is no state for a wrong key to strand.
                 key={index}
                 data-testid="widget-table-row"
-                className="border-b border-border/50 last:border-0"
+                /* Full-strength `border-border`, matching this table's own
+                   header rule above. A row separator delimits the data rather
+                   than decorating it, so it has to meet the 3:1 that WCAG asks
+                   of a meaningful boundary; at half alpha it measured 1.11:1
+                   against the page surface. */
+                className="border-b border-border last:border-0"
               >
                 {columns.map(column => (
                   <td

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -1428,7 +1428,22 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
    */
   const entryFields = useEntryFieldsPanel(name);
 
-  const documentDirty = useDocumentDirty(control, editor.undoDepth > 0);
+  /*
+   * `hasUnsavedWork` rather than `undoDepth` alone, so an inline edit that is
+   * OPEN counts. Until it commits, the typed value lives in the DOM and neither
+   * the editor's history nor the form's dirty fields have moved — so a reading
+   * built on those two says "nothing outstanding" while an author is midway
+   * through a paragraph.
+   *
+   * The same answer the navigation guard reports, asked once here. The guard
+   * keeps reporting only the EDITOR's half, because it tells the form about
+   * work the form's own values do not contain; this composes that half with the
+   * form's own dirtiness, which is what a reading of the whole document needs.
+   */
+  const documentDirty = useDocumentDirty(
+    control,
+    hasUnsavedWork(editor, inline)
+  );
 
   /*
    * The getting-started card, and the host's switch for it.

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -145,8 +145,12 @@ import { readSiteStyleRecord } from "../site-style-record";
 
 import { BlocksSummary } from "./BlocksSummary";
 import { DocumentStatusPill } from "./DocumentStatusPill";
+/* The save state, which the status pill cannot carry: it renders nothing on a
+   collection with no publish lifecycle, and took the only reading of unsaved
+   work down with it. */
 import { useSaveSiteStyle, useSiteStyle } from "./site-style-client";
 import { withValueAtPath } from "./snapshot-merge";
+import { UnsavedChangesPill } from "./UnsavedChangesPill";
 import { useShown } from "./use-shown";
 
 export interface BlocksFieldProps<
@@ -2038,6 +2042,10 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
         topBar={
           <>
             <DocumentStatusPill isDirty={documentDirty} />
+            {/* Beside the publish state, not folded into it. The two answer
+                different questions and one of them has no answer where a
+                collection declares no lifecycle. */}
+            <UnsavedChangesPill isDirty={documentDirty} />
             {/*
              * Gated on the SAME read the canvas and the cascade are gated on.
              * Until the stored style has answered, `canvasSiteStyle` is the

--- a/packages/plugin-page-builder/src/admin/UnsavedChangesPill.test.tsx
+++ b/packages/plugin-page-builder/src/admin/UnsavedChangesPill.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+
+/**
+ * The reading that says work is outstanding.
+ *
+ * Its whole reason for existing is the case the status pill cannot cover: a
+ * collection with no publish lifecycle, where that pill renders nothing and an
+ * author had no reading in the toolbar at all. So the cases below are about
+ * WHEN it speaks, not about how it looks.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/UnsavedChangesPill.test
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { UnsavedChangesPill } from "./UnsavedChangesPill";
+
+describe("the unsaved-work reading", () => {
+  it("says so while the document holds uncommitted edits", () => {
+    render(<UnsavedChangesPill isDirty />);
+    expect(screen.getByText(/unsaved changes/i)).toBeTruthy();
+  });
+
+  it("says NOTHING once everything is committed", () => {
+    /*
+     * Silence rather than "Saved". The same `false` is produced by a document
+     * that was never saved — a blocks field renders inside a create form and
+     * inside previews — so a positive claim there would tell an author their
+     * work was safe on the strength of nothing having been typed.
+     */
+    const { container } = render(<UnsavedChangesPill isDirty={false} />);
+    expect(container.textContent).toBe("");
+  });
+
+  it("announces politely, so an edit does not interrupt on every keystroke", () => {
+    // The state flips on almost every edit. An assertive region would speak
+    // over the author continuously, which is how a reading gets ignored.
+    render(<UnsavedChangesPill isDirty />);
+    const region = screen.getByText(/unsaved changes/i).closest("[aria-live]");
+    expect(region?.getAttribute("aria-live")).toBe("polite");
+  });
+});

--- a/packages/plugin-page-builder/src/admin/UnsavedChangesPill.test.tsx
+++ b/packages/plugin-page-builder/src/admin/UnsavedChangesPill.test.tsx
@@ -8,6 +8,12 @@
  * author had no reading in the toolbar at all. So the cases below are about
  * WHEN it speaks, not about how it looks.
  *
+ * The transition is asserted rather than the dirty state alone. Rendering
+ * straight into the dirty state and checking the attribute passes whether or
+ * not the region was mounted beforehand — and a region inserted already holding
+ * its text is not reliably announced, which would lose the one announcement
+ * this exists to make.
+ *
  * @module @nextlyhq/plugin-page-builder/admin/UnsavedChangesPill.test
  */
 import { render, screen } from "@testing-library/react";
@@ -15,28 +21,55 @@ import { describe, expect, it } from "vitest";
 
 import { UnsavedChangesPill } from "./UnsavedChangesPill";
 
+const region = (container: HTMLElement) =>
+  container.querySelector("[aria-live]");
+
 describe("the unsaved-work reading", () => {
   it("says so while the document holds uncommitted edits", () => {
     render(<UnsavedChangesPill isDirty />);
     expect(screen.getByText(/unsaved changes/i)).toBeTruthy();
   });
 
-  it("says NOTHING once everything is committed", () => {
+  it("shows NOTHING once everything is committed", () => {
     /*
-     * Silence rather than "Saved". The same `false` is produced by a document
-     * that was never saved — a blocks field renders inside a create form and
-     * inside previews — so a positive claim there would tell an author their
-     * work was safe on the strength of nothing having been typed.
+     * No visible chip. The same `false` is produced by a document that was
+     * never saved — a blocks field renders inside a create form and inside
+     * previews — so a positive claim there would tell an author their work was
+     * safe on the strength of nothing having been typed.
      */
     const { container } = render(<UnsavedChangesPill isDirty={false} />);
     expect(container.textContent).toBe("");
   });
 
+  it("keeps the live region mounted while clean, so the change can be heard", () => {
+    // An empty region is what makes the later announcement work. It must also
+    // draw nothing: the chip's border and padding belong inside it.
+    const { container } = render(<UnsavedChangesPill isDirty={false} />);
+    expect(region(container)).not.toBeNull();
+    expect(region(container)?.textContent).toBe("");
+  });
+
+  it("announces into the SAME region it was already showing", () => {
+    /*
+     * Node identity across the transition is the property. A region that is
+     * unmounted while clean and inserted already holding its text is not
+     * reliably announced — the assistive technology never observed it change.
+     */
+    const { container, rerender } = render(
+      <UnsavedChangesPill isDirty={false} />
+    );
+    const before = region(container);
+    expect(before).not.toBeNull();
+
+    rerender(<UnsavedChangesPill isDirty />);
+    expect(region(container)).toBe(before);
+    expect(before?.textContent).toMatch(/unsaved changes/i);
+  });
+
   it("announces politely, so an edit does not interrupt on every keystroke", () => {
     // The state flips on almost every edit. An assertive region would speak
     // over the author continuously, which is how a reading gets ignored.
-    render(<UnsavedChangesPill isDirty />);
-    const region = screen.getByText(/unsaved changes/i).closest("[aria-live]");
-    expect(region?.getAttribute("aria-live")).toBe("polite");
+    const { container } = render(<UnsavedChangesPill isDirty />);
+    expect(region(container)?.getAttribute("aria-live")).toBe("polite");
   });
 });

--- a/packages/plugin-page-builder/src/admin/UnsavedChangesPill.tsx
+++ b/packages/plugin-page-builder/src/admin/UnsavedChangesPill.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+/**
+ * Whether the editor is holding work the document does not have yet.
+ *
+ * A DIFFERENT question from the one {@link DocumentStatusPill} answers, and
+ * that is why it is a second reading rather than another state in the first.
+ * "Is this page live?" and "is my work saved?" have different answers, they
+ * change at different moments, and one of them is undefined on a collection
+ * with no publish lifecycle — where the status pill correctly renders nothing
+ * and, until this existed, took the save state down with it. An author editing
+ * such a page had no reading in the toolbar at all.
+ *
+ * ## Silent when there is nothing certain to say
+ *
+ * Rendered only while work IS outstanding. The tempting other half — a
+ * "Saved" reading when `isDirty` is false — cannot be told apart from a
+ * document that was never saved: a blocks field renders inside a create form
+ * and inside previews, where the same `false` means "nothing typed yet". The
+ * status pill guards that case by refusing to name a status nobody persisted,
+ * and this refuses for the same reason. An absent reading says nothing; a
+ * wrong one says the work is safe.
+ *
+ * That asymmetry is deliberate rather than a gap: the state worth interrupting
+ * an author for is the one where leaving loses something.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/UnsavedChangesPill
+ */
+
+export interface UnsavedChangesPillProps {
+  /**
+   * Whether the document holds edits it has not persisted.
+   *
+   * The same value the status pill reads, derived once by `useDocumentDirty`
+   * so the two readings cannot disagree about whether work is outstanding.
+   */
+  isDirty: boolean;
+}
+
+/**
+ * @param props - whether the document holds unsaved work
+ * @returns the reading, or nothing while everything is committed
+ */
+export function UnsavedChangesPill({ isDirty }: UnsavedChangesPillProps) {
+  if (!isDirty) return null;
+
+  return (
+    // A reading, not a control: there is no save button in this toolbar to
+    // pair it with — blocks reach the entry when the author leaves the editor —
+    // so anything pressable here would promise an action that does not exist.
+    <span
+      className="border-[color:var(--nx-builder-border)] text-[color:var(--nx-builder-text)] inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium"
+      // `polite` rather than `assertive`: the state changes on almost every
+      // edit, and a reading that interrupts on each keystroke is noise an
+      // author would learn to ignore.
+      aria-live="polite"
+    >
+      {/* Carries the meaning without colour, for the reason the status pill
+          uses weight rather than a second hue. */}
+      <span
+        aria-hidden="true"
+        className="bg-[color:var(--nx-builder-text)] size-1.5 rounded-full"
+      />
+      Unsaved changes
+    </span>
+  );
+}

--- a/packages/plugin-page-builder/src/admin/UnsavedChangesPill.tsx
+++ b/packages/plugin-page-builder/src/admin/UnsavedChangesPill.tsx
@@ -11,18 +11,26 @@
  * and, until this existed, took the save state down with it. An author editing
  * such a page had no reading in the toolbar at all.
  *
+ * ## The region is always mounted; only its contents come and go
+ *
+ * A polite live region is announced when its CONTENTS change, and a region
+ * inserted into the document already holding its text is not reliably
+ * announced at all — the assistive technology never saw it empty. Since the
+ * transition this exists to report is exactly clean-to-dirty, mounting on that
+ * transition would lose the one announcement worth making.
+ *
+ * So the region is unconditional and the reading inside it is not. Empty, it
+ * draws nothing: the border, the padding and the dot belong to the inner
+ * element, so a document with nothing outstanding shows no chip.
+ *
  * ## Silent when there is nothing certain to say
  *
- * Rendered only while work IS outstanding. The tempting other half — a
- * "Saved" reading when `isDirty` is false — cannot be told apart from a
- * document that was never saved: a blocks field renders inside a create form
- * and inside previews, where the same `false` means "nothing typed yet". The
- * status pill guards that case by refusing to name a status nobody persisted,
- * and this refuses for the same reason. An absent reading says nothing; a
- * wrong one says the work is safe.
- *
- * That asymmetry is deliberate rather than a gap: the state worth interrupting
- * an author for is the one where leaving loses something.
+ * The tempting other half — a "Saved" reading when `isDirty` is false — cannot
+ * be told apart from a document that was never saved: a blocks field renders
+ * inside a create form and inside previews, where the same `false` means
+ * "nothing typed yet". The status pill guards that case by refusing to name a
+ * status nobody persisted, and this refuses for the same reason. An absent
+ * reading says nothing; a wrong one says the work is safe.
  *
  * @module @nextlyhq/plugin-page-builder/admin/UnsavedChangesPill
  */
@@ -31,37 +39,39 @@ export interface UnsavedChangesPillProps {
   /**
    * Whether the document holds edits it has not persisted.
    *
-   * The same value the status pill reads, derived once by `useDocumentDirty`
-   * so the two readings cannot disagree about whether work is outstanding.
+   * Derived once by the caller, from the same answer the navigation guard
+   * reports, so the two cannot disagree about whether work is outstanding —
+   * including while an inline edit is merely OPEN, which moves neither the
+   * editor's history nor the form's dirty fields.
    */
   isDirty: boolean;
 }
 
 /**
  * @param props - whether the document holds unsaved work
- * @returns the reading, or nothing while everything is committed
+ * @returns a live region, carrying the reading only while work is outstanding
  */
 export function UnsavedChangesPill({ isDirty }: UnsavedChangesPillProps) {
-  if (!isDirty) return null;
-
   return (
-    // A reading, not a control: there is no save button in this toolbar to
-    // pair it with — blocks reach the entry when the author leaves the editor —
-    // so anything pressable here would promise an action that does not exist.
-    <span
-      className="border-[color:var(--nx-builder-border)] text-[color:var(--nx-builder-text)] inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium"
-      // `polite` rather than `assertive`: the state changes on almost every
-      // edit, and a reading that interrupts on each keystroke is noise an
-      // author would learn to ignore.
-      aria-live="polite"
-    >
-      {/* Carries the meaning without colour, for the reason the status pill
-          uses weight rather than a second hue. */}
-      <span
-        aria-hidden="true"
-        className="bg-[color:var(--nx-builder-text)] size-1.5 rounded-full"
-      />
-      Unsaved changes
+    // `polite` rather than `assertive`: the state changes on almost every edit,
+    // and a reading that interrupts on each one is one an author learns to
+    // ignore. No styling here — an empty region must occupy nothing.
+    <span aria-live="polite">
+      {isDirty ? (
+        // A reading, not a control: there is no save button in this toolbar to
+        // pair it with — blocks reach the entry when the author leaves the
+        // editor — so anything pressable would promise an action that does not
+        // exist.
+        <span className="border-[color:var(--nx-builder-border)] text-[color:var(--nx-builder-text)] inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-xs font-medium">
+          {/* Carries the meaning without colour, for the reason the status pill
+              uses weight rather than a second hue. */}
+          <span
+            aria-hidden="true"
+            className="bg-[color:var(--nx-builder-text)] size-1.5 rounded-full"
+          />
+          Unsaved changes
+        </span>
+      ) : null}
     </span>
   );
 }


### PR DESCRIPTION
Builder toolbar pass, part 1 of the U-13/U-12/U-8/U-9 group. **U-13 only** — the other three turned out to need a decision, explained at the end.

## The defect

The page builder takes the whole window and asks the admin to hide its chrome, so nothing outside it is on screen while an author edits.

Inside it, the only reading was `DocumentStatusPill` — which answers a *different* question: "is this page live?". That question has no answer on a collection declaring no publish lifecycle, so the pill correctly renders `null` there — **and took the only indication of unsaved work down with it.**

Observed in the running builder: the toolbar showed `Exit editor · Breakpoints · Show empty containers · 100%` and no state at all, while `documentDirty` was being computed a few lines away and passed only to the pill that had already returned null.

## The fix

Two questions, two readings. `UnsavedChangesPill` reads the same `documentDirty` derivation, so the two cannot disagree about whether work is outstanding.

**It is silent when nothing is outstanding, and that asymmetry is deliberate.** The tempting other half — a "Saved" reading — cannot be told apart from a document that was never saved: a blocks field also renders inside a create form and inside previews, where the same `false` means "nothing typed yet". `DocumentStatusPill` already refuses to name a status nobody persisted; this refuses for the same reason. The state worth interrupting an author for is the one where leaving loses something.

`aria-live="polite"`, because the state flips on almost every edit and an assertive region would speak over the author continuously.

## Evidence

- 3 tests, each break-verified: rendering unconditionally kills the silence case; announcing assertively kills the politeness case.
- plugin-page-builder **50 files / 522 tests** green.
- `lint` 0, `check-types` 0, `fallow audit --base origin/main` **pass**, 4 files, 0 introduced.
- Found by opening the running builder, not by reading code — the toolbar's silence is not visible in the source.

## Why the other three rows are not here

**U-12 (breakpoints control oversized)** has a constraint I did not expect: breakpoint tiers are **site-defined with arbitrary names** — "Tablet" is one site's word, and a site may define "Kiosk" or "Watch". So the obvious compaction, swapping labels for viewport icons, cannot represent them. The real options are a dropdown (costs a click on a frequent action) or a container-query collapse like `toolbar-density`. That is a design decision, not a tidy-up, and it deserves to be made deliberately.

**U-8 (Exit editor as an icon)** and **U-9 (explain "Show empty containers")** both push against reasoning already written down: the empty-containers switch is labelled *on purpose* — "a control governing a VISIBILITY affordance that an author cannot read at a glance would repeat the exact failure this feature exists to fix". Icon-ifying either is the shape of the U-3 trap.

I would rather bring those three back with a recommendation than spend them at the end of a long session.