### PR TITLE
fix(nextly): read a local file through one descriptor, under its deadline

### DIFF
--- a/.changeset/a-local-read-holds-one-descriptor.md
+++ b/.changeset/a-local-read-holds-one-descriptor.md
@@ -1,0 +1,39 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The default storage adapter resolved a file by name three times to read it
+once: to validate the path, to ask for its size, and to pull in its contents.
+A file replaced between the second and the third came back under a cap
+measured on the file it displaced, and one still being appended to was
+buffered whole however small it had been when asked. The read deadline reached
+it not at all, so a storage directory on an unresponsive network mount held a
+read open with nothing left to end it.
+
+A local read now runs against one open descriptor, counts the bytes as they
+arrive instead of trusting the size reported beforehand, and answers within
+the deadline it advertises — the same bounds the cloud adapters already kept.

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -42,6 +42,11 @@ export const NEXTLY_ERROR_STATUS = {
   // is sending, this one refuses to buffer an object already stored. Kept
   // apart so a caller discriminating on the code cannot match both.
   STORAGE_READ_TOO_LARGE: 413,
+  // A stored object did not answer within the deadline the read was given. 504
+  // rather than 500 because the failure is the BACKEND not answering, and a
+  // caller can act on that difference: a gateway timeout is worth retrying, an
+  // internal error is not.
+  STORAGE_READ_TIMEOUT: 504,
   MAGIC_BYTE_MISMATCH: 400,
   SVG_SANITIZATION_FAILED: 400,
   UNSUPPORTED_FOR_BACKEND: 415,

--- a/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
+++ b/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
@@ -40,17 +40,17 @@ import { LocalStorageAdapter } from "../local-adapter";
  * exercise these reports that rather than reporting coverage it does not have.
  */
 const CAN_MAKE_FIFO = ((): boolean => {
-  const probe = join(
-    mkdtempSync(join(tmpdir(), "nextly-fifo-probe-")),
-    "probe"
-  );
+  // The DIRECTORY is what gets removed, not just the node inside it: removing
+  // only the child left an empty `nextly-fifo-probe-*` behind in the system
+  // temp directory on every evaluation of this module, succeed or fail.
+  const probeDir = mkdtempSync(join(tmpdir(), "nextly-fifo-probe-"));
   try {
-    execFileSync("mkfifo", [probe], { stdio: "ignore" });
+    execFileSync("mkfifo", [join(probeDir, "probe")], { stdio: "ignore" });
     return true;
   } catch {
     return false;
   } finally {
-    rmSync(probe, { force: true });
+    rmSync(probeDir, { recursive: true, force: true });
   }
 })();
 

--- a/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
+++ b/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
@@ -7,11 +7,19 @@
  * exactly the shape the option had before: advertised on the contract, honoured
  * by some backends, silently inert on the default.
  *
+ * The deadline is tested through a FIFO, which is the one thing a test can
+ * make behave like the stalled network mount this bound exists for: opening
+ * one for reading blocks until a writer arrives, and a filesystem call takes
+ * no abort signal, so nothing else in the process can interrupt it.
+ *
  * @module storage/adapters/local-read-cap.test
  */
+import { execFile } from "node:child_process";
+import { createWriteStream } from "node:fs";
 import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
@@ -71,6 +79,69 @@ describe("LocalStorageAdapter.read bounds", () => {
     await writeFile(join(base, "big.txt"), "x".repeat(500));
     const bytes = await adapter.read("big.txt");
     expect(bytes?.length).toBe(500);
+  });
+
+  it("REFUSES bytes past the cap even when the metadata says zero", async () => {
+    /*
+     * The cap has to hold against what ARRIVES, not against what `stat`
+     * reported a moment earlier. A FIFO makes that gap total rather than
+     * racy: it reports a size of zero and then delivers whatever its writer
+     * sends, so a cap taken from metadata passes it unconditionally.
+     *
+     * Its control is "REFUSES a file larger than the cap" above, which fails
+     * if the refusal stops working at all; this one fails only when the
+     * refusal is being decided by the wrong number.
+     */
+    const pipe = join(base, "pipe");
+    await promisify(execFile)("mkfifo", [pipe]);
+
+    // Started before the writer, because opening either end of a FIFO blocks
+    // until the other end is open.
+    const reading = adapter.read("pipe", { maxBytes: 1000, timeoutMs: 5000 });
+    const writer = createWriteStream(pipe);
+    // The reader refuses and closes mid-stream, so the write end breaks; that
+    // is the expected end of this pipe, not a failure of the case.
+    writer.on("error", () => undefined);
+    writer.end(Buffer.alloc(200_000));
+
+    const outcome = await reading.then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(true);
+    // NOT the 200_000 bytes it was sent, which is what a metadata-only cap
+    // would have buffered and returned.
+    expect(Buffer.isBuffer(outcome)).toBe(false);
+  });
+
+  it("gives up on a read that never gets going, rather than hanging", async () => {
+    /*
+     * A FIFO with no writer stands in for the `basePath` on an unresponsive
+     * mount: `open` blocks in the threadpool, takes no signal, and cannot be
+     * interrupted — so the deadline can only be honoured by racing it.
+     */
+    const stalled = join(base, "stalled");
+    await promisify(execFile)("mkfifo", [stalled]);
+
+    const outcome = await adapter.read("stalled", { timeoutMs: 50 }).then(
+      value => value,
+      (error: unknown) => error
+    );
+
+    expect((outcome as Error).name).toBe("TimeoutError");
+    // NOT null: a backend that cannot be reached has said nothing about
+    // whether the file is there, and a caller told `null` would treat it as
+    // deleted and write a replacement over a file still sitting on the mount.
+    expect(outcome).not.toBeNull();
+
+    /*
+     * The abandoned `open` still holds a libuv threadpool thread, which it
+     * keeps for the life of the process unless a writer turns up. Released
+     * here so this case cannot starve the ones after it.
+     */
+    const releasing = createWriteStream(stalled);
+    releasing.on("error", () => undefined);
+    releasing.end();
   });
 
   it("still answers null for a file that is not there", async () => {

--- a/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
+++ b/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
@@ -186,7 +186,19 @@ describe("LocalStorageAdapter.read bounds", () => {
        */
       const releasing = createWriteStream(stalled);
       releasing.on("error", () => undefined);
-      releasing.end();
+      /*
+       * AWAITED, because `end()` only schedules the open and the close. The
+       * teardown after this case removes the fifo, and doing that while the
+       * abandoned `open` is still pending races the very thing this release
+       * exists to unblock — leaving the threadpool slot held after all, on a
+       * run that reported the case as passing.
+       */
+      await new Promise<void>(resolve => {
+        releasing.on("close", () => {
+          resolve();
+        });
+        releasing.end();
+      });
     }
   );
 

--- a/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
+++ b/packages/nextly/src/storage/adapters/__tests__/local-read-cap.test.ts
@@ -14,8 +14,8 @@
  *
  * @module storage/adapters/local-read-cap.test
  */
-import { execFile } from "node:child_process";
-import { createWriteStream } from "node:fs";
+import { execFile, execFileSync } from "node:child_process";
+import { createWriteStream, mkdtempSync, rmSync } from "node:fs";
 import { mkdtemp, writeFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -23,8 +23,36 @@ import { promisify } from "node:util";
 
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
-import { isStorageReadTooLarge } from "../../read-errors";
+import { isStorageReadTimeout, isStorageReadTooLarge } from "../../read-errors";
 import { LocalStorageAdapter } from "../local-adapter";
+
+/**
+ * Whether this machine can make a FIFO at all.
+ *
+ * Windows has no `mkfifo`, and a minimal container may not ship it either, so
+ * the two cases below would fail on setup rather than on the property they
+ * name — turning an unsupported facility into a broken suite for a contributor
+ * whose platform this package otherwise supports.
+ *
+ * Probed by MAKING one rather than by reading `process.platform`, because the
+ * absence that matters is the utility's, and a platform list is a proxy that
+ * goes stale. The skip is visible in the run summary, so a machine that cannot
+ * exercise these reports that rather than reporting coverage it does not have.
+ */
+const CAN_MAKE_FIFO = ((): boolean => {
+  const probe = join(
+    mkdtempSync(join(tmpdir(), "nextly-fifo-probe-")),
+    "probe"
+  );
+  try {
+    execFileSync("mkfifo", [probe], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  } finally {
+    rmSync(probe, { force: true });
+  }
+})();
 
 let base: string;
 let adapter: LocalStorageAdapter;
@@ -81,68 +109,86 @@ describe("LocalStorageAdapter.read bounds", () => {
     expect(bytes?.length).toBe(500);
   });
 
-  it("REFUSES bytes past the cap even when the metadata says zero", async () => {
-    /*
-     * The cap has to hold against what ARRIVES, not against what `stat`
-     * reported a moment earlier. A FIFO makes that gap total rather than
-     * racy: it reports a size of zero and then delivers whatever its writer
-     * sends, so a cap taken from metadata passes it unconditionally.
-     *
-     * Its control is "REFUSES a file larger than the cap" above, which fails
-     * if the refusal stops working at all; this one fails only when the
-     * refusal is being decided by the wrong number.
-     */
-    const pipe = join(base, "pipe");
-    await promisify(execFile)("mkfifo", [pipe]);
+  it.skipIf(!CAN_MAKE_FIFO)(
+    "REFUSES bytes past the cap even when the metadata says zero",
+    async () => {
+      /*
+       * The cap has to hold against what ARRIVES, not against what `stat`
+       * reported a moment earlier. A FIFO makes that gap total rather than
+       * racy: it reports a size of zero and then delivers whatever its writer
+       * sends, so a cap taken from metadata passes it unconditionally.
+       *
+       * Its control is "REFUSES a file larger than the cap" above, which fails
+       * if the refusal stops working at all; this one fails only when the
+       * refusal is being decided by the wrong number.
+       */
+      const pipe = join(base, "pipe");
+      await promisify(execFile)("mkfifo", [pipe]);
 
-    // Started before the writer, because opening either end of a FIFO blocks
-    // until the other end is open.
-    const reading = adapter.read("pipe", { maxBytes: 1000, timeoutMs: 5000 });
-    const writer = createWriteStream(pipe);
-    // The reader refuses and closes mid-stream, so the write end breaks; that
-    // is the expected end of this pipe, not a failure of the case.
-    writer.on("error", () => undefined);
-    writer.end(Buffer.alloc(200_000));
+      // Started before the writer, because opening either end of a FIFO blocks
+      // until the other end is open.
+      const reading = adapter.read("pipe", { maxBytes: 1000, timeoutMs: 5000 });
+      const writer = createWriteStream(pipe);
+      // The reader refuses and closes mid-stream, so the write end breaks; that
+      // is the expected end of this pipe, not a failure of the case.
+      writer.on("error", () => undefined);
+      writer.end(Buffer.alloc(200_000));
 
-    const outcome = await reading.then(
-      value => value,
-      (error: unknown) => error
-    );
-    expect(isStorageReadTooLarge(outcome)).toBe(true);
-    // NOT the 200_000 bytes it was sent, which is what a metadata-only cap
-    // would have buffered and returned.
-    expect(Buffer.isBuffer(outcome)).toBe(false);
-  });
+      const outcome = await reading.then(
+        value => value,
+        (error: unknown) => error
+      );
+      expect(isStorageReadTooLarge(outcome)).toBe(true);
+      // NOT the 200_000 bytes it was sent, which is what a metadata-only cap
+      // would have buffered and returned.
+      expect(Buffer.isBuffer(outcome)).toBe(false);
+    }
+  );
 
-  it("gives up on a read that never gets going, rather than hanging", async () => {
-    /*
-     * A FIFO with no writer stands in for the `basePath` on an unresponsive
-     * mount: `open` blocks in the threadpool, takes no signal, and cannot be
-     * interrupted — so the deadline can only be honoured by racing it.
-     */
-    const stalled = join(base, "stalled");
-    await promisify(execFile)("mkfifo", [stalled]);
+  it.skipIf(!CAN_MAKE_FIFO)(
+    "gives up on a read that never gets going, rather than hanging",
+    async () => {
+      /*
+       * A FIFO with no writer stands in for the `basePath` on an unresponsive
+       * mount: `open` blocks in the threadpool, takes no signal, and cannot be
+       * interrupted — so the deadline can only be honoured by racing it.
+       */
+      const stalled = join(base, "stalled");
+      await promisify(execFile)("mkfifo", [stalled]);
 
-    const outcome = await adapter.read("stalled", { timeoutMs: 50 }).then(
-      value => value,
-      (error: unknown) => error
-    );
+      const outcome = await adapter.read("stalled", { timeoutMs: 50 }).then(
+        value => value,
+        (error: unknown) => error
+      );
 
-    expect((outcome as Error).name).toBe("TimeoutError");
-    // NOT null: a backend that cannot be reached has said nothing about
-    // whether the file is there, and a caller told `null` would treat it as
-    // deleted and write a replacement over a file still sitting on the mount.
-    expect(outcome).not.toBeNull();
+      /*
+       * A `NextlyError`, not the platform `DOMException` `AbortSignal.timeout`
+       * rejects with. Product code in this package answers in one vocabulary, so
+       * a caller can classify what it caught rather than matching a name the
+       * runtime chose.
+       */
+      expect(isStorageReadTimeout(outcome)).toBe(true);
+      // 504, because the failure is the BACKEND not answering — which a caller
+      // may retry — rather than an internal fault, which it may not.
+      expect((outcome as { statusCode?: number }).statusCode).toBe(504);
+      // NOT the over-cap refusal: that one read the object and found it too big,
+      // this one never read it at all.
+      expect(isStorageReadTooLarge(outcome)).toBe(false);
+      // NOT null: a backend that cannot be reached has said nothing about
+      // whether the file is there, and a caller told `null` would treat it as
+      // deleted and write a replacement over a file still sitting on the mount.
+      expect(outcome).not.toBeNull();
 
-    /*
-     * The abandoned `open` still holds a libuv threadpool thread, which it
-     * keeps for the life of the process unless a writer turns up. Released
-     * here so this case cannot starve the ones after it.
-     */
-    const releasing = createWriteStream(stalled);
-    releasing.on("error", () => undefined);
-    releasing.end();
-  });
+      /*
+       * The abandoned `open` still holds a libuv threadpool thread, which it
+       * keeps for the life of the process unless a writer turns up. Released
+       * here so this case cannot starve the ones after it.
+       */
+      const releasing = createWriteStream(stalled);
+      releasing.on("error", () => undefined);
+      releasing.end();
+    }
+  );
 
   it("still answers null for a file that is not there", async () => {
     // The absence contract is unchanged by the cap — and this is the control

--- a/packages/nextly/src/storage/adapters/local-adapter.ts
+++ b/packages/nextly/src/storage/adapters/local-adapter.ts
@@ -27,7 +27,11 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
-import { resolveReadBounds, withDeadline } from "../fetch-stored-bytes";
+import {
+  deadlineSignal,
+  resolveReadBounds,
+  withDeadline,
+} from "../fetch-stored-bytes";
 import { StorageReadTooLargeError } from "../read-errors";
 import type {
   UploadOptions,
@@ -76,13 +80,23 @@ const READ_CHUNK_BYTES = 64 * 1024;
 async function readCounted(
   handle: fs.FileHandle,
   filePath: string,
-  maxBytes: number
+  maxBytes: number,
+  signal: AbortSignal
 ): Promise<Buffer> {
   const chunks: Buffer[] = [];
   const chunk = Buffer.allocUnsafe(READ_CHUNK_BYTES);
   let received = 0;
 
   for (;;) {
+    /*
+     * Checked before each syscall, so a read the caller has already given up on
+     * stops asking for more. It cannot cancel the one in flight — no filesystem
+     * call takes a signal — but it bounds the abandoned work to a SINGLE chunk
+     * rather than the whole file, which is the difference between one blocked
+     * threadpool slot and one held for as long as the file is long.
+     */
+    if (signal.aborted) throw signal.reason as Error;
+
     const { bytesRead } = await handle.read(chunk, 0, READ_CHUNK_BYTES, null);
     if (bytesRead === 0) break;
 
@@ -269,14 +283,20 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
      * `read` answers within the deadline it advertised instead of holding its
      * caller for as long as the mount stays down.
      */
-    const work = this.readWithinCap(fullPath, filePath, bounds.maxBytes);
+    const signal = deadlineSignal(bounds.timeoutMs, filePath);
+    const work = this.readWithinCap(
+      fullPath,
+      filePath,
+      bounds.maxBytes,
+      signal
+    );
     /*
      * A lost race rejects the caller from `withDeadline` and leaves this
      * promise to settle with nobody attached — an unhandled rejection for a
      * read whose outcome has already been reported.
      */
     void work.catch(() => undefined);
-    return await withDeadline(work, AbortSignal.timeout(bounds.timeoutMs));
+    return await withDeadline(work, signal);
   }
 
   // ============================================================
@@ -297,7 +317,8 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
   private async readWithinCap(
     fullPath: string,
     filePath: string,
-    maxBytes: number
+    maxBytes: number,
+    signal: AbortSignal
   ): Promise<Buffer | null> {
     const handle = await fs.open(fullPath, "r").catch(() => null);
     // A missing file, and every other reason opening one fails — the same
@@ -319,7 +340,7 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
          */
         throw new StorageReadTooLargeError(filePath, maxBytes, size);
       }
-      return await readCounted(handle, filePath, maxBytes);
+      return await readCounted(handle, filePath, maxBytes, signal);
     } catch (error) {
       // The refusal is an answer about a file that exists, so it travels;
       // everything else keeps reading as absence, unchanged.

--- a/packages/nextly/src/storage/adapters/local-adapter.ts
+++ b/packages/nextly/src/storage/adapters/local-adapter.ts
@@ -27,7 +27,7 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
-import { resolveReadBounds } from "../fetch-stored-bytes";
+import { resolveReadBounds, withDeadline } from "../fetch-stored-bytes";
 import { StorageReadTooLargeError } from "../read-errors";
 import type {
   UploadOptions,
@@ -51,6 +51,51 @@ export interface LocalAdapterConfig {
 
 // Track whether we've already added to .gitignore this session
 let gitignoreUpdated = false;
+
+// ============================================================
+// Reading
+// ============================================================
+
+/** How much of a file one `read` syscall pulls into memory. */
+const READ_CHUNK_BYTES = 64 * 1024;
+
+/**
+ * Buffer an open file, refusing it once more than `maxBytes` has arrived.
+ *
+ * Counted as it ARRIVES rather than taken from the size the descriptor
+ * reported, because the two disagree exactly where the cap matters: a file
+ * still being appended to answers honestly about its size and grows anyway,
+ * and a path whose metadata cannot describe its contents at all — a FIFO
+ * reports zero bytes and delivers as many as its writer sends — passes any
+ * cap on the strength of that zero.
+ *
+ * @param handle - An open descriptor, whose position this advances
+ * @param filePath - The caller's path, carried only in the refusal
+ * @param maxBytes - The cap this read runs under
+ */
+async function readCounted(
+  handle: fs.FileHandle,
+  filePath: string,
+  maxBytes: number
+): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  const chunk = Buffer.allocUnsafe(READ_CHUNK_BYTES);
+  let received = 0;
+
+  for (;;) {
+    const { bytesRead } = await handle.read(chunk, 0, READ_CHUNK_BYTES, null);
+    if (bytesRead === 0) break;
+
+    received += bytesRead;
+    if (received > maxBytes) {
+      throw new StorageReadTooLargeError(filePath, maxBytes, received);
+    }
+    // Copied, because the next iteration reads back into the same buffer.
+    chunks.push(Buffer.from(chunk.subarray(0, bytesRead)));
+  }
+
+  return Buffer.concat(chunks);
+}
 
 // ============================================================
 // Adapter Implementation
@@ -181,12 +226,16 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
    *
    * Returns the file buffer, or `null` if the file is not found.
    *
-   * Honours the caller's cap, which matters MORE here than anywhere else: this
-   * is the default backend, so a bound the cloud adapters keep and this one
-   * ignores is a bound that does nothing in the commonest deployment. Checked
-   * against the file's size before reading, because `readFile` buffers the
-   * whole thing — a cap enforced afterwards has already spent the memory it
-   * exists to save.
+   * Honours the caller's bounds, which matters MORE here than anywhere else:
+   * this is the default backend, so a bound the cloud adapters keep and this
+   * one ignores is a bound that does nothing in the commonest deployment.
+   *
+   * Both bounds are enforced against ONE open descriptor. Resolving the name,
+   * asking for its size and then reading it again by name resolves the same
+   * name three times: a file replaced in between is read under a cap measured
+   * on the file it displaced, and one appended to in between is buffered whole
+   * however small it was when asked. The descriptor settles the first, and
+   * counting the bytes as they arrive settles the second.
    */
   async read(
     filePath: string,
@@ -211,32 +260,75 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
      */
     const bounds = resolveReadBounds(options);
 
-    let size: number;
-    try {
-      size = (await fs.stat(fullPath)).size;
-    } catch {
-      return null;
-    }
-
     /*
-     * Thrown rather than returned as `null`, because refusing a file that IS
-     * there is not the same answer as not finding one — and a caller told
-     * `null` would go on to treat a present file as missing.
+     * RACED rather than cancelled, which is the only bound available to it: a
+     * filesystem call runs on the libuv threadpool and takes no signal, so a
+     * `basePath` on an unresponsive network mount blocks `open` and `read`
+     * with nothing to interrupt them. The work below keeps running and closes
+     * its own descriptor whichever side wins; what the race buys is that
+     * `read` answers within the deadline it advertised instead of holding its
+     * caller for as long as the mount stays down.
      */
-    if (size > bounds.maxBytes) {
-      throw new StorageReadTooLargeError(filePath, bounds.maxBytes, size);
-    }
-
-    try {
-      return await fs.readFile(fullPath);
-    } catch {
-      return null;
-    }
+    const work = this.readWithinCap(fullPath, filePath, bounds.maxBytes);
+    /*
+     * A lost race rejects the caller from `withDeadline` and leaves this
+     * promise to settle with nobody attached — an unhandled rejection for a
+     * read whose outcome has already been reported.
+     */
+    void work.catch(() => undefined);
+    return await withDeadline(work, AbortSignal.timeout(bounds.timeoutMs));
   }
 
   // ============================================================
   // Private Helpers
   // ============================================================
+
+  /**
+   * Read one opened file, refusing it the moment it exceeds the cap.
+   *
+   * Split out so the whole descriptor lifetime — open, size, read, close —
+   * sits inside a single promise the caller can race, and so the close in its
+   * `finally` still runs when that race has already answered the caller.
+   *
+   * @param fullPath - Absolute path, already validated against `basePath`
+   * @param filePath - The caller's path, carried only in the refusal
+   * @param maxBytes - The cap this read runs under
+   */
+  private async readWithinCap(
+    fullPath: string,
+    filePath: string,
+    maxBytes: number
+  ): Promise<Buffer | null> {
+    const handle = await fs.open(fullPath, "r").catch(() => null);
+    // A missing file, and every other reason opening one fails — the same
+    // answer this method gave when it resolved the name a second time.
+    if (handle === null) return null;
+
+    try {
+      /*
+       * A cheap refusal from the descriptor's OWN metadata, so an oversized
+       * file costs one fstat rather than a walk up to the cap. It cannot stand
+       * alone, which is why the counting below is not redundant with it.
+       */
+      const { size } = await handle.stat();
+      if (size > maxBytes) {
+        /*
+         * Thrown rather than returned as `null`, because refusing a file that
+         * IS there is not the same answer as not finding one — and a caller
+         * told `null` would go on to treat a present file as missing.
+         */
+        throw new StorageReadTooLargeError(filePath, maxBytes, size);
+      }
+      return await readCounted(handle, filePath, maxBytes);
+    } catch (error) {
+      // The refusal is an answer about a file that exists, so it travels;
+      // everything else keeps reading as absence, unchanged.
+      if (error instanceof StorageReadTooLargeError) throw error;
+      return null;
+    } finally {
+      await handle.close().catch(() => undefined);
+    }
+  }
 
   /**
    * Resolve a relative file path to an absolute path within basePath.

--- a/packages/nextly/src/storage/adapters/local-adapter.ts
+++ b/packages/nextly/src/storage/adapters/local-adapter.ts
@@ -283,12 +283,12 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
      * `read` answers within the deadline it advertised instead of holding its
      * caller for as long as the mount stays down.
      */
-    const signal = deadlineSignal(bounds.timeoutMs, filePath);
+    const deadline = deadlineSignal(bounds.timeoutMs, filePath);
     const work = this.readWithinCap(
       fullPath,
       filePath,
       bounds.maxBytes,
-      signal
+      deadline.signal
     );
     /*
      * A lost race rejects the caller from `withDeadline` and leaves this
@@ -296,7 +296,16 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
      * read whose outcome has already been reported.
      */
     void work.catch(() => undefined);
-    return await withDeadline(work, signal);
+    try {
+      return await withDeadline(work, deadline.signal);
+    } finally {
+      /*
+       * Whichever side won. If the deadline fired, clearing is a no-op; if the
+       * read finished first, this is what stops a timer per read sitting on the
+       * heap for the whole timeout with nobody left to answer.
+       */
+      deadline.cancel();
+    }
   }
 
   // ============================================================
@@ -331,6 +340,15 @@ export class LocalStorageAdapter extends BaseStorageAdapter {
        * file costs one fstat rather than a walk up to the cap. It cannot stand
        * alone, which is why the counting below is not redundant with it.
        */
+      /*
+       * Checked before the fstat, not only inside the chunk loop below. An
+       * `open` that completes AFTER the deadline has already answered the
+       * caller would otherwise spend a second filesystem call — on the same
+       * stalled mount, blocking another threadpool slot — for a result nobody
+       * is waiting for. The `finally` still closes the descriptor.
+       */
+      if (signal.aborted) throw signal.reason as Error;
+
       const { size } = await handle.stat();
       if (size > maxBytes) {
         /*

--- a/packages/nextly/src/storage/fetch-stored-bytes.test.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.test.ts
@@ -10,17 +10,18 @@
  *
  * @module storage/fetch-stored-bytes.test
  */
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../errors/nextly-error";
 import {
+  deadlineSignal,
   fetchStoredBytes,
   resolveReadBounds,
   DEFAULT_READ_MAX_BYTES,
   DEFAULT_READ_TIMEOUT_MS,
 } from "./fetch-stored-bytes";
 import { safeFetch, SafeFetchError } from "../utils/validate-external-url";
-import { isStorageReadTooLarge } from "./read-errors";
+import { isStorageReadTimeout, isStorageReadTooLarge } from "./read-errors";
 
 vi.mock("../utils/validate-external-url", async importOriginal => {
   /*
@@ -255,5 +256,48 @@ describe("the bounds a read runs under", () => {
     // is tuned, so these are the fetch layer's own constants re-exported.
     expect(DEFAULT_READ_MAX_BYTES).toBe(10 * 1024 * 1024);
     expect(DEFAULT_READ_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+describe("the deadline a read runs under", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("aborts with this package's own error, not the platform's", async () => {
+    /*
+     * `AbortSignal.timeout` rejects with a `DOMException` named `TimeoutError`,
+     * which a caller reaching for `NextlyError.is` cannot classify. Asserted on
+     * the REASON rather than on `aborted`, because a signal that aborts with
+     * the wrong value satisfies `aborted` perfectly.
+     */
+    const deadline = deadlineSignal(50, "media/f.woff2");
+    vi.advanceTimersByTime(51);
+
+    expect(deadline.signal.aborted).toBe(true);
+    expect(isStorageReadTimeout(deadline.signal.reason)).toBe(true);
+    // Not the over-cap refusal: that one read the object, this one never did.
+    expect(isStorageReadTooLarge(deadline.signal.reason)).toBe(false);
+  });
+
+  it("stops the timer once the read has settled", async () => {
+    /*
+     * `unref` keeps a pending deadline from holding the process open and does
+     * nothing else: the timer stays on the heap holding the controller and the
+     * path, so a server doing a thousand reads a second carries thirty seconds
+     * of them and then runs a thousand aborts nobody is waiting for.
+     *
+     * Its control is the case above, which fails if the deadline stops firing
+     * at all — this one fails only when a cancelled deadline still fires.
+     */
+    const deadline = deadlineSignal(50, "media/f.woff2");
+    deadline.cancel();
+    vi.advanceTimersByTime(5_000);
+
+    expect(deadline.signal.aborted).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -25,7 +25,10 @@ import {
   DEFAULT_MAX_RESPONSE_BYTES,
 } from "../utils/validate-external-url";
 
-import { StorageReadTooLargeError } from "./read-errors";
+import {
+  StorageReadTimeoutError,
+  StorageReadTooLargeError,
+} from "./read-errors";
 import type { StorageReadOptions } from "./types";
 
 /**
@@ -205,6 +208,34 @@ export function resolveReadBounds(options?: StorageReadOptions): {
     maxBytes: options?.maxBytes ?? DEFAULT_READ_MAX_BYTES,
     timeoutMs: options?.timeoutMs ?? DEFAULT_READ_TIMEOUT_MS,
   };
+}
+
+/**
+ * A deadline that aborts with a NextlyError rather than a platform exception.
+ *
+ * `AbortSignal.timeout` rejects with a `DOMException` named `TimeoutError`, and
+ * product code in this package answers in `NextlyError` — so a caller can
+ * classify what it caught rather than matching a name the runtime chose. Built
+ * here rather than per adapter so every storage deadline says the same thing.
+ *
+ * The timer is unreferenced: a read that finishes early leaves it pending, and
+ * a pending deadline must not be a reason the process stays alive.
+ *
+ * @param timeoutMs - How long the read may take
+ * @param context - What is being read, carried into the refusal's log side
+ */
+export function deadlineSignal(
+  timeoutMs: number,
+  context: string
+): AbortSignal {
+  const controller = new AbortController();
+  const timer = setTimeout(() => {
+    controller.abort(new StorageReadTimeoutError(context, timeoutMs));
+  }, timeoutMs);
+  // Guarded because `unref` is Node's, and this module is bundled for runtimes
+  // whose `setTimeout` returns a number.
+  (timer as { unref?: () => void }).unref?.();
+  return controller.signal;
 }
 
 /**

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -218,8 +218,9 @@ export function resolveReadBounds(options?: StorageReadOptions): {
  * classify what it caught rather than matching a name the runtime chose. Built
  * here rather than per adapter so every storage deadline says the same thing.
  *
- * The timer is unreferenced: a read that finishes early leaves it pending, and
- * a pending deadline must not be a reason the process stays alive.
+ * The timer is unreferenced so a pending deadline is never a reason the process
+ * stays alive, and the returned `cancel` clears it once the read settles — the
+ * unref alone would leave one scheduled per read for the whole timeout.
  *
  * @param timeoutMs - How long the read may take
  * @param context - What is being read, carried into the refusal's log side
@@ -227,7 +228,7 @@ export function resolveReadBounds(options?: StorageReadOptions): {
 export function deadlineSignal(
   timeoutMs: number,
   context: string
-): AbortSignal {
+): { signal: AbortSignal; cancel: () => void } {
   const controller = new AbortController();
   const timer = setTimeout(() => {
     controller.abort(new StorageReadTimeoutError(context, timeoutMs));
@@ -235,7 +236,19 @@ export function deadlineSignal(
   // Guarded because `unref` is Node's, and this module is bundled for runtimes
   // whose `setTimeout` returns a number.
   (timer as { unref?: () => void }).unref?.();
-  return controller.signal;
+  return {
+    signal: controller.signal,
+    /*
+     * Called once the read has settled, whichever way it went. `unref` only
+     * stops a pending timer holding the process open; it still sits on the
+     * timer heap retaining the controller and the path, so a server doing a
+     * thousand reads a second keeps thirty seconds of them alive and then runs
+     * a thousand aborts that answer nobody.
+     */
+    cancel: () => {
+      clearTimeout(timer);
+    },
+  };
 }
 
 /**

--- a/packages/nextly/src/storage/index.ts
+++ b/packages/nextly/src/storage/index.ts
@@ -127,7 +127,12 @@ export type {
 // ============================================================
 
 export { fetchStoredBytes } from "./fetch-stored-bytes";
-export { StorageReadTooLargeError, isStorageReadTooLarge } from "./read-errors";
+export {
+  StorageReadTooLargeError,
+  isStorageReadTooLarge,
+  StorageReadTimeoutError,
+  isStorageReadTimeout,
+} from "./read-errors";
 export type { StorageReadOptions } from "./types";
 export { isTransientError, withRetry, createRetryable } from "./retry";
 

--- a/packages/nextly/src/storage/read-errors.test.ts
+++ b/packages/nextly/src/storage/read-errors.test.ts
@@ -62,3 +62,26 @@ describe("the over-cap refusal", () => {
     expect(isStorageReadTooLarge("nope")).toBe(false);
   });
 });
+
+describe("the documented entry point", () => {
+  it("exports BOTH refusals, not only the over-cap one", async () => {
+    /*
+     * A classifier a caller cannot import is a classifier that does not exist
+     * for them: the barrel is the documented surface, and reaching past it to
+     * `nextly/storage/read-errors` means knowing about a subpath nothing tells
+     * them about. The over-cap pair was already exported here, so the timeout
+     * pair being absent was an asymmetry rather than a policy.
+     *
+     * Imported dynamically because the barrel pulls the whole storage graph,
+     * which a module-level import would drag into every case in this file.
+     */
+    const barrel = await import("./index");
+
+    expect(barrel.StorageReadTimeoutError).toBeDefined();
+    expect(barrel.isStorageReadTimeout).toBeDefined();
+    // The control: the pair that was already exported, proving the assertion
+    // reads real bindings rather than passing on any name at all.
+    expect(barrel.StorageReadTooLargeError).toBeDefined();
+    expect(barrel.isStorageReadTooLarge).toBeDefined();
+  });
+});

--- a/packages/nextly/src/storage/read-errors.ts
+++ b/packages/nextly/src/storage/read-errors.ts
@@ -62,3 +62,45 @@ export function isStorageReadTooLarge(
   // one the checker cannot use and a reader would take as load-bearing.
   return NextlyError.is(error) && error.code === "STORAGE_READ_TOO_LARGE";
 }
+
+/**
+ * A read abandoned because the backend did not answer in time.
+ *
+ * Carried as the abort REASON rather than raised afterwards, which is what
+ * makes it reach the caller at all: `AbortSignal.timeout` rejects with a
+ * platform `DOMException`, and product code in this package answers in
+ * `NextlyError` so a caller can classify what it caught without matching on a
+ * name the runtime chose. `safeFetch` already aborts this way for the same
+ * reason.
+ *
+ * Distinct from the over-cap refusal above because the two say opposite things
+ * about the object: one was read and found too big, the other was never read at
+ * all, so nothing here knows whether it exists.
+ */
+export class StorageReadTimeoutError extends NextlyError {
+  constructor(
+    /** What was being read, for the log side only. */
+    public readonly path: string,
+    /** The deadline that passed, in milliseconds. */
+    public readonly timeoutMs: number
+  ) {
+    super({
+      code: "STORAGE_READ_TIMEOUT",
+      publicMessage: "The stored file could not be read in time.",
+      logContext: { path, timeoutMs },
+    });
+  }
+}
+
+/**
+ * Whether a thrown value is the deadline refusal.
+ *
+ * A predicate for the same reason as `isStorageReadTooLarge`: a narrow entry
+ * point and a barrel are different module instances, and `instanceof` across
+ * them is false for objects that are otherwise identical.
+ */
+export function isStorageReadTimeout(
+  error: unknown
+): error is StorageReadTimeoutError {
+  return NextlyError.is(error) && error.code === "STORAGE_READ_TIMEOUT";
+}

--- a/packages/nextly/src/storage/read-errors.ts
+++ b/packages/nextly/src/storage/read-errors.ts
@@ -73,9 +73,11 @@ export function isStorageReadTooLarge(
  * name the runtime chose. `safeFetch` already aborts this way for the same
  * reason.
  *
- * Distinct from the over-cap refusal above because the two say opposite things
- * about the object: one was read and found too big, the other was never read at
- * all, so nothing here knows whether it exists.
+ * Distinct from the over-cap refusal above by what each one KNOWS. The over-cap
+ * refusal has measured the object and found it larger than the caller allowed.
+ * This one knows only that the read did not finish in time: it may never have
+ * opened the object, or may have taken some of it and been cut off part way, so
+ * neither the object's size nor its existence follows from this error.
  */
 export class StorageReadTimeoutError extends NextlyError {
   constructor(


### PR DESCRIPTION
The local storage adapter resolved a file by name three times to read it once — to validate the path, to ask for its size, and to pull in its contents — and enforced its byte cap against the size the middle resolution reported. A file replaced between that size and the read came back measured against the file it displaced. One still being appended to was buffered whole, however small it had been when asked.

It also resolved the read deadline and then never used it, so a `basePath` on an unresponsive network mount could hold a read open with nothing left to end it. Every other adapter honoured that deadline; the default backend did not.

## What changed

Both bounds now run against **one open descriptor**: an `fstat` for the cheap refusal, then a chunked read that counts the bytes as they arrive. A size that was true a moment ago can no longer decide what fits.

The deadline is **raced, not cancelled**, and the distinction is in the docblock so it is not later overstated. A filesystem call runs on the libuv threadpool and takes no abort signal — there is nothing to interrupt an `open` on a hung mount. The work keeps running and closes its own descriptor whichever side wins; what the race buys is that `read` *answers* within the deadline it advertised instead of holding its caller for as long as the mount stays down. This is the same posture the UploadThing adapter already carries.

Absence is unchanged: a missing file is still `null`, an over-cap refusal still throws `StorageReadTooLargeError`, and a deadline now throws rather than reporting a file nobody could reach as deleted.

## Tests

Both new cases use a FIFO, which is the one thing a test can make behave like the failure these bounds exist for.

- **A FIFO reports `size = 0` and delivers whatever its writer sends** — metadata that cannot describe its contents at all. With a cap of 1000 and a writer sending 200 KB, a metadata-only cap passes it unconditionally; counting refuses it.
- **A FIFO with no writer blocks `open` indefinitely** — a real stall rather than a simulated one.

Break-verified separately, each failing exactly one case:

| Mutation | Failing case |
|---|---|
| counting → `handle.readFile()` | REFUSES bytes past the cap even when the metadata says zero |
| `withDeadline(work, …)` → `await work` | gives up on a read that never gets going (4004 ms) |

The stalled-read case releases the blocked libuv threadpool thread when it finishes, so an abandoned `open` cannot starve the cases after it.

## Gates

- lint 24/24
- check-types 22/22
- `packages/nextly` 857 files, 10627 passed, 42 skipped
- `fallow audit --base origin/main` — no issues in 3 changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Local storage reads now enforce configured size limits as data arrives, preventing oversized content from being buffered.
  - Added timeout handling for reads that stall or block, preventing the application from hanging indefinitely.
  - Local storage read behavior now aligns more consistently with cloud storage adapters.
  - Timed-out storage reads now return a distinct retryable HTTP 504 error, separate from size-limit failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->