### PR TITLE
feat(builder): give the canvas drag its affordance vocabulary

### DIFF
--- a/.changeset/the-canvas-says-why-a-block-will-not-land.md
+++ b/.changeset/the-canvas-says-why-a-block-will-not-land.md
@@ -41,8 +41,13 @@ receive the block is outlined, which the line alone cannot say when the same
 coordinate is the bottom edge of one container and the top edge of the next.
 
 And a refusal explains itself. Dropping a block into a container that will not
-take it shows a "no drop" cursor, outlines that container, and names both the
-reason and what the container does accept — so "no" arrives as an instruction
-rather than as nothing happening. The three reasons a drop can be refused each
-get their own wording, because they need different things from an author: aim at
-a different container, put the block inside one, or use a different slot.
+take it shows a "no drop" cursor, outlines that container, gives the reason, and
+follows it with the remedy — so "no" arrives as an instruction rather than as
+nothing happening.
+
+The three reasons a drop can be refused each get their own wording, because they
+need different things from an author. A slot that admits only certain blocks
+says what it takes. The other two say where the block you are holding is allowed
+to go, which is a different fact and the one you can act on: a block refused by
+a container has not learned anything about that container's appetite, it has
+learned which containers will have it.

--- a/.changeset/the-canvas-says-why-a-block-will-not-land.md
+++ b/.changeset/the-canvas-says-why-a-block-will-not-land.md
@@ -1,0 +1,48 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The page builder says why a block will not go where you aimed it.
+
+Dragging a block on the canvas used to answer one question — a line showing where
+it would land between its siblings. Everything else was silent. A block gave no
+sign it could be picked up, nothing showed which block was moving once it was,
+and a region that would not accept it simply showed no line at all, which reads
+as the editor not noticing rather than as an answer.
+
+Dragging now says all of it. A block shows a grab cursor before the press and a
+grabbing one during; the block being moved dims where it sits, so it stays
+readable instead of being replaced by a floating copy; the container that will
+receive the block is outlined, which the line alone cannot say when the same
+coordinate is the bottom edge of one container and the top edge of the next.
+
+And a refusal explains itself. Dropping a block into a container that will not
+take it shows a "no drop" cursor, outlines that container, and names both the
+reason and what the container does accept — so "no" arrives as an instruction
+rather than as nothing happening. The three reasons a drop can be refused each
+get their own wording, because they need different things from an author: aim at
+a different container, put the block inside one, or use a different slot.

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -2728,4 +2728,42 @@ describe("the drag in flight is drawn on the canvas", () => {
     expect(notice?.getAttribute("role")).toBeNull();
     expect(notice?.getAttribute("aria-live")).toBeNull();
   });
+
+  it("clears a drag mark from an element that has LOST its node id", async () => {
+    /*
+     * The stale-mark case, driven at the DOM the way its selection neighbour is.
+     * A render can move a node id from one existing element to another without
+     * touching the child list — an async block committing its resolved root
+     * mid-drag is one way — and the element left behind then matches nothing
+     * selected by node id.
+     *
+     * If the walk only ever visits elements carrying an id, that element keeps
+     * whatever it was last given: a block dimmed to 0.4 with nothing left that
+     * will ever clear it. The selection attribute is in the walk's selector list
+     * for exactly this reason; these have to be too.
+     */
+    draw(dragging({ draggingId: "child" }), LOOP);
+    await act(async () => undefined);
+
+    // `Array.from` rather than a spread: a `NodeList` is only iterable under a
+    // lib that declares its iterator, and this package compiles without one.
+    const marked = Array.from(
+      document.querySelectorAll(`[${DRAG_SOURCE_ATTRIBUTE}]`)
+    );
+    // Control: two copies must be found first, or the assertion below is
+    // satisfied by there having been nothing to strand.
+    expect(marked).toHaveLength(2);
+
+    const orphan = marked[0];
+    await act(async () => {
+      orphan?.removeAttribute(NODE_ID_ATTRIBUTE);
+    });
+
+    expect(orphan?.hasAttribute(DRAG_SOURCE_ATTRIBUTE)).toBe(false);
+    // The copy that kept its id keeps its mark, so this separates "cleared the
+    // orphan" from "cleared everything".
+    expect(
+      document.querySelectorAll(`[${DRAG_SOURCE_ATTRIBUTE}]`)
+    ).toHaveLength(1);
+  });
 });

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -49,10 +49,14 @@ import { NODE_ID_ATTRIBUTE } from "@nextlyhq/blocks-react";
 import {
   CANVAS_ROOT_CLASS,
   Canvas,
+  DRAG_SOURCE_ATTRIBUTE,
+  DROP_PARENT_ATTRIBUTE,
+  DROP_REFUSED_ATTRIBUTE,
   SELECTED_ATTRIBUTE,
   canvasScale,
   nodeIdFromEvent,
 } from "./canvas";
+import type { CanvasDragState } from "./canvas-drag";
 import type { CanvasZoom } from "./canvas-zoom";
 
 // Explicit because this package does not enable vitest globals, and without
