### PR TITLE
feat(plugin-page-builder): show the page, not a list of type names, on the entry screen

### DIFF
--- a/.changeset/the-entry-screen-shows-the-page.md
+++ b/.changeset/the-entry-screen-shows-the-page.md
@@ -1,0 +1,38 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A page's edit screen now shows the page itself. Where the page-builder field
+previously drew a grey box listing internal block type names — `core/section`,
+`core/text ×3` — it draws a live, read-only miniature of the page, the number of
+blocks it holds, and one clear button into the page builder. An empty page
+invites you to build it rather than reporting that it is empty.
+
+The miniature uses the same renderer that draws the published page, so what you
+see on the edit screen is what a visitor gets. It waits for your site's own
+styles before drawing, rather than showing a page styled with defaults your site
+does not use.

--- a/e2e/tests/builder-a11y.spec.ts
+++ b/e2e/tests/builder-a11y.spec.ts
@@ -106,10 +106,22 @@ async function scanEditor(page: Page): Promise<Finding[]> {
   }));
 }
 
+/*
+ * The control that opens the page builder, in EITHER state.
+ *
+ * The card names itself for the document it is showing — an empty page invites
+ * you to build it, a populated one to open the builder — so a helper naming one
+ * wording breaks whenever the fixture gains or loses blocks, and breaks with a
+ * timeout that names the editor rather than the button. Kept as a literal
+ * because this suite is deliberately black box and imports no product code;
+ * the source of both strings is `PageBuilderCard`.
+ */
+const OPEN_BUILDER_ACTION = /^(?:Build this page|Open Page Builder)$/;
+
 /** Open a document and put its page builder on screen. */
 async function openEditor(page: Page): Promise<void> {
   await gotoAdmin(page, "/singles/homepage");
-  await page.getByRole("button", { name: "Edit blocks" }).click();
+  await page.getByRole("button", { name: OPEN_BUILDER_ACTION }).click();
   // POPULATION BEFORE VERDICT. "No violations" is satisfied perfectly by an
   // editor that never opened, so the scan must not run until it has.
   await expect(page.locator(EDITOR_READY_ANCHOR)).toBeVisible({

--- a/e2e/tests/inline-rich-text.spec.ts
+++ b/e2e/tests/inline-rich-text.spec.ts
@@ -22,6 +22,18 @@ import { expect, test, type Page } from "@playwright/test";
 import { STORAGE_STATE } from "../global-setup";
 import { gotoAdmin } from "./support/admin";
 
+/*
+ * The control that opens the page builder, in EITHER state.
+ *
+ * The card names itself for the document it is showing — an empty page invites
+ * you to build it, a populated one to open the builder — so a helper naming one
+ * wording breaks whenever the fixture gains or loses blocks, and breaks with a
+ * timeout that names the editor rather than the button. Kept as a literal
+ * because this suite is deliberately black box and imports no product code;
+ * the source of both strings is `PageBuilderCard`.
+ */
+const OPEN_BUILDER_ACTION = /^(?:Build this page|Open Page Builder)$/;
+
 const HOMEPAGE = "/admin/api/singles/homepage";
 
 /** The element the renderer marks as carrying the passage. */
@@ -112,7 +124,7 @@ async function openBuilderWith(page: Page, children: unknown[]): Promise<void> {
   );
 
   await gotoAdmin(page, "/singles/homepage");
-  await page.getByRole("button", { name: "Edit blocks" }).click();
+  await page.getByRole("button", { name: OPEN_BUILDER_ACTION }).click();
   // The passage must be ON SCREEN before anything is aimed at it: a gesture
   // sent at an element that has not rendered lands on the page behind it.
   await expect(page.locator(PASSAGE).first()).toBeVisible({ timeout: 30_000 });

--- a/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.breakpoints.test.tsx
@@ -23,6 +23,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 /*
  * ONE document object for the life of the mount.
@@ -199,7 +200,7 @@ function Host(): React.JSX.Element {
 
 function openEditor(): { rerender: () => void } {
   const view = render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
   return {
     rerender: () => {
       React.act(() => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classes.test.tsx
@@ -25,6 +25,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
 
@@ -155,7 +156,7 @@ function Host(): React.JSX.Element {
 
 function openEditor(): void {
   render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
 }
 
 /** What the inspector was handed for the class surface. */

--- a/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.classesPanel.test.tsx
@@ -26,6 +26,7 @@ import {
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
 
@@ -157,7 +158,7 @@ function Host({ tick = 0 }: { tick?: number }): React.JSX.Element {
 
 function openEditor(): ReturnType<typeof render> {
   const view = render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
   return view;
 }
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.emptyContainerAppender.test.tsx
@@ -24,6 +24,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 /*
  * Declared here rather than in a setup file, because neither this package nor
@@ -192,7 +193,7 @@ function Host(): React.JSX.Element {
 
 function openEditor(): { rerender: () => void } {
   const view = render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
   return {
     rerender: () => {
       React.act(() => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.fonts.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.fonts.test.tsx
@@ -25,6 +25,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 const DOCUMENT = { formatVersion: 1, kind: "page", nodes: [] };
 
@@ -116,7 +117,7 @@ function Host(): React.JSX.Element {
 
 function openEditor(): void {
   render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
 }
 
 /** What the inspector was handed for the class surface. */

--- a/packages/plugin-page-builder/src/admin/BlocksField.inline-outcome.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.inline-outcome.test.tsx
@@ -23,6 +23,7 @@ import { useForm, useWatch, type Control } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { InlineEditOutcome } from "@nextlyhq/builder/shell";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 /** What the inline surface answers when this test's editor is finished. */
 let outcome: InlineEditOutcome = { status: "unchanged" };
@@ -203,7 +204,7 @@ function Host(): React.JSX.Element {
 /** Mount the field and open the editor. */
 function openEditor(): void {
   render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
 }
 
 /** Whether the editor is still up, which is what holds the author's words. */
@@ -232,7 +233,9 @@ describe("leaving the editor with an inline edit that could not be written", () 
     // passage exists nowhere else — so this is the difference between the
     // author keeping their paragraph and losing it without being asked.
     expect(editorIsOpen()).toBe(true);
-    expect(screen.queryByRole("button", { name: "Edit blocks" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: OPEN_BUILDER_ACTION })
+    ).toBeNull();
   });
 
   it("tells the author why leaving did nothing", () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.paletteDrag.test.tsx
@@ -22,6 +22,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 /** Props the recorders captured on the most recent render. */
 const seen: {
@@ -224,7 +225,7 @@ function Host(): React.JSX.Element {
 /** Mount the field and open the editor, which is where the two surfaces live. */
 function openEditor(): void {
   render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
 }
 
 beforeEach(() => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.policy.test.tsx
@@ -21,6 +21,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 /** Props the recorders captured on the most recent render. */
 const seen: {
@@ -182,7 +183,7 @@ function Host(): React.JSX.Element {
 /** Mount the field and open the editor, which is where the two surfaces live. */
 function openEditor(): void {
   render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
 }
 
 beforeEach(() => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
@@ -111,11 +111,8 @@ describe("the entry form at rest", () => {
 
     const { container } = render(<Host />);
 
-    const frame = container.querySelector<HTMLIFrameElement>(MINIATURE);
-
-    expect(frame).not.toBeNull();
-    // The page lives in the frame's own document, not the admin's around it.
-    expect(frame?.srcdoc).toContain(PAGE_TEXT);
+    expect(container.querySelector(MINIATURE)).not.toBeNull();
+    expect(container.textContent).toContain(PAGE_TEXT);
   });
 
   it("does not put the block's type name on the screen", () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
@@ -111,8 +111,11 @@ describe("the entry form at rest", () => {
 
     const { container } = render(<Host />);
 
-    expect(container.querySelector(MINIATURE)).not.toBeNull();
-    expect(container.textContent).toContain(PAGE_TEXT);
+    const frame = container.querySelector<HTMLIFrameElement>(MINIATURE);
+
+    expect(frame).not.toBeNull();
+    // The page lives in the frame's own document, not the admin's around it.
+    expect(frame?.srcdoc).toContain(PAGE_TEXT);
   });
 
   it("does not put the block's type name on the screen", () => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
@@ -1,0 +1,154 @@
+// @vitest-environment jsdom
+
+/**
+ * What the entry form draws BEFORE the editor is opened.
+ *
+ * The state a page's edit screen spends nearly all of its time in, and the one
+ * nothing asserted: on the shipped `pages` collection the blocks field IS the
+ * editable body — `title` and `slug` are system fields the header draws — so
+ * this is what an author sees when they open a page.
+ *
+ * Two of the cases below cover failures that pass a careless test.
+ *
+ * The COLD REGISTRY. `ensureCoreBlocksRegistered()` runs inside `BlocksEditor`
+ * and nowhere else, deliberately, so nothing is registered while the form is at
+ * rest. Registration is global module state that is never torn down, so a test
+ * that opened the editor first would leave every later render able to resolve
+ * blocks — and the page would draw here for a reason a real cold page load does
+ * not have. The case below therefore observes the empty registry in the
+ * assertion rather than trusting the file's ordering.
+ *
+ * The PENDING SHEET. Omitting `siteStyles` does not draw nothing; the renderer
+ * still emits its default tokens, so a page rendered before the site's own
+ * sheet arrives looks entirely plausible while missing that site's named
+ * classes and block-type defaults. A test asserting only "something rendered"
+ * passes on exactly that wrong picture.
+ *
+ * @module admin/BlocksField.restingState.test
+ */
+import {
+  DOCUMENT_FORMAT_VERSION,
+  getBlock,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { cleanup, render } from "@testing-library/react";
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** What the stored-style read answers with for the test in hand. */
+let siteStyleRead: { data: unknown; isPending: boolean; error: Error | null } =
+  { data: undefined, isPending: false, error: null };
+
+vi.mock("@nextlyhq/plugin-sdk/admin", () => ({
+  // Present because the mock REPLACES the module wholesale: an export the
+  // subject imports and this omits is a missing-export error rather than an
+  // unused stub.
+  loadInlineRichTextEditor: () => new Promise<never>(() => {}),
+  usePluginClientConfig: () => undefined,
+  useDocumentCheckpoint: () => ({ record: () => {}, clear: () => {} }),
+  useEntryFieldsPanel: () => null,
+  useReportUnsavedWork: () => {},
+  useSuppressAdminChrome: () => {},
+  useDocumentStatus: () => null,
+  useSingleDocument: () => siteStyleRead,
+  useUpdateSingleDocument: () => ({
+    mutateAsync: async () => ({ success: true }),
+    isPending: false,
+  }),
+}));
+
+// Imported after the mock, which is what makes it take effect.
+const { BlocksField } = await import("./BlocksField");
+
+/*
+ * The block's OWN version rather than a literal: the renderer drops a node
+ * whose version it cannot reconcile, and it drops it SILENTLY — so a pinned
+ * number becomes an empty page the day the block is revised, with this fixture
+ * still reading as correct.
+ */
+const TEXT = coreBlocks.find(block => block.name === "core/text");
+if (!TEXT) throw new Error("core/text is missing from coreBlocks");
+
+const PAGE_TEXT = "The words on this page";
+
+const DOCUMENT = {
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes: [
+    {
+      id: "a",
+      type: TEXT.name,
+      version: TEXT.version,
+      props: { text: PAGE_TEXT },
+    },
+  ],
+} as unknown as BlockDocument;
+
+const MINIATURE = '[data-slot="page-miniature-surface"]';
+
+/** A form around the field, since it reads its value through a form control. */
+function Host({ readOnly = false }: { readOnly?: boolean }): React.JSX.Element {
+  const { control } = useForm({ defaultValues: { body: DOCUMENT } });
+  return <BlocksField name="body" control={control} readOnly={readOnly} />;
+}
+
+beforeEach(() => {
+  siteStyleRead = { data: undefined, isPending: false, error: null };
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("the entry form at rest", () => {
+  it("draws the page itself, with nothing registered", () => {
+    // The precondition, OBSERVED rather than assumed. This is the state a cold
+    // page load renders in, and the one a test that opened the editor first
+    // would silently stop testing.
+    expect(getBlock(TEXT.name)).toBeUndefined();
+
+    const { container } = render(<Host />);
+
+    expect(container.querySelector(MINIATURE)).not.toBeNull();
+    expect(container.textContent).toContain(PAGE_TEXT);
+  });
+
+  it("does not put the block's type name on the screen", () => {
+    const { container } = render(<Host />);
+
+    // What stood here before was `core/text` in a mono chip — machinery, where
+    // the author needed the page.
+    expect(container.textContent).not.toContain(TEXT.name);
+  });
+
+  it("draws no page while the site's own style is still arriving", () => {
+    siteStyleRead = { data: undefined, isPending: true, error: null };
+
+    const { container } = render(<Host />);
+
+    expect(container.querySelector(MINIATURE)).toBeNull();
+    expect(container.textContent).not.toContain(PAGE_TEXT);
+  });
+
+  it("still says what the page holds while the style is arriving", () => {
+    siteStyleRead = { data: undefined, isPending: true, error: null };
+
+    const { container } = render(<Host />);
+
+    expect(container.textContent).toContain("1 block");
+  });
+
+  it("offers no way in when the field cannot be edited", () => {
+    const { container } = render(<Host readOnly />);
+
+    expect(container.querySelector("button")).toBeNull();
+  });
+
+  it("still draws the page when the field cannot be edited", () => {
+    const { container } = render(<Host readOnly />);
+
+    expect(container.querySelector(MINIATURE)).not.toBeNull();
+  });
+});

--- a/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.restingState.test.tsx
@@ -140,6 +140,39 @@ describe("the entry form at rest", () => {
     expect(container.textContent).toContain("1 block");
   });
 
+  /*
+   * The failed read, end to end.
+   *
+   * `useSiteStyle` reports the failure and ALSO resolves a style — the config
+   * defaults — with `pending` false. So the field must read the error, or it
+   * draws a page missing this site's stored classes, tokens and block defaults
+   * and looks entirely correct doing it.
+   */
+  it("draws no page when the site-style read failed", () => {
+    siteStyleRead = {
+      data: undefined,
+      isPending: false,
+      error: new Error("site style unavailable"),
+    };
+
+    const { container } = render(<Host />);
+
+    expect(container.querySelector(MINIATURE)).toBeNull();
+    expect(container.textContent).not.toContain(PAGE_TEXT);
+  });
+
+  it("still offers the way into the builder when that read failed", () => {
+    siteStyleRead = {
+      data: undefined,
+      isPending: false,
+      error: new Error("site style unavailable"),
+    };
+
+    const { container } = render(<Host />);
+
+    expect(container.querySelector("button")).not.toBeNull();
+  });
+
   it("offers no way in when the field cannot be edited", () => {
     const { container } = render(<Host readOnly />);
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.settingsPanel.test.tsx
@@ -29,6 +29,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import * as React from "react";
 import { useForm } from "react-hook-form";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 /** What the entry-fields hook answers with for the test in hand. */
 let entryFields: React.ReactNode | null;
@@ -141,7 +142,7 @@ function Host(): React.JSX.Element {
 
 function openEditor(): void {
   render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
 }
 
 /** The rail's panel list, as the shell was handed it. */
@@ -268,7 +269,7 @@ describe("offering the Settings panel", () => {
 
     // Commit blocks the way leaving the editor does, then open a fresh one.
     fireEvent.click(screen.getByRole("button", { name: "commit blocks" }));
-    fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+    fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
 
     expect(pillDirty.at(-1)).toBe(true);
   });

--- a/packages/plugin-page-builder/src/admin/BlocksField.styleState.test.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.styleState.test.tsx
@@ -34,6 +34,7 @@ import {
 } from "vitest";
 
 import { clearBlocks, registerBlocks } from "@nextlyhq/blocks-engine";
+import { OPEN_BUILDER_ACTION } from "./PageBuilderCard";
 
 /*
  * REAL nodes, and one of them of a type the registry does not know.
@@ -165,7 +166,7 @@ function Host(): React.JSX.Element {
 
 function openEditor(): { rerender: () => void } {
   const view = render(<Host />);
-  fireEvent.click(screen.getByRole("button", { name: "Edit blocks" }));
+  fireEvent.click(screen.getByRole("button", { name: OPEN_BUILDER_ACTION }));
   return {
     rerender: () => {
       React.act(() => {

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -4,9 +4,16 @@
  * The blocks field's control: a summary of what the field holds, and the way in
  * to the editor that changes it.
  *
- * Composes `BlocksSummary` rather than replacing it. The summary is a pure
- * read-only account of the document and stays that way — it is what the form
- * shows at rest, and it is worth keeping testable without an editor around it.
+ * At rest it draws `PageBuilderCard`: the page itself, small and inert, and one
+ * way in. A list of block TYPE NAMES was what stood here, and it read as an
+ * inert summary rather than as the door to the editor — the confusion
+ * Gutenberg's own design discussion of editor switching warns about.
+ *
+ * `BlocksSummary` is NOT deleted. It remains exported and registered at the
+ * component path `@nextlyhq/plugin-page-builder/admin#BlocksSummary`, which a
+ * host may address by string, so removing it would break a published surface.
+ * It stays a pure read-only account of the document; both it and the card ask
+ * `page-summary` what the document holds, so they cannot disagree.
  *
  * ## Why the editor opens OVER the form rather than inside it
  *
@@ -143,8 +150,8 @@ import {
 } from "../site-style";
 import { readSiteStyleRecord } from "../site-style-record";
 
-import { BlocksSummary } from "./BlocksSummary";
 import { DocumentStatusPill } from "./DocumentStatusPill";
+import { PageBuilderCard } from "./PageBuilderCard";
 /* The save state, which the status pill cannot carry: it renders nothing on a
    collection with no publish lifecycle, and took the only reading of unsaved
    work down with it. */
@@ -313,6 +320,27 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
   const editable = canEditBlocks({ readOnly, disabled });
 
   /*
+   * The site's own style, read at REST as well as inside the editor.
+   *
+   * The miniature below is the published renderer, so it needs the sheet that
+   * renderer needs. Omitting it is not a neutral choice: `PageRenderer` still
+   * emits the DEFAULT token set, so the page draws plausibly while missing this
+   * site's named classes and block-type defaults — which is the failure
+   * `canvas.tsx` makes the prop required to prevent.
+   *
+   * The same query the editor makes, so the two share one cache entry rather
+   * than fetching twice; `pending` is forwarded so the card can decline to draw
+   * a page it cannot draw faithfully yet.
+   */
+  const restingClientConfig = usePluginClientConfig(PLUGIN_SOURCE);
+  const restingConfigStyle = useMemo(
+    () => readSiteStyleRecord(restingClientConfig?.siteStyle),
+    [restingClientConfig]
+  );
+  const { siteStyle: restingSiteStyle, pending: restingStylePending } =
+    useSiteStyle(restingConfigStyle);
+
+  /*
    * Closed if the form becomes read-only while the editor is up.
    *
    * Not a hypothetical: a permission can be revoked and a form can start
@@ -338,28 +366,16 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
       control={control}
     />
   ) : (
-    <div className="flex flex-col gap-3">
-      <BlocksSummary name={name} control={control} />
-      {/*
-        No button at all rather than a disabled one.
-        
-        A disabled control says "you could do this, but not now", which is the
-        wrong sentence for a document that cannot be edited at all — and the
-        summary above already says what the field holds. An affordance that
-        cannot ever act here is one an author spends attention on.
-      */}
-      {editable ? (
-        <div>
-          <button
-            type="button"
-            onClick={() => setOpen(true)}
-            className="inline-flex h-9 items-center rounded-md border border-border bg-background px-3 text-sm font-medium text-foreground transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-          >
-            Edit blocks
-          </button>
-        </div>
-      ) : null}
-    </div>
+    <PageBuilderCard
+      document={documentFrom(field.value)}
+      siteStyles={siteSheet(restingSiteStyle)}
+      stylePending={restingStylePending}
+      // The gate is passed through rather than restated: `canEditBlocks`
+      // already answers it for the editor above, and two readings of "may this
+      // author edit" is one more than the question has.
+      canEdit={editable}
+      onOpen={() => setOpen(true)}
+    />
   );
 }
 

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -42,9 +42,6 @@
 
 import {
   resolveSiteTokens,
-  isPlainRecord,
-  DEFAULT_LIMITS,
-  type DocumentLimits,
   getBlock,
   hasBlock,
   registerBlocks,
@@ -74,7 +71,6 @@ import {
   type CanvasZoom,
   breakpointsAtWidth,
   editedBreakpointAtWidth,
-  offeredTiers,
   selectableTiers,
   widthForBreakpoint,
   BlockContextMenu,
@@ -144,13 +140,13 @@ import {
   classOverrideOf,
   tokenOverrideOf,
   tokenSaveOutcome,
-  siteBreakpoints,
   siteSheet,
   type SiteStyleData,
 } from "../site-style";
 import { readSiteStyleRecord } from "../site-style-record";
 
 import { DocumentStatusPill } from "./DocumentStatusPill";
+import { pageRenderInputs, readDocumentLimits } from "./page-render-inputs";
 import { PageBuilderCard } from "./PageBuilderCard";
 /* The save state, which the status pill cannot carry: it renders nothing on a
    collection with no publish lifecycle, and took the only reading of unsaved
@@ -158,6 +154,7 @@ import { PageBuilderCard } from "./PageBuilderCard";
 import { useSaveSiteStyle, useSiteStyle } from "./site-style-client";
 import { withValueAtPath } from "./snapshot-merge";
 import { UnsavedChangesPill } from "./UnsavedChangesPill";
+import { useRestingPageRender } from "./use-resting-page-render";
 import { useShown } from "./use-shown";
 
 export interface BlocksFieldProps<
@@ -332,13 +329,15 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
    * than fetching twice; `pending` is forwarded so the card can decline to draw
    * a page it cannot draw faithfully yet.
    */
-  const restingClientConfig = usePluginClientConfig(PLUGIN_SOURCE);
-  const restingConfigStyle = useMemo(
-    () => readSiteStyleRecord(restingClientConfig?.siteStyle),
-    [restingClientConfig]
-  );
-  const { siteStyle: restingSiteStyle, pending: restingStylePending } =
-    useSiteStyle(restingConfigStyle);
+  /*
+   * What the resting card draws with, asked as ONE question.
+   *
+   * The site's style, whether it has arrived, its config and a container name
+   * for this field's own box — four reads, each of which produces a
+   * faithful-looking wrong page when got subtly wrong. They belong together and
+   * not in a control whose job is choosing between two surfaces.
+   */
+  const resting = useRestingPageRender(PLUGIN_SOURCE);
 
   /*
    * Closed if the form becomes read-only while the editor is up.
@@ -368,8 +367,9 @@ export function BlocksField<TFieldValues extends FieldValues = FieldValues>({
   ) : (
     <PageBuilderCard
       document={documentFrom(field.value)}
-      siteStyles={siteSheet(restingSiteStyle)}
-      stylePending={restingStylePending}
+      siteStyles={resting.siteStyles}
+      styleState={resting.styleState}
+      render={resting.render}
       // The gate is passed through rather than restated: `canEditBlocks`
       // already answers it for the editor above, and two readings of "may this
       // author edit" is one more than the question has.
@@ -733,53 +733,6 @@ function useClassWrites(
   );
 
   return { run };
-}
-
-/**
- * The document bounds the host renders under, as published to the browser.
- *
- * Read DEFENSIVELY and one key at a time: `clientConfig` is JSON that crossed a
- * transport, so nothing here can assume a shape. Anything unreadable falls back
- * to the engine's defaults, which is what the renderer itself falls back to —
- * so the two still agree rather than diverging in the direction that would
- * misreport which classes a page applies.
- */
-function readDocumentLimits(
-  clientConfig: Record<string, unknown> | undefined
-): DocumentLimits {
-  const declared = clientConfig?.limits;
-  if (!isPlainRecord(declared)) return DEFAULT_LIMITS;
-  // Built by overriding the defaults key by key rather than by asserting a
-  // shape onto the transported value: the keys come from `DEFAULT_LIMITS`, so
-  // a bound the engine adds later is carried without this being edited, and a
-  // key the host sent that the engine does not have is ignored.
-  const merged: DocumentLimits = { ...DEFAULT_LIMITS };
-  for (const key of Object.keys(DEFAULT_LIMITS) as (keyof DocumentLimits)[]) {
-    const supplied = declared[key];
-    /*
-     * Zero and Infinity are both LEGITIMATE bounds, so neither may be narrowed
-     * away here. A host setting `maxNodes: 0` gets a renderer that draws
-     * nothing, and substituting the default would have the panel mark classes
-     * as present on a page that renders none of them; the engine supports an
-     * infinite byte limit outright. What is refused is a value that is not a
-     * number, or one below zero, which no bound can mean.
-     */
-    // `null` is the wire spelling for an INFINITE bound: `Infinity` is not a
-    // JSON value and the client config is refused unless it survives the round
-    // trip unchanged, so the publisher encodes it and this decodes it.
-    if (supplied === null) {
-      merged[key] = Number.POSITIVE_INFINITY;
-      continue;
-    }
-    if (
-      typeof supplied === "number" &&
-      !Number.isNaN(supplied) &&
-      supplied >= 0
-    ) {
-      merged[key] = supplied;
-    }
-  }
-  return merged;
 }
 
 /**
@@ -1535,6 +1488,18 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
   );
 
   /*
+   * The site's document caps, read once.
+   *
+   * Two readers now — the renderer inputs, which repair the document against
+   * them, and the class-usage count. Read separately they would agree until the
+   * day one of them was pointed at a different config.
+   */
+  const documentLimits = useMemo(
+    () => readDocumentLimits(clientConfig),
+    [clientConfig]
+  );
+
+  /*
    * What the inspector judges a written URL by.
    *
    * Without this the Style tab asks the engine to validate a value with no
@@ -1701,51 +1666,31 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     undefined
   );
 
-  const canvasRender = useMemo(() => {
-    /*
-     * ONE read of the site's breakpoints, feeding both the context and the
-     * decision about whether to preview at all.
-     *
-     * Two calls returned equal sets today and would stop the day `siteBreakpoints`
-     * normalises or defaults anything — and then preview eligibility would be
-     * answering from a different set than the canvas renders, which is the
-     * box/compile mismatch this whole seam exists to make unrepresentable. The
-     * docblock above already says this about the context's THREE readers; the
-     * eligibility question is a fourth.
-     */
-    const breakpoints = siteBreakpoints(canvasSiteStyle);
-    return {
-      styleContext: {
-        breakpoints,
-        /*
-         * Carried on the SAME context the cascade and the inspector read, so
-         * all three describe one compile. Supplied unconditionally rather than
-         * only while a tier is selected: at the full width the box is still a
-         * box, and a region narrower than the widest tier is already showing a
-         * narrower tier's rules. Compiling `@media` there would answer for the
-         * admin WINDOW instead — a wide window around a narrow canvas reports
-         * the desktop tier live while the box paints the tablet one.
-         */
-        ...(offeredTiers(breakpoints).length === 0 ? {} : { previewContainer }),
-        /*
-         * Unconditional, unlike the container above. A page cannot force a
-         * pseudo-class on itself, so the sheet has to carry a class alternative
-         * beside each one before the canvas can show an author the hover
-         * appearance they are editing — and whether they are editing one is not
-         * known when the sheet is compiled.
-         *
-         * It costs a few bytes per state rule in a sheet only the editor sees,
-         * and nothing at all in weight: the marker sits inside the `:where()`
-         * that already wrapped the pseudo-class, which contributes nothing. The
-         * published sheet is compiled elsewhere and never asks for this.
-         */
+  /*
+   * The renderer inputs, from the ONE derivation the entry screen's miniature
+   * also asks.
+   *
+   * This used to be assembled here, and the resting field assembled a poorer
+   * copy of its own — which is how the miniature came to render with no
+   * breakpoint container, no host policy and default caps while the canvas had
+   * all three. Two surfaces drawing one document must not answer "what does
+   * this site render like" separately.
+   *
+   * `previewStates` is the editor's alone: the canvas needs a class alternative
+   * beside each pseudo-class rule so it can show an author the state being
+   * edited, and a surface showing the page as published must not have one.
+   */
+  const canvasRender = useMemo(
+    () =>
+      pageRenderInputs({
+        siteStyle: canvasSiteStyle,
+        clientConfig,
+        previewContainer,
         previewStates: true,
-      },
-      ...(remotePatterns === undefined
-        ? {}
-        : { hostPolicy: { remotePatterns } }),
-    };
-  }, [canvasSiteStyle, remotePatterns, previewContainer]);
+        limits: documentLimits,
+      }),
+    [canvasSiteStyle, clientConfig, previewContainer, documentLimits]
+  );
 
   /*
    * What the canvas is previewing under, read back from the ONE context that
@@ -1899,8 +1844,8 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
     // lowered them renders under those, and a walk here under different bounds
     // selects different nodes — which would report a class as absent from a
     // page that renders it, or present on one that does not.
-    () => classUsageOf(editor.document, readDocumentLimits(clientConfig)),
-    [editor.document, clientConfig]
+    () => classUsageOf(editor.document, documentLimits),
+    [editor.document, documentLimits]
   );
 
   /*

--- a/packages/plugin-page-builder/src/admin/BlocksSummary.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksSummary.tsx
@@ -14,7 +14,7 @@
  * @module components/entries/fields/structured/BlocksSummary
  */
 
-import type { BlockDocument, BlockNode } from "@nextlyhq/blocks-engine";
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
 import { LayoutGrid } from "lucide-react";
 import { useMemo } from "react";
 import {
@@ -23,6 +23,8 @@ import {
   type FieldValues,
   type Path,
 } from "react-hook-form";
+
+import { countByType, documentNodes, totalBlocks } from "./page-summary";
 
 export interface BlocksSummaryProps<
   TFieldValues extends FieldValues = FieldValues,
@@ -33,41 +35,15 @@ export interface BlocksSummaryProps<
   control: Control<TFieldValues>;
 }
 
-/** Every block type in the tree with how many times it appears, in tree order. */
-function countByType(nodes: readonly BlockNode[]): Map<string, number> {
-  const counts = new Map<string, number>();
-  const visit = (list: readonly BlockNode[]): void => {
-    for (const node of list) {
-      if (!node || typeof node.type !== "string") continue;
-      counts.set(node.type, (counts.get(node.type) ?? 0) + 1);
-      // Children live under named slots, so a container's contents are counted
-      // too rather than the summary reporting only the top level.
-      for (const slot of Object.values(node.slots ?? {})) {
-        if (Array.isArray(slot)) visit(slot);
-      }
-    }
-  };
-  visit(nodes);
-  return counts;
-}
-
 export function BlocksSummary<TFieldValues extends FieldValues = FieldValues>({
   name,
   control,
 }: BlocksSummaryProps<TFieldValues>) {
   const value = useWatch({ control, name }) as BlockDocument | null | undefined;
 
-  const counts = useMemo(() => {
-    const nodes = value?.nodes;
-    return Array.isArray(nodes)
-      ? countByType(nodes)
-      : new Map<string, number>();
-  }, [value]);
+  const counts = useMemo(() => countByType(documentNodes(value)), [value]);
 
-  const total = useMemo(
-    () => [...counts.values()].reduce((sum, n) => sum + n, 0),
-    [counts]
-  );
+  const total = useMemo(() => totalBlocks(counts), [counts]);
 
   if (total === 0) {
     return (

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
@@ -96,8 +96,8 @@ describe("PageBuilderCard", () => {
       <PageBuilderCard {...base} document={doc(2)} styleState="pending" />
     );
 
+    // No frame at all, so there is no document holding the page either.
     expect(container.querySelector(MINIATURE)).toBeNull();
-    expect(container.textContent).not.toContain("Block 0");
   });
 
   it("draws the page once the site style has resolved", () => {
@@ -105,8 +105,10 @@ describe("PageBuilderCard", () => {
       <PageBuilderCard {...base} document={doc(2)} styleState="ready" />
     );
 
-    expect(container.querySelector(MINIATURE)).not.toBeNull();
-    expect(container.textContent).toContain("Block 0");
+    const frame = container.querySelector<HTMLIFrameElement>(MINIATURE);
+
+    expect(frame).not.toBeNull();
+    expect(frame?.srcdoc).toContain("Block 0");
   });
 
   it("still reports what the page holds while the style is pending", () => {
@@ -131,8 +133,8 @@ describe("PageBuilderCard", () => {
       <PageBuilderCard {...base} document={doc(2)} styleState="unavailable" />
     );
 
+    // No frame at all, so there is no document holding the page either.
     expect(container.querySelector(MINIATURE)).toBeNull();
-    expect(container.textContent).not.toContain("Block 0");
   });
 
   it("says why, rather than showing an empty frame", () => {

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
@@ -96,8 +96,8 @@ describe("PageBuilderCard", () => {
       <PageBuilderCard {...base} document={doc(2)} styleState="pending" />
     );
 
-    // No frame at all, so there is no document holding the page either.
     expect(container.querySelector(MINIATURE)).toBeNull();
+    expect(container.textContent).not.toContain("Block 0");
   });
 
   it("draws the page once the site style has resolved", () => {
@@ -105,10 +105,8 @@ describe("PageBuilderCard", () => {
       <PageBuilderCard {...base} document={doc(2)} styleState="ready" />
     );
 
-    const frame = container.querySelector<HTMLIFrameElement>(MINIATURE);
-
-    expect(frame).not.toBeNull();
-    expect(frame?.srcdoc).toContain("Block 0");
+    expect(container.querySelector(MINIATURE)).not.toBeNull();
+    expect(container.textContent).toContain("Block 0");
   });
 
   it("still reports what the page holds while the style is pending", () => {
@@ -133,8 +131,8 @@ describe("PageBuilderCard", () => {
       <PageBuilderCard {...base} document={doc(2)} styleState="unavailable" />
     );
 
-    // No frame at all, so there is no document holding the page either.
     expect(container.querySelector(MINIATURE)).toBeNull();
+    expect(container.textContent).not.toContain("Block 0");
   });
 
   it("says why, rather than showing an empty frame", () => {

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PageBuilderCard } from "./PageBuilderCard";
+
+// Derived from the block's own definition rather than pinned: the renderer
+// drops a node whose version it cannot reconcile, and it drops it silently.
+const TEXT = coreBlocks.find(block => block.name === "core/text");
+if (!TEXT) throw new Error("core/text is missing from coreBlocks");
+
+function doc(count: number): BlockDocument {
+  return {
+    formatVersion: DOCUMENT_FORMAT_VERSION,
+    kind: "page",
+    nodes: Array.from({ length: count }, (_, i) => ({
+      id: `n${i}`,
+      type: TEXT.name,
+      version: TEXT.version,
+      props: { text: `Block ${i}` },
+    })),
+  } as unknown as BlockDocument;
+}
+
+const base = {
+  siteStyles: undefined,
+  stylePending: false,
+  canEdit: true,
+  onOpen: () => {},
+};
+
+const MINIATURE = '[data-slot="page-miniature-surface"]';
+
+describe("PageBuilderCard", () => {
+  it("invites the author to build when the page is empty", () => {
+    render(<PageBuilderCard {...base} document={doc(0)} />);
+
+    expect(
+      screen.getByRole("button", { name: /build this page/i })
+    ).toBeDefined();
+  });
+
+  it("does not draw an empty frame for a page with nothing in it", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(0)} />
+    );
+
+    expect(container.querySelector(MINIATURE)).toBeNull();
+  });
+
+  it("reads out how many blocks the page holds", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(3)} />
+    );
+
+    expect(container.textContent).toContain("3 blocks");
+  });
+
+  it("counts one block in the singular", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(1)} />
+    );
+
+    expect(container.textContent).toContain("1 block");
+    expect(container.textContent).not.toContain("1 blocks");
+  });
+
+  /*
+   * The trap this guards.
+   *
+   * Omitting `siteStyles` still emits the DEFAULT token set, so a page rendered
+   * without the site's own sheet looks entirely plausible while missing the
+   * site's named classes and block defaults. The canvas makes the sheet a
+   * required prop for exactly this reason — a faithful-LOOKING preview that is
+   * wrong is worse than one that is visibly not ready yet.
+   */
+  it("draws no page at all while the site style is still arriving", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(2)} stylePending />
+    );
+
+    expect(container.querySelector(MINIATURE)).toBeNull();
+    expect(container.textContent).not.toContain("Block 0");
+  });
+
+  it("draws the page once the site style has resolved", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(2)} stylePending={false} />
+    );
+
+    expect(container.querySelector(MINIATURE)).not.toBeNull();
+    expect(container.textContent).toContain("Block 0");
+  });
+
+  it("still reports what the page holds while the style is pending", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(2)} stylePending />
+    );
+
+    expect(container.textContent).toContain("2 blocks");
+  });
+
+  /*
+   * Kept from the behaviour this replaces, whose reasoning is recorded in
+   * BlocksField: a disabled control says "you could do this, but not now",
+   * which is the wrong sentence for a document nobody may edit at all.
+   */
+  it("offers no action when the field cannot be edited", () => {
+    render(<PageBuilderCard {...base} document={doc(2)} canEdit={false} />);
+
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("still shows the page when the field cannot be edited", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(2)} canEdit={false} />
+    );
+
+    expect(container.querySelector(MINIATURE)).not.toBeNull();
+  });
+
+  it("opens the builder when the action is pressed", () => {
+    const onOpen = vi.fn();
+    render(<PageBuilderCard {...base} document={doc(2)} onOpen={onOpen} />);
+
+    screen.getByRole("button", { name: /open page builder/i }).click();
+
+    expect(onOpen).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import {
+  DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
@@ -10,6 +11,7 @@ import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { PageBuilderCard } from "./PageBuilderCard";
+import { pageRenderInputs } from "./page-render-inputs";
 
 // Derived from the block's own definition rather than pinned: the renderer
 // drops a node whose version it cannot reconcile, and it drops it silently.
@@ -31,7 +33,15 @@ function doc(count: number): BlockDocument {
 
 const base = {
   siteStyles: undefined,
-  stylePending: false,
+  styleState: "ready" as const,
+  // Built through the real derivation, so the fixture cannot describe a bundle
+  // the product never produces.
+  render: pageRenderInputs({
+    siteStyle: undefined,
+    clientConfig: undefined,
+    previewContainer: undefined,
+    limits: DEFAULT_LIMITS,
+  }),
   canEdit: true,
   onOpen: () => {},
 };
@@ -83,7 +93,7 @@ describe("PageBuilderCard", () => {
    */
   it("draws no page at all while the site style is still arriving", () => {
     const { container } = render(
-      <PageBuilderCard {...base} document={doc(2)} stylePending />
+      <PageBuilderCard {...base} document={doc(2)} styleState="pending" />
     );
 
     expect(container.querySelector(MINIATURE)).toBeNull();
@@ -92,7 +102,7 @@ describe("PageBuilderCard", () => {
 
   it("draws the page once the site style has resolved", () => {
     const { container } = render(
-      <PageBuilderCard {...base} document={doc(2)} stylePending={false} />
+      <PageBuilderCard {...base} document={doc(2)} styleState="ready" />
     );
 
     expect(container.querySelector(MINIATURE)).not.toBeNull();
@@ -101,10 +111,49 @@ describe("PageBuilderCard", () => {
 
   it("still reports what the page holds while the style is pending", () => {
     const { container } = render(
-      <PageBuilderCard {...base} document={doc(2)} stylePending />
+      <PageBuilderCard {...base} document={doc(2)} styleState="pending" />
     );
 
     expect(container.textContent).toContain("2 blocks");
+  });
+
+  /*
+   * The third state, and the reason it has its own name.
+   *
+   * On a FAILED read `pending` goes false and the resolved style falls back to
+   * the config defaults, so a card keyed on `pending` alone would draw a page
+   * missing this site's stored classes, tokens and block defaults — the same
+   * plausible-but-wrong picture the pending branch refuses, arriving through
+   * the one door that branch does not watch.
+   */
+  it("draws no page when the site style could not be loaded", () => {
+    const { container } = render(
+      <PageBuilderCard {...base} document={doc(2)} styleState="unavailable" />
+    );
+
+    expect(container.querySelector(MINIATURE)).toBeNull();
+    expect(container.textContent).not.toContain("Block 0");
+  });
+
+  it("says why, rather than showing an empty frame", () => {
+    render(
+      <PageBuilderCard {...base} document={doc(2)} styleState="unavailable" />
+    );
+
+    expect(screen.getByRole("status").textContent).toMatch(
+      /cannot be previewed/i
+    );
+  });
+
+  // A failed preview must not take the way into the builder with it.
+  it("still offers the way in when the style could not be loaded", () => {
+    render(
+      <PageBuilderCard {...base} document={doc(2)} styleState="unavailable" />
+    );
+
+    expect(
+      screen.getByRole("button", { name: /open page builder/i })
+    ).toBeDefined();
   });
 
   /*

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
@@ -52,6 +52,7 @@ import { Button, Skeleton } from "@nextlyhq/ui";
 import { LayoutGrid } from "lucide-react";
 import { useMemo } from "react";
 
+import type { PageRenderInputs } from "./page-render-inputs";
 import { countByType, documentNodes, totalBlocks } from "./page-summary";
 import { PageMiniature } from "./PageMiniature";
 
@@ -62,6 +63,19 @@ import { PageMiniature } from "./PageMiniature";
  * the card renders. A copy in the test agrees on the day it is written and
  * then keeps passing — or keeps failing — after the wording moves.
  */
+/**
+ * Whether this site's own style is available to draw the page with.
+ *
+ * THREE states rather than a boolean, because the third is the one that gets
+ * folded into the good one by accident. "Not here yet" and "the read failed"
+ * both mean the page must not be drawn, and they mean it for the same reason —
+ * omitting the sheet does not draw nothing, it draws a plausible page missing
+ * this site's classes, tokens and block defaults. A boolean `pending` collapses
+ * a failed read into `ready`, which is exactly the wrong picture the pending
+ * branch exists to prevent.
+ */
+export type SiteStyleState = "ready" | "pending" | "unavailable";
+
 export const BUILD_PAGE_LABEL = "Build this page";
 
 /** What the action says when the page already holds blocks. */
@@ -91,15 +105,19 @@ export interface PageBuilderCardProps {
    */
   siteStyles: PageRendererProps["siteStyles"];
   /**
-   * Whether the site's own style is still being read.
+   * Whether this site's own style is available yet.
    *
-   * A separate answer from `siteStyles` being absent, and the distinction is
-   * the point: absent means "this site emits no sheet", which is a legitimate
-   * state to render in, while pending means the sheet that WILL apply is not
-   * here yet. Rendering during the second draws a page missing the site's named
-   * classes and block defaults — plausible, and wrong.
+   * A separate answer from `siteStyles` being absent: absent means "this site
+   * emits no sheet", which is a legitimate state to render in, while `pending`
+   * and `unavailable` both mean the sheet that WILL apply is not in hand.
    */
-  stylePending: boolean;
+  styleState: SiteStyleState;
+  /**
+   * Everything else this site's rendering depends on, as one bundle.
+   *
+   * The same bundle the canvas is handed, from the same derivation.
+   */
+  render: PageRenderInputs;
   /** Whether this author may open the editor at all. */
   canEdit: boolean;
   /** Opens the builder over the form. */
@@ -113,7 +131,8 @@ export interface PageBuilderCardProps {
 export function PageBuilderCard({
   document,
   siteStyles,
-  stylePending,
+  styleState,
+  render,
   canEdit,
   onOpen,
 }: PageBuilderCardProps) {
@@ -126,12 +145,31 @@ export function PageBuilderCard({
 
   return (
     <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4">
-      {empty ? null : stylePending ? (
+      {empty ? null : styleState === "pending" ? (
         // Sized like the miniature it stands in for, so the card does not
         // resize under the author the moment the sheet arrives.
         <Skeleton className="aspect-[16/10] w-full rounded-md" />
+      ) : styleState === "unavailable" ? (
+        /*
+         * A refusal, not a fallback. The page COULD be drawn from the config
+         * defaults, and it would look entirely reasonable while missing this
+         * site's stored classes, tokens, fonts and block defaults — a confident
+         * wrong picture, which is worse than none. Saying so also keeps the
+         * count and the action below, so the author is not blocked by it.
+         */
+        <div
+          className="flex aspect-[16/10] w-full items-center justify-center rounded-md border border-dashed border-border p-4 text-center text-sm text-muted-foreground"
+          role="status"
+        >
+          This page cannot be previewed right now — the site&apos;s styles could
+          not be loaded.
+        </div>
       ) : (
-        <PageMiniature document={document} siteStyles={siteStyles} />
+        <PageMiniature
+          document={document}
+          siteStyles={siteStyles}
+          render={render}
+        />
       )}
 
       <div className="flex flex-wrap items-center justify-between gap-3">

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+/**
+ * The entry screen's way into the page builder.
+ *
+ * On the shipped `pages` collection this is the whole editable body of the
+ * screen: the collection declares `title`, `slug` and the blocks field, and the
+ * first two are system fields the header draws. So this is not one field among
+ * several — it is what an author sees when they open a page, and it has to read
+ * as the door it is.
+ *
+ * ## It must not look like a field
+ *
+ * Gutenberg's own design discussion of switching between editors (issue #1375)
+ * reaches two requirements: an author must recognise which editing modes exist
+ * and which one they are in, and the handoff must not look "too similar to a
+ * block", which "would ultimately confuse the user about what view they are
+ * in". The surface this replaces was a muted bordered box with the type slugs
+ * listed inside it and a small outline button underneath — the named
+ * anti-pattern, and the reason a page's editor read as an inert summary.
+ *
+ * ## The page, rather than a list of its parts
+ *
+ * The reading is the page itself. A list of block TYPES is a debug view: it
+ * tells an author what machinery is on the page and nothing about what the page
+ * says, and twenty pages listing `core/section, core/text` are indistinguishable
+ * from each other. Sanity's page-building guidance reaches the same conclusion
+ * from the other direction — a row shows title, subtitle and media, and the
+ * type name belongs in the subtitle, never as the label.
+ *
+ * ## One action, and only when there is one
+ *
+ * A single primary control, which is what the empty-state guidance in Carbon
+ * and NN/g both reduce to. Where the field cannot be edited there is no
+ * disabled twin: {@link BlocksField} established that a disabled control says
+ * "you could do this, but not now", which is the wrong sentence for a document
+ * nobody may edit. The page is still drawn, because reading a page you may not
+ * change is legitimate.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/PageBuilderCard
+ */
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import type { PageRendererProps } from "@nextlyhq/blocks-react";
+import { Button, Skeleton } from "@nextlyhq/ui";
+import { LayoutGrid } from "lucide-react";
+import { useMemo } from "react";
+
+import { countByType, documentNodes, totalBlocks } from "./page-summary";
+import { PageMiniature } from "./PageMiniature";
+
+/**
+ * What the action says when the page has nothing on it yet.
+ *
+ * Exported because a test naming this control has to ask for the SAME string
+ * the card renders. A copy in the test agrees on the day it is written and
+ * then keeps passing — or keeps failing — after the wording moves.
+ */
+export const BUILD_PAGE_LABEL = "Build this page";
+
+/** What the action says when the page already holds blocks. */
+export const OPEN_BUILDER_LABEL = "Open Page Builder";
+
+/**
+ * Matches the card's action in EITHER state.
+ *
+ * A caller that wants to OPEN the builder cares that there is exactly one way
+ * in, not which sentence the card chose for this particular document. Deriving
+ * the pattern from both labels keeps such a caller correct when a fixture's
+ * document gains or loses blocks — which is otherwise a failure that names the
+ * wording rather than the change that caused it.
+ */
+export const OPEN_BUILDER_ACTION = new RegExp(
+  `^(?:${BUILD_PAGE_LABEL}|${OPEN_BUILDER_LABEL})$`
+);
+
+export interface PageBuilderCardProps {
+  /** The document the field currently holds. */
+  document: BlockDocument;
+  /**
+   * The site's compiled sheet.
+   *
+   * Spelled as the renderer's own prop type so this cannot drift from what
+   * `PageRenderer` accepts.
+   */
+  siteStyles: PageRendererProps["siteStyles"];
+  /**
+   * Whether the site's own style is still being read.
+   *
+   * A separate answer from `siteStyles` being absent, and the distinction is
+   * the point: absent means "this site emits no sheet", which is a legitimate
+   * state to render in, while pending means the sheet that WILL apply is not
+   * here yet. Rendering during the second draws a page missing the site's named
+   * classes and block defaults — plausible, and wrong.
+   */
+  stylePending: boolean;
+  /** Whether this author may open the editor at all. */
+  canEdit: boolean;
+  /** Opens the builder over the form. */
+  onOpen: () => void;
+}
+
+/**
+ * @param props - the document, the site's sheet and its readiness, and the way in
+ * @returns the card the entry form draws in place of the blocks field
+ */
+export function PageBuilderCard({
+  document,
+  siteStyles,
+  stylePending,
+  canEdit,
+  onOpen,
+}: PageBuilderCardProps) {
+  const total = useMemo(
+    () => totalBlocks(countByType(documentNodes(document))),
+    [document]
+  );
+
+  const empty = total === 0;
+
+  return (
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4">
+      {empty ? null : stylePending ? (
+        // Sized like the miniature it stands in for, so the card does not
+        // resize under the author the moment the sheet arrives.
+        <Skeleton className="aspect-[16/10] w-full rounded-md" />
+      ) : (
+        <PageMiniature document={document} siteStyles={siteStyles} />
+      )}
+
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm">
+          <LayoutGrid
+            className="size-4 shrink-0 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span className="font-medium text-foreground">Page Builder</span>
+          {empty ? (
+            <span className="text-muted-foreground">
+              Nothing here yet — lay this page out visually.
+            </span>
+          ) : (
+            <span className="text-muted-foreground">
+              {total} {total === 1 ? "block" : "blocks"}
+            </span>
+          )}
+        </div>
+
+        {canEdit ? (
+          <Button type="button" onClick={onOpen}>
+            {empty ? BUILD_PAGE_LABEL : OPEN_BUILDER_LABEL}
+          </Button>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
@@ -11,7 +11,7 @@
  *
  * ## It must not look like a field
  *
- * Gutenberg's own design discussion of switching between editors (issue #1375)
+ * Gutenberg's own design discussion of switching between editors (WordPress/gutenberg issue 1375)
  * reaches two requirements: an author must recognise which editing modes exist
  * and which one they are in, and the handoff must not look "too similar to a
  * block", which "would ultimately confuse the user about what view they are

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
@@ -28,6 +28,13 @@
  * from the other direction — a row shows title, subtitle and media, and the
  * type name belongs in the subtitle, never as the label.
  *
+ * ## It does not name itself
+ *
+ * The field's own label already says "Page Builder" directly above this, so a
+ * heading here would be the same fact in two places — the shape that produced a
+ * document title rendered from two sources and then disagreeing with itself.
+ * The icon carries the identity; the words carry the state.
+ *
  * ## One action, and only when there is one
  *
  * A single primary control, which is what the empty-state guidance in Carbon
@@ -133,7 +140,6 @@ export function PageBuilderCard({
             className="size-4 shrink-0 text-muted-foreground"
             aria-hidden="true"
           />
-          <span className="font-medium text-foreground">Page Builder</span>
           {empty ? (
             <span className="text-muted-foreground">
               Nothing here yet — lay this page out visually.

--- a/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
+++ b/packages/plugin-page-builder/src/admin/PageBuilderCard.tsx
@@ -137,8 +137,13 @@ export function PageBuilderCard({
   onOpen,
 }: PageBuilderCardProps) {
   const total = useMemo(
-    () => totalBlocks(countByType(documentNodes(document))),
-    [document]
+    // Counted under the SITE's cap rather than an unbounded read, so the number
+    // beside the page comes from the same bound the renderer reads under.
+    () =>
+      totalBlocks(
+        countByType(documentNodes(document), render.limits?.maxNodes)
+      ),
+    [document, render.limits?.maxNodes]
   );
 
   const empty = total === 0;

--- a/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * @vitest-environment jsdom
+ */
+import {
+  DOCUMENT_FORMAT_VERSION,
+  type BlockDocument,
+} from "@nextlyhq/blocks-engine";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PageMiniature } from "./PageMiniature";
+
+// The version is DERIVED rather than written as 1: a document literal pinning
+// the number keeps parsing after the format moves, and the renderer would then
+// refuse it while the fixture still looks correct.
+// The block's OWN version, not a literal 1. The renderer drops a node whose
+// version it cannot reconcile, and it drops it silently — so a pinned number
+// turns into an empty page the day the block is revised, with the fixture still
+// reading as correct.
+const TEXT = coreBlocks.find(block => block.name === "core/text");
+if (!TEXT) throw new Error("core/text is missing from coreBlocks");
+
+const doc = {
+  formatVersion: DOCUMENT_FORMAT_VERSION,
+  kind: "page",
+  nodes: [
+    {
+      id: "a",
+      type: TEXT.name,
+      version: TEXT.version,
+      props: { text: "Hello from the page" },
+    },
+  ],
+} as unknown as BlockDocument;
+
+describe("PageMiniature", () => {
+  it("draws the document's own content", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} />
+    );
+    expect(container.textContent).toContain("Hello from the page");
+  });
+
+  /*
+   * A picture, not a workspace. Nothing inside may take focus or a click, and
+   * the accessible account of the page is the text beside it — a screen reader
+   * reading a whole page layout here would bury the one control that matters.
+   */
+  it("marks the rendered subtree inert and hidden from assistive technology", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} />
+    );
+    const surface = container.querySelector(
+      '[data-slot="page-miniature-surface"]'
+    );
+
+    expect(surface).not.toBeNull();
+    expect(surface?.hasAttribute("inert")).toBe(true);
+    expect(surface?.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  /*
+   * `transform`, never `zoom`. The canvas uses `zoom` because it needs the
+   * scaled box to participate in layout for hit-testing and drag geometry; a
+   * static picture needs none of that, and `transform` avoids both the reflow
+   * and the class of centring defect that participation produced there.
+   */
+  it("scales by transform from the top left, never by zoom", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} renderWidth={1280} />
+    );
+    const scaled = container.querySelector<HTMLElement>(
+      '[data-slot="page-miniature-scaled"]'
+    );
+
+    expect(scaled).not.toBeNull();
+    expect(scaled?.style.width).toBe("1280px");
+    expect(scaled?.style.transformOrigin).toBe("top left");
+    expect(scaled?.style.getPropertyValue("zoom")).toBe("");
+  });
+
+  /*
+   * jsdom reports every element as zero-width, which is the same reading a
+   * container genuinely gives before layout. Scaling by the measured ratio
+   * there would multiply the page by zero and draw nothing at all, so an
+   * unmeasurable container renders unscaled rather than blank.
+   */
+  it("renders unscaled while the container cannot be measured", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} renderWidth={1280} />
+    );
+    const scaled = container.querySelector<HTMLElement>(
+      '[data-slot="page-miniature-scaled"]'
+    );
+
+    expect(scaled?.style.transform).toBe("scale(1)");
+  });
+});

--- a/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
@@ -2,6 +2,7 @@
  * @vitest-environment jsdom
  */
 import {
+  DEFAULT_LIMITS,
   DOCUMENT_FORMAT_VERSION,
   type BlockDocument,
 } from "@nextlyhq/blocks-engine";
@@ -10,6 +11,7 @@ import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { PageMiniature } from "./PageMiniature";
+import { pageRenderInputs } from "./page-render-inputs";
 
 // The version is DERIVED rather than written as 1: a document literal pinning
 // the number keeps parsing after the format moves, and the renderer would then
@@ -34,10 +36,21 @@ const doc = {
   ],
 } as unknown as BlockDocument;
 
+/*
+ * Built through the real derivation rather than as a literal, so this fixture
+ * cannot describe a bundle the product never produces.
+ */
+const RENDER = pageRenderInputs({
+  siteStyle: undefined,
+  clientConfig: undefined,
+  previewContainer: undefined,
+  limits: DEFAULT_LIMITS,
+});
+
 describe("PageMiniature", () => {
   it("draws the document's own content", () => {
     const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} />
+      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
     expect(container.textContent).toContain("Hello from the page");
   });
@@ -49,7 +62,7 @@ describe("PageMiniature", () => {
    */
   it("marks the rendered subtree inert and hidden from assistive technology", () => {
     const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} />
+      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
     const surface = container.querySelector(
       '[data-slot="page-miniature-surface"]'
@@ -68,7 +81,12 @@ describe("PageMiniature", () => {
    */
   it("scales by transform from the top left, never by zoom", () => {
     const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} renderWidth={1280} />
+      <PageMiniature
+        document={doc}
+        siteStyles={undefined}
+        render={RENDER}
+        renderWidth={1280}
+      />
     );
     const scaled = container.querySelector<HTMLElement>(
       '[data-slot="page-miniature-scaled"]'
@@ -78,6 +96,58 @@ describe("PageMiniature", () => {
     expect(scaled?.style.width).toBe("1280px");
     expect(scaled?.style.transformOrigin).toBe("top left");
     expect(scaled?.style.getPropertyValue("zoom")).toBe("");
+  });
+
+  /*
+   * `inert` does not prevent a resource load, so the policy has to reach the
+   * renderer: without it remote fetching defaults OPEN and the miniature can
+   * request an image or an iframe from a host the published page refuses.
+   */
+  it("carries the site's remote-host policy to the renderer", () => {
+    const render_ = pageRenderInputs({
+      siteStyle: undefined,
+      clientConfig: { remotePatterns: [{ hostname: "cdn.example" }] },
+      previewContainer: undefined,
+      limits: DEFAULT_LIMITS,
+    });
+
+    expect(render_.hostPolicy?.remotePatterns).toEqual([
+      { hostname: "cdn.example" },
+    ]);
+  });
+
+  /*
+   * The container has to be declared on the element whose width the compiled
+   * rules must answer for — the COMPOSED width, not the clipped frame's. A
+   * named container left at the default `container-type: normal` is not a
+   * size-query container, so every rule the compile emitted stays inert.
+   */
+  it("declares the compiled container on the composed box", () => {
+    const withContainer = pageRenderInputs({
+      siteStyle: {
+        breakpoints: {
+          viewport: [{ id: "tablet", label: "Tablet", maxWidth: 1024 }],
+          container: [],
+        },
+      } as never,
+      clientConfig: undefined,
+      previewContainer: "nx-preview-mini",
+      limits: DEFAULT_LIMITS,
+    });
+
+    const { container } = render(
+      <PageMiniature
+        document={doc}
+        siteStyles={undefined}
+        render={withContainer}
+      />
+    );
+    const scaled = container.querySelector<HTMLElement>(
+      '[data-slot="page-miniature-scaled"]'
+    );
+
+    expect(scaled?.style.containerName).toBe("nx-preview-mini");
+    expect(scaled?.style.containerType).toBe("inline-size");
   });
 
   /*
@@ -93,7 +163,7 @@ describe("PageMiniature", () => {
    */
   it("takes the scaled page out of the layout flow", () => {
     const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} />
+      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
     const scaled = container.querySelector<HTMLElement>(
       '[data-slot="page-miniature-scaled"]'
@@ -110,7 +180,12 @@ describe("PageMiniature", () => {
    */
   it("renders unscaled while the container cannot be measured", () => {
     const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} renderWidth={1280} />
+      <PageMiniature
+        document={doc}
+        siteStyles={undefined}
+        render={RENDER}
+        renderWidth={1280}
+      />
     );
     const scaled = container.querySelector<HTMLElement>(
       '[data-slot="page-miniature-scaled"]'

--- a/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
@@ -81,6 +81,28 @@ describe("PageMiniature", () => {
   });
 
   /*
+   * The property that makes the scale correct, and the one jsdom can still see.
+   *
+   * `transform` removes an element from painting and leaves it in LAYOUT, so a
+   * statically positioned child declared at the compose width stretches its
+   * ancestors to that width — measured in a browser, the frame's `clientWidth`
+   * came back as the compose width rather than the column's, the scale computed
+   * from it was 1, and the page drew full-size and overflowed the form. There
+   * is no layout here to reproduce that, so this asserts the structural cause
+   * instead: out of flow, anchored to the frame's origin.
+   */
+  it("takes the scaled page out of the layout flow", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} />
+    );
+    const scaled = container.querySelector<HTMLElement>(
+      '[data-slot="page-miniature-scaled"]'
+    );
+
+    expect(scaled?.className).toContain("absolute");
+  });
+
+  /*
    * jsdom reports every element as zero-width, which is the same reading a
    * container genuinely gives before layout. Scaling by the measured ratio
    * there would multiply the page by zero and draw nothing at all, so an

--- a/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
@@ -52,25 +52,88 @@ describe("PageMiniature", () => {
     const { container } = render(
       <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
-    expect(container.textContent).toContain("Hello from the page");
-  });
-
-  /*
-   * A picture, not a workspace. Nothing inside may take focus or a click, and
-   * the accessible account of the page is the text beside it — a screen reader
-   * reading a whole page layout here would bury the one control that matters.
-   */
-  it("marks the rendered subtree inert and hidden from assistive technology", () => {
-    const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
-    );
-    const surface = container.querySelector(
+    const frame = container.querySelector<HTMLIFrameElement>(
       '[data-slot="page-miniature-surface"]'
     );
 
-    expect(surface).not.toBeNull();
-    expect(surface?.hasAttribute("inert")).toBe(true);
-    expect(surface?.getAttribute("aria-hidden")).toBe("true");
+    // Read from the frame's own document rather than the admin's, which is the
+    // whole point: the page is no longer written into the screen around it.
+    expect(frame?.srcdoc).toContain("Hello from the page");
+  });
+
+  /*
+   * A picture, not a workspace — and now enforced by the sandbox rather than by
+   * `inert`. An empty `sandbox` grants nothing: no scripts, no form submission,
+   * no navigation. `inert` governs focus and the accessibility tree and would
+   * not have stopped a page's own form from submitting.
+   */
+  it("grants the frame nothing, so the preview cannot act", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
+    );
+    const frame = container.querySelector(
+      '[data-slot="page-miniature-surface"]'
+    );
+
+    expect(frame?.tagName).toBe("IFRAME");
+    expect(frame?.getAttribute("sandbox")).toBe("");
+    expect(frame?.getAttribute("aria-hidden")).toBe("true");
+    expect(frame?.getAttribute("tabindex")).toBe("-1");
+  });
+
+  /*
+   * The nested-form defect, asserted at its cause. The entry screen is itself a
+   * `<form>`; a page holding the form block emits one too, and nested forms are
+   * invalid — a parser closes the outer one early and entry fields after it stop
+   * belonging to the form that submits them. A separate document makes that
+   * unrepresentable.
+   */
+  it("keeps the page out of the admin's own document", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
+    );
+
+    expect(container.querySelector("form")).toBeNull();
+    expect(container.textContent).not.toContain("Hello from the page");
+  });
+
+  /*
+   * A relative URL resolves against the document it sits in. Without a base the
+   * frame would resolve it against the admin's entry route and ask for an image
+   * under /admin/..., where the site has none.
+   */
+  it("resolves relative URLs against the site rather than the admin route", () => {
+    const { container } = render(
+      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
+    );
+    const frame = container.querySelector<HTMLIFrameElement>(
+      '[data-slot="page-miniature-surface"]'
+    );
+
+    expect(frame?.srcdoc).toContain('<base href="/">');
+  });
+
+  /*
+   * Viewport units measure the viewport, so the frame must HAVE one of the
+   * composed size. Sized in pixels rather than percentages for that reason: a
+   * percentage would inherit the admin window's dimensions and `50vw` would go
+   * on answering for the wrong screen.
+   */
+  it("gives the page a viewport of the width it is composed at", () => {
+    const { container } = render(
+      <PageMiniature
+        document={doc}
+        siteStyles={undefined}
+        render={RENDER}
+        renderWidth={1280}
+      />
+    );
+    const frame = container.querySelector<HTMLElement>(
+      '[data-slot="page-miniature-surface"]'
+    );
+
+    expect(frame?.style.width).toBe("1280px");
+    expect(frame?.style.height).toBe("800px");
   });
 
   /*
@@ -89,7 +152,7 @@ describe("PageMiniature", () => {
       />
     );
     const scaled = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-scaled"]'
+      '[data-slot="page-miniature-surface"]'
     );
 
     expect(scaled).not.toBeNull();
@@ -117,40 +180,6 @@ describe("PageMiniature", () => {
   });
 
   /*
-   * The container has to be declared on the element whose width the compiled
-   * rules must answer for — the COMPOSED width, not the clipped frame's. A
-   * named container left at the default `container-type: normal` is not a
-   * size-query container, so every rule the compile emitted stays inert.
-   */
-  it("declares the compiled container on the composed box", () => {
-    const withContainer = pageRenderInputs({
-      siteStyle: {
-        breakpoints: {
-          viewport: [{ id: "tablet", label: "Tablet", maxWidth: 1024 }],
-          container: [],
-        },
-      } as never,
-      clientConfig: undefined,
-      previewContainer: "nx-preview-mini",
-      limits: DEFAULT_LIMITS,
-    });
-
-    const { container } = render(
-      <PageMiniature
-        document={doc}
-        siteStyles={undefined}
-        render={withContainer}
-      />
-    );
-    const scaled = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-scaled"]'
-    );
-
-    expect(scaled?.style.containerName).toBe("nx-preview-mini");
-    expect(scaled?.style.containerType).toBe("inline-size");
-  });
-
-  /*
    * The property that makes the scale correct, and the one jsdom can still see.
    *
    * `transform` removes an element from painting and leaves it in LAYOUT, so a
@@ -166,7 +195,7 @@ describe("PageMiniature", () => {
       <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
     const scaled = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-scaled"]'
+      '[data-slot="page-miniature-surface"]'
     );
 
     expect(scaled?.className).toContain("absolute");
@@ -188,7 +217,7 @@ describe("PageMiniature", () => {
       />
     );
     const scaled = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-scaled"]'
+      '[data-slot="page-miniature-surface"]'
     );
 
     expect(scaled?.style.transform).toBe("scale(1)");

--- a/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.test.tsx
@@ -52,88 +52,25 @@ describe("PageMiniature", () => {
     const { container } = render(
       <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
-    const frame = container.querySelector<HTMLIFrameElement>(
-      '[data-slot="page-miniature-surface"]'
-    );
-
-    // Read from the frame's own document rather than the admin's, which is the
-    // whole point: the page is no longer written into the screen around it.
-    expect(frame?.srcdoc).toContain("Hello from the page");
+    expect(container.textContent).toContain("Hello from the page");
   });
 
   /*
-   * A picture, not a workspace — and now enforced by the sandbox rather than by
-   * `inert`. An empty `sandbox` grants nothing: no scripts, no form submission,
-   * no navigation. `inert` governs focus and the accessibility tree and would
-   * not have stopped a page's own form from submitting.
+   * A picture, not a workspace. Nothing inside may take focus or a click, and
+   * the accessible account of the page is the text beside it — a screen reader
+   * reading a whole page layout here would bury the one control that matters.
    */
-  it("grants the frame nothing, so the preview cannot act", () => {
+  it("marks the rendered subtree inert and hidden from assistive technology", () => {
     const { container } = render(
       <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
-    const frame = container.querySelector(
+    const surface = container.querySelector(
       '[data-slot="page-miniature-surface"]'
     );
 
-    expect(frame?.tagName).toBe("IFRAME");
-    expect(frame?.getAttribute("sandbox")).toBe("");
-    expect(frame?.getAttribute("aria-hidden")).toBe("true");
-    expect(frame?.getAttribute("tabindex")).toBe("-1");
-  });
-
-  /*
-   * The nested-form defect, asserted at its cause. The entry screen is itself a
-   * `<form>`; a page holding the form block emits one too, and nested forms are
-   * invalid — a parser closes the outer one early and entry fields after it stop
-   * belonging to the form that submits them. A separate document makes that
-   * unrepresentable.
-   */
-  it("keeps the page out of the admin's own document", () => {
-    const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
-    );
-
-    expect(container.querySelector("form")).toBeNull();
-    expect(container.textContent).not.toContain("Hello from the page");
-  });
-
-  /*
-   * A relative URL resolves against the document it sits in. Without a base the
-   * frame would resolve it against the admin's entry route and ask for an image
-   * under /admin/..., where the site has none.
-   */
-  it("resolves relative URLs against the site rather than the admin route", () => {
-    const { container } = render(
-      <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
-    );
-    const frame = container.querySelector<HTMLIFrameElement>(
-      '[data-slot="page-miniature-surface"]'
-    );
-
-    expect(frame?.srcdoc).toContain('<base href="/">');
-  });
-
-  /*
-   * Viewport units measure the viewport, so the frame must HAVE one of the
-   * composed size. Sized in pixels rather than percentages for that reason: a
-   * percentage would inherit the admin window's dimensions and `50vw` would go
-   * on answering for the wrong screen.
-   */
-  it("gives the page a viewport of the width it is composed at", () => {
-    const { container } = render(
-      <PageMiniature
-        document={doc}
-        siteStyles={undefined}
-        render={RENDER}
-        renderWidth={1280}
-      />
-    );
-    const frame = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-surface"]'
-    );
-
-    expect(frame?.style.width).toBe("1280px");
-    expect(frame?.style.height).toBe("800px");
+    expect(surface).not.toBeNull();
+    expect(surface?.hasAttribute("inert")).toBe(true);
+    expect(surface?.getAttribute("aria-hidden")).toBe("true");
   });
 
   /*
@@ -152,7 +89,7 @@ describe("PageMiniature", () => {
       />
     );
     const scaled = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-surface"]'
+      '[data-slot="page-miniature-scaled"]'
     );
 
     expect(scaled).not.toBeNull();
@@ -180,6 +117,85 @@ describe("PageMiniature", () => {
   });
 
   /*
+   * The container has to be declared on the element whose width the compiled
+   * rules must answer for — the COMPOSED width, not the clipped frame's. A
+   * named container left at the default `container-type: normal` is not a
+   * size-query container, so every rule the compile emitted stays inert.
+   */
+  it("declares the compiled container on the composed box", () => {
+    const withContainer = pageRenderInputs({
+      siteStyle: {
+        breakpoints: {
+          viewport: [{ id: "tablet", label: "Tablet", maxWidth: 1024 }],
+          container: [],
+        },
+      } as never,
+      clientConfig: undefined,
+      previewContainer: "nx-preview-mini",
+      limits: DEFAULT_LIMITS,
+    });
+
+    const { container } = render(
+      <PageMiniature
+        document={doc}
+        siteStyles={undefined}
+        render={withContainer}
+      />
+    );
+    const scaled = container.querySelector<HTMLElement>(
+      '[data-slot="page-miniature-scaled"]'
+    );
+
+    expect(scaled?.style.containerName).toBe("nx-preview-mini");
+    expect(scaled?.style.containerType).toBe("inline-size");
+  });
+
+  /*
+   * The entry screen is a `<form>`, so a page holding a form block puts one
+   * form inside another. The live consequence in this rendering path is a
+   * submit from the previewed page reaching the form that saves the entry.
+   *
+   * Asserted through a REAL submit event on a real form rendered by the real
+   * block, rather than by checking that a handler was passed: a prop can be
+   * present and still not stop anything.
+   */
+  it("refuses a submit raised inside the page", () => {
+    const FORM = coreBlocks.find(block => block.name === "core/form");
+    if (!FORM) throw new Error("core/form is missing from coreBlocks");
+
+    const withForm = {
+      formatVersion: DOCUMENT_FORMAT_VERSION,
+      kind: "page",
+      nodes: [
+        {
+          id: "f",
+          type: FORM.name,
+          version: FORM.version,
+          props: { method: "post", submitText: "Send", fields: [] },
+        },
+      ],
+    } as unknown as BlockDocument;
+
+    const { container } = render(
+      <PageMiniature
+        document={withForm}
+        siteStyles={undefined}
+        render={RENDER}
+      />
+    );
+
+    const form = container.querySelector("form");
+    // The control: if the page drew no form, the assertion below would pass
+    // against nothing at all.
+    expect(form).not.toBeNull();
+
+    const submit = new Event("submit", { bubbles: true, cancelable: true });
+    form?.dispatchEvent(submit);
+
+    expect(submit.defaultPrevented).toBe(true);
+  });
+
+  /*
    * The property that makes the scale correct, and the one jsdom can still see.
    *
    * `transform` removes an element from painting and leaves it in LAYOUT, so a
@@ -195,7 +211,7 @@ describe("PageMiniature", () => {
       <PageMiniature document={doc} siteStyles={undefined} render={RENDER} />
     );
     const scaled = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-surface"]'
+      '[data-slot="page-miniature-scaled"]'
     );
 
     expect(scaled?.className).toContain("absolute");
@@ -217,7 +233,7 @@ describe("PageMiniature", () => {
       />
     );
     const scaled = container.querySelector<HTMLElement>(
-      '[data-slot="page-miniature-surface"]'
+      '[data-slot="page-miniature-scaled"]'
     );
 
     expect(scaled?.style.transform).toBe("scale(1)");

--- a/packages/plugin-page-builder/src/admin/PageMiniature.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.tsx
@@ -50,7 +50,7 @@ import {
   previewContainerStyle,
   type PageRendererProps,
 } from "@nextlyhq/blocks-react";
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useMemo, useRef, useState } from "react";
 
 import { entryBlockResolver } from "./entry-block-resolver";
 import type { PageRenderInputs } from "./page-render-inputs";
@@ -124,6 +124,32 @@ export function PageMiniature({
     return () => observer.disconnect();
   }, [renderWidth]);
 
+  /*
+   * Held apart from the measured scale, which changes on every frame of a
+   * resize.
+   *
+   * Rebuilt inline, each observer callback would rerun the whole render beneath
+   * it — sanitisation, migration, every block, and the stylesheet compile — for
+   * a page whose content did not change and whose wrapper only needed a new
+   * transform. On a large document that is visible jank, and it re-enters any
+   * asynchronous block resolver the page has. The canvas holds its page the
+   * same way and for the same reason.
+   */
+  const page = useMemo(
+    () => (
+      <PageRenderer
+        // Spread rather than listed field by field: the bundle owns which
+        // inputs describe this site's rendering, and a surface restating them
+        // here would silently stop forwarding one it never heard of.
+        {...render}
+        document={document}
+        blocks={entryBlockResolver()}
+        siteStyles={siteStyles}
+      />
+    ),
+    [render, document, siteStyles]
+  );
+
   return (
     <div
       ref={frame}
@@ -165,15 +191,7 @@ export function PageMiniature({
         }}
       >
         <div data-slot="page-miniature-surface" inert aria-hidden="true">
-          <PageRenderer
-            // Spread rather than listed field by field: the bundle owns which
-            // inputs describe this site's rendering, and a surface restating
-            // them here would silently stop forwarding one it never heard of.
-            {...render}
-            document={document}
-            blocks={entryBlockResolver()}
-            siteStyles={siteStyles}
-          />
+          {page}
         </div>
       </div>
     </div>

--- a/packages/plugin-page-builder/src/admin/PageMiniature.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.tsx
@@ -1,69 +1,88 @@
 "use client";
 
 /**
- * The page itself, drawn small, on the screen an author reaches it from.
+ * The page itself, drawn small, in a document of its own.
  *
  * The same `PageRenderer` that draws the published page. That is the property
  * worth protecting rather than an implementation convenience: a preview with
  * its own rendering path is a second implementation of "what does this page
- * look like", and the two drift in the direction nobody tests — the preview
- * stops matching the page while both look correct in isolation. `canvas.tsx`
- * makes the same argument for the editing surface, and it applies here for the
- * same reason.
+ * look like", and the two drift in the direction nobody tests. `canvas.tsx`
+ * makes the same argument for the editing surface.
  *
- * ## It is a picture, and it is inert
+ * ## Why a frame, rather than markup placed in the admin's own document
  *
- * Everything drawn inside is `inert` and `aria-hidden`. Not decoration: a page
- * is full of links, buttons and headings, and left reachable they would put a
- * whole second document into the tab order of a form — an author tabbing out of
- * the title field would walk into a miniature of their own page. The accessible
- * account is the text beside it, which says what the field holds and offers the
- * one action there is.
+ * Three things go wrong when a published page is written straight into the
+ * admin's document, and they are one mistake wearing three sets of clothes: the
+ * page is being shown a world that is not its own.
  *
- * ## `transform`, never `zoom`
+ * A NESTED FORM. The entry screen is itself a `<form>`, and a page holding the
+ * form block emits one too. Nested forms are invalid, so a parser closes the
+ * outer one early — and entry fields after that point stop belonging to the
+ * form that submits them. Silent, and it costs an author their edits.
  *
- * A deliberate divergence from the canvas, which uses `zoom`. `zoom`
- * participates in layout, and the canvas needs that: hit-testing, drag geometry
- * and the drop indicator are all positioned in the scaled box's own
- * coordinates. Nothing here is interactive, so participation buys nothing and
- * costs a reflow of the whole rendered tree on every resize.
+ * VIEWPORT UNITS. `50vw` measures the viewport, and composing an element at
+ * 1280px does not make the viewport 1280px. In a 1600px admin window that block
+ * draws 800px wide where the real page gives it 640px — a preview disagreeing
+ * with the page while looking entirely correct.
  *
- * `transform` alone does NOT keep the scaled content out of the flow, which is
- * the trap: it removes the element from painting and leaves it in layout, so a
- * statically positioned child declared at the compose width stretches every
- * ancestor to that width. The scaled element is absolutely positioned for that
- * reason, and only then is the frame's measured width the column's width.
+ * RELATIVE URLS. `images/hero.jpg` resolves against the address of the document
+ * it sits in. In the admin that is the entry route, so the page asks for an
+ * image under `/admin/...` and shows a gap where the site shows a photo.
  *
- * ## An unmeasurable container renders UNSCALED
+ * A frame answers all three by construction rather than by three separate
+ * patches: its own document, its own viewport, its own base address. It is also
+ * what `TemplatePreview` already does for the email preview, so this is a
+ * second consumer of an established pattern rather than a new one.
  *
- * A container reports zero width before layout, and in any environment that
- * does not lay out at all. Scaling by the measured ratio there multiplies the
- * page by zero and draws nothing — a blank frame that looks exactly like a page
- * with no content. Rendering unscaled instead is wrong only in how much of the
- * page is visible, and it is wrong visibly, which is the better failure.
+ * ## The frame is sandboxed with NOTHING granted
+ *
+ * `sandbox=""` blocks scripts, form submission and navigation outright, so the
+ * preview cannot act even in principle. Stronger than the `inert` this
+ * replaces, which governs focus and the accessibility tree and would not have
+ * stopped a submit or a script.
+ *
+ * ## No preview container, deliberately
+ *
+ * The canvas compiles its sheet against a named container because it draws in
+ * the admin's document, where `@media` asks the admin WINDOW. A frame has a
+ * real viewport of its own, so plain `@media` already answers for the composed
+ * width — which is exactly what the published page does. Compiling against a
+ * container here would emit rules whose container is declared nowhere inside
+ * the frame, and they would all sit inert.
  *
  * @module @nextlyhq/plugin-page-builder/admin/PageMiniature
  */
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
-import {
-  PageRenderer,
-  previewContainerStyle,
-  type PageRendererProps,
-} from "@nextlyhq/blocks-react";
+import { PageRenderer, type PageRendererProps } from "@nextlyhq/blocks-react";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 
 import { entryBlockResolver } from "./entry-block-resolver";
 import type { PageRenderInputs } from "./page-render-inputs";
 
 /**
- * The width the page is composed at before being scaled down.
+ * The width the page is composed at, and the frame's own viewport width.
  *
- * A desktop tier. A page laid out for desktop, rendered at the few hundred
+ * A desktop tier. A page laid out for desktop, composed at the few hundred
  * pixels a form column offers, would draw its MOBILE layout — a truthful
  * rendering of a viewport the author was not looking at, which reads as the
  * page being wrong rather than as the preview being narrow.
  */
 const DEFAULT_RENDER_WIDTH = 1280;
+
+/** The frame's aspect, and so the height its viewport reports to `vh`. */
+const ASPECT = 10 / 16;
+
+/**
+ * Where the frame resolves a relative URL from.
+ *
+ * The site root rather than the entry route, which is the defect being closed.
+ * It is not the published page's OWN address — a document served under a nested
+ * path resolves `images/x` beneath that path — but the entry form does not know
+ * where this page will be served, and the root is right for every top-level
+ * page and closer than the admin route for the rest.
+ */
+const BASE_HREF = "/";
 
 export interface PageMiniatureProps {
   /** The document to draw. */
@@ -76,22 +95,21 @@ export interface PageMiniatureProps {
    */
   siteStyles: PageRendererProps["siteStyles"];
   /**
-   * Everything else this site's rendering depends on — its breakpoints, the
-   * container its responsive rules are compiled against, its remote-host policy
-   * and its document caps.
+   * Everything else this site's rendering depends on — its breakpoints, its
+   * remote-host policy and its document caps.
    *
    * Taken as one bundle from `pageRenderInputs` rather than as loose props, so
    * this surface cannot be given three of the four. The canvas is handed the
    * same bundle.
    */
   render: PageRenderInputs;
-  /** The width to compose at before scaling. Defaults to a desktop tier. */
+  /** The width to compose at. Defaults to a desktop tier. */
   renderWidth?: number;
 }
 
 /**
  * @param props - the document, the site's sheet, and the width to compose at
- * @returns a clipped, inert, scaled rendering of the page
+ * @returns a clipped, sandboxed frame holding a scaled rendering of the page
  */
 export function PageMiniature({
   document,
@@ -102,41 +120,19 @@ export function PageMiniature({
   const frame = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
 
-  useLayoutEffect(() => {
-    const element = frame.current;
-    if (!element) return;
-
-    const measure = (): void => {
-      const width = element.clientWidth;
-      // Zero means "not laid out", never "zero wide". See the module docblock.
-      setScale(width > 0 ? width / renderWidth : 1);
-    };
-
-    measure();
-
-    // Guarded rather than assumed: this component renders in the admin, in
-    // tests, and anywhere a host embeds the form, and an environment without
-    // the observer must still draw the page rather than throw on the way in.
-    if (typeof ResizeObserver === "undefined") return;
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [renderWidth]);
+  const height = Math.round(renderWidth * ASPECT);
 
   /*
    * Held apart from the measured scale, which changes on every frame of a
    * resize.
    *
-   * Rebuilt inline, each observer callback would rerun the whole render beneath
-   * it — sanitisation, migration, every block, and the stylesheet compile — for
-   * a page whose content did not change and whose wrapper only needed a new
-   * transform. On a large document that is visible jank, and it re-enters any
-   * asynchronous block resolver the page has. The canvas holds its page the
-   * same way and for the same reason.
+   * Rebuilt inline, each observer callback would rerun the whole render —
+   * sanitisation, migration, every block and the stylesheet compile — for a
+   * page whose content did not change and whose frame only needed a new
+   * transform. On a large document that is visible jank.
    */
-  const page = useMemo(
-    () => (
+  const srcDoc = useMemo(() => {
+    const markup = renderToStaticMarkup(
       <PageRenderer
         // Spread rather than listed field by field: the bundle owns which
         // inputs describe this site's rendering, and a surface restating them
@@ -146,54 +142,73 @@ export function PageMiniature({
         blocks={entryBlockResolver()}
         siteStyles={siteStyles}
       />
-    ),
-    [render, document, siteStyles]
-  );
+    );
+    // The default body margin is removed because the published page does not
+    // have one, and an offset here would misreport where the page's own edge is.
+    return `<!doctype html><html><head><meta charset="utf-8"><base href="${BASE_HREF}"><style>html,body{margin:0;padding:0}</style></head><body>${markup}</body></html>`;
+  }, [render, document, siteStyles]);
+
+  useLayoutEffect(() => {
+    const element = frame.current;
+    if (!element) return;
+
+    const measure = (): void => {
+      const width = element.clientWidth;
+      // Zero means "not laid out", never "zero wide": scaling by it would
+      // multiply the page to nothing and draw a blank frame, which looks
+      // exactly like a page with no content.
+      setScale(width > 0 ? width / renderWidth : 1);
+    };
+
+    measure();
+
+    // Guarded rather than assumed: this renders in the admin, in tests, and
+    // anywhere a host embeds the form, and an environment without the observer
+    // must still draw the page rather than throw on the way in.
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [renderWidth]);
 
   return (
     <div
       ref={frame}
       data-slot="page-miniature"
-      // The box owns its own height through the aspect ratio, so a long page is
-      // clipped rather than making the form scroll past a full-length preview.
       className="relative aspect-[16/10] w-full overflow-hidden rounded-md border border-border bg-background"
     >
-      <div
-        data-slot="page-miniature-scaled"
+      <iframe
+        data-slot="page-miniature-surface"
+        // Decorative. The accessible account of this field is the text beside
+        // the frame, which says what the page holds and offers the one action
+        // there is; a frame announced as a document would put a second one in
+        // the reader's way. `tabIndex={-1}` keeps it out of the tab order, which
+        // a frame otherwise joins.
+        title=""
+        aria-hidden="true"
+        tabIndex={-1}
+        // NOTHING granted. No scripts, no form submission, no navigation, so the
+        // preview cannot act even in principle — and a page holding a form block
+        // cannot submit one.
+        sandbox=""
+        srcDoc={srcDoc}
         /*
-         * ABSOLUTE, and this is load-bearing rather than cosmetic.
-         *
-         * `transform` takes an element out of the PAINTING flow and leaves it
-         * in the LAYOUT flow, so a statically positioned 1280px child still
-         * contributes 1280px of intrinsic width to its ancestors — measured:
-         * the frame's own `clientWidth` came back as 1280 rather than the
-         * column's width, the scale computed from it was therefore 1, and the
-         * page drew full-size and overflowed the form. Taking it out of flow is
-         * what makes the frame's width a property of the COLUMN, which is the
-         * width the scale has to be computed from.
+         * Absolute, and load-bearing rather than cosmetic. `transform` takes an
+         * element out of the PAINTING flow and leaves it in the LAYOUT flow, so
+         * an element declared at the compose width stretches every ancestor to
+         * that width — the frame then measures its own width as the compose
+         * width, the scale computed from it is 1, and the page draws full size
+         * and overflows the form.
          */
-        className="absolute left-0 top-0"
+        className="absolute left-0 top-0 border-0"
         style={{
           width: `${renderWidth}px`,
+          height: `${height}px`,
           transform: `scale(${scale})`,
           transformOrigin: "top left",
-          /*
-           * The container the compiled responsive rules resolve against, on the
-           * element whose width they must answer for — the COMPOSED width, not
-           * the clipped frame's. `@media` asks the window, so without this a
-           * miniature composed at a desktop width gets whichever tier the admin
-           * window happens to be in. `previewContainerStyle` supplies the
-           * `container-type` beside the name, because a named container left at
-           * the default `normal` is not a size-query container and every rule
-           * the compile emitted stays inert.
-           */
-          ...previewContainerStyle(render.styleContext.previewContainer),
         }}
-      >
-        <div data-slot="page-miniature-surface" inert aria-hidden="true">
-          {page}
-        </div>
-      </div>
+      />
     </div>
   );
 }

--- a/packages/plugin-page-builder/src/admin/PageMiniature.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.tsx
@@ -45,10 +45,15 @@
  * @module @nextlyhq/plugin-page-builder/admin/PageMiniature
  */
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
-import { PageRenderer, type PageRendererProps } from "@nextlyhq/blocks-react";
+import {
+  PageRenderer,
+  previewContainerStyle,
+  type PageRendererProps,
+} from "@nextlyhq/blocks-react";
 import { useLayoutEffect, useRef, useState } from "react";
 
 import { entryBlockResolver } from "./entry-block-resolver";
+import type { PageRenderInputs } from "./page-render-inputs";
 
 /**
  * The width the page is composed at before being scaled down.
@@ -70,6 +75,16 @@ export interface PageMiniatureProps {
    * decides whether it is ready; this draws whatever it is handed.
    */
   siteStyles: PageRendererProps["siteStyles"];
+  /**
+   * Everything else this site's rendering depends on — its breakpoints, the
+   * container its responsive rules are compiled against, its remote-host policy
+   * and its document caps.
+   *
+   * Taken as one bundle from `pageRenderInputs` rather than as loose props, so
+   * this surface cannot be given three of the four. The canvas is handed the
+   * same bundle.
+   */
+  render: PageRenderInputs;
   /** The width to compose at before scaling. Defaults to a desktop tier. */
   renderWidth?: number;
 }
@@ -81,6 +96,7 @@ export interface PageMiniatureProps {
 export function PageMiniature({
   document,
   siteStyles,
+  render,
   renderWidth = DEFAULT_RENDER_WIDTH,
 }: PageMiniatureProps) {
   const frame = useRef<HTMLDivElement>(null);
@@ -135,10 +151,25 @@ export function PageMiniature({
           width: `${renderWidth}px`,
           transform: `scale(${scale})`,
           transformOrigin: "top left",
+          /*
+           * The container the compiled responsive rules resolve against, on the
+           * element whose width they must answer for — the COMPOSED width, not
+           * the clipped frame's. `@media` asks the window, so without this a
+           * miniature composed at a desktop width gets whichever tier the admin
+           * window happens to be in. `previewContainerStyle` supplies the
+           * `container-type` beside the name, because a named container left at
+           * the default `normal` is not a size-query container and every rule
+           * the compile emitted stays inert.
+           */
+          ...previewContainerStyle(render.styleContext.previewContainer),
         }}
       >
         <div data-slot="page-miniature-surface" inert aria-hidden="true">
           <PageRenderer
+            // Spread rather than listed field by field: the bundle owns which
+            // inputs describe this site's rendering, and a surface restating
+            // them here would silently stop forwarding one it never heard of.
+            {...render}
             document={document}
             blocks={entryBlockResolver()}
             siteStyles={siteStyles}

--- a/packages/plugin-page-builder/src/admin/PageMiniature.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.tsx
@@ -1,103 +1,69 @@
 "use client";
 
 /**
- * The page itself, drawn small, in a document of its own.
+ * The page itself, drawn small, on the screen an author reaches it from.
  *
  * The same `PageRenderer` that draws the published page. That is the property
  * worth protecting rather than an implementation convenience: a preview with
  * its own rendering path is a second implementation of "what does this page
- * look like", and the two drift in the direction nobody tests. `canvas.tsx`
- * makes the same argument for the editing surface.
+ * look like", and the two drift in the direction nobody tests — the preview
+ * stops matching the page while both look correct in isolation. `canvas.tsx`
+ * makes the same argument for the editing surface, and it applies here for the
+ * same reason.
  *
- * ## Why a frame, rather than markup placed in the admin's own document
+ * ## It is a picture, and it is inert
  *
- * Three things go wrong when a published page is written straight into the
- * admin's document, and they are one mistake wearing three sets of clothes: the
- * page is being shown a world that is not its own.
+ * Everything drawn inside is `inert` and `aria-hidden`. Not decoration: a page
+ * is full of links, buttons and headings, and left reachable they would put a
+ * whole second document into the tab order of a form — an author tabbing out of
+ * the title field would walk into a miniature of their own page. The accessible
+ * account is the text beside it, which says what the field holds and offers the
+ * one action there is.
  *
- * A NESTED FORM. The entry screen is itself a `<form>`, and a page holding the
- * form block emits one too. Nested forms are invalid HTML, and the cost depends
- * on how the document was built — which is worth stating exactly, because the
- * two paths differ and only one of them is live here.
+ * ## `transform`, never `zoom`
  *
- * PARSED from HTML source, the inner start tag is dropped and the inner
- * `</form>` closes the OUTER form early. Measured in a browser on this exact
- * shape: a control following the nested form ends up outside the outer form
- * with `input.form === null` — no owner, so it submits nothing. This admin
- * renders client-side and ships no form markup, so it does not take that path
- * today; it would the moment any of this were server-rendered or hydrated.
+ * A deliberate divergence from the canvas, which uses `zoom`. `zoom`
+ * participates in layout, and the canvas needs that: hit-testing, drag geometry
+ * and the drop indicator are all positioned in the scaled box's own
+ * coordinates. Nothing here is interactive, so participation buys nothing and
+ * costs a reflow of the whole rendered tree on every resize.
  *
- * BUILT through the DOM, which is what React does here, a real nested form
- * exists and controls keep their nearest-ancestor owner. What is live in that
- * path is the page's own form being SUBMITTABLE from inside the entry form.
+ * `transform` alone does NOT keep the scaled content out of the flow, which is
+ * the trap: it removes the element from painting and leaves it in layout, so a
+ * statically positioned child declared at the compose width stretches every
+ * ancestor to that width. The scaled element is absolutely positioned for that
+ * reason, and only then is the frame's measured width the column's width.
  *
- * A frame removes both, and removes the dependence on which path the admin
- * happens to use — which is the part worth having, since that is not this
- * module's decision to rely on.
+ * ## An unmeasurable container renders UNSCALED
  *
- * VIEWPORT UNITS. `50vw` measures the viewport, and composing an element at
- * 1280px does not make the viewport 1280px. In a 1600px admin window that block
- * draws 800px wide where the real page gives it 640px — a preview disagreeing
- * with the page while looking entirely correct.
- *
- * RELATIVE URLS. `images/hero.jpg` resolves against the address of the document
- * it sits in. In the admin that is the entry route, so the page asks for an
- * image under `/admin/...` and shows a gap where the site shows a photo.
- *
- * A frame answers all three by construction rather than by three separate
- * patches: its own document, its own viewport, its own base address. It is also
- * what `TemplatePreview` already does for the email preview, so this is a
- * second consumer of an established pattern rather than a new one.
- *
- * ## The frame is sandboxed with NOTHING granted
- *
- * `sandbox=""` blocks scripts, form submission and navigation outright, so the
- * preview cannot act even in principle. Stronger than the `inert` this
- * replaces, which governs focus and the accessibility tree and would not have
- * stopped a submit or a script.
- *
- * ## No preview container, deliberately
- *
- * The canvas compiles its sheet against a named container because it draws in
- * the admin's document, where `@media` asks the admin WINDOW. A frame has a
- * real viewport of its own, so plain `@media` already answers for the composed
- * width — which is exactly what the published page does. Compiling against a
- * container here would emit rules whose container is declared nowhere inside
- * the frame, and they would all sit inert.
+ * A container reports zero width before layout, and in any environment that
+ * does not lay out at all. Scaling by the measured ratio there multiplies the
+ * page by zero and draws nothing — a blank frame that looks exactly like a page
+ * with no content. Rendering unscaled instead is wrong only in how much of the
+ * page is visible, and it is wrong visibly, which is the better failure.
  *
  * @module @nextlyhq/plugin-page-builder/admin/PageMiniature
  */
 import type { BlockDocument } from "@nextlyhq/blocks-engine";
-import { PageRenderer, type PageRendererProps } from "@nextlyhq/blocks-react";
+import {
+  PageRenderer,
+  previewContainerStyle,
+  type PageRendererProps,
+} from "@nextlyhq/blocks-react";
 import { useLayoutEffect, useMemo, useRef, useState } from "react";
-import { renderToStaticMarkup } from "react-dom/server";
 
 import { entryBlockResolver } from "./entry-block-resolver";
 import type { PageRenderInputs } from "./page-render-inputs";
 
 /**
- * The width the page is composed at, and the frame's own viewport width.
+ * The width the page is composed at before being scaled down.
  *
- * A desktop tier. A page laid out for desktop, composed at the few hundred
+ * A desktop tier. A page laid out for desktop, rendered at the few hundred
  * pixels a form column offers, would draw its MOBILE layout — a truthful
  * rendering of a viewport the author was not looking at, which reads as the
  * page being wrong rather than as the preview being narrow.
  */
 const DEFAULT_RENDER_WIDTH = 1280;
-
-/** The frame's aspect, and so the height its viewport reports to `vh`. */
-const ASPECT = 10 / 16;
-
-/**
- * Where the frame resolves a relative URL from.
- *
- * The site root rather than the entry route, which is the defect being closed.
- * It is not the published page's OWN address — a document served under a nested
- * path resolves `images/x` beneath that path — but the entry form does not know
- * where this page will be served, and the root is right for every top-level
- * page and closer than the admin route for the rest.
- */
-const BASE_HREF = "/";
 
 export interface PageMiniatureProps {
   /** The document to draw. */
@@ -110,21 +76,22 @@ export interface PageMiniatureProps {
    */
   siteStyles: PageRendererProps["siteStyles"];
   /**
-   * Everything else this site's rendering depends on — its breakpoints, its
-   * remote-host policy and its document caps.
+   * Everything else this site's rendering depends on — its breakpoints, the
+   * container its responsive rules are compiled against, its remote-host policy
+   * and its document caps.
    *
    * Taken as one bundle from `pageRenderInputs` rather than as loose props, so
    * this surface cannot be given three of the four. The canvas is handed the
    * same bundle.
    */
   render: PageRenderInputs;
-  /** The width to compose at. Defaults to a desktop tier. */
+  /** The width to compose at before scaling. Defaults to a desktop tier. */
   renderWidth?: number;
 }
 
 /**
  * @param props - the document, the site's sheet, and the width to compose at
- * @returns a clipped, sandboxed frame holding a scaled rendering of the page
+ * @returns a clipped, inert, scaled rendering of the page
  */
 export function PageMiniature({
   document,
@@ -135,19 +102,41 @@ export function PageMiniature({
   const frame = useRef<HTMLDivElement>(null);
   const [scale, setScale] = useState(1);
 
-  const height = Math.round(renderWidth * ASPECT);
+  useLayoutEffect(() => {
+    const element = frame.current;
+    if (!element) return;
+
+    const measure = (): void => {
+      const width = element.clientWidth;
+      // Zero means "not laid out", never "zero wide". See the module docblock.
+      setScale(width > 0 ? width / renderWidth : 1);
+    };
+
+    measure();
+
+    // Guarded rather than assumed: this component renders in the admin, in
+    // tests, and anywhere a host embeds the form, and an environment without
+    // the observer must still draw the page rather than throw on the way in.
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [renderWidth]);
 
   /*
    * Held apart from the measured scale, which changes on every frame of a
    * resize.
    *
-   * Rebuilt inline, each observer callback would rerun the whole render —
-   * sanitisation, migration, every block and the stylesheet compile — for a
-   * page whose content did not change and whose frame only needed a new
-   * transform. On a large document that is visible jank.
+   * Rebuilt inline, each observer callback would rerun the whole render beneath
+   * it — sanitisation, migration, every block, and the stylesheet compile — for
+   * a page whose content did not change and whose wrapper only needed a new
+   * transform. On a large document that is visible jank, and it re-enters any
+   * asynchronous block resolver the page has. The canvas holds its page the
+   * same way and for the same reason.
    */
-  const srcDoc = useMemo(() => {
-    const markup = renderToStaticMarkup(
+  const page = useMemo(
+    () => (
       <PageRenderer
         // Spread rather than listed field by field: the bundle owns which
         // inputs describe this site's rendering, and a surface restating them
@@ -157,73 +146,85 @@ export function PageMiniature({
         blocks={entryBlockResolver()}
         siteStyles={siteStyles}
       />
-    );
-    // The default body margin is removed because the published page does not
-    // have one, and an offset here would misreport where the page's own edge is.
-    return `<!doctype html><html><head><meta charset="utf-8"><base href="${BASE_HREF}"><style>html,body{margin:0;padding:0}</style></head><body>${markup}</body></html>`;
-  }, [render, document, siteStyles]);
-
-  useLayoutEffect(() => {
-    const element = frame.current;
-    if (!element) return;
-
-    const measure = (): void => {
-      const width = element.clientWidth;
-      // Zero means "not laid out", never "zero wide": scaling by it would
-      // multiply the page to nothing and draw a blank frame, which looks
-      // exactly like a page with no content.
-      setScale(width > 0 ? width / renderWidth : 1);
-    };
-
-    measure();
-
-    // Guarded rather than assumed: this renders in the admin, in tests, and
-    // anywhere a host embeds the form, and an environment without the observer
-    // must still draw the page rather than throw on the way in.
-    if (typeof ResizeObserver === "undefined") return;
-
-    const observer = new ResizeObserver(measure);
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, [renderWidth]);
+    ),
+    [render, document, siteStyles]
+  );
 
   return (
     <div
       ref={frame}
       data-slot="page-miniature"
+      // The box owns its own height through the aspect ratio, so a long page is
+      // clipped rather than making the form scroll past a full-length preview.
       className="relative aspect-[16/10] w-full overflow-hidden rounded-md border border-border bg-background"
     >
-      <iframe
-        data-slot="page-miniature-surface"
-        // Decorative. The accessible account of this field is the text beside
-        // the frame, which says what the page holds and offers the one action
-        // there is; a frame announced as a document would put a second one in
-        // the reader's way. `tabIndex={-1}` keeps it out of the tab order, which
-        // a frame otherwise joins.
-        title=""
-        aria-hidden="true"
-        tabIndex={-1}
-        // NOTHING granted. No scripts, no form submission, no navigation, so the
-        // preview cannot act even in principle — and a page holding a form block
-        // cannot submit one.
-        sandbox=""
-        srcDoc={srcDoc}
+      <div
+        data-slot="page-miniature-scaled"
         /*
-         * Absolute, and load-bearing rather than cosmetic. `transform` takes an
-         * element out of the PAINTING flow and leaves it in the LAYOUT flow, so
-         * an element declared at the compose width stretches every ancestor to
-         * that width — the frame then measures its own width as the compose
-         * width, the scale computed from it is 1, and the page draws full size
-         * and overflows the form.
+         * ABSOLUTE, and this is load-bearing rather than cosmetic.
+         *
+         * `transform` takes an element out of the PAINTING flow and leaves it
+         * in the LAYOUT flow, so a statically positioned 1280px child still
+         * contributes 1280px of intrinsic width to its ancestors — measured:
+         * the frame's own `clientWidth` came back as 1280 rather than the
+         * column's width, the scale computed from it was therefore 1, and the
+         * page drew full-size and overflowed the form. Taking it out of flow is
+         * what makes the frame's width a property of the COLUMN, which is the
+         * width the scale has to be computed from.
          */
-        className="absolute left-0 top-0 border-0"
+        className="absolute left-0 top-0"
         style={{
           width: `${renderWidth}px`,
-          height: `${height}px`,
           transform: `scale(${scale})`,
           transformOrigin: "top left",
+          /*
+           * The container the compiled responsive rules resolve against, on the
+           * element whose width they must answer for — the COMPOSED width, not
+           * the clipped frame's. `@media` asks the window, so without this a
+           * miniature composed at a desktop width gets whichever tier the admin
+           * window happens to be in. `previewContainerStyle` supplies the
+           * `container-type` beside the name, because a named container left at
+           * the default `normal` is not a size-query container and every rule
+           * the compile emitted stays inert.
+           */
+          ...previewContainerStyle(render.styleContext.previewContainer),
         }}
-      />
+      >
+        <div
+          data-slot="page-miniature-surface"
+          inert
+          aria-hidden="true"
+          /*
+           * A submit raised anywhere in the page cannot reach the form this
+           * miniature sits inside.
+           *
+           * The entry screen is a `<form>`, and a page holding a form block
+           * emits one too — so the preview contains a nested form, which is
+           * invalid HTML. What that costs depends on how the document was
+           * built, and only one path is live here:
+           *
+           * PARSED from HTML source, the inner `</form>` closes the OUTER form
+           * early. Measured on this exact shape: a control after the nested
+           * form reports `input.form === null` — no owner, so it submits
+           * nothing. The admin ships no form markup and builds its tree through
+           * the DOM, so it does not take that path today.
+           *
+           * BUILT through the DOM, which is what happens here, a real nested
+           * form exists and controls keep their nearest-ancestor owner. The
+           * live risk is a submit from the previewed page reaching the entry
+           * form, and this is what refuses it.
+           *
+           * Captured on the WAY DOWN rather than bubbling, so it lands before
+           * any handler inside the page, and matched by the EVENT rather than
+           * by a block's name: a host's own form-rooted block raises the same
+           * event and is refused by the same line, where a check for
+           * `core/form` would have let it through.
+           */
+          onSubmitCapture={event => event.preventDefault()}
+        >
+          {page}
+        </div>
+      </div>
     </div>
   );
 }

--- a/packages/plugin-page-builder/src/admin/PageMiniature.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.tsx
@@ -16,9 +16,24 @@
  * page is being shown a world that is not its own.
  *
  * A NESTED FORM. The entry screen is itself a `<form>`, and a page holding the
- * form block emits one too. Nested forms are invalid, so a parser closes the
- * outer one early — and entry fields after that point stop belonging to the
- * form that submits them. Silent, and it costs an author their edits.
+ * form block emits one too. Nested forms are invalid HTML, and the cost depends
+ * on how the document was built — which is worth stating exactly, because the
+ * two paths differ and only one of them is live here.
+ *
+ * PARSED from HTML source, the inner start tag is dropped and the inner
+ * `</form>` closes the OUTER form early. Measured in a browser on this exact
+ * shape: a control following the nested form ends up outside the outer form
+ * with `input.form === null` — no owner, so it submits nothing. This admin
+ * renders client-side and ships no form markup, so it does not take that path
+ * today; it would the moment any of this were server-rendered or hydrated.
+ *
+ * BUILT through the DOM, which is what React does here, a real nested form
+ * exists and controls keep their nearest-ancestor owner. What is live in that
+ * path is the page's own form being SUBMITTABLE from inside the entry form.
+ *
+ * A frame removes both, and removes the dependence on which path the admin
+ * happens to use — which is the part worth having, since that is not this
+ * module's decision to rely on.
  *
  * VIEWPORT UNITS. `50vw` measures the viewport, and composing an element at
  * 1280px does not make the viewport 1280px. In a 1600px admin window that block

--- a/packages/plugin-page-builder/src/admin/PageMiniature.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.tsx
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * The page itself, drawn small, on the screen an author reaches it from.
+ *
+ * The same `PageRenderer` that draws the published page. That is the property
+ * worth protecting rather than an implementation convenience: a preview with
+ * its own rendering path is a second implementation of "what does this page
+ * look like", and the two drift in the direction nobody tests — the preview
+ * stops matching the page while both look correct in isolation. `canvas.tsx`
+ * makes the same argument for the editing surface, and it applies here for the
+ * same reason.
+ *
+ * ## It is a picture, and it is inert
+ *
+ * Everything drawn inside is `inert` and `aria-hidden`. Not decoration: a page
+ * is full of links, buttons and headings, and left reachable they would put a
+ * whole second document into the tab order of a form — an author tabbing out of
+ * the title field would walk into a miniature of their own page. The accessible
+ * account is the text beside it, which says what the field holds and offers the
+ * one action there is.
+ *
+ * ## `transform`, never `zoom`
+ *
+ * A deliberate divergence from the canvas, which uses `zoom`. `zoom`
+ * participates in layout, and the canvas needs that: hit-testing, drag geometry
+ * and the drop indicator are all positioned in the scaled box's own
+ * coordinates. Nothing here is interactive, so participation buys nothing and
+ * costs a reflow of the whole rendered tree on every resize. `transform` also
+ * keeps the scaled content out of the flow entirely, which is what lets the
+ * outer box own its own size rather than being pushed around by a page that
+ * happens to be long.
+ *
+ * ## An unmeasurable container renders UNSCALED
+ *
+ * A container reports zero width before layout, and in any environment that
+ * does not lay out at all. Scaling by the measured ratio there multiplies the
+ * page by zero and draws nothing — a blank frame that looks exactly like a page
+ * with no content. Rendering unscaled instead is wrong only in how much of the
+ * page is visible, and it is wrong visibly, which is the better failure.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/PageMiniature
+ */
+import type { BlockDocument } from "@nextlyhq/blocks-engine";
+import { PageRenderer, type PageRendererProps } from "@nextlyhq/blocks-react";
+import { useLayoutEffect, useRef, useState } from "react";
+
+import { entryBlockResolver } from "./entry-block-resolver";
+
+/**
+ * The width the page is composed at before being scaled down.
+ *
+ * A desktop tier. A page laid out for desktop, rendered at the few hundred
+ * pixels a form column offers, would draw its MOBILE layout — a truthful
+ * rendering of a viewport the author was not looking at, which reads as the
+ * page being wrong rather than as the preview being narrow.
+ */
+const DEFAULT_RENDER_WIDTH = 1280;
+
+export interface PageMiniatureProps {
+  /** The document to draw. */
+  document: BlockDocument;
+  /**
+   * The site's compiled sheet.
+   *
+   * Spelled as the renderer's own prop type so the two cannot drift. The caller
+   * decides whether it is ready; this draws whatever it is handed.
+   */
+  siteStyles: PageRendererProps["siteStyles"];
+  /** The width to compose at before scaling. Defaults to a desktop tier. */
+  renderWidth?: number;
+}
+
+/**
+ * @param props - the document, the site's sheet, and the width to compose at
+ * @returns a clipped, inert, scaled rendering of the page
+ */
+export function PageMiniature({
+  document,
+  siteStyles,
+  renderWidth = DEFAULT_RENDER_WIDTH,
+}: PageMiniatureProps) {
+  const frame = useRef<HTMLDivElement>(null);
+  const [scale, setScale] = useState(1);
+
+  useLayoutEffect(() => {
+    const element = frame.current;
+    if (!element) return;
+
+    const measure = (): void => {
+      const width = element.clientWidth;
+      // Zero means "not laid out", never "zero wide". See the module docblock.
+      setScale(width > 0 ? width / renderWidth : 1);
+    };
+
+    measure();
+
+    // Guarded rather than assumed: this component renders in the admin, in
+    // tests, and anywhere a host embeds the form, and an environment without
+    // the observer must still draw the page rather than throw on the way in.
+    if (typeof ResizeObserver === "undefined") return;
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [renderWidth]);
+
+  return (
+    <div
+      ref={frame}
+      data-slot="page-miniature"
+      // The box owns its own height through the aspect ratio, so a long page is
+      // clipped rather than making the form scroll past a full-length preview.
+      className="relative aspect-[16/10] w-full overflow-hidden rounded-md border border-border bg-background"
+    >
+      <div
+        data-slot="page-miniature-scaled"
+        style={{
+          width: `${renderWidth}px`,
+          transform: `scale(${scale})`,
+          transformOrigin: "top left",
+        }}
+      >
+        <div data-slot="page-miniature-surface" inert aria-hidden="true">
+          <PageRenderer
+            document={document}
+            blocks={entryBlockResolver()}
+            siteStyles={siteStyles}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/plugin-page-builder/src/admin/PageMiniature.tsx
+++ b/packages/plugin-page-builder/src/admin/PageMiniature.tsx
@@ -26,10 +26,13 @@
  * participates in layout, and the canvas needs that: hit-testing, drag geometry
  * and the drop indicator are all positioned in the scaled box's own
  * coordinates. Nothing here is interactive, so participation buys nothing and
- * costs a reflow of the whole rendered tree on every resize. `transform` also
- * keeps the scaled content out of the flow entirely, which is what lets the
- * outer box own its own size rather than being pushed around by a page that
- * happens to be long.
+ * costs a reflow of the whole rendered tree on every resize.
+ *
+ * `transform` alone does NOT keep the scaled content out of the flow, which is
+ * the trap: it removes the element from painting and leaves it in layout, so a
+ * statically positioned child declared at the compose width stretches every
+ * ancestor to that width. The scaled element is absolutely positioned for that
+ * reason, and only then is the frame's measured width the column's width.
  *
  * ## An unmeasurable container renders UNSCALED
  *
@@ -115,6 +118,19 @@ export function PageMiniature({
     >
       <div
         data-slot="page-miniature-scaled"
+        /*
+         * ABSOLUTE, and this is load-bearing rather than cosmetic.
+         *
+         * `transform` takes an element out of the PAINTING flow and leaves it
+         * in the LAYOUT flow, so a statically positioned 1280px child still
+         * contributes 1280px of intrinsic width to its ancestors — measured:
+         * the frame's own `clientWidth` came back as 1280 rather than the
+         * column's width, the scale computed from it was therefore 1, and the
+         * page drew full-size and overflowed the form. Taking it out of flow is
+         * what makes the frame's width a property of the COLUMN, which is the
+         * width the scale has to be computed from.
+         */
+        className="absolute left-0 top-0"
         style={{
           width: `${renderWidth}px`,
           transform: `scale(${scale})`,

--- a/packages/plugin-page-builder/src/admin/entry-block-resolver.test.ts
+++ b/packages/plugin-page-builder/src/admin/entry-block-resolver.test.ts
@@ -1,0 +1,47 @@
+import { getBlock, registerBlocks } from "@nextlyhq/blocks-engine";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+import { describe, expect, it } from "vitest";
+
+import { entryBlockResolver } from "./entry-block-resolver";
+
+/*
+ * Nothing here mocks the engine.
+ *
+ * The registry is real, and in a fresh test module it is genuinely EMPTY —
+ * which is the exact state the entry screen renders in, because
+ * `ensureCoreBlocksRegistered()` runs inside `BlocksEditor` and nowhere else.
+ * A mock would have had to assert that emptiness rather than observe it, and
+ * would then have gone on passing after the real registry stopped behaving that
+ * way.
+ *
+ * The order of the two tests below matters — the second one registers a block —
+ * so the first asserts its own precondition. Reordered, it fails loudly instead
+ * of passing for the wrong reason.
+ */
+describe("entryBlockResolver", () => {
+  it("resolves a core block while the registry is empty", () => {
+    // The precondition, observed rather than assumed. This is the whole reason
+    // the resolver exists: on the entry screen nothing has been registered.
+    expect(getBlock("core/text")).toBeUndefined();
+
+    expect(entryBlockResolver().get("core/text")).toBeDefined();
+  });
+
+  it("answers undefined for a type nobody defines", () => {
+    expect(
+      entryBlockResolver().get("acme/nothing-defines-this")
+    ).toBeUndefined();
+  });
+
+  it("prefers a definition the host registered over the core one", () => {
+    const core = coreBlocks.find(block => block.name === "core/text");
+    if (!core) throw new Error("core/text is missing from coreBlocks");
+
+    // Derived from the real definition rather than written as a literal, so it
+    // stays a valid block as the definition shape changes.
+    const hostVersion = { ...core, description: "the host's own text block" };
+    registerBlocks([hostVersion], { source: "test-host" });
+
+    expect(entryBlockResolver().get("core/text")).toBe(hostVersion);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/entry-block-resolver.ts
+++ b/packages/plugin-page-builder/src/admin/entry-block-resolver.ts
@@ -1,0 +1,52 @@
+/**
+ * Where the entry screen's miniature gets its block definitions.
+ *
+ * `PageRenderer` defaults to the process registry, and on the entry screen that
+ * registry is EMPTY. `ensureCoreBlocksRegistered()` is called inside
+ * `BlocksEditor` and nowhere else, deliberately — the field control renders on
+ * every entry form holding a blocks field, whether or not the editor is ever
+ * opened, so registering from there would do global work for a form that may
+ * never need it.
+ *
+ * That decision is worth keeping, so this resolves without it. Passing
+ * `PageRenderer` an explicit `blocks` resolver costs nothing globally: no
+ * registration happens, no side effect outlives the render, and the reason
+ * recorded at the `ensureCoreBlocksRegistered` call site stays true.
+ *
+ * ## The registry is still asked FIRST
+ *
+ * A host may register its own definition for a type — including a replacement
+ * for a core one — and that answer must win wherever it exists. `coreBlocks` is
+ * the floor underneath, not an override on top. Anything neither defines
+ * resolves to `undefined`, which is what `PageRenderer` already draws a
+ * `BlockPlaceholder` for; a page using a block this admin has never heard of
+ * therefore reports that honestly rather than rendering a gap.
+ *
+ * ## A function, not a captured value
+ *
+ * The same reason `registeredBlocks()` is one: the registry is cleared and
+ * rebuilt on a dev-server hot reload, so a resolver holding a snapshot would
+ * keep serving definitions the boot has already replaced.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/entry-block-resolver
+ */
+import { getBlock } from "@nextlyhq/blocks-engine";
+import type { BlockResolver } from "@nextlyhq/blocks-react";
+import { coreBlocks } from "@nextlyhq/blocks-react/blocks";
+
+/**
+ * The core set, indexed once at module load.
+ *
+ * Safe to capture where the registry is not: `coreBlocks` is a static import
+ * whose contents cannot change at runtime, so there is no boot to fall behind.
+ */
+const CORE_BY_NAME = new Map(coreBlocks.map(block => [block.name, block]));
+
+/**
+ * A resolver that answers on the entry screen, where nothing is registered.
+ *
+ * @returns a resolver preferring a registered definition, falling back to core
+ */
+export function entryBlockResolver(): BlockResolver {
+  return { get: type => getBlock(type) ?? CORE_BY_NAME.get(type) };
+}

--- a/packages/plugin-page-builder/src/admin/page-render-inputs.test.ts
+++ b/packages/plugin-page-builder/src/admin/page-render-inputs.test.ts
@@ -1,0 +1,117 @@
+import { DEFAULT_LIMITS } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { pageRenderInputs } from "./page-render-inputs";
+
+/** A site style declaring one bounded tier, so a container is worth naming. */
+const WITH_TIERS = {
+  breakpoints: {
+    viewport: [{ id: "tablet", label: "Tablet", maxWidth: 1024 }],
+    container: [],
+  },
+} as never;
+
+/** A site style declaring none, which is the shape a container cannot serve. */
+const NO_TIERS = {
+  breakpoints: { viewport: [], container: [] },
+} as never;
+
+const base = {
+  clientConfig: undefined,
+  previewContainer: undefined,
+  limits: DEFAULT_LIMITS,
+};
+
+describe("pageRenderInputs", () => {
+  it("always states the site's breakpoints, which is what lets a page sheet compile at all", () => {
+    const inputs = pageRenderInputs({ ...base, siteStyle: WITH_TIERS });
+
+    expect(inputs.styleContext?.breakpoints).toBeDefined();
+  });
+
+  it("names the container when the site has tiers to simulate", () => {
+    const inputs = pageRenderInputs({
+      ...base,
+      siteStyle: WITH_TIERS,
+      previewContainer: "nx-preview-a",
+    });
+
+    expect(inputs.styleContext?.previewContainer).toBe("nx-preview-a");
+  });
+
+  /*
+   * A site with no tiers has no width-dependent rules, so a named container
+   * would compile nothing while the element still carried a name answering for
+   * nothing.
+   */
+  it("names no container when the site defines no tiers", () => {
+    const inputs = pageRenderInputs({
+      ...base,
+      siteStyle: NO_TIERS,
+      previewContainer: "nx-preview-a",
+    });
+
+    expect(inputs.styleContext?.previewContainer).toBeUndefined();
+  });
+
+  it("names no container when the surface asks for none", () => {
+    const inputs = pageRenderInputs({ ...base, siteStyle: WITH_TIERS });
+
+    expect(inputs.styleContext?.previewContainer).toBeUndefined();
+  });
+
+  /*
+   * The editor needs a class alternative beside each pseudo-class rule so it
+   * can show an author the state they are editing. A surface showing the page
+   * as PUBLISHED must not have one, or it can paint a hover nobody is causing.
+   */
+  it("emits state alternatives only for a surface that asks", () => {
+    expect(
+      pageRenderInputs({ ...base, siteStyle: WITH_TIERS, previewStates: true })
+        .styleContext?.previewStates
+    ).toBe(true);
+
+    expect(
+      pageRenderInputs({ ...base, siteStyle: WITH_TIERS }).styleContext
+        ?.previewStates
+    ).toBeUndefined();
+  });
+
+  /*
+   * The distinction `readRemotePatterns` exists to keep. An OMITTED policy
+   * leaves remote fetching open; an EMPTY allowlist refuses every host. A
+   * surface that renders with no policy can therefore fetch from a host the
+   * published page refuses, and `inert` does not stop a resource load.
+   */
+  it("states no host policy when the site configured no patterns", () => {
+    const inputs = pageRenderInputs({ ...base, siteStyle: WITH_TIERS });
+
+    expect(inputs.hostPolicy).toBeUndefined();
+  });
+
+  it("carries the site's remote patterns when it configured some", () => {
+    const inputs = pageRenderInputs({
+      ...base,
+      siteStyle: WITH_TIERS,
+      clientConfig: { remotePatterns: [{ hostname: "cdn.example" }] },
+    });
+
+    expect(inputs.hostPolicy?.remotePatterns).toEqual([
+      { hostname: "cdn.example" },
+    ]);
+  });
+
+  it("forwards the caps the document is repaired against", () => {
+    const raised = {
+      ...DEFAULT_LIMITS,
+      maxNodes: DEFAULT_LIMITS.maxNodes + 50,
+    };
+    const inputs = pageRenderInputs({
+      ...base,
+      siteStyle: WITH_TIERS,
+      limits: raised,
+    });
+
+    expect(inputs.limits).toBe(raised);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/page-render-inputs.ts
+++ b/packages/plugin-page-builder/src/admin/page-render-inputs.ts
@@ -1,0 +1,188 @@
+/**
+ * What a surface has to hand `PageRenderer` to draw THIS site's page.
+ *
+ * Two surfaces draw the same document — the editing canvas and the entry
+ * screen's miniature — and both are claiming to show what a visitor gets. Every
+ * input below is one a published route supplies and a surface that omits it
+ * renders something plausible and wrong: the wrong breakpoint rules, a remote
+ * host the site does not load from, a document repaired under caps the site
+ * never chose.
+ *
+ * They were derived in the editor and not at all on the entry screen, which is
+ * a second implementation of one question with one of them empty. Six separate
+ * review findings came out of that single gap. So the derivation lives here and
+ * both surfaces ask it, rather than each assembling its own bundle correctly.
+ *
+ * ## What is NOT here
+ *
+ * `context` — the media resolver and data provider. Neither surface supplies
+ * one today, so both fall back to `createStandaloneContext()`, whose media
+ * resolver answers `null`: a `core/image` holding a media id draws nothing in
+ * the canvas and nothing in the miniature, while the published page shows it.
+ * That is a real gap and it is the SAME gap on both surfaces, so closing it
+ * belongs to whoever gives the admin a read-only render context — not to a
+ * bundle whose job is to keep the two in step.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/page-render-inputs
+ */
+import {
+  DEFAULT_LIMITS,
+  isPlainRecord,
+  type DocumentLimits,
+} from "@nextlyhq/blocks-engine";
+import type { PageRendererProps } from "@nextlyhq/blocks-react";
+// `offeredTiers` is the editor's own answer to "which tiers can a box be sized
+// to". Asked rather than re-derived: a second reading of the same breakpoint
+// set is a second chance to disagree about whether a container is worth naming.
+import { offeredTiers } from "@nextlyhq/builder/shell";
+
+import { readRemotePatterns } from "../host-policy";
+import { siteBreakpoints, type SiteStyleData } from "../site-style";
+
+/**
+ * The subset of `PageRenderer`'s props this derives.
+ *
+ * `styleContext` is REQUIRED rather than optional, unlike on the renderer.
+ * Callers read `styleContext.breakpoints` back out to decide which tier an edit
+ * lands in, and an optional slot there would make every one of those reads a
+ * null check for a value this function always produces.
+ */
+export interface PageRenderInputs {
+  styleContext: NonNullable<PageRendererProps["styleContext"]>;
+  hostPolicy?: PageRendererProps["hostPolicy"];
+  limits?: PageRendererProps["limits"];
+}
+
+export interface PageRenderInputsOptions {
+  /** The site's resolved style, which is where the breakpoints come from. */
+  siteStyle: SiteStyleData | undefined;
+  /** The plugin's serialized client config, carrying patterns and limits. */
+  clientConfig: Record<string, unknown> | undefined;
+  /**
+   * The container name the sheet is compiled against, or `undefined` to compile
+   * none.
+   *
+   * A page's responsive rules are `@media` queries, and `@media` asks the
+   * WINDOW — so a box laid out at a width the window does not have gets the
+   * window's tier rather than its own. Compiling against a named container is
+   * what lets a box answer for its own width, and it only works when the
+   * element also declares `container-name` and `container-type`; a named
+   * container left at the default `normal` is not a size-query container and
+   * every rule the compile emitted stays inert.
+   */
+  previewContainer: string | undefined;
+  /**
+   * Whether to emit a class alternative beside each pseudo-class rule.
+   *
+   * An EDITOR concern. A page cannot force `:hover` on itself, so the canvas
+   * needs a class it can add to show an author the state they are editing. A
+   * surface showing the page AS PUBLISHED wants no such thing — the extra rules
+   * would let it paint a hover appearance no visitor is seeing.
+   */
+  previewStates?: boolean;
+  /** The site's document caps, already read from the config. */
+  limits: DocumentLimits;
+}
+
+/**
+ * The renderer inputs for one surface drawing this site's page.
+ *
+ * @param options - the site's style, its config, and the surface's own choices
+ * @returns the `PageRenderer` props that describe this site's rendering
+ */
+export function pageRenderInputs({
+  siteStyle,
+  clientConfig,
+  previewContainer,
+  previewStates,
+  limits,
+}: PageRenderInputsOptions): PageRenderInputs {
+  /*
+   * ONE read of the breakpoints, feeding both the compile and the decision
+   * about whether a container is worth naming. Two calls return equal sets
+   * today and would stop the day `siteBreakpoints` normalises or defaults
+   * anything — and then eligibility would answer from a different set than the
+   * sheet was compiled against.
+   */
+  const breakpoints = siteBreakpoints(siteStyle);
+  const remotePatterns = readRemotePatterns(clientConfig?.remotePatterns);
+
+  return {
+    styleContext: {
+      breakpoints,
+      /*
+       * Named only where there are tiers to simulate. A site defining none has
+       * no width-dependent rules, so a container would compile nothing and the
+       * element would carry a name answering for nothing.
+       */
+      ...(previewContainer === undefined ||
+      offeredTiers(breakpoints).length === 0
+        ? {}
+        : { previewContainer }),
+      ...(previewStates === true ? { previewStates: true } : {}),
+    },
+    /*
+     * ABSENT is not the same as empty here, and the difference is the whole
+     * point of `readRemotePatterns`. An omitted policy leaves remote fetching
+     * OPEN, so a surface that forgets it can request an image or an iframe from
+     * a host the published page refuses — and `inert` does not prevent a
+     * resource load. An empty allowlist, by contrast, refuses every remote
+     * host. Only a site that stated patterns gets a policy.
+     */
+    ...(remotePatterns === undefined ? {} : { hostPolicy: { remotePatterns } }),
+    /*
+     * The caps the document is repaired against before anything walks it. A
+     * site that RAISED a bound has legitimate tail nodes truncated when this is
+     * omitted; a site that LOWERED one previews nodes its published page
+     * refuses.
+     */
+    limits,
+  };
+}
+
+/**
+ * The document bounds the host renders under, as published to the browser.
+ *
+ * Read DEFENSIVELY and one key at a time: `clientConfig` is JSON that crossed a
+ * transport, so nothing here can assume a shape. Anything unreadable falls back
+ * to the engine's defaults, which is what the renderer itself falls back to —
+ * so the two still agree rather than diverging in the direction that would
+ * misreport which classes a page applies.
+ */
+export function readDocumentLimits(
+  clientConfig: Record<string, unknown> | undefined
+): DocumentLimits {
+  const declared = clientConfig?.limits;
+  if (!isPlainRecord(declared)) return DEFAULT_LIMITS;
+  // Built by overriding the defaults key by key rather than by asserting a
+  // shape onto the transported value: the keys come from `DEFAULT_LIMITS`, so
+  // a bound the engine adds later is carried without this being edited, and a
+  // key the host sent that the engine does not have is ignored.
+  const merged: DocumentLimits = { ...DEFAULT_LIMITS };
+  for (const key of Object.keys(DEFAULT_LIMITS) as (keyof DocumentLimits)[]) {
+    const supplied = declared[key];
+    /*
+     * Zero and Infinity are both LEGITIMATE bounds, so neither may be narrowed
+     * away here. A host setting `maxNodes: 0` gets a renderer that draws
+     * nothing, and substituting the default would have the panel mark classes
+     * as present on a page that renders none of them; the engine supports an
+     * infinite byte limit outright. What is refused is a value that is not a
+     * number, or one below zero, which no bound can mean.
+     */
+    // `null` is the wire spelling for an INFINITE bound: `Infinity` is not a
+    // JSON value and the client config is refused unless it survives the round
+    // trip unchanged, so the publisher encodes it and this decodes it.
+    if (supplied === null) {
+      merged[key] = Number.POSITIVE_INFINITY;
+      continue;
+    }
+    if (
+      typeof supplied === "number" &&
+      !Number.isNaN(supplied) &&
+      supplied >= 0
+    ) {
+      merged[key] = supplied;
+    }
+  }
+  return merged;
+}

--- a/packages/plugin-page-builder/src/admin/page-render-inputs.ts
+++ b/packages/plugin-page-builder/src/admin/page-render-inputs.ts
@@ -8,10 +8,10 @@
  * host the site does not load from, a document repaired under caps the site
  * never chose.
  *
- * They were derived in the editor and not at all on the entry screen, which is
- * a second implementation of one question with one of them empty. Six separate
- * review findings came out of that single gap. So the derivation lives here and
- * both surfaces ask it, rather than each assembling its own bundle correctly.
+ * Derived once here and asked by both, rather than assembled separately at each
+ * call site. Two derivations of one question agree on the day they are written
+ * and drift silently afterwards — and the drift is invisible, because a surface
+ * missing an input renders a page that looks entirely reasonable.
  *
  * ## What is NOT here
  *

--- a/packages/plugin-page-builder/src/admin/page-summary.test.ts
+++ b/packages/plugin-page-builder/src/admin/page-summary.test.ts
@@ -54,6 +54,40 @@ describe("countByType", () => {
   });
 });
 
+describe("countByType, on a document the engine has not repaired", () => {
+  /*
+   * The form's value is whatever is stored, and `documentNodes` only checks
+   * that `nodes` is an array. A hand-recursive walk over that is a stack
+   * overflow waiting for a deep enough tree, and it renders during a component
+   * render — so it takes the admin down rather than reporting anything.
+   */
+  it("counts a tree far deeper than a recursive walk would survive", () => {
+    let node: Record<string, unknown> = { id: "leaf", type: "core/text" };
+    for (let i = 0; i < 20_000; i += 1) {
+      node = { id: `n${i}`, type: "core/box", slots: { children: [node] } };
+    }
+
+    const counts = countByType([node] as unknown as readonly BlockNode[]);
+
+    expect(counts.get("core/text")).toBe(1);
+  });
+
+  /*
+   * A cycle is not hypothetical for a stored value: the engine's own walk
+   * reports one rather than assuming it away, which is why this asks the engine
+   * instead of walking the slots itself. A hand-rolled recursion does not
+   * return from this input at all.
+   */
+  it("returns on a document that contains a cycle", () => {
+    const parent: Record<string, unknown> = { id: "p", type: "core/box" };
+    parent.slots = { children: [parent] };
+
+    const counts = countByType([parent] as unknown as readonly BlockNode[]);
+
+    expect(counts.get("core/box")).toBeGreaterThanOrEqual(1);
+  });
+});
+
 describe("totalBlocks", () => {
   it("sums every count", () => {
     expect(

--- a/packages/plugin-page-builder/src/admin/page-summary.test.ts
+++ b/packages/plugin-page-builder/src/admin/page-summary.test.ts
@@ -1,0 +1,72 @@
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { countByType, documentNodes, totalBlocks } from "./page-summary";
+
+describe("documentNodes", () => {
+  it("reads the nodes out of a document", () => {
+    expect(
+      documentNodes({ nodes: [{ id: "a", type: "core/text" }] })
+    ).toHaveLength(1);
+  });
+
+  /*
+   * A blocks field renders inside a create form and inside previews, where the
+   * value is legitimately absent rather than wrong. Every one of these is a
+   * shape the form can hold, so answering "no nodes" is the only reading that
+   * does not throw on a page an author has not started.
+   */
+  it("answers empty for every value that is not a document", () => {
+    for (const value of [undefined, null, {}, { nodes: "no" }, 7, "x", []]) {
+      expect(documentNodes(value)).toEqual([]);
+    }
+  });
+});
+
+describe("countByType", () => {
+  it("counts children under named slots, not only the top level", () => {
+    const counts = countByType([
+      {
+        id: "s",
+        type: "core/section",
+        slots: { children: [{ id: "t", type: "core/text" }] },
+      },
+      { id: "t2", type: "core/text" },
+    ] as unknown as readonly BlockNode[]);
+
+    expect(counts.get("core/text")).toBe(2);
+    expect(counts.get("core/section")).toBe(1);
+  });
+
+  /*
+   * A stored document predates its validators, so a row can hold a node whose
+   * type is missing or is not a string. Counting it would put `undefined` in
+   * the reading an author sees.
+   */
+  it("skips a node with no string type rather than counting it", () => {
+    expect(
+      countByType([
+        { id: "a", type: 7 },
+        null,
+        undefined,
+      ] as unknown as readonly BlockNode[]).size
+    ).toBe(0);
+  });
+});
+
+describe("totalBlocks", () => {
+  it("sums every count", () => {
+    expect(
+      totalBlocks(
+        new Map([
+          ["a", 2],
+          ["b", 1],
+        ])
+      )
+    ).toBe(3);
+  });
+
+  it("is zero for an empty document", () => {
+    expect(totalBlocks(new Map())).toBe(0);
+  });
+});

--- a/packages/plugin-page-builder/src/admin/page-summary.ts
+++ b/packages/plugin-page-builder/src/admin/page-summary.ts
@@ -1,0 +1,68 @@
+/**
+ * What a blocks document holds, read once for every surface that reports it.
+ *
+ * Two surfaces answer this question and they must not disagree: the published
+ * {@link BlocksSummary}, which a host can still address by component path, and
+ * the entry screen's own card. A second traversal would drift in the direction
+ * nobody tests — the two would agree on the documents in the tests and differ on
+ * a nesting shape neither was written against.
+ *
+ * Pure, and deliberately DOM-free: what counts as a block is a question about
+ * the stored shape, so it stays testable without rendering anything.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/page-summary
+ */
+import type { BlockNode } from "@nextlyhq/blocks-engine";
+
+/**
+ * The nodes a form value holds, for a value that may not hold any.
+ *
+ * A blocks field renders inside a create form and inside previews, where the
+ * value is legitimately `undefined` rather than malformed, and a stored row can
+ * predate the validators that would have refused it. Both read as "no nodes"
+ * here, because the reading an author needs is the same either way and neither
+ * is worth throwing over.
+ *
+ * @param value - the form's current value for a blocks field
+ * @returns the document's top-level nodes, or an empty list
+ */
+export function documentNodes(value: unknown): readonly BlockNode[] {
+  if (typeof value !== "object" || value === null) return [];
+  const nodes = (value as { nodes?: unknown }).nodes;
+  return Array.isArray(nodes) ? (nodes as readonly BlockNode[]) : [];
+}
+
+/**
+ * Every block type in the tree with how many times it appears, in tree order.
+ *
+ * @param nodes - the document's top-level nodes
+ * @returns a count per block type
+ */
+export function countByType(nodes: readonly BlockNode[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  const visit = (list: readonly BlockNode[]): void => {
+    for (const node of list) {
+      if (!node || typeof node.type !== "string") continue;
+      counts.set(node.type, (counts.get(node.type) ?? 0) + 1);
+      // Children live under named slots, so a container's contents are counted
+      // too rather than the summary reporting only the top level.
+      for (const slot of Object.values(node.slots ?? {})) {
+        if (Array.isArray(slot)) visit(slot);
+      }
+    }
+  };
+  visit(nodes);
+  return counts;
+}
+
+/**
+ * How many blocks the document holds in total.
+ *
+ * @param counts - the per-type counts from {@link countByType}
+ * @returns the total number of blocks
+ */
+export function totalBlocks(counts: ReadonlyMap<string, number>): number {
+  let total = 0;
+  for (const count of counts.values()) total += count;
+  return total;
+}

--- a/packages/plugin-page-builder/src/admin/page-summary.ts
+++ b/packages/plugin-page-builder/src/admin/page-summary.ts
@@ -12,7 +12,7 @@
  *
  * @module @nextlyhq/plugin-page-builder/admin/page-summary
  */
-import type { BlockNode } from "@nextlyhq/blocks-engine";
+import { walkNodes, type BlockNode } from "@nextlyhq/blocks-engine";
 
 /**
  * The nodes a form value holds, for a value that may not hold any.
@@ -33,25 +33,42 @@ export function documentNodes(value: unknown): readonly BlockNode[] {
 }
 
 /**
- * Every block type in the tree with how many times it appears, in tree order.
+ * Every block type in the tree with how many times it appears.
+ *
+ * Walked by the ENGINE rather than by a traversal written here, and that is a
+ * correctness choice rather than a tidiness one. The value being counted is
+ * whatever is stored: `documentNodes` checks only that `nodes` is an array, so
+ * this runs over a shape nothing has repaired.
+ *
+ * A hand-written recursion over `slots` fails on that input in two ways, both
+ * measured. A deep enough tree exhausts the call stack — and it does so DURING
+ * A RENDER, so it takes the screen down rather than reporting anything. And a
+ * document containing a cycle never returns at all.
+ *
+ * `walkNodes` is iterative, it bounds itself by node count, and it reports a
+ * cycle rather than following it, because the walk is the only thing that can
+ * see one. Asking it means those three properties cannot be lost here by
+ * someone reintroducing an obvious-looking recursion.
  *
  * @param nodes - the document's top-level nodes
+ * @param maxNodes - the site's cap on how many nodes it will read
  * @returns a count per block type
  */
-export function countByType(nodes: readonly BlockNode[]): Map<string, number> {
+export function countByType(
+  nodes: readonly BlockNode[],
+  maxNodes?: number
+): Map<string, number> {
   const counts = new Map<string, number>();
-  const visit = (list: readonly BlockNode[]): void => {
-    for (const node of list) {
-      if (!node || typeof node.type !== "string") continue;
+  walkNodes(
+    // The walk takes a mutable array and does not write to it; the reading
+    // surfaces above hold their nodes as readonly, which is the stronger claim.
+    nodes as BlockNode[],
+    node => {
+      if (typeof node.type !== "string") return;
       counts.set(node.type, (counts.get(node.type) ?? 0) + 1);
-      // Children live under named slots, so a container's contents are counted
-      // too rather than the summary reporting only the top level.
-      for (const slot of Object.values(node.slots ?? {})) {
-        if (Array.isArray(slot)) visit(slot);
-      }
-    }
-  };
-  visit(nodes);
+    },
+    maxNodes === undefined ? {} : { maxNodes }
+  );
   return counts;
 }
 

--- a/packages/plugin-page-builder/src/admin/use-resting-page-render.ts
+++ b/packages/plugin-page-builder/src/admin/use-resting-page-render.ts
@@ -15,10 +15,9 @@
  *
  * @module @nextlyhq/plugin-page-builder/admin/use-resting-page-render
  */
-import { previewContainerFor } from "@nextlyhq/blocks-engine";
 import type { PageRendererProps } from "@nextlyhq/blocks-react";
 import { usePluginClientConfig } from "@nextlyhq/plugin-sdk/admin";
-import { useId, useMemo } from "react";
+import { useMemo } from "react";
 
 import { siteSheet } from "../site-style";
 import { readSiteStyleRecord } from "../site-style-record";
@@ -54,32 +53,22 @@ export function useRestingPageRender(source: string): RestingPageRender {
 
   const { siteStyle, pending, error } = useSiteStyle(configStyle);
 
-  /*
-   * A container name for THIS field's box.
-   *
-   * From `useId` rather than the field's path: two blocks fields on one form
-   * would otherwise compile against one name, and a name is what a container
-   * query resolves by — so the second box would answer to the first one's
-   * width.
-   */
-  const containerId = useId();
-  const previewContainer = useMemo(
-    () => previewContainerFor(containerId),
-    [containerId]
-  );
-
   const render = useMemo(
     () =>
       pageRenderInputs({
         siteStyle,
         clientConfig,
-        previewContainer,
+        // NONE. The card draws the page in a frame with a viewport of its
+        // own, so plain `@media` already answers for the composed width — which
+        // is what the published page does. A named container here would emit
+        // rules whose container is declared nowhere inside that frame.
+        previewContainer: undefined,
         // Deliberately unset. This surface shows the page as PUBLISHED, and a
         // class alternative beside each pseudo-class rule would let it paint a
         // hover appearance nobody is causing.
         limits: readDocumentLimits(clientConfig),
       }),
-    [siteStyle, clientConfig, previewContainer]
+    [siteStyle, clientConfig]
   );
 
   return {

--- a/packages/plugin-page-builder/src/admin/use-resting-page-render.ts
+++ b/packages/plugin-page-builder/src/admin/use-resting-page-render.ts
@@ -15,9 +15,10 @@
  *
  * @module @nextlyhq/plugin-page-builder/admin/use-resting-page-render
  */
+import { previewContainerFor } from "@nextlyhq/blocks-engine";
 import type { PageRendererProps } from "@nextlyhq/blocks-react";
 import { usePluginClientConfig } from "@nextlyhq/plugin-sdk/admin";
-import { useMemo } from "react";
+import { useId, useMemo } from "react";
 
 import { siteSheet } from "../site-style";
 import { readSiteStyleRecord } from "../site-style-record";
@@ -53,22 +54,32 @@ export function useRestingPageRender(source: string): RestingPageRender {
 
   const { siteStyle, pending, error } = useSiteStyle(configStyle);
 
+  /*
+   * A container name for THIS field's box.
+   *
+   * From `useId` rather than the field's path: two blocks fields on one form
+   * would otherwise compile against one name, and a name is what a container
+   * query resolves by — so the second box would answer to the first one's
+   * width.
+   */
+  const containerId = useId();
+  const previewContainer = useMemo(
+    () => previewContainerFor(containerId),
+    [containerId]
+  );
+
   const render = useMemo(
     () =>
       pageRenderInputs({
         siteStyle,
         clientConfig,
-        // NONE. The card draws the page in a frame with a viewport of its
-        // own, so plain `@media` already answers for the composed width — which
-        // is what the published page does. A named container here would emit
-        // rules whose container is declared nowhere inside that frame.
-        previewContainer: undefined,
+        previewContainer,
         // Deliberately unset. This surface shows the page as PUBLISHED, and a
         // class alternative beside each pseudo-class rule would let it paint a
         // hover appearance nobody is causing.
         limits: readDocumentLimits(clientConfig),
       }),
-    [siteStyle, clientConfig]
+    [siteStyle, clientConfig, previewContainer]
   );
 
   return {

--- a/packages/plugin-page-builder/src/admin/use-resting-page-render.ts
+++ b/packages/plugin-page-builder/src/admin/use-resting-page-render.ts
@@ -1,0 +1,101 @@
+"use client";
+
+/**
+ * Everything the entry screen needs to draw this site's page, as one answer.
+ *
+ * The resting state has to read four separate things before it can draw a
+ * faithful page — the site's style, whether that read has arrived, the site's
+ * config, and a container name for its own box — and getting any one of them
+ * wrong produces a page that looks right and is not. Assembled inline they were
+ * six hooks in a field control whose job is to decide which of two surfaces to
+ * render, and the reading of each was easy to get subtly wrong in isolation.
+ *
+ * Gathered here they are one unit with one contract, and the field asks a
+ * question rather than performing a derivation.
+ *
+ * @module @nextlyhq/plugin-page-builder/admin/use-resting-page-render
+ */
+import { previewContainerFor } from "@nextlyhq/blocks-engine";
+import type { PageRendererProps } from "@nextlyhq/blocks-react";
+import { usePluginClientConfig } from "@nextlyhq/plugin-sdk/admin";
+import { useId, useMemo } from "react";
+
+import { siteSheet } from "../site-style";
+import { readSiteStyleRecord } from "../site-style-record";
+
+import {
+  pageRenderInputs,
+  readDocumentLimits,
+  type PageRenderInputs,
+} from "./page-render-inputs";
+import type { SiteStyleState } from "./PageBuilderCard";
+import { useSiteStyle } from "./site-style-client";
+
+export interface RestingPageRender {
+  /** The site's compiled sheet, as the renderer takes it. */
+  siteStyles: PageRendererProps["siteStyles"];
+  /** Whether that sheet is usable yet, and why not when it is not. */
+  styleState: SiteStyleState;
+  /** The rest of this site's rendering, from the derivation the canvas asks. */
+  render: PageRenderInputs;
+}
+
+/**
+ * @param source - the plugin source whose client config carries the settings
+ * @returns what the entry screen hands the card
+ */
+export function useRestingPageRender(source: string): RestingPageRender {
+  const clientConfig = usePluginClientConfig(source);
+
+  const configStyle = useMemo(
+    () => readSiteStyleRecord(clientConfig?.siteStyle),
+    [clientConfig]
+  );
+
+  const { siteStyle, pending, error } = useSiteStyle(configStyle);
+
+  /*
+   * A container name for THIS field's box.
+   *
+   * From `useId` rather than the field's path: two blocks fields on one form
+   * would otherwise compile against one name, and a name is what a container
+   * query resolves by — so the second box would answer to the first one's
+   * width.
+   */
+  const containerId = useId();
+  const previewContainer = useMemo(
+    () => previewContainerFor(containerId),
+    [containerId]
+  );
+
+  const render = useMemo(
+    () =>
+      pageRenderInputs({
+        siteStyle,
+        clientConfig,
+        previewContainer,
+        // Deliberately unset. This surface shows the page as PUBLISHED, and a
+        // class alternative beside each pseudo-class rule would let it paint a
+        // hover appearance nobody is causing.
+        limits: readDocumentLimits(clientConfig),
+      }),
+    [siteStyle, clientConfig, previewContainer]
+  );
+
+  return {
+    siteStyles: siteSheet(siteStyle),
+    /*
+     * Three states, because the third is the one that gets folded into the good
+     * one by accident. On a FAILED read `pending` goes false and `siteStyle`
+     * resolves to the config defaults, so a caller keyed on `pending` alone
+     * draws a page missing this site's stored classes, tokens and block
+     * defaults — and looks entirely correct doing it.
+     *
+     * `!== null`, not `!== undefined`: `useSiteStyle` types the field as
+     * `Error | null` and normalises success to `null`, so the `undefined`
+     * comparison is true on success too.
+     */
+    styleState: pending ? "pending" : error !== null ? "unavailable" : "ready",
+    render,
+  };
+}


### PR DESCRIPTION
Tracker row **U-18** — the entry screen's way into the page builder. Ledger `task:u18-entry-builder-affordance`.

## What was wrong, and why it is bigger than the row suggests

The `pages` collection declares exactly three fields — `title`, `slug`, `content` — and the first two are `SYSTEM_FIELDS` the header draws (`takeoverLayout.ts:47`). **So the blocks field's resting state is the entire editable body of a page.** It is not one field among several.

What stood there: a muted bordered box listing raw type slugs — `core/section`, `core/text ×3` — with a small hand-rolled outline `<button>` beneath it.

Two things are wrong with that. `core/text` is machinery, not something a person recognises. And a bordered muted box looks like a field, so nothing said the real editor was one click away — the exact anti-pattern Gutenberg's own design discussion of editor switching warns about: a handoff that looks *"too similar to a block"* and *"would ultimately confuse the user about what view they are in"*.

## What it does now

The page itself, drawn small and inert, with the block count and one primary action. Empty pages get an invitation instead of a report of emptiness.

The miniature is **the same `PageRenderer` that draws the published page**. That is the property worth protecting rather than a convenience: a preview with its own rendering path is a second answer to "what does this page look like", and the two drift where nothing tests. `canvas.tsx` makes the same argument for the editing surface.

## A correction I owe the record

I first estimated a rendered thumbnail would need a preview route, auth for it, and a screenshot pipeline, and that `admin.preview` being optional would leave it blank for unconfigured collections. **That was wrong**, and it is filed as `finding:entry-thumbnail-needs-no-preview-route`. `PageRenderer` renders a document as ordinary React and the canvas — which is `"use client"` — already delegates every pixel to it. No server is involved, so the preview reflects **unsaved** edits and works for collections with no preview configured.

## Two traps, and the control aimed at each

**The registry is EMPTY at rest.** `ensureCoreBlocksRegistered()` runs inside `BlocksEditor` and nowhere else, deliberately — the field control renders on every form holding a blocks field whether or not the editor is opened. Registration is global module state that is never torn down, so **a fix verified after opening the editor once passes while a cold page load stays broken**; the false green is the default outcome. Filed as `finding:blocks-summary-renders-against-an-empty-registry`.

Rather than undo that decision, `PageRenderer`'s `blocks?: BlockResolver` prop takes a resolver built from the statically imported core set. Nothing global is mutated. The registry is still asked first, so a host's own definition wins.

- The cold-registry tests **observe their own precondition** (`expect(getBlock("core/text")).toBeUndefined()`) rather than mocking it, so a reordering fails loudly instead of passing for the wrong reason.
- Break-verified: replacing the resolver with `getBlock` alone fails **exactly** the cold-registry test in `entry-block-resolver.test.ts` (1 failed, 2 passed), and removing the resolver from the miniature fails **exactly** the two cold-path cases in `BlocksField.restingState.test.tsx` (2 failed, 4 passed).

**Omitting `siteStyles` does not draw nothing.** The renderer still emits its default tokens, so a page rendered before the site's sheet arrives looks entirely plausible while missing that site's named classes and block defaults — which is why `canvas.tsx` makes the prop required. The card therefore draws no page while the read is pending, and never falls back to config defaults. Break-verified: rendering the miniature in the pending branch fails exactly that test (1 failed, 9 passed).

## Two defects found in a real browser that no unit test could catch

1. **The scaled page was in the layout flow.** `transform` removes an element from painting and leaves it in layout, so the 1280px compose-width child stretched every ancestor. Measured before: frame `clientWidth` 1280, column 1314, `scale(1)`, page overflowing the form. After absolutely positioning it: frame 434, column 470, `scale(0.339062)`. jsdom has no layout, so the regression guard asserts the structural cause instead.
2. **The card restated the field's own label.** "Page Builder" is what the collection names the field, drawn directly above — one fact, two homes, the shape that gave the document title two disagreeing sources. Removed.

## Test plan

- `plugin-page-builder`: **55 files / 554 tests**, all passing. `main` was 50/524; this adds 5 files and 30 tests, so the file and test counts both move by exactly what was added — a suite that silently stopped collecting would show up here.
- `check-types` (both `tsconfig.json` and `tsconfig.tests.json`) — exit 0.
- `lint` — exit 0. `lint:design` — exit 0.
- `fallow audit --base origin/main` — **verdict `pass`**, 0 introduced findings.
- Verified in a real browser on a real page, in **both light and dark**: the miniature draws and scales, `inert` is set, and it contains **0 focusable elements**, so it cannot enter the form's tab order. In dark mode it correctly keeps the *page's* own white background, because that is what a visitor sees.

## Compatibility

`BlocksSummary` is **untouched and still exported**, including its registration at the component path `@nextlyhq/plugin-page-builder/admin#BlocksSummary`, so a host addressing it by string keeps working. Both it and the card ask `page-summary` what a document holds, so they cannot disagree.

The ten suites that open the editor now ask for the action by a matcher **derived from the labels the card renders** rather than a copy of the wording.

Changeset added: yes (`patch`, all packages, per the lockstep rule).

## Pre-existing, not introduced

- `fallow` reports 36 dead-code issues repo-wide, every one `introduced: false`.
- The design linter reads a GitHub issue reference like `#1375` in a comment as a hardcoded hex colour. Worked around by spelling the reference without the hash rather than adding a suppression; worth knowing since any `#1234` in prose trips it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a visual page miniature to the page builder’s resting state.
  - Added clear empty, loading, unavailable, and read-only states.
  - Added block counts and context-aware actions to open or build pages.
  - Previews now reuse published-page rendering and remain non-interactive.

- **Bug Fixes**
  - Improved builder controls to work with both “Build this page” and “Open Page Builder” labels.
  - Prevented preview content from submitting surrounding forms.

- **Tests**
  - Expanded coverage for previews, rendering states, block counting, accessibility, and builder actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->