### PR TITLE
feat(nextly): serve a self-hosted font from this site's own origin

### DIFF
--- a/.changeset/a-font-can-be-served-from-this-origin.md
+++ b/.changeset/a-font-can-be-served-from-this-origin.md
@@ -1,0 +1,49 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A self-hosted font could be uploaded nowhere and served from nowhere. The
+upload allowlist carried no font type, so a `.woff2` was refused before it was
+stored; and a `@font-face` may not name another host, so a font that did reach
+S3, Vercel Blob or UploadThing was unusable at the only address it had.
+
+`font/woff2` and `font/woff` are now accepted — and only those two, because
+nothing here converts TTF or OTF, which would be stored and sent to every
+visitor at several times the size of the same face with nothing reporting it.
+
+Stored bytes can now be served from the site's own origin at
+`/api/media/:id/raw`, which the existing media handlers mount. It answers
+without a session, because the browser fetching a font does not have one, and
+what keeps that safe is the type: it serves the publicly servable formats and
+answers 404 — never 403 — for everything else, so it cannot be used to read a
+private file or to ask whether one exists.
+
+Reading a stored object also stopped being two implementations. The attachment
+path and the new route ask one function, which tries the adapter's own `read`
+and falls back to a bounded fetch of its public URL, refusing over-cap bytes in
+the same words either way. An over-sized error page is no longer reported as an
+over-sized file.

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -269,7 +269,7 @@ describe("the default accept map", () => {
 });
 
 describe("the browser boundary", () => {
-  it("offers exactly the formats the server accepts, in BOTH directions", () => {
+  it("offers every format the server accepts, and none it refuses", () => {
     /*
      * The two lists disagreed each way and neither side could see it. The map
      * offered AVI and MOV, which the allowlist refuses — so an author read that
@@ -277,23 +277,51 @@ describe("the browser boundary", () => {
      * AVIF, SVG, WebM and every audio format, which the allowlist accepts — so
      * files the server wanted could not be dragged at all.
      *
-     * Enumerated both ways because each direction fails differently and a test
-     * of one is satisfied by the other going wrong.
+     * A format counts as offered by its exact type OR by its family wildcard,
+     * because the wildcard is deliberate: an install adding `image/heic`
+     * through `additionalMimeTypes` is accepted by the server, and an
+     * exact-only map built from this build's defaults would refuse it in the
+     * browser before a request existed. What the wildcard must still carry is
+     * the SUFFIX, since a browser reporting no type has nothing else to match.
      */
     expect(DEFAULT_ACCEPTED_FORMATS.length).toBeGreaterThan(0);
 
     for (const format of DEFAULT_ACCEPTED_FORMATS) {
-      expect(DEFAULT_ACCEPTED_FILE_TYPES).toHaveProperty(format.mimeType);
+      const family = `${format.mimeType.split("/")[0] ?? ""}/*`;
+      const offered =
+        DEFAULT_ACCEPTED_FILE_TYPES[format.mimeType] ??
+        DEFAULT_ACCEPTED_FILE_TYPES[family];
+
+      expect(offered).toBeDefined();
       for (const extension of format.extensions) {
-        expect(DEFAULT_ACCEPTED_FILE_TYPES[format.mimeType]).toContain(
-          extension
-        );
+        expect(offered).toContain(extension);
       }
     }
 
-    const served = new Set(DEFAULT_ACCEPTED_FORMATS.map(f => f.mimeType));
-    for (const offered of Object.keys(DEFAULT_ACCEPTED_FILE_TYPES)) {
-      expect(served.has(offered)).toBe(true);
+    /*
+     * And nothing offered that the server refuses. A family wildcard passes
+     * because the server is the authority on what that family contains; an
+     * EXACT type must be one the allowlist names, which is what caught AVI.
+     */
+    for (const [offered, extensions] of Object.entries(
+      DEFAULT_ACCEPTED_FILE_TYPES
+    )) {
+      if (offered.endsWith("/*")) {
+        const family = offered.slice(0, -1);
+        for (const extension of extensions) {
+          expect(
+            DEFAULT_ACCEPTED_FORMATS.some(
+              format =>
+                format.mimeType.startsWith(family) &&
+                format.extensions.includes(extension)
+            )
+          ).toBe(true);
+        }
+        continue;
+      }
+      expect(
+        DEFAULT_ACCEPTED_FORMATS.some(format => format.mimeType === offered)
+      ).toBe(true);
     }
   });
 

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
 
+import { WEB_FONT_FORMATS } from "nextly/config";
+
 import {
   describeFileError,
   buildQueueFromDrop,
@@ -262,5 +264,24 @@ describe("the default accept map", () => {
     const description = getAcceptDescription(undefined, 10 * MB).toLowerCase();
     expect(description).not.toContain("ttf");
     expect(description).not.toContain("otf");
+  });
+});
+
+describe("the browser boundary", () => {
+  it("lets a person drag every format the server accepts", () => {
+    /*
+     * The map decides in the BROWSER, before any request exists, so a format
+     * the server accepts and this map omits is one nobody can upload — and no
+     * server-side test can see it. Enumerated from the shared table rather than
+     * from a list written here, which is what makes it fail when the table
+     * gains a format and this map is forgotten.
+     */
+    expect(WEB_FONT_FORMATS.length).toBeGreaterThan(0);
+    for (const format of WEB_FONT_FORMATS) {
+      expect(DEFAULT_ACCEPTED_FILE_TYPES).toHaveProperty(format.mimeType);
+      expect(DEFAULT_ACCEPTED_FILE_TYPES[format.mimeType]).toContain(
+        format.extension
+      );
+    }
   });
 });

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -230,9 +230,37 @@ describe("the default accept map", () => {
     expect(DEFAULT_ACCEPTED_FILE_TYPES).not.toHaveProperty("font/otf");
   });
 
-  it("names the fonts in the copy an author reads before dragging", () => {
-    // A format the dropzone accepts but the description omits is a format
-    // nobody tries, so the two have to move together.
-    expect(getAcceptDescription(undefined, 10 * MB)).toContain("WOFF2");
+  it("names EVERY accepted extension in the copy an author reads", () => {
+    /*
+     * Derived from the map rather than checked against a list written here,
+     * which is the only version that cannot drift: an earlier form asserted
+     * "WOFF2" alone and passed while the copy omitted WOFF, the very format
+     * the map had just gained.
+     *
+     * So the assertion enumerates the MAP. A format added there and forgotten
+     * in the description fails this without anyone editing the test.
+     */
+    const description = getAcceptDescription(undefined, 10 * MB).toLowerCase();
+    const extensions = Object.values(DEFAULT_ACCEPTED_FILE_TYPES).flat();
+
+    // The population, asserted before the verdict: an empty map would satisfy
+    // a loop that never runs, and read as every format being named.
+    expect(extensions.length).toBeGreaterThan(0);
+    for (const extension of extensions) {
+      // Case-insensitive, because the property is that the format is NAMED —
+      // some carry their own spelling (WebP) rather than plain capitals.
+      expect(description).toContain(extension.replace(/^\./, "").toLowerCase());
+    }
+  });
+
+  it("names no format the map does not accept", () => {
+    /*
+     * The control. The case above is satisfied by a description listing every
+     * format in existence, which would tell an author a TTF is welcome and let
+     * the server refuse it after the upload.
+     */
+    const description = getAcceptDescription(undefined, 10 * MB).toLowerCase();
+    expect(description).not.toContain("ttf");
+    expect(description).not.toContain("otf");
   });
 });

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from "vitest";
 
-import { describeFileError, buildQueueFromDrop } from "./index";
+import {
+  describeFileError,
+  buildQueueFromDrop,
+  DEFAULT_ACCEPTED_FILE_TYPES,
+  getAcceptDescription,
+} from "./index";
 
 const MB = 1024 * 1024;
 
@@ -195,5 +200,39 @@ describe("buildQueueFromDrop", () => {
     expect(failed[0].error).toBe(
       "File type is not supported, File is too large (max 10 MB)"
     );
+  });
+});
+
+describe("the default accept map", () => {
+  /*
+   * React Dropzone rejects a file whose type is absent from this map as
+   * `file-invalid-type`, in the browser, before any request is made — so a
+   * server allowlist that accepts a font is inert on its own. The upload an
+   * author actually performs is the one gated here.
+   */
+  it("accepts the web font formats, by type AND by extension", () => {
+    expect(DEFAULT_ACCEPTED_FILE_TYPES).toHaveProperty("font/woff2");
+    expect(DEFAULT_ACCEPTED_FILE_TYPES).toHaveProperty("font/woff");
+    // Both halves matter: some browsers report no type for a `.woff2` chosen
+    // from disk, and Dropzone then matches on the extension instead.
+    expect(DEFAULT_ACCEPTED_FILE_TYPES["font/woff2"]).toContain(".woff2");
+    expect(DEFAULT_ACCEPTED_FILE_TYPES["font/woff"]).toContain(".woff");
+  });
+
+  it("does NOT accept a font format the server refuses", () => {
+    /*
+     * The control. A map that accepted every font would satisfy the case above
+     * while letting an author drop a 4x larger TTF that the server then
+     * refuses — a rejection they only see after the upload, explained by
+     * nothing they can act on.
+     */
+    expect(DEFAULT_ACCEPTED_FILE_TYPES).not.toHaveProperty("font/ttf");
+    expect(DEFAULT_ACCEPTED_FILE_TYPES).not.toHaveProperty("font/otf");
+  });
+
+  it("names the fonts in the copy an author reads before dragging", () => {
+    // A format the dropzone accepts but the description omits is a format
+    // nobody tries, so the two have to move together.
+    expect(getAcceptDescription(undefined, 10 * MB)).toContain("WOFF2");
   });
 });

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { WEB_FONT_FORMATS } from "nextly/config";
+import { DEFAULT_ACCEPTED_FORMATS, WEB_FONT_FORMATS } from "nextly/config";
 
 import {
   describeFileError,
@@ -269,6 +269,34 @@ describe("the default accept map", () => {
 });
 
 describe("the browser boundary", () => {
+  it("offers exactly the formats the server accepts, in BOTH directions", () => {
+    /*
+     * The two lists disagreed each way and neither side could see it. The map
+     * offered AVI and MOV, which the allowlist refuses — so an author read that
+     * AVI was supported, dragged one, and the upload was rejected. It withheld
+     * AVIF, SVG, WebM and every audio format, which the allowlist accepts — so
+     * files the server wanted could not be dragged at all.
+     *
+     * Enumerated both ways because each direction fails differently and a test
+     * of one is satisfied by the other going wrong.
+     */
+    expect(DEFAULT_ACCEPTED_FORMATS.length).toBeGreaterThan(0);
+
+    for (const format of DEFAULT_ACCEPTED_FORMATS) {
+      expect(DEFAULT_ACCEPTED_FILE_TYPES).toHaveProperty(format.mimeType);
+      for (const extension of format.extensions) {
+        expect(DEFAULT_ACCEPTED_FILE_TYPES[format.mimeType]).toContain(
+          extension
+        );
+      }
+    }
+
+    const served = new Set(DEFAULT_ACCEPTED_FORMATS.map(f => f.mimeType));
+    for (const offered of Object.keys(DEFAULT_ACCEPTED_FILE_TYPES)) {
+      expect(served.has(offered)).toBe(true);
+    }
+  });
+
   it("lets a person drag every format the server accepts", () => {
     /*
      * The map decides in the BROWSER, before any request exists, so a format

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -302,6 +302,19 @@ describe("an explicit accept filter", () => {
     }
   });
 
+  it("carries every font extension for a WILDCARD font filter", () => {
+    /*
+     * `accept="font/*"` names every format this product serves, and the
+     * exact-type lookup cannot match it — so it fell to the generic branch with
+     * an empty list, and a browser reporting no type matched neither the type
+     * nor a suffix.
+     */
+    const parsed = parseAcceptString("font/*");
+    for (const format of WEB_FONT_FORMATS) {
+      expect(parsed?.["font/*"]).toContain(format.extension);
+    }
+  });
+
   it("still leaves an unknown type without invented extensions", () => {
     // The control: a parser attaching a suffix to everything would satisfy the
     // case above while telling Dropzone to accept files nothing asked for.

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/MediaUploadDropzone.test.ts
@@ -4,6 +4,7 @@ import { WEB_FONT_FORMATS } from "nextly/config";
 
 import {
   describeFileError,
+  parseAcceptString,
   buildQueueFromDrop,
   DEFAULT_ACCEPTED_FILE_TYPES,
   getAcceptDescription,
@@ -283,5 +284,29 @@ describe("the browser boundary", () => {
         format.extension
       );
     }
+  });
+});
+
+describe("an explicit accept filter", () => {
+  it("carries the extension for a font type it names", () => {
+    /*
+     * An upload field or picker can pass `accept="font/woff2"`. Without the
+     * extension the entry is `{ "font/woff2": [] }`, and a browser reporting an
+     * empty `type` for that same file then matches neither the type nor a
+     * suffix — so the explicit filter refuses the very format it names, while
+     * the default map accepts it.
+     */
+    for (const format of WEB_FONT_FORMATS) {
+      const parsed = parseAcceptString(format.mimeType);
+      expect(parsed?.[format.mimeType]).toContain(format.extension);
+    }
+  });
+
+  it("still leaves an unknown type without invented extensions", () => {
+    // The control: a parser attaching a suffix to everything would satisfy the
+    // case above while telling Dropzone to accept files nothing asked for.
+    expect(parseAcceptString("application/zip")?.["application/zip"]).toEqual(
+      []
+    );
   });
 });

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -42,7 +42,7 @@
 
 import { Progress, Button } from "@nextlyhq/ui";
 import { useQueryClient } from "@tanstack/react-query";
-import { WEB_FONT_FORMATS } from "nextly/config";
+import { DEFAULT_ACCEPTED_FORMATS, WEB_FONT_FORMATS } from "nextly/config";
 import * as React from "react";
 import {
   useDropzone,
@@ -133,25 +133,12 @@ export interface MediaUploadDropzoneProps {
  * - Documents: PDF
  * - Fonts: WOFF2, WOFF
  */
-export const DEFAULT_ACCEPTED_FILE_TYPES: Accept = {
-  "image/*": [".png", ".jpg", ".jpeg", ".gif", ".webp"],
-  "video/*": [".mp4", ".mov", ".avi"],
-  "application/pdf": [".pdf"],
-  /*
-   * Web fonts, DERIVED from the server's own table rather than restated here.
-   * React Dropzone refuses a file whose type is absent from this map as
-   * `file-invalid-type` in the browser, before any request exists — so this map
-   * and the server allowlist have to agree, and two hand-kept lists agree only
-   * until one of them is edited.
-   *
-   * Both halves of each entry are needed. Some browsers report no type at all
-   * for a `.woff2` chosen from disk, and Dropzone then matches the extension;
-   * the server fills the type back in from the same table.
-   */
-  ...Object.fromEntries(
-    WEB_FONT_FORMATS.map(format => [format.mimeType, [format.extension]])
-  ),
-};
+export const DEFAULT_ACCEPTED_FILE_TYPES: Accept = Object.fromEntries(
+  DEFAULT_ACCEPTED_FORMATS.map(format => [
+    format.mimeType,
+    [...format.extensions],
+  ])
+);
 
 /**
  * Default maximum file size. Matches the server's default `limits.fileSize`
@@ -185,23 +172,31 @@ const WEB_FONT_MIME_BY_TYPE = new Map(
 );
 
 /**
- * The extensions a family filter stands for.
+ * The extensions a family filter stands for, DERIVED from what the server
+ * actually accepts.
  *
- * A table rather than a branch per family: React Dropzone matches a file by
- * type OR by suffix, and a browser reporting no type at all — which it does for
- * any format its platform does not register — has only the suffix left. So an
- * entry without extensions refuses exactly the files its own filter names.
+ * React Dropzone matches a file by type OR by suffix, and a browser reporting
+ * no type — which it does for any format its platform does not register — has
+ * only the suffix left. So this list decides what can be dragged at all.
  *
- * Fonts come from the shared table, so a format added there reaches the
- * wildcard filter without anyone editing this.
+ * Written by hand it disagreed with the server in both directions: it offered
+ * AVI and MOV, which the allowlist refuses, and withheld AVIF, SVG, WebM and
+ * every audio format, which the allowlist accepts. Reading the same list the
+ * server validates against is what stops the two drifting again.
+ *
+ * The wildcard itself stays permissive on purpose: an install that widens
+ * `additionalMimeTypes` accepts types this build cannot know, and matching the
+ * family lets those through to the server that configured them.
  */
-const EXTENSIONS_BY_FAMILY: Record<string, readonly string[]> = {
-  "image/*": [".png", ".jpg", ".jpeg", ".gif", ".webp"],
-  "video/*": [".mp4", ".mov", ".avi"],
-  "audio/*": [".mp3", ".wav", ".ogg"],
-  "application/pdf": [".pdf"],
-  "font/*": WEB_FONT_FORMATS.map(format => format.extension),
-};
+const EXTENSIONS_BY_FAMILY: Record<string, readonly string[]> =
+  Object.fromEntries(
+    ["image/", "video/", "audio/", "font/"].map(family => [
+      `${family}*`,
+      DEFAULT_ACCEPTED_FORMATS.filter(format =>
+        format.mimeType.startsWith(family)
+      ).flatMap(format => format.extensions),
+    ])
+  );
 
 /**
  * The extensions one accepted type admits, or none for a type nothing here
@@ -210,6 +205,13 @@ const EXTENSIONS_BY_FAMILY: Record<string, readonly string[]> = {
 function extensionsForAcceptedType(type: string): string[] {
   const family = EXTENSIONS_BY_FAMILY[type];
   if (family !== undefined) return [...family];
+
+  // An exact type the server names, such as `application/pdf`, which belongs to
+  // no family wildcard and would otherwise arrive here with no suffix at all.
+  const exact = DEFAULT_ACCEPTED_FORMATS.find(
+    format => format.mimeType === type
+  );
+  if (exact !== undefined) return [...exact.extensions];
 
   const webFont = WEB_FONT_MIME_BY_TYPE.get(type);
   if (webFont !== undefined) return [webFont];

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -174,6 +174,17 @@ const MAX_FILES = 10;
 const UPLOAD_SUCCESS_DISPLAY_DURATION_MS = 4000;
 
 /**
+ * Each web font type against its extension, taken from the shared table.
+ *
+ * A lookup rather than a second list: the formats themselves are declared once
+ * on the server, and both the default map and an explicit filter read them from
+ * there so an added format reaches every path that decides what may be dragged.
+ */
+const WEB_FONT_MIME_BY_TYPE = new Map(
+  WEB_FONT_FORMATS.map(format => [format.mimeType, format.extension])
+);
+
+/**
  * Convert MIME type string to react-dropzone Accept format
  *
  * Supports formats like:
@@ -181,13 +192,17 @@ const UPLOAD_SUCCESS_DISPLAY_DURATION_MS = 4000;
  * - "image/png,image/jpeg" -> { "image/png": [".png"], "image/jpeg": [".jpg", ".jpeg"] }
  * - "application/pdf" -> { "application/pdf": [".pdf"] }
  */
-function parseAcceptString(acceptString?: string): Accept | undefined {
+export function parseAcceptString(acceptString?: string): Accept | undefined {
   if (!acceptString) return undefined;
 
   const accept: Accept = {};
   const types = acceptString.split(",").map(t => t.trim());
 
   for (const type of types) {
+    // Looked up once so the branch below narrows on the value rather than
+    // asserting it back out of the map.
+    const webFontExtension = WEB_FONT_MIME_BY_TYPE.get(type);
+
     if (type === "image/*") {
       accept["image/*"] = [".png", ".jpg", ".jpeg", ".gif", ".webp"];
     } else if (type === "video/*") {
@@ -196,6 +211,15 @@ function parseAcceptString(acceptString?: string): Accept | undefined {
       accept["audio/*"] = [".mp3", ".wav", ".ogg"];
     } else if (type === "application/pdf") {
       accept["application/pdf"] = [".pdf"];
+    } else if (webFontExtension !== undefined) {
+      /*
+       * Fonts carry their extension for the same reason the default map does:
+       * a browser reports an empty `type` for a `.woff2` chosen from disk, and
+       * Dropzone then matches on the extension instead. Falling through to the
+       * generic branch below produces an empty list, so an explicit
+       * `accept="font/woff2"` refuses the very file it names.
+       */
+      accept[type] = [webFontExtension];
     } else if (type.startsWith("image/")) {
       // Specific image types
       const subtype = type.split("/")[1];

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -28,7 +28,7 @@
  * - Drag reject: `border-destructive` (live feedback while dragging only)
  * - Uploading: spinner + count (shown where the target stays open, e.g. the picker)
  *
- * **Supported file types** (default): PNG, JPG, JPEG, GIF, WebP, MP4, MOV, AVI, PDF
+ * **Supported file types** (default): PNG, JPG, JPEG, GIF, WebP, MP4, MOV, AVI, PDF, WOFF2, WOFF
  * **File size limit**: 10MB per file by default (server default; overridable via `maxFileSize`)
  * **Batch cap**: 10 files per drop
  *
@@ -130,11 +130,23 @@ export interface MediaUploadDropzoneProps {
  * - Images: PNG, JPG, JPEG, GIF, WebP
  * - Videos: MP4, MOV, AVI
  * - Documents: PDF
+ * - Fonts: WOFF2, WOFF
  */
-const DEFAULT_ACCEPTED_FILE_TYPES: Accept = {
+export const DEFAULT_ACCEPTED_FILE_TYPES: Accept = {
   "image/*": [".png", ".jpg", ".jpeg", ".gif", ".webp"],
   "video/*": [".mp4", ".mov", ".avi"],
   "application/pdf": [".pdf"],
+  /*
+   * Web fonts, matching the server's own allowlist. React Dropzone rejects a
+   * file whose type is absent here as `file-invalid-type` before any request
+   * is made, so a server that accepts a font is not enough on its own: the
+   * upload the author actually performs never leaves the browser.
+   *
+   * Both halves are needed. Some browsers report no type at all for a `.woff2`
+   * chosen from disk, and Dropzone then falls back to matching the extension.
+   */
+  "font/woff2": [".woff2"],
+  "font/woff": [".woff"],
 };
 
 /**
@@ -201,14 +213,17 @@ function parseAcceptString(acceptString?: string): Accept | undefined {
 /**
  * Get human-readable file type description from accept string
  */
-function getAcceptDescription(
+export function getAcceptDescription(
   acceptString: string | undefined,
   maxSize: number
 ): string {
   const sizeLimit = ` up to ${formatFileSize(maxSize)}`;
 
   if (!acceptString) {
-    return `PNG, JPG, GIF, WebP, MP4, MOV, PDF${sizeLimit}`;
+    // Kept in step with DEFAULT_ACCEPTED_FILE_TYPES: this string is what an
+    // author reads to decide whether a file is worth dragging, so a format the
+    // dropzone accepts but the copy omits is a format nobody tries.
+    return `PNG, JPG, GIF, WebP, MP4, MOV, PDF, WOFF2${sizeLimit}`;
   }
 
   const types: string[] = [];
@@ -225,6 +240,9 @@ function getAcceptDescription(
   }
   if (acceptString.includes("application/pdf")) {
     types.push("PDF");
+  }
+  if (acceptString.includes("font/")) {
+    types.push("Fonts");
   }
 
   if (types.length === 0) {

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -185,6 +185,46 @@ const WEB_FONT_MIME_BY_TYPE = new Map(
 );
 
 /**
+ * The extensions a family filter stands for.
+ *
+ * A table rather than a branch per family: React Dropzone matches a file by
+ * type OR by suffix, and a browser reporting no type at all — which it does for
+ * any format its platform does not register — has only the suffix left. So an
+ * entry without extensions refuses exactly the files its own filter names.
+ *
+ * Fonts come from the shared table, so a format added there reaches the
+ * wildcard filter without anyone editing this.
+ */
+const EXTENSIONS_BY_FAMILY: Record<string, readonly string[]> = {
+  "image/*": [".png", ".jpg", ".jpeg", ".gif", ".webp"],
+  "video/*": [".mp4", ".mov", ".avi"],
+  "audio/*": [".mp3", ".wav", ".ogg"],
+  "application/pdf": [".pdf"],
+  "font/*": WEB_FONT_FORMATS.map(format => format.extension),
+};
+
+/**
+ * The extensions one accepted type admits, or none for a type nothing here
+ * knows — which leaves Dropzone matching on the MIME type alone, as before.
+ */
+function extensionsForAcceptedType(type: string): string[] {
+  const family = EXTENSIONS_BY_FAMILY[type];
+  if (family !== undefined) return [...family];
+
+  const webFont = WEB_FONT_MIME_BY_TYPE.get(type);
+  if (webFont !== undefined) return [webFont];
+
+  if (type.startsWith("image/")) {
+    const subtype = type.split("/")[1] ?? "";
+    // `image/jpeg` is written both ways on disk, and a picker naming the type
+    // should accept the file however the author's camera spelled it.
+    return subtype === "jpeg" ? [".jpeg", ".jpg"] : [`.${subtype}`];
+  }
+
+  return [];
+}
+
+/**
  * Convert MIME type string to react-dropzone Accept format
  *
  * Supports formats like:
@@ -196,43 +236,8 @@ export function parseAcceptString(acceptString?: string): Accept | undefined {
   if (!acceptString) return undefined;
 
   const accept: Accept = {};
-  const types = acceptString.split(",").map(t => t.trim());
-
-  for (const type of types) {
-    // Looked up once so the branch below narrows on the value rather than
-    // asserting it back out of the map.
-    const webFontExtension = WEB_FONT_MIME_BY_TYPE.get(type);
-
-    if (type === "image/*") {
-      accept["image/*"] = [".png", ".jpg", ".jpeg", ".gif", ".webp"];
-    } else if (type === "video/*") {
-      accept["video/*"] = [".mp4", ".mov", ".avi"];
-    } else if (type === "audio/*") {
-      accept["audio/*"] = [".mp3", ".wav", ".ogg"];
-    } else if (type === "application/pdf") {
-      accept["application/pdf"] = [".pdf"];
-    } else if (webFontExtension !== undefined) {
-      /*
-       * Fonts carry their extension for the same reason the default map does:
-       * a browser reports an empty `type` for a `.woff2` chosen from disk, and
-       * Dropzone then matches on the extension instead. Falling through to the
-       * generic branch below produces an empty list, so an explicit
-       * `accept="font/woff2"` refuses the very file it names.
-       */
-      accept[type] = [webFontExtension];
-    } else if (type.startsWith("image/")) {
-      // Specific image types
-      const subtype = type.split("/")[1];
-      // Handle common aliases
-      if (subtype === "jpeg") {
-        accept[type] = [`.${subtype}`, ".jpg"];
-      } else {
-        accept[type] = [`.${subtype}`];
-      }
-    } else {
-      // Generic MIME type
-      accept[type] = [];
-    }
+  for (const type of acceptString.split(",").map(t => t.trim())) {
+    accept[type] = extensionsForAcceptedType(type);
   }
 
   return Object.keys(accept).length > 0 ? accept : undefined;

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -211,6 +211,39 @@ function parseAcceptString(acceptString?: string): Accept | undefined {
 }
 
 /**
+ * Formats whose own spelling is not simply their extension in capitals.
+ *
+ * Presentation only, and deliberately separate from the map above: WHICH
+ * formats are offered stays derived, so an entry missing from here costs a
+ * capital letter rather than an omission an author acts on.
+ */
+const EXTENSION_CASING: Record<string, string> = { webp: "WebP" };
+
+/**
+ * Name the formats an accept map actually admits.
+ *
+ * DERIVED from the map rather than restated beside it. The hand-written
+ * version had already drifted: the map accepted WOFF and the copy named only
+ * WOFF2, so an author holding a `.woff` read that it was unsupported and did
+ * not try. A format the dropzone accepts but the copy omits is a format nobody
+ * uses, and the two lists have no mechanism keeping them level.
+ *
+ * Extensions rather than mime types, because that is what an author sees on
+ * their own file. Deduplicated through a Set: several entries can name the
+ * same extension, and a repeated one reads as a mistake in the copy.
+ */
+function describeAcceptedTypes(accept: Accept): string {
+  const labels = new Set<string>();
+  for (const extensions of Object.values(accept)) {
+    for (const extension of extensions) {
+      const bare = extension.replace(/^\./, "");
+      labels.add(EXTENSION_CASING[bare] ?? bare.toUpperCase());
+    }
+  }
+  return [...labels].join(", ");
+}
+
+/**
  * Get human-readable file type description from accept string
  */
 export function getAcceptDescription(
@@ -220,10 +253,7 @@ export function getAcceptDescription(
   const sizeLimit = ` up to ${formatFileSize(maxSize)}`;
 
   if (!acceptString) {
-    // Kept in step with DEFAULT_ACCEPTED_FILE_TYPES: this string is what an
-    // author reads to decide whether a file is worth dragging, so a format the
-    // dropzone accepts but the copy omits is a format nobody tries.
-    return `PNG, JPG, GIF, WebP, MP4, MOV, PDF, WOFF2${sizeLimit}`;
+    return `${describeAcceptedTypes(DEFAULT_ACCEPTED_FILE_TYPES)}${sizeLimit}`;
   }
 
   const types: string[] = [];

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -126,6 +126,52 @@ export interface MediaUploadDropzoneProps {
 }
 
 /**
+ * The extensions a family filter stands for, DERIVED from what the server
+ * actually accepts.
+ *
+ * React Dropzone matches a file by type OR by suffix, and a browser reporting
+ * no type — which it does for any format its platform does not register — has
+ * only the suffix left. So this list decides what can be dragged at all.
+ *
+ * Written by hand it disagreed with the server in both directions: it offered
+ * AVI and MOV, which the allowlist refuses, and withheld AVIF, SVG, WebM and
+ * every audio format, which the allowlist accepts. Reading the same list the
+ * server validates against is what stops the two drifting again.
+ *
+ * The wildcard itself stays permissive on purpose: an install that widens
+ * `additionalMimeTypes` accepts types this build cannot know, and matching the
+ * family lets those through to the server that configured them.
+ */
+const FAMILY_PREFIXES = ["image/", "video/", "audio/"] as const;
+
+const EXTENSIONS_BY_FAMILY: Record<string, readonly string[]> =
+  Object.fromEntries(
+    [...FAMILY_PREFIXES, "font/"].map(family => [
+      `${family}*`,
+      DEFAULT_ACCEPTED_FORMATS.filter(format =>
+        format.mimeType.startsWith(family)
+      ).flatMap(format => format.extensions),
+    ])
+  );
+
+/**
+ * The family wildcards the DEFAULT map offers, with the suffixes the server
+ * accepts under each.
+ *
+ * The wildcard is what keeps a configured install working: an install that adds
+ * `image/heic` through `additionalMimeTypes` is accepted by the server, and an
+ * exact-type map built from this build's defaults would refuse it in the
+ * browser before a request existed. The family lets it through to the
+ * authoritative validator; the extensions stay truthful for the default config.
+ */
+const EXTENSIONS_BY_FAMILY_ACCEPT: Accept = Object.fromEntries(
+  FAMILY_PREFIXES.map(family => [
+    `${family}*`,
+    [...(EXTENSIONS_BY_FAMILY[`${family}*`] ?? [])],
+  ])
+);
+
+/**
  * Default accepted file types for dropzone
  *
  * - Images: PNG, JPG, JPEG, GIF, WebP
@@ -133,12 +179,23 @@ export interface MediaUploadDropzoneProps {
  * - Documents: PDF
  * - Fonts: WOFF2, WOFF
  */
-export const DEFAULT_ACCEPTED_FILE_TYPES: Accept = Object.fromEntries(
-  DEFAULT_ACCEPTED_FORMATS.map(format => [
-    format.mimeType,
-    [...format.extensions],
-  ])
-);
+export const DEFAULT_ACCEPTED_FILE_TYPES: Accept = {
+  ...EXTENSIONS_BY_FAMILY_ACCEPT,
+  /*
+   * Exact types for what belongs to no family wildcard, and for fonts
+   * deliberately: `font/*` would admit TTF and OTF, which the server refuses
+   * because nothing converts them — a file accepted here and rejected there is
+   * a rejection an author only meets after the upload.
+   */
+  ...Object.fromEntries(
+    DEFAULT_ACCEPTED_FORMATS.filter(
+      format => !FAMILY_PREFIXES.some(f => format.mimeType.startsWith(f))
+    ).map(format => [format.mimeType, [...format.extensions]])
+  ),
+  ...Object.fromEntries(
+    WEB_FONT_FORMATS.map(format => [format.mimeType, [format.extension]])
+  ),
+};
 
 /**
  * Default maximum file size. Matches the server's default `limits.fileSize`
@@ -170,33 +227,6 @@ const UPLOAD_SUCCESS_DISPLAY_DURATION_MS = 4000;
 const WEB_FONT_MIME_BY_TYPE = new Map(
   WEB_FONT_FORMATS.map(format => [format.mimeType, format.extension])
 );
-
-/**
- * The extensions a family filter stands for, DERIVED from what the server
- * actually accepts.
- *
- * React Dropzone matches a file by type OR by suffix, and a browser reporting
- * no type — which it does for any format its platform does not register — has
- * only the suffix left. So this list decides what can be dragged at all.
- *
- * Written by hand it disagreed with the server in both directions: it offered
- * AVI and MOV, which the allowlist refuses, and withheld AVIF, SVG, WebM and
- * every audio format, which the allowlist accepts. Reading the same list the
- * server validates against is what stops the two drifting again.
- *
- * The wildcard itself stays permissive on purpose: an install that widens
- * `additionalMimeTypes` accepts types this build cannot know, and matching the
- * family lets those through to the server that configured them.
- */
-const EXTENSIONS_BY_FAMILY: Record<string, readonly string[]> =
-  Object.fromEntries(
-    ["image/", "video/", "audio/", "font/"].map(family => [
-      `${family}*`,
-      DEFAULT_ACCEPTED_FORMATS.filter(format =>
-        format.mimeType.startsWith(family)
-      ).flatMap(format => format.extensions),
-    ])
-  );
 
 /**
  * The extensions one accepted type admits, or none for a type nothing here

--- a/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
+++ b/packages/admin/src/components/features/media-library/MediaUploadDropzone/index.tsx
@@ -42,6 +42,7 @@
 
 import { Progress, Button } from "@nextlyhq/ui";
 import { useQueryClient } from "@tanstack/react-query";
+import { WEB_FONT_FORMATS } from "nextly/config";
 import * as React from "react";
 import {
   useDropzone,
@@ -137,16 +138,19 @@ export const DEFAULT_ACCEPTED_FILE_TYPES: Accept = {
   "video/*": [".mp4", ".mov", ".avi"],
   "application/pdf": [".pdf"],
   /*
-   * Web fonts, matching the server's own allowlist. React Dropzone rejects a
-   * file whose type is absent here as `file-invalid-type` before any request
-   * is made, so a server that accepts a font is not enough on its own: the
-   * upload the author actually performs never leaves the browser.
+   * Web fonts, DERIVED from the server's own table rather than restated here.
+   * React Dropzone refuses a file whose type is absent from this map as
+   * `file-invalid-type` in the browser, before any request exists — so this map
+   * and the server allowlist have to agree, and two hand-kept lists agree only
+   * until one of them is edited.
    *
-   * Both halves are needed. Some browsers report no type at all for a `.woff2`
-   * chosen from disk, and Dropzone then falls back to matching the extension.
+   * Both halves of each entry are needed. Some browsers report no type at all
+   * for a `.woff2` chosen from disk, and Dropzone then matches the extension;
+   * the server fills the type back in from the same table.
    */
-  "font/woff2": [".woff2"],
-  "font/woff": [".woff"],
+  ...Object.fromEntries(
+    WEB_FONT_FORMATS.map(format => [format.mimeType, [format.extension]])
+  ),
 };
 
 /**

--- a/packages/nextly/src/actions/upload-media.ts
+++ b/packages/nextly/src/actions/upload-media.ts
@@ -193,7 +193,11 @@ export async function uploadMediaAction(
      * this narrows what a caller must send rather than widening what is
      * believed.
      */
-    const claimedMimeType = resolveClaimedMimeType(file.name, file.type);
+    const claimedMimeType = resolveClaimedMimeType(
+      file.name,
+      file.type,
+      buffer
+    );
 
     const parseResult = UploadMediaInputSchema.safeParse({
       file: buffer,

--- a/packages/nextly/src/actions/upload-media.ts
+++ b/packages/nextly/src/actions/upload-media.ts
@@ -78,6 +78,7 @@ import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
 
 import { container } from "../di/container";
 import { ServiceContainer } from "../services";
+import { resolveClaimedMimeType } from "../services/upload-validation/web-fonts";
 import type { Media } from "../types/media";
 import { UploadMediaInputSchema } from "../types/media";
 
@@ -185,10 +186,19 @@ export async function uploadMediaAction(
     const buffer = Buffer.from(arrayBuffer);
 
     // 4. Validate input
+    /*
+     * A browser reports no type for formats its platform does not register,
+     * fonts among them, so the name fills it in. Only a known font name
+     * resolves and the claim still meets the magic-byte check downstream, so
+     * this narrows what a caller must send rather than widening what is
+     * believed.
+     */
+    const claimedMimeType = resolveClaimedMimeType(file.name, file.type);
+
     const parseResult = UploadMediaInputSchema.safeParse({
       file: buffer,
       filename: file.name,
-      mimeType: file.type,
+      mimeType: claimedMimeType,
       size: file.size,
       uploadedBy: options.uploadedBy,
     });

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -70,6 +70,7 @@ import type {
   ListMediaOptions,
 } from "../services/media/media-service";
 import type { RequestContext } from "../services/shared";
+import { resolveClaimedMimeType } from "../services/upload-validation/web-fonts";
 import { UploadMediaInputSchema, UpdateMediaInputSchema } from "../types/media";
 
 import { executeBulkDelete } from "./media-bulk";
@@ -427,7 +428,7 @@ async function handleUploadMedia(
   const input = {
     file: buffer,
     filename: file.name,
-    mimeType: file.type,
+    mimeType: resolveClaimedMimeType(file.name, file.type),
     size: file.size,
     uploadedBy: uploadedByEnsured,
   };
@@ -445,7 +446,9 @@ async function handleUploadMedia(
     {
       buffer,
       filename: file.name,
-      mimeType: file.type,
+      // The same resolution the schema was given above. Validating one value
+      // and storing another means the record can carry a type nothing checked.
+      mimeType: resolveClaimedMimeType(file.name, file.type),
       size: file.size,
       folderId: folderId || undefined,
     },

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -428,7 +428,7 @@ async function handleUploadMedia(
   const input = {
     file: buffer,
     filename: file.name,
-    mimeType: resolveClaimedMimeType(file.name, file.type),
+    mimeType: resolveClaimedMimeType(file.name, file.type, buffer),
     size: file.size,
     uploadedBy: uploadedByEnsured,
   };
@@ -448,7 +448,7 @@ async function handleUploadMedia(
       filename: file.name,
       // The same resolution the schema was given above. Validating one value
       // and storing another means the record can carry a type nothing checked.
-      mimeType: resolveClaimedMimeType(file.name, file.type),
+      mimeType: resolveClaimedMimeType(file.name, file.type, buffer),
       size: file.size,
       folderId: folderId || undefined,
     },

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -73,6 +73,7 @@ import type { RequestContext } from "../services/shared";
 import { UploadMediaInputSchema, UpdateMediaInputSchema } from "../types/media";
 
 import { executeBulkDelete } from "./media-bulk";
+import { handleServeMediaBytes } from "./media-raw";
 import { readJsonBody } from "./read-json-body";
 import {
   respondAction,
@@ -252,6 +253,7 @@ interface ParsedMediaRoute {
     | "update-media"
     | "delete-media"
     | "move-media"
+    | "serve-media-bytes"
     | "bulk-delete-media"
     | "list-folders"
     | "create-folder"
@@ -312,6 +314,12 @@ function parseMediaRoute(
       return { type: "not-found" };
     }
 
+    return { type: "not-found" };
+  }
+
+  if (segments.length === 2 && segments[1] === "raw") {
+    if (method === "GET")
+      return { type: "serve-media-bytes", mediaId: segments[0] };
     return { type: "not-found" };
   }
 
@@ -674,6 +682,18 @@ export function createMediaHandlers(options?: MediaHandlerOptions) {
       async (request: Request, ctx: RouteContext): Promise<Response> => {
         const resolvedParams = await ctx.params;
         const route = parseMediaRoute(resolvedParams.path, "GET");
+        /*
+         * Answered BEFORE the gate, and deliberately: a browser fetching a
+         * font carries no session, so on a gated mount this route would
+         * otherwise answer 401 and the page would fall back to another face.
+         * What keeps that safe is that the handler serves only the publicly
+         * servable mime types and 404s everything else — the whole of its
+         * access control, stated in one place.
+         */
+        if (route.type === "serve-media-bytes") {
+          await ensureInitialized();
+          return await handleServeMediaBytes(route.mediaId!);
+        }
         const gate = await gateMediaRoute(
           request,
           route,

--- a/packages/nextly/src/api/media-handlers.ts
+++ b/packages/nextly/src/api/media-handlers.ts
@@ -448,7 +448,10 @@ async function handleUploadMedia(
       filename: file.name,
       // The same resolution the schema was given above. Validating one value
       // and storing another means the record can carry a type nothing checked.
-      mimeType: resolveClaimedMimeType(file.name, file.type, buffer),
+      // The value the schema ACCEPTED, not a second resolution of the same
+      // question. Two calls can diverge under any later edit, and the one that
+      // reaches storage would be the one nothing checked.
+      mimeType: input.mimeType,
       size: file.size,
       folderId: folderId || undefined,
     },

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -18,7 +18,15 @@ import { createMediaHandlers } from "./media-handlers";
 
 const mocks = vi.hoisted(() => ({
   mediaService: { findById: vi.fn() },
-  storage: { read: vi.fn(), getPublicUrl: vi.fn() },
+  /*
+   * The ADAPTER is the thing that can read. Kept separate from the manager
+   * below, and the manager deliberately has NO `read` and NO `getPublicUrl`,
+   * because the real one has neither — an earlier double carried both and so
+   * passed while the route handed the manager over and could not serve a byte
+   * on any backend.
+   */
+  adapter: { read: vi.fn(), getPublicUrl: vi.fn() },
+  manager: { getAdapterForCollection: vi.fn() },
   requirePermission: vi.fn(),
 }));
 
@@ -32,7 +40,7 @@ vi.mock("../di", () => ({
 }));
 
 vi.mock("../storage/storage", () => ({
-  getMediaStorage: vi.fn(() => mocks.storage),
+  getMediaStorage: vi.fn(() => mocks.manager),
 }));
 
 vi.mock("../auth/middleware", async importOriginal => {
@@ -62,7 +70,8 @@ function storedAs(mimeType: string): void {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.storage.read.mockResolvedValue(Buffer.from("OTTO-bytes"));
+  mocks.manager.getAdapterForCollection.mockReturnValue(mocks.adapter);
+  mocks.adapter.read.mockResolvedValue(Buffer.from("OTTO-bytes"));
 });
 
 describe("the public byte route", () => {
@@ -91,7 +100,7 @@ describe("the public byte route", () => {
 
     expect(response.status).toBe(404);
     expect(response.status).not.toBe(403);
-    expect(mocks.storage.read).not.toHaveBeenCalled();
+    expect(mocks.adapter.read).not.toHaveBeenCalled();
     expect(await response.text()).toBe("");
   });
 
@@ -110,6 +119,37 @@ describe("the public byte route", () => {
 
     expect(response.status).toBe(200);
     expect(mocks.requirePermission).not.toHaveBeenCalled();
+  });
+
+  it("reads through the media collection's ADAPTER, not the manager", async () => {
+    /*
+     * The manager routes to an adapter and cannot read; it also needs the
+     * collection to choose one, so `getPublicUrl` called without it answers
+     * from the local default and yields a relative path `safeFetch` refuses.
+     * Handing the manager over therefore fails on EVERY backend — which the
+     * previous double concealed by implementing `read` itself.
+     *
+     * Asserted on the collection as well as on the bytes: an install routing
+     * media to S3 while everything else stays local gets the wrong backend
+     * from an omitted argument, and the bytes alone cannot show that.
+     */
+    storedAs("font/woff2");
+    const response = await getRaw("m1");
+
+    expect(response.status).toBe(200);
+    expect(mocks.manager.getAdapterForCollection).toHaveBeenCalledWith("media");
+    expect(mocks.adapter.read).toHaveBeenCalled();
+  });
+
+  it("serves a font whose stored type is spelled in another case", async () => {
+    /*
+     * `validateMimeType` lowercases what it compares and the record keeps what
+     * the client sent, so `Font/WOFF2` is accepted on upload and stored with
+     * that spelling. An exact lookup here would refuse to serve a font this
+     * same product had just approved.
+     */
+    storedAs("Font/WOFF2");
+    expect((await getRaw("m1")).status).toBe(200);
   });
 
   it("answers 404 for a record that is not there", async () => {

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -1,0 +1,142 @@
+/**
+ * What the public byte route will and will not hand to an anonymous caller.
+ *
+ * Driven through `createMediaHandlers` rather than by calling the handler
+ * directly, because the property worth protecting is not "the handler checks a
+ * mime type" — it is that the request reaches that check WITHOUT passing the
+ * auth gate. Calling the handler on its own would pass while the route was
+ * wired behind the gate, which is the arrangement that breaks fonts on exactly
+ * the installs that lock media down.
+ *
+ * @module api/media-raw.test
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { NextlyError } from "../errors/nextly-error";
+
+import { createMediaHandlers } from "./media-handlers";
+
+const mocks = vi.hoisted(() => ({
+  mediaService: { findById: vi.fn() },
+  storage: { read: vi.fn(), getPublicUrl: vi.fn() },
+  requirePermission: vi.fn(),
+}));
+
+vi.mock("../init", () => ({
+  getNextly: vi.fn(async () => ({})),
+  getCachedNextly: vi.fn(async () => ({})),
+}));
+
+vi.mock("../di", () => ({
+  getService: vi.fn(() => mocks.mediaService),
+}));
+
+vi.mock("../storage/storage", () => ({
+  getMediaStorage: vi.fn(() => mocks.storage),
+}));
+
+vi.mock("../auth/middleware", async importOriginal => {
+  const actual = await importOriginal<typeof import("../auth/middleware")>();
+  return { ...actual, requirePermission: mocks.requirePermission };
+});
+
+/** A GET through the real route table, as a browser would address it. */
+async function getRaw(
+  mediaId: string,
+  options?: { requireAuth?: boolean }
+): Promise<Response> {
+  const handlers = createMediaHandlers({ requireAuth: options?.requireAuth });
+  return await handlers.GET(
+    new Request(`https://site.test/api/media/${mediaId}/raw`),
+    { params: Promise.resolve({ path: [mediaId, "raw"] }) }
+  );
+}
+
+function storedAs(mimeType: string): void {
+  mocks.mediaService.findById.mockResolvedValue({
+    id: "m1",
+    filename: "2026/04/face.woff2",
+    mimeType,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.storage.read.mockResolvedValue(Buffer.from("OTTO-bytes"));
+});
+
+describe("the public byte route", () => {
+  it("serves a woff2 with its own content type", async () => {
+    storedAs("font/woff2");
+    const response = await getRaw("m1");
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Content-Type")).toBe("font/woff2");
+    expect(await response.text()).toBe("OTTO-bytes");
+  });
+
+  it("REFUSES a type outside the servable set, and says nothing about it", async () => {
+    /*
+     * The security property the whole design rests on. The route is reachable
+     * with no session, so if the mime gate stopped working, every stored
+     * object — a private PDF among them — would be readable by id.
+     *
+     * 404 rather than 403, because 403 answers the question "is there a record
+     * here?", which is the question an anonymous caller must not be able to ask.
+     * And the storage read must not happen at all: a route that fetched the
+     * bytes and then declined to send them would still have paid for them.
+     */
+    storedAs("application/pdf");
+    const response = await getRaw("m1");
+
+    expect(response.status).toBe(404);
+    expect(response.status).not.toBe(403);
+    expect(mocks.storage.read).not.toHaveBeenCalled();
+    expect(await response.text()).toBe("");
+  });
+
+  it("serves the font on a GATED mount, with no session", async () => {
+    /*
+     * The reason this route sits before the gate. A browser fetching a font
+     * sends no credentials, so a gated font route answers 401 and the page
+     * silently renders in a fallback face — a failure nobody sees in review,
+     * on exactly the installs that locked media down on purpose.
+     *
+     * Asserted on `requirePermission` never being consulted, because a 200
+     * alone would also be produced by a permission mock that happened to allow.
+     */
+    storedAs("font/woff2");
+    const response = await getRaw("m1", { requireAuth: true });
+
+    expect(response.status).toBe(200);
+    expect(mocks.requirePermission).not.toHaveBeenCalled();
+  });
+
+  it("answers 404 for a record that is not there", async () => {
+    mocks.mediaService.findById.mockRejectedValue(
+      NextlyError.notFound({ logContext: { entity: "media" } })
+    );
+    expect((await getRaw("gone")).status).toBe(404);
+  });
+
+  it("does NOT turn a lookup failure into 404", async () => {
+    /*
+     * An unreachable database has said nothing about whether the font exists,
+     * and this response is cacheable for a year. Folding the two together lets
+     * an outage be cached as a permanent absence long after it ended.
+     *
+     * Its control is the case above, which fails if absence stops reporting 404
+     * at all; this one fails only when absence and failure are being folded.
+     */
+    mocks.mediaService.findById.mockRejectedValue(
+      new Error("connection refused")
+    );
+
+    const outcome = await getRaw("m1").then(
+      value => value,
+      (error: unknown) => error
+    );
+    const status = outcome instanceof Response ? outcome.status : 500;
+    expect(status).not.toBe(404);
+  });
+});

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -83,10 +83,16 @@ function storedAs(mimeType: string): void {
   });
 }
 
+/** Bytes that genuinely begin as a WOFF2, which the route now requires. */
+const WOFF2_BYTES = Buffer.concat([
+  Buffer.from("wOF2", "ascii"),
+  Buffer.alloc(48),
+]);
+
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.manager.getAdapterForCollection.mockReturnValue(mocks.adapter);
-  mocks.adapter.read.mockResolvedValue(Buffer.from("OTTO-bytes"));
+  mocks.adapter.read.mockResolvedValue(WOFF2_BYTES);
 });
 
 describe("the public byte route", () => {
@@ -96,7 +102,9 @@ describe("the public byte route", () => {
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Content-Type")).toBe("font/woff2");
-    expect(await response.text()).toBe("OTTO-bytes");
+    expect(new Uint8Array(await response.arrayBuffer())).toEqual(
+      new Uint8Array(WOFF2_BYTES)
+    );
   });
 
   it("REFUSES a type outside the servable set, and says nothing about it", async () => {
@@ -184,6 +192,44 @@ describe("the public byte route", () => {
     // NOT 502: an outage tells a visitor to retry, and this response is
     // cacheable for a year.
     expect(response.status).not.toBe(502);
+  });
+
+  it("REFUSES a row whose stored type is not what its bytes are", async () => {
+    /*
+     * The row's MIME type is the whole of this route's access control, and that
+     * metadata was not always trustworthy: the published server action reaches
+     * the legacy service, which persisted whatever type a client sent without
+     * comparing it to the content. An installation upgrading into this feature
+     * can already hold a row labelled `font/woff2` carrying anything, and the
+     * upload-side check does not reach back and rewrite it.
+     *
+     * Its control is the serving case above, which fails if the route stops
+     * serving fonts at all; this one fails only when the label is trusted.
+     */
+    storedAs("font/woff2");
+    mocks.adapter.read.mockResolvedValue(Buffer.from("not-a-font", "utf8"));
+
+    const response = await getRaw("m1");
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+  });
+
+  it("serves a row stored under a LEGACY font type", async () => {
+    /*
+     * Rows predating the upload-side canonicalisation carry the older spelling,
+     * and nothing rewrites them — an exact lookup refuses a font this product
+     * has served since before it knew the canonical name.
+     */
+    storedAs("application/font-woff");
+    mocks.adapter.read.mockResolvedValue(
+      Buffer.concat([Buffer.from("wOFF", "ascii"), Buffer.alloc(48)])
+    );
+
+    const response = await getRaw("m1");
+    expect(response.status).toBe(200);
+    // Served under the name a browser expects, not the one the row happens to
+    // carry.
+    expect(response.headers.get("Content-Type")).toBe("font/woff");
   });
 
   it("answers 404 for a record that is not there", async () => {

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -30,6 +30,7 @@ const mocks = vi.hoisted(() => ({
    */
   adapter: { read: vi.fn(), getPublicUrl: vi.fn() },
   manager: { getAdapterForCollection: vi.fn() },
+  safeFetch: vi.fn(),
   requirePermission: vi.fn(),
 }));
 
@@ -45,6 +46,17 @@ vi.mock("../di", () => ({
 vi.mock("../storage/storage", () => ({
   getMediaStorage: vi.fn(() => mocks.manager),
 }));
+
+/*
+ * The URL fallback is only reached when the adapter cannot answer, which is one
+ * case below. Partial, so `SafeFetchError` stays real — the classifier the
+ * fallback runs keys on `instanceof`.
+ */
+vi.mock("../utils/validate-external-url", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("../utils/validate-external-url")>();
+  return { ...actual, safeFetch: mocks.safeFetch };
+});
 
 vi.mock("../auth/middleware", async importOriginal => {
   const actual = await importOriginal<typeof import("../auth/middleware")>();
@@ -153,6 +165,25 @@ describe("the public byte route", () => {
      */
     storedAs("Font/WOFF2");
     expect((await getRaw("m1")).status).toBe(200);
+  });
+
+  it("answers 404 when the row outlived its stored object", async () => {
+    /*
+     * The adapter says the object is gone while the record remains. From
+     * outside these are the same thing — there is no font here — and the
+     * alternative is a 502 telling a visitor to retry a file that will never
+     * return, cached for a year by the header this route sets.
+     */
+    storedAs("font/woff2");
+    mocks.adapter.read.mockResolvedValue(null);
+    mocks.adapter.getPublicUrl.mockReturnValue("https://cdn.test/f.woff2");
+    mocks.safeFetch.mockResolvedValue(new Response("gone", { status: 404 }));
+
+    const response = await getRaw("m1");
+    expect(response.status).toBe(404);
+    // NOT 502: an outage tells a visitor to retry, and this response is
+    // cacheable for a year.
+    expect(response.status).not.toBe(502);
   });
 
   it("answers 404 for a record that is not there", async () => {

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -14,7 +14,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { NextlyError } from "../errors/nextly-error";
 
+import { WEB_FONT_MIME_TYPES } from "../services/upload-validation/web-fonts";
+
 import { createMediaHandlers } from "./media-handlers";
+import { PUBLIC_SERVE_MIME_TYPES } from "./media-raw";
 
 const mocks = vi.hoisted(() => ({
   mediaService: { findById: vi.fn() },
@@ -178,5 +181,20 @@ describe("the public byte route", () => {
     );
     const status = outcome instanceof Response ? outcome.status : 500;
     expect(status).not.toBe(404);
+  });
+});
+
+describe("the serving boundary", () => {
+  it("serves exactly what the canonical table declares", () => {
+    /*
+     * Both directions, because they fail differently. A format in the table but
+     * not here is one an author can upload and never serve; one here but not in
+     * the table makes every stored object of that type world readable by id,
+     * which is the direction nobody notices.
+     */
+    expect([...PUBLIC_SERVE_MIME_TYPES].sort()).toEqual(
+      [...WEB_FONT_MIME_TYPES].sort()
+    );
+    expect(PUBLIC_SERVE_MIME_TYPES.size).toBeGreaterThan(0);
   });
 });

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -52,6 +52,15 @@ export const PUBLIC_SERVE_MIME_TYPES: ReadonlySet<string> = new Set([
  */
 const IMMUTABLE_FOR_A_YEAR = "public, max-age=31536000, immutable";
 
+/**
+ * The collection whose adapter serves these bytes.
+ *
+ * Named rather than passed as `undefined`, because the manager resolves an
+ * adapter FROM it — and an install routing media to S3 while everything else
+ * stays local gets the wrong backend from an omitted argument, not a default.
+ */
+const MEDIA_COLLECTION = "media";
+
 /** The response for a record this route will not talk about. */
 function notFound(): Response {
   return new Response(null, { status: 404 });
@@ -85,12 +94,28 @@ export async function handleServeMediaBytes(
     throw error;
   }
 
-  if (!PUBLIC_SERVE_MIME_TYPES.has(media.mimeType)) {
+  /*
+   * Normalised before the lookup, because upload validation and storage
+   * disagree about spelling: `validateMimeType` lowercases what it compares
+   * and the record keeps whatever the client sent. So `Font/WOFF2` is accepted
+   * on upload, stored with that spelling, and an exact match here would refuse
+   * to serve a font the same product had just approved. Mime tokens are
+   * case-insensitive, so the comparison has to be too.
+   */
+  if (!PUBLIC_SERVE_MIME_TYPES.has(media.mimeType.toLowerCase().trim())) {
     return notFound();
   }
 
+  /*
+   * The media collection's ADAPTER, not the manager that routes to it. The
+   * manager implements no `read` at all, so handing it over takes the URL
+   * fallback every time — and its `getPublicUrl` needs the collection to pick
+   * an adapter, so called without one it answers from the local default and
+   * produces a relative path that `safeFetch` refuses. Every backend fails,
+   * including the local one this route was supposed to work on first.
+   */
   const bytes = await readStoredMediaBytes(
-    getMediaStorage(),
+    getMediaStorage().getAdapterForCollection(MEDIA_COLLECTION),
     media.filename,
     DEFAULT_READ_MAX_BYTES
   );

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -24,6 +24,7 @@
 import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
 import type { RequestContext } from "../services/shared";
+import { WEB_FONT_MIME_TYPES } from "../services/upload-validation/web-fonts";
 import { DEFAULT_READ_MAX_BYTES } from "../storage/fetch-stored-bytes";
 import { readStoredMediaBytes } from "../storage/read-stored-media";
 import { getMediaStorage } from "../storage/storage";
@@ -37,10 +38,9 @@ import { getMediaStorage } from "../storage/storage";
  * answer to. Adding an entry here makes every stored object of that type world
  * readable by id.
  */
-export const PUBLIC_SERVE_MIME_TYPES: ReadonlySet<string> = new Set([
-  "font/woff2",
-  "font/woff",
-]);
+export const PUBLIC_SERVE_MIME_TYPES: ReadonlySet<string> = new Set(
+  WEB_FONT_MIME_TYPES
+);
 
 /**
  * A year, and `immutable` alongside it.

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -24,7 +24,11 @@
 import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
 import type { RequestContext } from "../services/shared";
-import { WEB_FONT_MIME_TYPES } from "../services/upload-validation/web-fonts";
+import {
+  canonicalWebFontMime,
+  matchesWebFontSignature,
+  WEB_FONT_MIME_TYPES,
+} from "../services/upload-validation/web-fonts";
 import { DEFAULT_READ_MAX_BYTES } from "../storage/fetch-stored-bytes";
 import { readStoredMediaBytes } from "../storage/read-stored-media";
 import { getMediaStorage } from "../storage/storage";
@@ -102,7 +106,14 @@ export async function handleServeMediaBytes(
    * to serve a font the same product had just approved. Mime tokens are
    * case-insensitive, so the comparison has to be too.
    */
-  if (!PUBLIC_SERVE_MIME_TYPES.has(media.mimeType.toLowerCase().trim())) {
+  /*
+   * Canonicalised, because a row PREDATING the upload-side fix may carry a
+   * legacy spelling — `application/font-woff` and its x- variant were what some
+   * clients sent, and nothing rewrites stored rows. An exact lookup refuses a
+   * font this product has served since before it knew the canonical name.
+   */
+  const servedType = canonicalWebFontMime(media.mimeType.toLowerCase().trim());
+  if (servedType === undefined || !PUBLIC_SERVE_MIME_TYPES.has(servedType)) {
     return notFound();
   }
 
@@ -123,10 +134,32 @@ export async function handleServeMediaBytes(
   // because from outside they are the same thing: there is no font here.
   if (bytes === null) return notFound();
 
+  /*
+   * THE BYTES DECIDE, at serve time, not only at upload time.
+   *
+   * This route makes a stored MIME type confer anonymous access, and that
+   * metadata was not always trustworthy: the published server action reaches
+   * the legacy service, which persisted whatever type a client sent without
+   * comparing it to the content. So an installation upgrading into this feature
+   * can already hold a row labelled `font/woff2` carrying anything at all, and
+   * the upload-side signature check does not reach back and rewrite it.
+   *
+   * Checked here rather than migrated, because the bytes are already in hand
+   * and the comparison is four of them — a migration would have to be run,
+   * would have to be run everywhere, and would still leave this route trusting
+   * a label. Refused as 404 rather than an error, for the same reason the type
+   * gate above is: the route says nothing about objects it will not serve.
+   */
+  if (!matchesWebFontSignature(bytes, servedType)) {
+    return notFound();
+  }
+
   return new Response(new Uint8Array(bytes), {
     status: 200,
     headers: {
-      "Content-Type": media.mimeType,
+      // The CANONICAL type, so a row stored under a legacy spelling is served
+      // under the name a browser expects.
+      "Content-Type": servedType,
       "Content-Length": String(bytes.byteLength),
       "Cache-Control": IMMUTABLE_FOR_A_YEAR,
       /*

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -1,0 +1,113 @@
+/**
+ * Serve a stored media object's bytes from this site's own origin.
+ *
+ * It exists because a `@font-face` may not name another host — a product rule
+ * the styling engine enforces rather than suggests, on the grounds that a font
+ * URL pointing elsewhere makes every visitor's browser announce its IP address
+ * to that server before a word of the page is readable. A font uploaded to S3,
+ * Vercel Blob or UploadThing is therefore unusable at its own address, and
+ * needs one on this origin.
+ *
+ * WHAT IT WILL SERVE IS THE WHOLE OF ITS ACCESS CONTROL. Every other media
+ * route is gated by `requireAuth`, which cannot work here: the browser asking
+ * for a font carries no session, so on a locked-down install a gated font route
+ * would answer 401 and the page would render in a fallback face. Running it
+ * ungated instead is only safe because it refuses to serve anything outside
+ * `PUBLIC_SERVE_MIME_TYPES` — the gate is the mime type, not the caller, and
+ * widening that set widens what any anonymous caller can read.
+ *
+ * A record outside the set answers 404 rather than 403, so the route cannot be
+ * used to ask whether a private object exists.
+ *
+ * @module api/media-raw
+ */
+import { getService } from "../di";
+import { NextlyError } from "../errors/nextly-error";
+import type { RequestContext } from "../services/shared";
+import { DEFAULT_READ_MAX_BYTES } from "../storage/fetch-stored-bytes";
+import { readStoredMediaBytes } from "../storage/read-stored-media";
+import { getMediaStorage } from "../storage/storage";
+
+/**
+ * The only types this route hands to an unauthenticated caller.
+ *
+ * Web font formats and nothing else. It is not a list of things that are
+ * harmless to serve — it is the list of things a page cannot work without
+ * serving, which is a much smaller question and the only one this route has an
+ * answer to. Adding an entry here makes every stored object of that type world
+ * readable by id.
+ */
+export const PUBLIC_SERVE_MIME_TYPES: ReadonlySet<string> = new Set([
+  "font/woff2",
+  "font/woff",
+]);
+
+/**
+ * A year, and `immutable` alongside it.
+ *
+ * Sound for exactly the types above: a font is written once and never
+ * regenerated, unlike an image, whose bytes a focal-point change rewrites in
+ * place under the same id. If this set ever grows to cover a type that IS
+ * rewritten, this header stops being true before the new type does.
+ */
+const IMMUTABLE_FOR_A_YEAR = "public, max-age=31536000, immutable";
+
+/** The response for a record this route will not talk about. */
+function notFound(): Response {
+  return new Response(null, { status: 404 });
+}
+
+/**
+ * Serve one media object's bytes, if its type is publicly servable.
+ *
+ * @param mediaId - The record to serve
+ * @returns The bytes with their content type, or 404
+ */
+export async function handleServeMediaBytes(
+  mediaId: string
+): Promise<Response> {
+  const mediaService = getService("mediaService");
+  const context: RequestContext = {};
+
+  let media;
+  try {
+    media = await mediaService.findById(mediaId, context);
+  } catch (error) {
+    /*
+     * Only an ABSENT record becomes 404. `findById` deliberately tells a
+     * missing row apart from a database that could not be reached, and folding
+     * the second into the first would answer a visitor "no such font" during an
+     * outage — a cache could then hold that answer long after the outage ended.
+     */
+    if (error instanceof NextlyError && error.code === "NOT_FOUND") {
+      return notFound();
+    }
+    throw error;
+  }
+
+  if (!PUBLIC_SERVE_MIME_TYPES.has(media.mimeType)) {
+    return notFound();
+  }
+
+  const bytes = await readStoredMediaBytes(
+    getMediaStorage(),
+    media.filename,
+    DEFAULT_READ_MAX_BYTES
+  );
+
+  return new Response(new Uint8Array(bytes), {
+    status: 200,
+    headers: {
+      "Content-Type": media.mimeType,
+      "Content-Length": String(bytes.byteLength),
+      "Cache-Control": IMMUTABLE_FOR_A_YEAR,
+      /*
+       * The type is already one of two known font types, so there is nothing
+       * for a browser to guess at — but a route that serves stored bytes should
+       * say so regardless, because the header stops being redundant the moment
+       * the set above changes.
+       */
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+}

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -119,6 +119,9 @@ export async function handleServeMediaBytes(
     media.filename,
     DEFAULT_READ_MAX_BYTES
   );
+  // The row outlived its object. Same answer as a row that never existed,
+  // because from outside they are the same thing: there is no font here.
+  if (bytes === null) return notFound();
 
   return new Response(new Uint8Array(bytes), {
     status: 200,

--- a/packages/nextly/src/api/media.ts
+++ b/packages/nextly/src/api/media.ts
@@ -184,11 +184,10 @@ export const POST = withErrorHandler(
       {
         buffer,
         filename: fileEnsured.name,
-        mimeType: resolveClaimedMimeType(
-          fileEnsured.name,
-          fileEnsured.type,
-          buffer
-        ),
+        // The value the schema ACCEPTED, not a second resolution of the same
+        // question — the one that reaches storage must be the one that was
+        // checked.
+        mimeType: input.mimeType,
         size: fileEnsured.size,
         folderId: folderId || undefined,
       },

--- a/packages/nextly/src/api/media.ts
+++ b/packages/nextly/src/api/media.ts
@@ -24,6 +24,7 @@ import type {
   ListMediaOptions,
 } from "../services/media/media-service";
 import type { RequestContext } from "../services/shared";
+import { resolveClaimedMimeType } from "../services/upload-validation/web-fonts";
 import { UploadMediaInputSchema, UpdateMediaInputSchema } from "../types/media";
 
 import { readJsonBody } from "./read-json-body";
@@ -161,7 +162,7 @@ export const POST = withErrorHandler(
     const input = {
       file: buffer,
       filename: fileEnsured.name,
-      mimeType: fileEnsured.type,
+      mimeType: resolveClaimedMimeType(fileEnsured.name, fileEnsured.type),
       size: fileEnsured.size,
       uploadedBy: uploadedByEnsured,
     };
@@ -179,7 +180,7 @@ export const POST = withErrorHandler(
       {
         buffer,
         filename: fileEnsured.name,
-        mimeType: fileEnsured.type,
+        mimeType: resolveClaimedMimeType(fileEnsured.name, fileEnsured.type),
         size: fileEnsured.size,
         folderId: folderId || undefined,
       },

--- a/packages/nextly/src/api/media.ts
+++ b/packages/nextly/src/api/media.ts
@@ -162,7 +162,11 @@ export const POST = withErrorHandler(
     const input = {
       file: buffer,
       filename: fileEnsured.name,
-      mimeType: resolveClaimedMimeType(fileEnsured.name, fileEnsured.type),
+      mimeType: resolveClaimedMimeType(
+        fileEnsured.name,
+        fileEnsured.type,
+        buffer
+      ),
       size: fileEnsured.size,
       uploadedBy: uploadedByEnsured,
     };
@@ -180,7 +184,11 @@ export const POST = withErrorHandler(
       {
         buffer,
         filename: fileEnsured.name,
-        mimeType: resolveClaimedMimeType(fileEnsured.name, fileEnsured.type),
+        mimeType: resolveClaimedMimeType(
+          fileEnsured.name,
+          fileEnsured.type,
+          buffer
+        ),
         size: fileEnsured.size,
         folderId: folderId || undefined,
       },

--- a/packages/nextly/src/api/media.upload.test.ts
+++ b/packages/nextly/src/api/media.upload.test.ts
@@ -131,6 +131,55 @@ describe("POST /api/media — unified validation pipeline", () => {
     expect(code).toBe("VALIDATION_ERROR");
   });
 
+  it("accepts a font the browser could not name, as its canonical type", async () => {
+    /*
+     * The case the extension entry in the admin dropzone exists for. A browser
+     * reports an empty `type` for a `.woff2` chosen from disk — fonts are not
+     * in every platform's registry — and the upload was then refused for
+     * claiming no type at all, whatever the allowlist said. Dropzone let the
+     * file through and the server turned it away.
+     *
+     * Asserted on what reaches STORAGE rather than on a 201, because the
+     * response is the same either way once the upload succeeds; what the record
+     * carries is the thing that was wrong.
+     */
+    const bundle = buildStubBundle();
+    container.registerSingleton("mediaService", () => bundle.service);
+    const { POST } = await import("./media");
+
+    // Bytes `file-type` does not recognise, so the magic-byte check trusts the
+    // claim — the point here is the claim's RESOLUTION, not the sniffer.
+    const bytes = Buffer.from("not-really-a-font", "utf8");
+    const res = await POST(makeRequest(bytes, "Inter.woff2", ""));
+
+    expect(res.status).toBe(201);
+    // The stored claim, read off the call rather than matched against a whole
+    // argument list — the shape around it is not what this case is about.
+    const stored = bundle.legacyUploadMedia.mock.calls[0]?.[0] as {
+      mimeType?: string;
+    };
+    expect(stored.mimeType).toBe("font/woff2");
+  });
+
+  it("does NOT invent a type for a name it does not know", async () => {
+    /*
+     * The control, and the half that matters for safety: this fills in a claim
+     * the caller never made, so it must resolve for font names only. A `.bin`
+     * with no type stays unnamed and is refused exactly as before — otherwise
+     * the inference would be a way to launder anything past the allowlist.
+     */
+    container.registerSingleton(
+      "mediaService",
+      () => buildStubBundle().service
+    );
+    const { POST } = await import("./media");
+
+    const res = await POST(
+      makeRequest(Buffer.from("x", "utf8"), "payload.bin", "")
+    );
+    expect(res.status).not.toBe(201);
+  });
+
   it("rejects .exe regardless of MIME claim", async () => {
     container.registerSingleton(
       "mediaService",

--- a/packages/nextly/src/api/media.upload.test.ts
+++ b/packages/nextly/src/api/media.upload.test.ts
@@ -147,9 +147,14 @@ describe("POST /api/media — unified validation pipeline", () => {
     container.registerSingleton("mediaService", () => bundle.service);
     const { POST } = await import("./media");
 
-    // Bytes `file-type` does not recognise, so the magic-byte check trusts the
-    // claim — the point here is the claim's RESOLUTION, not the sniffer.
-    const bytes = Buffer.from("not-really-a-font", "utf8");
+    // REAL WOFF2 bytes, so the case distinguishes a font from anything else
+    // renamed to look like one. Text here would pass a validator that trusts
+    // whatever it cannot identify, which is the implementation this must fail
+    // against.
+    const bytes = Buffer.concat([
+      Buffer.from("wOF2", "ascii"),
+      Buffer.alloc(64),
+    ]);
     const res = await POST(makeRequest(bytes, "Inter.woff2", ""));
 
     expect(res.status).toBe(201);
@@ -159,6 +164,29 @@ describe("POST /api/media — unified validation pipeline", () => {
       mimeType?: string;
     };
     expect(stored.mimeType).toBe("font/woff2");
+  });
+
+  it("REFUSES content that is not the font it is named as", async () => {
+    /*
+     * The claim can be inferred from a filename, so nothing but the bytes
+     * stands behind it — and the public route serves these types to anonymous
+     * callers as immutable, cacheable assets. `file-type` recognises neither
+     * WOFF nor WOFF2, so a validator trusting what it cannot identify accepts
+     * arbitrary content under a servable type.
+     *
+     * Its control is the case above, which fails if font uploads stop working
+     * at all; this one fails only when the signature goes unchecked.
+     */
+    container.registerSingleton(
+      "mediaService",
+      () => buildStubBundle().service
+    );
+    const { POST } = await import("./media");
+
+    const res = await POST(
+      makeRequest(Buffer.from("not-really-a-font", "utf8"), "Evil.woff2", "")
+    );
+    expect(res.status).toBe(400);
   });
 
   it("does NOT invent a type for a name it does not know", async () => {

--- a/packages/nextly/src/api/media.upload.test.ts
+++ b/packages/nextly/src/api/media.upload.test.ts
@@ -4,6 +4,14 @@ import { container } from "../di/container";
 import { MediaService } from "../domains/media/services/media-service";
 import { UploadValidator } from "../services/upload-validation";
 
+const mocks = vi.hoisted(() => ({ requirePermission: vi.fn() }));
+
+// Partial: the real ErrorResponse helpers stay, only the gate is driven here.
+vi.mock("../auth/middleware", async importOriginal => {
+  const actual = await importOriginal<typeof import("../auth/middleware")>();
+  return { ...actual, requirePermission: mocks.requirePermission };
+});
+
 vi.mock("../init", () => ({
   getNextly: vi.fn(async () => ({})),
   getCachedNextly: vi.fn(async () => ({})),
@@ -20,6 +28,34 @@ vi.mock("../di", async () => {
 // Stable user UUID v4 for the form payload (the Zod schema requires
 // a strict UUID, so the version+variant bits matter).
 const TEST_USER_ID = "00000000-0000-4000-8000-000000000000";
+
+/** The gated mount, which is what a consumer wires up. */
+async function mountedHandlers(): Promise<{
+  POST: (
+    request: Request,
+    ctx: { params: Promise<{ path?: string[] }> }
+  ) => Promise<Response>;
+}> {
+  const { createMediaHandlers } = await import("./media-handlers");
+  const handlers = createMediaHandlers({ requireAuth: true });
+  return {
+    POST: (request, ctx) => handlers.POST(request, ctx),
+  };
+}
+
+/** A POST the mounted route will parse: no `uploadedBy`, which comes from auth. */
+function mountedRequest(
+  file: Buffer,
+  filename: string,
+  mimeType: string
+): [Request, { params: Promise<{ path?: string[] }> }] {
+  const form = new FormData();
+  form.append("file", new Blob([file], { type: mimeType }), filename);
+  return [
+    new Request("http://localhost/api/media", { method: "POST", body: form }),
+    { params: Promise.resolve({ path: [] }) },
+  ];
+}
 
 function makeRequest(
   file: Buffer,
@@ -131,83 +167,6 @@ describe("POST /api/media — unified validation pipeline", () => {
     expect(code).toBe("VALIDATION_ERROR");
   });
 
-  it("accepts a font the browser could not name, as its canonical type", async () => {
-    /*
-     * The case the extension entry in the admin dropzone exists for. A browser
-     * reports an empty `type` for a `.woff2` chosen from disk — fonts are not
-     * in every platform's registry — and the upload was then refused for
-     * claiming no type at all, whatever the allowlist said. Dropzone let the
-     * file through and the server turned it away.
-     *
-     * Asserted on what reaches STORAGE rather than on a 201, because the
-     * response is the same either way once the upload succeeds; what the record
-     * carries is the thing that was wrong.
-     */
-    const bundle = buildStubBundle();
-    container.registerSingleton("mediaService", () => bundle.service);
-    const { POST } = await import("./media");
-
-    // REAL WOFF2 bytes, so the case distinguishes a font from anything else
-    // renamed to look like one. Text here would pass a validator that trusts
-    // whatever it cannot identify, which is the implementation this must fail
-    // against.
-    const bytes = Buffer.concat([
-      Buffer.from("wOF2", "ascii"),
-      Buffer.alloc(64),
-    ]);
-    const res = await POST(makeRequest(bytes, "Inter.woff2", ""));
-
-    expect(res.status).toBe(201);
-    // The stored claim, read off the call rather than matched against a whole
-    // argument list — the shape around it is not what this case is about.
-    const stored = bundle.legacyUploadMedia.mock.calls[0]?.[0] as {
-      mimeType?: string;
-    };
-    expect(stored.mimeType).toBe("font/woff2");
-  });
-
-  it("REFUSES content that is not the font it is named as", async () => {
-    /*
-     * The claim can be inferred from a filename, so nothing but the bytes
-     * stands behind it — and the public route serves these types to anonymous
-     * callers as immutable, cacheable assets. `file-type` recognises neither
-     * WOFF nor WOFF2, so a validator trusting what it cannot identify accepts
-     * arbitrary content under a servable type.
-     *
-     * Its control is the case above, which fails if font uploads stop working
-     * at all; this one fails only when the signature goes unchecked.
-     */
-    container.registerSingleton(
-      "mediaService",
-      () => buildStubBundle().service
-    );
-    const { POST } = await import("./media");
-
-    const res = await POST(
-      makeRequest(Buffer.from("not-really-a-font", "utf8"), "Evil.woff2", "")
-    );
-    expect(res.status).toBe(400);
-  });
-
-  it("does NOT invent a type for a name it does not know", async () => {
-    /*
-     * The control, and the half that matters for safety: this fills in a claim
-     * the caller never made, so it must resolve for font names only. A `.bin`
-     * with no type stays unnamed and is refused exactly as before — otherwise
-     * the inference would be a way to launder anything past the allowlist.
-     */
-    container.registerSingleton(
-      "mediaService",
-      () => buildStubBundle().service
-    );
-    const { POST } = await import("./media");
-
-    const res = await POST(
-      makeRequest(Buffer.from("x", "utf8"), "payload.bin", "")
-    );
-    expect(res.status).not.toBe(201);
-  });
-
   it("rejects .exe regardless of MIME claim", async () => {
     container.registerSingleton(
       "mediaService",
@@ -295,5 +254,106 @@ describe("MediaService.upload — svgCsp honored", () => {
       contentDisposition?: string;
     };
     expect(args.contentDisposition).toBeUndefined();
+  });
+});
+
+/**
+ * The font cases run through the MOUNTED handler.
+ *
+ * `./media` names itself internal and superseded; consumers mount
+ * `createMediaHandlers`. Driving these through the superseded module leaves
+ * them green if the inference is removed from the handler a site actually
+ * serves, which is coverage of a path nobody runs.
+ */
+describe("POST through the mounted media handlers — font uploads", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    container.clear();
+    mocks.requirePermission.mockResolvedValue({ userId: TEST_USER_ID });
+  });
+
+  afterEach(() => {
+    container.clear();
+  });
+
+  it("accepts a font the browser could not name, as its canonical type", async () => {
+    /*
+     * The case the extension entry in the admin dropzone exists for. A browser
+     * reports an empty `type` for a `.woff2` chosen from disk — fonts are not
+     * in every platform's registry — and the upload was then refused for
+     * claiming no type at all, whatever the allowlist said. Dropzone let the
+     * file through and the server turned it away.
+     *
+     * Asserted on what reaches STORAGE rather than on a 201, because the
+     * response is the same either way once the upload succeeds; what the record
+     * carries is the thing that was wrong.
+     */
+    const bundle = buildStubBundle();
+    container.registerSingleton("mediaService", () => bundle.service);
+    const { POST } = await mountedHandlers();
+
+    // REAL WOFF2 bytes, so the case distinguishes a font from anything else
+    // renamed to look like one. Text here would pass a validator that trusts
+    // whatever it cannot identify, which is the implementation this must fail
+    // against.
+    const bytes = Buffer.concat([
+      Buffer.from("wOF2", "ascii"),
+      Buffer.alloc(64),
+    ]);
+    const res = await POST(...mountedRequest(bytes, "Inter.woff2", ""));
+
+    expect(res.status).toBe(201);
+    // The stored claim, read off the call rather than matched against a whole
+    // argument list — the shape around it is not what this case is about.
+    const stored = bundle.legacyUploadMedia.mock.calls[0]?.[0] as {
+      mimeType?: string;
+    };
+    expect(stored.mimeType).toBe("font/woff2");
+  });
+
+  it("REFUSES content that is not the font it is named as", async () => {
+    /*
+     * The claim can be inferred from a filename, so nothing but the bytes
+     * stands behind it — and the public route serves these types to anonymous
+     * callers as immutable, cacheable assets. `file-type` recognises neither
+     * WOFF nor WOFF2, so a validator trusting what it cannot identify accepts
+     * arbitrary content under a servable type.
+     *
+     * Its control is the case above, which fails if font uploads stop working
+     * at all; this one fails only when the signature goes unchecked.
+     */
+    container.registerSingleton(
+      "mediaService",
+      () => buildStubBundle().service
+    );
+    const { POST } = await mountedHandlers();
+
+    const res = await POST(
+      ...mountedRequest(
+        Buffer.from("not-really-a-font", "utf8"),
+        "Evil.woff2",
+        ""
+      )
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("does NOT invent a type for a name it does not know", async () => {
+    /*
+     * The control, and the half that matters for safety: this fills in a claim
+     * the caller never made, so it must resolve for font names only. A `.bin`
+     * with no type stays unnamed and is refused exactly as before — otherwise
+     * the inference would be a way to launder anything past the allowlist.
+     */
+    container.registerSingleton(
+      "mediaService",
+      () => buildStubBundle().service
+    );
+    const { POST } = await mountedHandlers();
+
+    const res = await POST(
+      ...mountedRequest(Buffer.from("x", "utf8"), "payload.bin", "")
+    );
+    expect(res.status).not.toBe(201);
   });
 });

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -252,4 +252,13 @@ export {
   WEB_FONT_MIME_TYPES,
   webFontMimeFromFilename,
 } from "./services/upload-validation/web-fonts";
+// The formats an upload may carry, with the suffixes they wear on disk. The
+// admin's dropzone decides in the BROWSER what may be dragged, and a list of
+// its own drifts from this one — which is how a picker comes to advertise a
+// format the server refuses and refuse one the server accepts.
+export {
+  DEFAULT_ACCEPTED_FORMATS,
+  DEFAULT_ALLOWED_MIME_TYPES,
+} from "./services/upload-validation/mime";
+export type { AcceptedFormat } from "./services/upload-validation/mime";
 export type { WebFontFormat } from "./services/upload-validation/web-fonts";

--- a/packages/nextly/src/config.ts
+++ b/packages/nextly/src/config.ts
@@ -239,3 +239,17 @@ export type {
 // naturally configures. Sharing the one substitution rule keeps a template and
 // a function from drifting into two different addresses for the same entry.
 export { previewUrlFromTemplate } from "./domains/collections/services/preview-url-resolver";
+
+// The web font formats, for the same reason MAX_QUERIES_PER_REQUEST is here: a
+// second copy on the client is a copy that drifts. The admin dropzone decides
+// in the BROWSER what a person may drag, before any request exists, so a format
+// this server accepts and that map omits is one nobody can upload — and one the
+// map admits and the server refuses is a rejection an author only sees after
+// the upload. Its module has no imports, so taking it here costs a
+// `nextly.config.ts` nothing.
+export {
+  WEB_FONT_FORMATS,
+  WEB_FONT_MIME_TYPES,
+  webFontMimeFromFilename,
+} from "./services/upload-validation/web-fonts";
+export type { WebFontFormat } from "./services/upload-validation/web-fonts";

--- a/packages/nextly/src/di/registrations/register-email.ts
+++ b/packages/nextly/src/di/registrations/register-email.ts
@@ -194,11 +194,17 @@ export function registerEmailServices(ctx: RegistrationContext): void {
            */
           const limits = getAttachmentLimits();
           try {
-            return await readStoredMediaBytes(
+            const bytes = await readStoredMediaBytes(
               storage,
               storagePath,
               limits.maxTotalBytes
             );
+            // An attachment whose object is gone cannot be sent, and the author
+            // is owed the same answer as any other failure to read it.
+            if (bytes === null) {
+              throw new StoredMediaUnreachableError(storagePath, 404);
+            }
+            return bytes;
           } catch (err) {
             throw asAttachmentReadError(err, limits.maxTotalBytes);
           }

--- a/packages/nextly/src/di/registrations/register-email.ts
+++ b/packages/nextly/src/di/registrations/register-email.ts
@@ -23,7 +23,10 @@ import { EmailTemplateService } from "../../services/email/email-template-servic
 import type { MediaService as UnifiedMediaService } from "../../services/media/media-service";
 import { SYSTEM_CONTEXT } from "../../shared/types";
 import { isStorageReadTooLarge } from "../../storage/read-errors";
-import { SafeFetchError, safeFetch } from "../../utils/validate-external-url";
+import {
+  readStoredMediaBytes,
+  StoredMediaUnreachableError,
+} from "../../storage/read-stored-media";
 import { container } from "../container";
 
 import type { RegistrationContext } from "./types";
@@ -52,6 +55,18 @@ export function asAttachmentReadError(
   error: unknown,
   maxBytes: number
 ): unknown {
+  if (error instanceof StoredMediaUnreachableError) {
+    // Unchanged in what it reports: the URL route used to raise this inline,
+    // and it is the storage read that failed rather than the attachment that
+    // was too big.
+    return NextlyError.internal({
+      logContext: {
+        emailAttachmentCode: EmailErrorCode.ATTACHMENT_STORAGE_READ_FAILED,
+        url: error.url,
+        status: error.status,
+      },
+    });
+  }
   if (!isStorageReadTooLarge(error)) return error;
   return NextlyError.validation({
     errors: [
@@ -173,88 +188,20 @@ export function registerEmailServices(ctx: RegistrationContext): void {
         },
         readBytes: async storagePath => {
           /*
-           * The SAME cap on both routes, because which one runs is a property
-           * of the adapter rather than of the request.
-           *
-           * This branch is taken whenever the adapter implements `read`, and
-           * which adapters do has changed underneath this code before: the
-           * cloud adapters had no `read`, so every one of them fell through to
-           * the bounded fetch below, and implementing it moved them onto a path
-           * that buffered the whole object first and checked its size after.
-           * Passing the limit down means the branch cannot decide whether the
-           * limit applies.
-           */
-          /*
-           * ONE snapshot for both branches. Reading the policy twice let the
-           * native read and the URL fallback enforce and report different caps
-           * — the environment backing it can change between the two calls, and
-           * a later normalisation would drift them silently — while the comment
-           * below promises the SAME cap. One read is what makes that true.
+           * ONE snapshot, because reading the policy twice let the two routes
+           * enforce and report different caps: the environment backing it can
+           * change between the calls, and nothing would have said so.
            */
           const limits = getAttachmentLimits();
-          // 1. Try native read() (local disk, S3, etc.)
-          if (typeof storage.read === "function") {
-            let buffer: Buffer | null;
-            try {
-              buffer = await storage.read(storagePath, {
-                maxBytes: limits.maxTotalBytes,
-              });
-            } catch (err) {
-              throw asAttachmentReadError(err, limits.maxTotalBytes);
-            }
-            if (buffer) return buffer;
-          }
-          // 2. Fallback: fetch via URL.
-          //    Vercel Blob (and similar adapters) store the full public
-          //    URL as the media filename, so storagePath may already be
-          //    a URL. Only call getPublicUrl for relative paths.
-          //    Use safeFetch to reject URLs that resolve to private/
-          //    loopback/link-local/cloud-metadata addresses — closes
-          //    SSRF when an attacker controls the `storagePath` field.
-          const url = storagePath.startsWith("http")
-            ? storagePath
-            : storage.getPublicUrl(storagePath);
-          // Cap the fetch at the attachment size limit so a valid large
-          // attachment is not rejected by the smaller default safeFetch cap. A
-          // body over the limit surfaces as the same size-exceeded validation
-          // error the local/S3 path produces, not an opaque storage failure.
-          let response: Response;
           try {
-            response = await safeFetch(url, {
-              maxResponseBytes: limits.maxTotalBytes,
-            });
+            return await readStoredMediaBytes(
+              storage,
+              storagePath,
+              limits.maxTotalBytes
+            );
           } catch (err) {
-            if (
-              err instanceof SafeFetchError &&
-              err.reason === "response-too-large"
-            ) {
-              throw NextlyError.validation({
-                errors: [
-                  {
-                    path: "attachments",
-                    code: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED,
-                    message: "Attachment size exceeds the limit.",
-                  },
-                ],
-                logContext: {
-                  emailAttachmentCode: EmailErrorCode.ATTACHMENT_SIZE_EXCEEDED,
-                  max: limits.maxTotalBytes,
-                },
-              });
-            }
-            throw err;
+            throw asAttachmentReadError(err, limits.maxTotalBytes);
           }
-          if (!response.ok) {
-            throw NextlyError.internal({
-              logContext: {
-                emailAttachmentCode:
-                  EmailErrorCode.ATTACHMENT_STORAGE_READ_FAILED,
-                url,
-                status: response.status,
-              },
-            });
-          }
-          return Buffer.from(await response.arrayBuffer());
         },
       };
     }

--- a/packages/nextly/src/errors/error-codes.ts
+++ b/packages/nextly/src/errors/error-codes.ts
@@ -42,6 +42,10 @@ export const NEXTLY_ERROR_STATUS = {
   // is sending, this one refuses to buffer an object already stored. Kept
   // apart so a caller discriminating on the code cannot match both.
   STORAGE_READ_TOO_LARGE: 413,
+  // The store answered, and answered badly. 502 rather than 500 because the
+  // fault is UPSTREAM of this process: a caller can retry it, and an operator
+  // reading the log needs to look at the bucket rather than at this service.
+  STORAGE_READ_UNREACHABLE: 502,
   MAGIC_BYTE_MISMATCH: 400,
   SVG_SANITIZATION_FAILED: 400,
   UNSUPPORTED_FOR_BACKEND: 415,

--- a/packages/nextly/src/services/upload-validation/magic-bytes.ts
+++ b/packages/nextly/src/services/upload-validation/magic-bytes.ts
@@ -15,12 +15,15 @@
 
 import { isSvgMimeType } from "../../storage/svg-security";
 
+import { matchesWebFontSignature } from "./web-fonts";
+
 export type MagicByteResult =
   | { ok: true }
   | {
       ok: false;
       reason:
         | "svg-claim-without-svg-content"
+        | "font-claim-without-font-content"
         | "xml-content-non-svg-claim"
         | "general-mismatch";
       sniffedMime?: string;
@@ -46,6 +49,18 @@ export async function detectAndCompareMime(
     return looksLikeSvg(buffer)
       ? { ok: true }
       : { ok: false, reason: "svg-claim-without-svg-content" };
+  }
+
+  /*
+   * Checked against the signature directly, because `file-type` recognises
+   * neither WOFF nor WOFF2 — so an unidentified buffer below is trusted, and a
+   * font claim would be the one claim that reaches the store unverified. It is
+   * also the claim most worth verifying: the public byte route serves these
+   * types to anonymous callers, and the type itself may have been inferred
+   * from a filename rather than sent by anyone.
+   */
+  if (!matchesWebFontSignature(buffer, claimedMime)) {
+    return { ok: false, reason: "font-claim-without-font-content" };
   }
 
   const { fileTypeFromBuffer } = await import("file-type");

--- a/packages/nextly/src/services/upload-validation/mime.test.ts
+++ b/packages/nextly/src/services/upload-validation/mime.test.ts
@@ -22,6 +22,22 @@ describe("DEFAULT_ALLOWED_MIME_TYPES", () => {
   it("contains image/svg+xml (allowed; sanitized downstream)", () => {
     expect(DEFAULT_ALLOWED_MIME_TYPES).toContain("image/svg+xml");
   });
+
+  it("allows the two web font formats, and no other font format", () => {
+    /*
+     * A precondition rather than a nicety: a `@font-face` may not name another
+     * host, so a font has to be uploaded before it can be used at all, and an
+     * allowlist without these refuses the upload that makes one usable.
+     *
+     * The negative half is the part worth keeping. TTF and OTF have no
+     * conversion step here, so allowing them would store and serve several
+     * times the bytes of the same face as WOFF2 with nothing reporting it.
+     */
+    expect(DEFAULT_ALLOWED_MIME_TYPES).toContain("font/woff2");
+    expect(DEFAULT_ALLOWED_MIME_TYPES).toContain("font/woff");
+    expect(DEFAULT_ALLOWED_MIME_TYPES).not.toContain("font/ttf");
+    expect(DEFAULT_ALLOWED_MIME_TYPES).not.toContain("font/otf");
+  });
 });
 
 describe("resolveAllowlist", () => {

--- a/packages/nextly/src/services/upload-validation/mime.ts
+++ b/packages/nextly/src/services/upload-validation/mime.ts
@@ -8,6 +8,8 @@
  * @module services/upload-validation/mime
  */
 
+import { WEB_FONT_MIME_TYPES } from "./web-fonts";
+
 export const BLOCKED_MIME_TYPES: ReadonlySet<string> = new Set([
   "text/html",
   "application/xhtml+xml",
@@ -35,21 +37,11 @@ export const DEFAULT_ALLOWED_MIME_TYPES: readonly string[] = [
   "audio/mpeg",
   "audio/wav",
   "audio/ogg",
-  /*
-   * Web font formats only, and deliberately just these two.
-   *
-   * A `@font-face` may not name another host — a rule the styling engine
-   * enforces rather than suggests — so a site's own fonts have to be uploaded
-   * before they can be used at all, and an allowlist without them refuses the
-   * upload that makes a font usable.
-   *
-   * TTF and OTF are left out because nothing here converts them: they would be
-   * accepted, stored and served at several times the size of the same face as
-   * WOFF2, to every visitor, with no signal that anything was wrong. A refusal
-   * a designer can act on is better than a silent cost they cannot see.
-   */
-  "font/woff2",
-  "font/woff",
+  // DERIVED, not restated. The serving gate and the admin dropzone need the
+  // same answer, and three lists that agree today drift silently — a format
+  // added to only one of them either serves what nobody can upload or exposes
+  // what nobody meant to publish.
+  ...WEB_FONT_MIME_TYPES,
 ];
 
 export type MimeValidationResult =

--- a/packages/nextly/src/services/upload-validation/mime.ts
+++ b/packages/nextly/src/services/upload-validation/mime.ts
@@ -35,6 +35,21 @@ export const DEFAULT_ALLOWED_MIME_TYPES: readonly string[] = [
   "audio/mpeg",
   "audio/wav",
   "audio/ogg",
+  /*
+   * Web font formats only, and deliberately just these two.
+   *
+   * A `@font-face` may not name another host — a rule the styling engine
+   * enforces rather than suggests — so a site's own fonts have to be uploaded
+   * before they can be used at all, and an allowlist without them refuses the
+   * upload that makes a font usable.
+   *
+   * TTF and OTF are left out because nothing here converts them: they would be
+   * accepted, stored and served at several times the size of the same face as
+   * WOFF2, to every visitor, with no signal that anything was wrong. A refusal
+   * a designer can act on is better than a silent cost they cannot see.
+   */
+  "font/woff2",
+  "font/woff",
 ];
 
 export type MimeValidationResult =

--- a/packages/nextly/src/services/upload-validation/mime.ts
+++ b/packages/nextly/src/services/upload-validation/mime.ts
@@ -8,7 +8,7 @@
  * @module services/upload-validation/mime
  */
 
-import { WEB_FONT_MIME_TYPES } from "./web-fonts";
+import { WEB_FONT_FORMATS } from "./web-fonts";
 
 export const BLOCKED_MIME_TYPES: ReadonlySet<string> = new Set([
   "text/html",
@@ -20,29 +20,55 @@ export const BLOCKED_MIME_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Default allowlist when the caller doesn't specify `allowedMimeTypes`
- * or `additionalMimeTypes`. SVG is included — allowed but sanitized
- * downstream.
+ * One accepted format: what it is called, and what it is called on disk.
+ *
+ * The extensions are here because a CLIENT needs them and only this list knows
+ * which types are accepted. A browser reports no type for formats its platform
+ * does not register, so a picker matching on the suffix is the difference
+ * between a file being draggable and not — and a picker keeping its own list
+ * drifts from this one, which is how a dropzone comes to advertise a format the
+ * server refuses and refuse one the server accepts.
  */
-export const DEFAULT_ALLOWED_MIME_TYPES: readonly string[] = [
-  "image/jpeg",
-  "image/png",
-  "image/gif",
-  "image/webp",
-  "image/avif",
-  "image/svg+xml",
-  "application/pdf",
-  "video/mp4",
-  "video/webm",
-  "audio/mpeg",
-  "audio/wav",
-  "audio/ogg",
-  // DERIVED, not restated. The serving gate and the admin dropzone need the
-  // same answer, and three lists that agree today drift silently — a format
-  // added to only one of them either serves what nobody can upload or exposes
-  // what nobody meant to publish.
-  ...WEB_FONT_MIME_TYPES,
+export interface AcceptedFormat {
+  readonly mimeType: string;
+  readonly extensions: readonly string[];
+}
+
+/**
+ * The formats an upload may carry when the caller names none.
+ *
+ * SVG is included — allowed but sanitized downstream.
+ */
+export const DEFAULT_ACCEPTED_FORMATS: readonly AcceptedFormat[] = [
+  { mimeType: "image/jpeg", extensions: [".jpg", ".jpeg"] },
+  { mimeType: "image/png", extensions: [".png"] },
+  { mimeType: "image/gif", extensions: [".gif"] },
+  { mimeType: "image/webp", extensions: [".webp"] },
+  { mimeType: "image/avif", extensions: [".avif"] },
+  { mimeType: "image/svg+xml", extensions: [".svg"] },
+  { mimeType: "application/pdf", extensions: [".pdf"] },
+  { mimeType: "video/mp4", extensions: [".mp4"] },
+  { mimeType: "video/webm", extensions: [".webm"] },
+  { mimeType: "audio/mpeg", extensions: [".mp3"] },
+  { mimeType: "audio/wav", extensions: [".wav"] },
+  { mimeType: "audio/ogg", extensions: [".ogg"] },
+  // Web fonts, from the table that declares them, so a format added there is
+  // accepted here without this list being edited.
+  ...WEB_FONT_FORMATS.map(format => ({
+    mimeType: format.mimeType,
+    extensions: [format.extension],
+  })),
 ];
+
+/**
+ * Default allowlist when the caller doesn't specify `allowedMimeTypes`
+ * or `additionalMimeTypes`.
+ *
+ * DERIVED from the formats above so the types a server accepts and the suffixes
+ * a client offers cannot disagree — they are two views of one list.
+ */
+export const DEFAULT_ALLOWED_MIME_TYPES: readonly string[] =
+  DEFAULT_ACCEPTED_FORMATS.map(format => format.mimeType);
 
 export type MimeValidationResult =
   | { ok: true }

--- a/packages/nextly/src/services/upload-validation/web-fonts.test.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.test.ts
@@ -188,6 +188,51 @@ describe("checking a font claim against the bytes", () => {
   });
 });
 
+describe("a font claim under an older spelling", () => {
+  it("comes back canonical, so the allowlist recognises it", () => {
+    /*
+     * Some operating systems and multipart libraries still report the pre-IANA
+     * names. Such a claim is not generic, so nothing falls back to the
+     * filename, and the allowlist — which knows one name per format — refuses a
+     * font this product accepts under its other spelling.
+     */
+    for (const format of WEB_FONT_FORMATS) {
+      expect(format.aliases.length).toBeGreaterThan(0);
+      for (const alias of format.aliases) {
+        expect(
+          resolveClaimedMimeType(
+            `Inter${format.extension}`,
+            alias,
+            fontBytes(format.signature)
+          )
+        ).toBe(format.mimeType);
+      }
+    }
+  });
+
+  it("still answers to the bytes under the older spelling", () => {
+    /*
+     * The control. Canonicalising a name must not become a way to launder
+     * content: an alias is a claim like any other and the signature decides.
+     */
+    expect(
+      resolveClaimedMimeType(
+        "Evil.woff",
+        "application/x-font-woff",
+        Buffer.from("not-a-font")
+      )
+    ).toBe("");
+  });
+
+  it("leaves a type that is not a font alias alone", () => {
+    // A second control: a canonicaliser that rewrote everything would satisfy
+    // both cases above while renaming every upload in the product.
+    expect(
+      resolveClaimedMimeType("photo.png", "image/png", Buffer.from("png"))
+    ).toBe("image/png");
+  });
+});
+
 describe("the inference answers to the bytes", () => {
   it("refuses an EXPLICIT font claim the bytes do not support", () => {
     /*

--- a/packages/nextly/src/services/upload-validation/web-fonts.test.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.test.ts
@@ -1,0 +1,84 @@
+/**
+ * That the boundaries agree, rather than that each one lists what it lists.
+ *
+ * Three places need the same answer — what may be uploaded, what the public
+ * route will serve, what the browser lets a person drag — and a test per list
+ * asserting its own literals passes happily while they disagree. What matters
+ * is the relation between them, so that is what these assert.
+ *
+ * @module services/upload-validation/web-fonts.test
+ */
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_ALLOWED_MIME_TYPES } from "./mime";
+import {
+  WEB_FONT_FORMATS,
+  WEB_FONT_MIME_TYPES,
+  webFontMimeFromFilename,
+} from "./web-fonts";
+
+describe("the canonical web font table", () => {
+  it("is not empty, and every entry carries both vocabularies", () => {
+    // The population, asserted before anything is derived from it: an empty
+    // table satisfies every "each entry is..." loop below by never running one.
+    expect(WEB_FONT_FORMATS.length).toBeGreaterThan(0);
+    for (const format of WEB_FONT_FORMATS) {
+      expect(format.mimeType).toMatch(/^font\//);
+      expect(format.extension.startsWith(".")).toBe(true);
+    }
+  });
+
+  it("offers only formats that need no conversion", () => {
+    /*
+     * The control on the table itself. Nothing here converts TTF or OTF, so
+     * admitting one would store and serve several times the bytes of the same
+     * face with nothing reporting it.
+     */
+    expect(WEB_FONT_MIME_TYPES).not.toContain("font/ttf");
+    expect(WEB_FONT_MIME_TYPES).not.toContain("font/otf");
+    expect(WEB_FONT_MIME_TYPES).not.toContain("application/font-sfnt");
+  });
+});
+
+describe("the upload boundary", () => {
+  it("accepts every format the table declares", () => {
+    /*
+     * The relation Codex's finding is about. A format the serving route hands
+     * out but the allowlist refuses is one an author can never put there; the
+     * reverse leaves an upload nothing will serve.
+     */
+    for (const mimeType of WEB_FONT_MIME_TYPES) {
+      expect(DEFAULT_ALLOWED_MIME_TYPES).toContain(mimeType);
+    }
+  });
+
+  it("does not accept a font format the table withholds", () => {
+    // The control: an allowlist containing every font would satisfy the case
+    // above while admitting the formats the table exists to exclude.
+    expect(DEFAULT_ALLOWED_MIME_TYPES).not.toContain("font/ttf");
+    expect(DEFAULT_ALLOWED_MIME_TYPES).not.toContain("font/otf");
+  });
+});
+
+describe("inferring a font type from a filename", () => {
+  it("names the canonical type for each format, whatever the case", () => {
+    // Browsers report no type at all for a font chosen from disk, which is the
+    // case this exists for — and the name they send keeps the author's casing.
+    expect(webFontMimeFromFilename("Inter.woff2")).toBe("font/woff2");
+    expect(webFontMimeFromFilename("Inter.WOFF2")).toBe("font/woff2");
+    expect(webFontMimeFromFilename("Inter.woff")).toBe("font/woff");
+  });
+
+  it("names nothing for anything else", () => {
+    /*
+     * The control, and the security-relevant half: this fills in a claim the
+     * caller did not make, so it must resolve for font names ONLY. Everything
+     * else keeps whatever the caller sent, and the magic-byte check downstream
+     * still compares that claim against the bytes.
+     */
+    expect(webFontMimeFromFilename("payload.ttf")).toBeUndefined();
+    expect(webFontMimeFromFilename("archive.zip")).toBeUndefined();
+    expect(webFontMimeFromFilename("woff2")).toBeUndefined();
+    expect(webFontMimeFromFilename("")).toBeUndefined();
+  });
+});

--- a/packages/nextly/src/services/upload-validation/web-fonts.test.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.test.ts
@@ -12,6 +12,8 @@ import { describe, expect, it } from "vitest";
 
 import { DEFAULT_ALLOWED_MIME_TYPES } from "./mime";
 import {
+  matchesWebFontSignature,
+  resolveClaimedMimeType,
   WEB_FONT_FORMATS,
   WEB_FONT_MIME_TYPES,
   webFontMimeFromFilename,
@@ -43,9 +45,9 @@ describe("the canonical web font table", () => {
 describe("the upload boundary", () => {
   it("accepts every format the table declares", () => {
     /*
-     * The relation Codex's finding is about. A format the serving route hands
-     * out but the allowlist refuses is one an author can never put there; the
-     * reverse leaves an upload nothing will serve.
+     * A format the serving route hands out but the allowlist refuses is one an
+     * author can never put there; the reverse leaves an upload nothing will
+     * serve. Neither shows up in a test that reads one list on its own.
      */
     for (const mimeType of WEB_FONT_MIME_TYPES) {
       expect(DEFAULT_ALLOWED_MIME_TYPES).toContain(mimeType);
@@ -80,5 +82,84 @@ describe("inferring a font type from a filename", () => {
     expect(webFontMimeFromFilename("archive.zip")).toBeUndefined();
     expect(webFontMimeFromFilename("woff2")).toBeUndefined();
     expect(webFontMimeFromFilename("")).toBeUndefined();
+  });
+});
+
+describe("resolving the type an upload claims", () => {
+  it("keeps a real type the client sent, even for a font name", () => {
+    /*
+     * The control, and the fixture has to be a FONT name: with a name that
+     * infers nothing, dropping the guard still returns what the caller sent, so
+     * the case would pass against a resolver that overwrites every claim.
+     *
+     * A client that says `font/woff` about `Inter.woff2` is telling us
+     * something the filename cannot — the extension is not the format.
+     */
+    expect(resolveClaimedMimeType("Inter.woff2", "font/woff")).toBe(
+      "font/woff"
+    );
+    expect(resolveClaimedMimeType("photo.png", "image/png")).toBe("image/png");
+  });
+
+  it("fills in from the name when the client sent nothing", () => {
+    expect(resolveClaimedMimeType("Inter.woff2", "")).toBe("font/woff2");
+    expect(resolveClaimedMimeType("Inter.woff2", "   ")).toBe("font/woff2");
+  });
+
+  it("fills in for the generic type, however it is spelled", () => {
+    /*
+     * Multipart clients send `application/octet-stream` for a format they
+     * cannot name, and mime tokens are case-insensitive — an exact comparison
+     * skips the fallback and the allowlist then refuses a font the name could
+     * have identified.
+     */
+    expect(
+      resolveClaimedMimeType("Inter.woff2", "application/octet-stream")
+    ).toBe("font/woff2");
+    expect(
+      resolveClaimedMimeType("Inter.woff2", "Application/Octet-Stream")
+    ).toBe("font/woff2");
+  });
+
+  it("leaves a generic type alone when the name says nothing", () => {
+    // Absence of a font name is not licence to invent one; the value the caller
+    // sent survives and the allowlist judges it as before.
+    expect(
+      resolveClaimedMimeType("payload.bin", "application/octet-stream")
+    ).toBe("application/octet-stream");
+  });
+});
+
+describe("checking a font claim against the bytes", () => {
+  it("accepts each format's own signature", () => {
+    for (const format of WEB_FONT_FORMATS) {
+      const bytes = Buffer.concat([
+        Buffer.from(format.signature, "ascii"),
+        Buffer.alloc(32),
+      ]);
+      expect(matchesWebFontSignature(bytes, format.mimeType)).toBe(true);
+    }
+  });
+
+  it("refuses content that is not the font it claims to be", () => {
+    expect(
+      matchesWebFontSignature(Buffer.from("not-a-font"), "font/woff2")
+    ).toBe(false);
+    // And a WOFF is not a WOFF2: the signatures differ, and serving one as the
+    // other hands a browser a file it cannot parse.
+    const woff = Buffer.concat([
+      Buffer.from("wOFF", "ascii"),
+      Buffer.alloc(32),
+    ]);
+    expect(matchesWebFontSignature(woff, "font/woff2")).toBe(false);
+    expect(matchesWebFontSignature(woff, "font/woff")).toBe(true);
+  });
+
+  it("says nothing about a type that is not a web font", () => {
+    // The control: a checker refusing everything would satisfy the case above
+    // while rejecting every image in the product.
+    expect(
+      matchesWebFontSignature(Buffer.from("<svg/>"), "image/svg+xml")
+    ).toBe(true);
   });
 });

--- a/packages/nextly/src/services/upload-validation/web-fonts.test.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.test.ts
@@ -85,6 +85,11 @@ describe("inferring a font type from a filename", () => {
   });
 });
 
+/** Bytes that genuinely begin as the format they are named for. */
+function fontBytes(signature: string): Buffer {
+  return Buffer.concat([Buffer.from(signature, "ascii"), Buffer.alloc(32)]);
+}
+
 describe("resolving the type an upload claims", () => {
   it("keeps a real type the client sent, even for a font name", () => {
     /*
@@ -95,15 +100,21 @@ describe("resolving the type an upload claims", () => {
      * A client that says `font/woff` about `Inter.woff2` is telling us
      * something the filename cannot — the extension is not the format.
      */
-    expect(resolveClaimedMimeType("Inter.woff2", "font/woff")).toBe(
-      "font/woff"
-    );
-    expect(resolveClaimedMimeType("photo.png", "image/png")).toBe("image/png");
+    expect(
+      resolveClaimedMimeType("Inter.woff2", "font/woff", fontBytes("wOF2"))
+    ).toBe("font/woff");
+    expect(
+      resolveClaimedMimeType("photo.png", "image/png", Buffer.from("png"))
+    ).toBe("image/png");
   });
 
   it("fills in from the name when the client sent nothing", () => {
-    expect(resolveClaimedMimeType("Inter.woff2", "")).toBe("font/woff2");
-    expect(resolveClaimedMimeType("Inter.woff2", "   ")).toBe("font/woff2");
+    expect(resolveClaimedMimeType("Inter.woff2", "", fontBytes("wOF2"))).toBe(
+      "font/woff2"
+    );
+    expect(
+      resolveClaimedMimeType("Inter.woff2", "   ", fontBytes("wOF2"))
+    ).toBe("font/woff2");
   });
 
   it("fills in for the generic type, however it is spelled", () => {
@@ -114,10 +125,18 @@ describe("resolving the type an upload claims", () => {
      * have identified.
      */
     expect(
-      resolveClaimedMimeType("Inter.woff2", "application/octet-stream")
+      resolveClaimedMimeType(
+        "Inter.woff2",
+        "application/octet-stream",
+        fontBytes("wOF2")
+      )
     ).toBe("font/woff2");
     expect(
-      resolveClaimedMimeType("Inter.woff2", "Application/Octet-Stream")
+      resolveClaimedMimeType(
+        "Inter.woff2",
+        "Application/Octet-Stream",
+        fontBytes("wOF2")
+      )
     ).toBe("font/woff2");
   });
 
@@ -125,7 +144,11 @@ describe("resolving the type an upload claims", () => {
     // Absence of a font name is not licence to invent one; the value the caller
     // sent survives and the allowlist judges it as before.
     expect(
-      resolveClaimedMimeType("payload.bin", "application/octet-stream")
+      resolveClaimedMimeType(
+        "payload.bin",
+        "application/octet-stream",
+        Buffer.from("bin")
+      )
     ).toBe("application/octet-stream");
   });
 });
@@ -161,5 +184,38 @@ describe("checking a font claim against the bytes", () => {
     expect(
       matchesWebFontSignature(Buffer.from("<svg/>"), "image/svg+xml")
     ).toBe(true);
+  });
+});
+
+describe("the inference answers to the bytes", () => {
+  it("refuses to name a font when the content is not one", () => {
+    /*
+     * The inference invents a claim nobody made, and not every upload path runs
+     * a magic-byte comparison afterwards — the published server action reaches
+     * the legacy service, which does not. So a name alone would let anything
+     * called `.woff2` acquire a type the public route serves to anonymous
+     * callers as an immutable asset. The proof travels with the inference.
+     */
+    expect(
+      resolveClaimedMimeType("Evil.woff2", "", Buffer.from("not-a-font"))
+    ).toBe("");
+    expect(
+      resolveClaimedMimeType(
+        "Evil.woff2",
+        "application/octet-stream",
+        Buffer.from("not-a-font")
+      )
+    ).toBe("application/octet-stream");
+  });
+
+  it("still names a real font", () => {
+    // The control: a resolver refusing everything would satisfy the case above
+    // while making font uploads impossible.
+    expect(resolveClaimedMimeType("Inter.woff2", "", fontBytes("wOF2"))).toBe(
+      "font/woff2"
+    );
+    expect(resolveClaimedMimeType("Inter.woff", "", fontBytes("wOFF"))).toBe(
+      "font/woff"
+    );
   });
 });

--- a/packages/nextly/src/services/upload-validation/web-fonts.test.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.test.ts
@@ -98,10 +98,11 @@ describe("resolving the type an upload claims", () => {
      * the case would pass against a resolver that overwrites every claim.
      *
      * A client that says `font/woff` about `Inter.woff2` is telling us
-     * something the filename cannot — the extension is not the format.
+     * something the filename cannot — the extension is not the format, and the
+     * BYTES here are a WOFF, so the claim is the true one.
      */
     expect(
-      resolveClaimedMimeType("Inter.woff2", "font/woff", fontBytes("wOF2"))
+      resolveClaimedMimeType("Inter.woff2", "font/woff", fontBytes("wOFF"))
     ).toBe("font/woff");
     expect(
       resolveClaimedMimeType("photo.png", "image/png", Buffer.from("png"))
@@ -188,6 +189,32 @@ describe("checking a font claim against the bytes", () => {
 });
 
 describe("the inference answers to the bytes", () => {
+  it("refuses an EXPLICIT font claim the bytes do not support", () => {
+    /*
+     * Platforms that register these formats send `font/woff2` themselves, so an
+     * explicit claim reaches the same anonymous route with the same bytes — the
+     * only difference being who typed the string. The caller that most needs
+     * this has no validator behind it: the published server action reaches the
+     * legacy service, which persists the type it is handed.
+     */
+    expect(
+      resolveClaimedMimeType("Evil.woff2", "font/woff2", Buffer.from("nope"))
+    ).toBe("");
+    // A real font sent with its real type is untouched — the control, since a
+    // rule refusing every font claim would satisfy the case above.
+    expect(
+      resolveClaimedMimeType("Inter.woff2", "font/woff2", fontBytes("wOF2"))
+    ).toBe("font/woff2");
+  });
+
+  it("leaves a NON-font claim alone whatever the bytes are", () => {
+    // The bytes are only this module's business for the formats it declares;
+    // an image claim is somebody else's check and must pass through untouched.
+    expect(
+      resolveClaimedMimeType("photo.png", "image/png", Buffer.from("nope"))
+    ).toBe("image/png");
+  });
+
   it("refuses to name a font when the content is not one", () => {
     /*
      * The inference invents a claim nobody made, and not every upload path runs

--- a/packages/nextly/src/services/upload-validation/web-fonts.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.ts
@@ -23,12 +23,21 @@ export interface WebFontFormat {
   readonly mimeType: string;
   /** The suffix a person sees on their own file, dot included. */
   readonly extension: string;
+  /**
+   * The four bytes the format begins with, as ASCII.
+   *
+   * Both formats carry a fixed signature the W3C specifies, which is what makes
+   * a claim checkable at all: `file-type` does not recognise either of them, so
+   * a font claim it cannot identify is indistinguishable from arbitrary bytes
+   * unless something reads the signature directly.
+   */
+  readonly signature: string;
 }
 
 /** Every web font format this product accepts, serves and advertises. */
 export const WEB_FONT_FORMATS: readonly WebFontFormat[] = [
-  { mimeType: "font/woff2", extension: ".woff2" },
-  { mimeType: "font/woff", extension: ".woff" },
+  { mimeType: "font/woff2", extension: ".woff2", signature: "wOF2" },
+  { mimeType: "font/woff", extension: ".woff", signature: "wOFF" },
 ];
 
 /** The same set as MIME types, for the allowlist and the serving gate. */
@@ -57,10 +66,9 @@ export function webFontMimeFromFilename(filename: string): string | undefined {
 /**
  * The type an upload claims, filled in from its name where nothing was sent.
  *
- * ONE implementation, because four upload entry points needed the same answer
- * and three of them read the file's type under a different variable name — a
- * search for one spelling found some of them, which is exactly how a fix that
- * looks complete covers a subset.
+ * ONE implementation, because four upload entry points need the same answer and
+ * each names its file differently — so the resolution lives here rather than
+ * beside each of them, where a reader looking for one spelling sees a subset.
  *
  * A browser reports no type for formats its platform does not register, which
  * fonts routinely are not, and several multipart clients send
@@ -82,6 +90,38 @@ export function resolveClaimedMimeType(
   reportedType: string
 ): string {
   const claimed = reportedType.trim();
-  if (claimed !== "" && claimed !== "application/octet-stream") return claimed;
+  // Compared in lower case, because a client may spell the generic type
+  // `Application/Octet-Stream` — mime tokens are case-insensitive, and an exact
+  // comparison would skip the fallback and let the allowlist refuse a font the
+  // name could have identified.
+  const generic = claimed.toLowerCase();
+  if (generic !== "" && generic !== "application/octet-stream") return claimed;
   return webFontMimeFromFilename(filename) ?? claimed;
+}
+
+/**
+ * Whether a buffer actually begins as the font type it claims to be.
+ *
+ * The claim decides what an allowlist admits and what the public route will
+ * serve, and a type inferred from a filename is a claim nobody made — so the
+ * bytes have to answer for it. Without this, arbitrary content renamed to
+ * `.woff2` is stored under a servable type and handed to any anonymous caller
+ * as an immutable font.
+ *
+ * @param buffer - The uploaded bytes
+ * @param mimeType - The claimed type; anything not a web font is not this
+ *   function's question and answers `true`
+ */
+export function matchesWebFontSignature(
+  buffer: Buffer,
+  mimeType: string
+): boolean {
+  const format = WEB_FONT_FORMATS.find(
+    candidate => candidate.mimeType === mimeType.toLowerCase().trim()
+  );
+  if (format === undefined) return true;
+  return (
+    buffer.subarray(0, format.signature.length).toString("ascii") ===
+    format.signature
+  );
 }

--- a/packages/nextly/src/services/upload-validation/web-fonts.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.ts
@@ -64,42 +64,6 @@ export function webFontMimeFromFilename(filename: string): string | undefined {
 }
 
 /**
- * The type an upload claims, filled in from its name where nothing was sent.
- *
- * ONE implementation, because four upload entry points need the same answer and
- * each names its file differently — so the resolution lives here rather than
- * beside each of them, where a reader looking for one spelling sees a subset.
- *
- * A browser reports no type for formats its platform does not register, which
- * fonts routinely are not, and several multipart clients send
- * `application/octet-stream` for the same reason. Both are refused by an
- * allowlist keyed on the type, whatever the allowlist contains.
- *
- * This NARROWS what a caller must send rather than widening what is believed:
- * only a name matching a declared font format resolves, everything else keeps
- * whatever arrived, and the resulting claim is still compared against the
- * file's own magic bytes downstream — so a renamed archive is refused exactly
- * as it was before.
- *
- * @param filename - The uploaded name
- * @param reportedType - The type the client sent, which may be empty
- * @returns The type to validate and store
- */
-export function resolveClaimedMimeType(
-  filename: string,
-  reportedType: string
-): string {
-  const claimed = reportedType.trim();
-  // Compared in lower case, because a client may spell the generic type
-  // `Application/Octet-Stream` — mime tokens are case-insensitive, and an exact
-  // comparison would skip the fallback and let the allowlist refuse a font the
-  // name could have identified.
-  const generic = claimed.toLowerCase();
-  if (generic !== "" && generic !== "application/octet-stream") return claimed;
-  return webFontMimeFromFilename(filename) ?? claimed;
-}
-
-/**
  * Whether a buffer actually begins as the font type it claims to be.
  *
  * The claim decides what an allowlist admits and what the public route will
@@ -124,4 +88,48 @@ export function matchesWebFontSignature(
     buffer.subarray(0, format.signature.length).toString("ascii") ===
     format.signature
   );
+}
+
+/**
+ * The type an upload claims, filled in from its name where nothing was sent.
+ *
+ * ONE implementation, because four upload entry points need the same answer and
+ * each names its file differently — so the resolution lives here rather than
+ * beside each of them, where a reader looking for one spelling sees a subset.
+ *
+ * A browser reports no type for formats its platform does not register, which
+ * fonts routinely are not, and several multipart clients send
+ * `application/octet-stream` for the same reason. Both are refused by an
+ * allowlist keyed on the type, whatever the allowlist contains.
+ *
+ * THE BYTES DECIDE, which is what keeps this from being a way to launder
+ * content. A name alone would let anything called `.woff2` acquire a type the
+ * public route serves to anonymous callers, and not every upload path runs the
+ * magic-byte comparison afterwards — the published server action reaches the
+ * legacy service, which does not. So the inference carries its own proof rather
+ * than relying on a check further down that some callers never reach.
+ *
+ * @param filename - The uploaded name
+ * @param reportedType - The type the client sent, which may be empty
+ * @param buffer - The uploaded bytes, which must back an inferred font type
+ * @returns The type to validate and store
+ */
+export function resolveClaimedMimeType(
+  filename: string,
+  reportedType: string,
+  buffer: Buffer
+): string {
+  const claimed = reportedType.trim();
+  // Compared in lower case, because a client may spell the generic type
+  // `Application/Octet-Stream` — mime tokens are case-insensitive, and an exact
+  // comparison would skip the fallback and let the allowlist refuse a font the
+  // name could have identified.
+  const generic = claimed.toLowerCase();
+  if (generic !== "" && generic !== "application/octet-stream") return claimed;
+
+  const inferred = webFontMimeFromFilename(filename);
+  if (inferred === undefined) return claimed;
+  // A name that does not match its contents infers nothing, and the caller is
+  // left with whatever it arrived with — which the allowlist then refuses.
+  return matchesWebFontSignature(buffer, inferred) ? inferred : claimed;
 }

--- a/packages/nextly/src/services/upload-validation/web-fonts.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.ts
@@ -1,0 +1,87 @@
+/**
+ * The web font formats this product handles, declared ONCE.
+ *
+ * Three boundaries need the same answer and each used to state it separately:
+ * what an upload may contain, what the public byte route will serve, and what
+ * the admin dropzone lets a browser send. Three lists that agree on the day
+ * they are written and drift afterwards, silently — and the drift is not
+ * symmetrical. A format added only to the serving set makes stored objects of
+ * that type world readable; added only to the upload set, an author uploads
+ * something nothing will serve.
+ *
+ * WOFF2 and WOFF only. Nothing here converts TTF or OTF, so accepting them
+ * would store and send several times the bytes of the same face to every
+ * visitor with nothing reporting it — a refusal a designer can act on beats a
+ * cost they cannot see.
+ *
+ * @module services/upload-validation/web-fonts
+ */
+
+/** One web font format, in the two vocabularies the boundaries speak. */
+export interface WebFontFormat {
+  /** The IANA type, which is what an allowlist and a stored record carry. */
+  readonly mimeType: string;
+  /** The suffix a person sees on their own file, dot included. */
+  readonly extension: string;
+}
+
+/** Every web font format this product accepts, serves and advertises. */
+export const WEB_FONT_FORMATS: readonly WebFontFormat[] = [
+  { mimeType: "font/woff2", extension: ".woff2" },
+  { mimeType: "font/woff", extension: ".woff" },
+];
+
+/** The same set as MIME types, for the allowlist and the serving gate. */
+export const WEB_FONT_MIME_TYPES: readonly string[] = WEB_FONT_FORMATS.map(
+  format => format.mimeType
+);
+
+/**
+ * The font type a filename implies, if any.
+ *
+ * For the case a browser reports no type at all — which is the ordinary
+ * outcome for a `.woff2` chosen from disk, since fonts are not in every
+ * platform's type registry. The claim is still checked against the bytes
+ * downstream, so inferring here narrows what a caller must send rather than
+ * widening what is believed.
+ *
+ * @param filename - The uploaded name, whose extension is read case-insensitively
+ * @returns The canonical MIME type, or `undefined` for anything else
+ */
+export function webFontMimeFromFilename(filename: string): string | undefined {
+  const lower = filename.toLowerCase();
+  return WEB_FONT_FORMATS.find(format => lower.endsWith(format.extension))
+    ?.mimeType;
+}
+
+/**
+ * The type an upload claims, filled in from its name where nothing was sent.
+ *
+ * ONE implementation, because four upload entry points needed the same answer
+ * and three of them read the file's type under a different variable name — a
+ * search for one spelling found some of them, which is exactly how a fix that
+ * looks complete covers a subset.
+ *
+ * A browser reports no type for formats its platform does not register, which
+ * fonts routinely are not, and several multipart clients send
+ * `application/octet-stream` for the same reason. Both are refused by an
+ * allowlist keyed on the type, whatever the allowlist contains.
+ *
+ * This NARROWS what a caller must send rather than widening what is believed:
+ * only a name matching a declared font format resolves, everything else keeps
+ * whatever arrived, and the resulting claim is still compared against the
+ * file's own magic bytes downstream — so a renamed archive is refused exactly
+ * as it was before.
+ *
+ * @param filename - The uploaded name
+ * @param reportedType - The type the client sent, which may be empty
+ * @returns The type to validate and store
+ */
+export function resolveClaimedMimeType(
+  filename: string,
+  reportedType: string
+): string {
+  const claimed = reportedType.trim();
+  if (claimed !== "" && claimed !== "application/octet-stream") return claimed;
+  return webFontMimeFromFilename(filename) ?? claimed;
+}

--- a/packages/nextly/src/services/upload-validation/web-fonts.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.ts
@@ -111,8 +111,10 @@ export function matchesWebFontSignature(
  *
  * @param filename - The uploaded name
  * @param reportedType - The type the client sent, which may be empty
- * @param buffer - The uploaded bytes, which must back an inferred font type
- * @returns The type to validate and store
+ * @param buffer - The uploaded bytes, which must back ANY font type — one the
+ *   caller sent as much as one inferred from the name
+ * @returns The type to validate and store, or `""` when a font claim's bytes
+ *   do not support it
  */
 export function resolveClaimedMimeType(
   filename: string,
@@ -125,7 +127,21 @@ export function resolveClaimedMimeType(
   // comparison would skip the fallback and let the allowlist refuse a font the
   // name could have identified.
   const generic = claimed.toLowerCase();
-  if (generic !== "" && generic !== "application/octet-stream") return claimed;
+
+  if (generic !== "" && generic !== "application/octet-stream") {
+    /*
+     * A font type the CLIENT sent answers to the bytes exactly as an inferred
+     * one does. Platforms that do register these formats send `font/woff2`
+     * themselves, so trusting an explicit claim leaves the same objects
+     * servable by the same anonymous route on the same platforms — the only
+     * difference being who typed the string.
+     *
+     * Refused as an empty claim rather than passed on, because the caller that
+     * most needs this has no validator behind it: the published server action
+     * reaches the legacy service, which persists the type it is handed.
+     */
+    return matchesWebFontSignature(buffer, generic) ? claimed : "";
+  }
 
   const inferred = webFontMimeFromFilename(filename);
   if (inferred === undefined) return claimed;

--- a/packages/nextly/src/services/upload-validation/web-fonts.ts
+++ b/packages/nextly/src/services/upload-validation/web-fonts.ts
@@ -32,12 +32,31 @@ export interface WebFontFormat {
    * unless something reads the signature directly.
    */
   readonly signature: string;
+  /**
+   * Older spellings a client may still report for this format.
+   *
+   * Some operating systems and multipart libraries carry the pre-IANA names,
+   * and a claim wearing one is not generic — so nothing would fall back to the
+   * filename, and the allowlist, which knows only the canonical name, refuses a
+   * font the product accepts under its other spelling.
+   */
+  readonly aliases: readonly string[];
 }
 
 /** Every web font format this product accepts, serves and advertises. */
 export const WEB_FONT_FORMATS: readonly WebFontFormat[] = [
-  { mimeType: "font/woff2", extension: ".woff2", signature: "wOF2" },
-  { mimeType: "font/woff", extension: ".woff", signature: "wOFF" },
+  {
+    mimeType: "font/woff2",
+    extension: ".woff2",
+    signature: "wOF2",
+    aliases: ["application/font-woff2", "application/x-font-woff2"],
+  },
+  {
+    mimeType: "font/woff",
+    extension: ".woff",
+    signature: "wOFF",
+    aliases: ["application/font-woff", "application/x-font-woff"],
+  },
 ];
 
 /** The same set as MIME types, for the allowlist and the serving gate. */
@@ -61,6 +80,18 @@ export function webFontMimeFromFilename(filename: string): string | undefined {
   const lower = filename.toLowerCase();
   return WEB_FONT_FORMATS.find(format => lower.endsWith(format.extension))
     ?.mimeType;
+}
+
+/**
+ * The canonical name for a font type, whichever spelling arrived.
+ *
+ * @param mimeType - A lower-cased claim
+ * @returns The IANA name, or `undefined` when this is not a web font at all
+ */
+export function canonicalWebFontMime(mimeType: string): string | undefined {
+  return WEB_FONT_FORMATS.find(
+    format => format.mimeType === mimeType || format.aliases.includes(mimeType)
+  )?.mimeType;
 }
 
 /**
@@ -128,19 +159,20 @@ export function resolveClaimedMimeType(
   // name could have identified.
   const generic = claimed.toLowerCase();
 
+  /*
+   * A font claim under ANY of its spellings, canonical or legacy, answers to
+   * the bytes and comes back canonical. The allowlist knows one name per
+   * format, so a claim arriving as `application/x-font-woff` is a font the
+   * product accepts being refused for how the client spelled it.
+   */
+  const canonical = canonicalWebFontMime(generic);
+  if (canonical !== undefined) {
+    return matchesWebFontSignature(buffer, canonical) ? canonical : "";
+  }
+
   if (generic !== "" && generic !== "application/octet-stream") {
-    /*
-     * A font type the CLIENT sent answers to the bytes exactly as an inferred
-     * one does. Platforms that do register these formats send `font/woff2`
-     * themselves, so trusting an explicit claim leaves the same objects
-     * servable by the same anonymous route on the same platforms — the only
-     * difference being who typed the string.
-     *
-     * Refused as an empty claim rather than passed on, because the caller that
-     * most needs this has no validator behind it: the published server action
-     * reaches the legacy service, which persists the type it is handed.
-     */
-    return matchesWebFontSignature(buffer, generic) ? claimed : "";
+    // Not a font by any spelling, so its bytes are somebody else's check.
+    return claimed;
   }
 
   const inferred = webFontMimeFromFilename(filename);

--- a/packages/nextly/src/storage/fetch-stored-bytes.ts
+++ b/packages/nextly/src/storage/fetch-stored-bytes.ts
@@ -166,7 +166,7 @@ export async function fetchStoredBytes(
  *   that means the failure arrived before any status did, which says nothing
  *   about whether the object was oversized.
  */
-function classifyFetchFailure(
+export function classifyFetchFailure(
   error: unknown
 ): "absent" | "oversized" | "unknown" {
   if (!(error instanceof SafeFetchError)) return "unknown";

--- a/packages/nextly/src/storage/read-stored-media.test.ts
+++ b/packages/nextly/src/storage/read-stored-media.test.ts
@@ -14,6 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SafeFetchError } from "../utils/validate-external-url";
 
+import { DEFAULT_READ_TIMEOUT_MS } from "./fetch-stored-bytes";
 import { isStorageReadTimeout, isStorageReadTooLarge } from "./read-errors";
 import {
   readStoredMediaBytes,
@@ -202,6 +203,16 @@ describe("reading a stored object", () => {
     expect(isStorageReadTimeout(outcome)).toBe(true);
     // NOT the raw platform error, which is what carried the 500.
     expect(outcome).not.toBe(platformTimeout);
+    /*
+     * The DEADLINE, not the cap. Two numbers behind one positional signature:
+     * passing the byte cap here logged a timeout of 10,485,760 ms for a read
+     * that waited 30,000 — a figure an operator reading the 504 would take at
+     * face value while investigating something that never happened.
+     */
+    expect((outcome as { timeoutMs?: number }).timeoutMs).toBe(
+      DEFAULT_READ_TIMEOUT_MS
+    );
+    expect((outcome as { timeoutMs?: number }).timeoutMs).not.toBe(1000);
   });
 
   it("passes a NON-timeout adapter failure through unchanged", async () => {

--- a/packages/nextly/src/storage/read-stored-media.test.ts
+++ b/packages/nextly/src/storage/read-stored-media.test.ts
@@ -39,6 +39,32 @@ beforeEach(() => {
 });
 
 describe("reading a stored object", () => {
+  it("calls the adapter's read AS A METHOD, keeping its receiver", async () => {
+    /*
+     * A real adapter is a class instance whose `read` reaches for `this` — the
+     * local one resolves the path through a private method, the cloud ones
+     * reach their client and config. Handed over detached the call throws
+     * inside the adapter, which catches it and reports every existing object as
+     * missing.
+     *
+     * A `vi.fn()` CANNOT show this: it has no receiver to lose, so every case
+     * below passes against a reader that strips it. The double here reads its
+     * answer off `this`, which is the only shape that fails when the receiver
+     * goes.
+     */
+    const storage = {
+      bytes: "from-the-instance",
+      read(this: { bytes: string }): Promise<Buffer | null> {
+        return Promise.resolve(Buffer.from(this.bytes, "utf8"));
+      },
+      getPublicUrl: vi.fn(),
+    };
+
+    const bytes = await readStoredMediaBytes(storage, "f.woff2", 1000);
+    expect(bytes?.toString("utf8")).toBe("from-the-instance");
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
   it("asks an adapter that CAN read, and does not fetch", async () => {
     const storage = {
       read: vi.fn().mockResolvedValue(Buffer.from("native")),

--- a/packages/nextly/src/storage/read-stored-media.test.ts
+++ b/packages/nextly/src/storage/read-stored-media.test.ts
@@ -14,7 +14,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SafeFetchError } from "../utils/validate-external-url";
 
-import { isStorageReadTooLarge } from "./read-errors";
+import { isStorageReadTimeout, isStorageReadTooLarge } from "./read-errors";
 import {
   readStoredMediaBytes,
   StoredMediaUnreachableError,
@@ -176,6 +176,69 @@ describe("reading a stored object", () => {
     ).resolves.toBeNull();
     expect(safeFetch).not.toHaveBeenCalled();
     expect(storage.getPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it("translates an adapter's own deadline into this package's error", async () => {
+    /*
+     * Adapters in sibling packages bound their reads with
+     * `AbortSignal.timeout`, which rejects with a platform `DOMException` this
+     * package can neither construct nor extend. Passed through, the route's
+     * error handler sees no `NextlyError` and answers 500 — an internal fault —
+     * for a backend that simply did not reply, which a caller and a gateway
+     * would both retry if they could read it as such.
+     */
+    const platformTimeout = Object.assign(new Error("aborted"), {
+      name: "TimeoutError",
+    });
+    const storage = {
+      read: vi.fn().mockRejectedValue(platformTimeout),
+      getPublicUrl: vi.fn(),
+    };
+
+    const outcome = await readStoredMediaBytes(storage, "f.woff2", 1000).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTimeout(outcome)).toBe(true);
+    // NOT the raw platform error, which is what carried the 500.
+    expect(outcome).not.toBe(platformTimeout);
+  });
+
+  it("passes a NON-timeout adapter failure through unchanged", async () => {
+    /*
+     * The control: a translation that renamed every adapter rejection would
+     * satisfy the case above while reporting a credential failure as a
+     * retryable timeout, which a caller would retry forever.
+     */
+    const outage = new Error("bucket unreachable");
+    const storage = {
+      read: vi.fn().mockRejectedValue(outage),
+      getPublicUrl: vi.fn(),
+    };
+
+    const outcome = await readStoredMediaBytes(storage, "f.woff2", 1000).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBe(outage);
+    expect(isStorageReadTimeout(outcome)).toBe(false);
+  });
+
+  it("treats a KEY beginning with http as a key, not an address", async () => {
+    /*
+     * `http-font.woff2` is a valid object name, and reading it as an address
+     * sends it to `safeFetch`, which refuses it — so an ordinary file became
+     * unservable on exactly the read-less adapters this fallback exists for.
+     *
+     * Asserted on which ADDRESS was fetched, since both routes end in a fetch
+     * and the outcome alone cannot say which string was used.
+     */
+    safeFetch.mockResolvedValue(new Response("ok"));
+    await readStoredMediaBytes(urlOnly, "http-font.woff2", 1000);
+
+    expect(safeFetch.mock.calls[0]?.[0]).toBe(
+      "https://cdn.test/http-font.woff2"
+    );
   });
 
   it("reports a MISSING object as absence, not as an outage", async () => {

--- a/packages/nextly/src/storage/read-stored-media.test.ts
+++ b/packages/nextly/src/storage/read-stored-media.test.ts
@@ -45,7 +45,10 @@ describe("reading a stored object", () => {
     };
     const bytes = await readStoredMediaBytes(storage, "f.woff2", 1000);
 
-    expect(bytes.toString("utf8")).toBe("native");
+    // `?.` rather than a non-null assertion: `null` is now a real answer from
+    // this function, and a case that read it as bytes would say "undefined"
+    // instead of failing on the absence.
+    expect(bytes?.toString("utf8")).toBe("native");
     // The cap travels INTO the adapter: checked on the way back, the memory it
     // exists to save has already been spent.
     expect(storage.read).toHaveBeenCalledWith("f.woff2", { maxBytes: 1000 });
@@ -56,7 +59,7 @@ describe("reading a stored object", () => {
     safeFetch.mockResolvedValue(new Response("fetched"));
     const bytes = await readStoredMediaBytes(urlOnly, "f.woff2", 1000);
 
-    expect(bytes.toString("utf8")).toBe("fetched");
+    expect(bytes?.toString("utf8")).toBe("fetched");
     expect(safeFetch).toHaveBeenCalledWith("https://cdn.test/f.woff2", {
       maxResponseBytes: 1000,
     });
@@ -149,6 +152,23 @@ describe("reading a stored object", () => {
       (error: unknown) => error
     );
     expect(isStorageReadTooLarge(outcome)).toBe(false);
+  });
+
+  it("reports a MISSING object as absence, not as an outage", async () => {
+    /*
+     * A row can outlive its object — a lifecycle rule, a manual cleanup, a
+     * concurrent delete. Calling that an upstream failure tells a caller to
+     * retry something that will never come back, and reaches a visitor as a
+     * 502 for a font that is simply gone, on a response cacheable for a year.
+     *
+     * Its control is the case below, which fails if every non-2xx started
+     * reading as absence; this one fails only when the two are folded.
+     */
+    safeFetch.mockResolvedValue(new Response("gone", { status: 404 }));
+
+    await expect(
+      readStoredMediaBytes(urlOnly, "f.woff2", 1000)
+    ).resolves.toBeNull();
   });
 
   it("reports a non-2xx as unreachable, carrying the status", async () => {

--- a/packages/nextly/src/storage/read-stored-media.test.ts
+++ b/packages/nextly/src/storage/read-stored-media.test.ts
@@ -154,6 +154,30 @@ describe("reading a stored object", () => {
     expect(isStorageReadTooLarge(outcome)).toBe(false);
   });
 
+  it("takes a read-capable adapter's null as the answer, without fetching", async () => {
+    /*
+     * An adapter that implements `read` is authoritative about absence. Asking
+     * its public URL afterwards answers a different question badly: the local
+     * adapter's URL is a relative `/uploads/...` path, which `safeFetch`
+     * refuses as invalid, so a missing file came back as a blocked external URL
+     * rather than as missing.
+     *
+     * Asserted on `safeFetch` NEVER BEING CALLED, not on the `null` — a
+     * fallback that also ends in absence returns `null` too, which is how this
+     * hid: the outcome is identical and the route it took is not.
+     */
+    const storage = {
+      read: vi.fn().mockResolvedValue(null),
+      getPublicUrl: vi.fn(() => "/uploads/f.woff2"),
+    };
+
+    await expect(
+      readStoredMediaBytes(storage, "f.woff2", 1000)
+    ).resolves.toBeNull();
+    expect(safeFetch).not.toHaveBeenCalled();
+    expect(storage.getPublicUrl).not.toHaveBeenCalled();
+  });
+
   it("reports a MISSING object as absence, not as an outage", async () => {
     /*
      * A row can outlive its object — a lifecycle rule, a manual cleanup, a

--- a/packages/nextly/src/storage/read-stored-media.test.ts
+++ b/packages/nextly/src/storage/read-stored-media.test.ts
@@ -107,16 +107,42 @@ describe("reading a stored object", () => {
     expect(isStorageReadTooLarge(outcome)).toBe(true);
   });
 
+  it("reports a FALLBACK deadline as the same timeout a native read gives", async () => {
+    /*
+     * A deadline is a deadline whichever route hit it. Left as a
+     * `SafeFetchError`, the fallback's timeout reached the route as
+     * `EXTERNAL_REQUEST_FAILED`/502 while the native read's became
+     * `STORAGE_READ_TIMEOUT`/504 — so whether a caller retried depended on
+     * whether the adapter happened to implement `read`, which describes the
+     * deployment rather than what went wrong.
+     */
+    safeFetch.mockRejectedValue(
+      new SafeFetchError("slow", "https://cdn.test/f.woff2", "timeout")
+    );
+
+    const outcome = await readStoredMediaBytes(urlOnly, "f.woff2", 1000).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTimeout(outcome)).toBe(true);
+    expect((outcome as { timeoutMs?: number }).timeoutMs).toBe(
+      DEFAULT_READ_TIMEOUT_MS
+    );
+  });
+
   it("passes a fetch failure that is NOT about size straight through", async () => {
     /*
      * The control for the case above: a translation that answered
      * `StorageReadTooLargeError` for every fetch failure would satisfy it while
      * telling the caller an unreachable host was an oversized file.
      */
+    // `decode-failed`, deliberately: `timeout` is translated now, and `too
+    // large` is the case above — this needs a reason that is neither, or it
+    // stops being a pass-through control at all.
     const refused = new SafeFetchError(
-      "timed out",
+      "could not decode",
       "https://cdn.test/f.woff2",
-      "timeout"
+      "decode-failed"
     );
     safeFetch.mockRejectedValue(refused);
 
@@ -126,6 +152,30 @@ describe("reading a stored object", () => {
     );
     expect(outcome).toBe(refused);
     expect(isStorageReadTooLarge(outcome)).toBe(false);
+  });
+
+  it("keeps a 404 whose error page was itself over the cap as absence", async () => {
+    /*
+     * `safeFetch` caps while buffering, so a verbose 404 page raises before a
+     * `Response` exists and the status check never runs — the object is still
+     * gone, and reporting that as a fault tells a caller to retry what will
+     * never come back.
+     *
+     * Uncovered until now, and a refactor turned it back into an error without
+     * a single case going red.
+     */
+    safeFetch.mockRejectedValue(
+      new SafeFetchError(
+        "too big",
+        "https://cdn.test/f.woff2",
+        "response-too-large",
+        404
+      )
+    );
+
+    await expect(
+      readStoredMediaBytes(urlOnly, "f.woff2", 10)
+    ).resolves.toBeNull();
   });
 
   it("does NOT call an over-cap ERROR PAGE an oversized file", async () => {

--- a/packages/nextly/src/storage/read-stored-media.test.ts
+++ b/packages/nextly/src/storage/read-stored-media.test.ts
@@ -1,0 +1,166 @@
+/**
+ * That both routes to a stored object refuse in the SAME vocabulary.
+ *
+ * The translation is the whole point of this module. Which route runs is a
+ * property of the adapter rather than of the request, so a caller that has to
+ * know which one it got before it can read the failure will eventually read it
+ * wrongly — and has: implementing `read` on the cloud adapters moved the email
+ * attachment path off the bounded fetch onto an unbounded buffer, with nothing
+ * in that change mentioning email.
+ *
+ * @module storage/read-stored-media.test
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SafeFetchError } from "../utils/validate-external-url";
+
+import { isStorageReadTooLarge } from "./read-errors";
+import {
+  readStoredMediaBytes,
+  StoredMediaUnreachableError,
+} from "./read-stored-media";
+
+const safeFetch = vi.hoisted(() => vi.fn());
+vi.mock("../utils/validate-external-url", async importOriginal => {
+  // Partial: `SafeFetchError` stays REAL, because the translation below keys on
+  // `instanceof`, and a stubbed class would make this suite pass against an
+  // implementation that never recognises the error it is meant to translate.
+  const actual =
+    await importOriginal<typeof import("../utils/validate-external-url")>();
+  return { ...actual, safeFetch };
+});
+
+/** A backend that cannot hand back its own bytes, so the URL route runs. */
+const urlOnly = { getPublicUrl: (p: string) => `https://cdn.test/${p}` };
+
+beforeEach(() => {
+  safeFetch.mockReset();
+});
+
+describe("reading a stored object", () => {
+  it("asks an adapter that CAN read, and does not fetch", async () => {
+    const storage = {
+      read: vi.fn().mockResolvedValue(Buffer.from("native")),
+      getPublicUrl: vi.fn(),
+    };
+    const bytes = await readStoredMediaBytes(storage, "f.woff2", 1000);
+
+    expect(bytes.toString("utf8")).toBe("native");
+    // The cap travels INTO the adapter: checked on the way back, the memory it
+    // exists to save has already been spent.
+    expect(storage.read).toHaveBeenCalledWith("f.woff2", { maxBytes: 1000 });
+    expect(safeFetch).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the URL when the adapter cannot read", async () => {
+    safeFetch.mockResolvedValue(new Response("fetched"));
+    const bytes = await readStoredMediaBytes(urlOnly, "f.woff2", 1000);
+
+    expect(bytes.toString("utf8")).toBe("fetched");
+    expect(safeFetch).toHaveBeenCalledWith("https://cdn.test/f.woff2", {
+      maxResponseBytes: 1000,
+    });
+  });
+
+  it("does not build an address out of an address", async () => {
+    // Vercel Blob records the full public URL as the stored path, so asking for
+    // a public URL for one produces `https://cdn.test/https://...`.
+    safeFetch.mockResolvedValue(new Response("ok"));
+    const getPublicUrl = vi.fn();
+    await readStoredMediaBytes(
+      { getPublicUrl },
+      "https://blob.test/f.woff2",
+      1000
+    );
+
+    expect(safeFetch.mock.calls[0]?.[0]).toBe("https://blob.test/f.woff2");
+    expect(getPublicUrl).not.toHaveBeenCalled();
+  });
+
+  it("refuses an over-cap FETCH in the same words as an over-cap READ", async () => {
+    /*
+     * The property this module exists for. Left as a `SafeFetchError`, an
+     * over-cap fetch is a DIFFERENT error from an over-cap read of the very
+     * same object, and every caller would have to know which backend it
+     * happened to be talking to before it could tell a size problem from an
+     * outage.
+     */
+    safeFetch.mockRejectedValue(
+      // status 200: the object itself was oversized, which is the ONLY shape
+      // that means "too large". See the case below for the other one.
+      new SafeFetchError(
+        "too big",
+        "https://cdn.test/big.woff2",
+        "response-too-large",
+        200
+      )
+    );
+
+    const outcome = await readStoredMediaBytes(urlOnly, "big.woff2", 10).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(true);
+  });
+
+  it("passes a fetch failure that is NOT about size straight through", async () => {
+    /*
+     * The control for the case above: a translation that answered
+     * `StorageReadTooLargeError` for every fetch failure would satisfy it while
+     * telling the caller an unreachable host was an oversized file.
+     */
+    const refused = new SafeFetchError(
+      "timed out",
+      "https://cdn.test/f.woff2",
+      "timeout"
+    );
+    safeFetch.mockRejectedValue(refused);
+
+    const outcome = await readStoredMediaBytes(urlOnly, "f.woff2", 10).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBe(refused);
+    expect(isStorageReadTooLarge(outcome)).toBe(false);
+  });
+
+  it("does NOT call an over-cap ERROR PAGE an oversized file", async () => {
+    /*
+     * `safeFetch` caps while buffering, so a verbose 500 page raises
+     * `response-too-large` before this code sees a status — and the object it
+     * was asking about may be perfectly small. Translating on the reason alone
+     * reports a backend outage as the author's file being too big, which is a
+     * cause they would act on, wrongly.
+     *
+     * This is the control for the case above: a translation keyed on the reason
+     * satisfies that one and fails this one.
+     */
+    safeFetch.mockRejectedValue(
+      new SafeFetchError(
+        "too big",
+        "https://cdn.test/f.woff2",
+        "response-too-large",
+        500
+      )
+    );
+
+    const outcome = await readStoredMediaBytes(urlOnly, "f.woff2", 10).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(isStorageReadTooLarge(outcome)).toBe(false);
+  });
+
+  it("reports a non-2xx as unreachable, carrying the status", async () => {
+    safeFetch.mockResolvedValue(new Response("nope", { status: 503 }));
+
+    const outcome = await readStoredMediaBytes(urlOnly, "f.woff2", 1000).then(
+      value => value,
+      (error: unknown) => error
+    );
+    expect(outcome).toBeInstanceOf(StoredMediaUnreachableError);
+    // The status travels, because an API route answering a visitor and an
+    // attachment path answering an author owe different explanations for it.
+    expect((outcome as StoredMediaUnreachableError).status).toBe(503);
+  });
+});

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -134,7 +134,18 @@ export async function readStoredMediaBytes(
    * The URL route is for adapters that cannot read at all.
    */
   if (typeof storage.read === "function") {
-    return await readThroughAdapter(storage.read, storagePath, maxBytes);
+    /*
+     * BOUND, because an adapter is a class instance and its `read` reaches for
+     * `this` — the local one resolves the path through a private method, the
+     * cloud ones reach their client and config. Handed over detached, the call
+     * throws inside the adapter, which catches it and reports every existing
+     * object as missing.
+     */
+    return await readThroughAdapter(
+      storage.read.bind(storage),
+      storagePath,
+      maxBytes
+    );
   }
   return await readThroughPublicUrl(storage, storagePath, maxBytes);
 }
@@ -270,5 +281,13 @@ function translateFetchFailure(
     // as a fault tells a caller to retry what will never return.
     return null;
   }
-  return error instanceof Error ? error : new Error(String(error));
+  /*
+   * A rejection that is not an `Error` at all — a string, an object — still has
+   * to reach the caller as this package's own failure, with a code and a status
+   * rather than a bare shape nothing can classify.
+   */
+  if (error instanceof Error) return error;
+  return NextlyError.internal({
+    logContext: { storagePath, reason: String(error) },
+  });
 }

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -18,6 +18,7 @@
  *
  * @module storage/read-stored-media
  */
+import { NextlyError } from "../errors/nextly-error";
 import { safeFetch } from "../utils/validate-external-url";
 
 import { classifyFetchFailure } from "./fetch-stored-bytes";
@@ -48,14 +49,24 @@ export interface StoredMediaSource {
  * Carries the status rather than a sentence, so a caller can decide what to say
  * — an API route answering a visitor and an attachment path answering an author
  * owe different explanations for the same failure.
+ *
+ * A `NextlyError` because this is product code in this package: a caller
+ * reaching for `NextlyError.is` must be able to classify what it caught without
+ * matching on a class name, and the envelope and structured logging follow from
+ * the code rather than from the message.
  */
-export class StoredMediaUnreachableError extends Error {
+export class StoredMediaUnreachableError extends NextlyError {
   constructor(
     readonly url: string,
     readonly status: number
   ) {
-    super(`Stored object could not be read (status ${String(status)}).`);
-    this.name = "StoredMediaUnreachableError";
+    super({
+      code: "STORAGE_READ_UNREACHABLE",
+      publicMessage: "The stored file could not be read.",
+      // The URL is operator-side only: it names a bucket and a key, and whoever
+      // asked for the file has no use for either.
+      logContext: { url, status },
+    });
   }
 }
 

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -21,7 +21,10 @@
 import { NextlyError } from "../errors/nextly-error";
 import { safeFetch } from "../utils/validate-external-url";
 
-import { classifyFetchFailure } from "./fetch-stored-bytes";
+import {
+  classifyFetchFailure,
+  DEFAULT_READ_TIMEOUT_MS,
+} from "./fetch-stored-bytes";
 import {
   StorageReadTimeoutError,
   StorageReadTooLargeError,
@@ -148,7 +151,13 @@ export async function readStoredMediaBytes(
        * treat as retryable if they could read it.
        */
       if (isNativeTimeout(error)) {
-        throw new StorageReadTimeoutError(storagePath, maxBytes);
+        /*
+         * The DEADLINE, not the cap. This reader passes only `maxBytes` to the
+         * adapter, so the adapter resolved its own deadline from the shared
+         * default — which is therefore the true figure, and the one an operator
+         * needs when they come to the 504 asking what was waited for.
+         */
+        throw new StorageReadTimeoutError(storagePath, DEFAULT_READ_TIMEOUT_MS);
       }
       throw error;
     }

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -22,7 +22,10 @@ import { NextlyError } from "../errors/nextly-error";
 import { safeFetch } from "../utils/validate-external-url";
 
 import { classifyFetchFailure } from "./fetch-stored-bytes";
-import { StorageReadTooLargeError } from "./read-errors";
+import {
+  StorageReadTimeoutError,
+  StorageReadTooLargeError,
+} from "./read-errors";
 import type { StorageReadOptions } from "./types";
 
 /**
@@ -71,6 +74,39 @@ export class StoredMediaUnreachableError extends NextlyError {
 }
 
 /**
+ * Whether a stored path is itself an address, rather than a key.
+ *
+ * Parsed rather than prefix-matched: a key may legitimately begin with those
+ * four letters — `http-font.woff2` is a valid object name — and reading it as
+ * an address sends it to `safeFetch`, which refuses it, so an ordinary file
+ * became unservable on exactly the adapters this fallback exists for.
+ */
+function isAbsoluteHttpUrl(storagePath: string): boolean {
+  try {
+    const { protocol } = new URL(storagePath);
+    return protocol === "http:" || protocol === "https:";
+  } catch {
+    // Not a URL at all, which is the ordinary case for a stored key.
+    return false;
+  }
+}
+
+/**
+ * Whether a rejection is a platform deadline rather than this package's.
+ *
+ * Adapters in sibling packages bound their reads with `AbortSignal.timeout`,
+ * whose rejection is a `DOMException` this package cannot construct or extend —
+ * so it is recognised by name, which is the only thing the runtime guarantees
+ * about it.
+ */
+function isNativeTimeout(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (error.name === "TimeoutError" || error.name === "AbortError")
+  );
+}
+
+/**
  * Read one stored object, bounded by `maxBytes` whichever route serves it.
  *
  * @param storage - The backend, which may or may not implement `read`
@@ -100,7 +136,22 @@ export async function readStoredMediaBytes(
      *
      * The URL route below is for adapters that cannot read at all.
      */
-    return await storage.read(storagePath, { maxBytes });
+    try {
+      return await storage.read(storagePath, { maxBytes });
+    } catch (error) {
+      /*
+       * An adapter outside this package bounds its own read with
+       * `AbortSignal.timeout`, which rejects with a platform `DOMException`
+       * named `TimeoutError`. Passed through, the route's error handler sees no
+       * `NextlyError` and answers 500 — an internal fault — for a backend that
+       * simply did not reply in time, which a caller and a gateway would both
+       * treat as retryable if they could read it.
+       */
+      if (isNativeTimeout(error)) {
+        throw new StorageReadTimeoutError(storagePath, maxBytes);
+      }
+      throw error;
+    }
   }
 
   /*
@@ -108,7 +159,7 @@ export async function readStoredMediaBytes(
    * stored path, so asking for a public URL for one would build an address out
    * of an address.
    */
-  const url = storagePath.startsWith("http")
+  const url = isAbsoluteHttpUrl(storagePath)
     ? storagePath
     : storage.getPublicUrl(storagePath);
 

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -76,15 +76,15 @@ export class StoredMediaUnreachableError extends NextlyError {
  * @param storage - The backend, which may or may not implement `read`
  * @param storagePath - The stored path, which some backends record as a full URL
  * @param maxBytes - The cap both routes run under
- * @returns The object's bytes
+ * @returns The object's bytes, or `null` when the store says it is not there
  * @throws StorageReadTooLargeError when the object exceeds `maxBytes`
- * @throws StoredMediaUnreachableError when the URL route answers non-2xx
+ * @throws StoredMediaUnreachableError when the store answers, but badly
  */
 export async function readStoredMediaBytes(
   storage: StoredMediaSource,
   storagePath: string,
   maxBytes: number
-): Promise<Buffer> {
+): Promise<Buffer | null> {
   if (typeof storage.read === "function") {
     /*
      * The cap travels INTO the adapter rather than being checked on what comes
@@ -128,13 +128,20 @@ export async function readStoredMediaBytes(
     }
     if (verdict === "absent") {
       // A 404 whose error page was itself over the cap, so `safeFetch` refused
-      // before a `Response` existed. The object is gone; the status below is
-      // the one that never got as far as being read.
-      throw new StoredMediaUnreachableError(url, 404);
+      // before a `Response` existed. Still an absence, and reported as one.
+      return null;
     }
     throw error;
   }
 
+  /*
+   * ABSENCE, not a fault. A row can outlive its object — a bucket lifecycle
+   * rule, a manual cleanup, a concurrent delete — and calling that an upstream
+   * failure tells a caller to retry something that will never come back. It
+   * also reaches a visitor as 502 for a font that is simply gone, on a response
+   * cacheable for a year.
+   */
+  if (response.status === 404) return null;
   if (!response.ok) {
     throw new StoredMediaUnreachableError(url, response.status);
   }

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -91,10 +91,16 @@ export async function readStoredMediaBytes(
      * back: a size checked afterwards has already spent the memory it exists to
      * save. Adapters that find the object oversized refuse it themselves.
      */
-    const buffer = await storage.read(storagePath, { maxBytes });
-    if (buffer) return buffer;
-    // `null` is absence from THIS backend, and the URL route below is a second
-    // way of asking rather than a contradiction of it.
+    /*
+     * An adapter that implements `read` is AUTHORITATIVE about absence: `null`
+     * from it means the object is not there, and asking its public URL next
+     * answers a different question badly. The local adapter's URL is a relative
+     * `/uploads/...` path, which `safeFetch` refuses as invalid — so a missing
+     * file came back as a blocked external URL rather than as missing.
+     *
+     * The URL route below is for adapters that cannot read at all.
+     */
+    return await storage.read(storagePath, { maxBytes });
   }
 
   /*

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -19,7 +19,7 @@
  * @module storage/read-stored-media
  */
 import { NextlyError } from "../errors/nextly-error";
-import { safeFetch } from "../utils/validate-external-url";
+import { SafeFetchError, safeFetch } from "../utils/validate-external-url";
 
 import {
   classifyFetchFailure,
@@ -124,45 +124,75 @@ export async function readStoredMediaBytes(
   storagePath: string,
   maxBytes: number
 ): Promise<Buffer | null> {
+  /*
+   * An adapter that implements `read` is AUTHORITATIVE about absence: `null`
+   * from it means the object is not there, and asking its public URL next
+   * answers a different question badly. The local adapter's URL is a relative
+   * `/uploads/...` path, which `safeFetch` refuses as invalid — so a missing
+   * file came back as a blocked external URL rather than as missing.
+   *
+   * The URL route is for adapters that cannot read at all.
+   */
   if (typeof storage.read === "function") {
-    /*
-     * The cap travels INTO the adapter rather than being checked on what comes
-     * back: a size checked afterwards has already spent the memory it exists to
-     * save. Adapters that find the object oversized refuse it themselves.
-     */
-    /*
-     * An adapter that implements `read` is AUTHORITATIVE about absence: `null`
-     * from it means the object is not there, and asking its public URL next
-     * answers a different question badly. The local adapter's URL is a relative
-     * `/uploads/...` path, which `safeFetch` refuses as invalid — so a missing
-     * file came back as a blocked external URL rather than as missing.
-     *
-     * The URL route below is for adapters that cannot read at all.
-     */
-    try {
-      return await storage.read(storagePath, { maxBytes });
-    } catch (error) {
-      /*
-       * An adapter outside this package bounds its own read with
-       * `AbortSignal.timeout`, which rejects with a platform `DOMException`
-       * named `TimeoutError`. Passed through, the route's error handler sees no
-       * `NextlyError` and answers 500 — an internal fault — for a backend that
-       * simply did not reply in time, which a caller and a gateway would both
-       * treat as retryable if they could read it.
-       */
-      if (isNativeTimeout(error)) {
-        /*
-         * The DEADLINE, not the cap. This reader passes only `maxBytes` to the
-         * adapter, so the adapter resolved its own deadline from the shared
-         * default — which is therefore the true figure, and the one an operator
-         * needs when they come to the 504 asking what was waited for.
-         */
-        throw new StorageReadTimeoutError(storagePath, DEFAULT_READ_TIMEOUT_MS);
-      }
-      throw error;
-    }
+    return await readThroughAdapter(storage.read, storagePath, maxBytes);
   }
+  return await readThroughPublicUrl(storage, storagePath, maxBytes);
+}
 
+/**
+ * Ask the backend for its own bytes.
+ *
+ * @param read - The adapter's reader, already known to exist
+ * @param storagePath - The stored path
+ * @param maxBytes - The cap, which travels INTO the adapter rather than being
+ *   checked on the way back: a size checked afterwards has already spent the
+ *   memory the cap exists to save
+ */
+async function readThroughAdapter(
+  read: NonNullable<StoredMediaSource["read"]>,
+  storagePath: string,
+  maxBytes: number
+): Promise<Buffer | null> {
+  try {
+    return await read(storagePath, { maxBytes });
+  } catch (error) {
+    /*
+     * An adapter outside this package bounds its own read with
+     * `AbortSignal.timeout`, which rejects with a platform `DOMException` named
+     * `TimeoutError`. Passed through, the route's error handler sees no
+     * `NextlyError` and answers 500 — an internal fault — for a backend that
+     * simply did not reply in time, which a caller and a gateway would both
+     * treat as retryable if they could read it.
+     *
+     * The DEADLINE is reported, not the cap: this reader passes only `maxBytes`
+     * to the adapter, so the adapter resolved its own deadline from the shared
+     * default, which is the figure an operator needs when they reach the 504.
+     */
+    if (isNativeTimeout(error)) {
+      throw new StorageReadTimeoutError(storagePath, DEFAULT_READ_TIMEOUT_MS);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Fetch the object from the address the backend serves it at.
+ *
+ * For adapters that cannot hand back their own bytes. Goes through `safeFetch`,
+ * which refuses hosts resolving to private, loopback, link-local and
+ * cloud-metadata addresses — it has to, since the path can come from a stored
+ * field and an attacker who can write one would otherwise be choosing what this
+ * server connects to.
+ *
+ * @param storage - The backend, for its public URL
+ * @param storagePath - The stored path, which some backends record as a URL
+ * @param maxBytes - The cap this read runs under
+ */
+async function readThroughPublicUrl(
+  storage: StoredMediaSource,
+  storagePath: string,
+  maxBytes: number
+): Promise<Buffer | null> {
   /*
    * Some backends — Vercel Blob among them — record the full public URL as the
    * stored path, so asking for a public URL for one would build an address out
@@ -176,28 +206,11 @@ export async function readStoredMediaBytes(
   try {
     response = await safeFetch(url, { maxResponseBytes: maxBytes });
   } catch (error) {
-    /*
-     * Translated rather than rethrown, so the two routes refuse identically.
-     * Left as a `SafeFetchError`, an over-cap fetch would be a different error
-     * from an over-cap read of the same object, and every caller would have to
-     * know which backend it happened to be talking to.
-     *
-     * Classified by the SAME function the URL-backed adapters use, because the
-     * distinction it draws is not one a second implementation would keep: an
-     * over-cap body on a FAILED response — a 500 page, a verbose error document
-     * — is a backend outage, and reading the reason alone reports it as the
-     * author's file being too big.
-     */
-    const verdict = classifyFetchFailure(error);
-    if (verdict === "oversized") {
-      throw new StorageReadTooLargeError(storagePath, maxBytes);
-    }
-    if (verdict === "absent") {
-      // A 404 whose error page was itself over the cap, so `safeFetch` refused
-      // before a `Response` existed. Still an absence, and reported as one.
-      return null;
-    }
-    throw error;
+    const translated = translateFetchFailure(error, storagePath, maxBytes);
+    // `null` is an ABSENCE the fetch never got to report as a status: a 404
+    // whose error page was itself over the cap, refused while buffering.
+    if (translated === null) return null;
+    throw translated;
   }
 
   /*
@@ -212,4 +225,50 @@ export async function readStoredMediaBytes(
     throw new StoredMediaUnreachableError(url, response.status);
   }
   return Buffer.from(await response.arrayBuffer());
+}
+
+/**
+ * Say what a failed fetch means, in the vocabulary both routes share.
+ *
+ * A caller that has to ask which backend answered before it can read the
+ * failure is a caller that will eventually read it wrongly, so every refusal
+ * here is one the adapter route can also produce.
+ *
+ * @returns The error to throw, or `null` when the object is simply absent
+ */
+function translateFetchFailure(
+  error: unknown,
+  storagePath: string,
+  maxBytes: number
+): Error | null {
+  /*
+   * A deadline is a deadline whichever route hit it. Left as a
+   * `SafeFetchError`, the fallback's timeout reached the route as
+   * `EXTERNAL_REQUEST_FAILED`/502 while the native read's became
+   * `STORAGE_READ_TIMEOUT`/504 — so whether a caller retried depended on
+   * whether the adapter happened to implement `read`, which describes the
+   * deployment rather than what went wrong.
+   */
+  if (error instanceof SafeFetchError && error.reason === "timeout") {
+    return new StorageReadTimeoutError(storagePath, DEFAULT_READ_TIMEOUT_MS);
+  }
+
+  /*
+   * Classified by the SAME function the URL-backed adapters use, because the
+   * distinction it draws is not one a second implementation would keep: an
+   * over-cap body on a FAILED response — a 500 page, a verbose error document —
+   * is a backend outage, and reading the reason alone reports it as the
+   * author's file being too big.
+   */
+  const verdict = classifyFetchFailure(error);
+  if (verdict === "oversized") {
+    return new StorageReadTooLargeError(storagePath, maxBytes);
+  }
+  if (verdict === "absent") {
+    // A 404 whose error page was itself over the cap, so `safeFetch` refused
+    // before a `Response` existed. The object is gone, and an absence reported
+    // as a fault tells a caller to retry what will never return.
+    return null;
+  }
+  return error instanceof Error ? error : new Error(String(error));
 }

--- a/packages/nextly/src/storage/read-stored-media.ts
+++ b/packages/nextly/src/storage/read-stored-media.ts
@@ -1,0 +1,131 @@
+/**
+ * Read the bytes behind a stored media path, whatever the backend supports.
+ *
+ * Two routes to the same answer, and which one runs is a property of the
+ * ADAPTER rather than of the request: one that implements `read` is asked
+ * directly, and one that does not is fetched over its own public URL. Both are
+ * bounded by the caller's cap, and both refuse in the same vocabulary — a
+ * `StorageReadTooLargeError` — because a caller that has to ask which route ran
+ * before it can interpret the failure is a caller that will eventually get it
+ * wrong. That is not hypothetical: implementing `read` on the cloud adapters
+ * silently moved the email attachment path from the bounded fetch onto an
+ * unbounded buffer, and nothing in that change mentioned email.
+ *
+ * The URL route goes through `safeFetch`, which refuses hosts resolving to
+ * private, loopback, link-local and cloud-metadata addresses. It has to: the
+ * path can come from a stored field, so an attacker who can write one would
+ * otherwise be choosing what this server connects to.
+ *
+ * @module storage/read-stored-media
+ */
+import { safeFetch } from "../utils/validate-external-url";
+
+import { classifyFetchFailure } from "./fetch-stored-bytes";
+import { StorageReadTooLargeError } from "./read-errors";
+import type { StorageReadOptions } from "./types";
+
+/**
+ * The part of a storage backend this needs.
+ *
+ * Structural rather than the full adapter interface, so a caller holding a
+ * media storage facade, a bare adapter or a test double can all be read from
+ * without one of them having to pretend to be another.
+ */
+export interface StoredMediaSource {
+  /** Present only on backends that can hand back their own bytes. */
+  read?: (
+    filePath: string,
+    options?: StorageReadOptions
+  ) => Promise<Buffer | null>;
+  /** The address the same object is served from. */
+  getPublicUrl: (filePath: string) => string;
+}
+
+/**
+ * A stored object that could not be reached, as distinct from one that is not
+ * there.
+ *
+ * Carries the status rather than a sentence, so a caller can decide what to say
+ * — an API route answering a visitor and an attachment path answering an author
+ * owe different explanations for the same failure.
+ */
+export class StoredMediaUnreachableError extends Error {
+  constructor(
+    readonly url: string,
+    readonly status: number
+  ) {
+    super(`Stored object could not be read (status ${String(status)}).`);
+    this.name = "StoredMediaUnreachableError";
+  }
+}
+
+/**
+ * Read one stored object, bounded by `maxBytes` whichever route serves it.
+ *
+ * @param storage - The backend, which may or may not implement `read`
+ * @param storagePath - The stored path, which some backends record as a full URL
+ * @param maxBytes - The cap both routes run under
+ * @returns The object's bytes
+ * @throws StorageReadTooLargeError when the object exceeds `maxBytes`
+ * @throws StoredMediaUnreachableError when the URL route answers non-2xx
+ */
+export async function readStoredMediaBytes(
+  storage: StoredMediaSource,
+  storagePath: string,
+  maxBytes: number
+): Promise<Buffer> {
+  if (typeof storage.read === "function") {
+    /*
+     * The cap travels INTO the adapter rather than being checked on what comes
+     * back: a size checked afterwards has already spent the memory it exists to
+     * save. Adapters that find the object oversized refuse it themselves.
+     */
+    const buffer = await storage.read(storagePath, { maxBytes });
+    if (buffer) return buffer;
+    // `null` is absence from THIS backend, and the URL route below is a second
+    // way of asking rather than a contradiction of it.
+  }
+
+  /*
+   * Some backends — Vercel Blob among them — record the full public URL as the
+   * stored path, so asking for a public URL for one would build an address out
+   * of an address.
+   */
+  const url = storagePath.startsWith("http")
+    ? storagePath
+    : storage.getPublicUrl(storagePath);
+
+  let response: Response;
+  try {
+    response = await safeFetch(url, { maxResponseBytes: maxBytes });
+  } catch (error) {
+    /*
+     * Translated rather than rethrown, so the two routes refuse identically.
+     * Left as a `SafeFetchError`, an over-cap fetch would be a different error
+     * from an over-cap read of the same object, and every caller would have to
+     * know which backend it happened to be talking to.
+     *
+     * Classified by the SAME function the URL-backed adapters use, because the
+     * distinction it draws is not one a second implementation would keep: an
+     * over-cap body on a FAILED response — a 500 page, a verbose error document
+     * — is a backend outage, and reading the reason alone reports it as the
+     * author's file being too big.
+     */
+    const verdict = classifyFetchFailure(error);
+    if (verdict === "oversized") {
+      throw new StorageReadTooLargeError(storagePath, maxBytes);
+    }
+    if (verdict === "absent") {
+      // A 404 whose error page was itself over the cap, so `safeFetch` refused
+      // before a `Response` existed. The object is gone; the status below is
+      // the one that never got as far as being read.
+      throw new StoredMediaUnreachableError(url, 404);
+    }
+    throw error;
+  }
+
+  if (!response.ok) {
+    throw new StoredMediaUnreachableError(url, response.status);
+  }
+  return Buffer.from(await response.arrayBuffer());
+}


### PR DESCRIPTION
Foundation for the Fonts panel (tracker row U-4), and the piece #1442 existed to unblock.

## The problem

A font could be uploaded nowhere and served from nowhere.

`DEFAULT_ALLOWED_MIME_TYPES` carried no font type, so a `.woff2` was refused before it was stored. And a `@font-face` may not name another host — a documented product rule the styling engine enforces, on the grounds that a font URL pointing elsewhere makes every visitor's browser announce its IP address to that server before a word of the page is readable. So a font that *did* reach S3, Vercel Blob or UploadThing was unusable at the only address it had.

## What changed

**The allowlist gains `font/woff2` and `font/woff`, and only those two.** Nothing here converts TTF or OTF, so allowing them would store and send several times the bytes of the same face to every visitor with nothing reporting it. A refusal a designer can act on beats a silent cost they cannot see.

**`GET /api/media/:id/raw`**, mounted by the existing `createMediaHandlers()` — no app adds a route file.

It answers **ahead of the auth gate**, deliberately. Media auth is opt-in (`requireAuth`, default false), and on a gated mount a font route behind the gate would answer 401 to a browser that carries no session — so the page would render in a fallback face, on exactly the installs that locked media down on purpose, with nothing visibly wrong.

What keeps that safe is **the type, not the caller**: it serves only `PUBLIC_SERVE_MIME_TYPES` and answers **404 rather than 403** for everything else, so it cannot be used to read a private object or to ask whether one exists. Widening that set widens what any anonymous caller can read, and the module says so where someone would edit it.

**Reading a stored object is now one implementation instead of two.** The attachment path and the new route call the same function: try the adapter's own `read`, fall back to a bounded `safeFetch` of the public URL, refuse over-cap bytes in the same words either way. This also retires the 74-line closure that lived inside the email DI factory.

### That extraction found a live defect

`SafeFetchError` carries a `status`, and its docblock says why: `safeFetch` caps **while buffering**, so a verbose 500 page raises `response-too-large` before any status is read. The email path translated on `reason` alone — so a backend outage was reported to an author as **"your attachment is too big"**, a cause they would act on, wrongly.

`fetch-stored-bytes` already solved this in #1442's round six, so the shared reader calls that same `classifyFetchFailure` rather than carrying a second copy of the judgement.

Email behaviour is otherwise unchanged: `asAttachmentReadError` now also maps the unreachable error to the same `ATTACHMENT_STORAGE_READ_FAILED` the URL route raised inline before.

## Evidence

Every new test break-verified individually; each break kills exactly the case that names it.

| Mutation | Failing case |
|---|---|
| mime gate removed | REFUSES a type outside the servable set |
| route moved behind the auth gate | serves the font on a GATED mount, with no session |
| absence and unreachability folded | does NOT turn a lookup failure into 404 |
| 404 → 403 | REFUSES a type… + answers 404 for a record that is not there |
| `classifyFetchFailure` → reason only | does NOT call an over-cap ERROR PAGE an oversized file |
| native read skipped | asks an adapter that CAN read, and does not fetch |
| `getPublicUrl` on a stored URL | does not build an address out of an address |
| non-2xx read as success | reports a non-2xx as unreachable, carrying the status |

The mime allowlist is verified in **both** directions — removing the fonts fails it, and adding `font/ttf` fails it too. Over-widening is the silent failure there.

Control that email behaviour did not change: **47 files / 616 tests** across `domains/email` and `di/registrations`, green.

## Gates

- lint 24/24 (`EXIT=0`)
- check-types 22/22 (`EXIT=0`)
- `packages/nextly` — 859 files, 10638 passed, 42 skipped
- `fallow audit --base origin/main` — no issues in 10 changed files, which is the whole diff