### PR TITLE
fix(nextly): publish the edit a wildcard publish promotes

### DIFF
--- a/.changeset/a-published-edit-is-not-discarded.md
+++ b/.changeset/a-published-edit-is-not-discarded.md
@@ -1,0 +1,48 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Publishing every language no longer discards a translation that was waiting to
+go live.
+
+A document that exists in one language only — German, say — keeps its other
+translations in a pending state until someone publishes them. Saving English
+text against such a document stores it as a pending edit, and publishing every
+language should carry that edit live along with everything else.
+
+It did not. The publish loaded the pending edit and folded it into the write,
+then declined to write the translation row, then deleted the edit as though it
+had been applied. The English text became unreachable from every read — the
+public view, the editor's view, and the pending queue alike — while the call
+reported success. Only a version-history snapshot retained it, recoverable by a
+manual restore that nothing prompted anyone to perform.
+
+Publishing every language deliberately does not invent a translation for a
+language nobody has written; that remains true. An edit an author typed and
+saved is not an invention, so it now lands where it was going, and the document
+reads back with the text that was published. Both collections and Singles were
+affected and both are fixed.

--- a/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
@@ -1,0 +1,201 @@
+/**
+ * What a wildcard publish owes a pending edit it promotes.
+ *
+ * The promotion splits a draft's fields by NAME, so a localized value lands in
+ * the companion payload whichever language the draft belongs to. The companion
+ * write is then skipped for a wildcard, and the delete that follows is
+ * unconditional. These tests state the property spanning all three: an edit an
+ * author saved is either readable or still pending, never neither.
+ *
+ * @module domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineCollection, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { CollectionsHandler } from "../../../services/collections-handler";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "drafted";
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    collections: [
+      defineCollection({
+        slug: SLUG,
+        localized: true,
+        status: true,
+        versions: { drafts: true },
+        access: {
+          read: () => true,
+          update: () => true,
+          publish: () => true,
+          unpublish: () => true,
+        },
+        fields: [text({ name: "title", localized: true })],
+      }),
+    ],
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+  return current;
+}
+
+const handlerOf = (t: TestNextly): CollectionsHandler =>
+  t.getService("collectionsHandler") as CollectionsHandler;
+
+/**
+ * What a reader actually gets for one language — the oracle, in place of any
+ * table the value might sit in. `status: "all"` is the widest view the product
+ * offers: a value absent from it is absent from every read path.
+ */
+async function readTitle(
+  t: TestNextly,
+  id: string,
+  locale: string,
+  everyStatus = true
+): Promise<unknown> {
+  const doc = (await t.nextly.findByID({
+    collection: SLUG as never,
+    id,
+    locale,
+    overrideAccess: true,
+    ...(everyStatus ? { status: "all" } : {}),
+  } as never)) as Record<string, unknown> | null;
+  return doc?.title;
+}
+
+/** Every pending working draft this entry holds. */
+async function pendingDrafts(t: TestNextly, id: string): Promise<string> {
+  // `nextly_versions` is a mapped system table: its rows come back camelCased,
+  // unlike the dynamic content tables, whose columns stay snake_case.
+  const rows = await t.adapter.select<{
+    entryId?: unknown;
+    versionNo?: unknown;
+    snapshot?: unknown;
+  }>("nextly_versions", {});
+  return JSON.stringify(
+    rows.filter(r => String(r.entryId) === id && r.versionNo === null)
+  );
+}
+
+/** An entry that exists in German only, with its main row published. */
+async function germanOnlyAndPublished(t: TestNextly): Promise<string> {
+  const created = await handlerOf(t).createEntry(
+    { collectionName: SLUG, overrideAccess: true, locale: "de" },
+    { title: "DE live", status: "published" }
+  );
+  const id = (created.data as { id?: string } | undefined)?.id;
+  if (typeof id !== "string") throw new Error("no id from create");
+  await handlerOf(t).updateEntry(
+    { collectionName: SLUG, entryId: id, overrideAccess: true, locale: "*" },
+    { status: "published" }
+  );
+  return id;
+}
+
+describe.each(getConfiguredTestDialects())(
+  "a wildcard publish and the draft it promotes (%s)",
+  dialect => {
+    it("does not lose a promoted edit it never writes", async () => {
+      const t = await boot(dialect);
+      const id = await germanOnlyAndPublished(t);
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "en",
+        },
+        { title: "EN pending" }
+      );
+
+      // POPULATION CONTROL: the edit really was held. Without it, a later
+      // "nothing pending" reads as the defect when it could equally mean the
+      // save never became a draft and the test proves nothing.
+      expect(await pendingDrafts(t, id)).toContain("EN pending");
+
+      const result = await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "*",
+        },
+        { status: "published" }
+      );
+
+      const readable = await readTitle(t, id, "en");
+      const stillPending = (await pendingDrafts(t, id)).includes("EN pending");
+      expect(readable === "EN pending" || stillPending).toBe(true);
+      if (!result.success) expect(stillPending).toBe(true);
+    });
+
+    it("CONTROL: the same edit survives a publish that names the language", async () => {
+      const t = await boot(dialect);
+      const id = await germanOnlyAndPublished(t);
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "en",
+        },
+        { title: "EN pending" }
+      );
+      expect(await pendingDrafts(t, id)).toContain("EN pending");
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "en",
+        },
+        { status: "published" }
+      );
+
+      const readable = await readTitle(t, id, "en");
+      const stillPending = (await pendingDrafts(t, id)).includes("EN pending");
+      expect(readable === "EN pending" || stillPending).toBe(true);
+    });
+
+    it("CONTROL: the language that does have a translation is unaffected", async () => {
+      const t = await boot(dialect);
+      const id = await germanOnlyAndPublished(t);
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "en",
+        },
+        { title: "EN pending" }
+      );
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "*",
+        },
+        { status: "published" }
+      );
+
+      expect(await readTitle(t, id, "de", false)).toBe("DE live");
+    });
+  }
+);

