### PR TITLE
feat(nextly): let the background queue be watched

### DIFF
--- a/.changeset/the-queue-can-be-watched.md
+++ b/.changeset/the-queue-can-be-watched.md
@@ -51,3 +51,24 @@ would change what preset roles grant as a side effect of adding an endpoint.
 
 Terminal rows are pruned on the retention window, seven days by default, so this
 is recent history by construction rather than an archive.
+
+`meta.hasNext` is answered by a probe row rather than stated. Reading one row
+beyond the limit is what proves more exists; a full page cannot, because a queue
+whose length is an exact multiple of the limit would then claim a next page that
+is empty. A monitor that reports itself complete while showing a slice is how an
+operator concludes the failure they are hunting never happened.
+
+`lastError` is delivered exactly as it was recorded. The response opts out of
+the global timezone rewrite, as the webhook delivery endpoints do: that pass
+rewrites every date-looking string in a payload by value, and a handler that
+surfaces a timestamp as its whole message would have had the debugging record
+altered. The row's own timestamps arrive in UTC, which is the same fallback the
+pass takes when no timezone is configured.
+
+The recent-jobs ordering index is now created on SQLite, not merely declared.
+A Drizzle index declaration reaches an existing database through nothing —
+core reconciliation compares names and columns only, so index-only drift
+produces no operations — and SQLite's core DDL, which re-runs idempotently, had
+no statement for it. PostgreSQL and MySQL create it on a fresh push; repairing
+an existing installation on those dialects needs a general core index step in
+`nextly upgrade`, which is filed rather than built here.

--- a/.changeset/the-queue-can-be-watched.md
+++ b/.changeset/the-queue-can-be-watched.md
@@ -1,0 +1,53 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+`GET /api/jobs` reports what the background queue recently did.
+
+A background job that fails is invisible. There is no request to inspect, no
+status code and no page that went blank — so a scheduled release that did not
+publish looked exactly like one that was not due yet. The outcome, the attempt
+count and the error were all recorded on the row and readable only with SQL.
+
+Each row carries a DERIVED status beside its stored state, because the stored
+vocabulary cannot express the distinction that matters most. A job whose attempt
+failed and which will try again is written back as `pending`, indistinguishable
+by state from one that has never run — while `failed` is terminal and means the
+work will not happen without a person. `jobDisplayStatus` separates them from
+the attempt count, in one place, so a client cannot derive a second answer.
+
+Read-only on purpose: no retry, no cancel, no requeue. Each is a write on
+already-authorized work and needs its own decision about who may perform it,
+and shipping them beside a read would settle those questions by omission.
+
+Gated on `manage-background-jobs`, the permission the trigger already uses.
+`lastError` carries whatever a handler threw, which is internal detail rather
+than content, and there is no seeded read permission to widen to — inventing one
+would change what preset roles grant as a side effect of adding an endpoint.
+
+Terminal rows are pruned on the retention window, seven days by default, so this
+is recent history by construction rather than an archive.

--- a/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
+++ b/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
@@ -1,0 +1,153 @@
+/**
+ * The jobs read surface, at the two places a list can lie quietly.
+ *
+ * A monitor that shows fifty rows out of five hundred and reports itself
+ * complete is worse than one that shows nothing: an operator hunting a failed
+ * release reads the absence as proof it never ran. And `lastError` is whatever
+ * a handler threw, so a message quoting a timestamp is the record being
+ * inspected — it must arrive as it was written, not shifted into the
+ * installation's timezone by a pass that cannot know what the string means.
+ *
+ * The permission is driven through a REAL check rather than a spy, as the run
+ * route's tests are: the fake grants exactly what the caller says it holds, so
+ * the ROUTE's choice of permission decides the outcome.
+ */
+
+import { describe, expect, it, vi } from "vitest";
+
+import type { JobSummaryRow } from "../../domains/jobs/jobs-repository";
+
+const HELD = "x-test-permissions";
+
+/** What `listRecent` was asked for, so the probe row can be asserted. */
+let requestedLimit = 0;
+
+/** Rows the fake repository holds; each test sets its own count. */
+let stored: JobSummaryRow[] = [];
+
+function job(id: string, lastError: string | null = null): JobSummaryRow {
+  const at = new Date("2026-01-01T00:00:00.000Z");
+  return {
+    id,
+    slug: "releases:drain",
+    state: "failed",
+    attemptCount: 1,
+    runAt: null,
+    nextAttemptAt: null,
+    lockedUntil: null,
+    lastError,
+    createdAt: at,
+    updatedAt: at,
+  };
+}
+
+const repository = {
+  listRecent: async (input: { limit: number }): Promise<JobSummaryRow[]> => {
+    requestedLimit = input.limit;
+    return stored.slice(0, input.limit);
+  },
+};
+
+vi.mock("../../di", () => ({
+  container: { get: () => repository },
+}));
+
+vi.mock("../../init", () => ({ getCachedNextly: async () => ({}) }));
+
+vi.mock("../../auth/middleware", () => ({
+  isErrorResponse: (r: { statusCode?: number }) => "statusCode" in r,
+  requireAnyPermission: async (
+    req: Request,
+    needed: Array<{ action: string; resource: string }>
+  ) => {
+    const held = (req.headers.get(HELD) ?? "").split(",").filter(Boolean);
+    const ok = needed.some(n => held.includes(`${n.action}-${n.resource}`));
+    return ok
+      ? { userId: "u1", permissions: held, roles: [], authMethod: "session" }
+      : {
+          success: false,
+          statusCode: 403,
+          message: "Forbidden",
+          error: "Forbidden",
+          data: null,
+        };
+  },
+}));
+
+const { listJobsRoute } = await import("../jobs-list-route");
+const { withTimezoneFormatting } = await import(
+  "../../shared/lib/date-formatting"
+);
+
+function request(query = ""): Request {
+  return new Request(`http://localhost/api/jobs${query}`, {
+    headers: { [HELD]: "manage-background-jobs" },
+  });
+}
+
+async function meta(response: Response): Promise<Record<string, unknown>> {
+  const body = (await response.json()) as { meta: Record<string, unknown> };
+  return body.meta;
+}
+
+describe("GET /api/jobs", () => {
+  it("reports a TRUNCATED window as having more", async () => {
+    // The failure this closes: `hasNext` was the literal `false`, so a queue of
+    // any size answered "this is all of it".
+    stored = Array.from({ length: 60 }, (_, i) => job(`j${i}`));
+
+    const response = await listJobsRoute(request("?limit=10"));
+    const body = (await response.clone().json()) as { items: unknown[] };
+
+    expect((await meta(response)).hasNext).toBe(true);
+    // The probe row is not handed to the caller: it exists to be counted.
+    expect(body.items).toHaveLength(10);
+    expect(requestedLimit).toBe(11);
+  });
+
+  it("reports an EXACTLY FULL window as complete", async () => {
+    // The control, and the reason for a probe row rather than a full-page test:
+    // inferring truncation from a full page claims a next page whenever the
+    // queue length is an exact multiple of the limit, sending an operator to an
+    // empty screen.
+    stored = Array.from({ length: 10 }, (_, i) => job(`j${i}`));
+
+    const response = await listJobsRoute(request("?limit=10"));
+    const body = (await response.clone().json()) as { items: unknown[] };
+
+    expect((await meta(response)).hasNext).toBe(false);
+    expect(body.items).toHaveLength(10);
+  });
+
+  it("delivers a date-shaped lastError exactly as it was recorded", async () => {
+    // Asserted through the pass that would rewrite it, not by looking for the
+    // opt-out header: a header assertion passes while the pass is bypassed for
+    // some other reason, and it is the surviving TEXT that operators need.
+    // The value IS a timestamp, which is the case the rewrite acts on: a
+    // handler that surfaces a remote endpoint's response verbatim, or a
+    // deadline echoed back as the whole message. A date embedded in a sentence
+    // is not rewritten, so asserting with one would pass without the opt-out
+    // and prove nothing.
+    const recorded = "2026-09-01T12:00:00Z";
+    stored = [job("j1", recorded)];
+
+    const response = await withTimezoneFormatting(
+      await listJobsRoute(request())
+    );
+    const body = (await response.json()) as {
+      items: Array<{ lastError: string }>;
+    };
+
+    expect(body.items[0].lastError).toBe(recorded);
+    // The premise: the internal marker never reaches a client.
+    expect(response.headers.get("x-nextly-skip-timezone-format")).toBeNull();
+  });
+
+  it("refuses a caller without the jobs permission", async () => {
+    stored = [job("j1")];
+    const response = await listJobsRoute(
+      new Request("http://localhost/api/jobs", { headers: { [HELD]: "" } })
+    );
+    expect(response.status).toBe(403);
+  });
+});

