### PR TITLE
fix(nextly): one rule for a queryless widget's query, asked by both channels

### DIFF
--- a/.changeset/one-rule-for-a-queryless-widgets-query.md
+++ b/.changeset/one-rule-for-a-queryless-widgets-query.md
@@ -1,0 +1,38 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+One rule for a queryless widget's query, not two.
+
+The registry refused a `query` on a `text` or `actions` widget while the same
+declaration reached boot through `contributes.admin.widgets` and passed. Core
+draws those archetypes from the declaration alone, so the admin batched a read
+on every mount and refetch whose result the declared renderer never looks at.
+
+`querylessQueryProblem` is now the single non-throwing rule, and both the
+registry validator and the boot gate ask it — the same shape `actionProblem`
+already established for shortcut items.

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -346,16 +346,41 @@ export function actionProblem(action: unknown): string | undefined {
   return undefined;
 }
 
+/**
+ * Why a queryless archetype may not carry this `query`, or `undefined`.
+ *
+ * The non-throwing half of a rule {@link validateQuery} also enforces, exported
+ * for the same reason {@link actionProblem} is: the CONTRIBUTIONS channel needs
+ * the identical answer without a throw, and one rule spelled twice is exactly
+ * how the two channels came to disagree. The registry refused a query on an
+ * `actions` widget while a contributed one carrying the same query passed boot
+ * -- and since core draws `actions` from the declaration, the admin then issued
+ * a batched read on every mount and refetch whose result the declared renderer
+ * never looks at.
+ *
+ * Takes the two values rather than a definition, so both a validated
+ * `WidgetDefinition` and a decoded JSON object can ask it without either side
+ * casting to the other's shape.
+ */
+export function querylessQueryProblem(
+  archetype: unknown,
+  query: unknown
+): string | undefined {
+  if (typeof archetype !== "string") return undefined;
+  if (!QUERYLESS_ARCHETYPE_SET.has(archetype as WidgetArchetype)) {
+    return undefined;
+  }
+  if (query === undefined) return undefined;
+  return `query is only valid for a data archetype or "custom", not "${archetype}"`;
+}
+
 function validateQuery(d: Partial<WidgetDefinition>): void {
   const archetype = d.archetype as WidgetArchetype;
   if (DATA_ARCHETYPE_SET.has(archetype) && !d.query) {
     fail(`${d.id}: archetype "${d.archetype}" requires a query`);
   }
-  if (QUERYLESS_ARCHETYPE_SET.has(archetype) && d.query !== undefined) {
-    fail(
-      `${d.id}: query is only valid for a data archetype or "custom", not "${d.archetype}"`
-    );
-  }
+  const problem = querylessQueryProblem(archetype, d.query);
+  if (problem !== undefined) fail(`${d.id}: ${problem}`);
 }
 
 /** Throws with a named reason if `def` is not a usable definition. */

--- a/packages/nextly/src/plugins/validate-admin-widgets.test.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.test.ts
@@ -356,6 +356,66 @@ describe("contributed widgets are validated at boot", () => {
     ).not.toThrow();
   });
 
