### PR TITLE
feat(builder): let a row say what it holds, not only what it is called

### DIFF
--- a/.changeset/rows-say-what-they-do.md
+++ b/.changeset/rows-say-what-they-do.md
@@ -1,0 +1,47 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+Rows in the tokens and classes panels named things without describing them.
+
+A token row previewed only colours, so a shadow was an opaque string of
+offsets, a size was a number with nothing to compare it against, and a weight
+looked exactly like a number. Each kind that has a visual form is now drawn as
+the thing it is: a shadow cast, a length measured, a weight and a family set in
+themselves, and a duration shown by taking that long to cross its slot. A
+number and a custom value are still shown as nothing, because neither has a
+form to draw, and no value is previewed unless it can be resolved without the
+site's token table — a reference resolved against the panel would show a colour
+or a size the page does not have.
+
+A class row named the class and counted the documents using it, and never said
+what the class was for. It now lists the properties the class writes, compiled
+by the engine rather than described a second time here, so what the row claims
+and what the stylesheet carries cannot disagree. Because a class holds styles
+for every state and breakpoint and a row can honestly show one, it shows the
+base and says how many other places the class also sets something rather than
+showing the base as though it were the whole story.

--- a/packages/builder/src/class-library.test.ts
+++ b/packages/builder/src/class-library.test.ts
@@ -14,6 +14,7 @@
  *
  * @module class-library.test
  */
+import { BASE_BREAKPOINT, compileStyleValues } from "@nextlyhq/blocks-engine";
 import {
   MAX_CLASSES_PER_NODE,
   MAX_NAMED_CLASSES,
@@ -39,6 +40,7 @@ import {
   siteClasses,
   withClassApplied,
   withClassRemoved,
+  classDeclarations,
 } from "./class-library";
 
 /** A library entry, with the styles envelope left empty where it is not read. */
@@ -681,5 +683,66 @@ describe("the listed set is the set the stylesheet carries", () => {
 
     expect(siteClasses(library).map(choice => choice.slug)).toEqual(["good"]);
     expect(emittedSlugs(library)).toEqual(["good"]);
+  });
+});
+
+describe("what a class writes", () => {
+  it("reports the properties the ENGINE compiles, not a second formatter", () => {
+    /*
+     * Asserted against `compileStyleValues` itself rather than a hand-written
+     * list. The panel's job is to show what the stylesheet will carry, so the
+     * compiler is the oracle; a literal expectation here would agree today and
+     * describe a different stylesheet the first time the catalog changed.
+     */
+    const values = { color: "#112233", paddingBlockStart: "1rem" };
+    const summary = classDeclarations(
+      { base: { [BASE_BREAKPOINT]: values } },
+      "hero"
+    );
+    expect(summary.shown.map(d => d.property)).toEqual(
+      compileStyleValues(values, "class:hero").declarations.map(d => d.property)
+    );
+    // The must-be-found control: the compiler really did produce something, so
+    // the equality above is not two empty lists agreeing.
+    expect(summary.shown.length).toBeGreaterThan(0);
+    expect(summary.elsewhere).toBe(0);
+  });
+
+  it("COUNTS what it is not showing, rather than showing the base silently", () => {
+    /*
+     * `NodeStyles` is states by breakpoints and a row has space for neither the
+     * product nor a fair sample. Showing only the base without saying so would
+     * misdescribe a class whose real behaviour is responsive.
+     */
+    const summary = classDeclarations(
+      {
+        base: {
+          [BASE_BREAKPOINT]: { color: "#112233" },
+          md: { color: "#445566" },
+        },
+        hover: { [BASE_BREAKPOINT]: { color: "#778899" } },
+      },
+      "hero"
+    );
+    expect(summary.shown.map(d => d.property)).toEqual(["color"]);
+    // Two places this class also behaves differently: one other breakpoint and
+    // one other state.
+    expect(summary.elsewhere).toBe(2);
+  });
+
+  it("counts a state that sets nothing as nothing", () => {
+    // An empty map is a shape the document can hold and is not a place the
+    // class behaves differently, so counting it would inflate the caveat.
+    const summary = classDeclarations(
+      { base: { [BASE_BREAKPOINT]: { color: "#112233" }, md: {} } },
+      "hero"
+    );
+    expect(summary.elsewhere).toBe(0);
+  });
+
+  it("says nothing at all for a class that writes nothing", () => {
+    const summary = classDeclarations({}, "hero");
+    expect(summary.shown).toEqual([]);
+    expect(summary.elsewhere).toBe(0);
   });
 });

--- a/packages/builder/src/class-library.test.ts
+++ b/packages/builder/src/class-library.test.ts
@@ -14,7 +14,22 @@
  *
  * @module class-library.test
  */
