### PR TITLE
fix(nextly): chrome is a string in every version, and rows must name their rule

### DIFF
--- a/.changeset/widget-contract-shape-followups.md
+++ b/.changeset/widget-contract-shape-followups.md
@@ -1,0 +1,43 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Three follow-ups to the widget contract boundary.
+
+`chrome` is a string in every version, and moving its closed vocabulary to the
+registry took the shape check with it -- so `chrome: 42` was published as a
+`WidgetChrome`. The renderer treats anything but `"none"` as `"card"`, so it
+rendered and boot said nothing about a configuration its author got wrong.
+
+The divergence rows now name the diagnostic they exist for. A fixture can
+violate more than one rule -- `{ defaultSize: "sm", minSize: "xl", maxSize: "sm" }`
+breaks both size orderings -- so a row could stay green when its own rule was
+deleted and another caught the input.
+
+And an acceptance case for `{ component, chrome: "none" }` with no archetype,
+which is the typed and renderable form: resolution supplies `custom`, where
+`"none"` is legal. Nothing else exercised that standing through the chrome rule.

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -225,6 +225,16 @@ export function widgetValueProblem(
     return "title, when given, must be a string";
   }
 
+  // Chrome is a STRING in every version. Moving the closed-vocabulary check to
+  // the registry took the shape check with it, so `chrome: 42` was published as
+  // a `WidgetChrome` -- and the renderer treats anything but `"none"` as
+  // `"card"`, so it renders and boot says nothing about a configuration its
+  // author got wrong. Unknown STRING values still pass, which is the version
+  // skew this boundary exists for.
+  if (widget.chrome !== undefined && typeof widget.chrome !== "string") {
+    return "chrome, when given, must be a string";
+  }
+
   // A query is an OBJECT in every version, so it belongs here rather than
   // beside the body checks. There it was reachable only when the query had to
   // establish a body, so a widget shipping a component skipped it -- and the

--- a/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
+++ b/packages/nextly/src/plugins/__tests__/channel-divergence.test.ts
@@ -215,8 +215,19 @@ const DECLARED_DIFFERENCES: Array<{
   },
 ];
 
