### PR TITLE
feat(admin): watch the background queue from the admin

### DIFF
--- a/.changeset/watch-the-queue-from-the-admin.md
+++ b/.changeset/watch-the-queue-from-the-admin.md
@@ -1,0 +1,64 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Background jobs are visible in the admin, under Settings.
+
+A job that fails is invisible. There is no request to inspect, no status code
+and no page that went blank, so a scheduled release that did not publish looks
+exactly like one that was not due yet. `GET /api/jobs` made that readable; this
+is the screen that reads it.
+
+Read-only, and that is the design rather than a first step. Retry, cancel and
+requeue are writes on already-authorized work, each needing its own decision
+about who may perform it, and offering them beside a read would settle those
+questions by omission.
+
+Failures are stated ABOVE the table, because the question that brings someone
+here is almost always "did the thing I expected happen", and a red row twelve
+lines down is a worse answer than a sentence at the top. The notice is its own
+component and fetches and authorizes for itself, so a release or a webhook page
+can mount it beside the object whose work failed by adding one element. It stays
+silent when nothing failed, when the window is still loading, and for a viewer
+who may not read jobs — a notice that appears routinely is one its reader learns
+to skip.
+
+A retrying job is deliberately not presented as a failure. It is the system
+healing itself and needs nobody; colouring it like a dead job is the documented
+mistake in queue tooling, which raises an alarm for the harmless case and buries
+the one that matters. `failed` is the only red pill on the screen.
+
+Two sentences keep the screen honest. It says when the window is truncated,
+because otherwise fifty rows read as the whole story. And it states the
+seven-day retention, because a list that silently forgets is one an operator
+reads as proof a job never ran.
+
+The status vocabulary is imported from the core rather than restated. `nextly`
+now publishes `nextly/api/jobs-list-types`, and the wire item is DERIVED from
+the row the route emits, so a field or a status added on the server reaches the
+admin's types without a second edit — and an unfamiliar status still renders
+verbatim rather than blank, for a server ahead of the client.

--- a/.changeset/watch-the-queue-from-the-admin.md
+++ b/.changeset/watch-the-queue-from-the-admin.md
@@ -98,6 +98,30 @@ sets a timezone and a date format; a local `toLocaleString` reads the browser's
 instead, so the same instant appeared two different ways on one page and nothing
 said so.
 
+The table narrows on the SERVER too. Once the summary started asking the
+database for failures, a locally-filtered table could show nothing under a
+notice reporting one — the two halves of one screen disagreeing, because only
+one of them had asked. Choosing a status now sends the stored states that can
+produce it, and the client separates only the statuses that share a state.
+
+"Needs attention" is total over wire strings. A newer server can send a status
+this build has never heard of, which `jobStatusPresentation` already degrades
+for; the predicate indexed its table directly and threw on that key, taking down
+the page whose job is to report that something is wrong. It answers false for an
+unfamiliar status, so the summary keeps two rules rather than one: a status the
+core calls actionable is kept, and so is one this build does not recognise —
+because the rows a stale client would otherwise drop are exactly the new kind of
+failure nobody has seen yet. What it drops is only what it knows to be quiet.
+
+A failed job is described as terminal, not as having spent its attempts. The
+runner returns terminal immediately when the identity it would run as is gone,
+so a job can reach that state on its first attempt, and telling an operator the
+retries were exhausted sends them looking for a backoff that never happened.
+
+An expanded error keeps an operable label. Hiding every child of the disclosure
+on open left an empty control — nothing to click to collapse it and nothing for
+a screen reader to announce.
+
 It also asks for FAILURES rather than sifting recent rows. A window is the most
 recent N jobs, so N healthy ones running after a failure push it out — and a
 summary that looked inside that window would report nothing wrong with the

--- a/.changeset/watch-the-queue-from-the-admin.md
+++ b/.changeset/watch-the-queue-from-the-admin.md
@@ -57,15 +57,26 @@ because otherwise fifty rows read as the whole story. And it states the
 seven-day retention, because a list that silently forgets is one an operator
 reads as proof a job never ran.
 
-The Settings rail entry now opens for the background-jobs grant. It is a
-capability list that decides whether the panel appears at all, separate from the
-gate on each destination inside it, so an operator holding only
-`manage-background-jobs` passed the inner gate and was stopped by the outer one
-— the page reachable only by typing its URL, with nothing erroring to say so.
-That list is a second enumeration of the settings navigation, which is why the
-omission was possible; deriving the rail from the panel's own visible
-destinations is the real repair and is filed separately, because it means
-reworking a component this change has no other business in.
+The grants that reveal the Settings panel are now read off the panel itself.
+A capability list decides whether the rail entry appears at all, separate from
+the gate on each destination inside it, and it was maintained by hand beside the
+navigation table — so Background Jobs was added to one side only, its own gate
+passed, and an operator holding just `manage-background-jobs` was stopped by the
+rail above it, with the page reachable solely by typing its URL and nothing
+erroring to say so. The list is now derived from the navigation, so a
+destination added to the panel reveals it by construction and the same omission
+cannot be made twice.
+
+The failure summary asks the SERVER for one task's jobs. It was fetching the
+global recent window and filtering it, which filters rows a busier task has
+already crowded out: mounted beside a release, it would have stayed silent about
+that release's failure whenever webhook deliveries were noisier. The endpoint
+takes a `slug` and narrows in the query, before the limit.
+
+A failed read no longer looks like a healthy queue. When the request errors
+there is no data, and rendering nothing there is exactly what "nothing failed"
+renders — telling an operator that nothing needs attention when the truth is
+that nothing could be checked. It now says the queue could not be read.
 
 Retention is presented as the DEFAULT, not as the installation's policy. A host
 passing `retentionMs` to `runJobsPass` keeps rows for another period, and `null`

--- a/.changeset/watch-the-queue-from-the-admin.md
+++ b/.changeset/watch-the-queue-from-the-admin.md
@@ -57,6 +57,38 @@ because otherwise fifty rows read as the whole story. And it states the
 seven-day retention, because a list that silently forgets is one an operator
 reads as proof a job never ran.
 
+The Settings rail entry now opens for the background-jobs grant. It is a
+capability list that decides whether the panel appears at all, separate from the
+gate on each destination inside it, so an operator holding only
+`manage-background-jobs` passed the inner gate and was stopped by the outer one
+— the page reachable only by typing its URL, with nothing erroring to say so.
+That list is a second enumeration of the settings navigation, which is why the
+omission was possible; deriving the rail from the panel's own visible
+destinations is the real repair and is filed separately, because it means
+reworking a component this change has no other business in.
+
+Retention is presented as the DEFAULT, not as the installation's policy. A host
+passing `retentionMs` to `runJobsPass` keeps rows for another period, and `null`
+disables pruning entirely; nothing on the read path can see which was chosen, so
+a flat "removed after 7 days" is a claim the screen cannot support — and this is
+the sentence operators are meant to trust about absent rows. The number itself
+now comes from the core's own constant, moved to a leaf module so a client
+importing it does not pull the Direct API graph along with it.
+
+"Needs attention" is asked of the core's `jobNeedsAttention` rather than
+compared against `failed` here, so a second actionable terminal state cannot be
+silently omitted from the notice while the exhaustive presentation map goes on
+compiling.
+
+A due time reads the schedule as well as the retry. `runAt` is when a job asked
+to run and `nextAttemptAt` is when a failed one will try again; reading only the
+second showed a dash for a scheduled release, which is the case that brings
+someone to this screen.
+
+The failed-job reason stays in the narrow render. `hideOnMobile` removes a
+column from the card view rather than truncating it, so marking the error text
+that way left a phone showing that a job failed with no way to read why.
+
 The status vocabulary is imported from the core rather than restated. `nextly`
 now publishes `nextly/api/jobs-list-types`, and the wire item is DERIVED from
 the row the route emits, so a field or a status added on the server reaches the

--- a/.changeset/watch-the-queue-from-the-admin.md
+++ b/.changeset/watch-the-queue-from-the-admin.md
@@ -80,6 +80,24 @@ already crowded out: mounted beside a release, it would have stayed silent about
 that release's failure whenever webhook deliveries were noisier. The endpoint
 takes a `slug` and narrows in the query, before the limit.
 
+Which statuses need attention, and which stored states express them, are one
+declaration. A predicate saying "this needs a person" and a list saying "select
+these rows" are the same decision at two layers, and written separately they
+agree only until a second actionable status is added — at which point the list
+goes stale and the database discards the new failures before the predicate can
+see them. The list is now computed from the same table the predicate reads, and
+a test derives that table from the status function rather than trusting it.
+
+An unknown job state is refused rather than dropped. Dropping looks
+conservative and inverts the request: with every name dropped the filter
+disappears, so `?state=faield` returned a successful read of every state — the
+widest possible answer to a request for a narrower one.
+
+Job timestamps render through the admin's configured formatter. An installation
+sets a timezone and a date format; a local `toLocaleString` reads the browser's
+instead, so the same instant appeared two different ways on one page and nothing
+said so.
+
 It also asks for FAILURES rather than sifting recent rows. A window is the most
 recent N jobs, so N healthy ones running after a failure push it out — and a
 summary that looked inside that window would report nothing wrong with the

--- a/.changeset/watch-the-queue-from-the-admin.md
+++ b/.changeset/watch-the-queue-from-the-admin.md
@@ -67,11 +67,28 @@ erroring to say so. The list is now derived from the navigation, so a
 destination added to the panel reveals it by construction and the same omission
 cannot be made twice.
 
+Two enumerations of the Settings panel became one. Whether the rail entry
+appears and whether `/admin/settings` opens at all were each maintained by hand
+beside the navigation table, so Background Jobs was added to the panel and to
+neither — and fixing only the first produced a rail entry that led to a page
+which turned the operator away. Both now read the table, so a destination added
+to the panel is both visible and reachable by construction.
+
 The failure summary asks the SERVER for one task's jobs. It was fetching the
 global recent window and filtering it, which filters rows a busier task has
 already crowded out: mounted beside a release, it would have stayed silent about
 that release's failure whenever webhook deliveries were noisier. The endpoint
 takes a `slug` and narrows in the query, before the limit.
+
+It also asks for FAILURES rather than sifting recent rows. A window is the most
+recent N jobs, so N healthy ones running after a failure push it out — and a
+summary that looked inside that window would report nothing wrong with the
+confidence of a check it never performed. The endpoint takes stored states, and
+the core publishes which of them need attention.
+
+A long error is readable without a mouse. A clipped line with the full text in a
+`title` is unreachable on touch, which is where a queue often gets checked; a
+long error is now a native disclosure, operable by pointer, touch and keyboard.
 
 A failed read no longer looks like a healthy queue. When the request errors
 there is no data, and rendering nothing there is exactly what "nothing failed"

