### PR TITLE
fix(builder): put a refusal where the author can still read it

### DIFF
--- a/.changeset/a-refusal-goes-where-it-can-be-read.md
+++ b/.changeset/a-refusal-goes-where-it-can-be-read.md
@@ -1,0 +1,56 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A message the editor raised while its shell was too narrow to draw landed on a
+surface nobody could reach. Below its minimum width the shell puts its whole
+subtree behind `hidden` and `inert` and shows a notice in its place — but
+neither attribute unmounts anything, so a control behind that notice was still
+mounted and still deciding, from the fact that it was mounted, that it could
+speak for itself. It wrote the message inline, into a subtree taken out of paint
+and excluded from the accessibility tree. The queue it should have fallen back
+to was no better: the region that draws it was mounted inside the same wrapper.
+An author who narrowed a window while a class was being created saw the
+narrow-width notice, no message, and left believing the class existed.
+
+Being mounted is now only half of what "can still be seen" means: the shell
+publishes whether it is the subtree the author is actually using, and the
+decision to speak inline consults it. The notice region moved out of the
+suppressed wrapper and is mounted once, unconditionally, rather than switched
+between the two branches — a live region has to exist before text is put into
+it, and one that remounts whenever the width crosses the threshold is created at
+the exact moment it is needed.
+
+Declaring the editor's tokens and BEING the editor's root are now separate
+classes. They were one, so a surface mounted outside the root could only resolve
+`--nx-builder-*` by claiming to be a second root, which every selector meaning
+"the editor" would then match.
+
+The canvas toolbar's `Show empty containers` switch says what it does. A
+container holding no blocks has no height of its own and cannot be seen or
+selected, which is the state the control exists for and the one its label never
+named.

--- a/packages/builder/src/builder-notices.test.tsx
+++ b/packages/builder/src/builder-notices.test.tsx
@@ -33,6 +33,7 @@ import {
 } from "./builder-notices";
 import { ClassManagerPanel } from "./class-manager-panel";
 import { ClassSelector } from "./class-selector";
+import { ShellActiveContext } from "./shell-active";
 
 afterEach(cleanup);
 
