### PR TITLE
test(ci): cover a heading's default size where dev cannot see it

### DIFF
--- a/e2e/tests/production/block-typography.spec.ts
+++ b/e2e/tests/production/block-typography.spec.ts
@@ -1,0 +1,112 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * A heading a visitor reads is set apart from the body text around it.
+ *
+ * IN A PRODUCTION BUILD SPECIFICALLY, and that is the whole reason this lives
+ * here rather than beside the other blocks tests. `next dev` serves the CSS of
+ * every route it has compiled, so a stylesheet imported by the admin route
+ * reaches a public page that never imports it — and the dev suite therefore
+ * cannot tell a page that styles its own headings from one borrowing the
+ * admin's. Measured under `next dev`, this passed with the renderer's
+ * stylesheet removed entirely.
+ *
+ * What makes the question real: a host applying a CSS reset — Tailwind's
+ * Preflight, which the scaffolded template uses — sets `h1`-`h6` to
+ * `font-size: inherit; font-weight: inherit`, and the style compiler emits only
+ * what a document DECLARES. A heading nobody has styled therefore has no size
+ * of its own, and renders identically to a paragraph.
+ *
+ * @module tests/production/block-typography
+ */
+
+const DEV_USER = { email: "dev@nextly.local", password: "DevPassword123!" };
+
+const HEADING = "A heading nobody has styled";
+const BODY = "A paragraph nobody has styled, beneath it.";
+
+test("a heading outranks body text with no author styling at all", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/admin");
+  await page.getByRole("textbox", { name: /email/i }).fill(DEV_USER.email);
+  // By ROLE, not by label: `getByLabel(/password/i)` also matches the "Show
+  // password" toggle beside the input, and a locator resolving to two elements
+  // fails on strict mode rather than on anything about the product.
+  await page
+    .getByRole("textbox", { name: /password/i })
+    .fill(DEV_USER.password);
+  await page.getByRole("button", { name: /sign in|log in/i }).click();
+  await expect(page.locator("main")).toBeVisible({ timeout: 60_000 });
+
+  const cookies = await page.context().cookies();
+  const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join("; ");
+
+  /*
+   * Authored through the API the editor writes with, and carrying NO styles.
+   * A `styles` key here would answer a different question: the compiler is
+   * known to emit what a document declares, and what is in doubt is what a
+   * document that declares nothing looks like.
+   */
+  const authored = await request.patch("/admin/api/singles/homepage", {
+    headers: { cookie: cookieHeader, "content-type": "application/json" },
+    data: {
+      layout: {
+        formatVersion: 1,
+        kind: "page",
+        nodes: [
+          {
+            id: "typography-heading",
+            type: "core/heading",
+            version: 1,
+            props: { text: HEADING, level: "h1" },
+          },
+          {
+            id: "typography-body",
+            type: "core/text",
+            version: 1,
+            props: { text: BODY },
+          },
+        ],
+      },
+    },
+  });
+  expect(
+    authored.ok(),
+    `authoring failed: ${authored.status()} ${await authored.text()}`
+  ).toBe(true);
+
+  await page.goto("/");
+  const root = page.locator(".nx-pb-page");
+  await expect(root).toBeVisible({ timeout: 60_000 });
+
+  const sizes = await root.evaluate(el => {
+    const px = (selector: string) => {
+      const found = el.querySelector(selector);
+      return found === null
+        ? null
+        : parseFloat(getComputedStyle(found).fontSize);
+    };
+    return { heading: px("h1"), body: px("p") };
+  });
+
+  // Reported so a future failure names the two sizes rather than only their
+  // order, and so the hierarchy can be judged rather than merely detected.
+  console.log(`TYPOGRAPHY heading=${sizes.heading} body=${sizes.body}`);
+
+  // POPULATION FIRST. "The heading is bigger" is satisfied just as well by a
+  // page that rendered neither element, and both would read as null.
+  expect(sizes.heading, "the page must render the heading").not.toBeNull();
+  expect(sizes.body, "the page must render the body text").not.toBeNull();
+
+  /*
+   * A RELATION rather than a pixel value. The claim is that the two are
+   * distinguishable; pinning 36px would fail on a scale change that kept the
+   * hierarchy perfectly intact, which is a worse test of the same idea.
+   */
+  expect(
+    sizes.heading as number,
+    `a heading with no authored size must outrank body text (heading ${sizes.heading}px, body ${sizes.body}px)`
+  ).toBeGreaterThan(sizes.body as number);
+});


### PR DESCRIPTION
Settles tracker row **U-5** ("`baseStyles` missing from 11 of 21 blocks"). **The row was not a defect** — but the property had no production-build coverage, and this adds it.

## Why the dev suite could not answer

`next dev` serves the CSS of every route it has compiled, so the admin's stylesheet reaches a public page that never imports it. **Measured: the same assertion passed under `next dev` with the renderer's typography removed entirely.** Any dev-server test here is a false green.

## What a production build actually shows

A heading carrying **no authored styles at all**, on a real `next build`:

```
heading = 36px      body = 16px
```

The hierarchy is intact. U-5 is closed as not-a-defect.

## The mechanism, since "it works" is not an explanation

`blocks-react` ships `TYPOGRAPHY_DEFAULTS` and injects them as the compiler's `elementBases` — a tier below block defaults, keyed by **tag name**.

That design already encodes the constraint I had independently concluded was fatal to fixing this at the block level: a heading's level is a *prop*, so one block-type class cannot be six sizes, and only the element distinguishes them. Its docblock says so directly.

It also solves the specificity problem better than the stylesheet I had drafted for this row and reverted. I used `:where()`, which weighs `0-0-1` — that merely *ties* with Tailwind's Preflight and wins on source order. The engine anchors one class outside the wrapper for `0-1-0`, which beats a bare element reset outright and still loses to a host's own class. **A stylesheet here would have been a second implementation of a solved question.**

## Why the test is worth keeping anyway

Nothing exercised `elementBases` end to end in a production build, and the failure it guards against is invisible in dev by construction. The property is not exotic: every scaffolded Nextly app imports Tailwind, whose Preflight sets `h1`–`h6` to `font-size: inherit`.

- Authored through the API the editor writes with, carrying no `styles` key — what the compiler does with a *declared* value is not in doubt.
- Asserted as a **relation**, not a pixel value, so a scale change that keeps the hierarchy intact does not fail it. Both sizes are in the failure message.
- **Population first**: "the heading is bigger" is satisfied by a page that rendered neither element.

## Break-verified against `dist`, which mattered

Lowering `h1` to `1em` in the **source alone changed nothing** — the playground builds against the package's `dist`, so the break never reached the tested tree and the green meant nothing. Rebuilt into `dist`, the test **fails**; restored, it **passes**.

Test-only, so no changeset.