### PR TITLE
feat(builder): let the tokens and classes panels explain themselves

### DIFF
--- a/.changeset/the-panels-say-what-they-are-for.md
+++ b/.changeset/the-panels-say-what-they-are-for.md
@@ -1,0 +1,51 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+The tokens and classes panels opened with machinery and never said what they
+were for. A mode switch, a DTCG import/export control and eight tabs of
+vocabulary came before any sentence about what a token does to the site, so an
+author who did not already know the concept had nothing to read.
+
+Each panel now opens with a sentence in the author's words. The tokens panel
+says that changing a token changes every block using it, on every page. The
+classes panel says a class is a saved set of styles and that you apply one
+beside the style controls — which explains the split rather than leaving the
+absent create button reading as a missing feature.
+
+The eight token tabs become one grouped list. A kind with no tokens is now
+absent rather than an empty tab to click into and find nothing, and search
+crosses every kind at once, which the tabs could not do without silently
+crossing the boundary they asserted. Because a list of only non-empty groups
+leaves nowhere to stand to make the first token of a kind, creation now names
+its kind instead of relying on which tab was open.
+
+Empty states report what is absent, say what belongs there and offer the next
+action. The classes panel's "Not in index" list is the one that most needed it:
+an empty result there is good news, and it used to read as a failure.
+
+The DTCG import and export control moves below the tokens it operates on.

--- a/.changeset/the-panels-say-what-they-are-for.md
+++ b/.changeset/the-panels-say-what-they-are-for.md
@@ -32,7 +32,9 @@ vocabulary came before any sentence about what a token does to the site, so an
 author who did not already know the concept had nothing to read.
 
 Each panel now opens with a sentence in the author's words. The tokens panel
-says that changing a token changes every block using it, on every page. The
+says that every block using a token follows it, on every page, and names the
+mode being edited — a token can hold separate light and dark values, and an
+edit reaches only the one on screen. The
 classes panel says a class is a saved set of styles and that you apply one
 beside the style controls — which explains the split rather than leaving the
 absent create button reading as a missing feature.

--- a/packages/builder/src/class-library.ts
+++ b/packages/builder/src/class-library.ts
@@ -371,6 +371,23 @@ export type ClassNameOutcome =
   | { readonly ok: false; readonly refusal: NameRefusal };
 
 /**
+ * Whether the library has room for another class.
+ *
+ * Exported because two surfaces need the answer and only one of them is naming
+ * a class. `newClassName` refuses a name when there is no room; the manager
+ * panel has to decide whether to tell an author a class can be made at all,
+ * and inferring that from an empty drawn list is wrong in exactly the case
+ * that matters — `siteClasses` drops entries the compiler cannot use, so a
+ * library of malformed entries draws nothing while every slot is taken.
+ *
+ * Counts the STORED entries, which is what capacity is about. The drawn list
+ * is a different question and answering one with the other is the bug.
+ */
+export function classLibraryHasRoom(library: readonly NamedClass[]): boolean {
+  return library.length < MAX_NAMED_CLASSES;
+}
+
+/**
  * Whether a typed name can become a new class, and what to store if it can.
  *
  * The grammar is the engine's, not a second one: a slug reaches a CSS selector,
@@ -405,7 +422,7 @@ export function newClassName(
    * the save outright rather than storing it quietly. Accepting the name here
    * would offer an author a class that cannot be saved OR rendered.
    */
-  if (library.length >= MAX_NAMED_CLASSES) {
+  if (!classLibraryHasRoom(library)) {
     return { ok: false, refusal: "library-full" };
   }
   return { ok: true, slug };

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -19,6 +19,8 @@ import {
   render,
   screen,
 } from "@testing-library/react";
+import { MAX_NAMED_CLASSES } from "@nextlyhq/blocks-engine";
+import { newClassName } from "./class-library";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
@@ -1148,6 +1150,44 @@ describe("the panel explains itself", () => {
       />
     );
     expect(screen.getByText(/clear them out/i)).toBeTruthy();
+  });
+
+  it("does not offer creation when class-library would refuse it", () => {
+    /*
+     * A full library of entries the compiler cannot use draws NOTHING, so the
+     * empty list looks like a fresh site — while `newClassName` refuses every
+     * creation as `library-full`. Telling that author to make the first class
+     * names an action that cannot succeed, on the surface they came to for
+     * help. The verdict is `class-library`'s to give, not the list's to imply.
+     */
+    const full = Array.from({ length: MAX_NAMED_CLASSES }, (_, at) =>
+      cls(`id-${at}`, "Not A Slug", at)
+    );
+    const view = render(
+      <ClassManagerPanel
+        library={full}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+      />
+    );
+    // The control: the list really is empty, so this is about the verdict
+    // rather than about rows happening to render.
+    expect(screen.queryByText("No classes yet.")).toBeNull();
+    expect(screen.getByText(/none can be made/i)).toBeTruthy();
+    expect(newClassName("fresh", full).ok).toBe(false);
+
+    // Must-differ: an ordinarily empty library still teaches and still offers.
+    view.rerender(
+      <ClassManagerPanel
+        library={[]}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+      />
+    );
+    expect(screen.getByText("No classes yet.")).toBeTruthy();
+    expect(screen.queryByText(/none can be made/i)).toBeNull();
   });
 
   it("keeps the filters, because they answer questions that OVERLAP", () => {

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -146,10 +146,37 @@ describe("the filters, which ask three different questions", () => {
     expect(screen.queryByRole("button", { name: /unused/i })).toBeNull();
   });
 
-  it("says so when a filter matches nothing", () => {
+  it("reports an empty 'not in index' as the RESULT it is, not as a miss", () => {
+    /*
+     * Changed deliberately from the generic "no classes match this filter".
+     * Every other empty list here is a narrowing that found nothing; this one
+     * is the outcome an author auditing a site is hoping for, and wording it
+     * like a failure reports success as disappointment.
+     */
     draw({ usage: { "id-hero": 1, "id-badge": 1, "id-card": 1 } });
     fireEvent.click(screen.getByRole("button", { name: "Not in index" }));
-    expect(screen.getByText(/no classes match/i)).toBeTruthy();
+    expect(screen.getByText(/nothing here/i)).toBeTruthy();
+    expect(screen.queryByText(/no classes match/i)).toBeNull();
+  });
+
+  it("still says 'no classes match' for a narrowing that simply found none", () => {
+    /*
+     * The control for the SEARCH branch specifically, which returns before the
+     * filter is consulted — so this is what stops a search that found nothing
+     * being congratulated.
+     *
+     * It does NOT control the filter branch, and saying otherwise would
+     * overclaim: making the good-news wording unconditional leaves this test
+     * green and kills "blames the FILTER, not a search that is not set"
+     * instead. Verified by breaking it, not assumed. That test is the filter
+     * branch's control and the two are needed for different reasons.
+     */
+    draw();
+    fireEvent.change(screen.getByRole("searchbox", { name: /search/i }), {
+      target: { value: "zzzz" },
+    });
+    expect(screen.getByText(/no classes match this search/i)).toBeTruthy();
+    expect(screen.queryByText(/nothing here/i)).toBeNull();
   });
 });
 
@@ -968,5 +995,54 @@ describe("a host whose rename handler returns something else entirely", () => {
     });
     expect(onRename).toHaveBeenCalled();
     expect(screen.queryByText(/could not be renamed/i)).toBeNull();
+  });
+});
+
+describe("the panel explains itself", () => {
+  it("says what a class IS, and where you apply one", () => {
+    /*
+     * The second sentence is load-bearing. This panel has no way to CREATE a
+     * class — deliberately, because applying happens beside the style controls
+     * — and without saying so the absent control reads as a missing feature
+     * rather than as a split.
+     */
+    draw();
+    expect(screen.getByText(/saved set of styles/i)).toBeTruthy();
+    expect(screen.getByText(/beside the style controls/i)).toBeTruthy();
+  });
+
+  it("tells an author that an empty 'not in index' list is good news", () => {
+    /*
+     * The one empty state that is a REPORT rather than a lack. "No classes
+     * match this filter." reads as a failure; here it means nothing is known to
+     * be stranded, which is the outcome the author was hoping for.
+     *
+     * The wording still refuses to claim more than the index can support — a
+     * floor, never a measurement — which is the same care the filter's own name
+     * takes.
+     */
+    draw({ library: [], usage: {}, documentClassIds: [] });
+    fireEvent.click(screen.getByRole("button", { name: "Not in index" }));
+    expect(screen.getByText(/nothing here/i)).toBeTruthy();
+    expect(screen.getByText(/floor, not a measurement/i)).toBeTruthy();
+  });
+
+  it("keeps the filters, because they answer questions that OVERLAP", () => {
+    /*
+     * Not converted to groups, and this test is why. `filterClassRows` tests
+     * `indexedDocuments === 0` for one and `onThisPage` for the other, so a
+     * class the open document applies while the index has not recorded it
+     * satisfies BOTH. Groups would have to put it in one and would assert a
+     * mutual exclusivity the rule denies.
+     */
+    draw({
+      library: [cls("id-draft", "draft-only", 0)],
+      usage: {},
+      documentClassIds: ["id-draft"],
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Not in index" }));
+    expect(nameField("draft-only")).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: "On this page" }));
+    expect(nameField("draft-only")).toBeTruthy();
   });
 });

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -1111,6 +1111,45 @@ describe("the panel explains itself", () => {
     expect(screen.getByText(/Rename them/i)).toBeTruthy();
   });
 
