### PR TITLE
feat(builder): draw a style control as the kind of value it edits

### DIFF
--- a/.changeset/style-fields-read-as-rows.md
+++ b/.changeset/style-fields-read-as-rows.md
@@ -1,0 +1,35 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The page builder's inspector is easier to read. A property's label now sits
+beside its control instead of above it, so a group of settings fits on screen
+together instead of being scrolled through — and the panel re-stacks on its own
+when you drag the rail narrow.
+
+Settings offering three short choices, such as font style, are now shown as
+three buttons rather than a menu you have to open to see them.

--- a/packages/builder/src/style-field-layout-styles.test.ts
+++ b/packages/builder/src/style-field-layout-styles.test.ts
@@ -1,0 +1,171 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * How a style field lays out, asserted against the sheet that decides it.
+ *
+ * A field's shape is not observable from a render test: jsdom applies no
+ * stylesheet, so every assertion about which column a control sits in passes
+ * whatever the sheet says. The declarations ARE the behaviour here, and this
+ * reads them from the source sheet — `dist` is gitignored, so a check against
+ * the built copy answers differently before and after a build.
+ *
+ * Each test below asserts a declaration inside the block that owns it, rather
+ * than a substring of the file. A 2000-line sheet contains most short strings
+ * somewhere, so `toContain` alone would go green on a declaration sitting in an
+ * unrelated rule — which is the reading these tests exist to rule out.
+ *
+ * @module style-field-layout-styles.test
+ */
+const CHROME = readFileSync(
+  fileURLToPath(new URL("./styles/builder-chrome.css", import.meta.url)),
+  "utf8"
+);
+
+/**
+ * The declarations of one rule, found by its exact selector.
+ *
+ * Scoped to the selector's own braces so a declaration is attributed to the
+ * rule that makes it. Declaration blocks here hold no nested braces, so the
+ * first `}` closes the rule.
+ *
+ * @param sheet - the stylesheet to read
+ * @param selector - the selector text, exactly as written in the sheet
+ * @returns the text between that rule's braces
+ */
+function ruleBody(sheet: string, selector: string): string {
+  const open = sheet.indexOf(`${selector} {`);
+  if (open === -1) throw new Error(`no rule for selector: ${selector}`);
+  const start = open + `${selector} {`.length;
+  const close = sheet.indexOf("}", start);
+  if (close === -1) throw new Error(`unterminated rule: ${selector}`);
+  return sheet.slice(start, close);
+}
+
+describe("a style field is a row", () => {
+  it("puts the label in the label column by being a LABEL, not by position", () => {
+    /*
+     * The property that survives a field whose children arrive in another
+     * order. A positional rule answers the same way for an ordinary field and
+     * gets a checkbox row exactly backwards, so the sheet must not be
+     * addressing the first child.
+     */
+    expect(ruleBody(CHROME, ".nx-inspector__field > label")).toContain(
+      "grid-column: 1"
+    );
+    expect(CHROME).not.toContain(".nx-inspector__field > :first-child");
+  });
+
+  it("finds nothing for a selector that was never written", () => {
+    /*
+     * The control. Every assertion here is a search over one long file, and one
+     * needle that MUST be absent is what shows the search can come out empty
+     * rather than matching something incidental.
+     */
+    expect(CHROME).not.toContain(".nx-inspector__field > :nth-child(97)");
+  });
+});
+
+describe("a checkbox row opts out of the label column", () => {
+  it("restates display, which is what the grid makes necessary", () => {
+    /*
+     * The defect this replaces: the modifier set flex properties only, and a
+     * flex property does not displace `display: grid`. The checkbox was then
+     * sized to the label column with its words in the column beside it.
+     */
+    const inline = ruleBody(
+      CHROME,
+      ".nx-inspector__field.nx-inspector__field--inline"
+    );
+
+    expect(inline).toContain("display: flex");
+    expect(inline).toContain("flex-direction: row");
+  });
+
+  it("wins regardless of where the two rules sit in the file", () => {
+    /*
+     * Two single-class selectors of equal specificity are decided by source
+     * order, which makes the layout a property of the file's arrangement. The
+     * doubled class states the precedence instead, so moving either rule cannot
+     * silently put the checkbox back in the label column.
+     */
+    expect(CHROME).toContain(
+      ".nx-inspector__field.nx-inspector__field--inline {"
+    );
+  });
+});
+
+describe("the segmented control", () => {
+  it("draws each shared edge once, for three buttons as well as two", () => {
+    /*
+     * With two buttons "the last one" and "every one after the first" select
+     * the same button, so the narrower rule looked correct for as long as two
+     * was the only width offered. At three it leaves the first seam two borders
+     * wide and the second one, and the segments stop reading as one control.
+     */
+    expect(
+      ruleBody(CHROME, ".nx-style-inspector__toggle > button + button")
+    ).toContain("border-inline-start-width: 0");
+  });
+
+  it("no longer takes the shared edge off the last button alone", () => {
+    /*
+     * The other half of the same decision. Left in place it would remove the
+     * border a second time on the final button, which is harmless, and leave
+     * the reason for the seam split between two rules that disagree about what
+     * decides it.
+     */
+    expect(
+      ruleBody(CHROME, ".nx-style-inspector__toggle > button:last-child")
+    ).not.toContain("border-inline-start-width");
+  });
+
+  it("lets its buttons shrink, so the control cannot overflow the rail", () => {
+    /*
+     * A flex item's automatic minimum is its content, so without this the
+     * control keeps its full text width and overflows the panel rather than
+     * fitting inside it. This is what makes the control answer for its own
+     * width at any rail size, and therefore what stops the field's stacking
+     * threshold from being a second answer to the same question.
+     */
+    expect(ruleBody(CHROME, ".nx-style-inspector__toggle > button")).toContain(
+      "min-width: 0"
+    );
+  });
+});
+
+describe("the field stacks before a control runs out of room", () => {
+  it("asks the container, not the viewport", () => {
+    /*
+     * The rail is resizable while the window stays wide, so a media query would
+     * answer for the wrong box.
+     *
+     * Read from the fields rule's own body rather than from the file. Three
+     * comments elsewhere in this sheet discuss `container-type: inline-size`,
+     * and a bare search over the file is satisfied by that prose — measured, by
+     * removing the declaration and watching this test go on passing.
+     */
+    const fields = ruleBody(CHROME, ".nx-inspector__fields");
+
+    expect(fields).toContain("container-type: inline-size");
+    expect(fields).toContain("container-name: nx-inspector-fields");
+  });
+
+  it("stacks at a width the supported minimum rail actually reaches", () => {
+    /*
+     * The inspector's minimum is 280px and it carries 0.75rem of padding on
+     * each side, which leaves 16rem of container. A threshold below that never
+     * fires at the narrowest size the panel supports, so the row stays
+     * two-column exactly where it has least room to be.
+     *
+     * Asserted as the number rather than as "some threshold" because the
+     * arithmetic is the decision: 6.5rem of label and 0.5rem of gap leave under
+     * 11rem for a control below 18rem.
+     */
+    expect(CHROME).toContain(
+      "@container nx-inspector-fields (max-width: 18rem)"
+    );
+  });
+});

