### PR TITLE
feat(nextly): store a dashboard arrangement, guarded by version and visibility

### DIFF
--- a/.changeset/a-dashboard-stays-where-you-left-it.md
+++ b/.changeset/a-dashboard-stays-where-you-left-it.md
@@ -1,0 +1,52 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+A dashboard arrangement now survives a reload.
+
+`nextly_widget_layout` stores one row per reader: which cards, in which order,
+at which size, and which they have put away. `GET /api/dashboard/layout` returns
+that arrangement resolved against the live registry, and `PUT` replaces it,
+guarded by a version so two tabs cannot silently overwrite each other. A reader
+who has never arranged anything still sees the registry's own order, so nothing
+changes for anybody until they move a card.
+
+The stored row holds an identity and a position and nothing else. It never
+copies a widget's `requiredPermission`: every question about whether this reader
+may see a card is asked of the live registry on each read, so tightening a
+permission takes effect immediately rather than after the reader next saves.
+A card they may not see is dropped from the response silently -- and carried
+through untouched on the next write, so being unable to see it is not a way to
+lose it.
+
+Both guards travel on the wire, and a write must echo both. `version` catches a
+second tab that saved first. `scope` catches the other half: the snapshot a
+client holds was shaped by which widgets it could see, and a permission grant
+moves that without touching the row -- so a card that was hidden at read time
+and visible at write time would otherwise be in neither the submission nor the
+carried-through set, and the write would delete it with `version` still
+matching.

--- a/packages/nextly/src/api/read-json-body.ts
+++ b/packages/nextly/src/api/read-json-body.ts
@@ -38,3 +38,102 @@ export async function readJsonBody<T = unknown>(
     });
   }
 }
+
+/**
+ * Read a JSON body, refusing anything past `maxBytes` WITHOUT buffering it.
+ *
+ * `req.json()` buffers the whole body before anything can look at it, so a
+ * quota checked on the parsed result has already paid for the memory and the
+ * parse it exists to prevent — an authenticated caller can send a body far past
+ * the advertised limit and be refused only after the cost is sunk.
+ *
+ * This reads the stream in chunks and stops at the first one that crosses the
+ * cap, so the work is bounded by the cap rather than by what the caller sent.
+ *
+ * `Content-Length` is deliberately NOT trusted as the gate: a chunked request
+ * carries none, and a declared length is the sender's claim rather than a
+ * measurement. It is consulted only as a cheap early refusal for a caller
+ * honest enough to declare an oversized body; the running count is what
+ * actually enforces.
+ *
+ * Refuses with the same `invalid_json` contract shape as {@link readJsonBody},
+ * under a distinct `too_large` code so a client can tell "unreadable" from
+ * "too big".
+ */
+export async function readBoundedJsonBody<T = unknown>(
+  req: Request,
+  maxBytes: number,
+  extraLogContext?: Record<string, unknown>
+): Promise<T> {
+  const tooLarge = (): never => {
+    throw new NextlyError({
+      code: "VALIDATION_ERROR",
+      publicMessage: "Validation failed.",
+      publicData: {
+        errors: [
+          {
+            path: "",
+            code: "too_large",
+            message: `Request body must be at most ${maxBytes} bytes.`,
+          },
+        ],
+      },
+      logContext: { reason: "body-too-large", maxBytes, ...extraLogContext },
+    });
+  };
+
+  const declared = Number(req.headers.get("content-length"));
+  if (Number.isFinite(declared) && declared > maxBytes) tooLarge();
+
+  const body = req.body;
+  // No stream to bound — an empty body, or a runtime that does not expose one.
+  // Falling back keeps this correct rather than refusing a legal request; the
+  // parse below still runs, and the caller's own quotas still apply.
+  if (!body) return readJsonBody<T>(req, extraLogContext);
+
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        // Released before throwing, so an oversized upload stops arriving
+        // rather than draining in the background after the refusal.
+        await reader.cancel();
+        tooLarge();
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const merged = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    merged.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  try {
+    return JSON.parse(new TextDecoder().decode(merged)) as T;
+  } catch {
+    throw new NextlyError({
+      code: "VALIDATION_ERROR",
+      publicMessage: "Validation failed.",
+      publicData: {
+        errors: [
+          {
+            path: "",
+            code: "invalid_json",
+            message: "Request body is not valid JSON.",
+          },
+        ],
+      },
+      logContext: { reason: "invalid-json-body", ...extraLogContext },
+    });
+  }
+}

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -45,6 +45,7 @@ import {
   visibilityToken,
   type WidgetPlacement,
 } from "../domains/widgets/layout";
+import { SKIP_DATE_FORMATTING_HEADER } from "./response-shapes";
 import {
   clearWidgets,
   listWidgets,
@@ -124,13 +125,32 @@ function putReq(body: unknown): Request {
   });
 }
 
