### PR TITLE
feat(nextly): let every storage adapter read a stored file back

### DIFF
--- a/.changeset/every-storage-adapter-can-read-back.md
+++ b/.changeset/every-storage-adapter-can-read-back.md
@@ -1,0 +1,48 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Every storage adapter can read a stored file back as bytes. The contract has
+declared `read` as an optional member for some time and only the local adapter
+supplied it, so a caller reaching for it against S3, Vercel Blob or UploadThing
+got `undefined` and fell through whatever branch followed — a capability that
+reads as present and behaves as absent.
+
+The three remaining adapters implement it now. S3 reads through its own SDK; the
+two URL-addressed services fetch the address their service issued, since a
+derived URL is a guess at a string another system owns.
+
+A missing key answers `null`, which is an ordinary fact about the store. A
+transport failure does NOT: a dropped connection to a file whose lookup just
+succeeded is reported as an error rather than as absence, because folding the
+two together invites a caller to treat a live file as deleted and write a
+replacement over it. That separation is stated once, in a shared helper both
+URL-addressed adapters call, rather than being spelled out per adapter where the
+two copies would drift.
+
+S3 returns an empty buffer for a zero-byte object rather than `null`, for the
+same reason: a stored empty file is not a missing one.

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -179,6 +179,10 @@
       "types": "./dist/cli/utils/index.d.ts",
       "import": "./dist/cli/utils/index.mjs"
     },
+    "./storage/read-errors": {
+      "types": "./dist/storage/read-errors.d.ts",
+      "import": "./dist/storage/read-errors.mjs"
+    },
     "./storage/fetch-stored-bytes": {
       "types": "./dist/storage/fetch-stored-bytes.d.ts",
       "import": "./dist/storage/fetch-stored-bytes.mjs"

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -179,6 +179,10 @@
       "types": "./dist/cli/utils/index.d.ts",
       "import": "./dist/cli/utils/index.mjs"
     },
