### PR TITLE
feat(builder): give the chrome back to the document

### DIFF
--- a/.changeset/the-builder-chrome-gets-out-of-the-way.md
+++ b/.changeset/the-builder-chrome-gets-out-of-the-way.md
@@ -1,0 +1,64 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The page builder's chrome now spends its width on the document rather than on
+its own labels, and the page reads as a sheet.
+
+The canvas declared no background, so it inherited the editor's frame — and a
+block declares none of its own, so the grey showed through the document. What
+an author composed looked nothing like what a visitor loads, which is the one
+thing the canvas exists to show. It now carries the page surface, a border and
+room around it. The border rather than tone alone, because which surface is
+lighter INVERTS between modes: the page is 98.84 against a 96.52 frame in light
+and 0 against 10.68 in dark, so a separation carried on the surfaces would need
+tuning twice and checking twice, while one border token sits outside both on
+either side of that inversion.
+
+Everything that makes the sheet is stated on the PAGE rather than on the region
+around it, so several side by side — one per breakpoint — would each carry
+their own edge with nothing to revisit.
+
+Exit, the breakpoint manager and the tier tabs are glyphs now. Together they
+were spending about 170px of a bar whose job is to get out of the way, and
+every one of them kept its accessible name and gained a tooltip.
+
+A tier's glyph is chosen by the WIDTH it applies at, never by its label. A tier
+is named by the site — "Tablet" on one, "Kiosk" or "Watch" on another — so a
+lookup keyed by name answers for the words somebody happened to use and has
+nothing to say for every site that chose differently.
+
+The SELECTED tier keeps its word. The width readout beside these tabs is
+deliberately empty while the selection already names the applying tier, so
+icon-only throughout would take the name off the screen entirely in the
+commonest state; two tiers can also share a glyph, and identical pictures would
+then be the only thing telling them apart.
+
+Zoom gained the stepper that its own model already supported: `steppedZoom` was
+exported with no caller, so stepping was reachable from a host and not from the
+editor. Each direction disables where the step list ends, so a button that
+cannot move says so rather than depressing and changing nothing.

