### PR TITLE
test(nextly): fit the wildcard fixture's version id in MySQL's varchar(36)

### DIFF
--- a/packages/nextly/src/domains/collections/__tests__/wildcard-locale-contract.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/wildcard-locale-contract.integration.test.ts
@@ -10,6 +10,8 @@
  *
  * @module domains/collections/__tests__/wildcard-locale-contract.integration.test
  */
+import { randomUUID } from "node:crypto";
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { defineCollection, defineSingle, text } from "../../../config";
@@ -690,7 +692,10 @@ describe.each(getConfiguredTestDialects())(
 
       // A pending edit in `fr`, which this app does not configure.
       await t.adapter.insert("nextly_versions", {
-        id: `stale-${id}`,
+        // `nextly_versions.id` is varchar(36) on MySQL, a width a UUID exactly
+        // fills, so a prefixed id does not fit. Nothing reads this value: the
+        // row is located by entryId and locale.
+        id: randomUUID(),
         scopeKind: "collection",
         scopeSlug: DRAFTS_SLUG,
         entryId: id,


### PR DESCRIPTION
Repairs `main`, which is red on `c2f01c621` (#1420).

## What failed

`Integration (mysql)` — **1 test of 1881**. Every other check on that commit
passed, including the blocking one.

```
FAIL src/domains/collections/__tests__/wildcard-locale-contract.integration.test.ts
  > the wildcard locale's contract (mysql)
  > is not blocked forever by work held in a language that was removed

ER_DATA_TOO_LONG (errno 1406, sqlState 22001)
Data too long for column 'id' at row 1
```

## Why

Not a product defect. The suite hand-inserts a `nextly_versions` row and built
its primary key as `` `stale-${uuid}` `` — 42 characters.

| dialect | `nextly_versions.id` | result |
| --- | --- | --- |
| MySQL | `varchar("id", { length: 36 })` | rejects 42 chars |
| Postgres | `text` | accepts |
| SQLite | `text` | accepts |

`varchar(36)` is exactly a UUID's width with no slack, so a prefixed id
overflows it. Nothing in the product builds such an id — a search of
`packages/nextly/src` excluding `__tests__` returns only unrelated prose and a
`stale-while-revalidate` header.

## Why it surfaced only after the merge

The sqlite leg finished in ~4 minutes and postgres passed as well; the mysql
leg runs ~27. Both fast legs had reported green while the slow one was still
running, so the board at merge time showed nothing wrong — the check that would
fail had not spoken yet.

## The fix

`randomUUID()` from `node:crypto`, which is the convention in
`storage-migration.integration.test.ts` and elsewhere. The value is a primary
key nothing reads: the row is located by `entryId` and `locale`, so the test
exercises exactly what it did before. A comment records the width constraint so
the prefix is not reintroduced.

## Verification

Run against the real MySQL container, both ways:

| fixture | result |
| --- | --- |
| `randomUUID()` | **32 passed, 0 failed** |
| `stale-${id}` restored | **1 failed** — `ER_DATA_TOO_LONG`, identical to CI |

The break-verify also confirms the MySQL leg executed, since that error can
only originate there — a green run alone would not have shown it.

## No changeset

Deliberate, and checked rather than assumed: the CI gate validates changesets a
PR *touches* and does not require one, and both test-only commits among main's
last 60 carry none. A changeset here would bump all 25 lockstep packages with a
changelog entry no user can act on. Happy to add one if preferred.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved integration test reliability across database configurations.
  * Updated test data generation to use valid, universally supported identifiers.
  * Added coverage safeguards for locale-specific collection version handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->