### PR TITLE
fix(nextly): one rule set for widget field values, and a test that pins the rest

### DIFF
--- a/.changeset/one-rule-set-for-widget-values.md
+++ b/.changeset/one-rule-set-for-widget-values.md
@@ -1,0 +1,47 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+One rule set for widget field values, whichever channel a widget arrives by.
+
+`registerWidget` and `contributes.admin.widgets` validate related but distinct
+shapes, and the rules they genuinely share had been written twice. Four fields
+had already drifted apart one at a time -- the shortcut rule, the queryless
+no-query rule, `defaultOrder` and `chrome` -- each added to one validator,
+missed by the other, and each time the contributed side was the more permissive.
+
+Measuring the whole surface rather than the next instance found five more:
+a blank title, a `defaultSize` outside the vocabulary (which silently rendered
+the card full width), `minSize` above `defaultSize`, an unknown `defaultHeight`,
+and `actions` declared on an archetype that is not `actions`.
+
+`widgetValueProblem` is now the single rule both channels ask. Shape stays with
+each channel, because they differ there on purpose: a contribution may omit
+`title` and `defaultSize`, which resolution fills in.
+
+A divergence test pins the whole relationship -- every rule both channels must
+agree on, and the four differences that are deliberate, each recorded with the
+reason it is not drift.

--- a/.changeset/one-rule-set-for-widget-values.md
+++ b/.changeset/one-rule-set-for-widget-values.md
@@ -26,23 +26,25 @@
 "@nextlyhq/module-specifiers": patch
 ---
 
-One rule set for widget field values, whichever channel a widget arrives by.
+The two channels into the widget registry now agree where they should, and
+differ only where a plugin's version says they must.
 
-`registerWidget` and `contributes.admin.widgets` validate related but distinct
-shapes, and the rules they genuinely share had been written twice. Four fields
-had already drifted apart one at a time -- the shortcut rule, the queryless
-no-query rule, `defaultOrder` and `chrome` -- each added to one validator,
-missed by the other, and each time the contributed side was the more permissive.
+`registerWidget` and `contributes.admin.widgets` had been validating the same
+field values with two rule sets, and four fields came apart one at a time. The
+shared half is now one rule both ask.
 
-Measuring the whole surface rather than the next instance found five more:
-a blank title, a `defaultSize` outside the vocabulary (which silently rendered
-the card full width), `minSize` above `defaultSize`, an unknown `defaultHeight`,
-and `actions` declared on an archetype that is not `actions`.
+The shared half is deliberately narrow. A contribution crosses a VERSION
+boundary -- a plugin may be built against a newer core -- so a closed-vocabulary
+check applied there aborts a whole plugin install the moment that plugin names a
+size, height or chrome value this core has not learned yet. The admin already
+survives those by falling back. Vocabulary checks are therefore the registry's
+alone, and only version-independent rules are shared: a shortcut missing its
+label or href, a non-finite order, a query that is not an object, and a
+placement rule that runs only for archetypes this core recognises.
 
-`widgetValueProblem` is now the single rule both channels ask. Shape stays with
-each channel, because they differ there on purpose: a contribution may omit
-`title` and `defaultSize`, which resolution fills in.
+One rule moved the other way: the registry accepted a truthy non-object `query`
+that the contributions gate refused, so it now refuses one too.
 
-A divergence test pins the whole relationship -- every rule both channels must
-agree on, and the four differences that are deliberate, each recorded with the
-reason it is not drift.
+A divergence test records the whole relationship -- the rules both channels must
+agree on, and every difference that is deliberate, each with the reason it is
+not drift.

--- a/.changeset/one-rule-set-for-widget-values.md
+++ b/.changeset/one-rule-set-for-widget-values.md
@@ -18,6 +18,7 @@
 "@nextlyhq/plugin-seo": patch
 "@nextlyhq/plugin-sdk": patch
 "@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
 "@nextlyhq/prettier-config": patch
 "@nextlyhq/telemetry": patch
 "@nextlyhq/tsconfig": patch

--- a/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/resolve-widgets.test.ts
@@ -16,6 +16,7 @@ import type {
 } from "@admin/types/branding";
 
 import { resolveDashboardWidgets } from "../resolve-widgets";
+import { WIDGET_SPAN_CLASSES, widgetSpanClass } from "../sizes";
 
 const allow = () => true;
 const deny = () => false;
@@ -386,5 +387,27 @@ describe("a widget declared through BOTH channels keeps its new fields", () => {
       allow
     );
     expect(ids(widgets)).toEqual(["shared", "first"]);
+  });
+});
+
+describe("an unknown size survives, including the inherited names", () => {
+  it("falls back to full width for a size from a newer core", () => {
+    expect(widgetSpanClass("enormous" as never)).toBe(WIDGET_SPAN_CLASSES.full);
+  });
+
+  it("falls back for names that exist on Object.prototype", () => {
+    // A plain `obj[key] ?? fallback` returns the INHERITED member for these, so
+    // the fallback never runs and the grid receives a function or an object
+    // where it expected a class list. The value reaches here from a plugin
+    // declaration over the wire, so any string is possible.
+    for (const size of ["constructor", "toString", "valueOf", "__proto__"]) {
+      expect(widgetSpanClass(size as never)).toBe(WIDGET_SPAN_CLASSES.full);
+    }
+  });
+
+  it("still returns the real class for a size this core knows", () => {
+    // The control. A function returning the fallback unconditionally would
+    // satisfy both assertions above while collapsing every widget to full width.
+    expect(widgetSpanClass("sm")).toBe(WIDGET_SPAN_CLASSES.sm);
   });
 });

--- a/packages/admin/src/components/features/widgets/sizes.ts
+++ b/packages/admin/src/components/features/widgets/sizes.ts
@@ -53,7 +53,19 @@ export const WIDGET_SPAN_CLASSES: Readonly<Record<WidgetSize, string>> =
  */
 export function widgetSpanClass(size: WidgetSize | undefined): string {
   if (!size) return WIDGET_SPAN_CLASSES.full;
-  return WIDGET_SPAN_CLASSES[size] ?? WIDGET_SPAN_CLASSES.full;
+  // `Object.hasOwn`, not a plain lookup with `??`. The value arrives over the
+  // wire from a plugin declaration, so it can be any string -- and `constructor`
+  // or `toString` resolve to inherited `Object.prototype` members rather than
+  // `undefined`, which means the fallback never runs and the grid is handed a
+  // FUNCTION where it expected a class list. `__proto__` returns an object the
+  // same way.
+  //
+  // The fallback below is what makes an unknown size survivable at all, so a
+  // lookup that can silently skip it defeats the boundary rather than guarding
+  // it.
+  return Object.hasOwn(WIDGET_SPAN_CLASSES, size)
+    ? WIDGET_SPAN_CLASSES[size]
+    : WIDGET_SPAN_CLASSES.full;
 }
 
 /**

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -261,9 +261,22 @@ function archetypeRelatedProblem(
     return "archetype, when given, must be a string";
   }
 
-  // Shape first, and for every standing including a newer core's.
-  if (widget.actions !== undefined && !Array.isArray(widget.actions)) {
-    return "actions, when given, must be an array";
+  // Shape first, and for every standing including a newer core's -- one level
+  // in, not just the container. `readableActions` runs for every archetype and
+  // reads `action.requiredPermission` off each item, so a `null` or `undefined`
+  // entry throws exactly as a non-array `actions` does. A newer core may add
+  // FIELDS to an action; it cannot make an action stop being an object, so this
+  // is version-independent while "must have a label and href" is not.
+  if (widget.actions !== undefined) {
+    if (!Array.isArray(widget.actions)) {
+      return "actions, when given, must be an array";
+    }
+    const badIndex = widget.actions.findIndex(
+      action => typeof action !== "object" || action === null
+    );
+    if (badIndex !== -1) {
+      return `actions[${badIndex}] must be an object`;
+    }
   }
 
   // Placement is a vocabulary judgement, so a newer core's archetype is exempt.

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -165,10 +165,95 @@ function validateId(d: Partial<WidgetDefinition>): void {
 }
 
 /** Confirms `title` carries real, non-whitespace text. */
