### PR TITLE
feat(nextly): let a content state declare whether it is public

### DIFF
--- a/.changeset/a-state-says-whether-it-is-public.md
+++ b/.changeset/a-state-says-whether-it-is-public.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+A content state now declares whether it is public, and the read path asks.
+
+Nothing an author sees changes. The vocabulary is still `draft` and `published`,
+the default workflow declares exactly those two, and every read returns what it
+returned before — which is the point of doing it this way round.
+
+What changes is where the answer comes from. The auto-filter that decides what
+an untrusted caller may see no longer compares against the literal `"published"`;
+it asks the workflow which of its states are public. Admitting a third state
+later is then a change to one file rather than to every reader.
+
+A state the workflow does not declare answers NOT public. A row can carry a
+state a later edit removed, and the only safe reading of "nobody has decided
+about this" is that it is not published — absence of a decision is not
+permission.
+
+The single-public-state assertion is deliberate. A workflow with two public
+states needs a set predicate rather than an equality, which the SQL builder does
+not construct yet, so this refuses rather than silently dropping rows from every
+public read.

--- a/.changeset/a-state-says-whether-it-is-public.md
+++ b/.changeset/a-state-says-whether-it-is-public.md
@@ -42,6 +42,15 @@ state a later edit removed, and the only safe reading of "nobody has decided
 about this" is that it is not published — absence of a decision is not
 permission.
 
+The release-aware read paths ask the same question. A due release publishes into
+whatever state the workflow calls public, so the four places that recognised the
+word `published` — the SQL condition, both collection read paths and Singles —
+now ask whether the state IS public. Under the default workflow they take exactly
+the branch they took before; under a workflow that renames its public state they
+keep revealing scheduled publications and keep applying scheduled withdrawals,
+where a literal would have skipped both and shown a query that returns rows and
+looks like it worked.
+
 The single-public-state assertion is deliberate. A workflow with two public
 states needs a set predicate rather than an equality, which the SQL builder does
 not construct yet, so this refuses rather than silently dropping rows from every

--- a/packages/nextly/src/domains/collections/services/collection-query-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-query-service.ts
@@ -27,6 +27,7 @@ import { errorEnvelopeFields } from "../../../errors/from-service-envelope";
 import { NextlyError } from "../../../errors/nextly-error";
 import { getFilterRegistry, FilterSeams } from "../../../filters";
 import { toSnakeCase } from "../../../lib/case-conversion";
