### PR TITLE
fix(admin): land the settings rail on a page the reader can open

### DIFF
--- a/.changeset/settings-lands-where-you-can-go.md
+++ b/.changeset/settings-lands-where-you-can-go.md
@@ -1,0 +1,41 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The Settings entry in the admin sidebar now sends each reader to the first
+destination in the panel they can actually open, read off the panel's own
+navigation table rather than a list maintained beside it.
+
+An operator whose only settings-area grant was `manage-background-jobs` saw
+the Settings entry, followed it, and landed on General Settings — a page whose
+data answers to `manage-settings` and returns 403 — because the landing was a
+hand-written chain of seven destinations that Background Jobs had never been
+added to. Their one reachable screen was never offered.
+
+A destination is now skipped when its own route is guarded more narrowly than
+the link that shows it, so a reader holding only `read-api-keys` is no longer
+sent to a page that turns them away.

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -28,11 +28,16 @@ import type { ApiCollection } from "@admin/types/entities";
 
 import { useSuppressedChrome } from "../ChromeSuppression";
 
-import { hasPluginsSection } from "./lib/has-plugins-section";
+import { hasCollectionsSection as hasCollectionsSectionHelper } from "./lib/has-collections-section";
+import {
+  hasPluginsSection,
+  hasVisiblePluginCollection,
+} from "./lib/has-plugins-section";
 import { isSubSidebarCategory } from "./lib/has-sub-sidebar";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
 import { resolveActiveSection } from "./lib/resolve-section";
 import { resolveSettingsLanding } from "./lib/resolve-settings-landing";
+import { resolveStandaloneLabel } from "./lib/resolve-standalone-label";
 import type { MainMenuCategory, MainMenuItem } from "./sidebar-types";
 import { getFilteredMenuItems } from "./sidebar-types";
 import { SubSidebarPanel } from "./SubSidebarPanel";
@@ -207,19 +212,12 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     isPermissionsLoading ||
     (!!permissionsError && permissions.length === 0);
 
-  const hasCollectionsSection =
-    capabilities.canViewCollections &&
-    (hasPermissionDataPending ||
-      isCollectionsLoading ||
-      isCollectionsError ||
-      permittedCollections.some(collection => {
-        if (collection.admin?.hidden) return false;
-        if (collection.admin?.isPlugin) {
-          const placement = getCollectionPlacement(collection);
-          return placement === "collections" || !placement;
-        }
-        return true;
-      }));
+  const hasCollectionsSection = hasCollectionsSectionHelper(capabilities, {
+    isPending: hasPermissionDataPending || isCollectionsLoading,
+    isError: isCollectionsError,
+    permittedCollections,
+    placementOf: getCollectionPlacement,
+  });
 
   const hasSinglesSection =
     capabilities.canViewCollections &&
@@ -234,11 +232,10 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     // `canManageSettings` the panel then has no destination at all, so keeping
     // the rail item would open an empty panel rather than defer a decision.
     isPending: hasPermissionDataPending || isCollectionsLoading,
-    hasVisiblePluginCollection: permittedCollections.some(collection => {
-      if (!collection.admin?.isPlugin || collection.admin?.hidden) return false;
-      const placement = getCollectionPlacement(collection);
-      return !placement || placement === "plugins";
-    }),
+    hasVisiblePluginCollection: hasVisiblePluginCollection(
+      permittedCollections,
+      getCollectionPlacement
+    ),
   });
 
   const hasMediaSection = hasPermissionDataPending
@@ -405,12 +402,15 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   }, [selectedMain, visibleStandalonePlugins, authorizedPlugins]);
 
   // Resolve the label for the active standalone plugin
-  const standaloneLabel = useMemo(() => {
-    if (!selectedMain.startsWith("standalone-")) return "";
-    const slug = selectedMain.replace("standalone-", "");
-    const sp = visibleStandalonePlugins.find(p => pluginSlug(p.name) === slug);
-    return sp?.appearance?.label || sp?.name || slug;
-  }, [selectedMain, visibleStandalonePlugins]);
+  const standaloneLabel = useMemo(
+    () =>
+      resolveStandaloneLabel(
+        selectedMain,
+        visibleStandalonePlugins,
+        pluginSlug
+      ),
+    [selectedMain, visibleStandalonePlugins]
+  );
 
   return (
     <div className="flex h-full overflow-hidden">

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -8,7 +8,10 @@ import * as Icons from "@admin/components/icons";
 import { Database } from "@admin/components/icons";
 import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
 import { Link } from "@admin/components/ui/link";
-import { SIDEBAR_NAVIGATION } from "@admin/constants/navigation";
+import {
+  API_KEYS_LIST_PERMISSIONS,
+  SIDEBAR_NAVIGATION,
+} from "@admin/constants/navigation";
 import { ROUTES } from "@admin/constants/routes";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useMediaContext } from "@admin/context/providers/MediaProvider";
@@ -241,10 +244,10 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const hasMediaSection = hasPermissionDataPending
     ? true
     : capabilities.canViewMedia;
-  const canAccessApiKeys =
-    hasPermission("read-api-keys") ||
-    hasPermission("create-api-keys") ||
-    hasPermission("update-api-keys");
+  // What OPENS the list, not every grant naming the resource: `create-` and
+  // `delete-api-keys` act through the API without listing, so showing the entry
+  // to them offered a link that turned them away.
+  const canAccessApiKeys = API_KEYS_LIST_PERMISSIONS.some(hasPermission);
   // Any webhook grant reveals the link, matching the list route: read/update
   // view the list, create reaches the create form from it.
   const canAccessWebhooks =

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -8,10 +8,7 @@ import * as Icons from "@admin/components/icons";
 import { Database } from "@admin/components/icons";
 import { ThemeAwareLogo } from "@admin/components/shared/ThemeAwareLogo";
 import { Link } from "@admin/components/ui/link";
-import {
-  API_KEYS_LIST_PERMISSIONS,
-  SIDEBAR_NAVIGATION,
-} from "@admin/constants/navigation";
+import { SIDEBAR_NAVIGATION } from "@admin/constants/navigation";
 import { ROUTES } from "@admin/constants/routes";
 import { useBranding } from "@admin/context/providers/BrandingProvider";
 import { useMediaContext } from "@admin/context/providers/MediaProvider";
@@ -36,7 +33,13 @@ import {
   hasPluginsSection,
   hasVisiblePluginCollection,
 } from "./lib/has-plugins-section";
+import {
+  canAccessApiKeys,
+  canAccessWebhooks,
+  hasSettingsSection as hasSettingsSectionHelper,
+} from "./lib/has-settings-section";
 import { isSubSidebarCategory } from "./lib/has-sub-sidebar";
+import { placeStandalonePlugins } from "./lib/place-standalone-plugins";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
 import { resolveActiveSection } from "./lib/resolve-section";
 import { resolveSettingsLanding } from "./lib/resolve-settings-landing";
@@ -93,80 +96,25 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
     });
   }, [standalonePlugins, readableResources, capabilities.canViewSettings]);
 
-  // Build dynamic menu items for standalone plugins, positioned by `after` + `order`
+  // Standalone plugins take their place in the rail by the anchor they declare.
+  // The placement rule lives in `lib/` with the other rail decisions; what stays
+  // here is the icon resolution, which needs this module's icon registry.
   const filteredMenuItems = useMemo(() => {
-    const ID_TO_ANCHOR: Record<string, string> = {
-      dashboard: "dashboard",
-      collections: "collections",
-      singles: "singles",
-      media: "media",
-      plugins: "plugins",
-      settings: "settings",
-    };
-
-    if (visibleStandalonePlugins.length === 0) return baseMenuItems;
-
     const iconMap = Icons as unknown as Record<string, React.ElementType>;
-
-    const byAnchor = new Map<
-      string,
-      Array<{ item: MainMenuItem; order: number }>
-    >();
-    for (const sp of visibleStandalonePlugins) {
-      const slug = pluginSlug(sp.name);
-      // A menu item stores an ElementType rendered as `<Icon className=… />`,
-      // so this surface cannot show an image. It says so rather than resolving
-      // an asset and discarding it, which would also discard the lucide name a
-      // plugin declared alongside the asset for precisely this surface.
-      const resolved = resolvePluginIcon(sp, {
-        fallback: "Database",
-        allowAsset: false,
-      });
-      const iconName = resolved.name;
-      const IconComponent = iconMap[iconName] || Database;
-      // The former top-level Users icon is gone; User Management now lives
-      // under Settings, so a plugin still declaring `after: "users"` is anchored
-      // next to Settings instead of falling through to the end of the rail.
-      const rawAnchor = sp.after || "plugins";
-      const anchor = rawAnchor === "users" ? "settings" : rawAnchor;
-
-      const entry = {
-        item: {
-          id: `standalone-${slug}` as MainMenuCategory,
-          label: sp.appearance?.label || sp.name,
-          icon: IconComponent,
-          href: "#",
-        },
-        order: sp.order ?? 100,
-      };
-
-      if (!byAnchor.has(anchor)) byAnchor.set(anchor, []);
-      byAnchor.get(anchor)!.push(entry);
-    }
-
-    for (const group of byAnchor.values()) {
-      group.sort((a, b) => a.order - b.order);
-    }
-
-    const result: MainMenuItem[] = [];
-    for (const item of baseMenuItems) {
-      result.push(item);
-      const anchor = ID_TO_ANCHOR[item.id];
-      if (anchor && byAnchor.has(anchor)) {
-        for (const { item: standaloneItem } of byAnchor.get(anchor)!) {
-          result.push(standaloneItem);
-        }
-        byAnchor.delete(anchor);
-      }
-    }
-
-    for (const group of byAnchor.values()) {
-      for (const { item: standaloneItem } of group) {
-        result.push(standaloneItem);
-      }
-    }
-
-    return result;
+    return placeStandalonePlugins(baseMenuItems, visibleStandalonePlugins, {
+      slugOf: pluginSlug,
+      iconFor: plugin => {
+        // A menu item stores an ElementType rendered as `<Icon className=… />`,
+        // so this surface cannot show an image. It says so rather than
+        // resolving an asset and discarding it, which would also discard the
+        // lucide name a plugin declared alongside the asset for this surface.
+        const resolved = resolvePluginIcon(plugin, {
+          fallback: "Database",
+          allowAsset: false,
+        });
+        return iconMap[resolved.name] || Database;
+      },
+    });
   }, [baseMenuItems, visibleStandalonePlugins]);
 
   // Fetch data for automatic navigation