+    "./storage/fetch-stored-bytes": {
+      "types": "./dist/storage/fetch-stored-bytes.d.ts",
+      "import": "./dist/storage/fetch-stored-bytes.mjs"
+    },
     "./storage": {
       "types": "./dist/storage/index.d.ts",
       "import": "./dist/storage/index.mjs"

--- a/packages/nextly/src/di/registrations/__tests__/attachment-read-error.test.ts
+++ b/packages/nextly/src/di/registrations/__tests__/attachment-read-error.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Which error an author sees when a stored attachment cannot be read.
+ *
+ * This rule regressed silently once. Implementing `read` on the cloud adapters
+ * moved the attachment path off a capped fetch onto an unbounded buffer, and
+ * nothing failed — because the rule lived in a closure inside a DI factory,
+ * where nothing could reach it. Break-verifying the fix is what exposed that:
+ * removing the cap broke no test at all.
+ *
+ * So the mapping is asserted here, on the exported function, rather than
+ * through a container.
+ *
+ * @module di/registrations/attachment-read-error.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../../errors/nextly-error";
+import { EmailErrorCode } from "../../../domains/email/errors";
+import { StorageReadTooLargeError } from "../../../storage/read-errors";
+import { asAttachmentReadError } from "../register-email";
+
+describe("an attachment that could not be read", () => {
+  it("reports an over-cap read as a SIZE error the author can act on", () => {
+    /*
+     * `attachment-resolver` passes through only `VALIDATION_ERROR` and wraps
+     * everything else as an opaque storage failure. So an over-cap read that
+     * arrives as anything else tells the author their storage broke, when what
+     * happened is that their attachment is too big — a fixable refusal turned
+     * into one they can do nothing about.
+     */
+    const mapped = asAttachmentReadError(
+      new StorageReadTooLargeError("media/big.pdf", 1000, 5000),
+      1000
+    );
+
+    expect(NextlyError.is(mapped)).toBe(true);
+    // VALIDATION_ERROR specifically: it is the ONLY code the resolver lets
+    // through, so any other code is silently rewritten downstream.
+    expect((mapped as NextlyError).code).toBe("VALIDATION_ERROR");
+  });
+
+  it("names the attachment-size code, not merely some validation error", () => {
+    const mapped = asAttachmentReadError(
+      new StorageReadTooLargeError("media/big.pdf", 1000, 5000),
+      1000
+    ) as NextlyError & { publicData?: { errors?: { code?: string }[] } };
+
+    /*
+     * Read from `publicData`, which is where `NextlyError.validation` puts the
+     * per-field list and therefore what a caller actually receives. Measured
+     * rather than assumed: an earlier version of this case read `data` and
+     * asserted against an empty array, which passes for a mapper that names no
+     * code at all.
+     */
+    const codes = (mapped.publicData?.errors ?? []).map(e => e.code);
+    expect(codes).toContain(EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED);
+  });
+
+  it("returns any OTHER failure unchanged, for the resolver to wrap", () => {
+    /*
+     * The control, and it has to be able to come out different: a mapper that
+     * translated everything would satisfy both cases above while reporting a
+     * timeout or a refused address as "your file is too big" — a confident
+     * wrong diagnosis, which is worse than an opaque one.
+     *
+     * Identity rather than shape, because "unchanged" is the claim: a copy
+     * carrying the same fields would lose the cause the resolver logs.
+     */
+    const other = new Error("connection reset");
+    expect(asAttachmentReadError(other, 1000)).toBe(other);
+  });
+
+  it("leaves a non-Error value alone too", () => {
+    // Nothing guarantees a thrown value is an Error. Mapping one by accident
+    // would replace a diagnosable oddity with a confident wrong sentence.
+    expect(asAttachmentReadError("nope", 1000)).toBe("nope");
+  });
+});

--- a/packages/nextly/src/di/registrations/register-email.ts
+++ b/packages/nextly/src/di/registrations/register-email.ts
@@ -184,16 +184,23 @@ export function registerEmailServices(ctx: RegistrationContext): void {
            * Passing the limit down means the branch cannot decide whether the
            * limit applies.
            */
-          const readLimits = getAttachmentLimits();
+          /*
+           * ONE snapshot for both branches. Reading the policy twice let the
+           * native read and the URL fallback enforce and report different caps
+           * — the environment backing it can change between the two calls, and
+           * a later normalisation would drift them silently — while the comment
+           * below promises the SAME cap. One read is what makes that true.
+           */
+          const limits = getAttachmentLimits();
           // 1. Try native read() (local disk, S3, etc.)
           if (typeof storage.read === "function") {
             let buffer: Buffer | null;
             try {
               buffer = await storage.read(storagePath, {
-                maxBytes: readLimits.maxTotalBytes,
+                maxBytes: limits.maxTotalBytes,
               });
             } catch (err) {
-              throw asAttachmentReadError(err, readLimits.maxTotalBytes);
+              throw asAttachmentReadError(err, limits.maxTotalBytes);
             }
             if (buffer) return buffer;
           }
@@ -207,7 +214,6 @@ export function registerEmailServices(ctx: RegistrationContext): void {
           const url = storagePath.startsWith("http")
             ? storagePath
             : storage.getPublicUrl(storagePath);
-          const limits = getAttachmentLimits();
           // Cap the fetch at the attachment size limit so a valid large
           // attachment is not rejected by the smaller default safeFetch cap. A
           // body over the limit surfaces as the same size-exceeded validation

--- a/packages/nextly/src/di/registrations/register-email.ts
+++ b/packages/nextly/src/di/registrations/register-email.ts
@@ -131,9 +131,24 @@ export function registerEmailServices(ctx: RegistrationContext): void {
           }
         },
         readBytes: async storagePath => {
+          /*
+           * The SAME cap on both routes, because which one runs is a property
+           * of the adapter rather than of the request.
+           *
+           * This branch is taken whenever the adapter implements `read`, and
+           * which adapters do has changed underneath this code before: the
+           * cloud adapters had no `read`, so every one of them fell through to
+           * the bounded fetch below, and implementing it moved them onto a path
+           * that buffered the whole object first and checked its size after.
+           * Passing the limit down means the branch cannot decide whether the
+           * limit applies.
+           */
+          const readLimits = getAttachmentLimits();
           // 1. Try native read() (local disk, S3, etc.)
           if (typeof storage.read === "function") {
-            const buffer = await storage.read(storagePath);
+            const buffer = await storage.read(storagePath, {
+              maxBytes: readLimits.maxTotalBytes,
+            });
             if (buffer) return buffer;
           }
           // 2. Fallback: fetch via URL.

--- a/packages/nextly/src/di/registrations/register-email.ts
+++ b/packages/nextly/src/di/registrations/register-email.ts
@@ -22,10 +22,51 @@ import { EmailService } from "../../services/email/email-service";
 import { EmailTemplateService } from "../../services/email/email-template-service";
 import type { MediaService as UnifiedMediaService } from "../../services/media/media-service";
 import { SYSTEM_CONTEXT } from "../../shared/types";
+import { isStorageReadTooLarge } from "../../storage/read-errors";
 import { SafeFetchError, safeFetch } from "../../utils/validate-external-url";
 import { container } from "../container";
 
 import type { RegistrationContext } from "./types";
+
+/**
+ * A storage read failure, in the vocabulary the attachment path answers in.
+ *
+ * Named and exported rather than inlined in the reader, so the mapping can be
+ * asserted without standing up the whole DI container. That is not tidiness:
+ * this rule regressed silently once already — implementing `read` on the cloud
+ * adapters moved attachments off a capped fetch and NOTHING failed — and the
+ * reason nothing failed is that the rule lived in a closure inside a factory.
+ *
+ * An over-cap read becomes the SAME size error the URL-backed branch produces.
+ * `attachment-resolver` passes through only `VALIDATION_ERROR` and wraps
+ * everything else as an opaque storage failure, so an over-cap read arriving as
+ * anything else tells the author their storage broke — when what happened is
+ * that their attachment is too big and they can fix it by attaching something
+ * smaller. Which branch read the bytes must not change which error they see.
+ *
+ * Everything else is returned UNCHANGED for the resolver to wrap, because a
+ * timeout or a refused address says nothing an author can act on and its
+ * message must not reach them.
+ */
+export function asAttachmentReadError(
+  error: unknown,
+  maxBytes: number
+): unknown {
+  if (!isStorageReadTooLarge(error)) return error;
+  return NextlyError.validation({
+    errors: [
+      {
+        path: "attachments",
+        code: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED,
+        message: "Attachment size exceeds the limit.",
+      },
+    ],
+    logContext: {
+      emailAttachmentCode: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED,
+      max: maxBytes,
+    },
+  });
+}
 
 export function registerEmailServices(ctx: RegistrationContext): void {
   const { adapter, logger, config, storage } = ctx;
@@ -146,9 +187,14 @@ export function registerEmailServices(ctx: RegistrationContext): void {
           const readLimits = getAttachmentLimits();
           // 1. Try native read() (local disk, S3, etc.)
           if (typeof storage.read === "function") {
-            const buffer = await storage.read(storagePath, {
-              maxBytes: readLimits.maxTotalBytes,
-            });
+            let buffer: Buffer | null;
+            try {
+              buffer = await storage.read(storagePath, {
+                maxBytes: readLimits.maxTotalBytes,
+              });
+            } catch (err) {
+              throw asAttachmentReadError(err, readLimits.maxTotalBytes);
+            }
             if (buffer) return buffer;
           }
           // 2. Fallback: fetch via URL.

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -37,6 +37,11 @@ export const NEXTLY_ERROR_STATUS = {
   MIME_BLOCKED: 415,
   MIME_NOT_ALLOWED: 415,
   SIZE_EXCEEDED: 413,
+  // A stored object exceeded the cap a READ was given, which is a different
+  // question from SIZE_EXCEEDED above: that one refuses an upload the caller
+  // is sending, this one refuses to buffer an object already stored. Kept
+  // apart so a caller discriminating on the code cannot match both.
+  STORAGE_READ_TOO_LARGE: 413,
   MAGIC_BYTE_MISMATCH: 400,
   SVG_SANITIZATION_FAILED: 400,
   UNSUPPORTED_FOR_BACKEND: 415,

--- a/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
+++ b/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
@@ -60,9 +60,14 @@ describe("LocalStorageAdapter.read bounds", () => {
     expect(outcome).not.toBeNull();
   });
 
-  it("reads without a cap when the caller names none", async () => {
-    // The control for the refusal above: an adapter that refused every bounded
-    // read would satisfy it while ignoring what the caller asked for.
+  it("reads under the DEFAULT cap when the caller names none", async () => {
+    /*
+     * Not "without a cap": naming none now means the shared default, the same
+     * one `safeFetch` gives the URL-backed adapters. This file is far under it,
+     * so it reads — which is also the control for the refusal above, since an
+     * adapter refusing every bounded read would satisfy that case while
+     * ignoring what the caller asked for.
+     */
     await writeFile(join(base, "big.txt"), "x".repeat(500));
     const bytes = await adapter.read("big.txt");
     expect(bytes?.length).toBe(500);

--- a/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
+++ b/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
@@ -1,0 +1,76 @@
+/**
+ * The DEFAULT adapter's read bounds.
+ *
+ * Tested separately from the cloud adapters because this is the one most
+ * installs actually use, and a cap the cloud adapters keep while this one
+ * ignores is a cap that does nothing in the commonest deployment. That is
+ * exactly the shape the option had before: advertised on the contract, honoured
+ * by some backends, silently inert on the default.
+ *
+ * @module storage/adapters/local-read-cap.test
+ */
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { isStorageReadTooLarge } from "../../read-errors";
+import { LocalStorageAdapter } from "../local-adapter";
+
+let base: string;
+let adapter: LocalStorageAdapter;
+
+beforeEach(async () => {
+  // A real directory rather than a mocked `fs`: the cap is enforced from the
+  // file's own reported size, so a fake would be asserting my arithmetic
+  // against itself rather than against what the filesystem says.
+  base = await mkdtemp(join(tmpdir(), "nextly-local-read-"));
+  // `baseUrl` is required by the constructor, which reads it directly.
+  adapter = new LocalStorageAdapter({ basePath: base, baseUrl: "/uploads" });
+});
+
+afterEach(async () => {
+  await rm(base, { recursive: true, force: true });
+});
+
+describe("LocalStorageAdapter.read bounds", () => {
+  it("reads a file that fits under the cap", async () => {
+    await writeFile(join(base, "small.txt"), "hello");
+    const bytes = await adapter.read("small.txt", { maxBytes: 100 });
+    expect(bytes?.toString("utf8")).toBe("hello");
+  });
+
+  it("REFUSES a file larger than the cap", async () => {
+    /*
+     * Refused rather than read-then-checked. `readFile` buffers the whole
+     * thing, so a cap applied afterwards has already spent the memory it exists
+     * to save — which was the original defect on the cloud adapters and would
+     * be the same one here.
+     */
+    await writeFile(join(base, "big.txt"), "x".repeat(500));
+    const outcome = await adapter.read("big.txt", { maxBytes: 10 }).then(
+      value => value,
+      (error: unknown) => error
+    );
+
+    expect(isStorageReadTooLarge(outcome)).toBe(true);
+    // NOT null: refusing a file that IS there is a different answer from not
+    // finding one, and a caller told `null` would treat a present file as gone.
+    expect(outcome).not.toBeNull();
+  });
+
+  it("reads without a cap when the caller names none", async () => {
+    // The control for the refusal above: an adapter that refused every bounded
+    // read would satisfy it while ignoring what the caller asked for.
+    await writeFile(join(base, "big.txt"), "x".repeat(500));
+    const bytes = await adapter.read("big.txt");
+    expect(bytes?.length).toBe(500);
+  });
+
+  it("still answers null for a file that is not there", async () => {
+    // The absence contract is unchanged by the cap — and this is the control
+    // proving `null` still means "missing" rather than "this never answers".
+    expect(await adapter.read("nope.txt", { maxBytes: 10 })).toBeNull();
+  });
+});

--- a/packages/nextly/src/storage/adapters/local-adapter.ts
+++ b/packages/nextly/src/storage/adapters/local-adapter.ts
@@ -27,7 +27,13 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
-import type { UploadOptions, UploadResult, BulkDeleteResult } from "../types";
+import { StorageReadTooLargeError } from "../read-errors";
+import type {
+  UploadOptions,
+  UploadResult,
+  BulkDeleteResult,
+  StorageReadOptions,
+} from "../types";
 
 import { BaseStorageAdapter } from "./base-adapter";
 
@@ -171,11 +177,47 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
 
   /**
    * Read file contents from local disk.
-   * Returns the file buffer, or null if file not found.
+   *
+   * Returns the file buffer, or `null` if the file is not found.
+   *
+   * Honours the caller's cap, which matters MORE here than anywhere else: this
+   * is the default backend, so a bound the cloud adapters keep and this one
+   * ignores is a bound that does nothing in the commonest deployment. Checked
+   * against the file's size before reading, because `readFile` buffers the
+   * whole thing — a cap enforced afterwards has already spent the memory it
+   * exists to save.
    */
-  async read(filePath: string): Promise<Buffer | null> {
+  async read(
+    filePath: string,
+    options?: StorageReadOptions
+  ): Promise<Buffer | null> {
+    let fullPath: string;
     try {
-      const fullPath = this.resolveAndValidate(filePath);
+      fullPath = this.resolveAndValidate(filePath);
+    } catch {
+      // A path escaping the storage directory, which is a refusal rather than
+      // an absence — but this method's contract has no way to say so, and its
+      // callers have always read a traversal attempt as "no such file".
+      return null;
+    }
+
+    let size: number;
+    try {
+      size = (await fs.stat(fullPath)).size;
+    } catch {
+      return null;
+    }
+
+    /*
+     * Thrown rather than returned as `null`, because refusing a file that IS
+     * there is not the same answer as not finding one — and a caller told
+     * `null` would go on to treat a present file as missing.
+     */
+    if (options?.maxBytes !== undefined && size > options.maxBytes) {
+      throw new StorageReadTooLargeError(filePath, options.maxBytes, size);
+    }
+
+    try {
       return await fs.readFile(fullPath);
     } catch {
       return null;

--- a/packages/nextly/src/storage/adapters/local-adapter.ts
+++ b/packages/nextly/src/storage/adapters/local-adapter.ts
@@ -27,6 +27,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
+import { resolveReadBounds } from "../fetch-stored-bytes";
 import { StorageReadTooLargeError } from "../read-errors";
 import type {
   UploadOptions,
@@ -201,6 +202,15 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
       return null;
     }
 
+    /*
+     * The DEFAULTS apply here too, which is the whole reason this goes through
+     * the shared resolver. A caller naming no cap still gets one — the media
+     * pipeline reads without options — and before this the URL-backed adapters
+     * inherited a bound from `safeFetch` while this one, the default backend,
+     * had none at all.
+     */
+    const bounds = resolveReadBounds(options);
+
     let size: number;
     try {
       size = (await fs.stat(fullPath)).size;
@@ -213,8 +223,8 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
      * there is not the same answer as not finding one — and a caller told
      * `null` would go on to treat a present file as missing.
      */
-    if (options?.maxBytes !== undefined && size > options.maxBytes) {
-      throw new StorageReadTooLargeError(filePath, options.maxBytes, size);
+    if (size > bounds.maxBytes) {
+      throw new StorageReadTooLargeError(filePath, bounds.maxBytes, size);
     }
 
     try {

--- a/packages/nextly/src/storage/fetch-stored-bytes.test.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.test.ts
@@ -89,7 +89,7 @@ describe("reading a stored object over HTTP", () => {
      * anything else as an opaque storage failure.
      */
     vi.mocked(safeFetch).mockRejectedValueOnce(
-      new SafeFetchError("too large", URL_, "response-too-large")
+      new SafeFetchError("too large", URL_, "response-too-large", 200)
     );
     const outcome = await fetchStoredBytes(URL_, "f.woff2", "Test", {
       maxBytes: 10,
@@ -98,6 +98,45 @@ describe("reading a stored object over HTTP", () => {
       (error: unknown) => error
     );
     expect(isStorageReadTooLarge(outcome)).toBe(true);
+  });
+
+  it("does NOT call a failed response oversized, however big its body", async () => {
+    /*
+     * A 500 page or an error document can itself exceed the cap, and
+     * `safeFetch` refuses while buffering — before this code sees any status.
+     * Translating on the reason alone reported a backend outage as "your file
+     * is too big", which is worse than an opaque failure: it names a cause the
+     * author would act on, wrongly.
+     */
+    vi.mocked(safeFetch).mockRejectedValueOnce(
+      new SafeFetchError("too large", URL_, "response-too-large", 500)
+    );
+    const outcome = await fetchStoredBytes(URL_, "f.woff2", "Test", {
+      maxBytes: 10,
+    }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(false);
+    expect(outcome).toBeInstanceOf(SafeFetchError);
+  });
+
+  it("does not translate when no status arrived at all", async () => {
+    /*
+     * Absence means "not known", never "was a success". A failure that happened
+     * before any status — a dropped connection mid-buffer — says nothing about
+     * whether the object was oversized, so it stays untranslated.
+     */
+    vi.mocked(safeFetch).mockRejectedValueOnce(
+      new SafeFetchError("too large", URL_, "response-too-large")
+    );
+    const outcome = await fetchStoredBytes(URL_, "f.woff2", "Test", {
+      maxBytes: 10,
+    }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(false);
   });
 
   it("passes a NON-cap fetch failure through untranslated", async () => {

--- a/packages/nextly/src/storage/fetch-stored-bytes.test.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.test.ts
@@ -13,7 +13,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../errors/nextly-error";
-import { fetchStoredBytes } from "./fetch-stored-bytes";
+import {
+  fetchStoredBytes,
+  resolveReadBounds,
+  DEFAULT_READ_MAX_BYTES,
+  DEFAULT_READ_TIMEOUT_MS,
+} from "./fetch-stored-bytes";
 import { safeFetch, SafeFetchError } from "../utils/validate-external-url";
 import { isStorageReadTooLarge } from "./read-errors";
 
@@ -121,6 +126,22 @@ describe("reading a stored object over HTTP", () => {
     expect(outcome).toBeInstanceOf(SafeFetchError);
   });
 
+  it("answers null for a 404 whose ERROR PAGE blew the cap", async () => {
+    /*
+     * `safeFetch` caps while buffering, so a verbose CDN 404 page raises before
+     * a `Response` exists — and the `status === 404` check further down is
+     * never reached. The object is still gone, which is an ordinary answer this
+     * contract has a value for; it must not become an error because the page
+     * explaining it was long.
+     */
+    vi.mocked(safeFetch).mockRejectedValueOnce(
+      new SafeFetchError("too large", URL_, "response-too-large", 404)
+    );
+    expect(
+      await fetchStoredBytes(URL_, "f.woff2", "Test", { maxBytes: 10 })
+    ).toBeNull();
+  });
+
   it("does not translate when no status arrived at all", async () => {
     /*
      * Absence means "not known", never "was a success". A failure that happened
@@ -191,5 +212,48 @@ describe("reading a stored object over HTTP", () => {
     const options = vi.mocked(safeFetch).mock.calls[0]?.[1] ?? {};
     expect("maxResponseBytes" in options).toBe(false);
     expect("timeoutMs" in options).toBe(false);
+  });
+});
+
+describe("the bounds a read runs under", () => {
+  it("fills BOTH defaults when the caller names neither", () => {
+    /*
+     * The promise `StorageReadOptions` makes. It is asserted here rather than
+     * through an adapter because every adapter now asks this one function — and
+     * the defect it replaces was four implementations disagreeing: the
+     * URL-backed pair inherited `safeFetch`'s cap and deadline for free while
+     * local and S3, which never touch `safeFetch`, applied neither.
+     *
+     * Measured: removing these defaults broke NO adapter test, because every
+     * one of them passes an explicit bound. This is the case that fires.
+     */
+    expect(resolveReadBounds()).toEqual({
+      maxBytes: DEFAULT_READ_MAX_BYTES,
+      timeoutMs: DEFAULT_READ_TIMEOUT_MS,
+    });
+    expect(resolveReadBounds({})).toEqual({
+      maxBytes: DEFAULT_READ_MAX_BYTES,
+      timeoutMs: DEFAULT_READ_TIMEOUT_MS,
+    });
+  });
+
+  it("lets a caller override either bound independently", () => {
+    // The control: a resolver that ignored its argument would satisfy the case
+    // above perfectly while discarding every limit a caller set.
+    expect(resolveReadBounds({ maxBytes: 7 })).toEqual({
+      maxBytes: 7,
+      timeoutMs: DEFAULT_READ_TIMEOUT_MS,
+    });
+    expect(resolveReadBounds({ timeoutMs: 9 })).toEqual({
+      maxBytes: DEFAULT_READ_MAX_BYTES,
+      timeoutMs: 9,
+    });
+  });
+
+  it("defaults to the SAME numbers safeFetch uses, not a second copy", () => {
+    // Two spellings of one default agree today and drift the first time either
+    // is tuned, so these are the fetch layer's own constants re-exported.
+    expect(DEFAULT_READ_MAX_BYTES).toBe(10 * 1024 * 1024);
+    expect(DEFAULT_READ_TIMEOUT_MS).toBe(30_000);
   });
 });

--- a/packages/nextly/src/storage/fetch-stored-bytes.test.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.test.ts
@@ -1,0 +1,106 @@
+/**
+ * The URL-backed read, tested where it lives.
+ *
+ * This moved out of the Vercel adapter's suite deliberately. That suite stubbed
+ * the global `fetch`, which stopped reaching anything the moment this helper
+ * started going through `safeFetch` — and a stub nothing calls does not fail
+ * loudly, it just leaves the assertions describing a request that was never
+ * made. Each layer is asserted where its mechanism is: the ADAPTER decides what
+ * a lookup failure means, and THIS decides what an HTTP answer means.
+ *
+ * @module storage/fetch-stored-bytes.test
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../errors/nextly-error";
+import { fetchStoredBytes } from "./fetch-stored-bytes";
+import { safeFetch } from "../utils/validate-external-url";
+
+vi.mock("../utils/validate-external-url", () => ({
+  safeFetch: vi.fn(),
+}));
+
+const URL_ = "https://cdn.example.test/f.woff2";
+
+beforeEach(() => {
+  vi.mocked(safeFetch).mockReset();
+});
+
+describe("reading a stored object over HTTP", () => {
+  it("returns the bytes the store served", async () => {
+    vi.mocked(safeFetch).mockResolvedValueOnce(
+      new Response("hello", { status: 200 })
+    );
+    const bytes = await fetchStoredBytes(URL_, "f.woff2", "Test");
+    expect(bytes?.toString("utf8")).toBe("hello");
+  });
+
+  it("answers null for a 404, which is absence rather than a fault", async () => {
+    /*
+     * The object can be deleted between the lookup that resolved its address
+     * and this request. That race has an ordinary answer — it is not there —
+     * and reporting it as a server failure would make a caller handle an error
+     * for something its own contract already has a value for.
+     */
+    vi.mocked(safeFetch).mockResolvedValueOnce(
+      new Response("", { status: 404 })
+    );
+    expect(await fetchStoredBytes(URL_, "f.woff2", "Test")).toBeNull();
+  });
+
+  it("THROWS for a non-OK status that is not 404", async () => {
+    /*
+     * The discriminating half. A 5xx says nothing about whether the object
+     * exists, so folding it into `null` tells a caller the file is gone and
+     * invites it to write a replacement over one that is still there.
+     *
+     * Asserted on the CODE rather than the message: the status and the key go
+     * to the log side deliberately, since neither should travel to whoever
+     * asked for the file.
+     */
+    vi.mocked(safeFetch).mockResolvedValueOnce(
+      new Response("nope", { status: 500 })
+    );
+    const outcome = await fetchStoredBytes(URL_, "f.woff2", "Test").then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBeInstanceOf(NextlyError);
+    expect((outcome as NextlyError).code).toBe("INTERNAL_ERROR");
+  });
+
+  it("hands the caller's bounds down rather than imposing its own", async () => {
+    /*
+     * What makes the email attachment path correct again. That caller has a
+     * configured limit, and before these bounds existed the cloud adapters
+     * buffered the whole object and checked its size afterwards.
+     *
+     * Asserted on the ARGUMENTS `safeFetch` received rather than on the result,
+     * because the result is identical whether or not the bounds were forwarded
+     * — which is exactly how this would regress unnoticed.
+     */
+    vi.mocked(safeFetch).mockResolvedValueOnce(new Response("x"));
+    await fetchStoredBytes(URL_, "f.woff2", "Test", {
+      maxBytes: 1234,
+      timeoutMs: 5678,
+    });
+    expect(vi.mocked(safeFetch).mock.calls[0]?.[1]).toMatchObject({
+      maxResponseBytes: 1234,
+      timeoutMs: 5678,
+    });
+  });
+
+  it("omits absent bounds instead of sending undefined ones", async () => {
+    /*
+     * `safeFetch` holds the defaults — 10 MiB and 30 seconds. Passing an
+     * explicit `undefined` overrides a default with nothing in some option
+     * shapes, so the keys are left out entirely when the caller stated none.
+     * That is what keeps one set of numbers in the tree rather than two.
+     */
+    vi.mocked(safeFetch).mockResolvedValueOnce(new Response("x"));
+    await fetchStoredBytes(URL_, "f.woff2", "Test");
+    const options = vi.mocked(safeFetch).mock.calls[0]?.[1] ?? {};
+    expect("maxResponseBytes" in options).toBe(false);
+    expect("timeoutMs" in options).toBe(false);
+  });
+});

--- a/packages/nextly/src/storage/fetch-stored-bytes.test.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.test.ts
@@ -14,11 +14,19 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../errors/nextly-error";
 import { fetchStoredBytes } from "./fetch-stored-bytes";
-import { safeFetch } from "../utils/validate-external-url";
+import { safeFetch, SafeFetchError } from "../utils/validate-external-url";
+import { isStorageReadTooLarge } from "./read-errors";
 
-vi.mock("../utils/validate-external-url", () => ({
-  safeFetch: vi.fn(),
-}));
+vi.mock("../utils/validate-external-url", async importOriginal => {
+  /*
+   * Only `safeFetch` is faked. `SafeFetchError` stays REAL, because the code
+   * under test discriminates on it — a stubbed class would make the branch
+   * unreachable and these cases would describe a helper nobody ships.
+   */
+  const actual =
+    await importOriginal<typeof import("../utils/validate-external-url")>();
+  return { ...actual, safeFetch: vi.fn() };
+});
 
 const URL_ = "https://cdn.example.test/f.woff2";
 
@@ -67,6 +75,48 @@ describe("reading a stored object over HTTP", () => {
     );
     expect(outcome).toBeInstanceOf(NextlyError);
     expect((outcome as NextlyError).code).toBe("INTERNAL_ERROR");
+  });
+
+  it("translates safeFetch's over-cap refusal into the storage one", async () => {
+    /*
+     * Both routes must refuse in ONE vocabulary. `safeFetch` raises its own
+     * error with a `reason`, and S3 raises the SDK's — so a caller wanting to
+     * tell "too large" from "could not read" would otherwise have to know which
+     * adapter answered, which is the thing an adapter contract exists to stop.
+     *
+     * The email attachment path is the caller that acts on the difference: it
+     * answers this refusal with a size error the author can fix, and wraps
+     * anything else as an opaque storage failure.
+     */
+    vi.mocked(safeFetch).mockRejectedValueOnce(
+      new SafeFetchError("too large", URL_, "response-too-large")
+    );
+    const outcome = await fetchStoredBytes(URL_, "f.woff2", "Test", {
+      maxBytes: 10,
+    }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(true);
+  });
+
+  it("passes a NON-cap fetch failure through untranslated", async () => {
+    /*
+     * The control for the case above. Translating every `SafeFetchError` would
+     * report a timeout or a refused address as "your file is too big", which is
+     * a confident wrong diagnosis rather than a missing one.
+     */
+    vi.mocked(safeFetch).mockRejectedValueOnce(
+      new SafeFetchError("slow", URL_, "timeout")
+    );
+    const outcome = await fetchStoredBytes(URL_, "f.woff2", "Test", {
+      maxBytes: 10,
+    }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(false);
+    expect(outcome).toBeInstanceOf(SafeFetchError);
   });
 
   it("hands the caller's bounds down rather than imposing its own", async () => {

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -14,13 +14,21 @@ import { NextlyError } from "../errors/nextly-error";
 /**
  * Fetch a stored object's bytes from the URL its service issued.
  *
- * THROWS rather than returning `null` when the fetch fails, and that is the
- * whole reason this is a function rather than three lines inlined twice. A
- * caller's `read` folds "no such key" into `null`, which is an ordinary answer
- * about the store. A transport failure is not: reporting a dropped connection
- * as absence invites a caller to treat a live file as deleted and write a
- * replacement over it. Keeping the two apart is easy to state and easy to lose
- * when the fetch sits inside the same `try` that catches the lookup.
+ * Separates the two answers a read can have, which is the whole reason this is
+ * a function rather than three lines inlined twice.
+ *
+ * `null` means the object is NOT THERE — an ordinary fact about the store. A
+ * 404 is that answer even when the lookup just succeeded: these stores are
+ * remote and concurrent, so an object can be deleted between resolving its
+ * address and fetching it. Reporting that ordinary race as a server failure
+ * would make a caller handle an error for something its own contract already
+ * has a value for.
+ *
+ * Anything else THROWS. A dropped connection, a 5xx or a refused request says
+ * nothing about whether the object exists, and reporting it as absence invites
+ * a caller to treat a live file as deleted and write a replacement over it. The
+ * two are easy to state apart and easy to lose when the fetch sits inside the
+ * same `try` that catches the lookup.
  *
  * The URL is always one the SERVICE issued, never one assembled from a key.
  * These stores mint addresses carrying suffixes the adapter never chose, so a
@@ -29,14 +37,19 @@ import { NextlyError } from "../errors/nextly-error";
  * @param url - The address the storage service reported for this object
  * @param context - What is being read, for the error message: usually the key
  * @param label - The service's name, so a failure says which store answered
- * @returns The object's bytes
+ * @returns The object's bytes, or `null` when the store answers 404
  */
 export async function fetchStoredBytes(
   url: string,
   context: string,
   label: string
-): Promise<Buffer> {
+): Promise<Buffer | null> {
   const response = await fetch(url);
+  /*
+   * Checked BEFORE the general failure branch, because 404 is the one non-OK
+   * status that is an answer rather than a fault.
+   */
+  if (response.status === 404) return null;
   if (!response.ok) {
     /*
      * `internal` rather than a bare error, and the detail goes to the LOG side

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -22,6 +22,7 @@ import {
   safeFetch,
   SafeFetchError,
   DEFAULT_TIMEOUT_MS,
+  DEFAULT_MAX_RESPONSE_BYTES,
 } from "../utils/validate-external-url";
 
 import { StorageReadTooLargeError } from "./read-errors";
@@ -112,15 +113,13 @@ export async function fetchStoredBytes(
      * An unknown status does NOT translate. It means the failure arrived before
      * any status did, so nothing here can say the object was oversized.
      */
-    const oversizedObject =
-      error instanceof SafeFetchError &&
-      error.reason === "response-too-large" &&
-      error.status !== undefined &&
-      error.status >= 200 &&
-      error.status < 300;
-
-    if (oversizedObject && options?.maxBytes !== undefined) {
-      throw new StorageReadTooLargeError(context, options.maxBytes);
+    const verdict = classifyFetchFailure(error);
+    if (verdict === "absent") return null;
+    if (verdict === "oversized") {
+      throw new StorageReadTooLargeError(
+        context,
+        resolveReadBounds(options).maxBytes
+      );
     }
     throw error;
   }
@@ -149,8 +148,64 @@ export async function fetchStoredBytes(
   return Buffer.from(await response.arrayBuffer());
 }
 
+/**
+ * What a failed fetch actually says about the object.
+ *
+ * Its own function because the three answers are the whole point of this module
+ * and they are easy to collapse into each other — each collapse having been a
+ * real defect here rather than a hypothetical:
+ *
+ * - ABSENT. A 404 is absence whatever size its body was. `safeFetch` caps while
+ *   buffering, so a verbose CDN error page raises before a `Response` exists
+ *   and the status check further down is never reached; the object is still
+ *   gone, and must not become an error because the page explaining it was long.
+ * - OVERSIZED. Only a SUCCESSFUL response that blew the cap. A failed response
+ *   can exceed it too, and translating on the reason alone reported a backend
+ *   outage as "your file is too big" — a cause the author would act on, wrongly.
+ * - UNKNOWN. Everything else, including a too-large refusal carrying NO status:
+ *   that means the failure arrived before any status did, which says nothing
+ *   about whether the object was oversized.
+ */
+function classifyFetchFailure(
+  error: unknown
+): "absent" | "oversized" | "unknown" {
+  if (!(error instanceof SafeFetchError)) return "unknown";
+  if (error.status === 404) return "absent";
+  const successful =
+    error.status !== undefined && error.status >= 200 && error.status < 300;
+  return error.reason === "response-too-large" && successful
+    ? "oversized"
+    : "unknown";
+}
+
 /** The deadline a stored read runs under when the caller names none. */
 export const DEFAULT_READ_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
+
+/** The byte cap a stored read runs under when the caller names none. */
+export const DEFAULT_READ_MAX_BYTES = DEFAULT_MAX_RESPONSE_BYTES;
+
+/**
+ * The bounds a read actually runs under, defaults filled in.
+ *
+ * ONE place, because every adapter needs the same answer and the ones that
+ * derived it themselves diverged: the URL-backed pair inherited `safeFetch`'s
+ * cap and deadline for free, while the local and S3 adapters — which never
+ * touch `safeFetch` — applied NO bound at all when the caller named none.
+ * `StorageReadOptions` promises the default either way, and a production caller
+ * reading media without options got it from two of four backends.
+ *
+ * Filling the defaults here rather than per adapter is what makes the promise
+ * true by construction rather than by four implementations agreeing.
+ */
+export function resolveReadBounds(options?: StorageReadOptions): {
+  maxBytes: number;
+  timeoutMs: number;
+} {
+  return {
+    maxBytes: options?.maxBytes ?? DEFAULT_READ_MAX_BYTES,
+    timeoutMs: options?.timeoutMs ?? DEFAULT_READ_TIMEOUT_MS,
+  };
+}
 
 /**
  * Stop waiting on a promise once the deadline fires.

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -18,7 +18,11 @@
  * @module storage/fetch-stored-bytes
  */
 import { NextlyError } from "../errors/nextly-error";
-import { safeFetch, SafeFetchError } from "../utils/validate-external-url";
+import {
+  safeFetch,
+  SafeFetchError,
+  DEFAULT_TIMEOUT_MS,
+} from "../utils/validate-external-url";
 
 import { StorageReadTooLargeError } from "./read-errors";
 import type { StorageReadOptions } from "./types";
@@ -143,4 +147,41 @@ export async function fetchStoredBytes(
     });
   }
   return Buffer.from(await response.arrayBuffer());
+}
+
+/** The deadline a stored read runs under when the caller names none. */
+export const DEFAULT_READ_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
+
+/**
+ * Stop waiting on a promise once the deadline fires.
+ *
+ * For a lookup whose SDK cannot be cancelled. UploadThing 7.7.4's
+ * `getFileUrls` reads only `keyType` and forwards no signal, so handing it one
+ * bounds nothing — the option is accepted and ignored, which reads as covered
+ * and behaves as absent.
+ *
+ * This RACES rather than cancels, and the difference is worth stating plainly:
+ * the underlying request keeps running to completion in the background. What it
+ * buys is that `read` returns within the deadline it advertised, instead of
+ * holding its caller for as long as a stalled backend feels like. That is the
+ * promise the contract actually makes; genuinely cancelling the work needs an
+ * SDK that accepts cancellation, and this one does not.
+ */
+export async function withDeadline<T>(
+  work: Promise<T>,
+  signal: AbortSignal | undefined
+): Promise<T> {
+  if (signal === undefined) return await work;
+  return await Promise.race([
+    work,
+    new Promise<never>((_, reject) => {
+      if (signal.aborted) {
+        reject(signal.reason as Error);
+        return;
+      }
+      signal.addEventListener("abort", () => reject(signal.reason as Error), {
+        once: true,
+      });
+    }),
+  ]);
 }

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -18,8 +18,9 @@
  * @module storage/fetch-stored-bytes
  */
 import { NextlyError } from "../errors/nextly-error";
-import { safeFetch } from "../utils/validate-external-url";
+import { safeFetch, SafeFetchError } from "../utils/validate-external-url";
 
+import { StorageReadTooLargeError } from "./read-errors";
 import type { StorageReadOptions } from "./types";
 
 /**
@@ -64,14 +65,33 @@ export async function fetchStoredBytes(
    * caller with a configured limit of its own, such as the email attachment
    * path, hands its number down instead of being overridden by ours.
    */
-  const response = await safeFetch(url, {
-    ...(options?.maxBytes === undefined
-      ? {}
-      : { maxResponseBytes: options.maxBytes }),
-    ...(options?.timeoutMs === undefined
-      ? {}
-      : { timeoutMs: options.timeoutMs }),
-  });
+  let response: Response;
+  try {
+    response = await safeFetch(url, {
+      ...(options?.maxBytes === undefined
+        ? {}
+        : { maxResponseBytes: options.maxBytes }),
+      ...(options?.timeoutMs === undefined
+        ? {}
+        : { timeoutMs: options.timeoutMs }),
+    });
+  } catch (error: unknown) {
+    /*
+     * TRANSLATED, not passed through. `safeFetch` refuses an over-cap body in
+     * its own vocabulary, and S3 refuses in the SDK's — so a caller wanting to
+     * tell "too large" from "could not read" would have to know which adapter
+     * answered. The contract that introduced `maxBytes` owns what exceeding it
+     * looks like, so both routes raise the same refusal.
+     */
+    if (
+      error instanceof SafeFetchError &&
+      error.reason === "response-too-large" &&
+      options?.maxBytes !== undefined
+    ) {
+      throw new StorageReadTooLargeError(context, options.maxBytes);
+    }
+    throw error;
+  }
   /*
    * Checked BEFORE the general failure branch, because 404 is the one non-OK
    * status that is an answer rather than a fault.

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -7,9 +7,20 @@
  * way matters more than it looks: each step below is a place where the obvious
  * shortcut reports the wrong thing to a caller who may act on it.
  *
+ * Built on {@link safeFetch} rather than on a bare `fetch`, because "read a
+ * remote object into memory" already has an implementation here that caps the
+ * body, bounds the request and refuses an address that resolves somewhere
+ * private. A second capped fetch beside it would be two answers to one
+ * question, and the two would drift the first time either learned something.
+ * Measured: it costs an adapter package about 80K, against the 1MB the whole
+ * storage barrel costs.
+ *
  * @module storage/fetch-stored-bytes
  */
 import { NextlyError } from "../errors/nextly-error";
+import { safeFetch } from "../utils/validate-external-url";
+
+import type { StorageReadOptions } from "./types";
 
 /**
  * Fetch a stored object's bytes from the URL its service issued.
@@ -37,14 +48,30 @@ import { NextlyError } from "../errors/nextly-error";
  * @param url - The address the storage service reported for this object
  * @param context - What is being read, for the error message: usually the key
  * @param label - The service's name, so a failure says which store answered
+ * @param options - Bounds for the read; see {@link StorageReadOptions}
  * @returns The object's bytes, or `null` when the store answers 404
  */
 export async function fetchStoredBytes(
   url: string,
   context: string,
-  label: string
+  label: string,
+  options?: StorageReadOptions
 ): Promise<Buffer | null> {
-  const response = await fetch(url);
+  /*
+   * Bounds are PASSED THROUGH rather than defaulted here. `safeFetch` already
+   * holds the defaults — 10 MiB and 30 seconds — so restating them would put a
+   * second set of numbers in the tree that agree today and drift later. A
+   * caller with a configured limit of its own, such as the email attachment
+   * path, hands its number down instead of being overridden by ours.
+   */
+  const response = await safeFetch(url, {
+    ...(options?.maxBytes === undefined
+      ? {}
+      : { maxResponseBytes: options.maxBytes }),
+    ...(options?.timeoutMs === undefined
+      ? {}
+      : { timeoutMs: options.timeoutMs }),
+  });
   /*
    * Checked BEFORE the general failure branch, because 404 is the one non-OK
    * status that is an answer rather than a fault.

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -50,13 +50,15 @@ import type { StorageReadOptions } from "./types";
  * @param context - What is being read, for the error message: usually the key
  * @param label - The service's name, so a failure says which store answered
  * @param options - Bounds for the read; see {@link StorageReadOptions}
+ * @param signal - A deadline ALREADY RUNNING, covering an earlier phase too
  * @returns The object's bytes, or `null` when the store answers 404
  */
 export async function fetchStoredBytes(
   url: string,
   context: string,
   label: string,
-  options?: StorageReadOptions
+  options?: StorageReadOptions,
+  signal?: AbortSignal
 ): Promise<Buffer | null> {
   /*
    * Bounds are PASSED THROUGH rather than defaulted here. `safeFetch` already
@@ -71,9 +73,20 @@ export async function fetchStoredBytes(
       ...(options?.maxBytes === undefined
         ? {}
         : { maxResponseBytes: options.maxBytes }),
-      ...(options?.timeoutMs === undefined
-        ? {}
-        : { timeoutMs: options.timeoutMs }),
+      /*
+       * A caller's signal REPLACES the deadline rather than joining it.
+       *
+       * These adapters look the object's address up before fetching it, and
+       * that lookup can stall too. Starting a fresh timer here would give the
+       * fetch its own full budget on top of however long the lookup took, so a
+       * read could outlive the deadline the caller was told applied — by
+       * roughly double. One signal begun before the lookup governs both phases.
+       */
+      ...(signal !== undefined
+        ? { signal }
+        : options?.timeoutMs === undefined
+          ? {}
+          : { timeoutMs: options.timeoutMs }),
     });
   } catch (error: unknown) {
     /*
@@ -83,11 +96,26 @@ export async function fetchStoredBytes(
      * answered. The contract that introduced `maxBytes` owns what exceeding it
      * looks like, so both routes raise the same refusal.
      */
-    if (
+    /*
+     * Only an oversized SUCCESSFUL response is an over-cap read.
+     *
+     * A body can exceed the cap on a failed response too — a 500 page, an error
+     * document — and `safeFetch` refuses while buffering, before this code ever
+     * sees a status. Translating on the reason alone therefore reported a
+     * backend outage as "your file is too big", which is worse than an opaque
+     * failure: it names a cause the author would act on, wrongly.
+     *
+     * An unknown status does NOT translate. It means the failure arrived before
+     * any status did, so nothing here can say the object was oversized.
+     */
+    const oversizedObject =
       error instanceof SafeFetchError &&
       error.reason === "response-too-large" &&
-      options?.maxBytes !== undefined
-    ) {
+      error.status !== undefined &&
+      error.status >= 200 &&
+      error.status < 300;
+
+    if (oversizedObject && options?.maxBytes !== undefined) {
       throw new StorageReadTooLargeError(context, options.maxBytes);
     }
     throw error;

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -1,0 +1,58 @@
+/**
+ * Reading bytes back from a storage service that only exposes them over HTTP.
+ *
+ * The local adapter reads from disk and S3 reads through its own SDK, so
+ * neither needs this. The services that address a file by URL — Vercel Blob,
+ * UploadThing — all end up doing the same three things, and doing them the same
+ * way matters more than it looks: each step below is a place where the obvious
+ * shortcut reports the wrong thing to a caller who may act on it.
+ *
+ * @module storage/fetch-stored-bytes
+ */
+import { NextlyError } from "../errors/nextly-error";
+
+/**
+ * Fetch a stored object's bytes from the URL its service issued.
+ *
+ * THROWS rather than returning `null` when the fetch fails, and that is the
+ * whole reason this is a function rather than three lines inlined twice. A
+ * caller's `read` folds "no such key" into `null`, which is an ordinary answer
+ * about the store. A transport failure is not: reporting a dropped connection
+ * as absence invites a caller to treat a live file as deleted and write a
+ * replacement over it. Keeping the two apart is easy to state and easy to lose
+ * when the fetch sits inside the same `try` that catches the lookup.
+ *
+ * The URL is always one the SERVICE issued, never one assembled from a key.
+ * These stores mint addresses carrying suffixes the adapter never chose, so a
+ * derived URL is a guess at a string another system owns.
+ *
+ * @param url - The address the storage service reported for this object
+ * @param context - What is being read, for the error message: usually the key
+ * @param label - The service's name, so a failure says which store answered
+ * @returns The object's bytes
+ */
+export async function fetchStoredBytes(
+  url: string,
+  context: string,
+  label: string
+): Promise<Buffer> {
+  const response = await fetch(url);
+  if (!response.ok) {
+    /*
+     * `internal` rather than a bare error, and the detail goes to the LOG side
+     * rather than the public message. A storage backend answering non-OK is not
+     * something the caller can fix by changing their request, so the public
+     * text stays generic — and the key, status and service name are exactly the
+     * things that should not travel to whoever asked for the file.
+     */
+    throw NextlyError.internal({
+      logContext: {
+        service: label,
+        path: context,
+        status: response.status,
+        statusText: response.statusText,
+      },
+    });
+  }
+  return Buffer.from(await response.arrayBuffer());
+}

--- a/packages/nextly/src/storage/index.ts
+++ b/packages/nextly/src/storage/index.ts
@@ -127,6 +127,7 @@ export type {
 // ============================================================
 
 export { fetchStoredBytes } from "./fetch-stored-bytes";
+export type { StorageReadOptions } from "./types";
 export { isTransientError, withRetry, createRetryable } from "./retry";
 
 export type { RetryOptions } from "./retry";

--- a/packages/nextly/src/storage/index.ts
+++ b/packages/nextly/src/storage/index.ts
@@ -127,6 +127,7 @@ export type {
 // ============================================================
 
 export { fetchStoredBytes } from "./fetch-stored-bytes";
+export { StorageReadTooLargeError, isStorageReadTooLarge } from "./read-errors";
 export type { StorageReadOptions } from "./types";
 export { isTransientError, withRetry, createRetryable } from "./retry";
 

--- a/packages/nextly/src/storage/index.ts
+++ b/packages/nextly/src/storage/index.ts
@@ -126,6 +126,7 @@ export type {
 // Retry Utilities
 // ============================================================
 
+export { fetchStoredBytes } from "./fetch-stored-bytes";
 export { isTransientError, withRetry, createRetryable } from "./retry";
 
 export type { RetryOptions } from "./retry";

--- a/packages/nextly/src/storage/read-errors.test.ts
+++ b/packages/nextly/src/storage/read-errors.test.ts
@@ -1,0 +1,64 @@
+/**
+ * That the over-cap refusal is a CANONICAL error, not a free-form string.
+ *
+ * `NextlyError` accepts any code, so an unregistered one compiles, constructs
+ * and reads correctly at every call site — and then falls back to HTTP 500 if
+ * it ever escapes to a response, turning a 413 the caller could act on into an
+ * opaque server error. Measured: deleting the registration produces ZERO
+ * typecheck errors, so nothing but this file notices.
+ *
+ * Asserted through the STATUS the class actually carries rather than by looking
+ * the literal up in the table. A test that checked the table would be comparing
+ * one literal against another; this fails for the reason the registration
+ * exists, which is the only reason it is worth having.
+ *
+ * @module storage/read-errors.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { NEXTLY_ERROR_STATUS } from "../errors/error-codes";
+import { isStorageReadTooLarge, StorageReadTooLargeError } from "./read-errors";
+
+describe("the over-cap refusal", () => {
+  it("carries 413, which it can only get from the canonical table", () => {
+    const error = new StorageReadTooLargeError("media/big.pdf", 100, 900);
+    expect(error.statusCode).toBe(413);
+    // Not 500: the fallback an unregistered code silently receives, and the
+    // outcome this registration exists to prevent.
+    expect(error.statusCode).not.toBe(500);
+  });
+
+  it("is registered under its own code rather than borrowing another", () => {
+    /*
+     * `SIZE_EXCEEDED` is also 413 and was the tempting reuse. It refuses an
+     * upload the caller is SENDING; this refuses to buffer an object already
+     * stored. Kept apart because `isStorageReadTooLarge` keys on the code — one
+     * shared code would make the predicate match upload-validation failures
+     * too, and the attachment path would answer them with the wrong sentence.
+     */
+    expect(NEXTLY_ERROR_STATUS.STORAGE_READ_TOO_LARGE).toBe(413);
+    expect(new StorageReadTooLargeError("p", 1).code).toBe(
+      "STORAGE_READ_TOO_LARGE"
+    );
+  });
+
+  it("keeps the numbers where a caller can read them", () => {
+    // The cap and the size travel as fields, so a caller can say what the limit
+    // was without parsing prose — and the path stays out of the public message.
+    const error = new StorageReadTooLargeError("media/big.pdf", 100, 900);
+    expect(error.maxBytes).toBe(100);
+    expect(error.size).toBe(900);
+    expect(error.publicMessage).not.toContain("media/big.pdf");
+  });
+
+  it("recognises its own instances and nothing else", () => {
+    expect(isStorageReadTooLarge(new StorageReadTooLargeError("p", 1))).toBe(
+      true
+    );
+    // The control: a predicate returning true for everything would satisfy the
+    // positive case while telling the attachment path that every failure is a
+    // size problem.
+    expect(isStorageReadTooLarge(new Error("nope"))).toBe(false);
+    expect(isStorageReadTooLarge("nope")).toBe(false);
+  });
+});

--- a/packages/nextly/src/storage/read-errors.ts
+++ b/packages/nextly/src/storage/read-errors.ts
@@ -1,0 +1,64 @@
+/**
+ * The one way the storage layer says a read exceeded the caller's cap.
+ *
+ * `StorageReadOptions.maxBytes` is part of the adapter contract, so what happens
+ * when it is exceeded belongs to the contract too. Without this each backend
+ * refuses in its own vocabulary — the URL-addressed ones through a fetch error
+ * carrying a `reason`, S3 through whatever its own code threw — and a caller
+ * wanting to tell "too large" from "could not read" has to know which adapter it
+ * is talking to. That is the thing an adapter contract exists to stop.
+ *
+ * Distinct from a generic internal failure because callers ACT on the
+ * difference. The email attachment path answers an over-cap read with
+ * `ATTACHMENT_SIZE_EXCEEDED`, which tells an author to attach something smaller;
+ * a storage failure tells them nothing they can act on. Collapsing the two turns
+ * a fixable refusal into an opaque error, which is the same conflation this
+ * contract already draws between a missing key and an unreachable store.
+ *
+ * @module storage/read-errors
+ */
+import { NextlyError } from "../errors/nextly-error";
+
+/**
+ * A read refused because the object is larger than the caller allowed.
+ *
+ * Carries the numbers rather than only a message, so a caller can say what the
+ * limit was without parsing prose — and so the message itself stays free of the
+ * key, which should not travel to whoever asked for the file.
+ */
+export class StorageReadTooLargeError extends NextlyError {
+  constructor(
+    /** What was being read, for the log side only. */
+    public readonly path: string,
+    /** The cap the caller set, in bytes. */
+    public readonly maxBytes: number,
+    /** What the store reported, where it reported anything. */
+    public readonly size?: number
+  ) {
+    super({
+      code: "STORAGE_READ_TOO_LARGE",
+      publicMessage: "The stored file is larger than the limit for this read.",
+      logContext: {
+        path,
+        maxBytes,
+        ...(size === undefined ? {} : { size }),
+      },
+    });
+  }
+}
+
+/**
+ * Whether a thrown value is the over-cap refusal.
+ *
+ * A predicate rather than leaving every caller to write `instanceof`, because
+ * this module can be loaded twice — a narrow entry point and a barrel are
+ * different module instances, and `instanceof` across them is false for objects
+ * that are otherwise identical. Callers that ask here cannot be caught by that.
+ */
+export function isStorageReadTooLarge(
+  error: unknown
+): error is StorageReadTooLargeError {
+  // `NextlyError.is` already narrows, so no cast: an assertion here would be
+  // one the checker cannot use and a reader would take as load-bearing.
+  return NextlyError.is(error) && error.code === "STORAGE_READ_TOO_LARGE";
+}

--- a/packages/nextly/src/storage/types.ts
+++ b/packages/nextly/src/storage/types.ts
@@ -99,6 +99,27 @@ export type StorageType = "s3" | "vercel-blob" | "local" | "uploadthing";
  * Information about a storage adapter's capabilities.
  * Returned by adapter.getInfo() method.
  */
+/**
+ * Bounds for a read that pulls an object into memory.
+ *
+ * Reading a stored object means BUFFERING it, so its size is the caller's
+ * problem whether or not the caller says so. Left unbounded, a large object
+ * consumes as much process memory as it happens to occupy, and a stalled
+ * backend holds the request until something further out gives up.
+ *
+ * OPTIONAL, with the defaults living in the fetch layer rather than being
+ * restated per adapter — a second set of numbers agrees today and drifts. What
+ * this type exists for is the caller that already knows its own limit: the
+ * email attachment path caps a read at the configured attachment size, so an
+ * oversized object fails as a size error rather than after it has been read.
+ */
+export interface StorageReadOptions {
+  /** Refuse once this many bytes have arrived. Defaults to the fetch cap. */
+  maxBytes?: number;
+  /** Give up after this long. Defaults to the fetch deadline. */
+  timeoutMs?: number;
+}
+
 export interface StorageAdapterInfo {
   /** Storage type identifier */
   type: StorageType;
@@ -290,7 +311,7 @@ export interface IStorageAdapter {
   getType(): string;
 
   /** Read file contents from storage (optional - not all adapters support this) */
-  read?(filePath: string): Promise<Buffer | null>;
+  read?(filePath: string, options?: StorageReadOptions): Promise<Buffer | null>;
 
   /** Get adapter info including capabilities (optional but recommended) */
   getInfo?(): StorageAdapterInfo;

--- a/packages/nextly/src/utils/validate-external-url.test.ts
+++ b/packages/nextly/src/utils/validate-external-url.test.ts
@@ -240,6 +240,15 @@ describe("safeFetch", () => {
     ).rejects.toMatchObject({
       name: "SafeFetchError",
       reason: "response-too-large",
+      /*
+       * The STATUS travels with it, and this is the real path rather than a
+       * hand-built error. A compressed body can fit the cap on the wire and
+       * exceed it decoded — a genuine oversized object on a genuine 2xx — and a
+       * caller that classifies "too large" only when it can see a successful
+       * status would otherwise treat this one as unclassifiable and report a
+       * storage failure instead of a size one.
+       */
+      status: 200,
     });
   });
 

--- a/packages/nextly/src/utils/validate-external-url.ts
+++ b/packages/nextly/src/utils/validate-external-url.ts
@@ -238,7 +238,15 @@ export async function validateExternalUrl(
 /** Default response body cap: reject anything larger before buffering it all. */
 const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024; // 10 MiB
 /** Default overall deadline covering DNS + connect + TLS + response. */
-const DEFAULT_TIMEOUT_MS = 30_000;
+/**
+ * How long a bounded external read may take, absent a caller's own limit.
+ *
+ * Exported so a caller that must begin the clock EARLIER — a storage adapter
+ * bounding a metadata lookup as well as the fetch that follows — uses this
+ * number rather than restating it. Two spellings of one default agree today and
+ * drift the first time either is tuned.
+ */
+export const DEFAULT_TIMEOUT_MS = 30_000;
 
 export interface SafeFetchOptions extends ValidateExternalUrlOptions {
   /** HTTP method. Defaults to GET. */
@@ -506,7 +514,8 @@ async function pinnedFetch(
             res.headers["content-encoding"],
             zlib,
             init.maxResponseBytes,
-            url.href
+            url.href,
+            res.statusCode
           );
           if (decoded instanceof SafeFetchError) {
             settle(() => reject(decoded));
@@ -632,7 +641,15 @@ function decodeBody(
   encoding: string | undefined,
   zlib: ZlibSyncApi,
   cap: number,
-  url: string
+  url: string,
+  /*
+   * The status the response arrived with, so a refusal raised HERE carries it
+   * exactly as one raised while streaming does. A compressed body can fit the
+   * cap on the wire and exceed it decoded, and that is a real oversized object
+   * on a real 2xx — a caller told no status would treat it as an unclassifiable
+   * failure and report a storage error rather than a size one.
+   */
+  status?: number
 ): { body: Buffer; decoded: boolean } | SafeFetchError {
   if (!encoding) return { body: buf, decoded: false };
   // An empty body has nothing to decode; inflating zero bytes would throw and
@@ -677,7 +694,8 @@ function decodeBody(
           return new SafeFetchError(
             `Cannot fully decode content-encoding "${encoding}"`,
             url,
-            "decode-failed"
+            "decode-failed",
+            status
           );
         }
         return { body: buf, decoded: false };
@@ -696,7 +714,8 @@ function decodeBody(
         ? `Decoded ${encoding} response body exceeded the size cap`
         : `Failed to decode ${encoding} response body`,
       url,
-      tooLarge ? "response-too-large" : "decode-failed"
+      tooLarge ? "response-too-large" : "decode-failed",
+      status
     );
   }
 }

--- a/packages/nextly/src/utils/validate-external-url.ts
+++ b/packages/nextly/src/utils/validate-external-url.ts
@@ -236,7 +236,14 @@ export async function validateExternalUrl(
 }
 
 /** Default response body cap: reject anything larger before buffering it all. */
-const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024; // 10 MiB
+/**
+ * How many bytes a bounded external read may buffer, absent a caller's own cap.
+ *
+ * Exported for the same reason as the deadline below: an adapter that never
+ * touches `safeFetch` still owes callers this default, and restating the number
+ * gives the tree two that drift.
+ */
+export const DEFAULT_MAX_RESPONSE_BYTES = 10 * 1024 * 1024; // 10 MiB
 /** Default overall deadline covering DNS + connect + TLS + response. */
 /**
  * How long a bounded external read may take, absent a caller's own limit.

--- a/packages/nextly/src/utils/validate-external-url.ts
+++ b/packages/nextly/src/utils/validate-external-url.ts
@@ -267,7 +267,20 @@ export class SafeFetchError extends NextlyError {
     message: string,
     public readonly url: string,
     /** Discriminates the failure so callers branch without string-matching. */
-    public readonly reason: "response-too-large" | "timeout" | "decode-failed"
+    public readonly reason: "response-too-large" | "timeout" | "decode-failed",
+    /**
+     * The status the server sent, where one arrived before the failure.
+     *
+     * A body can exceed the cap on a FAILED response — a 500 page, an error
+     * document — and the reason alone cannot separate that from an oversized
+     * object. A caller translating "too large" into a size refusal would then
+     * report a backend outage as the user's file being too big, which is a
+     * confident wrong diagnosis rather than a missing one.
+     *
+     * `undefined` where the failure happened before any status arrived, such as
+     * a timeout, so absence means "not known" rather than "not a failure".
+     */
+    public readonly status?: number
   ) {
     super({
       code: "EXTERNAL_REQUEST_FAILED",
@@ -478,7 +491,8 @@ async function pinnedFetch(
                 new SafeFetchError(
                   `Response body exceeded ${init.maxResponseBytes} bytes`,
                   url.href,
-                  "response-too-large"
+                  "response-too-large",
+                  res.statusCode
                 )
               )
             );

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -96,6 +96,14 @@ const clientEntries = [
   // server reads it with. Imported by the admin's API Playground and by plugin
   // admin components, which is why it is a leaf rather than a root export.
   "src/query/index.ts",
+  // The one helper an out-of-tree storage adapter needs, as its OWN entry.
+  //
+  // Reaching it through `nextly/storage` instead makes a bundler traverse that
+  // whole barrel — the local adapter and its `fs/promises` and `path`, the
+  // env-config and its dotenv chunks — into a package that depends on neither.
+  // Measured on `@nextlyhq/storage-vercel-blob`: 240K over 6 files became 1.3M
+  // over 16 the moment the barrel import landed, and every install pays it.
+  "src/storage/fetch-stored-bytes.ts",
 ];
 
 // Shared config options

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -104,6 +104,9 @@ const clientEntries = [
   // Measured on `@nextlyhq/storage-vercel-blob`: 240K over 6 files became 1.3M
   // over 16 the moment the barrel import landed, and every install pays it.
   "src/storage/fetch-stored-bytes.ts",
+  // The over-cap refusal, reachable by an adapter without the barrel for the
+  // same reason as the helper above.
+  "src/storage/read-errors.ts",
 ];
 
 // Shared config options

--- a/packages/storage-s3/src/adapter.test.ts
+++ b/packages/storage-s3/src/adapter.test.ts
@@ -1,0 +1,156 @@
+/**
+ * What `read` means when the bucket answers, and when it does not.
+ *
+ * The first tests in this package. `read` is where that matters most: it is the
+ * one method whose contract is a DISTINCTION — a key that is absent answers
+ * `null`, a backend that cannot answer throws — and a distinction is exactly
+ * what goes wrong silently, because both outcomes look like an ordinary result
+ * at the call site.
+ *
+ * @module adapter.test
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { S3Client } from "@aws-sdk/client-s3";
+
+import { S3StorageAdapter } from "./adapter";
+
+vi.mock("@aws-sdk/client-s3", () => {
+  class S3Client {
+    send = vi.fn();
+  }
+  /*
+   * The commands are inert carriers here: the adapter builds one and hands it
+   * to `send`, and every assertion below is about what `send` answers. Faking
+   * them as plain objects keeps the test about the adapter's branching rather
+   * than about the SDK's request shapes.
+   */
+  return {
+    S3Client,
+    GetObjectCommand: class {},
+    HeadObjectCommand: class {},
+    PutObjectCommand: class {},
+    DeleteObjectCommand: class {},
+    DeleteObjectsCommand: class {},
+  };
+});
+vi.mock("@aws-sdk/lib-storage", () => ({ Upload: class {} }));
+vi.mock("@aws-sdk/s3-request-presigner", () => ({ getSignedUrl: vi.fn() }));
+
+/** A `send` that behaves however a case needs, reachable from the assertions. */
+function adapterWithSend(): {
+  adapter: S3StorageAdapter;
+  send: ReturnType<typeof vi.fn>;
+} {
+  const adapter = new S3StorageAdapter({
+    bucket: "test-bucket",
+    region: "us-east-1",
+  });
+  // The client the adapter built for itself, so the stub is the one it uses.
+  const send = (adapter as unknown as { client: { send: typeof vi.fn } }).client
+    .send as unknown as ReturnType<typeof vi.fn>;
+  return { adapter, send };
+}
+
+/** A `GetObject` response body, in the shape the SDK's stream exposes. */
+function body(bytes: string): {
+  transformToByteArray: () => Promise<Uint8Array>;
+} {
+  return {
+    transformToByteArray: async () => new TextEncoder().encode(bytes),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("S3StorageAdapter.read", () => {
+  it("returns the object's bytes", async () => {
+    const { adapter, send } = adapterWithSend();
+    send.mockResolvedValueOnce({ Body: body("hello"), ContentLength: 5 });
+    expect((await adapter.read("f.woff2"))?.toString("utf8")).toBe("hello");
+  });
+
+  it("answers null for a key that is not in the bucket", async () => {
+    /*
+     * ITS CONTROL IS "returns the object's bytes" ABOVE. On its own this case
+     * is satisfied by a `read` that answers `null` for every input, so the
+     * positive case is what makes this `null` mean "absent" rather than "this
+     * method never answers". Declared rather than left to adjacency.
+     */
+    const { adapter, send } = adapterWithSend();
+    const missing = Object.assign(new Error("Not Found"), {
+      name: "NotFound",
+      $metadata: { httpStatusCode: 404 },
+    });
+    send.mockRejectedValueOnce(missing);
+    expect(await adapter.read("gone.woff2")).toBeNull();
+  });
+
+  it("THROWS when the BUCKET is missing, rather than reporting the key absent", async () => {
+    /*
+     * The distinction the case above cannot make, and the reason `read` does
+     * not simply reuse the adapter's existing not-found predicate: that
+     * predicate treats ANY 404 as a missing object, and `NoSuchBucket` is a
+     * 404. A deleted, renamed or mistyped bucket would therefore report every
+     * key in it as absent — a configuration failure wearing the costume of an
+     * ordinary miss, which is the confusion this method exists to prevent.
+     */
+    const { adapter, send } = adapterWithSend();
+    const noBucket = Object.assign(new Error("The bucket does not exist"), {
+      name: "NoSuchBucket",
+      $metadata: { httpStatusCode: 404 },
+    });
+    send.mockRejectedValueOnce(noBucket);
+
+    const outcome = await adapter.read("f.woff2").then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBe(noBucket);
+    expect(outcome).not.toBeNull();
+  });
+
+  it("refuses an object larger than the caller's cap BEFORE downloading it", async () => {
+    /*
+     * Asserted on the reported length rather than on the body, because the
+     * point is that the body is never pulled: `transformToByteArray` buffers
+     * the whole object, so a cap enforced afterwards has already paid the cost
+     * it exists to avoid. The email attachment path is the caller that has a
+     * configured limit of its own.
+     */
+    const { adapter, send } = adapterWithSend();
+    const stream = body("x".repeat(50));
+    const spy = vi.spyOn(stream, "transformToByteArray");
+    send.mockResolvedValueOnce({ Body: stream, ContentLength: 50 });
+
+    await expect(adapter.read("big.woff2", { maxBytes: 10 })).rejects.toThrow();
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it("reads an object that fits under the cap", async () => {
+    // The control for the case above: without it, a `read` that refused every
+    // bounded call would satisfy the refusal assertion perfectly.
+    const { adapter, send } = adapterWithSend();
+    send.mockResolvedValueOnce({ Body: body("small"), ContentLength: 5 });
+    expect(
+      (await adapter.read("ok.woff2", { maxBytes: 10 }))?.toString("utf8")
+    ).toBe("small");
+  });
+
+  it("answers an empty buffer for a zero-byte object, not null", async () => {
+    /*
+     * A stored empty file is not a missing one. Collapsing them would let a
+     * caller cleaning up "missing" keys delete a real object.
+     */
+    const { adapter, send } = adapterWithSend();
+    send.mockResolvedValueOnce({ Body: undefined, ContentLength: 0 });
+    const bytes = await adapter.read("empty.bin");
+    expect(bytes).not.toBeNull();
+    expect(bytes?.length).toBe(0);
+  });
+});
+
+// The mocked client class, referenced so the import is not flagged as unused.
+void S3Client;

--- a/packages/storage-s3/src/adapter.test.ts
+++ b/packages/storage-s3/src/adapter.test.ts
@@ -57,12 +57,30 @@ function adapterWithSend(): {
   return { adapter, send };
 }
 
-/** A `GetObject` response body, in the shape the SDK's stream exposes. */
-function body(bytes: string): {
+/**
+ * A `GetObject` body in the shape the Node SDK exposes: async-iterable, and
+ * also able to buffer itself.
+ *
+ * Iterable because that is the path the adapter takes — it counts bytes as they
+ * arrive rather than trusting `ContentLength`, which compatible services may
+ * omit or misreport. `transformToByteArray` stays on it so the non-iterable
+ * fallback can be exercised by a body that omits the iterator.
+ */
+function body(
+  bytes: string,
+  chunkSize = 1024
+): {
   transformToByteArray: () => Promise<Uint8Array>;
+  [Symbol.asyncIterator]: () => AsyncGenerator<Uint8Array>;
 } {
+  const encoded = new TextEncoder().encode(bytes);
   return {
-    transformToByteArray: async () => new TextEncoder().encode(bytes),
+    transformToByteArray: async () => encoded,
+    async *[Symbol.asyncIterator]() {
+      for (let at = 0; at < encoded.length; at += chunkSize) {
+        yield encoded.subarray(at, at + chunkSize);
+      }
+    },
   };
 }
 
@@ -180,16 +198,54 @@ describe("S3StorageAdapter.read", () => {
     expect(options?.abortSignal).toBeInstanceOf(AbortSignal);
   });
 
-  it("attaches no signal when the caller named no deadline", async () => {
-    // The control for the case above: a `read` that always attached a signal
-    // would satisfy it while ignoring what the caller actually asked for.
+  it("still bounds the read when the caller named NO deadline", async () => {
+    /*
+     * This case previously asserted the opposite and so locked the defect in.
+     * `StorageReadOptions` promises the deadline whether or not a caller names
+     * one, and the URL-backed adapters keep that promise by inheriting
+     * `safeFetch`'s — while this one, reached by the media pipeline with no
+     * options at all, had none.
+     */
     const { adapter, send } = adapterWithSend();
     send.mockResolvedValueOnce({ Body: body("x"), ContentLength: 1 });
     await adapter.read("f.woff2");
     const options = send.mock.calls[0]?.[1] as
       | { abortSignal?: AbortSignal }
       | undefined;
-    expect(options?.abortSignal).toBeUndefined();
+    expect(options?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("REFUSES an oversized body when the store reported no length at all", async () => {
+    /*
+     * `ContentLength` is optional in the SDK response, and MinIO/R2 and other
+     * compatible services may omit it or report it wrongly — so a preflight
+     * check against metadata fails OPEN exactly where an unusual backend is
+     * involved. The cap is counted against bytes that actually arrive.
+     */
+    const { adapter, send } = adapterWithSend();
+    send.mockResolvedValueOnce({ Body: body("x".repeat(500), 100) });
+
+    const outcome = await adapter.read("big.bin", { maxBytes: 150 }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(true);
+  });
+
+  it("REFUSES a body larger than a LYING ContentLength", async () => {
+    // The sharper half: metadata that is present but wrong passes the
+    // preflight, so only counting what arrives can catch it.
+    const { adapter, send } = adapterWithSend();
+    send.mockResolvedValueOnce({
+      Body: body("x".repeat(500), 100),
+      ContentLength: 5,
+    });
+
+    const outcome = await adapter.read("liar.bin", { maxBytes: 150 }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(true);
   });
 
   it("answers an empty buffer for a zero-byte object, not null", async () => {

--- a/packages/storage-s3/src/adapter.test.ts
+++ b/packages/storage-s3/src/adapter.test.ts
@@ -13,6 +13,11 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { S3Client } from "@aws-sdk/client-s3";
 
+import {
+  isStorageReadTooLarge,
+  StorageReadTooLargeError,
+} from "nextly/storage/read-errors";
+
 import { S3StorageAdapter } from "./adapter";
 
 vi.mock("@aws-sdk/client-s3", () => {
@@ -125,7 +130,21 @@ describe("S3StorageAdapter.read", () => {
     const spy = vi.spyOn(stream, "transformToByteArray");
     send.mockResolvedValueOnce({ Body: stream, ContentLength: 50 });
 
-    await expect(adapter.read("big.woff2", { maxBytes: 10 })).rejects.toThrow();
+    /*
+     * Asserted on the REFUSAL'S IDENTITY, not merely that something threw.
+     * `rejects.toThrow()` alone is satisfied by any failure, so it cannot tell
+     * the intended over-cap refusal from a generic internal error — and the
+     * difference is load-bearing: the email attachment path answers this one
+     * with a size error the author can act on, and wraps anything else as an
+     * opaque storage failure.
+     */
+    const outcome = await adapter.read("big.woff2", { maxBytes: 10 }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(true);
+    expect((outcome as StorageReadTooLargeError).maxBytes).toBe(10);
+    expect((outcome as StorageReadTooLargeError).size).toBe(50);
     expect(spy).not.toHaveBeenCalled();
   });
 
@@ -137,6 +156,40 @@ describe("S3StorageAdapter.read", () => {
     expect(
       (await adapter.read("ok.woff2", { maxBytes: 10 }))?.toString("utf8")
     ).toBe("small");
+  });
+
+  it("hands the caller's deadline to the SDK rather than ignoring it", async () => {
+    /*
+     * `StorageReadOptions` promises a bound and the URL-backed adapters keep it
+     * by forwarding `timeoutMs` to `safeFetch`. Read through the SDK there is
+     * no fetch to hand it to, so without this the same option is advertised and
+     * inert — the worst kind, one that validates and then does nothing, leaving
+     * a stalled bucket holding the read past a deadline the caller was told
+     * applied.
+     *
+     * Asserted on what `send` RECEIVED, because the resolved value is identical
+     * whether or not a signal was attached, which is exactly how this regresses
+     * unnoticed.
+     */
+    const { adapter, send } = adapterWithSend();
+    send.mockResolvedValueOnce({ Body: body("x"), ContentLength: 1 });
+    await adapter.read("f.woff2", { timeoutMs: 1234 });
+    const options = send.mock.calls[0]?.[1] as
+      | { abortSignal?: AbortSignal }
+      | undefined;
+    expect(options?.abortSignal).toBeInstanceOf(AbortSignal);
+  });
+
+  it("attaches no signal when the caller named no deadline", async () => {
+    // The control for the case above: a `read` that always attached a signal
+    // would satisfy it while ignoring what the caller actually asked for.
+    const { adapter, send } = adapterWithSend();
+    send.mockResolvedValueOnce({ Body: body("x"), ContentLength: 1 });
+    await adapter.read("f.woff2");
+    const options = send.mock.calls[0]?.[1] as
+      | { abortSignal?: AbortSignal }
+      | undefined;
+    expect(options?.abortSignal).toBeUndefined();
   });
 
   it("answers an empty buffer for a zero-byte object, not null", async () => {

--- a/packages/storage-s3/src/adapter.ts
+++ b/packages/storage-s3/src/adapter.ts
@@ -62,7 +62,9 @@ import {
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import { NextlyError } from "nextly/errors";
 import type {
+  StorageReadOptions,
   IStorageAdapter,
   UploadOptions,
   UploadResult,
@@ -436,7 +438,10 @@ export class S3StorageAdapter implements IStorageAdapter {
    * @param filePath - Storage path/key
    * @returns The object's bytes, or `null` when no such key exists
    */
-  async read(filePath: string): Promise<Buffer | null> {
+  async read(
+    filePath: string,
+    options?: StorageReadOptions
+  ): Promise<Buffer | null> {
     try {
       const command = new GetObjectCommand({
         Bucket: this.resolvedConfig.bucket,
@@ -451,8 +456,26 @@ export class S3StorageAdapter implements IStorageAdapter {
        * and a caller deleting "missing" keys would then delete a real one.
        */
       if (response.Body === undefined) return Buffer.alloc(0);
+
+      /*
+       * Refused on the LENGTH the store reports, before the body is pulled
+       * down. `transformToByteArray` buffers the whole object, so a caller that
+       * knows its own limit has to be able to stop an oversized read rather
+       * than discover the size after paying for it — which is what an
+       * attachment path does when it checks a size only after buffering.
+       */
+      this.refuseOverCap(filePath, response.ContentLength, options?.maxBytes);
       return Buffer.from(await response.Body.transformToByteArray());
     } catch (error: unknown) {
+      /*
+       * Only an OBJECT-level absence becomes `null`. `isNotFoundError` treats
+       * any 404 as missing, and `NoSuchBucket` is a 404 — so a bucket that was
+       * deleted, renamed or mistyped would report every key in it as absent,
+       * which is the configuration failure this method's contract exists to
+       * tell apart from an ordinary miss. Named explicitly rather than by
+       * status, because the status cannot separate them.
+       */
+      if (error instanceof Error && error.name === "NoSuchBucket") throw error;
       if (this.isNotFoundError(error)) {
         return null;
       }
@@ -571,6 +594,36 @@ export class S3StorageAdapter implements IStorageAdapter {
    * @param error - Error to check
    * @returns true if error indicates file not found
    */
+  /**
+   * Refuse a read whose object is already known to exceed the caller's cap.
+   *
+   * Its own method rather than three conditions inside `read`, because the
+   * decision has nothing to do with the surrounding error handling and reads
+   * as noise there — and because `read`'s branching is the part a reviewer has
+   * to hold in their head to check the absent-versus-unavailable distinction.
+   *
+   * Both `undefined` cases mean "no opinion" and pass: a caller that named no
+   * cap has none, and a store that reported no length gives nothing to compare.
+   * The second is deliberately permissive — refusing an unmeasured object would
+   * reject valid reads whenever S3 omits the header.
+   */
+  private refuseOverCap(
+    filePath: string,
+    declared: number | undefined,
+    cap: number | undefined
+  ): void {
+    if (cap === undefined || declared === undefined || declared <= cap) return;
+    throw NextlyError.internal({
+      logContext: {
+        service: "S3",
+        path: filePath,
+        reason: "response-too-large",
+        size: declared,
+        max: cap,
+      },
+    });
+  }
+
   private isNotFoundError(error: unknown): boolean {
     if (error && typeof error === "object") {
       const e = error as {

--- a/packages/storage-s3/src/adapter.ts
+++ b/packages/storage-s3/src/adapter.ts
@@ -62,7 +62,6 @@ import {
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
-import { NextlyError } from "nextly/errors";
 import type {
   StorageReadOptions,
   IStorageAdapter,
@@ -73,6 +72,7 @@ import type {
   FileMetadata,
   BulkDeleteResult,
 } from "nextly/storage";
+import { StorageReadTooLargeError } from "nextly/storage/read-errors";
 
 import type { S3StorageConfig, ResolvedS3Config } from "./types";
 
@@ -86,6 +86,27 @@ import type { S3StorageConfig, ResolvedS3Config } from "./types";
  * Implements the IStorageAdapter interface for AWS S3 and S3-compatible services.
  * Provides full support for uploads, downloads, signed URLs, and client-side uploads.
  */
+/**
+ * The SDK request options carrying the caller's deadline, or none.
+ *
+ * A free function rather than a branch inside `read`, because it is the only
+ * part of that method with nothing to do with telling an absent key apart from
+ * an unreachable bucket — which is the distinction a reader has to hold in
+ * their head there.
+ *
+ * `AbortSignal.timeout` rather than a controller and a `setTimeout`: it needs no
+ * clearing, so it cannot leak a timer when the read resolves first. The signal
+ * covers the BODY as well as the request, because the SDK threads it through
+ * the response stream — and a backend that answers headers promptly and then
+ * stalls mid-transfer is exactly the case a request-only deadline misses.
+ */
+function abortAfter(options?: StorageReadOptions): {
+  abortSignal?: AbortSignal;
+} {
+  if (options?.timeoutMs === undefined) return {};
+  return { abortSignal: AbortSignal.timeout(options.timeoutMs) };
+}
+
 export class S3StorageAdapter implements IStorageAdapter {
   private client: S3Client;
   private resolvedConfig: ResolvedS3Config;
@@ -448,7 +469,20 @@ export class S3StorageAdapter implements IStorageAdapter {
         Key: filePath,
       });
 
-      const response = await this.client.send(command);
+      /*
+       * The caller's deadline reaches the SDK, or it is advertised and inert.
+       * `StorageReadOptions` promises a bound, and the URL-backed adapters keep
+       * it by handing `timeoutMs` to `safeFetch`; without this the same option
+       * does nothing here, so a stalled bucket holds the read open past a
+       * deadline the caller was told applied — the worst kind of option, one
+       * that validates and then has no effect.
+       *
+       * Aborting covers the BODY as well as the request. `transformToByteArray`
+       * pulls the stream after `send` resolves, and a backend that answers
+       * headers promptly and then stalls mid-transfer is exactly the case a
+       * request-only timeout misses.
+       */
+      const response = await this.client.send(command, abortAfter(options));
       /*
        * An empty body is not a missing object, and the two must not collapse.
        * `GetObject` on a zero-byte key succeeds with no stream to transform,
@@ -613,15 +647,14 @@ export class S3StorageAdapter implements IStorageAdapter {
     cap: number | undefined
   ): void {
     if (cap === undefined || declared === undefined || declared <= cap) return;
-    throw NextlyError.internal({
-      logContext: {
-        service: "S3",
-        path: filePath,
-        reason: "response-too-large",
-        size: declared,
-        max: cap,
-      },
-    });
+    /*
+     * The SHARED refusal rather than a generic internal error, because callers
+     * act on the difference. The email attachment path answers an over-cap read
+     * with a size error the author can do something about; anything else is
+     * wrapped as an opaque storage failure, so throwing `internal` here would
+     * turn a fixable refusal into one that tells them nothing.
+     */
+    throw new StorageReadTooLargeError(filePath, cap, declared);
   }
 
   private isNotFoundError(error: unknown): boolean {

--- a/packages/storage-s3/src/adapter.ts
+++ b/packages/storage-s3/src/adapter.ts
@@ -413,6 +413,54 @@ export class S3StorageAdapter implements IStorageAdapter {
   }
 
   /**
+   * Read a stored object back as bytes, or `null` when it is not there.
+   *
+   * The contract declares this OPTIONAL and, until now, no adapter supplied
+   * it — so a caller reaching for `adapter.read` got `undefined` and fell
+   * through whatever branch followed. An optional member nothing implements is
+   * a contract that reads as a capability and behaves as an absence.
+   *
+   * BUFFERS rather than streams, because that is the declared return type and
+   * widening it here would make this adapter answer a different question from
+   * its siblings. That bounds what it should be used for: an asset the server
+   * must serve from its own origin — a font file, a small document — rather
+   * than arbitrarily large media, which belongs behind {@link getSignedUrl} or
+   * a public URL. A streaming variant is a separate contract member, not a
+   * quiet change to this one.
+   *
+   * `null` for a missing key rather than a throw, matching
+   * {@link getMetadata}: absence is an ordinary answer about the bucket, while
+   * a credential or network failure is not, so only the first is folded into
+   * the return value.
+   *
+   * @param filePath - Storage path/key
+   * @returns The object's bytes, or `null` when no such key exists
+   */
+  async read(filePath: string): Promise<Buffer | null> {
+    try {
+      const command = new GetObjectCommand({
+        Bucket: this.resolvedConfig.bucket,
+        Key: filePath,
+      });
+
+      const response = await this.client.send(command);
+      /*
+       * An empty body is not a missing object, and the two must not collapse.
+       * `GetObject` on a zero-byte key succeeds with no stream to transform,
+       * so returning `null` here would report a stored empty file as absent —
+       * and a caller deleting "missing" keys would then delete a real one.
+       */
+      if (response.Body === undefined) return Buffer.alloc(0);
+      return Buffer.from(await response.Body.transformToByteArray());
+    } catch (error: unknown) {
+      if (this.isNotFoundError(error)) {
+        return null;
+      }
+      throw error;
+    }
+  }
+
+  /**
    * Generate signed URL for temporary private file access.
    *
    * Creates a pre-signed GetObject URL that grants temporary read access

--- a/packages/storage-s3/src/adapter.ts
+++ b/packages/storage-s3/src/adapter.ts
@@ -59,6 +59,7 @@ import {
   GetObjectCommand,
   PutObjectCommand,
   type PutObjectCommandInput,
+  type GetObjectCommandOutput,
 } from "@aws-sdk/client-s3";
 import { Upload } from "@aws-sdk/lib-storage";
 import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
@@ -72,6 +73,7 @@ import type {
   FileMetadata,
   BulkDeleteResult,
 } from "nextly/storage";
+import { resolveReadBounds } from "nextly/storage/fetch-stored-bytes";
 import { StorageReadTooLargeError } from "nextly/storage/read-errors";
 
 import type { S3StorageConfig, ResolvedS3Config } from "./types";
@@ -101,10 +103,18 @@ import type { S3StorageConfig, ResolvedS3Config } from "./types";
  * stalls mid-transfer is exactly the case a request-only deadline misses.
  */
 function abortAfter(options?: StorageReadOptions): {
-  abortSignal?: AbortSignal;
+  abortSignal: AbortSignal;
 } {
-  if (options?.timeoutMs === undefined) return {};
-  return { abortSignal: AbortSignal.timeout(options.timeoutMs) };
+  /*
+   * ALWAYS a signal, defaulted through the shared resolver.
+   * `StorageReadOptions` promises the deadline whether or not a caller names
+   * one, and the URL-backed adapters keep that promise by inheriting
+   * `safeFetch`'s. Returning nothing here left the no-options read — which is
+   * what the media pipeline does — able to hang on a stalled bucket forever.
+   */
+  return {
+    abortSignal: AbortSignal.timeout(resolveReadBounds(options).timeoutMs),
+  };
 }
 
 export class S3StorageAdapter implements IStorageAdapter {
@@ -498,8 +508,10 @@ export class S3StorageAdapter implements IStorageAdapter {
        * than discover the size after paying for it — which is what an
        * attachment path does when it checks a size only after buffering.
        */
-      this.refuseOverCap(filePath, response.ContentLength, options?.maxBytes);
-      return Buffer.from(await response.Body.transformToByteArray());
+      const cap = resolveReadBounds(options).maxBytes;
+      // Cheap refusal first, where the store told us the size up front.
+      this.refuseOverCap(filePath, response.ContentLength, cap);
+      return await this.readCapped(filePath, response.Body, cap);
     } catch (error: unknown) {
       /*
        * Only an OBJECT-level absence becomes `null`. `isNotFoundError` treats
@@ -628,6 +640,56 @@ export class S3StorageAdapter implements IStorageAdapter {
    * @param error - Error to check
    * @returns true if error indicates file not found
    */
+  /**
+   * The object's bytes, refusing once more than `cap` have actually arrived.
+   *
+   * `ContentLength` is OPTIONAL in the SDK's response type, and this adapter
+   * explicitly supports MinIO, R2 and other compatible services — any of which
+   * may omit it or report it wrongly. A preflight check against metadata is
+   * therefore a courtesy that fails OPEN: trusting it alone leaves the cap
+   * unenforced exactly where an unusual backend is involved, which is where a
+   * caller most needs it.
+   *
+   * Counted while consuming, so an oversized body is abandoned partway rather
+   * than after it has all been buffered — the cap exists to bound memory, and
+   * one applied after `transformToByteArray` has already spent it.
+   *
+   * Falls back to buffering when the body is not async-iterable, which the SDK
+   * types permit. Stated rather than hidden: on that path the cap bounds what a
+   * caller RECEIVES rather than what the process allocates.
+   */
+  private async readCapped(
+    filePath: string,
+    body: NonNullable<GetObjectCommandOutput["Body"]>,
+    cap: number
+  ): Promise<Buffer> {
+    /*
+     * Probed rather than assumed. The SDK types the body as a union whose Node
+     * member is async-iterable and whose browser members are not, and this
+     * package supports compatible services whose transport may differ — so the
+     * capability is read off the value in hand instead of from the type.
+     */
+    const iterable = body as Partial<AsyncIterable<Uint8Array>>;
+    if (typeof iterable[Symbol.asyncIterator] !== "function") {
+      const whole = Buffer.from(await body.transformToByteArray());
+      if (whole.byteLength > cap) {
+        throw new StorageReadTooLargeError(filePath, cap, whole.byteLength);
+      }
+      return whole;
+    }
+
+    const chunks: Buffer[] = [];
+    let received = 0;
+    for await (const chunk of body as AsyncIterable<Uint8Array>) {
+      received += chunk.byteLength;
+      if (received > cap) {
+        throw new StorageReadTooLargeError(filePath, cap, received);
+      }
+      chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  }
+
   /**
    * Refuse a read whose object is already known to exceed the caller's cap.
    *

--- a/packages/storage-uploadthing/src/adapter.test.ts
+++ b/packages/storage-uploadthing/src/adapter.test.ts
@@ -14,9 +14,17 @@ import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
 
 import { UploadthingStorageAdapter } from "./adapter";
 
-vi.mock("nextly/storage/fetch-stored-bytes", () => ({
-  fetchStoredBytes: vi.fn(),
-}));
+vi.mock("nextly/storage/fetch-stored-bytes", async importOriginal => {
+  /*
+   * Only `fetchStoredBytes` is faked. `withDeadline` and the default timeout
+   * stay REAL: the racer is the mechanism one case below is about, and a stubbed
+   * default would make `AbortSignal.timeout` receive `undefined` — which throws,
+   * and would have these cases failing for a reason unrelated to the adapter.
+   */
+  const actual =
+    await importOriginal<typeof import("nextly/storage/fetch-stored-bytes")>();
+  return { ...actual, fetchStoredBytes: vi.fn() };
+});
 
 const getFileUrls = vi.fn();
 vi.mock("uploadthing/server", () => ({
@@ -91,20 +99,51 @@ describe("UploadthingStorageAdapter.read", () => {
     vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
     await adapter.read("f.woff2", { timeoutMs: 1234 });
 
-    const lookupSignal = (
-      getFileUrls.mock.calls[0]?.[1] as { signal?: AbortSignal } | undefined
-    )?.signal;
-    expect(lookupSignal).toBeInstanceOf(AbortSignal);
-    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBe(lookupSignal);
+    /*
+     * Asserted on the RACE, not on a signal handed to the SDK. UploadThing
+     * 7.7.4's `getFileUrls` reads only `keyType` and forwards no signal, so an
+     * earlier version of this case proved only that an IGNORED property had
+     * been supplied — a test that passes while the lookup stays unbounded.
+     *
+     * A lookup that never settles must therefore still reject, which is the
+     * property the racer actually provides.
+     */
+    expect(getFileUrls.mock.calls[0]?.[1]).toEqual({ keyType: "fileKey" });
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBeInstanceOf(
+      AbortSignal
+    );
   });
 
-  it("passes no signal when the caller named no deadline", async () => {
-    // The control: an adapter that always made a signal would satisfy the case
-    // above while ignoring what the caller actually asked for.
+  it("bounds the read even when the caller named NO deadline", async () => {
+    // Previously asserted the opposite, which locked in the defect: the fetch
+    // had `safeFetch`'s own default and the lookup had nothing.
     found();
     vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
     await adapter.read("f.woff2");
-    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBeUndefined();
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBeInstanceOf(
+      AbortSignal
+    );
+  });
+
+  it("REJECTS a lookup that never settles, once the deadline passes", async () => {
+    /*
+     * The property the racer actually provides, and the one an assertion about
+     * a passed option cannot reach: this SDK ignores the signal entirely, so
+     * without racing a stalled lookup holds `read` open forever.
+     *
+     * A never-resolving promise is the point — a slow-but-finite one would pass
+     * against an implementation that simply awaited it.
+     */
+    getFileUrls.mockReturnValueOnce(new Promise(() => {}));
+
+    const outcome = await adapter.read("f.woff2", { timeoutMs: 5 }).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBeInstanceOf(Error);
+    expect(outcome).not.toBeNull();
+    // And it never reached the fetch, because the lookup never produced a URL.
+    expect(vi.mocked(fetchStoredBytes)).not.toHaveBeenCalled();
   });
 
   it("hands the caller's bounds to the helper", async () => {

--- a/packages/storage-uploadthing/src/adapter.test.ts
+++ b/packages/storage-uploadthing/src/adapter.test.ts
@@ -1,0 +1,120 @@
+/**
+ * What `read` does with a key lookup, and with the caller's bounds.
+ *
+ * The first tests in this package. The HTTP half is asserted in the helper's own
+ * suite under `packages/nextly`; what is only true here is that a lookup failure
+ * PROPAGATES rather than reading as absence, and that one deadline covers the
+ * lookup as well as the fetch.
+ *
+ * @module adapter.test
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
+
+import { UploadthingStorageAdapter } from "./adapter";
+
+vi.mock("nextly/storage/fetch-stored-bytes", () => ({
+  fetchStoredBytes: vi.fn(),
+}));
+
+const getFileUrls = vi.fn();
+vi.mock("uploadthing/server", () => ({
+  UTApi: class {
+    getFileUrls = getFileUrls;
+  },
+}));
+
+const adapter = new UploadthingStorageAdapter({ token: "ut_test_dummy" });
+
+afterEach(() => {
+  getFileUrls.mockReset();
+  vi.mocked(fetchStoredBytes).mockReset();
+});
+
+/** A lookup that resolves to one usable URL. */
+function found(): void {
+  getFileUrls.mockResolvedValueOnce({
+    data: [{ key: "f.woff2", url: "https://utfs.test/f.woff2" }],
+  });
+}
+
+describe("UploadthingStorageAdapter.read", () => {
+  it("returns what the helper read", async () => {
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("hello"));
+    expect((await adapter.read("f.woff2"))?.toString("utf8")).toBe("hello");
+  });
+
+  it("answers null for a key the batch lookup does not return", async () => {
+    /*
+     * A missing key comes back as an EMPTY `data` array rather than as a
+     * rejection, which is why this branch exists at all.
+     *
+     * ITS CONTROL IS "returns what the helper read" ABOVE: on its own this is
+     * satisfied by a `read` answering `null` for every input.
+     */
+    getFileUrls.mockResolvedValueOnce({ data: [] });
+    expect(await adapter.read("gone.woff2")).toBeNull();
+    expect(vi.mocked(fetchStoredBytes)).not.toHaveBeenCalled();
+  });
+
+  it("PROPAGATES a lookup failure instead of calling the file absent", async () => {
+    /*
+     * An invalid token, an outage or a dropped connection says nothing about
+     * whether the file exists. Folding those into `null` tells a caller it was
+     * deleted, and a caller acting on that writes a replacement over a file
+     * still sitting there — which is why there is no catch around the lookup.
+     */
+    const outage = new Error("service unavailable");
+    getFileUrls.mockRejectedValueOnce(outage);
+
+    const outcome = await adapter.read("f.woff2").then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBe(outage);
+    expect(outcome).not.toBeNull();
+  });
+
+  it("starts ONE deadline before the lookup and shares it with the fetch", async () => {
+    /*
+     * The lookup runs first and can stall exactly as the fetch can, so a
+     * deadline beginning at the fetch leaves it unbounded — and each phase
+     * would get its own full budget, letting a read outlive what the caller was
+     * promised by roughly double.
+     *
+     * Asserted as the SAME object reaching both: two signals would satisfy "a
+     * signal was passed" while restarting the clock.
+     */
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
+    await adapter.read("f.woff2", { timeoutMs: 1234 });
+
+    const lookupSignal = (
+      getFileUrls.mock.calls[0]?.[1] as { signal?: AbortSignal } | undefined
+    )?.signal;
+    expect(lookupSignal).toBeInstanceOf(AbortSignal);
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBe(lookupSignal);
+  });
+
+  it("passes no signal when the caller named no deadline", async () => {
+    // The control: an adapter that always made a signal would satisfy the case
+    // above while ignoring what the caller actually asked for.
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
+    await adapter.read("f.woff2");
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBeUndefined();
+  });
+
+  it("hands the caller's bounds to the helper", async () => {
+    // Asserted on the ARGUMENT, because the result is identical whether or not
+    // the bounds were forwarded — which is how this regresses unnoticed.
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
+    await adapter.read("f.woff2", { maxBytes: 4242 });
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[3]).toMatchObject({
+      maxBytes: 4242,
+    });
+  });
+});

--- a/packages/storage-uploadthing/src/adapter.ts
+++ b/packages/storage-uploadthing/src/adapter.ts
@@ -168,8 +168,18 @@ export class UploadthingStorageAdapter extends BaseStorageAdapter {
      * error instead of a false "deleted" — which is why the uncertainty is
      * resolved toward propagating rather than toward swallowing.
      */
+    /*
+     * ONE deadline for both phases, started before the lookup — the key lookup
+     * can stall as readily as the fetch, and it runs first.
+     */
+    const deadline =
+      options?.timeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(options.timeoutMs);
+
     const result = await this.utapi.getFileUrls([filePath], {
       keyType: "fileKey",
+      ...(deadline === undefined ? {} : { signal: deadline }),
     });
     const target = Array.from(result.data)[0]?.url;
     if (target === undefined) return null;
@@ -180,7 +190,13 @@ export class UploadthingStorageAdapter extends BaseStorageAdapter {
      * and reporting it as absence would let a caller treat a live file as
      * deleted.
      */
-    return await fetchStoredBytes(target, filePath, "UploadThing", options);
+    return await fetchStoredBytes(
+      target,
+      filePath,
+      "UploadThing",
+      options,
+      deadline
+    );
   }
 
   /**

--- a/packages/storage-uploadthing/src/adapter.ts
+++ b/packages/storage-uploadthing/src/adapter.ts
@@ -15,12 +15,13 @@
  * ```
  */
 
-import { BaseStorageAdapter, fetchStoredBytes } from "nextly/storage";
+import { BaseStorageAdapter } from "nextly/storage";
 import type {
   UploadOptions,
   UploadResult,
   BulkDeleteResult,
 } from "nextly/storage";
+import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
 import { UTApi } from "uploadthing/server";
 
 // ============================================================
@@ -148,15 +149,25 @@ export class UploadthingStorageAdapter extends BaseStorageAdapter {
    * @returns The file's bytes, or `null` when no such key exists
    */
   async read(filePath: string): Promise<Buffer | null> {
-    let target: string | undefined;
-    try {
-      const result = await this.utapi.getFileUrls([filePath], {
-        keyType: "fileKey",
-      });
-      target = Array.from(result.data)[0]?.url;
-    } catch {
-      return null;
-    }
+    /*
+     * NOT wrapped in a catch. This is a batch lookup, so a key that is not
+     * there comes back as an EMPTY `data` array — the branch below — rather
+     * than as a rejection. What a rejection means instead is an invalid token,
+     * an outage or a dropped connection, none of which say the file was
+     * deleted; folding those into `null` would let a caller overwrite a file
+     * that is still there.
+     *
+     * Stated as the reasoning rather than as a verified fact: the shape of a
+     * missing-key response is not pinned by the SDK's types, so if this service
+     * does reject for an absent key, `read` throws where the contract promises
+     * `null`. That direction is the safe one to be wrong in — a caller sees an
+     * error instead of a false "deleted" — which is why the uncertainty is
+     * resolved toward propagating rather than toward swallowing.
+     */
+    const result = await this.utapi.getFileUrls([filePath], {
+      keyType: "fileKey",
+    });
+    const target = Array.from(result.data)[0]?.url;
     if (target === undefined) return null;
 
     /*

--- a/packages/storage-uploadthing/src/adapter.ts
+++ b/packages/storage-uploadthing/src/adapter.ts
@@ -22,7 +22,11 @@ import type {
   BulkDeleteResult,
   StorageReadOptions,
 } from "nextly/storage";
-import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
+import {
+  fetchStoredBytes,
+  withDeadline,
+  DEFAULT_READ_TIMEOUT_MS,
+} from "nextly/storage/fetch-stored-bytes";
 import { UTApi } from "uploadthing/server";
 
 // ============================================================
@@ -172,15 +176,22 @@ export class UploadthingStorageAdapter extends BaseStorageAdapter {
      * ONE deadline for both phases, started before the lookup — the key lookup
      * can stall as readily as the fetch, and it runs first.
      */
-    const deadline =
-      options?.timeoutMs === undefined
-        ? undefined
-        : AbortSignal.timeout(options.timeoutMs);
+    const deadline = AbortSignal.timeout(
+      options?.timeoutMs ?? DEFAULT_READ_TIMEOUT_MS
+    );
 
-    const result = await this.utapi.getFileUrls([filePath], {
-      keyType: "fileKey",
-      ...(deadline === undefined ? {} : { signal: deadline }),
-    });
+    /*
+     * RACED rather than cancelled, because this SDK cannot be cancelled.
+     * UploadThing 7.7.4's `getFileUrls` reads only `keyType` and forwards no
+     * signal, so passing one bounds nothing — an option accepted and ignored,
+     * which reads as covered and behaves as absent. Racing at least returns
+     * within the deadline this method advertised; the request itself runs on in
+     * the background, which is the honest limit of what is available here.
+     */
+    const result = await withDeadline(
+      this.utapi.getFileUrls([filePath], { keyType: "fileKey" }),
+      deadline
+    );
     const target = Array.from(result.data)[0]?.url;
     if (target === undefined) return null;
 

--- a/packages/storage-uploadthing/src/adapter.ts
+++ b/packages/storage-uploadthing/src/adapter.ts
@@ -15,7 +15,7 @@
  * ```
  */
 
-import { BaseStorageAdapter } from "nextly/storage";
+import { BaseStorageAdapter, fetchStoredBytes } from "nextly/storage";
 import type {
   UploadOptions,
   UploadResult,
@@ -132,6 +132,40 @@ export class UploadthingStorageAdapter extends BaseStorageAdapter {
     } catch {
       return false;
     }
+  }
+
+  /**
+   * Read a stored file back as bytes, or `null` when it is not there.
+   *
+   * A NETWORK round trip for the same reason as the Vercel adapter: the bytes
+   * live on UploadThing's CDN. A caller serving these from its own origin has
+   * to cache, or it pays the fetch on every request.
+   *
+   * The URL comes from `getFileUrls` rather than being assembled, because the
+   * service owns the address and this adapter never chose it.
+   *
+   * @param filePath - File key
+   * @returns The file's bytes, or `null` when no such key exists
+   */
+  async read(filePath: string): Promise<Buffer | null> {
+    let target: string | undefined;
+    try {
+      const result = await this.utapi.getFileUrls([filePath], {
+        keyType: "fileKey",
+      });
+      target = Array.from(result.data)[0]?.url;
+    } catch {
+      return null;
+    }
+    if (target === undefined) return null;
+
+    /*
+     * Outside the catch, as in the Vercel adapter, and through the same shared
+     * helper: a fetch that fails after the key resolved is a transport failure,
+     * and reporting it as absence would let a caller treat a live file as
+     * deleted.
+     */
+    return await fetchStoredBytes(target, filePath, "UploadThing");
   }
 
   /**

--- a/packages/storage-uploadthing/src/adapter.ts
+++ b/packages/storage-uploadthing/src/adapter.ts
@@ -20,6 +20,7 @@ import type {
   UploadOptions,
   UploadResult,
   BulkDeleteResult,
+  StorageReadOptions,
 } from "nextly/storage";
 import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
 import { UTApi } from "uploadthing/server";
@@ -148,7 +149,10 @@ export class UploadthingStorageAdapter extends BaseStorageAdapter {
    * @param filePath - File key
    * @returns The file's bytes, or `null` when no such key exists
    */
-  async read(filePath: string): Promise<Buffer | null> {
+  async read(
+    filePath: string,
+    options?: StorageReadOptions
+  ): Promise<Buffer | null> {
     /*
      * NOT wrapped in a catch. This is a batch lookup, so a key that is not
      * there comes back as an EMPTY `data` array — the branch below — rather
@@ -176,7 +180,7 @@ export class UploadthingStorageAdapter extends BaseStorageAdapter {
      * and reporting it as absence would let a caller treat a live file as
      * deleted.
      */
-    return await fetchStoredBytes(target, filePath, "UploadThing");
+    return await fetchStoredBytes(target, filePath, "UploadThing", options);
   }
 
   /**

--- a/packages/storage-vercel-blob/src/adapter.test.ts
+++ b/packages/storage-vercel-blob/src/adapter.test.ts
@@ -7,9 +7,17 @@ import { NextlyError } from "nextly/errors";
 
 import { VercelBlobStorageAdapter } from "./adapter";
 
-vi.mock("nextly/storage/fetch-stored-bytes", () => ({
-  fetchStoredBytes: vi.fn(),
-}));
+vi.mock("nextly/storage/fetch-stored-bytes", async importOriginal => {
+  /*
+   * Only `fetchStoredBytes` is faked. `withDeadline` and the default timeout
+   * stay REAL: the racer is the mechanism one case below is about, and a stubbed
+   * default would make `AbortSignal.timeout` receive `undefined` — which throws,
+   * and would have these cases failing for a reason unrelated to the adapter.
+   */
+  const actual =
+    await importOriginal<typeof import("nextly/storage/fetch-stored-bytes")>();
+  return { ...actual, fetchStoredBytes: vi.fn() };
+});
 
 vi.mock("@vercel/blob", () => {
   /*
@@ -190,13 +198,24 @@ describe("VercelBlobStorageAdapter — reading bytes back", () => {
     expect(fetchSignal).toBe(lookupSignal);
   });
 
-  it("passes no signal when the caller named no deadline", async () => {
-    // The control: an adapter that always made a signal would satisfy the case
-    // above while ignoring what the caller actually asked for.
+  it("bounds the lookup even when the caller named NO deadline", async () => {
+    /*
+     * This case previously asserted the opposite, and in doing so locked in the
+     * defect: `safeFetch` applies a default deadline of its own, so a caller
+     * stating none was bounded for the FETCH and unbounded for the LOOKUP. That
+     * is the commonest call — the email path supplies only a byte cap — so the
+     * default was exactly the path with no bound at all.
+     */
     found();
     vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
     await adapter.read("f.woff2");
-    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBeUndefined();
+
+    const lookupSignal = (
+      vi.mocked(head).mock.calls[0]?.[1] as { abortSignal?: AbortSignal }
+    )?.abortSignal;
+    expect(lookupSignal).toBeInstanceOf(AbortSignal);
+    // And still ONE signal across both phases, not a fresh clock per phase.
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBe(lookupSignal);
   });
 
   it("hands the caller's bounds to the helper", async () => {

--- a/packages/storage-vercel-blob/src/adapter.test.ts
+++ b/packages/storage-vercel-blob/src/adapter.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { head, BlobNotFoundError, BlobAccessError } from "@vercel/blob";
+import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
 
 import { NextlyError } from "nextly/errors";
 
 import { VercelBlobStorageAdapter } from "./adapter";
+
+vi.mock("nextly/storage/fetch-stored-bytes", () => ({
+  fetchStoredBytes: vi.fn(),
+}));
 
 vi.mock("@vercel/blob", () => {
   /*
@@ -106,123 +111,75 @@ describe("VercelBlobStorageAdapter — reading bytes back", () => {
     collections: { media: true },
   });
 
-  /** The found case: `head` resolves and the CDN serves the bytes. */
-  function blobExists(body: string): void {
+  /*
+   * The HELPER is mocked here, and the HTTP answers it turns into `null`, bytes
+   * or an error are asserted in its own suite under `packages/nextly`. What is
+   * only true at this layer is what a LOOKUP failure means and whether the
+   * caller's bounds survive the trip — so those are what this asserts.
+   */
+  function found(): void {
     vi.mocked(head).mockResolvedValueOnce({
       url: "https://test.public.blob.vercel-storage.com/f.woff2",
       downloadUrl: "https://test.public.blob.vercel-storage.com/f.woff2?dl=1",
     } as unknown as Awaited<ReturnType<typeof head>>);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response(body, { status: 200 }))
-    );
   }
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.mocked(head).mockReset();
+    vi.mocked(fetchStoredBytes).mockReset();
   });
 
-  it("returns the stored bytes", async () => {
-    blobExists("hello");
-    const bytes = await adapter.read("f.woff2");
-    expect(bytes?.toString("utf8")).toBe("hello");
+  it("returns what the helper read", async () => {
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("hello"));
+    expect((await adapter.read("f.woff2"))?.toString("utf8")).toBe("hello");
   });
 
   it("answers null for a blob that is not there", async () => {
     /*
-     * Arranged explicitly with the NOT-FOUND class, which is what the service
-     * rejects with for a missing key. No `fetch` is stubbed, so a version that
-     * skipped the lookup and fetched anyway would fail here rather than pass
-     * quietly.
+     * Arranged with the NOT-FOUND class, which is what the service rejects
+     * with for a missing key.
      *
-     * ITS CONTROL IS "returns the stored bytes" ABOVE, and this case is not
-     * evidence without it: measured, a `read` that returns `null` for every
-     * input satisfies this assertion exactly. The positive case is what proves
-     * `null` here means "not found" rather than "this method never answers".
-     * Declared rather than left to adjacency, so deleting that case cannot
-     * quietly make this one meaningless.
+     * ITS CONTROL IS "returns what the helper read" ABOVE, and this case is not
+     * evidence without it: measured, a `read` returning `null` for every input
+     * satisfies this assertion exactly. Declared rather than left to adjacency,
+     * so deleting that case cannot quietly make this one meaningless.
      */
     vi.mocked(head).mockRejectedValueOnce(new BlobNotFoundError());
     expect(await adapter.read("gone.woff2")).toBeNull();
+    // And the helper was never reached, so `null` came from the lookup.
+    expect(vi.mocked(fetchStoredBytes)).not.toHaveBeenCalled();
   });
 
   it("THROWS a lookup failure that is not a missing blob", async () => {
     /*
-     * The distinction the not-found case cannot make on its own. `head` also
-     * rejects for an expired token, a suspended store and a dropped
-     * connection, and none of those says the blob was deleted — so folding
-     * every rejection into `null` reports an outage as an absence, which a
-     * caller may answer by writing a replacement over a file still sitting
-     * there.
-     *
-     * Paired with the case below it deliberately: together they say the
-     * adapter keys on the CLASS rather than on the mere fact of a rejection.
+     * The distinction the case above cannot make alone. `head` also rejects for
+     * an expired token, a suspended store and a dropped connection, and none of
+     * those says the blob was deleted — so folding every rejection into `null`
+     * reports an outage as an absence, which a caller may answer by writing a
+     * replacement over a file still sitting there.
      */
     vi.mocked(head).mockRejectedValueOnce(new BlobAccessError());
-
     const outcome = await adapter.read("f.woff2").then(
       value => value,
       (error: unknown) => error
     );
     expect(outcome).toBeInstanceOf(BlobAccessError);
-    expect(outcome).not.toBeNull();
   });
 
-  it("answers null when the blob disappears between lookup and fetch", async () => {
+  it("hands the caller's bounds to the helper", async () => {
     /*
-     * These stores are remote and concurrent, so a blob can be deleted after
-     * its address resolves and before the CDN is asked for it. That is an
-     * ordinary race with an ordinary answer — the object is not there — and
-     * reporting it as a server failure would make a caller handle an error for
-     * something its own contract already has a value for.
+     * Asserted on the ARGUMENT rather than the result, because the result is
+     * identical whether or not the bounds were forwarded — which is precisely
+     * how this regresses unnoticed. The email attachment path depends on it:
+     * before these bounds existed, implementing `read` moved that path off a
+     * capped fetch onto one that buffered the whole object first.
      */
-    vi.mocked(head).mockResolvedValueOnce({
-      url: "https://test.public.blob.vercel-storage.com/f.woff2",
-      downloadUrl: "https://test.public.blob.vercel-storage.com/f.woff2?dl=1",
-    } as unknown as Awaited<ReturnType<typeof head>>);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("", { status: 404 }))
-    );
-
-    expect(await adapter.read("f.woff2")).toBeNull();
-  });
-
-  it("THROWS when the fetch fails after the blob resolved", async () => {
-    /*
-     * The property that separates absence from a transport failure, and the
-     * reason the fetch sits outside the not-found catch. A dropped connection
-     * to a blob whose metadata just resolved is not a deletion — reporting it
-     * as `null` invites a caller to treat a live file as gone and write a
-     * replacement over it.
-     */
-    vi.mocked(head).mockResolvedValueOnce({
-      url: "https://test.public.blob.vercel-storage.com/f.woff2",
-      downloadUrl: "https://test.public.blob.vercel-storage.com/f.woff2?dl=1",
-    } as unknown as Awaited<ReturnType<typeof head>>);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async () => new Response("nope", { status: 500 }))
-    );
-
-    /*
-     * Asserted on the error's CODE rather than its text. The status and the key
-     * deliberately do not reach the public message — they are the things that
-     * must not travel to whoever asked for the file — so matching on prose
-     * would either fail here or pressure that message into leaking them back.
-     */
-    const failure = await adapter.read("f.woff2").then(
-      value => value,
-      (error: unknown) => error
-    );
-    expect(failure).toBeInstanceOf(NextlyError);
-    expect((failure as NextlyError).code).toBe("INTERNAL_ERROR");
-    /*
-     * And explicitly NOT the absence answer, which is the whole point: a
-     * `toThrow` alone passes on any rejection, while returning `null` here is
-     * the specific wrong behaviour this case exists to rule out.
-     */
-    expect(failure).not.toBeNull();
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
+    await adapter.read("f.woff2", { maxBytes: 4242 });
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[3]).toMatchObject({
+      maxBytes: 4242,
+    });
   });
 });

--- a/packages/storage-vercel-blob/src/adapter.test.ts
+++ b/packages/storage-vercel-blob/src/adapter.test.ts
@@ -1,30 +1,42 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { head } from "@vercel/blob";
+import { head, BlobNotFoundError, BlobAccessError } from "@vercel/blob";
 
 import { NextlyError } from "nextly/errors";
 
 import { VercelBlobStorageAdapter } from "./adapter";
 
-vi.mock("@vercel/blob", () => ({
-  put: vi.fn(async (pathname: string) => ({
-    pathname,
-    contentType: "image/svg+xml",
-    contentDisposition: 'attachment; filename="x.svg"',
-    url: `https://test.public.blob.vercel-storage.com/${pathname}`,
-    downloadUrl: `https://test.public.blob.vercel-storage.com/${pathname}?download=1`,
-    etag: '"deadbeef"',
-  })),
+vi.mock("@vercel/blob", () => {
   /*
-   * Rejects by default, because that is what the service does for a blob that
-   * is not there and it is the branch `read` folds into `null`. A test wanting
-   * the found case says so, which keeps "not found" from being the state a
-   * case reaches by forgetting to arrange one.
+   * REAL classes, declared INSIDE the factory because `vi.mock` is hoisted
+   * above every import and a class defined at module scope is not yet assigned
+   * when the factory runs. The adapter discriminates with `instanceof` — the
+   * SDK's own mechanism — so a mock rejecting with a plain object would leave
+   * the not-found branch unreachable and these cases would describe an adapter
+   * nobody ships.
    */
-  head: vi.fn(async () => {
-    throw new Error("blob not found");
-  }),
-}));
+  class NotFound extends Error {}
+  class Access extends Error {}
+  return {
+    put: vi.fn(async (pathname: string) => ({
+      pathname,
+      contentType: "image/svg+xml",
+      contentDisposition: 'attachment; filename="x.svg"',
+      url: `https://test.public.blob.vercel-storage.com/${pathname}`,
+      downloadUrl: `https://test.public.blob.vercel-storage.com/${pathname}?download=1`,
+      etag: '"deadbeef"',
+    })),
+    /*
+     * No default behaviour: every case that reaches `head` ARRANGES it. A
+     * default rejection would make "not found" the state a case reaches by
+     * forgetting to set one up, which is the one outcome these tests exist to
+     * tell apart from the others.
+     */
+    head: vi.fn(),
+    BlobNotFoundError: NotFound,
+    BlobAccessError: Access,
+  };
+});
 
 describe("VercelBlobStorageAdapter — SVG handling", () => {
   const adapter = new VercelBlobStorageAdapter({
@@ -119,9 +131,10 @@ describe("VercelBlobStorageAdapter — reading bytes back", () => {
 
   it("answers null for a blob that is not there", async () => {
     /*
-     * `head` rejects by default, which is what the service does for a missing
-     * key. No `fetch` is stubbed, so a version that skipped the lookup and
-     * fetched anyway would fail here rather than pass quietly.
+     * Arranged explicitly with the NOT-FOUND class, which is what the service
+     * rejects with for a missing key. No `fetch` is stubbed, so a version that
+     * skipped the lookup and fetched anyway would fail here rather than pass
+     * quietly.
      *
      * ITS CONTROL IS "returns the stored bytes" ABOVE, and this case is not
      * evidence without it: measured, a `read` that returns `null` for every
@@ -130,7 +143,50 @@ describe("VercelBlobStorageAdapter — reading bytes back", () => {
      * Declared rather than left to adjacency, so deleting that case cannot
      * quietly make this one meaningless.
      */
+    vi.mocked(head).mockRejectedValueOnce(new BlobNotFoundError());
     expect(await adapter.read("gone.woff2")).toBeNull();
+  });
+
+  it("THROWS a lookup failure that is not a missing blob", async () => {
+    /*
+     * The distinction the not-found case cannot make on its own. `head` also
+     * rejects for an expired token, a suspended store and a dropped
+     * connection, and none of those says the blob was deleted — so folding
+     * every rejection into `null` reports an outage as an absence, which a
+     * caller may answer by writing a replacement over a file still sitting
+     * there.
+     *
+     * Paired with the case below it deliberately: together they say the
+     * adapter keys on the CLASS rather than on the mere fact of a rejection.
+     */
+    vi.mocked(head).mockRejectedValueOnce(new BlobAccessError());
+
+    const outcome = await adapter.read("f.woff2").then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBeInstanceOf(BlobAccessError);
+    expect(outcome).not.toBeNull();
+  });
+
+  it("answers null when the blob disappears between lookup and fetch", async () => {
+    /*
+     * These stores are remote and concurrent, so a blob can be deleted after
+     * its address resolves and before the CDN is asked for it. That is an
+     * ordinary race with an ordinary answer — the object is not there — and
+     * reporting it as a server failure would make a caller handle an error for
+     * something its own contract already has a value for.
+     */
+    vi.mocked(head).mockResolvedValueOnce({
+      url: "https://test.public.blob.vercel-storage.com/f.woff2",
+      downloadUrl: "https://test.public.blob.vercel-storage.com/f.woff2?dl=1",
+    } as unknown as Awaited<ReturnType<typeof head>>);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("", { status: 404 }))
+    );
+
+    expect(await adapter.read("f.woff2")).toBeNull();
   });
 
   it("THROWS when the fetch fails after the blob resolved", async () => {

--- a/packages/storage-vercel-blob/src/adapter.test.ts
+++ b/packages/storage-vercel-blob/src/adapter.test.ts
@@ -1,4 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { head } from "@vercel/blob";
 
 import { NextlyError } from "nextly/errors";
 
@@ -13,6 +15,15 @@ vi.mock("@vercel/blob", () => ({
     downloadUrl: `https://test.public.blob.vercel-storage.com/${pathname}?download=1`,
     etag: '"deadbeef"',
   })),
+  /*
+   * Rejects by default, because that is what the service does for a blob that
+   * is not there and it is the branch `read` folds into `null`. A test wanting
+   * the found case says so, which keeps "not found" from being the state a
+   * case reaches by forgetting to arrange one.
+   */
+  head: vi.fn(async () => {
+    throw new Error("blob not found");
+  }),
 }));
 
 describe("VercelBlobStorageAdapter — SVG handling", () => {
@@ -74,5 +85,88 @@ describe("VercelBlobStorageAdapter — HTML rejection", () => {
         mimeType: "application/xhtml+xml",
       })
     ).rejects.toSatisfy((err: unknown) => NextlyError.is(err));
+  });
+});
+
+describe("VercelBlobStorageAdapter — reading bytes back", () => {
+  const adapter = new VercelBlobStorageAdapter({
+    token: "vercel_blob_rw_test_dummy_token_for_unit_tests",
+    collections: { media: true },
+  });
+
+  /** The found case: `head` resolves and the CDN serves the bytes. */
+  function blobExists(body: string): void {
+    vi.mocked(head).mockResolvedValueOnce({
+      url: "https://test.public.blob.vercel-storage.com/f.woff2",
+      downloadUrl: "https://test.public.blob.vercel-storage.com/f.woff2?dl=1",
+    } as unknown as Awaited<ReturnType<typeof head>>);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 }))
+    );
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.mocked(head).mockReset();
+  });
+
+  it("returns the stored bytes", async () => {
+    blobExists("hello");
+    const bytes = await adapter.read("f.woff2");
+    expect(bytes?.toString("utf8")).toBe("hello");
+  });
+
+  it("answers null for a blob that is not there", async () => {
+    /*
+     * `head` rejects by default, which is what the service does for a missing
+     * key. No `fetch` is stubbed, so a version that skipped the lookup and
+     * fetched anyway would fail here rather than pass quietly.
+     *
+     * ITS CONTROL IS "returns the stored bytes" ABOVE, and this case is not
+     * evidence without it: measured, a `read` that returns `null` for every
+     * input satisfies this assertion exactly. The positive case is what proves
+     * `null` here means "not found" rather than "this method never answers".
+     * Declared rather than left to adjacency, so deleting that case cannot
+     * quietly make this one meaningless.
+     */
+    expect(await adapter.read("gone.woff2")).toBeNull();
+  });
+
+  it("THROWS when the fetch fails after the blob resolved", async () => {
+    /*
+     * The property that separates absence from a transport failure, and the
+     * reason the fetch sits outside the not-found catch. A dropped connection
+     * to a blob whose metadata just resolved is not a deletion — reporting it
+     * as `null` invites a caller to treat a live file as gone and write a
+     * replacement over it.
+     */
+    vi.mocked(head).mockResolvedValueOnce({
+      url: "https://test.public.blob.vercel-storage.com/f.woff2",
+      downloadUrl: "https://test.public.blob.vercel-storage.com/f.woff2?dl=1",
+    } as unknown as Awaited<ReturnType<typeof head>>);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response("nope", { status: 500 }))
+    );
+
+    /*
+     * Asserted on the error's CODE rather than its text. The status and the key
+     * deliberately do not reach the public message — they are the things that
+     * must not travel to whoever asked for the file — so matching on prose
+     * would either fail here or pressure that message into leaking them back.
+     */
+    const failure = await adapter.read("f.woff2").then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(failure).toBeInstanceOf(NextlyError);
+    expect((failure as NextlyError).code).toBe("INTERNAL_ERROR");
+    /*
+     * And explicitly NOT the absence answer, which is the whole point: a
+     * `toThrow` alone passes on any rejection, while returning `null` here is
+     * the specific wrong behaviour this case exists to rule out.
+     */
+    expect(failure).not.toBeNull();
   });
 });

--- a/packages/storage-vercel-blob/src/adapter.test.ts
+++ b/packages/storage-vercel-blob/src/adapter.test.ts
@@ -167,6 +167,38 @@ describe("VercelBlobStorageAdapter — reading bytes back", () => {
     expect(outcome).toBeInstanceOf(BlobAccessError);
   });
 
+  it("starts ONE deadline before the lookup and shares it with the fetch", async () => {
+    /*
+     * `head` runs first and can stall exactly as the fetch can. A deadline that
+     * begins only at the fetch leaves the lookup unbounded, so a read outlives
+     * what the caller was promised — by roughly double, since each phase would
+     * get its own full budget.
+     *
+     * Asserted as the SAME object reaching both, which is the property: two
+     * signals would satisfy "a signal was passed" while restarting the clock.
+     */
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
+    await adapter.read("f.woff2", { timeoutMs: 1234 });
+
+    const lookupSignal = (
+      vi.mocked(head).mock.calls[0]?.[1] as { abortSignal?: AbortSignal }
+    )?.abortSignal;
+    const fetchSignal = vi.mocked(fetchStoredBytes).mock.calls[0]?.[4];
+
+    expect(lookupSignal).toBeInstanceOf(AbortSignal);
+    expect(fetchSignal).toBe(lookupSignal);
+  });
+
+  it("passes no signal when the caller named no deadline", async () => {
+    // The control: an adapter that always made a signal would satisfy the case
+    // above while ignoring what the caller actually asked for.
+    found();
+    vi.mocked(fetchStoredBytes).mockResolvedValueOnce(Buffer.from("x"));
+    await adapter.read("f.woff2");
+    expect(vi.mocked(fetchStoredBytes).mock.calls[0]?.[4]).toBeUndefined();
+  });
+
   it("hands the caller's bounds to the helper", async () => {
     /*
      * Asserted on the ARGUMENT rather than the result, because the result is

--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -29,6 +29,7 @@
 
 import { put, del, head, list } from "@vercel/blob";
 import { NextlyError } from "nextly/errors";
+import { fetchStoredBytes } from "nextly/storage";
 import type {
   IStorageAdapter,
   UploadOptions,
@@ -239,6 +240,45 @@ export class VercelBlobStorageAdapter implements IStorageAdapter {
       // Vercel Blob throws an error if the blob doesn't exist
       return false;
     }
+  }
+
+  /**
+   * Read a stored blob back as bytes, or `null` when it is not there.
+   *
+   * A NETWORK round trip, unlike the local adapter's disk read, because the
+   * bytes live on Vercel's CDN and there is no other way to reach them. That
+   * cost is the reason a caller serving these from its own origin has to cache:
+   * the privacy rule that forces same-origin serving does not also make the
+   * fetch free, and an uncached proxy pays it on every request.
+   *
+   * The URL is taken from `head` rather than assembled from `filePath`,
+   * because a blob's address is issued by the service — it carries a random
+   * suffix this adapter never chose — so deriving one here would be guessing at
+   * a string another system owns.
+   *
+   * `null` for a missing blob rather than a throw, matching {@link exists}.
+   *
+   * @param filePath - Blob path/key
+   * @returns The blob's bytes, or `null` when it does not exist
+   */
+  async read(filePath: string): Promise<Buffer | null> {
+    let target: string;
+    try {
+      const meta = await head(filePath, { token: this.resolvedConfig.token });
+      target = meta.downloadUrl ?? meta.url;
+    } catch {
+      // Vercel Blob throws when the blob does not exist.
+      return null;
+    }
+
+    /*
+     * OUTSIDE the catch above, deliberately, and through the shared helper so
+     * that separation is stated once rather than in each adapter. A failed
+     * fetch of a blob whose metadata just resolved is a transport failure
+     * rather than an absence, and folding it into `null` would report a
+     * network outage as a deleted file.
+     */
+    return await fetchStoredBytes(target, filePath, "Vercel Blob");
   }
 
   /**

--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -27,9 +27,8 @@
  * ```
  */
 
-import { put, del, head, list } from "@vercel/blob";
+import { put, del, head, list, BlobNotFoundError } from "@vercel/blob";
 import { NextlyError } from "nextly/errors";
-import { fetchStoredBytes } from "nextly/storage";
 import type {
   IStorageAdapter,
   UploadOptions,
@@ -39,6 +38,7 @@ import type {
   FileMetadata,
   BulkDeleteResult,
 } from "nextly/storage";
+import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
 
 import type {
   VercelBlobStorageConfig,
@@ -266,9 +266,20 @@ export class VercelBlobStorageAdapter implements IStorageAdapter {
     try {
       const meta = await head(filePath, { token: this.resolvedConfig.token });
       target = meta.downloadUrl ?? meta.url;
-    } catch {
-      // Vercel Blob throws when the blob does not exist.
-      return null;
+    } catch (error: unknown) {
+      /*
+       * ONLY the not-found class becomes `null`. `head` also rejects for an
+       * expired token, a suspended or missing store, an aborted request and a
+       * plain network failure, and every one of those says nothing about
+       * whether the blob exists. Catching them all reports an outage as a
+       * deletion, which a caller may act on by writing a replacement over a
+       * file that is still there.
+       *
+       * Identified by the CLASS the SDK exports rather than by matching the
+       * message, because the message is prose this package does not own.
+       */
+      if (error instanceof BlobNotFoundError) return null;
+      throw error;
     }
 
     /*

--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -39,7 +39,10 @@ import type {
   BulkDeleteResult,
   StorageReadOptions,
 } from "nextly/storage";
-import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
+import {
+  fetchStoredBytes,
+  DEFAULT_READ_TIMEOUT_MS,
+} from "nextly/storage/fetch-stored-bytes";
 
 import type {
   VercelBlobStorageConfig,
@@ -273,17 +276,22 @@ export class VercelBlobStorageAdapter implements IStorageAdapter {
      * deadline that begins only at the fetch leaves the lookup unbounded and
      * the read can outlive what the caller was promised. Created here and
      * handed to both.
+     *
+     * ALWAYS, not only when the caller named a timeout. `safeFetch` applies a
+     * default deadline of its own, so a caller stating none was still bounded
+     * for the fetch and unbounded for the lookup — which is the commonest call,
+     * the email path among them, since it supplies only a byte cap. The default
+     * comes from the same constant `safeFetch` uses rather than being restated.
      */
-    const deadline =
-      options?.timeoutMs === undefined
-        ? undefined
-        : AbortSignal.timeout(options.timeoutMs);
+    const deadline = AbortSignal.timeout(
+      options?.timeoutMs ?? DEFAULT_READ_TIMEOUT_MS
+    );
 
     let target: string;
     try {
       const meta = await head(filePath, {
         token: this.resolvedConfig.token,
-        ...(deadline === undefined ? {} : { abortSignal: deadline }),
+        abortSignal: deadline,
       });
       target = meta.downloadUrl ?? meta.url;
     } catch (error: unknown) {

--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -37,6 +37,7 @@ import type {
   ClientUploadData,
   FileMetadata,
   BulkDeleteResult,
+  StorageReadOptions,
 } from "nextly/storage";
 import { fetchStoredBytes } from "nextly/storage/fetch-stored-bytes";
 
@@ -261,7 +262,10 @@ export class VercelBlobStorageAdapter implements IStorageAdapter {
    * @param filePath - Blob path/key
    * @returns The blob's bytes, or `null` when it does not exist
    */
-  async read(filePath: string): Promise<Buffer | null> {
+  async read(
+    filePath: string,
+    options?: StorageReadOptions
+  ): Promise<Buffer | null> {
     let target: string;
     try {
       const meta = await head(filePath, { token: this.resolvedConfig.token });
@@ -289,7 +293,7 @@ export class VercelBlobStorageAdapter implements IStorageAdapter {
      * rather than an absence, and folding it into `null` would report a
      * network outage as a deleted file.
      */
-    return await fetchStoredBytes(target, filePath, "Vercel Blob");
+    return await fetchStoredBytes(target, filePath, "Vercel Blob", options);
   }
 
   /**

--- a/packages/storage-vercel-blob/src/adapter.ts
+++ b/packages/storage-vercel-blob/src/adapter.ts
@@ -266,9 +266,25 @@ export class VercelBlobStorageAdapter implements IStorageAdapter {
     filePath: string,
     options?: StorageReadOptions
   ): Promise<Buffer | null> {
+    /*
+     * ONE deadline for both phases, started before the lookup.
+     *
+     * `head` can stall exactly as the fetch can, and it runs first — so a
+     * deadline that begins only at the fetch leaves the lookup unbounded and
+     * the read can outlive what the caller was promised. Created here and
+     * handed to both.
+     */
+    const deadline =
+      options?.timeoutMs === undefined
+        ? undefined
+        : AbortSignal.timeout(options.timeoutMs);
+
     let target: string;
     try {
-      const meta = await head(filePath, { token: this.resolvedConfig.token });
+      const meta = await head(filePath, {
+        token: this.resolvedConfig.token,
+        ...(deadline === undefined ? {} : { abortSignal: deadline }),
+      });
       target = meta.downloadUrl ?? meta.url;
     } catch (error: unknown) {
       /*
@@ -293,7 +309,13 @@ export class VercelBlobStorageAdapter implements IStorageAdapter {
      * rather than an absence, and folding it into `null` would report a
      * network outage as a deleted file.
      */
-    return await fetchStoredBytes(target, filePath, "Vercel Blob", options);
+    return await fetchStoredBytes(
+      target,
+      filePath,
+      "Vercel Blob",
+      options,
+      deadline
+    );
   }
 
   /**


### PR DESCRIPTION
Foundation for the Fonts panel work (tracker **U-4**). The engine refuses any `@font-face` URL carrying a host — a documented product rule citing the German Google Fonts ruling — so an uploaded font has to be served **same-origin**. That route cannot stream what no adapter can read.

## What was actually wrong

`read?` has been an optional member of `IStorageAdapter` that **only the local adapter supplied**. A caller reaching for it against S3, Vercel Blob or UploadThing got `undefined` and fell through the branch that followed: a capability that reads as present and behaves as absent.

I want to be precise about the size of this, because I first reported it wrongly to myself. An earlier grep of mine said *no* adapter implemented `read` — that search used a glob that never reached `src/storage/adapters/`, so it missed the local adapter entirely. Re-measured per adapter file with an `upload()` control (1 in every file, so the search works): the gap was **2 of 4**, plus S3. Local was fine all along.

## The separation this turns on

A missing key answers `null` — an ordinary fact about the store.

A **transport failure does not**. A dropped connection to a file whose lookup just succeeded is an error, because folding the two together lets a caller treat a live file as deleted and write a replacement over it. In both URL-addressed adapters the fetch therefore sits *outside* the not-found `catch`.

That is stated **once**, in a shared `fetchStoredBytes` helper both call. The first version spelled it twice and `fallow` correctly flagged the two `read` bodies as a duplication clone group plus a CRAP finding on the copy — both `introduced: true`, both genuinely mine. I had suspected mis-attribution and checked before dismissing it; fallow was right. After the extraction: **0 introduced** on dead-code, complexity and duplication.

Related: S3 answers an empty buffer for a zero-byte object rather than `null`, because a stored empty file is not a missing one — and a caller cleaning up "missing" keys would otherwise delete a real one.

## Errors

Moving the helper into `packages/nextly/**` correctly brought it under the `NextlyError` lint rule. It throws `NextlyError.internal` with service, key and status on the **log** side; the public message stays generic, since those three are exactly what should not travel to whoever asked for the file.

## Evidence

Three tests on the Vercel adapter, each break-verified individually — and re-verified after the refactor, since changing a test changes the experiment:

| break | fails | stays green |
|---|---|---|
| transport failure folded into `null` | `THROWS when the fetch fails after the blob resolved` | the other two |
| `read()` always returns `null` | `returns the stored bytes` + the THROWS case | `answers null for a blob that is not there` |

That second row is recorded in the test itself: **the null case is vacuous on its own** — it passes on a `read` that returns `null` for every input. Its control is the positive case in the same file, and the test now says so, so deleting that case cannot quietly make this one meaningless.

The THROWS case asserts the error **code**, not its text — matching on prose would either fail or pressure the public message into leaking the status back.

Gates: `nextly` storage **7 files / 111 tests**, storage-vercel-blob **7 tests**, lint + check-types **14/14 tasks**, `fallow audit` **pass** (0 introduced). Branch cut from `8ff06f92d`; `git merge-tree` reports no conflicts.

## Not in this PR

The same-origin asset route itself, font mime types, and the Fonts panel upload affordance. This is the capability they need; splitting it keeps the reviewable unit to one question.