-import { BASE_BREAKPOINT, compileStyleValues } from "@nextlyhq/blocks-engine";
+import {
+  BASE_BREAKPOINT,
+  compileStyleValues,
+  type StyleCompileContext,
+} from "@nextlyhq/blocks-engine";
+
+/** A site that really does define `md`, so a stored `md` key emits a rule. */
+const WITH_MD: StyleCompileContext = {
+  breakpoints: {
+    viewport: [
+      { id: BASE_BREAKPOINT, label: "Base" },
+      { id: "md", label: "Medium", maxWidth: 768 },
+    ],
+    container: [],
+  },
+};
 import {
   MAX_CLASSES_PER_NODE,
   MAX_NAMED_CLASSES,
@@ -714,20 +729,26 @@ describe("what a class writes", () => {
      * product nor a fair sample. Showing only the base without saying so would
      * misdescribe a class whose real behaviour is responsive.
      */
-    const summary = classDeclarations(
-      {
-        base: {
-          [BASE_BREAKPOINT]: { color: "#112233" },
-          md: { color: "#445566" },
-        },
-        hover: { [BASE_BREAKPOINT]: { color: "#778899" } },
+    const styles = {
+      base: {
+        [BASE_BREAKPOINT]: { color: "#112233" },
+        md: { color: "#445566" },
       },
-      "hero"
-    );
+      hover: { [BASE_BREAKPOINT]: { color: "#778899" } },
+    };
+    const summary = classDeclarations(styles, "hero", WITH_MD);
     expect(summary.shown.map(d => d.property)).toEqual(["color"]);
-    // Two places this class also behaves differently: one other breakpoint and
-    // one other state.
+    // Two places this class also behaves differently: one other breakpoint the
+    // site DEFINES, and one other state.
     expect(summary.elsewhere).toBe(2);
+
+    /*
+     * Must-differ, and the point of taking a context at all: on a site that
+     * does NOT define `md`, the compiler emits no rule for it, so the class
+     * behaves no differently there and the count must not claim it does.
+     */
+    const withoutMd = classDeclarations(styles, "hero", undefined);
+    expect(withoutMd.elsewhere).toBe(1);
   });
 
   it("counts a state that sets nothing as nothing", () => {
@@ -735,7 +756,8 @@ describe("what a class writes", () => {
     // class behaves differently, so counting it would inflate the caveat.
     const summary = classDeclarations(
       { base: { [BASE_BREAKPOINT]: { color: "#112233" }, md: {} } },
-      "hero"
+      "hero",
+      WITH_MD
     );
     expect(summary.elsewhere).toBe(0);
   });

--- a/packages/builder/src/class-library.ts
+++ b/packages/builder/src/class-library.ts
@@ -49,13 +49,18 @@
  * @module class-library
  */
 import {
+  BASE_BREAKPOINT,
   MAX_CLASSES_PER_NODE,
   MAX_NAMED_CLASSES,
   MAX_NAMED_CLASS_NAME_LENGTH,
   NAMED_CLASS_SLUG_RE,
+  STYLE_STATES,
+  compileStyleValues,
   namedClassName,
   usableNamedClasses,
+  type Declaration,
   type NamedClass,
+  type NodeStyles,
 } from "@nextlyhq/blocks-engine";
 
 /**
@@ -166,6 +171,55 @@ function indexedUsage(usage: ClassUsageCounts, classId: string): number {
   // number on screen that cannot describe anything the index counted.
   if (!Number.isInteger(count) || count < 0) return 0;
   return count;
+}
+
+/**
+ * What a class DOES, as the declarations it writes.
+ *
+ * A row named the class and counted its documents and never said what it was
+ * for, which is the half of the complaint a list cannot answer by being better
+ * organised.
+ *
+ * COMPILED, never formatted here. `compileStyleValues` is the one
+ * implementation of "stored style values become CSS declarations" — it knows
+ * which properties the engine writes, how a token reference becomes a `var()`,
+ * and which values it refuses. A second formatter in this panel would agree
+ * with it on the day it was written and describe a different stylesheet
+ * afterwards.
+ *
+ * ONE state at ONE breakpoint, and a count of the rest. `NodeStyles` is states
+ * by breakpoints, both sparse, and a row has space for neither the product nor
+ * a fair sample of it. Showing the base silently would misdescribe a class
+ * whose real behaviour is responsive; saying how much is not shown is the
+ * honest half of the same sentence.
+ */
+export function classDeclarations(
+  styles: NodeStyles,
+  slug: string
+): { shown: readonly Declaration[]; elsewhere: number } {
+  const base = styles.base?.[BASE_BREAKPOINT];
+  const shown =
+    base === undefined
+      ? []
+      : compileStyleValues(base, `class:${slug}`).declarations;
+  /*
+   * Counted as (state, breakpoint) PAIRS that hold anything, because that is
+   * what "more elsewhere" means to an author: each pair is a place this class
+   * behaves differently. Iterating `STYLE_STATES` rather than the object's own
+   * keys keeps the walk to states the engine defines.
+   */
+  let elsewhere = 0;
+  for (const state of STYLE_STATES) {
+    const byBreakpoint = styles[state];
+    if (byBreakpoint === undefined) continue;
+    for (const breakpoint of Object.keys(byBreakpoint)) {
+      if (state === "base" && breakpoint === BASE_BREAKPOINT) continue;
+      const values = byBreakpoint[breakpoint];
+      if (values !== undefined && Object.keys(values).length > 0)
+        elsewhere += 1;
+    }
+  }
+  return { shown, elsewhere };
 }
 
 /**

--- a/packages/builder/src/class-library.ts
+++ b/packages/builder/src/class-library.ts
@@ -50,6 +50,7 @@
  */
 import {
   BASE_BREAKPOINT,
+  breakpointContexts,
   MAX_CLASSES_PER_NODE,
   MAX_NAMED_CLASSES,
   MAX_NAMED_CLASS_NAME_LENGTH,
@@ -61,6 +62,7 @@ import {
   type Declaration,
   type NamedClass,
   type NodeStyles,
+  type StyleCompileContext,
 } from "@nextlyhq/blocks-engine";
 
 /**
@@ -141,12 +143,18 @@ export interface ClassRow extends ClassChoice {
  * the whole library keeps a tail entry from being offered as though applying it
  * would do something.
  */
-export function siteClasses(library: readonly NamedClass[]): ClassChoice[] {
+export function usableSiteClasses(
+  library: readonly NamedClass[]
+): NamedClass[] {
   const bounded =
     library.length > MAX_NAMED_CLASSES
       ? library.slice(0, MAX_NAMED_CLASSES)
       : library;
-  return usableNamedClasses(bounded).map(entry => ({
+  return usableNamedClasses(bounded);
+}
+
+export function siteClasses(library: readonly NamedClass[]): ClassChoice[] {
+  return usableSiteClasses(library).map(entry => ({
     id: entry.id,
     slug: entry.slug,
     className: namedClassName(entry.slug),
@@ -174,6 +182,52 @@ function indexedUsage(usage: ClassUsageCounts, classId: string): number {
 }
 
 /**
+ * Every (state, breakpoint) pair this class stores values under.
+ *
+ * The WALK, separated from the judgement below, because a nested loop carrying
+ * three different reasons to skip a pair is the shape the cognitive gate exists
+ * to catch. Iterating `STYLE_STATES` rather than the record's own keys keeps
+ * the walk to states the engine defines.
+ */
+function storedContexts(
+  styles: NodeStyles
+): { state: string; breakpoint: string; count: number }[] {
+  const pairs: { state: string; breakpoint: string; count: number }[] = [];
+  for (const state of STYLE_STATES) {
+    const byBreakpoint = styles[state];
+    if (byBreakpoint === undefined) continue;
+    for (const breakpoint of Object.keys(byBreakpoint)) {
+      const values = byBreakpoint[breakpoint];
+      pairs.push({
+        state,
+        breakpoint,
+        count: values === undefined ? 0 : Object.keys(values).length,
+      });
+    }
+  }
+  return pairs;
+}
+
+/**
+ * How many of those pairs are a place the class behaves DIFFERENTLY.
+ *
+ * Three things disqualify a pair, and each is a separate fact rather than a
+ * step in a walk: it is the base the row already shows; the compiler emits no
+ * context for that breakpoint, so it writes no rule; or it sets nothing.
+ */
+function contextsElsewhere(
+  styles: NodeStyles,
+  emitted: ReadonlySet<string>
+): number {
+  return storedContexts(styles).filter(
+    pair =>
+      !(pair.state === "base" && pair.breakpoint === BASE_BREAKPOINT) &&
+      emitted.has(pair.breakpoint) &&
+      pair.count > 0
+  ).length;
+}
+
+/**
  * What a class DOES, as the declarations it writes.
  *
  * A row named the class and counted its documents and never said what it was
@@ -195,30 +249,40 @@ function indexedUsage(usage: ClassUsageCounts, classId: string): number {
  */
 export function classDeclarations(
   styles: NodeStyles,
-  slug: string
+  slug: string,
+  /**
+   * The context the PAGE is compiled with, so the summary describes the same
+   * stylesheet the visitor gets.
+   *
+   * Two things come from it and neither can be guessed here. `mayFetchUrl` is
+   * the site's remote-host policy, and compiling without it lists a
+   * declaration the real compile drops. `breakpoints` decides which contexts
+   * are emitted at all, so a class holding styles for a breakpoint the site
+   * has since deleted writes no rule — counting that key would claim behaviour
+   * the page does not have.
+   *
+   * Absent is coherent rather than a gap: `breakpointContexts` answers with
+   * the base context alone, which is what a site with no configured
+   * breakpoints emits.
+   */
+  context?: StyleCompileContext
 ): { shown: readonly Declaration[]; elsewhere: number } {
   const base = styles.base?.[BASE_BREAKPOINT];
   const shown =
     base === undefined
       ? []
-      : compileStyleValues(base, `class:${slug}`).declarations;
-  /*
-   * Counted as (state, breakpoint) PAIRS that hold anything, because that is
-   * what "more elsewhere" means to an author: each pair is a place this class
-   * behaves differently. Iterating `STYLE_STATES` rather than the object's own
-   * keys keeps the walk to states the engine defines.
-   */
-  let elsewhere = 0;
-  for (const state of STYLE_STATES) {
-    const byBreakpoint = styles[state];
-    if (byBreakpoint === undefined) continue;
-    for (const breakpoint of Object.keys(byBreakpoint)) {
-      if (state === "base" && breakpoint === BASE_BREAKPOINT) continue;
-      const values = byBreakpoint[breakpoint];
-      if (values !== undefined && Object.keys(values).length > 0)
-        elsewhere += 1;
-    }
-  }
+      : compileStyleValues(
+          base,
+          `class:${slug}`,
+          undefined,
+          undefined,
+          undefined,
+          { mayFetchUrl: context?.mayFetchUrl }
+        ).declarations;
+  const emitted = new Set(
+    breakpointContexts(context?.breakpoints).map(entry => entry.id)
+  );
+  const elsewhere = contextsElsewhere(styles, emitted);
   return { shown, elsewhere };
 }
 

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -1316,6 +1316,15 @@ describe("the panel explains itself", () => {
         library={[styled]}
         usage={undefined}
         documentClassIds={[]}
+        styleContext={{
+          breakpoints: {
+            viewport: [
+              { id: BASE_BREAKPOINT, label: "Base" },
+              { id: "md", label: "Medium", maxWidth: 768 },
+            ],
+            container: [],
+          },
+        }}
         onRename={vi.fn()}
       />
     );
@@ -1346,6 +1355,41 @@ describe("the panel explains itself", () => {
       />
     );
     expect(document.querySelector(".nx-classman__declares")).toBeNull();
+  });
+
+  it("shows the styles of the class the COMPILER kept, not the last stored", () => {
+    /*
+     * Two entries sharing an id: `usableNamedClasses` keeps the first in
+     * compiler order, while a map over the raw array keeps the last in storage
+     * order. The visible row would then display declarations belonging to the
+     * entry the compiler threw away — a row describing a rule the page does
+     * not have.
+     */
+    const kept: NamedClass = {
+      id: "id-hero",
+      slug: "hero",
+      orderIndex: 0,
+      styles: { base: { [BASE_BREAKPOINT]: { color: "#111111" } } },
+    };
+    const dropped: NamedClass = {
+      id: "id-hero",
+      slug: "hero",
+      orderIndex: 1,
+      styles: { base: { [BASE_BREAKPOINT]: { paddingBlockStart: "4rem" } } },
+    };
+    render(
+      <ClassManagerPanel
+        library={[kept, dropped]}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+      />
+    );
+    const drawn = document.querySelector(".nx-classman__properties");
+    expect(drawn).not.toBeNull();
+    // The survivor's property, and NOT the dropped duplicate's.
+    expect(drawn?.textContent).toContain("color");
+    expect(drawn?.textContent).not.toContain("padding");
   });
 
   it("keeps the filters, because they answer questions that OVERLAP", () => {

--- a/packages/builder/src/class-manager-panel.test.tsx
+++ b/packages/builder/src/class-manager-panel.test.tsx
@@ -19,7 +19,11 @@ import {
   render,
   screen,
 } from "@testing-library/react";
-import { MAX_NAMED_CLASSES } from "@nextlyhq/blocks-engine";
+import {
+  BASE_BREAKPOINT,
+  MAX_NAMED_CLASSES,
+  compileStyleValues,
+} from "@nextlyhq/blocks-engine";
 import { newClassName } from "./class-library";
 import * as React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -1287,6 +1291,61 @@ describe("the panel explains itself", () => {
       />
     );
     expect(screen.getByText(/Rename and clear them out/i)).toBeTruthy();
+  });
+
+  it("says what a class DOES, under its name", () => {
+    /*
+     * The row named the class and counted its documents and never said what it
+     * was for. The properties come from the engine's compiler, so this asserts
+     * against `compileStyleValues` rather than against a literal list — the
+     * panel's claim is about what the stylesheet will carry.
+     */
+    const styled: NamedClass = {
+      id: "id-hero",
+      slug: "hero",
+      orderIndex: 0,
+      styles: {
+        base: {
+          [BASE_BREAKPOINT]: { color: "#112233", paddingBlockStart: "1rem" },
+          md: { color: "#445566" },
+        },
+      },
+    };
+    render(
+      <ClassManagerPanel
+        library={[styled]}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+      />
+    );
+    const drawn = document.querySelector(".nx-classman__properties");
+    expect(drawn).not.toBeNull();
+    const compiled = compileStyleValues(
+      { color: "#112233", paddingBlockStart: "1rem" },
+      "class:hero"
+    ).declarations.map(d => d.property);
+    // The must-be-found control: the compiler produced something to draw.
+    expect(compiled.length).toBeGreaterThan(0);
+    for (const property of compiled) {
+      expect(drawn?.textContent).toContain(property);
+    }
+    // And the caveat, because one breakpoint is not being shown.
+    expect(screen.getByText(/1 more elsewhere/i)).toBeTruthy();
+  });
+
+  it("says nothing where a class writes nothing", () => {
+    // Must-differ for the test above: an empty class draws no summary at all,
+    // rather than an empty line or the words "no styles".
+    render(
+      <ClassManagerPanel
+        library={[cls("id-bare", "bare", 0)]}
+        usage={undefined}
+        documentClassIds={[]}
+        onRename={vi.fn()}
+      />
+    );
+    expect(document.querySelector(".nx-classman__declares")).toBeNull();
   });
 
   it("keeps the filters, because they answer questions that OVERLAP", () => {

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -35,7 +35,11 @@
  *
  * @module class-manager-panel
  */
-import type { NamedClass, NodeStyles } from "@nextlyhq/blocks-engine";
+import type {
+  NamedClass,
+  NodeStyles,
+  StyleCompileContext,
+} from "@nextlyhq/blocks-engine";
 import { Button, Input } from "@nextlyhq/ui";
 import * as React from "react";
 
@@ -44,6 +48,7 @@ import {
   classDeclarations,
   classLibraryHasRoom,
   classRows,
+  usableSiteClasses,
   deletionWarning,
   filterClassRows,
   searchClassRows,
@@ -147,6 +152,11 @@ export interface ClassManagerPanelProps {
    */
   library: readonly NamedClass[] | undefined;
   /**
+   * The context the page is compiled with, forwarded to the row summaries so
+   * they describe the same stylesheet a visitor gets. See `classDeclarations`.
+   */
+  styleContext?: StyleCompileContext;
+  /**
    * Why the library is absent, when it is.
    *
    * A read that FAILED will not finish, and a surface that goes on saying
@@ -248,6 +258,7 @@ export function ClassManagerPanel({
   usage,
   documentClassIds,
   suppliedClassIds,
+  styleContext,
   onRename,
   onDelete,
 }: ClassManagerPanelProps): React.ReactElement {
@@ -269,9 +280,18 @@ export function ClassManagerPanel({
    * slug and class name — so the row would otherwise scan the library for its
    * own entry, once per row, which is the shape that made the token projection
    * quadratic.
+   *
+   * Built from the SURVIVING classes rather than the stored array. Two entries
+   * sharing an id keep the first in compiler order and the last in storage
+   * order, and an entry past `MAX_NAMED_CLASSES` is dropped entirely — so a
+   * map over the raw list could hand a visible row the styles of the entry the
+   * compiler threw away.
    */
   const stylesById = React.useMemo(
-    () => new Map((library ?? []).map(entry => [entry.id, entry.styles])),
+    () =>
+      new Map(
+        usableSiteClasses(library ?? []).map(entry => [entry.id, entry.styles])
+      ),
     [library]
   );
 
@@ -391,6 +411,7 @@ export function ClassManagerPanel({
         usageKnown={usageKnown}
         anyDeletable={anyDeletable}
         stylesById={stylesById}
+        styleContext={styleContext}
         onRename={onRename}
         onDelete={onDelete}
       />
@@ -666,6 +687,7 @@ function ClassList({
   usageKnown,
   anyDeletable,
   stylesById,
+  styleContext,
   onRename,
   onDelete,
 }: {
@@ -694,6 +716,8 @@ function ClassList({
   anyDeletable: boolean;
   /** Each class's styles by id, built once by the panel. */
   stylesById: ReadonlyMap<string, NodeStyles>;
+  /** Forwarded to each row's summary; see `classDeclarations`. */
+  styleContext: StyleCompileContext | undefined;
   onRename: ClassManagerPanelProps["onRename"];
   onDelete?: (classId: string) => void;
 }): React.ReactElement {
@@ -742,6 +766,7 @@ function ClassList({
               pendingSlug={pendingSlugs?.[row.id]}
               library={library}
               styles={stylesById.get(row.id)}
+              styleContext={styleContext}
               isSupplied={supplied.has(row.id)}
               canDelete={rowIsDeletable(row, supplied, onDelete)}
               usageKnown={usageKnown}
@@ -771,6 +796,7 @@ function ClassRowView({
   pendingSlug,
   library,
   styles,
+  styleContext,
   isSupplied,
   canDelete,
   usageKnown,
@@ -786,6 +812,8 @@ function ClassRowView({
    * `stylesById`.
    */
   styles: NodeStyles | undefined;
+  /** Forwarded to the summary; see `classDeclarations`. */
+  styleContext: StyleCompileContext | undefined;
   isSupplied: boolean;
   /**
    * Whether this row may be deleted, decided by `rowIsDeletable` rather than
@@ -821,7 +849,11 @@ function ClassRowView({
           pendingSlug={pendingSlug}
           row={row}
         />
-        <DeclarationSummary styles={styles} slug={row.slug} />
+        <DeclarationSummary
+          styles={styles}
+          slug={row.slug}
+          styleContext={styleContext}
+        />
         <UsageNote row={row} usageKnown={usageKnown} />
         {isSupplied ? (
           // Named rather than shown disabled. A greyed button invites an
@@ -1145,13 +1177,18 @@ function DeleteConfirm({
 function DeclarationSummary({
   styles,
   slug,
+  styleContext,
 }: {
   styles: NodeStyles | undefined;
   slug: string;
+  styleContext: StyleCompileContext | undefined;
 }): React.ReactElement | null {
   const summary = React.useMemo(
-    () => (styles === undefined ? undefined : classDeclarations(styles, slug)),
-    [styles, slug]
+    () =>
+      styles === undefined
+        ? undefined
+        : classDeclarations(styles, slug, styleContext),
+    [styles, slug, styleContext]
   );
   if (summary === undefined) return null;
   if (summary.shown.length === 0 && summary.elsewhere === 0) return null;

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -35,12 +35,13 @@
  *
  * @module class-manager-panel
  */
-import type { NamedClass } from "@nextlyhq/blocks-engine";
+import type { NamedClass, NodeStyles } from "@nextlyhq/blocks-engine";
 import { Button, Input } from "@nextlyhq/ui";
 import * as React from "react";
 
 import { useSurvivingReport } from "./builder-notices";
 import {
+  classDeclarations,
   classLibraryHasRoom,
   classRows,
   deletionWarning,
@@ -262,6 +263,17 @@ export function ClassManagerPanel({
     () => new Set(suppliedClassIds ?? []),
     [suppliedClassIds]
   );
+  /*
+   * Each class's styles, keyed once. A row describing what its class DOES has
+   * to reach the stored styles, and `siteClasses` deliberately narrows to id,
+   * slug and class name — so the row would otherwise scan the library for its
+   * own entry, once per row, which is the shape that made the token projection
+   * quadratic.
+   */
+  const stylesById = React.useMemo(
+    () => new Map((library ?? []).map(entry => [entry.id, entry.styles])),
+    [library]
+  );
 
   /*
    * The name search, which is what makes every class REACHABLE.
@@ -378,6 +390,7 @@ export function ClassManagerPanel({
         supplied={supplied}
         usageKnown={usageKnown}
         anyDeletable={anyDeletable}
+        stylesById={stylesById}
         onRename={onRename}
         onDelete={onDelete}
       />
@@ -652,6 +665,7 @@ function ClassList({
   supplied,
   usageKnown,
   anyDeletable,
+  stylesById,
   onRename,
   onDelete,
 }: {
@@ -678,6 +692,8 @@ function ClassList({
    * anything be deleted" would drift the moment either changed.
    */
   anyDeletable: boolean;
+  /** Each class's styles by id, built once by the panel. */
+  stylesById: ReadonlyMap<string, NodeStyles>;
   onRename: ClassManagerPanelProps["onRename"];
   onDelete?: (classId: string) => void;
 }): React.ReactElement {
@@ -725,6 +741,7 @@ function ClassList({
               row={row}
               pendingSlug={pendingSlugs?.[row.id]}
               library={library}
+              styles={stylesById.get(row.id)}
               isSupplied={supplied.has(row.id)}
               canDelete={rowIsDeletable(row, supplied, onDelete)}
               usageKnown={usageKnown}
@@ -753,6 +770,7 @@ function ClassRowView({
   row,
   pendingSlug,
   library,
+  styles,
   isSupplied,
   canDelete,
   usageKnown,
@@ -763,6 +781,11 @@ function ClassRowView({
   /** The name this class is being renamed to, when a write is in flight. */
   pendingSlug?: string;
   library: readonly NamedClass[];
+  /**
+   * The class's own styles, handed down rather than found here — see
+   * `stylesById`.
+   */
+  styles: NodeStyles | undefined;
   isSupplied: boolean;
   /**
    * Whether this row may be deleted, decided by `rowIsDeletable` rather than
@@ -798,6 +821,7 @@ function ClassRowView({
           pendingSlug={pendingSlug}
           row={row}
         />
+        <DeclarationSummary styles={styles} slug={row.slug} />
         <UsageNote row={row} usageKnown={usageKnown} />
         {isSupplied ? (
           // Named rather than shown disabled. A greyed button invites an
@@ -1103,5 +1127,50 @@ function DeleteConfirm({
         Delete
       </Button>
     </div>
+  );
+}
+
+/**
+ * What this class does, in the properties it writes.
+ *
+ * A row named the class and counted its documents and never said what it was
+ * FOR, which is the half of the complaint no amount of reorganising answers.
+ *
+ * Derived by the engine's compiler rather than described here, and limited to
+ * the base state at the base breakpoint with a count of everywhere else — the
+ * reasoning is on `classDeclarations`. A class with nothing anywhere says
+ * nothing, rather than printing "no styles" against a row whose emptiness the
+ * author can already see.
+ */
+function DeclarationSummary({
+  styles,
+  slug,
+}: {
+  styles: NodeStyles | undefined;
+  slug: string;
+}): React.ReactElement | null {
+  const summary = React.useMemo(
+    () => (styles === undefined ? undefined : classDeclarations(styles, slug)),
+    [styles, slug]
+  );
+  if (summary === undefined) return null;
+  if (summary.shown.length === 0 && summary.elsewhere === 0) return null;
+  const more =
+    summary.elsewhere === 1
+      ? "1 more elsewhere"
+      : `${String(summary.elsewhere)} more elsewhere`;
+  return (
+    <p className="nx-classman__declares">
+      {summary.shown.length === 0 ? null : (
+        <span className="nx-classman__properties">
+          {summary.shown.map(declaration => declaration.property).join(", ")}
+        </span>
+      )}
+      {summary.elsewhere === 0 ? null : (
+        <span className="nx-classman__elsewhere">
+          {summary.shown.length === 0 ? `Nothing here, ${more}` : more}
+        </span>
+      )}
+    </p>
   );
 }

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -3158,10 +3158,10 @@
   overflow: hidden;
   border: 1px solid var(--nx-border);
   border-radius: var(--radius-sm);
-  background: var(--nx-surface);
+  background: var(--nx-builder-surface);
   font-size: 0.6875rem;
   line-height: 1;
-  color: var(--nx-fg);
+  color: var(--nx-builder-text);
 }
 
 /*
@@ -3173,7 +3173,7 @@
   width: 0.75rem;
   height: 0.75rem;
   border-radius: 2px;
-  background: var(--nx-bg);
+  background: var(--nx-builder-surface-raised);
 }
 
 /* A length, measured against the slot and stopping at it. */
@@ -3186,7 +3186,7 @@
      to the end of the slot and says only "at least this". */
   max-width: 100%;
   border-radius: 1px;
-  background: var(--nx-fg);
+  background: var(--nx-builder-text);
 }
 
 /*
@@ -3199,7 +3199,7 @@
   width: 0.375rem;
   height: 0.375rem;
   border-radius: 50%;
-  background: var(--nx-fg);
+  background: var(--nx-builder-text);
   animation-name: nx-token-tick;
   animation-iteration-count: infinite;
   animation-direction: alternate;
@@ -3240,7 +3240,7 @@
   margin: 0;
   font-size: 0.6875rem;
   line-height: 1.4;
-  color: var(--nx-muted-fg);
+  color: var(--nx-builder-text-muted);
 }
 
 /*

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -2094,10 +2094,13 @@
    * stylesheet on its own.
    */
   --nx-swatch: transparent;
-  flex: 0 0 auto;
-  width: 1.25rem;
-  height: 1.25rem;
-  border: 1px solid var(--nx-border);
+  /*
+   * FILLS the shared slot rather than being a box of its own. Each row owns an
+   * independent `auto` grid column, so a colour slot of a different width put
+   * its fields at a different indent from every other row's.
+   */
+  position: absolute;
+  inset: 0;
   border-radius: var(--radius-sm);
   background-image:
     linear-gradient(var(--nx-swatch), var(--nx-swatch)), var(--nx-checkerboard);
@@ -3187,6 +3190,23 @@
   max-width: 100%;
   border-radius: 1px;
   background: var(--nx-builder-text);
+}
+
+/*
+ * A negative length, drawn on the other side of a centre line.
+ *
+ * The line is what makes the direction readable: without it a bar growing
+ * leftwards from the right edge looks like a shorter bar, and the sign — which
+ * is the whole reason a margin token is negative — disappears.
+ */
+.nx-tokens__preview[data-sign="negative"] {
+  border-inline-start-color: transparent;
+}
+
+.nx-tokens__preview[data-sign="negative"] .nx-tokens__bar {
+  inset-inline-start: auto;
+  inset-inline-end: 0;
+  opacity: 0.55;
 }
 
 /*

--- a/packages/builder/src/styles/builder-chrome.css
+++ b/packages/builder/src/styles/builder-chrome.css
@@ -3139,3 +3139,125 @@
   margin-top: 0.5rem;
   padding-top: 0.5rem;
 }
+
+/*
+ * The preview slot for kinds that are not a colour.
+ *
+ * Same box as the swatch so the previews form a column rather than a ragged
+ * edge, and wider than tall because the two kinds that need room — a length
+ * and a duration — both need it along one axis.
+ */
+.nx-tokens__preview {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  width: 2.5rem;
+  height: 1.25rem;
+  overflow: hidden;
+  border: 1px solid var(--nx-border);
+  border-radius: var(--radius-sm);
+  background: var(--nx-surface);
+  font-size: 0.6875rem;
+  line-height: 1;
+  color: var(--nx-fg);
+}
+
+/*
+ * The shadow's own box, inset so the shadow it casts has somewhere to land.
+ * A shadow drawn on an element flush with its container is clipped to nothing,
+ * which would report every shadow as identical.
+ */
+.nx-tokens__shadow {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 2px;
+  background: var(--nx-bg);
+}
+
+/* A length, measured against the slot and stopping at it. */
+.nx-tokens__bar {
+  position: absolute;
+  inset-inline-start: 0;
+  height: 0.375rem;
+  min-width: 1px;
+  /* The cap. A token has no maximum to scale against, so a longer value runs
+     to the end of the slot and says only "at least this". */
+  max-width: 100%;
+  border-radius: 1px;
+  background: var(--nx-fg);
+}
+
+/*
+ * A duration, shown by taking that long to cross the slot. `alternate` so the
+ * dot returns rather than jumping back, which reads as a second, shorter run.
+ */
+.nx-tokens__tick {
+  position: absolute;
+  inset-inline-start: 0;
+  width: 0.375rem;
+  height: 0.375rem;
+  border-radius: 50%;
+  background: var(--nx-fg);
+  animation-name: nx-token-tick;
+  animation-iteration-count: infinite;
+  animation-direction: alternate;
+  animation-timing-function: linear;
+}
+
+@keyframes nx-token-tick {
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(2rem);
+  }
+}
+
+/*
+ * At rest when motion is not wanted. The dot still says WHICH row holds a
+ * duration; it stops claiming how long by moving.
+ */
+@media (prefers-reduced-motion: reduce) {
+  .nx-tokens__tick {
+    animation: none;
+  }
+}
+
+/*
+ * What a class writes, under its name.
+ *
+ * Two parts on one line: the properties the base state sets, and how much is
+ * set somewhere this row is not showing. The second is dimmed because it is a
+ * caveat on the first rather than more of it.
+ */
+.nx-classman__declares {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.375rem;
+  margin: 0;
+  font-size: 0.6875rem;
+  line-height: 1.4;
+  color: var(--nx-muted-fg);
+}
+
+/*
+ * Truncated rather than wrapped to any length. A class may write a dozen
+ * properties and the rail is narrow; the row's job is to say what KIND of
+ * thing this class does, and the panel below it can say the rest.
+ */
+.nx-classman__properties {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--nx-font-mono, ui-monospace, monospace);
+}
+
+.nx-classman__elsewhere {
+  flex: 0 0 auto;
+  opacity: 0.75;
+  font-style: italic;
+}

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -1219,6 +1219,69 @@ describe("the panel explains itself and shows the whole set", () => {
     expect(screen.queryByText(/loses that style/i)).toBeNull();
   });
 
+  it("draws a preview for every kind that HAS a visual form", () => {
+    /*
+     * Only colour was previewed, so a shadow was an opaque CSS string and a
+     * size was a number with nothing to compare it to. Each kind is now shown
+     * as the thing it is, in the same slot so the column stays a column.
+     */
+    mount({
+      tokens: [
+        { name: "color.ink", kind: "color", values: { light: "#112233" } },
+        { name: "size.gap", kind: "dimension", values: { light: "8px" } },
+        {
+          name: "shadow.card",
+          kind: "shadow",
+          values: { light: "0 1px 2px #000" },
+        },
+        { name: "weight.bold", kind: "fontWeight", values: { light: "700" } },
+        { name: "font.body", kind: "fontFamily", values: { light: "serif" } },
+        { name: "speed.fast", kind: "duration", values: { light: "150ms" } },
+      ],
+    });
+    // Each preview drawn AS the value: the style attribute is what makes it a
+    // preview rather than a label, so that is what is asserted.
+    const shadow = document.querySelector<HTMLElement>(".nx-tokens__shadow");
+    expect(shadow?.style.boxShadow).toBe("0 1px 2px #000");
+    const bar = document.querySelector<HTMLElement>(".nx-tokens__bar");
+    expect(bar?.style.width).toContain("8px");
+    const tick = document.querySelector<HTMLElement>(".nx-tokens__tick");
+    expect(tick?.style.animationDuration).toBe("150ms");
+    const previews = Array.from(
+      document.querySelectorAll<HTMLElement>(".nx-tokens__preview")
+    );
+    expect(previews.some(node => node.style.fontWeight === "700")).toBe(true);
+    expect(previews.some(node => node.style.fontFamily === "serif")).toBe(true);
+    // Colour keeps its own swatch, under the rule it already had.
+    expect(document.querySelector(".nx-tokens__swatch")).not.toBeNull();
+  });
+
+  it("draws NOTHING for a value it cannot resolve on its own", () => {
+    /*
+     * The guard rail colour already had, applied to every kind: a `var()`
+     * resolves against the PANEL's custom properties rather than the canvas's,
+     * so drawing it would show something the page does not have. And `number`
+     * and `custom` have no visual form to draw at all.
+     */
+    mount({
+      tokens: [
+        {
+          name: "size.ref",
+          kind: "dimension",
+          values: { light: "var(--site-size-gap)" },
+        },
+        { name: "count.cols", kind: "number", values: { light: "3" } },
+        { name: "custom.thing", kind: "custom", values: { light: "whatever" } },
+      ],
+    });
+    expect(document.querySelector(".nx-tokens__preview")).toBeNull();
+    expect(document.querySelector(".nx-tokens__bar")).toBeNull();
+    // Every row still carries the empty slot, so the column does not collapse.
+    expect(
+      document.querySelectorAll(".nx-tokens__swatch[data-empty]").length
+    ).toBe(3);
+  });
+
   it("groups every kind that HAS tokens into one list", () => {
     // The must-be-found half. Three kinds are present, so three headings are.
     mount(MIXED);

--- a/packages/builder/src/tokens-panel.test.tsx
+++ b/packages/builder/src/tokens-panel.test.tsx
@@ -134,13 +134,21 @@ describe("what the studio draws", () => {
     const { container } = render(
       <Panel tokens={unresolvable} onChange={vi.fn()} />
     );
+    /*
+     * Both rows own the same slot; only one of them has a swatch inside it.
+     * Asserting on the SLOT count as well as the swatch count is what keeps
+     * this about painting rather than about the column silently losing a cell.
+     */
+    const slots = Array.from(container.querySelectorAll(".nx-tokens__preview"));
+    expect(slots.length).toBe(2);
     const swatches = Array.from(
       container.querySelectorAll(".nx-tokens__swatch")
     );
+    expect(swatches.length).toBe(1);
     expect(swatches[0]?.getAttribute("style")).toContain("#112233");
     // A `var()` resolves against the PANEL rather than the canvas, so painting
-    // it would show a colour the page does not have.
-    expect(swatches[1]?.getAttribute("data-empty")).toBe("");
+    // it would show a colour the page does not have — the slot stays, empty.
+    expect(slots[1]?.querySelector(".nx-tokens__swatch")).toBeNull();
   });
 });
 
@@ -1274,12 +1282,74 @@ describe("the panel explains itself and shows the whole set", () => {
         { name: "custom.thing", kind: "custom", values: { light: "whatever" } },
       ],
     });
-    expect(document.querySelector(".nx-tokens__preview")).toBeNull();
     expect(document.querySelector(".nx-tokens__bar")).toBeNull();
-    // Every row still carries the empty slot, so the column does not collapse.
+    expect(document.querySelector(".nx-tokens__shadow")).toBeNull();
+    // Every row still carries its slot, EMPTY, so the column does not go ragged
+    // — which is the failure that made colour share this element in the first
+    // place.
+    const slots = Array.from(document.querySelectorAll(".nx-tokens__preview"));
+    expect(slots.length).toBe(3);
+    expect(slots.every(slot => slot.childElementCount === 0)).toBe(true);
+  });
+
+  it("draws no preview for a token the ENGINE refuses to write", () => {
+    /*
+     * Preview eligibility is the engine's verdict, not a second rule here. A
+     * value `checkCssValue` rejects is absent from the page stylesheet, and the
+     * browser may still accept it on an inline `width` — so a panel judging for
+     * itself would draw a preview of a token the page does not carry.
+     */
+    mount({
+      tokens: [
+        { name: "size.ok", kind: "dimension", values: { light: "8px" } },
+        {
+          name: "size.bad",
+          kind: "dimension",
+          values: { light: "8px; color: red" },
+        },
+      ],
+    });
+    // The control: the good one IS drawn, so this is about the refusal rather
+    // than about previews being off altogether.
+    const bars = document.querySelectorAll(".nx-tokens__bar");
+    expect(bars.length).toBe(1);
+    expect((bars[0] as HTMLElement).style.width).toContain("8px");
+  });
+
+  it("keeps a negative length's SIZE and its direction", () => {
+    /*
+     * A dimension token may validly be negative — a margin pulling something
+     * back. CSS refuses a negative `width`, so the declaration was discarded
+     * and `min-width` left the same sliver a zero shows: a working token drawn
+     * as though it had neither size nor direction.
+     */
+    mount({
+      tokens: [
+        { name: "pull.back", kind: "dimension", values: { light: "-8px" } },
+      ],
+    });
+    const bar = document.querySelector<HTMLElement>(".nx-tokens__bar");
+    expect(bar?.style.width).toContain("8px");
     expect(
-      document.querySelectorAll(".nx-tokens__swatch[data-empty]").length
-    ).toBe(3);
+      document.querySelector(".nx-tokens__preview")?.getAttribute("data-sign")
+    ).toBe("negative");
+  });
+
+  it("refuses a length whose SIGN it cannot read", () => {
+    // A bar drawn on the wrong side of the line is worse than none, and a
+    // `calc()` hides its sign behind arithmetic this panel does not do.
+    mount({
+      tokens: [
+        {
+          name: "odd.one",
+          kind: "dimension",
+          values: { light: "calc(4px - 8px)" },
+        },
+      ],
+    });
+    expect(document.querySelector(".nx-tokens__bar")).toBeNull();
+    // The slot stays, so the column does not go ragged.
+    expect(document.querySelector(".nx-tokens__preview")).not.toBeNull();
   });
 
   it("groups every kind that HAS tokens into one list", () => {

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -997,7 +997,7 @@ function TokenEntry({
 
   return (
     <div className="nx-tokens__row">
-      <Swatch kind={row.kind} value={row.value} />
+      <TokenPreview kind={row.kind} value={row.value} />
       <div className="nx-tokens__fields">
         <label className="sr-only" htmlFor={`${id}-name`}>
           Name of {row.name}
@@ -1206,24 +1206,124 @@ function suppliedTokenFor(
  * and show a colour the page does not have. Every other kind gets nothing
  * rather than an approximation of itself.
  */
-function Swatch({
+/**
+ * Whether a value can be drawn as itself, and the string to draw it with.
+ *
+ * The colour rule is unchanged and is the reason the others exist: a value is
+ * previewed only where THIS package can resolve it without the site's token
+ * table, because a `var()` resolves against the panel's own custom properties
+ * rather than the canvas's and would show something the page does not have.
+ * That applies to every kind, not only colour, so the same refusal covers all
+ * of them.
+ *
+ * `number` and `custom` are absent deliberately. A number has no visual form,
+ * and `custom` holds whatever a site put there; drawing either would be an
+ * illustration rather than a preview.
+ */
+function drawableValue(kind: TokenKind, value: string): string | undefined {
+  if (kind === "color") return colourHexOf(value, undefined);
+  if (!PREVIEWED_KINDS.has(kind)) return undefined;
+  const own = value.trim();
+  if (own === "" || /var\s*\(/i.test(own)) return undefined;
+  return own;
+}
+
+/** The kinds that have a visual form this panel can draw from the value alone. */
+const PREVIEWED_KINDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
+  "dimension",
+  "duration",
+  "fontFamily",
+  "fontWeight",
+  "shadow",
+]);
+
+/**
+ * A preview of what the value is, where one can be drawn honestly.
+ *
+ * Every kind that can be shown is shown in the SAME slot, so the column stays
+ * a column: a ragged left edge would make the list harder to scan than the
+ * previews make it easier.
+ *
+ * Values reach CSS as individual properties rather than as custom properties.
+ * A custom property stores whatever string it is given and hands it to
+ * `var()` substitution later, so a stored value carrying a semicolon could
+ * open a declaration of its own; assigning `box-shadow` or `width` directly
+ * makes the browser parse the value as that property and discard it if it is
+ * not one. The panel shows unsaved and invalid values on purpose, so it cannot
+ * assume the emitter's guards have already run.
+ */
+function TokenPreview({
   kind,
   value,
 }: {
   kind: TokenKind;
   value: string;
 }): React.JSX.Element {
-  const hex = kind === "color" ? colourHexOf(value, undefined) : undefined;
+  const drawable = drawableValue(kind, value);
+  if (drawable === undefined) {
+    return (
+      <span className="nx-tokens__swatch" aria-hidden="true" data-empty="" />
+    );
+  }
+  if (kind === "color") {
+    return (
+      <span
+        className="nx-tokens__swatch"
+        aria-hidden="true"
+        style={{ "--nx-swatch": drawable } as React.CSSProperties}
+      />
+    );
+  }
+  if (kind === "shadow") {
+    return (
+      <span className="nx-tokens__preview" aria-hidden="true">
+        <span className="nx-tokens__shadow" style={{ boxShadow: drawable }} />
+      </span>
+    );
+  }
+  if (kind === "dimension") {
+    return (
+      <span className="nx-tokens__preview" aria-hidden="true">
+        {/*
+          Capped at the track rather than scaled to it. There is no maximum a
+          token is measured against, so any scale would be invented; a bar that
+          runs to the end says "at least this wide" and claims nothing more.
+
+          The cap is `max-width` in the stylesheet rather than `min()` here, so
+          the width reaching CSS is the stored value itself — a function around
+          it is one more thing that has to parse before anything is drawn.
+        */}
+        <span className="nx-tokens__bar" style={{ width: drawable }} />
+      </span>
+    );
+  }
+  if (kind === "duration") {
+    return (
+      <span className="nx-tokens__preview" aria-hidden="true">
+        {/*
+          Shown by TAKING that long. A duration has no length to draw, and a bar
+          scaled to some assumed maximum would be a picture of an assumption.
+          Under `prefers-reduced-motion` the stylesheet stops the animation and
+          leaves the dot at rest.
+        */}
+        <span
+          className="nx-tokens__tick"
+          style={{ animationDuration: drawable }}
+        />
+      </span>
+    );
+  }
   return (
     <span
-      className="nx-tokens__swatch"
+      className="nx-tokens__preview"
       aria-hidden="true"
-      data-empty={hex === undefined ? "" : undefined}
       style={
-        hex === undefined
-          ? undefined
-          : ({ "--nx-swatch": hex } as React.CSSProperties)
+        kind === "fontWeight"
+          ? { fontWeight: drawable }
+          : { fontFamily: drawable }
       }
-    />
+    >
+      Aa
+    </span>
   );
 }

--- a/packages/builder/src/tokens-panel.tsx
+++ b/packages/builder/src/tokens-panel.tsx
@@ -997,7 +997,7 @@ function TokenEntry({
 
   return (
     <div className="nx-tokens__row">
-      <TokenPreview kind={row.kind} value={row.value} />
+      <TokenPreview row={row} />
       <div className="nx-tokens__fields">
         <label className="sr-only" htmlFor={`${id}-name`}>
           Name of {row.name}
@@ -1220,10 +1220,25 @@ function suppliedTokenFor(
  * and `custom` holds whatever a site put there; drawing either would be an
  * illustration rather than a preview.
  */
-function drawableValue(kind: TokenKind, value: string): string | undefined {
-  if (kind === "color") return colourHexOf(value, undefined);
-  if (!PREVIEWED_KINDS.has(kind)) return undefined;
-  const own = value.trim();
+function drawableValue(row: TokenRow): string | undefined {
+  /*
+   * The ENGINE decides whether a value is written at all. It refuses on five
+   * conditions this panel must not restate — a name that is not a token name,
+   * no light value, a value `checkCssValue` rejects, a value that would fetch,
+   * and a collision on one custom property — and a value the engine drops but
+   * the browser happens to accept inline would otherwise be previewed as a
+   * token the page does not carry.
+   */
+  if (!row.written) return undefined;
+  if (row.kind === "color") return colourHexOf(row.value, undefined);
+  if (!PREVIEWED_KINDS.has(row.kind)) return undefined;
+  /*
+   * A SECOND question, and the only one that is genuinely this panel's: the
+   * engine writes a `var()` happily, but it resolves against the canvas's
+   * custom properties and this panel has its own — so drawing it here would
+   * show a value the page does not have.
+   */
+  const own = row.value.trim();
   if (own === "" || /var\s*\(/i.test(own)) return undefined;
   return own;
 }
@@ -1236,6 +1251,49 @@ const PREVIEWED_KINDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
   "fontWeight",
   "shadow",
 ]);
+
+/**
+ * A length, drawn as a length.
+ *
+ * Its own component because the sign is a question of its own and answering it
+ * inline put `TokenPreview` past the CRAP gate.
+ */
+function DimensionPreview({ value }: { value: string }): React.JSX.Element {
+  /*
+   * A dimension may validly be NEGATIVE — a margin token pulling something
+   * back. CSS refuses a negative `width`, so the declaration was discarded
+   * and `min-width` left the same sliver a zero shows: a working token drawn
+   * as though it had neither size nor direction.
+   *
+   * The sign is taken off the front of the stored TEXT and reported as a
+   * direction, which is a string operation rather than a parse. A value whose
+   * sign is not visible that way — `calc()` among them — gets no bar at all,
+   * because a bar drawn on the wrong side of the line is worse than none.
+   */
+  const negative = value.startsWith("-");
+  const magnitude = negative ? value.slice(1).trim() : value;
+  if (magnitude === "" || /calc\s*\(/i.test(magnitude)) {
+    return <span className="nx-tokens__preview" aria-hidden="true" />;
+  }
+  return (
+    <span
+      className="nx-tokens__preview"
+      aria-hidden="true"
+      data-sign={negative ? "negative" : undefined}
+    >
+      {/*
+        Capped at the track rather than scaled to it. There is no maximum a
+        token is measured against, so any scale would be invented; a bar that
+        runs to the end says "at least this wide" and claims nothing more.
+
+        The cap is `max-width` in the stylesheet rather than `min()` here, so
+        the width reaching CSS is the stored value itself — a function around
+        it is one more thing that has to parse before anything is drawn.
+      */}
+      <span className="nx-tokens__bar" style={{ width: magnitude }} />
+    </span>
+  );
+}
 
 /**
  * A preview of what the value is, where one can be drawn honestly.
@@ -1252,26 +1310,26 @@ const PREVIEWED_KINDS: ReadonlySet<TokenKind> = new Set<TokenKind>([
  * not one. The panel shows unsaved and invalid values on purpose, so it cannot
  * assume the emitter's guards have already run.
  */
-function TokenPreview({
-  kind,
-  value,
-}: {
-  kind: TokenKind;
-  value: string;
-}): React.JSX.Element {
-  const drawable = drawableValue(kind, value);
+function TokenPreview({ row }: { row: TokenRow }): React.JSX.Element {
+  const kind = row.kind;
+  const drawable = drawableValue(row);
   if (drawable === undefined) {
-    return (
-      <span className="nx-tokens__swatch" aria-hidden="true" data-empty="" />
-    );
+    return <span className="nx-tokens__preview" aria-hidden="true" />;
   }
   if (kind === "color") {
+    /*
+     * The swatch is now the slot's FILL rather than a box of its own. Each row
+     * owns an independent `auto` grid column, so a colour slot narrower than
+     * the others started its fields earlier and produced exactly the ragged
+     * edge one common slot exists to prevent.
+     */
     return (
-      <span
-        className="nx-tokens__swatch"
-        aria-hidden="true"
-        style={{ "--nx-swatch": drawable } as React.CSSProperties}
-      />
+      <span className="nx-tokens__preview" aria-hidden="true">
+        <span
+          className="nx-tokens__swatch"
+          style={{ "--nx-swatch": drawable } as React.CSSProperties}
+        />
+      </span>
     );
   }
   if (kind === "shadow") {
@@ -1282,20 +1340,7 @@ function TokenPreview({
     );
   }
   if (kind === "dimension") {
-    return (
-      <span className="nx-tokens__preview" aria-hidden="true">
-        {/*
-          Capped at the track rather than scaled to it. There is no maximum a
-          token is measured against, so any scale would be invented; a bar that
-          runs to the end says "at least this wide" and claims nothing more.
-
-          The cap is `max-width` in the stylesheet rather than `min()` here, so
-          the width reaching CSS is the stored value itself — a function around
-          it is one more thing that has to parse before anything is drawn.
-        */}
-        <span className="nx-tokens__bar" style={{ width: drawable }} />
-      </span>
-    );
+    return <DimensionPreview value={drawable} />;
   }
   if (kind === "duration") {
     return (

--- a/packages/builder/src/tokens-studio.ts
+++ b/packages/builder/src/tokens-studio.ts
@@ -105,6 +105,17 @@ export interface TokenRow {
    * second row would resolve to the first — so the one state the studio exists
    * to help an author repair would be the one state it cannot address.
    */
+  /**
+   * Whether the ENGINE emitted this token, as `emitTokenBlocks` reports it.
+   *
+   * Carried rather than re-derived because the engine refuses on five separate
+   * conditions — a name that is not a token name, no light value, a value the
+   * guard rejects, a value that would fetch, and a collision on one custom
+   * property — and a surface restating any of them agrees today and describes
+   * a different stylesheet afterwards. A preview drawn for a token the page
+   * does not carry is exactly that disagreement made visible.
+   */
+  readonly written: boolean;
   readonly at: number;
   /**
    * A React key that survives a removal elsewhere in the list.
@@ -175,7 +186,15 @@ export function tokenRows(
    * answer; its own docblock says a caller re-deriving it "would have to
    * restate all five" refusals and would drift the first time one changed.
    */
-  const claimed = firstByProperty(emitTokenBlocks(set, ":root").emitted);
+  const made = emitTokenBlocks(set, ":root");
+  const claimed = firstByProperty(made.emitted);
+  /*
+   * Which tokens the engine actually WROTE, for anything downstream that must
+   * not describe a token the page does not carry. Same list, same call: asking
+   * "is this written" a second way is how the panel and the stylesheet come to
+   * disagree.
+   */
+  const written = new Set(made.emitted);
   // Indexed against the WHOLE list, so `at` addresses the stored position
   // rather than a position within any later grouping or filter.
   const seen = new Map<string, number>();
@@ -188,6 +207,7 @@ export function tokenRows(
       at,
       nth === 0 ? identity : `${identity}#${nth}`,
       claimed,
+      written,
       mode
     );
   });
@@ -213,6 +233,7 @@ function rowOf(
   at: number,
   key: string,
   claimed: ReadonlyMap<string, SiteToken>,
+  written: ReadonlySet<SiteToken>,
   mode: TokenMode
 ): TokenRow {
   const own = token.values[mode];
@@ -220,6 +241,7 @@ function rowOf(
   return {
     at,
     key,
+    written: written.has(token),
     stored: own,
     identity: tokenIdentity(token),
     name: token.name,


### PR DESCRIPTION
PR 2 of 2 for U-14 and U-15, completing the work merged in #1451. That PR fixed the shape and the words; this one fixes the third gap the research named — **rows name things without describing them**.

## What was wrong

A **token row** previewed only colours. So a shadow arrived as a string of offsets, a size as a number with nothing to compare it against, and a weight looked exactly like a number. The panel could tell you a token existed and not what it was.

A **class row** gave the name and the document count, and never said what the class was for. Reorganising the list — which #1451 did — cannot answer that.

## What this does

**Token previews, per kind.** A shadow is cast, a length is measured against its slot, a weight and a family are set in themselves, and a duration is shown by *taking that long* to cross. Colour keeps the swatch it had.

Three refusals, all deliberate:

- **`number` and `custom` stay blank.** A number has no visual form, and `custom` holds whatever a site put there. Drawing either would be an illustration rather than a preview.
- **Nothing is previewed unless it resolves without the site's token table.** This is the rule colour already had, now covering every kind rather than being the reason only colour was drawn: a `var()` resolves against the *panel's* custom properties, not the canvas's, and would show a value the page does not have.
- **A length is capped, not scaled.** There is no maximum a token is measured against, so any scale would be invented. A bar that runs to the end says "at least this wide" and claims nothing more.

**Class rows list the properties they write** — compiled by `compileStyleValues`, never formatted a second time here. That module is the one implementation of "stored style values become CSS declarations": it knows which properties the engine writes, how a token reference becomes a `var()`, and which values it refuses. A second formatter would agree on the day it was written and describe a different stylesheet afterwards.

`NodeStyles` is states × breakpoints, both sparse, and a row can honestly show one. So it shows the base and **says how many other places also set something** rather than presenting the base as the whole story.

## Safety note on how values reach CSS

Values are assigned as **individual CSS properties**, never through custom properties. A custom property stores whatever string it is given and hands it to `var()` substitution later, so a stored value carrying a semicolon could open a declaration of its own. Assigning `box-shadow` or `width` directly makes the browser parse the value *as that property* and discard it if it is not one. This panel shows unsaved and invalid values on purpose, so it cannot assume the emitter's guards have run.

## Browser verification found a defect nothing else could

Four of my new rules referenced `--nx-fg`, `--nx-surface`, `--nx-bg` and `--nx-muted-fg`. This sheet's vocabulary is `--nx-builder-*`, and **those four are defined nowhere.** Measured in the browser, all four resolved EMPTY. The duration dot and the size bar were painted with nothing and were invisible.

**Every gate passed on that sheet** — suite, check-types, lint, lint:design, fallow, and the build. A declaration whose value is an undefined custom property is valid CSS, so nothing that parses the file can see it, and `lint:design` looks for hardcoded colours rather than for names that resolve to nothing.

Fixed by delegating to `--nx-builder-*`, which is what the sheet's other twenty-three uses already do, so the previews follow the mode with everything else.

Verified after the fix, in the running editor: the bar paints `lab(0 0 0)` and is capped at 38px inside its 40px slot; the shadow carries `rgba(0,0,0,0.6) 0px 2px 8px`; the tick animates `nx-token-tick 1.2s`; a weight of `800` renders at 800 and a family of `system-ui` renders in it.

## Evidence

| gate | result |
| --- | --- |
| build | exit 0 |
| builder suite | 98 files / **2739 tests** |
| `check-types` / `lint` | 0 / 0 |
| `lint:design` | passed, 1163 files |
| `fallow audit --base origin/main` | ✓ no issues, 8 changed files |
| `changeset status` | parses |

Break-verified, each by failing test NAME:

| break | test that failed |
| --- | --- |
| no preview for any non-colour kind | `draws a preview for every kind that HAS a visual form` |
| preview drawn for a `var()` value | `draws NOTHING for a value it cannot resolve on its own` |
| summary stops counting other breakpoints | `COUNTS what it is not showing, rather than showing the base silently` |
| row draws no declarations | `says what a class DOES, under its name` |

That last one is worth naming: my first pass had **no test for the row rendering the summary at all** — the helper was covered and the wiring was not, so removing the component from the row broke nothing. The break-verify is what found it.

The class summary is asserted against `compileStyleValues` output rather than a literal list, with a must-be-found control that the compiler actually produced something, so the test cannot drift from the compiler or pass on two empty lists agreeing.

## Risk

Presentation only. No stored shape changes, and no new data is derived — the class summary reads what the engine already compiles.
