### PR TITLE
feat(admin): put the webhook signing secret before the form

### DIFF
--- a/.changeset/the-secret-comes-first.md
+++ b/.changeset/the-secret-comes-first.md
@@ -1,0 +1,47 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The webhook signing secret is now the first thing on the edit page, not the last.
+
+Setting up an endpoint means copying the signing secret into the receiving
+system. That value sat below every configuration field, so the task a person
+arrives to do was reachable only by scrolling past the form they had not come to
+edit — and on a short window it was not visible at all.
+
+The secret, its rotation controls and the link to the delivery log now sit in
+one panel under the page header, which is where an integration credential lives
+in every service a developer already uses. Configuration keeps its own reading
+order beneath, and deletion stays at the bottom: the one irreversible act on the
+page is not something to put where a reader lands.
+
+Nothing changes about who may do what. Rotation was never gated on the update
+permission and still is not, which is pinned by a test so a later reading of
+`canManage` as "may rotate" has to be a deliberate change.
+
+The create page shows no panel, because an endpoint has no secret until it
+exists.

--- a/packages/admin/src/components/features/webhooks/EditWebhookLayout.tsx
+++ b/packages/admin/src/components/features/webhooks/EditWebhookLayout.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+/**
+ * The order the edit page's three regions appear in.
+ *
+ * A component rather than three siblings in the page, because the ORDER is the
+ * decision and a decision spread across a JSX body is one nothing can hold. The
+ * page hands over what goes in each region; where they land is settled here,
+ * once, and a test of this component is therefore a test of what a reader gets
+ * — not of a fixture that happens to be arranged the same way.
+ *
+ * The order, and why:
+ *
+ * 1. `credential` — the signing secret. What a person copies when WIRING UP the
+ *    endpoint, which is the task they arrive to do.
+ * 2. `configuration` — the form. What they came to change on every later visit.
+ * 3. `dangerZone` — deletion. The one irreversible act, last, because a
+ *    destructive control where a reader lands is reached by accident more often
+ *    than on purpose.
+ *
+ * `credential` is optional: an endpoint has no secret until it exists, so the
+ * create page passes none and the region is absent rather than empty.
+ *
+ * @module components/features/webhooks/EditWebhookLayout
+ */
+
+import type React from "react";
+
+export interface EditWebhookLayoutProps {
+  /** The signing secret and its acts. Absent while creating. */
+  credential?: React.ReactNode;
+  configuration: React.ReactNode;
+  dangerZone?: React.ReactNode;
+}
+
+export const EditWebhookLayout: React.FC<EditWebhookLayoutProps> = ({
+  credential,
+  configuration,
+  dangerZone,
+}) => {
+  return (
+    <div data-testid="edit-webhook-layout">
+      {credential ? (
+        <div data-testid="region-credential">{credential}</div>
+      ) : null}
+      <div data-testid="region-configuration">{configuration}</div>
+      {dangerZone ? <div data-testid="region-danger">{dangerZone}</div> : null}
+    </div>
+  );
+};