@@ -2506,5 +2510,188 @@ describe("forcing a state onto a tree React commits over time", () => {
     expect(second.getAttribute(SELECTED_ATTRIBUTE)).toBe("primary");
     expect(first.getAttribute(SELECTED_ATTRIBUTE)).toBeNull();
     expect(first.className).not.toContain(previewStateClass("hover"));
+  });
+});
+
+describe("the drag in flight is drawn on the canvas", () => {
+  /*
+   * A container plus the repeating block, because the two marks answer
+   * different questions and one fixture cannot exercise both: the source mark
+   * is about one node drawn many times, and the region marks are about a
+   * container node named by a drop.
+   */
+  beforeAll(() => {
+    clearBlocks();
+    registerBlocks(
+      [
+        {
+          name: "acme/leaf",
+          version: 1,
+          description: "A block.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+        {
+          // Draws its own child twice, which is what makes one node id many
+          // elements — the shape `core/collection-loop` has in the library.
+          name: "acme/twice",
+          version: 1,
+          description: "A block that repeats its child.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement(
+              "div",
+              { className },
+              createElement("div", {
+                key: "one",
+                [NODE_ID_ATTRIBUTE]: "child",
+              }),
+              createElement("div", { key: "two", [NODE_ID_ATTRIBUTE]: "child" })
+            ),
+        },
+        {
+          name: "acme/box",
+          version: 1,
+          description: "A container.",
+          example: { props: {} },
+          render: ({ className }: { className: string }) =>
+            createElement("div", { className }),
+        },
+      ] as never,
+      { source: "canvas-drag-marks-test" }
+    );
+  });
+  afterAll(clearBlocks);
+
+  const PAGE = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      { id: "box", type: "acme/box", version: 1, props: {} },
+      { id: "leaf", type: "acme/leaf", version: 1, props: {} },
+    ],
+  };
+
+  const LOOP = {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [{ id: "loop", type: "acme/twice", version: 1, props: {} }],
+  };
+
+  function draw(drag: CanvasDragState | undefined, page: unknown = PAGE) {
+    return render(
+      <Canvas
+        document={page as never}
+        siteStyles={{ css: "", classes: {} } as never}
+        drag={drag}
+      />
+    );
+  }
+
+  const dragging = (over: Partial<CanvasDragState>): CanvasDragState => ({
+    draggingId: null,
+    draggingBlockName: "acme/leaf",
+    target: null,
+    refusal: null,
+    ...over,
+  });
+
+  it("marks EVERY rendering of the node in flight, not the first one found", async () => {
+    // A node id is unique in a document and not in the tree drawn from it, so a
+    // walk stopping at the first match dims one copy of a repeated block and
+    // leaves the rest at full opacity.
+    const { container } = draw(dragging({ draggingId: "child" }), LOOP);
+    await act(async () => undefined);
+
+    expect(
+      container.querySelectorAll(`[${DRAG_SOURCE_ATTRIBUTE}]`)
+    ).toHaveLength(2);
+  });
+
+  it("marks the container a drop would land in", async () => {
+    const { container } = draw(
+      dragging({
+        draggingId: "leaf",
+        target: {
+          id: "t",
+          regionId: "box::children",
+          at: { parentId: "box", slot: "children", index: 0 },
+        } as never,
+      })
+    );
+    await act(async () => undefined);
+
+    const parent = container.querySelector(`[${DROP_PARENT_ATTRIBUTE}]`);
+    expect(parent?.getAttribute(NODE_ID_ATTRIBUTE)).toBe("box");
+    // The two region marks are mutually exclusive: `DropResolution` is a union,
+    // so a canvas showing both at once is drawing a state the engine cannot be in.
+    expect(container.querySelector(`[${DROP_REFUSED_ATTRIBUTE}]`)).toBeNull();
+  });
+
+  it("marks the container that refuses, and says why and what it takes", async () => {
+    const { container, getByText } = draw(
+      dragging({
+        draggingId: "leaf",
+        refusal: {
+          regionId: "box::children",
+          parentId: "box",
+          reason: "wrong-parent",
+          permitted: ["acme/twice"],
+        } as never,
+      })
+    );
+    await act(async () => undefined);
+
+    const refused = container.querySelector(`[${DROP_REFUSED_ATTRIBUTE}]`);
+    expect(refused?.getAttribute(NODE_ID_ATTRIBUTE)).toBe("box");
+    expect(container.querySelector(`[${DROP_PARENT_ATTRIBUTE}]`)).toBeNull();
+
+    // The whole point of the row: the reason the engine computed reaches the
+    // author, in words, naming the container and what it would accept.
+    expect(getByText("Box does not take a Leaf.")).toBeTruthy();
+    expect(getByText("Takes Twice")).toBeTruthy();
+  });
+
+  it("draws no drag marks at all when no drag is supplied", async () => {
+    // The back-compat control: every host that has not been wired yet omits
+    // this prop, and must get exactly the canvas it had before.
+    const { container } = draw(undefined);
+    await act(async () => undefined);
+
+    expect(container.querySelector(`[${DRAG_SOURCE_ATTRIBUTE}]`)).toBeNull();
+    expect(container.querySelector(`[${DROP_PARENT_ATTRIBUTE}]`)).toBeNull();
+    expect(container.querySelector(`[${DROP_REFUSED_ATTRIBUTE}]`)).toBeNull();
+  });
+
+  it("does not rewrite a mark whose value has not changed", async () => {
+    /*
+     * The spacing overlay observes this subtree with a MutationObserver, and
+     * `setAttribute` queues a record even when the value written is the value
+     * already there. Unguarded, a mark rewritten on every pointermove is a
+     * re-measure per frame — which reads as jank rather than as a defect, so
+     * nothing else in the suite would catch it.
+     */
+    const state = dragging({ draggingId: "child" });
+    const { container, rerender } = draw(state, LOOP);
+    await act(async () => undefined);
+
+    const seen: MutationRecord[] = [];
+    const observer = new MutationObserver(records => seen.push(...records));
+    observer.observe(container, { attributes: true, subtree: true });
+
+    rerender(
+      <Canvas
+        document={LOOP as never}
+        siteStyles={{ css: "", classes: {} } as never}
+        drag={state}
+      />
+    );
+    await act(async () => undefined);
+    observer.disconnect();
+
+    expect(
+      seen.filter(record => record.attributeName === DRAG_SOURCE_ATTRIBUTE)
+    ).toHaveLength(0);
   });
 });

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -52,6 +52,7 @@ import {
   DRAG_SOURCE_ATTRIBUTE,
   DROP_PARENT_ATTRIBUTE,
   DROP_REFUSED_ATTRIBUTE,
+  LOCKED_ATTRIBUTE,
   SELECTED_ATTRIBUTE,
   canvasScale,
   nodeIdFromEvent,
@@ -2650,7 +2651,46 @@ describe("the drag in flight is drawn on the canvas", () => {
     // The whole point of the row: the reason the engine computed reaches the
     // author, in words, naming the container and what it would accept.
     expect(getByText("Box does not take a Leaf.")).toBeTruthy();
-    expect(getByText("Takes Twice")).toBeTruthy();
+    // `wrong-parent` carries the MOVING block's valid parents, so the remedy
+    // says where the leaf can go — never that the box accepts a Twice.
+    expect(getByText("Leaf goes inside Twice")).toBeTruthy();
+  });
+
+  it("draws no refusal while a target is still committed", async () => {
+    /*
+     * `useCanvasDrag` holds the committed target across a short crossing while
+     * setting the refusal from the region under the pointer immediately, so
+     * both are non-null for the width of the switch threshold.
+     *
+     * Drawing the refusal there contradicts two things at once: the indicator
+     * still points at the held target, and releasing commits it. The chrome
+     * would say the block cannot land while letting go moves it.
+     */
+    const { container, queryByText } = draw(
+      dragging({
+        draggingId: "leaf",
+        target: {
+          id: "t",
+          regionId: "box::children",
+          at: { parentId: "box", slot: "children", index: 0 },
+        } as never,
+        refusal: {
+          regionId: "box::children",
+          parentId: "box",
+          reason: "wrong-parent",
+          permitted: ["acme/twice"],
+        } as never,
+      })
+    );
+    await act(async () => undefined);
+
+    // Control: the target half IS drawn, so the absences below are about the
+    // refusal being withheld rather than about nothing having rendered.
+    expect(
+      container.querySelector(`[${DROP_PARENT_ATTRIBUTE}]`)
+    ).not.toBeNull();
+    expect(container.querySelector(`[${DROP_REFUSED_ATTRIBUTE}]`)).toBeNull();
+    expect(queryByText(/does not take/)).toBeNull();
   });
 
   it("draws no drag marks at all when no drag is supplied", async () => {
@@ -2727,6 +2767,31 @@ describe("the drag in flight is drawn on the canvas", () => {
     expect(notice?.getAttribute("aria-hidden")).toBe("true");
     expect(notice?.getAttribute("role")).toBeNull();
     expect(notice?.getAttribute("aria-live")).toBeNull();
+  });
+
+  it("marks a locked node, so the grab cursor can be withheld from it", async () => {
+    /*
+     * `useCanvasDrag` returns before creating a gesture for a locked node, and
+     * with no drag handle the cursor is the only thing advertising a block as
+     * movable. Offering it on a node the engine has already refused leaves an
+     * author pressing repeatedly at something that will never move.
+     *
+     * Both halves asserted: marking every node would withhold the affordance
+     * from the whole page, which is the same defect pointing the other way.
+     */
+    const { container } = draw(undefined, {
+      formatVersion: 1,
+      kind: "page",
+      nodes: [
+        { id: "box", type: "acme/box", version: 1, props: {}, locked: true },
+        { id: "leaf", type: "acme/leaf", version: 1, props: {} },
+      ],
+    });
+    await act(async () => undefined);
+
+    const locked = container.querySelectorAll(`[${LOCKED_ATTRIBUTE}]`);
+    expect(locked).toHaveLength(1);
+    expect(locked[0]?.getAttribute(NODE_ID_ATTRIBUTE)).toBe("box");
   });
 
   it("clears a drag mark from an element that has LOST its node id", async () => {

--- a/packages/builder/src/canvas.test.tsx
+++ b/packages/builder/src/canvas.test.tsx
@@ -2694,4 +2694,38 @@ describe("the drag in flight is drawn on the canvas", () => {
       seen.filter(record => record.attributeName === DRAG_SOURCE_ATTRIBUTE)
     ).toHaveLength(0);
   });
+
+  it("does not announce the refusal, because the keyboard move already does", async () => {
+    /*
+     * The drop indicator is `aria-hidden` for a stated reason: the equivalent
+     * keyboard move reports its own outcome through the editor's single live
+     * region, so a second element describing the same pointer gesture is read
+     * alongside the first. This message is the same kind of chrome and has to
+     * make the same choice, or one author's move is announced twice.
+     *
+     * Asserted on the absence of a live region rather than on the attribute
+     * alone, so swapping `aria-hidden` for `role="status"` — or for any other
+     * implicit live role — fails here rather than passing on a technicality.
+     */
+    const { container } = draw(
+      dragging({
+        draggingId: "leaf",
+        refusal: {
+          regionId: "box::children",
+          parentId: "box",
+          reason: "wrong-parent",
+          permitted: ["acme/twice"],
+        } as never,
+      })
+    );
+    await act(async () => undefined);
+
+    const notice = container.querySelector(".nx-drop-refusal");
+    // Control: the element must be FOUND, or the assertions below are
+    // satisfied by a selector that matches nothing.
+    expect(notice).not.toBeNull();
+    expect(notice?.getAttribute("aria-hidden")).toBe("true");
+    expect(notice?.getAttribute("role")).toBeNull();
+    expect(notice?.getAttribute("aria-live")).toBeNull();
+  });
 });

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -86,17 +86,6 @@ export { CANVAS_ROOT_CLASS };
 export const SELECTED_ATTRIBUTE = "data-nx-selected";
 
 /**
- * Marks every element drawing the block currently being dragged.
- *
- * EVERY element rather than one: a node id is unique in a document and not in
- * the tree drawn from it, so a repeating block is many elements for one id and
- * a mark that stopped at the first would dim one copy of a block that is
- * wholly in flight.
- *
- * Boolean by presence, for the reason {@link SELECTED_ATTRIBUTE} is: the
- * element already states its id.
- */
-/**
  * Marks a node the drag engine will refuse to pick up.
  *
  * Drawn so the grab cursor can be withheld from it. With no drag handle, that
@@ -107,6 +96,17 @@ export const SELECTED_ATTRIBUTE = "data-nx-selected";
  */
 export const LOCKED_ATTRIBUTE = "data-nx-locked";
 
+/**
+ * Marks every element drawing the block currently being dragged.
+ *
+ * EVERY element rather than one: a node id is unique in a document and not in
+ * the tree drawn from it, so a repeating block is many elements for one id and
+ * a mark that stopped at the first would dim one copy of a block that is
+ * wholly in flight.
+ *
+ * Boolean by presence, for the reason {@link SELECTED_ATTRIBUTE} is: the
+ * element already states its id.
+ */
 export const DRAG_SOURCE_ATTRIBUTE = "data-nx-drag-source";
 
 /**
@@ -1650,7 +1650,8 @@ function DropRefusalNotice({
 }): React.JSX.Element {
   const notice = useRef<HTMLDivElement | null>(null);
   const [at, setAt] = useState<{ x: number; y: number } | null>(null);
-  const { parentId, reason } = refusal;
+  const { parentId } = refusal;
+  const { headline, remedy } = refusalWording(refusal, movingType, regionType);
 
   /*
    * Measured BEFORE the browser paints, not after.
@@ -1736,9 +1737,22 @@ function DropRefusalNotice({
     return () => {
       scroller.removeEventListener("scroll", measure);
     };
-  }, [parentId, reason]);
+    /*
+     * Re-measured when the WORDING changes, not merely when the container does.
+     *
+     * Two slots on one container share a `parentId` and a reason while carrying
+     * different permitted lists, so the message can be replaced without any of
+     * the identity this effect anchors on moving. A longer remedy wraps onto
+     * another line, and the clamp would still be holding the height of the
+     * sentence it replaced — which is exactly the case that pushes it back out
+     * of the band near the bottom of the viewport.
+     *
+     * Keyed on the rendered strings rather than on `regionId`, because height
+     * is a property of the text: two regions producing identical sentences need
+     * no re-measure, and one region whose list changed does.
+     */
+  }, [parentId, headline, remedy]);
 