+  it("refuses a query on a queryless archetype, as the registry does", () => {
+    // The registry contract forbids a query on `text`/`actions`, and this
+    // channel accepted one -- so a contributed widget could carry a query the
+    // registry would have refused. Not merely inconsistent: core draws
+    // `actions` from the declaration, so the grid batched a read on every mount
+    // and refetch whose result the declared renderer never looks at.
+    expect(() =>
+      assertAdminWidgets([
+        withWidget({
+          id: "acme/shortcuts",
+          archetype: "actions",
+          actions: [{ label: "New post", href: NEW_ENTRY_HREF }],
+          query: { source: "collection:posts", op: "count" },
+        }),
+      ])
+    ).toThrow(NextlyError);
+
+    // The other queryless archetype, so the rule is the vocabulary's rather
+    // than one arm's.
+    expect(() =>
+      assertAdminWidgets([
+        withWidget({
+          id: "acme/note",
+          archetype: "text",
+          query: { source: "collection:posts", op: "count" },
+        }),
+      ])
+    ).toThrow(NextlyError);
+  });
+
+  it("refuses that query even behind a component fallback", () => {
+    // Same bypass the shortcut rule had: the component short-circuit must not
+    // skip a declaration core will draw from.
+    expect(() =>
+      assertAdminWidgets([
+        withWidget({
+          id: "acme/shortcuts",
+          archetype: "actions",
+          component: "@acme/p/admin#Shortcuts",
+          actions: [{ label: "New post", href: NEW_ENTRY_HREF }],
+          query: { source: "collection:posts", op: "count" },
+        }),
+      ])
+    ).toThrow(NextlyError);
+  });
+
+  it("leaves a DATA archetype's query alone", () => {
+    // The bound. The refusal is the queryless vocabulary's, not a ban on
+    // queries -- a `metric` is drawn FROM one.
+    expect(() =>
+      assertAdminWidgets([
+        withWidget({
+          id: "acme/revenue",
+          archetype: "metric",
+          query: { source: "collection:posts", op: "count" },
+        }),
+      ])
+    ).not.toThrow();
+  });
+
   it("accepts a contributed actions widget whose shortcuts are complete", () => {
     // The control. A gate that refused every actions widget would satisfy the
     // assertions above while making the archetype undeclarable.

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -20,6 +20,7 @@
 import {
   actionProblem,
   DATA_ARCHETYPES,
+  querylessQueryProblem,
   QUERYLESS_ARCHETYPES,
   WIDGET_ARCHETYPES,
 } from "../domains/widgets/definition";
@@ -81,6 +82,13 @@ const QUERYLESS_ARCHETYPE_SET: ReadonlySet<string> = new Set(
  * nothing further here.
  */
 function querylessProblem(widget: Record<string, unknown>): string | undefined {
+  // Through the SAME rule the registry applies. A queryless archetype is drawn
+  // from its declaration, so a query beside it is never read -- and because
+  // `coreDraws` is true for one, the grid batched a request per mount and
+  // refetch for a result the declared renderer discards.
+  const queryProblem = querylessQueryProblem(widget.archetype, widget.query);
+  if (queryProblem !== undefined) return queryProblem;
+
   if (widget.archetype !== "actions") return undefined;
 
   if (!Array.isArray(widget.actions) || widget.actions.length === 0) {


### PR DESCRIPTION
Follow-up to #1430, from a codex finding that landed three minutes after it merged.

## The defect

The registry contract forbids a `query` on a queryless archetype — `validateQuery` in `domains/widgets/definition.ts` refuses one on `text` and `actions`. The **contributions** channel did not. A plugin declaring

```ts
{ id: "acme/shortcuts", archetype: "actions",
  actions: [{ label: "New post", href: "/admin/collections/posts/create" }],
  query: { source: "collection:posts", op: "count" } }
```

passed `assertAdminWidgets` and shipped.

That is not merely two validators disagreeing. Core draws `actions` from the declaration alone, so `coreDraws` is true, and `WidgetGrid` batches on `widget.query && (archetype === "custom" || coreDraws(widget))` — the query goes into the batch, a database read is issued on **every mount and every refetch**, and the declared renderer never looks at the result.

Confirmed by construction before fixing: the registry channel threw, the contributions channel did not.

## The fix

`querylessQueryProblem` becomes the single non-throwing rule, and both callers ask it — the shape `actionProblem` already established for shortcut items. `validateQuery` composes its message from the helper unchanged, so the registry's existing diagnostic is preserved character-for-character.

This is the same asymmetry #1430 closed for the per-action rule. That PR fixed one half of "one contract, two channels, one rule" and left this half open.

## Evidence

Break-verified in both directions, which matters here because the claim is that there is now *one* implementation:

| break | result |
| --- | --- |
| boot gate stops asking the shared rule | the 2 new contributions tests fail; the registry's own test still passes |
| the shared rule itself returns `undefined` | **3** fail — both new tests **and the registry's pre-existing test** |

The second is the one that earns the claim: the registry genuinely derives from the helper rather than keeping a copy.

Bounds are tested too — a `metric`'s query is untouched (the refusal belongs to the queryless vocabulary, not to queries), and the rule is asserted on `text` as well as `actions` so it is the vocabulary's rule rather than one arm's.

Gates: build, `check-types` (both programs), `lint` all clean; fallow `pass` over 3 changed files with 0 introduced findings; `changeset status` exits 0.