-async function bodyOf(res: Response) {
-  return (await res.json()) as {
-    placements?: WidgetPlacement[];
-    version?: number;
-    source?: string;
-    error?: { message?: string };
+interface LayoutPayload {
+  placements?: WidgetPlacement[];
+  version?: number;
+  source?: string;
+  scope?: string;
+}
+
+/** A GET answers with the object itself. */
+async function bodyOf(res: Response): Promise<LayoutPayload> {
+  return (await res.json()) as LayoutPayload;
+}
+
+/**
+ * A PUT answers with the canonical mutation envelope, so the payload is under
+ * `item`. Read through its own helper rather than by reaching into `bodyOf`'s
+ * result, so a test asserting on the payload cannot silently pass against a
+ * body that never had one.
+ */
+async function itemOf(res: Response): Promise<LayoutPayload> {
+  const body = (await res.json()) as {
+    message?: string;
+    item?: LayoutPayload;
   };
+  expect(body.message).toEqual(expect.any(String));
+  expect(body.item).toBeDefined();
+  return body.item as LayoutPayload;
 }
 
 beforeEach(() => {
@@ -251,6 +271,37 @@ describe("GET /api/dashboard/layout", () => {
   });
 });
 
+describe("opaque config survives the response pipeline", () => {
+  it.each([
+    ["GET", async () => getWidgetLayout(getReq())],
+    [
+      "PUT",
+      async () =>
+        putWidgetLayout(
+          putReq({
+            placements: [
+              { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+            ],
+            version: 0,
+            scope: visibilityToken(["core/a"]),
+          })
+        ),
+    ],
+  ])("%s opts out of date formatting", async (_verb, call) => {
+    // The route handler rewrites date-looking strings in every JSON payload by
+    // VALUE, not merely by key name -- so a plugin's opaque
+    // `config: { cutoff: "2026-09-02T04:00:00.000Z" }` comes back timezone
+    // shifted, the client submits the shifted value in its next whole-snapshot
+    // PUT, and it is persisted. The configuration this endpoint calls opaque
+    // then drifts one offset further on every save.
+    registerWidget(widget({ id: "core/a" }));
+
+    const res = await call();
+
+    expect(res.headers.get(SKIP_DATE_FORMATTING_HEADER)).toBe("1");
+  });
+});
+
 describe("PUT /api/dashboard/layout", () => {
   const onePlacement: WidgetPlacement[] = [
     { id: "p1", widgetId: "core/a", order: 0, hidden: false },
@@ -313,19 +364,21 @@ describe("PUT /api/dashboard/layout", () => {
       ]),
     };
 
-    const body = await bodyOf(
-      await putWidgetLayout(
-        putReq({
-          placements: onePlacement,
-          version: 2,
-          scope: scopeFor(["core/a"]),
-        })
-      )
+    const res = await putWidgetLayout(
+      putReq({
+        placements: onePlacement,
+        version: 2,
+        scope: scopeFor(["core/a"]),
+      })
     );
+    const raw = res.clone();
+    const item = await itemOf(res);
 
-    // Preserving it must not become a way to learn it is there.
-    expect(JSON.stringify(body)).not.toContain("gated");
-    expect(body.placements?.map(p => p.id)).toEqual(["p1"]);
+    // Preserving it must not become a way to learn it is there -- asserted over
+    // the WHOLE response body, not just the payload, so a leak in the envelope
+    // or a warning line would fail too.
+    expect(await raw.text()).not.toContain("gated");
+    expect(item.placements?.map(p => p.id)).toEqual(["p1"]);
   });
 
   it("refuses a placement naming a widget the caller cannot see", async () => {
@@ -462,9 +515,11 @@ describe("PUT /api/dashboard/layout", () => {
 
   it("refuses an API key, which has no dashboard to arrange", async () => {
     registerWidget(widget({ id: "core/a" }));
-    readCaller.mockResolvedValue({
-      user: { id: "user-1", roles: [] },
-      authenticatedScope: { actorType: "apiKey", permissions: ["read-posts"] },
+    reqAuth.mockResolvedValue({
+      userId: "user-1",
+      permissions: ["read-posts"],
+      roles: [],
+      authMethod: "api-key",
     });
 
     const res = await putWidgetLayout(
@@ -500,6 +555,115 @@ describe("PUT /api/dashboard/layout", () => {
 
     expect(res.status).toBe(400);
     expect(saved).toBeUndefined();
+  });
+
+  it("refuses an API key BEFORE it reads the body", async () => {
+    // The refusal is a precondition, so it must not depend on the body being
+    // well formed. With the check placed after the parse, this unparseable body
+    // came back as a validation error -- telling a caller which field it got
+    // wrong on a request it was never allowed to make, and paying for the parse
+    // in order to say so.
+    registerWidget(widget({ id: "core/a" }));
+    reqAuth.mockResolvedValue({
+      userId: "user-1",
+      permissions: [],
+      roles: [],
+      authMethod: "api-key",
+    });
+
+    const res = await putWidgetLayout(
+      new Request("http://localhost/api/dashboard/layout", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: "{ this is not json",
+      })
+    );
+
+    expect(res.status).toBe(403);
+  });
+
+  it("carries invisible defaults into the FIRST save", async () => {
+    // With no stored row the caller was still shown a FILTERED default set, so
+    // writing back only what they saw freezes a snapshot that never contained
+    // the gated defaults -- and `defaultPlacements` runs only while the row is
+    // absent, so a permission granted afterwards could never reveal them. The
+    // visibility token catches a grant between the read and the write; nothing
+    // catches one that lands after a successful save except this.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+
+    await putWidgetLayout(
+      putReq({
+        placements: onePlacement,
+        version: 0,
+        scope: scopeFor(["core/a"]),
+      })
+    );
+
+    expect(saved?.placements.map(p => p.widgetId)).toEqual([
+      "core/a",
+      "core/gated",
+    ]);
+  });
+
+  /*
+   * There is deliberately no test here for a widget whose `requiredPermission`
+   * is a truthy non-string.
+   *
+   * Two locks stand between that value and this endpoint, and BOTH are outside
+   * it: `widgetValueProblem` refuses the declaration (covered in
+   * `domains/widgets/__tests__/definition.test.ts`), and `registerWidget`
+   * stores a FROZEN snapshot, so the entry cannot be mutated into that state
+   * afterwards either -- measured, not assumed: assigning to what `listWidgets`
+   * returns throws `object is not extensible`.
+   *
+   * So `isVisibleTo`'s non-string branch is unreachable from any caller outside
+   * the widgets domain, and a test claiming to exercise it would be producing
+   * the state by some route the product does not have. The branch stays,
+   * because unreachability is a property of the current call graph rather than
+   * of the code, and a `typeof` on a value already in hand costs nothing when
+   * its rejection never runs.
+   */
+
+  it("does not report a size that depends on hidden placements", async () => {
+    // A refusal whose number varies with carried data lets a caller grow one
+    // visible placement until it appears and read the difference as the size of
+    // configuration they are not allowed to see.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+    stored = {
+      version: 1,
+      layout: serializeLayout([
+        {
+          id: "p9",
+          widgetId: "core/gated",
+          order: 0,
+          hidden: false,
+          config: { blob: "y".repeat(60_000) },
+        },
+      ]),
+    };
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: onePlacement,
+        version: 1,
+        scope: scopeFor(["core/a"]),
+      })
+    );
+    const text = await res.text();
+
+    expect(res.status).toBe(400);
+    // No quantity at all, so nothing in the message moves with the hidden
+    // placement's size.
+    expect(text).not.toMatch(/\d{3,}/);
+    expect(text).not.toContain("gated");
   });
 
   it("reports a version conflict as a conflict", async () => {

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -628,15 +628,27 @@ describe("PUT /api/dashboard/layout", () => {
    * its rejection never runs.
    */
 
-  it("does not report a size that depends on hidden placements", async () => {
-    // A refusal whose number varies with carried data lets a caller grow one
-    // visible placement until it appears and read the difference as the size of
-    // configuration they are not allowed to see.
+  it("accepts the same submission whether or not hidden data is carried", async () => {
+    // 🔴 The oracle is the pass/fail EDGE, not the number in the message.
+    // Omitting the byte count from a merged-size refusal leaves acceptance
+    // itself varying with data the caller cannot see, so a caller could
+    // binary-search a visible placement's size against it and read the boundary
+    // as the size of configuration they are not allowed to see. There is no
+    // merged check at all now: the stored column cannot be reached, so the
+    // answer to an identical submission is identical either way.
     registerWidget(widget({ id: "core/a" }));
     registerWidget(
       widget({ id: "core/gated", requiredPermission: "read-secrets" })
     );
     callerHoldsPermission.mockResolvedValue(false);
+
+    const submission = {
+      placements: onePlacement,
+      version: 1,
+      scope: scopeFor(["core/a"]),
+    };
+
+    // With a large hidden placement carried.
     stored = {
       version: 1,
       layout: serializeLayout([
@@ -649,21 +661,114 @@ describe("PUT /api/dashboard/layout", () => {
         },
       ]),
     };
+    const withHidden = await putWidgetLayout(putReq(submission));
 
-    const res = await putWidgetLayout(
-      putReq({
-        placements: onePlacement,
-        version: 1,
-        scope: scopeFor(["core/a"]),
+    // And with none.
+    saved = undefined;
+    stored = {
+      version: 1,
+      layout: serializeLayout([
+        { id: "p9", widgetId: "core/gated", order: 0, hidden: false },
+      ]),
+    };
+    const withoutHidden = await putWidgetLayout(putReq(submission));
+
+    expect(withHidden.status).toBe(withoutHidden.status);
+    expect(withHidden.status).toBe(200);
+  });
+
+  it("keeps a carried default in its DECLARED position", async () => {
+    // 🔴 Positions come from a placement's index in the sorted set, so
+    // materializing over the FILTERED set and materializing over the full
+    // registry produce colliding numbers: visible A and B surrounding a gated G
+    // give A=0, B=10 from the filtered view and G=10 from the full one. The
+    // stored row then holds two placements at 10, and the moment the permission
+    // is granted the tie sorts A, B, G instead of the declared A, G, B — the
+    // reader's arrangement reordering itself because they gained access.
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+    registerWidget(
+      widget({
+        id: "core/gated",
+        defaultOrder: 10,
+        requiredPermission: "read-secrets",
       })
     );
-    const text = await res.text();
+    registerWidget(widget({ id: "core/b", defaultOrder: 20 }));
+    callerHoldsPermission.mockResolvedValue(false);
+
+    const shown = await bodyOf(await getWidgetLayout(getReq()));
+    expect(shown.placements?.map(p => p.widgetId)).toEqual([
+      "core/a",
+      "core/b",
+    ]);
+
+    await putWidgetLayout(
+      putReq({
+        placements: shown.placements,
+        version: 0,
+        scope: scopeFor(["core/a", "core/b"]),
+      })
+    );
+
+    // Sorted the way a later read will sort it, with the gate lifted.
+    const order = [...(saved?.placements ?? [])]
+      .sort((x, y) => x.order - y.order)
+      .map(p => p.widgetId);
+    expect(order).toEqual(["core/a", "core/gated", "core/b"]);
+  });
+
+  it("refuses an oversized body without buffering it", async () => {
+    // `req.json()` reads the whole body before anything can look at it, so a
+    // quota checked on the parsed result has already paid for the memory and
+    // the parse it exists to prevent.
+    registerWidget(widget({ id: "core/a" }));
+    const huge = JSON.stringify({
+      placements: [
+        {
+          id: "p1",
+          widgetId: "core/a",
+          order: 0,
+          hidden: false,
+          config: { blob: "z".repeat(200_000) },
+        },
+      ],
+      version: 0,
+      scope: "x",
+    });
+
+    const res = await putWidgetLayout(
+      new Request("http://localhost/api/dashboard/layout", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: huge,
+      })
+    );
 
     expect(res.status).toBe(400);
-    // No quantity at all, so nothing in the message moves with the hidden
-    // placement's size.
-    expect(text).not.toMatch(/\d{3,}/);
-    expect(text).not.toContain("gated");
+    expect(await res.text()).toContain("too_large");
+    // Refused before any of the work it protects.
+    expect(saved).toBeUndefined();
+    expect(callerHoldsPermission).not.toHaveBeenCalled();
+  });
+
+  it("checks the caller's quota before resolving anything", async () => {
+    // The quota is a precondition and it is cheap, so nothing it protects
+    // should be paid for first. Under the body cap, over the placement count.
+    registerWidget(widget({ id: "core/a" }));
+    const many = Array.from({ length: 400 }, (_, i) => ({
+      id: `p${i}`,
+      widgetId: "core/a",
+      order: i,
+      hidden: false,
+    }));
+
+    const res = await putWidgetLayout(
+      putReq({ placements: many, version: 0, scope: "x" })
+    );
+
+    expect(res.status).toBe(400);
+    expect(callerHoldsPermission).not.toHaveBeenCalled();
+    expect(saved).toBeUndefined();
   });
 
   it("reports a version conflict as a conflict", async () => {

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -127,6 +127,7 @@ function putReq(body: unknown): Request {
 
 interface LayoutPayload {
   placements?: WidgetPlacement[];
+  available?: string[];
   version?: number;
   source?: string;
   scope?: string;
@@ -268,6 +269,79 @@ describe("GET /api/dashboard/layout", () => {
     // that is still there -- turning a recoverable bad row into a dashboard
     // that can never be saved.
     expect(body.version).toBe(7);
+  });
+});
+
+describe("a widget registered after the reader last saved", () => {
+  it("is not inserted into their arrangement", async () => {
+    // The product decision: a newly installed plugin's card is never pushed
+    // into somebody's saved layout behind their back.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(widget({ id: "core/new" }));
+    stored = {
+      version: 3,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+      ]),
+    };
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements?.map(p => p.widgetId)).toEqual(["core/a"]);
+  });
+
+  it("is still named, so it can be added", async () => {
+    // 🔴 "Not auto-added" only works if it is ADDABLE. Without this the widget
+    // was discoverable from nothing: absent from every read, absent from the
+    // snapshot the next write persisted, and the reader with no way to learn it
+    // existed at all.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(widget({ id: "core/new" }));
+    stored = {
+      version: 3,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+      ]),
+    };
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.available).toEqual(["core/new"]);
+  });
+
+  it("names nothing this caller may not see", async () => {
+    // The unplaced set is drawn from the widgets already filtered by
+    // permission, so it cannot become the disclosure the placements avoid.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+    stored = {
+      version: 1,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+      ]),
+    };
+
+    const res = await getWidgetLayout(getReq());
+    const raw = await res.clone().text();
+    const body = await bodyOf(res);
+
+    expect(body.available).toEqual([]);
+    expect(raw).not.toContain("gated");
+  });
+
+  it("names nothing when the reader has no stored row", async () => {
+    // Every visible widget is placed by the default arrangement, so there is
+    // nothing left to offer.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(widget({ id: "core/b" }));
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.available).toEqual([]);
+    expect(body.placements).toHaveLength(2);
   });
 });
 

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -1,0 +1,516 @@
+/**
+ * The layout endpoint's two jobs: never disclose a card this reader may not
+ * know about, and never lose one because it was not disclosed.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../auth/middleware", () => ({
+  requireAuthentication: vi.fn(),
+  isErrorResponse: (x: unknown) =>
+    !!x && typeof x === "object" && "statusCode" in x,
+}));
+vi.mock("../auth/middleware/to-nextly-error", () => ({
+  toNextlyAuthError: vi.fn((e: unknown) => new Error(String(e))),
+}));
+vi.mock("../init", () => ({
+  getCachedNextly: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { readCaller } = vi.hoisted(() => ({ readCaller: vi.fn() }));
+vi.mock("./authenticated-read", async importOriginal => {
+  const actual = await importOriginal<typeof import("./authenticated-read")>();
+  return { ...actual, readCaller };
+});
+
+const { containerGet } = vi.hoisted(() => ({ containerGet: vi.fn() }));
+vi.mock("../di", () => ({ container: { get: containerGet } }));
+
+// `callerHoldsPermission` is the seam a caller is put on either side of.
+// `authorizationGroups` stays REAL: it is a pure function of a slug list and
+// the concurrency bound, so a stand-in would make the batching assert against
+// the test's own arithmetic rather than the bound the product enforces.
+const { callerHoldsPermission } = vi.hoisted(() => ({
+  callerHoldsPermission: vi.fn(),
+}));
+vi.mock("../auth/entity-read-access", async importOriginal => {
+  const actual =
+    await importOriginal<typeof import("../auth/entity-read-access")>();
+  return { ...actual, callerHoldsPermission };
+});
+
+import { requireAuthentication } from "../auth/middleware";
+import type { WidgetDefinition } from "../domains/widgets/definition";
+import {
+  serializeLayout,
+  visibilityToken,
+  type WidgetPlacement,
+} from "../domains/widgets/layout";
+import {
+  clearWidgets,
+  listWidgets,
+  registerWidget,
+} from "../domains/widgets/registry";
+
+import { getWidgetLayout, putWidgetLayout } from "./widget-layout";
+
+const reqAuth = vi.mocked(requireAuthentication);
+
+/** A stand-in for the row, so a test can state what is stored and read it back. */
+let stored: { layout: string; version: number } | undefined;
+let saved: { placements: WidgetPlacement[]; expected: number } | undefined;
+let saveThrows: Error | undefined;
+const logged: object[] = [];
+
+const fakeService = {
+  getLayout: async () => {
+    if (!stored) return { layout: undefined, version: 0, unreadable: false };
+    // The real service decodes here and reports an unreadable row rather than
+    // throwing onward; reproduced so this test sees the same three outcomes.
+    const { readStoredLayout } = await import("../domains/widgets/layout");
+    try {
+      return {
+        layout: readStoredLayout(stored.layout),
+        version: stored.version,
+        unreadable: false,
+      };
+    } catch {
+      logged.push({ unreadable: true });
+      return { layout: undefined, version: stored.version, unreadable: true };
+    }
+  },
+  saveLayout: async (
+    _kind: string,
+    _scope: string,
+    placements: WidgetPlacement[],
+    expected: number
+  ) => {
+    if (saveThrows) throw saveThrows;
+    saved = { placements, expected };
+    return expected + 1;
+  },
+};
+
+function widget(patch: Partial<WidgetDefinition>): WidgetDefinition {
+  return {
+    id: "core/one",
+    title: "One",
+    archetype: "custom",
+    defaultSize: "full",
+    component: "core#One",
+    ...patch,
+  } as WidgetDefinition;
+}
+
+function getReq(): Request {
+  return new Request("http://localhost/api/dashboard/layout");
+}
+
+/**
+ * The token the endpoint will compute for a given visible set.
+ *
+ * Derived from the registry the test just populated rather than hard-coded, so
+ * a test that changes its fixtures cannot leave a stale literal behind that
+ * happens to still pass.
+ */
+function scopeFor(visibleIds?: string[]): string {
+  return visibilityToken(visibleIds ?? listWidgets().map(w => w.id));
+}
+
+function putReq(body: unknown): Request {
+  return new Request("http://localhost/api/dashboard/layout", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function bodyOf(res: Response) {
+  return (await res.json()) as {
+    placements?: WidgetPlacement[];
+    version?: number;
+    source?: string;
+    error?: { message?: string };
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  stored = undefined;
+  saved = undefined;
+  saveThrows = undefined;
+  logged.length = 0;
+  clearWidgets();
+  reqAuth.mockResolvedValue({
+    userId: "user-1",
+    permissions: [],
+    roles: [],
+    authMethod: "session",
+  });
+  readCaller.mockResolvedValue({ user: { id: "user-1", roles: ["editor"] } });
+  callerHoldsPermission.mockResolvedValue(true);
+  containerGet.mockImplementation((name: string) => {
+    if (name === "widgetLayoutService") return fakeService;
+    throw new Error(`unexpected container.get("${name}") in this test`);
+  });
+});
+
+describe("GET /api/dashboard/layout", () => {
+  it("answers from the registry when nothing is stored", async () => {
+    registerWidget(widget({ id: "core/b", defaultOrder: 10 }));
+    registerWidget(widget({ id: "core/a", defaultOrder: 0 }));
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.source).toBe("default");
+    expect(body.version).toBe(0);
+    expect(body.placements?.map(p => p.widgetId)).toEqual(["core/a", "core/b"]);
+  });
+
+  it("omits a widget whose permission this caller lacks", async () => {
+    registerWidget(widget({ id: "core/open" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements?.map(p => p.widgetId)).toEqual(["core/open"]);
+    // Asked about the gated widget's slug, and NOT about the ungated one --
+    // omitting `requiredPermission` means "any authenticated reader", so a
+    // check there would be a decision nobody declared.
+    expect(callerHoldsPermission).toHaveBeenCalledTimes(1);
+    expect(callerHoldsPermission).toHaveBeenCalledWith(
+      "read-secrets",
+      expect.anything()
+    );
+  });
+
+  it("denies when the permission decision itself rejects", async () => {
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockRejectedValue(new Error("rbac down"));
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    // Fail closed: a check that threw has told us nothing, and "nothing" must
+    // not read as "allowed".
+    expect(body.placements).toEqual([]);
+  });
+
+  it("returns a stored arrangement in its own order", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(widget({ id: "core/b" }));
+    stored = {
+      version: 4,
+      layout: serializeLayout([
+        { id: "p2", widgetId: "core/b", order: 0, hidden: false },
+        { id: "p1", widgetId: "core/a", order: 10, hidden: true },
+      ]),
+    };
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.source).toBe("own");
+    expect(body.version).toBe(4);
+    // Sorted by the reader's own order, not the registry's -- and the hidden
+    // one still comes back, or nothing could ever put it back.
+    expect(body.placements?.map(p => p.id)).toEqual(["p2", "p1"]);
+  });
+
+  it("drops a stored placement whose widget is gone, without saying so", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    stored = {
+      version: 1,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+        { id: "p2", widgetId: "plugin/uninstalled", order: 10, hidden: false },
+      ]),
+    };
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements?.map(p => p.id)).toEqual(["p1"]);
+    expect(JSON.stringify(body)).not.toContain("uninstalled");
+  });
+
+  it("falls back to the registry on an unreadable row, keeping its version", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    stored = { version: 7, layout: "{not json" };
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.source).toBe("default");
+    expect(body.placements?.map(p => p.widgetId)).toEqual(["core/a"]);
+    // The TRUE version, not 0. Reporting 0 would tell the client there is no
+    // row, sending its next PUT down the insert path to collide with the row
+    // that is still there -- turning a recoverable bad row into a dashboard
+    // that can never be saved.
+    expect(body.version).toBe(7);
+  });
+});
+
+describe("PUT /api/dashboard/layout", () => {
+  const onePlacement: WidgetPlacement[] = [
+    { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+  ];
+
+  it("stores what the caller submitted", async () => {
+    registerWidget(widget({ id: "core/a" }));
+
+    const res = await putWidgetLayout(
+      putReq({ placements: onePlacement, version: 0, scope: scopeFor() })
+    );
+
+    expect(res.status).toBe(200);
+    expect(saved?.expected).toBe(0);
+    expect(saved?.placements.map(p => p.id)).toEqual(["p1"]);
+  });
+
+  it("carries through a placement the caller was never shown", async () => {
+    // 🔴 THE rule. The client is handed a FILTERED list and sends the whole
+    // thing back. Writing it verbatim would delete every placement the filter
+    // hid, so a reader who opened the dashboard once while a permission of
+    // theirs was narrowed would lose those cards permanently.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+    stored = {
+      version: 2,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+        { id: "p9", widgetId: "core/gated", order: 10, hidden: false },
+      ]),
+    };
+
+    await putWidgetLayout(
+      putReq({
+        placements: onePlacement,
+        version: 2,
+        scope: scopeFor(["core/a"]),
+      })
+    );
+
+    expect(saved?.placements.map(p => p.widgetId)).toEqual([
+      "core/a",
+      "core/gated",
+    ]);
+  });
+
+  it("does not echo the carried placement back to the caller", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+    stored = {
+      version: 2,
+      layout: serializeLayout([
+        { id: "p9", widgetId: "core/gated", order: 10, hidden: false },
+      ]),
+    };
+
+    const body = await bodyOf(
+      await putWidgetLayout(
+        putReq({
+          placements: onePlacement,
+          version: 2,
+          scope: scopeFor(["core/a"]),
+        })
+      )
+    );
+
+    // Preserving it must not become a way to learn it is there.
+    expect(JSON.stringify(body)).not.toContain("gated");
+    expect(body.placements?.map(p => p.id)).toEqual(["p1"]);
+  });
+
+  it("refuses a placement naming a widget the caller cannot see", async () => {
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "p1", widgetId: "core/gated", order: 0, hidden: false },
+        ],
+        version: 0,
+        // The visible set is EMPTY here, and that is the scope the client
+        // would have been handed -- so this reaches the foreign-widget rule
+        // rather than being turned away by the scope guard first.
+        scope: scopeFor([]),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(saved).toBeUndefined();
+  });
+
+  it("refuses two placements sharing an id", async () => {
+    registerWidget(widget({ id: "core/a" }));
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "dup", widgetId: "core/a", order: 0, hidden: false },
+          { id: "dup", widgetId: "core/a", order: 1, hidden: false },
+        ],
+        version: 0,
+        scope: scopeFor(),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(saved).toBeUndefined();
+  });
+
+  it.each([
+    ["a missing version", { placements: [], scope: "x" }],
+    ["a string version", { placements: [], version: "3", scope: "x" }],
+    ["a fractional version", { placements: [], version: 1.5, scope: "x" }],
+    ["a negative version", { placements: [], version: -1, scope: "x" }],
+  ])("refuses %s rather than coercing it", async (_label, body) => {
+    // `Number("")` is 0, which is the "there is no row yet" version -- so a
+    // coerced empty field would assert the row does not exist and overwrite a
+    // real arrangement through the insert path.
+    const res = await putWidgetLayout(putReq(body));
+    expect(res.status).toBe(400);
+    expect(saved).toBeUndefined();
+  });
+
+  it("refuses a body that is not an object", async () => {
+    const res = await putWidgetLayout(putReq([]));
+    expect(res.status).toBe(400);
+    expect(saved).toBeUndefined();
+  });
+
+  it("refuses a write whose visible set moved since the read", async () => {
+    // 🔴 The regression this token exists for, in the exact shape that lost
+    // data. The client read while `core/gated` was invisible, so its snapshot
+    // holds only `core/a`. A grant lands. Without the guard, `core/gated` is
+    // visible at write time -- so it is in neither the submission nor the
+    // carried-through set, and the write DELETES it, with `version` matching
+    // because a permission grant does not touch the row.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    stored = {
+      version: 2,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+        { id: "p9", widgetId: "core/gated", order: 10, hidden: false },
+      ]),
+    };
+    // The grant has landed by the time the PUT arrives.
+    callerHoldsPermission.mockResolvedValue(true);
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: onePlacement,
+        version: 2,
+        // The token the client was handed while the widget was still hidden.
+        scope: scopeFor(["core/a"]),
+      })
+    );
+
+    expect(res.status).toBe(409);
+    // Nothing was written, so the placement is still there to be re-read.
+    expect(saved).toBeUndefined();
+  });
+
+  it("refuses a write whose visible set SHRANK since the read", async () => {
+    // The mirror case, and it must be a CONFLICT rather than a validation
+    // error: the client is holding a stale view, not a malformed body.
+    registerWidget(widget({ id: "core/a" }));
+    registerWidget(
+      widget({ id: "core/gated", requiredPermission: "read-secrets" })
+    );
+    callerHoldsPermission.mockResolvedValue(false);
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "p1", widgetId: "core/gated", order: 0, hidden: false },
+        ],
+        version: 0,
+        scope: scopeFor(["core/a", "core/gated"]),
+      })
+    );
+
+    expect(res.status).toBe(409);
+    expect(saved).toBeUndefined();
+  });
+
+  it("requires the scope token rather than treating it as optional", async () => {
+    // Optional would mean absent for every client that has not been updated --
+    // which is every client that still has the bug.
+    registerWidget(widget({ id: "core/a" }));
+
+    const res = await putWidgetLayout(
+      putReq({ placements: onePlacement, version: 0 })
+    );
+
+    expect(res.status).toBe(400);
+    expect(saved).toBeUndefined();
+  });
+
+  it("refuses an API key, which has no dashboard to arrange", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    readCaller.mockResolvedValue({
+      user: { id: "user-1", roles: [] },
+      authenticatedScope: { actorType: "apiKey", permissions: ["read-posts"] },
+    });
+
+    const res = await putWidgetLayout(
+      putReq({ placements: onePlacement, version: 0, scope: scopeFor() })
+    );
+
+    expect(res.status).toBe(403);
+    expect(saved).toBeUndefined();
+  });
+
+  it("refuses a payload larger than the narrowest dialect's column", async () => {
+    // MySQL's TEXT is 65535 BYTES and the other two are effectively unbounded,
+    // so without a cap the same PUT stores on two dialects and truncates on the
+    // third -- leaving JSON the next read cannot parse, which loses the whole
+    // saved dashboard on one deployment only.
+    registerWidget(widget({ id: "core/a" }));
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          {
+            id: "p1",
+            widgetId: "core/a",
+            order: 0,
+            hidden: false,
+            config: { blob: "x".repeat(40_000) },
+          },
+        ],
+        version: 0,
+        scope: scopeFor(),
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(saved).toBeUndefined();
+  });
+
+  it("reports a version conflict as a conflict", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    const { NextlyError } = await import("../errors/nextly-error");
+    saveThrows = NextlyError.conflict({ reason: "version" });
+
+    const res = await putWidgetLayout(
+      putReq({ placements: onePlacement, version: 1, scope: scopeFor() })
+    );
+
+    expect(res.status).toBe(409);
+  });
+});

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -1,0 +1,370 @@
+/**
+ * GET / PUT `/api/dashboard/layout`
+ *
+ * One reader's arrangement of the dashboard: which cards, in which order, at
+ * which size, and which they have put away.
+ *
+ * ## The response is resolved, not stored
+ *
+ * A GET never returns the row. It returns the row RESOLVED against the live
+ * registry: placements whose widget no longer exists are gone, and so are
+ * placements whose widget declares a `requiredPermission` this caller does not
+ * hold. Both are dropped silently -- not drawn as an empty slot, not drawn as a
+ * "you may not see this" card. Either of those would disclose that the widget
+ * is there, which is the whole thing a permission on a card is for.
+ *
+ * That resolution happens on EVERY read rather than at save time, which is why
+ * a placement stores no copy of `requiredPermission`. Tightening a permission
+ * takes effect on the next request; a copy would have frozen the old answer
+ * into the reader's row.
+ *
+ * ## Why a PUT does not simply overwrite
+ *
+ * 🔴 The wire contract is a whole snapshot, and the snapshot a client holds has
+ * already been filtered. Writing it back verbatim would DELETE every placement
+ * the filter hid -- so a reader who opened the dashboard once while a
+ * permission of theirs was narrowed, or while a plugin was briefly disabled,
+ * would silently and permanently lose those cards. So the writer merges: the
+ * submitted placements replace what this caller could see, and everything they
+ * could not see is carried through untouched.
+ *
+ * @module api/widget-layout
+ */
+
+import {
+  authorizationGroups,
+  callerHoldsPermission,
+  type ReadAccessCaller,
+} from "../auth/entity-read-access";
+import { isErrorResponse, requireAuthentication } from "../auth/middleware";
+import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
+import { container } from "../di";
+import type { WidgetDefinition } from "../domains/widgets/definition";
+import {
+  defaultPlacements,
+  layoutSizeProblem,
+  mergePreservingHidden,
+  partitionPlacements,
+  readPlacements,
+  visibilityToken,
+  type WidgetPlacement,
+} from "../domains/widgets/layout";
+import { listWidgets } from "../domains/widgets/registry";
+import { NextlyError } from "../errors/nextly-error";
+import { getCachedNextly } from "../init";
+import {
+  NO_STORED_LAYOUT_VERSION,
+  type WidgetLayoutService,
+} from "../services/widgets/widget-layout-service";
+
+import {
+  PRIVATE_NO_STORE_HEADERS,
+  readAccessCaller,
+  readCaller,
+} from "./authenticated-read";
+import { readJsonBody } from "./read-json-body";
+import { respondData } from "./response-shapes";
+import { withErrorHandler } from "./with-error-handler";
+
+/** Which layer the returned arrangement came from. */
+type LayoutSource = "own" | "default";
+
+/**
+ * The scope a layout belongs to today.
+ *
+ * Every row this endpoint writes is the caller's own. The role layer is
+ * designed into the table's key and deliberately not built (founder,
+ * 2026-09-01), so there is exactly one scope kind to resolve and no resolution
+ * ORDER to get wrong yet.
+ */
+const SCOPE_KIND = "user" as const;
+
+async function getLayoutService(): Promise<WidgetLayoutService> {
+  await getCachedNextly();
+  return container.get<WidgetLayoutService>("widgetLayoutService");
+}
+
+/**
+ * The widgets this caller is permitted to know exist.
+ *
+ * A widget with no `requiredPermission` is visible to any authenticated
+ * reader -- that is what omitting it means, and it is what core's own four
+ * cards rely on. A widget that declares one is asked about, and the decision is
+ * taken through the same bounded rounds `authorizationGroups` prescribes for
+ * the query batch: a permission check resolves a session caller through a
+ * per-user TTL cache, so firing thirty of them at once makes every one a miss.
+ *
+ * Verdicts are memoized per SLUG, not per widget: several widgets commonly
+ * name the same permission, and asking twice is two database reads for one
+ * answer.
+ */
+async function visibleWidgets(
+  caller: ReadAccessCaller
+): Promise<WidgetDefinition[]> {
+  const all = listWidgets();
+
+  const slugs = [
+    ...new Set(
+      all
+        .map(widget => widget.requiredPermission)
+        .filter(
+          (slug): slug is string => typeof slug === "string" && slug !== ""
+        )
+    ),
+  ];
+
+  const verdicts = new Map<string, boolean>();
+  for (const group of authorizationGroups(slugs)) {
+    const settled = await Promise.allSettled(
+      group.map(slug => callerHoldsPermission(slug, caller))
+    );
+    group.forEach((slug, index) => {
+      const outcome = settled[index];
+      // A rejected decision denies. A permission check that threw has told us
+      // nothing, and "nothing" must not read as "allowed" -- the same
+      // fail-closed direction `canReadEntity` takes when RBAC is unreachable.
+      verdicts.set(slug, outcome.status === "fulfilled" && outcome.value);
+    });
+  }
+
+  return all.filter(widget => {
+    const slug = widget.requiredPermission;
+    if (typeof slug !== "string" || slug === "") return true;
+    return verdicts.get(slug) === true;
+  });
+}
+
+/**
+ * The version the client must echo back.
+ *
+ * An unreadable row keeps its real version rather than reporting 0. Reporting 0
+ * would tell the client "there is no row", and its next PUT would take the
+ * INSERT path and collide with the row that is still sitting there -- turning a
+ * recoverable bad row into a dashboard that cannot be saved at all. Echoing the
+ * true version lets the next PUT overwrite the unreadable row, which is exactly
+ * the repair the reader is trying to perform.
+ */
+export const getWidgetLayout = withErrorHandler(async (req: Request) => {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+  const service = await getLayoutService();
+  const caller = readAccessCaller(await readCaller(auth));
+
+  const [stored, widgets] = await Promise.all([
+    service.getLayout(SCOPE_KIND, caller.userId),
+    visibleWidgets(caller),
+  ]);
+
+  const source: LayoutSource = stored.layout ? "own" : "default";
+  const placements = stored.layout
+    ? partitionPlacements(
+        stored.layout.placements,
+        new Set(widgets.map(widget => widget.id))
+      ).visible
+    : defaultPlacements(widgets);
+
+  return respondData(
+    {
+      placements,
+      version: stored.version,
+      source,
+      scope: visibilityToken(widgets.map(w => w.id)),
+    },
+    { headers: PRIVATE_NO_STORE_HEADERS }
+  );
+});
+
+/**
+ * Reads the `version` a PUT is guarded by.
+ *
+ * A non-integer is refused rather than coerced. `Number("")` is 0, which is the
+ * "there is no row yet" version -- so a client that omitted the field, or sent
+ * an empty string, would be read as asserting the row does not exist and would
+ * overwrite a real arrangement through the insert path.
+ */
+function readVersion(body: Record<string, unknown>): number {
+  const { version } = body;
+  if (!Number.isInteger(version) || (version as number) < 0) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "version",
+          code: "INVALID_VALUE",
+          message: `"version" must be a non-negative integer; send ${NO_STORED_LAYOUT_VERSION} if you have never read one.`,
+        },
+      ],
+    });
+  }
+  return version as number;
+}
+
+/**
+ * Reads the visibility token a PUT must echo.
+ *
+ * Required, not optional. An optional token would be absent for every client
+ * that has not been updated -- which is every client that has the bug this
+ * token exists to prevent.
+ */
+function readScope(body: Record<string, unknown>): string {
+  const { scope } = body;
+  if (typeof scope !== "string" || scope === "") {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "scope",
+          code: "INVALID_VALUE",
+          message:
+            '"scope" must be the string returned by GET /api/dashboard/layout.',
+        },
+      ],
+    });
+  }
+  return scope;
+}
+
+export const putWidgetLayout = withErrorHandler(async (req: Request) => {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+  const body = await readJsonBody(req);
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "",
+          code: "INVALID_VALUE",
+          message: "Body must be { placements: Placement[], version: number }.",
+        },
+      ],
+    });
+  }
+  const submitted = readPlacements(
+    (body as Record<string, unknown>).placements
+  );
+  const expectedVersion = readVersion(body as Record<string, unknown>);
+  const submittedScope = readScope(body as Record<string, unknown>);
+
+  const service = await getLayoutService();
+  const resolved = await readCaller(auth);
+  const caller = readAccessCaller(resolved);
+
+  // A dashboard arrangement is one person's personalization of their own admin
+  // screen, and an API key has no screen. Refused rather than gated behind a
+  // permission slug, because there is no grant that would make it meaningful:
+  // the key would be rewriting the layout of whoever minted it. Reading stays
+  // open -- a read tells a key nothing it could not already ask the registry.
+  if (caller.authMethod === "api-key") {
+    // `forbidden` carries a fixed public message by design, so the reason
+    // travels in the log rather than to the caller.
+    throw NextlyError.forbidden({
+      logContext: { reason: "an api key may not write a dashboard layout" },
+    });
+  }
+
+  const widgets = await visibleWidgets(caller);
+  const visibleIds = new Set(widgets.map(widget => widget.id));
+
+  // 🔴 BEFORE the per-placement checks below, and before the write. The row's
+  // `version` guards the row; this guards the FILTER that shaped what the
+  // client was shown. Without it, a placement that was invisible when the
+  // client read and is visible now sits in neither the submission nor the
+  // carried-through set, and the write deletes it -- with `version` matching,
+  // because a permission grant does not touch the row.
+  //
+  // It also turns the opposite case into the right refusal: a placement that
+  // has just become INVISIBLE would otherwise be rejected below as naming an
+  // unavailable widget, telling the client its body is malformed when what it
+  // actually holds is a stale view.
+  const scope = visibilityToken(widgets.map(widget => widget.id));
+  if (submittedScope !== scope) {
+    throw NextlyError.conflict({
+      reason: "state",
+      message:
+        "The widgets available to you changed since you loaded the dashboard. Reload and try again.",
+    });
+  }
+
+  // Refused rather than silently dropped. A placement naming a widget this
+  // caller cannot see is not a stale client -- the client was handed a filtered
+  // list and is sending back something that was never in it. Accepting it would
+  // let any authenticated caller confirm a widget's existence by watching which
+  // ids survive a round trip, which is the same oracle the query endpoint
+  // collapses its two dead ends to avoid.
+  const foreign = submitted.find(
+    placement => !visibleIds.has(placement.widgetId)
+  );
+  if (foreign) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "placements",
+          code: "INVALID_VALUE",
+          message: `No widget is available under "${foreign.widgetId}".`,
+        },
+      ],
+    });
+  }
+
+  const duplicate = firstDuplicateId(submitted);
+  if (duplicate !== undefined) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "placements",
+          code: "INVALID_VALUE",
+          message: `Placement id "${duplicate}" appears more than once.`,
+        },
+      ],
+    });
+  }
+
+  const stored = await service.getLayout(SCOPE_KIND, caller.userId);
+  // An unreadable row contributes nothing to carry through: its contents could
+  // not be decoded, so there is no invisible placement to preserve. The write
+  // replaces it wholesale, which is the repair.
+  const carried = stored.layout
+    ? partitionPlacements(stored.layout.placements, visibleIds).invisible
+    : [];
+
+  const toStore = mergePreservingHidden(submitted, carried);
+  const tooLarge = layoutSizeProblem(toStore);
+  if (tooLarge !== undefined) {
+    throw NextlyError.validation({
+      errors: [{ path: "placements", code: "TOO_LARGE", message: tooLarge }],
+    });
+  }
+
+  const version = await service.saveLayout(
+    SCOPE_KIND,
+    caller.userId,
+    toStore,
+    expectedVersion
+  );
+
+  return respondData(
+    {
+      placements: submitted,
+      version,
+      source: "own" satisfies LayoutSource,
+      // Echoed so a client can make a second edit without a round trip. It is
+      // the token this write was checked against, which is still current: any
+      // change to it since would have to have happened during the write, and
+      // the next PUT will catch that on its own terms.
+      scope,
+    },
+    { headers: PRIVATE_NO_STORE_HEADERS }
+  );
+});
+
+/** The first placement id used twice, or `undefined`. */
+function firstDuplicateId(
+  placements: readonly WidgetPlacement[]
+): string | undefined {
+  const seen = new Set<string>();
+  for (const placement of placements) {
+    if (seen.has(placement.id)) return placement.id;
+    seen.add(placement.id);
+  }
+  return undefined;
+}

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -44,6 +44,7 @@ import {
   defaultPlacements,
   layoutSizeProblem,
   mergePreservingHidden,
+  mergedLayoutExceedsColumn,
   partitionPlacements,
   readPlacements,
   visibilityToken,
@@ -63,19 +64,76 @@ import {
   readCaller,
 } from "./authenticated-read";
 import { readJsonBody } from "./read-json-body";
-import { respondData } from "./response-shapes";
+import {
+  respondData,
+  respondMutation,
+  SKIP_DATE_FORMATTING_HEADER,
+} from "./response-shapes";
 import { withErrorHandler } from "./with-error-handler";
+
+/**
+ * Headers every layout response carries.
+ *
+ * 🔴 The date-formatting opt-out is load-bearing, not tidiness. The route
+ * handler rewrites date-looking strings in every JSON payload by VALUE, not
+ * merely by key name, to present stored timestamps in the installation's
+ * timezone — so a plugin's opaque `placement.config` of
+ * `{ cutoff: "2026-09-02T04:00:00.000Z" }` comes back as
+ * `"2026-09-02T00:00:00.000-04:00"`. The client then submits that transformed
+ * value in its next whole-snapshot PUT and it is persisted, so a configuration
+ * this endpoint promises to treat as opaque does not survive a round trip, and
+ * drifts one timezone offset further on every save.
+ *
+ * `config` is configuration rather than records, which is precisely the case
+ * {@link SKIP_DATE_FORMATTING_HEADER} exists for. The header is internal and is
+ * stripped before the response reaches a client.
+ */
+const OPAQUE_CONFIG_HEADERS = {
+  ...PRIVATE_NO_STORE_HEADERS,
+  [SKIP_DATE_FORMATTING_HEADER]: "1",
+} as const;
 
 /** Which layer the returned arrangement came from. */
 type LayoutSource = "own" | "default";
 
 /**
+ * The placements a write must carry through untouched.
+ *
+ * Two cases, and the second is the one that is easy to miss. With a stored row,
+ * it is the placements this caller could not see. With NO stored row, the
+ * caller was still shown a FILTERED default set — so a first save would freeze
+ * a snapshot that never contained the gated defaults, and a permission granted
+ * afterwards could never reveal them: `defaultPlacements` runs only while the
+ * row is absent, and after that first write it never runs again. The visibility
+ * token catches a grant that lands BETWEEN the read and the write; it cannot
+ * catch one that lands after a successful save. So the invisible half of the
+ * default set is carried into the first row exactly as a stored row's invisible
+ * half is carried into every later one.
+ *
+ * Derived from `defaultPlacements` over the WHOLE registry rather than
+ * generated separately, so a carried default keeps the position it would have
+ * had — and so there is one implementation of "where does an unplaced widget
+ * go" rather than two that agree today.
+ */
+function carriedPlacements(
+  storedPlacements: readonly WidgetPlacement[] | undefined,
+  visibleIds: ReadonlySet<string>
+): WidgetPlacement[] {
+  if (storedPlacements) {
+    return partitionPlacements(storedPlacements, visibleIds).invisible;
+  }
+  return defaultPlacements(listWidgets()).filter(
+    placement => !visibleIds.has(placement.widgetId)
+  );
+}
+
+/**
  * The scope a layout belongs to today.
  *
- * Every row this endpoint writes is the caller's own. The role layer is
- * designed into the table's key and deliberately not built (founder,
- * 2026-09-01), so there is exactly one scope kind to resolve and no resolution
- * ORDER to get wrong yet.
+ * Every row this endpoint writes is the caller's own, so there is exactly one
+ * scope kind to resolve and no resolution ORDER to get wrong yet. The key
+ * reserves the dimension anyway: a second kind of owner added after rows exist
+ * is a migration, and reserving one column now costs nothing.
  */
 const SCOPE_KIND = "user" as const;
 
@@ -127,11 +185,31 @@ async function visibleWidgets(
     });
   }
 