-/** Rules that must hold identically on both sides. */
-const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
+/**
+ * Rules that must hold identically on both sides.
+ *
+ * `expect` names the diagnostic the row exists for. Without it a fixture can be
+ * refused by a DIFFERENT rule and the row stays green when its own is deleted:
+ * `{ defaultSize: "sm", minSize: "xl", maxSize: "sm" }` violates both size
+ * orderings, so removing either left the pair assertion satisfied by the other.
+ */
+const MUST_AGREE: Array<{
+  case: string;
+  widget: Record<string, unknown>;
+  expect?: RegExp;
+}> = [
   {
     case: "minSize above defaultSize",
     widget: {
@@ -291,6 +302,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "a query that is not an object",
+    expect: /query must be an object/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -301,6 +313,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "a title that is not a string",
+    expect: /title, when given, must be a string/,
     widget: {
       id: "acme/thing",
       title: 42,
@@ -322,6 +335,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "a defaultSize below minSize when only maxSize is unknown",
+    expect: /below minSize/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -334,6 +348,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "minSize above maxSize",
+    expect: /exceeds maxSize/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -346,6 +361,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "minSize above maxSize when defaultSize is from a newer core",
+    expect: /exceeds maxSize/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -358,6 +374,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "defaultSize above maxSize",
+    expect: /above maxSize/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -369,6 +386,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "defaultSize above maxSize when minSize is from a newer core",
+    expect: /above maxSize/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -381,6 +399,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "an archetype that is not a string",
+    expect: /archetype, when given, must be a string/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -391,6 +410,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "actions beside a component with no archetype at all",
+    expect: /only valid for archetype "actions"/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -401,6 +421,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "a non-array actions on an archetype this core does not know",
+    expect: /must be an array/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -411,6 +432,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "a null action item on an archetype this core does not know",
+    expect: /must be an object/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -421,6 +443,7 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
   },
   {
     case: "a primitive action item on an archetype this core does not know",
+    expect: /must be an object/,
     widget: {
       id: "acme/thing",
       title: "T",
@@ -429,10 +452,22 @@ const MUST_AGREE: Array<{ case: string; widget: Record<string, unknown> }> = [
       actions: [42],
     },
   },
+  {
+    case: "a chrome that is not a string",
+    expect: /chrome, when given, must be a string/,
+    widget: {
+      id: "acme/thing",
+      title: "T",
+      archetype: "custom",
+      defaultSize: "sm",
+      component: "p#X",
+      chrome: 42,
+    },
+  },
 ];
 
 describe("the registry and contributions channels agree except where declared", () => {
-  it.each(MUST_AGREE)("both refuse: $case", ({ widget }) => {
+  it.each(MUST_AGREE)("both refuse: $case", ({ widget, expect: expected }) => {
     const registry = refuses(() => validateWidgetDefinition(widget));
     const contributions = refuses(() => assertAdminWidgets([asPlugin(widget)]));
 
@@ -447,9 +482,13 @@ describe("the registry and contributions channels agree except where declared", 
     // runs -- so the registry half was green for every row whatever the rule
     // under test did, and deleting a registry rule would not have moved it. A
     // pair of booleans cannot see that; only the message can.
-    expect(reasonFrom(() => validateWidgetDefinition(widget))).not.toMatch(
-      /id must be namespace/
-    );
+    const reason = reasonFrom(() => validateWidgetDefinition(widget));
+    expect(reason).not.toMatch(/id must be namespace/);
+
+    // And, where the row names one, that the refusal is the rule the row is
+    // FOR. A fixture can violate more than one rule, so without this a row
+    // stays green when its own rule is deleted and another catches the input.
+    if (expected) expect(reason).toMatch(expected);
   });
 
   it.each(DECLARED_DIFFERENCES)(
@@ -462,6 +501,23 @@ describe("the registry and contributions channels agree except where declared", 
       expect(refuses(() => assertAdminWidgets([asPlugin(widget)]))).toBe(false);
     }
   );
+
+  it("accepts chrome none on an archetype resolution supplies", () => {
+    // `{ component, chrome: "none" }` with no archetype is the typed, renderable
+    // form: resolution fills in `custom`, which is exactly where `"none"` is
+    // legal. Nothing else exercises the `resolved-custom` standing THROUGH the
+    // chrome rule -- the valid-chrome case spells `archetype: "custom"` out --
+    // so remapping that standing would start refusing this and no row would
+    // move.
+    const widget = {
+      id: "acme/thing",
+      title: "T",
+      defaultSize: "sm",
+      component: "p#X",
+      chrome: "none",
+    };
+    expect(refuses(() => assertAdminWidgets([asPlugin(widget)]))).toBe(false);
+  });
 
   it("accepts a well-formed widget through BOTH channels", () => {
     // The positive control. Two validators that refused everything would


### PR DESCRIPTION
Three follow-ups to #1444, which merged while these were still local. All three were verified against the code and break-verified.

## `chrome` lost its shape check

Moving chrome's closed vocabulary to the registry — correct, for version skew — took the **shape** check with it. Measured: `chrome: 42`, `null` and `{}` were all ACCEPTED and published as a `WidgetChrome`.

That is worse than it sounds. The renderer treats anything other than `"none"` as `"card"`, so the card renders fine and boot says nothing about a configuration its author got wrong. Unknown *string* values still pass, which is the skew the boundary exists for.

## A divergence row could pass via the wrong rule

`{ defaultSize: "sm", minSize: "xl", maxSize: "sm" }` violates **both** size orderings. So deleting the `minSize > maxSize` rule left that row green, satisfied by `defaultSize < minSize`.

Rows now name the diagnostic they exist for. Verified before and after: previously only the newer-core variant failed that break; now both rows do.

**That assertion immediately earned itself.** Break-verifying the chrome fix showed all 209 tests still passing — the guard had nothing reaching it. A row had to be added before the break could fail, which is exactly the gap the change was meant to expose.

## The implicit-custom standing had no chrome coverage

`{ component, chrome: "none" }` with no archetype is the typed, renderable form — resolution supplies `custom`, where `"none"` is legal. Nothing reached the `resolved-custom` standing *through* the chrome rule, so remapping it would have started refusing a valid widget with no row moving.

Gates: build, `check-types` (both programs), lint, comment convention, fallow `pass` with 0 introduced, 728 widget/plugin tests.