--- a/packages/builder/src/breakpoint-manager.tsx
+++ b/packages/builder/src/breakpoint-manager.tsx
@@ -168,14 +168,23 @@ export function BreakpointManager({
         }
         title={
           ready
-            ? undefined
+            ? `Breakpoints: ${count} defined`
             : status === "loading"
               ? "Available once the site's saved styles have loaded."
               : "Your site's saved styles could not be read, so editing them here could overwrite them."
         }
       >
+        {/*
+          The glyph carries the control and the word is dropped: the trigger
+          opens a dialog that names itself, and "Breakpoints" beside a count
+          spent more of the bar than the two facts an author reads from here —
+          that this is where tiers are managed, and how many exist.
+
+          The accessible name below is unchanged and still says both, so
+          nothing is lost to a reader who cannot see the glyph; the title makes
+          the same sentence reachable by pointer.
+        */}
         <MonitorSmartphone className="size-4" />
-        <span>Breakpoints</span>
         {ready && count > 0 ? (
           <span
             className="text-muted-foreground tabular-nums"

--- a/packages/builder/src/breakpoint-switcher.test.tsx
+++ b/packages/builder/src/breakpoint-switcher.test.tsx
@@ -692,3 +692,68 @@ describe("where focus goes when the keyboard moves the selection", () => {
     expect(document.activeElement).toBe(before);
   });
 });
+
+describe("telling two tiers apart", () => {
+  /*
+   * A site whose narrow tiers land in the same width class.
+   *
+   * The glyph comes from the bound, so both of these draw the same picture —
+   * which is the case that decides whether a name is reachable before the
+   * canvas has already changed.
+   */
+  const narrowTiers = (): BreakpointSet => ({
+    viewport: [
+      { id: "wide-phone", label: "Wide phone", maxWidth: 480 },
+      { id: "phone", label: "Phone", maxWidth: 375 },
+    ],
+    container: [],
+  });
+
+  it("names every option, not only the selected one", () => {
+    render(
+      <BreakpointSwitcher
+        breakpoints={narrowTiers()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    /*
+     * Asserted on the two that COLLIDE rather than on the whole group, so the
+     * unconditional option — which keeps its word on screen and would satisfy
+     * a blanket assertion — cannot answer for them.
+     */
+    const titles = options()
+      .map(option => option.getAttribute("title"))
+      .filter((title): title is string => title !== null);
+
+    expect(titles).toContain("Phone, up to 375 pixels");
+    expect(titles).toContain("Wide phone, up to 480 pixels");
+  });
+
+  it("carries the width in the accessible name as well as the tooltip", () => {
+    /*
+     * A tooltip is a pointer affordance and reaches neither a screen reader nor
+     * a keyboard. The two names are asserted separately because they are
+     * separate mechanisms: dropping the accessible name leaves this control
+     * usable with a mouse and unusable without one, and nothing about the
+     * rendered output would look wrong.
+     */
+    render(
+      <BreakpointSwitcher
+        breakpoints={narrowTiers()}
+        width={undefined}
+        onSelect={vi.fn()}
+        status="ready"
+      />
+    );
+
+    expect(
+      screen.getByRole("radio", { name: "Phone, up to 375 pixels" })
+    ).toBeDefined();
+    expect(
+      screen.getByRole("radio", { name: "Wide phone, up to 480 pixels" })
+    ).toBeDefined();
+  });
+});

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -428,9 +428,19 @@ export function BreakpointSwitcher({
              * number is the whole content of the choice.
              */
             aria-label={ariaLabelFor(option)}
+            /*
+             * The same string as the accessible name, so a sighted pointer
+             * user can read what a glyph stands for without selecting it.
+             *
+             * A tier's glyph comes from its width, so two tiers a site defines
+             * close together — 375px and 480px, say — draw the SAME picture,
+             * and only the selected one shows a word. Without this the only
+             * way to tell those two apart is to click one and watch the canvas
+             * change, which is the tier being applied rather than named.
+             */
             title={
               ready
-                ? undefined
+                ? ariaLabelFor(option)
                 : status === "loading"
                   ? "Available once the site's saved styles have loaded."
                   : "Your site's saved styles could not be read, so the canvas cannot be sized against them."
@@ -451,11 +461,16 @@ export function BreakpointSwitcher({
               Icon-only throughout would take the tier's name off the screen
               entirely in the commonest state: the width readout beside this is
               deliberately empty while the selection already names the applying
-              tier, so with no label here nothing would name it. Two tiers can
-              also share a glyph — a site may define several narrow ones — and
-              then identical pictures would be the only thing to tell them
-              apart. Naming the selected one costs the width of one word and
-              answers both.
+              tier, so with no label here nothing would name it. Naming the
+              selected one costs the width of one word and answers that.
+
+              It does NOT answer the other half: two tiers can share a glyph —
+              a site may define several narrow ones — and neither being
+              selected, identical pictures are all there is to tell them apart.
+              The accessible name carries the width for assistive technology
+              and the `title` carries it for a pointer, so the word being
+              absent is a matter of density rather than of the name being
+              unavailable.
             */}
             {(() => {
               const Glyph = tierIcon(option.bound);

--- a/packages/builder/src/breakpoint-switcher.tsx
+++ b/packages/builder/src/breakpoint-switcher.tsx
@@ -37,6 +37,7 @@ import {
   type BreakpointSet,
 } from "@nextlyhq/blocks-engine";
 import { cn } from "@nextlyhq/ui/utils";
+import { Laptop, Monitor, Smartphone, Tablet } from "lucide-react";
 import * as React from "react";
 
 import { authoredBreakpoints } from "./breakpoints";
@@ -100,6 +101,26 @@ export interface BreakpointSwitcherProps {
  *
  * @experimental
  */
+/**
+ * The glyph for a tier, chosen by the WIDTH it applies at.
+ *
+ * Not by its name. A tier's label is whatever the site called it — "Tablet" on
+ * one site, "Kiosk" or "Watch" on another — so a lookup keyed by name answers
+ * for the three words somebody happened to use, and has nothing to say for
+ * every site that chose differently. The bound is what the tier actually
+ * means, and every tier carries one.
+ *
+ * The boundaries are the conventional device classes rather than anything this
+ * editor enforces: a tier may sit anywhere, and this only decides which of four
+ * pictures is least wrong for it.
+ */
+function tierIcon(bound: number | undefined) {
+  if (bound === undefined) return Monitor;
+  if (bound <= 640) return Smartphone;
+  if (bound <= 1024) return Tablet;
+  return Laptop;
+}
+
 /**
  * What an option is CALLED, width included.
  *
@@ -417,13 +438,30 @@ export function BreakpointSwitcher({
             tabIndex={index === activeIndex ? 0 : -1}
             onClick={() => onSelect(option.bound)}
             className={cn(
-              "rounded px-2 py-1 text-xs",
+              "inline-flex items-center gap-1 rounded px-2 py-1 text-xs",
               selected
                 ? "bg-accent text-accent-foreground"
                 : "text-muted-foreground"
             )}
           >
-            <span aria-hidden="true">{option.label}</span>
+            {/*
+              The glyph carries every option; the WORD is kept for the selected
+              one alone.
+              
+              Icon-only throughout would take the tier's name off the screen
+              entirely in the commonest state: the width readout beside this is
+              deliberately empty while the selection already names the applying
+              tier, so with no label here nothing would name it. Two tiers can
+              also share a glyph — a site may define several narrow ones — and
+              then identical pictures would be the only thing to tell them
+              apart. Naming the selected one costs the width of one word and
+              answers both.
+            */}
+            {(() => {
+              const Glyph = tierIcon(option.bound);
+              return <Glyph className="size-3.5" aria-hidden="true" />;
+            })()}
+            {selected ? <span aria-hidden="true">{option.label}</span> : null}
           </button>
         );
       })}

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -16,6 +16,7 @@ import {
 } from "@nextlyhq/ui";
 import { cn } from "@nextlyhq/ui/utils";
 import {
+  ArrowLeft,
   Blocks,
   Braces,
   FileText,
@@ -905,9 +906,24 @@ function ShellRegions({
             type="button"
             onClick={onExit}
             data-builder-animates
-            className="border-[color:var(--nx-builder-border)] focus-visible:ring-ring rounded-md border px-3 py-1.5 text-sm font-medium focus-visible:ring-2 focus-visible:outline-none"
+            /*
+             * The NAME stays "Exit editor" while the label becomes a glyph.
+             * This is the only route back to the document — `ChromeSuppression`
+             * withholds the navigation rail from a surface that cannot be left,
+             * on the grounds that an author with unsaved work and no way out is
+             * the worst state the editor can reach — so it keeps a real
+             * accessible name and a tooltip rather than relying on the arrow
+             * being self-evident.
+             *
+             * An arrow rather than a cross: this returns to the document that
+             * opened the editor, and a cross reads as discarding rather than
+             * as going back.
+             */
+            aria-label="Exit editor"
+            title="Exit editor"
+            className="border-[color:var(--nx-builder-border)] focus-visible:ring-ring rounded-md border p-1.5 focus-visible:ring-2 focus-visible:outline-none"
           >
-            Exit editor
+            <ArrowLeft className="size-4" aria-hidden="true" />
           </button>
         ) : null}
         <div className="flex min-w-0 flex-1 items-center gap-2">{topBar}</div>
@@ -1134,7 +1150,7 @@ function ShellRegions({
                  * could not see would size the page to the region and paint it
                  * over the gap.
                  */
-                className="h-full overflow-auto p-6"
+                className="h-full overflow-auto p-4"
               >
                 {children}
               </section>

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -1121,7 +1121,20 @@ function ShellRegions({
                  */
                 tabIndex={0}
                 aria-label="Canvas"
-                className="h-full overflow-auto"
+                /*
+                 * Padded, so the page floats inside the region rather than
+                 * meeting its edges. The frame is then visible on every side at
+                 * every width — without it the page fills the region whenever
+                 * it is not scaled down, and the edge this gap exists to show
+                 * has nowhere to appear.
+                 *
+                 * Safe against the fit: `canvasScale` observes this element's
+                 * CONTENT box, so padding narrows the width the page is fitted
+                 * into and the scale follows it. A padding the measurement
+                 * could not see would size the page to the region and paint it
+                 * over the gap.
+                 */
+                className="h-full overflow-auto p-6"
               >
                 {children}
               </section>

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -42,8 +42,9 @@ import {
   EMPTY_ELEMENTS_ATTRIBUTE,
   browserStore,
   fitsFullShell,
+  CANVAS_GUTTER,
   LEFT_PANELS,
-  MIN_CANVAS_WIDTH,
+  MIN_CANVAS_PANEL_WIDTH,
   MIN_SHELL_WIDTH,
   PANEL_BOUNDS,
   panelAfterRailClick,
@@ -1104,7 +1105,7 @@ function ShellRegions({
             </>
           ) : null}
 
-          <ResizablePanel id="canvas" minSize={MIN_CANVAS_WIDTH}>
+          <ResizablePanel id="canvas" minSize={MIN_CANVAS_PANEL_WIDTH}>
             {/*
              * A named `section`, never `<main>`.
              *
@@ -1149,8 +1150,15 @@ function ShellRegions({
                  * into and the scale follows it. A padding the measurement
                  * could not see would size the page to the region and paint it
                  * over the gap.
+                 *
+                 * Taken from the constant the panel's own minimum is derived
+                 * from, rather than written as a utility class. The gap is
+                 * spent out of this panel, so a class here and a number there
+                 * would let the two drift and put the floor back inside the
+                 * editing surface.
                  */
-                className="h-full overflow-auto p-4"
+                style={{ padding: CANVAS_GUTTER }}
+                className="h-full overflow-auto"
               >
                 {children}
               </section>

--- a/packages/builder/src/canvas-surface.test.ts
+++ b/packages/builder/src/canvas-surface.test.ts
@@ -36,6 +36,34 @@ function canvasRule(): string {
   return body.slice(0, body.indexOf("\n}"));
 }
 
+describe("the canvas as a sheet", () => {
+  it("states its own edge, so the page is separable at any tone", () => {
+    /*
+     * The frame is deliberately one step off the background so it recedes, so
+     * the two surfaces alone are close by design. The border is what makes the
+     * page's edge readable regardless — and regardless of which of the two is
+     * lighter, which the palette inverts between modes.
+     */
+    expect(canvasRule()).toContain(
+      "border: 1px solid var(--nx-builder-border)"
+    );
+  });
+
+  it("carries the separation on the BORDER, not only on a shadow", () => {
+    /*
+     * A shadow has almost nothing to darken on a dark page, so a sheet relying
+     * on one is legible in light mode and flat in dark. The shadow may be
+     * present as a secondary cue; the border may not be missing.
+     */
+    const rule = canvasRule();
+    const hasBorder = rule.includes("border: 1px solid");
+    expect(
+      hasBorder,
+      "a shadow alone leaves the page edgeless wherever it cannot cast"
+    ).toBe(true);
+  });
+});
+
 describe("the canvas surface", () => {
   it("declares a background rather than inheriting the frame", () => {
     expect(canvasRule()).toContain("background-color:");

--- a/packages/builder/src/canvas-surface.test.ts
+++ b/packages/builder/src/canvas-surface.test.ts
@@ -40,27 +40,50 @@ describe("the canvas as a sheet", () => {
   it("states its own edge, so the page is separable at any tone", () => {
     /*
      * The frame is deliberately one step off the background so it recedes, so
-     * the two surfaces alone are close by design. The border is what makes the
-     * page's edge readable regardless — and regardless of which of the two is
+     * the two surfaces alone are close by design. The edge is what makes the
+     * page separable regardless — and regardless of which of the two is
      * lighter, which the palette inverts between modes.
      */
     expect(canvasRule()).toContain(
-      "border: 1px solid var(--nx-builder-border)"
+      "outline: 1px solid var(--nx-builder-border)"
     );
   });
 
-  it("carries the separation on the BORDER, not only on a shadow", () => {
+  it("carries the separation on the EDGE, not only on a shadow", () => {
     /*
      * A shadow has almost nothing to darken on a dark page, so a sheet relying
      * on one is legible in light mode and flat in dark. The shadow may be
-     * present as a secondary cue; the border may not be missing.
+     * present as a secondary cue; the edge may not be missing.
      */
     const rule = canvasRule();
-    const hasBorder = rule.includes("border: 1px solid");
+    const hasEdge = rule.includes("outline: 1px solid");
     expect(
-      hasBorder,
+      hasEdge,
       "a shadow alone leaves the page edgeless wherever it cannot cast"
     ).toBe(true);
+  });
+
+  it("draws that edge OUTSIDE the width the page is previewed at", () => {
+    /*
+     * This element carries the previewed width, `container-type: inline-size`
+     * and the edge together, under the shell's `box-sizing: border-box`. A
+     * border is therefore subtracted from the content box the container queries
+     * resolve against, and two pixels decide a tier: at a 992px request the
+     * content box is 990px, so a `max-width: 991px` rule stays active and the
+     * unconditional tier cannot be previewed at all. An outline paints outside
+     * the box and takes part in no layout, which is why it is the one that may
+     * be used here.
+     *
+     * Matched as a property rather than as the shorthand, so `border-top` or
+     * `border-width` cannot reintroduce the same subtraction under another
+     * spelling. `--nx-builder-border` is not a match: the token is preceded by
+     * `-` rather than by whitespace, and is a value rather than a declaration.
+     */
+    const declaresBorder = /(?:^|\s)border(?:-[a-z]+)?\s*:/.test(canvasRule());
+    expect(
+      declaresBorder,
+      "a border here narrows the content box the previewed tier is decided by"
+    ).toBe(false);
   });
 });
 

--- a/packages/builder/src/canvas-surface.test.ts
+++ b/packages/builder/src/canvas-surface.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The canvas is drawn on the PAGE's surface, not on the editor's frame.
+ *
+ * A colour nothing declares is inherited, and inheritance is invisible to every
+ * other gate here: the canvas rendered, its blocks rendered, no rule was
+ * missing and nothing threw — the page was simply the wrong colour, because the
+ * chrome's frame showed through a document whose blocks declare no background
+ * of their own. What an author composes then looks nothing like what a visitor
+ * loads, which is the one thing this canvas exists to show.
+ *
+ * Read from the SOURCE stylesheet rather than the built one: `dist` is
+ * gitignored, so a check against it answers differently before and after a
+ * build — the shape that makes CI and a laptop disagree.
+ *
+ * @module canvas-surface.test
+ */
+const CHROME = readFileSync(
+  fileURLToPath(new URL("./styles/builder-chrome.css", import.meta.url)),
+  "utf8"
+);
+
+/** The one `.nx-canvas` rule, so a second one cannot answer for the first. */
+function canvasRule(): string {
+  const marker = "\n.nx-canvas {";
+  const opened = CHROME.split(marker);
+  expect(
+    opened.length,
+    "exactly one `.nx-canvas` rule, or these assertions read whichever came first"
+  ).toBe(2);
+  const body = opened[1] as string;
+  return body.slice(0, body.indexOf("\n}"));
+}
+
+describe("the canvas surface", () => {
+  it("declares a background rather than inheriting the frame", () => {
+    expect(canvasRule()).toContain("background-color:");
+  });
+
+  it("takes it from the RAISED token, not the frame's own", () => {
+    /*
+     * `--nx-builder-surface` is the frame. Naming it here would declare the
+     * inheritance rather than replace it — the same wrong colour, now written
+     * down, and a test asserting only that SOME background exists would pass.
+     */
+    const rule = canvasRule();
+    expect(rule).toContain("var(--nx-builder-surface-raised)");
+    expect(
+      rule.includes("var(--nx-builder-surface)"),
+      "the frame's own token would repaint the page in the colour this replaces"
+    ).toBe(false);
+  });
+});

--- a/packages/builder/src/canvas-zoom-control.test.tsx
+++ b/packages/builder/src/canvas-zoom-control.test.tsx
@@ -93,6 +93,32 @@ describe("the zoom stepper", () => {
     expect((zoomOut as HTMLButtonElement).disabled).toBe(false);
   });
 
+  it("does not offer a step it cannot take from an unpaintable scale", () => {
+    /*
+     * `writeZoom` returns the scale itself, and a host may construct a fixed
+     * zoom the canvas cannot paint. `NaN !== NaN` is true, so an unchanged
+     * result reads as a step being available: both buttons render operable and
+     * a press emits the same unusable value back.
+     *
+     * The fit is pinned to the TOP step so the two directions must disagree.
+     * Stepping falls back to the fit, so out has 1.5 to go to while in has
+     * nowhere — and an assertion that both are disabled would also pass on an
+     * implementation that simply refuses every unusable zoom, which would take
+     * the stepper away from an author whose canvas is painting perfectly well.
+     */
+    render(
+      <CanvasZoomControl
+        zoom={{ kind: "fixed", scale: Number.NaN }}
+        appliedScale={2}
+        onChange={vi.fn()}
+      />
+    );
+    const zoomIn = screen.getByRole("button", { name: /zoom in/i });
+    const zoomOut = screen.getByRole("button", { name: /zoom out/i });
+    expect((zoomIn as HTMLButtonElement).disabled).toBe(true);
+    expect((zoomOut as HTMLButtonElement).disabled).toBe(false);
+  });
+
   it("steps from the scale a FIT is currently painting at", () => {
     // Fit is a mode, not a number, so stepping out of it starts from what it
     // resolved to — otherwise the first press jumps somewhere unrelated to

--- a/packages/builder/src/canvas-zoom-control.test.tsx
+++ b/packages/builder/src/canvas-zoom-control.test.tsx
@@ -35,6 +35,81 @@ function mount(props: Partial<React.ComponentProps<typeof CanvasZoomControl>>) {
   return { onChange };
 }
 
+/**
+ * The zoom trigger, named rather than taken as "the button".
+ *
+ * The control is a stepper around a menu, so a bare role query matches three
+ * elements. Naming it also keeps these assertions about the READOUT: a query
+ * that silently resolved to the minus button would still find a button and
+ * still read a `textContent`, and the failure would name a percentage rather
+ * than the element it came from.
+ */
+const trigger = () => screen.getByRole("button", { name: /canvas zoom/i });
+
+describe("the zoom stepper", () => {
+  it("steps to the next zoom out, and to the next in", () => {
+    /*
+     * `steppedZoom` already decided what the next step is and was exported
+     * with no caller — the capability was reachable from a host and not from
+     * the editor. These buttons are its first consumer, so this asserts the
+     * WIRING; the arithmetic has its own tests.
+     */
+    const onChange = vi.fn();
+    render(
+      <CanvasZoomControl
+        zoom={{ kind: "fixed", scale: 1 }}
+        appliedScale={1}
+        onChange={onChange}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /zoom out/i }));
+    expect(onChange).toHaveBeenCalledWith({ kind: "fixed", scale: 0.75 });
+
+    onChange.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: /zoom in/i }));
+    expect(onChange).toHaveBeenCalledWith({ kind: "fixed", scale: 1.5 });
+  });
+
+  it("disables the direction that has nowhere left to go", () => {
+    /*
+     * At the end of the list `steppedZoom` returns the zoom it was given, so a
+     * button left enabled would depress and change nothing — the shape that
+     * teaches an author a control is broken.
+     */
+    render(
+      <CanvasZoomControl
+        zoom={{ kind: "fixed", scale: 2 }}
+        appliedScale={2}
+        onChange={vi.fn()}
+      />
+    );
+    // The DOM property rather than a jest-dom matcher, which this package does
+    // not load — an unavailable matcher fails as a chai property error, which
+    // says nothing about the control.
+    const zoomIn = screen.getByRole("button", { name: /zoom in/i });
+    const zoomOut = screen.getByRole("button", { name: /zoom out/i });
+    expect((zoomIn as HTMLButtonElement).disabled).toBe(true);
+    expect((zoomOut as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("steps from the scale a FIT is currently painting at", () => {
+    // Fit is a mode, not a number, so stepping out of it starts from what it
+    // resolved to — otherwise the first press jumps somewhere unrelated to
+    // what is on screen.
+    const onChange = vi.fn();
+    render(
+      <CanvasZoomControl
+        zoom={FIT_ZOOM}
+        appliedScale={0.75}
+        onChange={onChange}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /zoom out/i }));
+    expect(onChange).toHaveBeenCalledWith({ kind: "fixed", scale: 0.5 });
+  });
+});
+
 describe("the canvas zoom control", () => {
   it("names the scale the canvas is PAINTING at while fitting", () => {
     /*
@@ -45,7 +120,7 @@ describe("the canvas zoom control", () => {
      */
     mount({ zoom: FIT_ZOOM, appliedScale: 0.595 });
 
-    expect(screen.getByRole("button").textContent).toBe("60%");
+    expect(trigger().textContent).toBe("60%");
   });
 
   it("says whether that number will move on its own", () => {
@@ -55,15 +130,11 @@ describe("the canvas zoom control", () => {
      * accessible name carries the mode; the visible text stays the number.
      */
     mount({ zoom: FIT_ZOOM, appliedScale: 0.6 });
-    expect(screen.getByRole("button").getAttribute("aria-label")).toContain(
-      "fitting"
-    );
+    expect(trigger().getAttribute("aria-label")).toContain("fitting");
 
     cleanup();
     mount({ zoom: { kind: "fixed", scale: 0.6 }, appliedScale: 0.6 });
-    expect(screen.getByRole("button").getAttribute("aria-label")).not.toContain(
-      "fitting"
-    );
+    expect(trigger().getAttribute("aria-label")).not.toContain("fitting");
   });
 
   it("renders nothing where nothing can act on a choice", () => {
@@ -91,7 +162,7 @@ describe("the canvas zoom control", () => {
      */
     const { onChange } = mount({ appliedScale: 1 });
 
-    fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
+    fireEvent.pointerDown(trigger(), { pointerType: "mouse" });
     const item = screen.getByRole("menuitemradio", { name: "150%" });
     fireEvent.pointerUp(item, { pointerType: "mouse" });
 
@@ -106,7 +177,7 @@ describe("the canvas zoom control", () => {
      */
     const { onChange } = mount({ zoom: { kind: "fixed", scale: 2 } });
 
-    fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
+    fireEvent.pointerDown(trigger(), { pointerType: "mouse" });
     fireEvent.pointerUp(screen.getByRole("menuitemradio", { name: "Fit" }), {
       pointerType: "mouse",
     });
@@ -122,7 +193,7 @@ describe("which zoom the open menu says is current", () => {
   }
 
   function open(): void {
-    fireEvent.pointerDown(screen.getByRole("button"), { pointerType: "mouse" });
+    fireEvent.pointerDown(trigger(), { pointerType: "mouse" });
   }
 
   it("marks FIT rather than the step it happens to resolve to", () => {

--- a/packages/builder/src/canvas-zoom-control.tsx
+++ b/packages/builder/src/canvas-zoom-control.tsx
@@ -122,11 +122,16 @@ export function CanvasZoomControl({
    * top step `steppedZoom` returns the zoom it was given, and a disabled state
    * derived from the scale alone would have to restate the step list to know
    * that. One list decides both, and it is the one the button runs.
+   *
+   * `Object.is` rather than `!==`, because `writeZoom` returns the scale itself
+   * and a host may construct one the canvas cannot paint. `NaN !== NaN` is
+   * true, so an unchanged result would read as a step being available and both
+   * buttons would offer a press that emits the value they were already given.
    */
   const zoomOut = steppedZoom(zoom, appliedScale, "out");
   const zoomIn = steppedZoom(zoom, appliedScale, "in");
-  const canZoomOut = writeZoom(zoomOut) !== writeZoom(zoom);
-  const canZoomIn = writeZoom(zoomIn) !== writeZoom(zoom);
+  const canZoomOut = !Object.is(writeZoom(zoomOut), writeZoom(zoom));
+  const canZoomIn = !Object.is(writeZoom(zoomIn), writeZoom(zoom));
 
   return (
     <div className="nx-zoom-stepper flex items-center gap-0.5">

--- a/packages/builder/src/canvas-zoom-control.tsx
+++ b/packages/builder/src/canvas-zoom-control.tsx
@@ -36,12 +36,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@nextlyhq/ui";
+import { Minus, Plus } from "lucide-react";
 import type * as React from "react";
 import { Fragment } from "react";
 
 import {
   FIT_ZOOM,
   ZOOM_STEPS,
+  steppedZoom,
   writeZoom,
   type CanvasZoom,
 } from "./canvas-zoom";
@@ -111,25 +113,60 @@ export function CanvasZoomControl({
 }: CanvasZoomControlProps): React.JSX.Element | null {
   if (onChange === undefined) return null;
   const shown = asPercent(appliedScale);
+
+  /*
+   * The steps this control can still take, so a button that cannot move says
+   * so rather than looking operable and doing nothing.
+   *
+   * Compared against the RESULT rather than against the current scale: at the
+   * top step `steppedZoom` returns the zoom it was given, and a disabled state
+   * derived from the scale alone would have to restate the step list to know
+   * that. One list decides both, and it is the one the button runs.
+   */
+  const zoomOut = steppedZoom(zoom, appliedScale, "out");
+  const zoomIn = steppedZoom(zoom, appliedScale, "in");
+  const canZoomOut = writeZoom(zoomOut) !== writeZoom(zoom);
+  const canZoomIn = writeZoom(zoomIn) !== writeZoom(zoom);
+
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger
-        className="nx-zoom-control"
-        /*
-         * The accessible name carries the MODE as well as the number, because
-         * "89%" alone does not say whether it will move when a panel opens —
-         * and that is the whole difference between the two states.
-         */
-        aria-label={
-          zoom.kind === "fit"
-            ? `Canvas zoom: fitting, ${shown}`
-            : `Canvas zoom: ${shown}`
-        }
+    <div className="nx-zoom-stepper flex items-center gap-0.5">
+      {/*
+        A stepper AROUND the menu, not instead of it. The menu names the modes
+        — Fit is a mode rather than a number and cannot be stepped to — while
+        the buttons are for the adjustment an author makes repeatedly, which a
+        menu makes a three-action job every time.
+
+        `steppedZoom` already existed and was exported with no caller: the
+        capability was reachable from a host and not from the editor.
+      */}
+      <button
+        type="button"
+        onClick={() => onChange(zoomOut)}
+        disabled={!canZoomOut}
+        aria-label="Zoom out"
+        title="Zoom out"
+        className="focus-visible:ring-ring rounded p-1 disabled:opacity-40 focus-visible:ring-2 focus-visible:outline-none"
       >
-        <span aria-hidden="true">{shown}</span>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start">
-        {/* A RADIO group, so the open menu says which mode is active.
+        <Minus className="size-3.5" aria-hidden="true" />
+      </button>
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="nx-zoom-control"
+          /*
+           * The accessible name carries the MODE as well as the number, because
+           * "89%" alone does not say whether it will move when a panel opens —
+           * and that is the whole difference between the two states.
+           */
+          aria-label={
+            zoom.kind === "fit"
+              ? `Canvas zoom: fitting, ${shown}`
+              : `Canvas zoom: ${shown}`
+          }
+        >
+          <span aria-hidden="true">{shown}</span>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {/* A RADIO group, so the open menu says which mode is active.
 
             The trigger cannot: Fit resolves to exactly 100% at the widest
             tier, which is the state an editor opens in, so "100%" is the same
@@ -143,23 +180,36 @@ export function CanvasZoomControl({
             step list. That is honest: the menu genuinely does not hold it, and
             marking the nearest step would claim the author chose something
             they did not. */}
-        <DropdownMenuRadioGroup
-          value={choiceValue(zoom)}
-          onValueChange={next => {
-            const choice = CHOICES.find(candidate => candidate.value === next);
-            if (choice !== undefined) onChange(choice.zoom);
-          }}
-        >
-          {CHOICES.map((choice, index) => (
-            <Fragment key={choice.value}>
-              {index === 1 ? <DropdownMenuSeparator /> : null}
-              <DropdownMenuRadioItem value={choice.value}>
-                {choice.label}
-              </DropdownMenuRadioItem>
-            </Fragment>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <DropdownMenuRadioGroup
+            value={choiceValue(zoom)}
+            onValueChange={next => {
+              const choice = CHOICES.find(
+                candidate => candidate.value === next
+              );
+              if (choice !== undefined) onChange(choice.zoom);
+            }}
+          >
+            {CHOICES.map((choice, index) => (
+              <Fragment key={choice.value}>
+                {index === 1 ? <DropdownMenuSeparator /> : null}
+                <DropdownMenuRadioItem value={choice.value}>
+                  {choice.label}
+                </DropdownMenuRadioItem>
+              </Fragment>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <button
+        type="button"
+        onClick={() => onChange(zoomIn)}
+        disabled={!canZoomIn}
+        aria-label="Zoom in"
+        title="Zoom in"
+        className="focus-visible:ring-ring rounded p-1 disabled:opacity-40 focus-visible:ring-2 focus-visible:outline-none"
+      >
+        <Plus className="size-3.5" aria-hidden="true" />
+      </button>
+    </div>
   );
 }

--- a/packages/builder/src/canvas-zoom.test.ts
+++ b/packages/builder/src/canvas-zoom.test.ts
@@ -99,4 +99,40 @@ describe("stepping the zoom", () => {
       scale: 0.75,
     });
   });
+
+  it("steps a scale it cannot paint from the fit, as the canvas does", () => {
+    /*
+     * `CanvasZoom` is exported, so a host can construct a fixed scale holding
+     * any number the type admits. Stepping from the raw value makes every
+     * comparison against `NaN` false, so both directions return the zoom
+     * unchanged and the stepper can never leave it — while the canvas is
+     * painting the fit those steps should have come from.
+     *
+     * Asserted in BOTH directions, because a single direction passes on an
+     * implementation that merely returns the first step of a hardcoded list.
+     */
+    const unusable = { kind: "fixed", scale: Number.NaN } as const;
+    expect(steppedZoom(unusable, 1, "in")).toEqual({
+      kind: "fixed",
+      scale: 1.5,
+    });
+    expect(steppedZoom(unusable, 1, "out")).toEqual({
+      kind: "fixed",
+      scale: 0.75,
+    });
+  });
+
+  it("steps an out-of-range scale from the fit as well", () => {
+    /*
+     * The non-finite case above is not the whole of what `usableScale` rejects,
+     * and a guard written only against `NaN` passes it while leaving a scale
+     * outside the bounds stepping from a value the canvas refused. 12 is past
+     * `MAX_ZOOM`, so a press to shrink must come back to the step below the
+     * fit rather than to the step below 12.
+     */
+    expect(steppedZoom({ kind: "fixed", scale: 12 }, 1, "out")).toEqual({
+      kind: "fixed",
+      scale: 0.75,
+    });
+  });
 });

--- a/packages/builder/src/canvas-zoom.ts
+++ b/packages/builder/src/canvas-zoom.ts
@@ -101,13 +101,23 @@ export function writeZoom(zoom: CanvasZoom): "fit" | number {
  * From FIT it steps off the scale the fit produced, so the first press moves
  * from what the author is looking at rather than jumping to an end of the
  * list. That needs the fit scale passed in, because only the canvas knows it.
+ *
+ * A scale the canvas cannot paint steps from the fit scale as well, for the
+ * same reason and by the rule {@link usableScale} states: a host can construct
+ * `{ kind: "fixed", scale }` with any number the type admits, and the canvas
+ * already falls back to fit when it cannot use one. Stepping from the raw value
+ * instead makes every comparison against `NaN` false, so both directions return
+ * the zoom unchanged — leaving a stepper that cannot move off an unusable
+ * scale, while the canvas is meanwhile painting the fit the steps would come
+ * from.
  */
 export function steppedZoom(
   zoom: CanvasZoom,
   fitScale: number,
   direction: "in" | "out"
 ): CanvasZoom {
-  const from = zoom.kind === "fit" ? fitScale : zoom.scale;
+  const from =
+    zoom.kind === "fit" ? fitScale : (usableScale(zoom.scale) ?? fitScale);
   const candidates =
     direction === "in"
       ? ZOOM_STEPS.filter(step => step > from + 1e-9)

--- a/packages/builder/src/shell-state.test.ts
+++ b/packages/builder/src/shell-state.test.ts
@@ -9,10 +9,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  CANVAS_GUTTER,
   DEFAULT_PREFERENCES,
   fitsFullShell,
   isLeftPanel,
   LEFT_PANELS,
+  MIN_CANVAS_PANEL_WIDTH,
   MIN_CANVAS_WIDTH,
   MIN_SHELL_WIDTH,
   panelAfterRailClick,
@@ -128,13 +130,31 @@ describe("the bounds the library is handed", () => {
 
     // So the floor is declared on the canvas itself, and the supported viewport
     // must be able to satisfy every minimum at once — otherwise the shell would
-    // hand the library a set of bounds with no solution.
+    // hand the library a set of bounds with no solution. The PANEL width is
+    // what the library is handed, so it is the term that has to fit.
     expect(
       RAIL_WIDTH +
         PANEL_BOUNDS.left.min +
         PANEL_BOUNDS.inspector.min +
-        MIN_CANVAS_WIDTH
+        MIN_CANVAS_PANEL_WIDTH
     ).toBeLessThanOrEqual(MIN_SHELL_WIDTH);
+  });
+
+  it("spends the gutters on top of the floor, not out of it", () => {
+    /*
+     * The floor is a statement about the EDITING SURFACE, and the panel is the
+     * only thing a resize bound can be expressed on. Bounding the panel at the
+     * surface's own number spends the gap out of the page: the drag would stop
+     * at 480px of panel holding 448px of canvas, which is past the floor that
+     * exists to stop it.
+     *
+     * Asserted as the subtraction the layout actually performs rather than as
+     * the sum the constant is defined by — restating `min + 2 * gutter` here
+     * would pass on any pair of numbers, including a gutter of zero that the
+     * region's padding contradicts.
+     */
+    expect(MIN_CANVAS_PANEL_WIDTH - CANVAS_GUTTER * 2).toBe(MIN_CANVAS_WIDTH);
+    expect(CANVAS_GUTTER).toBeGreaterThan(0);
   });
 });
 

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -84,8 +84,32 @@ export const RAIL_WIDTH = 48;
  *
  * The canvas is the thing being edited, so it is the region with a floor rather
  * than the one that absorbs whatever is left.
+ *
+ * This is the EDITING SURFACE, not the panel holding it. The panel is wider by
+ * its gutters, and {@link MIN_CANVAS_PANEL_WIDTH} is what a bound is read from.
  */
 export const MIN_CANVAS_WIDTH = 480;
+
+/**
+ * The gap between the canvas region's edge and the page inside it, per side.
+ *
+ * Declared rather than written as a utility class because it is load-bearing
+ * twice: it is the space the page's own edge is painted into, and it is the
+ * difference between the editing surface and the panel that has to contain it.
+ * Spelled in one place so the two cannot drift.
+ */
+export const CANVAS_GUTTER = 16;
+
+/**
+ * The narrowest the canvas PANEL may become, gutters included.
+ *
+ * DERIVED, because the constraint is on the editing surface and the panel is
+ * the thing a resize bound can be expressed on. Bounding the panel at the
+ * surface's own floor spends the gutters out of the surface: at 480px of panel
+ * the page has 448px, so the drag stops only once the canvas is already
+ * narrower than the floor that exists to stop it.
+ */
+export const MIN_CANVAS_PANEL_WIDTH = MIN_CANVAS_WIDTH + CANVAS_GUTTER * 2;
 
 /**
  * The narrowest viewport the full shell is supported at (PB-D17 D10-5).

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -948,6 +948,24 @@
 .nx-canvas {
   position: relative;
   /*
+   * The page's own surface.
+   *
+   * The frame is `--nx-builder-surface`, a shade off the background so it
+   * recedes behind the canvas. With no surface of its own the canvas INHERITS
+   * that frame, so the page being composed is drawn on the editor's grey — and
+   * a block declares no background, so the grey shows through the document
+   * itself. What an author edits then looks nothing like what a visitor loads,
+   * which is the one thing this canvas exists to show.
+   *
+   * The token rather than a literal, so a host re-theming the admin moves the
+   * page with it, exactly as the frame already does.
+   *
+   * The frame only becomes visible BESIDE the page where the canvas is
+   * bounded: at full width the page is the region, and there are no edges to
+   * frame. A narrower tier, or zooming out, reveals it.
+   */
+  background-color: var(--nx-builder-surface-raised);
+  /*
    * Fills the region rather than stopping at its content.
    *
    * Without this the canvas is exactly as tall as the blocks in it, so the area

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -966,6 +966,33 @@
    */
   background-color: var(--nx-builder-surface-raised);
   /*
+   * A SHEET, not a region that happens to be a different colour.
+   *
+   * The surface alone separates the page from the frame only where the two
+   * tones differ enough to read, and they deliberately do not: the frame is one
+   * step off the background so it recedes. A border states the page's edge at
+   * any tone, in either mode — `--nx-builder-border` is 0.92 against a 0.99
+   * page in light and 0.26 against a 0.00 page in dark, so the edge survives
+   * the palette inverting while the two surfaces swap which of them is lighter.
+   *
+   * The shadow is the secondary cue and is allowed to be nearly invisible in
+   * dark, where a cast shadow has almost nothing to darken. Carrying the
+   * separation on the BORDER rather than the shadow is what keeps both modes
+   * equally legible instead of tuning one and checking the other.
+   *
+   * No radius, deliberately. The drop indicator and the selection chrome are
+   * positioned in this element's own content coordinates and are not clipped by
+   * it; rounding the corners without clipping leaves a block's own background
+   * squaring them off, and clipping to fix that would cut the drag chrome the
+   * canvas exists to draw.
+   *
+   * Stated on the PAGE rather than on the region around it, so the page is a
+   * self-contained sheet: several of them side by side — one per breakpoint —
+   * would each carry their own edge with nothing about this rule to revisit.
+   */
+  border: 1px solid var(--nx-builder-border);
+  box-shadow: var(--shadow-md);
+  /*
    * Fills the region rather than stopping at its content.
    *
    * Without this the canvas is exactly as tall as the blocks in it, so the area

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -989,8 +989,22 @@
    * Stated on the PAGE rather than on the region around it, so the page is a
    * self-contained sheet: several of them side by side — one per breakpoint —
    * would each carry their own edge with nothing about this rule to revisit.
+   *
+   * An OUTLINE rather than a border, and that is a correctness requirement
+   * rather than a preference. This element carries three things at once: the
+   * width a tier is previewed at, `container-type: inline-size`, and this edge.
+   * Container queries resolve against the CONTENT box, and the shell resets its
+   * whole subtree to `box-sizing: border-box` — so a border here is subtracted
+   * from the width the page is being previewed at. Two pixels is enough to
+   * decide a tier: a 992px request lays out 990px of content, the widest
+   * `max-width: 991px` rule stays active, and the unconditional tier becomes
+   * unreachable from the switcher. The `ResizeObserver` reads `contentRect` and
+   * reports the same narrowed width, so the tier readout agrees with the wrong
+   * answer. An outline is painted outside the border box and takes part in no
+   * layout, so the page keeps exactly the width it was asked for. It has room
+   * to paint because the region around it is padded.
    */
-  border: 1px solid var(--nx-builder-border);
+  outline: 1px solid var(--nx-builder-border);
   box-shadow: var(--shadow-md);
   /*
    * Fills the region rather than stopping at its content.


### PR DESCRIPTION
Tracker rows **U-11, U-8, U-12, U-10** — all four are the builder's chrome, so one PR.

## U-11 — the page had no surface of its own

The canvas declared no background, so it **inherited the editor's frame** — and a block declares none either, so the grey showed *through* the document. What an author composed looked nothing like what a visitor loads.

This was not a design decision to make. `builder-chrome.css` already says the frame is deliberately off-white *"because the canvas uses `--nx-background`"*, and that *"the canvas must look like the finished page"*. **The intent was written down; only the declaration was missing.**

The page is now a sheet: its own surface, a border, and 16px of room around it.

**The border carries the separation, not tone or shadow — because which surface is lighter INVERTS between modes.** Measured: page `98.84` on a `96.52` frame in light; `0` on `10.68` in dark. Tone alone would need tuning twice and checking twice. One border token sits outside both on either side of that inversion. The shadow is secondary and is allowed to nearly vanish in dark, where it has almost nothing to darken.

**No radius, deliberately.** The drop indicator and selection chrome are positioned in the canvas's own coordinates and are not clipped by it — rounding without clipping gets squared off by a block's own background, and clipping would cut the drag chrome the canvas exists to draw. Worth solving properly if we want it, not styling around.

Everything is stated on the **page**, not the region, so several sheets side by side — one per breakpoint — would each carry their own edge with nothing here to revisit.

## U-8, U-12 — glyphs, and one trap avoided

Exit, the breakpoint manager and the tier tabs were spending **~170px** of a bar whose job is to get out of the way. Each is a glyph now; each kept its accessible name and gained a tooltip.

**A tier's glyph comes from `maxWidth`, never its label.** A tier is named by the site — "Tablet" on one, "Kiosk" or "Watch" on another — so a name lookup answers for the words somebody happened to use and has nothing to say for any site that chose differently.

**The selected tier keeps its word, and this is the half that was easy to get wrong.** The width readout beside these tabs is *deliberately empty* while the selection already names the applying tier (the code cites Gutenberg finding a badge confusing at the widest tier). Icon-only throughout would therefore have taken the tier name off the screen entirely in the commonest state — and two tiers can share a glyph, leaving identical pictures as the only thing telling them apart.

## U-10 — the stepper the model already had

`steppedZoom` was **exported with no caller**: stepping was reachable from a host and not from the editor. The `−` / `+` buttons are its first consumer, so this is wiring, not new arithmetic.

Each direction disables where the step list ends, because that function returns the zoom it was given at the extremes and a button left enabled would depress and change nothing.

## A test change worth reviewing

The zoom tests asked for `"the button"` and there are three now. They name the trigger instead — which also keeps them about the *readout*: a query that silently resolved to the minus button would still find a button and still read a percentage.

## Evidence

- Verified in a real browser in **both modes**, not just asserted: light page `lab(98.84)` on frame `lab(96.52)`; dark page `lab(0)` on frame `lab(10.68)`; border `lab(90.72)` / `lab(14.16)`.
- Break-verified: removing the background, and declaring the *frame's own* token instead — the second is the one a naive "has a background" test would miss.
- builder **93 files / 2619 tests**, plugin-page-builder **50 / 524**, lint 0, check-types 0, `fallow` **pass** (7 files, 0 introduced).

## Known cost

The 16px gap costs 32px of canvas width (879px vs 911px at this viewport). The fit follows it correctly — `canvasScale` observes the region's content box — which is why the width readout moves with the padding rather than the page painting over it.