-  return all.filter(widget => {
-    const slug = widget.requiredPermission;
-    if (typeof slug !== "string" || slug === "") return true;
-    return verdicts.get(slug) === true;
-  });
+  return all.filter(widget => isVisibleTo(widget, verdicts));
+}
+
+/**
+ * Whether one widget may be mentioned to this caller.
+ *
+ * 🔴 Only `undefined` means ungated. Every other non-string is DENIED, which is
+ * the opposite of what "not a string, so no permission was declared" gives
+ * you: `requiredPermission: 42` or `{ read: true }` would then be treated as an
+ * open widget and returned to every authenticated caller — a declaration whose
+ * author plainly meant to restrict it, failing open because it was malformed.
+ *
+ * `widgetValueProblem` now refuses such a declaration, so this is the second of
+ * two locks rather than the only one. It stays because the registry is also
+ * writable from code that never passes through that validator, and because a
+ * `typeof` on a value already in hand costs nothing.
+ */
+function isVisibleTo(
+  widget: WidgetDefinition,
+  verdicts: ReadonlyMap<string, boolean>
+): boolean {
+  const slug: unknown = widget.requiredPermission;
+  if (slug === undefined) return true;
+  if (typeof slug !== "string" || slug === "") return false;
+  return verdicts.get(slug) === true;
 }
 
 /**
@@ -171,7 +249,7 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
       source,
       scope: visibilityToken(widgets.map(w => w.id)),
     },
-    { headers: PRIVATE_NO_STORE_HEADERS }
+    { headers: OPAQUE_CONFIG_HEADERS }
   );
 });
 
@@ -227,6 +305,28 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const auth = await requireAuthentication(req);
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
 
+  // 🔴 BEFORE the body is read, and before anything is parsed, resolved or
+  // constructed. This is a precondition, not a defensive check: a caller that
+  // can never perform this operation must be refused on that ground, and
+  // refused first. Placed after the body it answered a malformed payload with a
+  // validation error — telling a caller which FIELD it got wrong on a request
+  // it was never allowed to make, and paying for the parse to say so.
+  //
+  // A dashboard arrangement is one person's personalization of their own admin
+  // screen, and an API key has no screen. Refused rather than gated behind a
+  // permission slug, because no grant would make it meaningful: the key would
+  // be rewriting the layout of whoever minted it. Reading stays open — it tells
+  // a key nothing it could not already ask the registry.
+  //
+  // Read off the auth context rather than the resolved caller, because that is
+  // available here and the resolved caller is not: resolving it is a database
+  // read, which is work this refusal exists to avoid doing.
+  if (auth.authMethod === "api-key") {
+    throw NextlyError.forbidden({
+      logContext: { reason: "an api key may not write a dashboard layout" },
+    });
+  }
+
   const body = await readJsonBody(req);
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     throw NextlyError.validation({
@@ -246,22 +346,7 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const submittedScope = readScope(body as Record<string, unknown>);
 
   const service = await getLayoutService();
-  const resolved = await readCaller(auth);
-  const caller = readAccessCaller(resolved);
-
-  // A dashboard arrangement is one person's personalization of their own admin
-  // screen, and an API key has no screen. Refused rather than gated behind a
-  // permission slug, because there is no grant that would make it meaningful:
-  // the key would be rewriting the layout of whoever minted it. Reading stays
-  // open -- a read tells a key nothing it could not already ask the registry.
-  if (caller.authMethod === "api-key") {
-    // `forbidden` carries a fixed public message by design, so the reason
-    // travels in the log rather than to the caller.
-    throw NextlyError.forbidden({
-      logContext: { reason: "an api key may not write a dashboard layout" },
-    });
-  }
-
+  const caller = readAccessCaller(await readCaller(auth));
   const widgets = await visibleWidgets(caller);
   const visibleIds = new Set(widgets.map(widget => widget.id));
 
@@ -320,18 +405,36 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   }
 
   const stored = await service.getLayout(SCOPE_KIND, caller.userId);
-  // An unreadable row contributes nothing to carry through: its contents could
-  // not be decoded, so there is no invisible placement to preserve. The write
-  // replaces it wholesale, which is the repair.
-  const carried = stored.layout
-    ? partitionPlacements(stored.layout.placements, visibleIds).invisible
-    : [];
+  const carried = carriedPlacements(stored.layout?.placements, visibleIds);
 
-  const toStore = mergePreservingHidden(submitted, carried);
-  const tooLarge = layoutSizeProblem(toStore);
+  // The caller's OWN submission, measured and reported with its real size --
+  // every number in this refusal describes data they sent.
+  const tooLarge = layoutSizeProblem(submitted);
   if (tooLarge !== undefined) {
     throw NextlyError.validation({
       errors: [{ path: "placements", code: "TOO_LARGE", message: tooLarge }],
+    });
+  }
+
+  const toStore = mergePreservingHidden(submitted, carried);
+  // And the payload actually written, measured WITHOUT reporting a quantity.
+  // The number here is partly made of placements this caller may not know
+  // exist, so a caller could otherwise grow one visible placement until the
+  // refusal appeared and read the difference as the size of configuration they
+  // are not allowed to see.
+  if (mergedLayoutExceedsColumn(toStore)) {
+    throw NextlyError.validation({
+      errors: [
+        {
+          path: "placements",
+          code: "TOO_LARGE",
+          message: "This dashboard layout is too large to store.",
+        },
+      ],
+      logContext: {
+        submitted: submitted.length,
+        carried: carried.length,
+      },
     });
   }
 
@@ -342,7 +445,11 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
     expectedVersion
   );
 
-  return respondData(
+  // `respondMutation`, not `respondData`: this is a write, and every write in
+  // this package answers `{ message, item }`. A bespoke top-level shape would
+  // be one the shared client parser cannot read at all.
+  return respondMutation(
+    "Dashboard layout saved.",
     {
       placements: submitted,
       version,
@@ -353,7 +460,7 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
       // the next PUT will catch that on its own terms.
       scope,
     },
-    { headers: PRIVATE_NO_STORE_HEADERS }
+    { headers: OPAQUE_CONFIG_HEADERS }
   );
 });
 

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -41,10 +41,10 @@ import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
 import type { WidgetDefinition } from "../domains/widgets/definition";
 import {
+  MAX_LAYOUT_BYTES,
   defaultPlacements,
   layoutSizeProblem,
   mergePreservingHidden,
-  mergedLayoutExceedsColumn,
   partitionPlacements,
   readPlacements,
   visibilityToken,
@@ -63,7 +63,7 @@ import {
   readAccessCaller,
   readCaller,
 } from "./authenticated-read";
-import { readJsonBody } from "./read-json-body";
+import { readBoundedJsonBody } from "./read-json-body";
 import {
   respondData,
   respondMutation,
@@ -122,9 +122,32 @@ function carriedPlacements(
   if (storedPlacements) {
     return partitionPlacements(storedPlacements, visibleIds).invisible;
   }
-  return defaultPlacements(listWidgets()).filter(
-    placement => !visibleIds.has(placement.widgetId)
-  );
+  return partitionPlacements(defaultPlacements(listWidgets()), visibleIds)
+    .invisible;
+}
+
+/**
+ * The default arrangement as this caller sees it: materialized over the WHOLE
+ * registry, then filtered.
+ *
+ * 🔴 Materializing over the filtered set instead produces positions that
+ * COLLIDE with the carried half. Positions come from a placement's index in the
+ * sorted set, so with visible defaults A and B surrounding a gated G, filtering
+ * first gives A=0 and B=10, while the carried half — materialized over the full
+ * registry — gives G=10. The stored row then holds two placements at 10, and
+ * once the permission is granted the tie sorts A, B, G instead of the declared
+ * A, G, B: the reader's arrangement silently reorders itself the moment they
+ * gain access to something.
+ *
+ * So there is ONE materialization and two views of it, rather than two
+ * materializations that agree only while nothing is hidden.
+ */
+function visibleDefaults(
+  widgets: readonly WidgetDefinition[]
+): WidgetPlacement[] {
+  const visibleIds = new Set(widgets.map(widget => widget.id));
+  return partitionPlacements(defaultPlacements(listWidgets()), visibleIds)
+    .visible;
 }
 
 /**
@@ -240,7 +263,7 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
         stored.layout.placements,
         new Set(widgets.map(widget => widget.id))
       ).visible
-    : defaultPlacements(widgets);
+    : visibleDefaults(widgets);
 
   return respondData(
     {
@@ -327,7 +350,12 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
     });
   }
 
-  const body = await readJsonBody(req);
+  // Bounded BEFORE it is buffered. `req.json()` reads the whole body first, so
+  // a quota checked on the parsed result has already paid for the memory and
+  // the parse it exists to prevent. The cap is the caller's own payload budget
+  // plus a small allowance for the envelope's other fields, so a body this
+  // reader accepts is one `layoutSizeProblem` can still refuse on its merits.
+  const body = await readBoundedJsonBody(req, MAX_LAYOUT_BYTES + 1024);
   if (typeof body !== "object" || body === null || Array.isArray(body)) {
     throw NextlyError.validation({
       errors: [
@@ -344,6 +372,18 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   );
   const expectedVersion = readVersion(body as Record<string, unknown>);
   const submittedScope = readScope(body as Record<string, unknown>);
+
+  // The caller's own quota, asked HERE — before the service, the role-slug
+  // resolution, the permission decisions and the stored row. It is a
+  // precondition and it is cheap, so nothing it protects should be paid for
+  // first. It measures only what the caller sent, so the answer depends on
+  // nothing hidden from them.
+  const tooLarge = layoutSizeProblem(submitted);
+  if (tooLarge !== undefined) {
+    throw NextlyError.validation({
+      errors: [{ path: "placements", code: "TOO_LARGE", message: tooLarge }],
+    });
+  }
 
   const service = await getLayoutService();
   const caller = readAccessCaller(await readCaller(auth));
@@ -407,37 +447,7 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   const stored = await service.getLayout(SCOPE_KIND, caller.userId);
   const carried = carriedPlacements(stored.layout?.placements, visibleIds);
 
-  // The caller's OWN submission, measured and reported with its real size --
-  // every number in this refusal describes data they sent.
-  const tooLarge = layoutSizeProblem(submitted);
-  if (tooLarge !== undefined) {
-    throw NextlyError.validation({
-      errors: [{ path: "placements", code: "TOO_LARGE", message: tooLarge }],
-    });
-  }
-
   const toStore = mergePreservingHidden(submitted, carried);
-  // And the payload actually written, measured WITHOUT reporting a quantity.
-  // The number here is partly made of placements this caller may not know
-  // exist, so a caller could otherwise grow one visible placement until the
-  // refusal appeared and read the difference as the size of configuration they
-  // are not allowed to see.
-  if (mergedLayoutExceedsColumn(toStore)) {
-    throw NextlyError.validation({
-      errors: [
-        {
-          path: "placements",
-          code: "TOO_LARGE",
-          message: "This dashboard layout is too large to store.",
-        },
-      ],
-      logContext: {
-        submitted: submitted.length,
-        carried: carried.length,
-      },
-    });
-  }
-
   const version = await service.saveLayout(
     SCOPE_KIND,
     caller.userId,

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -265,9 +265,30 @@ export const getWidgetLayout = withErrorHandler(async (req: Request) => {
       ).visible
     : visibleDefaults(widgets);
 
+  // Widgets this caller may see and has not placed. A stored arrangement is a
+  // full snapshot, so a widget registered AFTER the reader last saved has no
+  // placement in it and appears nowhere in `placements` — which is correct, and
+  // is the decision this product has taken: a newly installed plugin's card is
+  // never inserted into somebody's arrangement behind their back.
+  //
+  // 🔴 But "not auto-added" only works if it is ADDABLE, and without this the
+  // widget was discoverable from nothing: the card was absent from every read,
+  // the next write persisted a snapshot that still lacked it, and the reader
+  // had no way to learn it existed. Naming the unplaced set is what makes the
+  // prompt possible, and it costs nothing to a client that ignores it.
+  //
+  // Ids only. Titles and icons already reach the admin through the widget
+  // metadata it renders from; what only this endpoint can answer is WHICH of
+  // them this caller is allowed to know about.
+  const placed = new Set(placements.map(placement => placement.widgetId));
+  const available = widgets
+    .map(widget => widget.id)
+    .filter(id => !placed.has(id));
+
   return respondData(
     {
       placements,
+      available,
       version: stored.version,
       source,
       scope: visibilityToken(widgets.map(w => w.id)),

--- a/packages/nextly/src/auth/entity-read-access.ts
+++ b/packages/nextly/src/auth/entity-read-access.ts
@@ -16,6 +16,7 @@
 import { container } from "../di/container";
 import type { RBACAccessControlService } from "../domains/auth/services/rbac-access-control-service";
 import { NextlyError } from "../errors/nextly-error";
+import { parsePermissionSlug } from "../plugins/routes/permission-slug";
 import type {
   AccessControlContext,
   CollectionAccessControl,
@@ -140,6 +141,70 @@ export async function canReadEntity(
   // the safe direction; the route-level gate has already run for any real
   // request that reaches a dispatcher handler.
   return false;
+}
+
+/**
+ * Whether this caller holds one named permission, by its `{action}-{resource}`
+ * slug.
+ *
+ * The general form of {@link canReadEntity}, which asks the same two-branch
+ * question about the fixed slug `read-{entity}`. They live side by side so the
+ * two branch structures cannot drift apart unnoticed.
+ *
+ * The session branch delegates WHOLE to `rbac.checkAccess`, which is the same
+ * thing `requirePermission` does for a permission-gated route -- so a widget's
+ * `requiredPermission` is decided by exactly the machinery that would decide a
+ * route declaring the same slug. That includes the super-admin bypass and any
+ * registered code-access rule for the named resource, neither of which is
+ * reproduced here; a second implementation of either is a second thing to keep
+ * in step.
+ *
+ * Used to decide whether a dashboard widget declaring `requiredPermission` is
+ * even mentioned to this caller. That field was previously gated in the admin
+ * alone, which is a rendering decision rather than an access one -- a client
+ * that simply did not run the check saw every card's existence.
+ *
+ * Deny-by-default in both directions the way `canReadEntity` is: an empty
+ * caller id, an unparseable slug and an unreachable RBAC service each answer
+ * false.
+ */
+export async function callerHoldsPermission(
+  slug: string,
+  caller: ReadAccessCaller
+): Promise<boolean> {
+  if (!caller.userId || !slug) return false;
+
+  // An API key is judged on its OWN stamped grant, never on the roles of
+  // whoever minted it -- and a super admin does not bypass that, for the same
+  // reason spelled out on `canReadEntity`: a read-only key issued by an
+  // administrator must not become equivalent to their full account.
+  if (caller.authMethod === "api-key") {
+    return caller.permissions.includes(slug);
+  }
+
+  const rbac = getRBACService();
+  if (!rbac) return false;
+
+  const { action, resource } = parsePermissionSlug(slug);
+  // A slug with no hyphen parses to an empty resource. `checkAccess` would be
+  // asked about a resource that cannot exist, so refuse it here where the
+  // reason is legible rather than letting it read as an ordinary denial.
+  if (!action || !resource) return false;
+
+  return rbac.checkAccess({
+    // `CheckAccessParams` types `operation` as the five CRUD verbs, and a
+    // permission slug's action is not bounded by them -- `export-submissions`
+    // and `manage-settings` are both real grants in this codebase. The
+    // implementation reads it as a plain string throughout (it indexes
+    // `codeAccess` by it and forwards it to `hasPermission`), so the value is
+    // carried correctly; the type is simply narrower than the function. This
+    // is the identical cast `requirePermission` makes for the identical reason,
+    // and widening the parameter is a change to the RBAC service's own contract
+    // rather than something to settle from a caller.
+    operation: action as "create" | "read" | "update" | "delete",
+    userId: caller.userId,
+    resource,
+  });
 }
 
 /**

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -58,8 +58,18 @@ function schemaColumns(): Map<string, Set<string>> {
     } catch {
       continue;
     }
+    // Two call shapes, and missing the second is how this guard went blind.
+    // `sqliteTable("t", { ... })` closes its column object at column 0 (`\n});`)
+    // while `sqliteTable(\n  "t",\n  { ... },\n  t => [...])` closes it at two
+    // spaces (`\n  }`). A pattern anchored to the indented form silently
+    // discovered NOTHING in a single-argument schema file -- so the table was
+    // absent from `schemas` entirely, `missing` came back empty, and the
+    // "creates every core table" assertion below passed while the table it was
+    // written to catch had no DDL at all. The closing brace is matched at
+    // either indent, and `TABLES_EXPECTED` below is the control that keeps this
+    // honest rather than a comment promising it.
     for (const m of source.matchAll(
-      /sqliteTable\(\s*"([a-z_]+)"\s*,\s*\{([\s\S]*?)\n {2}\}/g
+      /sqliteTable\(\s*"([a-z_]+)"\s*,\s*\{([\s\S]*?)\n {0,2}\}/g
     )) {
       tables.set(
         m[1],
@@ -78,11 +88,40 @@ describe("the SQLite bootstrap DDL", () => {
   const ddl = ddlColumns();
   const schemas = schemaColumns();
 
+  /**
+   * Tables whose discovery is asserted BY NAME.
+   *
+   * A size floor is not enough, and that is not hypothetical: the extractor
+   * matched 30-odd tables while missing `nextly_widget_layout` completely,
+   * because that file writes its columns in the single-argument call shape.
+   * Every count-based check stayed green and the table shipped with no
+   * bootstrap DDL.
+   *
+   * So the control names one schema of EACH call shape. A future extractor
+   * change that stops seeing either one fails here, where the message says
+   * which, rather than silently narrowing what the rest of this file compares.
+   */
+  const TABLES_EXPECTED = [
+    // `sqliteTable(\n  "t",\n  { ... },\n  t => [...])` -- indented close.
+    "nextly_document_lock",
+    // `sqliteTable("t", { ... })` -- closes at column 0.
+    "nextly_widget_layout",
+  ];
+
   it("reads back as tables at all", () => {
     // Both halves are parsed out of source text, so a parser that quietly
     // matched nothing would make every comparison below vacuously true.
     expect(ddl.size).toBeGreaterThan(10);
     expect(schemas.size).toBeGreaterThan(10);
+  });
+
+  it.each(TABLES_EXPECTED)("discovers %s in the schema sources", table => {
+    expect(
+      schemas.has(table),
+      `the schema extractor did not find ${table}. Every comparison in this ` +
+        "file iterates what it found, so a table it cannot see is not " +
+        "checked against the bootstrap DDL at all -- it passes by absence."
+    ).toBe(true);
   });
 
   /**
@@ -101,6 +140,17 @@ describe("the SQLite bootstrap DDL", () => {
    */
   const NOT_BOOTSTRAPPED = new Set([
     "activity_log",
+    // These two were not a decision either: they were INVISIBLE. The schema
+    // extractor above could not see a `sqliteTable("t", { ... })` written as a
+    // single argument, so neither table reached `schemas` and neither could
+    // ever appear in `missing`. Widening the pattern surfaced them, and they
+    // are recorded here rather than given DDL in the same change that found
+    // them -- transcribing `site_settings` by hand is how this file drifts, and
+    // it is the drift this suite exists to catch. Both are real gaps: a
+    // database built from this fallback has no general settings and no
+    // migration lock.
+    "nextly_field_group_lock",
+    "site_settings",
     "api_keys",
     "audit_log",
     "dynamic_collections",

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -316,6 +316,19 @@ export function generateSqliteCoreTableStatements(): string[] {
       ON "nextly_document_lock" ("expires_at")`,
     `CREATE INDEX IF NOT EXISTS "ndl_scope_idx"
       ON "nextly_document_lock" ("scope_kind", "slug")`,
+    // One reader's dashboard arrangement. Declared here and not only in the
+    // Drizzle bundle, because this fallback is what builds the database when
+    // `freshPushSchema` cannot run -- the non-TTY path -- and a table missing
+    // from it is a table every read and write fails against, on exactly the
+    // installs where nobody is watching the boot.
+    `CREATE TABLE IF NOT EXISTS "nextly_widget_layout" (
+      "id" TEXT PRIMARY KEY NOT NULL,
+      "scope_kind" TEXT NOT NULL,
+      "scope_id" TEXT NOT NULL,
+      "layout" TEXT NOT NULL,
+      "version" INTEGER NOT NULL DEFAULT 1,
+      "updated_at" INTEGER NOT NULL
+    )`,
     // No REFERENCES to "email_providers": that table is not bootstrapped here,
     // and SQLite resolves a foreign key at insert time rather than at CREATE,
     // so declaring one would turn every recorded delivery into a failure on a

--- a/packages/nextly/src/di/registrations/register-dashboard.ts
+++ b/packages/nextly/src/di/registrations/register-dashboard.ts
@@ -9,11 +9,18 @@
  *   the dashboard API.
  * - DashboardService — aggregates content stats, recent entries, and
  *   project metrics via read-only adapter queries.
+ * - WidgetLayoutService — reads and writes one reader's dashboard
+ *   arrangement. Registered here rather than beside the widget REGISTRY,
+ *   which is a `globalThis`-pinned store with no container entry at all
+ *   (`registrations/register-widgets.ts` explains why): this one is an
+ *   ordinary adapter-backed service and belongs with the other admin-surface
+ *   services its endpoint sits beside.
  */
 
 import { ActivityLogService } from "../../services/dashboard/activity-log-service";
 import { DashboardService } from "../../services/dashboard/dashboard-service";
 import { GeneralSettingsService } from "../../services/general-settings/general-settings-service";
+import { WidgetLayoutService } from "../../services/widgets/widget-layout-service";
 import { container } from "../container";
 
 import type { RegistrationContext } from "./types";
@@ -34,5 +41,10 @@ export function registerDashboardServices(ctx: RegistrationContext): void {
   container.registerSingleton<DashboardService>(
     "dashboardService",
     () => new DashboardService(adapter, logger)
+  );
+
+  container.registerSingleton<WidgetLayoutService>(
+    "widgetLayoutService",
+    () => new WidgetLayoutService(adapter, logger)
   );
 }

--- a/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
+++ b/packages/nextly/src/domains/schema/pipeline/__tests__/v1-golden/upgrade-sim-045.integration.test.ts
@@ -134,6 +134,15 @@ const POST_045_TABLES = [
   // disagrees between any two of them is re-proposed on every reconcile rather
   // than settling to silence.
   "nextly_document_lock",
+  // One reader's dashboard arrangement, post-0.45 like the tables above: an
+  // existing install gains it on upgrade, so its CREATE TABLE is legitimate
+  // rather than phantom. The pass-2 assertion below is what proves the
+  // declaration round-trips — this table is reached through the core schema,
+  // the dialect bundles AND the SQLite bootstrap DDL, and a shape that
+  // disagrees between any two of them is re-proposed on every reconcile
+  // instead of settling to silence. It declares no index, so the CREATE TABLE
+  // is the whole of what an upgrade emits for it.
+  "nextly_widget_layout",
 ];
 
 // The post-045 names are static identifiers, but escape defensively so the

--- a/packages/nextly/src/domains/users/services/user-mutation-service.ts
+++ b/packages/nextly/src/domains/users/services/user-mutation-service.ts
@@ -44,6 +44,11 @@ import type {
 import { actorForWrite, type RequestActor } from "../../../auth/request-actor";
 import { toDbError } from "../../../database/errors";
 import { NextlyError } from "../../../errors";
+import {
+  layoutRowId,
+  widgetLayoutTables,
+  WIDGET_LAYOUT_TABLE,
+} from "../../../schemas/widget-layout";
 import { BaseService } from "../../../services/base-service";
 import type { EmailService } from "../../../services/email/email-service";
 import { ServiceContainer } from "../../../services/index";
@@ -1502,6 +1507,30 @@ export class UserMutationService extends BaseService {
     } catch {
       mediaExists = true;
     }
+
+    // The account's dashboard arrangement, probed out here for the same reason
+    // as the three above: a failed statement aborts an open Postgres
+    // transaction and there would be no way back.
+    //
+    // The row carries the account's identifier and its opaque per-placement
+    // configuration, and nothing else removes it — `scope_id` holds a user id
+    // by convention rather than by a foreign key, precisely so a future role
+    // scope can share the table. Left behind, that configuration outlives the
+    // person indefinitely, and an external identity provider that reuses an
+    // identifier hands the replacement account its predecessor's dashboard.
+    //
+    // An unanswerable probe is treated as PRESENT, matching the media and
+    // deliveries decisions above: attempting the delete against a genuinely
+    // absent table fails the statement and takes the deletion with it, which is
+    // the invariant those two protect — an account is never removed while data
+    // belonging to it is left behind. Databases without the table exist, since
+    // the SQLite fallback bootstrap created a subset of the core tables.
+    let widgetLayoutExists: boolean;
+    try {
+      widgetLayoutExists = await this.adapter.tableExists(WIDGET_LAYOUT_TABLE);
+    } catch {
+      widgetLayoutExists = true;
+    }
     // The two answer a legacy shape differently, because what happens to an
     // un-erased row differs. A legacy `activity_log` still cascades from the
     // account, so its rows go with the deletion and there is nothing left to
@@ -1587,6 +1616,19 @@ export class UserMutationService extends BaseService {
 
         // Delete user accounts
         await txDb.delete(accounts).where(eq(accounts.userId, userId));
+
+        // And the dashboard arrangement, addressed by the SAME derivation the
+        // layout service writes with rather than by a second spelling of the
+        // key — two derivations of one identifier agree until one is edited,
+        // and the failure here is silent: the delete matches no row, the
+        // account goes, and the layout stays.
+        if (widgetLayoutExists) {
+          const layoutTable = widgetLayoutTables(this.dialect)
+            .nextlyWidgetLayout as unknown as { id: Column };
+          await txDb
+            .delete(layoutTable)
+            .where(eq(layoutTable.id, layoutRowId("user", String(userId))));
+        }
 
         // Strip the person out of the audit trail while leaving the trail
         // standing. `activity_log.user_id` carries no foreign key precisely so

--- a/packages/nextly/src/domains/widgets/__tests__/definition.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/definition.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { validateWidgetDefinition } from "../definition";
+import { validateWidgetDefinition, widgetValueProblem } from "../definition";
 
 const valid = {
   id: "core/recent-entries",
@@ -385,5 +385,32 @@ describe("chrome decides whether the HOST frames the widget", () => {
     expect(() =>
       validateWidgetDefinition({ ...custom, chrome: "borderless" })
     ).toThrow();
+  });
+});
+
+describe("a declared permission", () => {
+  it("is refused when it is not a string", () => {
+    // The field was declared and never checked, and the gap failed OPEN: the
+    // dashboard's server filter reads "not a string" as "no permission
+    // declared", so a widget whose author wrote `requiredPermission: { read:
+    // true }` was gated for nobody and returned to every authenticated caller.
+    // Refusing the declaration is the only place the mistake is still visible
+    // to the person who made it.
+    expect(widgetValueProblem({ requiredPermission: { read: true } })).toMatch(
+      /requiredPermission, when given, must be a string/
+    );
+    expect(widgetValueProblem({ requiredPermission: 42 })).toMatch(
+      /requiredPermission/
+    );
+  });
+
+  it("accepts a slug this core has never minted", () => {
+    // Shape, not vocabulary. A newer core may mint new slugs; it cannot make a
+    // slug stop being a string, and refusing an unknown one here would abort a
+    // whole plugin install over a permission this core has not learned yet.
+    expect(
+      widgetValueProblem({ requiredPermission: "invent-something" })
+    ).toBeUndefined();
+    expect(widgetValueProblem({})).toBeUndefined();
   });
 });

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -1,0 +1,353 @@
+/**
+ * What a stored dashboard arrangement may hold, and -- the half that is easy to
+ * get backwards -- what it must NOT refuse.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { WidgetDefinition } from "../definition";
+import {
+  LAYOUT_SCHEMA_VERSION,
+  MAX_PLACEMENTS,
+  defaultPlacements,
+  layoutSizeProblem,
+  visibilityToken,
+  mergePreservingHidden,
+  partitionPlacements,
+  placementProblem,
+  readPlacements,
+  readStoredLayout,
+  serializeLayout,
+  type WidgetPlacement,
+} from "../layout";
+
+/** A placement that satisfies every rule, for a test to break one field of. */
+function placement(
+  patch: Record<string, unknown> = {}
+): Record<string, unknown> {
+  return {
+    id: "p1",
+    widgetId: "core/team",
+    order: 0,
+    hidden: false,
+    ...patch,
+  };
+}
+
+function widget(patch: Partial<WidgetDefinition>): WidgetDefinition {
+  return {
+    id: "core/team",
+    title: "Team",
+    archetype: "custom",
+    defaultSize: "full",
+    component: "core#TeamSummary",
+    ...patch,
+  } as WidgetDefinition;
+}
+
+describe("placement shape", () => {
+  it.each([
+    ["a non-object", 42, /must be an object/],
+    ["a null", null, /must be an object/],
+    ["a blank id", placement({ id: "   " }), /non-empty "id"/],
+    ["a missing id", placement({ id: undefined }), /non-empty "id"/],
+    ["a blank widgetId", placement({ widgetId: "" }), /non-empty "widgetId"/],
+    ["a string order", placement({ order: "1" }), /"order" must be a finite/],
+    [
+      "a NaN order",
+      placement({ order: Number.NaN }),
+      /"order" must be a finite/,
+    ],
+    [
+      "an infinite order",
+      placement({ order: Number.POSITIVE_INFINITY }),
+      /"order" must be a finite/,
+    ],
+    [
+      "a missing hidden",
+      placement({ hidden: undefined }),
+      /"hidden" must be a boolean/,
+    ],
+    ["a truthy hidden", placement({ hidden: 1 }), /"hidden" must be a boolean/],
+    [
+      "a numeric size",
+      placement({ size: 3 }),
+      /"size", when given, must be a string/,
+    ],
+    [
+      "a numeric height",
+      placement({ height: 3 }),
+      /"height", when given, must be a string/,
+    ],
+    [
+      "an array config",
+      placement({ config: [] }),
+      /"config", when given, must be an object/,
+    ],
+  ])("refuses %s", (_label, value, expected) => {
+    const problem = placementProblem(value);
+    expect(problem).toBeDefined();
+    // The diagnostic is asserted, not merely its presence: several of these
+    // fixtures could be refused by a DIFFERENT rule than the one they are here
+    // to exercise, and a bare `toBeDefined()` would stay green if the rule
+    // under test were deleted.
+    expect(problem).toMatch(expected);
+  });
+
+  it("accepts a size this core has never heard of", () => {
+    // 🔴 THE rule this module exists to get right. `size` is seeded from a
+    // widget's `defaultSize`, and that widget may come from a plugin built
+    // against a NEWER core -- so a stored layout can legitimately name a size
+    // outside `WIDGET_SIZES`. Refusing it here would throw on read and destroy
+    // the reader's entire saved dashboard over one card, while the admin that
+    // draws it already survives the same value by falling back to `full`.
+    expect(placementProblem(placement({ size: "xxl" }))).toBeUndefined();
+    expect(placementProblem(placement({ height: "enormous" }))).toBeUndefined();
+  });
+
+  it("accepts a widgetId that names nothing", () => {
+    // Whether a widget exists is a question about the LIVE registry, asked on
+    // every read. Freezing it here would refuse a layout naming a plugin that
+    // is merely disabled today.
+    expect(
+      placementProblem(placement({ widgetId: "gone/away" }))
+    ).toBeUndefined();
+  });
+
+  it("accepts a negative and a fractional order", () => {
+    expect(placementProblem(placement({ order: -5 }))).toBeUndefined();
+    expect(placementProblem(placement({ order: 1.5 }))).toBeUndefined();
+  });
+});
+
+describe("reading placements", () => {
+  it("keeps only the fields core stores", () => {
+    const [read] = readPlacements([
+      placement({ config: { a: 1 }, smuggled: "nope" }),
+    ]);
+    expect(read).toEqual({
+      id: "p1",
+      widgetId: "core/team",
+      order: 0,
+      hidden: false,
+      config: { a: 1 },
+    });
+    expect(read).not.toHaveProperty("smuggled");
+  });
+
+  it("names the index of the offending placement", () => {
+    expect(() =>
+      readPlacements([placement(), placement({ order: "x" })])
+    ).toThrow(/placements\[1\]/);
+  });
+
+  it("refuses a non-array", () => {
+    expect(() => readPlacements({})).toThrow(/"placements" must be an array/);
+  });
+});
+
+describe("reading a stored row", () => {
+  it("round-trips what it serialized", () => {
+    const placements: WidgetPlacement[] = [
+      { id: "a", widgetId: "core/team", order: 0, hidden: true, size: "md" },
+    ];
+    expect(readStoredLayout(serializeLayout(placements)).placements).toEqual(
+      placements
+    );
+  });
+
+  it.each([
+    ["unparseable JSON", "{not json"],
+    ["a JSON array", "[]"],
+    ["a JSON scalar", "7"],
+  ])("throws on %s", (_label, raw) => {
+    expect(() => readStoredLayout(raw)).toThrow();
+  });
+
+  it("throws on a schema version this core did not write", () => {
+    // The ONE closed vocabulary in the module, and legitimate because core
+    // wrote the value itself. A higher version means the row came from a newer
+    // core and holds fields the next write would silently drop.
+    const newer = JSON.stringify({
+      schemaVersion: LAYOUT_SCHEMA_VERSION + 1,
+      placements: [],
+    });
+    expect(() => readStoredLayout(newer)).toThrow();
+    expect(() =>
+      readStoredLayout(JSON.stringify({ placements: [] }))
+    ).toThrow();
+  });
+});
+
+describe("the default arrangement", () => {
+  it("follows the declared order and materializes it as finite numbers", () => {
+    const placements = defaultPlacements([
+      widget({ id: "core/c", defaultOrder: 20 }),
+      widget({ id: "core/a", defaultOrder: 0 }),
+      widget({ id: "core/b", defaultOrder: 10 }),
+    ]);
+    expect(placements.map(p => p.widgetId)).toEqual([
+      "core/a",
+      "core/b",
+      "core/c",
+    ]);
+    // Finite, because `defaultOrder`'s own "unstated" sentinel is
+    // POSITIVE_INFINITY, which JSON turns into `null` and the shape rules then
+    // refuse -- a layout that could be written and never read.
+    for (const p of placements) expect(Number.isFinite(p.order)).toBe(true);
+  });
+
+  it("puts a widget that states no order after every widget that does", () => {
+    const placements = defaultPlacements([
+      widget({ id: "core/unstated" }),
+      widget({ id: "core/last", defaultOrder: 9999 }),
+    ]);
+    expect(placements.map(p => p.widgetId)).toEqual([
+      "core/last",
+      "core/unstated",
+    ]);
+    // Asserted HERE and not only in the test above, because this is the one
+    // arrangement where the sentinel could leak: a widget stating no order
+    // carries POSITIVE_INFINITY through the comparator, and materializing that
+    // straight into a placement writes a row JSON turns into `null`. Every
+    // widget in the previous test states an order, so its finiteness check
+    // cannot see this at all.
+    for (const p of placements) expect(Number.isFinite(p.order)).toBe(true);
+  });
+
+  it("names each default placement after its widget, so reads are idempotent", () => {
+    const once = defaultPlacements([widget({ id: "core/team" })]);
+    const twice = defaultPlacements([widget({ id: "core/team" })]);
+    expect(once).toEqual(twice);
+    expect(once[0].id).toBe("core/team");
+  });
+
+  it("leaves room to insert between two neighbours", () => {
+    const placements = defaultPlacements([
+      widget({ id: "core/a", defaultOrder: 0 }),
+      widget({ id: "core/b", defaultOrder: 1 }),
+    ]);
+    expect(placements[1].order - placements[0].order).toBeGreaterThan(1);
+  });
+});
+
+describe("partitioning by what a reader may see", () => {
+  const stored: WidgetPlacement[] = [
+    { id: "p2", widgetId: "core/visible", order: 20, hidden: false },
+    { id: "p1", widgetId: "core/secret", order: 10, hidden: false },
+    { id: "p0", widgetId: "core/visible-2", order: 0, hidden: false },
+  ];
+
+  it("returns the visible half sorted by order", () => {
+    const { visible } = partitionPlacements(
+      stored,
+      new Set(["core/visible", "core/visible-2"])
+    );
+    expect(visible.map(p => p.id)).toEqual(["p0", "p2"]);
+  });
+
+  it("returns the invisible half rather than discarding it", () => {
+    // The half a whole-snapshot PUT has to carry back. Discarding it here is
+    // how a reader loses a card permanently by opening the dashboard once
+    // while a permission of theirs was narrowed.
+    const { invisible } = partitionPlacements(
+      stored,
+      new Set(["core/visible", "core/visible-2"])
+    );
+    expect(invisible.map(p => p.widgetId)).toEqual(["core/secret"]);
+  });
+
+  it("keeps a hidden placement visible to its owner", () => {
+    // `hidden` is the reader's own choice to put a card away, so it must come
+    // back to them -- otherwise nothing could ever put it back.
+    const { visible } = partitionPlacements(
+      [{ id: "p", widgetId: "core/x", order: 0, hidden: true }],
+      new Set(["core/x"])
+    );
+    expect(visible).toHaveLength(1);
+  });
+});
+
+describe("merging a write with what the writer could not see", () => {
+  const invisible: WidgetPlacement[] = [
+    { id: "hidden-1", widgetId: "core/secret", order: 5, hidden: false },
+  ];
+
+  it("carries the invisible placements through", () => {
+    const merged = mergePreservingHidden(
+      [{ id: "p1", widgetId: "core/team", order: 0, hidden: false }],
+      invisible
+    );
+    expect(merged.map(p => p.widgetId)).toEqual(["core/team", "core/secret"]);
+  });
+
+  it("re-keys a carried placement rather than refusing the write", () => {
+    // Refusing would answer differently depending on whether a hidden
+    // placement happens to hold that id -- an oracle for the existence of a
+    // card this caller must not know about.
+    const merged = mergePreservingHidden(
+      [{ id: "hidden-1", widgetId: "core/team", order: 0, hidden: false }],
+      invisible
+    );
+    expect(merged).toHaveLength(2);
+    expect(new Set(merged.map(p => p.id)).size).toBe(2);
+    // The carried placement survives with all of its own content intact.
+    const carried = merged.find(p => p.widgetId === "core/secret");
+    expect(carried).toMatchObject({ order: 5, hidden: false });
+    expect(carried?.id).not.toBe("hidden-1");
+  });
+});
+
+describe("the size ceiling", () => {
+  it("accepts an ordinary layout", () => {
+    expect(layoutSizeProblem(defaultPlacements([widget({})]))).toBeUndefined();
+  });
+
+  it("refuses more placements than a dashboard could mean", () => {
+    const many = Array.from({ length: MAX_PLACEMENTS + 1 }, (_, i) => ({
+      id: `p${i}`,
+      widgetId: "core/team",
+      order: i,
+      hidden: false,
+    }));
+    expect(layoutSizeProblem(many)).toMatch(/at most 200 placements/);
+  });
+
+  it("measures BYTES, not characters", () => {
+    // MySQL's TEXT limit is bytes, and a `config` of CJK or emoji is three to
+    // four times its own `.length`. A layout that passes a character count and
+    // fails a byte count is the one that truncates on one dialect.
+    const wide = [
+      {
+        id: "p",
+        widgetId: "core/team",
+        order: 0,
+        hidden: false,
+        config: { note: "\u{1F600}".repeat(9000) },
+      },
+    ];
+    expect(JSON.stringify(wide).length).toBeLessThan(32 * 1024);
+    expect(layoutSizeProblem(wide)).toMatch(/bytes/);
+  });
+});
+
+describe("the visibility token", () => {
+  it("depends on the set, not the order it was registered in", () => {
+    // A hot reload re-registers the same widgets in a different order. If that
+    // moved the token, every write would be refused with nothing changed.
+    expect(visibilityToken(["b", "a"])).toBe(visibilityToken(["a", "b"]));
+  });
+
+  it("moves when a widget becomes visible or stops being", () => {
+    const before = visibilityToken(["core/a"]);
+    expect(visibilityToken(["core/a", "core/gated"])).not.toBe(before);
+    expect(visibilityToken([])).not.toBe(before);
+  });
+
+  it("does not carry the ids it was built from", () => {
+    // It is echoed to the client, and the id list is the one thing this
+    // endpoint must never hand back -- it names every widget the caller may see.
+    const token = visibilityToken(["core/secret-project"]);
+    expect(token).not.toContain("secret");
+    expect(token.length).toBeLessThan(20);
+  });
+});