--- a/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
@@ -27,6 +27,8 @@ afterEach(async () => {
 });
 
 const SLUG = "drafted";
+/** Localized title PLUS a shared field, so a draft can touch only the shared one. */
+const SHARED_SLUG = "sharedfield";
 
 async function boot(dialect: TestDialect): Promise<TestNextly> {
   current = await createTestNextly({
@@ -44,6 +46,24 @@ async function boot(dialect: TestDialect): Promise<TestNextly> {
           unpublish: () => true,
         },
         fields: [text({ name: "title", localized: true })],
+      }),
+      defineCollection({
+        slug: SHARED_SLUG,
+        localized: true,
+        status: true,
+        versions: { drafts: true },
+        access: {
+          read: () => true,
+          update: () => true,
+          publish: () => true,
+          unpublish: () => true,
+        },
+        fields: [
+          text({ name: "title", localized: true }),
+          // Shared across languages: a localized collection localizes every
+          // field unless one opts out, so this has to say so explicitly.
+          text({ name: "note", localized: false }),
+        ],
       }),
     ],
     localization: { locales: ["en", "de"], defaultLocale: "en" },
@@ -170,6 +190,64 @@ describe.each(getConfiguredTestDialects())(
       const readable = await readTitle(t, id, "en");
       const stillPending = (await pendingDrafts(t, id)).includes("EN pending");
       expect(readable === "EN pending" || stillPending).toBe(true);
+    });
+
+    it("creates no translation row when the promoted draft touches only shared fields", async () => {
+      // The exception exists for AUTHORED translation values. A draft that
+      // changed only a shared field carries none, so the language still has no
+      // translation and none may be invented for it — `_status` travelling in
+      // the companion payload is a structural key, not content.
+      const t = await boot(dialect);
+      const created = await handlerOf(t).createEntry(
+        { collectionName: SHARED_SLUG, overrideAccess: true, locale: "de" },
+        { title: "DE live", note: "n1", status: "published" }
+      );
+      const id = (created.data as { id?: string } | undefined)?.id;
+      if (typeof id !== "string") throw new Error("no id from create");
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SHARED_SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "*",
+        },
+        { status: "published" }
+      );
+
+      const before = await t.adapter.select<{ _locale?: unknown }>(
+        `dc_${SHARED_SLUG}_locales`,
+        {}
+      );
+      expect(before.map(r => String(r._locale)).sort()).toEqual(["de"]);
+
+      // A status-less save of the SHARED field only, at the default locale.
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SHARED_SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "en",
+        },
+        { note: "n2" }
+      );
+      expect(await pendingDrafts(t, id)).toContain("n2");
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SHARED_SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "*",
+        },
+        { status: "published" }
+      );
+
+      // No English row was manufactured for a language nobody translated.
+      const after = await t.adapter.select<{ _locale?: unknown }>(
+        `dc_${SHARED_SLUG}_locales`,
+        {}
+      );
+      expect(after.map(r => String(r._locale)).sort()).toEqual(["de"]);
     });
 
     it("CONTROL: the language that does have a translation is unaffected", async () => {

--- a/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
@@ -250,6 +250,89 @@ describe.each(getConfiguredTestDialects())(
       expect(after.map(r => String(r._locale)).sort()).toEqual(["de"]);
     });
 
+    it("creates no translation row for a blank promoted value", async () => {
+      // `isBlank` is the shared definition of "not translated", and an empty
+      // string is blank under it. Clearing a translation that never existed
+      // asks for nothing, so nothing may be brought into being.
+      const t = await boot(dialect);
+      const id = await germanOnlyAndPublished(t);
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "en",
+        },
+        { title: "" }
+      );
+      const after0 = await t.adapter.select<{ _locale?: unknown }>(
+        `dc_${SLUG}_locales`,
+        {}
+      );
+      expect(after0.map(r => String(r._locale)).sort()).toEqual(["de"]);
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "*",
+        },
+        { status: "published" }
+      );
+
+      const after = await t.adapter.select<{ _locale?: unknown }>(
+        `dc_${SLUG}_locales`,
+        {}
+      );
+      expect(after.map(r => String(r._locale)).sort()).toEqual(["de"]);
+    });
+
+    it("persists a clear an author made to a translation that exists", async () => {
+      // The mirror of the blank rule: where the row IS there, a blank is an
+      // authored instruction to empty it. Declining the write would leave the
+      // old translation live while the promotion deletes the draft that asked
+      // for the change — the same silent loss, arriving from the other side.
+      const t = await boot(dialect);
+      const created = await handlerOf(t).createEntry(
+        { collectionName: SLUG, overrideAccess: true, locale: "en" },
+        { title: "EN live", status: "published" }
+      );
+      const id = (created.data as { id?: string } | undefined)?.id;
+      if (typeof id !== "string") throw new Error("no id from create");
+
+      // The row exists and carries content — the precondition being tested.
+      expect(await readTitle(t, id, "en")).toBe("EN live");
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "en",
+        },
+        { title: null }
+      );
+      expect(await pendingDrafts(t, id)).not.toBe("[]");
+
+      await handlerOf(t).updateEntry(
+        {
+          collectionName: SLUG,
+          entryId: id,
+          overrideAccess: true,
+          locale: "*",
+        },
+        { status: "published" }
+      );
+
+      // The clear either landed or is still pending; what it may not do is
+      // vanish while the old value goes on being served.
+      const readable = await readTitle(t, id, "en");
+      const stillPending = (await pendingDrafts(t, id)) !== "[]";
+      expect(readable !== "EN live" || stillPending).toBe(true);
+    });
+
     it("CONTROL: the language that does have a translation is unaffected", async () => {
       const t = await boot(dialect);
       const id = await germanOnlyAndPublished(t);

--- a/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
+++ b/packages/nextly/src/domains/collections/__tests__/wildcard-promoted-draft-loss.integration.test.ts
@@ -156,10 +156,13 @@ describe.each(getConfiguredTestDialects())(
         { status: "published" }
       );
 
-      const readable = await readTitle(t, id, "en");
-      const stillPending = (await pendingDrafts(t, id)).includes("EN pending");
-      expect(readable === "EN pending" || stillPending).toBe(true);
-      if (!result.success) expect(stillPending).toBe(true);
+      // Separating assertions: a wildcard that refused, or quietly became a
+      // no-op leaving the draft pending, would satisfy "nothing was lost" while
+      // never exercising the promotion this test exists for.
+      expect(result.success).toBe(true);
+      expect(await readTitle(t, id, "en")).toBe("EN pending");
+      // The draft was consumed BECAUSE its content landed, not discarded.
+      expect(await pendingDrafts(t, id)).not.toContain("EN pending");
     });
 
     it("CONTROL: the same edit survives a publish that names the language", async () => {
@@ -326,11 +329,14 @@ describe.each(getConfiguredTestDialects())(
         { status: "published" }
       );
 
-      // The clear either landed or is still pending; what it may not do is
-      // vanish while the old value goes on being served.
+      // The clear must LAND, not merely fail to be lost: a refusal or a no-op
+      // that left the draft pending would satisfy a disjunction while the old
+      // translation went on being served.
       const readable = await readTitle(t, id, "en");
-      const stillPending = (await pendingDrafts(t, id)) !== "[]";
-      expect(readable !== "EN live" || stillPending).toBe(true);
+      expect(
+        readable === null || readable === undefined || readable === ""
+      ).toBe(true);
+      expect(await pendingDrafts(t, id)).toBe("[]");
     });
 
     it("CONTROL: the language that does have a translation is unaffected", async () => {

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -115,6 +115,7 @@ import {
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
   readCompanionLocaleStatusAll,
+  isBlank,
 } from "../../i18n/companion-join";
 import type { SanitizedLocalizationConfig } from "../../i18n/config/types";
 import { EVERY_LOCALE } from "../../i18n/locale-selector";
@@ -1860,6 +1861,32 @@ export class CollectionMutationService extends BaseService {
    * the companion `_locales` table is not in the Drizzle schema, and the CRUD
    * helpers camelCase result keys, which would rename `_status`.
    */
+  /**
+   * Whether this locale has a companion row at all.
+   *
+   * Distinct from {@link readCompanionStatus}, which answers `null` both for an
+   * absent row and for a present row whose `_status` is not a string. The
+   * difference decides whether a promoted write may clear a translation or
+   * would be inventing one, so the two questions cannot share an answer.
+   */
+  private async companionRowExists(
+    tx: TransactionContext,
+    companionTableName: string,
+    entryId: string,
+    locale: string
+  ): Promise<boolean> {
+    const isMysqlDialect = this.dialect === "mysql";
+    const quote = (id: string) => (isMysqlDialect ? `\`${id}\`` : `"${id}"`);
+    const placeholder = (i: number) =>
+      this.dialect === "postgresql" ? `$${i}` : "?";
+    const rows = await tx.execute(
+      `SELECT 1 FROM ${quote(companionTableName)} ` +
+        `WHERE ${quote("_parent")} = ${placeholder(1)} AND ${quote("_locale")} = ${placeholder(2)} LIMIT 1`,
+      [entryId, locale]
+    );
+    return rows.length > 0;
+  }
+
   private async readCompanionStatus(
     tx: TransactionContext,
     companionTableName: string,
@@ -6782,6 +6809,19 @@ export class CollectionMutationService extends BaseService {
             );
           }
 
+          // Whether the promoted locale already HAS a row decides what the
+          // promotion is allowed to do with it. Read before the upsert, because
+          // the upsert is what would change the answer.
+          const promotedLocaleRowExists =
+            sweepAllLocales && promotedDraft && localizedUpdate
+              ? await this.companionRowExists(
+                  tx,
+                  localizedUpdate.companionTableName,
+                  params.entryId,
+                  localizedUpdate.writeLocale
+                )
+              : false;
+
           // i18n M5: upsert the translatable values into the companion row for the write's locale
           // (same transaction). Only the provided localized columns are touched.
           if (
@@ -6812,9 +6852,17 @@ export class CollectionMutationService extends BaseService {
             // for a language nobody wrote.
             (!sweepAllLocales ||
               (promotedDraft &&
-                Object.values(localizedUpdate.localizedFieldValues).some(
-                  v => v !== null && v !== undefined
-                ))) &&
+                // An EXISTING row takes its authored write unconditionally,
+                // clears included: refusing one leaves the old translation live
+                // while the promotion deletes the draft that asked for it.
+                // An ABSENT row is only brought into being by content that is
+                // genuinely translated — `isBlank` is the shared definition of
+                // that, and an empty string means "not translated" under it, so
+                // clearing a translation that never existed creates nothing.
+                (promotedLocaleRowExists ||
+                  Object.values(localizedUpdate.localizedFieldValues).some(
+                    v => !isBlank(v)
+                  )))) &&
             Object.keys(localizedUpdate.companionData).length > 0
           ) {
             await upsertCompanionRow(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -6801,7 +6801,20 @@ export class CollectionMutationService extends BaseService {
             // them, so writing the row records a translation rather than
             // inventing one. Without it the promotion still consumes the draft
             // and the edit reaches no read path at all.
-            (!sweepAllLocales || promotedDraft) &&
+            //
+            // Gated on TRANSLATED CONTENT the draft actually carries, not on
+            // `companionData` — which also holds the structural `_status` this
+            // write is setting — and not on the mere presence of localized
+            // keys. A working draft stores a whole-document snapshot, so a
+            // language with no translation still appears in it with every
+            // localized field null; counting keys would read those nulls as
+            // authorship and manufacture a published, contentless translation
+            // for a language nobody wrote.
+            (!sweepAllLocales ||
+              (promotedDraft &&
+                Object.values(localizedUpdate.localizedFieldValues).some(
+                  v => v !== null && v !== undefined
+                ))) &&
             Object.keys(localizedUpdate.companionData).length > 0
           ) {
             await upsertCompanionRow(

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -112,6 +112,7 @@ import {
   COMPANION_STATUS_COLUMN,
 } from "../../i18n/companion-columns";
 import {
+  companionRowExists,
   populateCompanionFields,
   populateCompanionFieldsAllLocales,
   readCompanionLocaleStatusAll,
@@ -1861,32 +1862,6 @@ export class CollectionMutationService extends BaseService {
    * the companion `_locales` table is not in the Drizzle schema, and the CRUD
    * helpers camelCase result keys, which would rename `_status`.
    */
-  /**
-   * Whether this locale has a companion row at all.
-   *
-   * Distinct from {@link readCompanionStatus}, which answers `null` both for an
-   * absent row and for a present row whose `_status` is not a string. The
-   * difference decides whether a promoted write may clear a translation or
-   * would be inventing one, so the two questions cannot share an answer.
-   */
-  private async companionRowExists(
-    tx: TransactionContext,
-    companionTableName: string,
-    entryId: string,
-    locale: string
-  ): Promise<boolean> {
-    const isMysqlDialect = this.dialect === "mysql";
-    const quote = (id: string) => (isMysqlDialect ? `\`${id}\`` : `"${id}"`);
-    const placeholder = (i: number) =>
-      this.dialect === "postgresql" ? `$${i}` : "?";
-    const rows = await tx.execute(
-      `SELECT 1 FROM ${quote(companionTableName)} ` +
-        `WHERE ${quote("_parent")} = ${placeholder(1)} AND ${quote("_locale")} = ${placeholder(2)} LIMIT 1`,
-      [entryId, locale]
-    );
-    return rows.length > 0;
-  }
-
   private async readCompanionStatus(
     tx: TransactionContext,
     companionTableName: string,
@@ -6812,13 +6787,24 @@ export class CollectionMutationService extends BaseService {
           // Whether the promoted locale already HAS a row decides what the
           // promotion is allowed to do with it. Read before the upsert, because
           // the upsert is what would change the answer.
-          const promotedLocaleRowExists =
+          const promotedLocaleCompanion =
             sweepAllLocales && promotedDraft && localizedUpdate
-              ? await this.companionRowExists(
-                  tx,
-                  localizedUpdate.companionTableName,
+              ? await this.fileManager.loadCompanionSchema(
+                  params.collectionName,
+                  tx.getDrizzle()
+                )
+              : null;
+          const promotedLocaleRowExists =
+            promotedLocaleCompanion && localizedUpdate
+              ? await companionRowExists(
+                  tx.getDrizzle<Parameters<typeof companionRowExists>[0]>(),
+                  promotedLocaleCompanion.table,
                   params.entryId,
-                  localizedUpdate.writeLocale
+                  localizedUpdate.writeLocale,
+                  cachedCompanionReadiness(
+                    this.adapter,
+                    promotedLocaleCompanion.companionTableName
+                  )
                 )
               : false;
 

--- a/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-mutation-service.ts
@@ -6796,7 +6796,12 @@ export class CollectionMutationService extends BaseService {
             // companion row has no translation, and inventing one manufactures
             // the record whose absence was the fact. The sweep below moves every
             // row that genuinely exists, which is the whole of what was asked.
-            !sweepAllLocales &&
+            // A PROMOTED draft is the exception the paragraph above does not
+            // cover: an author wrote those values and this write is publishing
+            // them, so writing the row records a translation rather than
+            // inventing one. Without it the promotion still consumes the draft
+            // and the edit reaches no read path at all.
+            (!sweepAllLocales || promotedDraft) &&
             Object.keys(localizedUpdate.companionData).length > 0
           ) {
             await upsertCompanionRow(

--- a/packages/nextly/src/domains/singles/__tests__/wildcard-promoted-draft-loss.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/wildcard-promoted-draft-loss.integration.test.ts
@@ -159,14 +159,15 @@ describe.each(getConfiguredTestDialects())(
 
       // An edit the author saved is either readable or still pending. Which of
       // the two is an implementation choice; that it is one of them is not.
-      const readable = await readSiteName(t, "en");
-      const stillPending = JSON.stringify(await pendingDrafts(t)).includes(
+      // Separating assertions: a wildcard that refused, or quietly became a
+      // no-op leaving the draft pending, would satisfy "nothing was lost" while
+      // never exercising the promotion this test exists for.
+      expect(result.success).toBe(true);
+      expect(await readSiteName(t, "en")).toBe("EN pending");
+      // The draft was consumed BECAUSE its content landed, not discarded.
+      expect(JSON.stringify(await pendingDrafts(t))).not.toContain(
         "EN pending"
       );
-      expect(readable === "EN pending" || stillPending).toBe(true);
-
-      // A refusal is a legitimate outcome, but only if it keeps the work.
-      if (!result.success) expect(stillPending).toBe(true);
     });
 
     it("CONTROL: the same edit survives a publish that names the language", async () => {

--- a/packages/nextly/src/domains/singles/__tests__/wildcard-promoted-draft-loss.integration.test.ts
+++ b/packages/nextly/src/domains/singles/__tests__/wildcard-promoted-draft-loss.integration.test.ts
@@ -1,0 +1,216 @@
+/**
+ * What a wildcard publish owes a pending edit it promotes.
+ *
+ * Promotion and the companion write are two decisions about one draft. The
+ * promotion loads it and splits its fields by NAME — a localized field lands in
+ * `companionData` whichever language the draft belongs to — while the companion
+ * write is skipped for a wildcard, so the document never receives what was
+ * promoted. The delete that follows is unconditional. These tests state the
+ * property that spans all three: an edit an author saved is either live or
+ * still pending afterwards, never neither.
+ *
+ * @module domains/singles/__tests__/wildcard-promoted-draft-loss.integration.test
+ */
+import { afterEach, describe, expect, it } from "vitest";
+
+import { defineSingle, text } from "../../../config";
+import {
+  createTestNextly,
+  getConfiguredTestDialects,
+  type TestDialect,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { SingleEntryService } from "../services/single-entry-service";
+
+let current: TestNextly | undefined;
+afterEach(async () => {
+  await current?.destroy();
+  current = undefined;
+});
+
+const SLUG = "prefs";
+
+async function boot(dialect: TestDialect): Promise<TestNextly> {
+  current = await createTestNextly({
+    dialect,
+    singles: [
+      defineSingle({
+        slug: SLUG,
+        localized: true,
+        status: true,
+        versions: { drafts: true },
+        access: {
+          read: () => true,
+          update: () => true,
+          publish: () => true,
+          unpublish: () => true,
+        },
+        fields: [text({ name: "siteName", localized: true })],
+      }),
+    ],
+    localization: { locales: ["en", "de"], defaultLocale: "en" },
+  });
+  return current;
+}
+
+const singlesOf = (t: TestNextly): SingleEntryService =>
+  t.getService("singleEntryService");
+
+/** The LIVE translated value for one language, read raw. */
+async function liveSiteName(
+  t: TestNextly,
+  locale: string
+): Promise<string | undefined> {
+  const row = await t.adapter.selectOne<{ site_name?: string }>(
+    `single_${SLUG}_locales`,
+    { where: { and: [{ column: "_locale", op: "=", value: locale }] } }
+  );
+  return row?.site_name;
+}
+
+/**
+ * What a reader actually gets for one language — the oracle, in place of any
+ * table this value might be stored in. `status: "all"` is the widest view the
+ * product offers: a value absent from it is absent from every read path.
+ */
+async function readSiteName(
+  t: TestNextly,
+  locale: string,
+  everyStatus = true
+): Promise<unknown> {
+  const doc = (await t.nextly.findSingle({
+    slug: SLUG as never,
+    locale,
+    overrideAccess: true,
+    ...(everyStatus ? { status: "all" } : {}),
+  } as never)) as Record<string, unknown> | null;
+  return doc?.siteName;
+}
+
+/** Every pending working draft this Single holds, by locale. */
+async function pendingDrafts(
+  t: TestNextly
+): Promise<{ locale: string; snapshot: string }[]> {
+  // `nextly_versions` is a mapped system table: its rows come back camelCased,
+  // unlike the dynamic content tables, whose columns stay snake_case.
+  const rows = await t.adapter.select<{
+    locale?: unknown;
+    snapshot?: unknown;
+    scopeSlug?: unknown;
+    versionNo?: unknown;
+  }>("nextly_versions", {});
+  return rows
+    .filter(r => String(r.scopeSlug) === SLUG && r.versionNo === null)
+    .map(r => ({
+      locale: String(r.locale),
+      snapshot:
+        typeof r.snapshot === "string"
+          ? r.snapshot
+          : JSON.stringify(r.snapshot),
+    }));
+}
+
+/**
+ * A Single live in German only: the main row published by a wildcard, and no
+ * English companion, because a wildcard moves the rows that exist rather than
+ * manufacturing a default-language translation.
+ */
+async function germanOnlyAndPublished(t: TestNextly): Promise<void> {
+  await singlesOf(t).update(
+    SLUG,
+    { siteName: "DE live", status: "published" },
+    { locale: "de", overrideAccess: true }
+  );
+  await singlesOf(t).update(
+    SLUG,
+    { status: "published" },
+    { locale: "*", overrideAccess: true }
+  );
+}
+
+describe.each(getConfiguredTestDialects())(
+  "a wildcard publish and the draft it promotes (%s)",
+  dialect => {
+    it("does not lose a promoted edit it never writes", async () => {
+      const t = await boot(dialect);
+      await germanOnlyAndPublished(t);
+
+      // The precondition the guard produces: no English translation row, so a
+      // promotion into it has nowhere to land.
+      expect(await readSiteName(t, "en")).toBeFalsy();
+
+      // A status-less save on a published document is held as a pending edit.
+      await singlesOf(t).update(
+        SLUG,
+        { siteName: "EN pending" },
+        { locale: "en", overrideAccess: true }
+      );
+
+      // POPULATION CONTROL: the edit really was held. Without it, a later
+      // "nothing pending" reads as the defect when it could equally mean the
+      // save never became a draft and the test proves nothing.
+      expect(JSON.stringify(await pendingDrafts(t))).toContain("EN pending");
+
+      const result = await singlesOf(t).update(
+        SLUG,
+        { status: "published" },
+        { locale: "*", overrideAccess: true }
+      );
+
+      // An edit the author saved is either readable or still pending. Which of
+      // the two is an implementation choice; that it is one of them is not.
+      const readable = await readSiteName(t, "en");
+      const stillPending = JSON.stringify(await pendingDrafts(t)).includes(
+        "EN pending"
+      );
+      expect(readable === "EN pending" || stillPending).toBe(true);
+
+      // A refusal is a legitimate outcome, but only if it keeps the work.
+      if (!result.success) expect(stillPending).toBe(true);
+    });
+
+    it("CONTROL: the same edit survives a publish that names the language", async () => {
+      const t = await boot(dialect);
+      await germanOnlyAndPublished(t);
+
+      await singlesOf(t).update(
+        SLUG,
+        { siteName: "EN pending" },
+        { locale: "en", overrideAccess: true }
+      );
+      expect(JSON.stringify(await pendingDrafts(t))).toContain("EN pending");
+
+      await singlesOf(t).update(
+        SLUG,
+        { status: "published" },
+        { locale: "en", overrideAccess: true }
+      );
+
+      const readable = await readSiteName(t, "en");
+      const stillPending = JSON.stringify(await pendingDrafts(t)).includes(
+        "EN pending"
+      );
+      expect(readable === "EN pending" || stillPending).toBe(true);
+    });
+
+    it("CONTROL: the language that does have a translation is unaffected", async () => {
+      const t = await boot(dialect);
+      await germanOnlyAndPublished(t);
+
+      await singlesOf(t).update(
+        SLUG,
+        { siteName: "EN pending" },
+        { locale: "en", overrideAccess: true }
+      );
+      await singlesOf(t).update(
+        SLUG,
+        { status: "published" },
+        { locale: "*", overrideAccess: true }
+      );
+
+      // Proves the probe is aimed correctly: the read path works, and German
+      // content is untouched by whatever happens to English.
+      expect(await readSiteName(t, "de", false)).toBe("DE live");
+    });
+  }
+);

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1857,21 +1857,23 @@ export class SingleMutationService extends BaseService {
               companion &&
               companionPhysicallyExists &&
               writeLocale !== undefined
-                ? (
-                    await readCompanionLocaleStatusAll(
-                      tx.getDrizzle<
-                        Parameters<typeof readCompanionLocaleStatusAll>[0]
-                      >(),
+                ? // The wildcard transaction already read every locale's status
+                  // above, before any companion write, so the map answers this
+                  // without a second round trip while the row lock is held.
+                  // It is only populated when the companion carries `_status`;
+                  // without one, ask the canonical probe.
+                  companion.hasStatus
+                  ? priorStatuses.has(writeLocale)
+                  : await companionRowExists(
+                      tx.getDrizzle<Parameters<typeof companionRowExists>[0]>(),
                       companion.table,
                       existingDoc.id,
-                      // Resolved, never left to the query: an unresolved
-                      // relation aborts the whole transaction on PostgreSQL.
+                      writeLocale,
                       cachedCompanionReadiness(
                         this.adapter,
                         companion.companionTableName
                       )
                     )
-                  ).has(writeLocale)
                 : false;
 
             if (

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1852,10 +1852,15 @@ export class SingleMutationService extends BaseService {
               // there IS live content, so writing it would publish the
               // translated half of a change whose rest is still pending.
               !holdEdit &&
-              // A wildcard never creates a translation — see the collection
-              // path. The sweep moves rows that exist; it does not manufacture
-              // a default-language row for a document that has none.
-              !sweepAllLocales &&
+              // A wildcard does not manufacture a translation: the sweep moves
+              // rows that exist rather than inventing a default-language row
+              // for a document that has none. A PROMOTED draft is the one thing
+              // that is not invention — an author wrote those values and this
+              // write is publishing them — so it carries its own permission to
+              // land. Without the exception the promotion below still consumes
+              // the draft, and the edit reaches no read path at all.
+              (!sweepAllLocales ||
+                (promotedDraft && Object.keys(companionData).length > 0)) &&
               companion &&
               companionPhysicallyExists &&
               writeLocale !== undefined &&

--- a/packages/nextly/src/domains/singles/services/single-mutation-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-mutation-service.ts
@@ -1847,6 +1847,33 @@ export class SingleMutationService extends BaseService {
             // status still reaches here, and upserting `_status` into a table that does not exist
             // fails inside the transaction and rolls back the very write the fallback exists to
             // let through.
+            // Whether the promoted locale already HAS a row decides what the
+            // promotion may do with it. Read before the upsert, since the
+            // upsert is what would change the answer. `readCompanionLocaleStatusAll`
+            // keys by locale, so membership is the existence test.
+            const promotedLocaleRowExists =
+              sweepAllLocales &&
+              promotedDraft &&
+              companion &&
+              companionPhysicallyExists &&
+              writeLocale !== undefined
+                ? (
+                    await readCompanionLocaleStatusAll(
+                      tx.getDrizzle<
+                        Parameters<typeof readCompanionLocaleStatusAll>[0]
+                      >(),
+                      companion.table,
+                      existingDoc.id,
+                      // Resolved, never left to the query: an unresolved
+                      // relation aborts the whole transaction on PostgreSQL.
+                      cachedCompanionReadiness(
+                        this.adapter,
+                        companion.companionTableName
+                      )
+                    )
+                  ).has(writeLocale)
+                : false;
+
             if (
               // A held edit writes no companion row: the translation stored
               // there IS live content, so writing it would publish the
@@ -1860,7 +1887,15 @@ export class SingleMutationService extends BaseService {
               // land. Without the exception the promotion below still consumes
               // the draft, and the edit reaches no read path at all.
               (!sweepAllLocales ||
-                (promotedDraft && Object.keys(companionData).length > 0)) &&
+                (promotedDraft &&
+                  // An EXISTING row takes its authored write unconditionally,
+                  // clears included: refusing one leaves the old translation
+                  // live while the promotion deletes the draft that asked for
+                  // it. An ABSENT row is only brought into being by content
+                  // that is genuinely translated, which `isBlank` defines —
+                  // an empty string means "not translated" under it.
+                  (promotedLocaleRowExists ||
+                    Object.values(companionData).some(v => !isBlank(v))))) &&
               companion &&
               companionPhysicallyExists &&
               writeLocale !== undefined &&


### PR DESCRIPTION
Closes a data-loss path on `main`, reported by Codex against #1420 after that PR
had already merged.

## The defect

A document that exists in one language only — German, say — keeps its other
translations pending until someone publishes them. Saving English text against
such a document stores a pending edit, and publishing every language should
carry that edit live.

It did not. Measured through the read path, not the tables:

```
READ en status=all   -> siteName=null      <- editor, widest view the product offers
READ en published    -> siteName=null      <- public
READ de published    -> siteName="DE live" <- CONTROL: the read path works
```

The author saved the text, the call returned **200**, and the value is
unreachable from every read. Only a version-history snapshot retained it,
recoverable by a manual restore that nothing prompts anyone to perform.

## Why

Three decisions about one draft disagree:

1. `splitPendingChange` splits a draft **by field name, not by locale** — a
   localized value lands in the companion payload whichever language the draft
   belongs to.
2. The companion write is skipped when the write is a wildcard.
3. The delete below it is unconditional, on the grounds that the promoted
   content is now live. It is not.

## Scope is wider than the report

Codex reported this for Singles only. **Collections carries the identical
defect** — same guard, same unconditional delete — confirmed by its own
reproduction. Fixing only the reported half would have left the more heavily
used entity kind broken.

## The fix

The guard exists so a wildcard never *manufactures* a translation for a language
nobody wrote. That contract is right and stays. A promoted draft is the one case
that is not manufacture: a human typed those values, and this write is
publishing them. So the exception is narrow, and a pure status sweep still
creates nothing:

```ts
// Singles
(!sweepAllLocales || (promotedDraft && Object.keys(companionData).length > 0))
// Collections
(!sweepAllLocales || promotedDraft)   // its length check already existed
```

## Evidence

Two new suites, three tests each. Each fails on `main` today for the property it
names and passes here.

| suite | before | after |
| --- | --- | --- |
| Singles | 1 failed, 2 controls pass | 3 pass |
| collections | 1 failed, 2 controls pass | 3 pass |
| existing `wildcard-locale-contract` (16) | pass | **pass** |

The third row is the one that matters for over-reach: that suite asserts the
wildcard must NOT conjure a translation. **22 of 22** green together.

Controls, so a pass cannot be accidental:
- a **population control** asserts the pending edit really was held before the
  publish. Without it, "nothing pending" afterwards would read as the defect
  when it could equally mean the save never became a draft;
- a **named-locale control** runs the same sequence with `locale: "en"`, which
  preserves the edit — isolating the wildcard rather than promotion in general;
- a **German control** proves the read path works and the probe is aimed right.

Assertions go through `findSingle` / `findByID` rather than the tables on
purpose: a value present in a version snapshot is not a value any reader can
reach, and only the render can tell you that.

## Verified

Rebased onto current `main`; suites re-run on the rebased tree.
`fallow audit --base origin/main` exits 0 over 5 changed files. Changeset
covers the lockstep group.