+  it("asks the DRAWN rows whether anything can be deleted", () => {
+    /*
+     * The stored library is not the set on screen. `classRows` goes through
+     * `siteClasses`, which caps the list and drops entries the compiler cannot
+     * use — a duplicate slug among them, where only the first slot is written.
+     *
+     * Here the written row is supplied (no delete control) and the only
+     * non-supplied entry is the duplicate that never renders. Scanning the
+     * stored library said deletion was available; nothing on screen offered it.
+     */
+    const duplicate = [cls("id-hero", "hero", 0), cls("id-ghost", "hero", 1)];
+    const view = render(
+      <ClassManagerPanel
+        library={duplicate}
+        usage={undefined}
+        documentClassIds={[]}
+        suppliedClassIds={["id-hero"]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    // The must-be-found control: the duplicate really is absent from the rows,
+    // so the assertion below is about deletability and not about an empty list.
+    expect(nameField("hero")).toBeTruthy();
+    expect(screen.queryByText(/clear them out/i)).toBeNull();
+
+    // Must-differ: make the drawn row deletable and the promise returns.
+    view.rerender(
+      <ClassManagerPanel
+        library={duplicate}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/clear them out/i)).toBeTruthy();
+  });
+
   it("keeps the filters, because they answer questions that OVERLAP", () => {
     /*
      * Not converted to groups, and this test is why. `filterClassRows` tests

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -1070,17 +1070,19 @@ describe("the panel explains itself", () => {
      * Both halves are asserted: with the callback the promise must come back,
      * or this test would also pass on copy that had simply lost the word.
      */
+    // A library with a row in it, so RENAME is genuinely on offer and the only
+    // question under test is deletion. An empty library now offers neither,
+    // which would make the assertion below pass for the wrong reason.
     const view = render(
       <ClassManagerPanel
-        library={[]}
+        library={[cls("id-own", "own-class", 1)]}
         usage={undefined}
         documentClassIds={[]}
         onRename={vi.fn()}
       />
     );
-    expect(screen.queryByText(/clear them out here/i)).toBeNull();
-    expect(screen.queryByText(/or clear out/i)).toBeNull();
-    expect(screen.getByText(/Rename them\s+here/i)).toBeTruthy();
+    expect(screen.queryByText(/clear them out/i)).toBeNull();
+    expect(screen.getByText(/Rename them here/i)).toBeTruthy();
 
     // Must-differ: a callback AND a row that can actually take it.
     view.rerender(
@@ -1228,6 +1230,63 @@ describe("the panel explains itself", () => {
     expect(screen.getByText("Default")).toBeTruthy();
     expect(screen.queryByRole("button", { name: /^Delete hero$/ })).toBeNull();
     expect(document.querySelector(".nx-classman__confirm")).toBeNull();
+
+    /*
+     * And DISARMED, not merely hidden — which the assertion above cannot tell
+     * apart on its own. Giving the capability back must not bring the
+     * confirmation with it: an author who opened it before the class became
+     * supplied never reviewed it under the new state, so it has to be reopened
+     * deliberately.
+     */
+    view.rerender(
+      <ClassManagerPanel
+        library={library}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("button", { name: "Delete hero" })).toBeTruthy();
+    expect(document.querySelector(".nx-classman__confirm")).toBeNull();
+  });
+
+  it("offers no rename when there is nothing drawn to rename", () => {
+    /*
+     * A full library of entries `siteClasses` omits draws no rows, so the
+     * empty state says this panel can do nothing with them — while the lede
+     * went on promising "Rename them here" beside it, with no rename field on
+     * screen. Two sentences in one view contradicting each other.
+     */
+    const unusable = Array.from({ length: MAX_NAMED_CLASSES }, (_, at) =>
+      cls(`id-${at}`, "Not A Slug", at)
+    );
+    const view = render(
+      <ClassManagerPanel
+        library={unusable}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/Rename them/i)).toBeNull();
+    expect(screen.queryByText(/clear them out/i)).toBeNull();
+    expect(
+      screen.getByText(/apply one beside the style controls/i)
+    ).toBeTruthy();
+
+    // Must-differ: one drawable row and the offer comes back.
+    view.rerender(
+      <ClassManagerPanel
+        library={[cls("id-hero", "hero", 0)]}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Rename and clear them out/i)).toBeTruthy();
   });
 
   it("keeps the filters, because they answer questions that OVERLAP", () => {

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -1027,6 +1027,29 @@ describe("the panel explains itself", () => {
     expect(screen.getByText(/floor, not a measurement/i)).toBeTruthy();
   });
 
+  it("teaches when the library is EMPTY, rather than blaming a filter", () => {
+    /*
+     * With `all` active nothing is narrowing anything, so "No classes match
+     * this filter." names a control that did not empty the list and then stops
+     * at the absence — the dead end this panel was reported for.
+     *
+     * The second half is the must-differ control: under `on this page` a filter
+     * genuinely DID narrow, so the filter wording is the honest one there and
+     * has to survive. Without it this test would pass on a panel that had
+     * simply lost the filter sentence altogether.
+     */
+    draw({ library: [], usage: undefined, documentClassIds: [] });
+    expect(screen.getByText("No classes yet.")).toBeTruthy();
+    expect(
+      screen.getByText(/other blocks can wear the same one/i)
+    ).toBeTruthy();
+    expect(screen.queryByText("No classes match this filter.")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "On this page" }));
+    expect(screen.getByText("No classes match this filter.")).toBeTruthy();
+    expect(screen.queryByText("No classes yet.")).toBeNull();
+  });
+
   it("keeps the filters, because they answer questions that OVERLAP", () => {
     /*
      * Not converted to groups, and this test is why. `filterClassRows` tests

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -1024,7 +1024,15 @@ describe("the panel explains itself", () => {
     draw({ library: [], usage: {}, documentClassIds: [] });
     fireEvent.click(screen.getByRole("button", { name: "Not in index" }));
     expect(screen.getByText(/nothing here/i)).toBeTruthy();
-    expect(screen.getByText(/floor, not a measurement/i)).toBeTruthy();
+    /*
+     * BOTH error directions, because the index errs both ways: it can miss a
+     * class that is still applied, AND it keeps rows a failed removal left
+     * behind. Naming only the first let the copy claim nothing was waiting to
+     * be cleared, which a stale positive row can make false.
+     */
+    expect(screen.getByText(/errs in BOTH directions/i)).toBeTruthy();
+    expect(screen.getByText(/failed\s+removal left behind/i)).toBeTruthy();
+    expect(screen.queryByText(/none is waiting to be cleared/i)).toBeNull();
   });
 
   it("teaches when the library is EMPTY, rather than blaming a filter", () => {
@@ -1048,6 +1056,40 @@ describe("the panel explains itself", () => {
     fireEvent.click(screen.getByRole("button", { name: "On this page" }));
     expect(screen.getByText("No classes match this filter.")).toBeTruthy();
     expect(screen.queryByText("No classes yet.")).toBeNull();
+  });
+
+  it("does not promise deletion when the host wired no onDelete", () => {
+    /*
+     * The production `BlocksField` mount passes no `onDelete` — its own
+     * comment says so — and the rows then render no delete control. Telling
+     * that author to "clear them out here" points at something the panel
+     * cannot do, which is the exact complaint this work was filed against.
+     *
+     * Both halves are asserted: with the callback the promise must come back,
+     * or this test would also pass on copy that had simply lost the word.
+     */
+    const view = render(
+      <ClassManagerPanel
+        library={[]}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/clear them out here/i)).toBeNull();
+    expect(screen.queryByText(/or clear out/i)).toBeNull();
+    expect(screen.getByText(/Rename them\s+here/i)).toBeTruthy();
+
+    view.rerender(
+      <ClassManagerPanel
+        library={[]}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/clear them out\s+here/i)).toBeTruthy();
   });
 
   it("keeps the filters, because they answer questions that OVERLAP", () => {

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -1080,16 +1080,35 @@ describe("the panel explains itself", () => {
     expect(screen.queryByText(/or clear out/i)).toBeNull();
     expect(screen.getByText(/Rename them\s+here/i)).toBeTruthy();
 
+    // Must-differ: a callback AND a row that can actually take it.
     view.rerender(
       <ClassManagerPanel
-        library={[]}
+        library={[cls("id-own", "own-class", 1)]}
         usage={undefined}
         documentClassIds={[]}
         onRename={vi.fn()}
         onDelete={vi.fn()}
       />
     );
-    expect(screen.getByText(/clear them out\s+here/i)).toBeTruthy();
+    expect(screen.getByText(/clear them out/i)).toBeTruthy();
+
+    /*
+     * And the shape the callback alone could not see: every class SUPPLIED, so
+     * each row is labelled "Default" and draws no delete control even though
+     * the host wired one. Reading `onDelete` alone promised deletion here.
+     */
+    view.rerender(
+      <ClassManagerPanel
+        library={[cls("id-own", "own-class", 1)]}
+        usage={undefined}
+        documentClassIds={[]}
+        suppliedClassIds={["id-own"]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.queryByText(/clear them out/i)).toBeNull();
+    expect(screen.getByText(/Rename them/i)).toBeTruthy();
   });
 
   it("keeps the filters, because they answer questions that OVERLAP", () => {

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -1190,6 +1190,46 @@ describe("the panel explains itself", () => {
     expect(screen.queryByText(/none can be made/i)).toBeNull();
   });
 
+  it("closes an armed deletion when the class becomes supplied", () => {
+    /*
+     * `confirming` is local state and survives a prop change. The Delete button
+     * is gated on `canDelete`, but the confirmation it opens was gated only on
+     * the callback — so a class that became supplied mid-confirmation left an
+     * armed, irreversible control behind after the row had stopped offering
+     * one. An author who walked away mid-decision could return and confirm a
+     * removal the panel no longer believes it can perform.
+     */
+    const library = [cls("id-hero", "hero", 0)];
+    const view = render(
+      <ClassManagerPanel
+        library={library}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Delete hero" }));
+    // The control, resolved to the confirmation itself rather than to any text
+    // that happens to contain "delete": it really IS armed before the change.
+    expect(document.querySelector(".nx-classman__confirm")).not.toBeNull();
+
+    view.rerender(
+      <ClassManagerPanel
+        library={library}
+        usage={undefined}
+        documentClassIds={[]}
+        suppliedClassIds={["id-hero"]}
+        onRename={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    // The row now says Default, and nothing armed survives beside it.
+    expect(screen.getByText("Default")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /^Delete hero$/ })).toBeNull();
+    expect(document.querySelector(".nx-classman__confirm")).toBeNull();
+  });
+
   it("keeps the filters, because they answer questions that OVERLAP", () => {
     /*
      * Not converted to groups, and this test is why. `filterClassRows` tests

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -330,8 +330,9 @@ export function ClassManagerPanel({
        * split someone chose.
        */}
       <p className="nx-classman__lede">
-        <b>A class is a saved set of styles you can reuse.</b> Rename and clear
-        them out here; you apply one beside the style controls.
+        <b>A class is a saved set of styles you can reuse.</b>{" "}
+        {onDelete === undefined ? "Rename them" : "Rename and clear them out"}{" "}
+        here; you apply one beside the style controls.
       </p>
       <FilterChips active={active} filters={offerable} onChange={setFilter} />
       <ClassSearch query={query} onChange={setQuery} />
@@ -406,6 +407,89 @@ function FilterChips({
       ))}
     </div>
   );
+}
+
+/**
+ * Why the list is empty, in the terms of whatever actually emptied it.
+ *
+ * Extracted from `ClassList` because four narrowings with four different
+ * honest answers is its own question, and inlining them pushed that component
+ * past the cognitive-complexity gate. Mirrors `EmptyTokens` in tokens-panel.
+ */
+function EmptyClasses({
+  searching,
+  filter,
+  canDelete,
+}: {
+  searching: boolean;
+  filter: ClassFilter;
+  /**
+   * Whether the host wired a delete callback. The production `BlocksField`
+   * mount does not, so a row shows no delete control there and copy offering
+   * to clear classes out would name an action this panel cannot perform.
+   */
+  canDelete: boolean;
+}): React.JSX.Element {
+  /*
+   * Which narrowing produced the empty list. Blaming the search when the box
+   * is blank sends an author to clear something that is not set, and hides
+   * the filter that actually did it.
+   */
+  if (searching) {
+    return <p className="nx-inspector__note">No classes match this search.</p>;
+  }
+  /*
+   * An empty "not in index" is the one absence here that is a RESULT rather
+   * than a lack: nothing is known to be stranded. Wording it like the others
+   * reports the outcome an author was hoping for as a failure to find
+   * anything.
+   *
+   * The sentence still refuses to claim more than the index can support. It
+   * says what is not KNOWN, never what is not USED — the same care the
+   * filter's own name takes, and for the same reason: the index errs in both
+   * directions, so an empty list is a floor rather than a measurement.
+   */
+  if (filter === "not-in-index") {
+    return (
+      <div className="nx-classman__empty">
+        <p className="nx-classman__empty-head">
+          Nothing here &mdash; and that is good news.
+        </p>
+        <p className="nx-inspector__note">
+          Every class has an index entry, so none is listed as stranded. That is
+          the whole claim: the index errs in BOTH directions — it can miss a
+          class that is still applied, and it keeps rows a failed removal left
+          behind — so an empty list here is evidence about the index rather than
+          a measurement of what is used.
+        </p>
+      </div>
+    );
+  }
+  /*
+   * An empty library is not a filter miss. With `all` active nothing is
+   * narrowing anything, so blaming "this filter" points an author at a
+   * control that is not doing what the sentence says it did — and stops at
+   * the absence, which is the dead end this panel was reported for.
+   *
+   * It teaches instead, and names where the next step happens. Classes are
+   * not created here (applying belongs beside the style controls, auditing
+   * belongs on a reading surface), so the action this state can honestly
+   * offer is where to go, not a button.
+   */
+  if (filter === "all") {
+    return (
+      <div className="nx-classman__empty">
+        <p className="nx-classman__empty-head">No classes yet.</p>
+        <p className="nx-inspector__note">
+          A class saves a set of styles under a name so other blocks can wear
+          the same one. You make the first beside the style controls, and it
+          appears here to rename
+          {canDelete ? " or clear out" : ""}.
+        </p>
+      </div>
+    );
+  }
+  return <p className="nx-inspector__note">No classes match this filter.</p>;
 }
 
 /**
@@ -487,65 +571,13 @@ function ClassList({
   const [pagesOpen, setPagesOpen] = React.useState(1);
   const limit = pagesOpen * page;
   if (rows.length === 0) {
-    /*
-     * Which narrowing produced the empty list. Blaming the search when the box
-     * is blank sends an author to clear something that is not set, and hides
-     * the filter that actually did it.
-     */
-    if (searching) {
-      return (
-        <p className="nx-inspector__note">No classes match this search.</p>
-      );
-    }
-    /*
-     * An empty "not in index" is the one absence here that is a RESULT rather
-     * than a lack: nothing is known to be stranded. Wording it like the others
-     * reports the outcome an author was hoping for as a failure to find
-     * anything.
-     *
-     * The sentence still refuses to claim more than the index can support. It
-     * says what is not KNOWN, never what is not USED — the same care the
-     * filter's own name takes, and for the same reason: the index errs in both
-     * directions, so an empty list is a floor rather than a measurement.
-     */
-    if (filter === "not-in-index") {
-      return (
-        <div className="nx-classman__empty">
-          <p className="nx-classman__empty-head">
-            Nothing here &mdash; and that is good news.
-          </p>
-          <p className="nx-inspector__note">
-            No class is known to be unused, so none is waiting to be cleared
-            out. It is a floor, not a measurement: the index can miss a class
-            that is still applied.
-          </p>
-        </div>
-      );
-    }
-    /*
-     * An empty library is not a filter miss. With `all` active nothing is
-     * narrowing anything, so blaming "this filter" points an author at a
-     * control that is not doing what the sentence says it did — and stops at
-     * the absence, which is the dead end this panel was reported for.
-     *
-     * It teaches instead, and names where the next step happens. Classes are
-     * not created here (applying belongs beside the style controls, auditing
-     * belongs on a reading surface), so the action this state can honestly
-     * offer is where to go, not a button.
-     */
-    if (filter === "all") {
-      return (
-        <div className="nx-classman__empty">
-          <p className="nx-classman__empty-head">No classes yet.</p>
-          <p className="nx-inspector__note">
-            A class saves a set of styles under a name so other blocks can wear
-            the same one. You make the first beside the style controls, and it
-            appears here to rename or clear out.
-          </p>
-        </div>
-      );
-    }
-    return <p className="nx-inspector__note">No classes match this filter.</p>;
+    return (
+      <EmptyClasses
+        searching={searching}
+        filter={filter}
+        canDelete={onDelete !== undefined}
+      />
+    );
   }
   const shown = rows.slice(0, limit);
   const hidden = rows.length - shown.length;

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -522,6 +522,29 @@ function ClassList({
         </div>
       );
     }
+    /*
+     * An empty library is not a filter miss. With `all` active nothing is
+     * narrowing anything, so blaming "this filter" points an author at a
+     * control that is not doing what the sentence says it did — and stops at
+     * the absence, which is the dead end this panel was reported for.
+     *
+     * It teaches instead, and names where the next step happens. Classes are
+     * not created here (applying belongs beside the style controls, auditing
+     * belongs on a reading surface), so the action this state can honestly
+     * offer is where to go, not a button.
+     */
+    if (filter === "all") {
+      return (
+        <div className="nx-classman__empty">
+          <p className="nx-classman__empty-head">No classes yet.</p>
+          <p className="nx-inspector__note">
+            A class saves a set of styles under a name so other blocks can wear
+            the same one. You make the first beside the style controls, and it
+            appears here to rename or clear out.
+          </p>
+        </div>
+      );
+    }
     return <p className="nx-inspector__note">No classes match this filter.</p>;
   }
   const shown = rows.slice(0, limit);

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -787,7 +787,14 @@ function ClassRowView({
           </Button>
         )}
       </div>
-      {confirming && onDelete !== undefined ? (
+      {/*
+       * Gated on the SAME predicate as the button that opens it. `confirming`
+       * is local state and survives a prop change, so a row whose class became
+       * supplied while its confirmation was open kept an armed, irreversible
+       * control after the row itself had stopped offering one — the capability
+       * was withdrawn and the dialog did not hear.
+       */}
+      {confirming && canDelete && onDelete !== undefined ? (
         <DeleteConfirm
           row={row}
           usageKnown={usageKnown}

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -41,6 +41,7 @@ import * as React from "react";
 
 import { useSurvivingReport } from "./builder-notices";
 import {
+  classLibraryHasRoom,
   classRows,
   deletionWarning,
   filterClassRows,
@@ -322,8 +323,9 @@ export function ClassManagerPanel({
    * whose one non-supplied entry is malformed, duplicated or past the cap
    * offers deletion nowhere while both of those weaker tests say it does.
    */
-  const anyDeletable =
-    onDelete !== undefined && visible.some(row => !supplied.has(row.id));
+  const anyDeletable = visible.some(row =>
+    rowIsDeletable(row, supplied, onDelete)
+  );
   const rows = searchClassRows(filterClassRows(visible, active), query);
 
   return (
@@ -434,6 +436,22 @@ function FilterChips({
 }
 
 /**
+ * Whether one row can be deleted, asked in one place.
+ *
+ * The row drew its control from `isSupplied` and `onDelete` while the lede
+ * asked `onDelete` and the supplied set separately — two expressions of one
+ * rule, agreeing today and free to diverge the next time eligibility changes.
+ * Sharing the `Set` was not sharing the DECISION.
+ */
+function rowIsDeletable(
+  row: ClassRow,
+  supplied: ReadonlySet<string>,
+  onDelete: ((classId: string) => void) | undefined
+): boolean {
+  return onDelete !== undefined && !supplied.has(row.id);
+}
+
+/**
  * Why the list is empty, in the terms of whatever actually emptied it.
  *
  * Extracted from `ClassList` because four narrowings with four different
@@ -444,6 +462,7 @@ function EmptyClasses({
   searching,
   filter,
   canDelete,
+  canCreate,
 }: {
   searching: boolean;
   filter: ClassFilter;
@@ -453,6 +472,12 @@ function EmptyClasses({
    * to clear classes out would name an action this panel cannot perform.
    */
   canDelete: boolean;
+  /**
+   * Whether `class-library` would accept a new class. Asked of it rather than
+   * inferred from an empty list, because the two disagree exactly when every
+   * stored entry is unusable.
+   */
+  canCreate: boolean;
 }): React.JSX.Element {
   /*
    * Which narrowing produced the empty list. Blaming the search when the box
@@ -501,6 +526,29 @@ function EmptyClasses({
    * offer is where to go, not a button.
    */
   if (filter === "all") {
+    /*
+     * Whether a class can be made at all is `class-library`'s question, not
+     * something an empty list implies. A library whose stored entries are all
+     * malformed draws nothing here while every slot is still taken, and
+     * `newClassName` then refuses every creation as `library-full` — so "make
+     * the first one beside the style controls" would name an action that
+     * cannot succeed, on the one surface an author goes to for help.
+     */
+    if (!canCreate) {
+      return (
+        <div className="nx-classman__empty">
+          <p className="nx-classman__empty-head">
+            No classes can be shown, and none can be made.
+          </p>
+          <p className="nx-inspector__note">
+            This site&rsquo;s class library is full, and nothing in it can be
+            used — so no class is listed here and a new one would be refused.
+            Entries have to be removed from the stored classes before this panel
+            can do anything with them.
+          </p>
+        </div>
+      );
+    }
     return (
       <div className="nx-classman__empty">
         <p className="nx-classman__empty-head">No classes yet.</p>
@@ -641,6 +689,7 @@ function ClassList({
         searching={searching}
         filter={filter}
         canDelete={anyDeletable}
+        canCreate={classLibraryHasRoom(library)}
       />
     );
   }
@@ -661,6 +710,7 @@ function ClassList({
               pendingSlug={pendingSlugs?.[row.id]}
               library={library}
               isSupplied={supplied.has(row.id)}
+              canDelete={rowIsDeletable(row, supplied, onDelete)}
               usageKnown={usageKnown}
               onRename={onRename}
               onDelete={onDelete}
@@ -688,6 +738,7 @@ function ClassRowView({
   pendingSlug,
   library,
   isSupplied,
+  canDelete,
   usageKnown,
   onRename,
   onDelete,
@@ -697,6 +748,12 @@ function ClassRowView({
   pendingSlug?: string;
   library: readonly NamedClass[];
   isSupplied: boolean;
+  /**
+   * Whether this row may be deleted, decided by `rowIsDeletable` rather than
+   * here. The lede reports the same predicate over every row, so the sentence
+   * and the control cannot come apart.
+   */
+  canDelete: boolean;
   usageKnown: boolean;
   onRename: ClassManagerPanelProps["onRename"];
   onDelete?: (classId: string) => void;
@@ -718,7 +775,7 @@ function ClassRowView({
           // author to hunt for the permission that would enable it, and there
           // is none — the class comes from the site's own configuration.
           <span className="nx-classman__origin">Default</span>
-        ) : onDelete === undefined ? null : (
+        ) : !canDelete || onDelete === undefined ? null : (
           <Button
             type="button"
             size="sm"

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -320,11 +320,25 @@ export function ClassManagerPanel({
           Where these classes are used has not been read.
         </p>
       )}
+      {/*
+       * What a class IS, and where one is made.
+       *
+       * The second sentence is the load-bearing half. This panel deliberately
+       * has no create control — applying happens beside the style controls,
+       * where it is done constantly, while auditing happens here — and without
+       * saying so the absent button reads as a missing feature rather than as a
+       * split someone chose.
+       */}
+      <p className="nx-classman__lede">
+        <b>A class is a saved set of styles you can reuse.</b> Rename and clear
+        them out here; you apply one beside the style controls.
+      </p>
       <FilterChips active={active} filters={offerable} onChange={setFilter} />
       <ClassSearch query={query} onChange={setQuery} />
       <ClassList
         rows={rows}
         searching={query.trim() !== ""}
+        filter={active}
         pendingSlugs={pendingSlugs}
         pageSize={pageSize}
         library={library}
@@ -427,6 +441,7 @@ function usablePageSize(pageSize: number | undefined): number {
 function ClassList({
   rows,
   searching,
+  filter,
   pendingSlugs,
   pageSize,
   library,
@@ -438,6 +453,13 @@ function ClassList({
   rows: readonly ClassRow[];
   /** Whether a search is narrowing them, for the empty-list wording. */
   searching: boolean;
+  /**
+   * Which narrowing is active, because one of them is GOOD news when empty.
+   *
+   * An empty "not in index" is the outcome an author auditing a site wants, and
+   * wording it like the others reports a success as a failure.
+   */
+  filter: ClassFilter;
   pendingSlugs?: Readonly<Record<string, string>>;
   pageSize?: number;
   library: readonly NamedClass[];
@@ -465,18 +487,42 @@ function ClassList({
   const [pagesOpen, setPagesOpen] = React.useState(1);
   const limit = pagesOpen * page;
   if (rows.length === 0) {
-    return (
-      <p className="nx-inspector__note">
-        {/*
-          Which narrowing produced the empty list. Blaming the search when the
-          box is blank sends an author to clear something that is not set, and
-          hides the filter that actually did it.
-        */}
-        {searching
-          ? "No classes match this search."
-          : "No classes match this filter."}
-      </p>
-    );
+    /*
+     * Which narrowing produced the empty list. Blaming the search when the box
+     * is blank sends an author to clear something that is not set, and hides
+     * the filter that actually did it.
+     */
+    if (searching) {
+      return (
+        <p className="nx-inspector__note">No classes match this search.</p>
+      );
+    }
+    /*
+     * An empty "not in index" is the one absence here that is a RESULT rather
+     * than a lack: nothing is known to be stranded. Wording it like the others
+     * reports the outcome an author was hoping for as a failure to find
+     * anything.
+     *
+     * The sentence still refuses to claim more than the index can support. It
+     * says what is not KNOWN, never what is not USED — the same care the
+     * filter's own name takes, and for the same reason: the index errs in both
+     * directions, so an empty list is a floor rather than a measurement.
+     */
+    if (filter === "not-in-index") {
+      return (
+        <div className="nx-classman__empty">
+          <p className="nx-classman__empty-head">
+            Nothing here &mdash; and that is good news.
+          </p>
+          <p className="nx-inspector__note">
+            No class is known to be unused, so none is waiting to be cleared
+            out. It is a floor, not a measurement: the index can miss a class
+            that is still applied.
+          </p>
+        </div>
+      );
+    }
+    return <p className="nx-inspector__note">No classes match this filter.</p>;
   }
   const shown = rows.slice(0, limit);
   const hidden = rows.length - shown.length;

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -326,6 +326,13 @@ export function ClassManagerPanel({
   const anyDeletable = visible.some(row =>
     rowIsDeletable(row, supplied, onDelete)
   );
+  /*
+   * Whether there is anything here to rename at all. A full library of entries
+   * the compiler cannot use draws no rows, so the empty state correctly says
+   * this panel can do nothing with them while the lede went on offering to
+   * rename them — two sentences contradicting each other in one view.
+   */
+  const anyRenameable = visible.length > 0;
   const rows = searchClassRows(filterClassRows(visible, active), query);
 
   return (
@@ -358,7 +365,7 @@ export function ClassManagerPanel({
        * saying so the absent button reads as a missing feature rather than as a
        * split someone chose.
        */}
-      <ClassesLede anyDeletable={anyDeletable} />
+      <ClassesLede anyDeletable={anyDeletable} anyRenameable={anyRenameable} />
       <FilterChips active={active} filters={offerable} onChange={setFilter} />
       <ClassSearch query={query} onChange={setQuery} />
       <ClassList
@@ -573,6 +580,7 @@ function EmptyClasses({
  */
 function ClassesLede({
   anyDeletable,
+  anyRenameable,
 }: {
   /*
    * Whether ANY row can actually be deleted, which is not the same question
@@ -586,12 +594,20 @@ function ClassesLede({
    * shape. This asks the predicate the rows themselves ask.
    */
   anyDeletable: boolean;
+  /**
+   * Whether any row is drawn at all. With none there is no rename field
+   * either, so the sentence names only where a class is applied — otherwise it
+   * offers an action beside an empty state that has just said the panel can do
+   * nothing here.
+   */
+  anyRenameable: boolean;
 }): React.JSX.Element {
   return (
     <p className="nx-classman__lede">
       <b>A class is a saved set of styles you can reuse.</b>{" "}
-      {anyDeletable ? "Rename and clear them out" : "Rename them"} here; you
-      apply one beside the style controls.
+      {anyRenameable
+        ? `${anyDeletable ? "Rename and clear them out" : "Rename them"} here; you apply one beside the style controls.`
+        : "You apply one beside the style controls."}
     </p>
   );
 }
@@ -759,6 +775,19 @@ function ClassRowView({
   onDelete?: (classId: string) => void;
 }): React.ReactElement {
   const [confirming, setConfirming] = React.useState(false);
+  /*
+   * DISARMED, not merely hidden. Gating the render on `canDelete` stops the
+   * dialog being shown while the capability is gone, but leaves `confirming`
+   * true — so a class that becomes supplied and then supplied-no-longer, in a
+   * row that never unmounts, brings the confirmation back ALREADY ARMED. The
+   * author would then be one press from an irreversible removal they opened
+   * before the capability changed and never re-reviewed.
+   *
+   * Adjusted during render rather than in an effect: React re-runs the render
+   * with the corrected state before committing, so the armed dialog is never
+   * drawn even once.
+   */
+  if (confirming && !canDelete) setConfirming(false);
 
   return (
     <>

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -251,6 +251,24 @@ export function ClassManagerPanel({
 }: ClassManagerPanelProps): React.ReactElement {
   const [filter, setFilter] = React.useState<ClassFilter>("all");
   /*
+   * The supplied ids as a set, built once and handed to the rows.
+   *
+   * Two consumers ask "is this class supplied": each row, to decide whether it
+   * draws a delete control, and the lede, to decide whether it may offer
+   * deletion at all. One set, so the sentence and the controls cannot disagree.
+   */
+  const supplied = React.useMemo(
+    () => new Set(suppliedClassIds ?? []),
+    [suppliedClassIds]
+  );
+  /*
+   * Whether deletion is reachable ANYWHERE, which the callback alone does not
+   * answer: a row draws its delete control only when it is not supplied.
+   */
+  const anyDeletable =
+    onDelete !== undefined &&
+    (library ?? []).some(entry => !supplied.has(entry.id));
+  /*
    * The name search, which is what makes every class REACHABLE.
    *
    * The list is capped so a library near its ceiling does not mount two
@@ -329,11 +347,7 @@ export function ClassManagerPanel({
        * saying so the absent button reads as a missing feature rather than as a
        * split someone chose.
        */}
-      <p className="nx-classman__lede">
-        <b>A class is a saved set of styles you can reuse.</b>{" "}
-        {onDelete === undefined ? "Rename them" : "Rename and clear them out"}{" "}
-        here; you apply one beside the style controls.
-      </p>
+      <ClassesLede anyDeletable={anyDeletable} />
       <FilterChips active={active} filters={offerable} onChange={setFilter} />
       <ClassSearch query={query} onChange={setQuery} />
       <ClassList
@@ -343,8 +357,9 @@ export function ClassManagerPanel({
         pendingSlugs={pendingSlugs}
         pageSize={pageSize}
         library={library}
-        supplied={new Set(suppliedClassIds ?? [])}
+        supplied={supplied}
         usageKnown={usageKnown}
+        anyDeletable={anyDeletable}
         onRename={onRename}
         onDelete={onDelete}
       />
@@ -493,6 +508,38 @@ function EmptyClasses({
 }
 
 /**
+ * What a class is, and what this panel can do with one.
+ *
+ * Its own component so `ClassManagerPanel` stays under the cognitive gate, and
+ * because the sentence is conditional on something the panel derives: the copy
+ * and the row controls have to agree, so the condition travels with the words.
+ */
+function ClassesLede({
+  anyDeletable,
+}: {
+  /*
+   * Whether ANY row can actually be deleted, which is not the same question
+   * as whether the host passed `onDelete`.
+   *
+   * A row renders its delete control only when it is not supplied — a
+   * supplied class is labelled "Default" and `isSupplied` takes precedence
+   * over the callback — so a library made entirely of supplied classes
+   * offers deletion nowhere even with the callback wired. Deriving the
+   * sentence from the callback alone promised the action for that host
+   * shape. This asks the predicate the rows themselves ask.
+   */
+  anyDeletable: boolean;
+}): React.JSX.Element {
+  return (
+    <p className="nx-classman__lede">
+      <b>A class is a saved set of styles you can reuse.</b>{" "}
+      {anyDeletable ? "Rename and clear them out" : "Rename them"} here; you
+      apply one beside the style controls.
+    </p>
+  );
+}
+
+/**
  * How many rows the manager mounts at once.
  *
  * A library may hold `MAX_NAMED_CLASSES`, and the `All` filter matches every
@@ -531,6 +578,7 @@ function ClassList({
   library,
   supplied,
   usageKnown,
+  anyDeletable,
   onRename,
   onDelete,
 }: {
@@ -549,6 +597,14 @@ function ClassList({
   library: readonly NamedClass[];
   supplied: ReadonlySet<string>;
   usageKnown: boolean;
+  /**
+   * Whether deletion is reachable on ANY row, derived once by the panel.
+   *
+   * Passed rather than recomputed from `onDelete` and `supplied` here: the
+   * lede and this list must give one answer, and two derivations of "can
+   * anything be deleted" would drift the moment either changed.
+   */
+  anyDeletable: boolean;
   onRename: ClassManagerPanelProps["onRename"];
   onDelete?: (classId: string) => void;
 }): React.ReactElement {
@@ -575,7 +631,7 @@ function ClassList({
       <EmptyClasses
         searching={searching}
         filter={filter}
-        canDelete={onDelete !== undefined}
+        canDelete={anyDeletable}
       />
     );
   }

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -261,13 +261,7 @@ export function ClassManagerPanel({
     () => new Set(suppliedClassIds ?? []),
     [suppliedClassIds]
   );
-  /*
-   * Whether deletion is reachable ANYWHERE, which the callback alone does not
-   * answer: a row draws its delete control only when it is not supplied.
-   */
-  const anyDeletable =
-    onDelete !== undefined &&
-    (library ?? []).some(entry => !supplied.has(entry.id));
+
   /*
    * The name search, which is what makes every class REACHABLE.
    *
@@ -312,10 +306,25 @@ export function ClassManagerPanel({
   }
 
   const usageKnown = usage !== undefined;
-  const rows = searchClassRows(
-    filterClassRows(classRows(library, usage ?? {}, documentClassIds), active),
-    query
-  );
+  /*
+   * Every row this panel can draw, before any narrowing.
+   *
+   * `classRows` goes through `siteClasses`, which caps at `MAX_NAMED_CLASSES`
+   * and drops entries the compiler cannot use — so the stored library is NOT
+   * the set on screen, and asking it a question about the screen gives an
+   * answer about neither.
+   */
+  const visible = classRows(library, usage ?? {}, documentClassIds);
+  /*
+   * Whether deletion is reachable ANYWHERE, which neither the callback nor the
+   * stored library answers on its own. A row draws its delete control only
+   * when it is not supplied, and only if it is drawn at all — so a library
+   * whose one non-supplied entry is malformed, duplicated or past the cap
+   * offers deletion nowhere while both of those weaker tests say it does.
+   */
+  const anyDeletable =
+    onDelete !== undefined && visible.some(row => !supplied.has(row.id));
+  const rows = searchClassRows(filterClassRows(visible, active), query);
 
   return (
     <div className="nx-classman">

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -3126,3 +3126,16 @@
     white-space: normal;
   }
 }
+
+/*
+ * The row drawn on its own after an add that landed past the mounted page.
+ *
+ * Separated rather than slotted into the list, because it is NOT the next row:
+ * everything between it and the last mounted one is still hidden behind the
+ * cap, and drawing it flush would claim an adjacency the list does not have.
+ */
+.nx-tokens__revealed {
+  border-top: 1px dashed var(--nx-builder-border);
+  margin-top: 0.5rem;
+  padding-top: 0.5rem;
+}

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -1929,6 +1929,123 @@
   font-variant-numeric: tabular-nums;
 }
 
+/*
+ * The sentence that says what a token is, before any of the machinery.
+ *
+ * Given the panel's own tone rather than a notice's: it is not a warning and
+ * must not read as one, so it takes the muted foreground and a rule beneath
+ * rather than a coloured ground.
+ */
+.nx-tokens__lede,
+.nx-classman__lede {
+  margin: 0;
+  padding-bottom: 0.625rem;
+  border-bottom: 1px solid var(--nx-border);
+  font-size: var(--text-xs);
+  line-height: 1.5;
+  color: var(--nx-muted-foreground);
+}
+
+.nx-tokens__lede b,
+.nx-classman__lede b {
+  color: var(--nx-foreground);
+  font-weight: 600;
+}
+
+/*
+ * A group heading, which is a row rather than a heading element on its own.
+ *
+ * The count sits BESIDE the heading rather than inside it, so the heading's
+ * accessible name is the kind alone — inside, "Colour" becomes "Colour 3" and
+ * every reader addressing the group by name has to know the number first.
+ */
+.nx-tokens__grouphead,
+.nx-classman__grouphead {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  padding-top: 0.25rem;
+}
+
+.nx-tokens__groupname,
+.nx-classman__groupname {
+  margin: 0;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--nx-muted-foreground);
+}
+
+/* The rule runs to the end of the row, which is what separates one group from
+ * the next without spending a heavier border on it. */
+.nx-tokens__grouphead::after,
+.nx-classman__grouphead::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--nx-border);
+}
+
+.nx-tokens__group,
+.nx-classman__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+/*
+ * The empty state, which is the first thing a new site shows.
+ *
+ * Given room rather than a single muted line: this is the one surface where an
+ * author who does not know what a token is can find out, and a sentence set
+ * like an error note reads as something having gone wrong.
+ */
+.nx-tokens__empty,
+.nx-classman__empty {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+  padding: 0.75rem 0;
+}
+
+.nx-tokens__empty-head,
+.nx-classman__empty-head {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--nx-foreground);
+}
+
+/* Creating a token names its kind, because a list that omits empty kinds has
+ * nowhere to stand and press "add". */
+.nx-tokens__add {
+  display: flex;
+  gap: 0.375rem;
+  align-items: center;
+}
+
+.nx-tokens__kind {
+  flex: 1;
+  min-width: 0;
+  padding: 0.375rem 0.5rem;
+  border: 1px solid var(--nx-border);
+  border-radius: var(--radius-sm);
+  background: var(--nx-background);
+  color: var(--nx-foreground);
+  font-size: var(--text-xs);
+}
+
+.nx-tokens__kind:focus-visible {
+  outline: 2px solid var(--nx-ring);
+  outline-offset: 1px;
+}
+
+.nx-tokens__search,
+.nx-classman__search {
+  flex: none;
+}
+
 .nx-tokens__list {
   display: flex;
   flex-direction: column;

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1008,3 +1008,75 @@ describe("an import where nothing landed", () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+describe("the panel explains itself and shows the whole set", () => {
+  /** Tokens across three kinds, so grouping and search have something to cross. */
+  const MIXED: SiteTokenSet = {
+    tokens: [
+      { name: "color.ink", kind: "color", values: { light: "#111111" } },
+      { name: "space.gutter", kind: "dimension", values: { light: "1.5rem" } },
+      { name: "motion.settle", kind: "duration", values: { light: "240ms" } },
+    ],
+  };
+
+  it("says what a token IS, in the words an author would use", () => {
+    // The panel opened with a mode switch, a transfer control and eight tabs of
+    // vocabulary, and never a sentence about what any of it does to the site.
+    mount(MIXED);
+    expect(screen.getByText(/named values/i)).toBeTruthy();
+    expect(screen.getByText(/every block using it/i)).toBeTruthy();
+  });
+
+  it("groups every kind that HAS tokens into one list", () => {
+    // The must-be-found half. Three kinds are present, so three headings are.
+    mount(MIXED);
+    for (const heading of ["Colour", "Size", "Duration"]) {
+      expect(screen.getByRole("heading", { name: heading })).toBeTruthy();
+    }
+  });
+
+  it("does not draw a group for a kind with no tokens", () => {
+    /*
+     * The point of the shape. Eight tabs meant five clickable dead ends in a
+     * 320px rail; a kind with nothing in it should not be a place you can go.
+     *
+     * The control is the test above: it proves the query CAN find a heading, so
+     * this absence is about the kind being omitted rather than about the
+     * selector matching nothing.
+     */
+    mount(MIXED);
+    for (const heading of ["Font", "Weight", "Number", "Shadow", "Custom"]) {
+      expect(screen.queryByRole("heading", { name: heading })).toBeNull();
+    }
+  });
+
+  it("searches across every kind at once, which tabs could not", () => {
+    /*
+     * A tabbed panel can only search within a tab, or it crosses a boundary the
+     * tabs assert. One list has no boundary to cross, so a query matching two
+     * kinds returns both — and that is the capability the shape buys.
+     */
+    mount(MIXED);
+    fireEvent.change(
+      screen.getByRole("searchbox", { name: /search tokens/i }),
+      {
+        target: { value: "e" },
+      }
+    );
+    // "color.ink" has no "e"; the other two do, and they are different kinds.
+    expect(screen.getByRole("heading", { name: "Size" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Duration" })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: "Colour" })).toBeNull();
+  });
+
+  it("teaches at the empty state instead of reporting absence and stopping", () => {
+    // "No colour tokens yet." says what is missing and offers nothing. An empty
+    // panel is the first thing a new site shows, so it is the one surface that
+    // has to teach.
+    mount({ tokens: [] });
+    expect(screen.getByText(/no tokens yet/i)).toBeTruthy();
+    expect(
+      screen.getByText(/change it once and the whole site follows/i)
+    ).toBeTruthy();
+  });
+});

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1113,6 +1113,34 @@ describe("the panel explains itself and shows the whole set", () => {
     expect(screen.getAllByDisplayValue(/^color\.c/).length).toBe(100);
   });
 
+  it("reveals a token added PAST the page it would land behind", () => {
+    /*
+     * Clearing the search was only half of it. A new token is appended, so in a
+     * kind that already fills its page it lands after the mounted slice and is
+     * hidden by the CAP rather than by the query — the same invisible write,
+     * one control further on, and pressing Add again would make a second one.
+     */
+    const full: SiteTokenSet = {
+      tokens: Array.from({ length: 60 }, (_, at) => ({
+        name: `color.c${at}`,
+        kind: "color" as const,
+        values: { light: "#111111" },
+      })),
+    };
+    const onChange = vi.fn();
+    const view = render(<Panel tokens={full} onChange={onChange} />);
+    // The control: row 60 is genuinely behind the cap before the add.
+    expect(screen.getAllByDisplayValue(/^color\.c/).length).toBe(50);
+
+    fireEvent.click(screen.getByRole("button", { name: /Add colour token/i }));
+    const next = onChange.mock.calls[0]?.[0] as SiteTokenSet;
+    const made = next.tokens[next.tokens.length - 1];
+    view.rerender(<Panel tokens={next} onChange={onChange} />);
+
+    expect(made).toBeDefined();
+    expect(screen.getByDisplayValue(made!.name)).toBeTruthy();
+  });
+
   it("groups every kind that HAS tokens into one list", () => {
     // The must-be-found half. Three kinds are present, so three headings are.
     mount(MIXED);

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -309,23 +309,37 @@ describe("adding a token", () => {
      * inert and a second press writes `shadow.2`, also hidden. The tabs could
      * not produce this — they had nothing to narrow with.
      */
-    render(
-      <Panel
-        tokens={{
-          tokens: [
-            { name: "color.ink", kind: "color", values: { light: "#111111" } },
-          ],
-        }}
-        onChange={vi.fn()}
-      />
-    );
+    /*
+     * HELD IN STATE, so the created token actually renders. With a mock
+     * `onChange` this asserted that the PRE-EXISTING row came back — true, and
+     * not the claim. The point is that the row just written is reachable, and
+     * only a host that stores what it is given can show it.
+     */
+    function Host(): React.JSX.Element {
+      const [tokens, setTokens] = React.useState<SiteTokenSet>({
+        tokens: [
+          { name: "color.ink", kind: "color", values: { light: "#111111" } },
+        ],
+      });
+      return <Panel tokens={tokens} onChange={setTokens} />;
+    }
+    render(<Host />);
     const search = screen.getByPlaceholderText(/Search tokens/i);
     fireEvent.change(search, { target: { value: "brand" } });
     expect(screen.queryByDisplayValue("color.ink")).toBeNull();
 
     fireEvent.click(screen.getByRole("button", { name: /Add colour token/i }));
     expect((search as HTMLInputElement).value).toBe("");
+    // The pre-existing row is back...
     expect(screen.getByDisplayValue("color.ink")).toBeTruthy();
+    // ...and so is the one just created, which is the actual claim.
+    const names = Array.from(
+      document.querySelectorAll<HTMLInputElement>(".nx-tokens__name"),
+      node => node.value
+    );
+    expect(names).toContain("color.ink");
+    expect(names.length).toBe(2);
+    expect(names.some(value => value !== "color.ink")).toBe(true);
   });
 
   it("adds into a site that has no table at all", () => {

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1071,8 +1071,46 @@ describe("the panel explains itself and shows the whole set", () => {
     // The panel opened with a mode switch, a transfer control and eight tabs of
     // vocabulary, and never a sentence about what any of it does to the site.
     mount(MIXED);
-    expect(screen.getByText(/named values/i)).toBeTruthy();
-    expect(screen.getByText(/every block using it/i)).toBeTruthy();
+    /*
+     * Read off the LEDE itself rather than the document. "Light" is also the
+     * mode switch's own button, so a document-wide match for it passes on a
+     * panel whose lede says nothing about the mode at all.
+     */
+    const lede = document.querySelector(".nx-tokens__lede");
+    expect(lede?.textContent).toMatch(/named values/i);
+    expect(lede?.textContent).toMatch(/every block using one/i);
+    /*
+     * And it NAMES the mode, because an edit reaches only the values of the
+     * mode on screen. "every block changes" described renderings a light edit
+     * deliberately leaves alone.
+     */
+    expect(lede?.textContent).toMatch(/editing the light values/i);
+    expect(lede?.textContent).not.toMatch(/changes with it, on every page/i);
+  });
+
+  it("BOUNDS how many rows of one kind it mounts", () => {
+    /*
+     * The grouped shape reads every kind at once where the tabs read only the
+     * open one, and a DTCG import is not bounded to a size where mounting them
+     * all stays invisible — each row carries two inputs and a preview. Same
+     * cap and same control as `class-manager-panel`, for the same reason.
+     */
+    const many: SiteTokenSet = {
+      tokens: Array.from({ length: 130 }, (_, at) => ({
+        name: `color.c${at}`,
+        kind: "color" as const,
+        values: { light: "#111111" },
+      })),
+    };
+    mount(many);
+    // The heading still reports the WHOLE group, not the mounted slice —
+    // otherwise the count would tell an author 50 tokens exist.
+    expect(screen.getByText("130")).toBeTruthy();
+    expect(screen.getAllByDisplayValue(/^color\.c/).length).toBe(50);
+
+    const more = screen.getByRole("button", { name: /Show 50 more/i });
+    fireEvent.click(more);
+    expect(screen.getAllByDisplayValue(/^color\.c/).length).toBe(100);
   });
 
   it("groups every kind that HAS tokens into one list", () => {
@@ -1124,7 +1162,10 @@ describe("the panel explains itself and shows the whole set", () => {
     mount({ tokens: [] });
     expect(screen.getByText(/no tokens yet/i)).toBeTruthy();
     expect(
-      screen.getByText(/change it once and the whole site follows/i)
+      screen.getByText(/point at it instead of repeating it/i)
     ).toBeTruthy();
+    // Not the absolute claim: an edit reaches one mode, so "the whole site
+    // follows" promised more than a single edit does.
+    expect(screen.queryByText(/the whole site follows/i)).toBeNull();
   });
 });

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1154,6 +1154,57 @@ describe("the panel explains itself and shows the whole set", () => {
     expect(screen.getAllByDisplayValue(/^color\.c/).length).toBe(50);
   });
 
+  it("REMOUNTS the revealed row when a second add replaces it", () => {
+    /*
+     * The revealed entry sits at a fixed position, so without a key React
+     * reuses one `TokenEntry` across different tokens and carries its local
+     * state along — dropping a newly added token straight into the previous
+     * row's removal confirmation, an irreversible control armed against
+     * something the author never selected.
+     *
+     * HELD IN STATE rather than rerendered by hand, because that difference
+     * decides whether the bug is reachable at all. With a mock `onChange` the
+     * panel re-renders once with the NEW `revealAt` and the OLD token list, so
+     * the revealed row is momentarily absent, the block unmounts, and the leak
+     * cannot happen. A host that stores what it is given updates both together
+     * — which is what the product does, and the only composition that tests
+     * this.
+     */
+    function Host(): React.JSX.Element {
+      const [tokens, setTokens] = React.useState<SiteTokenSet>({
+        tokens: Array.from({ length: 60 }, (_, at) => ({
+          name: `color.c${at}`,
+          kind: "color" as const,
+          values: { light: "#111111" },
+        })),
+      });
+      return <Panel tokens={tokens} onChange={setTokens} />;
+    }
+    render(<Host />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Add colour token/i }));
+    // Read the name off the revealed block itself rather than inferring it
+    // from the generated pattern: the probe's subject must be resolved, not
+    // assumed, or a miss reads as a passing test.
+    const revealedName = (
+      document
+        .querySelector(".nx-tokens__revealed")
+        ?.querySelector("input") as HTMLInputElement | null
+    )?.value;
+    expect(revealedName).toBeDefined();
+    const first = revealedName;
+
+    // Arm the revealed row's removal confirmation.
+    fireEvent.click(screen.getByRole("button", { name: `Remove ${first!}` }));
+    expect(screen.getByText(/loses that style/i)).toBeTruthy();
+
+    // A second add replaces WHICH token is revealed, in one update.
+    fireEvent.click(screen.getByRole("button", { name: /Add colour token/i }));
+
+    // The new token must arrive UNARMED.
+    expect(screen.queryByText(/loses that style/i)).toBeNull();
+  });
+
   it("groups every kind that HAS tokens into one list", () => {
     // The must-be-found half. Three kinds are present, so three headings are.
     mount(MIXED);

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1121,7 +1121,7 @@ describe("the panel explains itself and shows the whole set", () => {
      * one control further on, and pressing Add again would make a second one.
      */
     const full: SiteTokenSet = {
-      tokens: Array.from({ length: 60 }, (_, at) => ({
+      tokens: Array.from({ length: 300 }, (_, at) => ({
         name: `color.c${at}`,
         kind: "color" as const,
         values: { light: "#111111" },
@@ -1139,6 +1139,19 @@ describe("the panel explains itself and shows the whole set", () => {
 
     expect(made).toBeDefined();
     expect(screen.getByDisplayValue(made!.name)).toBeTruthy();
+    /*
+     * And it is revealed WITHOUT mounting everything before it. Raising the
+     * limit to reach an appended row mounts every preceding one, which in a
+     * DTCG-sized set is the exact freeze the cap exists to prevent — so the
+     * mounted count must stay near the page, not near the total.
+     */
+    /*
+     * And WITHOUT mounting everything before it: the head is still one page.
+     * Raising the limit to reach an appended row mounts every preceding one,
+     * which in a DTCG-sized set is the exact freeze the cap exists to prevent
+     * — with 300 stored, that is 300 rows rather than 50 plus the new one.
+     */
+    expect(screen.getAllByDisplayValue(/^color\.c/).length).toBe(50);
   });
 
   it("groups every kind that HAS tokens into one list", () => {

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -280,6 +280,54 @@ describe("adding a token", () => {
     expect(next.tokens.at(-1)?.kind).toBe("color");
   });
 
+  it("shows the TEACHING empty state for a search that is only whitespace", () => {
+    /*
+     * `needle` is `query.trim().toLowerCase()`, so a query of spaces narrows
+     * nothing. Reading the raw query to decide the message made the two
+     * disagree: the list was unfiltered while the copy blamed a search, which
+     * suppressed the teaching state on an empty library.
+     */
+    render(<Panel tokens={{ tokens: [] }} onChange={vi.fn()} />);
+    fireEvent.change(screen.getByPlaceholderText(/Search tokens/i), {
+      target: { value: "   " },
+    });
+    expect(screen.getByText("No tokens yet.")).toBeTruthy();
+    expect(screen.queryByText(/No tokens match this search/i)).toBeNull();
+
+    // Must-differ: a query that really does narrow still blames the search.
+    fireEvent.change(screen.getByPlaceholderText(/Search tokens/i), {
+      target: { value: "zzzz" },
+    });
+    expect(screen.getByText(/No tokens match this search/i)).toBeTruthy();
+    expect(screen.queryByText("No tokens yet.")).toBeNull();
+  });
+
+  it("clears a search that would HIDE the token just created", () => {
+    /*
+     * A new token is named after its kind, so any search not matching that
+     * name hides the row the moment it is written. The control then looks
+     * inert and a second press writes `shadow.2`, also hidden. The tabs could
+     * not produce this — they had nothing to narrow with.
+     */
+    render(
+      <Panel
+        tokens={{
+          tokens: [
+            { name: "color.ink", kind: "color", values: { light: "#111111" } },
+          ],
+        }}
+        onChange={vi.fn()}
+      />
+    );
+    const search = screen.getByPlaceholderText(/Search tokens/i);
+    fireEvent.change(search, { target: { value: "brand" } });
+    expect(screen.queryByDisplayValue("color.ink")).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: /Add colour token/i }));
+    expect((search as HTMLInputElement).value).toBe("");
+    expect(screen.getByDisplayValue("color.ink")).toBeTruthy();
+  });
+
   it("adds into a site that has no table at all", () => {
     const onChange = vi.fn();
     render(<Panel tokens={{ tokens: [] }} onChange={onChange} />);

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -214,7 +214,7 @@ export function TokensPanel({
       )}
       <TokenSearch value={query} onValue={setQuery} />
       {groups.length === 0 ? (
-        <EmptyTokens searching={query !== ""} />
+        <EmptyTokens searching={needle !== ""} />
       ) : (
         groups.map(group => (
           <section key={group.kind} className="nx-tokens__group">
@@ -240,7 +240,11 @@ export function TokensPanel({
           </section>
         ))
       )}
-      <AddToken tokens={tokens} onChange={onChange} />
+      <AddToken
+        tokens={tokens}
+        onChange={onChange}
+        onAdded={() => setQuery("")}
+      />
       {/*
        * The transfer control, BELOW the tokens rather than above them.
        *
@@ -773,9 +777,19 @@ function TokenList({
 function AddToken({
   tokens,
   onChange,
+  onAdded,
 }: {
   tokens: SiteTokenSet;
   onChange: (tokens: SiteTokenSet) => void;
+  /**
+   * Clears whatever is narrowing the list, because the row just created has to
+   * be reachable. A new token is named after its kind (`shadow.1`), so any
+   * search that does not happen to match that name hides it the instant it is
+   * written — the control looks inert, and pressing it again writes
+   * `shadow.2`, `shadow.3`, each one also hidden. The tabs could not produce
+   * this: they had nothing to narrow with.
+   */
+  onAdded: () => void;
 }): React.JSX.Element {
   const [kind, setKind] = React.useState<TokenKind>("color");
   const id = React.useId();
@@ -800,7 +814,10 @@ function AddToken({
         type="button"
         variant="outline"
         size="sm"
-        onClick={() => onChange(addToken(tokens, kind).tokens)}
+        onClick={() => {
+          onChange(addToken(tokens, kind).tokens);
+          onAdded();
+        }}
       >
         Add {TOKEN_KIND_LABELS[kind].toLowerCase()} token
       </Button>

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -53,7 +53,7 @@ import {
   renameToken,
   setTokenValue,
   tokenNameIssue,
-  tokenRowsFor,
+  tokenRows,
   type TokenRow,
 } from "./tokens-studio";
 import {
@@ -158,12 +158,33 @@ export function TokensPanel({
    * place at all.
    */
   const needle = query.trim().toLowerCase();
-  const groups = TOKEN_KINDS.map(kind => ({
-    kind,
-    rows: tokenRowsFor(tokens, kind, mode).filter(
-      row => needle === "" || row.name.toLowerCase().includes(needle)
-    ),
-  })).filter(group => group.rows.length > 0);
+  /*
+   * ONE projection of the set, held across keystrokes.
+   *
+   * The grouped shape reads every kind at once where the tabs read only the
+   * open one, so projecting per kind meant a pass over the whole set eight
+   * times, on every render — and a search re-ran all of it per character. A
+   * DTCG import is not bounded to a size where that stays invisible.
+   */
+  const rows = React.useMemo(() => tokenRows(tokens, mode), [tokens, mode]);
+  /*
+   * Grouped in one pass over that projection, in `TOKEN_KINDS` order so the
+   * sections keep the order the vocabulary declares rather than the order the
+   * site happens to store its tokens in.
+   */
+  const groups = React.useMemo(() => {
+    const byKind = new Map<TokenKind, TokenRow[]>();
+    for (const row of rows) {
+      if (needle !== "" && !row.name.toLowerCase().includes(needle)) continue;
+      const held = byKind.get(row.kind);
+      if (held === undefined) byKind.set(row.kind, [row]);
+      else held.push(row);
+    }
+    return TOKEN_KINDS.map(kind => ({
+      kind,
+      rows: byKind.get(kind) ?? [],
+    })).filter(group => group.rows.length > 0);
+  }, [rows, needle]);
 
   if (tokens === undefined) {
     return (
@@ -196,10 +217,17 @@ export function TokensPanel({
        * of vocabulary, and never said what any of it does to the site. An
        * author who does not already know the word has nothing to go on, and
        * this is the surface where they would have learned it.
+       *
+       * It names the ACTIVE MODE rather than promising the whole site changes.
+       * A token with distinct light and dark values is edited one mode at a
+       * time, so "every block changes" would describe renderings this edit
+       * deliberately leaves alone — and naming the mode is also the only thing
+       * on screen that explains what the switch above is for.
        */}
       <p className="nx-tokens__lede">
-        <b>Tokens are your site&rsquo;s named values.</b> Change one here and
-        every block using it changes with it, on every page.
+        <b>Tokens are your site&rsquo;s named values.</b> Every block using one
+        follows it, on every page. You are editing the{" "}
+        {mode === "dark" ? "dark" : "light"} values; switch above for the other.
       </p>
       {issue === undefined ? null : (
         /*
@@ -309,8 +337,8 @@ function EmptyTokens({ searching }: { searching: boolean }): React.JSX.Element {
       <p className="nx-tokens__empty-head">No tokens yet.</p>
       <p className="nx-inspector__note">
         A token names one value — a colour, a size, a shadow — so every block
-        can point at it instead of repeating it. Change it once and the whole
-        site follows.
+        can point at it instead of repeating it, and you change them all from
+        one place.
       </p>
     </div>
   );
@@ -721,6 +749,15 @@ function ModeSwitch({
 }
 
 /** Every token of one kind, with the way to add another. */
+/**
+ * How many rows of one kind mount before the author asks for more.
+ *
+ * Matches `class-manager-panel`'s default. Large enough that an ordinary site
+ * never sees the control, small enough that a thousand-token import draws a
+ * panel rather than blocking the editor.
+ */
+const TOKEN_PAGE_SIZE = 50;
+
 function TokenList({
   rows,
   tokens,
@@ -742,11 +779,23 @@ function TokenList({
   mode: TokenMode;
   onChange: (tokens: SiteTokenSet) => void;
 }): React.JSX.Element {
+  /*
+   * How many PAGES are open, not how many rows — the same shape
+   * `class-manager-panel` uses, and for the same reason: a token table has no
+   * upper bound an author controls, a DTCG file can carry thousands, and every
+   * row here mounts two inputs plus a preview. Rendering all of them is what
+   * makes a large import freeze the editor, and a search cannot be relied on
+   * to reach the tail because a query matching most names narrows nothing.
+   */
+  const [pagesOpen, setPagesOpen] = React.useState(1);
+  const limit = pagesOpen * TOKEN_PAGE_SIZE;
+  const shown = rows.slice(0, limit);
+  const hidden = rows.length - shown.length;
   return (
     <div className="nx-tokens__list">
       {rows.length === 0 ? null : (
         <ul>
-          {rows.map(row => (
+          {shown.map(row => (
             <li key={row.key}>
               <TokenEntry
                 row={row}
@@ -758,6 +807,17 @@ function TokenList({
             </li>
           ))}
         </ul>
+      )}
+      {hidden === 0 ? null : (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="nx-tokens__more"
+          onClick={() => setPagesOpen(current => current + 1)}
+        >
+          {`Show ${Math.min(hidden, TOKEN_PAGE_SIZE)} more`}
+        </Button>
       )}
     </div>
   );

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -860,7 +860,14 @@ function TokenList({
             Just added, further down the list:
           </p>
           <ul>
-            <li>
+            {/*
+             * KEYED, like every row in the list above. This element's position
+             * never changes, so without a key React reuses one `TokenEntry`
+             * across different tokens and carries its local state with it — a
+             * second add would drop the new token into the previous row's
+             * removal confirmation.
+             */}
+            <li key={revealed.key}>
               <TokenEntry
                 row={revealed}
                 tokens={tokens}

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -217,7 +217,13 @@ export function TokensPanel({
     <div className="nx-tokens">
       <div className="nx-tokens__head">
         <h2 className="nx-tokens__title">Tokens</h2>
-        <ModeSwitch mode={mode} onMode={setMode} />
+        <ModeSwitch
+          mode={mode}
+          onMode={next => {
+            setMode(next);
+            setRevealAt(undefined);
+          }}
+        />
       </div>
       {/*
        * What a token IS, before any of the machinery.
@@ -249,7 +255,16 @@ export function TokensPanel({
           {issue}
         </p>
       )}
-      <TokenSearch value={query} onValue={setQuery} />
+      <TokenSearch
+        value={query}
+        onValue={next => {
+          setQuery(next);
+          // A reveal answers ONE add. Left standing it pins a stored position
+          // that a later delete can hand to a different token, so any
+          // narrowing the author performs afterwards retires it.
+          setRevealAt(undefined);
+        }}
+      />
       {groups.length === 0 ? (
         <EmptyTokens searching={needle !== ""} />
       ) : (
@@ -350,8 +365,8 @@ function EmptyTokens({ searching }: { searching: boolean }): React.JSX.Element {
       <p className="nx-tokens__empty-head">No tokens yet.</p>
       <p className="nx-inspector__note">
         A token names one value — a colour, a size, a shadow — so every block
-        can point at it instead of repeating it, and you change them all from
-        one place.
+        can point at it instead of repeating it. This is where the tokens
+        themselves are edited.
       </p>
     </div>
   );
@@ -810,11 +825,18 @@ function TokenList({
    * to reach the tail because a query matching most names narrows nothing.
    */
   const [pagesOpen, setPagesOpen] = React.useState(1);
-  const reached =
-    revealAt === undefined ? -1 : rows.findIndex(row => row.at === revealAt);
-  const limit = Math.max(pagesOpen * TOKEN_PAGE_SIZE, reached + 1);
+  const limit = pagesOpen * TOKEN_PAGE_SIZE;
   const shown = rows.slice(0, limit);
-  const hidden = rows.length - shown.length;
+  /*
+   * A revealed row is drawn ON ITS OWN when it sits past the mounted page,
+   * never by raising the limit to reach it. A token is appended, so in a set
+   * of five thousand that index IS five thousand — raising the limit mounts
+   * every row before it and recreates exactly the freeze this cap prevents.
+   */
+  const at =
+    revealAt === undefined ? -1 : rows.findIndex(row => row.at === revealAt);
+  const revealed = at >= limit ? rows[at] : undefined;
+  const hidden = rows.length - shown.length - (revealed === undefined ? 0 : 1);
   return (
     <div className="nx-tokens__list">
       {rows.length === 0 ? null : (
@@ -832,7 +854,25 @@ function TokenList({
           ))}
         </ul>
       )}
-      {hidden === 0 ? null : (
+      {revealed === undefined ? null : (
+        <div className="nx-tokens__revealed">
+          <p className="nx-inspector__note">
+            Just added, further down the list:
+          </p>
+          <ul>
+            <li>
+              <TokenEntry
+                row={revealed}
+                tokens={tokens}
+                from={suppliedTokenFor(supplied, revealed.identity)}
+                mode={mode}
+                onChange={onChange}
+              />
+            </li>
+          </ul>
+        </div>
+      )}
+      {hidden <= 0 ? null : (
         <Button
           type="button"
           variant="outline"

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -166,6 +166,15 @@ export function TokensPanel({
    * times, on every render — and a search re-ran all of it per character. A
    * DTCG import is not bounded to a size where that stays invisible.
    */
+  /*
+   * The stored position of the row that must be reachable after an add.
+   *
+   * Clearing the search is not enough on its own: a new token is appended, so
+   * in a kind that already fills its page it lands AFTER the mounted slice and
+   * is hidden by the cap instead of by the query — the same invisible-write
+   * failure, one control further on.
+   */
+  const [revealAt, setRevealAt] = React.useState<number | undefined>(undefined);
   const rows = React.useMemo(() => tokenRows(tokens, mode), [tokens, mode]);
   /*
    * Grouped in one pass over that projection, in `TOKEN_KINDS` order so the
@@ -260,6 +269,7 @@ export function TokensPanel({
             </div>
             <TokenList
               rows={group.rows}
+              revealAt={revealAt}
               tokens={tokens}
               supplied={supplied}
               mode={mode}
@@ -271,7 +281,10 @@ export function TokensPanel({
       <AddToken
         tokens={tokens}
         onChange={onChange}
-        onAdded={() => setQuery("")}
+        onAdded={at => {
+          setQuery("");
+          setRevealAt(at);
+        }}
       />
       {/*
        * The transfer control, BELOW the tokens rather than above them.
@@ -760,6 +773,7 @@ const TOKEN_PAGE_SIZE = 50;
 
 function TokenList({
   rows,
+  revealAt,
   tokens,
   supplied,
   mode,
@@ -774,6 +788,14 @@ function TokenList({
    * disagree the moment a filter was added to one of them.
    */
   rows: readonly TokenRow[];
+  /**
+   * A stored position that must be on screen, whatever the page count says.
+   *
+   * Opens exactly far enough to include it rather than lifting the cap: the
+   * cap exists because every row mounts two inputs and a preview, and an add
+   * is no reason to mount a thousand of them.
+   */
+  revealAt: number | undefined;
   tokens: SiteTokenSet;
   supplied: SiteTokenSet | undefined;
   mode: TokenMode;
@@ -788,7 +810,9 @@ function TokenList({
    * to reach the tail because a query matching most names narrows nothing.
    */
   const [pagesOpen, setPagesOpen] = React.useState(1);
-  const limit = pagesOpen * TOKEN_PAGE_SIZE;
+  const reached =
+    revealAt === undefined ? -1 : rows.findIndex(row => row.at === revealAt);
+  const limit = Math.max(pagesOpen * TOKEN_PAGE_SIZE, reached + 1);
   const shown = rows.slice(0, limit);
   const hidden = rows.length - shown.length;
   return (
@@ -849,7 +873,7 @@ function AddToken({
    * `shadow.2`, `shadow.3`, each one also hidden. The tabs could not produce
    * this: they had nothing to narrow with.
    */
-  onAdded: () => void;
+  onAdded: (at: number) => void;
 }): React.JSX.Element {
   const [kind, setKind] = React.useState<TokenKind>("color");
   const id = React.useId();
@@ -875,8 +899,9 @@ function AddToken({
         variant="outline"
         size="sm"
         onClick={() => {
-          onChange(addToken(tokens, kind).tokens);
-          onAdded();
+          const made = addToken(tokens, kind);
+          onChange(made.tokens);
+          onAdded(made.at);
         }}
       >
         Add {TOKEN_KIND_LABELS[kind].toLowerCase()} token

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -41,14 +41,7 @@ import {
   type TokenKind,
   type TokenMode,
 } from "@nextlyhq/blocks-engine";
-import {
-  Button,
-  Input,
-  Tabs,
-  TabsContent,
-  TabsList,
-  TabsTrigger,
-} from "@nextlyhq/ui";
+import { Button, Input } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { colourHexOf } from "./style-colour";
@@ -59,7 +52,6 @@ import {
   removeToken,
   renameToken,
   setTokenValue,
-  tokenCounts,
   tokenNameIssue,
   tokenRowsFor,
   type TokenRow,
@@ -155,7 +147,23 @@ export function TokensPanel({
   const [mode, setMode] = React.useState<TokenMode>(
     prefersDark ? "dark" : "light"
   );
-  const counts = tokenCounts(tokens);
+  const [query, setQuery] = React.useState("");
+
+  /*
+   * The kinds that have something to show, in catalog order.
+   *
+   * A kind with no rows produces no group at all rather than an empty one. That
+   * is the whole of the shape change: eight tabs meant five clickable dead ends
+   * in a narrow rail, and a place you can go to find nothing is worse than no
+   * place at all.
+   */
+  const needle = query.trim().toLowerCase();
+  const groups = TOKEN_KINDS.map(kind => ({
+    kind,
+    rows: tokenRowsFor(tokens, kind, mode).filter(
+      row => needle === "" || row.name.toLowerCase().includes(needle)
+    ),
+  })).filter(group => group.rows.length > 0);
 
   if (tokens === undefined) {
     return (
@@ -181,7 +189,18 @@ export function TokensPanel({
         <h2 className="nx-tokens__title">Tokens</h2>
         <ModeSwitch mode={mode} onMode={setMode} />
       </div>
-      <TokenTransfer onChange={onChange} currentTokens={currentTokens} />
+      {/*
+       * What a token IS, before any of the machinery.
+       *
+       * The panel opened with a mode switch, a transfer control and eight tabs
+       * of vocabulary, and never said what any of it does to the site. An
+       * author who does not already know the word has nothing to go on, and
+       * this is the surface where they would have learned it.
+       */}
+      <p className="nx-tokens__lede">
+        <b>Tokens are your site&rsquo;s named values.</b> Change one here and
+        every block using it changes with it, on every page.
+      </p>
       {issue === undefined ? null : (
         /*
          * A save that did not happen. `role="alert"` because it reports on an
@@ -193,29 +212,102 @@ export function TokensPanel({
           {issue}
         </p>
       )}
-      <Tabs defaultValue="color" className="nx-tokens__tabs">
-        <TabsList>
-          {TOKEN_KINDS.map(kind => (
-            <TabsTrigger key={kind} value={kind}>
-              {TOKEN_KIND_LABELS[kind]}
-              {counts[kind] > 0 ? (
-                <span className="nx-tokens__count">{counts[kind]}</span>
-              ) : null}
-            </TabsTrigger>
-          ))}
-        </TabsList>
-        {TOKEN_KINDS.map(kind => (
-          <TabsContent key={kind} value={kind}>
+      <TokenSearch value={query} onValue={setQuery} />
+      {groups.length === 0 ? (
+        <EmptyTokens searching={query !== ""} />
+      ) : (
+        groups.map(group => (
+          <section key={group.kind} className="nx-tokens__group">
+            <div className="nx-tokens__grouphead">
+              {/*
+               * The count OUTSIDE the heading, so the heading's accessible name
+               * is the kind itself. Inside it, "Colour" becomes "Colour 3" and
+               * anything addressing the group by name — a test, a screen
+               * reader's heading list — has to know the number to find it.
+               */}
+              <h3 className="nx-tokens__groupname">
+                {TOKEN_KIND_LABELS[group.kind]}
+              </h3>
+              <span className="nx-tokens__count">{group.rows.length}</span>
+            </div>
             <TokenList
-              kind={kind}
+              rows={group.rows}
               tokens={tokens}
               supplied={supplied}
               mode={mode}
               onChange={onChange}
             />
-          </TabsContent>
-        ))}
-      </Tabs>
+          </section>
+        ))
+      )}
+      <AddToken tokens={tokens} onChange={onChange} />
+      {/*
+       * The transfer control, BELOW the tokens rather than above them.
+       *
+       * Importing a token file is a thing an author does once and then rarely;
+       * reading and nudging values is what the panel is for. Putting the rare
+       * one first spends the top of a narrow rail on machinery and pushes the
+       * content it operates on out of view.
+       */}
+      <TokenTransfer onChange={onChange} currentTokens={currentTokens} />
+    </div>
+  );
+}
+
+/**
+ * Search across the whole set, which the tabbed shape could not offer.
+ *
+ * A tabbed panel can only search within a tab, or it crosses a boundary the
+ * tabs assert — so the question "where did I put that token" had no answer
+ * short of clicking through eight of them. One list has no boundary to cross.
+ */
+function TokenSearch({
+  value,
+  onValue,
+}: {
+  value: string;
+  onValue: (value: string) => void;
+}): React.JSX.Element {
+  const id = React.useId();
+  return (
+    <div className="nx-tokens__search">
+      <label className="sr-only" htmlFor={id}>
+        Search tokens
+      </label>
+      <Input
+        id={id}
+        type="search"
+        placeholder="Search tokens"
+        value={value}
+        onChange={event => onValue(event.target.value)}
+      />
+    </div>
+  );
+}
+
+/**
+ * The empty state, which is the first thing a new site shows.
+ *
+ * Three jobs rather than one: say what is absent, say what belongs here, and
+ * offer the way in. "No colour tokens yet." did the first and stopped, which
+ * leaves an author who does not already know what a token is with nowhere to
+ * go — and this panel is where they would have found out.
+ *
+ * A search that matched nothing is a DIFFERENT state and must not be taught at:
+ * the author already knows what a token is, they are looking for one.
+ */
+function EmptyTokens({ searching }: { searching: boolean }): React.JSX.Element {
+  if (searching) {
+    return <p className="nx-inspector__note">No tokens match this search.</p>;
+  }
+  return (
+    <div className="nx-tokens__empty">
+      <p className="nx-tokens__empty-head">No tokens yet.</p>
+      <p className="nx-inspector__note">
+        A token names one value — a colour, a size, a shadow — so every block
+        can point at it instead of repeating it. Change it once and the whole
+        site follows.
+      </p>
     </div>
   );
 }
@@ -626,26 +718,29 @@ function ModeSwitch({
 
 /** Every token of one kind, with the way to add another. */
 function TokenList({
-  kind,
+  rows,
   tokens,
   supplied,
   mode,
   onChange,
 }: {
-  kind: TokenKind;
+  /*
+   * The rows to draw, resolved by the caller rather than here.
+   *
+   * The panel has to know how many rows a kind has BEFORE it draws the group,
+   * because a kind with none does not get a heading at all — so computing them
+   * here as well would be the same question answered twice, and the two would
+   * disagree the moment a filter was added to one of them.
+   */
+  rows: readonly TokenRow[];
   tokens: SiteTokenSet;
   supplied: SiteTokenSet | undefined;
   mode: TokenMode;
   onChange: (tokens: SiteTokenSet) => void;
 }): React.JSX.Element {
-  const rows = tokenRowsFor(tokens, kind, mode);
   return (
     <div className="nx-tokens__list">
-      {rows.length === 0 ? (
-        <p className="nx-inspector__note">
-          No {TOKEN_KIND_LABELS[kind].toLowerCase()} tokens yet.
-        </p>
-      ) : (
+      {rows.length === 0 ? null : (
         <ul>
           {rows.map(row => (
             <li key={row.key}>
@@ -660,6 +755,47 @@ function TokenList({
           ))}
         </ul>
       )}
+    </div>
+  );
+}
+
+/**
+ * The one way to create a token, and the price the grouped shape has to pay.
+ *
+ * Tabs offered creation for free: every kind had a tab, so an empty one was
+ * still somewhere you could stand and press "add". A list that omits empty
+ * kinds has nowhere to stand, so the kind has to be NAMED instead — which is
+ * the same move Figma's variables panel makes.
+ *
+ * One control rather than one per group. Two ways to perform one action drift,
+ * and the per-group button could not reach a kind that had no group anyway.
+ */
+function AddToken({
+  tokens,
+  onChange,
+}: {
+  tokens: SiteTokenSet;
+  onChange: (tokens: SiteTokenSet) => void;
+}): React.JSX.Element {
+  const [kind, setKind] = React.useState<TokenKind>("color");
+  const id = React.useId();
+  return (
+    <div className="nx-tokens__add">
+      <label className="sr-only" htmlFor={id}>
+        Kind of token to add
+      </label>
+      <select
+        id={id}
+        className="nx-tokens__kind"
+        value={kind}
+        onChange={event => setKind(event.target.value as TokenKind)}
+      >
+        {TOKEN_KINDS.map(option => (
+          <option key={option} value={option}>
+            {TOKEN_KIND_LABELS[option]}
+          </option>
+        ))}
+      </select>
       <Button
         type="button"
         variant="outline"

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -109,6 +109,12 @@ describe("what each tab shows", () => {
 
     const rows = tokenRowsFor(clashing, "color");
     const survivor = rows.find(row => row.name === "color-primary");
+    // Stated separately so a MISSING row reads as a missing row. The optional
+    // chain below already fails when it is absent — `expect(undefined).toBe(
+    // false)` is not satisfied — but it fails saying "expected undefined to be
+    // false", which describes the issue check rather than the row that never
+    // arrived.
+    expect(survivor).toBeDefined();
     expect(survivor?.issues.some(issue => /both become/.test(issue))).toBe(
       false
     );

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -27,7 +27,6 @@ import {
   removeToken,
   renameToken,
   setTokenValue,
-  tokenCounts,
   tokenNameIssue,
   tokenRowsFor,
 } from "./tokens-studio";
@@ -95,11 +94,7 @@ describe("what each tab shows", () => {
     }
   });
 
-  it("counts each kind for the tab", () => {
-    expect(tokenCounts(TOKENS).color).toBe(2);
-    expect(tokenCounts(TOKENS).dimension).toBe(1);
-    expect(tokenCounts(TOKENS).shadow).toBe(0);
-  });
+  it("counts each kind for the tab", () => {});
 });
 
 describe("renaming a token keeps every reference resolving", () => {

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -86,6 +86,34 @@ describe("what each tab shows", () => {
     expect(tokenRowsFor(undefined, "color")).toEqual([]);
   });
 
+  it("gives a property to the token the EMITTER wrote, not the first stored", () => {
+    /*
+     * A token refused before `seen` is updated — a bad name, no light value, an
+     * unusable value, or a value that fetches — claims no custom property, so a
+     * later token with the same one is emitted normally.
+     *
+     * Ranking by stored position told that written token only the refused one
+     * survives, which is the opposite of the compiled page. `color.primary`
+     * here carries a value the guard rejects, so `color-primary` is what the
+     * page resolves.
+     */
+    const clashing: SiteTokenSet = {
+      tokens: [
+        { name: "color.primary", kind: "color", values: { light: "red;}" } },
+        { name: "color-primary", kind: "color", values: { light: "#00ff00" } },
+      ],
+    };
+    // The emitter is the oracle: it is what the page is compiled from.
+    const written = emitTokenBlocks(clashing, ":root").emitted.map(t => t.name);
+    expect(written).toEqual(["color-primary"]);
+
+    const rows = tokenRowsFor(clashing, "color");
+    const survivor = rows.find(row => row.name === "color-primary");
+    expect(survivor?.issues.some(issue => /both become/.test(issue))).toBe(
+      false
+    );
+  });
+
   it("labels every kind the engine defines", () => {
     // A kind added to the engine with no label here would draw a tab named
     // after its own identifier.

--- a/packages/builder/src/tokens-studio.test.ts
+++ b/packages/builder/src/tokens-studio.test.ts
@@ -93,8 +93,6 @@ describe("what each tab shows", () => {
       expect(label).not.toBe("");
     }
   });
-
-  it("counts each kind for the tab", () => {});
 });
 
 describe("renaming a token keeps every reference resolving", () => {

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -156,12 +156,26 @@ export function tokenRows(
   tokens: SiteTokenSet | undefined,
   mode: TokenMode = "light"
 ): readonly TokenRow[] {
-  const all = tokens?.tokens ?? [];
-  // Built ONCE for the whole set rather than rediscovered per row. Asking
-  // "who else compiles to my custom property" with a linear scan inside a
-  // per-row call makes the projection quadratic, and a DTCG import is not
-  // bounded to a size where that stays invisible.
-  const claimed = firstByProperty(all);
+  const set: SiteTokenSet = tokens ?? { tokens: [] };
+  const all = set.tokens ?? [];
+  /*
+   * Built ONCE for the whole set rather than rediscovered per row: asking "who
+   * else compiles to my custom property" with a linear scan inside a per-row
+   * call makes the projection quadratic, and a DTCG import is not bounded to a
+   * size where that stays invisible.
+   *
+   * And built from what the emitter actually WROTE, not from document order.
+   * A token refused for its name, a missing light value, an unusable value or
+   * a value that fetches never reaches `seen`, so it claims no property and a
+   * later token with the same one is emitted normally. Ranking by position
+   * handed the property to the refused token and told the written one that
+   * only the refused one survives — the opposite of the compiled page.
+   *
+   * `emitTokenBlocks` reports `emitted` precisely so this question has one
+   * answer; its own docblock says a caller re-deriving it "would have to
+   * restate all five" refusals and would drift the first time one changed.
+   */
+  const claimed = firstByProperty(emitTokenBlocks(set, ":root").emitted);
   // Indexed against the WHOLE list, so `at` addresses the stored position
   // rather than a position within any later grouping or filter.
   const seen = new Map<string, number>();
@@ -247,17 +261,18 @@ function issuesOf(token: SiteToken): readonly string[] {
  * engine's; only the pairwise comparison is done here.
  */
 /**
- * Which token each custom property belongs to, by first claim.
+ * Which token each custom property belongs to.
  *
- * The compiler writes the FIRST token to claim a property and drops the rest,
- * so "who owns this name" is one question about the whole set. Answering it
- * once here is what keeps the projection linear.
+ * Takes the tokens the emitter WROTE, so a property is owned by whatever the
+ * page actually resolves rather than by whatever came first in the stored
+ * order. A refused token owns nothing, which is the whole point: it is not in
+ * the emitted list to be found.
  */
 function firstByProperty(
-  among: readonly SiteToken[]
+  emitted: readonly SiteToken[]
 ): ReadonlyMap<string, SiteToken> {
   const claimed = new Map<string, SiteToken>();
-  for (const token of among) {
+  for (const token of emitted) {
     const property = tokenCustomProperty(tokenIdentity(token), "");
     if (!claimed.has(property)) claimed.set(property, token);
   }

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -37,7 +37,6 @@
  * @module tokens-studio
  */
 import {
-  TOKEN_KINDS,
   emitTokenBlocks,
   MAX_TOKEN_NAME_LENGTH,
   MAX_TOKEN_NAME_SEGMENTS,
@@ -452,17 +451,4 @@ export function addToken(
     tokens: { ...base, tokens: [...base.tokens, token] },
     at: base.tokens.length,
   };
-}
-
-/** How many tokens each kind holds, for the tab labels. */
-export function tokenCounts(
-  tokens: SiteTokenSet | undefined
-): Readonly<Record<TokenKind, number>> {
-  const counts = Object.fromEntries(
-    TOKEN_KINDS.map(kind => [kind, 0])
-  ) as Record<TokenKind, number>;
-  for (const token of tokens?.tokens ?? []) {
-    if (token.kind in counts) counts[token.kind] += 1;
-  }
-  return counts;
 }

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -152,35 +152,57 @@ export interface TokenRow {
 }
 
 /** The tokens of one kind, in stored order, as rows. */
+export function tokenRows(
+  tokens: SiteTokenSet | undefined,
+  mode: TokenMode = "light"
+): readonly TokenRow[] {
+  const all = tokens?.tokens ?? [];
+  // Built ONCE for the whole set rather than rediscovered per row. Asking
+  // "who else compiles to my custom property" with a linear scan inside a
+  // per-row call makes the projection quadratic, and a DTCG import is not
+  // bounded to a size where that stays invisible.
+  const claimed = firstByProperty(all);
+  // Indexed against the WHOLE list, so `at` addresses the stored position
+  // rather than a position within any later grouping or filter.
+  const seen = new Map<string, number>();
+  return all.map((token, at) => {
+    const identity = tokenIdentity(token);
+    const nth = seen.get(identity) ?? 0;
+    seen.set(identity, nth + 1);
+    return rowOf(
+      token,
+      at,
+      nth === 0 ? identity : `${identity}#${nth}`,
+      claimed,
+      mode
+    );
+  });
+}
+
+/**
+ * The rows of ONE kind.
+ *
+ * Derived from {@link tokenRows} rather than projecting again, so a caller
+ * asking for every kind pays for one pass over the set instead of one per
+ * kind, and the two can never disagree about a row's key or its issues.
+ */
 export function tokenRowsFor(
   tokens: SiteTokenSet | undefined,
   kind: TokenKind,
   mode: TokenMode = "light"
 ): readonly TokenRow[] {
-  const all = tokens?.tokens ?? [];
-  // Indexed against the WHOLE list before filtering, so `at` addresses the
-  // stored position rather than a position within this tab.
-  const seen = new Map<string, number>();
-  return all
-    .map((token, at) => {
-      const identity = tokenIdentity(token);
-      const nth = seen.get(identity) ?? 0;
-      seen.set(identity, nth + 1);
-      return { token, at, key: nth === 0 ? identity : `${identity}#${nth}` };
-    })
-    .filter(entry => entry.token.kind === kind)
-    .map(entry => rowOf(entry.token, entry.at, entry.key, all, mode));
+  return tokenRows(tokens, mode).filter(row => row.kind === kind);
 }
 
 function rowOf(
   token: SiteToken,
   at: number,
   key: string,
-  among: readonly SiteToken[],
+  claimed: ReadonlyMap<string, SiteToken>,
   mode: TokenMode
 ): TokenRow {
   const own = token.values[mode];
-  const collision = collisionFor(token, among);
+  const collision = collisionFor(token, claimed);
   return {
     at,
     key,
@@ -224,14 +246,30 @@ function issuesOf(token: SiteToken): readonly string[] {
  * `tokenCustomProperty` composes the key, so the normalisation stays the
  * engine's; only the pairwise comparison is done here.
  */
+/**
+ * Which token each custom property belongs to, by first claim.
+ *
+ * The compiler writes the FIRST token to claim a property and drops the rest,
+ * so "who owns this name" is one question about the whole set. Answering it
+ * once here is what keeps the projection linear.
+ */
+function firstByProperty(
+  among: readonly SiteToken[]
+): ReadonlyMap<string, SiteToken> {
+  const claimed = new Map<string, SiteToken>();
+  for (const token of among) {
+    const property = tokenCustomProperty(tokenIdentity(token), "");
+    if (!claimed.has(property)) claimed.set(property, token);
+  }
+  return claimed;
+}
+
 function collisionFor(
   token: SiteToken,
-  among: readonly SiteToken[]
+  claimed: ReadonlyMap<string, SiteToken>
 ): string | undefined {
   const property = tokenCustomProperty(tokenIdentity(token), "");
-  const first = among.find(
-    other => tokenCustomProperty(tokenIdentity(other), "") === property
-  );
+  const first = claimed.get(property);
   if (first === undefined || first === token) return undefined;
   return `"${token.name}" and "${first.name}" both become "${property}", so only "${first.name}" is written.`;
 }


### PR DESCRIPTION
Closes U-14 and U-15. This is PR 1 of 2 — shape and words. PR 2 adds token
previews and class declaration summaries derived from `compileStyleValues`.

## What was wrong

> "the tokens panel looks so weird. i don't understood it at all. the worst ui
> and worst ux" — and the same words for the classes panel.

Research (`research:tokens-and-classes-comprehension`) put the complaint in
three places, none of them the table:

1. **Nothing says what the thing is.** Both panels opened with machinery — a
   mode switch, a DTCG import/export control, eight tabs of vocabulary — and
   never one sentence about what a token or a class does to the site.
2. **Empty states are dead ends.** NN/g: an empty state does three jobs —
   report status, teach what belongs there, offer the next action — and a
   primary surface earns the teaching. These did one of three.
3. **Rows name without describing.** That is PR 2.

## What this changes

**Tokens.** Eight tabs become one grouped scrolling list (the Figma Variables
shape). A kind with no tokens is now *absent* rather than an empty tab to click
into and find nothing. Search filters across every kind at once — something the
tabbed shape could not do without silently crossing the boundary the tabs
asserted. DTCG import/export moves below the tokens it operates on.

**Both panels** gain a lede in the author's words. The classes one is
load-bearing: *"you apply one beside the style controls"* explains the Webflow
split rather than leaving the absent create button reading as a missing feature.

**Empty states teach.** Two are worth calling out because both used to report a
non-failure as a failure:
- `not-in-index` empty means nothing is known to be stranded — good news, and it
  said *"No classes match this filter."* It now says so, while still refusing to
  claim more than the index supports: a floor, not a measurement.
- An empty class library under `all` is not a filter miss — nothing is
  narrowing anything — so blaming "this filter" pointed at a control that had
  not acted. **Found in browser verification, not by the suite.**

## Deviations from the approved design — please read these

**1. The class filters are NOT converted to groups, deliberately.** The approved
artifact showed them becoming groups. That is unsafe:

```ts
if (filter === "not-in-index") return rows.filter(row => row.indexedDocuments === 0);
if (filter === "on-this-page")  return rows.filter(row => row.onThisPage);
```

They test **different fields**. A class the open document applies while the
index has not recorded it satisfies **both**. Groups require exclusivity;
converting would force that row into one bucket and assert a mutual exclusivity
`class-library.ts` explicitly denies. The artifact could not reveal this because
its fixture was mocked as exclusive — the mock agreed with the design instead of
testing it. A test now pins the overlap
(`keeps the filters, because they answer questions that OVERLAP`), so a future
attempt to group them fails there.

**2. Creation had to be rebuilt.** Tabs gave creation for free: every kind had a
tab, so an empty one was still somewhere to stand and press "Add shadow token".
A list that omits empty kinds has nowhere to stand. `AddToken` now names the
kind in a select — one control, not one per group, because two ways to perform
one action drift and a per-group button could not reach a kind with no group.
The existing suite caught this: `adds into a site that has no table at all`
went red.

**3. `tokenCounts` was deleted.** Its only consumer was the tab counts.
`fallow dead-code --trace ...:tokenCounts` reported one reference — its own
test. Group headings show the *filtered* count, a different question from its
unfiltered totals. Deleted with its three assertions, so the test count drops
for a reason.

**4. One existing test's wording was changed on purpose.**
`says so when a filter matches nothing` asserted the generic sentence for an
empty `not-in-index`; that state is now the good-news wording, so the test
asserts the new text and a companion control covers the other branch.

## The guard rail

Six correctness decisions with their reasons recorded in the modules — a colour
is typed not picked; the filter says "Not in index" never "Unused"; deletion
confirms unconditionally; classes are not created here; a swatch only where the
colour resolves without the site table; the table is the editor. **None is
touched.** This was scoped as comprehension, not redesign, because four board
rows have already been lost to "fixes" that undid considered decisions.

## Evidence

Gates at head `63270b53b`, rebased onto `9e79e1150`, run from the worktree root
(fallow, lint:design) and the package dir (suites):

| gate | result |
| --- | --- |
| `pnpm --filter builder... build` | exit 0 |
| builder suite | 95 files / 2675 tests passed |
| `check-types` | 0 |
| `lint` | 0 |
| `lint:design` | passed, 1161 files |
| `fallow audit --base origin/main` | ✓ no issues in **8 changed files** |

The fallow line names 8 files — the 7 sources plus the changeset — matching the
diff, rather than the vacuous 0-file pass a default base produces after a push.

**Break-verify**, each by failing test NAME:

- invert the empty-library branch → `teaches when the library is EMPTY, rather
  than blaming a filter` fails, and `blames the FILTER, not a search that is not
  set` fails with it (the correct consequence).

**Browser-verified** on a real post in the playground at :3200 — the product's
own `blocks()` field, not a harness. Confirmed in the live render: the lede,
three groups with counts (Colour 6, Size 2, Font 1), no empty kinds among the
five kinds with no tokens, search crossing kinds (`on` → Size + Font with Colour
gone; `color` → Colour only as the must-differ control), the kind chooser
reaching kinds that have no group, and transfer at the bottom.

## Review round 1 — all five findings correct

Codex raised five P2s and every one held. Four were the same shape: copy
describing something the code was not doing. Answered in their threads and in
[this comment](https://github.com/nextlyhq/nextly/pull/1451#issuecomment-5503938003);
the headline one is that the lede promised "clear them out here" while the
production `BlocksField` mount passes no `onDelete`, so no delete control
renders — the exact dead end U-15 reported, shipped inside its own fix. Every
unit test mounted the panel with all callbacks supplied, so the production
shape was the one shape nothing rendered.

`EmptyClasses` was extracted at the same time: the added branches pushed
`ClassList` to `18 ! cognitive` on the fallow gate.

## Risk

Presentation only; no new data is derived and no stored shape changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redesigned the tokens panel with searchable, grouped lists, kind selection, counts, pagination, and improved empty states.
  - Added clearer guidance about tokens, classes, and where they are created.
  - Improved class management messaging and filtering, including library capacity information.
  - Added safeguards so supplied classes cannot be deleted.

- **Bug Fixes**
  - Newly added tokens remain visible despite search or pagination.
  - Corrected token collision handling so invalid emitted values do not override valid tokens.

- **Style**
  - Added consistent styling for token and class manager panels, search controls, empty states, and grouped sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->