--- a/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/layout.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from "vitest";
 import type { WidgetDefinition } from "../definition";
 import {
   LAYOUT_SCHEMA_VERSION,
+  MAX_CONFIG_DEPTH,
   MAX_PLACEMENTS,
   defaultPlacements,
   layoutSizeProblem,
@@ -349,5 +350,76 @@ describe("the visibility token", () => {
     const token = visibilityToken(["core/secret-project"]);
     expect(token).not.toContain("secret");
     expect(token.length).toBeLessThan(20);
+  });
+});
+
+describe("declared geometry on a default placement", () => {
+  it("carries the widget's size and height", () => {
+    // A placement that omits its own size is not a persisted arrangement: the
+    // first save would store a row with no `size`, so a later change to the
+    // plugin's `defaultSize` silently resizes what the reader was told is
+    // their saved layout.
+    const [placement] = defaultPlacements([
+      widget({ id: "core/a", defaultSize: "md", defaultHeight: "tall" }),
+    ]);
+    expect(placement.size).toBe("md");
+    expect(placement.height).toBe("tall");
+  });
+
+  it("omits height when the widget declares none", () => {
+    const [placement] = defaultPlacements([widget({ id: "core/a" })]);
+    expect(placement).not.toHaveProperty("height");
+  });
+
+  it("survives its own round trip", () => {
+    // The geometry it seeds must satisfy the shape rules it will be read back
+    // through, or the first save writes a row the next read refuses.
+    const placements = defaultPlacements([
+      widget({ id: "core/a", defaultSize: "lg", defaultHeight: "short" }),
+    ]);
+    expect(readStoredLayout(serializeLayout(placements)).placements).toEqual(
+      placements
+    );
+  });
+});
+
+describe("config nesting", () => {
+  /** An object nested `depth` levels deep. */
+  function nest(depth: number): Record<string, unknown> {
+    let node: Record<string, unknown> = {};
+    for (let i = 0; i < depth - 1; i += 1) node = { child: node };
+    return node;
+  }
+
+  it("accepts ordinary settings", () => {
+    expect(
+      placementProblem(placement({ config: nest(MAX_CONFIG_DEPTH) }))
+    ).toBeUndefined();
+  });
+
+  it("refuses a config deeper than the limit", () => {
+    expect(
+      placementProblem(placement({ config: nest(MAX_CONFIG_DEPTH + 2) }))
+    ).toMatch(/nest at most/);
+  });
+
+  it("refuses a depth that would crash the serializer", () => {
+    // The failure this exists for: `JSON.parse` accepts a structure thousands
+    // of levels deep and `JSON.stringify` throws `RangeError` on the same
+    // value, so a body under every byte and count limit became an internal 500
+    // on the way back out.
+    const deep = nest(20_000);
+    expect(() => JSON.stringify(deep)).toThrow(RangeError);
+    expect(placementProblem(placement({ config: deep }))).toMatch(
+      /nest at most/
+    );
+  });
+
+  it("counts depth through arrays as well as objects", () => {
+    let node: unknown = "leaf";
+    for (let i = 0; i < MAX_CONFIG_DEPTH + 4; i += 1) node = [node];
+    expect(placementProblem(placement({ config: { a: node } }))).toMatch(
+      /nest at most/
+    );
   });
 });