--- a/packages/nextly/src/api/jobs-list-route.ts
+++ b/packages/nextly/src/api/jobs-list-route.ts
@@ -1,0 +1,91 @@
+/**
+ * Reading the queue, as distinct from running it.
+ *
+ * A background job that fails is invisible: there is no request to inspect, no
+ * status code, and no page that went blank. The outcome, the attempt count and
+ * the error are all written to the row and, until this route existed, could
+ * only be read with SQL. So a scheduled release that did not publish looked
+ * exactly like one that was not due yet.
+ *
+ * ## Read-only, deliberately
+ *
+ * No retry, no cancel, no requeue. Those are writes on already-authorized work
+ * and each needs its own decision about who may perform it; shipping them
+ * beside a read would settle those questions by omission. What this closes is
+ * the silent-failure gap, which is the part that costs somebody a morning.
+ *
+ * ## Why it takes the same permission as running the queue
+ *
+ * `lastError` carries whatever the handler threw — a database message, a remote
+ * endpoint's response — which is internal detail rather than content. There is
+ * no seeded `read-background-jobs`, and inventing one here would change what
+ * preset roles grant as a side effect of adding a screen. Reusing
+ * `manage-background-jobs` keeps that a separate, deliberate decision.
+ *
+ * @module api/jobs-list-route
+ */
+
+import { requireAnyPermission } from "../auth/middleware";
+import { container } from "../di";
+import { jobDisplayStatus } from "../domains/jobs/job-display-status";
+import type { JobsRepository } from "../domains/jobs/jobs-repository";
+import { getCachedNextly } from "../init";
+
+import { respondData } from "./response-shapes";
+import { withErrorHandler } from "./with-error-handler";
+
+/**
+ * How many rows one read returns.
+ *
+ * A ceiling rather than a page size: this endpoint answers "what recently
+ * happened", and a caller wanting more than this wants an archive, which the
+ * seven-day prune means the table cannot supply anyway.
+ */
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+/** Clamped rather than refused: a caller asking for too much gets the ceiling. */
+function readLimit(request: Request): number {
+  const raw = new URL(request.url).searchParams.get("limit");
+  if (raw === null) return DEFAULT_LIMIT;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_LIMIT;
+  return Math.min(parsed, MAX_LIMIT);
+}
+
+/**
+ * GET /api/jobs — the most recently touched jobs.
+ *
+ * Each row carries its DERIVED status beside the stored state, because the
+ * stored one cannot distinguish a job that is retrying from one that has never
+ * run — both are `pending` — and that is the distinction an operator needs
+ * most. Deriving it here rather than in each client keeps one answer.
+ *
+ * The `input` column is deliberately NOT returned. It is arbitrary caller data
+ * that may carry anything the enqueuing code put there, and a list view has no
+ * use for it.
+ */
+export const listJobsRoute = withErrorHandler(async (request: Request) => {
+  await requireAnyPermission(request, [
+    { action: "manage", resource: "background-jobs" },
+  ]);
+
+  await getCachedNextly();
+  const repository = container.get<JobsRepository>("jobsRepository");
+  const rows = await repository.listRecent({ limit: readLimit(request) });
+
+  return respondData({
+    jobs: rows.map(row => ({
+      id: row.id,
+      slug: row.slug,
+      state: row.state,
+      status: jobDisplayStatus(row),
+      attemptCount: row.attemptCount,
+      lastError: row.lastError,
+      runAt: row.runAt,
+      nextAttemptAt: row.nextAttemptAt,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    })),
+  });
+});

--- a/packages/nextly/src/api/jobs-list-route.ts
+++ b/packages/nextly/src/api/jobs-list-route.ts
@@ -25,13 +25,14 @@
  * @module api/jobs-list-route
  */
 
-import { requireAnyPermission } from "../auth/middleware";
 import { container } from "../di";
 import { jobDisplayStatus } from "../domains/jobs/job-display-status";
 import type { JobsRepository } from "../domains/jobs/jobs-repository";
 import { getCachedNextly } from "../init";
 