@@ -244,27 +192,12 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const hasMediaSection = hasPermissionDataPending
     ? true
     : capabilities.canViewMedia;
-  // What OPENS the list, not every grant naming the resource: `create-` and
-  // `delete-api-keys` act through the API without listing, so showing the entry
-  // to them offered a link that turned them away.
-  const canAccessApiKeys = API_KEYS_LIST_PERMISSIONS.some(hasPermission);
-  // Any webhook grant reveals the link, matching the list route: read/update
-  // view the list, create reaches the create form from it.
-  const canAccessWebhooks =
-    hasPermission("read-webhooks") ||
-    hasPermission("update-webhooks") ||
-    hasPermission("create-webhooks");
-  // Settings now also hosts User Management (Users, User Fields, Roles), so a
-  // user whose only access is users/roles must still see the Settings icon.
-  const hasSettingsSection = hasPermissionDataPending
-    ? true
-    : capabilities.canViewSettings ||
-      capabilities.canManageEmailProviders ||
-      capabilities.canManageEmailTemplates ||
-      canAccessApiKeys ||
-      canAccessWebhooks ||
-      capabilities.canViewUsers ||
-      capabilities.canViewRoles;
+  const apiKeysReachable = canAccessApiKeys(hasPermission);
+  const webhooksReachable = canAccessWebhooks(hasPermission);
+  const hasSettingsSection = hasSettingsSectionHelper(capabilities, {
+    isPending: hasPermissionDataPending,
+    hasPermission,
+  });
   const hasBuildersSection = showBuilder;
 
   const visibleMenuItems = useMemo(
@@ -373,8 +306,8 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   // manage-settings and returns 403.
   const settingsHref = resolveSettingsLanding({
     hasPermission,
-    canAccessApiKeys,
-    canAccessWebhooks,
+    canAccessApiKeys: apiKeysReachable,
+    canAccessWebhooks: webhooksReachable,
   });
 
   const resolveItemHref = (item: MainMenuItem): string =>
@@ -527,8 +460,8 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
           onPluginSearchChange: setPluginSearch,
           isActive,
           hasPermission,
-          canAccessApiKeys,
-          canAccessWebhooks,
+          canAccessApiKeys: apiKeysReachable,
+          canAccessWebhooks: webhooksReachable,
           pluginCollectionsForSection,
           showBuilder,
         }}

--- a/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
+++ b/packages/admin/src/components/layout/sidebar/DualSidebar.tsx
@@ -32,6 +32,7 @@ import { hasPluginsSection } from "./lib/has-plugins-section";
 import { isSubSidebarCategory } from "./lib/has-sub-sidebar";
 import { resolveItemHref as resolveItemHrefHelper } from "./lib/resolve-item-href";
 import { resolveActiveSection } from "./lib/resolve-section";
+import { resolveSettingsLanding } from "./lib/resolve-settings-landing";
 import type { MainMenuCategory, MainMenuItem } from "./sidebar-types";
 import { getFilteredMenuItems } from "./sidebar-types";
 import { SubSidebarPanel } from "./SubSidebarPanel";