--- a/packages/nextly/src/domains/widgets/definition.ts
+++ b/packages/nextly/src/domains/widgets/definition.ts
@@ -235,6 +235,21 @@ export function widgetValueProblem(
     return "chrome, when given, must be a string";
   }
 
+  // A permission slug is a STRING in every version -- a newer core may mint new
+  // slugs, but it cannot make a slug stop being a string -- so this is shape
+  // rather than vocabulary, and it is shared by both channels. The field was
+  // declared and never checked, and the gap failed OPEN: the dashboard's server
+  // filter reads "not a string" as "no permission declared", so a widget whose
+  // author wrote `requiredPermission: { read: true }` was gated for nobody and
+  // returned to every authenticated caller. Refusing the declaration is the
+  // only place the mistake is still visible to the person who made it.
+  if (
+    widget.requiredPermission !== undefined &&
+    typeof widget.requiredPermission !== "string"
+  ) {
+    return "requiredPermission, when given, must be a string";
+  }
+
   // A query is an OBJECT in every version, so it belongs here rather than
   // beside the body checks. There it was reachable only when the query had to
   // establish a body, so a widget shipping a component skipped it -- and the

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -1,0 +1,456 @@
+/**
+ * A reader's own arrangement of the dashboard: what it stores, and what it
+ * refuses to store.
+ *
+ * ## The stored layout is a THIRD reader of the widget contract
+ *
+ * The registry and the plugin channel are the other two. This one is different
+ * in a way that decides most of the file: it holds data THIS core wrote, about
+ * widgets it did not.
+ *
+ * That distinction is why the validation here is SHAPE ONLY, and why applying
+ * `validateWidgetDefinition` to a stored row would be a defect rather than a
+ * reuse. A placement's `size` is seeded from a widget's `defaultSize`, and that
+ * widget may come from a plugin built against a NEWER core -- so a stored
+ * layout can legitimately contain a size value this core has never heard of.
+ * A closed-vocabulary check on read would throw on it and take the reader's
+ * ENTIRE saved dashboard down, when the admin that draws it already survives
+ * the same value by falling back to `full` (`admin/.../widgets/sizes.ts`:
+ * "a value outside the enum is a shape the admin has to survive").
+ *
+ * So: `size` and `height` are checked as STRINGS, never against
+ * `WIDGET_SIZES`/`WIDGET_HEIGHTS`, and they are TYPED as strings here for the
+ * same reason -- a narrower type would be a promise this module cannot keep.
+ * The one closed vocabulary in the file is {@link LAYOUT_SCHEMA_VERSION}, which
+ * is the single field this core wrote itself and therefore the single field it
+ * is entitled to have an opinion about.
+ *
+ * ## What a placement deliberately does NOT hold
+ *
+ * 🔴 No `requiredPermission`, and no other copy of anything the definition
+ * owns. A placement stores an identity and a position. Every question about
+ * whether this reader may SEE the widget is asked of the live registry on every
+ * read -- so a permission tightened after a layout was saved takes effect
+ * immediately. A copy here would be a permission decision frozen at save time,
+ * which is drift in the one place where drift is a security bug.
+ *
+ * ## Why a placement id is not a widget id
+ *
+ * Placements are a full snapshot with their own identity, so one widget can
+ * appear twice with different `config`. Keying by `widgetId` -- the WordPress
+ * model -- makes every widget a singleton and cannot express that at all.
+ * The DEFAULT set names each placement after its widget, because that is the
+ * one arrangement where the two are genuinely one-to-one and a stable id keeps
+ * repeated reads idempotent; a copy made later gets a generated one.
+ *
+ * @module domains/widgets/layout
+ */
+
+import { createHash } from "node:crypto";
+
+import { NextlyError } from "../../errors/nextly-error";
+
+import type { WidgetDefinition } from "./definition";
+
+/**
+ * The shape this core writes and understands.
+ *
+ * Bumped only when the payload's structure changes, alongside a migrator that
+ * carries the older shape forward. A row naming a version this core does not
+ * have is a DOWNGRADE -- the row was written by a newer core -- and that is
+ * refused rather than guessed at, because guessing would silently discard the
+ * fields this core cannot see.
+ */
+export const LAYOUT_SCHEMA_VERSION = 1;
+
+/**
+ * One card, at one position, for one reader.
+ *
+ * `size` and `height` are `string`, not `WidgetSize`/`WidgetHeight`, and that
+ * is load-bearing rather than lazy -- see the module docblock.
+ */
+export interface WidgetPlacement {
+  /** Opaque and unique WITHIN a layout. Not a widget id, except by default. */
+  id: string;
+  /** Which registry entry this draws. Resolved live on every read. */
+  widgetId: string;
+  /** Ascending. Finite, so it survives a JSON round trip. */
+  order: number;
+  /** Hidden placements are RETURNED, so the reader can put them back. */
+  hidden: boolean;
+  size?: string;
+  height?: string;
+  /** Per-placement settings. Opaque to core; the widget's own vocabulary. */
+  config?: Record<string, unknown>;
+}
+
+/** The decoded contents of one `nextly_widget_layout.layout` column. */
+export interface StoredLayout {
+  schemaVersion: number;
+  placements: WidgetPlacement[];
+}
+
+/** How far apart default placements sit, so one can be inserted between two. */
+const DEFAULT_ORDER_STEP = 10;
+
+function isUsableText(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** `undefined`, or a string with real text in it. */
+function optionalTextProblem(
+  value: unknown,
+  field: string
+): string | undefined {
+  if (value === undefined) return undefined;
+  return typeof value === "string"
+    ? undefined
+    : `"${field}", when given, must be a string`;
+}
+
+/**
+ * The rules a placement must satisfy, as a LIST rather than a ladder.
+ *
+ * A list because the ladder form put every rule in one function and tripped the
+ * repository's complexity gate; the same shape `plugins/validate-admin-widgets`
+ * uses, and for the same reason. Each rule answers about one field and says so
+ * in words the reader of a rejected PUT can act on.
+ *
+ * Every rule here is a SHAPE rule. There is deliberately no rule asking whether
+ * `size` is one of five, or whether `widgetId` names a widget that exists --
+ * the first would refuse a newer plugin's size, and the second is a question
+ * about the live registry, which is asked on every read rather than frozen here.
+ */
+const PLACEMENT_RULES: ReadonlyArray<
+  (placement: Record<string, unknown>) => string | undefined
+> = [
+  p => (isUsableText(p.id) ? undefined : 'a placement needs a non-empty "id"'),
+  p =>
+    isUsableText(p.widgetId)
+      ? undefined
+      : 'a placement needs a non-empty "widgetId"',
+  // `Number.isFinite`, not `typeof === "number"`: `NaN` and both infinities are
+  // numbers that JSON cannot carry -- each serializes to `null` and comes back
+  // failing this same rule, so accepting one here would write a row that could
+  // never be read.
+  p =>
+    Number.isFinite(p.order) ? undefined : '"order" must be a finite number',
+  p =>
+    typeof p.hidden === "boolean" ? undefined : '"hidden" must be a boolean',
+  p => optionalTextProblem(p.size, "size"),
+  p => optionalTextProblem(p.height, "height"),
+  p =>
+    p.config === undefined || isPlainObject(p.config)
+      ? undefined
+      : '"config", when given, must be an object',
+];
+
+/**
+ * Why this value cannot be a placement, or `undefined`.
+ *
+ * Exported so the endpoint that accepts a PUT and the reader that decodes a
+ * stored row ask the identical question. They used to be able to disagree, and
+ * a shape one accepted and the other refused is a row that can be written and
+ * never read.
+ */
+export function placementProblem(value: unknown): string | undefined {
+  if (!isPlainObject(value)) return "a placement must be an object";
+  for (const rule of PLACEMENT_RULES) {
+    const problem = rule(value);
+    if (problem !== undefined) return problem;
+  }
+  return undefined;
+}
+
+/** A placement, with only the fields this core stores, in a stable order. */
+function toPlacement(value: Record<string, unknown>): WidgetPlacement {
+  return {
+    id: value.id as string,
+    widgetId: value.widgetId as string,
+    order: value.order as number,
+    hidden: value.hidden as boolean,
+    ...(value.size === undefined ? {} : { size: value.size as string }),
+    ...(value.height === undefined ? {} : { height: value.height as string }),
+    ...(value.config === undefined
+      ? {}
+      : { config: value.config as Record<string, unknown> }),
+  };
+}
+
+/**
+ * Reads the caller-or-column supplied placement array, or says why it cannot.
+ *
+ * Rebuilds each placement from the fields this core knows rather than passing
+ * the decoded object through. A row round-tripped verbatim would carry back
+ * whatever else was in it -- including, on a PUT, anything a client chose to
+ * add -- and the next reader would have no way to tell core's vocabulary from
+ * a stranger's.
+ */
+export function readPlacements(value: unknown): WidgetPlacement[] {
+  if (!Array.isArray(value)) {
+    throw NextlyError.invalidInput({
+      message: 'Invalid dashboard layout: "placements" must be an array.',
+    });
+  }
+  return value.map((entry, index) => {
+    const problem = placementProblem(entry);
+    if (problem !== undefined) {
+      throw NextlyError.invalidInput({
+        message: `Invalid dashboard layout: placements[${index}] ${problem}.`,
+      });
+    }
+    return toPlacement(entry as Record<string, unknown>);
+  });
+}
+
+/**
+ * Decodes one stored `layout` column.
+ *
+ * THROWS on anything it cannot read, rather than quietly resetting to the
+ * default. A server-persisted record vanishing with no signal is the worse
+ * failure here: the reader would see their arrangement gone and nothing
+ * anywhere would say why. The caller decides what to do with the throw -- the
+ * service logs it and falls back so the dashboard still draws, and marks the
+ * response as coming from the default so the admin never claims the row was
+ * honoured.
+ */
+export function readStoredLayout(raw: string): StoredLayout {
+  let decoded: unknown;
+  try {
+    decoded = JSON.parse(raw);
+  } catch (cause) {
+    throw NextlyError.internal({
+      ...(cause instanceof Error ? { cause } : {}),
+      logContext: { reason: "stored dashboard layout is not valid JSON" },
+    });
+  }
+
+  if (!isPlainObject(decoded)) {
+    throw NextlyError.internal({
+      logContext: { reason: "stored dashboard layout is not an object" },
+    });
+  }
+
+  // The ONE vocabulary check in this module, and it is legitimate precisely
+  // because this core wrote the value. A version above ours means the row came
+  // from a NEWER core and holds fields we would silently drop on the next
+  // write; a version below ours means a migrator is missing. Neither is a
+  // shape to guess at. When v2 arrives this is where `migrateLayout` runs.
+  if (decoded.schemaVersion !== LAYOUT_SCHEMA_VERSION) {
+    throw NextlyError.internal({
+      logContext: {
+        reason: "stored dashboard layout names an unknown schema version",
+        found: String(decoded.schemaVersion),
+        expected: LAYOUT_SCHEMA_VERSION,
+      },
+    });
+  }
+
+  return {
+    schemaVersion: LAYOUT_SCHEMA_VERSION,
+    placements: readPlacements(decoded.placements),
+  };
+}
+
+/** The payload written into the `layout` column. */
+export function serializeLayout(
+  placements: readonly WidgetPlacement[]
+): string {
+  return JSON.stringify({
+    schemaVersion: LAYOUT_SCHEMA_VERSION,
+    placements,
+  });
+}
+
+/**
+ * The declared order, as the admin's own comparator reads it: a widget with no
+ * `defaultOrder` sits after every widget that states one.
+ *
+ * `POSITIVE_INFINITY` rather than a large finite sentinel, because there is no
+ * largest finite number a declaration could not legally name -- `Number.MAX_VALUE`
+ * as the sentinel sorted a widget declaring it BELOW the unstated ones.
+ * Two unstated widgets compare as `NaN`, which `Array.prototype.sort` treats as
+ * "leave them alone", so they keep registration order.
+ */
+function byDeclaredOrder(a: WidgetDefinition, b: WidgetDefinition): number {
+  return (
+    (a.defaultOrder ?? Number.POSITIVE_INFINITY) -
+    (b.defaultOrder ?? Number.POSITIVE_INFINITY)
+  );
+}
+
+/**
+ * What a reader who has never arranged anything sees.
+ *
+ * The declared order, MATERIALIZED into finite positions -- `defaultOrder`
+ * itself is never copied into a placement, because `POSITIVE_INFINITY` is not
+ * JSON and a widget's declaration may change under a stored row that quoted it.
+ * The step leaves room to insert between two neighbours without renumbering.
+ *
+ * The placement id is the widget id here, and only here. It makes repeated
+ * reads of an unsaved dashboard return identical ids, which is what lets the
+ * admin treat the default set as real placements rather than as a preview it
+ * has to re-key on every fetch.
+ */
+export function defaultPlacements(
+  widgets: readonly WidgetDefinition[]
+): WidgetPlacement[] {
+  return [...widgets].sort(byDeclaredOrder).map((widget, index) => ({
+    id: widget.id,
+    widgetId: widget.id,
+    order: index * DEFAULT_ORDER_STEP,
+    hidden: false,
+  }));
+}
+
+/**
+ * Splits a stored layout by what this reader is allowed to know exists.
+ *
+ * BOTH halves are returned, and the second one is the point. A placement whose
+ * widget no longer resolves, or whose `requiredPermission` this caller lacks,
+ * is dropped from the response -- never drawn as an empty slot, never drawn as
+ * a "you may not see this" card, both of which disclose that it is there.
+ *
+ * 🔴 But it must not be dropped from the ROW. The wire contract is a whole
+ * snapshot: the admin sends back what it was given. A caller who was shown a
+ * filtered list and PUTs it back would otherwise DELETE every placement the
+ * filter hid -- so a user opening the dashboard once, while a permission of
+ * theirs was temporarily narrowed, would silently lose those cards forever.
+ * The `invisible` half is what the writer merges back in, and it is why this is
+ * one function returning two lists rather than a filter used twice.
+ */
+export function partitionPlacements(
+  placements: readonly WidgetPlacement[],
+  visibleWidgetIds: ReadonlySet<string>
+): { visible: WidgetPlacement[]; invisible: WidgetPlacement[] } {
+  const visible: WidgetPlacement[] = [];
+  const invisible: WidgetPlacement[] = [];
+  for (const placement of placements) {
+    if (visibleWidgetIds.has(placement.widgetId)) visible.push(placement);
+    else invisible.push(placement);
+  }
+  visible.sort((a, b) => a.order - b.order);
+  return { visible, invisible };
+}
+
+/** A fresh, opaque placement id. Used when a copy of a widget is placed. */
+export function newPlacementId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * The array a write stores: what this caller submitted, plus what they were
+ * never shown.
+ *
+ * 🔴 A carried placement whose id collides with a submitted one is RE-KEYED,
+ * never refused. Refusing would answer differently depending on whether a
+ * hidden placement happens to hold that id -- which is an oracle for the
+ * existence of a card this caller is not allowed to know about, and hiding the
+ * card was the entire point of filtering it. Re-keying is safe because a
+ * placement id is opaque and everything hung off it, `config` included, travels
+ * on the placement itself.
+ *
+ * Collisions are not expected: default ids are widget ids, and a submitted
+ * placement can only name a VISIBLE widget while a carried one names a widget
+ * this caller cannot see. It is guarded anyway because the ids a client may
+ * mint are unconstrained, and the failure it prevents -- two placements sharing
+ * an id in a stored row -- is one the next reader could not untangle.
+ */
+export function mergePreservingHidden(
+  submitted: readonly WidgetPlacement[],
+  invisible: readonly WidgetPlacement[]
+): WidgetPlacement[] {
+  const taken = new Set(submitted.map(placement => placement.id));
+  const carried = invisible.map(placement => {
+    if (!taken.has(placement.id)) {
+      taken.add(placement.id);
+      return placement;
+    }
+    let fresh = newPlacementId();
+    while (taken.has(fresh)) fresh = newPlacementId();
+    taken.add(fresh);
+    return { ...placement, id: fresh };
+  });
+  return [...submitted, ...carried];
+}
+
+/**
+ * How many placements one layout may hold, and how large its payload may be.
+ *
+ * MySQL's `TEXT` is 65535 BYTES, and the other two dialects are effectively
+ * unbounded — so without a cap the same PUT stores cleanly on two dialects and,
+ * on the third, either errors or (under a permissive `sql_mode`) TRUNCATES,
+ * leaving JSON the next read cannot parse. That failure destroys the whole
+ * saved dashboard, and it destroys it on one deployment only.
+ *
+ * The ceiling is on the SERIALIZED payload rather than on `config` alone,
+ * because `config` is opaque to core — the widget owns its vocabulary — so
+ * there is nothing here to measure except the bytes actually stored. 32 KiB is
+ * half MySQL's limit, which leaves room for multi-byte characters to expand
+ * without any caller ever meeting the dialect's own edge.
+ */
+export const MAX_PLACEMENTS = 200;
+export const MAX_LAYOUT_BYTES = 32 * 1024;
+
+/**
+ * Why this layout cannot be stored, or `undefined`.
+ *
+ * Asked of the payload that will actually be written — including the
+ * placements merged back in on the caller's behalf, which the caller never
+ * submitted and cannot be blamed for. A refusal is still the right answer: a
+ * layout that cannot be re-read is worse than one that will not save.
+ */
+export function layoutSizeProblem(
+  placements: readonly WidgetPlacement[]
+): string | undefined {
+  if (placements.length > MAX_PLACEMENTS) {
+    return `a layout may hold at most ${MAX_PLACEMENTS} placements`;
+  }
+  // Byte length, not string length: the column's limit is bytes, and a layout
+  // of CJK or emoji `config` values is three to four times its own `.length`.
+  const bytes = Buffer.byteLength(serializeLayout(placements), "utf8");
+  if (bytes > MAX_LAYOUT_BYTES) {
+    return `a layout may be at most ${MAX_LAYOUT_BYTES} bytes; this one is ${bytes}`;
+  }
+  return undefined;
+}
+
+/**
+ * A short, stable stand-in for "which widgets this caller could see".
+ *
+ * 🔴 The row's `version` guards the ROW, and that is only half of what shaped
+ * the snapshot the client is holding. The other half is VISIBILITY: a GET
+ * returns placements filtered by what this caller may see, and a permission
+ * grant, a role change or a plugin registering on another instance changes that
+ * filter without touching the row. `version` therefore still matches, the
+ * conditional write still succeeds, and a placement that was invisible at read
+ * time but is visible at write time is in neither the client's submission nor
+ * the carried-through set — so it is silently and permanently deleted, along
+ * with its order and its `config`.
+ *
+ * Echoing this token back closes that. The client's snapshot is stale whenever
+ * the visible set has moved under it, and stale is exactly what a conflict
+ * means: re-read and try again.
+ *
+ * A hash rather than the id list itself, because the list is the one thing this
+ * endpoint must never hand back — it names every widget the caller may see, and
+ * comparing two tokens across two callers would otherwise reveal whether their
+ * grants differ. Truncated to 16 base64url characters: this is a
+ * change-detector between two reads by ONE caller, not a security boundary, and
+ * a collision costs a preserved placement rather than a leaked one.
+ */
+export function visibilityToken(widgetIds: readonly string[]): string {
+  return (
+    createHash("sha256")
+      // Sorted, so the token depends on the SET and not on registration order —
+      // otherwise a hot reload that re-registered the same widgets in a different
+      // order would refuse every write with nothing actually changed.
+      .update([...widgetIds].sort().join("\n"))
+      .digest("base64url")
+      .slice(0, 16)
+  );
+}

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -147,7 +147,37 @@ const PLACEMENT_RULES: ReadonlyArray<
     p.config === undefined || isPlainObject(p.config)
       ? undefined
       : '"config", when given, must be an object',
+  p =>
+    p.config !== undefined && exceedsDepth(p.config, MAX_CONFIG_DEPTH)
+      ? `"config" may nest at most ${MAX_CONFIG_DEPTH} levels`
+      : undefined,
 ];