--- a/packages/builder/src/style-field-layout-styles.test.ts
+++ b/packages/builder/src/style-field-layout-styles.test.ts
@@ -100,22 +100,26 @@ describe("a checkbox row opts out of the label column", () => {
 describe("the segmented control", () => {
   it("draws each shared edge once, for three buttons as well as two", () => {
     /*
-     * With two buttons "the last one" and "every one after the first" select
-     * the same button, so the narrower rule looked correct for as long as two
-     * was the only width offered. At three it leaves the first seam two borders
-     * wide and the second one, and the segments stop reading as one control.
+     * Every button gives its leading border up and the first takes it back, so
+     * the number of buttons cannot enter into it. The alternative — removing
+     * the border from the LAST button — is right only while there are exactly
+     * two, because at two "the last one" and "every one after the first" select
+     * the same element. At three it leaves the first seam two borders wide and
+     * the second one, and the segments stop reading as one control.
      */
+    expect(ruleBody(CHROME, ".nx-style-inspector__toggle > button")).toContain(
+      "border-inline-start-width: 0"
+    );
     expect(
-      ruleBody(CHROME, ".nx-style-inspector__toggle > button + button")
-    ).toContain("border-inline-start-width: 0");
+      ruleBody(CHROME, ".nx-style-inspector__toggle > button:first-child")
+    ).toContain("border-inline-start-width: 1px");
   });
 
   it("no longer takes the shared edge off the last button alone", () => {
     /*
-     * The other half of the same decision. Left in place it would remove the
-     * border a second time on the final button, which is harmless, and leave
-     * the reason for the seam split between two rules that disagree about what
-     * decides it.
+     * The other half of the same decision, and the reason this is stated from
+     * the first button rather than the last: a rule keyed on the final button
+     * is a rule about the count, and it agrees with this one only at two.
      */
     expect(
       ruleBody(CHROME, ".nx-style-inspector__toggle > button:last-child")

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -1257,19 +1257,22 @@ describe("a free-form value the panel must let an author repair", () => {
     expect(editor.applyAll).toHaveBeenCalledTimes(1);
   });
 
-  it("still draws a SELECT for a value the keyword arm accepts", () => {
+  it("still draws the KEYWORD control for a value the keyword arm accepts", () => {
     // The control that separates "the rank learned something" from "the panel
-    // stopped drawing selects".
+    // stopped drawing keyword controls and hands everything a text field".
+    //
+    // Which keyword control it is, is not the property under test. `fontStyle`
+    // offers three short values, so it draws them as a group of buttons rather
+    // than a menu — the discriminator here is that an accepted keyword does NOT
+    // fall through to the free-form field the case above repairs in.
     const styles = {
       base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
     } as NodeStyles;
     mount({ typography: true }, styles);
 
-    // Named, because a union property draws TWO comboboxes — the form selector
-    // and the value — and an unnamed query would pass on either.
     expect(fieldsOf("fontStyle").queryByRole("textbox")).toBeNull();
     expect(
-      fieldsOf("fontStyle").getByRole("combobox", { name: "Font style" })
+      fieldsOf("fontStyle").getByRole("button", { name: "italic" })
     ).toBeDefined();
   });
 });

--- a/packages/builder/src/style-inspector-panel.tsx
+++ b/packages/builder/src/style-inspector-panel.tsx
@@ -3162,14 +3162,14 @@ function ToggleField({
 }: {
   id: string;
   labelledBy: string;
-  options: readonly [string, string];
+  options: readonly string[];
   stored: StyleValue | undefined;
   describedBy: string | undefined;
   onCommit: (value: StyleValue | null) => CommitOutcome;
 }): React.JSX.Element {
   return (
     <div
-      // The field's id sits on the GROUP rather than on either button. The
+      // The field's id sits on the GROUP rather than on any one button. The
       // field label carries `htmlFor`, and a label pointing at a button
       // forwards a click to it — so naming the first option that way would make
       // clicking the property label press it, or clear it when already pressed,
@@ -3197,8 +3197,8 @@ function ToggleField({
             // announces the message as a hint rather than as a failure.
             aria-invalid={describedBy === undefined ? undefined : true}
             // Pressing the pressed option CLEARS rather than re-writing it,
-            // which is the only way a two-button group can reach unset without
-            // a third button standing for "neither".
+            // which is the only way a group of options can reach unset without
+            // spending a button on "neither".
             onClick={() => onCommit(pressed ? null : option)}
           >
             {option}

--- a/packages/builder/src/style-numeric.test.ts
+++ b/packages/builder/src/style-numeric.test.ts
@@ -280,7 +280,46 @@ describe("a toggle is a projection of a keyword leaf", () => {
     expect(toggleOptionsFor(two)).toEqual(["normal", "italic"]);
   });
 
-  it("declines a vocabulary that does not fit in two buttons", () => {
+  /*
+   * Three fits too. The rule was never "two is special" — the docblock's own
+   * condition is that the WHOLE vocabulary fits in the control, so a keyword
+   * offering three short values is offered whole rather than folded into a menu
+   * an author has to open to see three words.
+   */
+  it("offers all three when the whole vocabulary is three short keywords", () => {
+    const three = {
+      kind: "keyword",
+      values: ["normal", "italic", "oblique"],
+    } as unknown as StyleLeaf;
+
+    expect(toggleOptionsFor(three)).toEqual(["normal", "italic", "oblique"]);
+  });
+
+  /*
+   * Length decides as well as count, because the control is a row in a rail an
+   * author can drag narrow. Three long words do not fit side by side, and a
+   * segmented control that wraps to three lines is worse than the menu it
+   * replaced — it takes more height AND still has to be read word by word.
+   */
+  it("declines three keywords too long to sit side by side", () => {
+    const long = {
+      kind: "keyword",
+      values: ["nowrap", "wrap", "wrap-reverse-and-then-some"],
+    } as unknown as StyleLeaf;
+
+    expect(toggleOptionsFor(long)).toBeUndefined();
+  });
+
+  it("declines a vocabulary of four, whatever its length", () => {
+    const four = {
+      kind: "keyword",
+      values: ["a", "b", "c", "d"],
+    } as unknown as StyleLeaf;
+
+    expect(toggleOptionsFor(four)).toBeUndefined();
+  });
+
+  it("declines a vocabulary that does not fit in the control", () => {
     // `display` has many values; drawing two of them would hide the rest.
     const display = entry("display").shape as unknown as StyleLeaf;
     expect(toggleOptionsFor(display)).toBeUndefined();

--- a/packages/builder/src/style-numeric.ts
+++ b/packages/builder/src/style-numeric.ts
@@ -447,25 +447,55 @@ function stepDecimals(valueDecimals: number, delta: number): number {
 }
 
 /**
- * The two options a keyword leaf offers, when offering both at once is
- * possible.
+ * How many options a segmented control may offer.
+ *
+ * Three, not two — the condition was never that two is special, it is that the
+ * WHOLE vocabulary fits in the control. A keyword offering three short values
+ * fits, and folding it into a menu makes an author open something to read three
+ * words that could have been on screen.
+ */
+const MAX_TOGGLE_OPTIONS = 3;
+
+/**
+ * The longest a single option may be, and the longest they may be together.
+ *
+ * Length decides as well as count, because this draws in a rail an author can
+ * drag narrow. Three long words do not sit side by side there, and a segmented
+ * control that wraps onto three lines is worse than the menu it replaced: it
+ * takes MORE height and still has to be read word by word. The bounds are
+ * deliberately mean, so the control appears only where it plainly fits and the
+ * menu keeps everything else.
+ */
+const MAX_OPTION_LENGTH = 8;
+const MAX_OPTIONS_LENGTH = 20;
+
+/**
+ * The options a keyword leaf offers, when offering all of them at once fits.
  *
  * A toggle is a PROJECTION of a keyword leaf and not a shape of its own — the
  * engine has no boolean — so it is offered only where the whole vocabulary fits
- * in it: exactly two values, and one keyword per value. A leaf taking a
- * shorthand of two keywords (`overflow: hidden auto`) has more to say than two
- * buttons can, and drawing one would hide the second axis entirely.
+ * in it: at most three values, each short, and one keyword per value. A leaf
+ * taking a shorthand of two keywords (`overflow: hidden auto`) has more to say
+ * than a row of buttons can, and drawing one would hide the second axis
+ * entirely.
+ *
+ * Returned whole or not at all. Offering the first three of a longer vocabulary
+ * would be a control that silently cannot reach the values it does not show.
  */
 export function toggleOptionsFor(
   leaf: StyleLeaf
-): readonly [string, string] | undefined {
+): readonly string[] | undefined {
   if (leaf.kind !== "keyword") return undefined;
   if ((leaf.maxParts ?? 1) !== 1) return undefined;
-  const [first, second, ...rest] = leaf.values;
-  if (first === undefined || second === undefined || rest.length > 0) {
-    return undefined;
-  }
-  return [first, second];
+
+  const values = leaf.values;
+  if (values.length < 2 || values.length > MAX_TOGGLE_OPTIONS) return undefined;
+  if (values.some(value => value.length > MAX_OPTION_LENGTH)) return undefined;
+
+  const together = values.reduce((sum, value) => sum + value.length, 0);
+  if (together > MAX_OPTIONS_LENGTH) return undefined;
+
+  return values;
 }
 
 /**
@@ -478,7 +508,7 @@ export function toggleOptionsFor(
  * show what is actually stored.
  */
 export function toggleShows(
-  options: readonly [string, string],
+  options: readonly string[],
   value: StyleValue | undefined
 ): boolean {
   if (value === undefined) return true;

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -577,16 +577,72 @@
   color: var(--nx-muted-foreground);
 }
 
+/*
+ * A container, so a field can answer for the RAIL's width rather than the
+ * window's. The rail is resizable, so the width that decides whether a label
+ * fits beside its control is not a property of the viewport.
+ */
 .nx-inspector__fields {
   display: flex;
   flex-direction: column;
-  gap: 0.875rem;
+  gap: 0.5rem;
+  container-type: inline-size;
+  container-name: nx-inspector-fields;
 }
 
+/*
+ * A label BESIDE its control rather than stacked above it.
+ *
+ * Stacked, every field spent two rows and a gap on one value, so a panel
+ * offering eleven groups of properties showed a handful at a time and an author
+ * scrolled to compare two numbers that belong together. Beside, the same field
+ * is one row: the panel roughly halves in height and a group can be read at
+ * once, which is what makes a group a group.
+ *
+ * The label column is bounded rather than sized to content. Content sizing
+ * would let the longest label in a group set the indent for every other one, so
+ * the controls in Typography and the controls in Spacing would start at
+ * different places and stop reading as columns at all.
+ */
 .nx-inspector__field {
-  display: flex;
-  flex-direction: column;
-  gap: 0.375rem;
+  display: grid;
+  grid-template-columns: minmax(0, 5.5rem) minmax(0, 1fr);
+  align-items: center;
+  column-gap: 0.5rem;
+  row-gap: 0.25rem;
+}
+
+/*
+ * Everything that is not the label sits in the second column and stacks: a
+ * field holds its control, sometimes a breakpoint action, and sometimes an
+ * error, and all three describe the same value. Addressed by position rather
+ * than by element, because the control is whichever component the value's kind
+ * chose and naming them here would be a list to keep in step.
+ */
+.nx-inspector__field > * {
+  grid-column: 2;
+  min-width: 0;
+}
+
+.nx-inspector__field > :first-child {
+  grid-column: 1;
+  grid-row: 1;
+}
+
+/*
+ * Below the width where a label and a control can share a row, the field goes
+ * back to stacking. Asked of the CONTAINER: the rail can be dragged narrow
+ * while the window stays wide, and a media query would answer for the window.
+ */
+@container nx-inspector-fields (max-width: 15rem) {
+  .nx-inspector__field {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .nx-inspector__field > *,
+  .nx-inspector__field > :first-child {
+    grid-column: 1;
+  }
 }
 
 /*

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -874,6 +874,8 @@
   min-width: 0;
   padding: 0.25rem 0.5rem;
   border: 1px solid var(--nx-border);
+  /* Given up here and taken back by the first button, so a seam is one border. */
+  border-inline-start-width: 0;
   background: var(--nx-background);
   color: var(--nx-foreground);
   font: inherit;
@@ -881,18 +883,18 @@
 }
 
 /*
- * The shared edge is drawn ONCE, by the button on its leading side.
+ * The group's leading edge belongs to the group, not to each button in it.
  *
- * Addressed as "every button after the first" rather than as the last one: with
- * two buttons those are the same button and with three they are not, so the
- * narrower rule leaves the middle seam two borders wide while the one beside it
- * is one, and the segments stop reading as a single control.
+ * Every button gives its leading border up and the first one takes it back, so
+ * a seam between two buttons is drawn once however many there are. Stated this
+ * way round because the alternative — removing the border from the LAST button
+ * — is right only while there are exactly two: with three it leaves the first
+ * seam two borders wide and the second one, and the segments stop reading as a
+ * single control. This way the count cannot enter into it, and the rule needs
+ * no selector beyond the two the radii already use.
  */
-.nx-style-inspector__toggle > button + button {
-  border-inline-start-width: 0;
-}
-
 .nx-style-inspector__toggle > button:first-child {
+  border-inline-start-width: 1px;
   border-start-start-radius: var(--radius-md);
   border-end-start-radius: var(--radius-md);
 }

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -629,7 +629,16 @@
   min-width: 0;
 }
 
-.nx-inspector__field > :first-child {
+/*
+ * The label, addressed as a LABEL rather than as the first child.
+ *
+ * Position is not a property a field has: a checkbox row puts its control
+ * first so the box sits beside the words it names, and a positional rule sends
+ * that checkbox to the label column and the words to the control column. The
+ * element answers what the position only usually implies, and it keeps
+ * answering for a field whose children arrive in another order.
+ */
+.nx-inspector__field > label {
   grid-column: 1;
   grid-row: 1;
 }
@@ -638,14 +647,26 @@
  * Below the width where a label and a control can share a row, the field goes
  * back to stacking. Asked of the CONTAINER: the rail can be dragged narrow
  * while the window stays wide, and a media query would answer for the window.
+ *
+ * The threshold is the row's own arithmetic rather than a round number: the
+ * label column is 6.5rem and the gap 0.5rem, so a control keeps less than 11rem
+ * below 18rem — under what the widest segmented control needs to show its whole
+ * vocabulary. The inspector's supported minimum is 280px, which is 16rem of
+ * container once its 0.75rem padding is taken, so this fires there rather than
+ * leaving a control to overflow the rail it is drawn in.
+ *
+ * It decides ONLY whether the label sits beside the control or above it. What
+ * keeps a control inside the rail is the control's own layout — see the
+ * segmented control, whose buttons may shrink — so this number and the
+ * eligibility rules are not two answers to the same question.
  */
-@container nx-inspector-fields (max-width: 15rem) {
+@container nx-inspector-fields (max-width: 18rem) {
   .nx-inspector__field {
     grid-template-columns: minmax(0, 1fr);
   }
 
   .nx-inspector__field > *,
-  .nx-inspector__field > :first-child {
+  .nx-inspector__field > label {
     grid-column: 1;
   }
 }
@@ -654,8 +675,17 @@
  * A checkbox reads as one line with its label beside it rather than stacked
  * above it: the control is small enough that a label on its own line separates
  * the two further than they belong.
+ *
+ * `display` is restated rather than inherited, and that is the whole rule: an
+ * ordinary field is a grid with a fixed label column, and a checkbox row wants
+ * neither the column nor the order it implies. Setting only the flex properties
+ * leaves the grid in force — they describe a layout the field is not using —
+ * and the checkbox is then sized to a 6.5rem label column with its words in the
+ * column beside it. Declared on both classes so the layout does not depend on
+ * which rule appears later in this file.
  */
-.nx-inspector__field--inline {
+.nx-inspector__field.nx-inspector__field--inline {
+  display: flex;
   flex-direction: row;
   align-items: center;
   gap: 0.5rem;
@@ -834,12 +864,32 @@
 
 .nx-style-inspector__toggle > button {
   flex: 1 1 0;
+  /*
+   * A flex item will not shrink below its own text by default, so without this
+   * the control keeps its content width and overflows the rail rather than
+   * fitting in it. Overriding that makes the control answer for its own width
+   * at any rail size, which is what leaves the field's stacking threshold free
+   * to be about where the label reads best rather than about what fits.
+   */
+  min-width: 0;
   padding: 0.25rem 0.5rem;
   border: 1px solid var(--nx-border);
   background: var(--nx-background);
   color: var(--nx-foreground);
   font: inherit;
   cursor: pointer;
+}
+
+/*
+ * The shared edge is drawn ONCE, by the button on its leading side.
+ *
+ * Addressed as "every button after the first" rather than as the last one: with
+ * two buttons those are the same button and with three they are not, so the
+ * narrower rule leaves the middle seam two borders wide while the one beside it
+ * is one, and the segments stop reading as a single control.
+ */
+.nx-style-inspector__toggle > button + button {
+  border-inline-start-width: 0;
 }
 
 .nx-style-inspector__toggle > button:first-child {
@@ -850,8 +900,6 @@
 .nx-style-inspector__toggle > button:last-child {
   border-start-end-radius: var(--radius-md);
   border-end-end-radius: var(--radius-md);
-  /* The shared edge is drawn once, by the first button. */
-  border-inline-start-width: 0;
 }
 
 /*

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -603,10 +603,15 @@
  * would let the longest label in a group set the indent for every other one, so
  * the controls in Typography and the controls in Spacing would start at
  * different places and stop reading as columns at all.
+ *
+ * Its width is what the longest ORDINARY label needs rather than a round
+ * number: the logical side names — "Block start", "Inline start" — are the
+ * longest the catalog produces, and at a narrower column they wrap onto two
+ * lines, which puts the row back to the height the stacked layout had.
  */
 .nx-inspector__field {
   display: grid;
-  grid-template-columns: minmax(0, 5.5rem) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 6.5rem) minmax(0, 1fr);
   align-items: center;
   column-gap: 0.5rem;
   row-gap: 0.25rem;


### PR DESCRIPTION
Tracker rows **U-19** and **U-20**. Ledger `task:u19-style-controls-fit-their-values`. The founder chose option **B** from the proposal; **C** — reopening which groups exist and what folds away — is deliberately not here.

## What was wrong

The Style tab draws **52 CSS properties across 11 groups with 7 kinds of value**, and **three CSS rules** decided how all of them looked: a column, a gap, and a label stacked above a full-width box.

So a spacing measurement, a choice between three keywords and a colour all arrived looking identical. Nothing on screen said which was which, or which properties were actually set. That is why the tab reads as unfinished rather than ugly — there was no design to dislike yet.

This is not a copy that drifted from a source; it is the absence of a decision. Nothing ever said what a dimension should look like as opposed to a keyword, so the work is to decide, and to key the decision on the value's KIND — so a 53rd property inherits an appearance instead of needing a rule of its own.

## A field is a row

Label beside its control rather than above it. Stacked, every field spent two rows and a gap on one value, so a group could not be read at once and an author scrolled to compare two numbers that belong together.

- The label column is **bounded rather than content-sized**. Content sizing would let the longest label in a group set the indent for every other group, and the controls would stop reading as columns at all.
- Below the width where a label and a control share a row, the field stacks again. Asked of the **container**, not the viewport: the rail can be dragged narrow while the window stays wide, and a media query would answer for the window.
- The label is addressed **as a label**, not as the first child. Position is not a property a field has: a checkbox row puts its control first so the box sits beside the words it names. A positional rule answers the same way for both and gets that row exactly backwards.

This reaches Content, Style and Advanced, since all three share the field class. **U-20 needs nothing of its own**: it is the block's ID and custom attributes, and it inherits the row.

## The segmented control takes three

Its own docblock already carried the rule — *"offered only where the whole vocabulary fits in it"*. Never that two is special. Three short keywords fit, and folding them into a menu makes an author open something to read three words.

- **Length decides as well as count.** This draws in a narrow rail, and a control that wraps onto three lines is worse than the menu it replaced.
- **Whole or not at all.** Offering the first three of a longer vocabulary would be a control that silently cannot reach what it does not show.
- **Each shared edge is drawn once**, by the button on its leading side. With two buttons "the last one" and "every one after the first" select the same button, so the narrower rule looked right for as long as two was the only width offered.

Properties that gain it: `font-style`, `background-attachment`. `flex-wrap`, `align-items` and `container-type` are declined on length.

Worth recording, because the proposal implied otherwise: **`display` has more than four values**, so `block | flex | grid` is not reachable this way. That is Webflow's "primary options plus a dropdown", and it belongs to C.

## Fitting is one question with one answer

The review found the sharpest thing in this change: the eligibility length limits and the stacking threshold were **two independent answers to "does this control fit"**, and they disagreed. At the supported 280px rail the container is 16rem, so a 15rem threshold never fired, and the three-button control overflowed the column it was given.

They are now separate questions with one answer each:

- **The control answers for its own width.** Its buttons may shrink below their text, so it cannot overflow the rail at any size.
- **The threshold decides only whether the label sits beside the control or above it**, and it is the row's own arithmetic rather than a round number: 6.5rem of label and 0.5rem of gap leave under 11rem for a control below 18rem.

## Evidence

- builder **95 files / 2663 tests** green; `check-types`, `lint`, `lint:design`, comment-convention and `fallow` all clean.
- Nine new tests read the declarations out of the stylesheet, each scoped to the rule that owns it — a bare search over a 2000-line sheet is satisfied by an unrelated match. **Each was break-verified individually** and fails only its own case.
- One of those breaks found a test of mine that was **passing on prose**: `container-type: inline-size` appears in three comments, so a file-wide search went green with the declaration deleted. It now reads the rule's body.
- **Verified in a real browser at the 280px minimum and the 320px default**, each against a control that restores the pre-fix rule in the live page:
  - checkbox row — fixed: control and label adjacent, 8px apart. Forced back to the grid: they separate by 112px and the label lands on the wrong side of the box.
  - segmented control — fixed: border widths 1px, 0, 0. Pre-fix: 1px, **1px**, 0, so the first seam is two borders wide and the second one.
  - fit at 280px — fixed: the field stacks to one 256px column and the control fits exactly. Pre-fix: two columns of 104px and 144px holding a control that needs 174px, a 30px overflow.

## The box model is not in this PR

`margin` and `padding` drawn as the box they describe was on this branch and has been taken off it. The review raised five findings against it, two of them P1, and one is a design question rather than a defect: the box places "inline start" by grid column, which follows the **admin's** writing direction rather than that of the element being edited — so on an RTL page edited in an LTR admin the diagram points at the opposite edge from the one it changes.

That is worth doing properly rather than patching. `spacing-overlay.tsx` already reads the edited element's computed writing mode off the canvas for these same sides, so the box should ask that one derivation rather than assume. It gets its own PR, with the placement addressed by identity rather than by `nth-of-type` — which is also what the `css-selector-complexity` warnings on those selectors were pointing at.

The work is preserved; nothing here needs to wait for it.
