### PR TITLE
fix(blocks-react): give the divider a line and the spacer a height

### DIFF
--- a/.changeset/a-divider-draws-a-line.md
+++ b/.changeset/a-divider-draws-a-line.md
@@ -1,0 +1,45 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A divider draws a line, and a spacer takes up space.
+
+Both blocks rendered nothing an author could see. `core/divider` is an `<hr>`,
+which a user agent draws with an inset 3D border no design system wants and a
+CSS reset removes entirely — so the element was either wrong or invisible
+depending on the host. It now states all four sides itself: three at zero and
+one hairline in the border token, a token because it is a colour and a literal
+would be wrong in whichever of light and dark it was not chosen for.
+
+`core/spacer` renders an empty `<div>`, which is zero-high with nothing
+declared, so inserting one produced no space and nothing to select. It starts at
+`2rem`. That stays a style rather than becoming a prop — height is per-breakpoint
+in this system — so any breakpoint may override it.
+
+The population assertion in `base-styles.test.tsx` names both, which is what
+makes a future block that declares a default the compiler silently drops fail
+here rather than in a browser.

--- a/packages/blocks-react/src/blocks/base-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/base-styles.test.tsx
@@ -250,11 +250,13 @@ describe("every default the core library declares", () => {
       "core/card",
       "core/column",
       "core/columns",
+      "core/divider",
       "core/form",
       "core/gallery",
       "core/image",
       "core/list",
       "core/quote",
+      "core/spacer",
     ]);
   });
 

--- a/packages/blocks-react/src/blocks/divider.tsx
+++ b/packages/blocks-react/src/blocks/divider.tsx
@@ -23,6 +23,33 @@ export function renderDivider({
   return <hr className={className} />;
 }
 
+/**
+ * The rule itself, and the air around it.
+ *
+ * A user agent draws `<hr>` with an inset 3D border that no design system wants
+ * and a reset removes entirely — so the element is either wrong or invisible
+ * depending on the host. All four sides are stated so neither outcome survives:
+ * three at zero, one hairline in the border token, which is a token because it
+ * is a COLOUR and a literal would be wrong in one of the two themes.
+ */
+const DIVIDER_BASE_STYLES = {
+  base: {
+    base: {
+      margin: { blockStart: "1.5em", blockEnd: "1.5em" },
+      border: {
+        width: {
+          blockStart: "1px",
+          blockEnd: "0",
+          inlineStart: "0",
+          inlineEnd: "0",
+        },
+        style: "solid",
+        color: { $token: "color.border" },
+      },
+    },
+  },
+} as const;
+
 // Defined against the ENGINE's `defineBlock`, not the plugin SDK's: the engine
 // declares the contract and the SDK re-exports it for third parties. The
 // context is named rather than augmented, so a block compiled against the
@@ -51,5 +78,6 @@ export const divider = defineBlock<DividerProps, PageContext>({
     dimensions: true,
     effects: true,
   },
+  baseStyles: DIVIDER_BASE_STYLES,
   render: renderDivider,
 });

--- a/packages/blocks-react/src/blocks/spacer.tsx
+++ b/packages/blocks-react/src/blocks/spacer.tsx
@@ -27,6 +27,23 @@ export function renderSpacer({
   return <div className={className} aria-hidden="true" />;
 }
 
+/**
+ * A starting height, so the block exists before it is styled.
+ *
+ * A spacer renders an empty `<div>`, which is zero-high with nothing declared —
+ * so inserting one produced no space and nothing to select, and the block read
+ * as broken rather than as unstyled. This is a DEFAULT rather than a fixed size:
+ * height stays a style, per this module's note on why it is not a prop, so any
+ * breakpoint may override it.
+ */
+const SPACER_BASE_STYLES = {
+  base: {
+    base: {
+      height: "2rem",
+    },
+  },
+} as const;
+
 // Defined against the ENGINE's `defineBlock`, not the plugin SDK's: the engine
 // declares the contract and the SDK re-exports it for third parties. The
 // context is named rather than augmented, so a block compiled against the
@@ -49,5 +66,6 @@ export const spacer = defineBlock<SpacerProps, PageContext>({
   defaultProps: {},
   example: { props: {} },
   supports: { dimensions: true, spacing: true },
+  baseStyles: SPACER_BASE_STYLES,
   render: renderSpacer,
 });


### PR DESCRIPTION
Part of R-9. **Two blocks, not eleven** — the audit is the substance of this PR,
so it is written out below.

## What changed

**`core/divider`** is an `<hr>`. A user agent draws it with an inset 3D border no
design system wants, and a CSS reset removes it entirely — so the element was
either wrong or invisible depending on the host. It now states all four sides
itself: three at zero, one hairline in the border token. A token because it is a
**colour**, and a literal is wrong in whichever of light and dark it was not
chosen for.

**`core/spacer`** renders an empty `<div>`, which is zero-high with nothing
declared, so inserting one produced no space and nothing to select — the block
read as broken rather than unstyled. It starts at `2rem`, and that stays a
**style** rather than becoming a prop, because height is per-breakpoint here.

## Why not the other nine

R-9 is recorded as "11 blocks carry no `baseStyles`". That is true and it is not
the remedy for nine of them.

**`heading`, `paragraph`, `rich-text` — already solved, and `baseStyles` is the
wrong mechanism.** `withTypographyDefaults` is wired into the render path
(`styles.ts:410`) and supplies per-level sizes and line-heights — `h1` 2.25em/1.15
through `h6` 0.875em/1.5 — plus paragraph rhythm. Its own docblock says why these
must not be block defaults:

> A heading's level is a PROP, so every `core/heading` wears the same block-type
> class — one default there would give `h1` and `h3` the same size, which is the
> defect rather than the fix.

I had written defaults for all three before finding it. Redundant and actively
wrong; reverted.

**`box`, `section`, `container`, `collection-loop`, `accordion-item`, `embed` —
not a styles problem.** `box` declares itself *"full width with no
content-width constraint and no padding"*; giving it visible defaults would
contradict its purpose and change **published** output. `embed` returns `null`
with no source, deliberately. What an empty container needs is an **editor-only**
affordance, and the renderer cannot express one: `isEditor` / `renderMode` match
**0 files**, and `PageContext` says of its one mode flag that *"the renderer
itself does not change behaviour on it."*

A peer also measured that `.nx-canvas` carried **no background at all** until
their open #1433 adds one — so "renders invisible" had two candidate causes and
the canvas was one of them. Adding backgrounds to blocks now would be a double
fix. That half should be decided after #1433 lands.

## Evidence

`base-styles.test.tsx` already existed and is the reason this PR is correct
rather than plausible. It rejected my first attempt with
**`lineHeight (0 of 1 emitted)`** — the property is in the catalog, but a bare
numeric string is neither a number nor a dimension, so the compiler dropped it
while TypeScript accepted it happily. That file exists because `core/columns`
once shipped a `flex` default that compiled to nothing.

Both new defaults break-verified against production:

| Mutation | Result |
|---|---|
| remove `baseStyles` from `divider` | population assertion fails — 11 vs 12 |
| `height: "two-rem"` on `spacer` | *"nothing was emitted for core/spacer"* |

Full `pnpm build`, `check-types` and `lint` exit 0. blocks-react **1024 tests
across 43 files** (1018 before; +6 are the cases these two blocks now generate).
`fallow audit --gate new-only`: **verdict: pass**, all introduced counts zero.

Typechecked with **both** tsc programs — the package tsconfig excludes tests, so
a bare green would hide an error in the test file this PR edits.