+
+/**
+ * Whether a value nests deeper than `limit`.
+ *
+ * Iterative rather than recursive, deliberately: a recursive walk overflows the
+ * stack on exactly the input this exists to reject, so the guard would fail the
+ * same way the bug does. The traversal stops at the first violation, so a
+ * pathological payload costs `limit` levels of work rather than all of them.
+ */
+function exceedsDepth(value: unknown, limit: number): boolean {
+  const stack: Array<{ value: unknown; depth: number }> = [{ value, depth: 1 }];
+  while (stack.length > 0) {
+    const { value: current, depth } = stack.pop() as {
+      value: unknown;
+      depth: number;
+    };
+    if (current === null || typeof current !== "object") continue;
+    if (depth > limit) return true;
+    for (const child of Array.isArray(current)
+      ? current
+      : Object.values(current)) {
+      stack.push({ value: child, depth: depth + 1 });
+    }
+  }
+  return false;
+}
 
 /**
  * Why this value cannot be a placement, or `undefined`.
@@ -304,6 +334,17 @@ export function defaultPlacements(
     widgetId: widget.id,
     order: index * DEFAULT_ORDER_STEP,
     hidden: false,
+    // The declared geometry travels WITH the placement, rather than being left
+    // for a reader to look up. A placement is a persisted arrangement, and an
+    // arrangement that omits its own size is not one: the first save would
+    // store a row with no `size`, so a later change to the plugin's
+    // `defaultSize` would silently resize what the reader was told is their
+    // saved layout. Copied as strings, because a newer plugin's value is a
+    // shape this core has to survive rather than a vocabulary it can check.
+    size: widget.defaultSize,
+    ...(widget.defaultHeight === undefined
+      ? {}
+      : { height: widget.defaultHeight }),
   }));
 }
 
@@ -397,27 +438,35 @@ export const MAX_PLACEMENTS = 200;
 export const MAX_LAYOUT_BYTES = 32 * 1024;
 
 /**
- * The ceiling on the payload actually written, carried placements included.
+ * How deep a `config` object may nest.
  *
- * Higher than one caller's budget because a write legitimately stores more than
- * the caller sent, and lower than MySQL's 65535 so a multi-byte payload cannot
- * reach the dialect's own edge and truncate.
+ * `JSON.parse` accepts a structure thousands of levels deep and
+ * `JSON.stringify` throws `RangeError: Maximum call stack size exceeded` on the
+ * same value, so a syntactically valid body under every byte and count limit
+ * turned a write into an internal 500 on the way back out. Bounded here, where
+ * it becomes an ordinary validation refusal naming the field.
+ *
+ * 16 is far past anything a widget's settings need and far short of a stack.
  */
-export const MAX_STORED_BYTES = 56 * 1024;
+export const MAX_CONFIG_DEPTH = 16;
 
 /**
  * Why the caller's OWN submission cannot be stored, or `undefined`.
  *
  * 🔴 Measures only what the caller sent, and that scope is the point rather
- * than an omission. Measuring the merged payload — the submission plus the
- * placements carried back on the caller's behalf — and reporting its byte count
- * hands back a number that VARIES WITH HIDDEN DATA. A caller who has lost
- * access to a widget could then grow one visible placement until the refusal
- * appears and read the difference as the size of configuration they are not
- * allowed to see, which is exactly the observability this endpoint spends the
- * rest of its effort denying. Whether the merged total still fits the column is
- * a separate question, asked by {@link mergedLayoutExceedsColumn}, which
- * answers yes or no and never a quantity.
+ * than an omission. A budget that also weighed the placements carried back on
+ * the caller's behalf would make ACCEPTANCE ITSELF depend on data the caller
+ * cannot see — so a caller who had lost access to a widget could grow one
+ * visible placement until the refusal appeared and read the boundary as the
+ * size of configuration they are not allowed to see. Omitting the byte count
+ * from the message does not fix that: the pass/fail edge is the oracle, not the
+ * number.
+ *
+ * So there is no merged check at all. The stored column is `mediumtext` on the
+ * narrowest dialect, which no accumulation of 200 placements built from
+ * submissions this size can reach — the ceiling was removed rather than
+ * policed, which is a boundary the system cannot cross instead of a check that
+ * looks for crossings.
  */
 export function layoutSizeProblem(
   placements: readonly WidgetPlacement[]
@@ -432,28 +481,6 @@ export function layoutSizeProblem(
     return `a layout may be at most ${MAX_LAYOUT_BYTES} bytes; this one is ${bytes}`;
   }
   return undefined;
-}
-
-/**
- * Whether the payload that will actually be WRITTEN overruns the narrowest
- * dialect's column.
- *
- * A boolean, deliberately. Every caller-visible refusal above reports a
- * quantity; this one cannot, because the quantity it would report is partly
- * made of placements the caller may not know exist.
- *
- * Reachable only when carried-through placements push a submission that was
- * itself within budget past the ceiling — so the caller has done nothing wrong
- * and there is nothing for them to fix. Refusing is still right: a row that
- * cannot be re-read loses the whole dashboard, which is strictly worse than a
- * save that did not happen.
- */
-export function mergedLayoutExceedsColumn(
-  placements: readonly WidgetPlacement[]
-): boolean {
-  return (
-    Buffer.byteLength(serializeLayout(placements), "utf8") > MAX_STORED_BYTES
-  );
 }
 
 /**

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -397,12 +397,27 @@ export const MAX_PLACEMENTS = 200;
 export const MAX_LAYOUT_BYTES = 32 * 1024;
 
 /**
- * Why this layout cannot be stored, or `undefined`.
+ * The ceiling on the payload actually written, carried placements included.
  *
- * Asked of the payload that will actually be written — including the
- * placements merged back in on the caller's behalf, which the caller never
- * submitted and cannot be blamed for. A refusal is still the right answer: a
- * layout that cannot be re-read is worse than one that will not save.
+ * Higher than one caller's budget because a write legitimately stores more than
+ * the caller sent, and lower than MySQL's 65535 so a multi-byte payload cannot
+ * reach the dialect's own edge and truncate.
+ */
+export const MAX_STORED_BYTES = 56 * 1024;
+
+/**
+ * Why the caller's OWN submission cannot be stored, or `undefined`.
+ *
+ * 🔴 Measures only what the caller sent, and that scope is the point rather
+ * than an omission. Measuring the merged payload — the submission plus the
+ * placements carried back on the caller's behalf — and reporting its byte count
+ * hands back a number that VARIES WITH HIDDEN DATA. A caller who has lost
+ * access to a widget could then grow one visible placement until the refusal
+ * appears and read the difference as the size of configuration they are not
+ * allowed to see, which is exactly the observability this endpoint spends the
+ * rest of its effort denying. Whether the merged total still fits the column is
+ * a separate question, asked by {@link mergedLayoutExceedsColumn}, which
+ * answers yes or no and never a quantity.
  */
 export function layoutSizeProblem(
   placements: readonly WidgetPlacement[]
@@ -417,6 +432,28 @@ export function layoutSizeProblem(
     return `a layout may be at most ${MAX_LAYOUT_BYTES} bytes; this one is ${bytes}`;
   }
   return undefined;
+}
+
+/**
+ * Whether the payload that will actually be WRITTEN overruns the narrowest
+ * dialect's column.
+ *
+ * A boolean, deliberately. Every caller-visible refusal above reports a
+ * quantity; this one cannot, because the quantity it would report is partly
+ * made of placements the caller may not know exist.
+ *
+ * Reachable only when carried-through placements push a submission that was
+ * itself within budget past the ceiling — so the caller has done nothing wrong
+ * and there is nothing for them to fix. Refusing is still right: a row that
+ * cannot be re-read loses the whole dashboard, which is strictly worse than a
+ * save that did not happen.
+ */
+export function mergedLayoutExceedsColumn(
+  placements: readonly WidgetPlacement[]
+): boolean {
+  return (
+    Buffer.byteLength(serializeLayout(placements), "utf8") > MAX_STORED_BYTES
+  );
 }
 
 /**

--- a/packages/nextly/src/route-handler/__tests__/route-parser.dashboard.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.dashboard.test.ts
@@ -1,11 +1,11 @@
 /**
  * `/api/dashboard` routes.
  *
- * Four routes, none deeper than the top-level id segment (`stats`,
- * `recent-entries`, `activity`, `query`). The risk this file pins: a longer
- * path must 404 rather than match one of those four and silently drop the
- * tail, which would let `/api/dashboard/query/extra` reach the widget-query
- * executor as if it were the bare route.
+ * Six routes, none deeper than the top-level id segment (`stats`,
+ * `recent-entries`, `activity`, `query`, and `layout` under two verbs). The
+ * risk this file pins: a longer path must 404 rather than match one of them
+ * and silently drop the tail, which would let `/api/dashboard/query/extra`
+ * reach the widget-query executor as if it were the bare route.
  */
 import { describe, expect, it } from "vitest";
 
@@ -58,8 +58,65 @@ describe("dashboard routes", () => {
     expect(parseRestRoute(["dashboard", "unknown"], "GET")).toEqual({});
   });
 
-  it("rejects a verb neither GET nor POST declares", () => {
+  it("resolves the layout route under both of its verbs", () => {
+    expect(parseRestRoute(["dashboard", "layout"], "GET")).toMatchObject({
+      method: "getWidgetLayout",
+    });
+    expect(parseRestRoute(["dashboard", "layout"], "PUT")).toMatchObject({
+      method: "putWidgetLayout",
+    });
+  });
+
+  it("does not claim a path with extra segments after layout", () => {
+    expect(
+      parseRestRoute(["dashboard", "layout", "extra"], "PUT").method
+    ).not.toBe("putWidgetLayout");
+    expect(
+      parseRestRoute(["dashboard", "layout", "extra"], "GET").method
+    ).not.toBe("getWidgetLayout");
+  });
+
+  it("rejects a PUT to an id other than layout", () => {
+    // The PUT branch is checked BEFORE the blanket GET guard, so a PUT that
+    // names no layout must fall out of the parser rather than through it.
+    expect(parseRestRoute(["dashboard", "stats"], "PUT")).toEqual({});
+    expect(parseRestRoute(["dashboard", "query"], "PUT")).toEqual({});
+  });
+
+  it.each([
+    ["constructor", "constructor"],
+    ["toString", "toString"],
+    ["__proto__", "__proto__"],
+    ["hasOwnProperty", "hasOwnProperty"],
+  ])("does not resolve %s as a route id", (_label, id) => {
+    // The parser dispatches off a TABLE, and both of its keys come off the
+    // URL. `TABLE[key]` reaches `Object.prototype`, so these four names are
+    // present on every object literal ever written: `constructor` is a
+    // function and `__proto__` an object, either of which would get past a
+    // bare truthiness check and be dispatched on.
+    expect(parseRestRoute(["dashboard", id], "GET")).toEqual({});
+    expect(parseRestRoute(["dashboard", id], "PUT")).toEqual({});
+  });
+
+  it.each([
+    // The VERB guard needs an id that exists on whatever the verb lookup
+    // returns, or the id guard catches the request first and the verb guard is
+    // never the reason. `DASHBOARD_ROUTES.constructor` is `Object`, and
+    // `Object.call` / `Object.bind` are real functions -- so this pair walks
+    // straight through a bare truthiness check and dispatches with `method`
+    // and `operation` both undefined. `stats` under a bogus verb cannot show
+    // that, because `Object.stats` is undefined either way.
+    ["constructor", "call"],
+    ["constructor", "bind"],
+    ["__proto__", "toString"],
+  ])("does not resolve %s as an HTTP verb", (verb, id) => {
+    expect(parseRestRoute(["dashboard", id], verb)).toEqual({});
+  });
+
+  it("rejects a verb none of the routes declare", () => {
     expect(parseRestRoute(["dashboard", "stats"], "DELETE")).toEqual({});
     expect(parseRestRoute(["dashboard", "query"], "PATCH")).toEqual({});
+    expect(parseRestRoute(["dashboard", "layout"], "DELETE")).toEqual({});
+    expect(parseRestRoute(["dashboard", "layout"], "POST")).toEqual({});
   });
 });

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2488,11 +2488,50 @@ function parseTranslationRoutes(
 }
 
 /**
+ * Every `/api/dashboard` route, as a table keyed by verb and then by id.
+ *
+ * A table rather than a ladder of `if`s. The ladder's cyclomatic complexity
+ * grew with the route count and tripped the repository's threshold at the
+ * sixth route, and each new arm restated four lines of the same object literal
+ * — so a route added under the wrong `operation` looked exactly like one added
+ * under the right one.
+ */
+const DASHBOARD_ROUTES: Readonly<
+  Record<
+    string,
+    Readonly<
+      Record<
+        string,
+        { operation: NonNullable<ParsedRoute["operation"]>; method: string }
+      >
+    >
+  >
+> = {
+  GET: {
+    stats: { operation: "list", method: "getDashboardStats" },
+    "recent-entries": {
+      operation: "list",
+      method: "getDashboardRecentEntries",
+    },
+    activity: { operation: "list", method: "getDashboardActivity" },
+    layout: { operation: "list", method: "getWidgetLayout" },
+  },
+  POST: {
+    query: { operation: "list", method: "postWidgetQuery" },
+  },
+  PUT: {
+    layout: { operation: "update", method: "putWidgetLayout" },
+  },
+};
+
+/**
  * Parse dashboard-related routes.
  *
  *   GET  /api/dashboard/stats          → getDashboardStats
  *   GET  /api/dashboard/recent-entries → getDashboardRecentEntries
  *   GET  /api/dashboard/activity       → getDashboardActivity
+ *   GET  /api/dashboard/layout         → getWidgetLayout
+ *   PUT  /api/dashboard/layout         → putWidgetLayout
  *   POST /api/dashboard/query          → postWidgetQuery
  *
  * All require authentication (no specific permission). Handlers manage their
@@ -2510,50 +2549,26 @@ function parseDashboardRoutes(
   // `/api/dashboard/query/extra` reach the widget-query executor. Segments
   // are contiguous, so a truthy `subresource` is the only way a sub-id or
   // anything past it could exist — the same shape `parseJobRoutes` uses.
-  if (subresource) return null;
+  if (subresource || id === undefined) return null;
 
-  if (httpMethod === "POST") {
-    if (id === "query") {
-      return {
-        service: "dashboard",
-        operation: "list",
-        method: "postWidgetQuery",
-        routeParams,
-      };
-    }
-    return null;
-  }
+  // 🔴 `Object.hasOwn` on BOTH lookups, because both keys come off the URL.
+  // A plain `TABLE[key]` reaches `Object.prototype`, so `OPTIONS` is safely
+  // absent but `constructor` is not: `DASHBOARD_ROUTES.constructor` is a
+  // function, and `.constructor.constructor` a truthy object, so
+  // `/api/dashboard/constructor` would get past a bare presence check and
+  // dispatch on `route.method` read off `Object`. This is the same hole the
+  // widget span-class and archetype tables already closed.
+  if (!Object.hasOwn(DASHBOARD_ROUTES, httpMethod)) return null;
+  const byId = DASHBOARD_ROUTES[httpMethod];
+  if (!Object.hasOwn(byId, id)) return null;
 
-  if (httpMethod !== "GET") return null;
-
-  if (id === "stats") {
-    return {
-      service: "dashboard",
-      operation: "list",
-      method: "getDashboardStats",
-      routeParams,
-    };
-  }
-
-  if (id === "recent-entries") {
-    return {
-      service: "dashboard",
-      operation: "list",
-      method: "getDashboardRecentEntries",
-      routeParams,
-    };
-  }
-
-  if (id === "activity") {
-    return {
-      service: "dashboard",
-      operation: "list",
-      method: "getDashboardActivity",
-      routeParams,
-    };
-  }
-
-  return null;
+  const route = byId[id];
+  return {
+    service: "dashboard",
+    operation: route.operation,
+    method: route.method,
+    routeParams,
+  };
 }
 
 // ============================================================================

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -84,6 +84,7 @@ import {
   redeliverWebhookDelivery,
   drainWebhooks,
 } from "./api/webhooks";
+import { getWidgetLayout, putWidgetLayout } from "./api/widget-layout";
 import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
@@ -486,6 +487,10 @@ async function handleDashboardRequest(
       return getDashboardActivity(req);
     case "postWidgetQuery":
       return postWidgetQuery(req);
+    case "getWidgetLayout":
+      return getWidgetLayout(req);
+    case "putWidgetLayout":
+      return putWidgetLayout(req);
     default:
       return new Response(
         JSON.stringify({ error: "Unknown dashboard operation" }),
@@ -1104,8 +1109,8 @@ async function handleServiceRequest(
   // ==================== DASHBOARD DIRECT DISPATCH ====================
   // Dashboard handlers own their auth (requireAuthentication). Intercepting
   // here keeps the pattern consistent with API keys and general settings; the
-  // GET endpoints have no body, and postWidgetQuery reads its own via
-  // req.json() before anything else touches the stream.
+  // GET endpoints have no body, and postWidgetQuery and putWidgetLayout read
+  // their own via req.json() before anything else touches the stream.
   if (service === "dashboard") {
     return handleDashboardRequest(req, method);
   }

--- a/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/mysql.ts
@@ -17,6 +17,7 @@ export { users, accounts, sessions } from "../users/mysql";
 // `reconcileCore` hands drizzle-kit.
 export { nextlyFieldGroupLock } from "../field-group-lock/mysql";
 export { nextlyDocumentLock } from "../document-lock/mysql";
+export { nextlyWidgetLayout } from "../widget-layout/mysql";
 
 export {
   emailVerificationTokens,

--- a/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/postgres.ts
@@ -32,6 +32,7 @@ export { users, accounts, sessions } from "../users/postgres";
 // `reconcileCore` hands drizzle-kit.
 export { nextlyFieldGroupLock } from "../field-group-lock/postgres";
 export { nextlyDocumentLock } from "../document-lock/postgres";
+export { nextlyWidgetLayout } from "../widget-layout/postgres";
 
 // Auth tokens.
 export {

--- a/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
+++ b/packages/nextly/src/schemas/_dialect-bundles/sqlite.ts
@@ -17,6 +17,7 @@ export { users, accounts, sessions } from "../users/sqlite";
 // `reconcileCore` hands drizzle-kit.
 export { nextlyFieldGroupLock } from "../field-group-lock/sqlite";
 export { nextlyDocumentLock } from "../document-lock/sqlite";
+export { nextlyWidgetLayout } from "../widget-layout/sqlite";
 
 export {
   emailVerificationTokens,

--- a/packages/nextly/src/schemas/index.ts
+++ b/packages/nextly/src/schemas/index.ts
@@ -68,6 +68,7 @@ import { userFieldDefinitionsSqlite } from "./user-field-definitions/sqlite";
 import { userTables } from "./users";
 import { versionsTables } from "./versions";
 import { webhookTables } from "./webhooks";
+import { widgetLayoutTables } from "./widget-layout";
 
 // =============================================================================
 // Public API — populated incrementally by Plan A tasks 4–14.
@@ -200,6 +201,12 @@ export function getCoreSchema(
     ...Object.values(releasesTables(dialect)),
     ...Object.values(jobsTables(dialect)),
     ...Object.values(webhookTables(dialect)),
+    // `nextly_widget_layout` — one row per reader who has arranged the
+    // dashboard. Declared here for the same reason as every table above: the
+    // snapshot is the set `nextly migrate` pushes, so a table outside it is
+    // never created on a real installation however completely its own module
+    // declares it.
+    ...Object.values(widgetLayoutTables(dialect)),
   ];
 
   const fieldGroupRegistry = fieldGroupRegistryFor(dialect, options);
@@ -284,6 +291,7 @@ export const CORE_TABLE_NAMES: readonly string[] = [
   // snapshot, so the drift check proposes adding it again on every run.
   "nextly_field_group_lock",
   "nextly_document_lock",
+  "nextly_widget_layout",
   "dynamic_collections",
   "dynamic_singles",
   STORAGE_FORMAT.registryTable,

--- a/packages/nextly/src/schemas/widget-layout/index.ts
+++ b/packages/nextly/src/schemas/widget-layout/index.ts
@@ -4,6 +4,8 @@
  * @module schemas/widget-layout
  */
 
+import { createHash } from "node:crypto";
+
 import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 
 import { NextlyError } from "../../errors/nextly-error";
@@ -16,6 +18,41 @@ export { pg, my, sl };
 
 /** The physical table name, spelled once. */
 export const WIDGET_LAYOUT_TABLE = "nextly_widget_layout";
+
+/**
+ * Which kind of owner a layout row belongs to.
+ *
+ * Only `user` is written today. `role` is spelled in the key rather than added
+ * later because it is half of what identifies a row, and a key that learns a
+ * second value after rows exist is a migration.
+ */
+export type LayoutScopeKind = "user";
+
+/**
+ * The primary key for one scope.
+ *
+ * 🔴 A DIGEST of the scope, not `${kind}:${scopeId}` spelled out. The readable
+ * form does not fit: `id` is `varchar(191)`, and a user id is itself
+ * `varchar(191)` on MySQL and unbounded `text` on PostgreSQL — so prefixing
+ * `user:` overruns the key for any id past 186 characters. Those accounts can
+ * READ the endpoint, because an absent row is a legal answer, and then fail on
+ * every save with a database length error: a bug only some installations have,
+ * found by the unlucky user rather than by a test.
+ *
+ * Widening the column is the alternative and it is worse. 191 is the width
+ * MySQL will index for a utf8mb4 key, which is why every composite-string key
+ * in this codebase is exactly that. A digest is 64 characters whatever the
+ * scope is, so no future scope kind — a role slug, a team id — can reintroduce
+ * the same overflow.
+ *
+ * Nothing is lost to an operator: `scope_kind` and `scope_id` are stored as
+ * their own readable columns. Declared HERE, beside the table whose key it is,
+ * so every reader and every deleter derives it from one implementation rather
+ * than two that agree until one of them is edited.
+ */
+export function layoutRowId(kind: LayoutScopeKind, scopeId: string): string {
+  return createHash("sha256").update(`${kind}:${scopeId}`).digest("hex");
+}
 
 /**
  * The ONE place a dialect is turned into a layout table.

--- a/packages/nextly/src/schemas/widget-layout/index.ts
+++ b/packages/nextly/src/schemas/widget-layout/index.ts
@@ -1,0 +1,52 @@
+/**
+ * `nextly_widget_layout` — dialect-aware barrel.
+ *
+ * @module schemas/widget-layout
+ */
+
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
+
+import { NextlyError } from "../../errors/nextly-error";
+
+import * as my from "./mysql";
+import * as pg from "./postgres";
+import * as sl from "./sqlite";
+
+export { pg, my, sl };
+
+/** The physical table name, spelled once. */
+export const WIDGET_LAYOUT_TABLE = "nextly_widget_layout";
+
+/**
+ * The ONE place a dialect is turned into a layout table.
+ *
+ * 🔴 A ternary chain ending in a bare `else` would silently assign every future
+ * dialect to whichever branch came last, so adding one to `SupportedDialect`
+ * would compile and hand back another dialect's table. The `never` assignment
+ * below makes the compiler demand a case instead. Same shape, same reason, as
+ * `schemas/document-lock/index.ts`.
+ */
+function layoutForDialect(dialect: SupportedDialect) {
+  switch (dialect) {
+    case "postgresql":
+      return pg.nextlyWidgetLayout;
+    case "mysql":
+      return my.nextlyWidgetLayout;
+    case "sqlite":
+      return sl.nextlyWidgetLayout;
+    default: {
+      const _exhaustive: never = dialect;
+      throw NextlyError.internal({
+        logContext: {
+          reason: "no widget layout table for this dialect",
+          dialect: String(_exhaustive),
+        },
+      });
+    }
+  }
+}
+
+/** The layout table for the requested dialect, as a schema fragment. */
+export function widgetLayoutTables(dialect: SupportedDialect) {
+  return { nextlyWidgetLayout: layoutForDialect(dialect) };
+}