-  const { headline, remedy } = refusalWording(refusal, movingType, regionType);
   return (
     <div
       ref={notice}

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -1581,9 +1581,22 @@ function DropRefusalNotice({
       // the style inspector both skip it.
       {...{ [CHROME_ATTRIBUTE]: "" }}
       style={at === null ? undefined : { left: at.x, top: at.y }}
-      // Announced, because this is the one thing in a drag that a sighted
-      // author learns from the cursor and everyone else learns from nothing.
-      role="status"
+      /*
+       * NOT announced, and that matches {@link DropIndicator} rather than
+       * differing from it.
+       *
+       * This describes a POINTER gesture, and the equivalent keyboard move
+       * reports its own outcome through the editor's single live region. A
+       * second region describing the same act is read alongside the first, so
+       * an author performing one move hears it twice — which is why nothing
+       * else in this drag announces either.
+       *
+       * The accessible route to this information is not missing, it is
+       * elsewhere: a block is selected by clicking and moved with `alt+Arrow`,
+       * and a refused keyboard move is announced there. Adding a live region
+       * here would speak to someone who is not the one dragging.
+       */
+      aria-hidden="true"
     >
       <span className="nx-drop-refusal__why">{headline}</span>
       {takes === null ? null : (

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -36,6 +36,7 @@ import {
   previewStateClass,
   statePropagatesToAncestors,
   STYLE_STATES,
+  walkNodes,
   type BlockDocument,
   type BreakpointSet,
   type StyleState,
@@ -55,7 +56,8 @@ import type { CanvasDragHandlers, CanvasDragState } from "./canvas-drag";
 import { offeredTiers } from "./canvas-width";
 import { FIT_ZOOM, usableScale, type CanvasZoom } from "./canvas-zoom";
 import { refusalWording } from "./drag-refusal";
-import { canvasContentRect } from "./geometry-dom";
+import { canvasContentRect, scrollableAncestor } from "./geometry-dom";
+import { isLocked } from "./locking";
 import { observeRenderedTree } from "./rendered-tree";
 import { selectionModeFor, type SelectionMode } from "./selection";
 import { CANVAS_ROOT_CLASS } from "./shell-state";
@@ -94,6 +96,17 @@ export const SELECTED_ATTRIBUTE = "data-nx-selected";
  * Boolean by presence, for the reason {@link SELECTED_ATTRIBUTE} is: the
  * element already states its id.
  */
+/**
+ * Marks a node the drag engine will refuse to pick up.
+ *
+ * Drawn so the grab cursor can be withheld from it. With no drag handle, that
+ * cursor is the only thing advertising a block as movable, so offering it on a
+ * node `useCanvasDrag` returns early for leaves an author pressing repeatedly
+ * at something that will never move — an affordance promising what the engine
+ * has already decided against.
+ */
+export const LOCKED_ATTRIBUTE = "data-nx-locked";
+
 export const DRAG_SOURCE_ATTRIBUTE = "data-nx-drag-source";
 
 /**
@@ -748,7 +761,8 @@ function useCanvasMarkers(
   selectedId: string | null,
   page: React.ReactNode,
   forcedState: StyleState | undefined,
-  drag: CanvasDragState | undefined
+  drag: CanvasDragState | undefined,
+  lockedIds: ReadonlySet<string>
 ): void {
   /*
    * The drag's three marks are read into plain ids here rather than inside the
@@ -759,7 +773,7 @@ function useCanvasMarkers(
    */
   const sourceId = drag?.draggingId ?? null;
   const parentId = drag?.target?.at.parentId ?? null;
-  const refusedId = drag?.refusal?.parentId ?? null;
+  const refusedId = drawnRefusal(drag)?.parentId ?? null;
   useEffect(() => {
     const container = box.current;
     if (container === null) return;
@@ -810,6 +824,7 @@ function useCanvasMarkers(
             `[${DRAG_SOURCE_ATTRIBUTE}]`,
             `[${DROP_PARENT_ATTRIBUTE}]`,
             `[${DROP_REFUSED_ATTRIBUTE}]`,
+            `[${LOCKED_ATTRIBUTE}]`,
             ...STYLE_STATES.map(state => `.${previewStateClass(state)}`),
           ].join(", ")
         )
@@ -859,17 +874,15 @@ function useCanvasMarkers(
         [DROP_REFUSED_ATTRIBUTE, refusedId],
       ];
       touched.forEach(element => {
+        if (!ownedByCanvas(element, container)) return;
         const id = element.getAttribute(NODE_ID_ATTRIBUTE);
+        // Whether the engine would refuse to move this node, asked from the set
+        // rather than from the document per element: this walk re-runs on every
+        // change to the rendered tree, and a tree search per element would make
+        // that quadratic on a large page.
+        setFlag(element, LOCKED_ATTRIBUTE, id !== null && lockedIds.has(id));
         for (const [attribute, wanted] of dragMarks) {
-          // Compared before writing, for the reason the selection attribute
-          // above is: `setAttribute` queues a mutation record even when the
-          // value it writes is the value already there, the appender observes
-          // this subtree, and a drag writes on every pointer move — so an
-          // unguarded mark is a re-measure per frame rather than per drop.
-          const should = id !== null && id === wanted;
-          if (should === element.hasAttribute(attribute)) continue;
-          if (should) element.setAttribute(attribute, "");
-          else element.removeAttribute(attribute);
+          setFlag(element, attribute, id !== null && id === wanted);
         }
       });
 
@@ -981,7 +994,40 @@ function useCanvasMarkers(
     sourceId,
     parentId,
     refusedId,
+    lockedIds,
   ]);
+}
+
+/**
+ * Whether this element belongs to the canvas doing the marking.
+ *
+ * A node id is unique within a DOCUMENT and not across documents, so a block
+ * that renders a second canvas puts another document's ids inside the outer
+ * walk's reach. An inner node sharing the dragged id would then be dimmed by a
+ * drag it has no part in, and the refusal could anchor to it.
+ */
+function ownedByCanvas(element: Element, container: HTMLElement): boolean {
+  if (element === container) return true;
+  return element.closest(`.${CANVAS_ROOT_CLASS}`) === container;
+}
+
+/**
+ * Add or remove a boolean attribute, writing only when the answer changes.
+ *
+ * The comparison is the point rather than a saving. `setAttribute` queues a
+ * mutation record even when the value it writes is the value already there,
+ * the empty-container appender observes this subtree, and a drag re-marks on
+ * every pointer move — so an unguarded write is a re-measure per frame rather
+ * than one per drop.
+ *
+ * One function rather than the same three lines at each mark: they are one
+ * rule, and four copies of it are four chances for the guard to be dropped
+ * from whichever copy is edited next.
+ */
+function setFlag(element: Element, attribute: string, wanted: boolean): void {
+  if (wanted === element.hasAttribute(attribute)) return;
+  if (wanted) element.setAttribute(attribute, "");
+  else element.removeAttribute(attribute);
 }
 
 /**
@@ -1539,6 +1585,28 @@ export interface CanvasProps {
  * different block rather than at nothing.
  */
 /**
+ * The refusal a canvas should DRAW, which is not every refusal it is given.
+ *
+ * `useCanvasDrag` holds the committed target across a short crossing so the
+ * indicator does not flicker, while setting the refusal from the region under
+ * the pointer immediately — so both are non-null for the width of the switch
+ * threshold. Drawing the refusal there contradicts two things at once: the
+ * line still points at the held target, and releasing commits it. The chrome
+ * would say the block cannot land while letting go moves it.
+ *
+ * So a refusal is the honest answer only once there is no target to disagree
+ * with. One function rather than the same condition written at the mark and
+ * again at the message, because two spellings of one rule drift and the drift
+ * shows up as chrome that half-agrees with itself.
+ */
+function drawnRefusal(
+  drag: CanvasDragState | undefined
+): CanvasDragState["refusal"] {
+  if (drag === undefined || drag.target !== null) return null;
+  return drag.refusal;
+}
+
+/**
  * The sentence a refused drop draws, over the container that refused it.
  *
  * Anchored to the CONTAINER rather than to the pointer. The drag state carries
@@ -1582,7 +1650,8 @@ function DropRefusalNotice({
    */
   useIsomorphicLayoutEffect(() => {
     const element = notice.current;
-    const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
+    if (element === null) return;
+    const root = element.closest(`.${CANVAS_ROOT_CLASS}`);
     if (!(root instanceof HTMLElement)) return;
     // The root itself when the refusal is at the page level: there is no
     // container node to point at, which is the whole of what
@@ -1590,10 +1659,40 @@ function DropRefusalNotice({
     const region = parentId === undefined ? root : nodeElement(root, parentId);
     if (region === null) return;
     const rect = canvasContentRect(region, root);
-    setAt({ x: rect.x, y: rect.y });
+
+    /*
+     * Clamped into the part of the canvas the author can actually see.
+     *
+     * The anchor alone is not enough. A root refusal has no container to point
+     * at, so it resolves to the canvas itself and lands at the page origin —
+     * which on a long page is several screens above someone dragging near the
+     * bottom, so the explanation for what just refused them is drawn where they
+     * are not looking. A very tall container scrolled past does the same.
+     *
+     * The scroller defines "visible": the shell scrolls an ancestor rather than
+     * the canvas, and its rectangle measured in this canvas's own content
+     * coordinates is exactly the band on screen.
+     */
+    const scroller = scrollableAncestor(root);
+    if (scroller === null) {
+      setAt({ x: rect.x, y: rect.y });
+      return;
+    }
+    const band = canvasContentRect(scroller, root);
+    const inset = 12;
+    const lowest = band.y + band.height - inset - element.offsetHeight;
+    const top = band.y + inset;
+    // A band shorter than the message puts `lowest` above its own top, which
+    // makes the range inverted rather than narrow. Taking the top there keeps
+    // the message on screen instead of pinning it to a bound derived from a
+    // height that does not fit.
+    setAt({
+      x: rect.x,
+      y: lowest < top ? top : Math.max(top, Math.min(rect.y, lowest)),
+    });
   }, [parentId, reason]);
 
-  const { headline, takes } = refusalWording(refusal, movingType, regionType);
+  const { headline, remedy } = refusalWording(refusal, movingType, regionType);
   return (
     <div
       ref={notice}
@@ -1620,8 +1719,8 @@ function DropRefusalNotice({
       aria-hidden="true"
     >
       <span className="nx-drop-refusal__why">{headline}</span>
-      {takes === null ? null : (
-        <span className="nx-drop-refusal__takes">{takes}</span>
+      {remedy === null ? null : (
+        <span className="nx-drop-refusal__takes">{remedy}</span>
       )}
     </div>
   );
@@ -1722,7 +1821,34 @@ export function Canvas({
     [rendered, document, sheet]
   );
 
-  useCanvasMarkers(root, marked, selectedId, page, forcedState, drag);
+  /*
+   * The locked nodes, collected in ONE traversal per document rather than asked
+   * per element inside the marker walk, which re-runs on every change to the
+   * rendered tree.
+   */
+  const lockedIds = useMemo(() => {
+    const ids = new Set<string>();
+    walkNodes(document.nodes, node => {
+      if (isLocked(node)) ids.add(node.id);
+    });
+    return ids;
+  }, [document]);
+
+  useCanvasMarkers(
+    root,
+    marked,
+    selectedId,
+    page,
+    forcedState,
+    drag,
+    lockedIds
+  );
+
+  // Bound once rather than called per prop: three calls would be three chances
+  // for the narrowing to be spelt differently, and the last one needed a
+  // non-null assertion to type-check at all.
+  const refusalDrawn = drawnRefusal(drag);
+  const refusedParentId = refusalDrawn?.parentId;
 
   return (
     <div
@@ -1768,10 +1894,10 @@ export function Canvas({
     >
       {page}
       {overlay}
-      {drag?.refusal == null ? null : (
+      {refusalDrawn === null ? null : (
         <DropRefusalNotice
-          refusal={drag.refusal}
-          movingType={drag.draggingBlockName ?? ""}
+          refusal={refusalDrawn}
+          movingType={drag?.draggingBlockName ?? ""}
           /*
            * The container's TYPE, resolved from the document the canvas is
            * already drawing. The refusal names the node; what an author reads
@@ -1779,9 +1905,9 @@ export function Canvas({
            * mapping exists.
            */
           regionType={
-            drag.refusal.parentId === undefined
+            refusedParentId === undefined
               ? undefined
-              : findNode(document.nodes, drag.refusal.parentId)?.type
+              : findNode(document.nodes, refusedParentId)?.type
           }
         />
       )}

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -802,6 +802,14 @@ function useCanvasMarkers(
             `.${PAGE_ROOT_CLASS}`,
             `[${NODE_ID_ATTRIBUTE}]`,
             `[${SELECTED_ATTRIBUTE}]`,
+            // The drag marks belong here for the reason the selection attribute
+            // does, and the case is the same one: an element that LOSES its node
+            // id matches nothing selected by node id, so leaving these out
+            // strands whatever they were last given. A block that stopped being
+            // the drag source would stay dimmed with nothing left to clear it.
+            `[${DRAG_SOURCE_ATTRIBUTE}]`,
+            `[${DROP_PARENT_ATTRIBUTE}]`,
+            `[${DROP_REFUSED_ATTRIBUTE}]`,
             ...STYLE_STATES.map(state => `.${previewStateClass(state)}`),
           ].join(", ")
         )

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -30,6 +30,7 @@
  */
 
 import {
+  findNode,
   PAGE_ROOT_CLASS,
   previewContainerName,
   previewStateClass,
@@ -49,9 +50,11 @@ import type { PageRendererProps } from "@nextlyhq/blocks-react";
 import { cn } from "@nextlyhq/ui/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
-import type { CanvasDragHandlers } from "./canvas-drag";
+import type { CanvasDragHandlers, CanvasDragState } from "./canvas-drag";
 import { offeredTiers } from "./canvas-width";
 import { FIT_ZOOM, usableScale, type CanvasZoom } from "./canvas-zoom";
+import { refusalWording } from "./drag-refusal";
+import { canvasContentRect } from "./geometry-dom";
 import { observeRenderedTree } from "./rendered-tree";
 import { selectionModeFor, type SelectionMode } from "./selection";
 import { CANVAS_ROOT_CLASS } from "./shell-state";
@@ -78,6 +81,38 @@ export { CANVAS_ROOT_CLASS };
  * no compiler behind it.
  */
 export const SELECTED_ATTRIBUTE = "data-nx-selected";
+
+/**
+ * Marks every element drawing the block currently being dragged.
+ *
+ * EVERY element rather than one: a node id is unique in a document and not in
+ * the tree drawn from it, so a repeating block is many elements for one id and
+ * a mark that stopped at the first would dim one copy of a block that is
+ * wholly in flight.
+ *
+ * Boolean by presence, for the reason {@link SELECTED_ATTRIBUTE} is: the
+ * element already states its id.
+ */
+export const DRAG_SOURCE_ATTRIBUTE = "data-nx-drag-source";
+
+/**
+ * Marks the container a drop would land in.
+ *
+ * The line says WHERE among siblings; this says WHICH container, and the two
+ * are different questions. They come apart exactly where the line alone is
+ * ambiguous — the coordinate at the bottom edge of one container is also the
+ * top edge of the next, and only this mark separates them.
+ */
+export const DROP_PARENT_ATTRIBUTE = "data-nx-drop-parent";
+
+/**
+ * Marks the container that will not take the block being dragged.
+ *
+ * Mutually exclusive with {@link DROP_PARENT_ATTRIBUTE} by construction: the
+ * engine answers with a target or a refusal, never both, so an element carrying
+ * the two at once is drawing a state that cannot exist.
+ */
+export const DROP_REFUSED_ATTRIBUTE = "data-nx-drop-refused";
 
 /**
  * Marks editor chrome drawn over the page, which is not part of the page.
@@ -706,13 +741,24 @@ function useCanvasSurface(
  * a re-render replaces the elements, and an effect keyed on the selection alone
  * would leave the new tree carrying none at all.
  */
-function useSelectionMarkers(
+function useCanvasMarkers(
   box: React.RefObject<HTMLElement | null>,
   marked: readonly string[],
   selectedId: string | null,
   page: React.ReactNode,
-  forcedState: StyleState | undefined
+  forcedState: StyleState | undefined,
+  drag: CanvasDragState | undefined
 ): void {
+  /*
+   * The drag's three marks are read into plain ids here rather than inside the
+   * walk, so the effect depends on the VALUES that change the answer instead of
+   * on the drag object's identity. `useCanvasDrag` returns a fresh object on
+   * every pointer move, and an effect keyed on it would re-walk the whole tree
+   * per frame while writing nothing new.
+   */
+  const sourceId = drag?.draggingId ?? null;
+  const parentId = drag?.target?.at.parentId ?? null;
+  const refusedId = drag?.refusal?.parentId ?? null;
   useEffect(() => {
     const container = box.current;
     if (container === null) return;
@@ -785,6 +831,36 @@ function useSelectionMarkers(
         const value = id === selectedId ? "primary" : "";
         if (element.getAttribute(SELECTED_ATTRIBUTE) !== value) {
           element.setAttribute(SELECTED_ATTRIBUTE, value);
+        }
+      });
+
+      /*
+       * The drag's marks, in the SAME walk and over the SAME set, for the
+       * reason the forced state below is: all of them answer "what is marked on
+       * this element right now", and two walks over one question drift — one
+       * runs on a change the other does not.
+       *
+       * Over `touched` rather than a fresh query, so an element that has just
+       * LOST the node id is visited and cleared. Left out, a block that stopped
+       * being the drag source keeps the mark and stays dimmed after the drop.
+       */
+      const dragMarks: ReadonlyArray<readonly [string, string | null]> = [
+        [DRAG_SOURCE_ATTRIBUTE, sourceId],
+        [DROP_PARENT_ATTRIBUTE, parentId],
+        [DROP_REFUSED_ATTRIBUTE, refusedId],
+      ];
+      touched.forEach(element => {
+        const id = element.getAttribute(NODE_ID_ATTRIBUTE);
+        for (const [attribute, wanted] of dragMarks) {
+          // Compared before writing, for the reason the selection attribute
+          // above is: `setAttribute` queues a mutation record even when the
+          // value it writes is the value already there, the appender observes
+          // this subtree, and a drag writes on every pointer move — so an
+          // unguarded mark is a re-measure per frame rather than per drop.
+          const should = id !== null && id === wanted;
+          if (should === element.hasAttribute(attribute)) continue;
+          if (should) element.setAttribute(attribute, "");
+          else element.removeAttribute(attribute);
         }
       });
 
@@ -887,7 +963,16 @@ function useSelectionMarkers(
     // there. Writing the markers cannot re-enter this: what counts as the tree
     // changing excludes every attribute `mark` writes.
     return observeRenderedTree(container, mark);
-  }, [box, selectedId, marked, page, forcedState]);
+  }, [
+    box,
+    selectedId,
+    marked,
+    page,
+    forcedState,
+    sourceId,
+    parentId,
+    refusedId,
+  ]);
 }
 
 /**
@@ -1377,6 +1462,25 @@ export interface CanvasProps {
    */
   dragHandlers?: CanvasDragHandlers;
   /**
+   * What the pointer currently means, or absent when nothing is being dragged.
+   *
+   * ONE object rather than separate `draggingId`, `target` and `refusal` props,
+   * for the reason {@link CanvasProps.dragHandlers} and
+   * {@link CanvasProps.preview} are each one: a set spread across several
+   * optional props can be PARTIALLY wired, and every partial wiring here fails
+   * silently. A host passing the refusal without the moving id explains a
+   * refusal while dimming nothing; one passing the id without the refusal is
+   * precisely the state this prop exists to end.
+   *
+   * It is the shape `useCanvasDrag` already returns, so a host forwards what it
+   * holds and restates none of it. Deriving a narrower view here would be a
+   * second answer to a question the hook has already answered.
+   *
+   * Drawing only. Nothing here decides where a block may land — `resolveDrop`
+   * does that, and this canvas draws whatever it was told.
+   */
+  drag?: CanvasDragState;
+  /**
    * The layout scale this canvas applies to the page it lays out.
    *
    * Defaults to fitting, so a host that offers no zoom control never has to
@@ -1425,6 +1529,70 @@ export interface CanvasProps {
  * breaks the moment a sibling is inserted above it — silently, by pointing at a
  * different block rather than at nothing.
  */
+/**
+ * The sentence a refused drop draws, over the container that refused it.
+ *
+ * Anchored to the CONTAINER rather than to the pointer. The drag state carries
+ * no pointer coordinate — reading one back would mean a second answer to a
+ * question `useCanvasDrag` already owns — and a message pinned to the region is
+ * steadier to read than one that moves with the hand.
+ *
+ * Measured in the canvas's own CONTENT coordinates, the space the drop
+ * indicator and the block toolbar are already positioned in, so the three agree
+ * at any scroll offset and under zoom.
+ *
+ * Keyed on the region and the reason rather than on the refusal OBJECT: the
+ * drag hook returns a fresh object every pointer move, and re-measuring per
+ * frame would cost a layout read for an answer that changes only when the
+ * pointer crosses into a different container.
+ */
+function DropRefusalNotice({
+  refusal,
+  movingType,
+  regionType,
+}: {
+  refusal: NonNullable<CanvasDragState["refusal"]>;
+  movingType: string;
+  regionType: string | undefined;
+}): React.JSX.Element {
+  const notice = useRef<HTMLDivElement | null>(null);
+  const [at, setAt] = useState<{ x: number; y: number } | null>(null);
+  const { parentId, reason } = refusal;
+
+  useEffect(() => {
+    const element = notice.current;
+    const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
+    if (!(root instanceof HTMLElement)) return;
+    // The root itself when the refusal is at the page level: there is no
+    // container node to point at, which is the whole of what
+    // `restricted-at-root` means.
+    const region = parentId === undefined ? root : nodeElement(root, parentId);
+    if (region === null) return;
+    const rect = canvasContentRect(region, root);
+    setAt({ x: rect.x, y: rect.y });
+  }, [parentId, reason]);
+
+  const { headline, takes } = refusalWording(refusal, movingType, regionType);
+  return (
+    <div
+      ref={notice}
+      className="nx-drop-refusal"
+      // Chrome drawn over the page rather than part of it, so hit-testing and
+      // the style inspector both skip it.
+      {...{ [CHROME_ATTRIBUTE]: "" }}
+      style={at === null ? undefined : { left: at.x, top: at.y }}
+      // Announced, because this is the one thing in a drag that a sighted
+      // author learns from the cursor and everyone else learns from nothing.
+      role="status"
+    >
+      <span className="nx-drop-refusal__why">{headline}</span>
+      {takes === null ? null : (
+        <span className="nx-drop-refusal__takes">{takes}</span>
+      )}
+    </div>
+  );
+}
+
 export function Canvas({
   document,
   rootRef,
@@ -1437,6 +1605,7 @@ export function Canvas({
   render,
   className,
   dragHandlers,
+  drag,
   zoom = FIT_ZOOM,
   onScale,
   onDoubleClick,
@@ -1519,7 +1688,7 @@ export function Canvas({
     [rendered, document, sheet]
   );
 
-  useSelectionMarkers(root, marked, selectedId, page, forcedState);
+  useCanvasMarkers(root, marked, selectedId, page, forcedState, drag);
 
   return (
     <div
@@ -1536,6 +1705,24 @@ export function Canvas({
       // a single name meaning both is the kind of thing that reads correctly
       // right up until someone writes a selector against the wrong one.
       data-nx-selected-id={selectedId ?? undefined}
+      /*
+       * What the pointer means, for the cursor.
+       *
+       * On the ROOT rather than per block, because a cursor during a drag is a
+       * property of the gesture and not of whatever happens to be under the
+       * pointer — and pointer capture means the events keep arriving here
+       * however far the hand travels.
+       *
+       * Absent when nothing is dragging, so the hover cursor on a block is not
+       * competing with a state that does not exist.
+       */
+      data-nx-dragging={
+        drag?.draggingBlockName == null
+          ? undefined
+          : drag.refusal === null
+            ? ""
+            : "refused"
+      }
       onClick={pointer.onClick}
       onDoubleClick={pointer.onDoubleClick}
       onContextMenu={pointer.onContextMenu}
@@ -1547,6 +1734,23 @@ export function Canvas({
     >
       {page}
       {overlay}
+      {drag?.refusal == null ? null : (
+        <DropRefusalNotice
+          refusal={drag.refusal}
+          movingType={drag.draggingBlockName ?? ""}
+          /*
+           * The container's TYPE, resolved from the document the canvas is
+           * already drawing. The refusal names the node; what an author reads
+           * is the block's name, and the document is the only place that
+           * mapping exists.
+           */
+          regionType={
+            drag.refusal.parentId === undefined
+              ? undefined
+              : findNode(document.nodes, drag.refusal.parentId)?.type
+          }
+        />
+      )}
     </div>
   );
 }

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -47,6 +47,7 @@ import {
   sharedStyleInputs,
 } from "@nextlyhq/blocks-react";
 import type { PageRendererProps } from "@nextlyhq/blocks-react";
+import { useIsomorphicLayoutEffect } from "@nextlyhq/ui";
 import { cn } from "@nextlyhq/ui/utils";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -1559,7 +1560,19 @@ function DropRefusalNotice({
   const [at, setAt] = useState<{ x: number; y: number } | null>(null);
   const { parentId, reason } = refusal;
 
-  useEffect(() => {
+  /*
+   * Measured BEFORE the browser paints, not after.
+   *
+   * A plain effect runs after paint, so the message draws once at the canvas's
+   * top-left — where an unpositioned absolute box lands — and jumps to the
+   * container on the next frame. During a drag that is not a single flash: a
+   * refusal is re-entered every time the pointer crosses into a region that
+   * will not take the block, so the jump repeats.
+   *
+   * The isomorphic form rather than `useLayoutEffect` directly, because a
+   * client component is still server-rendered and the plain hook warns there.
+   */
+  useIsomorphicLayoutEffect(() => {
     const element = notice.current;
     const root = element?.closest(`.${CANVAS_ROOT_CLASS}`);
     if (!(root instanceof HTMLElement)) return;

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -1585,6 +1585,22 @@ export interface CanvasProps {
  * different block rather than at nothing.
  */
 /**
+ * The element drawing a node, restricted to the canvas that owns it.
+ *
+ * {@link nodeElement} answers with the first match anywhere beneath the root,
+ * which is the wrong question once a block can render a canvas of its own: node
+ * ids are unique within a DOCUMENT, so an inner document may legitimately carry
+ * the same id and appear earlier in tree order.
+ */
+function ownedNodeElement(root: HTMLElement, id: string): Element | null {
+  for (const candidate of nodeElements(root)) {
+    if (candidate.getAttribute(NODE_ID_ATTRIBUTE) !== id) continue;
+    if (ownedByCanvas(candidate, root)) return candidate;
+  }
+  return null;
+}
+
+/**
  * The refusal a canvas should DRAW, which is not every refusal it is given.
  *
  * `useCanvasDrag` holds the committed target across a short crossing so the
@@ -1653,43 +1669,73 @@ function DropRefusalNotice({
     if (element === null) return;
     const root = element.closest(`.${CANVAS_ROOT_CLASS}`);
     if (!(root instanceof HTMLElement)) return;
-    // The root itself when the refusal is at the page level: there is no
-    // container node to point at, which is the whole of what
-    // `restricted-at-root` means.
-    const region = parentId === undefined ? root : nodeElement(root, parentId);
-    if (region === null) return;
-    const rect = canvasContentRect(region, root);
+    const measure = (): void => {
+      // The root itself when the refusal is at the page level: there is no
+      // container node to point at, which is the whole of what
+      // `restricted-at-root` means.
+      /*
+       * Resolved within THIS canvas, for the reason the marks are: a node id is
+       * unique in a document and not across documents, so a block rendering a
+       * second canvas can put a matching id earlier in the tree — and the message
+       * would then be anchored over a block belonging to another document.
+       */
+      const region =
+        parentId === undefined ? root : ownedNodeElement(root, parentId);
+      if (region === null) return;
+      const rect = canvasContentRect(region, root);
+
+      /*
+       * Clamped into the part of the canvas the author can actually see.
+       *
+       * The anchor alone is not enough. A root refusal has no container to point
+       * at, so it resolves to the canvas itself and lands at the page origin —
+       * which on a long page is several screens above someone dragging near the
+       * bottom, so the explanation for what just refused them is drawn where they
+       * are not looking. A very tall container scrolled past does the same.
+       *
+       * The scroller defines "visible": the shell scrolls an ancestor rather than
+       * the canvas, and its rectangle measured in this canvas's own content
+       * coordinates is exactly the band on screen.
+       */
+      const within = scrollableAncestor(root);
+      if (within === null) {
+        setAt({ x: rect.x, y: rect.y });
+        return;
+      }
+      const band = canvasContentRect(within, root);
+      const inset = 12;
+      const lowest = band.y + band.height - inset - element.offsetHeight;
+      const top = band.y + inset;
+      // A band shorter than the message puts `lowest` above its own top, which
+      // makes the range inverted rather than narrow. Taking the top there keeps
+      // the message on screen instead of pinning it to a bound derived from a
+      // height that does not fit.
+      setAt({
+        x: rect.x,
+        y: lowest < top ? top : Math.max(top, Math.min(rect.y, lowest)),
+      });
+    };
+
+    measure();
 
     /*
-     * Clamped into the part of the canvas the author can actually see.
+     * Re-measured while the canvas scrolls under a stationary pointer.
      *
-     * The anchor alone is not enough. A root refusal has no container to point
-     * at, so it resolves to the canvas itself and lands at the page origin —
-     * which on a long page is several screens above someone dragging near the
-     * bottom, so the explanation for what just refused them is drawn where they
-     * are not looking. A very tall container scrolled past does the same.
+     * Autoscroll is the case that makes this necessary rather than tidy: a drag
+     * held near an edge keeps scrolling without the pointer moving, so the
+     * refusal does not change and nothing in this effect's inputs does either —
+     * while the band the message was clamped into travels away from it. The
+     * explanation would sit still and the page would leave.
      *
-     * The scroller defines "visible": the shell scrolls an ancestor rather than
-     * the canvas, and its rectangle measured in this canvas's own content
-     * coordinates is exactly the band on screen.
+     * Passive, because this only reads geometry, and on the SCROLLER rather
+     * than the canvas: the canvas does not scroll, its ancestor does.
      */
     const scroller = scrollableAncestor(root);
-    if (scroller === null) {
-      setAt({ x: rect.x, y: rect.y });
-      return;
-    }
-    const band = canvasContentRect(scroller, root);
-    const inset = 12;
-    const lowest = band.y + band.height - inset - element.offsetHeight;
-    const top = band.y + inset;
-    // A band shorter than the message puts `lowest` above its own top, which
-    // makes the range inverted rather than narrow. Taking the top there keeps
-    // the message on screen instead of pinning it to a bound derived from a
-    // height that does not fit.
-    setAt({
-      x: rect.x,
-      y: lowest < top ? top : Math.max(top, Math.min(rect.y, lowest)),
-    });
+    if (scroller === null) return;
+    scroller.addEventListener("scroll", measure, { passive: true });
+    return () => {
+      scroller.removeEventListener("scroll", measure);
+    };
   }, [parentId, reason]);
 
   const { headline, remedy } = refusalWording(refusal, movingType, regionType);
@@ -1702,19 +1748,20 @@ function DropRefusalNotice({
       {...{ [CHROME_ATTRIBUTE]: "" }}
       style={at === null ? undefined : { left: at.x, top: at.y }}
       /*
-       * NOT announced, and that matches {@link DropIndicator} rather than
-       * differing from it.
+       * NOT announced, matching {@link DropIndicator} rather than differing
+       * from it: this describes a POINTER gesture, and a live region here
+       * would speak to someone who is not the one dragging.
        *
-       * This describes a POINTER gesture, and the equivalent keyboard move
-       * reports its own outcome through the editor's single live region. A
-       * second region describing the same act is read alongside the first, so
-       * an author performing one move hears it twice — which is why nothing
-       * else in this drag announces either.
+       * What must NOT be claimed is that the keyboard path covers it.
+       * `keyboardMovePosition` is purely positional and never asks the nesting
+       * question, so an `alt+Arrow` move is refused by the STORE rather than by
+       * the rule, and `keyboard-actions` returns silently — its own test pins
+       * that. So the nesting reason this message carries currently has no
+       * spoken counterpart anywhere.
        *
-       * The accessible route to this information is not missing, it is
-       * elsewhere: a block is selected by clicking and moved with `alt+Arrow`,
-       * and a refused keyboard move is announced there. Adding a live region
-       * here would speak to someone who is not the one dragging.
+       * That gap is real and it is not this element's to close. Announcing a
+       * pointer drag would put the sentence on the wrong gesture; the fix
+       * belongs where the keyboard move is refused.
        */
       aria-hidden="true"
     >
@@ -1879,7 +1926,7 @@ export function Canvas({
       data-nx-dragging={
         drag?.draggingBlockName == null
           ? undefined
-          : drag.refusal === null
+          : refusalDrawn === null
             ? ""
             : "refused"
       }

--- a/packages/builder/src/drag-refusal.test.ts
+++ b/packages/builder/src/drag-refusal.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Whether a refused drop tells the author something they can act on.
+ *
+ * Each case pins one property that separates an instruction from a "no": the
+ * three refusal reasons imply three different remedies, so a sentence that is
+ * right for one is wrong advice for another; and naming what the region DOES
+ * take is the difference between a wall and a direction.
+ *
+ * Asserted on the exact strings rather than on a shape. Wording is the whole
+ * deliverable here — a test that only checked a sentence was non-empty would
+ * pass on every wrong sentence.
+ *
+ * @module drag-refusal.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { refusalWording } from "./drag-refusal";
+import type { DropRefusal } from "./drop-targets";
+
+const refusal = (
+  reason: DropRefusal["reason"],
+  permitted: readonly string[] = []
+): DropRefusal => ({ regionId: "r1", reason, permitted });
+
+describe("refusalWording", () => {
+  it("names the parent and the block for wrong-parent", () => {
+    const { headline } = refusalWording(
+      refusal("wrong-parent"),
+      "core/image",
+      "core/accordion"
+    );
+    expect(headline).toBe("Accordion does not take an Image.");
+  });
+
+  it("tells restricted-at-root to go inside something, not to aim elsewhere", () => {
+    const { headline } = refusalWording(
+      refusal("restricted-at-root"),
+      "core/list-item",
+      undefined
+    );
+    expect(headline).toBe("List item has to sit inside a container.");
+    // The remedy for this reason is NOT "choose another container": at the root
+    // there is no container on screen that would satisfy it, so that advice
+    // cannot be followed. This assertion is what stops the three reasons being
+    // collapsed into one sentence later.
+    expect(headline).not.toContain("another");
+  });
+
+  it("names the slot rather than the parent for not-allowed-in-slot", () => {
+    const { headline } = refusalWording(
+      refusal("not-allowed-in-slot"),
+      "core/image",
+      "core/columns"
+    );
+    expect(headline).toBe("This slot does not take an Image.");
+  });
+
+  it("turns a refusal into an instruction by naming what is permitted", () => {
+    const { takes } = refusalWording(
+      refusal("wrong-parent", ["core/heading", "core/paragraph"]),
+      "core/image",
+      "core/accordion"
+    );
+    expect(takes).toBe("Takes Heading and Paragraph");
+  });
+
+  it("reads as prose for three or more permitted types", () => {
+    const { takes } = refusalWording(
+      refusal("wrong-parent", ["core/heading", "core/paragraph", "core/list"]),
+      "core/image",
+      "core/accordion"
+    );
+    expect(takes).toBe("Takes Heading, Paragraph and List");
+  });
+
+  it("omits the second line entirely when nothing is permitted", () => {
+    // Rendering "Takes " with an empty list reads as a sentence that was cut
+    // off, which is worse than saying nothing about what the region accepts.
+    const { takes } = refusalWording(
+      refusal("wrong-parent", []),
+      "core/image",
+      "core/accordion"
+    );
+    expect(takes).toBeNull();
+  });
+
+  it("chooses the article from the LABEL, not from the block type", () => {
+    // "core/image" starts with a consonant and reads as "an Image". Deciding
+    // from the type would produce "a Image" on every vowel-initial label.
+    const { headline } = refusalWording(
+      refusal("wrong-parent"),
+      "core/accordion",
+      "core/card"
+    );
+    expect(headline).toBe("Card does not take an Accordion.");
+  });
+
+  it("still produces a sentence with an EMPTY block registry", () => {
+    // The registry is empty at rest, and blockLabel humanises an unregistered
+    // type rather than failing. A test that opened the editor first would pass
+    // while a cold load rendered raw identities at the author.
+    const { headline, takes } = refusalWording(
+      refusal("wrong-parent", ["acme/rich-text"]),
+      "acme/hero-banner",
+      "acme/tab-set"
+    );
+    expect(headline).toBe("Tab set does not take a Hero banner.");
+    expect(takes).toBe("Takes Rich text");
+  });
+
+  it("does not name a container it was not given", () => {
+    // wrong-parent normally knows its region, but the caller resolves that from
+    // the document by id and can legitimately come up empty. The sentence must
+    // degrade rather than render "undefined does not take…".
+    const { headline } = refusalWording(
+      refusal("wrong-parent"),
+      "core/image",
+      undefined
+    );
+    expect(headline).toBe("That container does not take an Image.");
+    expect(headline).not.toContain("undefined");
+  });
+});

--- a/packages/builder/src/drag-refusal.test.ts
+++ b/packages/builder/src/drag-refusal.test.ts
@@ -55,33 +55,65 @@ describe("refusalWording", () => {
     expect(headline).toBe("This slot does not take an Image.");
   });
 
-  it("turns a refusal into an instruction by naming what is permitted", () => {
-    const { takes } = refusalWording(
-      refusal("wrong-parent", ["core/heading", "core/paragraph"]),
+  it("says what a SLOT admits, because that is what its list means", () => {
+    // `canHoldInSlot` returns the slot's allow-list, so "Takes" is a true
+    // statement about the region here and only here.
+    const { remedy } = refusalWording(
+      refusal("not-allowed-in-slot", ["core/heading", "core/paragraph"]),
       "core/image",
       "core/accordion"
     );
-    expect(takes).toBe("Takes Heading and Paragraph");
+    expect(remedy).toBe("Takes Heading and Paragraph");
   });
 
-  it("reads as prose for three or more permitted types", () => {
-    const { takes } = refusalWording(
-      refusal("wrong-parent", ["core/heading", "core/paragraph", "core/list"]),
+  it("does NOT claim the region accepts a moving block's valid parents", () => {
+    /*
+     * The separating case. For `wrong-parent`, `canNest` returns
+     * `restrictionFor(childType)` — the containers the MOVING block may sit
+     * inside — not anything the refusing region accepts. Wording it as "Takes"
+     * produces "Accordion does not take a Column. Takes Columns", which asserts
+     * the accordion admits columns. Nothing measured that.
+     */
+    const { remedy } = refusalWording(
+      refusal("wrong-parent", ["core/columns"]),
+      "core/column",
+      "core/accordion"
+    );
+    expect(remedy).toBe("Column goes inside Columns");
+    expect(remedy).not.toContain("Takes");
+  });
+
+  it("offers a parent list as alternatives to choose between", () => {
+    const { remedy } = refusalWording(
+      refusal("restricted-at-root", ["core/accordion", "core/columns"]),
+      "core/accordion-item",
+      undefined
+    );
+    expect(remedy).toBe("Accordion item goes inside Accordion or Columns");
+  });
+
+  it("reads as prose for three or more admitted types", () => {
+    const { remedy } = refusalWording(
+      refusal("not-allowed-in-slot", [
+        "core/heading",
+        "core/paragraph",
+        "core/list",
+      ]),
       "core/image",
       "core/accordion"
     );
-    expect(takes).toBe("Takes Heading, Paragraph and List");
+    expect(remedy).toBe("Takes Heading, Paragraph and List");
   });
 
   it("omits the second line entirely when nothing is permitted", () => {
-    // Rendering "Takes " with an empty list reads as a sentence that was cut
-    // off, which is worse than saying nothing about what the region accepts.
-    const { takes } = refusalWording(
+    // Rendering the lead-in with an empty list reads as a sentence that was cut
+    // off, which is worse than saying nothing about the remedy at all.
+    const { remedy } = refusalWording(
       refusal("wrong-parent", []),
       "core/image",
       "core/accordion"
     );
-    expect(takes).toBeNull();
+    expect(remedy).toBeNull();
   });
 
   it("chooses the article from the LABEL, not from the block type", () => {
@@ -99,13 +131,13 @@ describe("refusalWording", () => {
     // The registry is empty at rest, and blockLabel humanises an unregistered
     // type rather than failing. A test that opened the editor first would pass
     // while a cold load rendered raw identities at the author.
-    const { headline, takes } = refusalWording(
+    const { headline, remedy } = refusalWording(
       refusal("wrong-parent", ["acme/rich-text"]),
       "acme/hero-banner",
       "acme/tab-set"
     );
     expect(headline).toBe("Tab set does not take a Hero banner.");
-    expect(takes).toBe("Takes Rich text");
+    expect(remedy).toBe("Hero banner goes inside Rich text");
   });
 
   it("does not name a container it was not given", () => {

--- a/packages/builder/src/drag-refusal.test.ts
+++ b/packages/builder/src/drag-refusal.test.ts
@@ -105,6 +105,28 @@ describe("refusalWording", () => {
     expect(remedy).toBe("Takes Heading, Paragraph and List");
   });
 
+  it("names a namespace wildcard as a group, not as a block called *", () => {
+    // `nesting.ts` matches an allow entry ending "/*" as a prefix, so a slot
+    // can admit a whole namespace. Humanising that as a block name yields the
+    // bare "*", and the slot would announce "Takes *".
+    const { remedy } = refusalWording(
+      refusal("not-allowed-in-slot", ["core/*"]),
+      "acme/widget",
+      "core/columns"
+    );
+    expect(remedy).toBe("Takes any core block");
+    expect(remedy).not.toContain("*");
+  });
+
+  it("mixes a wildcard with named types in one list", () => {
+    const { remedy } = refusalWording(
+      refusal("not-allowed-in-slot", ["core/heading", "acme/*"]),
+      "core/image",
+      "core/columns"
+    );
+    expect(remedy).toBe("Takes Heading and any acme block");
+  });
+
   it("omits the second line entirely when nothing is permitted", () => {
     // Rendering the lead-in with an empty list reads as a sentence that was cut
     // off, which is worse than saying nothing about the remedy at all.

--- a/packages/builder/src/drag-refusal.ts
+++ b/packages/builder/src/drag-refusal.ts
@@ -40,13 +40,20 @@ export interface RefusalWording {
   /** Why the drop will not happen, in one sentence. */
   readonly headline: string;
   /**
-   * What the region does take, or null when the engine named nothing.
+   * What the author can do about it, or null when the engine named nothing.
+   *
+   * Named for the job rather than for one of its sentences, because
+   * `permitted` does NOT mean the same thing for every reason and the wording
+   * has to follow that. A slot refusal names what the SLOT admits; the other
+   * two name the containers the MOVING BLOCK is allowed to sit inside. Calling
+   * both "takes" asserts something about the region that the second kind never
+   * said — "Accordion does not take a Column. Takes Columns" reads as the
+   * accordion accepting columns, which is not what was measured.
    *
    * Null rather than an empty string: a caller rendering it unconditionally
-   * would draw "Takes" with nothing after it, which reads as a sentence that
-   * was cut off rather than as an absent fact.
+   * would draw a sentence that was cut off rather than an absent fact.
    */
-  readonly takes: string | null;
+  readonly remedy: string | null;
 }
 
 /**
@@ -72,11 +79,11 @@ function article(label: string): string {
  * rather than a delimiter. Two members join without a comma; three or more take
  * commas up to the last.
  */
-function asList(labels: readonly string[]): string {
+function asList(labels: readonly string[], joiner: string): string {
   if (labels.length === 1) return labels[0] ?? "";
-  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  if (labels.length === 2) return `${labels[0]} ${joiner} ${labels[1]}`;
   const last = labels[labels.length - 1];
-  return `${labels.slice(0, -1).join(", ")} and ${last}`;
+  return `${labels.slice(0, -1).join(", ")} ${joiner} ${last}`;
 }
 
 /**
@@ -114,9 +121,23 @@ export function refusalWording(
     }
   })();
 
+  /*
+   * The second line follows the REASON, because `permitted` is two different
+   * facts wearing one field name.
+   *
+   * `not-allowed-in-slot` carries the slot's allow-list — types the region
+   * admits — so "Takes" is a true statement about the region. The other two
+   * carry `parentsOf(movingType)`: the containers the block being dragged may
+   * sit inside, which says nothing about what the refusing region accepts.
+   *
+   * "or" rather than "and" for the parent list, because they are alternatives
+   * an author picks between; the slot's list is an enumeration of what it holds.
+   */
   const permitted = refusal.permitted.map(blockLabel);
-  return {
-    headline,
-    takes: permitted.length === 0 ? null : `Takes ${asList(permitted)}`,
-  };
+  if (permitted.length === 0) return { headline, remedy: null };
+  const remedy =
+    refusal.reason === "not-allowed-in-slot"
+      ? `Takes ${asList(permitted, "and")}`
+      : `${moving} goes inside ${asList(permitted, "or")}`;
+  return { headline, remedy };
 }

--- a/packages/builder/src/drag-refusal.ts
+++ b/packages/builder/src/drag-refusal.ts
@@ -1,0 +1,122 @@
+/**
+ * The words an author reads when a region will not take the block they hold.
+ *
+ * Separated from the engine deliberately, and by the engine's own instruction:
+ * {@link drop-targets} produces a refusal CODE plus the list of what the region
+ * accepts, because "wording is a presentation decision — it belongs where the
+ * words are drawn and where they can be translated — and a code is what a
+ * caller can branch on". This module is that caller.
+ *
+ * ## Three reasons, three remedies
+ *
+ * The reasons are not three spellings of "no". `wrong-parent` means aim at a
+ * different container; `restricted-at-root` means put the block inside
+ * something, because at the root there is no container on screen that would
+ * satisfy it; `not-allowed-in-slot` means this particular slot, not the block's
+ * parent. {@link nesting} keeps them distinct for exactly this reason, and a
+ * single sentence covering all three would answer the second with advice that
+ * cannot be followed.
+ *
+ * ## Naming what the region DOES take
+ *
+ * `permitted` is what turns a refusal into an instruction. A message that only
+ * says no leaves the author to discover the rule by trying containers one at a
+ * time; one that names the accepted types answers the next question before it
+ * is asked.
+ *
+ * ## Pure, and tested without a DOM
+ *
+ * Every sentence is a function of the refusal and two block types, so whether
+ * the wording is RIGHT for a given reason is checkable without rendering
+ * anything — which is the half most likely to be wrong.
+ *
+ * @module drag-refusal
+ */
+import type { DropRefusal } from "./drop-targets";
+import { blockLabel } from "./inserter";
+
+/** The two lines a refusal draws. */
+export interface RefusalWording {
+  /** Why the drop will not happen, in one sentence. */
+  readonly headline: string;
+  /**
+   * What the region does take, or null when the engine named nothing.
+   *
+   * Null rather than an empty string: a caller rendering it unconditionally
+   * would draw "Takes" with nothing after it, which reads as a sentence that
+   * was cut off rather than as an absent fact.
+   */
+  readonly takes: string | null;
+}
+
+/**
+ * "a" or "an", decided by the LABEL rather than by the type it came from.
+ *
+ * The label is what appears in the sentence, so it is what the article has to
+ * agree with. Deciding from the type would ask about "core/image", which begins
+ * with a consonant, and produce "a Image".
+ *
+ * Spelling rather than pronunciation, which is the honest bound: this is right
+ * for the vowel-initial labels a block palette actually produces and would be
+ * wrong for an initialism read letter by letter. A pronunciation dictionary is
+ * not worth carrying for a set of names the project chooses itself.
+ */
+function article(label: string): string {
+  return /^[aeiou]/i.test(label) ? "an" : "a";
+}
+
+/**
+ * The permitted types as prose.
+ *
+ * A sentence an author reads rather than a set they scan, so it takes "and"
+ * rather than a delimiter. Two members join without a comma; three or more take
+ * commas up to the last.
+ */
+function asList(labels: readonly string[]): string {
+  if (labels.length === 1) return labels[0] ?? "";
+  if (labels.length === 2) return `${labels[0]} and ${labels[1]}`;
+  const last = labels[labels.length - 1];
+  return `${labels.slice(0, -1).join(", ")} and ${last}`;
+}
+
+/**
+ * Why this drop will not happen, and what would.
+ *
+ * `regionType` is optional because one reason has no region to name —
+ * `restricted-at-root` is a block sitting where there is no parent at all — and
+ * because the caller resolves the region from the document by id, which can
+ * legitimately come up empty while the refusal itself is sound. Both cases get
+ * a sentence rather than a gap where a name should be.
+ */
+export function refusalWording(
+  refusal: DropRefusal,
+  movingType: string,
+  regionType: string | undefined
+): RefusalWording {
+  const moving = blockLabel(movingType);
+  const region = regionType === undefined ? undefined : blockLabel(regionType);
+  const moved = `${article(moving)} ${moving}`;
+
+  const headline = ((): string => {
+    switch (refusal.reason) {
+      case "restricted-at-root":
+        // Not "choose another container": there is none on screen that would
+        // take it, so the only remedy is to create the nesting.
+        return `${moving} has to sit inside a container.`;
+      case "not-allowed-in-slot":
+        // The slot refuses, not the block's parent — naming the parent here
+        // would send the author to change the wrong thing.
+        return `This slot does not take ${moved}.`;
+      case "wrong-parent":
+        return region === undefined
+          ? `That container does not take ${moved}.`
+          : `${region} does not take ${moved}.`;
+    }
+  })();
+
+  const permitted = refusal.permitted.map(blockLabel);
+  return {
+    headline,
+    takes: permitted.length === 0 ? null : `Takes ${asList(permitted)}`,
+  };
+}

--- a/packages/builder/src/drag-refusal.ts
+++ b/packages/builder/src/drag-refusal.ts
@@ -87,6 +87,24 @@ function asList(labels: readonly string[], joiner: string): string {
 }
 
 /**
+ * One entry of a permitted list, as an author reads it.
+ *
+ * A slot may admit a whole NAMESPACE rather than named types — `nesting.ts`
+ * matches an entry ending `/*` as a prefix — and such an entry is not a block
+ * name. Sending it through {@link blockLabel} humanises it into the bare
+ * `"*"`, so a slot admitting everything core would announce "Takes *".
+ *
+ * The group is named instead. It is deliberately lower case where a block label
+ * is not: "any core block" is a description of a set, and capitalising it would
+ * dress it as the name of a block that does not exist.
+ */
+function permittedLabel(entry: string): string {
+  if (!entry.endsWith("/*")) return blockLabel(entry);
+  const namespace = entry.slice(0, -2);
+  return namespace === "" ? "any block" : `any ${namespace} block`;
+}
+
+/**
  * Why this drop will not happen, and what would.
  *
  * `regionType` is optional because one reason has no region to name —
@@ -133,7 +151,7 @@ export function refusalWording(
    * "or" rather than "and" for the parent list, because they are alternatives
    * an author picks between; the slot's list is an enumeration of what it holds.
    */
-  const permitted = refusal.permitted.map(blockLabel);
+  const permitted = refusal.permitted.map(permittedLabel);
   if (permitted.length === 0) return { headline, remedy: null };
   const remedy =
     refusal.reason === "not-allowed-in-slot"

--- a/packages/builder/src/drop-targets.test.ts
+++ b/packages/builder/src/drop-targets.test.ts
@@ -453,12 +453,57 @@ describe("resolveDrop", () => {
 
     // A refusal rather than an absent target, because the canvas has to say
     // WHY: the author aimed at this region.
+    //
+    // `parentId` travels with it for the same reason `permitted` does. A region
+    // is identified by `"<parentId>::<slot>"`, which is a composite the surface
+    // drawing the refusal would otherwise have to take apart with a string
+    // split — and a container is the thing that has to be outlined and named,
+    // so the id of the node is the fact a caller actually needs.
     expect(resolution).toEqual({
       kind: "refused",
       refusal: {
         regionId: "acc::panels",
+        parentId: "acc",
         reason: "not-allowed-in-slot",
         permitted: ["core/accordion-item"],
+      },
+    });
+  });
+
+  it("carries no parent on a refusal at the ROOT region", () => {
+    // The root has no container node, so there is nothing to outline or name.
+    // Absent rather than a sentinel: a caller can then ask whether there is a
+    // container at all, which is exactly what separates `restricted-at-root`
+    // from a refusal an author can fix by aiming somewhere else.
+    const resolution = resolveDrop(
+      {
+        blockName: "core/accordion-item",
+        forbiddenParents: new Set(),
+        regions: [
+          {
+            id: ROOT_REGION,
+            at: { at: "root" },
+            depth: 0,
+            rect: { x: 0, y: 0, width: 400, height: 200 },
+            axis: "y",
+            childIds: [],
+          } satisfies DropRegion,
+        ],
+        rects: rectsOf({}),
+        nesting: {
+          parentsOf: () => ["core/accordion"],
+          slotAllowOf: () => undefined,
+        },
+      },
+      { x: 100, y: 100 }
+    );
+
+    expect(resolution).toEqual({
+      kind: "refused",
+      refusal: {
+        regionId: ROOT_REGION,
+        reason: "restricted-at-root",
+        permitted: ["core/accordion"],
       },
     });
   });

--- a/packages/builder/src/drop-targets.test.ts
+++ b/packages/builder/src/drop-targets.test.ts
@@ -498,7 +498,12 @@ describe("resolveDrop", () => {
       { x: 100, y: 100 }
     );
 
-    expect(resolution).toEqual({
+    // `toStrictEqual`, not `toEqual`. The looser matcher IGNORES properties
+    // whose value is undefined, so it passes whether the key is absent or
+    // present-and-empty — which is the exact distinction being asserted, and
+    // the one the docblock promises. A test that cannot see the difference is
+    // not coverage of it.
+    expect(resolution).toStrictEqual({
       kind: "refused",
       refusal: {
         regionId: ROOT_REGION,

--- a/packages/builder/src/drop-targets.ts
+++ b/packages/builder/src/drop-targets.ts
@@ -529,7 +529,15 @@ export function resolveDrop(query: DropQuery, pointer: Point): DropResolution {
         regionId: region.id,
         // Taken from the region rather than parsed back out of its id: the
         // region is the richer value and it is already in hand here.
-        parentId: region.parentId,
+        //
+        // SPREAD rather than assigned, so the root case has no `parentId` key
+        // at all. Writing `parentId: undefined` creates an own property whose
+        // value is undefined, which reads the same through `?.` and differently
+        // through `in`, `Object.keys` and a strict comparison — and the type
+        // documents the field as absent at the root rather than as present and
+        // empty. A shape that only matches its documentation under the loosest
+        // reading is one nobody can rely on.
+        ...(region.parentId === undefined ? {} : { parentId: region.parentId }),
         reason: verdict.reason,
         permitted: verdict.permitted,
       },

--- a/packages/builder/src/drop-targets.ts
+++ b/packages/builder/src/drop-targets.ts
@@ -176,6 +176,21 @@ export interface DropTarget {
  */
 export interface DropRefusal {
   readonly regionId: string;
+  /**
+   * The container node the refusing region belongs to, absent at the root.
+   *
+   * Carried for the same reason `permitted` is: a surface explaining the
+   * refusal needs it, and this is the only place it is still known. A region is
+   * identified by `"<parentId>::<slot>"`, so recovering the node from
+   * {@link DropRefusal.regionId} means splitting a composite string — reading a
+   * value back out of a spelling this module chose, which stops being correct
+   * the moment the spelling does.
+   *
+   * Absent rather than a sentinel at the root, because "there is no container"
+   * is the fact that separates a refusal an author can fix by aiming elsewhere
+   * from one that needs a container to exist first.
+   */
+  readonly parentId?: string;
   readonly reason: NestingRefusal;
   readonly permitted: readonly string[];
 }
@@ -512,6 +527,9 @@ export function resolveDrop(query: DropQuery, pointer: Point): DropResolution {
       kind: "refused",
       refusal: {
         regionId: region.id,
+        // Taken from the region rather than parsed back out of its id: the
+        // region is the richer value and it is already in hand here.
+        parentId: region.parentId,
         reason: verdict.reason,
         permitted: verdict.permitted,
       },

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1169,7 +1169,7 @@
  * palette tile has said this since it shipped; the canvas is the half that
  * never did.
  */
-.nx-canvas [data-nx-node]:not([data-nx-locked]) {
+.nx-canvas [data-nx-node] {
   cursor: grab;
 }
 
@@ -1180,6 +1180,12 @@
  * as movable promises something that can never happen and leaves an author
  * pressing repeatedly at a block that will not move. Since the whole element is
  * the grab surface here, the cursor is the only place that promise is made.
+ *
+ * Withdrawn by SPECIFICITY rather than by excluding it from the rule above: a
+ * negation there would have to name every reason a block might not be
+ * draggable, and each new reason would edit a selector that means "a block"
+ * into one that means "a block, except". Two rules keep the general statement
+ * general and let the exception say what it is.
  */
 .nx-canvas [data-nx-node][data-nx-locked] {
   cursor: default;

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1169,8 +1169,20 @@
  * palette tile has said this since it shipped; the canvas is the half that
  * never did.
  */
-.nx-canvas [data-nx-node] {
+.nx-canvas [data-nx-node]:not([data-nx-locked]) {
   cursor: grab;
+}
+
+/*
+ * A locked block does not offer the grab.
+ *
+ * The drag engine returns before creating a gesture for one, so advertising it
+ * as movable promises something that can never happen and leaves an author
+ * pressing repeatedly at a block that will not move. Since the whole element is
+ * the grab surface here, the cursor is the only place that promise is made.
+ */
+.nx-canvas [data-nx-node][data-nx-locked] {
+  cursor: default;
 }
 
 /*
@@ -1190,6 +1202,29 @@
 }
 
 .nx-canvas[data-nx-dragging="refused"] {
+  cursor: no-drop;
+}
+
+/*
+ * The drag state has to WIN over the block's own cursor, not merely be
+ * inherited past it.
+ *
+ * `cursor` inherits, but a descendant that declares its own value is not
+ * inheriting anything — and every block declares `grab` above. Setting the drag
+ * state only on the root therefore changes the cursor over the gaps between
+ * blocks and leaves it reading `grab` over the blocks themselves, which is
+ * where the pointer spends a drag. These two selectors are the ones that
+ * actually reach it.
+ *
+ * The locked rule above is deliberately NOT re-stated here: once a drag is in
+ * flight the subject is the block being carried, and the cursor describes the
+ * gesture rather than whatever it happens to be passing over.
+ */
+.nx-canvas[data-nx-dragging] [data-nx-node] {
+  cursor: grabbing;
+}
+
+.nx-canvas[data-nx-dragging="refused"] [data-nx-node] {
   cursor: no-drop;
 }
 

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1192,6 +1192,26 @@
 }
 
 /*
+ * Text being edited shows a caret, not a grab.
+ *
+ * Inline editing turns the node's own element into editable content and stops
+ * the pointer events a drag would start from, so the gesture the grab cursor
+ * advertises is unavailable at exactly the moment the element most needs to
+ * advertise a different one: where the caret will land, and what a press-drag
+ * will select.
+ *
+ * Both spellings, because the attribute and the property are set by different
+ * layers — the builder marks the element it is editing, the browser reflects
+ * the editable state — and a rule keyed on only one of them is right until
+ * whichever it did not name changes.
+ */
+.nx-canvas [data-nx-node][data-nx-editing],
+.nx-canvas [data-nx-node][contenteditable="true"],
+.nx-canvas [data-nx-node][contenteditable="plaintext-only"] {
+  cursor: text;
+}
+
+/*
  * Held, and refused.
  *
  * Both are reachable because this drag is built on POINTER events with pointer

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1131,6 +1131,153 @@
 }
 
 /*
+ * The line gets a terminal, so it reads as an insertion point.
+ *
+ * A bare 2px rule spanning a region is ambiguous with a border belonging to the
+ * block below it — which is exactly the reading to avoid, because a border says
+ * "this block" and the line means "between these blocks". A dot at the leading
+ * end is the convention every editor that draws this uses, and it costs no
+ * layout: the indicator is already absolutely positioned and takes part in no
+ * flow.
+ */
+.nx-drop-indicator::before {
+  content: "";
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--nx-primary);
+}
+
+.nx-drop-indicator[data-axis="y"]::before {
+  left: -4px;
+  top: -3px;
+}
+
+.nx-drop-indicator[data-axis="x"]::before {
+  top: -4px;
+  left: -3px;
+}
+
+/*
+ * A block on the canvas says it can be picked up.
+ *
+ * Blocks here have no drag handle: the whole element is the grab surface. That
+ * is a deliberate choice and it carries an obligation — with no handle to point
+ * at, the cursor is the ONLY thing that says the element can be moved, so its
+ * absence leaves the gesture undiscoverable rather than merely unadorned. The
+ * palette tile has said this since it shipped; the canvas is the half that
+ * never did.
+ */
+.nx-canvas [data-nx-node] {
+  cursor: grab;
+}
+
+/*
+ * Held, and refused.
+ *
+ * Both are reachable because this drag is built on POINTER events with pointer
+ * capture rather than on the HTML5 drag-and-drop API, where the cursor is taken
+ * over by the drop effect for the duration of the gesture and neither of these
+ * can be shown.
+ *
+ * On the ROOT rather than per block: pointer capture means the events keep
+ * arriving at the canvas however far the hand travels, so a cursor set on
+ * whatever happens to be underneath would flicker as the pointer crossed gaps.
+ */
+.nx-canvas[data-nx-dragging] {
+  cursor: grabbing;
+}
+
+.nx-canvas[data-nx-dragging="refused"] {
+  cursor: no-drop;
+}
+
+/*
+ * What is being held, dimmed where it sits.
+ *
+ * The block STAYS in place rather than being replaced by a preview that follows
+ * the pointer. On a canvas the block is the rendered artefact at its real size,
+ * so a simplified preview would show strictly less than is already on screen —
+ * the opposite of a list, where a row is a summary and the preview is the only
+ * thing carrying what is in flight.
+ */
+.nx-canvas [data-nx-drag-source] {
+  opacity: 0.4;
+}
+
+/*
+ * WHICH container, which the line cannot say.
+ *
+ * The line answers "between which two siblings"; this answers "inside which
+ * container", and the two come apart exactly where the line alone is ambiguous:
+ * the coordinate at the bottom edge of one container is also the top edge of
+ * the next, and only this separates them.
+ *
+ * DASHED and OUTSIDE, where the selection is solid and inset. They are both
+ * outlines in the same colour and they mean different things, so the shape has
+ * to carry the difference — a second solid outline would read as a second
+ * selection.
+ *
+ * An outline rather than a border, for the reason `.nx-canvas` documents: a
+ * container may carry `container-type: inline-size`, and a border is subtracted
+ * from the content box its queries resolve against, so a highlight drawn with
+ * one would change the layout it is describing.
+ */
+.nx-canvas [data-nx-drop-parent] {
+  outline: 2px dashed var(--nx-primary);
+  outline-offset: 2px;
+}
+
+.nx-canvas [data-nx-drop-refused] {
+  outline: 2px solid var(--nx-destructive);
+  outline-offset: 2px;
+}
+
+/*
+ * The sentence a refusal draws, over the container that refused.
+ *
+ * Positioned in the canvas's own content coordinates, the space the drop
+ * indicator and the block toolbar already use, so all three agree at any scroll
+ * offset and under zoom.
+ *
+ * Never a drop target itself: it sits over the region the pointer is aiming at
+ * by construction, so a hit-test that could land on it would resolve the drag
+ * to the message rather than to the container beneath.
+ */
+.nx-drop-refusal {
+  position: absolute;
+  z-index: 3;
+  pointer-events: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  max-width: 18rem;
+  padding: 0.5rem 0.625rem;
+  border-radius: var(--radius);
+  background: var(--nx-destructive);
+  color: var(--nx-destructive-foreground);
+  box-shadow: var(--shadow-md);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+}
+
+.nx-drop-refusal__why {
+  font-weight: 600;
+}
+
+/*
+ * The remedy, quieter than the refusal itself.
+ *
+ * Deliberately not hidden on a narrow canvas: naming what the region DOES take
+ * is what makes this an instruction rather than a wall, and it is the half an
+ * author acts on.
+ */
+.nx-drop-refusal__takes {
+  opacity: 0.9;
+}
+
+/*
  * The layers panel: a search field above a tree that takes the rest of the
  * height.
  *

--- a/packages/plugin-page-builder/src/admin/BlocksField.tsx
+++ b/packages/plugin-page-builder/src/admin/BlocksField.tsx
@@ -2350,6 +2350,16 @@ function BlocksEditor<TFieldValues extends FieldValues = FieldValues>({
                 // box actually got rather than from what it was offered.
                 preview={canvasPreview}
                 dragHandlers={drag.handlers}
+                // The same object those handlers came from, forwarded whole.
+                // The canvas draws what the pointer currently means — which
+                // block is in flight, which container is receiving it, and why
+                // a region will not take it — and decides none of it.
+                //
+                // Whole rather than picked apart for the reason the handlers
+                // are: a set spread across several props can be partially
+                // wired, and a canvas told about a refusal but not about the
+                // block in flight explains a refusal while dimming nothing.
+                drag={drag}
                 // The pointer route into typing a block's text. Its keyboard
                 // counterpart is the Enter binding above, registered in the same
                 // place so a surface cannot gain one without the other.


### PR DESCRIPTION
## What and why

Dragging a block on the canvas answered one of the four questions a drag asks. It drew a line for where a block would land among its siblings, and said nothing about whether a block could be picked up, which one was in flight, which container was receiving it, or why a region would not take it.

The last one is the defect rather than the gap. `drop-targets.ts` already returns a three-way `DropResolution`, and `DropRefusal` already carries a reason plus the list of types the region accepts. Its own docblock states why:

> A refusal is a distinct answer rather than an absent target… An author who drags a heading over an accordion has aimed at something; showing no indicator tells them the editor did not notice, while showing a refusal tells them the region does not take that block.

`BlocksField` read `drag.target` and never `drag.refusal`. So the editor knew why it would not take the block and said nothing — a defect against the module's own stated intent.

**Prior art.** Atlassian's Pragmatic drag-and-drop is explicit that handle-less "implied draggables" *must* carry cursor and background changes, since with no handle the cursor is the only thing saying an element can be picked up. Canvas blocks have no handle (zero `Grip`/`dragHandle` hits in `packages/builder/src`), so the missing cursor is a defect against that pattern, not taste. Webflow answers "which parent" with a second, differently-shaped indicator, which is what the container outline does here. Notably, **no system in either category communicates a refusal with a remedy** — Atlassian's guidelines do not cover refused targets at all — so this part is ahead of the field and was already built in the engine.

Payload, Strapi, Sanity and Directus are *not* prior art for this: verified from Payload's source, a blocks field is collapsible rows with a drag handle reordered by `moveFieldRow({ moveFromIndex, moveToIndex })` — a single-axis index move with no canvas, no nesting, and no refusal case possible.

## What changed

- **`drag-refusal.ts`** (new, pure, no DOM) turns a `DropRefusal` into two lines. Three reasons get three sentences because they imply three different remedies — `nesting.ts` records that collapsing them would answer `restricted-at-root` with advice that cannot be followed. Naming `permitted` is what makes each an instruction rather than a wall.
- **`canvas.tsx`** takes one `drag?: CanvasDragState` and stamps three attributes.
- **`builder-chrome.css`** turns those into cursors, a 0.4 dim, the indicator terminal, two region outlines and the refusal card.
- **`BlocksField.tsx`** forwards the object it already holds.

## Two deviations from the approved plan, both deliberate

**1. `DropRefusal` gained `parentId`.** The plan said presentation-only. That proved impossible: `regionId` is `"<parentId>::<slot>"`, not a node id, so the refused container was not addressable in the DOM. The alternative was splitting that string — identifying by a spelling the module chose, which `derived-checks.md` forbids. `region.parentId` was already in scope at the construction site, so this is derivation, not recomputation. `DropTarget` already carried `at.parentId`; this brings the refusal to parity.

**2. `BlocksField.tsx` was wired now rather than after #1441.** Coordinated directly with that lane, which offered "do the BlocksField wiring last" as the alternative to waiting. It is one line plus a comment in the `<Canvas>` props block; I take the rebase.

## Architecture notes for review

- **One `drag` object, not three props.** Forced by `CanvasProps.preview`'s own rule: *"the set cannot then be PARTIALLY wired, and every partial wiring here fails silently."* A canvas told about a refusal but not the moving block explains a refusal while dimming nothing.
- **Marks join the existing walk.** `useSelectionMarkers` (now `useCanvasMarkers`) already states it: *"two walks over one question drift — one runs on a change the other does not."*
- **Compare-before-write is load-bearing.** The appender observes this subtree with a `MutationObserver` and `setAttribute` queues a record even when the value is unchanged. Unguarded, a drag mark is a re-measure per frame. Verified safe against `RENDERED_TREE_MUTATIONS`, whose `attributeFilter` is `[NODE_ID_ATTRIBUTE]` only, so the new attributes cannot re-enter the observer.
- **Nothing enters the box model.** Every highlight is `outline`, never `border` — `.nx-canvas` documents that it carries the tier width *and* `container-type: inline-size` under `border-box`, so 2px of border makes the widest tier unreachable.
- **The refusal does not go through `builder-notices`.** Its contract is *"only a failure with nowhere else to appear… a control that can still be READ reports for itself and stays silent here."* A drag refusal is synchronous and belongs on the canvas.
- **No following drag preview**, deliberately. On a canvas the block is the rendered artefact at full size, so a simplified preview would show strictly less than is already on screen — the opposite of a list, where the row is a summary.

## Test plan

Suites, read by exit code:

| gate | result |
| --- | --- |
| `packages/builder` vitest | 94 files / 2643 tests, exit 0 (+6 = exactly the new tests; file count held) |
| `packages/plugin-page-builder` vitest | 50 files / 524 tests, exit 0 |
| `check-types` (builder, plugin-page-builder) | exit 0 |
| `lint` (builder, plugin-page-builder) | exit 0 |
| `lint:design` | exit 0, 1153 files across 8 roots |
| `fallow audit --base origin/main` | `pass`, `dead_code_introduced: 0` |
| `changeset status` | exit 0, all packages queued at patch |

**Break-verification, with the failing test NAMES per break** — a suite going red proves nothing, so each break must kill only what its property covers:

*`drag-refusal.ts`*
- collapse `restricted-at-root` into the wrong-parent sentence → **1** fails: "tells restricted-at-root to go inside something, not to aim elsewhere"
- render the takes line unconditionally → **1** fails: "omits the second line entirely when nothing is permitted"
- use the raw type instead of `blockLabel` → **6** fail; the 3 survivors are exactly the tests reading only `permitted`, which that break does not touch

*`canvas.tsx`*
- stop at the first element carrying the id (querySelector semantics) → "marks EVERY rendering of the node in flight" fails, plus the mutation test — explicable collateral, since stopping at the first makes the mark flap between copies every frame
- drop the compare-before-write guard → **1** fails: "does not rewrite a mark whose value has not changed"
- stamp the refused region with the parent attribute → **2** fail, both region tests

The "draws no drag marks at all" test asserts an absence, so the three must-be-found tests above it are its control; it is not evidence on its own.

## Changeset

Added: **yes** (`patch`, all published packages, per the lockstep rule).

## Pre-existing conditions, so they are not read as regressions

- `fallow` reports `styling_introduced: 4`. **These are not mine** — they sit at lines 1344, 1400, 1630 and 1858 (`.nx-layer-row__badge`, `.nx-breadcrumb__crumb`, `.nx-spacing-overlay__band`, `.nx-tokens__transfer`), all outside my added block at 1134–1278. My 147-line mid-file insertion shifted their line numbers and fallow attributed them to the diff. Verdict is `pass`.
- `builder-chrome.css:680` carries the only literal colours in the file (the chequerboard), pre-existing and marked `design-lint-ok`.

## Not covered

- `EntryForm` calling into this path has no test; nothing renders `EntryForm` in any suite.
- Rendered geometry is not asserted — jsdom cannot see layout, so the tests assert the marks and the words, not positions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual drag-and-drop feedback, including source highlighting, valid drop targets, locked blocks, and refused drop indicators.
  * Added contextual messages explaining why a block cannot be dropped and, where applicable, which block types are allowed.
  * Updated drag cursors and drop-target styling for clearer interaction feedback.
* **Bug Fixes**
  * Improved handling and cleanup of drag markers as canvas content changes.
  * Correctly distinguishes root-level restrictions from container-specific drop refusals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->