--- a/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+/**
+ * "Something the queue was doing for you did not happen."
+ *
+ * Mounted on the background jobs screen, and designed to be mounted BESIDE the
+ * object whose work failed — a release that was supposed to publish, a webhook
+ * endpoint whose deliveries are draining. That is why it fetches and authorizes
+ * for itself rather than taking rows from a parent: a page that wants the
+ * notice adds one element and nothing else, and a page that has no business
+ * showing it renders nothing.
+ *
+ * It renders NOTHING in three cases, all of them silence rather than emptiness:
+ * the viewer may not read jobs, the window is still loading, or nothing failed.
+ * A notice that appears only when there is something to say can be placed on a
+ * page that is usually fine without adding permanent furniture to it.
+ *
+ * Retrying jobs are excluded on purpose. They are the system healing itself,
+ * and a notice that fires for them teaches its reader to ignore it — which
+ * costs exactly the failure this component exists to surface.
+ */
+
+import { Alert, AlertDescription, AlertTitle } from "@nextlyhq/ui";
+import type React from "react";
+
+import { Link } from "@admin/components/ui/link";
+import { ROUTES } from "@admin/constants/routes";
+import { useJobs } from "@admin/hooks/queries/useJobs";
+import { useCan } from "@admin/hooks/useCan";
+import { JOB_RETENTION_DAYS, type JobListItem } from "@admin/types/jobs";
+
+export interface JobFailureSummaryProps {
+  /**
+   * Restrict to one task, e.g. `releases:drain`.
+   *
+   * Omitted means every task, which is what the jobs screen itself wants.
+   */
+  slug?: string;
+  /** Render a link to the full monitor. Off where this IS the monitor. */
+  linkToMonitor?: boolean;
+  /**
+   * How many recent rows to consider.
+   *
+   * The window is the endpoint's own recent history, so this reports failures
+   * among what it can see rather than a true count — see the wording below,
+   * which never claims to be exhaustive.
+   */
+  limit?: number;
+}
+
+/** Terminal failures only; a retry in flight is not one. */
+export function failedJobs(
+  items: readonly JobListItem[],
+  slug?: string
+): JobListItem[] {
+  return items.filter(
+    job => job.status === "failed" && (slug === undefined || job.slug === slug)
+  );
+}
+
+/** The distinct task names among a set of failures, in first-seen order. */
+export function failedSlugs(failures: readonly JobListItem[]): string[] {
+  return [...new Set(failures.map(job => job.slug))];
+}
+
+export const JobFailureSummary: React.FC<JobFailureSummaryProps> = ({
+  slug,
+  linkToMonitor = true,
+  limit = 50,
+}) => {
+  const canRead = useCan("manage-background-jobs");
+  const { data } = useJobs({ limit }, { enabled: canRead });
+
+  if (!canRead || !data) return null;
+
+  const failures = failedJobs(data.items, slug);
+  if (failures.length === 0) return null;
+
+  const tasks = failedSlugs(failures);
+  const count = failures.length;
+
+  return (
+    <Alert variant="destructive" role="status">
+      <AlertTitle>
+        {count === 1
+          ? "A background job failed"
+          : `${count} background jobs failed`}
+      </AlertTitle>
+      <AlertDescription>
+        {/* Named rather than counted: "2 failed" tells an operator to go
+            looking, "releases:drain failed" tells them what did not happen. */}
+        <span>
+          {tasks.join(", ")} stopped after using every attempt, so the work will
+          not happen without someone. Failures within the last{" "}
+          {JOB_RETENTION_DAYS} days.
+        </span>
+        {linkToMonitor && (
+          <>
+            {" "}
+            <Link
+              href={ROUTES.SETTINGS_BACKGROUND_JOBS}
+              className="font-medium underline underline-offset-4"
+            >
+              Open background jobs
+            </Link>
+          </>
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+};

--- a/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
@@ -29,6 +29,7 @@ import { useJobs } from "@admin/hooks/queries/useJobs";
 import { useCan } from "@admin/hooks/useCan";
 import {
   ATTENTION_STATES,
+  JOB_DISPLAY_STATUSES,
   DEFAULT_JOB_RETENTION_DAYS,
   jobNeedsAttention,
   type JobListItem,
@@ -56,21 +57,27 @@ export interface JobFailureSummaryProps {
 /**
  * The jobs a person has to do something about.
  *
- * Asked of the core's {@link jobNeedsAttention} rather than compared against
- * `"failed"` here. The core exports that question precisely so a caller does
- * not enumerate the vocabulary: if a second actionable terminal state is added,
- * the exhaustive presentation map forces an update while a literal comparison
- * goes on compiling and silently drops those jobs out of this notice — the one
- * failure mode a notice must not have.
+ * Two rules, and the second is the one that is easy to leave out. A status the
+ * core calls actionable is kept, obviously. A status THIS BUILD DOES NOT KNOW
+ * is also kept — because during a rolling deploy a newer server can send one,
+ * and `jobNeedsAttention` answers false for it. Dropping those would make the
+ * notice go quiet about the new kind of failure nobody has seen yet, which is
+ * the one failure mode a notice must not have.
+ *
+ * What is dropped is only what this build knows to be QUIET: a retry in flight,
+ * a job waiting, one that succeeded. That keeps the component honest about a
+ * server sending rows it did not ask for, rather than reporting them as
+ * failures because they arrived.
  */
 export function jobsNeedingAttention(
   items: readonly JobListItem[],
   slug?: string
 ): JobListItem[] {
-  return items.filter(
-    job =>
-      jobNeedsAttention(job.status) && (slug === undefined || job.slug === slug)
-  );
+  const known = new Set<string>(JOB_DISPLAY_STATUSES);
+  return items.filter(job => {
+    if (slug !== undefined && job.slug !== slug) return false;
+    return jobNeedsAttention(job.status) || !known.has(job.status);
+  });
 }
 
 /** The distinct task names among a set of failures, in first-seen order. */
@@ -154,7 +161,7 @@ export const JobFailureSummary: React.FC<JobFailureSummaryProps> = ({
         {/* Named rather than counted: "2 failed" tells an operator to go
             looking, "releases:drain failed" tells them what did not happen. */}
         <span>
-          {tasks.join(", ")} stopped after using every attempt, so the work will
+          {tasks.join(", ")} stopped and will not be retried, so the work will
           not happen without someone.{" "}
           {truncated
             ? "Counted among the most recent jobs loaded; older failures may exist."

--- a/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
@@ -28,6 +28,7 @@ import { ROUTES } from "@admin/constants/routes";
 import { useJobs } from "@admin/hooks/queries/useJobs";
 import { useCan } from "@admin/hooks/useCan";
 import {
+  ATTENTION_STATES,
   DEFAULT_JOB_RETENTION_DAYS,
   jobNeedsAttention,
   type JobListItem,
@@ -88,7 +89,16 @@ export const JobFailureSummary: React.FC<JobFailureSummaryProps> = ({
   // notice would stay silent about exactly the failure it was mounted to
   // report.
   const { data, isError } = useJobs(
-    { limit, ...(slug === undefined ? {} : { slug }) },
+    {
+      limit,
+      ...(slug === undefined ? {} : { slug }),
+      // Ask for the jobs that NEED ATTENTION, rather than for recent jobs to
+      // sift. A window of the most recent rows cannot answer "did anything
+      // fail": N healthy jobs running afterwards push the failure out of it,
+      // and the notice then reports silence with the confidence of a check it
+      // never performed.
+      states: ATTENTION_STATES,
+    },
     { enabled: canRead }
   );
 

--- a/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
@@ -27,7 +27,11 @@ import { Link } from "@admin/components/ui/link";
 import { ROUTES } from "@admin/constants/routes";
 import { useJobs } from "@admin/hooks/queries/useJobs";
 import { useCan } from "@admin/hooks/useCan";
-import { JOB_RETENTION_DAYS, type JobListItem } from "@admin/types/jobs";
+import {
+  DEFAULT_JOB_RETENTION_DAYS,
+  jobNeedsAttention,
+  type JobListItem,
+} from "@admin/types/jobs";
 
 export interface JobFailureSummaryProps {
   /**
@@ -48,13 +52,23 @@ export interface JobFailureSummaryProps {
   limit?: number;
 }
 
-/** Terminal failures only; a retry in flight is not one. */
-export function failedJobs(
+/**
+ * The jobs a person has to do something about.
+ *
+ * Asked of the core's {@link jobNeedsAttention} rather than compared against
+ * `"failed"` here. The core exports that question precisely so a caller does
+ * not enumerate the vocabulary: if a second actionable terminal state is added,
+ * the exhaustive presentation map forces an update while a literal comparison
+ * goes on compiling and silently drops those jobs out of this notice — the one
+ * failure mode a notice must not have.
+ */
+export function jobsNeedingAttention(
   items: readonly JobListItem[],
   slug?: string
 ): JobListItem[] {
   return items.filter(
-    job => job.status === "failed" && (slug === undefined || job.slug === slug)
+    job =>
+      jobNeedsAttention(job.status) && (slug === undefined || job.slug === slug)
   );
 }
 
@@ -73,26 +87,39 @@ export const JobFailureSummary: React.FC<JobFailureSummaryProps> = ({
 
   if (!canRead || !data) return null;
 
-  const failures = failedJobs(data.items, slug);
+  const failures = jobsNeedingAttention(data.items, slug);
   if (failures.length === 0) return null;
 
   const tasks = failedSlugs(failures);
   const count = failures.length;
+  /*
+   * The window may not hold every failure.
+   *
+   * `hasNext` says the server had more rows than this read asked for, so the
+   * count is a LOWER BOUND rather than a total — and a notice that reports a
+   * bound as a total is the same lie the screen's own truncation notice exists
+   * to prevent, made worse by being the headline.
+   */
+  const truncated = data.meta.hasNext === true;
 
   return (
     <Alert variant="destructive" role="status">
       <AlertTitle>
-        {count === 1
-          ? "A background job failed"
-          : `${count} background jobs failed`}
+        {truncated
+          ? `At least ${count} background job${count === 1 ? "" : "s"} failed`
+          : count === 1
+            ? "A background job failed"
+            : `${count} background jobs failed`}
       </AlertTitle>
       <AlertDescription>
         {/* Named rather than counted: "2 failed" tells an operator to go
             looking, "releases:drain failed" tells them what did not happen. */}
         <span>
           {tasks.join(", ")} stopped after using every attempt, so the work will
-          not happen without someone. Failures within the last{" "}
-          {JOB_RETENTION_DAYS} days.
+          not happen without someone.{" "}
+          {truncated
+            ? "Counted among the most recent jobs loaded; older failures may exist."
+            : `Among jobs from roughly the last ${DEFAULT_JOB_RETENTION_DAYS} days, the default retention.`}
         </span>
         {linkToMonitor && (
           <>

--- a/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobFailureSummary.tsx
@@ -83,9 +83,38 @@ export const JobFailureSummary: React.FC<JobFailureSummaryProps> = ({
   limit = 50,
 }) => {
   const canRead = useCan("manage-background-jobs");
-  const { data } = useJobs({ limit }, { enabled: canRead });
+  // Narrowed by the SERVER when a task is named. Filtering the global window
+  // here would filter rows a busier task had already crowded out, so this
+  // notice would stay silent about exactly the failure it was mounted to
+  // report.
+  const { data, isError } = useJobs(
+    { limit, ...(slug === undefined ? {} : { slug }) },
+    { enabled: canRead }
+  );
 
-  if (!canRead || !data) return null;
+  if (!canRead) return null;
+
+  /*
+   * A read that FAILED is not a read that found nothing.
+   *
+   * Collapsing them renders the same silence in both cases, which tells an
+   * operator that nothing needs attention when the truth is that nothing could
+   * be checked — the one wrong answer a safety notice must not give. Said
+   * quietly, because it is a degraded monitor rather than a failed job.
+   */
+  if (isError) {
+    return (
+      <Alert variant="warning" role="status">
+        <AlertTitle>Background job status unavailable</AlertTitle>
+        <AlertDescription>
+          The queue could not be read, so this page cannot say whether anything
+          failed.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (!data) return null;
 
   const failures = jobsNeedingAttention(data.items, slug);
   if (failures.length === 0) return null;

--- a/packages/admin/src/components/features/background-jobs/JobsTable.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobsTable.tsx
@@ -80,13 +80,22 @@ const JobErrorCell: React.FC<{ error: string | null }> = ({ error }) => {
     );
   }
   return (
-    <details className="max-w-80 group">
+    <details className="group max-w-80">
+      {/*
+        The summary must stay operable in BOTH states. Hiding every child on
+        open left an empty control: nothing to click to collapse it, and nothing
+        for a screen reader to announce it as. So the preview collapses and the
+        label SWAPS rather than disappearing.
+      */}
       <summary className="cursor-pointer list-none font-mono text-xs text-muted-foreground marker:content-none">
         <span className="line-clamp-2 break-words group-open:hidden">
           {error}
         </span>
         <span className="underline underline-offset-2 group-open:hidden">
           Show full error
+        </span>
+        <span className="hidden underline underline-offset-2 group-open:inline">
+          Hide full error
         </span>
       </summary>
       <span className="mt-1 block font-mono text-xs break-words whitespace-pre-wrap text-muted-foreground">

--- a/packages/admin/src/components/features/background-jobs/JobsTable.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobsTable.tsx
@@ -39,6 +39,22 @@ import {
 /** Sentinel for the "no filter" option (Radix Select forbids an empty value). */
 const ALL = "all" as const;
 
+/**
+ * When this job is next expected to run, or `null` when nothing is scheduled.
+ *
+ * `runAt` is the SCHEDULE and `nextAttemptAt` is the RETRY, and the core's own
+ * due rule reads both — a job scheduled for next Tuesday and never attempted
+ * has `runAt` set and `nextAttemptAt` null. Reading only the retry showed a
+ * dash for exactly the case that motivates this screen: a release scheduled to
+ * publish, which an operator opens the monitor to ask about.
+ *
+ * The retry wins when both are present, because it is the later decision: a
+ * job that failed an attempt runs at its backoff, not at its original time.
+ */
+export function dueAt(job: JobListItem): string | null {
+  return job.nextAttemptAt ?? job.runAt;
+}
+
 export interface JobsTableProps {
   rows: JobListItem[];
   isLoading?: boolean;
@@ -85,9 +101,12 @@ export const JobsTable: React.FC<JobsTableProps> = ({
         ),
       },
       {
+        // Kept in the card view. `hideOnMobile` does not truncate a column, it
+        // REMOVES it, so hiding this one leaves a phone showing that a job
+        // failed with no way to read why — the single fact this screen exists
+        // to deliver.
         name: "lastError",
         header: "Last error",
-        hideOnMobile: true,
         cell: ({ row }) =>
           row.lastError === null ? (
             <span className="text-sm text-muted-foreground">-</span>
@@ -103,20 +122,22 @@ export const JobsTable: React.FC<JobsTableProps> = ({
           ),
       },
       {
-        name: "nextAttemptAt",
-        header: "Next attempt",
+        name: "dueAt",
+        header: "Due",
         hideOnMobile: true,
-        cell: ({ row }) =>
-          row.nextAttemptAt === null ? (
+        cell: ({ row }) => {
+          const due = dueAt(row);
+          return due === null ? (
             <span className="text-sm text-muted-foreground">-</span>
           ) : (
             <span
               className="text-sm text-muted-foreground"
-              title={formatJobTimestamp(row.nextAttemptAt)}
+              title={formatJobTimestamp(due)}
             >
-              {formatJobAge(row.nextAttemptAt, now)}
+              {formatJobAge(due, now)}
             </span>
-          ),
+          );
+        },
       },
       {
         name: "updatedAt",
@@ -196,6 +217,10 @@ export const JobsTable: React.FC<JobsTableProps> = ({
       <DataTableView<JobListItem>
         columns={columns}
         rows={rows}
+        // Declared rather than left to the reflective fallback, which the admin
+        // conventions require and which keeps row identity part of this table's
+        // contract instead of a property of whatever shape the row has today.
+        getRowId={row => row.id}
         loading={isLoading}
         ariaLabel="Background jobs"
         emptyMessage={

--- a/packages/admin/src/components/features/background-jobs/JobsTable.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobsTable.tsx
@@ -1,0 +1,209 @@
+"use client";
+
+/**
+ * The recent-jobs table.
+ *
+ * Presentational: the parent owns the window size and the status filter, and
+ * every change is reported back. There is no pagination, because the endpoint
+ * has none to offer — it answers "the most recent N" over a table that is
+ * pruned behind you, and a page number into that is a promise it cannot keep.
+ */
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@nextlyhq/ui";
+import type React from "react";
+import { useMemo } from "react";
+
+import { DataTableView } from "@admin/components/ui/table/data-table";
+import type { NextlyColumn } from "@admin/components/ui/table/data-table";
+import {
+  JOB_DISPLAY_STATUSES,
+  JOB_WINDOW_SIZES,
+  type JobDisplayStatus,
+  type JobListItem,
+  type JobWindowSize,
+} from "@admin/types/jobs";
+
+import {
+  formatJobAge,
+  formatJobTimestamp,
+  JobStatusBadge,
+  jobStatusPresentation,
+} from "./jobStatus";
+
+/** Sentinel for the "no filter" option (Radix Select forbids an empty value). */
+const ALL = "all" as const;
+
+export interface JobsTableProps {
+  rows: JobListItem[];
+  isLoading?: boolean;
+  /** Active status filter; undefined means every status. */
+  status?: JobDisplayStatus;
+  windowSize: JobWindowSize;
+  /** The instant ages are measured against, so a test can fix it. */
+  now: Date;
+  onStatusChange: (status?: JobDisplayStatus) => void;
+  onWindowSizeChange: (size: JobWindowSize) => void;
+}
+
+export const JobsTable: React.FC<JobsTableProps> = ({
+  rows,
+  isLoading = false,
+  status,
+  windowSize,
+  now,
+  onStatusChange,
+  onWindowSizeChange,
+}) => {
+  const columns = useMemo(
+    (): NextlyColumn<JobListItem>[] => [
+      {
+        name: "status",
+        header: "Status",
+        cell: ({ row }) => <JobStatusBadge status={row.status} />,
+      },
+      {
+        name: "slug",
+        header: "Job",
+        cell: ({ row }) => (
+          <span className="font-medium text-foreground">{row.slug}</span>
+        ),
+      },
+      {
+        name: "attemptCount",
+        header: "Attempts",
+        hideOnMobile: true,
+        cell: ({ row }) => (
+          <span className="text-sm tabular-nums text-muted-foreground">
+            {row.attemptCount}
+          </span>
+        ),
+      },
+      {
+        name: "lastError",
+        header: "Last error",
+        hideOnMobile: true,
+        cell: ({ row }) =>
+          row.lastError === null ? (
+            <span className="text-sm text-muted-foreground">-</span>
+          ) : (
+            // Full text in the tooltip: the truncation is for the table's
+            // shape, and an error an operator cannot read is not reported.
+            <span
+              className="block max-w-80 truncate font-mono text-xs text-muted-foreground"
+              title={row.lastError}
+            >
+              {row.lastError}
+            </span>
+          ),
+      },
+      {
+        name: "nextAttemptAt",
+        header: "Next attempt",
+        hideOnMobile: true,
+        cell: ({ row }) =>
+          row.nextAttemptAt === null ? (
+            <span className="text-sm text-muted-foreground">-</span>
+          ) : (
+            <span
+              className="text-sm text-muted-foreground"
+              title={formatJobTimestamp(row.nextAttemptAt)}
+            >
+              {formatJobAge(row.nextAttemptAt, now)}
+            </span>
+          ),
+      },
+      {
+        name: "updatedAt",
+        header: "Last activity",
+        cell: ({ row }) => (
+          <span
+            className="text-sm text-muted-foreground"
+            title={formatJobTimestamp(row.updatedAt)}
+          >
+            {formatJobAge(row.updatedAt, now)}
+          </span>
+        ),
+      },
+    ],
+    [now]
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <label
+            className="text-sm text-muted-foreground"
+            htmlFor="job-status-filter"
+          >
+            Status
+          </label>
+          <Select
+            value={status ?? ALL}
+            onValueChange={next =>
+              onStatusChange(
+                next === ALL ? undefined : (next as JobDisplayStatus)
+              )
+            }
+          >
+            <SelectTrigger id="job-status-filter" className="w-44">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={ALL}>All statuses</SelectItem>
+              {JOB_DISPLAY_STATUSES.map(value => (
+                <SelectItem key={value} value={value}>
+                  {jobStatusPresentation(value).label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <label
+            className="text-sm text-muted-foreground"
+            htmlFor="job-window-size"
+          >
+            Show
+          </label>
+          <Select
+            value={String(windowSize)}
+            onValueChange={next =>
+              onWindowSizeChange(Number(next) as JobWindowSize)
+            }
+          >
+            <SelectTrigger id="job-window-size" className="w-32">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {JOB_WINDOW_SIZES.map(size => (
+                <SelectItem key={size} value={String(size)}>
+                  {size} rows
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <DataTableView<JobListItem>
+        columns={columns}
+        rows={rows}
+        loading={isLoading}
+        ariaLabel="Background jobs"
+        emptyMessage={
+          status === undefined
+            ? "No background jobs have run recently."
+            : `No ${jobStatusPresentation(status).label.toLowerCase()} jobs in this window.`
+        }
+      />
+    </div>
+  );
+};

--- a/packages/admin/src/components/features/background-jobs/JobsTable.tsx
+++ b/packages/admin/src/components/features/background-jobs/JobsTable.tsx
@@ -55,6 +55,47 @@ export function dueAt(job: JobListItem): string | null {
   return job.nextAttemptAt ?? job.runAt;
 }
 
+/** Longer than this and the cell offers to expand rather than clipping. */
+const ERROR_INLINE_LIMIT = 90;
+
+/**
+ * A recorded error, readable on every input device.
+ *
+ * A clipped line with the full text in `title` reads fine with a mouse and is
+ * unreadable without one: touch devices have no reliable hover, so the only
+ * complete copy was unreachable on exactly the screens an operator checks a
+ * queue from. A short error is shown whole and wrapped; a long one becomes a
+ * native disclosure, which is operable by pointer, touch and keyboard alike and
+ * needs no script.
+ */
+const JobErrorCell: React.FC<{ error: string | null }> = ({ error }) => {
+  if (error === null) {
+    return <span className="text-sm text-muted-foreground">-</span>;
+  }
+  if (error.length <= ERROR_INLINE_LIMIT) {
+    return (
+      <span className="block max-w-80 font-mono text-xs break-words text-muted-foreground">
+        {error}
+      </span>
+    );
+  }
+  return (
+    <details className="max-w-80 group">
+      <summary className="cursor-pointer list-none font-mono text-xs text-muted-foreground marker:content-none">
+        <span className="line-clamp-2 break-words group-open:hidden">
+          {error}
+        </span>
+        <span className="underline underline-offset-2 group-open:hidden">
+          Show full error
+        </span>
+      </summary>
+      <span className="mt-1 block font-mono text-xs break-words whitespace-pre-wrap text-muted-foreground">
+        {error}
+      </span>
+    </details>
+  );
+};
+
 export interface JobsTableProps {
   rows: JobListItem[];
   isLoading?: boolean;
@@ -107,19 +148,7 @@ export const JobsTable: React.FC<JobsTableProps> = ({
         // to deliver.
         name: "lastError",
         header: "Last error",
-        cell: ({ row }) =>
-          row.lastError === null ? (
-            <span className="text-sm text-muted-foreground">-</span>
-          ) : (
-            // Full text in the tooltip: the truncation is for the table's
-            // shape, and an error an operator cannot read is not reported.
-            <span
-              className="block max-w-80 truncate font-mono text-xs text-muted-foreground"
-              title={row.lastError}
-            >
-              {row.lastError}
-            </span>
-          ),
+        cell: ({ row }) => <JobErrorCell error={row.lastError} />,
       },
       {
         name: "dueAt",

--- a/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
+++ b/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
@@ -11,6 +11,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { render, screen } from "@admin/__tests__/utils";
 import {
+  ATTENTION_STATES,
   JOB_DISPLAY_STATUSES,
   jobNeedsAttention,
   type JobListItem,
@@ -149,6 +150,25 @@ describe("JobFailureSummary", () => {
     useJobs.mockReturnValue({ data: undefined, isError: true });
     render(<JobFailureSummary />);
     expect(screen.getByRole("status")).toHaveTextContent(/could not be read/i);
+  });
+
+  it("asks the database for FAILURES rather than sifting a recent window", () => {
+    /*
+     * The silence this closes. A window is the most recent N rows, so N healthy
+     * jobs running after a failure push it out — and a summary that looked
+     * inside that window would report nothing wrong, with the confidence of a
+     * check it never performed. Asking for the attention states makes the
+     * question one the database answers.
+     */
+    useJobs.mockReturnValue(holding([]));
+    render(<JobFailureSummary />);
+    expect(useJobs).toHaveBeenCalledWith(
+      expect.objectContaining({ states: ATTENTION_STATES }),
+      expect.anything()
+    );
+    // The premise: the core really names at least one such state, so this is
+    // not an empty filter that selects everything.
+    expect(ATTENTION_STATES.length).toBeGreaterThan(0);
   });
 
   it("asks the SERVER for one task rather than filtering the window", () => {

--- a/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
+++ b/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
@@ -49,6 +49,7 @@ function job(overrides: Partial<JobListItem> = {}): JobListItem {
 
 const holding = (items: JobListItem[], hasNext = false) => ({
   data: { items, meta: { hasNext } },
+  isError: false,
 });
 
 describe("jobsNeedingAttention", () => {
@@ -135,6 +136,31 @@ describe("JobFailureSummary", () => {
     const alert = screen.getByRole("status");
     expect(alert).toHaveTextContent(/2 background jobs failed/i);
     expect(alert).not.toHaveTextContent(/At least/i);
+  });
+
+  it("says the queue could not be READ rather than that nothing failed", () => {
+    /*
+     * The dangerous collapse. When the request fails React Query supplies no
+     * data, and returning null there renders exactly what a healthy queue with
+     * no failures renders. On a release page that silence reads as "nothing
+     * needs attention" when the truth is that nothing could be checked — the
+     * one answer a safety notice must never give.
+     */
+    useJobs.mockReturnValue({ data: undefined, isError: true });
+    render(<JobFailureSummary />);
+    expect(screen.getByRole("status")).toHaveTextContent(/could not be read/i);
+  });
+
+  it("asks the SERVER for one task rather than filtering the window", () => {
+    // Filtering afterwards filters a window a busier task may already have
+    // filled, so this task's failure would be missing from a result that looks
+    // complete.
+    useJobs.mockReturnValue(holding([]));
+    render(<JobFailureSummary slug="releases:drain" />);
+    expect(useJobs).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: "releases:drain" }),
+      expect.anything()
+    );
   });
 
   it("renders NOTHING when every job is fine", () => {

--- a/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
+++ b/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * The notice that is meant to be mountable anywhere.
+ *
+ * Its value depends entirely on staying silent: a component intended to sit on
+ * a release or a webhook page must add nothing when there is nothing wrong, and
+ * must not fire for a retry that needs nobody. A notice that appears routinely
+ * is one its reader learns to skip, which costs exactly the failure it exists
+ * to surface.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import type { JobListItem } from "@admin/types/jobs";
+
+import { failedJobs, JobFailureSummary } from "../JobFailureSummary";
+
+const { useJobs, canFor } = vi.hoisted(() => ({
+  useJobs: vi.fn(),
+  canFor: vi.fn((_slug: string) => true),
+}));
+
+vi.mock("@admin/hooks/queries/useJobs", () => ({
+  useJobs: (params: unknown, opts: unknown) => useJobs(params, opts),
+  JOBS_POLL_INTERVAL_MS: 15_000,
+}));
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (slug: string) => canFor(slug),
+}));
+
+function job(overrides: Partial<JobListItem> = {}): JobListItem {
+  return {
+    id: "j1",
+    slug: "releases:drain",
+    state: "failed",
+    status: "failed",
+    attemptCount: 5,
+    lastError: "boom",
+    runAt: null,
+    nextAttemptAt: null,
+    createdAt: "2026-09-02T11:00:00.000Z",
+    updatedAt: "2026-09-02T11:30:00.000Z",
+    ...overrides,
+  };
+}
+
+const holding = (items: JobListItem[]) => ({
+  data: { items, meta: { hasNext: false } },
+});
+
+describe("failedJobs", () => {
+  it("takes terminal failures and NOT retries", () => {
+    const rows = [
+      job({ id: "a", status: "failed" }),
+      job({ id: "b", status: "retrying" }),
+      job({ id: "c", status: "waiting" }),
+      job({ id: "d", status: "succeeded" }),
+    ];
+    expect(failedJobs(rows).map(row => row.id)).toEqual(["a"]);
+  });
+
+  it("restricts to one task when asked, and admits it otherwise", () => {
+    const rows = [
+      job({ id: "a", slug: "releases:drain" }),
+      job({ id: "b", slug: "webhooks:drain" }),
+    ];
+    expect(failedJobs(rows, "webhooks:drain").map(row => row.id)).toEqual([
+      "b",
+    ]);
+    // The control: without the filter both are failures, so the case above
+    // narrowed something rather than matching nothing for another reason.
+    expect(failedJobs(rows)).toHaveLength(2);
+  });
+});
+
+describe("JobFailureSummary", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canFor.mockImplementation(() => true);
+  });
+
+  it("names the task that failed", () => {
+    useJobs.mockReturnValue(holding([job()]));
+    render(<JobFailureSummary />);
+    expect(screen.getByRole("status")).toHaveTextContent("releases:drain");
+  });
+
+  it("renders NOTHING when every job is fine", () => {
+    useJobs.mockReturnValue(holding([job({ status: "succeeded" })]));
+    const { container } = render(<JobFailureSummary />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders NOTHING for a job that is merely retrying", () => {
+    // The distinction the whole component turns on. A retry is the system
+    // healing itself; a notice here would train its reader to ignore the one
+    // that matters.
+    useJobs.mockReturnValue(holding([job({ status: "retrying" })]));
+    const { container } = render(<JobFailureSummary />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders NOTHING, and asks for nothing, without the permission", () => {
+    canFor.mockImplementation(() => false);
+    useJobs.mockReturnValue(holding([job()]));
+    const { container } = render(<JobFailureSummary />);
+    expect(container).toBeEmptyDOMElement();
+    // The query is held rather than fired-and-discarded: a viewer who may not
+    // read jobs must not issue a request that can only be refused.
+    expect(useJobs).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it("shows only the named task's failure when scoped to one", () => {
+    useJobs.mockReturnValue(
+      holding([job({ id: "a", slug: "releases:drain" })])
+    );
+    const { container } = render(<JobFailureSummary slug="webhooks:drain" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
+++ b/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
@@ -86,6 +86,30 @@ describe("jobsNeedingAttention", () => {
     ).toEqual(["a"]);
   });
 
+  it("KEEPS a status this build does not know", () => {
+    /*
+     * The direction that matters during a rolling deploy. `jobNeedsAttention`
+     * answers false for an unfamiliar status, so filtering on it alone would
+     * drop exactly the rows carrying a new kind of failure — the notice goes
+     * quiet about the one thing nobody has seen before.
+     */
+    const rows = [job({ id: "a", status: "quarantined" })];
+    expect(
+      jobsNeedingAttention(rows).map((row: JobListItem) => row.id)
+    ).toEqual(["a"]);
+  });
+
+  it("still drops a status it knows to be QUIET", () => {
+    // The control. Without it the case above passes against a filter that keeps
+    // everything, which would report a healthy queue as failing.
+    const rows = [
+      job({ id: "a", status: "retrying" }),
+      job({ id: "b", status: "succeeded" }),
+      job({ id: "c", status: "waiting" }),
+    ];
+    expect(jobsNeedingAttention(rows)).toEqual([]);
+  });
+
   it("restricts to one task when asked, and admits it otherwise", () => {
     const rows = [
       job({ id: "a", slug: "releases:drain" }),

--- a/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
+++ b/packages/admin/src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx
@@ -10,9 +10,13 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 import { render, screen } from "@admin/__tests__/utils";
-import type { JobListItem } from "@admin/types/jobs";
+import {
+  JOB_DISPLAY_STATUSES,
+  jobNeedsAttention,
+  type JobListItem,
+} from "@admin/types/jobs";
 
-import { failedJobs, JobFailureSummary } from "../JobFailureSummary";
+import { JobFailureSummary, jobsNeedingAttention } from "../JobFailureSummary";
 
 const { useJobs, canFor } = vi.hoisted(() => ({
   useJobs: vi.fn(),
@@ -43,11 +47,31 @@ function job(overrides: Partial<JobListItem> = {}): JobListItem {
   };
 }
 
-const holding = (items: JobListItem[]) => ({
-  data: { items, meta: { hasNext: false } },
+const holding = (items: JobListItem[], hasNext = false) => ({
+  data: { items, meta: { hasNext } },
 });
 
-describe("failedJobs", () => {
+describe("jobsNeedingAttention", () => {
+  it("agrees with the CORE predicate on every status it declares", () => {
+    /*
+     * A guard rather than a defect test, and worth saying so: the core answers
+     * `failed` and nothing else today, so a reverted `=== "failed"` would still
+     * pass this. What it pins is the day that changes — a second actionable
+     * terminal state makes the two disagree, and this is what notices it, since
+     * the exhaustive presentation map would compile either way.
+     */
+    for (const status of JOB_DISPLAY_STATUSES) {
+      const rows = [job({ status })];
+      expect(jobsNeedingAttention(rows).length, status).toBe(
+        jobNeedsAttention(status) ? 1 : 0
+      );
+    }
+    // The premise: the vocabulary really has both kinds in it, so agreeing
+    // everywhere is not agreement over a single case.
+    expect(JOB_DISPLAY_STATUSES.some(s => jobNeedsAttention(s))).toBe(true);
+    expect(JOB_DISPLAY_STATUSES.some(s => !jobNeedsAttention(s))).toBe(true);
+  });
+
   it("takes terminal failures and NOT retries", () => {
     const rows = [
       job({ id: "a", status: "failed" }),
@@ -55,7 +79,9 @@ describe("failedJobs", () => {
       job({ id: "c", status: "waiting" }),
       job({ id: "d", status: "succeeded" }),
     ];
-    expect(failedJobs(rows).map(row => row.id)).toEqual(["a"]);
+    expect(
+      jobsNeedingAttention(rows).map((row: JobListItem) => row.id)
+    ).toEqual(["a"]);
   });
 
   it("restricts to one task when asked, and admits it otherwise", () => {
@@ -63,12 +89,14 @@ describe("failedJobs", () => {
       job({ id: "a", slug: "releases:drain" }),
       job({ id: "b", slug: "webhooks:drain" }),
     ];
-    expect(failedJobs(rows, "webhooks:drain").map(row => row.id)).toEqual([
-      "b",
-    ]);
+    expect(
+      jobsNeedingAttention(rows, "webhooks:drain").map(
+        (row: JobListItem) => row.id
+      )
+    ).toEqual(["b"]);
     // The control: without the filter both are failures, so the case above
     // narrowed something rather than matching nothing for another reason.
-    expect(failedJobs(rows)).toHaveLength(2);
+    expect(jobsNeedingAttention(rows)).toHaveLength(2);
   });
 });
 
@@ -82,6 +110,31 @@ describe("JobFailureSummary", () => {
     useJobs.mockReturnValue(holding([job()]));
     render(<JobFailureSummary />);
     expect(screen.getByRole("status")).toHaveTextContent("releases:drain");
+  });
+
+  it("reports a count from a TRUNCATED window as a lower bound", () => {
+    /*
+     * `hasNext` says the server held more rows than this read asked for, so
+     * failures may sit outside the window. A headline number stated flatly
+     * would under-report them with the confidence of a total — the same lie the
+     * screen's truncation notice exists to prevent, in the one place a reader
+     * looks first.
+     */
+    useJobs.mockReturnValue(holding([job(), job({ id: "j2" })], true));
+    render(<JobFailureSummary />);
+    expect(screen.getByRole("status")).toHaveTextContent(
+      /At least 2 background jobs failed/i
+    );
+  });
+
+  it("states a count PLAINLY when the window is complete", () => {
+    // The control: without it the qualifier could be permanent, which would
+    // make every count read as uncertain whether or not it is.
+    useJobs.mockReturnValue(holding([job(), job({ id: "j2" })], false));
+    render(<JobFailureSummary />);
+    const alert = screen.getByRole("status");
+    expect(alert).toHaveTextContent(/2 background jobs failed/i);
+    expect(alert).not.toHaveTextContent(/At least/i);
   });
 
   it("renders NOTHING when every job is fine", () => {

--- a/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
+++ b/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
@@ -12,6 +12,7 @@ import { describe, expect, it } from "vitest";
 
 import { JOB_DISPLAY_STATUSES } from "@admin/types/jobs";
 
+import { dueAt } from "../JobsTable";
 import { formatJobAge, jobStatusPresentation } from "../jobStatus";
 
 describe("job status presentation", () => {
@@ -69,5 +70,37 @@ describe("job age", () => {
 
   it("returns an unparseable value unchanged rather than NaN", () => {
     expect(formatJobAge("not-a-date", now)).toBe("not-a-date");
+  });
+});
+
+describe("when a job is due", () => {
+  /*
+   * `runAt` is the SCHEDULE and `nextAttemptAt` is the RETRY. A job scheduled
+   * for a future instant and never attempted carries the first and not the
+   * second, so reading only the retry showed a dash for exactly the case this
+   * screen exists to answer: a release scheduled to publish.
+   */
+  it("uses the schedule when nothing has been retried", () => {
+    expect(
+      dueAt({ runAt: "2026-09-03T09:00:00.000Z", nextAttemptAt: null } as never)
+    ).toBe("2026-09-03T09:00:00.000Z");
+  });
+
+  it("prefers the retry, which is the later decision", () => {
+    // A job that failed an attempt runs at its backoff, not at the time it was
+    // originally scheduled for.
+    expect(
+      dueAt({
+        runAt: "2026-09-03T09:00:00.000Z",
+        nextAttemptAt: "2026-09-03T09:05:00.000Z",
+      } as never)
+    ).toBe("2026-09-03T09:05:00.000Z");
+  });
+
+  it("is null only when neither is set", () => {
+    // The control: a job with no schedule and no retry is due now, and the
+    // column has nothing to say. Without this the two cases above would pass
+    // against a function that always returned its first argument.
+    expect(dueAt({ runAt: null, nextAttemptAt: null } as never)).toBeNull();
   });
 });

--- a/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
+++ b/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
@@ -8,12 +8,21 @@
  * among transient noise. `failed` is therefore the only destructive pill, and
  * the assertion below is what holds that apart.
  */
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  formatDateTime,
+  setGlobalDateTimeConfig,
+} from "@admin/lib/dates/format";
 
 import { JOB_DISPLAY_STATUSES } from "@admin/types/jobs";
 
 import { dueAt } from "../JobsTable";
-import { formatJobAge, jobStatusPresentation } from "../jobStatus";
+import {
+  formatJobAge,
+  formatJobTimestamp,
+  jobStatusPresentation,
+} from "../jobStatus";
 
 describe("job status presentation", () => {
   it("gives every status the core declares a label", () => {
@@ -102,5 +111,41 @@ describe("when a job is due", () => {
     // column has nothing to say. Without this the two cases above would pass
     // against a function that always returned its first argument.
     expect(dueAt({ runAt: null, nextAttemptAt: null } as never)).toBeNull();
+  });
+});
+
+describe("timestamp formatting", () => {
+  /*
+   * The admin renders dates through one configured formatter — an installation
+   * sets a timezone and a format, and `GeneralSettingsSyncProvider` applies it.
+   * A local `toLocaleString()` reads the BROWSER's settings instead, so the
+   * same instant renders two different ways on one page and whoever configured
+   * it sees no error.
+   */
+  const ISO = "2026-09-02T12:00:00.000Z";
+
+  afterEach(() => {
+    setGlobalDateTimeConfig({});
+  });
+
+  it("renders through the admin's configured formatter", () => {
+    setGlobalDateTimeConfig({ timezone: "Asia/Tokyo" });
+    expect(formatJobTimestamp(ISO)).toBe(formatDateTime(new Date(ISO)));
+  });
+
+  it("HONOURS the configured timezone, so the configuration is doing something", () => {
+    // The must-differ control. Without it the case above passes against a
+    // formatter that ignores the configuration entirely, since both sides would
+    // then fall back to the same browser default.
+    setGlobalDateTimeConfig({ timezone: "Asia/Tokyo" });
+    const tokyo = formatJobTimestamp(ISO);
+    setGlobalDateTimeConfig({ timezone: "America/Los_Angeles" });
+    const losAngeles = formatJobTimestamp(ISO);
+    expect(tokyo).not.toBe(losAngeles);
+  });
+
+  it("returns a placeholder for an absent instant and the raw text for an unparseable one", () => {
+    expect(formatJobTimestamp(null)).toBe("-");
+    expect(formatJobTimestamp("not-a-date")).toBe("not-a-date");
   });
 });

--- a/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
+++ b/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
@@ -1,0 +1,73 @@
+/**
+ * The status vocabulary, and the one distinction that must not be collapsed.
+ *
+ * A retrying job LOOKS like a failure in the log and is not one: the attempt
+ * failed, another is scheduled, and nobody needs to act. Presenting it in the
+ * same red as a terminal failure is the documented common mistake in queue
+ * tooling — it raises an alarm for a self-healing job, and buries the dead one
+ * among transient noise. So `failed` is the only destructive pill, and that is
+ * asserted rather than left to a reviewer to notice.
+ */
+import { describe, expect, it } from "vitest";
+
+import { JOB_DISPLAY_STATUSES } from "@admin/types/jobs";
+
+import { formatJobAge, jobStatusPresentation } from "../jobStatus";
+
+describe("job status presentation", () => {
+  it("gives every status the core declares a label", () => {
+    // Iterated over the CORE's list, not a copy: a status added there and not
+    // given a presentation here fails this test as well as the compiler.
+    for (const status of JOB_DISPLAY_STATUSES) {
+      const presentation = jobStatusPresentation(status);
+      expect(presentation.label, status).not.toBe("");
+      expect(presentation.label, status).not.toBe(status);
+    }
+    // The premise: the list is real and non-trivial.
+    expect(JOB_DISPLAY_STATUSES.length).toBeGreaterThan(3);
+  });
+
+  it("reserves the alarming variant for the TERMINAL failure only", () => {
+    expect(jobStatusPresentation("failed").variant).toBe("destructive");
+    expect(jobStatusPresentation("retrying").variant).not.toBe("destructive");
+    expect(jobStatusPresentation("succeeded").variant).toBe("success");
+  });
+
+  it("shows an unfamiliar status verbatim rather than nothing", () => {
+    // A server ahead of this build must degrade to "unfamiliar", not "blank".
+    const presentation = jobStatusPresentation("quarantined");
+    expect(presentation.label).toBe("quarantined");
+    expect(presentation.variant).toBe("default");
+  });
+
+  it("does not treat an inherited object property as a known status", () => {
+    // `toString` is on every object's prototype, so a lookup that asks `in` or
+    // reads the map directly would resolve it and render a function.
+    expect(jobStatusPresentation("toString").label).toBe("toString");
+    expect(jobStatusPresentation("constructor").label).toBe("constructor");
+  });
+});
+
+describe("job age", () => {
+  const now = new Date("2026-09-02T12:00:00.000Z");
+
+  it("reads in the past for a past instant and the future for a due one", () => {
+    expect(formatJobAge("2026-09-02T11:56:00.000Z", now)).toBe("4 minutes ago");
+    // A scheduled retry is in the future; "in 5 minutes" is the answer an
+    // operator wants, and "-5 minutes ago" is the one a subtraction gives.
+    expect(formatJobAge("2026-09-02T12:05:00.000Z", now)).toBe("in 5 minutes");
+  });
+
+  it("singularises, so nothing reads '1 minutes ago'", () => {
+    expect(formatJobAge("2026-09-02T11:59:00.000Z", now)).toBe("1 minute ago");
+  });
+
+  it("climbs to the coarsest true unit", () => {
+    expect(formatJobAge("2026-09-02T09:00:00.000Z", now)).toBe("3 hours ago");
+    expect(formatJobAge("2026-08-30T12:00:00.000Z", now)).toBe("3 days ago");
+  });
+
+  it("returns an unparseable value unchanged rather than NaN", () => {
+    expect(formatJobAge("not-a-date", now)).toBe("not-a-date");
+  });
+});

--- a/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
+++ b/packages/admin/src/components/features/background-jobs/__tests__/jobStatus.test.ts
@@ -5,8 +5,8 @@
  * failed, another is scheduled, and nobody needs to act. Presenting it in the
  * same red as a terminal failure is the documented common mistake in queue
  * tooling — it raises an alarm for a self-healing job, and buries the dead one
- * among transient noise. So `failed` is the only destructive pill, and that is
- * asserted rather than left to a reviewer to notice.
+ * among transient noise. `failed` is therefore the only destructive pill, and
+ * the assertion below is what holds that apart.
  */
 import { describe, expect, it } from "vitest";
 

--- a/packages/admin/src/components/features/background-jobs/index.ts
+++ b/packages/admin/src/components/features/background-jobs/index.ts
@@ -1,0 +1,14 @@
+export {
+  JobFailureSummary,
+  failedJobs,
+  failedSlugs,
+} from "./JobFailureSummary";
+export type { JobFailureSummaryProps } from "./JobFailureSummary";
+export { JobsTable } from "./JobsTable";
+export type { JobsTableProps } from "./JobsTable";
+export {
+  JobStatusBadge,
+  formatJobAge,
+  formatJobTimestamp,
+  jobStatusPresentation,
+} from "./jobStatus";

--- a/packages/admin/src/components/features/background-jobs/index.ts
+++ b/packages/admin/src/components/features/background-jobs/index.ts
@@ -1,7 +1,7 @@
 export {
   JobFailureSummary,
-  failedJobs,
   failedSlugs,
+  jobsNeedingAttention,
 } from "./JobFailureSummary";
 export type { JobFailureSummaryProps } from "./JobFailureSummary";
 export { JobsTable } from "./JobsTable";

--- a/packages/admin/src/components/features/background-jobs/jobStatus.tsx
+++ b/packages/admin/src/components/features/background-jobs/jobStatus.tsx
@@ -59,7 +59,11 @@ const STATUS_PRESENTATION: Record<JobDisplayStatus, StatusPresentation> = {
   failed: {
     variant: "destructive",
     label: "Failed",
-    hint: "Attempts are spent. This will not happen without a person.",
+    // NOT "attempts are spent": a job can reach this state on its first
+    // attempt. The runner returns terminal immediately when the identity it
+    // would run as is gone, so telling an operator the retries were exhausted
+    // sends them looking for a backoff that never happened.
+    hint: "Terminal — it will not be retried. This needs a person.",
   },
 };
 

--- a/packages/admin/src/components/features/background-jobs/jobStatus.tsx
+++ b/packages/admin/src/components/features/background-jobs/jobStatus.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+/**
+ * Presentational helpers for the background job monitor.
+ *
+ * Every status maps to an existing token-backed Badge variant, so no new colour
+ * pairing is introduced, and every badge carries text rather than colour alone.
+ *
+ * The map is keyed by the CORE's status union, so a status added there fails to
+ * compile here rather than rendering an unlabelled pill. That is the whole
+ * reason the vocabulary is imported instead of restated.
+ */
+
+import { Badge } from "@nextlyhq/ui";
+import type React from "react";
+
+import type { JobDisplayStatus } from "@admin/types/jobs";
+
+type BadgeVariant = "success" | "warning" | "destructive" | "default";
+
+interface StatusPresentation {
+  variant: BadgeVariant;
+  label: string;
+  /** What this status means for the person reading it. */
+  hint: string;
+}
+
+/**
+ * Status → presentation.
+ *
+ * `retrying` is deliberately NOT destructive. It is the system healing itself,
+ * and colouring it like a failure is the documented common mistake in queue
+ * tooling: it raises an alarm for something that needs nobody, and buries the
+ * dead job among transient noise. `failed` is the only terminal bad state and
+ * the only red one.
+ */
+const STATUS_PRESENTATION: Record<JobDisplayStatus, StatusPresentation> = {
+  waiting: {
+    variant: "default",
+    label: "Waiting",
+    hint: "Queued and not yet attempted.",
+  },
+  retrying: {
+    variant: "warning",
+    label: "Retrying",
+    hint: "An attempt failed and another is scheduled. No action needed.",
+  },
+  running: {
+    variant: "default",
+    label: "Running",
+    hint: "A runner holds this job right now.",
+  },
+  succeeded: {
+    variant: "success",
+    label: "Succeeded",
+    hint: "Finished.",
+  },
+  failed: {
+    variant: "destructive",
+    label: "Failed",
+    hint: "Attempts are spent. This will not happen without a person.",
+  },
+};
+
+/**
+ * Resolve a status as it arrives on the wire — an untrusted string — to its
+ * presentation. A value this build does not know falls back to a neutral pill
+ * showing it verbatim rather than rendering nothing, so a server ahead of the
+ * client degrades to "unfamiliar" instead of "blank".
+ */
+export function jobStatusPresentation(status: string): StatusPresentation {
+  const known = Object.prototype.hasOwnProperty.call(
+    STATUS_PRESENTATION,
+    status
+  )
+    ? (status as JobDisplayStatus)
+    : null;
+  return known
+    ? STATUS_PRESENTATION[known]
+    : { variant: "default", label: status, hint: "" };
+}
+
+/** Status pill for a job row. */
+export const JobStatusBadge: React.FC<{ status: string }> = ({ status }) => {
+  const presentation = jobStatusPresentation(status);
+  return (
+    <Badge variant={presentation.variant} title={presentation.hint}>
+      {presentation.label}
+    </Badge>
+  );
+};
+
+/**
+ * Render an ISO-8601 instant in the viewer's locale and timezone.
+ *
+ * The jobs read opts out of server-side timezone rewriting so a `lastError`
+ * that is itself a timestamp survives verbatim, which means every instant on
+ * this screen arrives in UTC and is formatted here.
+ */
+export function formatJobTimestamp(iso: string | null): string {
+  if (!iso) return "-";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return date.toLocaleString();
+}
+
+/**
+ * How long ago, in the coarsest unit that is still true.
+ *
+ * "4 minutes ago" answers an operator's actual question — is this moving —
+ * where a wall-clock time makes them do the subtraction. The absolute time
+ * stays available as the cell's tooltip.
+ */
+export function formatJobAge(iso: string, now: Date): string {
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return iso;
+  const seconds = Math.round((now.getTime() - then.getTime()) / 1000);
+  const ahead = seconds < 0;
+  const magnitude = Math.abs(seconds);
+  const say = (value: number, unit: string): string => {
+    const plural = `${value} ${unit}${value === 1 ? "" : "s"}`;
+    return ahead ? `in ${plural}` : `${plural} ago`;
+  };
+  if (magnitude < 45) return ahead ? "in a moment" : "just now";
+  if (magnitude < 3600) return say(Math.round(magnitude / 60), "minute");
+  if (magnitude < 86_400) return say(Math.round(magnitude / 3600), "hour");
+  return say(Math.round(magnitude / 86_400), "day");
+}

--- a/packages/admin/src/components/features/background-jobs/jobStatus.tsx
+++ b/packages/admin/src/components/features/background-jobs/jobStatus.tsx
@@ -14,6 +14,7 @@
 import { Badge } from "@nextlyhq/ui";
 import type React from "react";
 
+import { formatDateTime } from "@admin/lib/dates/format";
 import type { JobDisplayStatus } from "@admin/types/jobs";
 
 type BadgeVariant = "success" | "warning" | "destructive" | "default";
@@ -91,17 +92,24 @@ export const JobStatusBadge: React.FC<{ status: string }> = ({ status }) => {
 };
 
 /**
- * Render an ISO-8601 instant in the viewer's locale and timezone.
+ * Render an ISO-8601 instant the way the rest of the admin renders one.
+ *
+ * Through `formatDateTime` rather than `toLocaleString`, so these agree with
+ * every other date on screen. The installation configures a timezone and a
+ * date format, and a local call reads the BROWSER's instead — which produces
+ * two different renderings of the same instant on one page, and the
+ * disagreement is invisible to whoever set the configuration.
  *
  * The jobs read opts out of server-side timezone rewriting so a `lastError`
- * that is itself a timestamp survives verbatim, which means every instant on
- * this screen arrives in UTC and is formatted here.
+ * that is itself a timestamp survives verbatim, so every instant here arrives
+ * in UTC and is formatted on the client. That decides WHERE the formatting
+ * happens; it does not license a second answer to how.
  */
 export function formatJobTimestamp(iso: string | null): string {
   if (!iso) return "-";
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  return date.toLocaleString();
+  return formatDateTime(date);
 }
 
 /**

--- a/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
@@ -211,3 +211,54 @@ export function visibleSettingsNav(
     }))
     .filter(group => group.items.length > 0 || group.pluginPlacement);
 }
+
+/** Any grant that reaches the API-keys screen; the panel gates it as a capability. */
+const API_KEY_SLUGS = [
+  "read-api-keys",
+  "create-api-keys",
+  "update-api-keys",
+  "delete-api-keys",
+] as const;
+
+/** Any grant that reaches the webhooks screen, for the same reason. */
+const WEBHOOK_SLUGS = [
+  "read-webhooks",
+  "update-webhooks",
+  "create-webhooks",
+] as const;
+
+/**
+ * Every grant that reaches SOMETHING in the Settings panel.
+ *
+ * Read off the table rather than listed beside it, and consumed by three
+ * separate decisions that were each maintained by hand: whether the rail entry
+ * appears, whether `/admin/settings` opens at all, and which destination a
+ * viewer without `manage-settings` lands on. Background Jobs was added to the
+ * panel and to none of the three, so the destination passed its own gate while
+ * the rail was suppressed — and once the rail was fixed, the link led to a page
+ * that bounced. A destination added here now satisfies all three by
+ * construction.
+ *
+ * User Management is excluded deliberately. Those destinations answer to
+ * `canViewUsers` and `canViewRoles`, which the rail consults separately, and
+ * folding them in would widen every consumer of the settings capability to
+ * anybody who may read users.
+ */
+export function settingsPanelSlugs(): string[] {
+  const slugs = new Set<string>();
+  for (const group of SETTINGS_NAV) {
+    if (group.id === "users") continue;
+    for (const item of group.items) {
+      if (item.gate.kind === "permission") {
+        slugs.add(item.gate.permission);
+        continue;
+      }
+      for (const slug of item.gate.capability === "apiKeys"
+        ? API_KEY_SLUGS
+        : WEBHOOK_SLUGS) {
+        slugs.add(slug);
+      }
+    }
+  }
+  return [...slugs];
+}

--- a/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
@@ -10,6 +10,7 @@
  * permission.
  */
 import {
+  Activity,
   FileText,
   Image,
   Key,
@@ -98,6 +99,18 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
         icon: Webhook,
         href: ROUTES.SETTINGS_WEBHOOKS,
         gate: { kind: "capability", capability: "webhooks" },
+      },
+      {
+        id: "background-jobs",
+        label: "Background Jobs",
+        icon: Activity,
+        href: ROUTES.SETTINGS_BACKGROUND_JOBS,
+        // The same permission the queue trigger takes. `lastError` carries
+        // whatever a handler threw, which is internal detail rather than
+        // content, and there is no seeded read-only slug to gate on — inventing
+        // one here would change what preset roles grant as a side effect of
+        // adding a screen.
+        gate: { kind: "permission", permission: "manage-background-jobs" },
       },
       {
         id: "image-sizes",

--- a/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
+++ b/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
@@ -14,6 +14,7 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { buildCapabilities } from "@admin/hooks/useCurrentUserPermissions";
 import {
   SETTINGS_NAV,
   isSettingsNavItemVisible,
@@ -78,6 +79,48 @@ describe("the Background Jobs settings entry", () => {
     expect(item).toBeDefined();
     if (!item) return;
     expect(isSettingsNavItemVisible(item, only("manage-settings"))).toBe(false);
+  });
+});
+
+describe("the RAIL above that entry, which the item's own gate cannot see", () => {
+  /*
+   * Two ways to be invisible, and the assertions above reach only the second.
+   * `DualSidebar` shows the Settings rail entry when `canViewSettings` is true;
+   * the item's own gate then decides what is inside. An operator holding only
+   * `manage-background-jobs` passed the inner gate and was stopped by the outer
+   * one, so the destination was reachable only by typing its URL.
+   *
+   * Driven through `buildCapabilities`, which is what the product calls, rather
+   * than through a literal capability object — a hand-built one keeps passing
+   * after the real derivation stops setting the flag.
+   */
+  it("reveals Settings to an operator whose ONLY grant is the jobs permission", () => {
+    expect(
+      buildCapabilities(["manage-background-jobs"], false).canViewSettings
+    ).toBe(true);
+  });
+
+  it("still hides it from someone holding an unrelated grant", () => {
+    // The control: without it the case above passes against a capability that
+    // is true for everyone, which is the other way to be wrong here.
+    expect(buildCapabilities(["read-media"], false).canViewSettings).toBe(
+      false
+    );
+  });
+
+  it("keeps revealing it for the grants it always revealed for", () => {
+    // Adding to this list must not narrow it. One representative grant per
+    // group it already covered.
+    for (const grant of [
+      "manage-settings",
+      "read-api-keys",
+      "manage-email-providers",
+      "manage-email-templates",
+    ]) {
+      expect(buildCapabilities([grant], false).canViewSettings, grant).toBe(
+        true
+      );
+    }
   });
 });
 

--- a/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
+++ b/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
@@ -108,6 +108,32 @@ describe("the RAIL above that entry, which the item's own gate cannot see", () =
     );
   });
 
+  it("reveals Settings for EVERY destination the panel declares", () => {
+    /*
+     * The general form, and the specific case above is one instance of it.
+     * The capability that opens the rail is derived from `SETTINGS_NAV`, so a
+     * destination added to the panel reveals it by construction — which is the
+     * property that failed when the list was maintained by hand and Background
+     * Jobs was added to one side only.
+     *
+     * User Management is excluded because those destinations answer to their
+     * own capabilities, which the rail consults separately.
+     */
+    const gated = SETTINGS_NAV.filter(group => group.id !== "users")
+      .flatMap(group => group.items)
+      .filter(item => item.gate.kind === "permission");
+    for (const item of gated) {
+      const permission =
+        item.gate.kind === "permission" ? item.gate.permission : "";
+      expect(
+        buildCapabilities([permission], false).canViewSettings,
+        `${item.id} (${permission})`
+      ).toBe(true);
+    }
+    // The premise: this walked real destinations, not an empty list.
+    expect(gated.length).toBeGreaterThan(3);
+  });
+
   it("keeps revealing it for the grants it always revealed for", () => {
     // Adding to this list must not narrow it. One representative grant per
     // group it already covered.

--- a/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
+++ b/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
@@ -18,6 +18,7 @@ import { buildCapabilities } from "@admin/hooks/useCurrentUserPermissions";
 import {
   SETTINGS_NAV,
   isSettingsNavItemVisible,
+  settingsPanelSlugs,
   type SettingsNavAccess,
 } from "@admin/components/layout/sidebar/lib/settings-nav";
 import { routeConfig } from "@admin/pages/registry";
@@ -147,6 +148,27 @@ describe("the RAIL above that entry, which the item's own gate cannot see", () =
         true
       );
     }
+  });
+});
+
+describe("the panel's own URL, which the rail entry actually points at", () => {
+  /*
+   * The third place this journey can break, after the rail gate and the
+   * destination's gate. `/admin/settings` is both the panel's URL and the
+   * General settings page, so guarding it on `manage-settings` turned the rail
+   * entry into a door that closed in the face of anyone whose only destination
+   * was further in: they saw the link, clicked it, and were returned to the
+   * dashboard.
+   */
+  it("opens for every grant that reaches something in the panel", () => {
+    const guard = routeConfig[ROUTES.SETTINGS]?.requiredPermission;
+    const accepted = Array.isArray(guard) ? guard : [guard];
+    for (const slug of settingsPanelSlugs()) {
+      expect(accepted, slug).toContain(slug);
+    }
+    // The premise: the panel really declares several grants, so this is not a
+    // one-element list agreeing with itself.
+    expect(settingsPanelSlugs().length).toBeGreaterThan(3);
   });
 });
 

--- a/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
+++ b/packages/admin/src/constants/__tests__/background-jobs-nav.test.ts
@@ -1,0 +1,104 @@
+/**
+ * That the Background Jobs screen can actually be reached, and by the right
+ * people.
+ *
+ * Three failures are guarded, and each is silent in its own way. A page in the
+ * route registry with no navigation entry is routable and undiscoverable. A
+ * navigation entry gated on a permission whose RESOURCE is not seeded matches
+ * nobody, so the item is invisible to everyone including an administrator, with
+ * nothing erroring to say so. And an entry whose href is written out by hand
+ * rather than taken from `ROUTES` agrees with the registry until one of them is
+ * edited, at which point the link 404s.
+ *
+ * @module constants/__tests__/background-jobs-nav.test
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  SETTINGS_NAV,
+  isSettingsNavItemVisible,
+  type SettingsNavAccess,
+} from "@admin/components/layout/sidebar/lib/settings-nav";
+import { routeConfig } from "@admin/pages/registry";
+
+import { SYSTEM_RESOURCES_IN_DISPLAY_ORDER } from "../permissions";
+import { ROUTES } from "../routes";
+
+const item = SETTINGS_NAV.flatMap(group => group.items).find(
+  entry => entry.id === "background-jobs"
+);
+
+/** Holds exactly one permission and no capability. */
+const only = (permission: string): SettingsNavAccess => ({
+  hasPermission: value => value === permission,
+  canAccessApiKeys: false,
+  canAccessWebhooks: false,
+});
+
+describe("the Background Jobs settings entry", () => {
+  it("exists in the panel that is actually rendered", () => {
+    expect(item).toBeDefined();
+  });
+
+  it("takes its destination from ROUTES rather than a literal", () => {
+    // Resolved before comparing: optional chaining here would let an ABSENT
+    // entry compare `undefined` against a defined route and fail confusingly,
+    // or worse, compare two undefineds elsewhere and pass.
+    expect(item).toBeDefined();
+    if (!item) return;
+    expect(item.href).toBe(ROUTES.SETTINGS_BACKGROUND_JOBS);
+    expect(ROUTES.SETTINGS_BACKGROUND_JOBS).toBe(
+      "/admin/settings/background-jobs"
+    );
+  });
+
+  it("gates on a permission whose RESOURCE is registered", () => {
+    expect(item).toBeDefined();
+    if (!item) return;
+    expect(item.gate).toEqual({
+      kind: "permission",
+      permission: "manage-background-jobs",
+    });
+    // Checked against the one list the permission screens derive from, so a
+    // typo cannot agree with itself. An unseeded slug matches nobody.
+    expect(SYSTEM_RESOURCES_IN_DISPLAY_ORDER).toContain("background-jobs");
+  });
+
+  it("is shown to a holder of that permission", () => {
+    expect(item).toBeDefined();
+    if (!item) return;
+    expect(isSettingsNavItemVisible(item, only("manage-background-jobs"))).toBe(
+      true
+    );
+  });
+
+  it("is hidden from someone holding a different permission", () => {
+    // The control. Without it the case above passes against a gate that admits
+    // everyone.
+    expect(item).toBeDefined();
+    if (!item) return;
+    expect(isSettingsNavItemVisible(item, only("manage-settings"))).toBe(false);
+  });
+});
+
+describe("the route behind that entry", () => {
+  const route = routeConfig[ROUTES.SETTINGS_BACKGROUND_JOBS];
+
+  it("is registered, so the link leads somewhere", () => {
+    expect(route).toBeDefined();
+  });
+
+  it("is private and demands the same permission the navigation gates on", () => {
+    // Two gates on one screen: the nav decides whether it is offered, the
+    // registry decides whether it opens. Disagreeing means either a visible
+    // link that refuses, or a hidden page anyone can reach by URL.
+    expect(route).toBeDefined();
+    if (!route) return;
+    expect(route.type).toBe("private");
+    expect(route.requiredPermission).toBe("manage-background-jobs");
+    expect(item?.gate).toEqual({
+      kind: "permission",
+      permission: route.requiredPermission,
+    });
+  });
+});

--- a/packages/admin/src/constants/routes.ts
+++ b/packages/admin/src/constants/routes.ts
@@ -116,6 +116,10 @@ export const ROUTES = {
   SETTINGS_WEBHOOKS_DELIVERIES: "/admin/settings/webhooks/[id]/deliveries",
   SETTINGS_WEBHOOKS_DELIVERY_DETAIL:
     "/admin/settings/webhooks/[id]/deliveries/[deliveryId]",
+  // Background jobs: the queue's recent history, read-only. Under settings
+  // rather than in the rail because it is machinery an operator watches, not
+  // editorial work — the same reasoning that puts webhooks there.
+  SETTINGS_BACKGROUND_JOBS: "/admin/settings/background-jobs",
   SETTINGS_IMAGE_SIZES: "/admin/settings/image-sizes",
   SETTINGS_IMAGE_SIZES_CREATE: "/admin/settings/image-sizes/create",
   SETTINGS_IMAGE_SIZES_EDIT: "/admin/settings/image-sizes/edit/[id]",

--- a/packages/admin/src/hooks/queries/useJobs.ts
+++ b/packages/admin/src/hooks/queries/useJobs.ts
@@ -1,0 +1,47 @@
+"use client";
+
+/**
+ * Background job query hooks.
+ *
+ * Polled rather than fetched once: this screen is a monitor, and a queue that
+ * finishes a job while it is open must not leave a stale row saying the work is
+ * still waiting. The interval is deliberately modest and does NOT run while the
+ * tab is in the background — TanStack's default for `refetchInterval` — so a
+ * forgotten tab costs an installation nothing.
+ */
+
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
+
+import type { ListResponse } from "@admin/lib/api/response-types";
+import { jobsApi } from "@admin/services/jobsApi";
+import type { JobListItem, ListJobsParams } from "@admin/types/jobs";
+
+/** How often an open monitor asks again. */
+export const JOBS_POLL_INTERVAL_MS = 15_000;
+
+export const jobKeys = {
+  all: () => ["background-jobs"] as const,
+  list: (params: ListJobsParams) => [...jobKeys.all(), "list", params] as const,
+};
+
+/**
+ * The recent-jobs window.
+ *
+ * `enabled` lets the caller hold the fetch until it knows the viewer may read,
+ * so a viewer without the permission never issues a request that can only 403.
+ */
+export function useJobs(
+  params: ListJobsParams = {},
+  options?: { enabled?: boolean }
+) {
+  return useQuery<ListResponse<JobListItem>, Error>({
+    queryKey: jobKeys.list(params),
+    queryFn: () => jobsApi.listJobs(params),
+    enabled: options?.enabled ?? true,
+    // Widening the window refetches; keeping the previous rows on screen means
+    // the table does not blink empty on a change the reader initiated.
+    placeholderData: keepPreviousData,
+    refetchInterval: JOBS_POLL_INTERVAL_MS,
+    staleTime: JOBS_POLL_INTERVAL_MS,
+  });
+}

--- a/packages/admin/src/hooks/useCurrentUserPermissions.ts
+++ b/packages/admin/src/hooks/useCurrentUserPermissions.ts
@@ -1,5 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
+import { SETTINGS_NAV } from "../components/layout/sidebar/lib/settings-nav";
 import { SYSTEM_RESOURCE_SET } from "../constants/permissions";
 import { protectedApi } from "../lib/api/protectedApi";
 import type {
@@ -56,6 +57,55 @@ type SystemCapabilities = Omit<
  * generic `action-resource` lookup finds nothing and answers false for a caller
  * who holds the grant.
  */
+/** Any grant that reaches the API-keys screen; the panel gates it as a capability. */
+const API_KEY_SLUGS = [
+  "read-api-keys",
+  "create-api-keys",
+  "update-api-keys",
+  "delete-api-keys",
+] as const;
+
+/** Any grant that reaches the webhooks screen, for the same reason. */
+const WEBHOOK_SLUGS = [
+  "read-webhooks",
+  "update-webhooks",
+  "create-webhooks",
+] as const;
+
+/**
+ * The grants that reveal the Settings panel, READ OFF the panel itself.
+ *
+ * This was a hand-written list beside `SETTINGS_NAV`, and the duplication was
+ * not theoretical: Background Jobs was added to the panel, its own gate passed,
+ * and the rail above it stayed suppressed for anyone holding only that grant —
+ * the page reachable solely by typing its URL, with nothing erroring to say so.
+ * A destination added to the table now reveals the panel by construction, so
+ * the same omission cannot be made twice.
+ *
+ * User Management is excluded deliberately. Those destinations answer to
+ * `canViewUsers` and `canViewRoles`, which are separate capabilities the rail
+ * already consults, and folding them in here would widen every other consumer
+ * of `canViewSettings` to anybody who may read users.
+ */
+function settingsPanelSlugs(): string[] {
+  const slugs = new Set<string>();
+  for (const group of SETTINGS_NAV) {
+    if (group.id === "users") continue;
+    for (const item of group.items) {
+      if (item.gate.kind === "permission") {
+        slugs.add(item.gate.permission);
+        continue;
+      }
+      for (const slug of item.gate.capability === "apiKeys"
+        ? API_KEY_SLUGS
+        : WEBHOOK_SLUGS) {
+        slugs.add(slug);
+      }
+    }
+  }
+  return [...slugs];
+}
+
 const SYSTEM_CAPABILITY_SLUGS: Record<
   keyof SystemCapabilities,
   readonly string[]
@@ -63,26 +113,8 @@ const SYSTEM_CAPABILITY_SLUGS: Record<
   canViewUsers: ["read-users"],
   canViewRoles: ["read-roles"],
   canViewMedia: ["read-media", "manage-media"],
-  canViewSettings: [
-    "manage-settings",
-    "read-api-keys",
-    "create-api-keys",
-    "update-api-keys",
-    "delete-api-keys",
-    "manage-email-providers",
-    "manage-email-templates",
-    // Background Jobs lives in the Settings panel, so its grant has to reveal
-    // the panel. Without it the destination passes its own gate while the rail
-    // entry above stays suppressed, and an authorized operator has no way in
-    // short of typing the URL — with nothing erroring to say so.
-    //
-    // This list is a second enumeration of `SETTINGS_NAV`, which is why the
-    // omission was possible at all; deriving the rail from the panel's visible
-    // destinations is the real repair and is filed separately, because it means
-    // reworking a 504-line component that this change has no other business in.
-    "manage-background-jobs",
-  ],
-  canViewWebhooks: ["read-webhooks", "update-webhooks", "create-webhooks"],
+  canViewSettings: settingsPanelSlugs(),
+  canViewWebhooks: [...WEBHOOK_SLUGS],
   // Read alone. Unlike webhooks, assembling and publishing releases do not
   // reveal the section on their own — the list is a read, and a caller who may
   // create one but not read them would land on a page that shows nothing.

--- a/packages/admin/src/hooks/useCurrentUserPermissions.ts
+++ b/packages/admin/src/hooks/useCurrentUserPermissions.ts
@@ -71,6 +71,16 @@ const SYSTEM_CAPABILITY_SLUGS: Record<
     "delete-api-keys",
     "manage-email-providers",
     "manage-email-templates",
+    // Background Jobs lives in the Settings panel, so its grant has to reveal
+    // the panel. Without it the destination passes its own gate while the rail
+    // entry above stays suppressed, and an authorized operator has no way in
+    // short of typing the URL — with nothing erroring to say so.
+    //
+    // This list is a second enumeration of `SETTINGS_NAV`, which is why the
+    // omission was possible at all; deriving the rail from the panel's visible
+    // destinations is the real repair and is filed separately, because it means
+    // reworking a 504-line component that this change has no other business in.
+    "manage-background-jobs",
   ],
   canViewWebhooks: ["read-webhooks", "update-webhooks", "create-webhooks"],
   // Read alone. Unlike webhooks, assembling and publishing releases do not

--- a/packages/admin/src/hooks/useCurrentUserPermissions.ts
+++ b/packages/admin/src/hooks/useCurrentUserPermissions.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 
-import { SETTINGS_NAV } from "../components/layout/sidebar/lib/settings-nav";
+import { settingsPanelSlugs } from "../components/layout/sidebar/lib/settings-nav";
 import { SYSTEM_RESOURCE_SET } from "../constants/permissions";
 import { protectedApi } from "../lib/api/protectedApi";
 import type {
@@ -57,55 +57,6 @@ type SystemCapabilities = Omit<
  * generic `action-resource` lookup finds nothing and answers false for a caller
  * who holds the grant.
  */
-/** Any grant that reaches the API-keys screen; the panel gates it as a capability. */
-const API_KEY_SLUGS = [
-  "read-api-keys",
-  "create-api-keys",
-  "update-api-keys",
-  "delete-api-keys",
-] as const;
-
-/** Any grant that reaches the webhooks screen, for the same reason. */
-const WEBHOOK_SLUGS = [
-  "read-webhooks",
-  "update-webhooks",
-  "create-webhooks",
-] as const;
-
-/**
- * The grants that reveal the Settings panel, READ OFF the panel itself.
- *
- * This was a hand-written list beside `SETTINGS_NAV`, and the duplication was
- * not theoretical: Background Jobs was added to the panel, its own gate passed,
- * and the rail above it stayed suppressed for anyone holding only that grant —
- * the page reachable solely by typing its URL, with nothing erroring to say so.
- * A destination added to the table now reveals the panel by construction, so
- * the same omission cannot be made twice.
- *
- * User Management is excluded deliberately. Those destinations answer to
- * `canViewUsers` and `canViewRoles`, which are separate capabilities the rail
- * already consults, and folding them in here would widen every other consumer
- * of `canViewSettings` to anybody who may read users.
- */
-function settingsPanelSlugs(): string[] {
-  const slugs = new Set<string>();
-  for (const group of SETTINGS_NAV) {
-    if (group.id === "users") continue;
-    for (const item of group.items) {
-      if (item.gate.kind === "permission") {
-        slugs.add(item.gate.permission);
-        continue;
-      }
-      for (const slug of item.gate.capability === "apiKeys"
-        ? API_KEY_SLUGS
-        : WEBHOOK_SLUGS) {
-        slugs.add(slug);
-      }
-    }
-  }
-  return [...slugs];
-}
-
 const SYSTEM_CAPABILITY_SLUGS: Record<
   keyof SystemCapabilities,
   readonly string[]
@@ -114,7 +65,7 @@ const SYSTEM_CAPABILITY_SLUGS: Record<
   canViewRoles: ["read-roles"],
   canViewMedia: ["read-media", "manage-media"],
   canViewSettings: settingsPanelSlugs(),
-  canViewWebhooks: [...WEBHOOK_SLUGS],
+  canViewWebhooks: ["read-webhooks", "update-webhooks", "create-webhooks"],
   // Read alone. Unlike webhooks, assembling and publishing releases do not
   // reveal the section on their own — the list is a read, and a caller who may
   // create one but not read them would land on a page that shows nothing.

--- a/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * The two sentences that stop this screen from lying.
+ *
+ * A monitor's failure mode is not a wrong number, it is a confident absence.
+ * If the window is truncated and says nothing, an operator reads fifty rows as
+ * the whole story; if finished jobs are pruned and the screen does not say so,
+ * a job that ran last week and was cleaned up is indistinguishable from one
+ * that never ran. Both conclusions are wrong in the direction that stops
+ * someone looking further, which is why they are asserted rather than trusted
+ * to a reviewer's eye.
+ */
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { render, screen } from "@admin/__tests__/utils";
+import type { JobListItem } from "@admin/types/jobs";
+
+import { BackgroundJobsContent } from "../index";
+
+const { useJobs, canFor } = vi.hoisted(() => ({
+  useJobs: vi.fn(),
+  canFor: vi.fn((_slug: string) => true),
+}));
+
+vi.mock("@admin/hooks/queries/useJobs", () => ({
+  useJobs: (params: unknown, opts: unknown) => useJobs(params, opts),
+  JOBS_POLL_INTERVAL_MS: 15_000,
+}));
+vi.mock("@admin/hooks/useCan", () => ({
+  useCan: (slug: string) => canFor(slug),
+}));
+
+function job(overrides: Partial<JobListItem> = {}): JobListItem {
+  return {
+    id: "j1",
+    slug: "releases:drain",
+    state: "done",
+    status: "succeeded",
+    attemptCount: 1,
+    lastError: null,
+    runAt: null,
+    nextAttemptAt: null,
+    createdAt: "2026-09-02T11:00:00.000Z",
+    updatedAt: "2026-09-02T11:30:00.000Z",
+    ...overrides,
+  };
+}
+
+const window_ = (items: JobListItem[], hasNext: boolean) => ({
+  data: { items, meta: { hasNext } },
+  isLoading: false,
+  isError: false,
+  isPlaceholderData: false,
+});
+
+describe("what the background jobs screen admits to", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    canFor.mockImplementation(() => true);
+  });
+
+  it("says the window is truncated when the server says there is more", () => {
+    useJobs.mockReturnValue(window_([job()], true));
+    render(<BackgroundJobsContent />);
+    expect(
+      screen.getByText(/More exist than this window holds/i)
+    ).toBeVisible();
+  });
+
+  it("does NOT say so when the window is complete", () => {
+    // The control: without it the notice could be permanent furniture, which
+    // would tell every reader their list is incomplete whether or not it is.
+    useJobs.mockReturnValue(window_([job()], false));
+    render(<BackgroundJobsContent />);
+    expect(screen.queryByText(/More exist than this window holds/i)).toBeNull();
+  });
+
+  it("states the retention window, so an absence is not read as never-ran", () => {
+    useJobs.mockReturnValue(window_([job()], false));
+    render(<BackgroundJobsContent />);
+    expect(
+      screen.getByText(/Finished jobs are removed after 7 days/i)
+    ).toBeVisible();
+  });
+
+  it("refuses the whole screen without the permission, and asks for nothing", () => {
+    canFor.mockImplementation(() => false);
+    useJobs.mockReturnValue(window_([job()], false));
+    render(<BackgroundJobsContent />);
+    expect(
+      screen.getByText(/do not have permission to view background jobs/i)
+    ).toBeVisible();
+    expect(useJobs).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ enabled: false })
+    );
+  });
+
+  it("shows a failed job's error text in the table", () => {
+    useJobs.mockReturnValue(
+      window_([job({ status: "failed", lastError: "smtp refused" })], false)
+    );
+    render(<BackgroundJobsContent />);
+    // The premise for the notice above it: the row itself carries the reason.
+    expect(screen.getByTitle("smtp refused")).toBeVisible();
+  });
+});

--- a/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
@@ -77,9 +77,24 @@ describe("what the background jobs screen admits to", () => {
   it("states the retention window, so an absence is not read as never-ran", () => {
     useJobs.mockReturnValue(window_([job()], false));
     render(<BackgroundJobsContent />);
+    expect(screen.getByText(/Finished jobs are pruned/i)).toBeVisible();
+    expect(screen.getByText(/may have run and been cleaned up/i)).toBeVisible();
+  });
+
+  it("presents the retention as a DEFAULT rather than as this installation's", () => {
+    /*
+     * `runJobsPass` takes a `retentionMs`, and `null` disables pruning
+     * altogether, so nothing the read path can see says what this deployment
+     * actually keeps. A flat "removed after 7 days" is therefore a claim the
+     * screen cannot support — and this sentence exists precisely so operators
+     * trust what it says about absent rows.
+     */
+    useJobs.mockReturnValue(window_([job()], false));
+    render(<BackgroundJobsContent />);
     expect(
-      screen.getByText(/Finished jobs are removed after 7 days/i)
+      screen.getByText(/unless this installation configured otherwise/i)
     ).toBeVisible();
+    expect(screen.queryByText(/removed after 7 days/i)).toBeNull();
   });
 
   it("refuses the whole screen without the permission, and asks for nothing", () => {
@@ -95,12 +110,21 @@ describe("what the background jobs screen admits to", () => {
     );
   });
 
-  it("shows a failed job's error text in the table", () => {
+  it("carries the error text into the NARROW render as well as the wide one", () => {
+    /*
+     * `DataTableView` renders both a table and a card list and lets the layout
+     * choose, and `hideOnMobile` does not truncate a column — it REMOVES it
+     * from the card list. Marking `lastError` that way left a phone showing
+     * that a job failed with no way to read why, which is the single fact this
+     * screen exists to deliver.
+     *
+     * So the assertion is that the reason appears in BOTH renders. One
+     * occurrence is precisely the broken state.
+     */
     useJobs.mockReturnValue(
       window_([job({ status: "failed", lastError: "smtp refused" })], false)
     );
     render(<BackgroundJobsContent />);
-    // The premise for the notice above it: the row itself carries the reason.
-    expect(screen.getByTitle("smtp refused")).toBeVisible();
+    expect(screen.getAllByTitle("smtp refused").length).toBeGreaterThan(1);
   });
 });

--- a/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
@@ -13,7 +13,7 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 import { render, screen } from "@admin/__tests__/utils";
 import type { JobListItem } from "@admin/types/jobs";
 
-import { BackgroundJobsContent } from "../index";
+import { BackgroundJobsContent, jobsQueryFor } from "../index";
 
 const { useJobs, canFor } = vi.hoisted(() => ({
   useJobs: vi.fn(),
@@ -146,5 +146,34 @@ describe("what the background jobs screen admits to", () => {
     expect(disclosures.length).toBeGreaterThan(0);
     // The whole message is present, not a prefix of it.
     expect(screen.getAllByText(long).length).toBeGreaterThan(0);
+  });
+  it("asks the SERVER for the states a chosen status can hold", () => {
+    /*
+     * A window is the most recent N rows. Narrowing it only after it arrives
+     * showed an empty table under a notice reporting a failure — the summary
+     * asked the database and the table did not, so one screen contradicted
+     * itself.
+     */
+    expect(jobsQueryFor(50, "failed")).toEqual({
+      limit: 50,
+      states: ["failed"],
+    });
+  });
+
+  it("asks for a status's WHOLE stored set, not the one that shares its name", () => {
+    // `running` is produced by a live lease on a row in any state, so narrowing
+    // to the column value `running` would hide every job actually executing.
+    expect(jobsQueryFor(50, "running").states).toEqual([
+      "pending",
+      "running",
+      "done",
+      "failed",
+    ]);
+  });
+
+  it("sends no state filter when no status is chosen", () => {
+    // The control: without it the cases above pass against a query that always
+    // narrows, which would hide every job the moment the screen opened.
+    expect(jobsQueryFor(25, undefined)).toEqual({ limit: 25 });
   });
 });

--- a/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
+++ b/packages/admin/src/pages/dashboard/settings/background-jobs/__tests__/honesty.test.tsx
@@ -6,8 +6,7 @@
  * the whole story; if finished jobs are pruned and the screen does not say so,
  * a job that ran last week and was cleaned up is indistinguishable from one
  * that never ran. Both conclusions are wrong in the direction that stops
- * someone looking further, which is why they are asserted rather than trusted
- * to a reviewer's eye.
+ * someone looking further, so both sentences are asserted here.
  */
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
@@ -125,6 +124,27 @@ describe("what the background jobs screen admits to", () => {
       window_([job({ status: "failed", lastError: "smtp refused" })], false)
     );
     render(<BackgroundJobsContent />);
-    expect(screen.getAllByTitle("smtp refused").length).toBeGreaterThan(1);
+    // Asserted on the TEXT rather than a tooltip: a `title` is unreachable on a
+    // touch device, so an error that lives only there is not reported at all on
+    // the screens an operator checks a queue from.
+    expect(screen.getAllByText("smtp refused").length).toBeGreaterThan(1);
+  });
+
+  it("offers a long error as an operable disclosure, not a clipped line", () => {
+    /*
+     * A clipped line plus `title` reads fine with a mouse and is unreadable
+     * without one. A native disclosure works by pointer, touch and keyboard,
+     * and the full text is in the DOM either way — so the reason is reachable
+     * rather than merely present.
+     */
+    const long = `connect ECONNREFUSED 10.0.0.5:587 ${"x".repeat(120)}`;
+    useJobs.mockReturnValue(
+      window_([job({ status: "failed", lastError: long })], false)
+    );
+    render(<BackgroundJobsContent />);
+    const disclosures = screen.getAllByText("Show full error");
+    expect(disclosures.length).toBeGreaterThan(0);
+    // The whole message is present, not a prefix of it.
+    expect(screen.getAllByText(long).length).toBeGreaterThan(0);
   });
 });

--- a/packages/admin/src/pages/dashboard/settings/background-jobs/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/background-jobs/index.tsx
@@ -35,7 +35,7 @@ import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundar
 import { JOBS_POLL_INTERVAL_MS, useJobs } from "@admin/hooks/queries/useJobs";
 import { useCan } from "@admin/hooks/useCan";
 import {
-  JOB_RETENTION_DAYS,
+  DEFAULT_JOB_RETENTION_DAYS,
   type JobDisplayStatus,
   type JobWindowSize,
 } from "@admin/types/jobs";
@@ -126,11 +126,11 @@ export const BackgroundJobsContent: React.FC = () => {
             them.{" "}
           </>
         )}
-        Finished jobs are removed after {JOB_RETENTION_DAYS} days, so a job
-        missing from this list may have run and been cleaned up rather than
-        never having run. Refreshes every{" "}
-        {Math.round(JOBS_POLL_INTERVAL_MS / 1000)} seconds while this tab is
-        open.
+        Finished jobs are pruned — after {DEFAULT_JOB_RETENTION_DAYS} days
+        unless this installation configured otherwise — so a job missing from
+        this list may have run and been cleaned up rather than never having run.
+        Refreshes every {Math.round(JOBS_POLL_INTERVAL_MS / 1000)} seconds while
+        this tab is open.
       </p>
     </div>
   );

--- a/packages/admin/src/pages/dashboard/settings/background-jobs/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/background-jobs/index.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+/**
+ * Background jobs — what the queue recently did.
+ *
+ * A background job that fails is invisible. There is no request to inspect, no
+ * status code, and no page that went blank, so a scheduled release that did not
+ * publish looks exactly like one that was not due yet. This screen is the place
+ * that difference becomes visible.
+ *
+ * READ-ONLY, deliberately. No retry, cancel or requeue: each is a write on
+ * already-authorized work and needs its own decision about who may perform it,
+ * and offering them beside a read would settle those questions by omission.
+ *
+ * Two honesty rules shape the layout. Failures are stated ABOVE the table,
+ * because an operator opening this page is nearly always answering "did the
+ * thing I expected happen", and a red row twelve lines down is a worse answer
+ * than a sentence at the top. And the retention window is stated at the bottom,
+ * because a list that silently forgets is one an operator will read as proof
+ * that a job never ran.
+ */
+
+import { Alert, AlertDescription, TableSkeleton } from "@nextlyhq/ui";
+import type React from "react";
+import { useEffect, useState } from "react";
+
+import {
+  JobFailureSummary,
+  JobsTable,
+} from "@admin/components/features/background-jobs";
+import { SettingsLayout } from "@admin/components/features/settings/SettingsLayout";
+import { PageContainer } from "@admin/components/layout/page-container";
+import { PageErrorFallback } from "@admin/components/shared/error-fallbacks";
+import { QueryErrorBoundary } from "@admin/components/shared/query-error-boundary";
+import { JOBS_POLL_INTERVAL_MS, useJobs } from "@admin/hooks/queries/useJobs";
+import { useCan } from "@admin/hooks/useCan";
+import {
+  JOB_RETENTION_DAYS,
+  type JobDisplayStatus,
+  type JobWindowSize,
+} from "@admin/types/jobs";
+
+const BACKGROUND_JOBS_PAGE = {
+  title: "Background Jobs",
+  description:
+    "What the queue recently ran, and what it could not finish. Read-only.",
+  crumb: "Background Jobs",
+} as const;
+
+const DEFAULT_WINDOW: JobWindowSize = 50;
+
+export const BackgroundJobsContent: React.FC = () => {
+  const canRead = useCan("manage-background-jobs");
+  const [windowSize, setWindowSize] = useState<JobWindowSize>(DEFAULT_WINDOW);
+  const [status, setStatus] = useState<JobDisplayStatus | undefined>();
+
+  const { data, isLoading, isError, error, isPlaceholderData } = useJobs(
+    { limit: windowSize },
+    { enabled: canRead }
+  );
+
+  /*
+   * The clock ages are measured against, advanced on the poll's own cadence.
+   *
+   * Read once per render from `new Date()` instead, and every row's "4 minutes
+   * ago" would freeze between fetches while the page looks live — and any
+   * render for an unrelated reason would jump them forward. One ticking value
+   * keeps every row's age consistent with every other row's.
+   */
+  const [now, setNow] = useState(() => new Date());
+  useEffect(() => {
+    const timer = setInterval(() => setNow(new Date()), JOBS_POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, []);
+
+  if (!canRead) {
+    return (
+      <Alert variant="info" role="status">
+        <AlertDescription>
+          You do not have permission to view background jobs.
+        </AlertDescription>
+      </Alert>
+    );
+  }
+
+  if (isError) {
+    return (
+      <PageErrorFallback error={error ?? new Error("Failed to load jobs")} />
+    );
+  }
+
+  if (isLoading && !data) {
+    return <TableSkeleton columns={6} rowCount={8} />;
+  }
+
+  const items = data?.items ?? [];
+  // Filtered here rather than by the server, and that is a property of the
+  // vocabulary rather than a shortcut: `waiting` and `retrying` are the SAME
+  // stored state, so a server-side status filter could not tell them apart.
+  // The window is what was fetched, so the filter narrows what is on screen and
+  // the count below says so.
+  const visible =
+    status === undefined ? items : items.filter(job => job.status === status);
+
+  return (
+    <div className="space-y-6">
+      <JobFailureSummary linkToMonitor={false} limit={windowSize} />
+
+      <JobsTable
+        rows={visible}
+        isLoading={isPlaceholderData}
+        status={status}
+        windowSize={windowSize}
+        now={now}
+        onStatusChange={setStatus}
+        onWindowSizeChange={setWindowSize}
+      />
+
+      <p className="text-xs text-muted-foreground">
+        {status === undefined
+          ? `Showing ${items.length} of the most recently active jobs.`
+          : `Showing ${visible.length} of ${items.length} loaded jobs.`}{" "}
+        {data?.meta.hasNext === true && (
+          <>
+            More exist than this window holds — raise &ldquo;Show&rdquo; to load
+            them.{" "}
+          </>
+        )}
+        Finished jobs are removed after {JOB_RETENTION_DAYS} days, so a job
+        missing from this list may have run and been cleaned up rather than
+        never having run. Refreshes every{" "}
+        {Math.round(JOBS_POLL_INTERVAL_MS / 1000)} seconds while this tab is
+        open.
+      </p>
+    </div>
+  );
+};
+
+export default function BackgroundJobsPage() {
+  return (
+    <QueryErrorBoundary fallback={<PageErrorFallback />}>
+      <PageContainer width="wide">
+        <SettingsLayout {...BACKGROUND_JOBS_PAGE}>
+          <BackgroundJobsContent />
+        </SettingsLayout>
+      </PageContainer>
+    </QueryErrorBoundary>
+  );
+}

--- a/packages/admin/src/pages/dashboard/settings/background-jobs/index.tsx
+++ b/packages/admin/src/pages/dashboard/settings/background-jobs/index.tsx
@@ -36,8 +36,10 @@ import { JOBS_POLL_INTERVAL_MS, useJobs } from "@admin/hooks/queries/useJobs";
 import { useCan } from "@admin/hooks/useCan";
 import {
   DEFAULT_JOB_RETENTION_DAYS,
+  storedStatesFor,
   type JobDisplayStatus,
   type JobWindowSize,
+  type ListJobsParams,
 } from "@admin/types/jobs";
 
 const BACKGROUND_JOBS_PAGE = {
@@ -49,13 +51,45 @@ const BACKGROUND_JOBS_PAGE = {
 
 const DEFAULT_WINDOW: JobWindowSize = 50;
 
+/**
+ * What the table asks the server for.
+ *
+ * A window is the most recent N rows, so narrowing it only after it arrives
+ * showed an empty table under a notice reporting a failure — the summary asked
+ * the database and the table did not, and one screen contradicted itself.
+ *
+ * The display vocabulary does not map onto the stored column one-for-one, so
+ * this narrows to the states that CAN produce the chosen status and the caller
+ * separates the ones that share a state. Exported because it is the decision
+ * worth asserting, and driving it through the select control would test the
+ * control rather than the query.
+ */
+export function jobsQueryFor(
+  windowSize: JobWindowSize,
+  status: JobDisplayStatus | undefined
+): ListJobsParams {
+  if (status === undefined) return { limit: windowSize };
+  return { limit: windowSize, states: storedStatesFor(status) };
+}
+
 export const BackgroundJobsContent: React.FC = () => {
   const canRead = useCan("manage-background-jobs");
   const [windowSize, setWindowSize] = useState<JobWindowSize>(DEFAULT_WINDOW);
   const [status, setStatus] = useState<JobDisplayStatus | undefined>();
 
+  /*
+   * The status filter is sent to the SERVER, not only applied to what came
+   * back.
+   *
+   * A window is the most recent N rows, so filtering it locally showed an empty
+   * table under a notice reporting a failure — the summary asks the database
+   * and the table did not, and the two disagreed on one screen. The display
+   * vocabulary does not map onto the column one-for-one, so the query narrows
+   * by the stored states that CAN produce the chosen status and the refinement
+   * below separates the ones sharing a state.
+   */
   const { data, isLoading, isError, error, isPlaceholderData } = useJobs(
-    { limit: windowSize },
+    jobsQueryFor(windowSize, status),
     { enabled: canRead }
   );
 
@@ -94,11 +128,12 @@ export const BackgroundJobsContent: React.FC = () => {
   }
 
   const items = data?.items ?? [];
-  // Filtered here rather than by the server, and that is a property of the
-  // vocabulary rather than a shortcut: `waiting` and `retrying` are the SAME
-  // stored state, so a server-side status filter could not tell them apart.
-  // The window is what was fetched, so the filter narrows what is on screen and
-  // the count below says so.
+  // The remaining refinement, and it is a property of the vocabulary rather
+  // than a shortcut: `waiting` and `retrying` are the SAME stored state, and a
+  // live lease makes any state display as `running`, so the column cannot
+  // separate them. The query above has already narrowed to the states that can
+  // produce this status, so what is dropped here is only the rows that share a
+  // state with it.
   const visible =
     status === undefined ? items : items.filter(job => job.status === status);
 

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -1,5 +1,6 @@
 import { lazy } from "react";
 
+import { settingsPanelSlugs } from "../components/layout/sidebar/lib/settings-nav";
 import { RELEASE_SECTION_PERMISSIONS } from "../constants/navigation";
 import { type PublicRoutePath, ROUTES } from "../constants/routes";
 import {
@@ -393,10 +394,14 @@ export const routeConfig: Record<string, RouteConfig> = {
   },
 
   // Settings routes
+  // Any grant that reaches SOMETHING in the panel may open the panel's own URL.
+  // Narrowing it to `manage-settings` turned the rail entry into a door that
+  // closed in the face of anyone whose only destination was further in; the
+  // page itself sends them on to the first one they can reach.
   [ROUTES.SETTINGS]: {
     component: SettingsPage,
     type: "private",
-    requiredPermission: "manage-settings",
+    requiredPermission: settingsPanelSlugs(),
     section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_EMAIL_PROVIDERS]: {

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -41,6 +41,7 @@ import RolesEditPage from "./dashboard/roles/edit";
 import CreateApiKeyPage from "./dashboard/settings/api-keys/create";
 import EditApiKeyPage from "./dashboard/settings/api-keys/edit/[id]";
 import ApiKeysPage from "./dashboard/settings/api-keys/index";
+import BackgroundJobsPage from "./dashboard/settings/background-jobs/index";
 import CreateEmailProviderPage from "./dashboard/settings/email-providers/create";
 import EditEmailProviderPage from "./dashboard/settings/email-providers/edit/[id]";
 import EmailProvidersPage from "./dashboard/settings/email-providers/index";
@@ -462,6 +463,15 @@ export const routeConfig: Record<string, RouteConfig> = {
   // Webhooks settings. `update-webhooks` is the backend's management umbrella
   // (it satisfies read/create/delete too), so each route accepts it in addition
   // to the specific slug — a role with only `update-webhooks` still reaches them.
+  // The background job monitor is a READ, but it is gated on the management
+  // permission: `lastError` is whatever a handler threw, and there is no seeded
+  // read-only slug for this resource to widen to.
+  [ROUTES.SETTINGS_BACKGROUND_JOBS]: {
+    component: BackgroundJobsPage,
+    type: "private",
+    requiredPermission: "manage-background-jobs",
+    section: overridableBy("settings"),
+  },
   [ROUTES.SETTINGS_WEBHOOKS]: {
     component: WebhooksPage,
     type: "private",

--- a/packages/admin/src/services/jobsApi.ts
+++ b/packages/admin/src/services/jobsApi.ts
@@ -20,6 +20,9 @@ function toQuery(params: ListJobsParams): string {
   if (params.limit !== undefined) search.set("limit", String(params.limit));
   // A blank slug is "no filter"; only a non-empty value narrows the query.
   if (params.slug) search.set("slug", params.slug);
+  if (params.states && params.states.length > 0) {
+    search.set("state", params.states.join(","));
+  }
   const query = search.toString();
   return query ? `?${query}` : "";
 }

--- a/packages/admin/src/services/jobsApi.ts
+++ b/packages/admin/src/services/jobsApi.ts
@@ -1,0 +1,42 @@
+/**
+ * Background jobs API service.
+ *
+ * One read: the most recently touched jobs. There is deliberately no retry,
+ * cancel or requeue here — those are writes on already-authorized work and the
+ * server does not offer them.
+ *
+ * Session-or-key read, gated on `manage-background-jobs`. `lastError` carries
+ * whatever a handler threw, so the response is private and uncached and its
+ * text is delivered exactly as recorded.
+ */
+
+import { fetcher } from "../lib/api/fetcher";
+import type { ListResponse } from "../lib/api/response-types";
+import type { JobListItem, ListJobsParams } from "../types/jobs";
+
+/** Build the query string, omitting an unset limit so the server's default applies. */
+function toQuery(params: ListJobsParams): string {
+  const search = new URLSearchParams();
+  if (params.limit !== undefined) search.set("limit", String(params.limit));
+  const query = search.toString();
+  return query ? `?${query}` : "";
+}
+
+/**
+ * The most recent jobs, newest activity first.
+ *
+ * `meta.hasNext` says the window was truncated; the meta carries no true total,
+ * because the endpoint has no count to give and a fabricated one would disagree
+ * with the rows beside it.
+ */
+export function listJobs(
+  params: ListJobsParams = {}
+): Promise<ListResponse<JobListItem>> {
+  return fetcher<ListResponse<JobListItem>>(
+    `/jobs${toQuery(params)}`,
+    {},
+    true
+  );
+}
+
+export const jobsApi = { listJobs };

--- a/packages/admin/src/services/jobsApi.ts
+++ b/packages/admin/src/services/jobsApi.ts
@@ -18,6 +18,8 @@ import type { JobListItem, ListJobsParams } from "../types/jobs";
 function toQuery(params: ListJobsParams): string {
   const search = new URLSearchParams();
   if (params.limit !== undefined) search.set("limit", String(params.limit));
+  // A blank slug is "no filter"; only a non-empty value narrows the query.
+  if (params.slug) search.set("slug", params.slug);
   const query = search.toString();
   return query ? `?${query}` : "";
 }

--- a/packages/admin/src/types/jobs.ts
+++ b/packages/admin/src/types/jobs.ts
@@ -13,6 +13,7 @@
 import { DEFAULT_RETENTION_MS } from "nextly/api/jobs-list-types";
 
 export {
+  ATTENTION_STATES,
   DEFAULT_RETENTION_MS,
   JOB_DISPLAY_STATUSES,
   jobNeedsAttention,
@@ -38,6 +39,14 @@ export interface ListJobsParams {
    * missing from a result that looks complete.
    */
   slug?: string;
+  /**
+   * Restrict to these STORED states.
+   *
+   * How a caller asks "did anything fail" without scanning a window: the
+   * endpoint answers "the most recent N", so looking for failures inside that
+   * window finds none whenever N healthy jobs ran more recently.
+   */
+  states?: readonly string[];
 }
 
 /** The window sizes the screen offers. The endpoint's own ceiling is 200. */

--- a/packages/admin/src/types/jobs.ts
+++ b/packages/admin/src/types/jobs.ts
@@ -10,8 +10,12 @@
  * of an operator.
  */
 
+import { DEFAULT_RETENTION_MS } from "nextly/api/jobs-list-types";
+
 export {
+  DEFAULT_RETENTION_MS,
   JOB_DISPLAY_STATUSES,
+  jobNeedsAttention,
   type JobDisplayStatus,
   type JobListItem,
 } from "nextly/api/jobs-list-types";
@@ -32,10 +36,17 @@ export const JOB_WINDOW_SIZES = [25, 50, 100, 200] as const;
 export type JobWindowSize = (typeof JOB_WINDOW_SIZES)[number];
 
 /**
- * How long the queue keeps a finished job.
+ * How long the queue keeps a finished job BY DEFAULT, in days.
  *
- * Stated so the screen can say it. An operator who does not know a job list is
- * pruned reads an absence as "this never ran", which is the one wrong
- * conclusion this screen exists to prevent.
+ * Derived from the core's own constant rather than written here, and presented
+ * as the default rather than as this installation's policy — because it may not
+ * be. A host passing `retentionMs` to `runJobsPass` keeps rows for some other
+ * period, and `null` disables pruning altogether; nothing on the read path can
+ * observe which was chosen. Saying "removed after 7 days" flatly would be a
+ * claim the screen cannot support, which is worse than the vagueness, since the
+ * whole point of stating retention is that an absence must not be read as
+ * proof a job never ran.
  */
-export const JOB_RETENTION_DAYS = 7;
+export const DEFAULT_JOB_RETENTION_DAYS = Math.round(
+  DEFAULT_RETENTION_MS / (24 * 60 * 60 * 1000)
+);

--- a/packages/admin/src/types/jobs.ts
+++ b/packages/admin/src/types/jobs.ts
@@ -17,6 +17,7 @@ export {
   DEFAULT_RETENTION_MS,
   JOB_DISPLAY_STATUSES,
   jobNeedsAttention,
+  storedStatesFor,
   type JobDisplayStatus,
   type JobListItem,
 } from "nextly/api/jobs-list-types";

--- a/packages/admin/src/types/jobs.ts
+++ b/packages/admin/src/types/jobs.ts
@@ -1,0 +1,41 @@
+/**
+ * Background job UI types.
+ *
+ * Re-exported from the core's published wire contract rather than mirrored.
+ * Every other admin type module in this directory restates the server's shape
+ * by hand, which is correct where the server has no published module to import
+ * — and is exactly how a vocabulary drifts when it does. The status list is the
+ * part that matters: an exhaustive presentation map keyed by it turns a status
+ * added in the core into a compile error here, instead of a blank pill in front
+ * of an operator.
+ */
+
+export {
+  JOB_DISPLAY_STATUSES,
+  type JobDisplayStatus,
+  type JobListItem,
+} from "nextly/api/jobs-list-types";
+
+/**
+ * What the list read accepts.
+ *
+ * `limit` only. The endpoint answers "the most recent N" and offers no offset
+ * paging, because terminal rows are pruned on a retention window and a cursor
+ * into a table that is being pruned behind you names rows that stop existing.
+ */
+export interface ListJobsParams {
+  limit?: number;
+}
+
+/** The window sizes the screen offers. The endpoint's own ceiling is 200. */
+export const JOB_WINDOW_SIZES = [25, 50, 100, 200] as const;
+export type JobWindowSize = (typeof JOB_WINDOW_SIZES)[number];
+
+/**
+ * How long the queue keeps a finished job.
+ *
+ * Stated so the screen can say it. An operator who does not know a job list is
+ * pruned reads an absence as "this never ran", which is the one wrong
+ * conclusion this screen exists to prevent.
+ */
+export const JOB_RETENTION_DAYS = 7;

--- a/packages/admin/src/types/jobs.ts
+++ b/packages/admin/src/types/jobs.ts
@@ -29,6 +29,15 @@ export {
  */
 export interface ListJobsParams {
   limit?: number;
+  /**
+   * Restrict to one registered task.
+   *
+   * Sent to the server rather than applied to the result, because the endpoint
+   * returns the most recent N rows: filtering afterwards filters a window a
+   * busier task may already have filled, and this task's failure would be
+   * missing from a result that looks complete.
+   */
+  slug?: string;
 }
 
 /** The window sizes the screen offers. The endpoint's own ceiling is 200. */

--- a/packages/nextly/package.json
+++ b/packages/nextly/package.json
@@ -202,6 +202,10 @@
     "./api/email-template-preview-types": {
       "types": "./dist/api/email-template-preview-types.d.ts",
       "import": "./dist/api/email-template-preview-types.mjs"
+    },
+    "./api/jobs-list-types": {
+      "types": "./dist/api/jobs-list-types.d.ts",
+      "import": "./dist/api/jobs-list-types.mjs"
     }
   },
   "files": [

--- a/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
+++ b/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
@@ -25,6 +25,9 @@ let requestedLimit = 0;
 /** What task the QUERY was narrowed to, if any. */
 let requestedSlug: string | undefined;
 
+/** Which stored states the QUERY was narrowed to, if any. */
+let requestedStates: readonly string[] | undefined;
+
 /** Rows the fake repository holds; each test sets its own count. */
 let stored: JobSummaryRow[] = [];
 
@@ -52,9 +55,11 @@ const repository = {
   listRecent: async (input: {
     limit: number;
     slug?: string;
+    states?: readonly string[];
   }): Promise<JobSummaryRow[]> => {
     requestedLimit = input.limit;
     requestedSlug = input.slug;
+    requestedStates = input.states;
     // Narrowed HERE, before the limit, exactly as the repository does it.
     const matching =
       input.slug === undefined
@@ -195,6 +200,26 @@ describe("GET /api/jobs", () => {
     stored = [job("j1")];
     await listJobsRoute(request("?slug="));
     expect(requestedSlug).toBeUndefined();
+  });
+
+  it("narrows to the asked-for stored states", async () => {
+    // How a caller asks "did anything fail" without scanning a window: N
+    // healthy jobs running after a failure would push it out of the recent
+    // rows, and the caller would report nothing wrong.
+    stored = [job("j1")];
+    await listJobsRoute(request("?state=failed"));
+    expect(requestedStates).toEqual(["failed"]);
+  });
+
+  it("drops a state name it does not recognise rather than querying it", async () => {
+    // The parameter narrows a read. A name this build does not know cannot be
+    // honoured, and querying it verbatim would return nothing while looking
+    // like a successful check.
+    stored = [job("j1")];
+    await listJobsRoute(request("?state=failed,not-a-state"));
+    expect(requestedStates).toEqual(["failed"]);
+    await listJobsRoute(request("?state=not-a-state"));
+    expect(requestedStates).toBeUndefined();
   });
 
   it("refuses a caller without the jobs permission", async () => {

--- a/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
+++ b/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
@@ -22,14 +22,21 @@ const HELD = "x-test-permissions";
 /** What `listRecent` was asked for, so the probe row can be asserted. */
 let requestedLimit = 0;
 
+/** What task the QUERY was narrowed to, if any. */
+let requestedSlug: string | undefined;
+
 /** Rows the fake repository holds; each test sets its own count. */
 let stored: JobSummaryRow[] = [];
 
-function job(id: string, lastError: string | null = null): JobSummaryRow {
+function job(
+  id: string,
+  lastError: string | null = null,
+  slug = "releases:drain"
+): JobSummaryRow {
   const at = new Date("2026-01-01T00:00:00.000Z");
   return {
     id,
-    slug: "releases:drain",
+    slug,
     state: "failed",
     attemptCount: 1,
     runAt: null,
@@ -42,9 +49,18 @@ function job(id: string, lastError: string | null = null): JobSummaryRow {
 }
 
 const repository = {
-  listRecent: async (input: { limit: number }): Promise<JobSummaryRow[]> => {
+  listRecent: async (input: {
+    limit: number;
+    slug?: string;
+  }): Promise<JobSummaryRow[]> => {
     requestedLimit = input.limit;
-    return stored.slice(0, input.limit);
+    requestedSlug = input.slug;
+    // Narrowed HERE, before the limit, exactly as the repository does it.
+    const matching =
+      input.slug === undefined
+        ? stored
+        : stored.filter(row => row.slug === input.slug);
+    return matching.slice(0, input.limit);
   },
 };
 
@@ -141,6 +157,44 @@ describe("GET /api/jobs", () => {
     expect(body.items[0].lastError).toBe(recorded);
     // The premise: the internal marker never reaches a client.
     expect(response.headers.get("x-nextly-skip-timezone-format")).toBeNull();
+  });
+
+  it("narrows to one task in the QUERY, not after the window", async () => {
+    /*
+     * The failure this closes: a caller wanting one task's recent jobs read the
+     * global window and filtered it afterwards. A busier task fills that window
+     * first, so the requested task's rows are simply not in it — and a caller
+     * asking "did releases:drain fail" gets "no" from a result that never
+     * looked.
+     *
+     * Fifty webhook jobs are more recent than the one release job here, so a
+     * window of ten cannot contain the release job unless the narrowing
+     * happened in the query.
+     */
+    stored = [
+      ...Array.from({ length: 50 }, (_, i) =>
+        job(`w${i}`, null, "webhooks:drain")
+      ),
+      job("r1", "boom", "releases:drain"),
+    ];
+
+    const response = await listJobsRoute(
+      request("?limit=10&slug=releases:drain")
+    );
+    const body = (await response.json()) as {
+      items: Array<{ id: string; slug: string }>;
+    };
+
+    expect(requestedSlug).toBe("releases:drain");
+    expect(body.items.map(item => item.id)).toEqual(["r1"]);
+  });
+
+  it("treats a blank slug as no filter rather than a task named nothing", async () => {
+    // A form submitting an empty field must not silently ask for jobs of a
+    // task that cannot exist, which would answer "nothing failed" forever.
+    stored = [job("j1")];
+    await listJobsRoute(request("?slug="));
+    expect(requestedSlug).toBeUndefined();
   });
 
   it("refuses a caller without the jobs permission", async () => {

--- a/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
+++ b/packages/nextly/src/api/__tests__/jobs-list-route.test.ts
@@ -211,15 +211,35 @@ describe("GET /api/jobs", () => {
     expect(requestedStates).toEqual(["failed"]);
   });
 
-  it("drops a state name it does not recognise rather than querying it", async () => {
-    // The parameter narrows a read. A name this build does not know cannot be
-    // honoured, and querying it verbatim would return nothing while looking
-    // like a successful check.
+  it("REFUSES a state name it does not recognise", async () => {
+    /*
+     * Dropping the unknown name looks conservative and inverts the request: with
+     * every name dropped the filter disappears, so a caller asking to narrow
+     * receives a successful read of EVERY state — the widest possible answer to
+     * a request for a narrower one, with a 200 on it.
+     */
     stored = [job("j1")];
-    await listJobsRoute(request("?state=failed,not-a-state"));
-    expect(requestedStates).toEqual(["failed"]);
-    await listJobsRoute(request("?state=not-a-state"));
+    requestedStates = undefined;
+
+    const response = await listJobsRoute(request("?state=faield"));
+
+    expect(response.status).toBe(400);
+    // And the query was never issued, so nothing widened on the way to failing.
     expect(requestedStates).toBeUndefined();
+  });
+
+  it("refuses a partially unknown filter rather than honouring half of it", async () => {
+    stored = [job("j1")];
+    const response = await listJobsRoute(request("?state=failed,faield"));
+    expect(response.status).toBe(400);
+  });
+
+  it("still accepts every name it does recognise", async () => {
+    // The control: without it the two cases above pass against a route that
+    // refuses all filters.
+    stored = [job("j1")];
+    await listJobsRoute(request("?state=failed,pending"));
+    expect(requestedStates).toEqual(["pending", "failed"]);
   });
 
   it("refuses a caller without the jobs permission", async () => {

--- a/packages/nextly/src/api/jobs-list-route.ts
+++ b/packages/nextly/src/api/jobs-list-route.ts
@@ -29,6 +29,7 @@ import { container } from "../di";
 import { jobDisplayStatus } from "../domains/jobs/job-display-status";
 import type { JobsRepository } from "../domains/jobs/jobs-repository";
 import { getCachedNextly } from "../init";
+import { JOB_STATES, type JobState } from "../schemas/jobs";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
 
 import { PRIVATE_NO_STORE_HEADERS } from "./authenticated-read";
@@ -57,6 +58,27 @@ const MAX_LIMIT = 200;
 function readSlug(request: Request): string | undefined {
   const raw = new URL(request.url).searchParams.get("slug");
   return raw === null || raw.length === 0 ? undefined : raw;
+}
+
+/**
+ * The stored states to restrict the window to, or `undefined` for every state.
+ *
+ * A caller asking "did anything fail" must be able to ask the DATABASE. This
+ * endpoint answers "the most recent N", so a caller that fetched the window and
+ * looked for failures inside it would find none whenever N healthy jobs ran
+ * more recently — and would report that nothing failed, which is the one wrong
+ * answer such a question has.
+ *
+ * Unrecognised names are dropped rather than refused: the parameter narrows a
+ * read, so a name this build does not know can only ever widen the result if
+ * honoured, and dropping it keeps the query to states that exist.
+ */
+function readStates(request: Request): JobState[] | undefined {
+  const raw = new URL(request.url).searchParams.get("state");
+  if (raw === null || raw.length === 0) return undefined;
+  const asked = raw.split(",").map(value => value.trim());
+  const known = JOB_STATES.filter(state => asked.includes(state));
+  return known.length === 0 ? undefined : [...known];
 }
 
 /** Clamped rather than refused: a caller asking for too much gets the ceiling. */
@@ -112,9 +134,11 @@ export const listJobsRoute = withErrorHandler(async (request: Request) => {
    * a result that looks complete. The filter has to happen before the limit or
    * it does not happen at all.
    */
+  const states = readStates(request);
   const window = await repository.listRecent({
     limit: limit + 1,
     ...(slug === undefined ? {} : { slug }),
+    ...(states === undefined ? {} : { states }),
   });
   const hasNext = window.length > limit;
   const rows = hasNext ? window.slice(0, limit) : window;

--- a/packages/nextly/src/api/jobs-list-route.ts
+++ b/packages/nextly/src/api/jobs-list-route.ts
@@ -28,6 +28,7 @@
 import { container } from "../di";
 import { jobDisplayStatus } from "../domains/jobs/job-display-status";
 import type { JobsRepository } from "../domains/jobs/jobs-repository";
+import { NextlyError } from "../errors";
 import { getCachedNextly } from "../init";
 import { JOB_STATES, type JobState } from "../schemas/jobs";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
@@ -69,16 +70,30 @@ function readSlug(request: Request): string | undefined {
  * more recently — and would report that nothing failed, which is the one wrong
  * answer such a question has.
  *
- * Unrecognised names are dropped rather than refused: the parameter narrows a
- * read, so a name this build does not know can only ever widen the result if
- * honoured, and dropping it keeps the query to states that exist.
+ * An unrecognised name is REFUSED, not dropped. Dropping looks conservative and
+ * inverts the request: drop every name in `?state=faield` and the filter is
+ * gone, so a caller asking to narrow gets a successful read of every state
+ * instead — the widest possible answer to a request for a narrower one, with a
+ * 200 on it. Refusing keeps a typo a typo.
  */
 function readStates(request: Request): JobState[] | undefined {
   const raw = new URL(request.url).searchParams.get("state");
   if (raw === null || raw.length === 0) return undefined;
   const asked = raw.split(",").map(value => value.trim());
-  const known = JOB_STATES.filter(state => asked.includes(state));
-  return known.length === 0 ? undefined : [...known];
+  const unknown = asked.filter(
+    value => !JOB_STATES.some(state => state === value)
+  );
+  if (unknown.length > 0) {
+    throw NextlyError.validation({
+      errors: unknown.map(value => ({
+        path: "state",
+        code: "unknown_job_state",
+        message: `Unknown job state "${value}". Known states: ${JOB_STATES.join(", ")}.`,
+      })),
+      logContext: { unknown, known: [...JOB_STATES] },
+    });
+  }
+  return JOB_STATES.filter(state => asked.includes(state));
 }
 
 /** Clamped rather than refused: a caller asking for too much gets the ceiling. */

--- a/packages/nextly/src/api/jobs-list-route.ts
+++ b/packages/nextly/src/api/jobs-list-route.ts
@@ -47,6 +47,18 @@ import { withErrorHandler } from "./with-error-handler";
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
 
+/**
+ * The task to restrict the window to, or `undefined` for every task.
+ *
+ * Read as an opaque string and passed to the query, never interpolated: the
+ * repository parameterises it. An empty value is "no filter" rather than a task
+ * named "", which is what a form submitting a blank field sends.
+ */
+function readSlug(request: Request): string | undefined {
+  const raw = new URL(request.url).searchParams.get("slug");
+  return raw === null || raw.length === 0 ? undefined : raw;
+}
+
 /** Clamped rather than refused: a caller asking for too much gets the ceiling. */
 function readLimit(request: Request): number {
   const raw = new URL(request.url).searchParams.get("limit");
@@ -90,7 +102,20 @@ export const listJobsRoute = withErrorHandler(async (request: Request) => {
    * an operator reading "showing the most recent 50 of more" would go looking
    * for jobs that are not there.
    */
-  const window = await repository.listRecent({ limit: limit + 1 });
+  const slug = readSlug(request);
+  /*
+   * The slug is applied by the QUERY, not after it.
+   *
+   * This endpoint returns the most recent N rows, so a caller that fetched the
+   * global window and filtered it afterwards would be filtering rows a busier
+   * task had already crowded out: its own task's failure would be missing from
+   * a result that looks complete. The filter has to happen before the limit or
+   * it does not happen at all.
+   */
+  const window = await repository.listRecent({
+    limit: limit + 1,
+    ...(slug === undefined ? {} : { slug }),
+  });
   const hasNext = window.length > limit;
   const rows = hasNext ? window.slice(0, limit) : window;
   const now = new Date();

--- a/packages/nextly/src/api/jobs-list-route.ts
+++ b/packages/nextly/src/api/jobs-list-route.ts
@@ -32,6 +32,7 @@ import { getCachedNextly } from "../init";
 import { SKIP_TIMEZONE_FORMAT_HEADER } from "../shared/lib/date-formatting";
 
 import { PRIVATE_NO_STORE_HEADERS } from "./authenticated-read";
+import type { JobListRow } from "./jobs-list-types";
 import { respondList } from "./response-shapes";
 import { requireRouteAnyPermission } from "./route-auth";
 import { withErrorHandler } from "./with-error-handler";
@@ -94,7 +95,11 @@ export const listJobsRoute = withErrorHandler(async (request: Request) => {
   const rows = hasNext ? window.slice(0, limit) : window;
   const now = new Date();
 
-  const items = rows.map(row => ({
+  // Annotated with the PUBLISHED row type, so the shape this route emits and
+  // the shape the admin is typed against are one declaration. A field added
+  // here without adding it there is a compile error rather than a property the
+  // client renders as `undefined`.
+  const items: JobListRow[] = rows.map(row => ({
     id: row.id,
     slug: row.slug,
     state: row.state,

--- a/packages/nextly/src/api/jobs-list-types.ts
+++ b/packages/nextly/src/api/jobs-list-types.ts
@@ -1,0 +1,73 @@
+/**
+ * The wire contract for `GET /api/jobs`, published so a client need not
+ * restate it.
+ *
+ * The admin screen that reads this endpoint has to enumerate the status
+ * vocabulary — to offer a filter, and to give each status a presentation — and
+ * a copy of that vocabulary written on the client is a second list that agrees
+ * only on the day it is written. Importing it makes a status added in the core
+ * a compile error in every exhaustive mapping downstream, which is the only
+ * kind of notice that arrives before a user sees a blank pill.
+ *
+ * Types only. Nothing here reaches into the database or the runtime, so a
+ * client that imports it pays for no graph beyond the shape.
+ *
+ * @module api/jobs-list-types
+ */
+
+import type { JobDisplayStatus } from "../domains/jobs/job-display-status";
+import type { JobState } from "../schemas/jobs";
+
+export {
+  JOB_DISPLAY_STATUSES,
+  type JobDisplayStatus,
+} from "../domains/jobs/job-display-status";
+
+/**
+ * One row as the route assembles it, with instants still `Date`.
+ *
+ * This is the shape the handler builds; {@link JobListItem} is what a client
+ * receives once it has been through JSON. Both exist because a route cannot be
+ * typed with the serialized form and a client cannot be typed with the other —
+ * and they are one declaration rather than two, so a field added here reaches
+ * the client's type without a second edit.
+ */
+export interface JobListRow {
+  id: string;
+  /** The registered task name, e.g. `releases:drain`. */
+  slug: string;
+  /** The stored lifecycle. Present for operators who know the queue. */
+  state: JobState;
+  /**
+   * The DERIVED status, which is the one to display.
+   *
+   * The stored state cannot express it: a retrying job and one that has never
+   * run are both `pending`, and a job executing right now is `pending` with a
+   * live lease.
+   */
+  status: JobDisplayStatus;
+  attemptCount: number;
+  /** Whatever the handler threw, verbatim. Never rewritten in transit. */
+  lastError: string | null;
+  /** When the job asked to run, or `null` for "as soon as a trigger sees it". */
+  runAt: Date | null;
+  /** When the next retry is due, or `null` when none is scheduled. */
+  nextAttemptAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+/**
+ * One row as a client receives it: {@link JobListRow} after JSON, where every
+ * instant is an ISO-8601 string.
+ *
+ * DERIVED from the row rather than transcribed. A transcription is the same
+ * list twice, and the copy is the one that stops tracking.
+ */
+export type JobListItem = {
+  [K in keyof JobListRow]: JobListRow[K] extends Date
+    ? string
+    : JobListRow[K] extends Date | null
+      ? string | null
+      : JobListRow[K];
+};

--- a/packages/nextly/src/api/jobs-list-types.ts
+++ b/packages/nextly/src/api/jobs-list-types.ts
@@ -9,8 +9,11 @@
  * a compile error in every exhaustive mapping downstream, which is the only
  * kind of notice that arrives before a user sees a blank pill.
  *
- * Types only. Nothing here reaches into the database or the runtime, so a
- * client that imports it pays for no graph beyond the shape.
+ * Shape and vocabulary, not machinery. What it carries besides types is the
+ * status list, the attention predicate that reads it, and the default
+ * retention — each one a decision a client would otherwise make for itself.
+ * Nothing here reaches into the database, so a client that imports it pays for
+ * no graph beyond what it asks.
  *
  * @module api/jobs-list-types
  */
@@ -20,8 +23,21 @@ import type { JobState } from "../schemas/jobs";
 
 export {
   JOB_DISPLAY_STATUSES,
+  jobNeedsAttention,
   type JobDisplayStatus,
 } from "../domains/jobs/job-display-status";
+
+/**
+ * How long a finished job is kept BY DEFAULT.
+ *
+ * Published because a monitor has to tell its reader that an absent job may
+ * have run and been pruned, and a client that writes its own "7 days" states a
+ * policy it cannot see. It is only the default: a host passing `retentionMs` to
+ * `runJobsPass` — `null` disables pruning entirely — keeps rows for some other
+ * period, and nothing on the read path can observe which. A client must present
+ * this as the default rather than as the installation's actual policy.
+ */
+export { DEFAULT_RETENTION_MS } from "../domains/jobs/job-retention";
 
 /**
  * One row as the route assembles it, with instants still `Date`.

--- a/packages/nextly/src/api/jobs-list-types.ts
+++ b/packages/nextly/src/api/jobs-list-types.ts
@@ -22,6 +22,7 @@ import type { JobDisplayStatus } from "../domains/jobs/job-display-status";
 import type { JobState } from "../schemas/jobs";
 
 export {
+  ATTENTION_STATES,
   JOB_DISPLAY_STATUSES,
   jobNeedsAttention,
   type JobDisplayStatus,

--- a/packages/nextly/src/api/jobs-list-types.ts
+++ b/packages/nextly/src/api/jobs-list-types.ts
@@ -25,6 +25,7 @@ export {
   ATTENTION_STATES,
   JOB_DISPLAY_STATUSES,
   jobNeedsAttention,
+  storedStatesFor,
   type JobDisplayStatus,
 } from "../domains/jobs/job-display-status";
 

--- a/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
@@ -148,6 +148,28 @@ describe("the status facts table, checked against the function it describes", ()
     expect(ATTENTION_STATES.length).toBeGreaterThan(0);
   });
 
+  it("answers a status this build has never heard of, rather than throwing", () => {
+    /*
+     * A status arrives from the wire. During a rolling deploy a newer server
+     * can send one this build does not know, and indexing the facts table on
+     * that key throws — taking down the page whose whole job is to report that
+     * something is wrong.
+     *
+     * It answers FALSE, which makes the predicate unsafe as the only filter: a
+     * caller asking "did anything fail" narrows by ATTENTION_STATES in the
+     * query, where the server's own vocabulary decides, and uses this to
+     * describe what came back rather than to find it.
+     */
+    expect(() => jobNeedsAttention("quarantined")).not.toThrow();
+    expect(jobNeedsAttention("quarantined")).toBe(false);
+    // Prototype keys are the sharp edge of a plain object lookup.
+    expect(jobNeedsAttention("toString")).toBe(false);
+    expect(jobNeedsAttention("constructor")).toBe(false);
+    // The premise: it still answers TRUE for a status it does know, so this is
+    // not a predicate that has simply stopped working.
+    expect(jobNeedsAttention("failed")).toBe(true);
+  });
+
   it("does not select a state that only quiet statuses can hold", () => {
     // The control. `done` is reachable only as `succeeded`, which needs nobody,
     // so a filter that included it would be selecting healthy rows.

--- a/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
+++ b/packages/nextly/src/domains/jobs/__tests__/job-display-status.test.ts
@@ -9,9 +9,13 @@
  */
 import { describe, expect, it } from "vitest";
 
+import { JOB_STATES } from "../../../schemas/jobs/types";
+
 import {
+  ATTENTION_STATES,
   jobDisplayStatus,
   jobNeedsAttention,
+  storedStatesFor,
   type JobStatusInput,
 } from "../job-display-status";
 
@@ -89,5 +93,64 @@ describe("what a job row means to a person", () => {
     ] as const) {
       expect(jobNeedsAttention(quiet)).toBe(false);
     }
+  });
+});
+
+describe("the status facts table, checked against the function it describes", () => {
+  /*
+   * `STATUS_FACTS` claims which stored states can appear as each display
+   * status, and `ATTENTION_STATES` is computed from it. A table asserted by
+   * hand is a second implementation of `jobDisplayStatus`; these derive it from
+   * the function instead, so the two cannot disagree.
+   */
+  const NOW = new Date("2026-09-02T12:00:00.000Z");
+  const PAST = new Date("2026-09-02T11:00:00.000Z");
+  const FUTURE = new Date("2026-09-02T13:00:00.000Z");
+
+  /** Every row shape the derivation can distinguish, over every stored state. */
+  const rows = JOB_STATES.flatMap(state =>
+    [0, 1].flatMap(attemptCount =>
+      [null, PAST, FUTURE].map(lockedUntil => ({
+        state,
+        attemptCount,
+        lockedUntil,
+      }))
+    )
+  );
+
+  it("declares every stored state that can actually produce each status", () => {
+    for (const row of rows) {
+      const status = jobDisplayStatus(row, NOW);
+      expect(
+        storedStatesFor(status),
+        `${row.state} attempts=${row.attemptCount} lease=${String(row.lockedUntil)} -> ${status}`
+      ).toContain(row.state);
+    }
+    // The premise: the sweep covered every stored state and produced more than
+    // one status, so "contains" is not trivially satisfied.
+    expect(new Set(rows.map(r => r.state)).size).toBe(JOB_STATES.length);
+    expect(
+      new Set(rows.map(r => jobDisplayStatus(r, NOW))).size
+    ).toBeGreaterThan(2);
+  });
+
+  it("selects exactly the states an attention-needing status can hold", () => {
+    // Computed here from the PREDICATE, independently of how the constant is
+    // built, so a constant that stopped tracking the predicate fails.
+    const expected = new Set(
+      rows
+        .filter(row => jobNeedsAttention(jobDisplayStatus(row, NOW)))
+        .map(row => row.state)
+    );
+    expect(new Set(ATTENTION_STATES)).toEqual(expected);
+    // The premise: some status really does need attention, so this is not two
+    // empty sets agreeing.
+    expect(ATTENTION_STATES.length).toBeGreaterThan(0);
+  });
+
+  it("does not select a state that only quiet statuses can hold", () => {
+    // The control. `done` is reachable only as `succeeded`, which needs nobody,
+    // so a filter that included it would be selecting healthy rows.
+    expect(ATTENTION_STATES).not.toContain("done");
   });
 });

--- a/packages/nextly/src/domains/jobs/job-display-status.ts
+++ b/packages/nextly/src/domains/jobs/job-display-status.ts
@@ -117,3 +117,20 @@ export function jobDisplayStatus(
 export function jobNeedsAttention(status: JobDisplayStatus): boolean {
   return status === "failed";
 }
+
+/**
+ * The STORED states that can produce an attention status.
+ *
+ * The bridge between the derived vocabulary and a SQL predicate. A caller
+ * asking "is anything wrong" wants to ask the database, not to fetch a recent
+ * window and inspect it — a window is the most recent N rows, so a busy queue
+ * hides an older failure inside it and the caller concludes, wrongly, that
+ * nothing is wrong.
+ *
+ * Derived from {@link jobDisplayStatus}: it answers `failed` only for a row
+ * whose stored state is `failed`, so that is the only state to select. Kept
+ * beside the predicate it mirrors, because the two must change together.
+ */
+export const ATTENTION_STATES = [
+  "failed",
+] as const satisfies readonly JobStatusInput["state"][];

--- a/packages/nextly/src/domains/jobs/job-display-status.ts
+++ b/packages/nextly/src/domains/jobs/job-display-status.ts
@@ -153,8 +153,21 @@ export function jobDisplayStatus(
  * so the answer stays in one place when a status is added. A caller asking "is
  * anything wrong" must not have to enumerate the vocabulary to find out.
  */
-export function jobNeedsAttention(status: JobDisplayStatus): boolean {
-  return STATUS_FACTS[status].needsAttention;
+export function jobNeedsAttention(status: string): boolean {
+  // TOTAL over strings, not only over the union. A status arrives from the
+  // wire, and during a rolling deploy a newer server can send one this build
+  // has never heard of — the same case `jobStatusPresentation` degrades for.
+  // Indexing the table directly would throw on that key and take the page down.
+  //
+  // An unfamiliar status answers FALSE rather than true, because this predicate
+  // decides whether to RAISE an alarm and a client cannot know what a word it
+  // does not have means. That makes it unsafe as the only filter: a caller
+  // asking "did anything fail" must narrow by ATTENTION_STATES in the query,
+  // where the server's own vocabulary decides, and use this to describe what
+  // came back rather than to find it.
+  return Object.prototype.hasOwnProperty.call(STATUS_FACTS, status)
+    ? STATUS_FACTS[status as JobDisplayStatus].needsAttention
+    : false;
 }
 
 /**

--- a/packages/nextly/src/domains/jobs/job-display-status.ts
+++ b/packages/nextly/src/domains/jobs/job-display-status.ts
@@ -21,18 +21,33 @@
  * @module domains/jobs/job-display-status
  */
 
-/** What a job row is doing, in the terms an operator reasons about. */
-export type JobDisplayStatus =
+/**
+ * Every status the derivation can produce, in the order a queue moves through
+ * them.
+ *
+ * A list rather than a bare union because a client needs to enumerate them —
+ * to offer a filter, or to map each to a presentation — and a client that
+ * writes its own copy of the vocabulary stops agreeing the moment a status is
+ * added here. The union below is derived from it, so there is one list.
+ *
+ * The order is the lifecycle, not a ranking, and a UI listing them may show
+ * them in it.
+ */
+export const JOB_DISPLAY_STATUSES = [
   /** Queued, never attempted. */
-  | "waiting"
+  "waiting",
   /** An attempt failed; another is scheduled. Self-healing, not an alarm. */
-  | "retrying"
+  "retrying",
   /** A runner holds the lease right now. */
-  | "running"
+  "running",
   /** Finished successfully. */
-  | "succeeded"
+  "succeeded",
   /** Attempts are spent. This will not happen without a person. */
-  | "failed";
+  "failed",
+] as const;
+
+/** What a job row is doing, in the terms an operator reasons about. */
+export type JobDisplayStatus = (typeof JOB_DISPLAY_STATUSES)[number];
 
 /** The columns the derivation reads, and nothing more. */
 export interface JobStatusInput {

--- a/packages/nextly/src/domains/jobs/job-display-status.ts
+++ b/packages/nextly/src/domains/jobs/job-display-status.ts
@@ -21,6 +21,8 @@
  * @module domains/jobs/job-display-status
  */
 
+import { JOB_STATES, type JobState } from "../../schemas/jobs/types";
+
 /**
  * Every status the derivation can produce, in the order a queue moves through
  * them.
@@ -49,9 +51,46 @@ export const JOB_DISPLAY_STATUSES = [
 /** What a job row is doing, in the terms an operator reasons about. */
 export type JobDisplayStatus = (typeof JOB_DISPLAY_STATUSES)[number];
 
+/**
+ * What each display status MEANS, in the two ways callers need to know.
+ *
+ * One declaration rather than a predicate and a list that happen to agree.
+ * `jobNeedsAttention` and {@link ATTENTION_STATES} answer the same question at
+ * different layers — "does a person have to act" and "which rows should SQL
+ * select to find out" — and written separately they agree only until a second
+ * actionable status is added. The list would then stay stale, and the database
+ * would discard the new failures before the predicate could ever see them.
+ *
+ * `storedStates` is the inverse of {@link jobDisplayStatus}: the states a row
+ * can hold and still be shown as this status. It is not one-to-one, and that
+ * asymmetry is the whole reason a derivation is needed — `waiting` and
+ * `retrying` are both stored `pending`, and a job executing right now is
+ * `pending` with a live lease. A test derives this table from the function
+ * rather than trusting it, so the two cannot drift either.
+ */
+interface JobStatusFacts {
+  /** Whether this status is one a person has to do something about. */
+  readonly needsAttention: boolean;
+  /** Every stored state that can be displayed as this status. */
+  readonly storedStates: readonly JobState[];
+}
+
+const STATUS_FACTS: Record<JobDisplayStatus, JobStatusFacts> = {
+  waiting: { needsAttention: false, storedStates: ["pending"] },
+  retrying: { needsAttention: false, storedStates: ["pending"] },
+  // EVERY stored state, because a live lease is read before the column and
+  // overrides it. `claim` takes the lease without changing the state, so an
+  // in-flight job is usually `pending` — but a row in any state that still
+  // carries an unexpired lease displays as running, so a caller narrowing by
+  // this status in SQL cannot use the column to do it and must test the lease.
+  running: { needsAttention: false, storedStates: [...JOB_STATES] },
+  succeeded: { needsAttention: false, storedStates: ["done"] },
+  failed: { needsAttention: true, storedStates: ["failed"] },
+};
+
 /** The columns the derivation reads, and nothing more. */
 export interface JobStatusInput {
-  state: "pending" | "running" | "done" | "failed";
+  state: JobState;
   attemptCount: number;
   /**
    * When this runner's lease expires, or `null` when nothing holds one.
@@ -115,11 +154,23 @@ export function jobDisplayStatus(
  * anything wrong" must not have to enumerate the vocabulary to find out.
  */
 export function jobNeedsAttention(status: JobDisplayStatus): boolean {
-  return status === "failed";
+  return STATUS_FACTS[status].needsAttention;
 }
 
 /**
- * The STORED states that can produce an attention status.
+ * The stored states a row can hold and still be displayed as `status`.
+ *
+ * The inverse of {@link jobDisplayStatus}, exposed so a caller narrowing a
+ * query by a DISPLAY status can name the stored states that produce it —
+ * `retrying` and `waiting` are both `pending`, so a caller comparing the
+ * display vocabulary against the column would select nothing.
+ */
+export function storedStatesFor(status: JobDisplayStatus): readonly JobState[] {
+  return STATUS_FACTS[status].storedStates;
+}
+
+/**
+ * The STORED states a caller must select to find every job needing attention.
  *
  * The bridge between the derived vocabulary and a SQL predicate. A caller
  * asking "is anything wrong" wants to ask the database, not to fetch a recent
@@ -127,10 +178,15 @@ export function jobNeedsAttention(status: JobDisplayStatus): boolean {
  * hides an older failure inside it and the caller concludes, wrongly, that
  * nothing is wrong.
  *
- * Derived from {@link jobDisplayStatus}: it answers `failed` only for a row
- * whose stored state is `failed`, so that is the only state to select. Kept
- * beside the predicate it mirrors, because the two must change together.
+ * COMPUTED from {@link STATUS_FACTS} rather than listed, so a status added
+ * there with `needsAttention` widens this set in the same edit. A hand-written
+ * list goes stale silently and in the dangerous direction: the SQL discards the
+ * new failures before any predicate can inspect them.
  */
-export const ATTENTION_STATES = [
-  "failed",
-] as const satisfies readonly JobStatusInput["state"][];
+export const ATTENTION_STATES: readonly JobState[] = [
+  ...new Set(
+    JOB_DISPLAY_STATUSES.filter(
+      status => STATUS_FACTS[status].needsAttention
+    ).flatMap(status => STATUS_FACTS[status].storedStates)
+  ),
+];

--- a/packages/nextly/src/domains/jobs/job-retention.ts
+++ b/packages/nextly/src/domains/jobs/job-retention.ts
@@ -1,0 +1,30 @@
+/**
+ * How long a finished job row is kept, as a leaf.
+ *
+ * Split out of `jobs-runner` for one reason: the runner imports the Direct API,
+ * so anything re-exporting this constant from there hands that whole graph to
+ * every client that only wanted a number. The admin's monitor has to state the
+ * retention policy — an absent job may have run and been pruned, and a reader
+ * who does not know that concludes it never ran — and it must not pay for the
+ * queue's runtime to say so.
+ *
+ * @module domains/jobs/job-retention
+ */
+
+/** How long a finished job row is kept before a pass may remove it. */
+export const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
+
+/**
+ * The retention a pass will apply, given what the caller asked for.
+ *
+ * `undefined` means "unspecified", which takes the default. `null` is a
+ * DECISION — keep everything — and must survive as itself: collapsing it into
+ * the default would turn an explicit opt-out into pruned history a deployment
+ * had asked to keep. Named and exported so that distinction is testable rather
+ * than one character inside a longer function.
+ */
+export function resolveRetentionMs(
+  option: number | null | undefined
+): number | null {
+  return option === undefined ? DEFAULT_RETENTION_MS : option;
+}

--- a/packages/nextly/src/domains/jobs/jobs-repository.ts
+++ b/packages/nextly/src/domains/jobs/jobs-repository.ts
@@ -335,6 +335,17 @@ export class JobsRepository {
     limit: number;
     /** Restrict to these states. Omitted means every state. */
     states?: readonly JobState[];
+    /**
+     * Restrict to one registered task. Omitted means every task.
+     *
+     * Applied in the QUERY rather than by the caller, and that is the whole
+     * point of it: this method returns the most recent `limit` rows, so a
+     * caller filtering afterwards is filtering a window that a busier task may
+     * already have filled. Its own task's failure would then be absent from a
+     * result that looks complete — a notice that stays silent about exactly the
+     * thing it was mounted to report.
+     */
+    slug?: string;
   }): Promise<JobSummaryRow[]> {
     // PROJECTED, deliberately. `input` is arbitrary caller data of unbounded
     // size and no consumer of this method reads it, so selecting it would let
@@ -342,13 +353,20 @@ export class JobsRepository {
     // database and into memory for nothing.
     return this.db.select<JobSummaryRow>(JOBS, {
       columns: [...SUMMARY_COLUMNS],
-      ...(input.states === undefined || input.states.length === 0
-        ? {}
-        : {
-            where: {
-              and: [{ column: "state", op: "IN", value: [...input.states] }],
-            },
-          }),
+      ...(() => {
+        const conditions: Array<Record<string, unknown>> = [];
+        if (input.states !== undefined && input.states.length > 0) {
+          conditions.push({
+            column: "state",
+            op: "IN",
+            value: [...input.states],
+          });
+        }
+        if (input.slug !== undefined) {
+          conditions.push({ column: "slug", op: "=", value: input.slug });
+        }
+        return conditions.length === 0 ? {} : { where: { and: conditions } };
+      })(),
       orderBy: [{ column: "updatedAt", direction: "desc" }],
       limit: input.limit,
     });

--- a/packages/nextly/src/domains/jobs/jobs-runner.ts
+++ b/packages/nextly/src/domains/jobs/jobs-runner.ts
@@ -15,6 +15,7 @@ import { listRoleSlugsForUserStrict } from "../../services/lib/permissions";
 import type { RunAsDeps, RunAsUser } from "../../shared/lib/resolve-run-as";
 
 import type { JobRegistry } from "./job-registry";
+import { DEFAULT_RETENTION_MS, resolveRetentionMs } from "./job-retention";
 import { JobsRepository, type JobsDatabase } from "./jobs-repository";
 import { SWEEP_KEY_PREFIX } from "./portable-key";
 import { runJobs, type RunJobsResult } from "./run-jobs";
@@ -54,24 +55,6 @@ function executorOf(db: UsersReadDb): unknown {
  */
 export type JobsPassDatabase = JobsDatabase & UsersReadDb;
 
-/** How long a finished job row is kept before a pass may remove it. */
-export const DEFAULT_RETENTION_MS = 7 * 24 * 60 * 60 * 1_000;
-
-/**
- * How long finished rows are kept, from the option a deployment passed.
- *
- * Three states, not two: `undefined` is "unset, take the default", `null` is
- * "keep everything, I prune it myself", and a number is a window. Nullish
- * coalescing collapses the first two, which is what turned the documented
- * opt-out back into the default and pruned history a deployment had asked to
- * keep. Named and exported so that distinction is testable rather than one
- * character inside a longer function.
- */
-export function resolveRetentionMs(
-  option: number | null | undefined
-): number | null {
-  return option === undefined ? DEFAULT_RETENTION_MS : option;
-}
 /** Rows a single pass may remove, so a sweep cannot become a long delete. */
 export const DEFAULT_PRUNE_LIMIT = 100;
 
@@ -257,3 +240,10 @@ export async function runJobsPass(
 
   return result;
 }
+
+/**
+ * Re-exported so existing importers keep one name for them. Declared in
+ * `./job-retention`, a leaf, because this module imports the Direct API and a
+ * client wanting the number must not pay for that.
+ */
+export { DEFAULT_RETENTION_MS, resolveRetentionMs };

--- a/packages/nextly/tsup.config.js
+++ b/packages/nextly/tsup.config.js
@@ -41,6 +41,7 @@ const serverEntries = [
   "src/api/email-providers.ts",
   "src/api/email-provider-types.ts",
   "src/api/email-template-preview-types.ts",
+  "src/api/jobs-list-types.ts",
   "src/api/email-providers-detail.ts",
   "src/api/email-providers-test.ts",
   "src/api/email-providers-default.ts",


### PR DESCRIPTION
A background job that fails is invisible: no request to inspect, no status code, no page that went blank. `GET /api/jobs` (#1438) made the queue readable. This is the screen that reads it.

## Where it lives

Settings → Background Jobs, beside Webhooks. It is machinery an operator watches rather than editorial work, which is the same reasoning that put webhooks there and the reason `background-jobs` sits after `webhooks` in the system-resource list.

## What it does, and what it deliberately does not

Read-only. No retry, no cancel, no requeue — each is a write on already-authorized work needing its own decision about who may perform it, and offering them beside a read would settle those questions by omission.

**Failures are stated above the table.** The question that brings someone to this page is almost always "did the thing I expected happen", and a red row twelve lines down is a worse answer than a sentence at the top.

`JobFailureSummary` is its own component and fetches and authorizes for itself, so a release or webhook page can mount it beside the object whose work failed by adding one element and nothing else. It renders nothing when nothing failed, while the window is loading, and for a viewer without the permission — a notice that appears routinely is one its reader learns to skip.

**A retrying job is not presented as a failure.** It is the system healing itself and needs nobody; colouring it like a dead job raises an alarm for the harmless case and buries the one that matters. `failed` is the only red pill on the screen. This is the distinction the derived status exists for: `waiting` and `retrying` are the same stored state.

## Two sentences that keep it honest

- It says when the window is truncated, driven by `meta.hasNext`. Otherwise fifty rows read as the whole story.
- It states the seven-day retention. A list that silently forgets is one an operator reads as proof a job never ran — the exact wrong conclusion this screen exists to prevent.

Both are asserted by tests that fail when the sentence is removed or made unconditional.

## The contract, imported rather than restated

`nextly` now publishes `nextly/api/jobs-list-types`. The wire item is DERIVED from the row type the route emits (a mapped type over it, not a transcription), and the status union is derived from a single list. So:

- a field added to the route reaches the admin's types without a second edit;
- a status added in the core is a compile error in the admin's presentation map rather than a blank pill;
- an unfamiliar status still renders verbatim, for a server ahead of the client.

The route now annotates its mapper with that published row type, so the two cannot drift.

## Evidence

22 new tests. Each group was break-verified against the production module:

- removing the settings-nav entry fails 6 of the 7 reachability assertions, and leaves "the route is registered" passing — the two failures the releases-nav test documents are distinguished;
- admitting `retrying` into `failedJobs` fails the exclusion test and the render test;
- making `retrying` destructive fails the variant test;
- making the truncation notice unconditional fails its control; removing the retention sentence fails its own test.

Full suites green: 853 files / 10 598 tests in `nextly`, 382 files / 3 647 tests in `admin`. Typecheck, eslint, comment-convention and `fallow --gate new-only` (21 changed files, no issues) all pass.

## Not verified

The page composes primitives that are already visually covered (`SettingsLayout`, `DataTableView`, `Alert`, `Badge`, `Select`), and jsdom cannot see layout. No browser check was run.

Prior art for the status vocabulary and the retry/dead distinction: Sidekiq's dashboard and dead set, and Laravel Horizon's failed-jobs view, both of which separate a retrying job from a terminal one and expose a retention boundary explicitly.