--- a/packages/nextly/src/schemas/widget-layout/mysql.ts
+++ b/packages/nextly/src/schemas/widget-layout/mysql.ts
@@ -1,0 +1,36 @@
+/**
+ * `nextly_widget_layout` — one reader's arrangement of the dashboard, MySQL.
+ *
+ * See `./postgres` for why the id is composite, why the payload is text rather
+ * than native JSON, and why `version` is an integer.
+ *
+ * @module schemas/widget-layout/mysql
+ */
+
+import {
+  datetime,
+  int,
+  mysqlTable,
+  text,
+  varchar,
+} from "drizzle-orm/mysql-core";
+
+export const nextlyWidgetLayout = mysqlTable("nextly_widget_layout", {
+  id: varchar("id", { length: 191 }).primaryKey(),
+  scopeKind: varchar("scope_kind", { length: 32 }).notNull(),
+  scopeId: varchar("scope_id", { length: 191 }).notNull(),
+  // MySQL's `TEXT` is 65535 BYTES, where PostgreSQL and SQLite are effectively
+  // unbounded. That asymmetry is not academic: a placement carries an opaque
+  // `config` the caller fills, so the payload's size is caller-controlled, and
+  // without a cap the same write stores cleanly on two dialects and here either
+  // errors or — under a permissive `sql_mode` — TRUNCATES, leaving JSON the next
+  // read cannot parse and losing the whole saved dashboard on one deployment
+  // only. `MAX_LAYOUT_BYTES` in `domains/widgets/layout` is the cap, set to
+  // half this limit so multi-byte characters cannot reach it.
+  layout: text("layout").notNull(),
+  version: int("version").notNull().default(1),
+  // `datetime` stores no zone. Nothing reads this column back, so unlike
+  // `nextly_document_lock` — whose two clocks have to agree across sessions —
+  // there is no comparison here for a session offset to corrupt.
+  updatedAt: datetime("updated_at").notNull(),
+});

--- a/packages/nextly/src/schemas/widget-layout/mysql.ts
+++ b/packages/nextly/src/schemas/widget-layout/mysql.ts
@@ -10,8 +10,8 @@
 import {
   datetime,
   int,
+  mediumtext,
   mysqlTable,
-  text,
   varchar,
 } from "drizzle-orm/mysql-core";
 