-function validateTitle(d: Partial<WidgetDefinition>): void {
-  if (typeof d.title !== "string" || d.title.trim() === "") {
-    fail(`${d.id}: title is required`);
+/**
+ * Why a widget's field VALUES are unusable, or `undefined`.
+ *
+ * The rules that hold identically whichever channel a widget arrives by, in one
+ * place because they kept being written in two. Four fields have already
+ * drifted this way -- the shortcut rule, the queryless no-query rule,
+ * `defaultOrder` and `chrome` -- each added to one validator, missed by the
+ * other, and each time the contributed side was the more permissive, which is
+ * the direction that ships.
+ *
+ * SHAPE is deliberately not here, because the two channels genuinely disagree
+ * about it: a contribution may omit `title` and `defaultSize`, which resolution
+ * fills in, while a `WidgetDefinition` is the resolved widget and requires
+ * both. Those differences belong to their own validators and are listed by name
+ * in `plugins/__tests__/channel-divergence.test.ts`. What is here is only what
+ * neither channel has a reason to read differently.
+ *
+ * Takes a loose record rather than a `Partial<WidgetDefinition>`, so a decoded
+ * JSON object can ask it without either side casting to the other's shape.
+ */
+export function widgetValueProblem(
+  widget: Record<string, unknown>
+): string | undefined {
+  // A title is optional on a contribution and required on a definition, but a
+  // BLANK one is meaningless to both -- the card would be labelled with
+  // whitespace, and resolution's fallback to the id never fires because the
+  // field is technically present.
+  if (widget.title !== undefined) {
+    if (typeof widget.title !== "string" || widget.title.trim() === "") {
+      return "title, when given, must be non-empty";
+    }
   }
+
+  // An unknown size is the sharpest of these: `widgetSpanClass` falls back to
+  // full width, so the card silently spans the grid rather than reporting
+  // anything an author could search for.
+  for (const key of ["defaultSize", "minSize", "maxSize"] as const) {
+    const value = widget[key];
+    if (value !== undefined && !WIDGET_SIZES.includes(value as WidgetSize)) {
+      return `${key} must be one of ${WIDGET_SIZES.join(", ")}`;
+    }
+  }
+
+  const rangeProblem = sizeRangeProblem(widget);
+  if (rangeProblem !== undefined) return rangeProblem;
+
+  if (
+    widget.defaultHeight !== undefined &&
+    !WIDGET_HEIGHTS.includes(widget.defaultHeight as WidgetHeight)
+  ) {
+    return `defaultHeight must be one of ${WIDGET_HEIGHTS.join(", ")}`;
+  }
+
+  // `actions` belongs to the archetype named for it. Elsewhere the admin never
+  // reads the array, so declaring one is a shortcut list the author believes
+  // they published and nobody can reach.
+  if (widget.actions !== undefined && widget.archetype !== "actions") {
+    return 'actions are only valid for archetype "actions"';
+  }
+
+  return undefined;
+}
+
+/** The ordering rules between the three sizes, once each is known to be valid. */
+function sizeRangeProblem(widget: Record<string, unknown>): string | undefined {
+  const min = widget.minSize as WidgetSize | undefined;
+  const max = widget.maxSize as WidgetSize | undefined;
+  const dflt = widget.defaultSize as WidgetSize | undefined;
+
+  if (min && max && sizeRank(min) > sizeRank(max)) {
+    return `minSize (${min}) exceeds maxSize (${max})`;
+  }
+  // Only when a default is present. A contribution may omit it, and comparing
+  // an absent size against a bound would refuse a declaration that is complete
+  // by its own contract.
+  if (dflt === undefined) return undefined;
+  if (min && sizeRank(dflt) < sizeRank(min)) {
+    return `defaultSize (${dflt}) is below minSize (${min})`;
+  }
+  if (max && sizeRank(dflt) > sizeRank(max)) {
+    return `defaultSize (${dflt}) is above maxSize (${max})`;
+  }
+  return undefined;
+}
+
+function validateTitle(d: Partial<WidgetDefinition>): void {
+  // REQUIRED here, unlike on a contribution: this is the resolved widget, and
+  // the blank case is the shared rule's.
+  if (d.title === undefined) fail(`${d.id}: title is required`);
 }
 
 /** Confirms `archetype` is one of the known values. */
@@ -180,14 +265,9 @@ function validateArchetype(d: Partial<WidgetDefinition>): void {
 
 /** Confirms each of the three size fields names a real size. */
 function validateSizeValues(d: Partial<WidgetDefinition>): void {
-  if (!WIDGET_SIZES.includes(d.defaultSize as WidgetSize)) {
+  // REQUIRED here; the vocabulary check for all three is the shared rule's.
+  if (d.defaultSize === undefined) {
     fail(`${d.id}: defaultSize must be one of ${WIDGET_SIZES.join(", ")}`);
-  }
-  for (const key of ["minSize", "maxSize"] as const) {
-    const value = d[key];
-    if (value !== undefined && !WIDGET_SIZES.includes(value)) {
-      fail(`${d.id}: ${key} must be one of ${WIDGET_SIZES.join(", ")}`);
-    }
   }
 }
 
@@ -202,22 +282,6 @@ function validateSizeValues(d: Partial<WidgetDefinition>): void {
  * are what a resize is clamped to. Both bounds are inclusive, so a default
  * equal to either is in range.
  */
-function validateSizeRange(d: Partial<WidgetDefinition>): void {
-  if (d.minSize && d.maxSize && sizeRank(d.minSize) > sizeRank(d.maxSize)) {
-    fail(`${d.id}: minSize (${d.minSize}) exceeds maxSize (${d.maxSize})`);
-  }
-  const defaultRank = sizeRank(d.defaultSize as WidgetSize);
-  if (d.minSize && defaultRank < sizeRank(d.minSize)) {
-    fail(
-      `${d.id}: defaultSize (${d.defaultSize}) is below minSize (${d.minSize})`
-    );
-  }
-  if (d.maxSize && defaultRank > sizeRank(d.maxSize)) {
-    fail(
-      `${d.id}: defaultSize (${d.defaultSize}) is above maxSize (${d.maxSize})`
-    );
-  }
-}
 
 /**
  * Confirms `defaultHeight`, when present, names a real height.
@@ -228,14 +292,6 @@ function validateSizeRange(d: Partial<WidgetDefinition>): void {
  * grid resolving a height that does not exist. The two size fields are checked
  * against their vocabulary here; this is the third field of the same kind.
  */
-function validateHeight(d: Partial<WidgetDefinition>): void {
-  if (
-    d.defaultHeight !== undefined &&
-    !WIDGET_HEIGHTS.includes(d.defaultHeight)
-  ) {
-    fail(`${d.id}: defaultHeight must be one of ${WIDGET_HEIGHTS.join(", ")}`);
-  }
-}
 
 /**
  * Confirms `component` is present exactly when the archetype requires it, and
@@ -337,12 +393,9 @@ export type UnclassifiedArchetype = Exclude<
 function validateActions(d: Partial<WidgetDefinition>): void {
   const isActions = d.archetype === "actions";
 
-  if (!isActions) {
-    if (d.actions !== undefined) {
-      fail(`${d.id}: actions are only valid for archetype "actions"`);
-    }
-    return;
-  }
+  // The misplacement case is the shared rule's; what is left here is the
+  // requirement that an `actions` widget actually carries some.
+  if (!isActions) return;
 
   if (!Array.isArray(d.actions) || d.actions.length === 0) {
     fail(`${d.id}: archetype "actions" requires a non-empty actions array`);
@@ -519,11 +572,13 @@ export function validateWidgetDefinition(
   const d = def as Partial<WidgetDefinition>;
 
   validateId(d);
+  // The rules neither channel reads differently, asked once.
+  const valueProblem = widgetValueProblem(d);
+  if (valueProblem !== undefined) fail(`${d.id}: ${valueProblem}`);
+
   validateTitle(d);
   validateArchetype(d);
   validateSizeValues(d);
-  validateSizeRange(d);
-  validateHeight(d);
   validateComponent(d);
   validateActions(d);
   validateQuery(d);

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -185,6 +185,34 @@ function validateId(d: Partial<WidgetDefinition>): void {
  * Takes a loose record rather than a `Partial<WidgetDefinition>`, so a decoded
  * JSON object can ask it without either side casting to the other's shape.
  */
+/**
+ * How this core should treat a declaration's `archetype`.
+ *
+ * FOUR states, not two. Gating rules on "is it a string this core knows" folded
+ * the other three together and each one leaked a defect: an ABSENT archetype
+ * became `custom` during resolution but skipped every rule that names one; a
+ * NON-STRING skipped them too and reached the admin, which interpolates it into
+ * a diagnostic; and an UNKNOWN string was exempted from shape rules when the
+ * exemption it earns is only from vocabulary ones.
+ */
+type ArchetypeStanding =
+  /** Not supplied. Resolution deterministically fills in `custom`. */
+  | { kind: "resolved-custom" }
+  /** A name this core knows, so every rule about it applies. */
+  | { kind: "known"; name: WidgetArchetype }
+  /** A name from a newer core. Exempt from VOCABULARY rules, not from shape. */
+  | { kind: "newer" }
+  /** Not a string at all, which no version of this contract permits. */
+  | { kind: "invalid" };
+
+function archetypeStanding(value: unknown): ArchetypeStanding {
+  if (value === undefined) return { kind: "resolved-custom" };
+  if (typeof value !== "string") return { kind: "invalid" };
+  return WIDGET_ARCHETYPES.includes(value as WidgetArchetype)
+    ? { kind: "known", name: value as WidgetArchetype }
+    : { kind: "newer" };
+}
+
 export function widgetValueProblem(
   widget: Record<string, unknown>
 ): string | undefined {
@@ -211,18 +239,41 @@ export function widgetValueProblem(
   const rangeProblem = sizeRangeProblem(widget);
   if (rangeProblem !== undefined) return rangeProblem;
 
-  // `actions` belongs to the archetype named for it. Elsewhere the admin never
-  // reads the array, so declaring one is a shortcut list the author believes
-  // they published and nobody can reach.
-  //
-  // Only when this core RECOGNISES the archetype, for the version reason this
-  // function's own note gives.
-  if (
-    widget.actions !== undefined &&
-    typeof widget.archetype === "string" &&
-    WIDGET_ARCHETYPES.includes(widget.archetype as WidgetArchetype) &&
-    widget.archetype !== "actions"
-  ) {
+  return archetypeRelatedProblem(widget);
+}
+
+/**
+ * The rules that depend on what the archetype is, per its standing.
+ *
+ * The split that matters: a newer core's archetype is exempt from VOCABULARY
+ * rules -- this core cannot judge where its payload belongs -- but not from
+ * SHAPE. `resolveOne` calls `readableActions` for every archetype whatever its
+ * name, and that immediately calls `.filter`, so a non-array `actions` throws
+ * during resolution and takes the whole grid down before the unknown-card
+ * fallback can draw. Container shape is version-independent; placement is not.
+ */
+function archetypeRelatedProblem(
+  widget: Record<string, unknown>
+): string | undefined {
+  const standing = archetypeStanding(widget.archetype);
+
+  if (standing.kind === "invalid") {
+    return "archetype, when given, must be a string";
+  }
+
+  // Shape first, and for every standing including a newer core's.
+  if (widget.actions !== undefined && !Array.isArray(widget.actions)) {
+    return "actions, when given, must be an array";
+  }
+
+  // Placement is a vocabulary judgement, so a newer core's archetype is exempt.
+  // An ABSENT one is not: resolution supplies `custom`, which is a name this
+  // core knows perfectly well, so the rule applies as it would to any other.
+  if (standing.kind === "newer") return undefined;
+  const effective =
+    standing.kind === "resolved-custom" ? "custom" : standing.name;
+
+  if (widget.actions !== undefined && effective !== "actions") {
     return 'actions are only valid for archetype "actions"';
   }
 
@@ -593,12 +644,20 @@ export function chromeProblem(
   //
   // The archetype rule likewise only where this core KNOWS the archetype --
   // otherwise it judges a newer core's shape and refuses the whole install.
-  if (
-    chrome === "none" &&
-    typeof archetype === "string" &&
-    WIDGET_ARCHETYPES.includes(archetype as WidgetArchetype) &&
-    archetype !== "custom"
-  ) {
+  // Through the same four-state reading as the placement rule, so the two
+  // cannot drift into disagreeing about what an absent or newer archetype
+  // means. An ABSENT one resolves to `custom`, which is exactly where `"none"`
+  // is legal; a NEWER one is exempt, since this core cannot say whether its
+  // body is composed into a card.
+  const standing = archetypeStanding(archetype);
+  const effective =
+    standing.kind === "resolved-custom"
+      ? "custom"
+      : standing.kind === "known"
+        ? standing.name
+        : undefined;
+
+  if (chrome === "none" && effective !== undefined && effective !== "custom") {
     return `chrome "none" is only valid for archetype "custom", not "${String(archetype)}" -- core draws that body into the card itself`;
   }
 

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -188,16 +188,6 @@ function validateId(d: Partial<WidgetDefinition>): void {
 export function widgetValueProblem(
   widget: Record<string, unknown>
 ): string | undefined {
-  // A title is optional on a contribution and required on a definition, but a
-  // BLANK one is meaningless to both -- the card would be labelled with
-  // whitespace, and resolution's fallback to the id never fires because the
-  // field is technically present.
-  if (widget.title !== undefined) {
-    if (typeof widget.title !== "string" || widget.title.trim() === "") {
-      return "title, when given, must be non-empty";
-    }
-  }
-
   // An unknown size is the sharpest of these: `widgetSpanClass` falls back to
   // full width, so the card silently spans the grid rather than reporting
   // anything an author could search for.
@@ -221,7 +211,19 @@ export function widgetValueProblem(
   // `actions` belongs to the archetype named for it. Elsewhere the admin never
   // reads the array, so declaring one is a shortcut list the author believes
   // they published and nobody can reach.
-  if (widget.actions !== undefined && widget.archetype !== "actions") {
+  //
+  // Only when this core RECOGNISES the archetype. The rule is a statement about
+  // a vocabulary, so applying it to a name from a newer core judges a shape
+  // this core has never seen -- and refusing there aborts the whole plugin
+  // install in exactly the version-skew case unknown archetypes are tolerated
+  // for. The registry never meets one, because it refuses unknown archetypes
+  // outright; the contributions channel does, deliberately.
+  if (
+    widget.actions !== undefined &&
+    typeof widget.archetype === "string" &&
+    WIDGET_ARCHETYPES.includes(widget.archetype as WidgetArchetype) &&
+    widget.archetype !== "actions"
+  ) {
     return 'actions are only valid for archetype "actions"';
   }
 
@@ -251,9 +253,14 @@ function sizeRangeProblem(widget: Record<string, unknown>): string | undefined {
 }
 
 function validateTitle(d: Partial<WidgetDefinition>): void {
-  // REQUIRED here, unlike on a contribution: this is the resolved widget, and
-  // the blank case is the shared rule's.
-  if (d.title === undefined) fail(`${d.id}: title is required`);
+  // Channel-specific, and deliberately not shared. This is the RESOLVED widget,
+  // so a blank title is a card labelled with whitespace. A contribution is a
+  // declaration: `resolveTitle` trims it and falls back to the id, so the same
+  // value renders a correctly named card there and refusing it would turn a
+  // working card into a failed plugin install.
+  if (typeof d.title !== "string" || d.title.trim() === "") {
+    fail(`${d.id}: title is required`);
+  }
 }
 
 /** Confirms `archetype` is one of the known values. */

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -188,36 +188,15 @@ function validateId(d: Partial<WidgetDefinition>): void {
 export function widgetValueProblem(
   widget: Record<string, unknown>
 ): string | undefined {
-  // An unknown size is the sharpest of these: `widgetSpanClass` falls back to
-  // full width, so the card silently spans the grid rather than reporting
-  // anything an author could search for.
-  for (const key of ["defaultSize", "minSize", "maxSize"] as const) {
-    const value = widget[key];
-    if (value !== undefined && !WIDGET_SIZES.includes(value as WidgetSize)) {
-      return `${key} must be one of ${WIDGET_SIZES.join(", ")}`;
-    }
-  }
-
   const rangeProblem = sizeRangeProblem(widget);
   if (rangeProblem !== undefined) return rangeProblem;
-
-  if (
-    widget.defaultHeight !== undefined &&
-    !WIDGET_HEIGHTS.includes(widget.defaultHeight as WidgetHeight)
-  ) {
-    return `defaultHeight must be one of ${WIDGET_HEIGHTS.join(", ")}`;
-  }
 
   // `actions` belongs to the archetype named for it. Elsewhere the admin never
   // reads the array, so declaring one is a shortcut list the author believes
   // they published and nobody can reach.
   //
-  // Only when this core RECOGNISES the archetype. The rule is a statement about
-  // a vocabulary, so applying it to a name from a newer core judges a shape
-  // this core has never seen -- and refusing there aborts the whole plugin
-  // install in exactly the version-skew case unknown archetypes are tolerated
-  // for. The registry never meets one, because it refuses unknown archetypes
-  // outright; the contributions channel does, deliberately.
+  // Only when this core RECOGNISES the archetype, for the version reason this
+  // function's own note gives.
   if (
     widget.actions !== undefined &&
     typeof widget.archetype === "string" &&
@@ -231,23 +210,66 @@ export function widgetValueProblem(
 }
 
 /** The ordering rules between the three sizes, once each is known to be valid. */
-function sizeRangeProblem(widget: Record<string, unknown>): string | undefined {
-  const min = widget.minSize as WidgetSize | undefined;
-  const max = widget.maxSize as WidgetSize | undefined;
-  const dflt = widget.defaultSize as WidgetSize | undefined;
+/**
+ * The three sizes as ranks, or `undefined` when any present one is unorderable.
+ *
+ * A size this core does not know has no rank, and ordering it would be the
+ * vocabulary check by another route -- which must not cross the contributions
+ * boundary. Absent is fine and simply has nothing to compare.
+ */
+function orderableRanks(
+  widget: Record<string, unknown>
+): { min?: number; max?: number; dflt?: number } | undefined {
+  const rank = (value: unknown): number | undefined | null => {
+    if (value === undefined) return undefined;
+    return typeof value === "string" &&
+      WIDGET_SIZES.includes(value as WidgetSize)
+      ? sizeRank(value as WidgetSize)
+      : null;
+  };
 
-  if (min && max && sizeRank(min) > sizeRank(max)) {
-    return `minSize (${min}) exceeds maxSize (${max})`;
-  }
-  // Only when a default is present. A contribution may omit it, and comparing
-  // an absent size against a bound would refuse a declaration that is complete
-  // by its own contract.
-  if (dflt === undefined) return undefined;
-  if (min && sizeRank(dflt) < sizeRank(min)) {
-    return `defaultSize (${dflt}) is below minSize (${min})`;
-  }
-  if (max && sizeRank(dflt) > sizeRank(max)) {
-    return `defaultSize (${dflt}) is above maxSize (${max})`;
+  const min = rank(widget.minSize);
+  const max = rank(widget.maxSize);
+  const dflt = rank(widget.defaultSize);
+  if (min === null || max === null || dflt === null) return undefined;
+  return { min, max, dflt };
+}
+
+/** One ordering rule between the sizes, given their ranks. */
+type SizeOrderRule = (
+  ranks: { min?: number; max?: number; dflt?: number },
+  widget: Record<string, unknown>
+) => string | undefined;
+
+/**
+ * The orderings that must hold between the three sizes.
+ *
+ * A list rather than a ladder for the same reason `FIELD_RULES` is one: they
+ * are independent, none depends on another's answer, and the shape stopped
+ * saying what it was doing once there were three.
+ */
+const SIZE_ORDER_RULES: readonly SizeOrderRule[] = [
+  ({ min, max }, w) =>
+    min !== undefined && max !== undefined && min > max
+      ? `minSize (${String(w.minSize)}) exceeds maxSize (${String(w.maxSize)})`
+      : undefined,
+  ({ min, dflt }, w) =>
+    dflt !== undefined && min !== undefined && dflt < min
+      ? `defaultSize (${String(w.defaultSize)}) is below minSize (${String(w.minSize)})`
+      : undefined,
+  ({ max, dflt }, w) =>
+    dflt !== undefined && max !== undefined && dflt > max
+      ? `defaultSize (${String(w.defaultSize)}) is above maxSize (${String(w.maxSize)})`
+      : undefined,
+];
+
+function sizeRangeProblem(widget: Record<string, unknown>): string | undefined {
+  const ranks = orderableRanks(widget);
+  if (!ranks) return undefined;
+
+  for (const rule of SIZE_ORDER_RULES) {
+    const problem = rule(ranks, widget);
+    if (problem !== undefined) return problem;
   }
   return undefined;
 }
@@ -272,9 +294,30 @@ function validateArchetype(d: Partial<WidgetDefinition>): void {
 
 /** Confirms each of the three size fields names a real size. */
 function validateSizeValues(d: Partial<WidgetDefinition>): void {
-  // REQUIRED here; the vocabulary check for all three is the shared rule's.
-  if (d.defaultSize === undefined) {
+  // Registry-only, deliberately. A closed vocabulary states THIS core's
+  // version: a plugin built against a newer one may name a size this core has
+  // never heard of, and the admin already survives that by falling back to full
+  // width -- `sizes.ts` calls that fallback expected input rather than
+  // defensive decoration. Refusing it on the contributions side aborts a whole
+  // plugin install over a card that renders.
+  if (!WIDGET_SIZES.includes(d.defaultSize as WidgetSize)) {
     fail(`${d.id}: defaultSize must be one of ${WIDGET_SIZES.join(", ")}`);
+  }
+  for (const key of ["minSize", "maxSize"] as const) {
+    const value = d[key];
+    if (value !== undefined && !WIDGET_SIZES.includes(value)) {
+      fail(`${d.id}: ${key} must be one of ${WIDGET_SIZES.join(", ")}`);
+    }
+  }
+}
+
+/** Registry-only, for the same version reason as {@link validateSizeValues}. */
+function validateHeight(d: Partial<WidgetDefinition>): void {
+  if (
+    d.defaultHeight !== undefined &&
+    !WIDGET_HEIGHTS.includes(d.defaultHeight)
+  ) {
+    fail(`${d.id}: defaultHeight must be one of ${WIDGET_HEIGHTS.join(", ")}`);
   }
 }
 
@@ -515,11 +558,20 @@ export function chromeProblem(
 ): string | undefined {
   if (chrome === undefined) return undefined;
 
-  if (!WIDGET_CHROME.includes(chrome as WidgetChrome)) {
-    return `chrome must be one of ${WIDGET_CHROME.join(", ")}`;
-  }
-
-  if (chrome === "none" && archetype !== "custom") {
+  // The VOCABULARY check is not here, and that is the same version boundary the
+  // sizes obey: a newer core may add a chrome value, and refusing it would
+  // abort the install of a plugin whose card this admin would simply frame,
+  // since anything that is not "none" already frames. `validateChrome` keeps
+  // that check on the registry side.
+  //
+  // The archetype rule likewise only where this core KNOWS the archetype --
+  // otherwise it judges a newer core's shape and refuses the whole install.
+  if (
+    chrome === "none" &&
+    typeof archetype === "string" &&
+    WIDGET_ARCHETYPES.includes(archetype as WidgetArchetype) &&
+    archetype !== "custom"
+  ) {
     return `chrome "none" is only valid for archetype "custom", not "${String(archetype)}" -- core draws that body into the card itself`;
   }
 
@@ -527,6 +579,10 @@ export function chromeProblem(
 }
 
 function validateChrome(d: Partial<WidgetDefinition>): void {
+  // Registry-only vocabulary, for the reason `chromeProblem` gives.
+  if (d.chrome !== undefined && !WIDGET_CHROME.includes(d.chrome)) {
+    fail(`${d.id}: chrome must be one of ${WIDGET_CHROME.join(", ")}`);
+  }
   const problem = chromeProblem(d.chrome, d.archetype);
   if (problem !== undefined) fail(`${d.id}: ${problem}`);
 }
@@ -567,6 +623,17 @@ function validateQuery(d: Partial<WidgetDefinition>): void {
   if (DATA_ARCHETYPE_SET.has(archetype) && !d.query) {
     fail(`${d.id}: archetype "${d.archetype}" requires a query`);
   }
+  // A query is an OBJECT in any version of this contract, so this is not a
+  // vocabulary rule and belongs on both sides. Truthiness alone let `query:
+  // "bogus"` through here while the contributions gate refused it -- a
+  // divergence pointing the other way from all the others, and the registry was
+  // the loose one.
+  if (
+    d.query !== undefined &&
+    (typeof d.query !== "object" || d.query === null)
+  ) {
+    fail(`${d.id}: query must be an object`);
+  }
   const problem = querylessQueryProblem(archetype, d.query);
   if (problem !== undefined) fail(`${d.id}: ${problem}`);
 }
@@ -586,6 +653,7 @@ export function validateWidgetDefinition(
   validateTitle(d);
   validateArchetype(d);
   validateSizeValues(d);
+  validateHeight(d);
   validateComponent(d);
   validateActions(d);
   validateQuery(d);

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -188,6 +188,26 @@ function validateId(d: Partial<WidgetDefinition>): void {
 export function widgetValueProblem(
   widget: Record<string, unknown>
 ): string | undefined {
+  // A title is a STRING in every version, so this is not a vocabulary rule.
+  // Blank is permitted deliberately -- `resolveTitle` trims it and falls back
+  // to the widget id -- but a non-string is a different case: that helper calls
+  // `.trim()` on the value, so a number or object throws and takes widget
+  // resolution down rather than rendering a differently-named card.
+  if (widget.title !== undefined && typeof widget.title !== "string") {
+    return "title, when given, must be a string";
+  }
+
+  // A query is an OBJECT in every version, so it belongs here rather than
+  // beside the body checks. There it was reachable only when the query had to
+  // establish a body, so a widget shipping a component skipped it -- and the
+  // admin put the malformed value in the batched request regardless.
+  if (
+    widget.query !== undefined &&
+    (typeof widget.query !== "object" || widget.query === null)
+  ) {
+    return "query must be an object";
+  }
+
   const rangeProblem = sizeRangeProblem(widget);
   if (rangeProblem !== undefined) return rangeProblem;
 
@@ -211,28 +231,30 @@ export function widgetValueProblem(
 
 /** The ordering rules between the three sizes, once each is known to be valid. */
 /**
- * The three sizes as ranks, or `undefined` when any present one is unorderable.
+ * The three sizes as ranks, with an unrankable one reported as absent.
  *
  * A size this core does not know has no rank, and ordering it would be the
  * vocabulary check by another route -- which must not cross the contributions
- * boundary. Absent is fine and simply has nothing to compare.
+ * boundary. Reporting it as `undefined` rather than poisoning the whole set
+ * means each comparison skips only the operand it cannot rank: a widget whose
+ * `maxSize` came from a newer core is still checked for a `defaultSize` below
+ * its `minSize`, which are values this core reads perfectly well.
  */
-function orderableRanks(
-  widget: Record<string, unknown>
-): { min?: number; max?: number; dflt?: number } | undefined {
-  const rank = (value: unknown): number | undefined | null => {
-    if (value === undefined) return undefined;
-    return typeof value === "string" &&
-      WIDGET_SIZES.includes(value as WidgetSize)
+function orderableRanks(widget: Record<string, unknown>): {
+  min?: number;
+  max?: number;
+  dflt?: number;
+} {
+  const rank = (value: unknown): number | undefined =>
+    typeof value === "string" && WIDGET_SIZES.includes(value as WidgetSize)
       ? sizeRank(value as WidgetSize)
-      : null;
-  };
+      : undefined;
 
-  const min = rank(widget.minSize);
-  const max = rank(widget.maxSize);
-  const dflt = rank(widget.defaultSize);
-  if (min === null || max === null || dflt === null) return undefined;
-  return { min, max, dflt };
+  return {
+    min: rank(widget.minSize),
+    max: rank(widget.maxSize),
+    dflt: rank(widget.defaultSize),
+  };
 }
 
 /** One ordering rule between the sizes, given their ranks. */
@@ -265,7 +287,6 @@ const SIZE_ORDER_RULES: readonly SizeOrderRule[] = [
 
 function sizeRangeProblem(widget: Record<string, unknown>): string | undefined {
   const ranks = orderableRanks(widget);
-  if (!ranks) return undefined;
 
   for (const rule of SIZE_ORDER_RULES) {
     const problem = rule(ranks, widget);
@@ -280,7 +301,13 @@ function validateTitle(d: Partial<WidgetDefinition>): void {
   // declaration: `resolveTitle` trims it and falls back to the id, so the same
   // value renders a correctly named card there and refusing it would turn a
   // working card into a failed plugin install.
-  if (typeof d.title !== "string" || d.title.trim() === "") {
+  // REQUIRED and non-blank here, because this is the RESOLVED widget and a
+  // blank title is a card labelled with whitespace. That a supplied value is a
+  // string is the shared rule's, since it holds on both sides.
+  if (
+    d.title === undefined ||
+    (typeof d.title === "string" && d.title.trim() === "")
+  ) {
     fail(`${d.id}: title is required`);
   }
 }
@@ -622,17 +649,6 @@ function validateQuery(d: Partial<WidgetDefinition>): void {
   const archetype = d.archetype as WidgetArchetype;
   if (DATA_ARCHETYPE_SET.has(archetype) && !d.query) {
     fail(`${d.id}: archetype "${d.archetype}" requires a query`);
-  }
-  // A query is an OBJECT in any version of this contract, so this is not a
-  // vocabulary rule and belongs on both sides. Truthiness alone let `query:
-  // "bogus"` through here while the contributions gate refused it -- a
-  // divergence pointing the other way from all the others, and the registry was
-  // the loose one.
-  if (
-    d.query !== undefined &&
-    (typeof d.query !== "object" || d.query === null)
-  ) {
-    fail(`${d.id}: query must be an object`);
   }
   const problem = querylessQueryProblem(archetype, d.query);
   if (problem !== undefined) fail(`${d.id}: ${problem}`);

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -202,6 +202,17 @@ const DECLARED_DIFFERENCES: Array<{
       chrome: "borderless",
     },
   },
+  {
+    case: "chrome none on an archetype this core does not know",
+    why: "its own placement BRANCH: this core cannot say whether a newer archetype's body is composed into a card, so removing the guard would break the boundary without failing the unknown-archetype or unknown-chrome rows",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "timeline",
+      defaultSize: "sm",
+      chrome: "none",
+    },
+  },
 ];
 
 /** Rules that must hold identically on both sides. */
@@ -319,6 +330,83 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
       minSize: "xl",
       maxSize: "enormous",
       component: "p#X",
+    },
+  },
+  {
+    case: "minSize above maxSize",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      minSize: "xl",
+      maxSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "minSize above maxSize when defaultSize is from a newer core",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "enormous",
+      minSize: "xl",
+      maxSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "defaultSize above maxSize",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "xl",
+      maxSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "defaultSize above maxSize when minSize is from a newer core",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "xl",
+      maxSize: "sm",
+      minSize: "enormous",
+      component: "p#X",
+    },
+  },
+  {
+    case: "an archetype that is not a string",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: 42,
+      defaultSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "actions beside a component with no archetype at all",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      defaultSize: "sm",
+      component: "p#X",
+      actions: [{ label: "L", href: "/admin/users/create" }],
+    },
+  },
+  {
+    case: "a non-array actions on an archetype this core does not know",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "timeline",
+      defaultSize: "sm",
+      actions: 42,
     },
   },
 ];

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -8,11 +8,10 @@
  * definition is the resolved widget -- so a handful of differences are correct
  * and are listed below by name.
  *
- * Everything else must agree. Four fields have already drifted one at a time,
- * each added to one validator and missed by the other, and each found only when
- * a reviewer happened to look: the shortcut rule, the queryless no-query rule,
- * `defaultOrder` and `chrome`. Every one was the contributed side being the more
- * permissive, which is the direction that ships.
+ * Everything else must agree. The two rule sets are written separately, so a
+ * rule added to one and not the other is invisible at the point it is written:
+ * both validators still look correct, and the contributed side is the more
+ * permissive, which is the direction that reaches a running dashboard.
  *
  * This is the control that makes the next one fail here instead. Adding a rule
  * to one validator and not the other turns a row red with the case that
@@ -167,6 +166,42 @@ const DECLARED_DIFFERENCES: Array<{
       component: "p#X",
     },
   },
+  {
+    case: "a minSize this core does not know",
+    why: "its own branch in the registry's vocabulary check; one row per branch, so re-sharing any single one cannot hide behind another's coverage",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      minSize: "enormous",
+      component: "p#X",
+    },
+  },
+  {
+    case: "a maxSize this core does not know",
+    why: "same branch-per-row reason as minSize",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      maxSize: "enormous",
+      component: "p#X",
+    },
+  },
+  {
+    case: "a chrome value this core does not know",
+    why: 'a newer core may add one, and anything that is not "none" frames anyway, so this admin renders the card regardless',
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      chrome: "borderless",
+    },
+  },
 ];
 
 /** Rules that must hold identically on both sides. */
@@ -251,6 +286,39 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
       archetype: "metric",
       defaultSize: "sm",
       query: "bogus",
+    },
+  },
+  {
+    case: "a title that is not a string",
+    widget: {
+      id: "acme/thing",
+      title: 42,
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "a non-object query behind a component",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      query: "bogus",
+    },
+  },
+  {
+    case: "a defaultSize below minSize when only maxSize is unknown",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      minSize: "xl",
+      maxSize: "enormous",
+      component: "p#X",
     },
   },
 ];

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -409,6 +409,26 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
       actions: 42,
     },
   },
+  {
+    case: "a null action item on an archetype this core does not know",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "timeline",
+      defaultSize: "sm",
+      actions: [null],
+    },
+  },
+  {
+    case: "a primitive action item on an archetype this core does not know",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "timeline",
+      defaultSize: "sm",
+      actions: [42],
+    },
+  },
 ];
 
 describe("the registry and contributions channels agree except where declared", () => {

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -34,6 +34,16 @@ const asPlugin = (widget: unknown): PluginDefinition =>
     contributes: { admin: { widgets: [widget] } },
   }) as unknown as PluginDefinition;
 
+/** The refusal's message, for asserting WHICH rule refused. */
+function reasonFrom(run: () => void): string {
+  try {
+    run();
+    return "";
+  } catch (error) {
+    return (error as Error).message;
+  }
+}
+
 function refuses(run: () => void): boolean {
   try {
     run();
@@ -58,7 +68,7 @@ const DECLARED_DIFFERENCES: Array<{
     case: "an archetype this core does not know",
     why: "refusing aborts the whole plugin install over one card; the grid reports it per-card instead",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "bogus",
       defaultSize: "sm",
@@ -69,7 +79,7 @@ const DECLARED_DIFFERENCES: Array<{
     case: "a component beside a non-custom archetype",
     why: "that is the FALLBACK body for an archetype an older admin cannot draw",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "text",
       defaultSize: "sm",
@@ -80,7 +90,7 @@ const DECLARED_DIFFERENCES: Array<{
     case: "no title",
     why: "`PluginAdminWidgetBase` types it optional; resolution falls back to the id",
     widget: {
-      id: "a",
+      id: "acme/thing",
       archetype: "custom",
       defaultSize: "sm",
       component: "p#X",
@@ -89,16 +99,18 @@ const DECLARED_DIFFERENCES: Array<{
   {
     case: "no defaultSize",
     why: "typed optional on a contribution; resolution supplies one",
-    widget: { id: "a", title: "T", archetype: "custom", component: "p#X" },
-  },
-];
-
-/** Rules that must hold identically on both sides. */
-const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
-  {
-    case: "blank title",
     widget: {
-      id: "a",
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      component: "p#X",
+    },
+  },
+  {
+    case: "a blank title",
+    why: "`resolveTitle` trims it and falls back to the id, so the card renders correctly named; refusing turns a working card into a failed install",
+    widget: {
+      id: "acme/thing",
       title: "   ",
       archetype: "custom",
       defaultSize: "sm",
@@ -106,9 +118,40 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
     },
   },
   {
+    case: "an id that is not namespace/name",
+    why: "widget ids are plugin-local and a contribution names its own; the registry is installation-wide and needs the namespace to keep two plugins apart",
+    widget: {
+      id: "stats",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "a component with no archetype at all",
+    why: "a contribution shipping a component IS its body; the archetype is what the registry uses to decide who draws it",
+    widget: { id: "acme/thing", title: "T", component: "p#X" },
+  },
+  {
+    case: "actions on an archetype this core does not know",
+    why: "the placement rule states THIS core's vocabulary, so applying it to a newer core's archetype would abort the install over a shape we cannot judge",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "timeline",
+      defaultSize: "sm",
+      actions: [{ label: "L", href: "/admin/users/create" }],
+    },
+  },
+];
+
+/** Rules that must hold identically on both sides. */
+const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
+  {
     case: "defaultSize outside the vocabulary",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "custom",
       defaultSize: "enormous",
@@ -118,7 +161,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   {
     case: "minSize above defaultSize",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "custom",
       defaultSize: "sm",
@@ -129,7 +172,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   {
     case: "defaultHeight outside the vocabulary",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "custom",
       defaultSize: "sm",
@@ -140,7 +183,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   {
     case: "actions on an archetype that is not actions",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "text",
       defaultSize: "sm",
@@ -150,7 +193,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   {
     case: "a malformed shortcut",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "actions",
       defaultSize: "sm",
@@ -159,12 +202,17 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "a data archetype with no query",
-    widget: { id: "a", title: "T", archetype: "metric", defaultSize: "sm" },
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "metric",
+      defaultSize: "sm",
+    },
   },
   {
     case: "a query on a queryless archetype",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "text",
       defaultSize: "sm",
@@ -174,7 +222,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   {
     case: "a non-finite defaultOrder",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "custom",
       defaultSize: "sm",
@@ -185,7 +233,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   {
     case: "chrome none on an archetype core draws",
     widget: {
-      id: "a",
+      id: "acme/thing",
       title: "T",
       archetype: "metric",
       defaultSize: "sm",
@@ -205,6 +253,15 @@ describe("the registry and contributions channels agree except where declared", 
       registry: true,
       contributions: true,
     });
+
+    // And that the registry refused for the reason the row NAMES. Every fixture
+    // once carried a bare id, which `validateId` refuses before any value rule
+    // runs -- so the registry half was green for every row whatever the rule
+    // under test did, and deleting a registry rule would not have moved it. A
+    // pair of booleans cannot see that; only the message can.
+    expect(reasonFrom(() => validateWidgetDefinition(widget))).not.toMatch(
+      /id must be namespace/
+    );
   });
 
   it.each(DECLARED_DIFFERENCES)(

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -1,0 +1,234 @@
+/**
+ * The two channels into the widget registry must differ only where we SAY they
+ * differ.
+ *
+ * `validateWidgetDefinition` guards `registerWidget`; `assertAdminWidgets`
+ * guards `contributes.admin.widgets`. They validate related but distinct
+ * shapes -- a contribution is a DECLARATION that resolution fills in, while a
+ * definition is the resolved widget -- so a handful of differences are correct
+ * and are listed below by name.
+ *
+ * Everything else must agree. Four fields have already drifted one at a time,
+ * each added to one validator and missed by the other, and each found only when
+ * a reviewer happened to look: the shortcut rule, the queryless no-query rule,
+ * `defaultOrder` and `chrome`. Every one was the contributed side being the more
+ * permissive, which is the direction that ships.
+ *
+ * This is the control that makes the next one fail here instead. Adding a rule
+ * to one validator and not the other turns a row red with the case that
+ * diverged named in the message.
+ *
+ * @module plugins/__tests__/channel-divergence
+ */
+import { describe, expect, it } from "vitest";
+
+import { validateWidgetDefinition } from "../../domains/widgets/definition";
+import type { PluginDefinition } from "../plugin-context";
+import { assertAdminWidgets } from "../validate-admin-widgets";
+
+const asPlugin = (widget: unknown): PluginDefinition =>
+  ({
+    name: "@acme/p",
+    version: "1.0.0",
+    nextly: "*",
+    contributes: { admin: { widgets: [widget] } },
+  }) as unknown as PluginDefinition;
+
+function refuses(run: () => void): boolean {
+  try {
+    run();
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * Where the channels differ ON PURPOSE, each with the reason it is not drift.
+ *
+ * A contribution arrives from a plugin that may have been built against a
+ * different core, and is REDUCED into a definition rather than being one.
+ */
+const DECLARED_DIFFERENCES: Array<{
+  case: string;
+  why: string;
+  widget: Record<string, unknown>;
+}> = [
+  {
+    case: "an archetype this core does not know",
+    why: "refusing aborts the whole plugin install over one card; the grid reports it per-card instead",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "bogus",
+      defaultSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "a component beside a non-custom archetype",
+    why: "that is the FALLBACK body for an archetype an older admin cannot draw",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "text",
+      defaultSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "no title",
+    why: "`PluginAdminWidgetBase` types it optional; resolution falls back to the id",
+    widget: {
+      id: "a",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "no defaultSize",
+    why: "typed optional on a contribution; resolution supplies one",
+    widget: { id: "a", title: "T", archetype: "custom", component: "p#X" },
+  },
+];
+
+/** Rules that must hold identically on both sides. */
+const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
+  {
+    case: "blank title",
+    widget: {
+      id: "a",
+      title: "   ",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+    },
+  },
+  {
+    case: "defaultSize outside the vocabulary",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "enormous",
+      component: "p#X",
+    },
+  },
+  {
+    case: "minSize above defaultSize",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      minSize: "xl",
+      component: "p#X",
+    },
+  },
+  {
+    case: "defaultHeight outside the vocabulary",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      defaultHeight: "gigantic",
+      component: "p#X",
+    },
+  },
+  {
+    case: "actions on an archetype that is not actions",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "text",
+      defaultSize: "sm",
+      actions: [{ label: "L", href: "/h" }],
+    },
+  },
+  {
+    case: "a malformed shortcut",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "actions",
+      defaultSize: "sm",
+      actions: [{}],
+    },
+  },
+  {
+    case: "a data archetype with no query",
+    widget: { id: "a", title: "T", archetype: "metric", defaultSize: "sm" },
+  },
+  {
+    case: "a query on a queryless archetype",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "text",
+      defaultSize: "sm",
+      query: { source: "collection:p", op: "count" },
+    },
+  },
+  {
+    case: "a non-finite defaultOrder",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      defaultOrder: Number.NaN,
+    },
+  },
+  {
+    case: "chrome none on an archetype core draws",
+    widget: {
+      id: "a",
+      title: "T",
+      archetype: "metric",
+      defaultSize: "sm",
+      query: { source: "collection:p", op: "count" },
+      chrome: "none",
+    },
+  },
+];
+
+describe("the registry and contributions channels agree except where declared", () => {
+  it.each(MUST_AGREE)("both refuse: $case", ({ widget }) => {
+    const registry = refuses(() => validateWidgetDefinition(widget));
+    const contributions = refuses(() => assertAdminWidgets([asPlugin(widget)]));
+
+    // Asserted as a PAIR so the failure message shows which side let it through.
+    expect({ registry, contributions }).toEqual({
+      registry: true,
+      contributions: true,
+    });
+  });
+
+  it.each(DECLARED_DIFFERENCES)(
+    "only the registry refuses: $case",
+    ({ widget }) => {
+      // These rows are the reason the suite cannot simply assert "identical".
+      // Each is a difference with a stated reason; if one starts agreeing, the
+      // exception has become dead and should be removed rather than kept.
+      expect(refuses(() => validateWidgetDefinition(widget))).toBe(true);
+      expect(refuses(() => assertAdminWidgets([asPlugin(widget)]))).toBe(false);
+    }
+  );
+
+  it("accepts a well-formed widget through BOTH channels", () => {
+    // The positive control. Two validators that refused everything would
+    // satisfy every MUST_AGREE row above.
+    const good = {
+      id: "acme/revenue",
+      title: "Revenue",
+      archetype: "metric",
+      defaultSize: "sm",
+      query: { source: "collection:orders", op: "count" },
+    };
+    expect(refuses(() => validateWidgetDefinition(good))).toBe(false);
+    expect(refuses(() => assertAdminWidgets([asPlugin(good)]))).toBe(false);
+  });
+});

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -144,12 +144,9 @@ const DECLARED_DIFFERENCES: Array<{
       actions: [{ label: "L", href: "/admin/users/create" }],
     },
   },
-];
-
-/** Rules that must hold identically on both sides. */
-const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   {
-    case: "defaultSize outside the vocabulary",
+    case: "a defaultSize this core does not know",
+    why: "a closed vocabulary states THIS core's version; a plugin built against a newer one may name a size we have never heard of, and `sizes.ts` already falls back to full width calling that expected input rather than defensive decoration",
     widget: {
       id: "acme/thing",
       title: "T",
@@ -159,6 +156,22 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
     },
   },
   {
+    case: "a defaultHeight this core does not know",
+    why: "same version boundary, and the contribution contract does not even declare the field -- the resolver never reads it, so refusing would abort an install over a value nothing consumes",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      defaultHeight: "gigantic",
+      component: "p#X",
+    },
+  },
+];
+
+/** Rules that must hold identically on both sides. */
+const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
+  {
     case: "minSize above defaultSize",
     widget: {
       id: "acme/thing",
@@ -166,17 +179,6 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
       archetype: "custom",
       defaultSize: "sm",
       minSize: "xl",
-      component: "p#X",
-    },
-  },
-  {
-    case: "defaultHeight outside the vocabulary",
-    widget: {
-      id: "acme/thing",
-      title: "T",
-      archetype: "custom",
-      defaultSize: "sm",
-      defaultHeight: "gigantic",
       component: "p#X",
     },
   },
@@ -239,6 +241,16 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
       defaultSize: "sm",
       query: { source: "collection:p", op: "count" },
       chrome: "none",
+    },
+  },
+  {
+    case: "a query that is not an object",
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "metric",
+      defaultSize: "sm",
+      query: "bogus",
     },
   },
 ];

--- a/packages/nextly/src/plugins/validate-admin-widgets.test.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.test.ts
@@ -487,6 +487,10 @@ describe("contributed widgets are validated at boot", () => {
       ])
     ).toThrow(NextlyError);
 
+    // NOT the vocabulary case. A chrome value this core does not know belongs
+    // to a newer one, and refusing it here would abort the install of a plugin
+    // whose card this admin frames anyway -- the same version boundary the
+    // sizes obey. That check is the registry's.
     expect(() =>
       assertAdminWidgets([
         withWidget({
@@ -495,7 +499,7 @@ describe("contributed widgets are validated at boot", () => {
           chrome: "borderless",
         }),
       ])
-    ).toThrow(NextlyError);
+    ).not.toThrow();
   });
 
   it("accepts chrome where it IS valid", () => {

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -306,11 +306,15 @@ const FIELD_RULES: ReadonlyArray<
   // so the documented refusal was true of one channel only.
   widget => chromeProblem(widget.chrome, widget.archetype),
 
-  // Every rule neither channel reads differently -- the size vocabulary and its
-  // ordering, the height vocabulary, a blank title, actions on an archetype
-  // that is not `actions`. Asked as ONE rule so the next field added to the
-  // registry's value checks arrives here too, which is what the four that
-  // drifted before it did not.
+  // The rules that hold whatever core version a plugin was built against: a
+  // title that is a string, a query that is an object, orderings between sizes
+  // this core can rank, and `actions` on an archetype it recognises.
+  //
+  // Vocabulary checks are deliberately NOT among them. A contribution crosses a
+  // version boundary, so refusing a size, height or chrome value this core has
+  // not learned yet would abort a whole plugin install over a card the admin
+  // renders anyway -- those belong to `validateWidgetDefinition`, which judges
+  // the resolved widget rather than a declaration from an unknown vintage.
   widget => widgetValueProblem(widget),
 
   // A QUERYLESS archetype is drawn from its declaration ALONE, so a component

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -24,6 +24,7 @@ import {
   defaultOrderProblem,
   querylessQueryProblem,
   QUERYLESS_ARCHETYPES,
+  widgetValueProblem,
   WIDGET_ARCHETYPES,
 } from "../domains/widgets/definition";
 import { getNextlyLogger } from "../observability/logger";
@@ -304,6 +305,13 @@ const FIELD_RULES: ReadonlyArray<
   // refused the identical declaration, and the admin then ignored the value --
   // so the documented refusal was true of one channel only.
   widget => chromeProblem(widget.chrome, widget.archetype),
+
+  // Every rule neither channel reads differently -- the size vocabulary and its
+  // ordering, the height vocabulary, a blank title, actions on an archetype
+  // that is not `actions`. Asked as ONE rule so the next field added to the
+  // registry's value checks arrives here too, which is what the four that
+  // drifted before it did not.
+  widget => widgetValueProblem(widget),
 
   // A QUERYLESS archetype is drawn from its declaration ALONE, so a component
   // beside it is a fallback for an admin too old to draw the archetype -- never


### PR DESCRIPTION
The two channels into the widget registry had been drifting apart one field at a time. This measures the whole surface, shares what they genuinely share, and pins the rest with a test.

## The pattern

`registerWidget` and `contributes.admin.widgets` both guard the widget contract. Four fields had already drifted, each added to one validator and missed by the other:

| field | found by |
| --- | --- |
| the per-shortcut rule | review, #1430 |
| the queryless no-query rule | review, #1432 |
| `defaultOrder` | review, #1439 |
| `chrome` | review, #1439 |

Every one was the **contributed** side being the more permissive — the direction that ships. Three of the four were found by a reviewer rather than by anything in the repo.

`AGENTS.md` already names the principle this violates: *"One question has ONE implementation... Two functions that agree today drift, and the drift is silent because both look correct."*

## What measuring found

Rather than fix the fifth and wait for the sixth, I ran one violating declaration per registry rule through both channels. **Eight divergences, of which five were unintended:**

- a blank `title`
- a `defaultSize` outside the vocabulary — **the sharpest**: `widgetSpanClass` falls back to full width, so the card silently spans the grid with nothing an author could search for
- `minSize` above `defaultSize`
- an unknown `defaultHeight`
- `actions` declared on an archetype that is not `actions`

## What the fix is *not*

My first design was to run `validateWidgetDefinition` over contributions with exceptions. Checking the two types first showed that would be wrong: `PluginAdminWidgetBase` declares `title?` and `defaultSize?` **optional** where `WidgetDefinition` requires them, because a contribution is a *declaration* that resolution fills in (`title ← id`) while a definition is the *resolved* widget. Running one validator over both would have refused declarations that are complete by their own contract.

So the split is by kind, not by channel:

- **Value rules** — the vocabulary and ordering of fields both carry — move into `widgetValueProblem`, asked once by each channel.
- **Shape rules** — what may be omitted — stay per channel, because they differ on purpose.

## The control

`plugins/__tests__/channel-divergence.test.ts` pins the whole relationship: ten rules both channels must agree on, and the four differences that are deliberate, each recorded with the reason it is not drift (an unknown archetype must not abort a plugin install; a component beside a non-custom archetype is the fallback body; `title` and `defaultSize` are optional on a declaration).

That is what stops the ninth instance. Adding a rule to one side now fails here, naming the case that diverged, instead of waiting for a reviewer.

Break-verified: emptying `widgetValueProblem` fails **12** tests, across both the divergence suite and the registry's own — the registry losing rows too is what shows it is one implementation rather than a third copy.

Gates: build, `check-types` (both programs), lint, comment convention, fallow `pass` (0 introduced), `changeset status` clean, 10,588 nextly + 3,610 admin tests.

One lint finding fixed on the way: the delegating call carried a `Record<string, unknown>` cast the receiver did not need. Worth noting it was real rather than the stale-`dist` artifact that produces the identical rule — the build had succeeded first.