@@ -363,28 +364,18 @@ export function DualSidebar({ isMobile }: DualSidebarProps = {}) {
   const hasSubSidebarCategory = (id: string) =>
     isSubSidebarCategory(id, isFolderTreeVisible);
 
-  // The Settings icon lands on the first subpage the user can actually OPEN —
-  // gated on each route's own guard, not the broader "can see the link" flag, so
-  // it never resolves to a page that would redirect. General needs
-  // manage-settings; the API Keys route needs update-api-keys; Webhooks accepts
-  // any webhook grant (its route's any-of). User Management now lives here too,
-  // so a role whose only access is read-users / read-roles lands on Users (or
-  // Roles) instead of bouncing off the manage-settings-guarded General page.
-  const settingsHref = hasPermission("manage-settings")
-    ? ROUTES.SETTINGS
-    : hasPermission("update-api-keys")
-      ? ROUTES.SETTINGS_API_KEYS
-      : canAccessWebhooks
-        ? ROUTES.SETTINGS_WEBHOOKS
-        : hasPermission("manage-email-providers")
-          ? ROUTES.SETTINGS_EMAIL_PROVIDERS
-          : hasPermission("manage-email-templates")
-            ? ROUTES.SETTINGS_EMAIL_TEMPLATES
-            : hasPermission("read-users")
-              ? ROUTES.USERS
-              : hasPermission("read-roles")
-                ? ROUTES.SECURITY_ROLES
-                : ROUTES.SETTINGS;
+  // The Settings icon lands on the first subpage the user can actually OPEN.
+  // Read off the panel's own table rather than listed here: this chain named
+  // seven destinations in an order of its own, and a destination added to the
+  // table and not to the chain became unreachable from the rail. Background
+  // Jobs was exactly that — the entry appeared, the link fell through every
+  // arm, and a jobs-only operator landed on General Settings, which answers to
+  // manage-settings and returns 403.
+  const settingsHref = resolveSettingsLanding({
+    hasPermission,
+    canAccessApiKeys,
+    canAccessWebhooks,
+  });
 
   const resolveItemHref = (item: MainMenuItem): string =>
     resolveItemHrefHelper(

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-collections-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-collections-section.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+import type { ApiCollection } from "@admin/types/entities";
+
+import {
+  belongsInCollectionsSection,
+  hasCollectionsSection,
+} from "../lib/has-collections-section";
+import { hasVisiblePluginCollection } from "../lib/has-plugins-section";
+
+const collection = (
+  name: string,
+  admin?: ApiCollection["admin"]
+): ApiCollection => ({ name, admin }) as ApiCollection;
+
+const ordinary = collection("posts");
+const hidden = collection("secrets", { hidden: true });
+const pluginOwned = collection("forms", { isPlugin: true });
+
+/** No plugin claims a placement, which is the common case. */
+const noPlacement = () => undefined;
+
+const SETTLED = {
+  isPending: false,
+  isError: false,
+  placementOf: noPlacement,
+};
+
+describe("belongsInCollectionsSection", () => {
+  it("counts an ordinary collection", () => {
+    expect(belongsInCollectionsSection(ordinary, noPlacement)).toBe(true);
+  });
+
+  it("never counts a hidden collection", () => {
+    expect(belongsInCollectionsSection(hidden, noPlacement)).toBe(false);
+  });
+
+  /**
+   * A plugin that has not claimed a placement leaves its collection here, so
+   * the section is the default home rather than something a plugin opts into.
+   */
+  it("counts a plugin collection that claims no placement", () => {
+    expect(belongsInCollectionsSection(pluginOwned, noPlacement)).toBe(true);
+  });
+
+  it("counts a plugin collection placed here explicitly", () => {
+    expect(belongsInCollectionsSection(pluginOwned, () => "collections")).toBe(
+      true
+    );
+  });
+
+  /**
+   * The rule this predicate exists for. A plugin that moved its collection
+   * elsewhere must not keep the Collections section alive, or the rail offers
+   * a section whose destinations have all gone.
+   */
+  it("does not count a plugin collection placed elsewhere", () => {
+    expect(belongsInCollectionsSection(pluginOwned, () => "plugins")).toBe(
+      false
+    );
+  });
+
+  it("ignores placement entirely for a hidden plugin collection", () => {
+    const hiddenPlugin = collection("forms", { isPlugin: true, hidden: true });
+    expect(belongsInCollectionsSection(hiddenPlugin, () => "collections")).toBe(
+      false
+    );
+  });
+});
+
+describe("hasCollectionsSection", () => {
+  it("hides the entry from a reader who may not view collections", () => {
+    expect(
+      hasCollectionsSection(
+        { canViewCollections: false },
+        { ...SETTLED, permittedCollections: [ordinary] }
+      )
+    ).toBe(false);
+  });
+
+  it("shows the entry once a visible collection has resolved", () => {
+    expect(
+      hasCollectionsSection(
+        { canViewCollections: true },
+        { ...SETTLED, permittedCollections: [ordinary] }
+      )
+    ).toBe(true);
+  });
+
+  it("hides it when every permitted collection is hidden or placed away", () => {
+    expect(
+      hasCollectionsSection(
+        { canViewCollections: true },
+        { ...SETTLED, permittedCollections: [hidden] }
+      )
+    ).toBe(false);
+  });
+
+  it("shows it while the answer is still loading", () => {
+    expect(
+      hasCollectionsSection(
+        { canViewCollections: true },
+        { ...SETTLED, isPending: true, permittedCollections: [] }
+      )
+    ).toBe(true);
+  });
+
+  /**
+   * The arm that differs from the plugins section beside it. A FAILED query
+   * cannot tell the rail whether this reader has collections, and hiding the
+   * section would remove their only route to content they may see. The plugins
+   * panel has a second destination for a settings manager and can afford to
+   * decide; this one cannot.
+   */
+  it("shows it when the collections query failed", () => {
+    expect(
+      hasCollectionsSection(
+        { canViewCollections: true },
+        { ...SETTLED, isError: true, permittedCollections: [] }
+      )
+    ).toBe(true);
+  });
+});
+
+describe("hasVisiblePluginCollection", () => {
+  it("ignores a collection no plugin owns", () => {
+    expect(hasVisiblePluginCollection([ordinary], noPlacement)).toBe(false);
+  });
+
+  it("counts a plugin collection that claims no placement", () => {
+    expect(hasVisiblePluginCollection([pluginOwned], noPlacement)).toBe(true);
+  });
+
+  it("counts one placed in the plugins panel", () => {
+    expect(hasVisiblePluginCollection([pluginOwned], () => "plugins")).toBe(
+      true
+    );
+  });
+
+  it("does not count one placed in the collections section", () => {
+    expect(hasVisiblePluginCollection([pluginOwned], () => "collections")).toBe(
+      false
+    );
+  });
+
+  it("never counts a hidden plugin collection", () => {
+    const hiddenPlugin = collection("forms", { isPlugin: true, hidden: true });
+    expect(hasVisiblePluginCollection([hiddenPlugin], noPlacement)).toBe(false);
+  });
+
+  /**
+   * The two sections partition the same set: a placement-less plugin
+   * collection is offered by both, and one that named a panel is offered by
+   * exactly that panel.
+   */
+  it("partitions plugin collections with the collections section", () => {
+    for (const placement of [undefined, "collections", "plugins"] as const) {
+      const placementOf = () => placement;
+      const inPlugins = hasVisiblePluginCollection([pluginOwned], placementOf);
+      const inCollections = belongsInCollectionsSection(
+        pluginOwned,
+        placementOf
+      );
+      expect(inPlugins || inCollections).toBe(true);
+    }
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/has-settings-section.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/has-settings-section.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  canAccessApiKeys,
+  canAccessWebhooks,
+  hasSettingsSection,
+} from "../lib/has-settings-section";
+
+const only =
+  (...grants: string[]) =>
+  (slug: string) =>
+    grants.includes(slug);
+
+const NONE = {
+  canViewSettings: false,
+  canManageEmailProviders: false,
+  canManageEmailTemplates: false,
+  canViewUsers: false,
+  canViewRoles: false,
+};
+
+describe("canAccessApiKeys", () => {
+  it("admits the grants that open the list", () => {
+    expect(canAccessApiKeys(only("read-api-keys"))).toBe(true);
+    expect(canAccessApiKeys(only("update-api-keys"))).toBe(true);
+  });
+
+  /**
+   * These act through the API without listing, and the panel's only api-key
+   * entry is the list — so treating them as access showed a link that turned
+   * the reader away.
+   */
+  it("refuses the grants that cannot list", () => {
+    expect(canAccessApiKeys(only("create-api-keys"))).toBe(false);
+    expect(canAccessApiKeys(only("delete-api-keys"))).toBe(false);
+  });
+});
+
+describe("canAccessWebhooks", () => {
+  it("admits any grant the list route accepts", () => {
+    for (const grant of [
+      "read-webhooks",
+      "update-webhooks",
+      "create-webhooks",
+    ]) {
+      expect(canAccessWebhooks(only(grant)), grant).toBe(true);
+    }
+  });
+
+  it("refuses a reader holding none of them", () => {
+    expect(canAccessWebhooks(only("read-users"))).toBe(false);
+  });
+});
+
+describe("hasSettingsSection", () => {
+  const settled = { isPending: false, hasPermission: only() };
+
+  it("hides the entry from a reader with no way in", () => {
+    expect(hasSettingsSection(NONE, settled)).toBe(false);
+  });
+
+  /**
+   * Shown while the grants resolve, matching the rest of the rail: an entry
+   * appearing a moment after the page settles reads as the UI changing its
+   * mind, and every destination refuses on its own anyway.
+   */
+  it("shows it while permissions are still loading", () => {
+    expect(hasSettingsSection(NONE, { ...settled, isPending: true })).toBe(
+      true
+    );
+  });
+
+  it.each([
+    "canViewSettings",
+    "canManageEmailProviders",
+    "canManageEmailTemplates",
+    "canViewUsers",
+    "canViewRoles",
+  ] as const)("shows it for a reader holding %s alone", capability => {
+    expect(hasSettingsSection({ ...NONE, [capability]: true }, settled)).toBe(
+      true
+    );
+  });
+
+  /**
+   * The two that arrive as permissions rather than capabilities. A reader whose
+   * only access is the API-keys or webhooks screen still needs the icon, or the
+   * destination they can open has no route to it.
+   */
+  it("shows it for an api-key or webhook grant alone", () => {
+    expect(
+      hasSettingsSection(NONE, {
+        ...settled,
+        hasPermission: only("read-api-keys"),
+      })
+    ).toBe(true);
+    expect(
+      hasSettingsSection(NONE, {
+        ...settled,
+        hasPermission: only("read-webhooks"),
+      })
+    ).toBe(true);
+  });
+
+  it("is not revealed by an api-key grant that opens nothing", () => {
+    expect(
+      hasSettingsSection(NONE, {
+        ...settled,
+        hasPermission: only("create-api-keys"),
+      })
+    ).toBe(false);
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/place-standalone-plugins.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/place-standalone-plugins.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+
+import { Database } from "@admin/components/icons";
+
+import {
+  placeStandalonePlugins,
+  type StandaloneMenuPlugin,
+} from "../lib/place-standalone-plugins";
+import type { MainMenuItem } from "../sidebar-types";
+
+const rail = (...ids: string[]): MainMenuItem[] =>
+  ids.map(
+    id => ({ id, label: id, icon: Database, href: `/${id}` }) as MainMenuItem
+  );
+
+const BASE = rail("dashboard", "collections", "media", "plugins", "settings");
+
+const deps = {
+  slugOf: (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, "-"),
+  iconFor: () => Database,
+};
+
+const idsOf = (items: readonly MainMenuItem[]) => items.map(item => item.id);
+
+describe("placeStandalonePlugins", () => {
+  it("returns the rail untouched when no plugin is visible", () => {
+    const placed = placeStandalonePlugins(BASE, [], deps);
+    expect(placed).toBe(BASE);
+  });
+
+  it("places a plugin after the entry it names", () => {
+    const plugins: StandaloneMenuPlugin[] = [{ name: "Forms", after: "media" }];
+    expect(idsOf(placeStandalonePlugins(BASE, plugins, deps))).toEqual([
+      "dashboard",
+      "collections",
+      "media",
+      "standalone-forms",
+      "plugins",
+      "settings",
+    ]);
+  });
+
+  it("defaults to the plugins entry when none is named", () => {
+    const plugins: StandaloneMenuPlugin[] = [{ name: "Forms" }];
+    expect(idsOf(placeStandalonePlugins(BASE, plugins, deps))).toEqual([
+      "dashboard",
+      "collections",
+      "media",
+      "plugins",
+      "standalone-forms",
+      "settings",
+    ]);
+  });
+
+  /**
+   * The remap, not a fallthrough. The top-level Users entry is gone and User
+   * Management lives under Settings, so a plugin still declaring `after:
+   * "users"` sits beside Settings rather than being appended at the end.
+   */
+  it("anchors a plugin asking for users next to settings", () => {
+    const plugins: StandaloneMenuPlugin[] = [{ name: "Audit", after: "users" }];
+    expect(idsOf(placeStandalonePlugins(BASE, plugins, deps))).toEqual([
+      "dashboard",
+      "collections",
+      "media",
+      "plugins",
+      "settings",
+      "standalone-audit",
+    ]);
+  });
+
+  it("orders plugins sharing an anchor by their declared order", () => {
+    const plugins: StandaloneMenuPlugin[] = [
+      { name: "Second", after: "media", order: 20 },
+      { name: "First", after: "media", order: 10 },
+    ];
+    expect(idsOf(placeStandalonePlugins(BASE, plugins, deps))).toEqual([
+      "dashboard",
+      "collections",
+      "media",
+      "standalone-first",
+      "standalone-second",
+      "plugins",
+      "settings",
+    ]);
+  });
+
+  /**
+   * A plugin anchored to an entry this rail does not show — because the reader
+   * cannot see it, or because the plugin named something that never existed —
+   * is appended rather than dropped. Losing it would make the plugin
+   * unreachable over a name it got wrong.
+   */
+  it("appends a plugin anchored to an entry the rail does not show", () => {
+    const plugins: StandaloneMenuPlugin[] = [
+      { name: "Orphan", after: "nowhere" },
+    ];
+    const placed = placeStandalonePlugins(rail("dashboard"), plugins, deps);
+    expect(idsOf(placed)).toEqual(["dashboard", "standalone-orphan"]);
+  });
+
+  it("prefers a declared label over the plugin name", () => {
+    const plugins: StandaloneMenuPlugin[] = [
+      { name: "Form Builder", appearance: { label: "Forms" } },
+    ];
+    const placed = placeStandalonePlugins(BASE, plugins, deps);
+    expect(
+      placed.find(item => item.id === "standalone-form-builder")?.label
+    ).toBe("Forms");
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
@@ -150,6 +150,37 @@ describe("resolveSettingsLanding", () => {
   });
 
   /**
+   * The other direction, which the assertion above cannot see.
+   *
+   * That one checks the DANGEROUS failure: a landing the route would refuse.
+   * A stale `routePermission` fails the other way — widen the route to admit
+   * `read-api-keys` and this table would still skip the entry, sending a
+   * reader who could now open the page somewhere else. The landing is simply
+   * absent, so nothing lands anywhere it should not and the check above stays
+   * green.
+   *
+   * Asserting equality with the route's own declaration closes it. Both now
+   * read one constant, so this passes by construction rather than by
+   * vigilance — and fails the moment someone re-types the value.
+   */
+  it("declares the same grant the route itself declares", () => {
+    const declaring = SETTINGS_NAV.flatMap(group => group.items).filter(
+      item => item.routePermission !== undefined
+    );
+
+    // The premise: an empty list would make this vacuous.
+    expect(declaring.length).toBeGreaterThan(0);
+
+    for (const item of declaring) {
+      expect(
+        item.routePermission,
+        `${item.id} declares a route grant that differs from the route's own ` +
+          `requiredPermission; the panel would skip a destination the page admits`
+      ).toEqual(routeConfig[item.href]?.requiredPermission);
+    }
+  });
+
+  /**
    * A control for the assertion above: it must be capable of failing. The
    * panel does show a destination whose route is narrower than its gate, so
    * consulting visibility ALONE — which is what the check would do if

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+
+import { ROUTES } from "@admin/constants/routes";
+import { routeConfig } from "@admin/pages/registry";
+
+import {
+  SETTINGS_NAV,
+  isSettingsNavItemVisible,
+  type SettingsNavAccess,
+} from "../lib/settings-nav";
+import { resolveSettingsLanding } from "../lib/resolve-settings-landing";
+
+/** A reader holding exactly the listed grants and nothing else. */
+function only(...grants: string[]): SettingsNavAccess {
+  const held = new Set(grants);
+  const hasPermission = (permission: string) => held.has(permission);
+  return {
+    hasPermission,
+    canAccessApiKeys:
+      hasPermission("read-api-keys") ||
+      hasPermission("create-api-keys") ||
+      hasPermission("update-api-keys"),
+    canAccessWebhooks:
+      hasPermission("read-webhooks") ||
+      hasPermission("update-webhooks") ||
+      hasPermission("create-webhooks"),
+  };
+}
+
+describe("resolveSettingsLanding", () => {
+  /**
+   * The defect this function exists for. Background Jobs was added to the
+   * panel table and to none of the hand-written arms, so a jobs-only operator
+   * saw the Settings entry, followed it, and landed on General Settings —
+   * whose query answers to `manage-settings` and returns 403. Their one
+   * reachable destination was never offered.
+   */
+  it("sends a jobs-only operator to Background Jobs", () => {
+    expect(resolveSettingsLanding(only("manage-background-jobs"))).toBe(
+      ROUTES.SETTINGS_BACKGROUND_JOBS
+    );
+  });
+
+  it("still sends a settings manager to General", () => {
+    expect(resolveSettingsLanding(only("manage-settings"))).toBe(
+      ROUTES.SETTINGS
+    );
+  });
+
+  /**
+   * `update-api-keys` is what the API Keys ROUTE demands, so this reader can
+   * open the page the panel offers them.
+   */
+  it("sends an api-key manager to API Keys", () => {
+    expect(resolveSettingsLanding(only("update-api-keys"))).toBe(
+      ROUTES.SETTINGS_API_KEYS
+    );
+  });
+
+  /**
+   * The narrower-route case, and the reason `routePermission` exists. The
+   * panel SHOWS API Keys to any api-key grant, but its route admits only
+   * `update-api-keys`. Landing a read-only holder there would bounce them to
+   * the dashboard, so the entry must be skipped rather than chosen.
+   */
+  it("does not land a read-only api-key holder on a page that refuses them", () => {
+    const landing = resolveSettingsLanding(only("read-api-keys"));
+    expect(landing).not.toBe(ROUTES.SETTINGS_API_KEYS);
+    expect(landing).toBe(ROUTES.SETTINGS);
+  });
+
+  it("sends a webhook reader to Webhooks", () => {
+    expect(resolveSettingsLanding(only("read-webhooks"))).toBe(
+      ROUTES.SETTINGS_WEBHOOKS
+    );
+  });
+
+  it("sends a user reader to Users", () => {
+    expect(resolveSettingsLanding(only("read-users"))).toBe(ROUTES.USERS);
+  });
+
+  it("sends a role reader to Roles", () => {
+    expect(resolveSettingsLanding(only("read-roles"))).toBe(
+      ROUTES.SECURITY_ROLES
+    );
+  });
+
+  it("falls back to the panel for a reader with no destination", () => {
+    expect(resolveSettingsLanding(only())).toBe(ROUTES.SETTINGS);
+  });
+
+  /**
+   * Panel order is landing order. A reader holding two grants lands on
+   * whichever destination the table lists first, so the page they arrive at is
+   * the first one in the panel they can see — not an order maintained
+   * separately from it.
+   */
+  it("follows the table's order when several destinations are open", () => {
+    expect(
+      resolveSettingsLanding(only("manage-background-jobs", "update-api-keys"))
+    ).toBe(ROUTES.SETTINGS_API_KEYS);
+  });
+
+  /**
+   * The anti-drift assertion, derived from the route registry rather than
+   * restated beside it. For every destination the panel can choose, whoever
+   * the landing admits, the ROUTE must admit too — otherwise the rail sends
+   * someone to a guard that turns them away.
+   *
+   * A destination added to the table whose route is narrower than its gate
+   * fails here until it declares `routePermission`, which is the whole reason
+   * the field exists.
+   */
+  it("never chooses a destination whose route would refuse the reader", () => {
+    const grants = [
+      "manage-settings",
+      "manage-background-jobs",
+      "manage-email-providers",
+      "manage-email-templates",
+      "read-users",
+      "read-roles",
+      "read-api-keys",
+      "create-api-keys",
+      "update-api-keys",
+      "read-webhooks",
+      "create-webhooks",
+      "update-webhooks",
+    ];
+
+    const items = SETTINGS_NAV.flatMap(group => group.items);
+    expect(items.length).toBeGreaterThan(5);
+
+    for (const grant of grants) {
+      const access = only(grant);
+      const landing = resolveSettingsLanding(access);
+      if (landing === ROUTES.SETTINGS) continue;
+
+      const required = routeConfig[landing]?.requiredPermission;
+      const admitted =
+        required === undefined ||
+        (Array.isArray(required)
+          ? required.some(access.hasPermission)
+          : access.hasPermission(required));
+
+      expect(
+        admitted,
+        `landing ${landing} chosen for "${grant}" is guarded by ${JSON.stringify(required)}`
+      ).toBe(true);
+    }
+  });
+
+  /**
+   * A control for the assertion above: it must be capable of failing. The
+   * panel does show a destination whose route is narrower than its gate, so
+   * consulting visibility ALONE — which is what the check would do if
+   * `routePermission` were ignored — picks a refusing route.
+   */
+  it("would pick a refusing route if visibility alone decided it", () => {
+    const access = only("read-api-keys");
+    const firstVisible = SETTINGS_NAV.flatMap(group => group.items).find(item =>
+      isSettingsNavItemVisible(item, access)
+    );
+
+    expect(firstVisible?.href).toBe(ROUTES.SETTINGS_API_KEYS);
+
+    const required = routeConfig[ROUTES.SETTINGS_API_KEYS]?.requiredPermission;
+    expect(required).toBe("update-api-keys");
+    expect(access.hasPermission(required as string)).toBe(false);
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-settings-landing.test.ts
@@ -6,6 +6,7 @@ import { routeConfig } from "@admin/pages/registry";
 import {
   SETTINGS_NAV,
   isSettingsNavItemVisible,
+  settingsPanelSlugs,
   type SettingsNavAccess,
 } from "../lib/settings-nav";
 import { resolveSettingsLanding } from "../lib/resolve-settings-landing";
@@ -58,15 +59,27 @@ describe("resolveSettingsLanding", () => {
   });
 
   /**
-   * The narrower-route case, and the reason `routePermission` exists. The
-   * panel SHOWS API Keys to any api-key grant, but its route admits only
-   * `update-api-keys`. Landing a read-only holder there would bounce them to
-   * the dashboard, so the entry must be skipped rather than chosen.
+   * The API is what settles this. `requireApiKeyPermission` accepts the
+   * action's own grant OR `update-api-keys`, so listing keys answers to
+   * read-or-update, and the route now says the same. A reader who could fetch
+   * the list over the API is no longer turned away from the page that shows it.
    */
-  it("does not land a read-only api-key holder on a page that refuses them", () => {
-    const landing = resolveSettingsLanding(only("read-api-keys"));
-    expect(landing).not.toBe(ROUTES.SETTINGS_API_KEYS);
-    expect(landing).toBe(ROUTES.SETTINGS);
+  it("sends an api-key reader to API Keys", () => {
+    expect(resolveSettingsLanding(only("read-api-keys"))).toBe(
+      ROUTES.SETTINGS_API_KEYS
+    );
+  });
+
+  /**
+   * `create-api-keys` opens the create form, not the list this entry links to,
+   * so it is not one of the grants that reaches the panel at all. The landing
+   * falls through, and the assertion further down proves no reader the panel
+   * admits can reach that fallthrough.
+   */
+  it("does not offer API Keys to a grant that cannot list them", () => {
+    expect(resolveSettingsLanding(only("create-api-keys"))).not.toBe(
+      ROUTES.SETTINGS_API_KEYS
+    );
   });
 
   it("sends a webhook reader to Webhooks", () => {
@@ -102,38 +115,35 @@ describe("resolveSettingsLanding", () => {
   });
 
   /**
-   * The anti-drift assertion, derived from the route registry rather than
-   * restated beside it. For every destination the panel can choose, whoever
-   * the landing admits, the ROUTE must admit too — otherwise the rail sends
-   * someone to a guard that turns them away.
+   * The invariant, derived from the route registry rather than restated.
    *
-   * A destination added to the table whose route is narrower than its gate
-   * fails here until it declares `routePermission`, which is the whole reason
-   * the field exists.
+   * For every grant that reaches the panel, the landing must be a page that
+   * grant can actually OPEN.
+   *
+   * A landing on `/admin/settings` itself does not count as placed.
+   * `settingsPanelSlugs()` admits a reader to that URL, but the page behind it
+   * is General Settings, whose query answers to `manage-settings` and returns
+   * 403 without it — so a reader sent there has been placed on a page that
+   * fails. There is therefore no escape hatch for the fallthrough: within this
+   * set it must never occur except for `manage-settings`, which is the grant
+   * General Settings itself needs.
    */
-  it("never chooses a destination whose route would refuse the reader", () => {
-    const grants = [
-      "manage-settings",
-      "manage-background-jobs",
-      "manage-email-providers",
-      "manage-email-templates",
-      "read-users",
-      "read-roles",
-      "read-api-keys",
-      "create-api-keys",
-      "update-api-keys",
-      "read-webhooks",
-      "create-webhooks",
-      "update-webhooks",
-    ];
-
-    const items = SETTINGS_NAV.flatMap(group => group.items);
-    expect(items.length).toBeGreaterThan(5);
+  it("lands every panel-reaching grant on a page that grant can open", () => {
+    const grants = settingsPanelSlugs();
+    expect(grants.length).toBeGreaterThan(3);
 
     for (const grant of grants) {
       const access = only(grant);
       const landing = resolveSettingsLanding(access);
-      if (landing === ROUTES.SETTINGS) continue;
+
+      if (landing === ROUTES.SETTINGS) {
+        expect(
+          grant,
+          `"${grant}" reaches the panel but lands on the panel URL itself, ` +
+            "whose page answers to manage-settings and returns 403 without it"
+        ).toBe("manage-settings");
+        continue;
+      }
 
       const required = routeConfig[landing]?.requiredPermission;
       const admitted =
@@ -181,21 +191,47 @@ describe("resolveSettingsLanding", () => {
   });
 
   /**
-   * A control for the assertion above: it must be capable of failing. The
-   * panel does show a destination whose route is narrower than its gate, so
-   * consulting visibility ALONE — which is what the check would do if
-   * `routePermission` were ignored — picks a refusing route.
+   * A control for the invariant above: it must be capable of failing.
+   *
+   * Two ways it could pass while asserting nothing. If `routeConfig` did not
+   * resolve the landings, `required` would be `undefined` throughout and every
+   * reader would count as admitted. And if the panel's gate were broader than
+   * what its destinations open, some grant would reach the panel with nothing
+   * to open, and the assertion above would be measuring an empty set.
+   *
+   * Both are checked directly rather than assumed: the landings resolve to
+   * real guards, and no grant that reaches the panel is left without a
+   * destination.
    */
-  it("would pick a refusing route if visibility alone decided it", () => {
-    const access = only("read-api-keys");
-    const firstVisible = SETTINGS_NAV.flatMap(group => group.items).find(item =>
-      isSettingsNavItemVisible(item, access)
-    );
+  it("resolves real route guards for the landings it checks", () => {
+    const guarded = settingsPanelSlugs()
+      .map(grant => resolveSettingsLanding(only(grant)))
+      .filter(landing => landing !== ROUTES.SETTINGS)
+      .map(landing => routeConfig[landing]?.requiredPermission);
 
-    expect(firstVisible?.href).toBe(ROUTES.SETTINGS_API_KEYS);
+    expect(guarded.length).toBeGreaterThan(2);
+    expect(guarded.every(required => required !== undefined)).toBe(true);
+  });
 
-    const required = routeConfig[ROUTES.SETTINGS_API_KEYS]?.requiredPermission;
-    expect(required).toBe("update-api-keys");
-    expect(access.hasPermission(required as string)).toBe(false);
+  /**
+   * The panel's gate and its destinations answer the same question.
+   *
+   * `settingsPanelSlugs()` is the umbrella that shows the rail entry and opens
+   * `/admin/settings`. A grant in it that opens no destination is a rail entry
+   * leading to a 403, which is the defect this file exists to prevent.
+   */
+  it("admits no grant that opens nothing", () => {
+    const stranded = settingsPanelSlugs().filter(grant => {
+      const access = only(grant);
+      return (
+        resolveSettingsLanding(access) === ROUTES.SETTINGS &&
+        grant !== "manage-settings"
+      );
+    });
+
+    expect(
+      stranded,
+      `these grants reach the Settings panel and open nothing in it: ${stranded.join(", ")}`
+    ).toEqual([]);
   });
 });

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-standalone-label.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-standalone-label.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  resolveStandaloneLabel,
+  type LabelledStandalonePlugin,
+} from "../lib/resolve-standalone-label";
+
+/** The real slug rule: lowercased, non-alphanumerics collapsed to a dash. */
+const slugOf = (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+
+const plugins: LabelledStandalonePlugin[] = [
+  { name: "Form Builder", appearance: { label: "Forms" } },
+  { name: "SEO Toolkit" },
+];
+
+describe("resolveStandaloneLabel", () => {
+  it("has no heading when the selection is not a standalone plugin", () => {
+    expect(resolveStandaloneLabel("collections", plugins, slugOf)).toBe("");
+  });
+
+  it("prefers the label a plugin declared", () => {
+    expect(
+      resolveStandaloneLabel("standalone-form-builder", plugins, slugOf)
+    ).toBe("Forms");
+  });
+
+  it("falls back to the plugin's name when it declared no label", () => {
+    expect(
+      resolveStandaloneLabel("standalone-seo-toolkit", plugins, slugOf)
+    ).toBe("SEO Toolkit");
+  });
+
+  /**
+   * The last resort. A panel selected for a plugin that is no longer visible
+   * still gets a heading rather than an empty one, so the panel never reads as
+   * broken while the rail catches up.
+   */
+  it("falls back to the slug when no plugin matches", () => {
+    expect(resolveStandaloneLabel("standalone-gone", plugins, slugOf)).toBe(
+      "gone"
+    );
+  });
+
+  /**
+   * An empty declared label is not a heading. `||` is load-bearing here rather
+   * than `??`: a plugin shipping `label: ""` would otherwise head its panel
+   * with nothing at all.
+   */
+  it("treats an empty declared label as absent", () => {
+    const blank: LabelledStandalonePlugin[] = [
+      { name: "Analytics", appearance: { label: "" } },
+    ];
+    expect(resolveStandaloneLabel("standalone-analytics", blank, slugOf)).toBe(
+      "Analytics"
+    );
+  });
+});

--- a/packages/admin/src/components/layout/sidebar/__tests__/resolve-standalone-label.test.ts
+++ b/packages/admin/src/components/layout/sidebar/__tests__/resolve-standalone-label.test.ts
@@ -1,12 +1,22 @@
 import { describe, expect, it } from "vitest";
 
+import { pluginSlug } from "@admin/lib/plugins/plugin-slug";
+
 import {
   resolveStandaloneLabel,
   type LabelledStandalonePlugin,
 } from "../lib/resolve-standalone-label";
 
-/** The real slug rule: lowercased, non-alphanumerics collapsed to a dash. */
-const slugOf = (name: string) => name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+/**
+ * The production slug rule, not a local restatement of it.
+ *
+ * A hand-written copy agreed with `pluginAdminSlug` on the plain names below
+ * and diverged on scoped or punctuation-wrapped ones, where the real rule also
+ * trims the dashes it produces at the ends. Those are exactly the names that
+ * would make this helper miss the plugin and exercise the slug fallback while
+ * the test claimed to be checking the matching branch.
+ */
+const slugOf = pluginSlug;
 
 const plugins: LabelledStandalonePlugin[] = [
   { name: "Form Builder", appearance: { label: "Forms" } },
@@ -35,6 +45,25 @@ describe("resolveStandaloneLabel", () => {
    * still gets a heading rather than an empty one, so the panel never reads as
    * broken while the rail catches up.
    */
+  /**
+   * A name the two rules spell differently, with the id written out rather
+   * than derived.
+   *
+   * `pluginAdminSlug("@acme/Analytics")` is "acme-analytics"; a lowercase
+   * dash-collapsing copy yields "-acme-analytics", because the real rule also
+   * trims the dashes that a leading `@` and an inner `/` produce. Deriving the
+   * id with the same helper the lookup uses would make this pass under either
+   * rule — both sides would move together — so the literal is the whole point.
+   * Under a local copy the plugin is never found and the label falls through to
+   * the slug.
+   */
+  it("matches a scoped plugin name", () => {
+    const scoped: LabelledStandalonePlugin[] = [{ name: "@acme/Analytics" }];
+    expect(
+      resolveStandaloneLabel("standalone-acme-analytics", scoped, slugOf)
+    ).toBe("@acme/Analytics");
+  });
+
   it("falls back to the slug when no plugin matches", () => {
     expect(resolveStandaloneLabel("standalone-gone", plugins, slugOf)).toBe(
       "gone"

--- a/packages/admin/src/components/layout/sidebar/lib/has-collections-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-collections-section.ts
@@ -1,0 +1,64 @@
+import type { ApiCollection } from "@admin/types/entities";
+import type { AdminCapabilities } from "@admin/types/permissions";
+
+/** Resolves where a collection has been placed, bound to one render's metadata. */
+export type CollectionPlacement = (
+  collection: ApiCollection
+) => string | undefined;
+
+/**
+ * Whether a collection would appear in the rail's Collections section.
+ *
+ * Hidden collections never do. A PLUGIN-owned collection appears there only
+ * when its placement says so or says nothing — a plugin that claims a placement
+ * of its own has moved its collection out of this section, and counting it here
+ * would offer a section whose destinations have all gone elsewhere.
+ *
+ * Placement arrives as a function rather than as resolved values because the
+ * caller memoises it over this render's plugin metadata, for the reason
+ * `types/route-section` gives: two implementations of "where does this
+ * collection belong" would let the rail and the panel disagree.
+ */
+export function belongsInCollectionsSection(
+  collection: ApiCollection,
+  placementOf: CollectionPlacement
+): boolean {
+  if (collection.admin?.hidden) return false;
+  if (!collection.admin?.isPlugin) return true;
+  const placement = placementOf(collection);
+  return placement === "collections" || !placement;
+}
+
+interface CollectionsSectionInputs {
+  /** True while permissions or the collections query are still resolving. */
+  isPending: boolean;
+  /** True when the collections query FAILED rather than returned nothing. */
+  isError: boolean;
+  /** The collections this reader may see. */
+  permittedCollections: readonly ApiCollection[];
+  placementOf: CollectionPlacement;
+}
+
+/**
+ * Whether the Collections entry appears in the primary rail.
+ *
+ * Shown while the answer is still unknown — permissions loading, collections
+ * loading, or the collections query having FAILED. That last arm is deliberate
+ * and is the opposite of the rule in `has-plugins-section` beside it: a failed
+ * query here means the rail cannot tell whether this reader has collections,
+ * and hiding the section would remove their only route to content they are
+ * allowed to see. The plugins panel has a second destination for a settings
+ * manager, so it can afford to decide; this one cannot.
+ *
+ * @module components/layout/sidebar/lib/has-collections-section
+ */
+export function hasCollectionsSection(
+  capabilities: Pick<AdminCapabilities, "canViewCollections">,
+  inputs: CollectionsSectionInputs
+): boolean {
+  if (!capabilities.canViewCollections) return false;
+  if (inputs.isPending || inputs.isError) return true;
+  return inputs.permittedCollections.some(collection =>
+    belongsInCollectionsSection(collection, inputs.placementOf)
+  );
+}

--- a/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-plugins-section.ts
@@ -1,4 +1,7 @@
+import type { ApiCollection } from "@admin/types/entities";
 import type { AdminCapabilities } from "@admin/types/permissions";
+
+import type { CollectionPlacement } from "./has-collections-section";
 
 interface PluginsSectionInputs {
   /** True while permissions or the collections query are still resolving. */
@@ -43,4 +46,23 @@ export function hasPluginsSection(
   // Pending counts as reachable so the entry does not flicker out and back in
   // while the collections query resolves.
   return inputs.isPending || inputs.hasVisiblePluginCollection;
+}
+
+/**
+ * Whether any plugin-owned collection is reachable through the plugins panel.
+ *
+ * The mirror of `belongsInCollectionsSection`: a plugin collection shows up
+ * HERE when its placement names this panel or names nothing, so the two
+ * sections partition the same set rather than each deciding on its own. Hidden
+ * collections and collections no plugin owns are not this panel's to offer.
+ */
+export function hasVisiblePluginCollection(
+  permittedCollections: readonly ApiCollection[],
+  placementOf: CollectionPlacement
+): boolean {
+  return permittedCollections.some(collection => {
+    if (!collection.admin?.isPlugin || collection.admin?.hidden) return false;
+    const placement = placementOf(collection);
+    return !placement || placement === "plugins";
+  });
 }

--- a/packages/admin/src/components/layout/sidebar/lib/has-settings-section.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/has-settings-section.ts
@@ -1,0 +1,65 @@
+import { API_KEYS_LIST_PERMISSIONS } from "@admin/constants/navigation";
+import type { AdminCapabilities } from "@admin/types/permissions";
+
+/** Any webhook grant reaches the list route, which is an any-of of these. */
+const WEBHOOK_LIST_PERMISSIONS = [
+  "read-webhooks",
+  "update-webhooks",
+  "create-webhooks",
+] as const;
+
+/** Whether this reader can open the API Keys list. */
+export function canAccessApiKeys(
+  hasPermission: (slug: string) => boolean
+): boolean {
+  return API_KEYS_LIST_PERMISSIONS.some(hasPermission);
+}
+
+/** Whether this reader can open the Webhooks list. */
+export function canAccessWebhooks(
+  hasPermission: (slug: string) => boolean
+): boolean {
+  return WEBHOOK_LIST_PERMISSIONS.some(hasPermission);
+}
+
+/**
+ * Whether the Settings entry appears in the primary rail.
+ *
+ * Settings is not one destination but a panel, and the grants that reach into
+ * it are not one permission: it hosts email configuration, API keys, webhooks
+ * and User Management alongside the settings screens themselves, each answering
+ * to its own grant. A reader whose only access is `read-users` must still see
+ * the icon, or the destination they can open has no route to it.
+ *
+ * Shown while the grants are still resolving, matching the rest of the rail.
+ * The alternative flashes: an entry appearing a moment after the page settles
+ * reads as the UI changing its mind, and every destination refuses on its own.
+ *
+ * @module components/layout/sidebar/lib/has-settings-section
+ */
+export function hasSettingsSection(
+  capabilities: Pick<
+    AdminCapabilities,
+    | "canViewSettings"
+    | "canManageEmailProviders"
+    | "canManageEmailTemplates"
+    | "canViewUsers"
+    | "canViewRoles"
+  >,
+  inputs: {
+    /** True while permissions are still resolving. */
+    isPending: boolean;
+    hasPermission: (slug: string) => boolean;
+  }
+): boolean {
+  if (inputs.isPending) return true;
+  return (
+    capabilities.canViewSettings ||
+    capabilities.canManageEmailProviders ||
+    capabilities.canManageEmailTemplates ||
+    capabilities.canViewUsers ||
+    capabilities.canViewRoles ||
+    canAccessApiKeys(inputs.hasPermission) ||
+    canAccessWebhooks(inputs.hasPermission)
+  );
+}

--- a/packages/admin/src/components/layout/sidebar/lib/place-standalone-plugins.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/place-standalone-plugins.ts
@@ -1,0 +1,96 @@
+import type { MainMenuCategory, MainMenuItem } from "../sidebar-types";
+
+/** What placing a plugin in the rail needs of it, and nothing more. */
+export interface StandaloneMenuPlugin {
+  name: string;
+  /** The rail entry this plugin asks to sit after. */
+  after?: string;
+  /** Tie-break among plugins anchored to the same entry; lower comes first. */
+  order?: number;
+  appearance?: { label?: string };
+}
+
+interface PlacementDeps<P> {
+  slugOf: (name: string) => string;
+  /**
+   * The icon component for this plugin.
+   *
+   * Resolved by the caller because a menu item stores an ElementType rendered
+   * as `<Icon className=… />`, so this surface cannot show an image, and the
+   * resolution that knows which asset to decline lives with the icon registry
+   * rather than here.
+   */
+  iconFor: (plugin: P) => MainMenuItem["icon"];
+}
+
+/**
+ * The rail entry each anchor name refers to.
+ *
+ * `users` is remapped rather than dropped: the top-level Users icon is gone and
+ * User Management lives under Settings, so a plugin still declaring
+ * `after: "users"` is anchored next to Settings instead of falling through to
+ * the end of the rail.
+ */
+const ANCHORS: Record<string, string> = {
+  dashboard: "dashboard",
+  collections: "collections",
+  singles: "singles",
+  media: "media",
+  plugins: "plugins",
+  settings: "settings",
+  users: "settings",
+};
+
+/**
+ * The primary rail's items, with standalone plugins placed among them.
+ *
+ * A plugin declares where it wants to sit (`after`) and how it sorts against
+ * others asking for the same place (`order`). Anything anchored to an entry
+ * that is not in the rail — because the reader cannot see it, or because the
+ * plugin named something that never existed — is appended rather than dropped,
+ * so a plugin is never made unreachable by a name it got wrong.
+ *
+ * @module components/layout/sidebar/lib/place-standalone-plugins
+ */
+export function placeStandalonePlugins<P extends StandaloneMenuPlugin>(
+  baseMenuItems: readonly MainMenuItem[],
+  plugins: readonly P[],
+  deps: PlacementDeps<P>
+): readonly MainMenuItem[] {
+  if (plugins.length === 0) return baseMenuItems;
+
+  const byAnchor = new Map<string, { item: MainMenuItem; order: number }[]>();
+  for (const plugin of plugins) {
+    const anchor = ANCHORS[plugin.after ?? "plugins"] ?? "plugins";
+    const entry = {
+      item: {
+        id: `standalone-${deps.slugOf(plugin.name)}` as MainMenuCategory,
+        label: plugin.appearance?.label || plugin.name,
+        icon: deps.iconFor(plugin),
+        href: "#",
+      },
+      order: plugin.order ?? 100,
+    };
+    byAnchor.set(anchor, [...(byAnchor.get(anchor) ?? []), entry]);
+  }
+
+  for (const group of byAnchor.values()) {
+    group.sort((a, b) => a.order - b.order);
+  }
+
+  const placed: MainMenuItem[] = [];
+  for (const item of baseMenuItems) {
+    placed.push(item);
+    for (const { item: standalone } of byAnchor.get(item.id) ?? []) {
+      placed.push(standalone);
+    }
+    byAnchor.delete(item.id);
+  }
+
+  // Anchored to something this rail does not show. Appended so the plugin
+  // stays reachable.
+  for (const group of byAnchor.values()) {
+    for (const { item: standalone } of group) placed.push(standalone);
+  }
+  return placed;
+}

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-settings-landing.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-settings-landing.ts
@@ -1,0 +1,68 @@
+/**
+ * Where the Settings rail entry sends this reader.
+ *
+ * The panel's table already decides two things: whether the rail entry appears
+ * (`settingsPanelSlugs` feeds `canViewSettings`) and whether `/admin/settings`
+ * opens at all (the same list guards the route). This is the third, and it was
+ * the one still maintained by hand — a ternary chain in `DualSidebar` naming
+ * seven destinations in an order of its own. A destination added to the table
+ * and not to that chain is unreachable from the rail: the entry appears, the
+ * link falls through every arm, and the reader lands on General Settings, whose
+ * own query answers to `manage-settings` and returns 403. Background Jobs was
+ * added to the table and to none of the arms, and that is exactly what a
+ * jobs-only operator saw.
+ *
+ * Deriving it here closes the class rather than the instance: the landing is
+ * the first destination in the panel, in the panel's own order, that this
+ * reader can actually OPEN. "Can see" and "can open" are different questions,
+ * so each item is tested against `routePermission` where it declares one and
+ * against its visibility gate otherwise.
+ *
+ * @module components/layout/sidebar/lib/resolve-settings-landing
+ */
+import { ROUTES } from "@admin/constants/routes";
+
+import {
+  SETTINGS_NAV,
+  isSettingsNavItemVisible,
+  type SettingsNavAccess,
+  type SettingsNavGroup,
+  type SettingsNavItem,
+} from "./settings-nav";
+
+/**
+ * Whether this reader satisfies a route's declared grant.
+ *
+ * Any-of over a list and a plain check over a single slug, which is what
+ * `PermissionGuard` does with `requiredPermission`. A destination declaring
+ * nothing extra is governed by its visibility gate alone.
+ */
+function mayOpen(item: SettingsNavItem, access: SettingsNavAccess): boolean {
+  const required = item.routePermission;
+  if (required === undefined) return true;
+  return Array.isArray(required)
+    ? required.some(access.hasPermission)
+    : access.hasPermission(required as string);
+}
+
+/**
+ * The first panel destination this reader can open, or the panel itself.
+ *
+ * The fallback is deliberate and unchanged: a reader who can open nothing in
+ * the panel is sent to `/admin/settings`, whose route guard refuses them and
+ * returns them to the dashboard. Inventing a friendlier destination here would
+ * be choosing a page on behalf of someone the table says has none.
+ */
+export function resolveSettingsLanding(
+  access: SettingsNavAccess,
+  nav: readonly SettingsNavGroup[] = SETTINGS_NAV
+): string {
+  for (const group of nav) {
+    for (const item of group.items) {
+      if (!isSettingsNavItemVisible(item, access)) continue;
+      if (!mayOpen(item, access)) continue;
+      return item.href;
+    }
+  }
+  return ROUTES.SETTINGS;
+}

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-standalone-label.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-standalone-label.ts
@@ -1,16 +1,17 @@
+import type { PluginMetadata } from "@admin/types/branding";
 import type { StandalonePluginSummary } from "@admin/types/route-section";
 
 /**
  * A standalone plugin plus the display label its panel may carry.
  *
- * Intersected with the shared summary rather than restated, because the route
- * registry names that type too and a second declaration of the same shape is
- * what lets the two drift. Only `appearance` is added: it is the one fact this
- * heading needs that the section resolver does not.
+ * Both halves are derived rather than restated. `StandalonePluginSummary` is
+ * deliberately narrow — its own docblock says so, to let callers pass a
+ * literal — so it is intersected rather than widened, and `appearance` is
+ * picked off `PluginMetadata` rather than re-spelled, so it tracks that type if
+ * it gains a field.
  */
-export type LabelledStandalonePlugin = StandalonePluginSummary & {
-  appearance?: { label?: string };
-};
+export type LabelledStandalonePlugin = StandalonePluginSummary &
+  Pick<PluginMetadata, "appearance">;
 
 /**
  * The heading a standalone plugin's panel carries.
@@ -19,6 +20,14 @@ export type LabelledStandalonePlugin = StandalonePluginSummary & {
  * slug is the last resort so a panel is never headed by nothing. Returns the
  * empty string when the selected rail item is not a standalone plugin at all,
  * which is what the caller renders as "no heading".
+ *
+ * `||` rather than `??`, deliberately, and this is the rule's disagreement with
+ * itself rather than a copied habit: `label` is free-form plugin config, so a
+ * plugin can ship `label: ""`, and under `??` that empty string is a value and
+ * heads the panel with nothing. Six other sites spell this rule and four of
+ * them use `??`, so a reader finding them should not assume this one is the
+ * stale copy. Converging all seven is filed separately; it spans the plugins
+ * pages, not just the sidebar.
  *
  * @module components/layout/sidebar/lib/resolve-standalone-label
  */

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-standalone-label.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-standalone-label.ts
@@ -21,13 +21,11 @@ export type LabelledStandalonePlugin = StandalonePluginSummary &
  * empty string when the selected rail item is not a standalone plugin at all,
  * which is what the caller renders as "no heading".
  *
- * `||` rather than `??`, deliberately, and this is the rule's disagreement with
- * itself rather than a copied habit: `label` is free-form plugin config, so a
+ * `||` rather than `??`, deliberately: `label` is free-form plugin config, so a
  * plugin can ship `label: ""`, and under `??` that empty string is a value and
  * heads the panel with nothing. Six other sites spell this rule and four of
  * them use `??`, so a reader finding them should not assume this one is the
- * stale copy. Converging all seven is filed separately; it spans the plugins
- * pages, not just the sidebar.
+ * stale copy.
  *
  * @module components/layout/sidebar/lib/resolve-standalone-label
  */

--- a/packages/admin/src/components/layout/sidebar/lib/resolve-standalone-label.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/resolve-standalone-label.ts
@@ -1,0 +1,36 @@
+import type { StandalonePluginSummary } from "@admin/types/route-section";
+
+/**
+ * A standalone plugin plus the display label its panel may carry.
+ *
+ * Intersected with the shared summary rather than restated, because the route
+ * registry names that type too and a second declaration of the same shape is
+ * what lets the two drift. Only `appearance` is added: it is the one fact this
+ * heading needs that the section resolver does not.
+ */
+export type LabelledStandalonePlugin = StandalonePluginSummary & {
+  appearance?: { label?: string };
+};
+
+/**
+ * The heading a standalone plugin's panel carries.
+ *
+ * A plugin may declare a display label; otherwise its name stands in, and the
+ * slug is the last resort so a panel is never headed by nothing. Returns the
+ * empty string when the selected rail item is not a standalone plugin at all,
+ * which is what the caller renders as "no heading".
+ *
+ * @module components/layout/sidebar/lib/resolve-standalone-label
+ */
+export function resolveStandaloneLabel(
+  selectedMain: string,
+  visibleStandalonePlugins: readonly LabelledStandalonePlugin[],
+  pluginSlug: (name: string) => string
+): string {
+  if (!selectedMain.startsWith("standalone-")) return "";
+  const slug = selectedMain.replace("standalone-", "");
+  const plugin = visibleStandalonePlugins.find(
+    candidate => pluginSlug(candidate.name) === slug
+  );
+  return plugin?.appearance?.label || plugin?.name || slug;
+}

--- a/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
@@ -21,7 +21,7 @@ import {
   Users,
   Webhook,
 } from "@admin/components/icons";
-import { API_KEYS_ROUTE_PERMISSION } from "@admin/constants/navigation";
+import { API_KEYS_LIST_PERMISSIONS } from "@admin/constants/navigation";
 import { ROUTES } from "@admin/constants/routes";
 
 /**
@@ -104,12 +104,9 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
         icon: Key,
         href: ROUTES.SETTINGS_API_KEYS,
         gate: { kind: "capability", capability: "apiKeys" },
-        // The list screen is guarded more narrowly than the link is shown: any
-        // api-key grant reveals this entry, but only `update-api-keys` opens
-        // it. Taken from the route's own constant rather than copied, so
-        // widening the route cannot leave this refusing a reader the page
-        // would now admit.
-        routePermission: API_KEYS_ROUTE_PERMISSION,
+        // Taken from the route's own constant rather than copied, so the two
+        // cannot drift in either direction.
+        routePermission: API_KEYS_LIST_PERMISSIONS,
       },
       {
         id: "webhooks",
@@ -230,13 +227,15 @@ export function visibleSettingsNav(
     .filter(group => group.items.length > 0 || group.pluginPlacement);
 }
 
-/** Any grant that reaches the API-keys screen; the panel gates it as a capability. */
-const API_KEY_SLUGS = [
-  "read-api-keys",
-  "create-api-keys",
-  "update-api-keys",
-  "delete-api-keys",
-] as const;
+/**
+ * Any grant that reaches the API-keys screen.
+ *
+ * The grants that OPEN it, not every grant naming the resource. `create-` and
+ * `delete-api-keys` let a holder act through the API but not list keys, so
+ * counting them here offered a rail entry whose only destination turned them
+ * away.
+ */
+const API_KEY_SLUGS = API_KEYS_LIST_PERMISSIONS;
 
 /** Any grant that reaches the webhooks screen, for the same reason. */
 const WEBHOOK_SLUGS = [

--- a/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
@@ -21,6 +21,7 @@ import {
   Users,
   Webhook,
 } from "@admin/components/icons";
+import { API_KEYS_ROUTE_PERMISSION } from "@admin/constants/navigation";
 import { ROUTES } from "@admin/constants/routes";
 
 /**
@@ -103,11 +104,12 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
         icon: Key,
         href: ROUTES.SETTINGS_API_KEYS,
         gate: { kind: "capability", capability: "apiKeys" },
-        // The list screen is guarded on `update-api-keys` alone, while the link
-        // is shown to any api-key grant. A reader holding only `read-api-keys`
-        // may therefore see this entry and not be able to open it, so it must
-        // never be chosen as their landing destination.
-        routePermission: "update-api-keys",
+        // The list screen is guarded more narrowly than the link is shown: any
+        // api-key grant reveals this entry, but only `update-api-keys` opens
+        // it. Taken from the route's own constant rather than copied, so
+        // widening the route cannot leave this refusing a reader the page
+        // would now admit.
+        routePermission: API_KEYS_ROUTE_PERMISSION,
       },
       {
         id: "webhooks",

--- a/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
+++ b/packages/admin/src/components/layout/sidebar/lib/settings-nav.ts
@@ -42,6 +42,17 @@ export interface SettingsNavItem {
   href: string;
   gate: SettingsNavGate;
   /**
+   * The grant the destination's own ROUTE demands, when that is narrower than
+   * the gate above.
+   *
+   * `gate` answers "may this reader see the link"; this answers "may they open
+   * it". They are usually the same fact and this is then omitted. Where they
+   * differ, a landing decision that consults only `gate` sends someone to a
+   * page the route guard refuses, which reads to them as the panel being
+   * broken. Any-of when a list, matching `PermissionGuard`.
+   */
+  routePermission?: string | readonly string[];
+  /**
    * Match the route exactly instead of by prefix, for a destination whose path
    * is a prefix of its siblings'.
    */
@@ -92,6 +103,11 @@ export const SETTINGS_NAV: readonly SettingsNavGroup[] = [
         icon: Key,
         href: ROUTES.SETTINGS_API_KEYS,
         gate: { kind: "capability", capability: "apiKeys" },
+        // The list screen is guarded on `update-api-keys` alone, while the link
+        // is shown to any api-key grant. A reader holding only `read-api-keys`
+        // may therefore see this entry and not be able to open it, so it must
+        // never be chosen as their landing destination.
+        routePermission: "update-api-keys",
       },
       {
         id: "webhooks",

--- a/packages/admin/src/constants/navigation.ts
+++ b/packages/admin/src/constants/navigation.ts
@@ -110,6 +110,22 @@ export type SidebarNavigation = NavigationItem[];
  * same implication, so a role holding only `create` can create a release
  * through the API and must be able to see the one it just made.
  */
+/**
+ * The grant the API Keys LIST route demands.
+ *
+ * Named because two places gate on it and they must agree, and because they
+ * are not the same question: the Settings panel SHOWS the entry to any api-key
+ * grant, while this route admits only `update-api-keys`. The sidebar consults
+ * it to avoid choosing a landing destination that would then refuse the
+ * reader, and a copy of the value there would go stale in the direction no
+ * test can see — widen the route and the copy still refuses someone the page
+ * would now admit.
+ *
+ * Lives here rather than in the panel's own table because `pages/registry`
+ * already imports that table, so the table cannot import the registry back.
+ */
+export const API_KEYS_ROUTE_PERMISSION = "update-api-keys";
+
 export const RELEASE_SECTION_PERMISSIONS = [
   "read-content-releases",
   "create-content-releases",

--- a/packages/admin/src/constants/navigation.ts
+++ b/packages/admin/src/constants/navigation.ts
@@ -111,20 +111,24 @@ export type SidebarNavigation = NavigationItem[];
  * through the API and must be able to see the one it just made.
  */
 /**
- * The grant the API Keys LIST route demands.
+ * The grants that reach the API Keys list, as ANY-OF.
  *
- * Named because two places gate on it and they must agree, and because they
- * are not the same question: the Settings panel SHOWS the entry to any api-key
- * grant, while this route admits only `update-api-keys`. The sidebar consults
- * it to avoid choosing a landing destination that would then refuse the
- * reader, and a copy of the value there would go stale in the direction no
- * test can see — widen the route and the copy still refuses someone the page
- * would now admit.
+ * Named because four places gate on it and they must agree: the route, the
+ * panel entry, the landing resolver, and the umbrella deciding whether the
+ * Settings rail appears at all.
  *
- * Lives here rather than in the panel's own table because `pages/registry`
- * already imports that table, so the table cannot import the registry back.
+ * Read off the API rather than chosen here. `requireApiKeyPermission` accepts
+ * the action's own grant OR `update-api-keys`, so listing keys answers to
+ * read-or-update. The route demanded `update-api-keys` alone, which was
+ * narrower than the endpoint behind it: a reader holding `read-api-keys` could
+ * fetch the list over the API and was turned away from the page that displays
+ * it. `create-api-keys` is deliberately absent — it opens the create form, not
+ * the list this entry links to.
  */
-export const API_KEYS_ROUTE_PERMISSION = "update-api-keys";
+export const API_KEYS_LIST_PERMISSIONS = [
+  "read-api-keys",
+  "update-api-keys",
+] as const;
 
 export const RELEASE_SECTION_PERMISSIONS = [
   "read-content-releases",

--- a/packages/admin/src/hooks/__tests__/capability-slugs.test.ts
+++ b/packages/admin/src/hooks/__tests__/capability-slugs.test.ts
@@ -41,16 +41,34 @@ describe("an UMBRELLA grant reveals what it covers", () => {
     expect(from("manage-media").canViewMedia).toBe(true);
   });
 
-  it("any api-key or email grant reveals settings", () => {
+  it("an api-key or email grant that opens a screen reveals settings", () => {
     for (const slug of [
       "read-api-keys",
-      "create-api-keys",
       "update-api-keys",
-      "delete-api-keys",
       "manage-email-providers",
       "manage-email-templates",
     ]) {
       expect(from(slug).canViewSettings, slug).toBe(true);
+    }
+  });
+
+  /**
+   * The other half, and the reason this list is not simply every slug naming
+   * the resource. `canViewSettings` shows the rail entry AND opens
+   * `/admin/settings`, whose page is General Settings — which answers to
+   * `manage-settings` and returns 403 without it. So a grant belongs here only
+   * if it opens a destination IN the panel.
+   *
+   * `create-` and `delete-api-keys` do not: the panel's only api-key entry is
+   * the list, and listing answers to read-or-update. Including them showed a
+   * rail entry whose every destination turned the reader away — they landed on
+   * General Settings and got a 403, which is not access they lose here, it is
+   * a dead end they no longer see. The create form remains reachable by URL,
+   * and its route still admits them.
+   */
+  it("an api-key grant that opens nothing in the panel does not", () => {
+    for (const slug of ["create-api-keys", "delete-api-keys"]) {
+      expect(from(slug).canViewSettings, slug).toBe(false);
     }
   });
 

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -1,7 +1,10 @@
 import { lazy } from "react";
 
 import { settingsPanelSlugs } from "../components/layout/sidebar/lib/settings-nav";
-import { RELEASE_SECTION_PERMISSIONS } from "../constants/navigation";
+import {
+  API_KEYS_ROUTE_PERMISSION,
+  RELEASE_SECTION_PERMISSIONS,
+} from "../constants/navigation";
 import { type PublicRoutePath, ROUTES } from "../constants/routes";
 import {
   builderSection,
@@ -457,7 +460,7 @@ export const routeConfig: Record<string, RouteConfig> = {
   [ROUTES.SETTINGS_API_KEYS]: {
     component: ApiKeysPage,
     type: "private",
-    requiredPermission: "update-api-keys",
+    requiredPermission: API_KEYS_ROUTE_PERMISSION,
     section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_API_KEYS_CREATE]: {

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -396,8 +396,16 @@ export const routeConfig: Record<string, RouteConfig> = {
   // Settings routes
   // Any grant that reaches SOMETHING in the panel may open the panel's own URL.
   // Narrowing it to `manage-settings` turned the rail entry into a door that
-  // closed in the face of anyone whose only destination was further in; the
-  // page itself sends them on to the first one they can reach.
+  // closed in the face of anyone whose only destination was further in.
+  //
+  // This guard admits them; it does not place them. The page behind it is
+  // General Settings, whose own query answers to `manage-settings`, so a reader
+  // admitted here without that grant sees a 403 rather than a redirect. Nothing
+  // sends them on — an earlier version of this comment said the page did, and
+  // it never has. The rail is what keeps them off this URL: `resolveSettingsLanding`
+  // picks the first destination in the panel they can actually open, so the
+  // fallthrough to `/admin/settings` is reached only by a reader who has no
+  // reachable destination at all.
   [ROUTES.SETTINGS]: {
     component: SettingsPage,
     type: "private",

--- a/packages/admin/src/pages/registry.ts
+++ b/packages/admin/src/pages/registry.ts
@@ -2,7 +2,7 @@ import { lazy } from "react";
 
 import { settingsPanelSlugs } from "../components/layout/sidebar/lib/settings-nav";
 import {
-  API_KEYS_ROUTE_PERMISSION,
+  API_KEYS_LIST_PERMISSIONS,
   RELEASE_SECTION_PERMISSIONS,
 } from "../constants/navigation";
 import { type PublicRoutePath, ROUTES } from "../constants/routes";
@@ -403,12 +403,11 @@ export const routeConfig: Record<string, RouteConfig> = {
   //
   // This guard admits them; it does not place them. The page behind it is
   // General Settings, whose own query answers to `manage-settings`, so a reader
-  // admitted here without that grant sees a 403 rather than a redirect. Nothing
-  // sends them on — an earlier version of this comment said the page did, and
-  // it never has. The rail is what keeps them off this URL: `resolveSettingsLanding`
-  // picks the first destination in the panel they can actually open, so the
-  // fallthrough to `/admin/settings` is reached only by a reader who has no
-  // reachable destination at all.
+  // admitted here without that grant sees a 403. Nothing on the page sends them
+  // elsewhere. The rail is what keeps them off this URL: `resolveSettingsLanding`
+  // picks the first destination in the panel they can actually open, and every
+  // grant in `settingsPanelSlugs()` opens one, so the fallthrough to
+  // `/admin/settings` is unreachable for anyone this guard admits.
   [ROUTES.SETTINGS]: {
     component: SettingsPage,
     type: "private",
@@ -460,7 +459,7 @@ export const routeConfig: Record<string, RouteConfig> = {
   [ROUTES.SETTINGS_API_KEYS]: {
     component: ApiKeysPage,
     type: "private",
-    requiredPermission: API_KEYS_ROUTE_PERMISSION,
+    requiredPermission: [...API_KEYS_LIST_PERMISSIONS],
     section: overridableBy("settings"),
   },
   [ROUTES.SETTINGS_API_KEYS_CREATE]: {


### PR DESCRIPTION
## The defect

An operator whose only settings-area grant is `manage-background-jobs` could see the Settings entry in the rail, follow it, and land on a page that fails to load — while Background Jobs, their one reachable screen, was never offered.

Measured end to end:

1. `settingsPanelSlugs()` includes `manage-background-jobs`, so `canViewSettings` is true and the rail entry appears.
2. `settingsHref` was a hand-written chain of seven destinations in `DualSidebar`. Background Jobs was never added to it, so the reader falls through every arm to `ROUTES.SETTINGS`.
3. That route is guarded by `settingsPanelSlugs()`, which **admits** them — so there is no bounce.
4. They land on General Settings, whose query answers to `read-settings` / `manage-settings`, and get a 403.

The `settingsPanelSlugs` docblock already named the three decisions this table has to satisfy: whether the rail entry appears, whether `/admin/settings` opens, and which destination a viewer without `manage-settings` lands on. The first two were derived from the table. The third was still a list maintained beside it, which is why a destination could be added to the panel and be unreachable from the rail.

## The fix

`resolveSettingsLanding` reads the landing off the panel's own table: the first destination, in the panel's order, that this reader can actually **open**. A destination added to `SETTINGS_NAV` now satisfies all three decisions by construction.

"Can see the link" and "can open the page" are different questions, and they genuinely differ today: the panel shows API Keys to any api-key grant, but `SETTINGS_API_KEYS` is guarded on `update-api-keys` alone. A landing that consulted visibility alone would send a `read-api-keys`-only holder to a page that turns them away, so an item may now declare the narrower grant its own route demands via `routePermission`.

## Why the extraction is in the same PR

`DualSidebar.tsx` is 544 lines, and fallow attributes **shifted** lines as introduced. Adding the one import this fix needs — at line 35, with no logic change at all — takes `complexity_introduced` from 0 to 3, naming `hasCollectionsSection`, `hasVisiblePluginCollection` and `standaloneLabel`: three functions the change never touches. Isolated and measured on its own commit.

So the three functions the gate names are moved into `lib/`, following the convention the file already uses four times. After the extraction, on the full change:

```
Audit scope: 11 changed files vs origin/main
complexity_introduced: 0   dead_code_introduced: 0
duplication_introduced: 0  styling_introduced: 0   -> exit 0
```

## Evidence

Every test was seen to fail for its intended reason before being kept.

- The **old implementation**, written back in place of the resolver, fails exactly one test — `sends a jobs-only operator to Background Jobs` — and the other ten pass. That is the load-bearing result: it shows this is a defect fix, not a behaviour rewrite, for every other role.
- Removing `routePermission` from the table fails the read-only api-key test **and** the registry-agreement test.
- Dropping the `isError` arm fails the failed-query test; `??` for `||` fails the empty-label test.

`never chooses a destination whose route would refuse the reader` derives its expectation from `routeConfig` rather than restating it, so a destination added later whose route is narrower than its gate fails until it declares one. It carries its own control: the panel really does show a destination whose route is narrower, so the check can fail.

## Also corrected

The comment above the Settings route claimed "the page itself sends them on to the first one they can reach". It does not, and never has — no redirect has ever existed in that file. I wrote that sentence in #1447; it asserted a mechanism I did not build. Replaced with what the guard actually does.

## Not fixed here

The panel **shows** API Keys to a `read-api-keys`-only holder whose route will bounce them. This PR stops it being a landing destination; the visible link remains. Which of the two gates is wrong is an access decision rather than a cleanup, so it is filed rather than guessed at.

The label rule (`appearance?.label` falling back to `name`) is spelled seven times across the sidebar and the plugins pages, and the spellings disagree — `||` in two places, `??` in four. This module picks `||`, deliberately, and says why. Converging the rest spans the plugins pages and is filed separately.

## Verification

- `pnpm --filter @nextlyhq/admin check-types` — clean
- Full admin suite — 385 files, 3716 tests, all passing
- `git merge-tree --write-tree HEAD origin/main` — exit 0, no conflicts
- `fallow audit --base origin/main --gate new-only` — exit 0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - The sidebar now more accurately separates collections and plugin-owned collections between their respective sections.
  - Settings opens directly to the first page available to you based on your permissions.
  - API Keys access is consistently available to users with read or update permissions.
  - Standalone plugin headings now use the plugin’s configured label, name, or slug as an appropriate fallback.
  - Settings visibility no longer appears for permissions that do not provide access to a Settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->