@@ -19,15 +19,16 @@ export const nextlyWidgetLayout = mysqlTable("nextly_widget_layout", {
   id: varchar("id", { length: 191 }).primaryKey(),
   scopeKind: varchar("scope_kind", { length: 32 }).notNull(),
   scopeId: varchar("scope_id", { length: 191 }).notNull(),
-  // MySQL's `TEXT` is 65535 BYTES, where PostgreSQL and SQLite are effectively
-  // unbounded. That asymmetry is not academic: a placement carries an opaque
-  // `config` the caller fills, so the payload's size is caller-controlled, and
-  // without a cap the same write stores cleanly on two dialects and here either
-  // errors or — under a permissive `sql_mode` — TRUNCATES, leaving JSON the next
-  // read cannot parse and losing the whole saved dashboard on one deployment
-  // only. `MAX_LAYOUT_BYTES` in `domains/widgets/layout` is the cap, set to
-  // half this limit so multi-byte characters cannot reach it.
-  layout: text("layout").notNull(),
+  // `mediumtext` (16 MiB), not `TEXT` (65535 bytes). The narrow type made the
+  // column a DECISION SURFACE: a write had to be refused when the payload
+  // outgrew it, and that payload is partly made of placements carried on the
+  // caller's behalf — so acceptance itself varied with data the caller may not
+  // see, and a caller could binary-search a visible placement's size against it
+  // to measure hidden configuration. Removing the ceiling removes the oracle by
+  // construction, which is a boundary rather than a check for crossings. The
+  // caller's own submission is still bounded, by a fixed budget that depends on
+  // nothing hidden.
+  layout: mediumtext("layout").notNull(),
   version: int("version").notNull().default(1),
   // `datetime` stores no zone. Nothing reads this column back, so unlike
   // `nextly_document_lock` — whose two clocks have to agree across sessions —

--- a/packages/nextly/src/schemas/widget-layout/postgres.ts
+++ b/packages/nextly/src/schemas/widget-layout/postgres.ts
@@ -19,10 +19,10 @@
  *
  * ## Why the scope kind is in the key on day one
  *
- * Only `user` rows are written today; the role layer is designed in and not
- * built (founder, 2026-09-01). Keyed on the reader alone, adding role defaults
- * later would mean migrating every existing row to make room for a second kind
- * of owner. The column costs 32 bytes now and removes a migration later.
+ * Only `user` rows are written today. The kind is part of the key anyway,
+ * because it is half of what identifies an owner: keyed on the reader alone, a
+ * second kind of owner added after rows exist means migrating every row to make
+ * room for it. The column costs 32 bytes now and removes that migration.
  *
  * ## Why `layout` is `text` and not `jsonb`
  *
@@ -59,7 +59,14 @@ export const nextlyWidgetLayout = pgTable("nextly_widget_layout", {
   // only.
   id: varchar("id", { length: 191 }).primaryKey(),
   scopeKind: varchar("scope_kind", { length: 32 }).notNull(),
-  scopeId: varchar("scope_id", { length: 191 }).notNull(),
+  // `text`, not `varchar(191)`, and this dialect alone. The KEY is a digest so
+  // no scope can overrun it, but this column stores the caller's id verbatim —
+  // and PostgreSQL's own `users.id` is unbounded `text`, so an externally
+  // supplied id longer than 191 characters would authenticate, read the default
+  // layout, and fail on the first save with a length error. Each dialect
+  // matches the width its own `users.id` declares; MySQL's is `varchar(191)`,
+  // so 191 there is not a limit a real user can reach.
+  scopeId: text("scope_id").notNull(),
   // The whole snapshot, as JSON text. `notNull` because a row that exists means
   // somebody arranged something; "no arrangement" is the ABSENCE of a row, and
   // giving it a second spelling here would make two states that read the same.

--- a/packages/nextly/src/schemas/widget-layout/postgres.ts
+++ b/packages/nextly/src/schemas/widget-layout/postgres.ts
@@ -1,0 +1,75 @@
+/**
+ * `nextly_widget_layout` — one reader's arrangement of the dashboard, PostgreSQL.
+ *
+ * A row exists only for a scope that has arranged the dashboard at all. Absent,
+ * the reader sees the registry's own order, which is exactly today's behaviour
+ * — so shipping this table changes nothing for anybody until they move a card.
+ *
+ * ## Why `id` is a composite string
+ *
+ * `id` holds `scopeKind:scopeId` rather than the table carrying a composite
+ * primary key, matching `schemas/document-lock/postgres.ts`. The layout is
+ * always addressed by an exact scope, never scanned by one half of the key, so
+ * a composite key would buy nothing a derived string does not already give —
+ * and one column is one thing for a future role layer to key on.
+ *
+ * `scope_kind` is a COLUMN as well as a prefix of the id, so the two halves stay
+ * readable to an operator and to any future sweep ("every role default") that
+ * has to find rows without knowing their ids.
+ *
+ * ## Why the scope kind is in the key on day one
+ *
+ * Only `user` rows are written today; the role layer is designed in and not
+ * built (founder, 2026-09-01). Keyed on the reader alone, adding role defaults
+ * later would mean migrating every existing row to make room for a second kind
+ * of owner. The column costs 32 bytes now and removes a migration later.
+ *
+ * ## Why `layout` is `text` and not `jsonb`
+ *
+ * The `site_settings` convention (`custom_sidebar_groups`, `plugin_placements`),
+ * not the `nextly_meta` native-JSON one. A layout is read and written WHOLE —
+ * nothing ever queries a JSON path inside it — so native JSON buys nothing, and
+ * `jsonb` re-normalizes key order, which this repository has already paid for
+ * once in a "has this changed" comparison. A personalization feature invites
+ * exactly that comparison (an audit diff, a "your layout vs the team default"
+ * view), so the cheap thing to do now is the thing that will not need undoing.
+ *
+ * ## Why `version` is a column and not a timestamp
+ *
+ * A whole-document PUT needs to detect that somebody else wrote in between, and
+ * two tabs belonging to one person can write in the same second. An integer
+ * bumped per write is exact where a timestamp is merely usually right.
+ *
+ * @module schemas/widget-layout/postgres
+ */
+
+import {
+  integer,
+  pgTable,
+  text,
+  timestamp,
+  varchar,
+} from "drizzle-orm/pg-core";
+
+export const nextlyWidgetLayout = pgTable("nextly_widget_layout", {
+  // 191 on every dialect, not because PostgreSQL needs it, but because MySQL
+  // will not index a longer utf8mb4 varchar. Same reasoning, same length, as
+  // `nextly_document_lock` — a key that worked on two dialects and threw on the
+  // third would surface as a dashboard that cannot be saved, on one deployment
+  // only.
+  id: varchar("id", { length: 191 }).primaryKey(),
+  scopeKind: varchar("scope_kind", { length: 32 }).notNull(),
+  scopeId: varchar("scope_id", { length: 191 }).notNull(),
+  // The whole snapshot, as JSON text. `notNull` because a row that exists means
+  // somebody arranged something; "no arrangement" is the ABSENCE of a row, and
+  // giving it a second spelling here would make two states that read the same.
+  layout: text("layout").notNull(),
+  // Starts at 1 on the first write, so a client that has never read one sends 0
+  // and can be told apart from one holding a real version.
+  version: integer("version").notNull().default(1),
+  // Written, never read back. It exists for an operator reading the table, not
+  // for any code path — which is deliberate: the three dialects disagree about
+  // what a timestamp round-trips as, and a column nothing reads cannot be
+  // corrupted by that disagreement.
+  updatedAt: timestamp("updated_at", { withTimezone: true }).notNull(),
+});

--- a/packages/nextly/src/schemas/widget-layout/postgres.ts
+++ b/packages/nextly/src/schemas/widget-layout/postgres.ts
@@ -5,17 +5,25 @@
  * the reader sees the registry's own order, which is exactly today's behaviour
  * — so shipping this table changes nothing for anybody until they move a card.
  *
- * ## Why `id` is a composite string
+ * ## Why `id` is a digest
  *
- * `id` holds `scopeKind:scopeId` rather than the table carrying a composite
- * primary key, matching `schemas/document-lock/postgres.ts`. The layout is
- * always addressed by an exact scope, never scanned by one half of the key, so
- * a composite key would buy nothing a derived string does not already give —
- * and one column is one thing for a future role layer to key on.
+ * `id` holds a sha256 of `scopeKind:scopeId` rather than that string spelled
+ * out. The readable form does not fit: this column is `varchar(191)` — the
+ * width MySQL will index for a utf8mb4 key — while a user id is itself
+ * `varchar(191)` on MySQL and unbounded `text` on PostgreSQL, so `user:` plus
+ * an id past 186 characters overruns the key. Those accounts could read the
+ * endpoint, because an absent row is a legal answer, and failed on every save.
  *
- * `scope_kind` is a COLUMN as well as a prefix of the id, so the two halves stay
- * readable to an operator and to any future sweep ("every role default") that
- * has to find rows without knowing their ids.
+ * 🔴 Do NOT construct this key by hand. A readable `user:<id>` matches no
+ * stored row, so a cleanup query or a migration written from an out-of-date
+ * reading of this comment silently affects nothing. `layoutRowId` in
+ * `schemas/widget-layout/index.ts` is the one derivation, and every reader,
+ * writer and deleter goes through it — which is also what lets the user
+ * deletion path address a row without importing the layout service.
+ *
+ * `scope_kind` and `scope_id` remain as their own readable columns, so an
+ * operator can still see whose row this is.
+ *
  *
  * ## Why the scope kind is in the key on day one
  *

--- a/packages/nextly/src/schemas/widget-layout/sqlite.ts
+++ b/packages/nextly/src/schemas/widget-layout/sqlite.ts
@@ -1,0 +1,21 @@
+/**
+ * `nextly_widget_layout` — one reader's arrangement of the dashboard, SQLite.
+ *
+ * See `./postgres` for why the id is composite, why the payload is text rather
+ * than native JSON, and why `version` is an integer.
+ *
+ * @module schemas/widget-layout/sqlite
+ */
+
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const nextlyWidgetLayout = sqliteTable("nextly_widget_layout", {
+  id: text("id").primaryKey(),
+  scopeKind: text("scope_kind").notNull(),
+  scopeId: text("scope_id").notNull(),
+  layout: text("layout").notNull(),
+  version: integer("version").notNull().default(1),
+  // Unix SECONDS, which is what `mode: "timestamp"` means here. Written, never
+  // read back — see `./postgres`.
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});

--- a/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
+++ b/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
@@ -1,0 +1,251 @@
+/**
+ * The layout row against a real database, on every dialect.
+ *
+ * The unit tests around this service mock it away entirely, so two things in it
+ * have no coverage anywhere else, and both are exactly the kind that pass on
+ * one dialect and fail on another after merge:
+ *
+ * - **The version guard reads a driver-specific field.** `affectedRowCount`
+ *   reads `changes` on SQLite, `rowCount` on PostgreSQL and
+ *   `ResultSetHeader.affectedRows` on MySQL. A missing field yields `undefined`
+ *   and `?? 0` turns that into a plausible zero -- so a guard reading the wrong
+ *   one reports EVERY write as a conflict, or, with the branches the other way
+ *   round, never reports one and lets two tabs overwrite each other silently.
+ * - **`id` is `varchar(191)`**, which only MySQL enforces. A scope id that fits
+ *   on two dialects and truncates on the third is a reader whose layout lands
+ *   on somebody else's row.
+ *
+ * SQLite runs with no URL; PostgreSQL and MySQL self-skip locally and run in
+ * CI's dialect matrix.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+
+import { createAdapter } from "../../../database/factory";
+import {
+  createTestNextly,
+  type TestNextly,
+} from "../../../plugins/test-nextly";
+import type { WidgetPlacement } from "../../../domains/widgets/layout";
+import { NextlyError } from "../../../errors/nextly-error";
+import { WidgetLayoutService } from "../widget-layout-service";
+
+const silentLogger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+function placement(patch: Partial<WidgetPlacement> = {}): WidgetPlacement {
+  return {
+    id: "p1",
+    widgetId: "core/team",
+    order: 0,
+    hidden: false,
+    ...patch,
+  };
+}
+
+/**
+ * The suite body, run once per dialect that is reachable.
+ *
+ * A factory rather than three copies, so a case added for one dialect cannot
+ * quietly go unrun on the other two -- which is how a cross-dialect guarantee
+ * ends up proven on the fastest dialect only.
+ */
+function layoutSuite(
+  label: string,
+  makeService: () => Promise<WidgetLayoutService>
+) {
+  describe(`widget layout row (${label})`, () => {
+    let service: WidgetLayoutService;
+
+    beforeAll(async () => {
+      service = await makeService();
+    });
+
+    it("round-trips an arrangement", async () => {
+      const scope = `u-roundtrip-${label}`;
+      const placements = [
+        placement({ id: "a", order: 0, size: "md" }),
+        placement({ id: "b", widgetId: "core/other", order: 10, hidden: true }),
+      ];
+
+      const version = await service.saveLayout("user", scope, placements, 0);
+      expect(version).toBe(1);
+
+      const read = await service.getLayout("user", scope);
+      expect(read.unreadable).toBe(false);
+      expect(read.version).toBe(1);
+      expect(read.layout?.placements).toEqual(placements);
+    });
+
+    it("reports no row before anything is written", async () => {
+      const read = await service.getLayout("user", `u-absent-${label}`);
+      expect(read.layout).toBeUndefined();
+      expect(read.version).toBe(0);
+      expect(read.unreadable).toBe(false);
+    });
+
+    it("accepts a write that names the current version", async () => {
+      const scope = `u-bump-${label}`;
+      await service.saveLayout("user", scope, [placement()], 0);
+
+      const second = await service.saveLayout(
+        "user",
+        scope,
+        [placement({ id: "moved", order: 5 })],
+        1
+      );
+
+      expect(second).toBe(2);
+      const read = await service.getLayout("user", scope);
+      expect(read.version).toBe(2);
+      expect(read.layout?.placements[0].id).toBe("moved");
+    });
+
+    it("refuses a write that names a stale version", async () => {
+      // 🔴 The `affectedRowCount` case. Reading the wrong driver field makes
+      // this pass -- the write lands and the second tab's arrangement replaces
+      // the first with nothing anywhere to say so.
+      const scope = `u-stale-${label}`;
+      await service.saveLayout("user", scope, [placement()], 0);
+      await service.saveLayout("user", scope, [placement({ id: "x" })], 1);
+
+      await expect(
+        service.saveLayout("user", scope, [placement({ id: "y" })], 1)
+      ).rejects.toSatisfy((e: unknown) => NextlyError.isConflict(e));
+
+      // And the losing write left nothing behind.
+      const read = await service.getLayout("user", scope);
+      expect(read.version).toBe(2);
+      expect(read.layout?.placements[0].id).toBe("x");
+    });
+
+    it("refuses an insert when a row already exists", async () => {
+      const scope = `u-dup-${label}`;
+      await service.saveLayout("user", scope, [placement({ id: "first" })], 0);
+
+      await expect(
+        service.saveLayout("user", scope, [placement({ id: "z" })], 0)
+      ).rejects.toSatisfy((e: unknown) => NextlyError.isConflict(e));
+
+      // `isConflict` alone would be satisfied by ANY error the insert can
+      // raise, including a fault that has nothing to do with a lost race -- so
+      // the row is read back too. It must be untouched: a conflict that half
+      // wrote is worse than one that did not fire.
+      const read = await service.getLayout("user", scope);
+      expect(read.version).toBe(1);
+      expect(read.layout?.placements[0].id).toBe("first");
+    });
+
+    it("keeps two scopes apart at the id column's full width", async () => {
+      // `id` is `${kind}:${scopeId}` in a varchar(191). Two ids that differ
+      // only past a truncation point must stay two rows -- on MySQL, which is
+      // the only dialect that enforces the width, a truncating column would
+      // merge them and hand one reader the other's dashboard.
+      const stem = "u".repeat(180);
+      const a = `${stem}-aaa`;
+      const b = `${stem}-bbb`;
+
+      await service.saveLayout("user", a, [placement({ id: "for-a" })], 0);
+      await service.saveLayout("user", b, [placement({ id: "for-b" })], 0);
+
+      expect(
+        (await service.getLayout("user", a)).layout?.placements[0].id
+      ).toBe("for-a");
+      expect(
+        (await service.getLayout("user", b)).layout?.placements[0].id
+      ).toBe("for-b");
+    });
+
+    it("reports an undecodable row rather than throwing", async () => {
+      const scope = `u-broken-${label}`;
+      await service.saveLayout("user", scope, [placement()], 0);
+      // Corrupt the stored payload the way a downgrade or a bad hand-edit
+      // would, without going through the service that would refuse it.
+      await corruptLayout(service, `user:${scope}`);
+
+      const read = await service.getLayout("user", scope);
+      expect(read.unreadable).toBe(true);
+      expect(read.layout).toBeUndefined();
+      // The TRUE version, so the reader's next write can repair the row
+      // instead of colliding with it.
+      expect(read.version).toBe(1);
+    });
+  });
+}
+
+/** Writes a payload the decoder must refuse, bypassing the service's own guard. */
+async function corruptLayout(
+  service: WidgetLayoutService,
+  id: string
+): Promise<void> {
+  const internals = service as unknown as {
+    db: {
+      update: (t: unknown) => {
+        set: (v: unknown) => { where: (w: unknown) => Promise<unknown> };
+      };
+    };
+    table: { id: unknown };
+  };
+  const { eq } = await import("drizzle-orm");
+  await internals.db
+    .update(internals.table)
+    .set({ layout: "{not json" })
+    .where(eq(internals.table.id as never, id));
+}
+
+// ---------------------------------------------------------------------------
+// SQLite — always available; `createTestNextly` boots a fresh in-memory
+// database with the full core schema pushed, so the table under test is
+// created by the same path a real install uses.
+// ---------------------------------------------------------------------------
+let sqliteHandle: TestNextly | undefined;
+layoutSuite("sqlite", async () => {
+  sqliteHandle = await createTestNextly();
+  return new WidgetLayoutService(sqliteHandle.adapter, silentLogger);
+});
+afterAll(async () => {
+  await sqliteHandle?.destroy();
+});
+
+// ---------------------------------------------------------------------------
+// PostgreSQL and MySQL — self-skipping without their URLs, run by CI's matrix.
+// ---------------------------------------------------------------------------
+const PG_URL = process.env.TEST_POSTGRES_URL ?? "";
+const MY_URL = process.env.TEST_MYSQL_URL ?? "";
+
+let pgHandle: TestNextly | undefined;
+describe.skipIf(!PG_URL)("postgres", () => {
+  layoutSuite("postgres", async () => {
+    process.env.DB_DIALECT = "postgresql";
+    process.env.DATABASE_URL = PG_URL;
+    const adapter = await createAdapter({
+      type: "postgresql",
+      url: PG_URL,
+    } as Parameters<typeof createAdapter>[0]);
+    pgHandle = await createTestNextly({ adapter });
+    return new WidgetLayoutService(pgHandle.adapter, silentLogger);
+  });
+  afterAll(async () => {
+    await pgHandle?.destroy();
+  });
+});
+
+let myHandle: TestNextly | undefined;
+describe.skipIf(!MY_URL)("mysql", () => {
+  layoutSuite("mysql", async () => {
+    process.env.DB_DIALECT = "mysql";
+    process.env.DATABASE_URL = MY_URL;
+    const adapter = await createAdapter({
+      type: "mysql",
+      url: MY_URL,
+    } as Parameters<typeof createAdapter>[0]);
+    myHandle = await createTestNextly({ adapter });
+    return new WidgetLayoutService(myHandle.adapter, silentLogger);
+  });
+  afterAll(async () => {
+    await myHandle?.destroy();
+  });
+});

--- a/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
+++ b/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
@@ -147,7 +147,14 @@ function layoutSuite(
       // fine -- an absent row is a legal answer -- and fail on every save with
       // a database length error. The key is a digest instead, so the scope's
       // own length cannot reach the column at all.
-      const long = "u".repeat(400);
+      // 191, which is the widest a real user id can be: MySQL's `users.id` is
+      // `varchar(191)` and so is this table's `scope_id` there. A longer
+      // fixture is not a stronger test, it is a value no caller can produce —
+      // and MySQL 8's strict mode rejects the insert, so the leg fails on the
+      // fixture rather than on the property. 191 still proves the point the
+      // test exists for: spelled into the key as `user:${scopeId}` it would be
+      // 196 characters against a `varchar(191)` primary key.
+      const long = "u".repeat(191);
       await service.saveLayout("user", long, [placement({ id: "long" })], 0);
       expect(
         (await service.getLayout("user", long)).layout?.placements[0].id

--- a/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
+++ b/packages/nextly/src/services/widgets/__tests__/widget-layout.integration.test.ts
@@ -27,6 +27,7 @@ import {
 } from "../../../plugins/test-nextly";
 import type { WidgetPlacement } from "../../../domains/widgets/layout";
 import { NextlyError } from "../../../errors/nextly-error";
+import { layoutRowId } from "../../../schemas/widget-layout";
 import { WidgetLayoutService } from "../widget-layout-service";
 
 const silentLogger = {
@@ -139,11 +140,24 @@ function layoutSuite(
       expect(read.layout?.placements[0].id).toBe("first");
     });
 
-    it("keeps two scopes apart at the id column's full width", async () => {
-      // `id` is `${kind}:${scopeId}` in a varchar(191). Two ids that differ
-      // only past a truncation point must stay two rows -- on MySQL, which is
-      // the only dialect that enforces the width, a truncating column would
-      // merge them and hand one reader the other's dashboard.
+    it("stores a scope id far longer than the key column", async () => {
+      // A user id is `varchar(191)` on MySQL and unbounded `text` on
+      // PostgreSQL. Spelled into the key as `user:${scopeId}` it overruns the
+      // 191-character primary key past 186 characters, so those accounts read
+      // fine -- an absent row is a legal answer -- and fail on every save with
+      // a database length error. The key is a digest instead, so the scope's
+      // own length cannot reach the column at all.
+      const long = "u".repeat(400);
+      await service.saveLayout("user", long, [placement({ id: "long" })], 0);
+      expect(
+        (await service.getLayout("user", long)).layout?.placements[0].id
+      ).toBe("long");
+    });
+
+    it("keeps two scopes apart past any truncation point", async () => {
+      // Two ids that differ only past a truncation point must stay two rows: a
+      // key that truncated would merge them and hand one reader the other's
+      // dashboard.
       const stem = "u".repeat(180);
       const a = `${stem}-aaa`;
       const b = `${stem}-bbb`;
@@ -164,7 +178,12 @@ function layoutSuite(
       await service.saveLayout("user", scope, [placement()], 0);
       // Corrupt the stored payload the way a downgrade or a bad hand-edit
       // would, without going through the service that would refuse it.
-      await corruptLayout(service, `user:${scope}`);
+      // Addressed through the SAME derivation the service writes with. Spelled
+      // out as `user:${scope}` it targeted a row that does not exist, the
+      // corruption landed nowhere, and the assertion below failed -- which is
+      // the good direction, but only because the test asserts the corrupt
+      // OUTCOME rather than the write having happened.
+      await corruptLayout(service, layoutRowId("user", scope));
 
       const read = await service.getLayout("user", scope);
       expect(read.unreadable).toBe(true);

--- a/packages/nextly/src/services/widgets/widget-layout-service.test.ts
+++ b/packages/nextly/src/services/widgets/widget-layout-service.test.ts
@@ -1,0 +1,97 @@
+/**
+ * How the service classifies a failed INSERT.
+ *
+ * A lost race and a broken write both arrive as a driver throw, and telling
+ * them apart is the whole job: reported as a conflict, a write fault becomes
+ * "reload and try again", so the client re-reads version 0, retries, loops, and
+ * no operator ever sees that the database is refusing writes.
+ *
+ * Exercised through a stubbed `db` rather than a real one, because the
+ * interesting inputs are failures a healthy database will not produce on
+ * demand -- and the discriminator under test is a second query, not any SQL the
+ * first one emitted.
+ */
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import { describe, expect, it } from "vitest";
+
+import { NextlyError } from "../../errors/nextly-error";
+import type { Logger } from "../shared";
+
+import { WidgetLayoutService } from "./widget-layout-service";
+
+const silentLogger: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+};
+
+const adapterStub = {
+  getCapabilities: () => ({ dialect: "sqlite" as const }),
+} as unknown as DrizzleAdapter;
+
+/**
+ * A service whose `db` answers exactly what a test wants.
+ *
+ * `insertThrows` is what the write does; `rowExistsAfter` is what the follow-up
+ * SELECT finds. Those two inputs are the entire decision.
+ */
+class StubbedService extends WidgetLayoutService {
+  constructor(
+    private readonly insertThrows: Error,
+    private readonly rowExistsAfter: boolean
+  ) {
+    super(adapterStub, silentLogger);
+  }
+
+  protected override get db(): never {
+    const rows = this.rowExistsAfter ? [{ id: "user:u1" }] : [];
+    const selectChain = {
+      from: () => selectChain,
+      where: () => selectChain,
+      limit: async () => rows,
+      then: (resolve: (v: unknown) => unknown) => resolve(rows),
+    };
+    return {
+      insert: () => ({
+        values: () => {
+          throw this.insertThrows;
+        },
+      }),
+      select: () => selectChain,
+    } as never;
+  }
+}
+
+const placements = [{ id: "p1", widgetId: "core/a", order: 0, hidden: false }];
+
+describe("a failed insert", () => {
+  it("is a conflict when a row is there afterwards", async () => {
+    const service = new StubbedService(new Error("UNIQUE constraint"), true);
+
+    await expect(
+      service.saveLayout("user", "u1", placements, 0)
+    ).rejects.toSatisfy((e: unknown) => NextlyError.isConflict(e));
+  });
+
+  it("propagates unchanged when no row is there afterwards", async () => {
+    // 🔴 The case a bare `catch` got wrong. A dropped connection, a missing
+    // table or an over-long payload is a write FAULT, and answering it with
+    // "reload and try again" sends the client into a retry loop while hiding
+    // the fault from everyone who could fix it.
+    const fault = new Error("connection terminated");
+    const service = new StubbedService(fault, false);
+
+    await expect(service.saveLayout("user", "u1", placements, 0)).rejects.toBe(
+      fault
+    );
+  });
+
+  it("does not classify a fault as a conflict merely because it threw", async () => {
+    const service = new StubbedService(new Error("no such table"), false);
+
+    await expect(
+      service.saveLayout("user", "u1", placements, 0)
+    ).rejects.toSatisfy((e: unknown) => !NextlyError.isConflict(e));
+  });
+});

--- a/packages/nextly/src/services/widgets/widget-layout-service.ts
+++ b/packages/nextly/src/services/widgets/widget-layout-service.ts
@@ -1,0 +1,235 @@
+/**
+ * Reads and writes one scope's dashboard arrangement.
+ *
+ * The row is a cache of a DECISION, not of data: it records where somebody put
+ * their cards, and nothing about what those cards contain or who may see them.
+ * Every such question is asked of the live registry by the endpoint above this,
+ * on every read.
+ *
+ * @module services/widgets/widget-layout-service
+ */
+
+import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import { and, eq } from "drizzle-orm";
+
+import {
+  readStoredLayout,
+  serializeLayout,
+  type StoredLayout,
+  type WidgetPlacement,
+} from "../../domains/widgets/layout";
+import { NextlyError } from "../../errors/nextly-error";
+import { nextlyWidgetLayout as layoutMysql } from "../../schemas/widget-layout/mysql";
+import { nextlyWidgetLayout as layoutPg } from "../../schemas/widget-layout/postgres";
+import { nextlyWidgetLayout as layoutSqlite } from "../../schemas/widget-layout/sqlite";
+import { affectedRowCount } from "../../shared/lib/affected-row-count";
+import { BaseService } from "../base-service";
+import type { Logger } from "../shared";
+
+/**
+ * Which kind of owner a layout row belongs to.
+ *
+ * Only `user` is written today. `role` is spelled here rather than added later
+ * because it is half of the primary key, and a key that learns a second value
+ * after rows exist is a migration.
+ */
+export type LayoutScopeKind = "user";
+
+/** The version a caller holds when they have never read a stored row. */
+export const NO_STORED_LAYOUT_VERSION = 0;
+
+/**
+ * What one scope currently has stored.
+ *
+ * `layout` is `undefined` both when no row exists and when the row could not be
+ * decoded, and `unreadable` is what tells those apart. The caller needs the
+ * distinction: the first is an ordinary new reader, the second is a fault an
+ * operator should see.
+ */
+export interface StoredLayoutRow {
+  layout: StoredLayout | undefined;
+  version: number;
+  unreadable: boolean;
+}
+
+function rowId(kind: LayoutScopeKind, scopeId: string): string {
+  return `${kind}:${scopeId}`;
+}
+
+export class WidgetLayoutService extends BaseService {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private table: any;
+
+  constructor(adapter: DrizzleAdapter, logger: Logger) {
+    super(adapter, logger);
+
+    switch (this.dialect) {
+      case "postgresql":
+        this.table = layoutPg;
+        break;
+      case "mysql":
+        this.table = layoutMysql;
+        break;
+      case "sqlite":
+        this.table = layoutSqlite;
+        break;
+      default:
+        throw NextlyError.internal({
+          logContext: {
+            reason: "no widget layout table for this dialect",
+            dialect: String(this.dialect),
+          },
+        });
+    }
+  }
+
+  /**
+   * The stored arrangement for one scope, or the absence of one.
+   *
+   * A row that cannot be decoded is LOGGED and reported as unreadable rather
+   * than thrown onward. `readStoredLayout` throws on purpose -- a persisted
+   * record must not vanish silently -- and this is the layer that decides what
+   * to do about it: the dashboard still draws, from the registry's own order,
+   * and the response says so. Letting the throw reach the endpoint would answer
+   * the whole dashboard with a 500 that no amount of clicking could clear,
+   * because the offending row would still be there on the next request.
+   */
+  async getLayout(
+    kind: LayoutScopeKind,
+    scopeId: string
+  ): Promise<StoredLayoutRow> {
+    const rows = await this.db
+      .select()
+      .from(this.table)
+      .where(eq(this.table.id, rowId(kind, scopeId)))
+      .limit(1);
+
+    const row = rows?.[0] as
+      | { layout?: unknown; version?: unknown }
+      | undefined;
+    if (!row) {
+      return {
+        layout: undefined,
+        version: NO_STORED_LAYOUT_VERSION,
+        unreadable: false,
+      };
+    }
+
+    const version =
+      typeof row.version === "number" ? row.version : NO_STORED_LAYOUT_VERSION;
+
+    try {
+      return {
+        layout: readStoredLayout(String(row.layout)),
+        version,
+        unreadable: false,
+      };
+    } catch (error) {
+      this.logger.error("Unreadable dashboard layout row", {
+        scopeKind: kind,
+        scopeId,
+        version,
+        ...(NextlyError.is(error)
+          ? error.toLogJSON("widget-layout")
+          : { err: error instanceof Error ? error.stack : String(error) }),
+      });
+      return { layout: undefined, version, unreadable: true };
+    }
+  }
+
+  /**
+   * Replaces one scope's arrangement, refusing if it moved since the caller
+   * read it.
+   *
+   * The guard is the WHERE clause, not the read before it. Two tabs belonging
+   * to one person can both read version 3 and both submit; comparing in
+   * application code would let both pass, and the second would overwrite the
+   * first with no sign. `WHERE version = ?` makes the database settle it: the
+   * second statement matches no row, and this reports the conflict rather than
+   * a success.
+   *
+   * `expectedVersion === NO_STORED_LAYOUT_VERSION` means "I believe there is no
+   * row", which is an INSERT. A concurrent insert loses on the primary key,
+   * which surfaces as a driver error rather than as a clean conflict.
+   *
+   * 🔴 That is classified by ASKING THE DATABASE whether a row now exists, not
+   * by catching every throw. A bare catch answered a dropped connection, an
+   * over-long payload and a missing table with "reload and try again" -- so the
+   * client re-read version 0, retried, and looped, while no operator ever saw a
+   * write fault. Re-reading discriminates without parsing a driver's error
+   * codes, which differ per dialect and are the other way this gets written
+   * wrong. Anything that is not a lost race is rethrown unchanged;
+   * `withErrorHandler` already wraps an unclassified throw as `internal` with a
+   * generic public message, so nothing leaks by letting it through.
+   */
+  async saveLayout(
+    kind: LayoutScopeKind,
+    scopeId: string,
+    placements: readonly WidgetPlacement[],
+    expectedVersion: number
+  ): Promise<number> {
+    const id = rowId(kind, scopeId);
+    const layout = serializeLayout(placements);
+    const now = new Date();
+
+    if (expectedVersion === NO_STORED_LAYOUT_VERSION) {
+      try {
+        await this.db.insert(this.table).values({
+          id,
+          scopeKind: kind,
+          scopeId,
+          layout,
+          version: 1,
+          updatedAt: now,
+        });
+        return 1;
+      } catch (error) {
+        // Only a row that is now THERE makes this a lost race. `select` rather
+        // than `getLayout`, because a row whose payload cannot be decoded still
+        // occupies the primary key and still means this insert lost.
+        const existing = await this.db
+          .select({ id: this.table.id })
+          .from(this.table)
+          .where(eq(this.table.id, id))
+          .limit(1);
+        if (existing?.length) throw layoutConflict(error);
+        throw error;
+      }
+    }
+
+    const nextVersion = expectedVersion + 1;
+    const result = await this.db
+      .update(this.table)
+      .set({ layout, version: nextVersion, updatedAt: now })
+      .where(
+        and(eq(this.table.id, id), eq(this.table.version, expectedVersion))
+      );
+
+    if (affectedRowCount(result, this.dialect) === 0) {
+      throw layoutConflict();
+    }
+    return nextVersion;
+  }
+}
+
+/**
+ * The one refusal a client is expected to recover from, by re-reading.
+ *
+ * `conflict` rather than `validation`: nothing about the submitted layout is
+ * wrong, and telling a client its body was invalid would send it to fix a
+ * document that is already correct.
+ *
+ * 409 with `reason: "version"`, which is this package's existing spelling for
+ * exactly this situation, rather than the 412 the design note sketched. A lone
+ * 412 would be the only one in the API, and `parseApiError` already gives
+ * clients a `CONFLICT` code to branch on -- a second status meaning the same
+ * thing buys nothing and costs every client a special case.
+ */
+function layoutConflict(cause?: unknown): NextlyError {
+  return NextlyError.conflict({
+    reason: "version",
+    message:
+      "The dashboard layout changed since you loaded it. Reload and try again.",
+    ...(cause instanceof Error ? { cause } : {}),
+  });
+}

--- a/packages/nextly/src/services/widgets/widget-layout-service.ts
+++ b/packages/nextly/src/services/widgets/widget-layout-service.ts
@@ -10,6 +10,7 @@
  */
 
 import type { DrizzleAdapter } from "@nextlyhq/adapter-drizzle";
+import type { SupportedDialect } from "@nextlyhq/adapter-drizzle/types";
 import { and, eq } from "drizzle-orm";
 
 import {
@@ -19,21 +20,13 @@ import {
   type WidgetPlacement,
 } from "../../domains/widgets/layout";
 import { NextlyError } from "../../errors/nextly-error";
+import { layoutRowId, type LayoutScopeKind } from "../../schemas/widget-layout";
 import { nextlyWidgetLayout as layoutMysql } from "../../schemas/widget-layout/mysql";
 import { nextlyWidgetLayout as layoutPg } from "../../schemas/widget-layout/postgres";
 import { nextlyWidgetLayout as layoutSqlite } from "../../schemas/widget-layout/sqlite";
 import { affectedRowCount } from "../../shared/lib/affected-row-count";
 import { BaseService } from "../base-service";
 import type { Logger } from "../shared";
-
-/**
- * Which kind of owner a layout row belongs to.
- *
- * Only `user` is written today. `role` is spelled here rather than added later
- * because it is half of the primary key, and a key that learns a second value
- * after rows exist is a migration.
- */
-export type LayoutScopeKind = "user";
 
 /** The version a caller holds when they have never read a stored row. */
 export const NO_STORED_LAYOUT_VERSION = 0;
@@ -52,35 +45,51 @@ export interface StoredLayoutRow {
   unreadable: boolean;
 }
 
-function rowId(kind: LayoutScopeKind, scopeId: string): string {
-  return `${kind}:${scopeId}`;
+/**
+ * The layout table for whichever dialect is running.
+ *
+ * A union of the three real table objects rather than `any`. The three declare
+ * the same column names, so every property this service reaches for resolves on
+ * all three arms; what the union buys is that a column this service invents, or
+ * one renamed in a schema and not here, stops compiling instead of failing at
+ * runtime on somebody's install.
+ */
+type LayoutTable = typeof layoutPg | typeof layoutMysql | typeof layoutSqlite;
+
+/**
+ * The ONE place a dialect is turned into a layout table.
+ *
+ * A `switch` with a `never` default rather than a lookup, so adding a dialect
+ * to `SupportedDialect` fails to compile here instead of resolving to whichever
+ * arm happened to come last.
+ */
+function layoutTableFor(dialect: SupportedDialect): LayoutTable {
+  switch (dialect) {
+    case "postgresql":
+      return layoutPg;
+    case "mysql":
+      return layoutMysql;
+    case "sqlite":
+      return layoutSqlite;
+    default: {
+      const exhaustive: never = dialect;
+      throw NextlyError.internal({
+        logContext: {
+          reason: "no widget layout table for this dialect",
+          dialect: String(exhaustive),
+        },
+      });
+    }
+  }
 }
 
 export class WidgetLayoutService extends BaseService {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  private table: any;
+  private readonly table: LayoutTable;
 
   constructor(adapter: DrizzleAdapter, logger: Logger) {
     super(adapter, logger);
 
-    switch (this.dialect) {
-      case "postgresql":
-        this.table = layoutPg;
-        break;
-      case "mysql":
-        this.table = layoutMysql;
-        break;
-      case "sqlite":
-        this.table = layoutSqlite;
-        break;
-      default:
-        throw NextlyError.internal({
-          logContext: {
-            reason: "no widget layout table for this dialect",
-            dialect: String(this.dialect),
-          },
-        });
-    }
+    this.table = layoutTableFor(this.dialect);
   }
 
   /**
@@ -101,7 +110,7 @@ export class WidgetLayoutService extends BaseService {
     const rows = await this.db
       .select()
       .from(this.table)
-      .where(eq(this.table.id, rowId(kind, scopeId)))
+      .where(eq(this.table.id, layoutRowId(kind, scopeId)))
       .limit(1);
 
     const row = rows?.[0] as
@@ -168,7 +177,7 @@ export class WidgetLayoutService extends BaseService {
     placements: readonly WidgetPlacement[],
     expectedVersion: number
   ): Promise<number> {
-    const id = rowId(kind, scopeId);
+    const id = layoutRowId(kind, scopeId);
     const layout = serializeLayout(placements);
     const now = new Date();
 


### PR DESCRIPTION
Phase 2 PR A of the dashboard widgets programme: the layout store's schema and API. **No UI** — that is PR B.

A reader who has never arranged anything still sees the registry's own order, which is exactly today's behaviour, so nothing changes for anybody until they move a card.

## What is here

| | |
|---|---|
| `nextly_widget_layout` | 3 dialects, `varchar(191)` id, plain `text` payload, integer `version` |
| `domains/widgets/layout.ts` | shape-only decoder, default materializer, partition + merge, size cap, visibility token |
| `WidgetLayoutService` | version-guarded read/write |
| `GET`/`PUT /api/dashboard/layout` | resolved server-side, never the raw row |
| `callerHoldsPermission` | `requiredPermission`'s first server-side enforcement |

## The three decisions worth reviewing

**Validation of a stored row is SHAPE only.** The design note said to validate it with `validateWidgetDefinition`. That is the version-boundary mistake in a new place: a placement's `size` is *seeded from a widget definition that may come from a plugin built against a newer core*, so a stored layout can legitimately hold a size this core has never heard of. A closed-vocabulary check would throw on read and destroy the reader's entire saved dashboard over one card — while `admin/.../widgets/sizes.ts` already survives the same value by falling back to `full`. `size` and `height` are therefore typed and checked as `string`. The one closed vocabulary is `schemaVersion`, legitimate only because core wrote it.

**A write echoes two guards, because two things shaped the snapshot it holds.** `version` catches a second tab that saved first. `scope` — a hash of the widget ids this caller can see — catches the other half. A whole-snapshot PUT plus server-side filtering silently deletes data: the client is handed a *filtered* list and sends it back. Placements that stay invisible are merged back in, but a card that was hidden at read time and visible at write time sits in neither the submission nor the carried set, and the write deletes it **with `version` still matching**, because a permission grant does not touch the row. Reproduced by construction before fixing.

**Nothing about a hidden placement is observable.** It is dropped from a GET on the same path whether it is forbidden or unresolvable; the PUT's refusal message is byte-identical for both; the version bump is `expectedVersion + 1` regardless of how many placements were carried; and an id collision **re-keys** the carried placement rather than refusing, because refusing would answer differently depending on whether a hidden placement holds that id.

## Verification

- 861 files / 10,736 tests, `check-types` (both tsc programs, and 22/22 repo-wide), lint clean, `fallow audit --base origin/main` exit 0.
- **Every guard break-verified individually** — reverted, watched the specific test fail, restored. Sixteen of them. Two found real gaps: a finiteness assertion that could not see the sentinel leak, and a prototype-hole test that passed with the guard deleted because a second lookup failed anyway (the pair that actually exercises it is verb `constructor` + id `call`, since `Object.call` is a real function).
- Cross-dialect integration suite for the row and the version guard. SQLite runs anywhere; **Postgres and MySQL self-skip locally and run in CI's matrix**. Break-verified by swapping PostgreSQL's `rowCount` in on SQLite — two tests go red, which is the exact bug class that has reddened `main` after merge before.

## Also in the diff, and why

`parseDashboardRoutes` became a table because my two route branches pushed it over the complexity gate — verified as mine by exit code before and after, not assumed inherited. The table introduced this codebase's **seventh** instance of the prototype-lookup hole, so both lookups use `Object.hasOwn`.

## Known and deliberate

`LayoutScopeKind` is `"user"` only. `scope_kind` is in the primary key from day one so the role layer needs no migration, per the founder's "user-only now, role layer designed in".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dashboard widget layout support through new GET and PUT endpoints.
  - Users can save, update, and retrieve personalized widget arrangements.
  - Layouts preserve hidden widgets and enforce permissions, size limits, and version conflicts.
  - Added support across SQLite, PostgreSQL, and MySQL databases.
  - Deleting a user now also removes their saved dashboard layout.

- **Bug Fixes**
  - Invalid widget permission values are now rejected instead of bypassing access checks.
  - Improved handling of unreadable or malformed saved layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->