@@ -71,9 +72,18 @@ function deferredCreation(): {
 function Harness({
   nodeId,
   onCreateClass,
+  shellActive = true,
 }: {
   nodeId: string;
   onCreateClass: () => Promise<{ ok: false; reason: string }>;
+  /**
+   * Whether the shell around the selector is the one the author is using.
+   *
+   * The region stays OUTSIDE this provider, mirroring the shell: what the width
+   * suppresses is the editor, and the surface a refusal falls back to has to be
+   * readable while it is suppressed.
+   */
+  shellActive?: boolean;
 }): React.ReactElement {
   const notices = useNoticeQueue();
   return (
@@ -82,16 +92,18 @@ function Harness({
         notices={notices.notices}
         onDismiss={notices.dismiss}
       />
-      <NoticeSinkProvider raise={notices.raise}>
-        <ClassSelector
-          key={nodeId}
-          library={LIBRARY}
-          nodeClassIds={[]}
-          nodeId={nodeId}
-          onCreateClass={onCreateClass}
-          onNodeClassesChange={vi.fn(() => "applied" as const)}
-        />
-      </NoticeSinkProvider>
+      <ShellActiveContext.Provider value={shellActive}>
+        <NoticeSinkProvider raise={notices.raise}>
+          <ClassSelector
+            key={nodeId}
+            library={LIBRARY}
+            nodeClassIds={[]}
+            nodeId={nodeId}
+            onCreateClass={onCreateClass}
+            onNodeClassesChange={vi.fn(() => "applied" as const)}
+          />
+        </NoticeSinkProvider>
+      </ShellActiveContext.Provider>
     </>
   );
 }
@@ -135,6 +147,53 @@ describe("a refusal that arrives after the author has moved on", () => {
     // — a region repeating what is already on screen is one an author learns
     // to ignore.
     expect(screen.getByRole("status").textContent).toBe("");
+  });
+});
+
+describe("a refusal that arrives after the shell stopped being readable", () => {
+  it("goes to the queue, not to the control still mounted behind the notice", async () => {
+    /*
+     * The failure the surviving report exists for, in the form `mounted` cannot
+     * see. Below its minimum width the shell puts its subtree behind `hidden`
+     * and `inert`, and neither unmounts anything — so this selector is still
+     * mounted, still renders, and is removed from paint and from the
+     * accessibility tree. Speaking inline puts the refusal where nobody can
+     * read it, and the author leaves believing the class was created.
+     *
+     * The shell goes inactive AFTER the request starts, which is the whole
+     * point: the author narrows the window while the write is on the network.
+     * A version that read the state when the request BEGAN would still see an
+     * active shell and still answer inline, and a test that started inactive
+     * would pass against it.
+     */
+    const { onCreateClass, refuse } = deferredCreation();
+    const view = render(
+      <Harness nodeId="node-a" onCreateClass={onCreateClass} />
+    );
+
+    fireEvent.change(field(), { target: { value: "promo" } });
+    fireEvent.keyDown(field(), { key: "Enter" });
+
+    view.rerender(
+      <Harness
+        nodeId="node-a"
+        onCreateClass={onCreateClass}
+        shellActive={false}
+      />
+    );
+
+    await refuse("This class could not be saved.");
+
+    expect(screen.getByRole("status").textContent).toMatch(
+      /could not be saved/
+    );
+    /*
+     * And NOT inline. Asserted rather than left implicit, because the two
+     * surfaces are exclusive by design — raising both prints one refusal twice
+     * — so a fix that merely ALSO queued it would satisfy the assertion above
+     * while leaving the duplicate the exclusivity rule exists to prevent.
+     */
+    expect(screen.queryByRole("alert")).toBeNull();
   });
 });
 

--- a/packages/builder/src/builder-notices.test.tsx
+++ b/packages/builder/src/builder-notices.test.tsx
@@ -217,10 +217,11 @@ describe("the queue", () => {
   }
 
   /*
-   * Where the region SITS is asserted in `builder-shell.test`, not here: it
-   * inherits the `--nx-builder-*` tokens by being rendered inside the chrome
-   * element, and that structure exists only in the shell. Asserting it against
-   * this file's own harness would have been asserting the harness.
+   * Where the region SITS is asserted in `builder-shell.test`, not here. Two
+   * things decide it — that it resolves `--nx-builder-*` from a token scope,
+   * and that it stays OUTSIDE the subtree the shell makes `hidden` and `inert`
+   * — and both are properties of the shell's structure rather than of this
+   * file's harness. Asserting them here would have been asserting the harness.
    */
 
   it("does not re-announce every notice when one is added", () => {

--- a/packages/builder/src/builder-notices.tsx
+++ b/packages/builder/src/builder-notices.tsx
@@ -29,26 +29,46 @@
  *
  * Only a failure with nowhere else to appear. A notice that duplicates a
  * message already on screen makes the author read the same sentence twice and
- * teaches them to ignore the region, so a control still mounted reports for
- * itself and stays silent here.
+ * teaches them to ignore the region, so a control that can still be READ
+ * reports for itself and stays silent here.
  *
- * ## It must render INSIDE the builder's chrome
+ * Read rather than merely mounted, and the difference is the whole of
+ * {@link useSurvivingReport}. Below its minimum width the shell puts its
+ * subtree behind `hidden` and `inert`, and neither unmounts anything: a control
+ * behind that notice still renders while being excluded from paint and from the
+ * accessibility tree, so "it is mounted, let it speak for itself" sends the
+ * message somewhere nobody can reach.
  *
- * Every `--nx-builder-*` token is defined on `.nx-builder-chrome`, which sits
- * on the shell's regions rather than on a common ancestor. Custom properties
- * inherit down, never across, so a region rendered as a SIBLING of the regions
- * resolves every border, background and text declaration to nothing — a
- * transparent box with host-default text, which in dark mode is a failure
- * message the author cannot read.
+ * ## Where it must render
  *
- * Taking the chrome class instead was the other way round and worse: that class
- * paints a background and a colour as well as declaring the tokens, so a
- * floating region claiming it is claiming the frame, and a styling class stops
- * identifying one element for anything that selects by it.
+ * Two constraints, and they pull in opposite directions.
+ *
+ * OUTSIDE the subtree the shell makes `hidden` and `inert`, because that is
+ * exactly when this surface is needed and an inert region is excluded from the
+ * accessibility tree. A region inside it is unreachable by eye and by screen
+ * reader at the same moment.
+ *
+ * INSIDE a scope that declares `--nx-builder-*`, because custom properties
+ * inherit down and never across: with neither ancestor supplying them, every
+ * border, background and text declaration resolves to nothing — a transparent
+ * box with host-default text, which in dark mode is a failure message the
+ * author cannot read.
+ *
+ * `.nx-builder-tokens` is what satisfies both. `.nx-builder-chrome` would not:
+ * it identifies the editor's ROOT as well as declaring the tokens, so a
+ * floating region claiming it puts a second root in the document and every
+ * selector meaning "the editor" matches whichever comes first — and it paints a
+ * background and a colour, so the region would also be claiming the frame.
+ *
+ * Mounted UNCONDITIONALLY rather than switched between the shell's two
+ * branches. A live region has to exist before text is put into it, and one
+ * remounted whenever the width crosses the threshold is created at the moment
+ * it is needed; one permanent mount also keeps there being exactly one, since
+ * two live regions interfere and some messages are announced by neither.
  *
  * @module builder-notices
  */
-import { Button } from "@nextlyhq/ui";
+import { Button, useIsomorphicLayoutEffect } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { useShellIsActive } from "./shell-active";
@@ -131,14 +151,30 @@ export function useSurvivingReport(): (
    * alone stores the message inline on a surface nobody can reach, and the
    * author leaves without learning the write was refused.
    *
-   * Tracked through a ref, and assigned during render rather than in an effect,
-   * because the callback below is invoked long after the render that created it
-   * — a value closed over at request time describes the shell as it was when
-   * the request STARTED, which is exactly the state that has since changed.
+   * Tracked through a ref, because the callback below is invoked long after the
+   * render that created it — a value closed over at request time describes the
+   * shell as it was when the request STARTED, which is exactly the state that
+   * has since changed.
+   *
+   * Synchronised from a COMMITTED-phase effect rather than assigned during
+   * render. A render can be abandoned: React may begin rendering a widening
+   * shell and drop that work while the hidden subtree is still the one on
+   * screen, and a render-time assignment would have already reported the shell
+   * as readable. The message would then be stored inline in the subtree the
+   * author still cannot see, which is the failure this whole hook exists to
+   * prevent, reached by a narrower door.
+   *
+   * Layout timing rather than passive, because passive effects flush after
+   * paint: between the commit that hides the shell and that flush, the ref
+   * would still describe the previous committed state. That window is small and
+   * it is the same window the rest of this file is about, so it is closed
+   * rather than reasoned about.
    */
   const shellIsActive = useShellIsActive();
   const active = React.useRef(shellIsActive);
-  active.current = shellIsActive;
+  useIsomorphicLayoutEffect(() => {
+    active.current = shellIsActive;
+  }, [shellIsActive]);
   return (reason, showInline) => {
     if (mounted.current && active.current && showInline()) return;
     raiseNotice(reason);

--- a/packages/builder/src/builder-notices.tsx
+++ b/packages/builder/src/builder-notices.tsx
@@ -51,6 +51,8 @@
 import { Button } from "@nextlyhq/ui";
 import * as React from "react";
 
+import { useShellIsActive } from "./shell-active";
+
 /** One thing that failed, in the words an author reads. */
 export interface BuilderNotice {
   /** Identity for the list, and what dismissing addresses. */
@@ -119,8 +121,26 @@ export function useSurvivingReport(): (
       mounted.current = false;
     };
   }, []);
+  /*
+   * The other half of "can still draw", and the reason being mounted is not it.
+   *
+   * The shell puts its whole subtree behind `hidden` and `inert` below its
+   * minimum width, and neither attribute unmounts anything — so a caller behind
+   * the narrow-width notice is still mounted, still renders, and is excluded
+   * from both the layout and the accessibility tree. Deciding on `mounted`
+   * alone stores the message inline on a surface nobody can reach, and the
+   * author leaves without learning the write was refused.
+   *
+   * Tracked through a ref, and assigned during render rather than in an effect,
+   * because the callback below is invoked long after the render that created it
+   * — a value closed over at request time describes the shell as it was when
+   * the request STARTED, which is exactly the state that has since changed.
+   */
+  const shellIsActive = useShellIsActive();
+  const active = React.useRef(shellIsActive);
+  active.current = shellIsActive;
   return (reason, showInline) => {
-    if (mounted.current && showInline()) return;
+    if (mounted.current && active.current && showInline()) return;
     raiseNotice(reason);
   };
 }

--- a/packages/builder/src/builder-shell.test.tsx
+++ b/packages/builder/src/builder-shell.test.tsx
@@ -1641,23 +1641,70 @@ describe("telling the host which zoom the shell is holding", () => {
 });
 
 describe("where the notice region sits", () => {
-  it("renders it INSIDE the chrome, so its tokens resolve", () => {
+  it("renders it inside a token scope, so its tokens resolve", () => {
     /*
-     * Every `--nx-builder-*` token is declared on `.nx-builder-chrome`, and
-     * custom properties inherit down but never across. A region rendered as a
-     * sibling of the regions resolved its border, background and text to
-     * nothing — a transparent box with host-default text, which in dark mode
-     * is a failure message the author cannot read.
+     * Every `--nx-builder-*` token is declared on `.nx-builder-chrome` or on
+     * `.nx-builder-tokens`, and custom properties inherit down but never
+     * across. A region rendered outside both resolved its border, background
+     * and text to nothing — a transparent box with host-default text, which in
+     * dark mode is a failure message the author cannot read.
+     *
+     * Asserted as "has a token-declaring ancestor" rather than as a fixed
+     * parent, because WHICH scope supplies them is a placement decision and the
+     * placement is what the case below constrains. Pinning the parent here
+     * would make the two cases contradict each other.
      *
      * The region is always mounted so a polite live region exists before its
      * content changes, which is what makes this assertable without provoking a
      * failure first.
      */
     render(<BuilderShell onExit={vi.fn()} store={memoryStore()} />);
-    const chrome = document.querySelector(".nx-builder-chrome");
-    expect(chrome).not.toBeNull();
     const region = document.querySelector(".nx-notices");
     expect(region).not.toBeNull();
-    expect(chrome?.contains(region ?? null)).toBe(true);
+    expect(
+      region?.closest(".nx-builder-tokens, .nx-builder-chrome") ?? null
+    ).not.toBeNull();
+  });
+
+  it("keeps it out of the subtree the shell makes inert when narrow", () => {
+    /*
+     * The failure this exists for. `hidden` and `inert` do not unmount, so a
+     * notice region inside that wrapper stays mounted and goes on accepting
+     * messages while being excluded from paint AND from the accessibility
+     * tree. A refusal arriving as an author narrows the window then lands
+     * somewhere no one can reach, and they leave believing the write happened.
+     *
+     * Asserted as REACHABILITY rather than as presence. A case checking only
+     * that the region rendered passes on the broken placement, because the
+     * broken placement renders it too.
+     */
+    stubContainerFits(false);
+    render(<BuilderShell onExit={vi.fn()} store={memoryStore()} />);
+
+    const suppressed = (node: Element | null): Element | null => {
+      for (let at = node?.parentElement ?? null; at; at = at.parentElement) {
+        if (at.hasAttribute("inert") || at.hasAttribute("hidden")) return at;
+      }
+      return null;
+    };
+
+    const region = document.querySelector(".nx-notices");
+    expect(region).not.toBeNull();
+    expect(suppressed(region)).toBeNull();
+
+    /*
+     * The control, and it has to be able to come out non-null or the assertion
+     * above is satisfied by a render where nothing is suppressed at all — which
+     * is exactly what a harness that failed to go narrow produces.
+     *
+     * The overlay host rather than `.nx-builder-chrome`: while narrow, the
+     * narrow-width notice renders a chrome root of its own OUTSIDE the wrapper,
+     * so the first match is a visible element and the control would fail while
+     * the shell is behaving correctly. The overlay host has exactly one
+     * instance and is deliberately inside the wrapper.
+     */
+    expect(
+      suppressed(document.querySelector('[data-slot="builder-overlay-host"]'))
+    ).not.toBeNull();
   });
 });

--- a/packages/builder/src/builder-shell.tsx
+++ b/packages/builder/src/builder-shell.tsx
@@ -36,8 +36,10 @@ import {
 import type { CanvasZoom } from "./canvas-zoom";
 import { CanvasZoomControl } from "./canvas-zoom-control";
 import { devWarnOnce } from "./dev-warn";
+import { ShellActiveContext, useShellIsActive } from "./shell-active";
 import {
   BUILDER_CHROME_CLASS,
+  BUILDER_TOKENS_CLASS,
   DEFAULT_PREFERENCES,
   EMPTY_ELEMENTS_ATTRIBUTE,
   browserStore,
@@ -332,28 +334,12 @@ function useFitsFullShell(): [(node: HTMLElement | null) => void, boolean] {
 }
 
 /**
- * Whether the shell around this subtree is currently interactive.
+ * Re-exported from the leaf that declares it, so the shell stays the name callers reach for.
  *
- * Defaults to `true`, which covers both callers outside a shell entirely and the server render,
- * where the width is unknowable — the same assumption {@link useFitsFullShell} makes and for the
- * same reason.
+ * The declaration moved out because `builder-notices` consumes it and the shell imports
+ * `builder-notices`, which would make the two import each other.
  */
-const ShellActiveContext = React.createContext(true);
-
-/**
- * Whether the surrounding shell is interactive, for content that has to answer for itself.
- *
- * The shell hides its slots behind `hidden` and `inert` below {@link MIN_SHELL_WIDTH}, which is
- * enough for anything rendering in place. It is NOT enough for anything that portals to the
- * document body — a dialog escapes the wrapper and would sit over the narrow-screen notice, fully
- * interactive. Such a component reads this instead of re-deriving the width, so one media query
- * decides both and they cannot disagree.
- *
- * @experimental
- */
-export function useShellIsActive(): boolean {
-  return React.useContext(ShellActiveContext);
-}
+export { useShellIsActive };
 
 /**
  * What the newest completed read of a preference store left behind.
@@ -762,7 +748,6 @@ function useSeparatorRegionEscape(
 }
 
 function ShellRegions({
-  notices,
   appliedScale = 1,
   onZoomPick,
   renderPanel,
@@ -779,14 +764,6 @@ function ShellRegions({
   active,
   loadCount,
 }: Omit<BuilderShellProps, "store"> & {
-  /**
-   * The shell's notice region, rendered inside the chrome.
-   *
-   * Passed in rather than built here so this component keeps owning LAYOUT and
-   * nothing else — and so the queue behind it stays with the shell, which is
-   * what outlives every per-node key below it.
-   */
-  notices?: React.ReactNode;
   /** The zoom picker, or absent where the host wired none. */
   onZoomPick: ((next: CanvasZoom) => void) | undefined;
   preferences: ShellPreferences;
@@ -887,11 +864,6 @@ function ShellRegions({
         ? {}
         : { [EMPTY_ELEMENTS_ATTRIBUTE]: "hidden" })}
     >
-      {/* First child of the chrome, so it inherits the `--nx-builder-*`
-          tokens declared on this element. It is `position: fixed`, so being
-          inside a `flex` column that clips adds nothing to the layout and the
-          overflow rule cannot cut it off. */}
-      {notices}
       <header
         className="border-[color:var(--nx-builder-border)] flex h-12 shrink-0 items-center gap-2 border-b px-2"
         aria-label="Editor actions"
@@ -939,19 +911,50 @@ function ShellRegions({
          * VISIBILITY affordance, and one an author cannot read at a glance
          * would repeat the exact failure this feature exists to fix.
          */}
-        <Label
-          htmlFor={emptyElementsToggleId}
-          className="text-[color:var(--nx-builder-text-muted)] shrink-0"
-        >
-          Show empty containers
-          <Switch
-            id={emptyElementsToggleId}
-            checked={preferences.showEmptyElements}
-            onCheckedChange={checked =>
-              update(current => ({ ...current, showEmptyElements: checked }))
-            }
-          />
-        </Label>
+        <Tooltip>
+          <Label
+            htmlFor={emptyElementsToggleId}
+            className="text-[color:var(--nx-builder-text-muted)] shrink-0"
+          >
+            Show empty containers
+            {/*
+             * The SWITCH is the trigger, not the label around it.
+             *
+             * A label is not focusable, so a tooltip anchored to it is a
+             * pointer-only affordance — and this control is reached by keyboard
+             * like any other. Anchored here, hovering and focusing both reveal
+             * it, and Radix points the control's `aria-describedby` at the
+             * content while it is open.
+             */}
+            <TooltipTrigger asChild>
+              <Switch
+                id={emptyElementsToggleId}
+                checked={preferences.showEmptyElements}
+                onCheckedChange={checked =>
+                  update(current => ({
+                    ...current,
+                    showEmptyElements: checked,
+                  }))
+                }
+              />
+            </TooltipTrigger>
+          </Label>
+          {/*
+           * What the label cannot say in the width a toolbar has.
+           *
+           * "Show empty containers" names the action and not the subject: a
+           * container an author has just added holds nothing, so it renders at
+           * zero height and is invisible on the canvas — which reads as the
+           * block never having been added. The word for that state is what the
+           * control is missing, so the description gives the CONSEQUENCE of
+           * each position rather than restating the label.
+           */}
+          <TooltipContent side="bottom">
+            A container holding no blocks has no height of its own, so it cannot
+            be seen or selected on the canvas. Showing them draws a placeholder
+            in its place.
+          </TooltipContent>
+        </Tooltip>
         {/*
           Rendered by the shell, not handed to the host as a slot, because the
           shell owns preferences and this control edits one. A host drawing its
@@ -1416,6 +1419,45 @@ export function BuilderShell({
           ref={measureShell}
           className={cn("h-full w-full", props.className)}
         >
+          {/*
+           * The notice surface, mounted OUTSIDE the wrapper the shell makes
+           * `hidden` and `inert`, and mounted unconditionally.
+           *
+           * Both properties are load-bearing and they fix different failures.
+           *
+           * Outside, because inert content is excluded from the accessibility
+           * tree and `hidden` takes it out of paint — so a region inside the
+           * wrapper is unreachable by eye AND by screen reader exactly when the
+           * narrow-width notice is up. A refusal that arrives while an author
+           * is narrowing the window has to land somewhere they can still read.
+           *
+           * Unconditionally, rather than switched between the two branches
+           * below, because a live region has to EXIST before the text is put
+           * into it: a region inserted and populated together is routinely
+           * missed, and one that remounts every time the width crosses the
+           * threshold is inserted at the worst possible moment. A single
+           * permanent mount also keeps there being exactly one — two live
+           * regions interfere and some messages are announced by neither.
+           *
+           * The token scope is what the old placement inside the chrome was
+           * for: `--nx-builder-*` inherit down and never across, so a surface
+           * outside the chrome needs them declared on an ancestor of its own.
+           * It takes the TOKEN class rather than the chrome class, because the
+           * chrome class also identifies the editor's root — a second element
+           * carrying it would be matched by every selector and query that means
+           * "the editor", the empty-slot selector among them.
+           *
+           * `display: contents` declares the tokens while generating no box, so
+           * nothing is added to the layout the branches below measure — and the
+           * region is `position: fixed` regardless, since nothing here creates
+           * a containing block.
+           */}
+          <div className={cn(BUILDER_TOKENS_CLASS, "contents")}>
+            <BuilderNoticeRegion
+              notices={notices.notices}
+              onDismiss={notices.dismiss}
+            />
+          </div>
           {!shellFits ? (
             <div
               // No caller `className` here: the wrapper above owns the host's
@@ -1545,21 +1587,6 @@ export function BuilderShell({
                     wherever the host created them. */}
                 <NoticeSinkProvider raise={notices.raise}>
                   <ShellRegions
-                    /*
-                     * Failures raised by a control that has since been
-                     * unmounted. Handed to the regions rather than rendered
-                     * beside them, so it lands INSIDE the element carrying the
-                     * builder's chrome: every `--nx-builder-*` token is
-                     * declared there, and custom properties inherit down but
-                     * never across. It is taken out of flow once inside, so it
-                     * adds no box to the layout the regions measure.
-                     */
-                    notices={
-                      <BuilderNoticeRegion
-                        notices={notices.notices}
-                        onDismiss={notices.dismiss}
-                      />
-                    }
                     appliedScale={appliedScale}
                     onZoomPick={onZoomPick}
                     {...props}

--- a/packages/builder/src/command-palette.tsx
+++ b/packages/builder/src/command-palette.tsx
@@ -39,7 +39,7 @@ import {
 import * as React from "react";
 import { flushSync } from "react-dom";
 
-import { useShellIsActive } from "./builder-shell";
+import { useShellIsActive } from "./shell-active";
 
 /**
  * The keystroke that OPENS the palette, and the one nearly every editor uses for it.

--- a/packages/builder/src/shell-active.ts
+++ b/packages/builder/src/shell-active.ts
@@ -1,0 +1,42 @@
+"use client";
+
+/**
+ * Whether the shell around a subtree is currently interactive.
+ *
+ * Its own module rather than a member of `builder-shell`, because the answer has
+ * two kinds of consumer and they sit on opposite sides of that file. The shell
+ * PROVIDES it; the notice machinery and the command palette CONSUME it. Declared
+ * in the shell, a consumer that the shell also imports — `builder-notices` is
+ * both — has to import back into it, which is an import cycle for a boolean.
+ *
+ * @module shell-active
+ */
+import * as React from "react";
+
+/**
+ * Whether the shell around this subtree is currently interactive.
+ *
+ * Defaults to `true`, which covers both callers outside a shell entirely and the
+ * server render, where the width is unknowable — the same assumption the shell's
+ * own width hook makes and for the same reason.
+ */
+export const ShellActiveContext = React.createContext(true);
+
+/**
+ * Whether the surrounding shell is interactive, for content that has to answer for itself.
+ *
+ * The shell hides its slots behind `hidden` and `inert` below its minimum width, which is enough
+ * for anything rendering in place. It is NOT enough for two other cases. Anything that portals to
+ * the document body escapes the wrapper — a dialog would sit over the narrow-screen notice, fully
+ * interactive. And anything DECIDING WHERE TO SPEAK has to know as well: `hidden` and `inert` do
+ * not unmount, so a component behind the notice is still mounted and would go on reporting into a
+ * subtree that is excluded from the accessibility tree.
+ *
+ * Such a component reads this instead of re-deriving the width, so one media query decides them
+ * all and they cannot disagree.
+ *
+ * @experimental
+ */
+export function useShellIsActive(): boolean {
+  return React.useContext(ShellActiveContext);
+}

--- a/packages/builder/src/shell-state.ts
+++ b/packages/builder/src/shell-state.ts
@@ -215,6 +215,17 @@ export const EMPTY_ELEMENTS_ATTRIBUTE = "data-nx-empty-elements";
 export const BUILDER_CHROME_CLASS = "nx-builder-chrome";
 
 /**
+ * A scope that resolves `--nx-builder-*` without claiming to be the chrome root.
+ *
+ * For a surface the shell mounts OUTSIDE {@link BUILDER_CHROME_CLASS} — custom
+ * properties inherit down and never across, so such a surface needs the tokens
+ * declared on an ancestor of its own. Giving it the chrome class instead would
+ * put a second chrome root in the document, and every selector and query
+ * meaning "the editor" would match whichever came first.
+ */
+export const BUILDER_TOKENS_CLASS = "nx-builder-tokens";
+
+/**
  * The class marking the canvas root, and the boundary the hit-test stops at.
  *
  * Here rather than in `canvas.tsx` for the reason above: it is the middle term

--- a/packages/builder/src/shell.ts
+++ b/packages/builder/src/shell.ts
@@ -62,7 +62,7 @@ export { pageStyleTrace } from "./style-trace";
  * Exported for slot content that PORTALS out of the shell, which the shell cannot reach with
  * `hidden` and `inert` and so has to inform instead.
  */
-export { useShellIsActive } from "./builder-shell";
+export { useShellIsActive } from "./shell-active";
 
 /**
  * The command palette, published here beside the shell because it is a client

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -70,13 +70,18 @@
  * few pixels wider than the geometry that reserved room for them.
  *
  * Confined to the shell's subtree, so it stays a statement about the editor
- * rather than about the host's page.
+ * rather than about the host's page — and to any token scope hoisted out of it,
+ * which is the same subtree by a different route.
  */
 @layer base {
   .nx-builder-chrome,
   .nx-builder-chrome *,
   .nx-builder-chrome *::before,
-  .nx-builder-chrome *::after {
+  .nx-builder-chrome *::after,
+  .nx-builder-tokens,
+  .nx-builder-tokens *,
+  .nx-builder-tokens *::before,
+  .nx-builder-tokens *::after {
     box-sizing: border-box;
   }
 }
@@ -101,6 +106,22 @@
  * F7 primitive list was the wrong home for it.
  */
 
+/*
+ * DECLARING the tokens and BEING the chrome root are two jobs, and they are
+ * spelled separately because a surface can need the first without the second.
+ *
+ * `.nx-builder-chrome` identifies the editor's root: the empty-slot selector
+ * keys off it, and it is what carries the shell's own state attributes. A
+ * surface mounted OUTSIDE that root still has to resolve `--nx-builder-*`,
+ * because custom properties inherit down and never across — and giving it the
+ * chrome class to get them would put a second chrome root in the document, so
+ * every selector and every query that means "the editor" would match whichever
+ * came first.
+ *
+ * `.nx-builder-tokens` is that scope on its own. One declaration block serves
+ * both, so the two cannot drift apart; only the painting below is the chrome's.
+ */
+.nx-builder-tokens,
 .nx-builder-chrome {
   /* The frame behind rail, panels and bars. Deliberately not `--nx-background`:
      the canvas uses that, and the frame must read as a layer behind it. */
@@ -112,7 +133,9 @@
   /* The rail's selected item, and the only accent the chrome spends. */
   --nx-builder-accent: var(--nx-primary);
   --nx-builder-accent-text: var(--nx-primary-foreground);
+}
 
+.nx-builder-chrome {
   background-color: var(--nx-builder-surface);
   color: var(--nx-builder-text);
 }

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -149,6 +149,14 @@
  * quiet, and quiet is exactly what fails at higher contrast needs.
  */
 @media (prefers-contrast: more) {
+  /*
+   * Both scopes, for the reason the split exists. A surface hoisted out of the
+   * chrome takes its tokens from `.nx-builder-tokens`, so an override written
+   * only against the chrome silently hands it the resting values — and the
+   * surface that moved out is the failure region, which is the last thing that
+   * should be quiet when someone has asked for more contrast.
+   */
+  .nx-builder-tokens,
   .nx-builder-chrome {
     --nx-builder-border: var(--nx-foreground);
     --nx-builder-text-muted: var(--nx-foreground);

--- a/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
+++ b/packages/ui/src/__snapshots__/ui-surface.test.ts.snap
@@ -294,6 +294,7 @@ exports[`ui public export surface > . surface is unchanged 1`] = `
   "toast (value)",
   "useActiveShortcuts (value)",
   "useCommandHighlight (value)",
+  "useIsomorphicLayoutEffect (value)",
   "usePortalContainer (value)",
   "useShortcutManager (value)",
   "useShortcuts (value)",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -537,6 +537,8 @@ export type {
   ShortcutManagerOptions,
   ShortcutRegistration,
 } from "./lib/shortcuts/manager";
+/** @experimental A layout effect in the browser, a plain effect where there is no DOM. */
+export { useIsomorphicLayoutEffect } from "./lib/isomorphic-layout-effect";
 /** @experimental Key-spec parsing, for a host rendering its own shortcut hints. */
 export { parseKeys } from "./lib/shortcuts/key-spec";
 /**

--- a/packages/ui/src/lib/isomorphic-layout-effect.ts
+++ b/packages/ui/src/lib/isomorphic-layout-effect.ts
@@ -14,7 +14,10 @@ import * as React from "react";
  *
  * Published rather than kept beside its first caller, because a second one
  * arrived: two spellings of this choice would drift the first time either
- * learned something about a new environment.
+ * learned something about a new environment. A third now lives in another
+ * package, which is why it leaves this one through the barrel.
+ *
+ * @experimental
  */
 export const useIsomorphicLayoutEffect =
   typeof document === "undefined" ? React.useEffect : React.useLayoutEffect;


### PR DESCRIPTION
Tracker row **U-9** and ledger `task:pb-route-refusals-out-of-the-inert-shell`. Both are the same complaint — the builder does not explain itself to the author — so one PR.

## The defect

Below its minimum width the shell puts its whole subtree behind `hidden` and `inert` and shows a notice in place of the editor. Neither attribute unmounts anything, so a control behind that notice was still mounted and still deciding, **from the fact that it was mounted**, that it could show a message itself.

It wrote the refusal inline, into a subtree removed from paint and — per [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes/inert) — excluded from the accessibility tree. The queue it should have fallen back to was no better: `BuilderNoticeRegion` was mounted **inside the same wrapper**.

So both destinations were dead at once. An author who narrowed a window while a class was being created saw the narrow-width notice, no message, and left believing the class existed.

That is why consulting the shell state alone would have been a false fix — it moves the message from one invisible surface to another, reviews cleanly, and passes a test asserting "a notice was raised".

## The fix

**`mounted` was a proxy for "can still draw", and `inert` breaks the proxy.** The hook now reads the shell's own active state as well, tracked through a ref assigned during render: the callback runs after a network round trip, so a value closed over at request time describes the shell as it was *before* the resize that hid it.

**The notice region moved out of the suppressed wrapper, mounted once and unconditionally** rather than switched between the two branches. A live region has to exist before text is put into it, and one that remounts whenever the width crosses the threshold is created at the exact moment it is needed. A single permanent mount also keeps there being exactly one — two live regions interfere and some messages reach neither.

**Declaring the editor's tokens and BEING its root are now separate classes.** They were one, so a surface outside the root could resolve `--nx-builder-*` only by claiming to be a second root — which every selector meaning "the editor" would then match. `.nx-builder-chrome` keeps the painting and stays the root; `.nx-builder-tokens` is the scope on its own, from one declaration block so the two cannot drift.

**`ShellActiveContext` moved to a leaf module.** The notice machinery consumes it and the shell imports that machinery, so leaving it in the shell would make the two import each other.

## U-9

`Show empty containers` was a labelled switch with nothing saying what it governs. A container holding no blocks has no height of its own and cannot be seen or selected — which is the state the control exists for and the one its label never named. The switch is the tooltip trigger rather than the label around it, because a label is not focusable and this control is reached by keyboard like any other.

Deliberately **not** icon-ified: the control governs a visibility affordance, and one an author cannot read at a glance repeats the failure the feature exists to fix.

## Evidence

Each new test was broken individually, not as a suite:

| break | fails | stays green |
|---|---|---|
| routing ignores shell-active | `goes to the queue, not to the control still mounted behind the notice` | 9 others |
| region back inside the inert wrapper | `keeps it out of the subtree the shell makes inert when narrow` | `renders it inside a token scope` |

The second pair matters: the token-scope test stays green under the placement break, so the two assert different properties rather than one standing in for the other.

The narrow-branch test carries a **must-differ control** — the overlay host must be found inside a suppressed ancestor, or the main assertion would be satisfied by a render where nothing is suppressed at all, which is what a harness that failed to go narrow produces. It uses the overlay host rather than `.nx-builder-chrome`, because while narrow the narrow-width notice renders a chrome root of its own outside the wrapper and the first match is a visible element.

Gates: builder **93 files / 2628 tests**, plugin-page-builder **50 / 524**, lint 0, check-types 0, `fallow audit` **pass** (10 files, 0 introduced, max CC 9). Rebased onto `270761c23`; `git merge-tree` reported no conflicts against the merged #1433.