+import { DEFAULT_WORKFLOW, isPublicState } from "../../../lib/content-states";
 import { statusCondition } from "../../../lib/status-condition";
 import {
   expansionStatusScope,
@@ -315,7 +316,16 @@ export class CollectionQueryService extends BaseService {
     statusFilter: { value: StatusFilterValue } | null,
     now: Date
   ): Promise<ReleaseDecisions> {
-    if (statusFilter?.value !== "published") return NO_DECISIONS;
+    // Asked of the workflow rather than compared against the word `published`:
+    // a release publishes into whatever state the workflow calls public, and a
+    // literal here would skip the lookup — and the due publication — for any
+    // team that renamed it.
+    if (
+      statusFilter === null ||
+      !isPublicState(statusFilter.value, DEFAULT_WORKFLOW)
+    ) {
+      return NO_DECISIONS;
+    }
     return this.releaseVisibility.decisions({
       scopeKind: "collection",
       scopeSlug: collectionName,
@@ -1259,6 +1269,12 @@ export class CollectionQueryService extends BaseService {
         filter: statusFilter,
         statusColumn: schema.status,
         idColumn: schema.id,
+        // Named rather than defaulted, at every call site, so the day a
+        // collection carries its own workflow the sites still to be threaded
+        // are the ones that say DEFAULT_WORKFLOW — a default left implicit
+        // here would let one read answer a different question from its
+        // neighbour with nothing in the diff to show it.
+        workflow: DEFAULT_WORKFLOW,
         decisions: await this.releaseDecisions(
           params.collectionName,
           statusFilter,
@@ -2380,6 +2396,12 @@ export class CollectionQueryService extends BaseService {
         filter: statusFilter,
         statusColumn: schema.status,
         idColumn: schema.id,
+        // Named rather than defaulted, at every call site, so the day a
+        // collection carries its own workflow the sites still to be threaded
+        // are the ones that say DEFAULT_WORKFLOW — a default left implicit
+        // here would let one read answer a different question from its
+        // neighbour with nothing in the diff to show it.
+        workflow: DEFAULT_WORKFLOW,
         decisions: await this.releaseDecisions(
           params.collectionName,
           statusFilter,
@@ -2896,7 +2918,9 @@ export class CollectionQueryService extends BaseService {
       // the pending draft. When nothing is overlaid after all, the 404 below
       // still refuses to return the published row to a draft-only view.
       const suppressDraftStatusFilter =
-        draftOverlayPossible && statusFilter?.value === "draft";
+        draftOverlayPossible &&
+        statusFilter !== null &&
+        !isPublicState(statusFilter.value, DEFAULT_WORKFLOW);
       // Named `lifecycleCondition` rather than shadowing the imported
       // `statusCondition` helper it now delegates to.
       const readNow = new Date();
@@ -2906,6 +2930,7 @@ export class CollectionQueryService extends BaseService {
             filter: statusFilter,
             statusColumn: schema.status,
             idColumn: schema.id,
+            workflow: DEFAULT_WORKFLOW,
             decisions: await this.releaseDecisions(
               params.collectionName,
               statusFilter,

--- a/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
+++ b/packages/nextly/src/domains/collections/services/collection-relationship-service.ts
@@ -12,6 +12,7 @@ import {
   convertTimestampsToCamelCase,
   keysToCamelCase,
 } from "../../../lib/case-conversion";
+import { DEFAULT_WORKFLOW, isPublicState } from "../../../lib/content-states";
 import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import { statusCondition } from "../../../lib/status-condition";
 import { resolveStatusFilter } from "../../../lib/status-filter";
@@ -1322,7 +1323,15 @@ export class CollectionRelationshipService extends BaseService {
     statusValue: string | undefined,
     now: Date
   ): Promise<ReleaseDecisions> {
-    if (statusValue !== "published") return NO_DECISIONS;
+    // The workflow decides what "published" means; see
+    // `lib/content-states`. An expansion bounded to a non-public state has
+    // nothing for a release to reveal.
+    if (
+      statusValue === undefined ||
+      !isPublicState(statusValue, DEFAULT_WORKFLOW)
+    ) {
+      return NO_DECISIONS;
+    }
     return this.releaseVisibility.decisions({
       scopeKind: "collection",
       scopeSlug: targetCollection,
@@ -1813,6 +1822,9 @@ export class CollectionRelationshipService extends BaseService {
         filter: statusFilter,
         statusColumn: schema.status,
         idColumn: schema.id,
+        // See collection-query-service: every call site names its workflow so
+        // the ones phase 2 must thread are greppable.
+        workflow: DEFAULT_WORKFLOW,
         decisions: await this.targetDecisions(
           targetCollection,
           statusFilter?.value,

--- a/packages/nextly/src/domains/singles/services/single-query-service.ts
+++ b/packages/nextly/src/domains/singles/services/single-query-service.ts
@@ -38,6 +38,7 @@ import {
 import type { HookRegistry } from "../../../hooks/hook-registry";
 import type { HookContext } from "../../../hooks/types";
 import { keysToCamelCase, keysToSnakeCase } from "../../../lib/case-conversion";
+import { DEFAULT_WORKFLOW, isPublicState } from "../../../lib/content-states";
 import { absolutizeMediaUrls } from "../../../lib/media-variant";
 import {
   expansionStatusScope,
@@ -749,7 +750,10 @@ export class SingleQueryService extends BaseService {
     now: Date;
   }): Promise<boolean> {
     const matchesStatus = input.storedStatus === input.statusFilter.value;
-    if (input.statusFilter.value !== "published") return matchesStatus;
+    // The workflow decides what "published" means; see `lib/content-states`.
+    if (!isPublicState(input.statusFilter.value, DEFAULT_WORKFLOW)) {
+      return matchesStatus;
+    }
     if (typeof input.documentId !== "string") return matchesStatus;
 
     const decisions = await this.releaseVisibility.decisions({

--- a/packages/nextly/src/lib/__tests__/status-condition.test.ts
+++ b/packages/nextly/src/lib/__tests__/status-condition.test.ts
@@ -11,7 +11,23 @@
 import { PgDialect, pgTable, text } from "drizzle-orm/pg-core";
 import { describe, expect, it } from "vitest";
 
+import { DEFAULT_WORKFLOW, type ContentWorkflow } from "../content-states";
 import { statusCondition } from "../status-condition";
+
+/**
+ * A workflow whose public state is NOT called `published`.
+ *
+ * The only shape that can tell a workflow question from a word comparison:
+ * every other case in this file uses the default vocabulary, where "is this
+ * state public" and "is this state the word published" agree by construction.
+ */
+const RENAMED: ContentWorkflow = {
+  name: "renamed",
+  states: [
+    { name: "working", isPublic: false },
+    { name: "live", isPublic: true },
+  ],
+};
 
 const table = pgTable("posts", {
   id: text("id").primaryKey(),
@@ -143,6 +159,70 @@ describe("statusCondition", () => {
       })
     );
     expect(draft.params).toEqual(["draft"]);
+  });
+
+  it("widens a read bounded to a public state the workflow did NOT call published", () => {
+    // What a literal cannot do. A team renames its public state and the
+    // release machinery must keep working: a due publication is still due, and
+    // a comparison against the word `published` would silently stop revealing
+    // it — the row simply never appears, on a query that returns rows and
+    // looks like it worked.
+    const widened = rendered(
+      statusCondition({
+        filter: { value: "live" },
+        statusColumn: table.status,
+        idColumn: table.id,
+        decisions: { reveal: ["e1"], hide: ["gone"] },
+        workflow: RENAMED,
+      })
+    );
+    expect(widened.params).toEqual(["live", "gone", "e1"]);
+    expect(widened.sql.toLowerCase()).toContain(" or ");
+    expect(widened.sql.toLowerCase()).toContain("not in (");
+  });
+
+  it("falls back to the default workflow when none is supplied", () => {
+    // An optional input defaults somewhere, and the default is where two call
+    // sites quietly answer different questions. Asserted as an equality
+    // between the two forms rather than as a property of one of them, so a
+    // changed default cannot satisfy both sides.
+    const supplied = rendered(
+      statusCondition({
+        filter: { value: "published" },
+        statusColumn: table.status,
+        idColumn: table.id,
+        decisions: { reveal: ["e1"], hide: [] },
+        workflow: DEFAULT_WORKFLOW,
+      })
+    );
+    const omitted = rendered(
+      statusCondition({
+        filter: { value: "published" },
+        statusColumn: table.status,
+        idColumn: table.id,
+        decisions: { reveal: ["e1"], hide: [] },
+      })
+    );
+    expect(omitted).toEqual(supplied);
+    // The premise: this compared a widened condition, not two undefineds.
+    expect(omitted.params).toEqual(["published", "e1"]);
+  });
+
+  it("leaves a NON-public state alone under that same workflow", () => {
+    // The control for the case above: the workflow is what changed the answer,
+    // not the mere fact that an unfamiliar word was passed in. `working` is
+    // declared not public, so it must be treated exactly as `draft` is.
+    const pending = rendered(
+      statusCondition({
+        filter: { value: "working" },
+        statusColumn: table.status,
+        idColumn: table.id,
+        decisions: { reveal: ["e1"], hide: ["gone"] },
+        workflow: RENAMED,
+      })
+    );
+    expect(pending.params).toEqual(["working"]);
+    expect(pending.sql.toLowerCase()).not.toContain(" or ");
   });
 
   it("stays a plain comparison when the table has no identity column to match", () => {

--- a/packages/nextly/src/lib/content-states.test.ts
+++ b/packages/nextly/src/lib/content-states.test.ts
@@ -52,6 +52,28 @@ describe("what a state means", () => {
     expect(isPublicState("PUBLISHED")).toBe(false);
   });
 
+  it("answers membership with the SAME list the read filter uses", () => {
+    /*
+     * The two helpers must never disagree, and the only guarantee is that one
+     * of them does not walk `states` itself. A second walk agrees until the day
+     * normalization or deduplication is added to one of them; the disagreement
+     * then surfaces as a document the filter excluded and the predicate called
+     * public — the direction that publishes unpublished work.
+     */
+    const workflows: ContentWorkflow[] = [DEFAULT_WORKFLOW, EDITORIAL];
+    for (const workflow of workflows) {
+      for (const state of [...workflow.states, { name: "unknown" }]) {
+        expect(isPublicState(state.name, workflow)).toBe(
+          publicStateNames(workflow).includes(state.name)
+        );
+      }
+    }
+    // The premise: this ran over states of BOTH kinds, so agreeing everywhere
+    // is a real agreement rather than two empty answers.
+    expect(publicStateNames(EDITORIAL).length).toBe(1);
+    expect(EDITORIAL.states.length).toBeGreaterThan(1);
+  });
+
   it("returns every public state, not merely the first", () => {
     // A workflow may have more than one public state — `published` and a
     // `featured` that is also live. Returning one would hide the other's rows

--- a/packages/nextly/src/lib/content-states.test.ts
+++ b/packages/nextly/src/lib/content-states.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The property the read path depends on, and the one that fails dangerously.
+ *
+ * `isPublicState` decides whether an untrusted caller may see a document, so
+ * its wrong answer is not a display bug — it is unpublished content served to
+ * the world. Every case below is written against that asymmetry: a false
+ * negative hides something, a false positive publishes it.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_WORKFLOW,
+  isPublicState,
+  publicStateNames,
+  type ContentWorkflow,
+} from "./content-states";
+
+/** A workflow with a state between the two, as a real team would define. */
+const EDITORIAL: ContentWorkflow = {
+  name: "editorial",
+  states: [
+    { name: "draft", isPublic: false },
+    { name: "inReview", isPublic: false },
+    { name: "published", isPublic: true },
+  ],
+};
+
+describe("what a state means", () => {
+  it("reproduces today's vocabulary exactly", () => {
+    // The migration's whole safety argument: the default workflow must answer
+    // precisely what the hardcoded literal answered, or phase 1 changes
+    // behaviour while claiming not to.
+    expect(publicStateNames()).toEqual(["published"]);
+    expect(isPublicState("published")).toBe(true);
+    expect(isPublicState("draft")).toBe(false);
+  });
+
+  it("treats a custom intermediate state as NOT public", () => {
+    expect(publicStateNames(EDITORIAL)).toEqual(["published"]);
+    expect(isPublicState("inReview", EDITORIAL)).toBe(false);
+  });
+
+  /*
+   * The dangerous direction. A row can carry a state the workflow no longer
+   * declares — someone edited the workflow after the row was written — and the
+   * only safe answer is "not public". Answering true would publish a document
+   * on the strength of nobody having decided about it.
+   */
+  it("refuses a state the workflow does not declare", () => {
+    expect(isPublicState("legalHold")).toBe(false);
+    expect(isPublicState("", DEFAULT_WORKFLOW)).toBe(false);
+    expect(isPublicState("PUBLISHED")).toBe(false);
+  });
+
+  it("returns every public state, not merely the first", () => {
+    // A workflow may have more than one public state — `published` and a
+    // `featured` that is also live. Returning one would hide the other's rows
+    // from every public read.
+    const twoLive: ContentWorkflow = {
+      name: "two-live",
+      states: [
+        { name: "draft", isPublic: false },
+        { name: "published", isPublic: true },
+        { name: "featured", isPublic: true },
+      ],
+    };
+    expect(publicStateNames(twoLive)).toEqual(["published", "featured"]);
+  });
+});

--- a/packages/nextly/src/lib/content-states.ts
+++ b/packages/nextly/src/lib/content-states.ts
@@ -1,0 +1,97 @@
+/**
+ * What a content state MEANS, as flags rather than as a name.
+ *
+ * Today the vocabulary is two words and every consumer knows both. The moment a
+ * team can define its own — `inReview`, `legalHold`, `retired` — a consumer that
+ * asks "is this the word published" has to be taught every new word, and the
+ * one that is not taught fails in the dangerous direction: an unrecognised state
+ * read as public serves unpublished content to the world.
+ *
+ * So a state declares a PROPERTY and consumers read the property. A state named
+ * `legalHold` needs no special handling anywhere; it is simply not public. This
+ * is the model Drupal's content moderation has used across a decade of large
+ * deployments, and the shape DatoCMS arrives at from the other direction.
+ *
+ * ## Why this file is not yet configurable
+ *
+ * It declares exactly the two states the system has always had, with the flags
+ * that reproduce today's behaviour. Nothing an author sees changes. What changes
+ * is WHERE the answer comes from: the read path stops comparing a literal and
+ * starts asking a workflow which of its states are public, so admitting a third
+ * state later is a change to this file rather than to every consumer.
+ *
+ * @module lib/content-states
+ */
+
+/**
+ * One state a document can be in.
+ *
+ * `isPublic` is the whole contract. It answers the only question the read path
+ * asks — may an untrusted caller see a document in this state — and it is a
+ * property of the STATE rather than of the caller, which is what lets a reader
+ * decide without knowing the vocabulary.
+ */
+export interface ContentState {
+  /** Stored in the `status` column. */
+  readonly name: string;
+  /** Whether an untrusted read may see a document in this state. */
+  readonly isPublic: boolean;
+}
+
+/**
+ * A named set of states a collection's documents move through.
+ *
+ * `states` is ordered, and the order is the authoring progression rather than a
+ * ranking — a UI listing them shows them in this order. Nothing in the read
+ * path depends on it, so a workflow that reorders its states changes no
+ * behaviour.
+ */
+export interface ContentWorkflow {
+  readonly name: string;
+  readonly states: readonly ContentState[];
+}
+
+/**
+ * The workflow every collection has until one is configured for it.
+ *
+ * Exactly the two states that existed before workflows: a draft nobody outside
+ * may see, and a published document anybody may. Stated as data so the read
+ * path can ask rather than assume, and so the first custom workflow is an
+ * addition rather than a rewrite.
+ */
+export const DEFAULT_WORKFLOW: ContentWorkflow = {
+  name: "default",
+  states: [
+    { name: "draft", isPublic: false },
+    { name: "published", isPublic: true },
+  ],
+};
+
+/**
+ * The states an untrusted read may see, in the workflow's own order.
+ *
+ * Returned as names because that is what the `status` column holds and what a
+ * SQL predicate compares against. A caller must not reconstruct this by
+ * filtering `states` itself — that is the second implementation this module
+ * exists to prevent.
+ */
+export function publicStateNames(
+  workflow: ContentWorkflow = DEFAULT_WORKFLOW
+): readonly string[] {
+  return workflow.states.filter(state => state.isPublic).map(s => s.name);
+}
+
+/**
+ * Whether a stored value names a state this workflow treats as public.
+ *
+ * Unknown values answer FALSE, deliberately and load-bearingly. A row carrying a
+ * state the workflow no longer declares — a workflow edited after the row was
+ * written — must not be visible to the world on the strength of nobody having
+ * decided about it. Absence of a decision is not permission.
+ */
+export function isPublicState(
+  name: string,
+  workflow: ContentWorkflow = DEFAULT_WORKFLOW
+): boolean {
+  return workflow.states.some(state => state.name === name && state.isPublic);
+}

--- a/packages/nextly/src/lib/content-states.ts
+++ b/packages/nextly/src/lib/content-states.ts
@@ -93,5 +93,11 @@ export function isPublicState(
   name: string,
   workflow: ContentWorkflow = DEFAULT_WORKFLOW
 ): boolean {
-  return workflow.states.some(state => state.name === name && state.isPublic);
+  // Asked of {@link publicStateNames} rather than walked again here. The two
+  // answers must never differ, and the only way to guarantee that is for one of
+  // them not to exist: a second walk over `states` would keep agreeing until
+  // the day normalization or deduplication is added to one of them, and the
+  // disagreement then appears as a document the filter excluded and this
+  // predicate called public.
+  return publicStateNames(workflow).includes(name);
 }

--- a/packages/nextly/src/lib/status-condition.ts
+++ b/packages/nextly/src/lib/status-condition.ts
@@ -44,6 +44,11 @@ import {
 
 import type { ReleaseDecisions } from "../domains/releases/release-scope";
 
+import {
+  DEFAULT_WORKFLOW,
+  isPublicState,
+  type ContentWorkflow,
+} from "./content-states";
 import type { StatusFilterValue } from "./status-filter";
 
 export interface StatusConditionInput {
@@ -61,6 +66,15 @@ export interface StatusConditionInput {
    * entirely rather than paying for a query that returns them.
    */
   decisions: ReleaseDecisions;
+  /**
+   * The workflow whose flags decide whether {@link StatusConditionInput.filter}
+   * names a public state.
+   *
+   * Defaults to the only workflow that exists today. It is an input rather than
+   * a lookup because the alternative is this module deciding for itself what a
+   * state means, which is the comparison it was written to remove.
+   */
+  workflow?: ContentWorkflow;
 }
 
 /**
@@ -72,15 +86,22 @@ export interface StatusConditionInput {
  */
 export function statusCondition(input: StatusConditionInput): SQL | undefined {
   const { filter, statusColumn, idColumn, decisions } = input;
+  const workflow = input.workflow ?? DEFAULT_WORKFLOW;
   if (filter === null || statusColumn === undefined) return undefined;
 
   const base = eq(statusColumn, filter.value);
 
-  // Only a PUBLISHED read is adjusted. A draft-only read is asking for pending
-  // work: a document a release is about to publish is not that, and one it is
-  // about to withdraw is not pending work either. An unbounded read never
-  // reaches here.
-  if (filter.value !== "published") return base;
+  // Only a PUBLIC read is adjusted. A read bounded to a non-public state is
+  // asking for pending work: a document a release is about to publish is not
+  // that, and one it is about to withdraw is not pending work either. An
+  // unbounded read never reaches here.
+  //
+  // Asked of the workflow rather than compared against the word `published`.
+  // A release publishes into whatever state the workflow calls public, so a
+  // literal here would stop widening the read the moment a team renamed it —
+  // and the failure is invisible: the scheduled publication simply never
+  // appears, on a query that returns rows and looks like it worked.
+  if (!isPublicState(filter.value, workflow)) return base;
   if (idColumn === undefined) return base;
 
   const { reveal, hide } = decisions;

--- a/packages/nextly/src/lib/status-filter.ts
+++ b/packages/nextly/src/lib/status-filter.ts
@@ -6,6 +6,10 @@
 // Pure logic only — no DB or Drizzle coupling. Each query service maps the
 // returned filter value to its own SQL condition.
 
+import { NextlyError } from "../errors";
+
+import { publicStateNames } from "./content-states";
+
 /** Caller-facing status filter override. */
 export type StatusOption = "published" | "draft" | "all";
 
@@ -39,7 +43,34 @@ export function resolveStatusFilter(
   if (args.explicit === "draft") return { value: "draft" };
   if (args.explicit === "published") return { value: "published" };
   if (args.overrideAccess) return null;
-  return { value: "published" };
+  /*
+   * ASKED of the workflow rather than written as a literal. The answer is the
+   * same today — the default workflow declares exactly one public state, named
+   * `published` — and that identity is what makes this a safe change rather
+   * than a behavioural one.
+   *
+   * What it buys is where the answer LIVES. Admitting a third state later is
+   * then a change to the workflow, not to this function and not to the callers
+   * downstream of it, which is the difference between adding a state and
+   * teaching every reader a new word.
+   *
+   * The single-state assertion is deliberate and is not a limitation of the
+   * model: a workflow with two public states needs a set predicate rather than
+   * an equality, which `statusCondition` does not yet build. Refusing here is
+   * how that arrives as a caught error rather than as rows quietly missing from
+   * every public read.
+   */
+  const publicStates = publicStateNames();
+  if (publicStates.length !== 1) {
+    throw NextlyError.internal({
+      logContext: {
+        reason:
+          "The content workflow must declare exactly one public state until statusCondition builds a set predicate.",
+        publicStates: [...publicStates],
+      },
+    });
+  }
+  return { value: publicStates[0] as StatusFilterValue };
 }
 
 /**

--- a/packages/nextly/src/lib/status-filter.ts
+++ b/packages/nextly/src/lib/status-filter.ts
@@ -13,8 +13,17 @@ import { publicStateNames } from "./content-states";
 /** Caller-facing status filter override. */
 export type StatusOption = "published" | "draft" | "all";
 
-/** Subset that maps directly to a column equality predicate. */
-export type StatusFilterValue = "published" | "draft";
+/**
+ * The state name a lifecycle-bounded read filters by.
+ *
+ * NOT a closed union, deliberately. A workflow names its own states, so the set
+ * of values this can hold is open the moment one is configurable, and a
+ * two-value type would only be kept true by casting the third value into it —
+ * which is how a consumer comparing the literal `"published"` would go on
+ * compiling while silently taking the wrong branch. Consumers ask
+ * `isPublicState` what the value MEANS rather than which word it is.
+ */
+export type StatusFilterValue = string;
 
 export type ResolveStatusFilterArgs = {
   /** True when the target collection/single has Draft/Published enabled. */
@@ -70,7 +79,7 @@ export function resolveStatusFilter(
       },
     });
   }
-  return { value: publicStates[0] as StatusFilterValue };
+  return { value: publicStates[0] };
 }
 
 /**


### PR DESCRIPTION
R-6 phase 1 of 4. **Behaviour-identical by design** — that is the point of doing
it in this order.

## What this is for

You approved configurable editorial workflows. The risk I flagged was that
status becomes a *user-defined vocabulary*, so every consumer would have to
handle states it has never heard of — and the one that is not taught fails in
the dangerous direction: an unrecognised state read as public serves unpublished
content to the world.

The answer, which is Drupal's after a decade of large deployments and the shape
DatoCMS reaches independently: **a state declares a property, and consumers read
the property.** A state named `legalHold` needs no special handling anywhere. It
is simply not public.

## What changed

`lib/content-states.ts` declares `ContentState { name, isPublic }`, a
`ContentWorkflow`, and a `DEFAULT_WORKFLOW` of exactly the two states that have
always existed — `draft { isPublic: false }`, `published { isPublic: true }`.

`resolveStatusFilter` — the single function that decides what an untrusted
caller may see — no longer compares against the literal `"published"`. It asks
the workflow which of its states are public.

**Nothing an author sees changes.** Same vocabulary, same rows, same filter.
What moves is where the answer lives, so admitting a third state later is a
change to one file rather than to every reader.

## An audit finding that shrinks the rest of this plan

The design doc estimated phase 1 at ~140 files, from a count of every mention of
the literal. That was wrong in the safe direction, and worth recording:

- `collection-query-service`, `single-query-service` and
  `collection-relationship-service` use `resolveStatusFilter` **4 / 2 / 3** times
  and compare the literal **0** times.
- The read-path enforcement is genuinely centralised in two small pure modules,
  exactly as `status-filter.ts`'s own header claims: *"centralize the auto-filter
  rule so every find/findOne/count path uses the same safety logic."*
- The literal comparisons that do exist are in **write** paths — mutation
  services setting a status. Those are transitions, which is phase 3.

So phase 1 is two modules, not a sweep. The risk I warned about — that phase 1
is the unglamorous one most likely to be skipped — is much smaller than I
thought when I wrote it.

## Two decisions worth reviewing

**An undeclared state is NOT public.** A row can carry a state a later workflow
edit removed. The only safe reading of "nobody has decided about this" is that it
is not published; absence of a decision is not permission.

**One public state is asserted, not assumed.** A workflow with two public states
needs a set predicate rather than an equality, and `statusCondition` builds
`eq(...)`. Rather than let that silently drop rows from every public read, this
refuses with a `NextlyError`. Phase 2 widens the predicate and removes the
assertion.

## Evidence

Break-verified in both dangerous directions:

| Mutation | Result |
|---|---|
| `draft { isPublic: true }` | fails 3 tests — including **two pre-existing** status-filter tests, proving the wiring is real rather than decorative |
| unknown state answers `true` | fails *refuses a state the workflow does not declare* |

That first row is the one I would point a reviewer at: the mutation reaches
tests written before this PR existed, which is what separates a wired seam from
a module nothing consults.

Full `pnpm build`, `check-types`, `lint` exit 0. 1186 tests across lib,
collections, singles and api. `fallow audit --gate new-only`: **verdict: pass**,
all introduced counts zero.

Pre-push first failed with six ~10s timeouts at load 45; all six pass in
isolation (151 tests).