### PR TITLE
fix(builder): a keyboard move that the rules refuse now says why

### DIFF
--- a/.changeset/a-refused-keyboard-move-says-why.md
+++ b/.changeset/a-refused-keyboard-move-says-why.md
@@ -1,0 +1,40 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+Moving a block with the keyboard now explains itself when the move is not
+allowed. Before, a block that could not go where you sent it simply did not
+move, with nothing said — while dragging the same block showed you why and what
+would work instead. The reason reached people using a mouse and nobody else,
+which is backwards: the keyboard route is the one someone uses when they cannot
+drag.
+
+The wording is the same one a drag shows, so both routes say the same thing. If
+the move fails for a reason the layout rules do not explain, it says only that
+the block did not move rather than inventing a cause. Pressing up on the first
+block is still silent — there is nowhere to go, and saying so on every press
+would be noise.

--- a/packages/builder/src/canvas.tsx
+++ b/packages/builder/src/canvas.tsx
@@ -1766,16 +1766,15 @@ function DropRefusalNotice({
        * from it: this describes a POINTER gesture, and a live region here
        * would speak to someone who is not the one dragging.
        *
-       * What must NOT be claimed is that the keyboard path covers it.
-       * `keyboardMovePosition` is purely positional and never asks the nesting
-       * question, so an `alt+Arrow` move is refused by the STORE rather than by
-       * the rule, and `keyboard-actions` returns silently — its own test pins
-       * that. So the nesting reason this message carries currently has no
-       * spoken counterpart anywhere.
+       * The spoken counterpart is `keyboard-actions`, which refuses a move the
+       * nesting rule forbids and announces the same reason and remedy through
+       * its own live region. `keyboardMovePosition` stays purely positional —
+       * it answers where a block goes, never whether it may — so the question
+       * is asked by the wiring on both routes, of one function.
        *
-       * That gap is real and it is not this element's to close. Announcing a
-       * pointer drag would put the sentence on the wrong gesture; the fix
-       * belongs where the keyboard move is refused.
+       * Which is why announcing here would be wrong rather than redundant: it
+       * would put the sentence on a pointer gesture, spoken to someone who is
+       * not the one dragging.
        */
       aria-hidden="true"
     >

--- a/packages/builder/src/drag-refusal.ts
+++ b/packages/builder/src/drag-refusal.ts
@@ -35,6 +35,18 @@
 import type { DropRefusal } from "./drop-targets";
 import { blockLabel } from "./inserter";
 
+/**
+ * The two facts a refusal's wording is built from.
+ *
+ * Narrower than {@link DropRefusal} on purpose. A drop carries a region id and
+ * a parent id because the canvas needs them to draw the refusal in place; the
+ * WORDS need only the reason and what the rule permits. Taking the pair rather
+ * than the whole lets a caller that never had a region — a keyboard move, which
+ * has a position and no pointer — reuse these sentences instead of inventing a
+ * second vocabulary, without fabricating a region id to satisfy a type.
+ */
+export type RefusalFacts = Pick<DropRefusal, "reason" | "permitted">;
+
 /** The two lines a refusal draws. */
 export interface RefusalWording {
   /** Why the drop will not happen, in one sentence. */
@@ -114,7 +126,7 @@ function permittedLabel(entry: string): string {
  * a sentence rather than a gap where a name should be.
  */
 export function refusalWording(
-  refusal: DropRefusal,
+  refusal: RefusalFacts,
   movingType: string,
   regionType: string | undefined
 ): RefusalWording {

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -380,11 +380,11 @@ describe("useBlockKeyboardActions", () => {
 
   it("REFUSES a move the nesting rule forbids, and says why", () => {
     /*
-     * The gap this closes. A pointer author who drags a block somewhere it
-     * cannot go is shown the reason and the remedy; before this, a keyboard
-     * author pressing the same move got silence — the rule reached one of them
-     * and not the other, which is the failure WCAG 4.1.3 describes and the one
-     * that costs exactly the people the keyboard route exists for.
+     * A pointer author who drags a block somewhere it cannot go is shown the
+     * reason and the remedy. The same move by keyboard must be refused and
+     * explained too: a rule that reaches one route and not the other costs
+     * exactly the people the keyboard route exists for, and a status that
+     * never arrives is the failure WCAG 4.1.3 describes.
      *
      * The nesting source is supplied rather than registered so the refusal is a
      * property of THIS test rather than of whatever the registry happens to
@@ -405,9 +405,9 @@ describe("useBlockKeyboardActions", () => {
 
     /*
      * REFUSED, not merely explained. The store never asks the nesting rule, so
-     * before this the move was applied and the document ended up holding a
-     * placement a drag would have refused. `apply` not being reached is the
-     * assertion that separates stopping it from narrating it.
+     * a move that reaches `apply` is applied — and the document would then hold
+     * a placement a drag refuses. `apply` not being reached is the assertion
+     * that separates stopping the move from narrating it.
      */
     expect(editor.apply).not.toHaveBeenCalled();
     const said = screen.getByRole("status").textContent ?? "";

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -355,15 +355,80 @@ describe("useBlockKeyboardActions", () => {
     expect(screen.getByRole("status").textContent).toBe("");
   });
 
-  it("says nothing when the store refuses the op", () => {
-    // `apply` answering null means the document moved underneath the press.
-    // The rule permitted it; the store did not.
+  it("says the move did not happen, naming no cause, when the rule permitted it", () => {
+    /*
+     * `apply` answering null means the document moved underneath the press:
+     * the nesting rule permitted the placement and the store still refused.
+     *
+     * This case asserted SILENCE until 2026-09-02. It was changed rather than
+     * added to, because silence here is the defect: a keyboard author cannot
+     * see that nothing moved, and a status that never arrives is the failure
+     * WCAG 4.1.3 describes. What has not changed is that no cause is named —
+     * nesting allowed this, so any reason given would be invented.
+     */
     const editor = editorSpy(pair(), "a");
     editor.apply.mockReturnValue(null);
     mount(editor);
 
     press("ArrowDown", { altKey: true });
 
+    const said = screen.getByRole("status").textContent ?? "";
+    expect(said).toContain("could not be moved");
+    // No cause, because none was established.
+    expect(said).not.toMatch(/take|inside|slot/i);
+  });
+
+  it("says WHY when the nesting rule is what refused the move", () => {
+    /*
+     * The gap this closes. A pointer author who drags a block somewhere it
+     * cannot go is shown the reason and the remedy; before this, a keyboard
+     * author pressing the same move got silence — the rule reached one of them
+     * and not the other, which is the failure WCAG 4.1.3 describes and the one
+     * that costs exactly the people the keyboard route exists for.
+     *
+     * The nesting source is supplied rather than registered so the refusal is a
+     * property of THIS test rather than of whatever the registry happens to
+     * hold: `acme/text` may only sit inside `acme/box`, so moving it to the
+     * root is refused by the rule, not by the store's other limits.
+     */
+    const editor = editorSpy(pair(), "a");
+    editor.apply.mockReturnValue(null);
+    render(
+      <ShortcutProvider>
+        <BlockKeyboardActions
+          editor={editor}
+          nesting={{ parentsOf: () => ["acme/box"] }}
+        />
+      </ShortcutProvider>
+    );
+
+    press("ArrowDown", { altKey: true });
+
+    const said = screen.getByRole("status").textContent ?? "";
+    // A REASON, not merely that something failed — the assertion the previous
+    // wording could not make, since "could not be moved" is true of both.
+    expect(said).toMatch(/has to sit inside a container/i);
+    // And the remedy, which is what turns a refusal into an instruction.
+    expect(said).toMatch(/goes inside/i);
+  });
+
+  it("stays silent at a BOUNDARY, which is not a refusal", () => {
+    /*
+     * The other half, and the reason this fix is not simply "announce more".
+     * The first block cannot move up: there is nowhere to go, the store is
+     * never asked, and saying "already first" on every press is noise an
+     * author cannot act on. Only a move the RULES refused has something to
+     * explain.
+     *
+     * Without this, the natural next change — announcing on every path that
+     * ends without a move — would pass every other case here.
+     */
+    const editor = editorSpy(pair(), "a");
+    mount(editor);
+
+    press("ArrowUp", { altKey: true });
+
+    expect(editor.apply).not.toHaveBeenCalled();
     expect(screen.getByRole("status").textContent).toBe("");
   });
 

--- a/packages/builder/src/keyboard-actions.test.tsx
+++ b/packages/builder/src/keyboard-actions.test.tsx
@@ -357,14 +357,14 @@ describe("useBlockKeyboardActions", () => {
 
   it("says the move did not happen, naming no cause, when the rule permitted it", () => {
     /*
-     * `apply` answering null means the document moved underneath the press:
-     * the nesting rule permitted the placement and the store still refused.
+     * The store refusing something the nesting rule permits: a byte cap, a
+     * depth limit, an op the forest rejects.
      *
-     * This case asserted SILENCE until 2026-09-02. It was changed rather than
-     * added to, because silence here is the defect: a keyboard author cannot
-     * see that nothing moved, and a status that never arrives is the failure
-     * WCAG 4.1.3 describes. What has not changed is that no cause is named —
-     * nesting allowed this, so any reason given would be invented.
+     * It is reported rather than passed over, because a keyboard author cannot
+     * see that nothing moved. And it names NO cause, because none was
+     * established — the rule allowed this placement, so any reason given here
+     * would be invented, and would send an author to change a container that
+     * was never the problem.
      */
     const editor = editorSpy(pair(), "a");
     editor.apply.mockReturnValue(null);
@@ -378,7 +378,7 @@ describe("useBlockKeyboardActions", () => {
     expect(said).not.toMatch(/take|inside|slot/i);
   });
 
-  it("says WHY when the nesting rule is what refused the move", () => {
+  it("REFUSES a move the nesting rule forbids, and says why", () => {
     /*
      * The gap this closes. A pointer author who drags a block somewhere it
      * cannot go is shown the reason and the remedy; before this, a keyboard
@@ -392,7 +392,6 @@ describe("useBlockKeyboardActions", () => {
      * root is refused by the rule, not by the store's other limits.
      */
     const editor = editorSpy(pair(), "a");
-    editor.apply.mockReturnValue(null);
     render(
       <ShortcutProvider>
         <BlockKeyboardActions
@@ -404,6 +403,13 @@ describe("useBlockKeyboardActions", () => {
 
     press("ArrowDown", { altKey: true });
 
+    /*
+     * REFUSED, not merely explained. The store never asks the nesting rule, so
+     * before this the move was applied and the document ended up holding a
+     * placement a drag would have refused. `apply` not being reached is the
+     * assertion that separates stopping it from narrating it.
+     */
+    expect(editor.apply).not.toHaveBeenCalled();
     const said = screen.getByRole("status").textContent ?? "";
     // A REASON, not merely that something failed — the assertion the previous
     // wording could not make, since "could not be moved" is true of both.

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -429,16 +429,14 @@ export function useBlockKeyboardActions({
       if (move === null) return;
 
       /*
-       * ASKED BEFORE THE MOVE, which is the whole of this fix.
+       * Asked BEFORE the move, because the op store does not consult the
+       * nesting rule — `ops.ts` holds no reference to it — so a placement the
+       * rule forbids is applied rather than refused.
        *
-       * The op store does not consult the nesting rule — measured, zero
-       * references in `ops.ts` — so a placement the rule forbids is applied
-       * rather than refused. The POINTER route is stopped because
-       * `drop-targets` asks `blockAllowedAt` before a drop resolves; asking
-       * here is the keyboard route's half of that same decision, of that same
-       * function, so the two surfaces cannot disagree about where a block may
-       * go. Without it a keyboard author builds documents a pointer author
-       * cannot, and nothing says so.
+       * This is the keyboard route's half of the decision `drop-targets` makes
+       * for the pointer, of the same function, so the two surfaces cannot
+       * disagree about where a block may go. A keyboard author who could not
+       * be refused here would build documents a pointer author cannot.
        */
       const refusal = nestingRefusalForMove(
         editorNow.document,

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -20,6 +20,8 @@
  * @module keyboard-actions
  */
 
+import { findNode, registryNestingSource } from "@nextlyhq/blocks-engine";
+import type { NestingSource } from "@nextlyhq/blocks-engine";
 import { useShortcuts } from "@nextlyhq/ui";
 import * as React from "react";
 
@@ -32,6 +34,7 @@ import {
 } from "./keyboard-move";
 import { layerLabel, pathTo } from "./layers";
 import { lockBlockingMove } from "./locking";
+import { refusalAnnouncement, refusedMoveWording } from "./move-refusal";
 import {
   isRefusal,
   selectionDeletion,
@@ -194,6 +197,15 @@ export interface BlockKeyboardActionsOptions {
    */
   editor: EditorState;
   /**
+   * The nesting rule source, for explaining a refused move.
+   *
+   * Optional, defaulting to the registry — which is what the canvas asks, so a
+   * refusal reads the same whether the author dragged the block or moved it
+   * with the keyboard. Present as an option only so a test can supply a rule
+   * set without registering blocks globally.
+   */
+  nesting?: NestingSource;
+  /**
    * Whether the bindings are live. Defaults to true.
    *
    * A host that mounts the canvas inside something modal turns them off rather
@@ -241,7 +253,19 @@ export function useBlockKeyboardActions({
   editor,
   enabled = true,
   onEditText,
+  nesting,
 }: BlockKeyboardActionsOptions): BlockKeyboardActionsResult {
+  /*
+   * The same rule source the pointer route asks, defaulted the way the insert
+   * panel defaults it. Taken as an option rather than resolved here only so a
+   * test can supply one; a host passing nothing gets the registry, which is
+   * what the canvas passes too — two surfaces asking one source, so a refusal
+   * cannot be explained one way on a drag and another on a keypress.
+   */
+  const nestingSource = React.useMemo(
+    () => nesting ?? registryNestingSource(),
+    [nesting]
+  );
   // The message a live region reads out. Held as state rather than written to
   // the DOM directly so React owns the node — a region mutated behind React's
   // back is reverted by the next render, silently and only sometimes.
@@ -414,16 +438,51 @@ export function useBlockKeyboardActions({
       // cannot see the result, and the store may refuse — announcing before
       // it answered would report a move that did not happen, which is worse
       // than silence because it cannot be told from one that did.
-      //
-      // Refusals stay silent, deliberately. "This block is already first"
-      // on every press at the end of a list is noise an author cannot act
-      // on, and the block not moving is itself the answer.
-      if (applied !== null) announce(EFFECT_ANNOUNCEMENT[move.effect]);
+      if (applied !== null) {
+        announce(EFFECT_ANNOUNCEMENT[move.effect]);
+        return;
+      }
+      /*
+       * A refusal HERE is not the same event as the silent one above, and
+       * conflating them is what left the nesting rule reaching a pointer user
+       * and nobody else.
+       *
+       * `move === null` is a boundary: the first block cannot move up, and
+       * saying so on every press is noise an author cannot act on. Reaching
+       * this line means the position was reachable and the STORE said no —
+       * which is a rule the author cannot see, and the same rule a drag
+       * explains on screen. Silence here is the editor knowing why and not
+       * saying.
+       *
+       * The reason is recovered rather than relayed, because `apply` answers
+       * `null` and carries none; and when the nesting rule would have allowed
+       * the placement, the move failed for some other reason and the sentence
+       * says only that, rather than naming a cause that was not the cause.
+       */
+      const why = refusedMoveWording(
+        editorNow.document,
+        selectedId,
+        move.to,
+        nestingSource
+      );
+      if (why !== null) {
+        announce(refusalAnnouncement(why));
+        return;
+      }
+      /*
+       * Nesting did not explain it, so the sentence names no cause. A block
+       * the document no longer holds cannot be named either, and "The block"
+       * is the honest subject there rather than a label invented for a node
+       * that is gone.
+       */
+      const moved = findNode(editorNow.document.nodes, selectedId);
+      const subject = moved === undefined ? "The block" : layerLabel(moved);
+      announce(`${subject} could not be moved.`);
       // The selection deliberately does NOT change. The block that moved is
       // the block still selected, so a second press continues moving the
       // same block — which is what makes a run of presses walk it across the
     },
-    [announce, moveSet]
+    [announce, moveSet, nestingSource]
   );
 
   /**
@@ -678,6 +737,7 @@ export function BlockKeyboardActions({
   editor,
   enabled,
   onEditText,
+  nesting,
   children,
 }: BlockKeyboardActionsOptions & {
   readonly children?: React.ReactNode;
@@ -686,6 +746,7 @@ export function BlockKeyboardActions({
     editor,
     enabled,
     ...(onEditText === undefined ? {} : { onEditText }),
+    ...(nesting === undefined ? {} : { nesting }),
   });
 
   // `polite`, not `assertive`: a move is the author's own action and its result

--- a/packages/builder/src/keyboard-actions.tsx
+++ b/packages/builder/src/keyboard-actions.tsx
@@ -34,7 +34,7 @@ import {
 } from "./keyboard-move";
 import { layerLabel, pathTo } from "./layers";
 import { lockBlockingMove } from "./locking";
-import { refusalAnnouncement, refusedMoveWording } from "./move-refusal";
+import { nestingRefusalForMove, refusalAnnouncement } from "./move-refusal";
 import {
   isRefusal,
   selectionDeletion,
@@ -428,6 +428,29 @@ export function useBlockKeyboardActions({
       // be an error message for pressing a key that did nothing.
       if (move === null) return;
 
+      /*
+       * ASKED BEFORE THE MOVE, which is the whole of this fix.
+       *
+       * The op store does not consult the nesting rule — measured, zero
+       * references in `ops.ts` — so a placement the rule forbids is applied
+       * rather than refused. The POINTER route is stopped because
+       * `drop-targets` asks `blockAllowedAt` before a drop resolves; asking
+       * here is the keyboard route's half of that same decision, of that same
+       * function, so the two surfaces cannot disagree about where a block may
+       * go. Without it a keyboard author builds documents a pointer author
+       * cannot, and nothing says so.
+       */
+      const refusal = nestingRefusalForMove(
+        editorNow.document,
+        selectedId,
+        move.to,
+        nestingSource
+      );
+      if (refusal !== null) {
+        announce(refusalAnnouncement(refusal));
+        return;
+      }
+
       const applied = editorNow.apply({
         kind: "move",
         id: selectedId,
@@ -435,45 +458,22 @@ export function useBlockKeyboardActions({
         dropSlotIfEmpty: move.dropSlotIfEmpty,
       });
       // Announced only once the store has accepted it. A keyboard author
-      // cannot see the result, and the store may refuse — announcing before
-      // it answered would report a move that did not happen, which is worse
-      // than silence because it cannot be told from one that did.
+      // cannot see the result, and announcing before it answered would report
+      // a move that did not happen, which is worse than silence because it
+      // cannot be told from one that did.
       if (applied !== null) {
         announce(EFFECT_ANNOUNCEMENT[move.effect]);
         return;
       }
       /*
-       * A refusal HERE is not the same event as the silent one above, and
-       * conflating them is what left the nesting rule reaching a pointer user
-       * and nobody else.
+       * The store refused something the nesting rule permits — a byte cap, a
+       * depth limit, an op the forest rejects. The sentence names no cause,
+       * because none was established: naming a nesting one here would send an
+       * author to change a container that was never the problem.
        *
-       * `move === null` is a boundary: the first block cannot move up, and
-       * saying so on every press is noise an author cannot act on. Reaching
-       * this line means the position was reachable and the STORE said no —
-       * which is a rule the author cannot see, and the same rule a drag
-       * explains on screen. Silence here is the editor knowing why and not
-       * saying.
-       *
-       * The reason is recovered rather than relayed, because `apply` answers
-       * `null` and carries none; and when the nesting rule would have allowed
-       * the placement, the move failed for some other reason and the sentence
-       * says only that, rather than naming a cause that was not the cause.
-       */
-      const why = refusedMoveWording(
-        editorNow.document,
-        selectedId,
-        move.to,
-        nestingSource
-      );
-      if (why !== null) {
-        announce(refusalAnnouncement(why));
-        return;
-      }
-      /*
-       * Nesting did not explain it, so the sentence names no cause. A block
-       * the document no longer holds cannot be named either, and "The block"
-       * is the honest subject there rather than a label invented for a node
-       * that is gone.
+       * Still spoken rather than silent. `move === null` above is a boundary
+       * with nowhere to go and is correctly quiet; reaching HERE means a move
+       * was attempted and did not happen, which a keyboard author cannot see.
        */
       const moved = findNode(editorNow.document.nodes, selectedId);
       const subject = moved === undefined ? "The block" : layerLabel(moved);

--- a/packages/builder/src/move-refusal.test.ts
+++ b/packages/builder/src/move-refusal.test.ts
@@ -1,11 +1,13 @@
 /**
- * What a refused move says, and when it admits it does not know.
+ * Whether the nesting rule refuses a move, and what it says when it does.
  *
- * The half most worth testing is the SILENCE. A wrong sentence here sends an
- * author to fix a container that was never the problem, and the store refuses
- * for reasons — a byte cap, a depth limit — that nesting has no words for. So
- * every case below that returns `null` is a case where inventing a reason would
- * have been easy and wrong.
+ * This DECIDES — the store never asks the rule, so a null here is what lets a
+ * move happen. That raises the stakes on both directions. A wrong refusal stops
+ * an author doing something legal; a wrong permission lets the keyboard build a
+ * document a drag would have refused, which is the defect this closes.
+ *
+ * The half most worth testing is still the NULL. Every case below that returns
+ * one is a case where inventing a refusal would have been easy and wrong.
  *
  * Pure, so none of it needs a DOM.
  *
@@ -14,7 +16,7 @@
 import type { BlockDocument, NestingSource } from "@nextlyhq/blocks-engine";
 import { describe, expect, it } from "vitest";
 
-import { refusalAnnouncement, refusedMoveWording } from "./move-refusal";
+import { refusalAnnouncement, nestingRefusalForMove } from "./move-refusal";
 
 /** A page holding a text block and a box that could contain one. */
 function documentOf(): BlockDocument {
@@ -36,7 +38,7 @@ const PERMISSIVE: NestingSource = { parentsOf: () => undefined };
 
 describe("explaining a refused move", () => {
   it("names the reason and the remedy when the rule refuses the root", () => {
-    const wording = refusedMoveWording(
+    const wording = nestingRefusalForMove(
       documentOf(),
       "text",
       { index: 0 },
@@ -55,7 +57,7 @@ describe("explaining a refused move", () => {
      * first sentence for the second case is told to do something they have
      * already done.
      */
-    const wording = refusedMoveWording(
+    const wording = nestingRefusalForMove(
       documentOf(),
       "text",
       { parentId: "box", slot: "default", index: 0 },
@@ -67,8 +69,8 @@ describe("explaining a refused move", () => {
   });
 });
 
-describe("refusing to invent a reason", () => {
-  it("says NOTHING when the nesting rule would have allowed the move", () => {
+describe("permitting, rather than inventing a refusal", () => {
+  it("PERMITS a placement the rule allows, rather than refusing it", () => {
     /*
      * The store refuses for reasons nesting has no words for — a document at
      * its byte cap, a depth limit, an op the forest rejects. Reporting a
@@ -77,24 +79,24 @@ describe("refusing to invent a reason", () => {
      * sentence was wrong.
      */
     expect(
-      refusedMoveWording(documentOf(), "text", { index: 0 }, PERMISSIVE)
+      nestingRefusalForMove(documentOf(), "text", { index: 0 }, PERMISSIVE)
     ).toBeNull();
   });
 
-  it("says nothing when the moving block is not in the document", () => {
+  it("permits when the moving block is not in the document", () => {
     expect(
-      refusedMoveWording(documentOf(), "gone", { index: 0 }, ONLY_IN_BOX)
+      nestingRefusalForMove(documentOf(), "gone", { index: 0 }, ONLY_IN_BOX)
     ).toBeNull();
   });
 
-  it("says nothing when the destination parent is not in the document", () => {
+  it("permits when the destination parent is not in the document", () => {
     /*
      * A position naming a parent the document does not hold cannot be judged:
      * the rule needs the parent's TYPE, and guessing one would answer about a
      * container that is not there.
      */
     expect(
-      refusedMoveWording(
+      nestingRefusalForMove(
         documentOf(),
         "text",
         { parentId: "gone", slot: "default", index: 0 },

--- a/packages/builder/src/move-refusal.test.ts
+++ b/packages/builder/src/move-refusal.test.ts
@@ -69,6 +69,37 @@ describe("explaining a refused move", () => {
   });
 });
 
+it("refuses on the SLOT's allow-list, and names what the slot takes", () => {
+  /*
+   * The other half of the rule, and the half whose wording differs.
+   *
+   * `blockAllowedAt` asks two questions — the child saying where it makes
+   * sense (`parentsOf`) and the container saying what it holds
+   * (`slotAllowOf`) — and `drag-refusal` keeps their answers apart because
+   * `permitted` is two different facts under one field name. A slot refusal
+   * names what the SLOT admits; a parent refusal names the containers the
+   * MOVING BLOCK may sit inside. Announcing one as the other tells an author
+   * something about the region that was never measured.
+   *
+   * Without this the slot path is reachable in production and exercised by
+   * nothing: every other case here goes through `parentsOf`.
+   */
+  const wording = nestingRefusalForMove(
+    documentOf(),
+    "text",
+    { parentId: "box", slot: "header", index: 0 },
+    {
+      parentsOf: () => undefined,
+      slotAllowOf: () => ["acme/heading"],
+    }
+  );
+
+  expect(wording?.headline).toMatch(/this slot does not take/i);
+  // "Takes" — a statement about the SLOT, which is true only for this reason.
+  expect(wording?.remedy).toMatch(/^Takes /);
+  expect(wording?.remedy).toContain("Heading");
+});
+
 describe("permitting, rather than inventing a refusal", () => {
   it("PERMITS a placement the rule allows, rather than refusing it", () => {
     /*

--- a/packages/builder/src/move-refusal.test.ts
+++ b/packages/builder/src/move-refusal.test.ts
@@ -1,0 +1,122 @@
+/**
+ * What a refused move says, and when it admits it does not know.
+ *
+ * The half most worth testing is the SILENCE. A wrong sentence here sends an
+ * author to fix a container that was never the problem, and the store refuses
+ * for reasons — a byte cap, a depth limit — that nesting has no words for. So
+ * every case below that returns `null` is a case where inventing a reason would
+ * have been easy and wrong.
+ *
+ * Pure, so none of it needs a DOM.
+ *
+ * @module move-refusal.test
+ */
+import type { BlockDocument, NestingSource } from "@nextlyhq/blocks-engine";
+import { describe, expect, it } from "vitest";
+
+import { refusalAnnouncement, refusedMoveWording } from "./move-refusal";
+
+/** A page holding a text block and a box that could contain one. */
+function documentOf(): BlockDocument {
+  return {
+    formatVersion: 1,
+    kind: "page",
+    nodes: [
+      { id: "text", type: "acme/text", version: 1, props: {} },
+      { id: "box", type: "acme/box", version: 1, props: {} },
+    ],
+  } as BlockDocument;
+}
+
+/** A rule saying `acme/text` may only sit inside `acme/box`. */
+const ONLY_IN_BOX: NestingSource = { parentsOf: () => ["acme/box"] };
+
+/** A rule restricting nothing. */
+const PERMISSIVE: NestingSource = { parentsOf: () => undefined };
+
+describe("explaining a refused move", () => {
+  it("names the reason and the remedy when the rule refuses the root", () => {
+    const wording = refusedMoveWording(
+      documentOf(),
+      "text",
+      { index: 0 },
+      ONLY_IN_BOX
+    );
+
+    expect(wording?.headline).toMatch(/has to sit inside a container/i);
+    expect(wording?.remedy).toMatch(/goes inside/i);
+  });
+
+  it("names the CONTAINER when the refusal is about a particular parent", () => {
+    /*
+     * The two reasons are not two spellings of one refusal: the root case says
+     * "put it inside something" because no container on screen would take it,
+     * and this one says "aim at a different container". An author given the
+     * first sentence for the second case is told to do something they have
+     * already done.
+     */
+    const wording = refusedMoveWording(
+      documentOf(),
+      "text",
+      { parentId: "box", slot: "default", index: 0 },
+      { parentsOf: () => ["acme/columns"] }
+    );
+
+    expect(wording?.headline).toMatch(/does not take/i);
+    expect(wording?.headline).toContain("Box");
+  });
+});
+
+describe("refusing to invent a reason", () => {
+  it("says NOTHING when the nesting rule would have allowed the move", () => {
+    /*
+     * The store refuses for reasons nesting has no words for — a document at
+     * its byte cap, a depth limit, an op the forest rejects. Reporting a
+     * nesting cause there would send an author to change a container that was
+     * never the problem, and they would have no way to discover that the
+     * sentence was wrong.
+     */
+    expect(
+      refusedMoveWording(documentOf(), "text", { index: 0 }, PERMISSIVE)
+    ).toBeNull();
+  });
+
+  it("says nothing when the moving block is not in the document", () => {
+    expect(
+      refusedMoveWording(documentOf(), "gone", { index: 0 }, ONLY_IN_BOX)
+    ).toBeNull();
+  });
+
+  it("says nothing when the destination parent is not in the document", () => {
+    /*
+     * A position naming a parent the document does not hold cannot be judged:
+     * the rule needs the parent's TYPE, and guessing one would answer about a
+     * container that is not there.
+     */
+    expect(
+      refusedMoveWording(
+        documentOf(),
+        "text",
+        { parentId: "gone", slot: "default", index: 0 },
+        ONLY_IN_BOX
+      )
+    ).toBeNull();
+  });
+});
+
+describe("the announced sentence", () => {
+  it("joins the headline and the remedy", () => {
+    expect(refusalAnnouncement({ headline: "No.", remedy: "Try a Box" })).toBe(
+      "No. Try a Box"
+    );
+  });
+
+  it("omits the remedy rather than trailing off when there is none", () => {
+    /*
+     * `remedy` is null when the engine named nothing permitted. Rendering it
+     * anyway would end the sentence in a space or an empty clause, which reads
+     * as a message that was cut off rather than one that had nothing to add.
+     */
+    expect(refusalAnnouncement({ headline: "No.", remedy: null })).toBe("No.");
+  });
+});

--- a/packages/builder/src/move-refusal.ts
+++ b/packages/builder/src/move-refusal.ts
@@ -1,34 +1,32 @@
 /**
- * Why a move the store refused was refused, in words an author can act on.
+ * Whether the nesting rule refuses a move, and the words for saying so.
  *
- * A DIAGNOSIS, never a decision, and the distinction is the whole design.
- * `keyboard-move` answers where a block goes and says in its own docblock that
- * it "answers WHERE, never WHETHER", because validity belongs to the op store
- * and asking a second time is a second implementation of one question. This
- * module does not ask whether the move may happen — the store has already said
- * no — it asks what the nesting rule would say about a placement that has
- * already been refused, so the refusal can be spoken.
+ * ## This DECIDES, and it has to
  *
- * That ordering is what keeps it from becoming a second gate. Nothing here can
- * permit or forbid anything: it runs only after `apply` returned null, and its
- * answer changes what is ANNOUNCED and nothing else.
+ * The op store does not ask the nesting rule — measured, zero references to it
+ * in `ops.ts`, with a control showing the symbol resolves elsewhere in the
+ * package. So a placement the rule forbids is not refused at apply time; it is
+ * applied. The POINTER route is stopped because `drop-targets` asks
+ * `blockAllowedAt` before a drop resolves, and until this module was called
+ * before the move rather than after it, the keyboard route asked nobody. A
+ * keyboard author could therefore build a document a pointer author cannot.
  *
- * ## Why the reason has to be recovered rather than relayed
+ * So this is the keyboard route's half of a decision the pointer route already
+ * makes, asked of the same function, rather than a second implementation of it:
+ * `blockAllowedAt` is the one answer and both surfaces ask it.
  *
- * `EditorState.apply` returns `BlockDocument | null`. The null carries no
- * reason, so a caller that wants to explain a refusal cannot pass one on. The
- * choice is between recovering the reason here and widening the store's return
- * type — and widening it would make every caller handle a value only this one
- * needs, for a case the store itself does not have words for.
+ * ## It does NOT move the question into `keyboard-move`
  *
- * ## Null is an honest answer
+ * That module answers where a block goes and says in its own docblock that it
+ * "answers WHERE, never WHETHER". It still does. The wiring asks whether — as
+ * the pointer wiring does — and the position function stays positional.
  *
- * The store refuses for reasons beyond nesting: a document at its byte cap, a
- * depth limit, an op the forest rejects. When the nesting rule would have
- * ALLOWED the placement, this returns null rather than inventing a reason, and
- * the caller says only that the move did not happen. Naming a nesting cause
- * that was not the cause would send an author to fix the wrong thing, which is
- * worse than a sentence that admits it does not know.
+ * ## Null is an honest answer, and it means ALLOWED
+ *
+ * Null is "the nesting rule does not refuse this", never "something went
+ * wrong". A move can still fail after this returns null — a byte cap, a depth
+ * limit, an op the forest rejects — and those are the store's to refuse and its
+ * caller's to report, without a nesting cause being invented for them.
  *
  * @module move-refusal
  */
@@ -40,15 +38,18 @@ import { blockAllowedAt } from "./inserter";
 import type { OpPosition } from "./ops";
 
 /**
- * The words for a refused move, or `null` when nesting does not explain it.
+ * The nesting rule's refusal for a proposed move, or `null` if it permits it.
  *
- * @param document - the document the move was attempted against
- * @param movingId - the block that was being moved
- * @param to - the position it was being moved to
+ * Asked BEFORE the move is applied, which is what makes it a refusal rather
+ * than a post-mortem.
+ *
+ * @param document - the document the move would change
+ * @param movingId - the block being moved
+ * @param to - the position it would move to
  * @param nesting - the rule source, the same one the pointer route asks
- * @returns the refusal's headline and remedy, or `null`
+ * @returns the refusal's headline and remedy, or `null` when it is permitted
  */
-export function refusedMoveWording(
+export function nestingRefusalForMove(
   document: BlockDocument,
   movingId: string,
   to: OpPosition,
@@ -74,8 +75,8 @@ export function refusedMoveWording(
       : ({ at: "slot", parentType: parent.type, slot: to.slot ?? "" } as const);
 
   const verdict = blockAllowedAt(moving.type, target, nesting);
-  // ALLOWED means nesting was not the cause. Something else in the store
-  // refused, and this module has nothing true to say about it.
+  // ALLOWED is null: the rule permits this placement. Whether it survives the
+  // store's own limits is a later question with a different answer.
   if (verdict.allowed) return null;
 
   return refusalWording(verdict, moving.type, parent?.type);

--- a/packages/builder/src/move-refusal.ts
+++ b/packages/builder/src/move-refusal.ts
@@ -7,9 +7,9 @@
  * in `ops.ts`, with a control showing the symbol resolves elsewhere in the
  * package. So a placement the rule forbids is not refused at apply time; it is
  * applied. The POINTER route is stopped because `drop-targets` asks
- * `blockAllowedAt` before a drop resolves, and until this module was called
- * before the move rather than after it, the keyboard route asked nobody. A
- * keyboard author could therefore build a document a pointer author cannot.
+ * `blockAllowedAt` before a drop resolves; the keyboard route asks this, before
+ * the move, for the same reason. Without it a keyboard author builds documents
+ * a pointer author cannot.
  *
  * So this is the keyboard route's half of a decision the pointer route already
  * makes, asked of the same function, rather than a second implementation of it:

--- a/packages/builder/src/move-refusal.ts
+++ b/packages/builder/src/move-refusal.ts
@@ -1,0 +1,99 @@
+/**
+ * Why a move the store refused was refused, in words an author can act on.
+ *
+ * A DIAGNOSIS, never a decision, and the distinction is the whole design.
+ * `keyboard-move` answers where a block goes and says in its own docblock that
+ * it "answers WHERE, never WHETHER", because validity belongs to the op store
+ * and asking a second time is a second implementation of one question. This
+ * module does not ask whether the move may happen — the store has already said
+ * no — it asks what the nesting rule would say about a placement that has
+ * already been refused, so the refusal can be spoken.
+ *
+ * That ordering is what keeps it from becoming a second gate. Nothing here can
+ * permit or forbid anything: it runs only after `apply` returned null, and its
+ * answer changes what is ANNOUNCED and nothing else.
+ *
+ * ## Why the reason has to be recovered rather than relayed
+ *
+ * `EditorState.apply` returns `BlockDocument | null`. The null carries no
+ * reason, so a caller that wants to explain a refusal cannot pass one on. The
+ * choice is between recovering the reason here and widening the store's return
+ * type — and widening it would make every caller handle a value only this one
+ * needs, for a case the store itself does not have words for.
+ *
+ * ## Null is an honest answer
+ *
+ * The store refuses for reasons beyond nesting: a document at its byte cap, a
+ * depth limit, an op the forest rejects. When the nesting rule would have
+ * ALLOWED the placement, this returns null rather than inventing a reason, and
+ * the caller says only that the move did not happen. Naming a nesting cause
+ * that was not the cause would send an author to fix the wrong thing, which is
+ * worse than a sentence that admits it does not know.
+ *
+ * @module move-refusal
+ */
+import type { BlockDocument, NestingSource } from "@nextlyhq/blocks-engine";
+import { findNode } from "@nextlyhq/blocks-engine";
+
+import { refusalWording, type RefusalWording } from "./drag-refusal";
+import { blockAllowedAt } from "./inserter";
+import type { OpPosition } from "./ops";
+
+/**
+ * The words for a refused move, or `null` when nesting does not explain it.
+ *
+ * @param document - the document the move was attempted against
+ * @param movingId - the block that was being moved
+ * @param to - the position it was being moved to
+ * @param nesting - the rule source, the same one the pointer route asks
+ * @returns the refusal's headline and remedy, or `null`
+ */
+export function refusedMoveWording(
+  document: BlockDocument,
+  movingId: string,
+  to: OpPosition,
+  nesting: NestingSource
+): RefusalWording | null {
+  const moving = findNode(document.nodes, movingId);
+  if (moving === undefined) return null;
+
+  /*
+   * The destination as the nesting rule describes it. A position with no
+   * `parentId` is the root, which the rule treats as its own case rather than
+   * as a slot with no container — a block restricted to living inside
+   * something is refused AT the root for a reason no slot could give.
+   */
+  const parent =
+    to.parentId === undefined
+      ? undefined
+      : findNode(document.nodes, to.parentId);
+  if (to.parentId !== undefined && parent === undefined) return null;
+  const target =
+    parent === undefined
+      ? ({ at: "root" } as const)
+      : ({ at: "slot", parentType: parent.type, slot: to.slot ?? "" } as const);
+
+  const verdict = blockAllowedAt(moving.type, target, nesting);
+  // ALLOWED means nesting was not the cause. Something else in the store
+  // refused, and this module has nothing true to say about it.
+  if (verdict.allowed) return null;
+
+  return refusalWording(verdict, moving.type, parent?.type);
+}
+
+/**
+ * One sentence for a refused move, ready to announce.
+ *
+ * Joined here rather than by the caller so the two halves cannot drift apart in
+ * spacing or order between the surfaces that speak them. The remedy is omitted
+ * rather than replaced when the engine named nothing — a trailing fragment
+ * would read as a sentence that was cut off.
+ *
+ * @param wording - the refusal's two lines
+ * @returns the announcement text
+ */
+export function refusalAnnouncement(wording: RefusalWording): string {
+  return wording.remedy === null
+    ? wording.headline
+    : `${wording.headline} ${wording.remedy}`;
+}


### PR DESCRIPTION
Ledger `task:pb-keyboard-move-asks-the-nesting-question`. Files `finding:keyboard-move-bypasses-the-nesting-rule`, which **refutes** the finding this task was written from.

## The defect is bigger than the task described

The task, and this PR's first revision, said a nesting-invalid keyboard move is *"refused by the store at apply time"* and only lacked an announcement. **That is false.** Measured in a running editor:

1. insert `core/columns` (two `core/column` children)
2. select a column, focus the canvas, press `alt+ArrowLeft`
3. the column becomes a **ROOT node**, and the editor announces *"Block moved out of its container"* — a success

`core/column` declares `parent: [COLUMNS_BLOCK]`, so that is a placement a drag refuses.

It is not refused because **nothing asks**. `ops.ts` holds zero references to the nesting rule (control: the symbol resolves in `inserter.ts`), and nothing validates the document before the op applies. The pointer route is stopped only because `drop-targets` asks `blockAllowedAt` before a drop resolves.

**So a keyboard author was not merely untold — they were unstopped**, able to build a document a pointer author cannot, with nothing saying so.

## The fix

`blockAllowedAt` is asked **before** the move, in the wiring. That is the keyboard route's half of the decision the pointer route already makes — one function, two callers, so the surfaces cannot disagree about where a block may go.

`keyboard-move` is untouched. Its docblock requires that it *"answers WHERE, never WHETHER"*, and it still does; the wiring asks whether, exactly as the pointer wiring does.

Three outcomes, kept distinct:

| case | behaviour |
| --- | --- |
| the rule forbids it | **refused**, with the reason and the remedy, in the drag's own words |
| the rule permits it, the store still refuses | reported, naming **no cause** — none was established |
| a boundary (`move === null`) | silent — nowhere to go, and saying so every press is noise |

## Verified in the editor, not only in jsdom

The same steps that produced the defect now leave both columns nested and announce **"Column has to sit inside a container. Column goes inside Columns"**. Before: one column at the root, announced as a success.

## Evidence

- builder **99 files / 2740 tests**; `check-types`, `lint`, `lint:design`, comment-convention all exit 0; `fallow` `pass` over 6 files, **0 introduced**.
- The nesting test asserts `expect(editor.apply).not.toHaveBeenCalled()` — the assertion that separates **stopping** the move from narrating it, and the one whose absence let the first revision look correct.
- Break-verified against three implementations: moving the check back after `apply`, explaining the refusal but applying anyway, and announcing on a boundary. Each fails only what it should.
- The pure module's tests are mostly about the `null` — it now *permits*, so a wrong null is a document a drag would have refused.

## What I got wrong, and how

The first revision explained a refusal that, for nesting, never happens — and its test **manufactured** the branch by mocking `apply` to return `null`. Codex found that from the code; I found the same thing from the editor. Two independent measurements of one defect, and neither the task nor my own audit caught it by reading.

## Still not verified

No screen reader. The tests and the browser check assert what reaches the live region — the mechanism, not what a user hears.