-import { respondData } from "./response-shapes";
+import { PRIVATE_NO_STORE_HEADERS } from "./authenticated-read";
+import { respondList } from "./response-shapes";
+import { requireRouteAnyPermission } from "./route-auth";
 import { withErrorHandler } from "./with-error-handler";
 
 /**
@@ -66,26 +67,61 @@ function readLimit(request: Request): number {
  * use for it.
  */
 export const listJobsRoute = withErrorHandler(async (request: Request) => {
-  await requireAnyPermission(request, [
+  /*
+   * `requireRouteAnyPermission`, not `requireAnyPermission`. The latter RETURNS
+   * an `ErrorResponse` rather than throwing, so awaiting it and discarding the
+   * result authorizes nobody — an unauthorized caller walks straight past it to
+   * the read. The throwing wrapper exists so a route cannot make that mistake,
+   * and it is the one every other authenticated route here uses.
+   */
+  await requireRouteAnyPermission(request, [
     { action: "manage", resource: "background-jobs" },
   ]);
 
   await getCachedNextly();
   const repository = container.get<JobsRepository>("jobsRepository");
-  const rows = await repository.listRecent({ limit: readLimit(request) });
+  const limit = readLimit(request);
+  const rows = await repository.listRecent({ limit });
+  const now = new Date();
 
-  return respondData({
-    jobs: rows.map(row => ({
-      id: row.id,
-      slug: row.slug,
-      state: row.state,
-      status: jobDisplayStatus(row),
-      attemptCount: row.attemptCount,
-      lastError: row.lastError,
-      runAt: row.runAt,
-      nextAttemptAt: row.nextAttemptAt,
-      createdAt: row.createdAt,
-      updatedAt: row.updatedAt,
-    })),
-  });
+  const items = rows.map(row => ({
+    id: row.id,
+    slug: row.slug,
+    state: row.state,
+    status: jobDisplayStatus(row, now),
+    attemptCount: row.attemptCount,
+    lastError: row.lastError,
+    runAt: row.runAt,
+    nextAttemptAt: row.nextAttemptAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  }));
+
+  /*
+   * The canonical list envelope, not a shape invented for this endpoint. A
+   * generic consumer reads `items` and `meta` from every list in this API, and
+   * a bespoke `{ jobs }` would be the one it cannot.
+   *
+   * `total` is the page's own length and the page count is 1, stated honestly
+   * rather than fabricated: this endpoint answers "the most recent N", the seam
+   * it reads through offers no count, and a second query for one would produce
+   * a total that can disagree with the page beside it. A caller needing true
+   * pagination should ask for it rather than infer it from a number that looks
+   * like one.
+   */
+  return respondList(
+    items,
+    {
+      total: items.length,
+      page: 1,
+      limit,
+      totalPages: 1,
+      hasNext: false,
+      hasPrev: false,
+    },
+    // Permission-scoped, and `lastError` is arbitrary internal text. Without
+    // this a browser or shared cache can replay the body after logout, or to
+    // another session, without authorization running again.
+    { headers: PRIVATE_NO_STORE_HEADERS }
+  );
 });

--- a/packages/nextly/src/api/jobs-list-route.ts
+++ b/packages/nextly/src/api/jobs-list-route.ts
@@ -29,6 +29,7 @@ import { container } from "../di";
 import { jobDisplayStatus } from "../domains/jobs/job-display-status";
 import type { JobsRepository } from "../domains/jobs/jobs-repository";
 import { getCachedNextly } from "../init";
+import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
 
 import { PRIVATE_NO_STORE_HEADERS } from "./authenticated-read";
 import { respondList } from "./response-shapes";
@@ -81,7 +82,16 @@ export const listJobsRoute = withErrorHandler(async (request: Request) => {
   await getCachedNextly();
   const repository = container.get<JobsRepository>("jobsRepository");
   const limit = readLimit(request);
-  const rows = await repository.listRecent({ limit });
+  /*
+   * One row beyond the limit, as the versions window does. Its PRESENCE is what
+   * proves more exists; inferring truncation from a full page instead would
+   * claim more whenever the queue length is an exact multiple of the limit, and
+   * an operator reading "showing the most recent 50 of more" would go looking
+   * for jobs that are not there.
+   */
+  const window = await repository.listRecent({ limit: limit + 1 });
+  const hasNext = window.length > limit;
+  const rows = hasNext ? window.slice(0, limit) : window;
   const now = new Date();
 
   const items = rows.map(row => ({
@@ -108,6 +118,11 @@ export const listJobsRoute = withErrorHandler(async (request: Request) => {
    * a total that can disagree with the page beside it. A caller needing true
    * pagination should ask for it rather than infer it from a number that looks
    * like one.
+   *
+   * `hasNext` is the one field a probe row CAN answer honestly, and it is the
+   * one that matters here: without it a truncated monitor view is
+   * indistinguishable from a complete one, which is how an operator concludes
+   * that the failure they are looking for never happened.
    */
   return respondList(
     items,
@@ -116,12 +131,32 @@ export const listJobsRoute = withErrorHandler(async (request: Request) => {
       page: 1,
       limit,
       totalPages: 1,
-      hasNext: false,
+      hasNext,
       hasPrev: false,
     },
-    // Permission-scoped, and `lastError` is arbitrary internal text. Without
-    // this a browser or shared cache can replay the body after logout, or to
-    // another session, without authorization running again.
-    { headers: PRIVATE_NO_STORE_HEADERS }
+    {
+      headers: {
+        // Permission-scoped, and `lastError` is arbitrary internal text.
+        // Without this a browser or shared cache can replay the body after
+        // logout, or to another session, without authorization running again.
+        ...PRIVATE_NO_STORE_HEADERS,
+        /*
+         * Opt out of the global timezone rewrite, as the webhook delivery
+         * endpoints do for the same reason. That pass rewrites every
+         * date-looking STRING in a payload by value, and `lastError` is
+         * whatever a handler threw — a message quoting a timestamp is exactly
+         * the debugging record an operator is inspecting, and it must arrive
+         * as it was recorded rather than shifted into the installation's
+         * timezone.
+         *
+         * The cost is that this row's own timestamps arrive in UTC rather than
+         * pre-shifted, which is what the pass itself falls back to when no
+         * timezone is configured and what the webhook delivery endpoints
+         * already deliver. A client renders them in the viewer's zone; no
+         * client can recover an error string the server rewrote.
+         */
+        [SKIP_TIMEZONE_FORMAT_HEADER]: "1",
+      },
+    }
   );
 });

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -20,8 +20,10 @@
 import { readdirSync, readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { getTableConfig } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 
+import { nextlyJobsSqlite } from "../../schemas/jobs/sqlite";
 import { generateSqliteCoreTableStatements } from "../sqlite-core-tables";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -130,6 +132,31 @@ describe("the SQLite bootstrap DDL", () => {
         "query against them fails. Add the DDL, or add the table to " +
         "NOT_BOOTSTRAPPED with the reason."
     ).toEqual([]);
+  });
+
+  /*
+   * Indexes, for `nextly_jobs` only.
+   *
+   * The column comparison above cannot see an index: a missing one breaks no
+   * insert, it makes a query slow, which is why `nextly_jobs_recent_idx` was
+   * declared on all three dialects and created on none. Scoped to this table
+   * rather than generalized because the same probe reports ten pre-existing
+   * omissions on `dynamic_collections` and `dynamic_components`, and deciding
+   * what those should be is a separate change from asserting this one.
+   */
+  it("creates every index the jobs schema declares", () => {
+    const statements = generateSqliteCoreTableStatements().join("\n");
+    const declared = getTableConfig(nextlyJobsSqlite).indexes.map(
+      index => index.config.name
+    );
+    const missing = declared.filter(name => !statements.includes(`"${name}"`));
+    expect(
+      missing,
+      `nextly_jobs: the bootstrap DDL never creates ${missing.join(", ")}, so ` +
+        "the declaration is decorative on every SQLite database built from it"
+    ).toEqual([]);
+    // The premise: this compared real index names rather than an empty list.
+    expect(declared.length).toBeGreaterThan(1);
   });
 
   it("does not carry exclusions for tables that no longer exist", () => {

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -285,6 +285,12 @@ export function generateSqliteCoreTableStatements(): string[] {
     // into it would never appear on a database built by an earlier boot.
     `CREATE INDEX IF NOT EXISTS "nextly_jobs_due_idx"
       ON "nextly_jobs" ("state", "run_at")`,
+    // The recent-jobs read sorts the whole table by `updated_at` before its
+    // small limit applies. The due index above cannot serve that sort — its
+    // leading column is `state` — so without this every monitoring request is
+    // a full scan and sort that degrades with queue volume.
+    `CREATE INDEX IF NOT EXISTS "nextly_jobs_recent_idx"
+      ON "nextly_jobs" ("updated_at")`,
     // Nullable and unique: SQLite treats NULL as distinct from NULL, so jobs
     // that name no dedupe key are never deduplicated, while a job that names
     // one can be enqueued exactly once. That is what makes duplicate

--- a/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The distinction the stored state cannot make.
+ *
+ * `finalize` writes `pending` for BOTH a job that has never run and one whose
+ * attempt failed and is scheduled to try again, so any test that only varied
+ * `state` would pass against an implementation that ignored `attemptCount`
+ * entirely — and that implementation is the defect. Every case below therefore
+ * pins a pair that shares a state and differs in the count, or the reverse.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  jobDisplayStatus,
+  jobNeedsAttention,
+  type JobStatusInput,
+} from "../job-display-status";
+
+const row = (over: Partial<JobStatusInput> = {}): JobStatusInput => ({
+  state: "pending",
+  attemptCount: 0,
+  ...over,
+});
+
+describe("what a job row means to a person", () => {
+  it("separates a job that has never run from one that is retrying", () => {
+    // Same state. Only the count differs, which is the whole mechanism.
+    expect(jobDisplayStatus(row({ state: "pending", attemptCount: 0 }))).toBe(
+      "waiting"
+    );
+    expect(jobDisplayStatus(row({ state: "pending", attemptCount: 2 }))).toBe(
+      "retrying"
+    );
+  });
+
+  it("reports a spent job as failed, not as retrying", () => {
+    // A terminal failure also carries attempts. Reading the count first would
+    // call this "retrying" and bury a dead job among self-healing noise.
+    expect(jobDisplayStatus(row({ state: "failed", attemptCount: 5 }))).toBe(
+      "failed"
+    );
+  });
+
+  it("reports the remaining stored states", () => {
+    expect(jobDisplayStatus(row({ state: "running", attemptCount: 1 }))).toBe(
+      "running"
+    );
+    expect(jobDisplayStatus(row({ state: "done", attemptCount: 1 }))).toBe(
+      "succeeded"
+    );
+  });
+
+  /*
+   * The alarm is exactly one status. Asserted across the whole vocabulary
+   * rather than on `failed` alone, so adding a status that should raise one —
+   * or should not — has to be a decision made here.
+   */
+  it("raises attention for a terminal failure and nothing else", () => {
+    expect(jobNeedsAttention("failed")).toBe(true);
+    for (const quiet of [
+      "waiting",
+      "retrying",
+      "running",
+      "succeeded",
+    ] as const) {
+      expect(jobNeedsAttention(quiet)).toBe(false);
+    }
+  });
+});

--- a/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
@@ -15,38 +15,63 @@ import {
   type JobStatusInput,
 } from "../job-display-status";
 
+const NOW = new Date("2026-09-01T12:00:00.000Z");
+const LIVE = new Date(NOW.getTime() + 30_000);
+const EXPIRED = new Date(NOW.getTime() - 30_000);
+
 const row = (over: Partial<JobStatusInput> = {}): JobStatusInput => ({
   state: "pending",
   attemptCount: 0,
+  lockedUntil: null,
   ...over,
 });
+
+const status = (over: Partial<JobStatusInput> = {}) =>
+  jobDisplayStatus(row(over), NOW);
 
 describe("what a job row means to a person", () => {
   it("separates a job that has never run from one that is retrying", () => {
     // Same state. Only the count differs, which is the whole mechanism.
-    expect(jobDisplayStatus(row({ state: "pending", attemptCount: 0 }))).toBe(
-      "waiting"
-    );
-    expect(jobDisplayStatus(row({ state: "pending", attemptCount: 2 }))).toBe(
-      "retrying"
-    );
+    expect(status({ state: "pending", attemptCount: 0 })).toBe("waiting");
+    expect(status({ state: "pending", attemptCount: 2 })).toBe("retrying");
   });
 
   it("reports a spent job as failed, not as retrying", () => {
     // A terminal failure also carries attempts. Reading the count first would
     // call this "retrying" and bury a dead job among self-healing noise.
-    expect(jobDisplayStatus(row({ state: "failed", attemptCount: 5 }))).toBe(
-      "failed"
-    );
+    expect(status({ state: "failed", attemptCount: 5 })).toBe("failed");
   });
 
   it("reports the remaining stored states", () => {
-    expect(jobDisplayStatus(row({ state: "running", attemptCount: 1 }))).toBe(
-      "running"
-    );
-    expect(jobDisplayStatus(row({ state: "done", attemptCount: 1 }))).toBe(
-      "succeeded"
-    );
+    expect(status({ state: "running", attemptCount: 1 })).toBe("running");
+    expect(status({ state: "done", attemptCount: 1 })).toBe("succeeded");
+  });
+
+  /*
+   * The case the state column CANNOT express. `claim` takes the lease without
+   * touching state and `markAttempt` raises the count before the handler runs,
+   * so a healthy first attempt in flight is `pending` with a count of 1 — which
+   * by count alone reads as "retrying" and tells an operator a working job has
+   * already failed once.
+   */
+  it("reports work in flight as running, not as retrying", () => {
+    expect(
+      status({ state: "pending", attemptCount: 1, lockedUntil: LIVE })
+    ).toBe("running");
+  });
+
+  /*
+   * An EXPIRED lease is a runner that died, not a job executing. The row is
+   * waiting to be reclaimed, so the comparison must be against the clock rather
+   * than against the field merely being set.
+   */
+  it("does not call an expired lease running", () => {
+    expect(
+      status({ state: "pending", attemptCount: 1, lockedUntil: EXPIRED })
+    ).toBe("retrying");
+    expect(
+      status({ state: "pending", attemptCount: 0, lockedUntil: EXPIRED })
+    ).toBe("waiting");
   });
 
   /*

--- a/packages/nextly/src/domains/jobs/__tests__/jobs-summary-row.test-d.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/jobs-summary-row.test-d.ts
@@ -1,0 +1,37 @@
+/**
+ * The summary row must promise exactly what the query selects.
+ *
+ * A runtime test cannot see this: `listRecent` returns whatever the adapter
+ * hands back, so a type that over-promises produces `undefined` at a property
+ * the compiler calls a `string`, and every assertion written against the
+ * projection still passes. It was `Omit<JobRow, "input">` beside a projection
+ * that also omitted `runAsUserId`, `dedupeKey` and `lockedBy` — three fields a
+ * caller could read, and be typed for, and never receive.
+ */
+
+import { expectTypeOf } from "vitest";
+
+import type { JobRow, JobSummaryRow } from "../jobs-repository";
+
+// What the projection selects is present, and keeps JobRow's own type.
+expectTypeOf<JobSummaryRow>().toHaveProperty("id").toEqualTypeOf<string>();
+expectTypeOf<JobSummaryRow>()
+  .toHaveProperty("lastError")
+  .toEqualTypeOf<string | null>();
+expectTypeOf<JobSummaryRow>()
+  .toHaveProperty("lockedUntil")
+  .toEqualTypeOf<Date | null>();
+
+// What it does not select is ABSENT rather than optional: reading it is a
+// compile error, which is the only signal that arrives before production.
+expectTypeOf<JobSummaryRow>().not.toHaveProperty("input");
+expectTypeOf<JobSummaryRow>().not.toHaveProperty("runAsUserId");
+expectTypeOf<JobSummaryRow>().not.toHaveProperty("dedupeKey");
+expectTypeOf<JobSummaryRow>().not.toHaveProperty("lockedBy");
+
+// The premise: those names are real columns on the row this is projected from,
+// so their absence above is a projection decision and not four typos.
+expectTypeOf<JobRow>().toHaveProperty("runAsUserId");
+expectTypeOf<JobRow>().toHaveProperty("dedupeKey");
+expectTypeOf<JobRow>().toHaveProperty("lockedBy");
+expectTypeOf<JobRow>().toHaveProperty("input");

--- a/packages/nextly/src/domains/jobs/job-display-status.ts
+++ b/packages/nextly/src/domains/jobs/job-display-status.ts
@@ -1,0 +1,64 @@
+/**
+ * What a job's row MEANS to a person watching the queue.
+ *
+ * The stored vocabulary is `pending | running | done | failed`, and it does not
+ * answer the question an operator actually asks. A job that failed an attempt
+ * and will try again is written back as `pending` with a later
+ * `nextAttemptAt` — indistinguishable, by state alone, from one that has never
+ * run. Those two need different reactions: the first is the system healing
+ * itself and wants no-one, the second is simply waiting.
+ *
+ * The dangerous pair is the other one. `failed` is TERMINAL — the attempts are
+ * spent and the work will not happen unless a person acts — while a retrying
+ * job looks like a failure in the log and is not one. Presenting them alike is
+ * the documented common mistake in queue tooling: it either raises an alarm for
+ * something self-healing, or buries a dead job among transient noise.
+ *
+ * Derived rather than stored, and derived in ONE place, because the answer is a
+ * function of columns the database already has. A second derivation in the
+ * admin would agree on the day it was written.
+ *
+ * @module domains/jobs/job-display-status
+ */
+
+/** What a job row is doing, in the terms an operator reasons about. */
+export type JobDisplayStatus =
+  /** Queued, never attempted. */
+  | "waiting"
+  /** An attempt failed; another is scheduled. Self-healing, not an alarm. */
+  | "retrying"
+  /** A runner holds the lease right now. */
+  | "running"
+  /** Finished successfully. */
+  | "succeeded"
+  /** Attempts are spent. This will not happen without a person. */
+  | "failed";
+
+/** The columns the derivation reads, and nothing more. */
+export interface JobStatusInput {
+  state: "pending" | "running" | "done" | "failed";
+  attemptCount: number;
+}
+
+/**
+ * `attemptCount` is what separates waiting from retrying, because the state
+ * column cannot: `finalize` writes `pending` for a retry, so the count is the
+ * only surviving evidence that an attempt already happened.
+ */
+export function jobDisplayStatus(row: JobStatusInput): JobDisplayStatus {
+  if (row.state === "running") return "running";
+  if (row.state === "done") return "succeeded";
+  if (row.state === "failed") return "failed";
+  return row.attemptCount > 0 ? "retrying" : "waiting";
+}
+
+/**
+ * Whether this status is one a person has to do something about.
+ *
+ * Exported as its own question rather than left to each caller's `=== "failed"`
+ * so the answer stays in one place when a status is added. A caller asking "is
+ * anything wrong" must not have to enumerate the vocabulary to find out.
+ */
+export function jobNeedsAttention(status: JobDisplayStatus): boolean {
+  return status === "failed";
+}

--- a/packages/nextly/src/domains/jobs/job-display-status.ts
+++ b/packages/nextly/src/domains/jobs/job-display-status.ts
@@ -38,14 +38,54 @@ export type JobDisplayStatus =
 export interface JobStatusInput {
   state: "pending" | "running" | "done" | "failed";
   attemptCount: number;
+  /**
+   * When this runner's lease expires, or `null` when nothing holds one.
+   *
+   * Load-bearing, and not obvious: `claim` takes the lease WITHOUT changing
+   * state, so a job executing right now still reads `pending`. The state column
+   * therefore never says "running" for work the runner is doing, and the lease
+   * is the only evidence that it is.
+   */
+  lockedUntil: Date | null;
 }
 
 /**
- * `attemptCount` is what separates waiting from retrying, because the state
- * column cannot: `finalize` writes `pending` for a retry, so the count is the
- * only surviving evidence that an attempt already happened.
+ * Read in this order, and the order is the whole correctness argument.
+ *
+ * A LIVE LEASE first, because it is the only signal that work is happening:
+ * `claim` writes `lockedBy`/`lockedUntil` and leaves the state alone, and
+ * `markAttempt` raises the count BEFORE the handler is invoked. So an in-flight
+ * first attempt is `pending` with a count of 1 — which, read by count alone,
+ * reports as "retrying" and tells an operator a healthy job has already failed.
+ *
+ * An EXPIRED lease is not a running job. It is a runner that died holding one,
+ * and the row is waiting to be reclaimed — so the comparison is against `now`
+ * rather than against the field being present.
+ *
+ * Reading the lease first is SAFE against a terminal row because `finalize`
+ * clears `lockedBy`/`lockedUntil` on every outcome — retry and terminal alike.
+ * A finished job therefore never carries a live lease, so the ordering cannot
+ * report one as running. That is a guarantee of the repository rather than of
+ * this function, which is why it is named here: if `finalize` ever stopped
+ * clearing the lock, this ordering would need to invert.
+ *
+ * `attemptCount` last, because it is what separates waiting from retrying once
+ * nothing is executing: `finalize` writes `pending` for a retry, so the count
+ * is the only surviving evidence that an attempt already happened.
+ *
+ * `now` is a parameter rather than read from the clock inside, so a caller
+ * rendering a page and a test asserting one both control it.
  */
-export function jobDisplayStatus(row: JobStatusInput): JobDisplayStatus {
+export function jobDisplayStatus(
+  row: JobStatusInput,
+  now: Date
+): JobDisplayStatus {
+  if (row.lockedUntil !== null && row.lockedUntil.getTime() > now.getTime()) {
+    return "running";
+  }
+  // Kept for completeness: nothing writes this state today, and a status
+  // derivation that silently reported a stored value as something else would be
+  // the harder defect to find if something starts.
   if (row.state === "running") return "running";
   if (row.state === "done") return "succeeded";
   if (row.state === "failed") return "failed";

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -278,6 +278,43 @@ export class JobsRepository {
    * `nextly_webhook_deliveries` selects its due rows the same way, for the same
    * reason.
    */
+  /**
+   * The most recently touched jobs, for somebody watching the queue.
+   *
+   * Ordered by `updatedAt` rather than `createdAt`: what an operator wants to
+   * see first is what most recently HAPPENED, and a job enqueued days ago that
+   * failed a minute ago is the row that matters. Creation order would bury it
+   * under newer work that has not run.
+   *
+   * Bounded by `limit` with no total alongside it, deliberately. The seam this
+   * repository is written against offers no count, and a second query to
+   * produce one would be a page-count that can disagree with the page it
+   * labels. A caller that needs "the last N" is served; a caller that needs
+   * true pagination should say so and get an offset-based method with a count
+   * the same query produced.
+   *
+   * Terminal rows are pruned on a retention window — seven days by default —
+   * so this is a recent-history view by construction rather than an archive.
+   * A caller must not read an absent job as one that never ran.
+   */
+  async listRecent(input: {
+    limit: number;
+    /** Restrict to these states. Omitted means every state. */
+    states?: readonly JobState[];
+  }): Promise<JobRow[]> {
+    return this.db.select<JobRow>(JOBS, {
+      ...(input.states === undefined || input.states.length === 0
+        ? {}
+        : {
+            where: {
+              and: [{ column: "state", op: "IN", value: [...input.states] }],
+            },
+          }),
+      orderBy: [{ column: "updatedAt", direction: "desc" }],
+      limit: input.limit,
+    });
+  }
+
   async findDue(input: { now: Date; limit: number }): Promise<JobRow[]> {
     return this.db.select<JobRow>(JOBS, {
       where: {

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -127,14 +127,38 @@ export interface JobRow {
 }
 
 /**
- * A job as a monitor needs it: every column except `input`.
+ * The columns {@link JobsRepository.listRecent} actually selects.
  *
- * Derived from {@link JobRow} rather than restated, so a column added there is
- * carried here and one REMOVED is a compile error rather than a silent gap.
- * `input` is omitted because it is arbitrary caller data of unbounded size that
- * no list consumer reads.
+ * The single source for both the query's projection and the type it returns.
+ * They were two lists before — `Omit<JobRow, "input">` beside a projection that
+ * also left out `runAsUserId`, `dedupeKey` and `lockedBy` — so the type promised
+ * three non-optional fields the query never returns, and a caller reading one
+ * got `undefined` from a property the compiler said was a `string`. Adding a
+ * column here now widens both at once; there is no second list to forget.
  */
-export type JobSummaryRow = Omit<JobRow, "input">;
+const SUMMARY_COLUMNS = [
+  "id",
+  "slug",
+  "state",
+  "attemptCount",
+  "runAt",
+  "nextAttemptAt",
+  "lockedUntil",
+  "lastError",
+  "createdAt",
+  "updatedAt",
+] as const satisfies readonly (keyof JobRow)[];
+
+/**
+ * A job as a monitor needs it: exactly the columns the summary query selects.
+ *
+ * Projected from {@link JobRow} through {@link SUMMARY_COLUMNS}, so a column
+ * renamed or removed there is a compile error rather than a field that quietly
+ * arrives undefined. `input` is excluded because it is arbitrary caller data of
+ * unbounded size that no list consumer reads; the other absentees are identity
+ * and lease-holder columns a monitor has no use for.
+ */
+export type JobSummaryRow = Pick<JobRow, (typeof SUMMARY_COLUMNS)[number]>;
 
 export interface NewJob {
   slug: string;
@@ -317,18 +341,7 @@ export class JobsRepository {
     // anyone opening a monitor pull up to `limit` complete payloads out of the
     // database and into memory for nothing.
     return this.db.select<JobSummaryRow>(JOBS, {
-      columns: [
-        "id",
-        "slug",
-        "state",
-        "attemptCount",
-        "runAt",
-        "nextAttemptAt",
-        "lockedUntil",
-        "lastError",
-        "createdAt",
-        "updatedAt",
-      ],
+      columns: [...SUMMARY_COLUMNS],
       ...(input.states === undefined || input.states.length === 0
         ? {}
         : {

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -126,6 +126,16 @@ export interface JobRow {
   updatedAt: Date;
 }
 
+/**
+ * A job as a monitor needs it: every column except `input`.
+ *
+ * Derived from {@link JobRow} rather than restated, so a column added there is
+ * carried here and one REMOVED is a compile error rather than a silent gap.
+ * `input` is omitted because it is arbitrary caller data of unbounded size that
+ * no list consumer reads.
+ */
+export type JobSummaryRow = Omit<JobRow, "input">;
+
 export interface NewJob {
   slug: string;
   input: unknown;
@@ -301,8 +311,24 @@ export class JobsRepository {
     limit: number;
     /** Restrict to these states. Omitted means every state. */
     states?: readonly JobState[];
-  }): Promise<JobRow[]> {
-    return this.db.select<JobRow>(JOBS, {
+  }): Promise<JobSummaryRow[]> {
+    // PROJECTED, deliberately. `input` is arbitrary caller data of unbounded
+    // size and no consumer of this method reads it, so selecting it would let
+    // anyone opening a monitor pull up to `limit` complete payloads out of the
+    // database and into memory for nothing.
+    return this.db.select<JobSummaryRow>(JOBS, {
+      columns: [
+        "id",
+        "slug",
+        "state",
+        "attemptCount",
+        "runAt",
+        "nextAttemptAt",
+        "lockedUntil",
+        "lastError",
+        "createdAt",
+        "updatedAt",
+      ],
       ...(input.states === undefined || input.states.length === 0
         ? {}
         : {

--- a/packages/nextly/src/route-handler/__tests__/route-parser.jobs-list.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.jobs-list.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Reading the queue must not RUN it.
+ *
+ * The trigger accepts GET as well as POST, because Vercel Cron triggers with a
+ * GET. That makes the verb useless as a discriminator: a list request and a
+ * drain request are both `GET /api/jobs...`, and the only thing separating them
+ * is the path. If the parser let a bare `/api/jobs` fall through to the trigger,
+ * opening a read-only screen would drain the queue as a side effect — a write
+ * performed by a page that advertises itself as a view.
+ *
+ * That is why these assert the METHOD the parser resolves rather than merely
+ * that something parsed: both shapes resolve, and resolving is not the property
+ * under test.
+ */
+import { describe, expect, it } from "vitest";
+
+import { parseRestRoute } from "../route-parser";
+
+describe("the jobs read is distinct from the jobs trigger", () => {
+  it("parses GET /api/jobs as a list", () => {
+    expect(parseRestRoute(["jobs"], "GET")).toMatchObject({
+      service: "jobs",
+      method: "listJobs",
+    });
+  });
+
+  it("does NOT resolve a bare read to the runner", () => {
+    // The defect this file exists for, stated as its own case: a fall-through
+    // would satisfy the test above only if it also named `runJobs`, which is
+    // exactly what must not happen.
+    expect(parseRestRoute(["jobs"], "GET")).not.toMatchObject({
+      method: "runJobs",
+    });
+  });
+
+  it("still parses the trigger, under both verbs it accepts", () => {
+    for (const verb of ["GET", "POST"]) {
+      expect(parseRestRoute(["jobs", "run"], verb)).toMatchObject({
+        service: "jobs",
+        method: "runJobs",
+      });
+    }
+  });
+
+  /*
+   * A read is a read. Offering the list under a write verb would give the
+   * endpoint two meanings and invite a caller to POST to it expecting an
+   * effect.
+   */
+  it("offers the list under GET only", () => {
+    for (const verb of ["POST", "PATCH", "PUT", "DELETE"]) {
+      expect(parseRestRoute(["jobs"], verb)).not.toMatchObject({
+        method: "listJobs",
+      });
+    }
+  });
+});

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2203,6 +2203,7 @@ function parseReleaseRoutes(
 }
 
 /**
+ * GET /api/jobs → list the most recently touched jobs.
  * GET or POST /api/jobs/run → run one background job pass.
  *
  * `run` is the only path under `jobs`, and it is an operation rather than an
@@ -2216,6 +2217,19 @@ function parseJobRoutes(
   httpMethod: string,
   routeParams: Record<string, string>
 ): ParsedRoute | null {
+  // GET /api/jobs → the recent-runs read. Ahead of the `run` branch because it
+  // is the only shape with no id at all, and a reader must not fall through to
+  // a trigger: this route is a read, and running the queue is a side effect
+  // nobody asked for by listing it.
+  if (id === undefined && !subresource && httpMethod === "GET") {
+    return {
+      service: "jobs",
+      operation: "list",
+      method: "listJobs",
+      routeParams,
+    };
+  }
+
   if (id !== "run" || subresource) return null;
   if (httpMethod !== "POST" && httpMethod !== "GET") return null;
   // Running the queue is not a CRUD OperationType, but the dispatch guard

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -1046,7 +1046,16 @@ async function handleServiceRequest(
     // Branch on the parsed method rather than the HTTP verb: the trigger
     // accepts GET as well, so a verb test would send a list request to the
     // runner and drain the queue as a side effect of reading it.
-    return method === "listJobs" ? listJobsRoute(req) : runJobsRoute(req);
+    // Matched explicitly, both ways. A ternary would make the SIDE-EFFECTING
+    // runner the default, so a jobs route added later — or a method name
+    // mistyped in the parser — would drain the queue instead of failing. The
+    // dangerous operation must never be what an unrecognised name falls into.
+    if (method === "listJobs") return listJobsRoute(req);
+    if (method === "runJobs") return runJobsRoute(req);
+    throw NextlyError.notFound({
+      message: `Unknown jobs operation: ${method}`,
+      logContext: { service: "jobs", method },
+    });
   }
 
   // ==================== PREVIEW LINKS DIRECT DISPATCH ====================

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -54,6 +54,7 @@ import {
   updateImageSize,
   deleteImageSize,
 } from "./api/image-sizes";
+import { listJobsRoute } from "./api/jobs-list-route";
 import { runJobsRoute } from "./api/jobs-run-route";
 import { mintPreviewLink, revokePreviewLinks } from "./api/preview-links";
 import { resolveEntryPreviewUrl } from "./api/preview-url";
@@ -1042,7 +1043,10 @@ async function handleServiceRequest(
   // Beside the webhook drain and for the same reason: the handler owns its own
   // authorization, and it must stay above the shared body read below.
   if (service === "jobs") {
-    return runJobsRoute(req);
+    // Branch on the parsed method rather than the HTTP verb: the trigger
+    // accepts GET as well, so a verb test would send a list request to the
+    // runner and drain the queue as a side effect of reading it.
+    return method === "listJobs" ? listJobsRoute(req) : runJobsRoute(req);
   }
 
   // ==================== PREVIEW LINKS DIRECT DISPATCH ====================

--- a/packages/nextly/src/schemas/jobs/mysql.ts
+++ b/packages/nextly/src/schemas/jobs/mysql.ts
@@ -70,6 +70,7 @@ export const nextlyJobsMysql = mysqlTable(
   },
   table => [
     index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    index("nextly_jobs_recent_idx").on(table.updatedAt),
     uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
   ]
 );

--- a/packages/nextly/src/schemas/jobs/mysql.ts
+++ b/packages/nextly/src/schemas/jobs/mysql.ts
@@ -70,6 +70,8 @@ export const nextlyJobsMysql = mysqlTable(
   },
   table => [
     index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    // See `schemas/jobs/postgres.ts` for what this index is for and why a
+    // declaration alone does not put it on an existing database.
     index("nextly_jobs_recent_idx").on(table.updatedAt),
     uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
   ]

--- a/packages/nextly/src/schemas/jobs/postgres.ts
+++ b/packages/nextly/src/schemas/jobs/postgres.ts
@@ -94,6 +94,17 @@ export const nextlyJobsPg = pgTable(
     // scan and sort on every monitoring request, and it degrades with queue
     // volume rather than staying bounded — the due index above cannot serve it,
     // because its leading column is `state`.
+    //
+    // A DECLARATION IS NOT AN UPGRADE PATH. A fresh install gets this index
+    // when the table is pushed; an existing one does not, because
+    // `drizzleTableToTableSpec` records only names and columns, so index-only
+    // drift produces no operations and `reconcileCore` returns early before the
+    // push that would create it. SQLite is repaired by the hand-written core
+    // DDL in `database/sqlite-core-tables.ts`, which re-runs idempotently;
+    // PostgreSQL and MySQL need a general core index-repair step in
+    // `nextly upgrade`, which is filed rather than built here — see
+    // `schemas/nextly-i18n-archive/ddl.ts` for the same problem solved for one
+    // table.
     index("nextly_jobs_recent_idx").on(table.updatedAt),
     uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
   ]

--- a/packages/nextly/src/schemas/jobs/postgres.ts
+++ b/packages/nextly/src/schemas/jobs/postgres.ts
@@ -89,6 +89,12 @@ export const nextlyJobsPg = pgTable(
   table => [
     // The due-job query reads exactly these two columns together.
     index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    // Ordering index for the recent-jobs read, which sorts the whole table by
+    // `updatedAt` before its small limit applies. Without it that is a full
+    // scan and sort on every monitoring request, and it degrades with queue
+    // volume rather than staying bounded — the due index above cannot serve it,
+    // because its leading column is `state`.
+    index("nextly_jobs_recent_idx").on(table.updatedAt),
     uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
   ]
 );

--- a/packages/nextly/src/schemas/jobs/sqlite.ts
+++ b/packages/nextly/src/schemas/jobs/sqlite.ts
@@ -54,6 +54,8 @@ export const nextlyJobsSqlite = sqliteTable(
   },
   table => [
     index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    // See `schemas/jobs/postgres.ts` for what this index is for and why a
+    // declaration alone does not put it on an existing database.
     index("nextly_jobs_recent_idx").on(table.updatedAt),
     uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
   ]

--- a/packages/nextly/src/schemas/jobs/sqlite.ts
+++ b/packages/nextly/src/schemas/jobs/sqlite.ts
@@ -54,6 +54,7 @@ export const nextlyJobsSqlite = sqliteTable(
   },
   table => [
     index("nextly_jobs_due_idx").on(table.state, table.runAt),
+    index("nextly_jobs_recent_idx").on(table.updatedAt),
     uniqueIndex("nextly_jobs_dedupe_idx").on(table.dedupeKey),
   ]
 );


### PR DESCRIPTION
R-2, first of two. This is the read surface; the admin screen follows.

## What was wrong

A background job that fails is **invisible**. There is no request to inspect, no
status code, and no page that went blank — so a scheduled release that did not
publish looked exactly like one that was not due yet. The outcome, the attempt
count and the error were all written to the row and readable only with SQL.

This is not theoretical: two jobs run in production today — **content releases
drain** and **webhook delivery drain** — plus any a plugin registers.

## The finding that shaped the design

**There is no `retrying` state.** `JOB_STATES` is `pending | running | done |
failed`, and `finalize` writes a retry back as `pending` with the attempt count
incremented. So a job that is healing itself is indistinguishable *by state*
from one that has never run — while `failed` is terminal and means the work will
not happen without a person.

Research on mature queues (Sidekiq, BullMQ, Oban) is explicit that conflating
those two is the common mistake: it either raises an alarm for something
self-healing, or buries a dead job among transient noise. Here they are not even
separable from the state column.

So `jobDisplayStatus` derives it — from the attempt count, in **one** place, so
no client can produce a second answer:

| stored | derived |
|---|---|
| `pending`, 0 attempts | `waiting` |
| `pending`, >0 attempts | `retrying` |
| `running` | `running` |
| `done` | `succeeded` |
| `failed` | `failed` — the only status that raises attention |

## Decisions worth reviewing

**Read-only.** No retry, cancel or requeue. Each is a write on already-authorized
work needing its own decision about who may perform it, and shipping them beside
a read would settle those questions by omission.

**Gated on `manage-background-jobs`** — the permission the trigger already uses.
`lastError` carries whatever a handler threw, which is internal detail rather
than content, and there is no seeded read permission. Inventing one would change
what preset roles grant as a side effect of adding an endpoint.

**The list branch sits AHEAD of the trigger's in the parser.** The trigger
accepts `GET` too (Vercel Cron uses it), so the verb cannot discriminate — a
fall-through would drain the queue as a side effect of *reading* it.

**No total alongside the rows.** The db seam this repository is written against
offers no count, and a second query would produce a page-count that can disagree
with the page it labels. Terminal rows are pruned on a 7-day retention window,
so this is recent history by construction — stated in the module, so an absent
job is never read as one that never ran.

**`input` is not returned.** It is arbitrary caller data and a list has no use
for it.

## Evidence

`jobDisplayStatus` break-verified in **both** directions — the two ways to get
it wrong:

| Mutation | Test that failed |
|---|---|
| ignore `attemptCount` | *separates a job that has never run from one that is retrying* |
| read the count before the state | *reports a spent job as failed, not as retrying* |

Routing break-verified by removing the list branch. One honest note: the
companion assertion *"does NOT resolve a bare read to the runner"* also passed
under that mutation, because the parser returns `null` rather than falling
through — it guards a future permissiveness change, not this one, and I am not
counting it as evidence here.

Full `pnpm build`, `check-types` and `lint` exit 0. 594 tests across the affected
nextly suites. `fallow audit --gate new-only`: **verdict: pass**, all introduced
counts zero. Changeset covers all 25 lockstep packages.

The pre-push gate failed twice before this landed, with every failure a
10 000 ms timeout while load average was **215** on 14 cores. All six files pass
in isolation (165 tests). Pushed once the machine recovered.