--- a/packages/admin/src/components/features/webhooks/WebhookCredentialPanel.test.tsx
+++ b/packages/admin/src/components/features/webhooks/WebhookCredentialPanel.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * The signing secret must be reachable WITHOUT scrolling past the form.
+ *
+ * The complaint this answers is positional rather than functional: every
+ * control worked, and a person setting an endpoint up could not find the value
+ * they had come for. So the property under test is ORDER — the credential panel
+ * precedes the configuration form in the document — which is what a screen
+ * reader announces first and what a sighted reader meets first.
+ *
+ * Asserted through DOM position rather than by checking a class name. A class
+ * says what was written; `compareDocumentPosition` says what the reader gets,
+ * and the two stop agreeing the moment anything wraps the panel.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { WebhookSecretInfo } from "@admin/types/webhooks";
+
+import { WebhookCredentialPanel } from "./WebhookCredentialPanel";
+
+afterEach(cleanup);
+
+const SECRETS: WebhookSecretInfo[] = [
+  {
+    prefix: "whsec_abc",
+    isPrimary: true,
+    createdAt: "2026-08-20T10:00:00.000Z",
+    expiresAt: null,
+  },
+];
+
+function panel(
+  overrides: Partial<React.ComponentProps<typeof WebhookCredentialPanel>> = {}
+) {
+  return (
+    <WebhookCredentialPanel
+      secrets={SECRETS}
+      canManage
+      onReveal={vi.fn()}
+      isRevealing={false}
+      onRotate={vi.fn()}
+      isRotating={false}
+      onExpireOld={vi.fn()}
+      isExpiring={false}
+      deliveriesHref="/admin/settings/webhooks/w1/deliveries"
+      {...overrides}
+    />
+  );
+}
+
+describe("the credential panel comes before the configuration form", () => {
+  it("precedes the form in document order", () => {
+    render(
+      <div>
+        {panel()}
+        <form data-testid="config-form">
+          <input aria-label="Name" />
+        </form>
+      </div>
+    );
+
+    const credential = screen.getByTestId("webhook-credential-panel");
+    const form = screen.getByTestId("config-form");
+
+    /*
+     * DOCUMENT_POSITION_FOLLOWING means `form` comes after `credential`. The
+     * inverse constant is what the old layout would satisfy, so this assertion
+     * separates the two arrangements rather than merely observing that both
+     * elements exist.
+     */
+    expect(
+      credential.compareDocumentPosition(form) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it("carries the three acts a person needs on the secret", () => {
+    render(panel());
+    expect(screen.getByText("Reveal signing secret")).toBeDefined();
+    expect(screen.getByText("Rotate signing secret")).toBeDefined();
+    expect(screen.getByText("View deliveries")).toBeDefined();
+  });
+
+  /*
+   * Rotation was NOT permission-gated before this panel existed, and moving a
+   * control must not change who may use it. Pinned so a later reading of
+   * `canManage` as "may rotate" is a deliberate change rather than a drift.
+   */
+  it("offers rotation regardless of manage permission", () => {
+    render(panel({ canManage: false }));
+    expect(screen.getByText("Rotate signing secret")).toBeDefined();
+  });
+
+  it("links deliveries at the href it is given", () => {
+    render(panel());
+    const link = screen.getByText("View deliveries").closest("a");
+    expect(link?.getAttribute("href")).toBe(
+      "/admin/settings/webhooks/w1/deliveries"
+    );
+  });
+});

--- a/packages/admin/src/components/features/webhooks/WebhookCredentialPanel.test.tsx
+++ b/packages/admin/src/components/features/webhooks/WebhookCredentialPanel.test.tsx
@@ -16,6 +16,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { WebhookSecretInfo } from "@admin/types/webhooks";
 
+import { EditWebhookLayout } from "./EditWebhookLayout";
 import { WebhookCredentialPanel } from "./WebhookCredentialPanel";
 
 afterEach(cleanup);
@@ -49,29 +50,59 @@ function panel(
 }
 
 describe("the credential panel comes before the configuration form", () => {
-  it("precedes the form in document order", () => {
+  /*
+   * Asserted through `EditWebhookLayout` — the component the page actually
+   * renders — rather than through a fixture arranged here. A test that lays out
+   * its own regions cannot fail when the PAGE puts them back the other way
+   * round, which is the regression worth catching: it would report the ordering
+   * as covered while the production order was free to move.
+   */
+  it("precedes the form in document order, as the page composes it", () => {
     render(
-      <div>
-        {panel()}
-        <form data-testid="config-form">
-          <input aria-label="Name" />
-        </form>
-      </div>
+      <EditWebhookLayout
+        credential={panel()}
+        configuration={
+          <form data-testid="config-form">
+            <input aria-label="Name" />
+          </form>
+        }
+      />
     );
 
     const credential = screen.getByTestId("webhook-credential-panel");
     const form = screen.getByTestId("config-form");
 
-    /*
-     * DOCUMENT_POSITION_FOLLOWING means `form` comes after `credential`. The
-     * inverse constant is what the old layout would satisfy, so this assertion
-     * separates the two arrangements rather than merely observing that both
-     * elements exist.
-     */
     expect(
       credential.compareDocumentPosition(form) &
         Node.DOCUMENT_POSITION_FOLLOWING
     ).toBeTruthy();
+  });
+
+  it("puts the irreversible act last", () => {
+    render(
+      <EditWebhookLayout
+        credential={panel()}
+        configuration={<form data-testid="config-form" />}
+        dangerZone={<button type="button">Delete endpoint</button>}
+      />
+    );
+
+    const form = screen.getByTestId("region-configuration");
+    const danger = screen.getByTestId("region-danger");
+    expect(
+      form.compareDocumentPosition(danger) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  /*
+   * The create page has no secret to show, so the region must be absent rather
+   * than an empty box asking the author to ignore it.
+   */
+  it("omits the credential region entirely when there is none", () => {
+    render(
+      <EditWebhookLayout configuration={<form data-testid="config-form" />} />
+    );
+    expect(screen.queryByTestId("region-credential")).toBeNull();
   });
 
   it("carries the three acts a person needs on the secret", () => {

--- a/packages/admin/src/components/features/webhooks/WebhookCredentialPanel.tsx
+++ b/packages/admin/src/components/features/webhooks/WebhookCredentialPanel.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+/**
+ * The endpoint's signing secret, and the acts that operate on it.
+ *
+ * Rendered ABOVE the configuration form, because the two are read at different
+ * moments and the secret is read first. Setting an endpoint up means copying
+ * this value into the receiving system; that is the task a person arrives to do,
+ * and it sat after every configuration field, reachable only by scrolling past
+ * the form. A credential belongs to the endpoint rather than inside its
+ * settings — the arrangement every developer already knows from the API keys and
+ * webhook secrets of the services they integrate with.
+ *
+ * Editing the configuration is the other moment, and it does not lose by this:
+ * the fields keep their own reading order beneath, and the panel is a fixed
+ * height that does not grow with the form.
+ *
+ * NOT rendered while creating. An endpoint has no secret until it exists, so
+ * there is nothing here to show and an empty shell would only ask the author to
+ * ignore it. The create page therefore mounts this at all.
+ *
+ * @module components/features/webhooks/WebhookCredentialPanel
+ */
+
+import { Button } from "@nextlyhq/ui";
+import type React from "react";
+
+import { Eye, List, Loader2, RefreshCw } from "@admin/components/icons";
+import { Link } from "@admin/components/ui/link";
+import type { WebhookSecretInfo } from "@admin/types/webhooks";
+
+import { SecretLifecycle } from "./SecretLifecycle";
+
+export interface WebhookCredentialPanelProps {
+  secrets: WebhookSecretInfo[];
+  /** Update permission gates rotation and early expiry, not reading. */
+  canManage: boolean;
+  onReveal: () => void;
+  isRevealing: boolean;
+  onRotate: () => void;
+  isRotating: boolean;
+  onExpireOld: () => void;
+  isExpiring: boolean;
+  /** Where the delivery log lives, so the panel does not need to know routes. */
+  deliveriesHref: string;
+}
+
+export const WebhookCredentialPanel: React.FC<WebhookCredentialPanelProps> = ({
+  secrets,
+  canManage,
+  onReveal,
+  isRevealing,
+  onRotate,
+  isRotating,
+  onExpireOld,
+  isExpiring,
+  deliveriesHref,
+}) => {
+  return (
+    <section
+      data-testid="webhook-credential-panel"
+      aria-label="Signing secret"
+      className="mb-6 rounded-lg border border-border bg-card p-4"
+    >
+      <SecretLifecycle
+        secrets={secrets}
+        canManage={canManage}
+        onExpireOld={onExpireOld}
+        isExpiring={isExpiring}
+      />
+
+      {/* Wraps rather than overflowing: three labelled buttons exceed a narrow
+          settings column, and a control pushed off-screen is one nobody finds. */}
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onReveal}
+          disabled={isRevealing}
+        >
+          {isRevealing ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <Eye className="h-4 w-4" />
+          )}
+          Reveal signing secret
+        </Button>
+
+        <Button
+          type="button"
+          variant="outline"
+          onClick={onRotate}
+          disabled={isRotating}
+        >
+          {isRotating ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RefreshCw className="h-4 w-4" />
+          )}
+          Rotate signing secret
+        </Button>
+
+        <Link href={deliveriesHref}>
+          <Button type="button" variant="outline">
+            <List className="h-4 w-4" />
+            View deliveries
+          </Button>
+        </Link>
+      </div>
+    </section>
+  );
+};

--- a/packages/admin/src/hooks/useWebhookDeletion.test.ts
+++ b/packages/admin/src/hooks/useWebhookDeletion.test.ts
@@ -1,0 +1,56 @@
+/**
+ * A destructive act must not fire before the thing it destroys has loaded.
+ *
+ * Hooks cannot be called conditionally, so this one is mounted while the
+ * endpoint document is still in flight — a window in which its name is not
+ * known. The handler this was extracted from returned early on exactly that
+ * (`if (!webhook) return;`), and an extraction that drops a guard leaves a
+ * delete whose only remaining protection is that nothing currently calls it.
+ *
+ * Today the confirmation dialog stands in the way, which is why this cannot be
+ * observed through the page — and is precisely why the guard belongs to the
+ * hook rather than to whichever caller remembers it.
+ */
+import { renderHook, act } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { deleteSpy } = vi.hoisted(() => ({ deleteSpy: vi.fn() }));
+
+vi.mock("@admin/hooks/queries/useWebhooks", () => ({
+  useDeleteWebhook: () => ({ mutate: deleteSpy, isPending: false }),
+}));
+vi.mock("@admin/components/ui", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+vi.mock("@admin/lib/navigation", () => ({ navigateTo: vi.fn() }));
+
+const { useWebhookDeletion } = await import("./useWebhookDeletion");
+
+beforeEach(() => {
+  deleteSpy.mockReset();
+});
+
+describe("deleting a webhook endpoint", () => {
+  it("refuses while the endpoint has not loaded", () => {
+    const { result } = renderHook(() => useWebhookDeletion("w1", null));
+
+    act(() => {
+      result.current.confirm();
+    });
+
+    // The outcome, not the guard: no delete was ISSUED. Asserting the early
+    // return itself would pass against a hook that returned and deleted anyway.
+    expect(deleteSpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes once the endpoint is known", () => {
+    const { result } = renderHook(() => useWebhookDeletion("w1", "Order sync"));
+
+    act(() => {
+      result.current.confirm();
+    });
+
+    expect(deleteSpy).toHaveBeenCalledTimes(1);
+    expect(deleteSpy.mock.calls[0][0]).toBe("w1");
+  });
+});

--- a/packages/admin/src/hooks/useWebhookDeletion.ts
+++ b/packages/admin/src/hooks/useWebhookDeletion.ts
@@ -31,12 +31,30 @@ export interface WebhookDeletion {
 /**
  * `name` is captured for the success message BEFORE the row is gone, which is
  * why it is a parameter rather than read from a document the delete invalidates.
+ *
+ * NULLABLE on purpose, and it is the readiness signal rather than a nicety. A
+ * caller mounts this hook while the endpoint is still loading — hooks cannot be
+ * called conditionally — so there is a window in which the document does not
+ * exist yet. Passing `null` for it says so, and `confirm` refuses rather than
+ * deleting a row whose name it would then report as an empty string.
+ *
+ * A default of `""` would type-check and read as harmless, which is what makes
+ * it the wrong shape: it turns "not loaded yet" into a legal value and leaves
+ * the guard to whichever caller remembers it. Today only the confirmation
+ * dialog stands between that window and a destructive write, and a guard that
+ * depends on the current call graph is one the call graph is free to remove.
  */
-export function useWebhookDeletion(id: string, name: string): WebhookDeletion {
+export function useWebhookDeletion(
+  id: string,
+  name: string | null
+): WebhookDeletion {
   const { mutate: doDelete, isPending: isDeleting } = useDeleteWebhook();
   const [confirming, setConfirming] = useState(false);
 
   const confirm = useCallback(() => {
+    // Refuses rather than proceeding: the endpoint is not loaded, so there is
+    // nothing to confirm the deletion OF.
+    if (name === null) return;
     doDelete(id, {
       onSuccess: () => {
         toast.success("Endpoint deleted", {

--- a/packages/admin/src/hooks/useWebhookDeletion.ts
+++ b/packages/admin/src/hooks/useWebhookDeletion.ts
@@ -1,0 +1,54 @@
+"use client";
+
+/**
+ * Deleting an endpoint: the confirmation it requires, and the act itself.
+ *
+ * Its own hook for the same reason the secret's actions are — a destructive act
+ * with a confirmation gate is a concern, not a line of the page. Kept SEPARATE
+ * from `useWebhookSecretActions` rather than folded in with it: rotating a
+ * secret and deleting an endpoint are gated on different permissions and have
+ * different consequences, and one hook holding both would invite a caller to
+ * treat them as interchangeable.
+ *
+ * @module hooks/useWebhookDeletion
+ */
+
+import { useCallback, useState } from "react";
+
+import { toast } from "@admin/components/ui";
+import { ROUTES } from "@admin/constants/routes";
+import { useDeleteWebhook } from "@admin/hooks/queries/useWebhooks";
+import { apiErrorMessage } from "@admin/lib/api/parseApiError";
+import { navigateTo } from "@admin/lib/navigation";
+
+export interface WebhookDeletion {
+  confirming: boolean;
+  setConfirming: (open: boolean) => void;
+  confirm: () => void;
+  isDeleting: boolean;
+}
+
+/**
+ * `name` is captured for the success message BEFORE the row is gone, which is
+ * why it is a parameter rather than read from a document the delete invalidates.
+ */
+export function useWebhookDeletion(id: string, name: string): WebhookDeletion {
+  const { mutate: doDelete, isPending: isDeleting } = useDeleteWebhook();
+  const [confirming, setConfirming] = useState(false);
+
+  const confirm = useCallback(() => {
+    doDelete(id, {
+      onSuccess: () => {
+        toast.success("Endpoint deleted", {
+          description: `"${name}" will no longer receive events.`,
+        });
+        navigateTo(ROUTES.SETTINGS_WEBHOOKS);
+      },
+      onError: (err: Error) => {
+        toast.error("Delete failed", { description: apiErrorMessage(err) });
+      },
+    });
+  }, [doDelete, id, name]);
+
+  return { confirming, setConfirming, confirm, isDeleting };
+}

--- a/packages/admin/src/hooks/useWebhookSecretActions.ts
+++ b/packages/admin/src/hooks/useWebhookSecretActions.ts
@@ -1,0 +1,124 @@
+"use client";
+
+/**
+ * Everything the signing secret's own lifecycle needs: revealing it, rotating
+ * it, and retiring an overlapping predecessor early.
+ *
+ * Split from the edit page because it is a different concern from editing the
+ * endpoint's configuration. The page fetches a document and saves a form; these
+ * three acts operate on a credential, each owns a piece of transient state — a
+ * revealed value, a one-time rotation result, a confirmation — and none of it
+ * outlives the page or belongs to the form.
+ *
+ * The state is here rather than in the panel that renders it because two of the
+ * three results are shown in MODALS, which the page mounts. A panel owning state
+ * its sibling renders would be the same coupling wearing a different shape.
+ *
+ * @module hooks/useWebhookSecretActions
+ */
+
+import { useCallback, useState } from "react";
+
+import { toast } from "@admin/components/ui";
+import {
+  useExpireOldSecrets,
+  useRevealSecret,
+  useRotateSecret,
+} from "@admin/hooks/queries/useWebhooks";
+import { apiErrorMessage } from "@admin/lib/api/parseApiError";
+
+export interface WebhookSecretActions {
+  /** Secrets returned by a reveal, shown in a modal until dismissed. */
+  revealed: string[] | null;
+  dismissRevealed: () => void;
+  reveal: () => void;
+  isRevealing: boolean;
+  /** The one-time secret a rotation mints, shown once. */
+  rotated: string | null;
+  dismissRotated: () => void;
+  confirmingRotate: boolean;
+  setConfirmingRotate: (open: boolean) => void;
+  rotate: (overlapSeconds: number) => void;
+  isRotating: boolean;
+  expireOld: () => void;
+  isExpiring: boolean;
+}
+
+export function useWebhookSecretActions(id: string): WebhookSecretActions {
+  const { mutate: doReveal, isPending: isRevealing } = useRevealSecret();
+  const { mutate: doRotate, isPending: isRotating } = useRotateSecret();
+  const { mutate: doExpireOld, isPending: isExpiring } = useExpireOldSecrets();
+
+  const [revealed, setRevealed] = useState<string[] | null>(null);
+  const [rotated, setRotated] = useState<string | null>(null);
+  const [confirmingRotate, setConfirmingRotate] = useState(false);
+
+  const reveal = useCallback(() => {
+    doReveal(id, {
+      onSuccess: setRevealed,
+      onError: (err: Error) => {
+        toast.error("Could not reveal the secret", {
+          description: apiErrorMessage(err),
+        });
+      },
+    });
+  }, [doReveal, id]);
+
+  const rotate = useCallback(
+    (overlapSeconds: number) => {
+      doRotate(
+        { id, input: { overlapSeconds } },
+        {
+          onSuccess: result => {
+            setConfirmingRotate(false);
+            // The fresh secret is shown once here; the reveal action can return
+            // it again later while it remains the primary.
+            setRotated(result.secret);
+            toast.success("Signing secret rotated", {
+              description:
+                overlapSeconds > 0
+                  ? "The previous secret keeps working until the overlap window ends."
+                  : "The previous secret was retired immediately.",
+            });
+          },
+          onError: (err: Error) => {
+            toast.error("Could not rotate the secret", {
+              description: apiErrorMessage(err),
+            });
+          },
+        }
+      );
+    },
+    [doRotate, id]
+  );
+
+  const expireOld = useCallback(() => {
+    doExpireOld(id, {
+      onSuccess: () => {
+        toast.success("Old signing secret expired", {
+          description: "Only the current secret can sign deliveries now.",
+        });
+      },
+      onError: (err: Error) => {
+        toast.error("Could not expire the old secret", {
+          description: apiErrorMessage(err),
+        });
+      },
+    });
+  }, [doExpireOld, id]);
+
+  return {
+    revealed,
+    dismissRevealed: useCallback(() => setRevealed(null), []),
+    reveal,
+    isRevealing,
+    rotated,
+    dismissRotated: useCallback(() => setRotated(null), []),
+    confirmingRotate,
+    setConfirmingRotate,
+    rotate,
+    isRotating,
+    expireOld,
+    isExpiring,
+  };
+}

--- a/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
@@ -6,6 +6,7 @@ import { useCallback } from "react";
 
 import { SettingsLayout } from "@admin/components/features/settings/SettingsLayout";
 import { DeleteWebhookDialog } from "@admin/components/features/webhooks/DeleteWebhookDialog";
+import { EditWebhookLayout } from "@admin/components/features/webhooks/EditWebhookLayout";
 import { RotateSecretDialog } from "@admin/components/features/webhooks/RotateSecretDialog";
 import { WebhookCredentialPanel } from "@admin/components/features/webhooks/WebhookCredentialPanel";
 import { WebhookForm } from "@admin/components/features/webhooks/WebhookForm";
@@ -44,7 +45,8 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
   const { data: webhook, isLoading, isError, error } = useWebhook(id);
   const { mutate: doUpdate, isPending } = useUpdateWebhook();
   const secretActions = useWebhookSecretActions(id);
-  const deletion = useWebhookDeletion(id, webhook?.name ?? "");
+  // `null` while the document is loading — the hook refuses to delete on it.
+  const deletion = useWebhookDeletion(id, webhook?.name ?? null);
 
   // Reaching this page requires update-webhooks (registry-gated). Delete is a
   // separate grant, but `update-webhooks` is the management umbrella that
@@ -97,50 +99,52 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
   return (
     <>
       {/*
-       * Above the form deliberately. The secret is what a person copies when
-       * WIRING UP the endpoint, which is the first thing they need and was
-       * previously reachable only by scrolling past every configuration field.
+       * The ORDER is the layout's, not this page's. Stated there once so a
+       * later edit here cannot quietly put the secret back below the form —
+       * moving these props around changes nothing about where they render.
        */}
-      <WebhookCredentialPanel
-        secrets={webhook.secrets}
-        canManage={canManageWebhooks}
-        onReveal={secretActions.reveal}
-        isRevealing={secretActions.isRevealing}
-        onRotate={() => secretActions.setConfirmingRotate(true)}
-        isRotating={secretActions.isRotating}
-        onExpireOld={secretActions.expireOld}
-        isExpiring={secretActions.isExpiring}
-        deliveriesHref={buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, { id })}
-      />
-
-      <WebhookForm
-        defaultValues={toFormValues(webhook)}
-        existingHeaderNames={
-          webhook.headers ? Object.keys(webhook.headers) : []
+      <EditWebhookLayout
+        credential={
+          <WebhookCredentialPanel
+            secrets={webhook.secrets}
+            canManage={canManageWebhooks}
+            onReveal={secretActions.reveal}
+            isRevealing={secretActions.isRevealing}
+            onRotate={() => secretActions.setConfirmingRotate(true)}
+            isRotating={secretActions.isRotating}
+            onExpireOld={secretActions.expireOld}
+            isExpiring={secretActions.isExpiring}
+            deliveriesHref={buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, {
+              id,
+            })}
+          />
         }
-        onSubmit={handleSubmit}
-        isPending={isPending}
-        submitLabel="Save changes"
-        pendingLabel="Saving…"
+        configuration={
+          <WebhookForm
+            defaultValues={toFormValues(webhook)}
+            existingHeaderNames={
+              webhook.headers ? Object.keys(webhook.headers) : []
+            }
+            onSubmit={handleSubmit}
+            isPending={isPending}
+            submitLabel="Save changes"
+            pendingLabel="Saving…"
+          />
+        }
+        dangerZone={
+          canDelete ? (
+            <div className="mt-6 flex justify-end">
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={() => deletion.setConfirming(true)}
+              >
+                Delete endpoint
+              </Button>
+            </div>
+          ) : undefined
+        }
       />
-
-      {/*
-       * Deletion stays BELOW, and after the form. It is the one act here that
-       * cannot be undone, and a destructive control at the top of a page is
-       * reached by accident far more often than on purpose.
-       */}
-      <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div />
-        {canDelete && (
-          <Button
-            type="button"
-            variant="destructive"
-            onClick={() => deletion.setConfirming(true)}
-          >
-            Delete endpoint
-          </Button>
-        )}
-      </div>
 
       <WebhookSecretModal
         open={secretActions.revealed !== null}

--- a/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
+++ b/packages/admin/src/pages/dashboard/settings/webhooks/edit/[id].tsx
@@ -2,31 +2,25 @@
 
 import { Alert, AlertDescription, Button, Skeleton } from "@nextlyhq/ui";
 import type React from "react";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { SettingsLayout } from "@admin/components/features/settings/SettingsLayout";
 import { DeleteWebhookDialog } from "@admin/components/features/webhooks/DeleteWebhookDialog";
 import { RotateSecretDialog } from "@admin/components/features/webhooks/RotateSecretDialog";
-import { SecretLifecycle } from "@admin/components/features/webhooks/SecretLifecycle";
+import { WebhookCredentialPanel } from "@admin/components/features/webhooks/WebhookCredentialPanel";
 import { WebhookForm } from "@admin/components/features/webhooks/WebhookForm";
 import { WebhookSecretModal } from "@admin/components/features/webhooks/WebhookSecretModal";
-import { Eye, List, Loader2, RefreshCw } from "@admin/components/icons";
 import { PageContainer } from "@admin/components/layout/page-container";
 import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
 import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
 import { toast } from "@admin/components/ui";
 import { Link } from "@admin/components/ui/link";
 import { ROUTES, buildRoute } from "@admin/constants/routes";
-import {
-  useDeleteWebhook,
-  useExpireOldSecrets,
-  useRevealSecret,
-  useRotateSecret,
-  useUpdateWebhook,
-  useWebhook,
-} from "@admin/hooks/queries/useWebhooks";
+import { useUpdateWebhook, useWebhook } from "@admin/hooks/queries/useWebhooks";
 import { useCan } from "@admin/hooks/useCan";
 import { useRouter } from "@admin/hooks/useRouter";
+import { useWebhookDeletion } from "@admin/hooks/useWebhookDeletion";
+import { useWebhookSecretActions } from "@admin/hooks/useWebhookSecretActions";
 import { apiErrorMessage } from "@admin/lib/api/parseApiError";
 import { navigateTo } from "@admin/lib/navigation";
 import {
@@ -49,16 +43,8 @@ const WEBHOOK_PAGE = {
 const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
   const { data: webhook, isLoading, isError, error } = useWebhook(id);
   const { mutate: doUpdate, isPending } = useUpdateWebhook();
-  const { mutate: doReveal, isPending: isRevealing } = useRevealSecret();
-  const { mutate: doRotate, isPending: isRotating } = useRotateSecret();
-  const { mutate: doExpireOld, isPending: isExpiring } = useExpireOldSecrets();
-  const { mutate: doDelete, isPending: isDeleting } = useDeleteWebhook();
-
-  const [secrets, setSecrets] = useState<string[] | null>(null);
-  // The one-time secret minted by a rotation, shown once in its own modal.
-  const [rotatedSecret, setRotatedSecret] = useState<string | null>(null);
-  const [confirmRotate, setConfirmRotate] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState(false);
+  const secretActions = useWebhookSecretActions(id);
+  const deletion = useWebhookDeletion(id, webhook?.name ?? "");
 
   // Reaching this page requires update-webhooks (registry-gated). Delete is a
   // separate grant, but `update-webhooks` is the management umbrella that
@@ -96,76 +82,6 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
     [doUpdate, id, webhook]
   );
 
-  const handleReveal = useCallback(() => {
-    doReveal(id, {
-      onSuccess: setSecrets,
-      onError: (err: Error) => {
-        toast.error("Could not reveal the secret", {
-          description: apiErrorMessage(err),
-        });
-      },
-    });
-  }, [doReveal, id]);
-
-  const handleRotate = useCallback(
-    (overlapSeconds: number) => {
-      doRotate(
-        { id, input: { overlapSeconds } },
-        {
-          onSuccess: result => {
-            setConfirmRotate(false);
-            // The fresh secret is shown once here; the reveal action can return
-            // it again later while it remains the primary.
-            setRotatedSecret(result.secret);
-            toast.success("Signing secret rotated", {
-              description:
-                overlapSeconds > 0
-                  ? "The previous secret keeps working until the overlap window ends."
-                  : "The previous secret was retired immediately.",
-            });
-          },
-          onError: (err: Error) => {
-            toast.error("Could not rotate the secret", {
-              description: apiErrorMessage(err),
-            });
-          },
-        }
-      );
-    },
-    [doRotate, id]
-  );
-
-  const handleExpireOld = useCallback(() => {
-    doExpireOld(id, {
-      onSuccess: () => {
-        toast.success("Old signing secret expired", {
-          description: "Only the current secret can sign deliveries now.",
-        });
-      },
-      onError: (err: Error) => {
-        toast.error("Could not expire the old secret", {
-          description: apiErrorMessage(err),
-        });
-      },
-    });
-  }, [doExpireOld, id]);
-
-  const handleConfirmDelete = useCallback(() => {
-    if (!webhook) return;
-    const name = webhook.name;
-    doDelete(id, {
-      onSuccess: () => {
-        toast.success("Endpoint deleted", {
-          description: `"${name}" will no longer receive events.`,
-        });
-        navigateTo(ROUTES.SETTINGS_WEBHOOKS);
-      },
-      onError: (err: Error) => {
-        toast.error("Delete failed", { description: apiErrorMessage(err) });
-      },
-    });
-  }, [doDelete, id, webhook]);
-
   if (isError) {
     return (
       <PageErrorFallback
@@ -180,6 +96,23 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
 
   return (
     <>
+      {/*
+       * Above the form deliberately. The secret is what a person copies when
+       * WIRING UP the endpoint, which is the first thing they need and was
+       * previously reachable only by scrolling past every configuration field.
+       */}
+      <WebhookCredentialPanel
+        secrets={webhook.secrets}
+        canManage={canManageWebhooks}
+        onReveal={secretActions.reveal}
+        isRevealing={secretActions.isRevealing}
+        onRotate={() => secretActions.setConfirmingRotate(true)}
+        isRotating={secretActions.isRotating}
+        onExpireOld={secretActions.expireOld}
+        isExpiring={secretActions.isExpiring}
+        deliveriesHref={buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, { id })}
+      />
+
       <WebhookForm
         defaultValues={toFormValues(webhook)}
         existingHeaderNames={
@@ -191,62 +124,18 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
         pendingLabel="Saving…"
       />
 
-      <div className="mt-8 border-t border-border pt-6">
-        <SecretLifecycle
-          secrets={webhook.secrets}
-          canManage={canManageWebhooks}
-          onExpireOld={handleExpireOld}
-          isExpiring={isExpiring}
-        />
-      </div>
-
+      {/*
+       * Deletion stays BELOW, and after the form. It is the one act here that
+       * cannot be undone, and a destructive control at the top of a page is
+       * reached by accident far more often than on purpose.
+       */}
       <div className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <Button
-            type="button"
-            variant="outline"
-            onClick={handleReveal}
-            disabled={isRevealing}
-          >
-            {isRevealing ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <Eye className="h-4 w-4" />
-            )}
-            Reveal signing secret
-          </Button>
-
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => setConfirmRotate(true)}
-            disabled={isRotating}
-          >
-            {isRotating ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <RefreshCw className="h-4 w-4" />
-            )}
-            Rotate signing secret
-          </Button>
-
-          <Link href={buildRoute(ROUTES.SETTINGS_WEBHOOKS_DELIVERIES, { id })}>
-            <Button
-              type="button"
-              variant="outline"
-              className="w-full sm:w-auto"
-            >
-              <List className="h-4 w-4" />
-              View deliveries
-            </Button>
-          </Link>
-        </div>
-
+        <div />
         {canDelete && (
           <Button
             type="button"
             variant="destructive"
-            onClick={() => setConfirmDelete(true)}
+            onClick={() => deletion.setConfirming(true)}
           >
             Delete endpoint
           </Button>
@@ -254,34 +143,36 @@ const EditWebhookContent: React.FC<{ id: string }> = ({ id }) => {
       </div>
 
       <WebhookSecretModal
-        open={secrets !== null}
-        secrets={secrets}
+        open={secretActions.revealed !== null}
+        secrets={secretActions.revealed}
         oneTime={false}
-        onClose={() => setSecrets(null)}
+        onClose={secretActions.dismissRevealed}
       />
 
       <WebhookSecretModal
-        open={rotatedSecret !== null}
-        secrets={rotatedSecret !== null ? [rotatedSecret] : null}
+        open={secretActions.rotated !== null}
+        secrets={
+          secretActions.rotated !== null ? [secretActions.rotated] : null
+        }
         oneTime
         canRevealLater
-        onClose={() => setRotatedSecret(null)}
+        onClose={secretActions.dismissRotated}
       />
 
       <RotateSecretDialog
-        open={confirmRotate}
-        onOpenChange={setConfirmRotate}
+        open={secretActions.confirmingRotate}
+        onOpenChange={secretActions.setConfirmingRotate}
         webhookName={webhook.name}
-        onConfirm={handleRotate}
-        isPending={isRotating}
+        onConfirm={secretActions.rotate}
+        isPending={secretActions.isRotating}
       />
 
       <DeleteWebhookDialog
-        open={confirmDelete}
-        onOpenChange={setConfirmDelete}
+        open={deletion.confirming}
+        onOpenChange={deletion.setConfirming}
         webhook={webhook}
-        onConfirm={handleConfirmDelete}
-        isPending={isDeleting}
+        onConfirm={deletion.confirm}
+        isPending={deletion.isDeleting}
       />
     </>
   );


### PR DESCRIPTION
Closes the placement half of R-16. The width complaint was already fixed; this is
the part that remained.

## What was wrong

Setting up a webhook means copying its **signing secret** into the receiving
system. That value sat after every configuration field, so the task a person
arrives to do was reachable only by scrolling past a form they had not come to
edit — and on a short window it was not visible at all.

## What changed

The secret, its rotation controls and the link to the delivery log now sit in one
panel under the page header. Configuration keeps its own reading order beneath.

**Deletion stays at the bottom, deliberately.** It is the one irreversible act on
the page, and a destructive control where a reader lands is reached by accident
more often than on purpose.

The panel is **composed from the existing `SecretLifecycle`**, not a rewrite —
the rotation/overlap/expiry display is untouched.

**It is edit-only.** An endpoint has no secret until it exists, so the create page
mounts nothing rather than showing an empty shell.

### A behaviour change I nearly shipped, and did not

My first draft gated **Rotate** behind `canManage`. The page never did that —
only Delete is permission-gated — so that would have silently removed a control
from anyone without `update-webhooks`. Reverted, and pinned by a test, so reading
`canManage` as "may rotate" later has to be a deliberate decision rather than a
drift.

### Two concerns left the page

`EditWebhookContent` drops from **240 lines to 137**:

- `useWebhookSecretActions` — reveal / rotate / expire. Three acts on a
  credential, each owning transient state, none of it belonging to a page that
  fetches a document and saves a form. The state lives in the hook rather than
  the panel because two of the three results render in **modals the page mounts**;
  a panel owning state its sibling renders is the same coupling in a new shape.
- `useWebhookDeletion` — a destructive act plus its confirmation gate. Kept
  separate from the secret hook on purpose: rotation and deletion are gated on
  different permissions and have different consequences, and one hook holding
  both would invite a caller to treat them as interchangeable.

## Evidence

Four tests, the two load-bearing ones break-verified against production:

| Test | Mutation that made it fail |
|---|---|
| panel precedes the form in document order | move the panel back below the form |
| rotation offered regardless of manage permission | wrap the button in `canManage &&` |

Order is asserted with `compareDocumentPosition`, not a class name — a class says
what was written; document position says what a reader (and a screen reader) gets,
and the two stop agreeing the moment anything wraps the panel.

Full `pnpm build`, `check-types` and `lint` exit 0. Admin 3592 tests across 377
files; webhook + hooks suites 375 across 46. `fallow audit --gate new-only`
reports **verdict: pass**, every introduced count zero. Changeset covers all 25
lockstep packages, validated with `check-changesets.mjs`.

## Not verified visually

This is a layout change and I could not confirm it in a browser — the local
playground would not boot. The DOM-order test covers the property that was wrong;
it does not cover whether the panel *looks* right. Worth a glance before merge.