### PR TITLE
fix(admin): type a job's wire status as the wire can carry it

### DIFF
--- a/.changeset/a-wire-status-is-a-string.md
+++ b/.changeset/a-wire-status-is-a-string.md
@@ -1,0 +1,39 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The admin types a job's status as the wire can actually carry it.
+
+The core's union describes what the current server sends and is right about
+that. A client is a different position: during a rolling deploy a newer server
+sends a status the bundle was built before, and typing the received field as the
+closed union asserts that cannot happen — the exact claim every guard in this
+feature exists because it is false.
+
+So the admin widens `status` to a string at the boundary, where the
+uncertainty actually is, and keeps the union for the exhaustive presentation
+map, which is the one place a closed set is correct.

--- a/packages/admin/src/types/jobs.ts
+++ b/packages/admin/src/types/jobs.ts
@@ -11,6 +11,7 @@
  */
 
 import { DEFAULT_RETENTION_MS } from "nextly/api/jobs-list-types";
+import type { JobListItem as ServerJobListItem } from "nextly/api/jobs-list-types";
 
 export {
   ATTENTION_STATES,
@@ -19,8 +20,25 @@ export {
   jobNeedsAttention,
   storedStatesFor,
   type JobDisplayStatus,
-  type JobListItem,
 } from "nextly/api/jobs-list-types";
+
+/**
+ * A job as the ADMIN receives it, which is not quite what the server emits.
+ *
+ * Identical to the published row except for `status`, which is a plain string
+ * here. The core's union describes what the CURRENT server sends and is right
+ * about that; a client is a different position, because during a rolling deploy
+ * a newer server sends a status this bundle was built before. Typing the field
+ * as the union would say that cannot happen, which is the claim every guard in
+ * this feature exists because it is false.
+ *
+ * So the widening is where the uncertainty actually is — at the boundary — and
+ * the union stays available as {@link JobDisplayStatus} for the exhaustive
+ * presentation map, which is the place a closed set is correct.
+ */
+export type JobListItem = Omit<ServerJobListItem, "status"> & {
+  status: string;
+};
 
 /**
  * What the list read accepts.


### PR DESCRIPTION
**main is red.** `pnpm check-types` fails in the admin, and #1447 introduced it — mine.

```
src/components/features/background-jobs/__tests__/JobFailureSummary.test.tsx(96,34):
error TS2322: Type '"quarantined"' is not assignable to type
'"failed" | "waiting" | "retrying" | "running" | "succeeded" | undefined'.
```

## What went wrong, and it is not only the type

The test models a status this build has never heard of — the rolling-deploy case the guard beside it exists for. The fixture typed that field as the closed union, which is precisely the type that cannot express the case.

**The union is right about the SERVER.** It describes what the current one emits. A client is a different position: during a rolling deploy a newer server sends a status the bundle was built before, and typing the received field as the union asserts that cannot happen — the exact claim every guard in this feature exists because it is false.

So the widening goes where the uncertainty actually is, at the boundary. `JobDisplayStatus` stays available for the exhaustive presentation map, which is the one place a closed set is correct. Same shape as `StatusFilterValue`, which stopped claiming to be a two-value union for the same reason.

## How it reached main, stated plainly

I reported #1447's CI as green. That was true of head `35bbf8eef`. I then pushed `fe111c137` — the last review round — and **did not re-check before it was merged**. That head's `Lint / Typecheck / Test / Build` is `completed/failure`, and the merge went ahead on my stale report.

The local gate did not catch it either: the pre-push hook runs lint, build and the suites, not `check-types`. The suites pass, because vitest strips types. So nothing between my keyboard and `main` ran the check that fails.

## Verification

- `npx tsc --noEmit` in `packages/admin` clean, measured on this branch.
- `packages/nextly` typecheck clean.
- Admin suite green, 3 674 tests.
- The unknown-status rule still discriminates: filtering on the predicate alone still fails `KEEPS a status this build does not know`, so the widening did not soften the test it exists for.
- `fallow` passes with zero introduced findings in any dimension.