### PR TITLE
test(builder): exercise the segmented control as a control

### DIFF
--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -2725,6 +2725,12 @@ describe("a segmented keyword control behaves as a toggle", () => {
   const optionButton = (name: string) =>
     fieldsOf("fontStyle").getByRole("button", { name });
 
+  /** Every option button, so an assertion can cover the control rather than one. */
+  const allOptions = () =>
+    within(fieldsOf("fontStyle").getByRole("group")).getAllByRole(
+      "button"
+    ) as HTMLButtonElement[];
+
   /** The styles one `applyAll` call would leave on the node. */
   const committedStyles = (
     editor: ReturnType<typeof editorFor>
@@ -2737,78 +2743,102 @@ describe("a segmented keyword control behaves as a toggle", () => {
     return (op.patch as { styles?: NodeStyles }).styles;
   };
 
-  it("shows the stored value as the pressed option, and only that one", () => {
+  /** The panel with one `fontStyle` value already stored, or none. */
+  const mountWith = (stored?: string) =>
+    mount(
+      { typography: true },
+      stored === undefined
+        ? undefined
+        : ({ base: { [BASE_BREAKPOINT]: { fontStyle: stored } } } as NodeStyles)
+    );
+
+  /*
+   * Every case below is driven from MORE THAN ONE option, and that is the point
+   * rather than thoroughness for its own sake. `fontStyle` offers three, so an
+   * implementation special-cased to whichever one a fixture happens to store —
+   * pressing `italic` whenever anything is set, committing `oblique` for every
+   * unpressed button, clearing only when `italic` is the pressed one — passes a
+   * suite that only ever exercises that value, and passes it while being wrong
+   * about the other two.
+   */
+  it.each(["normal", "italic", "oblique"])(
+    "shows %s as the pressed option when it is the stored value",
+    stored => {
+      mountWith(stored);
+
+      for (const button of allOptions()) {
+        expect(button.getAttribute("aria-pressed")).toBe(
+          String(button.textContent?.trim() === stored)
+        );
+      }
+    }
+  );
+
+  it.each(["normal", "italic", "oblique"])(
+    "CLEARS when the pressed option %s is pressed again",
+    stored => {
+      /*
+       * The only route to unset that does not spend a button on "neither".
+       *
+       * BOTH assertions are load-bearing. Re-writing a value the document
+       * already holds produces NO ops — the write path treats "the document
+       * already says this" as nothing to do — so `applyAll` is never reached
+       * and the styles it would have left read as absent. Absent is also what a
+       * clear leaves, so the value assertion alone passes for the very
+       * implementation it exists to reject.
+       */
+      const editor = mountWith(stored);
+
+      fireEvent.click(optionButton(stored));
+
+      // Exactly once: a handler committing twice would satisfy "was called" and
+      // spend two history entries on one gesture.
+      expect(editor.applyAll).toHaveBeenCalledTimes(1);
+      expect(committedStyles(editor)?.base?.[BASE_BREAKPOINT]?.fontStyle).toBe(
+        undefined
+      );
+    }
+  );
+
+  it.each([
+    ["italic", "normal"],
+    ["italic", "oblique"],
+    ["normal", "oblique"],
+  ])("writes %s -> %s when a different option is pressed", (stored, next) => {
     /*
-     * `aria-pressed` is the whole state model here — the group is buttons
-     * rather than a radio set precisely because "neither" is reachable — so a
-     * toggle that drew every option unpressed would still render three buttons
-     * with the right names and satisfy any assertion about their presence.
+     * The positive control for the clear case, and the option-to-value mapping
+     * with it: a handler that committed one constant for every unpressed button
+     * would leave the clear assertions green while storing the wrong style.
      */
-    mount({ typography: true }, {
-      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
-    } as NodeStyles);
+    const editor = mountWith(stored);
 
-    expect(optionButton("italic").getAttribute("aria-pressed")).toBe("true");
-    expect(optionButton("normal").getAttribute("aria-pressed")).toBe("false");
-    expect(optionButton("oblique").getAttribute("aria-pressed")).toBe("false");
-  });
+    fireEvent.click(optionButton(next));
 
-  it("CLEARS when the pressed option is pressed again", () => {
-    /*
-     * The only route to unset that does not spend a button on "neither". A
-     * toggle that re-wrote the value instead would leave an author who wants
-     * the block's inherited style with no way to ask for it from this control.
-     *
-     * BOTH halves are load-bearing, and the second was added after the first
-     * alone failed to catch a toggle that re-wrote the value. Re-writing
-     * `italic` onto a node that already holds `italic` produces NO ops — the
-     * write path treats "the document already says this" as nothing to do — so
-     * `applyAll` is never reached and the styles it would have left read as
-     * absent. Absent is also what a clear leaves behind, so the value assertion
-     * on its own passes for the very implementation it exists to reject.
-     */
-    const editor = mount({ typography: true }, {
-      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
-    } as NodeStyles);
-
-    fireEvent.click(optionButton("italic"));
-
-    expect(editor.applyAll).toHaveBeenCalled();
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
     expect(committedStyles(editor)?.base?.[BASE_BREAKPOINT]?.fontStyle).toBe(
-      undefined
+      next
     );
   });
 
-  it("writes the option when a DIFFERENT one is pressed", () => {
-    /*
-     * The positive control for the case above. Without it "cleared" and "did
-     * nothing at all" produce the same absent value, and a toggle whose click
-     * handler was removed entirely would pass that assertion.
-     */
-    const editor = mount({ typography: true }, {
-      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
-    } as NodeStyles);
-
-    fireEvent.click(optionButton("oblique"));
-
-    expect(committedStyles(editor)?.base?.[BASE_BREAKPOINT]?.fontStyle).toBe(
-      "oblique"
-    );
-  });
-
-  it("marks the buttons invalid when the store refuses the edit", () => {
+  it("marks EVERY button invalid when the store refuses the edit", () => {
     /*
      * A control described by a refusal and not marked invalid announces the
      * message as a HINT rather than as a failure. `aria-invalid` sits on the
      * buttons rather than on the group because `role="group"` does not support
      * the state, so setting it there is an attribute a reader may ignore.
+     *
+     * Asserted across the whole control: one refused control has one state, and
+     * marking only the button that was clicked would leave the other two
+     * reading as valid parts of a control that is not.
      */
     const editor = mount({ typography: true });
     editor.applyAll.mockReturnValue(null);
 
     fireEvent.click(optionButton("italic"));
 
-    expect(optionButton("italic").getAttribute("aria-invalid")).toBe("true");
+    for (const button of allOptions()) {
+      expect(button.getAttribute("aria-invalid")).toBe("true");
+    }
     const message = screen.getByRole("alert");
     expect(
       fieldsOf("fontStyle").getByRole("group").getAttribute("aria-describedby")
@@ -2823,9 +2853,7 @@ describe("a segmented keyword control behaves as a toggle", () => {
      * it, when already pressed. The group's id sits on a `div`, which is not
      * labelable, so the association is inert by construction.
      */
-    const editor = mount({ typography: true }, {
-      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
-    } as NodeStyles);
+    const editor = mountWith("italic");
 
     fireEvent.click(fieldsOf("fontStyle").getByText("Font style"));
 

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -2709,3 +2709,126 @@ describe("the action a control's breakpoint provenance earns", () => {
     expect(jumped).toEqual(["tablet"]);
   });
 });
+
+/**
+ * The segmented control, exercised as a control rather than as a rendering.
+ *
+ * These four assertions could not be written until a catalog property reached
+ * the toggle: it draws only where the whole keyword vocabulary fits, and until
+ * that admitted three options no supported property produced one. `fontStyle`
+ * does now, so the behaviours below are reachable — and each of them has been
+ * wrong once already, found by reading rather than by any test, because there
+ * was nothing that could render the control to ask.
+ */
+describe("a segmented keyword control behaves as a toggle", () => {
+  /** The buttons of the `fontStyle` toggle, by their option name. */
+  const optionButton = (name: string) =>
+    fieldsOf("fontStyle").getByRole("button", { name });
+
+  /** The styles one `applyAll` call would leave on the node. */
+  const committedStyles = (
+    editor: ReturnType<typeof editorFor>
+  ): NodeStyles | undefined => {
+    const ops = editor.applyAll.mock.calls[0]?.[0] as
+      | readonly { kind: string; patch?: unknown }[]
+      | undefined;
+    const op = ops?.[0];
+    if (op === undefined || op.kind !== "update") return undefined;
+    return (op.patch as { styles?: NodeStyles }).styles;
+  };
+
+  it("shows the stored value as the pressed option, and only that one", () => {
+    /*
+     * `aria-pressed` is the whole state model here — the group is buttons
+     * rather than a radio set precisely because "neither" is reachable — so a
+     * toggle that drew every option unpressed would still render three buttons
+     * with the right names and satisfy any assertion about their presence.
+     */
+    mount({ typography: true }, {
+      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
+    } as NodeStyles);
+
+    expect(optionButton("italic").getAttribute("aria-pressed")).toBe("true");
+    expect(optionButton("normal").getAttribute("aria-pressed")).toBe("false");
+    expect(optionButton("oblique").getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("CLEARS when the pressed option is pressed again", () => {
+    /*
+     * The only route to unset that does not spend a button on "neither". A
+     * toggle that re-wrote the value instead would leave an author who wants
+     * the block's inherited style with no way to ask for it from this control.
+     *
+     * BOTH halves are load-bearing, and the second was added after the first
+     * alone failed to catch a toggle that re-wrote the value. Re-writing
+     * `italic` onto a node that already holds `italic` produces NO ops — the
+     * write path treats "the document already says this" as nothing to do — so
+     * `applyAll` is never reached and the styles it would have left read as
+     * absent. Absent is also what a clear leaves behind, so the value assertion
+     * on its own passes for the very implementation it exists to reject.
+     */
+    const editor = mount({ typography: true }, {
+      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
+    } as NodeStyles);
+
+    fireEvent.click(optionButton("italic"));
+
+    expect(editor.applyAll).toHaveBeenCalled();
+    expect(committedStyles(editor)?.base?.[BASE_BREAKPOINT]?.fontStyle).toBe(
+      undefined
+    );
+  });
+
+  it("writes the option when a DIFFERENT one is pressed", () => {
+    /*
+     * The positive control for the case above. Without it "cleared" and "did
+     * nothing at all" produce the same absent value, and a toggle whose click
+     * handler was removed entirely would pass that assertion.
+     */
+    const editor = mount({ typography: true }, {
+      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
+    } as NodeStyles);
+
+    fireEvent.click(optionButton("oblique"));
+
+    expect(committedStyles(editor)?.base?.[BASE_BREAKPOINT]?.fontStyle).toBe(
+      "oblique"
+    );
+  });
+
+  it("marks the buttons invalid when the store refuses the edit", () => {
+    /*
+     * A control described by a refusal and not marked invalid announces the
+     * message as a HINT rather than as a failure. `aria-invalid` sits on the
+     * buttons rather than on the group because `role="group"` does not support
+     * the state, so setting it there is an attribute a reader may ignore.
+     */
+    const editor = mount({ typography: true });
+    editor.applyAll.mockReturnValue(null);
+
+    fireEvent.click(optionButton("italic"));
+
+    expect(optionButton("italic").getAttribute("aria-invalid")).toBe("true");
+    const message = screen.getByRole("alert");
+    expect(
+      fieldsOf("fontStyle").getByRole("group").getAttribute("aria-describedby")
+    ).toBe(message.getAttribute("id"));
+  });
+
+  it("does not write anything when the field's LABEL is clicked", () => {
+    /*
+     * The defect this guards is a click that edits the document without the
+     * author touching a control: a `<label>` with `htmlFor` forwards its click
+     * to the named element, so naming a button there would press it — or clear
+     * it, when already pressed. The group's id sits on a `div`, which is not
+     * labelable, so the association is inert by construction.
+     */
+    const editor = mount({ typography: true }, {
+      base: { [BASE_BREAKPOINT]: { fontStyle: "italic" } },
+    } as NodeStyles);
+
+    fireEvent.click(fieldsOf("fontStyle").getByText("Font style"));
+
+    expect(editor.applyAll).not.toHaveBeenCalled();
+  });
+});

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -2737,11 +2737,18 @@ describe("a segmented keyword control behaves as a toggle", () => {
   const optionButton = (name: string) =>
     fieldsOf("fontStyle").getByRole("button", { name });
 
-  /** Every option button, so an assertion can cover the control rather than one. */
+  /**
+   * Every option button, found through the group BY ITS ACCESSIBLE NAME.
+   *
+   * Named rather than merely located, because the name is what makes the group
+   * mean anything to a screen reader: without `aria-labelledby` the buttons are
+   * three unattached options with no property attached to them, and a query
+   * asking only for a group cannot tell those two states apart.
+   */
   const allOptions = () =>
-    within(fieldsOf("fontStyle").getByRole("group")).getAllByRole(
-      "button"
-    ) as HTMLButtonElement[];
+    within(
+      fieldsOf("fontStyle").getByRole("group", { name: "Font style" })
+    ).getAllByRole("button") as HTMLButtonElement[];
 
   /**
    * The node's styles AFTER the recorded ops are applied to the document.
@@ -2891,6 +2898,34 @@ describe("a segmented keyword control behaves as a toggle", () => {
     expect(messageId).toBeTruthy();
     expect(describedBy).toBeTruthy();
     expect(describedBy).toBe(messageId);
+  });
+
+  it("does not submit the entry it is mounted inside", () => {
+    /*
+     * The builder mounts inside the entry's `<form>` — `inspector-panel.test`
+     * states it, and guards the same hazard for Enter in a text field. A button
+     * with no explicit `type` defaults to `submit` there, so clicking a style
+     * option would SAVE THE WHOLE ENTRY as well as applying the style.
+     *
+     * Rendered under a form deliberately: every other case here mounts at the
+     * document root, where a missing `type` costs nothing and the defect is
+     * invisible. The host context is part of the behaviour.
+     */
+    const submitted = vi.fn((event: React.FormEvent) => event.preventDefault());
+    register({ typography: true });
+    const editor = editorFor(documentOf());
+    render(
+      <form onSubmit={submitted}>
+        <StyleInspectorPanel editor={editor} />
+      </form>
+    );
+
+    fireEvent.click(optionButton("italic"));
+
+    expect(submitted).not.toHaveBeenCalled();
+    // The positive control: the click still did its own job, so this does not
+    // pass merely because nothing happened at all.
+    expect(editor.applyAll).toHaveBeenCalledTimes(1);
   });
 
   it("does not write anything when the field's LABEL is clicked", () => {

--- a/packages/builder/src/style-inspector-panel.test.tsx
+++ b/packages/builder/src/style-inspector-panel.test.tsx
@@ -33,6 +33,7 @@ import * as React from "react";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
 import type { EditorState } from "./editor-state";
+import { applyOps, type BuilderOp } from "./ops";
 import { InspectorPanel } from "./inspector-panel";
 import {
   breakpointLabel,
@@ -87,7 +88,18 @@ function documentOf(styles?: NodeStyles): BlockDocument {
     formatVersion: 1,
     kind: "page",
     nodes: [
-      { id: "a", type: "acme/box", version: 1, props: {}, styles },
+      {
+        id: "a",
+        type: "acme/box",
+        version: 1,
+        props: {},
+        // OMITTED rather than set to `undefined` when there are no styles. A
+        // node holding `undefined` is not a document the product can produce —
+        // it will not serialise — and the op layer refuses to edit one, so a
+        // fixture carrying the key made the unstyled case unusable for any
+        // assertion that applies an op.
+        ...(styles === undefined ? {} : { styles }),
+      },
     ] as BlockNode[],
   } as BlockDocument;
 }
@@ -2731,20 +2743,35 @@ describe("a segmented keyword control behaves as a toggle", () => {
       "button"
     ) as HTMLButtonElement[];
 
-  /** The styles one `applyAll` call would leave on the node. */
-  const committedStyles = (
+  /**
+   * The node's styles AFTER the recorded ops are applied to the document.
+   *
+   * Applied rather than read out of the patch, because reading the patch cannot
+   * tell a removal from an operation that does nothing: an update carrying no
+   * `styles` key at all answers `undefined` exactly as a clear does, so every
+   * clear assertion below would pass against a handler that submits an empty
+   * edit and leaves the value on the page. `applyOps` also REFUSES an update
+   * that changes nothing, so a no-op cannot even reach a document to be read.
+   */
+  const styleAfter = (
     editor: ReturnType<typeof editorFor>
-  ): NodeStyles | undefined => {
+  ): string | undefined => {
     const ops = editor.applyAll.mock.calls[0]?.[0] as
-      | readonly { kind: string; patch?: unknown }[]
+      | readonly BuilderOp[]
       | undefined;
-    const op = ops?.[0];
-    if (op === undefined || op.kind !== "update") return undefined;
-    return (op.patch as { styles?: NodeStyles }).styles;
+    if (ops === undefined) throw new Error("no ops were applied");
+    const applied = applyOps(editor.document, ops);
+    if (applied.document === null) {
+      throw new Error("the ops were refused, so nothing was applied");
+    }
+    const node = applied.document.nodes[0] as { styles?: NodeStyles };
+    return node.styles?.base?.[BASE_BREAKPOINT]?.fontStyle as
+      | string
+      | undefined;
   };
 
   /** The panel with one `fontStyle` value already stored, or none. */
-  const mountWith = (stored?: string) =>
+  const mountWith = (stored?: string | undefined) =>
     mount(
       { typography: true },
       stored === undefined
@@ -2794,9 +2821,7 @@ describe("a segmented keyword control behaves as a toggle", () => {
       // Exactly once: a handler committing twice would satisfy "was called" and
       // spend two history entries on one gesture.
       expect(editor.applyAll).toHaveBeenCalledTimes(1);
-      expect(committedStyles(editor)?.base?.[BASE_BREAKPOINT]?.fontStyle).toBe(
-        undefined
-      );
+      expect(styleAfter(editor)).toBeUndefined();
     }
   );
 
@@ -2804,6 +2829,15 @@ describe("a segmented keyword control behaves as a toggle", () => {
     ["italic", "normal"],
     ["italic", "oblique"],
     ["normal", "oblique"],
+    // `italic` as a DESTINATION, which the rows above never make it: they only
+    // ever click it while it is already pressed. Without this a handler reading
+    // `pressed || option === "italic" ? null : option` clears instead of
+    // storing it, and every row still passes.
+    ["normal", "italic"],
+    // And from UNSET, which is the state a newly styled node is in. A handler
+    // treating an absent value as nothing-to-do would make the first click on
+    // any option do nothing, with only this row to say so.
+    [undefined, "italic"],
   ])("writes %s -> %s when a different option is pressed", (stored, next) => {
     /*
      * The positive control for the clear case, and the option-to-value mapping
@@ -2815,9 +2849,7 @@ describe("a segmented keyword control behaves as a toggle", () => {
     fireEvent.click(optionButton(next));
 
     expect(editor.applyAll).toHaveBeenCalledTimes(1);
-    expect(committedStyles(editor)?.base?.[BASE_BREAKPOINT]?.fontStyle).toBe(
-      next
-    );
+    expect(styleAfter(editor)).toBe(next);
   });
 
   it("marks EVERY button invalid when the store refuses the edit", () => {
@@ -2832,17 +2864,33 @@ describe("a segmented keyword control behaves as a toggle", () => {
      * reading as valid parts of a control that is not.
      */
     const editor = mount({ typography: true });
-    editor.applyAll.mockReturnValue(null);
 
+    // The positive control, BEFORE the refusal. Without it an implementation
+    // that marks every button invalid unconditionally passes — and that
+    // regression announces untouched, perfectly editable controls as erroneous.
+    for (const button of allOptions()) {
+      expect(button.getAttribute("aria-invalid")).toBeNull();
+    }
+
+    editor.applyAll.mockReturnValue(null);
     fireEvent.click(optionButton("italic"));
 
     for (const button of allOptions()) {
       expect(button.getAttribute("aria-invalid")).toBe("true");
     }
-    const message = screen.getByRole("alert");
-    expect(
-      fieldsOf("fontStyle").getByRole("group").getAttribute("aria-describedby")
-    ).toBe(message.getAttribute("id"));
+    /*
+     * Both identifiers are required to EXIST before they are compared. Omitting
+     * the alert's id and the group's `aria-describedby` leaves both reads
+     * `null`, and `null === null` would report the message as associated with
+     * the control while nothing connects them.
+     */
+    const messageId = screen.getByRole("alert").getAttribute("id");
+    const describedBy = fieldsOf("fontStyle")
+      .getByRole("group")
+      .getAttribute("aria-describedby");
+    expect(messageId).toBeTruthy();
+    expect(describedBy).toBeTruthy();
+    expect(describedBy).toBe(messageId);
   });
 
   it("does not write anything when the field's LABEL is clicked", () => {


### PR DESCRIPTION
Ledger `task:pb-two-value-keyword-toggle`. Test-only, so **no changeset**.

## The control was live with none of its behaviour asserted

`task:pb-two-value-keyword-toggle` recorded that the segmented control was **unreachable**: it draws only where a keyword vocabulary fits in it whole, and no catalog property declared one that did. So `ToggleField` shipped, correctly routed, rendering for nothing.

**#1448 changed that** by admitting three options rather than exactly two. Measured by walking `STYLE_CATALOG` through `styleControlsFor` and `toggleOptionsFor`, two properties draw one today:

```
fontStyle:  normal | italic | oblique
background: scroll | fixed  | local
```

That closed the ledger node's premise and left its consequence open. **Three defects had already been found in this path by reading** — a field label whose `htmlFor` pressed the first option, a refusal announced as a hint because the group carried a description without an invalid state, and a routing branch placed after one that matched every keyword leaf. None could be caught by a test, because nothing could render the control. The node predicted "a fourth of the same kind is more likely than not".

The one test that renders it asserts a button **exists**, and says so itself: *"which keyword control it is, is not the property under test."* A toggle drawing every option unpressed satisfies it.

## What is asserted now

Each is a behaviour that has been wrong once:

- the stored value reads as the pressed option **and the others do not**
- pressing the pressed option **clears** rather than re-writing — the only route to unset that does not spend a button on "neither"
- a store refusal marks the **buttons** invalid and points them at the message (`role="group"` does not support `aria-invalid`, so the group cannot carry it)
- a click on the field's **label** writes nothing

Plus a positive control: pressing a *different* option writes it. Without it, "cleared" and "did nothing at all" are the same absent value, and a toggle with its click handler deleted passes.

## Two of these did not work when first written

Found by break-verifying each test against the real implementation rather than running the suite:

**The clear test could not fail.** Re-writing `italic` onto a node already holding `italic` produces **no ops** — the write path treats "the document already says this" as nothing to do — so `applyAll` is never reached and the styles it would have left read as absent. A clear leaves absent too. The assertion passed for the exact implementation it exists to reject, until it also required that a write reached the store.

**The label break was malformed.** Removing the group's `id` does not create the defect it guards; it removes the association entirely, so clicking the label does nothing and the test passes. Moving the `id` **onto a button** — which is what the original defect was — fails it.

## Evidence

- builder **95 files / 2668 tests**; `check-types`, `lint`, comment-convention all exit 0; `fallow` `pass` over 1 changed file.
- Every one of the five break-verified individually, each failing only the test that names it. The two above are recorded because a suite-level run was green in both directions and said nothing.
