### PR TITLE
feat(admin): arrange your own dashboard — reorder, hide, remove, add

### DIFF
--- a/.changeset/a-dashboard-stays-where-you-left-it.md
+++ b/.changeset/a-dashboard-stays-where-you-left-it.md
@@ -26,14 +26,17 @@
 "nextly": patch
 ---
 
-A dashboard arrangement now survives a reload.
+The API a dashboard arrangement is stored through.
 
 `nextly_widget_layout` stores one row per reader: which cards, in which order,
 at which size, and which they have put away. `GET /api/dashboard/layout` returns
 that arrangement resolved against the live registry, and `PUT` replaces it,
-guarded by a version so two tabs cannot silently overwrite each other. A reader
-who has never arranged anything still sees the registry's own order, so nothing
-changes for anybody until they move a card.
+guarded by a version so two tabs cannot silently overwrite each other.
+
+This is the store and its endpoint only — the admin dashboard does not read it
+yet, so no reader's dashboard changes behaviour from this alone. It is the
+prerequisite the editing UI is built on, and the arrangement starts surviving a
+reload when that lands.
 
 The stored row holds an identity and a position and nothing else. It never
 copies a widget's `requiredPermission`: every question about whether this reader

--- a/.changeset/a-dashboard-stays-where-you-left-it.md
+++ b/.changeset/a-dashboard-stays-where-you-left-it.md
@@ -26,17 +26,14 @@
 "nextly": patch
 ---
 
-The API a dashboard arrangement is stored through.
+A dashboard arrangement now survives a reload.
 
 `nextly_widget_layout` stores one row per reader: which cards, in which order,
 at which size, and which they have put away. `GET /api/dashboard/layout` returns
 that arrangement resolved against the live registry, and `PUT` replaces it,
-guarded by a version so two tabs cannot silently overwrite each other.
-
-This is the store and its endpoint only — the admin dashboard does not read it
-yet, so no reader's dashboard changes behaviour from this alone. It is the
-prerequisite the editing UI is built on, and the arrangement starts surviving a
-reload when that lands.
+guarded by a version so two tabs cannot silently overwrite each other. A reader
+who has never arranged anything still sees the registry's own order, so nothing
+changes for anybody until they move a card.
 
 The stored row holds an identity and a position and nothing else. It never
 copies a widget's `requiredPermission`: every question about whether this reader

--- a/.changeset/arrange-your-own-dashboard.md
+++ b/.changeset/arrange-your-own-dashboard.md
@@ -1,0 +1,50 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+"create-nextly-app": patch
+"nextly": patch
+---
+
+Arrange your own dashboard.
+
+An "Edit dashboard" button turns the grid into edit mode: drag a card, or move it
+with buttons, hide one without losing where it sat, remove one entirely, and add
+back anything you are missing. Save commits the arrangement; Cancel discards it;
+Reset puts you back on the default and keeps you tracking it, so a widget added
+later still reaches you.
+
+Every change is held locally until you save. Each write is guarded twice -- by a
+version that catches another tab, and by a token that catches the set of widgets
+available to you moving underneath what you are looking at -- and both refuse the
+same way, with a message and a Reload rather than a silent overwrite. Your work
+stays on screen while you decide.
+
+Moving a card never requires a drag. Move up and Move down are ordinary buttons,
+because WCAG 2.2 requires a single-pointer alternative to every dragging movement
+and a keyboard shortcut does not satisfy it. Reorders are announced through the
+grid's existing live region.
+
+The dashboard also stops depending on the arrangement being reachable: if it has
+not loaded, or cannot load, the cards draw in their declared order exactly as
+before rather than leaving the page blank.

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -20,6 +20,8 @@
  * @module components/features/widgets/WidgetGrid
  */
 
+import { DndContext, closestCenter } from "@dnd-kit/core";
+import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
@@ -27,24 +29,15 @@ import {
   useBrandingStatus,
 } from "@admin/context/providers/BrandingProvider";
 import { useDashboardLayout } from "@admin/hooks/queries/useDashboardLayout";
-import {
-  useWidgetQueries,
-  type WidgetQueryRequest,
-} from "@admin/hooks/queries/useWidgetQueries";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
-import { cn } from "@admin/lib/utils";
-import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
 import { registerCoreWidgetComponents } from "./core-components";
 import { AddWidgetPicker } from "./edit/AddWidgetPicker";
-import { DashboardEditBar } from "./edit/DashboardEditBar";
-import { useLayoutEditor } from "./edit/useLayoutEditor";
-import { WidgetEditControls } from "./edit/WidgetEditControls";
-import { moveAffordance } from "./layout-editor";
-import { coreDraws, resolveWidgetOutcome } from "./outcome";
+import { ArrangedCell } from "./edit/ArrangedCell";
+import { DashboardEditChrome } from "./edit/DashboardEditChrome";
+import { useDashboardArrangement } from "./edit/useDashboardArrangement";
 import { resolveDashboardWidgets } from "./resolve-widgets";
-import { widgetSpanClass } from "./sizes";
-import { WidgetRenderer } from "./WidgetRenderer";
+import { useWidgetBatch } from "./useWidgetBatch";
 
 // At module scope, before any render. `PluginSlot` resolves a path DURING
 // render, so registering from an effect would land after the first paint and
@@ -158,159 +151,6 @@ export function WidgetGrid() {
     [branding, hasPermission]
   );
 
-  // The DECLARATIONS, by id. The arrangement says which cards and in what
-  // order; this says what each one actually is. Two questions, two sources:
-  // the server owns the arrangement because only it can filter by permission
-  // authoritatively, and branding owns the declaration because that is what
-  // carries the archetype, the query and the component.
-  const byId = useMemo(
-    () => new Map(declared.map(widget => [widget.id, widget])),
-    [declared]
-  );
-
-  const layout = useDashboardLayout();
-
-  // What an added card inherits. Read from the declaration rather than
-  // defaulted here, so a card the reader adds is the size its author intended.
-  const geometryFor = useCallback(
-    (widgetId: string) => {
-      const declaration = byId.get(widgetId);
-      if (!declaration) return undefined;
-      // `size` on a resolved declaration IS its declared default — the admin's
-      // resolver has already applied it. Reading it here rather than defaulting
-      // means a card the reader adds arrives the size its author intended.
-      return { size: declaration.size };
-    },
-    [byId]
-  );
-
-  const editor = useLayoutEditor(layout, geometryFor);
-
-  // The cards to draw, in the arrangement's order.
-  //
-  // A placement whose declaration this admin cannot resolve is SKIPPED rather
-  // than drawn as an empty cell: the server filtered by permission and by the
-  // registry, but a plugin's client bundle can still be absent, and a titled
-  // card with nothing under it reads as a product bug rather than as a missing
-  // plugin. While editing, hidden cards are drawn too — greyed — because a
-  // reader cannot bring back something they cannot see.
-  // 🔴 Whether an arrangement has been READ, which is not the same as whether
-  // it holds anything. Absent means the request is still in flight or it
-  // failed; empty means this reader has arranged their dashboard down to
-  // nothing. Folding the two together blanks the entire dashboard for the
-  // duration of every page load and for the whole of any outage — the grid
-  // drew from branding alone before this, and a personalization feature must
-  // not be able to take the page down when its own endpoint is unavailable.
-  const hasArrangement = layout.layout !== undefined;
-
-  const visible = useMemo(() => {
-    // No arrangement yet: draw the declarations in their declared order, which
-    // is exactly what this dashboard did before it could be arranged at all.
-    if (!hasArrangement) {
-      return declared.map(widget => ({
-        placementId: widget.id,
-        widget,
-        hidden: false,
-      }));
-    }
-    const rows: Array<{
-      placementId: string;
-      widget: DashboardWidget;
-      hidden: boolean;
-    }> = [];
-    for (const placement of editor.placements) {
-      const widget = byId.get(placement.widgetId);
-      if (!widget) continue;
-      if (placement.hidden && !editor.isEditing) continue;
-      rows.push({
-        placementId: placement.id,
-        widget,
-        hidden: placement.hidden,
-      });
-    }
-    return rows;
-  }, [hasArrangement, declared, editor.placements, editor.isEditing, byId]);
-
-  const widgets = useMemo(() => visible.map(row => row.widget), [visible]);
-
-  // Every widget that DECLARED a query, archetype notwithstanding. `custom` is
-  // included on purpose: core's widget validator puts it in neither the data
-  // set nor the query-less set, because a widget that draws its own body may
-  // still want the host to run its request -- and `WidgetRenderer` hands the
-  // resulting slot to the plugin component. A widget that declares no query
-  // contributes nothing here, which is what keeps a dashboard of plugin
-  // components from issuing a request at all.
-  const requests = useMemo<WidgetQueryRequest[]>(
-    () =>
-      widgets.flatMap(widget =>
-        // A query is only worth running if SOMETHING can draw its result. A
-        // widget naming an archetype core cannot draw yet, and shipping no
-        // component to draw it instead, resolves to a card that reads "not
-        // rendered yet" -- so asking for the data spends an access-checked
-        // read, and one of the batch's limited slots, on a result thrown away
-        // on arrival. `custom` always draws, because the plugin's component
-        // decides what to do with the slot.
-        //
-        // Asked of `coreDraws` rather than listed here, so the read starts
-        // happening on its own the day core learns to draw one -- and asked of
-        // the whole DECLARATION, not just the archetype, because a renderer
-        // that will refuse this particular widget makes the read just as
-        // wasted as no renderer at all.
-        widget.query && (widget.archetype === "custom" || coreDraws(widget))
-          ? [{ widgetId: widget.id, query: widget.query }]
-          : []
-      ),
-    [widgets]
-  );
-
-  const { slots, isFetching, updatedAt } = useWidgetQueries(requests);
-
-  // Which widgets are actually IN the batch, taken from the requests that were
-  // sent rather than re-derived from `widget.query`.
-  //
-  // Those two disagree, and the disagreement is the whole point of this set: a
-  // widget declaring a query whose archetype nothing can draw is deliberately
-  // left out of the batch above, but it still HAS a `widget.query`. Testing
-  // that field again below gave such a card a freshness line for a request that
-  // never ran, and marked it `aria-busy` during someone else's refetch.
-  const requested = useMemo(
-    () => new Set(requests.map(request => request.widgetId)),
-    [requests]
-  );
-
-  // The same answer the cards are drawn from, so the announcement cannot
-  // describe a dashboard other than the one on screen. Counting slots instead
-  // said "3 of 3 widgets updated" while a card read "the list archetype is not
-  // rendered yet": the response was fine and the card was not.
-  //
-  // Only widgets that ASKED are counted, and self-drawn ones are dropped even
-  // when they did. A plugin component decides what it shows from the slot it
-  // was handed, so core cannot say whether it worked, and guessing either way
-  // would put a number in the reader's ear that nothing on screen supports.
-  const counted = useMemo(
-    () =>
-      widgets
-        .filter(widget => widget.query)
-        .map(widget => resolveWidgetOutcome(widget, slots[widget.id]))
-        .filter(outcome => outcome.state !== "self-drawn"),
-    [widgets, slots]
-  );
-  const failed = counted.filter(outcome => outcome.state === "failed").length;
-  const settling = counted.some(outcome => outcome.state === "loading");
-
-  const [announcement, setAnnouncement] = useState("");
-
-  // A reorder speaks through the grid's ONE region, not a second one.
-  //
-  // The reason is the reason that region exists: several announcers on one
-  // surface interrupt each other, and a reader cannot tell which announcement
-  // belonged to what they just did. That argument does not weaken because the
-  // second announcer is the grid itself rather than a card.
-  //
-  // Nothing is clobbered by sharing it. The batch effect below fires only when
-  // its OWN sentence changes, and a move does not change it — so a move
-  // message survives until the batch has something new to say, which is
-  // precisely when it should stop being the latest news.
   const announceMove = useCallback(
     (title: string, position: number, count: number) => {
       // The zero-width space alternates the string, because a live region does
@@ -326,10 +166,50 @@ export function WidgetGrid() {
     },
     []
   );
+
+  const layout = useDashboardLayout();
+  const {
+    visible,
+    editor,
+    hasArrangement,
+    sortableItems,
+    sensors,
+    handleDragEnd,
+  } = useDashboardArrangement(declared, layout, announceMove);
+
+  const byId = useMemo(
+    () => new Map(declared.map(widget => [widget.id, widget])),
+    [declared]
+  );
+
+  const widgets = useMemo(() => visible.map(row => row.widget), [visible]);
+
+  const { slots, isFetching, updatedAt, requested, counted, failed, settling } =
+    useWidgetBatch(widgets);
+
+  const [announcement, setAnnouncement] = useState("");
+
+  // A reorder speaks through the grid's ONE region, not a second one.
+  //
+  // The reason is the reason that region exists: several announcers on one
+  // surface interrupt each other, and a reader cannot tell which announcement
+  // belonged to what they just did. That argument does not weaken because the
+  // second announcer is the grid itself rather than a card.
+  //
+  // Nothing is clobbered by sharing it. The batch effect below fires only when
+  // its OWN sentence changes, and a move does not change it — so a move
+  // message survives until the batch has something new to say, which is
+  // precisely when it should stop being the latest news.
+
+  // The drag path and the button path move a card through the SAME function.
+  // Two implementations of "where does this land" agree until one of them is
+  // edited, and a grid whose drag and whose buttons disagreed would be
+  // impossible to reason about from either.
+
   // What was last spoken, so an unchanged outcome does not re-fire. A ref
   // rather than state because it must not itself cause a render.
   const spoken = useRef("");
-  const next = settledAnnouncement(settling, counted.length, failed);
+  const next = settledAnnouncement(settling, counted, failed);
 
   useEffect(() => {
     if (!next || next === spoken.current) return;
@@ -353,139 +233,68 @@ export function WidgetGrid() {
 
   return (
     <div className="space-y-4">
-      {hasArrangement ? (
-        <DashboardEditBar
-          isEditing={editor.isEditing}
-          hasUnsavedChanges={editor.hasUnsavedChanges}
-          isSaving={editor.isSaving}
-          canReset={layout.layout?.source === "own"}
-          onBegin={editor.begin}
-          onSave={editor.save}
-          onCancel={editor.cancel}
-          onReset={editor.reset}
-        />
-      ) : null}
+      <DashboardEditChrome
+        editor={editor}
+        hasArrangement={hasArrangement}
+        canReset={layout.layout?.source === "own"}
+        onReload={() => void layout.reload()}
+      />
 
-      {editor.isConflict ? (
-        // Both guards refuse the same way and the remedy is the same, so this
-        // is one message rather than two. It does NOT clear the draft: the
-        // reader's work stays on screen while they decide, because discarding
-        // it at the moment they are told to try again is the worst possible
-        // time to throw it away.
-        <div
-          role="alert"
-          className="rounded-md border border-border bg-muted/50 px-3 py-2 text-sm"
-          data-testid="dashboard-edit-conflict"
-        >
-          Your dashboard changed somewhere else while you were editing. Reload
-          to pick up the current arrangement — your unsaved changes here will be
-          lost.{" "}
-          <button
-            type="button"
-            className="underline underline-offset-2"
-            onClick={() => void layout.reload()}
-            data-testid="dashboard-edit-reload"
-          >
-            Reload
-          </button>
-        </div>
-      ) : null}
-
-      <section
-        aria-label="Dashboard widgets"
-        className="grid grid-cols-12 gap-6"
+      <DndContext
+        sensors={sensors}
+        // `closestCenter` rather than pointer-within: the cells are different
+        // widths, so a small card dragged over a full-width one never contains
+        // the pointer and the drop target reads as nothing.
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
       >
-        <span
-          role="status"
-          aria-live="polite"
-          className="sr-only"
-          data-testid="widget-grid-live"
+        <SortableContext
+          items={sortableItems}
+          // The grid wraps, so cards move in two dimensions. The list strategy
+          // assumes a single column and animates neighbours the wrong way.
+          strategy={rectSortingStrategy}
         >
-          {announcement}
-        </span>
-        {visible.map((row, index) => {
-          const widget = row.widget;
-          const { canMoveUp, canMoveDown } = moveAffordance(
-            index,
-            visible.length
-          );
-          return (
-            <div
-              key={row.placementId}
-              data-testid={`widget-cell-${widget.id}`}
-              // `empty:hidden` so a widget that drew NOTHING costs no row. A framed
-              // widget always renders its card, so this can never hide one; it
-              // reaches only an unframed widget whose component returned null --
-              // which core's conditional sections do, and did before they were
-              // widgets. Without it each becomes a blank cell with a `gap-6` on
-              // either side, which is the empty-slot bug rather than the hiding
-              // those components have always performed.
-              //
-              // CSS rather than asking the component to declare its own emptiness:
-              // a declaration is a second statement of what the render already
-              // decided, and the two drift.
-              className={cn(
-                widgetSpanClass(widget.size),
-                "empty:hidden",
-                // An unframed widget is a SECTION, and sections on this page have
-                // always been 48px apart -- the `space-y-12` the dashboard used
-                // before these became widgets. The grid's own `gap-6` is a card
-                // rhythm and right for cards, so the difference belongs to the
-                // widgets that are not cards: 24px of trailing margin plus the
-                // 24px row gap puts two adjacent sections back at 48px.
-                //
-                // BOTTOM only. A symmetric `my-3` also pushed the FIRST row down,
-                // and the page's outer `space-y-12` already places the grid 48px
-                // below the welcome header -- so every dashboard gained 12px there
-                // while the inter-section gaps looked correct. Measuring the gaps
-                // alone could not see it; only the header-to-first-section distance
-                // could.
-                //
-                // Margins, not padding: a hidden cell contributes neither, but
-                // padding would also inset a body that draws its own background.
-                widget.chrome === "none" && "mb-6",
-                // A hidden card is drawn while editing so it can be brought
-                // back, and dimmed so it is not mistaken for a live one. The
-                // dimming is presentational only: the controls above it stay at
-                // full contrast, because they are what the reader needs to act
-                // on and a faded button is a button people cannot read.
-                row.hidden && "opacity-50"
-              )}
+          <section
+            aria-label="Dashboard widgets"
+            className="grid grid-cols-12 gap-6"
+          >
+            <span
+              role="status"
+              aria-live="polite"
+              className="sr-only"
+              data-testid="widget-grid-live"
             >
-              {editor.isEditing ? (
-                <WidgetEditControls
-                  title={widget.title}
-                  position={index + 1}
-                  count={visible.length}
-                  hidden={row.hidden}
-                  canMoveUp={canMoveUp}
-                  canMoveDown={canMoveDown}
-                  onMoveUp={() => {
-                    editor.moveBy(index, -1);
-                    announceMove(widget.title, index + 1 - 1, visible.length);
-                  }}
-                  onMoveDown={() => {
-                    editor.moveBy(index, 1);
-                    announceMove(widget.title, index + 1 + 1, visible.length);
-                  }}
-                  onToggleHidden={() => editor.toggleHidden(row.placementId)}
-                  onRemove={() => editor.remove(row.placementId)}
-                />
-              ) : null}
-              <WidgetRenderer
-                definition={widget}
-                slot={slots[widget.id]}
-                updatedAt={requested.has(widget.id) ? updatedAt : null}
-                // Only a widget that actually ASKED can be waiting on an answer.
-                // A card drawn entirely by a plugin component took no part in
-                // the batch, and neither did one whose archetype nothing can
-                // draw, so a refetch says nothing about either.
-                isFetching={requested.has(widget.id) ? isFetching : false}
+              {announcement}
+            </span>
+            {visible.map((row, index) => (
+              <ArrangedCell
+                key={row.placementId}
+                row={row}
+                index={index}
+                count={visible.length}
+                isEditing={editor.isEditing}
+                slot={slots[row.widget.id]}
+                // Only a widget that actually ASKED can be waiting on an answer. A
+                // card drawn entirely by a plugin component took no part in the
+                // batch, and neither did one whose archetype nothing can draw, so a
+                // refetch says nothing about either.
+                updatedAt={requested.has(row.widget.id) ? updatedAt : null}
+                isFetching={requested.has(row.widget.id) ? isFetching : false}
+                onMove={(from, delta) => {
+                  editor.moveBy(from, delta);
+                  announceMove(
+                    row.widget.title,
+                    from + 1 + delta,
+                    visible.length
+                  );
+                }}
+                onToggleHidden={editor.toggleHidden}
+                onRemove={editor.remove}
               />
-            </div>
-          );
-        })}
-      </section>
+            ))}
+          </section>
+        </SortableContext>
+      </DndContext>
 
       {editor.isEditing ? (
         <AddWidgetPicker

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -22,7 +22,7 @@
 
 import { DndContext, closestCenter } from "@dnd-kit/core";
 import { SortableContext, rectSortingStrategy } from "@dnd-kit/sortable";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef } from "react";
 
 import {
   useBranding,
@@ -37,41 +37,13 @@ import { ArrangedCell } from "./edit/ArrangedCell";
 import { DashboardEditChrome } from "./edit/DashboardEditChrome";
 import { useDashboardArrangement } from "./edit/useDashboardArrangement";
 import { resolveDashboardWidgets } from "./resolve-widgets";
+import { useGridAnnouncer } from "./useGridAnnouncer";
 import { useWidgetBatch } from "./useWidgetBatch";
 
 // At module scope, before any render. `PluginSlot` resolves a path DURING
 // render, so registering from an effect would land after the first paint and
 // every core card would show its unresolved fallback once on the way in.
 registerCoreWidgetComponents();
-
-/**
- * What the grid says once a batch settles, or `null` for a state not worth
- * interrupting a reader for.
- *
- * Mid-flight says nothing, for the same reason `DocumentStatusLive` stays quiet
- * during a save: this grid refetches on every window focus, and announcing the
- * start of each refresh would speak over the reader every time they came back
- * to the tab. What matters is where it came to rest.
- *
- * `failed` counts CARDS THAT SHOW AN ERROR, not slots the server marked bad,
- * and the two are different numbers. There is no separate "the whole request
- * failed" sentence either: a rejected request gives every widget in it a failed
- * slot, so the counts already say so -- and with the requests partitioned, one
- * batch failing does not mean the dashboard did.
- */
-function settledAnnouncement(
-  isLoading: boolean,
-  total: number,
-  failed: number
-): string | null {
-  if (total === 0) return null;
-  if (isLoading) return null;
-  const loaded = total - failed;
-  const noun = total === 1 ? "widget" : "widgets";
-  return failed > 0
-    ? `${loaded} of ${total} ${noun} updated, ${failed} failed.`
-    : `${loaded} of ${total} ${noun} updated.`;
-}
 
 /**
  * What the grid shows when it holds no widget, which is three different facts.
@@ -151,19 +123,17 @@ export function WidgetGrid() {
     [branding, hasPermission]
   );
 
+  // 🔴 A stable indirection, because these three hooks form a cycle: the
+  // announcer needs the batch's outcome, the batch needs the widgets the
+  // arrangement resolved, and the arrangement needs somewhere to announce a
+  // move. The ref is the one link that can be filled in after the fact — the
+  // wrapper's identity never changes, so nothing downstream re-renders on it,
+  // and by the time a reader can move a card the announcer is long since
+  // assigned.
+  const announcer = useRef<(t: string, p: number, c: number) => void>(() => {});
   const announceMove = useCallback(
-    (title: string, position: number, count: number) => {
-      // The zero-width space alternates the string, because a live region does
-      // not re-announce text that did not change -- and moving a card up twice
-      // produces the same sentence both times. Same device as the builder's
-      // `keyboard-actions`, which is where this grid's convention comes from.
-      setAnnouncement(
-        current =>
-          `${title} moved to position ${position} of ${count}.${
-            current.endsWith("\u200b") ? "" : "\u200b"
-          }`
-      );
-    },
+    (title: string, position: number, count: number) =>
+      announcer.current(title, position, count),
     []
   );
 
@@ -171,6 +141,7 @@ export function WidgetGrid() {
   const {
     visible,
     editor,
+    moveBy,
     hasArrangement,
     sortableItems,
     sensors,
@@ -187,35 +158,12 @@ export function WidgetGrid() {
   const { slots, isFetching, updatedAt, requested, counted, failed, settling } =
     useWidgetBatch(widgets);
 
-  const [announcement, setAnnouncement] = useState("");
-
-  // A reorder speaks through the grid's ONE region, not a second one.
-  //
-  // The reason is the reason that region exists: several announcers on one
-  // surface interrupt each other, and a reader cannot tell which announcement
-  // belonged to what they just did. That argument does not weaken because the
-  // second announcer is the grid itself rather than a card.
-  //
-  // Nothing is clobbered by sharing it. The batch effect below fires only when
-  // its OWN sentence changes, and a move does not change it — so a move
-  // message survives until the batch has something new to say, which is
-  // precisely when it should stop being the latest news.
-
-  // The drag path and the button path move a card through the SAME function.
-  // Two implementations of "where does this land" agree until one of them is
-  // edited, and a grid whose drag and whose buttons disagreed would be
-  // impossible to reason about from either.
-
-  // What was last spoken, so an unchanged outcome does not re-fire. A ref
-  // rather than state because it must not itself cause a render.
-  const spoken = useRef("");
-  const next = settledAnnouncement(settling, counted, failed);
-
-  useEffect(() => {
-    if (!next || next === spoken.current) return;
-    spoken.current = next;
-    setAnnouncement(next);
-  }, [next]);
+  const { announcement, announceMove: announceSettledMove } = useGridAnnouncer(
+    settling,
+    counted,
+    failed
+  );
+  announcer.current = announceSettledMove;
 
   // Nothing to draw. Returned after the hooks above so the hook order is the
   // same on every render, whatever the branding says.
@@ -235,8 +183,17 @@ export function WidgetGrid() {
     <div className="space-y-4">
       <DashboardEditChrome
         editor={editor}
+        writeError={layout.writeError}
         hasArrangement={hasArrangement}
-        canReset={layout.layout?.source === "own"}
+        // 🔴 A stored row exists whenever the VERSION is non-zero, which is not
+        // the same as `source === "own"`. A row the service could not decode is
+        // reported as `source: "default"` — the dashboard falls back to the
+        // registry's order — while keeping its real, non-zero version. Gating
+        // Reset on the source therefore hid the one control that could clear
+        // the bad row, and with an untouched draft Save is disabled too, so the
+        // reader had no way out and every read went on logging the same decode
+        // failure. The version is what says a row is there.
+        canReset={(layout.layout?.version ?? 0) > 0}
         onReload={() => void layout.reload()}
       />
 
@@ -280,14 +237,10 @@ export function WidgetGrid() {
                 // refetch says nothing about either.
                 updatedAt={requested.has(row.widget.id) ? updatedAt : null}
                 isFetching={requested.has(row.widget.id) ? isFetching : false}
-                onMove={(from, delta) => {
-                  editor.moveBy(from, delta);
-                  announceMove(
-                    row.widget.title,
-                    from + 1 + delta,
-                    visible.length
-                  );
-                }}
+                // The arrangement hook announces, because it is the one that
+                // resolves the destination -- announcing here would name a
+                // position computed a second time, and the two would drift.
+                onMove={moveBy}
                 onToggleHidden={editor.toggleHidden}
                 onRemove={editor.remove}
               />

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -20,20 +20,27 @@
  * @module components/features/widgets/WidgetGrid
  */
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import {
   useBranding,
   useBrandingStatus,
 } from "@admin/context/providers/BrandingProvider";
+import { useDashboardLayout } from "@admin/hooks/queries/useDashboardLayout";
 import {
   useWidgetQueries,
   type WidgetQueryRequest,
 } from "@admin/hooks/queries/useWidgetQueries";
 import { useCurrentUserPermissions } from "@admin/hooks/useCurrentUserPermissions";
 import { cn } from "@admin/lib/utils";
+import type { DashboardWidget } from "@admin/types/dashboard/widgets";
 
 import { registerCoreWidgetComponents } from "./core-components";
+import { AddWidgetPicker } from "./edit/AddWidgetPicker";
+import { DashboardEditBar } from "./edit/DashboardEditBar";
+import { useLayoutEditor } from "./edit/useLayoutEditor";
+import { WidgetEditControls } from "./edit/WidgetEditControls";
+import { moveAffordance } from "./layout-editor";
 import { coreDraws, resolveWidgetOutcome } from "./outcome";
 import { resolveDashboardWidgets } from "./resolve-widgets";
 import { widgetSpanClass } from "./sizes";
@@ -141,7 +148,7 @@ export function WidgetGrid() {
   // Both channels a widget can reach the dashboard by: `contributes.admin.widgets`
   // and the registry `registerWidget` writes to. Reading only the first made the
   // registry invisible to the renderer built around it.
-  const widgets = useMemo(
+  const declared = useMemo(
     () =>
       resolveDashboardWidgets(
         branding?.plugins,
@@ -150,6 +157,81 @@ export function WidgetGrid() {
       ),
     [branding, hasPermission]
   );
+
+  // The DECLARATIONS, by id. The arrangement says which cards and in what
+  // order; this says what each one actually is. Two questions, two sources:
+  // the server owns the arrangement because only it can filter by permission
+  // authoritatively, and branding owns the declaration because that is what
+  // carries the archetype, the query and the component.
+  const byId = useMemo(
+    () => new Map(declared.map(widget => [widget.id, widget])),
+    [declared]
+  );
+
+  const layout = useDashboardLayout();
+
+  // What an added card inherits. Read from the declaration rather than
+  // defaulted here, so a card the reader adds is the size its author intended.
+  const geometryFor = useCallback(
+    (widgetId: string) => {
+      const declaration = byId.get(widgetId);
+      if (!declaration) return undefined;
+      // `size` on a resolved declaration IS its declared default — the admin's
+      // resolver has already applied it. Reading it here rather than defaulting
+      // means a card the reader adds arrives the size its author intended.
+      return { size: declaration.size };
+    },
+    [byId]
+  );
+
+  const editor = useLayoutEditor(layout, geometryFor);
+
+  // The cards to draw, in the arrangement's order.
+  //
+  // A placement whose declaration this admin cannot resolve is SKIPPED rather
+  // than drawn as an empty cell: the server filtered by permission and by the
+  // registry, but a plugin's client bundle can still be absent, and a titled
+  // card with nothing under it reads as a product bug rather than as a missing
+  // plugin. While editing, hidden cards are drawn too — greyed — because a
+  // reader cannot bring back something they cannot see.
+  // 🔴 Whether an arrangement has been READ, which is not the same as whether
+  // it holds anything. Absent means the request is still in flight or it
+  // failed; empty means this reader has arranged their dashboard down to
+  // nothing. Folding the two together blanks the entire dashboard for the
+  // duration of every page load and for the whole of any outage — the grid
+  // drew from branding alone before this, and a personalization feature must
+  // not be able to take the page down when its own endpoint is unavailable.
+  const hasArrangement = layout.layout !== undefined;
+
+  const visible = useMemo(() => {
+    // No arrangement yet: draw the declarations in their declared order, which
+    // is exactly what this dashboard did before it could be arranged at all.
+    if (!hasArrangement) {
+      return declared.map(widget => ({
+        placementId: widget.id,
+        widget,
+        hidden: false,
+      }));
+    }
+    const rows: Array<{
+      placementId: string;
+      widget: DashboardWidget;
+      hidden: boolean;
+    }> = [];
+    for (const placement of editor.placements) {
+      const widget = byId.get(placement.widgetId);
+      if (!widget) continue;
+      if (placement.hidden && !editor.isEditing) continue;
+      rows.push({
+        placementId: placement.id,
+        widget,
+        hidden: placement.hidden,
+      });
+    }
+    return rows;
+  }, [hasArrangement, declared, editor.placements, editor.isEditing, byId]);
+
+  const widgets = useMemo(() => visible.map(row => row.widget), [visible]);
 
   // Every widget that DECLARED a query, archetype notwithstanding. `custom` is
   // included on purpose: core's widget validator puts it in neither the data
@@ -217,6 +299,33 @@ export function WidgetGrid() {
   const settling = counted.some(outcome => outcome.state === "loading");
 
   const [announcement, setAnnouncement] = useState("");
+
+  // A reorder speaks through the grid's ONE region, not a second one.
+  //
+  // The reason is the reason that region exists: several announcers on one
+  // surface interrupt each other, and a reader cannot tell which announcement
+  // belonged to what they just did. That argument does not weaken because the
+  // second announcer is the grid itself rather than a card.
+  //
+  // Nothing is clobbered by sharing it. The batch effect below fires only when
+  // its OWN sentence changes, and a move does not change it — so a move
+  // message survives until the batch has something new to say, which is
+  // precisely when it should stop being the latest news.
+  const announceMove = useCallback(
+    (title: string, position: number, count: number) => {
+      // The zero-width space alternates the string, because a live region does
+      // not re-announce text that did not change -- and moving a card up twice
+      // produces the same sentence both times. Same device as the builder's
+      // `keyboard-actions`, which is where this grid's convention comes from.
+      setAnnouncement(
+        current =>
+          `${title} moved to position ${position} of ${count}.${
+            current.endsWith("\u200b") ? "" : "\u200b"
+          }`
+      );
+    },
+    []
+  );
   // What was last spoken, so an unchanged outcome does not re-fire. A ref
   // rather than state because it must not itself cause a render.
   const spoken = useRef("");
@@ -243,64 +352,154 @@ export function WidgetGrid() {
   }
 
   return (
-    <section aria-label="Dashboard widgets" className="grid grid-cols-12 gap-6">
-      <span
-        role="status"
-        aria-live="polite"
-        className="sr-only"
-        data-testid="widget-grid-live"
-      >
-        {announcement}
-      </span>
-      {widgets.map(widget => (
+    <div className="space-y-4">
+      {hasArrangement ? (
+        <DashboardEditBar
+          isEditing={editor.isEditing}
+          hasUnsavedChanges={editor.hasUnsavedChanges}
+          isSaving={editor.isSaving}
+          canReset={layout.layout?.source === "own"}
+          onBegin={editor.begin}
+          onSave={editor.save}
+          onCancel={editor.cancel}
+          onReset={editor.reset}
+        />
+      ) : null}
+
+      {editor.isConflict ? (
+        // Both guards refuse the same way and the remedy is the same, so this
+        // is one message rather than two. It does NOT clear the draft: the
+        // reader's work stays on screen while they decide, because discarding
+        // it at the moment they are told to try again is the worst possible
+        // time to throw it away.
         <div
-          key={widget.id}
-          data-testid={`widget-cell-${widget.id}`}
-          // `empty:hidden` so a widget that drew NOTHING costs no row. A framed
-          // widget always renders its card, so this can never hide one; it
-          // reaches only an unframed widget whose component returned null --
-          // which core's conditional sections do, and did before they were
-          // widgets. Without it each becomes a blank cell with a `gap-6` on
-          // either side, which is the empty-slot bug rather than the hiding
-          // those components have always performed.
-          //
-          // CSS rather than asking the component to declare its own emptiness:
-          // a declaration is a second statement of what the render already
-          // decided, and the two drift.
-          className={cn(
-            widgetSpanClass(widget.size),
-            "empty:hidden",
-            // An unframed widget is a SECTION, and sections on this page have
-            // always been 48px apart -- the `space-y-12` the dashboard used
-            // before these became widgets. The grid's own `gap-6` is a card
-            // rhythm and right for cards, so the difference belongs to the
-            // widgets that are not cards: 24px of trailing margin plus the
-            // 24px row gap puts two adjacent sections back at 48px.
-            //
-            // BOTTOM only. A symmetric `my-3` also pushed the FIRST row down,
-            // and the page's outer `space-y-12` already places the grid 48px
-            // below the welcome header -- so every dashboard gained 12px there
-            // while the inter-section gaps looked correct. Measuring the gaps
-            // alone could not see it; only the header-to-first-section distance
-            // could.
-            //
-            // Margins, not padding: a hidden cell contributes neither, but
-            // padding would also inset a body that draws its own background.
-            widget.chrome === "none" && "mb-6"
-          )}
+          role="alert"
+          className="rounded-md border border-border bg-muted/50 px-3 py-2 text-sm"
+          data-testid="dashboard-edit-conflict"
         >
-          <WidgetRenderer
-            definition={widget}
-            slot={slots[widget.id]}
-            updatedAt={requested.has(widget.id) ? updatedAt : null}
-            // Only a widget that actually ASKED can be waiting on an answer. A
-            // card drawn entirely by a plugin component took no part in the
-            // batch, and neither did one whose archetype nothing can draw, so a
-            // refetch says nothing about either.
-            isFetching={requested.has(widget.id) ? isFetching : false}
-          />
+          Your dashboard changed somewhere else while you were editing. Reload
+          to pick up the current arrangement — your unsaved changes here will be
+          lost.{" "}
+          <button
+            type="button"
+            className="underline underline-offset-2"
+            onClick={() => void layout.reload()}
+            data-testid="dashboard-edit-reload"
+          >
+            Reload
+          </button>
         </div>
-      ))}
-    </section>
+      ) : null}
+
+      <section
+        aria-label="Dashboard widgets"
+        className="grid grid-cols-12 gap-6"
+      >
+        <span
+          role="status"
+          aria-live="polite"
+          className="sr-only"
+          data-testid="widget-grid-live"
+        >
+          {announcement}
+        </span>
+        {visible.map((row, index) => {
+          const widget = row.widget;
+          const { canMoveUp, canMoveDown } = moveAffordance(
+            index,
+            visible.length
+          );
+          return (
+            <div
+              key={row.placementId}
+              data-testid={`widget-cell-${widget.id}`}
+              // `empty:hidden` so a widget that drew NOTHING costs no row. A framed
+              // widget always renders its card, so this can never hide one; it
+              // reaches only an unframed widget whose component returned null --
+              // which core's conditional sections do, and did before they were
+              // widgets. Without it each becomes a blank cell with a `gap-6` on
+              // either side, which is the empty-slot bug rather than the hiding
+              // those components have always performed.
+              //
+              // CSS rather than asking the component to declare its own emptiness:
+              // a declaration is a second statement of what the render already
+              // decided, and the two drift.
+              className={cn(
+                widgetSpanClass(widget.size),
+                "empty:hidden",
+                // An unframed widget is a SECTION, and sections on this page have
+                // always been 48px apart -- the `space-y-12` the dashboard used
+                // before these became widgets. The grid's own `gap-6` is a card
+                // rhythm and right for cards, so the difference belongs to the
+                // widgets that are not cards: 24px of trailing margin plus the
+                // 24px row gap puts two adjacent sections back at 48px.
+                //
+                // BOTTOM only. A symmetric `my-3` also pushed the FIRST row down,
+                // and the page's outer `space-y-12` already places the grid 48px
+                // below the welcome header -- so every dashboard gained 12px there
+                // while the inter-section gaps looked correct. Measuring the gaps
+                // alone could not see it; only the header-to-first-section distance
+                // could.
+                //
+                // Margins, not padding: a hidden cell contributes neither, but
+                // padding would also inset a body that draws its own background.
+                widget.chrome === "none" && "mb-6",
+                // A hidden card is drawn while editing so it can be brought
+                // back, and dimmed so it is not mistaken for a live one. The
+                // dimming is presentational only: the controls above it stay at
+                // full contrast, because they are what the reader needs to act
+                // on and a faded button is a button people cannot read.
+                row.hidden && "opacity-50"
+              )}
+            >
+              {editor.isEditing ? (
+                <WidgetEditControls
+                  title={widget.title}
+                  position={index + 1}
+                  count={visible.length}
+                  hidden={row.hidden}
+                  canMoveUp={canMoveUp}
+                  canMoveDown={canMoveDown}
+                  onMoveUp={() => {
+                    editor.moveBy(index, -1);
+                    announceMove(widget.title, index + 1 - 1, visible.length);
+                  }}
+                  onMoveDown={() => {
+                    editor.moveBy(index, 1);
+                    announceMove(widget.title, index + 1 + 1, visible.length);
+                  }}
+                  onToggleHidden={() => editor.toggleHidden(row.placementId)}
+                  onRemove={() => editor.remove(row.placementId)}
+                />
+              ) : null}
+              <WidgetRenderer
+                definition={widget}
+                slot={slots[widget.id]}
+                updatedAt={requested.has(widget.id) ? updatedAt : null}
+                // Only a widget that actually ASKED can be waiting on an answer.
+                // A card drawn entirely by a plugin component took no part in
+                // the batch, and neither did one whose archetype nothing can
+                // draw, so a refetch says nothing about either.
+                isFetching={requested.has(widget.id) ? isFetching : false}
+              />
+            </div>
+          );
+        })}
+      </section>
+
+      {editor.isEditing ? (
+        <AddWidgetPicker
+          options={editor.available.map(widgetId => ({
+            widgetId,
+            // The declaration's own title where the admin can resolve it. The
+            // id is a poor label and it is TRUE, which an invented one would
+            // not be — a widget whose client bundle is absent still has to be
+            // addable by name.
+            title: byId.get(widgetId)?.title ?? widgetId,
+          }))}
+          onAdd={editor.add}
+        />
+      ) : null}
+    </div>
   );
 }

--- a/packages/admin/src/components/features/widgets/WidgetGrid.tsx
+++ b/packages/admin/src/components/features/widgets/WidgetGrid.tsx
@@ -105,6 +105,38 @@ function NothingToDraw({
   return null;
 }
 
+/**
+ * What the grid shows when the arrangement has emptied it out.
+ *
+ * A different question from {@link NothingToDraw}, which is about a dashboard
+ * that has no widgets to offer at all. This one is about a reader who HAS
+ * widgets and has put every one of them away -- so it says which way is back
+ * rather than what went wrong.
+ *
+ * Its own component, and it decides for itself whether to draw, so the grid
+ * body carries neither branch. Rendered inside the widgets section, so the
+ * landmark and the live region stay where a reader left them.
+ */
+function EmptyArrangement({
+  count,
+  isEditing,
+}: {
+  count: number;
+  isEditing: boolean;
+}) {
+  if (count > 0) return null;
+  return (
+    <p
+      data-testid="widget-grid-empty"
+      className="col-span-12 rounded-lg border border-dashed border-border px-4 py-10 text-center text-sm text-muted-foreground"
+    >
+      {isEditing
+        ? "Every card is put away. Add one back below, or reset to the default arrangement."
+        : "Your dashboard has no cards on it. Edit it to bring one back, or reset to the default arrangement."}
+    </p>
+  );
+}
+
 export function WidgetGrid() {
   const branding = useBranding();
   const { isPending, isUnavailable } = useBrandingStatus();
@@ -165,7 +197,7 @@ export function WidgetGrid() {
   );
   announcer.current = announceSettledMove;
 
-  // Nothing to draw. Returned after the hooks above so the hook order is the
+  // Nothing DECLARED. Returned after the hooks above so the hook order is the
   // same on every render, whatever the branding says.
   // THREE outcomes, not two. Every card on the dashboard now arrives through
   // the workspace query, so an empty list is no longer proof that there is
@@ -173,7 +205,15 @@ export function WidgetGrid() {
   // of one that never answered. Collapsing all three into `return null` blanked
   // the entire page on first paint and on any transient failure, where the
   // sections used to mount immediately and draw their own states.
-  if (widgets.length === 0) {
+  //
+  // 🔴 Asked of the DECLARATIONS, not of the arranged rows. `visible` is empty
+  // in a fourth case that is none of these three: a reader who has put every
+  // card away, or removed every card and saved. Returning here for that unmounted
+  // the edit bar, the Reset control and the add picker along with the grid --
+  // the whole page blank, with no way back to the one control that could undo
+  // it. An arrangement must never be able to reach a state it cannot leave, so
+  // the recovery chrome outlives the rows and the empty grid says so in place.
+  if (declared.length === 0) {
     return (
       <NothingToDraw isPending={isPending} isUnavailable={isUnavailable} />
     );
@@ -194,7 +234,6 @@ export function WidgetGrid() {
         // reader had no way out and every read went on logging the same decode
         // failure. The version is what says a row is there.
         canReset={(layout.layout?.version ?? 0) > 0}
-        onReload={() => void layout.reload()}
       />
 
       <DndContext
@@ -223,6 +262,10 @@ export function WidgetGrid() {
             >
               {announcement}
             </span>
+            <EmptyArrangement
+              count={visible.length}
+              isEditing={editor.isEditing}
+            />
             {visible.map((row, index) => (
               <ArrangedCell
                 key={row.placementId}

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -109,6 +109,28 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+/**
+ * Live regions the GRID owns, excluding the one dnd-kit contributes.
+ *
+ * dnd-kit's `DndContext` renders exactly one hidden `role="status"` region of
+ * its own, and it is not optional: it is what narrates pick up, move over, drop
+ * and cancel to a screen reader, which is the whole reason a drag is usable
+ * without sight. Counting it would make "the grid announces once" and
+ * "the drag announces at all" mutually exclusive.
+ *
+ * Excluded BY ITS OWN ID rather than by loosening the count to two. A bare
+ * `toHaveLength(2)` would keep passing if the grid grew a second announcer of
+ * its own and dnd-kit's disappeared, which is the pair of mistakes this
+ * invariant exists to catch.
+ */
+function gridLiveRegions(container: HTMLElement): Element[] {
+  return [
+    ...container.querySelectorAll(
+      '[aria-live], [role="status"], [role="alert"]'
+    ),
+  ].filter(node => !node.id.startsWith("DndLiveRegion"));
+}
+
 describe("WidgetGrid — collection and gating", () => {
   it("renders nothing when no plugin contributes a widget", () => {
     mockBranding = {
@@ -1054,9 +1076,7 @@ describe("WidgetGrid — accessibility", () => {
     await waitFor(() =>
       expect(screen.getAllByTestId("widget-card-error")).toHaveLength(3)
     );
-    expect(
-      container.querySelectorAll('[aria-live], [role="status"], [role="alert"]')
-    ).toHaveLength(1);
+    expect(gridLiveRegions(container)).toHaveLength(1);
   });
 
   it("counts a card that cannot RENDER as failed, not as updated", async () => {
@@ -1137,7 +1157,7 @@ describe("WidgetGrid — accessibility", () => {
     await waitFor(() =>
       expect(screen.getByTestId("widget-cell-posts")).toHaveTextContent("1")
     );
-    expect(container.querySelectorAll("[aria-live]")).toHaveLength(1);
+    expect(gridLiveRegions(container)).toHaveLength(1);
   });
 
   it("announces once for the batch, not once per widget", async () => {

--- a/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
+++ b/packages/admin/src/components/features/widgets/__tests__/WidgetGrid.test.tsx
@@ -123,6 +123,33 @@ afterEach(() => {
  * its own and dnd-kit's disappeared, which is the pair of mistakes this
  * invariant exists to catch.
  */
+/**
+ * A `POST /dashboard/query` mock that answers the query it was ASKED.
+ *
+ * Positional fixtures — an array of results lined up with the widgets as
+ * declared — encode the batch's ORDER into every test that uses one. The batch
+ * is built in a stable identity order rather than in display order, so that
+ * moving a card cannot change the query key and re-issue every request; the
+ * order is therefore an implementation detail, and a fixture that depends on it
+ * fails for a reason that has nothing to do with what it is testing.
+ *
+ * Keyed by source, so each widget gets its own number however the batch is
+ * arranged. A source the caller did not name comes back as a failed slot rather
+ * than as a silent zero, so a test that mis-names one is told.
+ */
+function mockCountsBySource(counts: Record<string, number>): void {
+  vi.mocked(protectedApi.post).mockImplementation(async (_path, body) => {
+    const queries = (body as { queries: Array<{ source: string }> }).queries;
+    return {
+      results: queries.map(query =>
+        query.source in counts
+          ? { ok: true, result: { op: "count", total: counts[query.source] } }
+          : { ok: false, error: `no fixture for ${query.source}` }
+      ),
+    };
+  });
+}
+
 function gridLiveRegions(container: HTMLElement): Element[] {
   return [
     ...container.querySelectorAll(
@@ -632,21 +659,30 @@ describe("WidgetGrid — collection and gating", () => {
         },
       ],
     } as unknown as AdminBranding;
-    vi.mocked(protectedApi.post).mockResolvedValue({
-      results: [
-        { ok: true, result: { op: "count", total: 1 } },
-        { ok: true, result: { op: "count", total: 2 } },
-      ],
+    mockCountsBySource({
+      "collection:posts": 1,
+      "collection:pages": 2,
     });
 
     renderGrid();
     await waitFor(() => expect(protectedApi.post).toHaveBeenCalledTimes(1));
-    expect(vi.mocked(protectedApi.post).mock.calls[0][1]).toEqual({
-      queries: [
+    // The SET, not the sequence. The batch is built in a stable identity order
+    // rather than in display order, so that moving a card cannot change the
+    // query key and re-issue every request -- which makes the sequence an
+    // implementation detail. What this test is about is that both channels land
+    // in ONE request, and that survives whatever order they are sent in.
+    const sent = (
+      vi.mocked(protectedApi.post).mock.calls[0][1] as {
+        queries: Array<{ source: string; op: string }>;
+      }
+    ).queries;
+    expect(sent).toHaveLength(2);
+    expect(sent).toEqual(
+      expect.arrayContaining([
         { source: "collection:posts", op: "count" },
         { source: "collection:orders", op: "count" },
-      ],
-    });
+      ])
+    );
   });
 
   it("gates a registered widget on its permission like any other", () => {
@@ -821,11 +857,9 @@ describe("WidgetGrid — batching", () => {
         query: { source: "collection:pages", op: "count" },
       },
     ]);
-    vi.mocked(protectedApi.post).mockResolvedValue({
-      results: [
-        { ok: true, result: { op: "count", total: 12 } },
-        { ok: true, result: { op: "count", total: 34 } },
-      ],
+    mockCountsBySource({
+      "collection:posts": 12,
+      "collection:pages": 34,
     });
 
     renderGrid();
@@ -1121,14 +1155,23 @@ describe("WidgetGrid — accessibility", () => {
         /1 of 3 widgets updated, 2 failed/i
       )
     );
-    // Two queries for three widgets, and the positional keying still lands each
-    // result on the widget that asked for it.
-    expect(vi.mocked(protectedApi.post).mock.calls[0][1]).toEqual({
-      queries: [
+    // Two queries for three widgets -- the undrawable one is never asked -- and
+    // the keying still lands each result on the widget that asked for it. The
+    // SET rather than the sequence: the batch is built in a stable identity
+    // order rather than in display order, so which of the two goes first is an
+    // implementation detail and not what this test is about.
+    const sent = (
+      vi.mocked(protectedApi.post).mock.calls[0][1] as {
+        queries: Array<{ source: string; op: string }>;
+      }
+    ).queries;
+    expect(sent).toHaveLength(2);
+    expect(sent).toEqual(
+      expect.arrayContaining([
         { source: "collection:posts", op: "count" },
         { source: "collection:pages", op: "count" },
-      ],
-    });
+      ])
+    );
   });
 
   it("has exactly ONE live region for the whole grid", async () => {
@@ -1146,11 +1189,9 @@ describe("WidgetGrid — accessibility", () => {
         query: { source: "collection:pages", op: "count" },
       },
     ]);
-    vi.mocked(protectedApi.post).mockResolvedValue({
-      results: [
-        { ok: true, result: { op: "count", total: 1 } },
-        { ok: true, result: { op: "count", total: 2 } },
-      ],
+    mockCountsBySource({
+      "collection:posts": 1,
+      "collection:pages": 2,
     });
 
     const { container } = renderGrid();
@@ -1175,11 +1216,9 @@ describe("WidgetGrid — accessibility", () => {
         query: { source: "collection:pages", op: "count" },
       },
     ]);
-    vi.mocked(protectedApi.post).mockResolvedValue({
-      results: [
-        { ok: true, result: { op: "count", total: 1 } },
-        { ok: true, result: { op: "count", total: 2 } },
-      ],
+    mockCountsBySource({
+      "collection:posts": 1,
+      "collection:pages": 2,
     });
 
     renderGrid();

--- a/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
+++ b/packages/admin/src/components/features/widgets/__tests__/layout-editor.test.ts
@@ -1,0 +1,194 @@
+/**
+ * The arrangement rules, at the edges a rendered grid makes hard to reach.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
+
+import {
+  addPlacement,
+  hasChanges,
+  moveAffordance,
+  movePlacement,
+  newPlacementId,
+  removePlacement,
+  renumber,
+  togglePlacementHidden,
+} from "../layout-editor";
+
+function placements(...ids: string[]): WidgetPlacement[] {
+  return ids.map((id, index) => ({
+    id,
+    widgetId: `core/${id}`,
+    order: index * 10,
+    hidden: false,
+  }));
+}
+
+describe("moving a card", () => {
+  it("moves it and shifts the rest", () => {
+    const moved = movePlacement(placements("a", "b", "c"), 0, 2);
+    expect(moved.map(p => p.id)).toEqual(["b", "c", "a"]);
+  });
+
+  it("returns a new array rather than mutating", () => {
+    const original = placements("a", "b");
+    const moved = movePlacement(original, 0, 1);
+    expect(original.map(p => p.id)).toEqual(["a", "b"]);
+    expect(moved).not.toBe(original);
+  });
+
+  it.each([
+    ["a drag that ended nowhere", 0, -1],
+    ["a move past the end", 0, 9],
+    ["a move from nowhere", 9, 0],
+    ["a move onto itself", 1, 1],
+  ])("leaves the order alone for %s", (_label, from, to) => {
+    // Each of these is an ordinary gesture — a drag released outside the list,
+    // a keyboard move at the last position — rather than an error. Throwing
+    // here would take the whole grid down over one of them.
+    const before = placements("a", "b", "c");
+    expect(movePlacement(before, from, to).map(p => p.id)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
+  });
+});
+
+describe("what a card can do", () => {
+  it.each([
+    [0, 3, false, true],
+    [1, 3, true, true],
+    [2, 3, true, false],
+    [0, 1, false, false],
+  ])(
+    "index %i of %i: up=%s down=%s",
+    (index, count, canMoveUp, canMoveDown) => {
+      expect(moveAffordance(index, count)).toEqual({ canMoveUp, canMoveDown });
+    }
+  );
+
+  it("offers nothing in an empty arrangement", () => {
+    expect(moveAffordance(0, 0)).toEqual({
+      canMoveUp: false,
+      canMoveDown: false,
+    });
+  });
+});
+
+describe("hiding and removing", () => {
+  it("hiding KEEPS the placement, so bringing it back restores its position", () => {
+    // The difference between hide and remove. A hidden card holds its slot and
+    // its config; a removed one is gone, and re-adding it appends to the end.
+    const hidden = togglePlacementHidden(placements("a", "b", "c"), "b");
+    expect(hidden.map(p => p.id)).toEqual(["a", "b", "c"]);
+    expect(hidden[1].hidden).toBe(true);
+    expect(togglePlacementHidden(hidden, "b")[1].hidden).toBe(false);
+  });
+
+  it("removing drops it", () => {
+    expect(removePlacement(placements("a", "b"), "a").map(p => p.id)).toEqual([
+      "b",
+    ]);
+  });
+
+  it("leaves a config intact while hidden", () => {
+    const withConfig: WidgetPlacement[] = [
+      {
+        id: "a",
+        widgetId: "core/a",
+        order: 0,
+        hidden: false,
+        config: { n: 1 },
+      },
+    ];
+    expect(togglePlacementHidden(withConfig, "a")[0].config).toEqual({ n: 1 });
+  });
+});
+
+describe("adding a widget", () => {
+  it("appends it, where the reader who just chose it will look", () => {
+    const added = addPlacement(placements("a", "b"), "core/new");
+    expect(added.map(p => p.widgetId)).toEqual([
+      "core/a",
+      "core/b",
+      "core/new",
+    ]);
+  });
+
+  it("takes the geometry its author declared", () => {
+    const [added] = addPlacement([], "core/new", {
+      size: "md",
+      height: "tall",
+    });
+    expect(added).toMatchObject({ size: "md", height: "tall" });
+  });
+
+  it("omits geometry the widget did not declare", () => {
+    const [added] = addPlacement([], "core/new", { size: "md" });
+    expect(added).not.toHaveProperty("height");
+  });
+
+  it("gives it an id that is not the widget id", () => {
+    // A placement id is opaque and independent, which is what lets the same
+    // widget appear twice with different config.
+    const [added] = addPlacement([], "core/new");
+    expect(added.id).not.toBe("core/new");
+    expect(added.id.length).toBeGreaterThan(8);
+  });
+
+  it("mints distinct ids", () => {
+    const ids = new Set(Array.from({ length: 200 }, () => newPlacementId()));
+    expect(ids.size).toBe(200);
+  });
+});
+
+describe("renumbering on the way out", () => {
+  it("renumbers from the array order, not from what a card carried in", () => {
+    // 🔴 The editor reorders an ARRAY, so a moved card still carries the
+    // `order` it had before. Sent as-is, the server sorts by a number that no
+    // longer matches what the reader sees, and their arrangement comes back
+    // rearranged.
+    const moved = movePlacement(placements("a", "b", "c"), 2, 0);
+    expect(moved.map(p => p.order)).toEqual([20, 0, 10]);
+    expect(renumber(moved).map(p => p.order)).toEqual([0, 10, 20]);
+    expect(renumber(moved).map(p => p.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("leaves gaps, so a later insertion renumbers nothing", () => {
+    const orders = renumber(placements("a", "b")).map(p => p.order);
+    expect(orders[1] - orders[0]).toBeGreaterThan(1);
+  });
+});
+
+describe("whether anything changed", () => {
+  it("says no for an untouched arrangement", () => {
+    const before = placements("a", "b");
+    expect(hasChanges(before, [...before])).toBe(false);
+  });
+
+  it("says no for a move that put the card back", () => {
+    // Compared on stored FIELDS, not references — every operation returns new
+    // objects, so a reference check would report a change here.
+    const before = placements("a", "b", "c");
+    const there = movePlacement(before, 0, 2);
+    expect(hasChanges(before, movePlacement(there, 2, 0))).toBe(false);
+  });
+
+  it.each([
+    ["a reorder", (p: WidgetPlacement[]) => movePlacement(p, 0, 1)],
+    ["a hide", (p: WidgetPlacement[]) => togglePlacementHidden(p, "a")],
+    ["a removal", (p: WidgetPlacement[]) => removePlacement(p, "a")],
+    ["an addition", (p: WidgetPlacement[]) => addPlacement(p, "core/new")],
+  ])("says yes after %s", (_label, edit) => {
+    const before = placements("a", "b");
+    expect(hasChanges(before, edit(before))).toBe(true);
+  });
+
+  it("notices a geometry change alone", () => {
+    const before = placements("a");
+    const resized = [{ ...before[0], size: "xl" }];
+    expect(hasChanges(before, resized)).toBe(true);
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/AddWidgetPicker.tsx
+++ b/packages/admin/src/components/features/widgets/edit/AddWidgetPicker.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+/**
+ * The widgets a reader may add, and the reason this exists at all.
+ *
+ * A newly installed plugin's card is never inserted into somebody's arrangement
+ * behind their back — that is a decision, and it matches every full-snapshot
+ * system in the prior art. But "not auto-added" only works if it is ADDABLE,
+ * and without a list naming the unplaced widgets the card was reachable from
+ * nothing: absent from every read, absent from the snapshot the next write
+ * persisted, with no way for the reader to learn it existed.
+ *
+ * The list is the server's `available`, narrowed by what the reader has added
+ * or removed since — never re-derived from the registry here, because the
+ * server is the only party that filters by permission authoritatively.
+ *
+ * @module components/features/widgets/edit/AddWidgetPicker
+ */
+
+import { Button } from "@nextlyhq/ui";
+
+import * as Icons from "@admin/components/icons";
+
+export interface AddWidgetOption {
+  widgetId: string;
+  title: string;
+  category?: string;
+}
+
+export interface AddWidgetPickerProps {
+  options: AddWidgetOption[];
+  onAdd: (widgetId: string) => void;
+}
+
+export function AddWidgetPicker({ options, onAdd }: AddWidgetPickerProps) {
+  if (options.length === 0) {
+    // Said rather than rendered blank. An empty picker and a picker that failed
+    // to load look identical, and "everything is already on your dashboard" is
+    // the reassuring one of the two — so it is the one that gets written down.
+    return (
+      <p
+        className="text-sm text-muted-foreground"
+        data-testid="add-widget-empty"
+      >
+        Every widget available to you is already on your dashboard.
+      </p>
+    );
+  }
+
+  return (
+    <section aria-label="Add a widget" data-testid="add-widget-picker">
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Add a widget
+      </h3>
+      <ul className="flex flex-wrap gap-2">
+        {options.map(option => (
+          <li key={option.widgetId}>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onAdd(option.widgetId)}
+              // The category rides in the accessible name rather than being
+              // rendered as a separate grouping. With a handful of widgets a
+              // grouped list is more chrome than help, and a reader who needs
+              // the distinction still hears it.
+              aria-label={
+                option.category
+                  ? `Add ${option.title} (${option.category})`
+                  : `Add ${option.title}`
+              }
+              data-testid={`add-widget-${option.widgetId}`}
+            >
+              <Icons.Plus aria-hidden className="mr-1.5 size-3.5" />
+              {option.title}
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
@@ -62,7 +62,14 @@ export function ArrangedCell({
         // `relative` so the drag handle, which is absolutely positioned, lands
         // on this cell rather than on the grid.
         "relative",
-        widgetSpanClass(widget.size),
+        // 🔴 The PLACEMENT's size wins over the declaration's. The stored size
+        // IS the reader's arrangement — the layout API preserves it precisely
+        // so a card they resized stays resized — and reading the declaration
+        // instead silently re-sized their dashboard whenever a plugin changed
+        // its `defaultSize`. `widgetSpanClass` already survives a value this
+        // admin does not recognise, which is what makes it safe to hand it one
+        // that came from storage rather than from this release's enum.
+        widgetSpanClass(row.size ?? widget.size),
         // `empty:hidden` so a widget that drew NOTHING costs no row. A framed
         // widget always renders its card, so this can never hide one; it
         // reaches only an unframed widget whose component returned null --
@@ -86,12 +93,7 @@ export function ArrangedCell({
         //
         // Margins, not padding: a hidden cell contributes neither, but padding
         // would also inset a body that draws its own background.
-        widget.chrome === "none" && "mb-6",
-        // A hidden card is drawn while editing so it can be brought back, and
-        // dimmed so it is not mistaken for a live one. Presentational only: the
-        // controls above it stay at full contrast, because they are what the
-        // reader acts on and a faded button is a button people cannot read.
-        row.hidden && "opacity-50"
+        widget.chrome === "none" && "mb-6"
       )}
     >
       {isEditing ? (
@@ -108,12 +110,20 @@ export function ArrangedCell({
           onRemove={() => onRemove(row.placementId)}
         />
       ) : null}
-      <WidgetRenderer
-        definition={widget}
-        slot={slot}
-        updatedAt={updatedAt}
-        isFetching={isFetching}
-      />
+      {/* The dimming wraps the BODY only. Applied to the cell it composited
+          every descendant — the controls, the drag handle, their labels and
+          their focus rings — so the buttons needed to bring a hidden card back
+          were themselves faded, which is the opposite of what the comment
+          beside it promised. A hidden card is dimmed so it is not mistaken for
+          a live one; the controls that act on it stay legible. */}
+      <div className={cn(row.hidden && "opacity-50")}>
+        <WidgetRenderer
+          definition={widget}
+          slot={slot}
+          updatedAt={updatedAt}
+          isFetching={isFetching}
+        />
+      </div>
     </SortableWidgetCell>
   );
 }

--- a/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/ArrangedCell.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * One cell of the grid: its width, its spacing, its edit controls and the
+ * widget inside it.
+ *
+ * Its own component because the grid was carrying every one of these decisions
+ * inline and the complexity gate objected before a reader would have. The split
+ * is by SUBJECT rather than by size: everything here is about one card, and
+ * everything left in the grid is about the set.
+ *
+ * @module components/features/widgets/edit/ArrangedCell
+ */
+
+import { cn } from "@admin/lib/utils";
+import type { WidgetSlot } from "@admin/types/dashboard/widgets";
+
+import { moveAffordance } from "../layout-editor";
+import { widgetSpanClass } from "../sizes";
+import { WidgetRenderer } from "../WidgetRenderer";
+
+import { SortableWidgetCell } from "./SortableWidgetCell";
+import type { ArrangedWidget } from "./useDashboardArrangement";
+import { WidgetEditControls } from "./WidgetEditControls";
+
+export interface ArrangedCellProps {
+  row: ArrangedWidget;
+  index: number;
+  count: number;
+  isEditing: boolean;
+  slot: WidgetSlot | undefined;
+  /** `null` when this card took no part in the batch. */
+  updatedAt: Date | null;
+  isFetching: boolean;
+  onMove: (index: number, delta: number) => void;
+  onToggleHidden: (placementId: string) => void;
+  onRemove: (placementId: string) => void;
+}
+
+export function ArrangedCell({
+  row,
+  index,
+  count,
+  isEditing,
+  slot,
+  updatedAt,
+  isFetching,
+  onMove,
+  onToggleHidden,
+  onRemove,
+}: ArrangedCellProps) {
+  const widget = row.widget;
+  const { canMoveUp, canMoveDown } = moveAffordance(index, count);
+
+  return (
+    <SortableWidgetCell
+      id={row.placementId}
+      title={widget.title}
+      isEditing={isEditing}
+      data-testid={`widget-cell-${widget.id}`}
+      className={cn(
+        // `relative` so the drag handle, which is absolutely positioned, lands
+        // on this cell rather than on the grid.
+        "relative",
+        widgetSpanClass(widget.size),
+        // `empty:hidden` so a widget that drew NOTHING costs no row. A framed
+        // widget always renders its card, so this can never hide one; it
+        // reaches only an unframed widget whose component returned null --
+        // which core's conditional sections do, and did before they were
+        // widgets. Without it each becomes a blank cell with a `gap-6` on
+        // either side, which is the empty-slot bug rather than the hiding those
+        // components have always performed.
+        "empty:hidden",
+        // An unframed widget is a SECTION, and sections on this page have
+        // always been 48px apart -- the `space-y-12` the dashboard used before
+        // these became widgets. The grid's own `gap-6` is a card rhythm and
+        // right for cards, so the difference belongs to the widgets that are
+        // not cards: 24px of trailing margin plus the 24px row gap puts two
+        // adjacent sections back at 48px.
+        //
+        // BOTTOM only. A symmetric `my-3` also pushed the FIRST row down, and
+        // the page's outer `space-y-12` already places the grid 48px below the
+        // welcome header -- so every dashboard gained 12px there while the
+        // inter-section gaps looked correct. Measuring the gaps alone could not
+        // see it; only the header-to-first-section distance could.
+        //
+        // Margins, not padding: a hidden cell contributes neither, but padding
+        // would also inset a body that draws its own background.
+        widget.chrome === "none" && "mb-6",
+        // A hidden card is drawn while editing so it can be brought back, and
+        // dimmed so it is not mistaken for a live one. Presentational only: the
+        // controls above it stay at full contrast, because they are what the
+        // reader acts on and a faded button is a button people cannot read.
+        row.hidden && "opacity-50"
+      )}
+    >
+      {isEditing ? (
+        <WidgetEditControls
+          title={widget.title}
+          position={index + 1}
+          count={count}
+          hidden={row.hidden}
+          canMoveUp={canMoveUp}
+          canMoveDown={canMoveDown}
+          onMoveUp={() => onMove(index, -1)}
+          onMoveDown={() => onMove(index, 1)}
+          onToggleHidden={() => onToggleHidden(row.placementId)}
+          onRemove={() => onRemove(row.placementId)}
+        />
+      ) : null}
+      <WidgetRenderer
+        definition={widget}
+        slot={slot}
+        updatedAt={updatedAt}
+        isFetching={isFetching}
+      />
+    </SortableWidgetCell>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditBar.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+/**
+ * The dashboard's edit controls: enter, commit, abandon, reset.
+ *
+ * One bar rather than controls scattered across the cards, because entering and
+ * leaving edit mode is a decision about the WHOLE arrangement — and because a
+ * reader needs one place to look for "how do I get out of this".
+ *
+ * @module components/features/widgets/edit/DashboardEditBar
+ */
+
+import { Button } from "@nextlyhq/ui";
+
+import * as Icons from "@admin/components/icons";
+
+export interface DashboardEditBarProps {
+  isEditing: boolean;
+  hasUnsavedChanges: boolean;
+  isSaving: boolean;
+  /** Whether the reader has an arrangement of their own to reset. */
+  canReset: boolean;
+  onBegin: () => void;
+  onSave: () => void;
+  onCancel: () => void;
+  onReset: () => void;
+}
+
+export function DashboardEditBar({
+  isEditing,
+  hasUnsavedChanges,
+  isSaving,
+  canReset,
+  onBegin,
+  onSave,
+  onCancel,
+  onReset,
+}: DashboardEditBarProps) {
+  if (!isEditing) {
+    return (
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onBegin}
+          data-testid="dashboard-edit-begin"
+        >
+          <Icons.Pencil aria-hidden className="mr-2 size-4" />
+          Edit dashboard
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      {/* Reset sits apart from Save/Cancel and reads as the destructive one,
+          because it discards an arrangement rather than an edit. Offered only
+          when there IS one: a reader already on the default has nothing to
+          reset, and a button that does nothing is worse than no button. */}
+      {canReset ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={onReset}
+          disabled={isSaving}
+          className="mr-auto text-muted-foreground"
+          data-testid="dashboard-edit-reset"
+        >
+          Reset to default
+        </Button>
+      ) : null}
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="sm"
+        onClick={onCancel}
+        disabled={isSaving}
+        data-testid="dashboard-edit-cancel"
+      >
+        Cancel
+      </Button>
+      <Button
+        type="button"
+        size="sm"
+        onClick={onSave}
+        // Disabled with nothing to save, so pressing it cannot spend a write —
+        // and a write is not free here: it is guarded, so a pointless one can
+        // still come back a conflict and send the reader to reload for nothing.
+        disabled={isSaving || !hasUnsavedChanges}
+        data-testid="dashboard-edit-save"
+      >
+        {isSaving ? "Saving…" : "Save"}
+      </Button>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
@@ -26,7 +26,6 @@ export interface DashboardEditChromeProps {
   hasArrangement: boolean;
   /** Whether this reader has an arrangement of their own to reset. */
   canReset: boolean;
-  onReload: () => void;
 }
 
 export function DashboardEditChrome({
@@ -34,7 +33,6 @@ export function DashboardEditChrome({
   writeError,
   hasArrangement,
   canReset,
-  onReload,
 }: DashboardEditChromeProps) {
   return (
     <>
@@ -57,6 +55,12 @@ export function DashboardEditChrome({
         // reader's work stays on screen while they decide, because discarding
         // it at the moment they are told to try again is the worst possible
         // time to throw it away.
+        //
+        // Reload is the editor's OWN recovery rather than a callback passed
+        // from the grid. The draft, the failed mutation and the query are three
+        // pieces of one state, and only the editor holds all three -- a caller
+        // that could reach the query alone refetched an arrangement this
+        // component then declined to draw, under an alert that never went away.
         <div
           role="alert"
           className="rounded-md border border-border bg-muted/50 px-3 py-2 text-sm"
@@ -68,7 +72,7 @@ export function DashboardEditChrome({
           <button
             type="button"
             className="underline underline-offset-2"
-            onClick={onReload}
+            onClick={editor.reload}
             data-testid="dashboard-edit-reload"
           >
             Reload

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
@@ -17,6 +17,8 @@ import type { LayoutEditor } from "./useLayoutEditor";
 
 export interface DashboardEditChromeProps {
   editor: LayoutEditor;
+  /** A write that failed for a reason other than losing a race. */
+  writeError: Error | null;
   /**
    * Whether an arrangement has been read. Editing is offered only then: a write
    * echoes a version and a scope token, and neither exists until a read lands.
@@ -29,6 +31,7 @@ export interface DashboardEditChromeProps {
 
 export function DashboardEditChrome({
   editor,
+  writeError,
   hasArrangement,
   canReset,
   onReload,
@@ -70,6 +73,23 @@ export function DashboardEditChrome({
           >
             Reload
           </button>
+        </div>
+      ) : null}
+
+      {writeError && !editor.isConflict ? (
+        // Reported because it previously was not. Only conflicts were rendered,
+        // so a save that failed on a network error, a 500 or an authorization
+        // change left the reader in edit mode with the spinner stopped and
+        // nothing said — believing their arrangement had been stored. The
+        // remedy differs from a conflict's too: this one is retried, not
+        // reloaded, so the arrangement stays exactly where it is.
+        <div
+          role="alert"
+          className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm"
+          data-testid="dashboard-edit-error"
+        >
+          Your dashboard could not be saved. Your changes are still here — try
+          again in a moment.
         </div>
       ) : null}
     </>

--- a/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
+++ b/packages/admin/src/components/features/widgets/edit/DashboardEditChrome.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * Everything that surrounds the grid while a reader is arranging it: the edit
+ * controls, and the one message a conflict produces.
+ *
+ * Together because they are one subject — the state of the EDIT, rather than of
+ * any card — and because keeping them in the grid put two more conditional
+ * branches and two more levels of JSX into a component the complexity gate was
+ * already objecting to.
+ *
+ * @module components/features/widgets/edit/DashboardEditChrome
+ */
+
+import { DashboardEditBar } from "./DashboardEditBar";
+import type { LayoutEditor } from "./useLayoutEditor";
+
+export interface DashboardEditChromeProps {
+  editor: LayoutEditor;
+  /**
+   * Whether an arrangement has been read. Editing is offered only then: a write
+   * echoes a version and a scope token, and neither exists until a read lands.
+   */
+  hasArrangement: boolean;
+  /** Whether this reader has an arrangement of their own to reset. */
+  canReset: boolean;
+  onReload: () => void;
+}
+
+export function DashboardEditChrome({
+  editor,
+  hasArrangement,
+  canReset,
+  onReload,
+}: DashboardEditChromeProps) {
+  return (
+    <>
+      {hasArrangement ? (
+        <DashboardEditBar
+          isEditing={editor.isEditing}
+          hasUnsavedChanges={editor.hasUnsavedChanges}
+          isSaving={editor.isSaving}
+          canReset={canReset}
+          onBegin={editor.begin}
+          onSave={editor.save}
+          onCancel={editor.cancel}
+          onReset={editor.reset}
+        />
+      ) : null}
+
+      {editor.isConflict ? (
+        // Both guards refuse the same way and the remedy is the same, so this
+        // is one message rather than two. It does NOT clear the draft: the
+        // reader's work stays on screen while they decide, because discarding
+        // it at the moment they are told to try again is the worst possible
+        // time to throw it away.
+        <div
+          role="alert"
+          className="rounded-md border border-border bg-muted/50 px-3 py-2 text-sm"
+          data-testid="dashboard-edit-conflict"
+        >
+          Your dashboard changed somewhere else while you were editing. Reload
+          to pick up the current arrangement — your unsaved changes here will be
+          lost.{" "}
+          <button
+            type="button"
+            className="underline underline-offset-2"
+            onClick={onReload}
+            data-testid="dashboard-edit-reload"
+          >
+            Reload
+          </button>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/SortableWidgetCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/SortableWidgetCell.tsx
@@ -79,7 +79,13 @@ export function SortableWidgetCell({
           {...listeners}
           // `cursor-grab`, not `cursor-move`: this reorders within a list, it
           // does not move the card to an arbitrary point.
-          className="absolute right-1 top-1 z-10 cursor-grab rounded p-1 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+          // 🔴 LEFT, not right. On the right it overlapped `WidgetEditControls`'
+          // Remove button — same corner, higher `z-index` — so the handle
+          // swallowed pointer input across most of a control the feature
+          // promises is ordinarily clickable. The toolbar's own content starts
+          // with a title that has room to spare, so the handle sits before it
+          // and the buttons keep the right edge to themselves.
+          className="absolute left-1 top-1 z-10 cursor-grab rounded p-1 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
           // Names the card, because a grid of identical handles is unusable
           // otherwise. dnd-kit supplies its own keyboard instructions through
           // `attributes`; this is the label they attach to.

--- a/packages/admin/src/components/features/widgets/edit/SortableWidgetCell.tsx
+++ b/packages/admin/src/components/features/widgets/edit/SortableWidgetCell.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+/**
+ * One grid cell, draggable while the reader is editing.
+ *
+ * A component rather than a branch inside the grid's map, because `useSortable`
+ * is a hook and a hook cannot be called from a loop body. That constraint is
+ * also the right shape: the cell owns its own drag state, and the grid stays a
+ * list of cells.
+ *
+ * ## Drag is the SECOND way to move a card, never the only one
+ *
+ * The Move up / Move down buttons in `WidgetEditControls` are what satisfy
+ * WCAG 2.2 SC 2.5.7, which requires a single-pointer alternative to every
+ * dragging movement. This handle is the affordance most people reach for
+ * first; it is not the one that makes the feature usable. If the two ever
+ * disagree, the buttons are correct.
+ *
+ * The handle carries the drag listeners rather than the whole cell, so a reader
+ * can still select text in a card, click a link inside it, and press the
+ * controls above it while editing.
+ *
+ * @module components/features/widgets/edit/SortableWidgetCell
+ */
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { ReactNode } from "react";
+
+import * as Icons from "@admin/components/icons";
+import { cn } from "@admin/lib/utils";
+
+export interface SortableWidgetCellProps {
+  id: string;
+  /** What the reader calls this card, so the handle can name what it moves. */
+  title: string;
+  isEditing: boolean;
+  className?: string;
+  "data-testid"?: string;
+  children: ReactNode;
+}
+
+export function SortableWidgetCell({
+  id,
+  title,
+  isEditing,
+  className,
+  "data-testid": testId,
+  children,
+}: SortableWidgetCellProps) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id, disabled: !isEditing });
+
+  return (
+    <div
+      ref={setNodeRef}
+      data-testid={testId}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={cn(
+        className,
+        // Lifted while dragging so it reads as picked up rather than as a hole
+        // in the grid. `relative` because a transformed cell with no stacking
+        // context slides UNDER its neighbours.
+        isDragging && "relative z-10 opacity-80"
+      )}
+    >
+      {isEditing ? (
+        <button
+          type="button"
+          ref={setActivatorNodeRef}
+          {...attributes}
+          {...listeners}
+          // `cursor-grab`, not `cursor-move`: this reorders within a list, it
+          // does not move the card to an arbitrary point.
+          className="absolute right-1 top-1 z-10 cursor-grab rounded p-1 text-muted-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring active:cursor-grabbing"
+          // Names the card, because a grid of identical handles is unusable
+          // otherwise. dnd-kit supplies its own keyboard instructions through
+          // `attributes`; this is the label they attach to.
+          aria-label={`Drag to reorder ${title}`}
+          data-testid="widget-drag-handle"
+        >
+          <Icons.GripVertical aria-hidden className="size-4" />
+        </button>
+      ) : null}
+      {children}
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
@@ -61,7 +61,10 @@ export function WidgetEditControls({
 }: WidgetEditControlsProps) {
   return (
     <div
-      className="flex items-center gap-1 border-b border-border bg-muted/40 px-2 py-1"
+      // `pl-9` reserves the drag handle's column. The handle is absolutely
+      // positioned over this toolbar, so without reserved space it sits ON the
+      // first thing here rather than beside it.
+      className="flex items-center gap-1 border-b border-border bg-muted/40 py-1 pl-9 pr-2"
       data-testid="widget-edit-controls"
     >
       {/* The name first, so a reader tabbing through a dozen identical control

--- a/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
+++ b/packages/admin/src/components/features/widgets/edit/WidgetEditControls.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+/**
+ * What a reader can do to one card while editing: move it, put it away, or
+ * take it off.
+ *
+ * ## The buttons are not a convenience
+ *
+ * 🔴 WCAG 2.2 SC 2.5.7 (Dragging Movements, AA) requires that anything achieved
+ * by dragging can also be achieved with a SINGLE POINTER — a click or a tap. A
+ * keyboard alternative does not satisfy it; that is 2.1.1, a different
+ * criterion, and the Understanding document says so in as many words. dnd-kit's
+ * `KeyboardSensor` therefore closes the keyboard gap and leaves this one wide
+ * open, which is how every other drag surface in this admin is currently
+ * non-conforming.
+ *
+ * Move up / Move down are pointer-clickable AND keyboard-reachable, so one pair
+ * of controls answers both criteria. They are the reason the drag handle is
+ * allowed to exist at all.
+ *
+ * ## Hide and remove are different, and the wording carries the difference
+ *
+ * Hiding KEEPS the placement — its position and its settings survive, so
+ * unhiding restores the card where it was. Removing drops it, and adding it
+ * back later appends a fresh one at the end. Two similar-sounding actions are
+ * exactly the pair a reader can confuse, so each label names the consequence
+ * rather than the gesture.
+ *
+ * @module components/features/widgets/edit/WidgetEditControls
+ */
+
+import { Button } from "@nextlyhq/ui";
+
+import * as Icons from "@admin/components/icons";
+
+export interface WidgetEditControlsProps {
+  /** What the reader calls this card, so every label can name it. */
+  title: string;
+  position: number;
+  count: number;
+  hidden: boolean;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  onToggleHidden: () => void;
+  onRemove: () => void;
+}
+
+export function WidgetEditControls({
+  title,
+  position,
+  count,
+  hidden,
+  canMoveUp,
+  canMoveDown,
+  onMoveUp,
+  onMoveDown,
+  onToggleHidden,
+  onRemove,
+}: WidgetEditControlsProps) {
+  return (
+    <div
+      className="flex items-center gap-1 border-b border-border bg-muted/40 px-2 py-1"
+      data-testid="widget-edit-controls"
+    >
+      {/* The name first, so a reader tabbing through a dozen identical control
+          groups can tell which card they are on without leaving the group. */}
+      <span className="mr-auto truncate text-xs font-medium text-muted-foreground">
+        {title}
+        <span className="sr-only">{`, position ${position} of ${count}`}</span>
+      </span>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-7"
+        onClick={onMoveUp}
+        disabled={!canMoveUp}
+        // The position travels in the label, because a reader who has just
+        // moved a card needs to know where it landed and the visible grid does
+        // not say it. `aria-label` rather than `title`: a title is not reliably
+        // announced and is unreachable by touch.
+        aria-label={`Move ${title} up, currently position ${position} of ${count}`}
+        data-testid="widget-move-up"
+      >
+        <Icons.ChevronUp aria-hidden className="size-4" />
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-7"
+        onClick={onMoveDown}
+        disabled={!canMoveDown}
+        aria-label={`Move ${title} down, currently position ${position} of ${count}`}
+        data-testid="widget-move-down"
+      >
+        <Icons.ChevronDown aria-hidden className="size-4" />
+      </Button>
+
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-7"
+        onClick={onToggleHidden}
+        // Names the OUTCOME, and says what hiding preserves. "Hide" alone reads
+        // as a synonym for "remove" to somebody deciding between the two.
+        aria-label={
+          hidden
+            ? `Show ${title} again, in the position it was hidden from`
+            : `Hide ${title}, keeping its position and settings`
+        }
+        data-testid="widget-toggle-hidden"
+      >
+        {hidden ? (
+          <Icons.Eye aria-hidden className="size-4" />
+        ) : (
+          <Icons.EyeOff aria-hidden className="size-4" />
+        )}
+      </Button>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="size-7 text-muted-foreground hover:text-destructive"
+        onClick={onRemove}
+        aria-label={`Remove ${title} from the dashboard, losing its position and settings`}
+        data-testid="widget-remove"
+      >
+        <Icons.X aria-hidden className="size-4" />
+      </Button>
+    </div>
+  );
+}

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -495,6 +495,89 @@ describe("a conflict", () => {
       "widget-cell-core/a",
     ]);
   });
+
+  it("Reload takes the server's arrangement and dismisses itself", async () => {
+    // 🔴 Reload only invalidated the query. The editor still preferred its
+    // local draft, so the refetched arrangement was never drawn, and the failed
+    // mutation kept the alert up -- the reader pressed the one control offered,
+    // lost nothing, gained nothing, and was told again to reload.
+    const conflict = Object.assign(new Error("changed"), { status: 409 });
+    api.put.mockRejectedValue(conflict);
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+    await screen.findByTestId("dashboard-edit-conflict");
+
+    // What the other tab stored while this one was editing.
+    layoutResponse = layout([
+      { id: "p3", widgetId: "core/c", order: 0 },
+      { id: "p1", widgetId: "core/a", order: 10 },
+      { id: "p2", widgetId: "core/b", order: 20 },
+    ]);
+    await user.click(screen.getByTestId("dashboard-edit-reload"));
+
+    await waitFor(() =>
+      expect(
+        screen
+          .getAllByTestId(/^widget-cell-/)
+          .map(node => node.getAttribute("data-testid"))
+      ).toEqual([
+        "widget-cell-core/c",
+        "widget-cell-core/a",
+        "widget-cell-core/b",
+      ])
+    );
+    expect(screen.queryByTestId("dashboard-edit-conflict")).toBeNull();
+    // The draft is gone, so the reader is out of edit mode rather than looking
+    // at server rows they believe are still theirs to save.
+    expect(screen.getByTestId("dashboard-edit-begin")).toBeInTheDocument();
+  });
+});
+
+describe("an arrangement with nothing left on it", () => {
+  it("KEEPS the way back when every card is put away", async () => {
+    // 🔴 The dead end. Deriving the grid's rows from the arrangement meant an
+    // all-hidden layout produced no rows, and the early return that draws the
+    // three no-widgets states unmounted the edit bar, Reset and the picker
+    // along with them -- a blank dashboard with no control left that could undo
+    // it. An arrangement must never reach a state it cannot leave.
+    layoutResponse = layout([
+      { id: "p1", widgetId: "core/a", order: 0, hidden: true },
+      { id: "p2", widgetId: "core/b", order: 10, hidden: true },
+      { id: "p3", widgetId: "core/c", order: 20, hidden: true },
+    ]);
+    renderGrid();
+
+    expect(
+      await screen.findByTestId("dashboard-edit-begin")
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("widget-grid-empty")).toBeInTheDocument();
+    expect(screen.queryAllByTestId(/^widget-cell-/)).toHaveLength(0);
+
+    // And the way back WORKS, rather than merely being on screen: editing
+    // reveals the put-away cards, which is the only route to bringing one back.
+    await beginEditing();
+    expect(screen.getAllByTestId(/^widget-cell-/)).toHaveLength(3);
+  });
+
+  it("offers Reset and the picker when the arrangement holds no placements", async () => {
+    // The other way to reach nothing: every card removed and saved. `available`
+    // then lists all three, so the picker is a real way back and not only a
+    // control that happens to be mounted.
+    layoutResponse = layout([], {
+      version: 4,
+      available: ["core/a", "core/b", "core/c"],
+    });
+    const user = userEvent.setup();
+    renderGrid();
+
+    await user.click(await screen.findByTestId("dashboard-edit-begin"));
+
+    expect(screen.getByTestId("dashboard-edit-reset")).toBeInTheDocument();
+    expect(await screen.findByTestId("add-widget-picker")).toBeInTheDocument();
+  });
 });
 
 describe("reset", () => {

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -3,7 +3,7 @@
  * and what happens when the arrangement is not there.
  */
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -59,6 +59,7 @@ function layout(
     widgetId: string;
     order: number;
     hidden?: boolean;
+    size?: string;
   }>,
   patch: Partial<DashboardLayoutResponse> = {}
 ): DashboardLayoutResponse {
@@ -74,12 +75,21 @@ function layout(
 
 function renderGrid() {
   const client = new QueryClient({
-    defaultOptions: { queries: { retry: false, retryDelay: 0, gcTime: 0 } },
+    defaultOptions: {
+      queries: { retry: false, retryDelay: 0, gcTime: 0 },
+      // 🔴 Mirrors the app's own `QueryProvider`, which sets
+      // `mutations.retry: MUTATION_RETRY_COUNT`. TanStack does not retry
+      // mutations by default, so a test client that stayed silent here could
+      // never observe an unwanted retry — the guard against one would read as
+      // covered while nothing exercised it. `retryDelay: 0` so the attempts
+      // happen in milliseconds rather than in backoff seconds.
+      mutations: { retry: 2, retryDelay: 0 },
+    },
   });
   const Wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={client}>{children}</QueryClientProvider>
   );
-  return render(<WidgetGrid />, { wrapper: Wrapper });
+  return { client, ...render(<WidgetGrid />, { wrapper: Wrapper }) };
 }
 
 beforeEach(() => {
@@ -347,6 +357,102 @@ describe("saving", () => {
   });
 });
 
+describe("the guards a save is sent against", () => {
+  it("uses the version the DRAFT was taken from, not the newest one", async () => {
+    // 🔴 The silent-overwrite bug. The query refetches on window focus, so
+    // another tab can save while this one is editing: the version advances
+    // underneath an untouched draft, and a save that reads it fresh then
+    // SUCCEEDS against a version its arrangement was never derived from —
+    // overwriting the other tab with no conflict reported. The guard was
+    // configured out of existence by the refresh policy beside it.
+    const { client } = renderGrid();
+    const user = await beginEditing();
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+
+    // Another tab saves, and this tab's layout refreshes underneath the draft.
+    // Driven through the client rather than a focus event, because what matters
+    // is that a refetch LANDED while editing -- `refetchOnWindowFocus` is one
+    // way to reach that state and not the property under test.
+    layoutResponse = layout([{ id: "p1", widgetId: "core/a", order: 0 }], {
+      version: 99,
+      scope: "moved-on",
+    });
+    await act(async () => {
+      await client.invalidateQueries({ queryKey: ["dashboard", "layout"] });
+    });
+    expect(api.get).toHaveBeenCalledTimes(2);
+
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+
+    await waitFor(() => expect(api.put).toHaveBeenCalledTimes(1));
+    const body = api.put.mock.calls[0][1] as { version: number; scope: string };
+    expect(body.version).toBe(3);
+    expect(body.scope).toBe("tok");
+  });
+
+  it("does not retry a failed save", async () => {
+    // A version-guarded write is not idempotent under an AMBIGUOUS failure: if
+    // the server commits and the response is lost, a retry sends the same
+    // now-stale version, is refused, and tells the reader another editor
+    // changed their dashboard — when their own save had already succeeded. The
+    // retry manufactures the very conflict the guard exists to report honestly.
+    api.put.mockRejectedValue(new Error("network"));
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+
+    await screen.findByTestId("dashboard-edit-error");
+    expect(api.put).toHaveBeenCalledTimes(1);
+  });
+
+  it("says so when a save fails for a reason that is not a conflict", async () => {
+    // Previously only conflicts rendered, so a network error or a 500 left the
+    // reader in edit mode with the spinner stopped and nothing said, believing
+    // their arrangement had been stored.
+    api.put.mockRejectedValue(new Error("boom"));
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+
+    await screen.findByTestId("dashboard-edit-error");
+    expect(screen.queryByTestId("dashboard-edit-conflict")).toBeNull();
+    // And the work is still there.
+    expect(
+      screen.getAllByTestId("widget-edit-controls").length
+    ).toBeGreaterThan(0);
+  });
+});
+
+describe("a card the reader resized", () => {
+  it("renders at its STORED size, not the declaration's", async () => {
+    // The stored size IS the arrangement — the layout API preserves it so a
+    // card the reader resized stays resized. Reading the declaration instead
+    // silently re-sized their dashboard whenever a plugin changed its default.
+    layoutResponse = layout([
+      { id: "p1", widgetId: "core/a", order: 0, size: "sm" },
+    ]);
+    renderGrid();
+    await screen.findByTestId("dashboard-edit-begin");
+
+    // `core/a` declares `full`; the placement says `sm`.
+    expect(screen.getByTestId("widget-cell-core/a").className).toContain(
+      "lg:col-span-3"
+    );
+  });
+
+  it("falls back to the declaration when the placement stored none", async () => {
+    renderGrid();
+    await screen.findByTestId("dashboard-edit-begin");
+    expect(screen.getByTestId("widget-cell-core/a").className).toContain(
+      "col-span-12"
+    );
+  });
+});
+
 describe("cancelling", () => {
   it("puts the arrangement back", async () => {
     renderGrid();
@@ -392,13 +498,32 @@ describe("a conflict", () => {
 });
 
 describe("reset", () => {
-  it("is offered only to a reader who has an arrangement of their own", async () => {
+  it("is not offered when there is no stored row at all", async () => {
+    // Version 0 is what "no row" means on the wire; `source: "default"` alone
+    // does not, which is the next case.
     layoutResponse = layout([{ id: "p1", widgetId: "core/a", order: 0 }], {
       source: "default",
+      version: 0,
     });
     renderGrid();
     await beginEditing();
     expect(screen.queryByTestId("dashboard-edit-reset")).toBeNull();
+  });
+
+  it("IS offered when a stored row exists but could not be decoded", async () => {
+    // 🔴 The state that had no way out. A row the service cannot decode is
+    // reported as `source: "default"` — the dashboard falls back to the
+    // registry's order — while keeping its real, non-zero version. Gating Reset
+    // on the source hid the one control that could clear it, and with an
+    // untouched draft Save is disabled too, so every read went on logging the
+    // same decode failure with the reader unable to do anything about it.
+    layoutResponse = layout([{ id: "p1", widgetId: "core/a", order: 0 }], {
+      source: "default",
+      version: 7,
+    });
+    renderGrid();
+    await beginEditing();
+    expect(screen.getByTestId("dashboard-edit-reset")).toBeInTheDocument();
   });
 
   it("deletes the row rather than writing the current defaults", async () => {

--- a/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
+++ b/packages/admin/src/components/features/widgets/edit/__tests__/WidgetGrid.edit.test.tsx
@@ -1,0 +1,415 @@
+/**
+ * Editing the dashboard: what the reader can do, what is sent when they save,
+ * and what happens when the arrangement is not there.
+ */
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+import type { AdminBranding } from "@admin/types/branding";
+import type { DashboardLayoutResponse } from "@admin/types/dashboard/widgets";
+
+import { WidgetGrid } from "../../WidgetGrid";
+
+let mockBranding: AdminBranding | undefined;
+let layoutResponse: DashboardLayoutResponse | undefined;
+let layoutRejects = false;
+
+vi.mock("@admin/context/providers/BrandingProvider", () => ({
+  useBranding: () => mockBranding,
+  useBrandingStatus: () => ({
+    isPending: false,
+    isUnavailable: false,
+    isBrandingUnavailable: false,
+  }),
+}));
+vi.mock("@admin/hooks/useCurrentUserPermissions", () => ({
+  useCurrentUserPermissions: () => ({ hasPermission: () => true }),
+}));
+vi.mock("@admin/lib/api/protectedApi", () => ({
+  protectedApi: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+const api = vi.mocked(protectedApi);
+
+/** Three registered widgets, drawn by a component so no query is issued. */
+function branding(ids: string[]): AdminBranding {
+  return {
+    widgets: ids.map(id => ({
+      id,
+      title: `Widget ${id}`,
+      archetype: "custom",
+      defaultSize: "full",
+      component: "core#Whatever",
+    })),
+  } as unknown as AdminBranding;
+}
+
+function layout(
+  placements: Array<{
+    id: string;
+    widgetId: string;
+    order: number;
+    hidden?: boolean;
+  }>,
+  patch: Partial<DashboardLayoutResponse> = {}
+): DashboardLayoutResponse {
+  return {
+    placements: placements.map(p => ({ ...p, hidden: p.hidden ?? false })),
+    available: [],
+    version: 3,
+    source: "own",
+    scope: "tok",
+    ...patch,
+  };
+}
+
+function renderGrid() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, retryDelay: 0, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={client}>{children}</QueryClientProvider>
+  );
+  return render(<WidgetGrid />, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  layoutRejects = false;
+  mockBranding = branding(["core/a", "core/b", "core/c"]);
+  layoutResponse = layout([
+    { id: "p1", widgetId: "core/a", order: 0 },
+    { id: "p2", widgetId: "core/b", order: 10 },
+    { id: "p3", widgetId: "core/c", order: 20 },
+  ]);
+  api.get.mockImplementation(() =>
+    layoutRejects
+      ? Promise.reject(new Error("layout unavailable"))
+      : Promise.resolve(layoutResponse)
+  );
+  api.put.mockResolvedValue({ message: "ok", item: {} });
+  api.delete.mockResolvedValue({ message: "ok" });
+});
+
+/** Enters edit mode and waits for the per-card controls to exist. */
+async function beginEditing() {
+  const user = userEvent.setup();
+  await user.click(await screen.findByTestId("dashboard-edit-begin"));
+  await screen.findAllByTestId("widget-edit-controls");
+  return user;
+}
+
+describe("when the arrangement has not been read", () => {
+  it("still draws the declared widgets", async () => {
+    // 🔴 The regression this guards. Deriving the grid from the layout alone
+    // blanked the entire dashboard while the request was in flight — every page
+    // load — and for the whole of any outage. A personalization feature must
+    // not be able to take the page down when its own endpoint is unavailable.
+    layoutRejects = true;
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-core/a")).toBeInTheDocument()
+    );
+    expect(screen.getByTestId("widget-cell-core/b")).toBeInTheDocument();
+    expect(screen.getByTestId("widget-cell-core/c")).toBeInTheDocument();
+  });
+
+  it("does not offer editing, because a write would have nothing to guard it", async () => {
+    layoutRejects = true;
+    renderGrid();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("widget-cell-core/a")).toBeInTheDocument()
+    );
+    expect(screen.queryByTestId("dashboard-edit-begin")).toBeNull();
+  });
+});
+
+describe("entering edit mode", () => {
+  it("shows controls on every card", async () => {
+    renderGrid();
+    await beginEditing();
+    expect(screen.getAllByTestId("widget-edit-controls")).toHaveLength(3);
+  });
+
+  it("orders cards by the arrangement, not the declaration order", async () => {
+    layoutResponse = layout([
+      { id: "p3", widgetId: "core/c", order: 0 },
+      { id: "p1", widgetId: "core/a", order: 10 },
+      { id: "p2", widgetId: "core/b", order: 20 },
+    ]);
+    renderGrid();
+    // Waits for the EDIT BUTTON, not for a cell. Every cell exists in the
+    // fallback too — the declared order renders before the arrangement lands —
+    // so awaiting one is satisfied by the state this test exists to tell apart,
+    // and the assertion ran against the fallback. The button is rendered only
+    // once an arrangement has actually been read.
+    await screen.findByTestId("dashboard-edit-begin");
+
+    const cells = screen
+      .getAllByTestId(/^widget-cell-/)
+      .map(node => node.getAttribute("data-testid"));
+    expect(cells).toEqual([
+      "widget-cell-core/c",
+      "widget-cell-core/a",
+      "widget-cell-core/b",
+    ]);
+  });
+});
+
+describe("moving a card without a drag", () => {
+  it("disables Move up on the first and Move down on the last", async () => {
+    // The single-pointer alternative WCAG 2.5.7 requires. Its affordances have
+    // to be right at the ends or a reader is offered a move that cannot happen.
+    renderGrid();
+    await beginEditing();
+
+    const ups = screen.getAllByTestId("widget-move-up");
+    const downs = screen.getAllByTestId("widget-move-down");
+    expect(ups[0]).toBeDisabled();
+    expect(downs[downs.length - 1]).toBeDisabled();
+    expect(ups[1]).toBeEnabled();
+    expect(downs[0]).toBeEnabled();
+  });
+
+  it("reorders the grid", async () => {
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+
+    const cells = screen
+      .getAllByTestId(/^widget-cell-/)
+      .map(node => node.getAttribute("data-testid"));
+    expect(cells.slice(0, 2)).toEqual([
+      "widget-cell-core/b",
+      "widget-cell-core/a",
+    ]);
+  });
+
+  it("says where the card landed", async () => {
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+
+    // Through the grid's ONE region -- a move is not worth a second announcer.
+    expect(screen.getByTestId("widget-grid-live").textContent).toMatch(
+      /Widget core\/a moved to position 2 of 3/
+    );
+  });
+
+  it("names the position in each button, so a reader knows where they are", async () => {
+    renderGrid();
+    await beginEditing();
+
+    expect(screen.getAllByTestId("widget-move-down")[0]).toHaveAttribute(
+      "aria-label",
+      "Move Widget core/a down, currently position 1 of 3"
+    );
+  });
+});
+
+describe("hiding and removing", () => {
+  it("keeps a hidden card on screen WHILE editing, so it can be brought back", async () => {
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-toggle-hidden")[0]);
+
+    expect(screen.getByTestId("widget-cell-core/a")).toBeInTheDocument();
+  });
+
+  it("removes a card from the grid entirely", async () => {
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-remove")[0]);
+
+    expect(screen.queryByTestId("widget-cell-core/a")).toBeNull();
+    expect(screen.getByTestId("widget-cell-core/b")).toBeInTheDocument();
+  });
+
+  it("labels the two by their consequence, not their gesture", async () => {
+    // The pair a reader confuses. "Hide" alone reads as a synonym for
+    // "remove" to somebody deciding between them.
+    renderGrid();
+    await beginEditing();
+
+    expect(screen.getAllByTestId("widget-toggle-hidden")[0]).toHaveAttribute(
+      "aria-label",
+      "Hide Widget core/a, keeping its position and settings"
+    );
+    expect(screen.getAllByTestId("widget-remove")[0]).toHaveAttribute(
+      "aria-label",
+      "Remove Widget core/a from the dashboard, losing its position and settings"
+    );
+  });
+});
+
+describe("adding a widget", () => {
+  it("offers what the server said is available", async () => {
+    layoutResponse = layout([{ id: "p1", widgetId: "core/a", order: 0 }], {
+      available: ["core/b"],
+    });
+    renderGrid();
+    await beginEditing();
+
+    expect(screen.getByTestId("add-widget-core/b")).toBeInTheDocument();
+  });
+
+  it("offers a card the reader just removed", async () => {
+    // Recomputed against the DRAFT. The server's list was true when the read
+    // landed; a card removed since is offerable again, and one just added is
+    // not.
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-remove")[0]);
+
+    expect(screen.getByTestId("add-widget-core/a")).toBeInTheDocument();
+  });
+
+  it("stops offering one that has been added", async () => {
+    layoutResponse = layout([{ id: "p1", widgetId: "core/a", order: 0 }], {
+      available: ["core/b"],
+    });
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getByTestId("add-widget-core/b"));
+
+    expect(screen.queryByTestId("add-widget-core/b")).toBeNull();
+    expect(screen.getByTestId("widget-cell-core/b")).toBeInTheDocument();
+  });
+
+  it("says so when everything is already placed", async () => {
+    // An empty picker and a picker that failed to load look identical.
+    renderGrid();
+    await beginEditing();
+    expect(screen.getByTestId("add-widget-empty")).toBeInTheDocument();
+  });
+});
+
+describe("saving", () => {
+  it("sends renumbered placements with BOTH guards", async () => {
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+
+    await waitFor(() => expect(api.put).toHaveBeenCalledTimes(1));
+    const [path, body] = api.put.mock.calls[0] as [
+      string,
+      {
+        placements: Array<{ id: string; order: number }>;
+        version: number;
+        scope: string;
+      },
+    ];
+    expect(path).toBe("/dashboard/layout");
+    expect(body.version).toBe(3);
+    expect(body.scope).toBe("tok");
+    // 🔴 Renumbered from the ARRAY. The editor reorders an array, so a moved
+    // card still carries the order it had before -- sent as-is, the server
+    // sorts by a number that no longer matches what the reader sees.
+    expect(body.placements.map(p => p.id)).toEqual(["p2", "p1", "p3"]);
+    expect(body.placements.map(p => p.order)).toEqual([0, 10, 20]);
+  });
+
+  it("cannot be pressed with nothing to save", async () => {
+    renderGrid();
+    await beginEditing();
+    expect(screen.getByTestId("dashboard-edit-save")).toBeDisabled();
+  });
+
+  it("leaves edit mode when it lands", async () => {
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+
+    await waitFor(() =>
+      expect(screen.queryByTestId("widget-edit-controls")).toBeNull()
+    );
+  });
+});
+
+describe("cancelling", () => {
+  it("puts the arrangement back", async () => {
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-cancel"));
+
+    const cells = screen
+      .getAllByTestId(/^widget-cell-/)
+      .map(node => node.getAttribute("data-testid"));
+    expect(cells).toEqual([
+      "widget-cell-core/a",
+      "widget-cell-core/b",
+      "widget-cell-core/c",
+    ]);
+    expect(api.put).not.toHaveBeenCalled();
+  });
+});
+
+describe("a conflict", () => {
+  it("explains it and KEEPS the reader's work on screen", async () => {
+    // Both guards refuse the same way and the remedy is a re-read, which
+    // discards the draft. Doing that automatically would throw the reader's
+    // work away at the exact moment they are told to try again.
+    const conflict = Object.assign(new Error("changed"), { status: 409 });
+    api.put.mockRejectedValue(conflict);
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getAllByTestId("widget-move-down")[0]);
+    await user.click(screen.getByTestId("dashboard-edit-save"));
+
+    await screen.findByTestId("dashboard-edit-conflict");
+    const cells = screen
+      .getAllByTestId(/^widget-cell-/)
+      .map(node => node.getAttribute("data-testid"));
+    expect(cells.slice(0, 2)).toEqual([
+      "widget-cell-core/b",
+      "widget-cell-core/a",
+    ]);
+  });
+});
+
+describe("reset", () => {
+  it("is offered only to a reader who has an arrangement of their own", async () => {
+    layoutResponse = layout([{ id: "p1", widgetId: "core/a", order: 0 }], {
+      source: "default",
+    });
+    renderGrid();
+    await beginEditing();
+    expect(screen.queryByTestId("dashboard-edit-reset")).toBeNull();
+  });
+
+  it("deletes the row rather than writing the current defaults", async () => {
+    // A written snapshot freezes today's defaults, so a widget added later
+    // never reaches a reader who has "reset".
+    renderGrid();
+    const user = await beginEditing();
+
+    await user.click(screen.getByTestId("dashboard-edit-reset"));
+
+    await waitFor(() => expect(api.delete).toHaveBeenCalledTimes(1));
+    expect(api.put).not.toHaveBeenCalled();
+  });
+});

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -1,0 +1,134 @@
+"use client";
+
+/**
+ * Which cards the grid draws, in what order, and everything editing them needs.
+ *
+ * Extracted because the grid had accumulated six jobs — batching queries,
+ * gating them, announcing outcomes, resolving the arrangement, holding edit
+ * state and wiring drag — and the complexity gate said so before a reader
+ * would have. The three that belong to the ARRANGEMENT live here; the grid
+ * keeps the three that belong to drawing and fetching.
+ *
+ * @module components/features/widgets/edit/useDashboardArrangement
+ */
+
+import { useCallback, useMemo } from "react";
+
+import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
+import type { DashboardWidget } from "@admin/types/dashboard/widgets";
+
+import { useSortableFieldArray } from "../../entries/fields/structured/field-array-helpers";
+
+import { useLayoutEditor, type LayoutEditor } from "./useLayoutEditor";
+
+/** One card to draw: which placement put it there, and whether it is put away. */
+export interface ArrangedWidget {
+  placementId: string;
+  widget: DashboardWidget;
+  hidden: boolean;
+}
+
+export interface DashboardArrangement {
+  /** The cards to draw, in the arrangement's order. */
+  visible: ArrangedWidget[];
+  editor: LayoutEditor;
+  /**
+   * Whether an arrangement has been READ — not whether it holds anything.
+   *
+   * 🔴 Absent means the request is in flight or it failed; empty means this
+   * reader has arranged their dashboard down to nothing. Folding the two
+   * together blanked the whole dashboard for the duration of every page load
+   * and the whole of any outage.
+   */
+  hasArrangement: boolean;
+  sortableItems: Array<{ id: string }>;
+  sensors: ReturnType<typeof useSortableFieldArray>["sensors"];
+  handleDragEnd: ReturnType<typeof useSortableFieldArray>["handleDragEnd"];
+}
+
+export function useDashboardArrangement(
+  declared: DashboardWidget[],
+  layout: UseDashboardLayoutResult,
+  announceMove: (title: string, position: number, count: number) => void
+): DashboardArrangement {
+  // The DECLARATIONS, by id. The arrangement says which cards and in what
+  // order; this says what each one actually is. Two questions, two sources:
+  // the server owns the arrangement because only it can filter by permission
+  // authoritatively, and branding owns the declaration because that carries the
+  // archetype, the query and the component.
+  const byId = useMemo(
+    () => new Map(declared.map(widget => [widget.id, widget])),
+    [declared]
+  );
+
+  // What an added card inherits. `size` on a resolved declaration IS its
+  // declared default, so a card the reader adds arrives the size its author
+  // intended rather than an arbitrary one.
+  const geometryFor = useCallback(
+    (widgetId: string) => {
+      const declaration = byId.get(widgetId);
+      return declaration ? { size: declaration.size } : undefined;
+    },
+    [byId]
+  );
+
+  const editor = useLayoutEditor(layout, geometryFor);
+  const hasArrangement = layout.layout !== undefined;
+
+  const visible = useMemo(() => {
+    // No arrangement yet: draw the declarations in their declared order, which
+    // is exactly what this dashboard did before it could be arranged at all.
+    if (!hasArrangement) {
+      return declared.map(widget => ({
+        placementId: widget.id,
+        widget,
+        hidden: false,
+      }));
+    }
+    const rows: ArrangedWidget[] = [];
+    for (const placement of editor.placements) {
+      const widget = byId.get(placement.widgetId);
+      // A placement whose declaration this admin cannot resolve is SKIPPED
+      // rather than drawn as an empty cell: the server filtered by permission
+      // and by the registry, but a plugin's client bundle can still be absent,
+      // and a titled card with nothing under it reads as a product bug.
+      if (!widget) continue;
+      // Hidden cards are drawn while editing — a reader cannot bring back
+      // something they cannot see.
+      if (placement.hidden && !editor.isEditing) continue;
+      rows.push({
+        placementId: placement.id,
+        widget,
+        hidden: placement.hidden,
+      });
+    }
+    return rows;
+  }, [hasArrangement, declared, editor.placements, editor.isEditing, byId]);
+
+  const sortableItems = useMemo(
+    () => visible.map(row => ({ id: row.placementId })),
+    [visible]
+  );
+
+  // The drag path and the button path move a card through the SAME function.
+  // Two implementations of "where does this land" agree until one is edited,
+  // and a grid whose drag and whose buttons disagreed would be impossible to
+  // reason about from either.
+  const { sensors, handleDragEnd } = useSortableFieldArray(
+    sortableItems,
+    (from, to) => {
+      editor.move(from, to);
+      const moved = visible[from];
+      if (moved) announceMove(moved.widget.title, to + 1, visible.length);
+    }
+  );
+
+  return {
+    visible,
+    editor,
+    hasArrangement,
+    sortableItems,
+    sensors,
+    handleDragEnd,
+  };
+}

--- a/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
+++ b/packages/admin/src/components/features/widgets/edit/useDashboardArrangement.ts
@@ -26,12 +26,22 @@ export interface ArrangedWidget {
   placementId: string;
   widget: DashboardWidget;
   hidden: boolean;
+  /**
+   * The size the reader's arrangement stored, when it stored one.
+   *
+   * A `string` rather than the size enum, for the reason every layout type is:
+   * it may have been written by a plugin built against a newer core, and the
+   * span helper already falls back on a value it does not recognise.
+   */
+  size?: string;
 }
 
 export interface DashboardArrangement {
   /** The cards to draw, in the arrangement's order. */
   visible: ArrangedWidget[];
   editor: LayoutEditor;
+  /** Move the card at a VIEW index one step, resolving ids for the editor. */
+  moveBy: (index: number, delta: number) => void;
   /**
    * Whether an arrangement has been READ — not whether it holds anything.
    *
@@ -100,6 +110,7 @@ export function useDashboardArrangement(
         placementId: placement.id,
         widget,
         hidden: placement.hidden,
+        ...(placement.size === undefined ? {} : { size: placement.size }),
       });
     }
     return rows;
@@ -114,18 +125,42 @@ export function useDashboardArrangement(
   // Two implementations of "where does this land" agree until one is edited,
   // and a grid whose drag and whose buttons disagreed would be impossible to
   // reason about from either.
+  // `useSortableFieldArray` hands back INDICES into the list it was given, and
+  // that list is the filtered view. They are turned into placement ids here,
+  // once, so the editor never sees a position that means something different to
+  // it than it did to the grid.
   const { sensors, handleDragEnd } = useSortableFieldArray(
     sortableItems,
     (from, to) => {
-      editor.move(from, to);
       const moved = visible[from];
-      if (moved) announceMove(moved.widget.title, to + 1, visible.length);
+      const target = visible[to];
+      if (!moved || !target) return;
+      editor.move(moved.placementId, target.placementId);
+      announceMove(moved.widget.title, to + 1, visible.length);
     }
+  );
+
+  /**
+   * The button path: move the card at `index` one step in the VIEW.
+   *
+   * Resolved to the neighbour's id here rather than to `index + delta`, because
+   * the neighbour in the view may not be the neighbour in the stored array.
+   */
+  const moveBy = useCallback(
+    (index: number, delta: number) => {
+      const moved = visible[index];
+      const target = visible[index + delta];
+      if (!moved || !target) return;
+      editor.move(moved.placementId, target.placementId);
+      announceMove(moved.widget.title, index + delta + 1, visible.length);
+    },
+    [visible, editor, announceMove]
   );
 
   return {
     visible,
     editor,
+    moveBy,
     hasArrangement,
     sortableItems,
     sensors,

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -59,6 +59,18 @@ export interface LayoutEditor {
   cancel: () => void;
   save: () => void;
   reset: () => void;
+  /**
+   * The remedy a conflict offers: take the server's arrangement, discard this
+   * one.
+   *
+   * 🔴 THREE pieces of state, because a conflict is three and clearing one
+   * leaves the other two contradicting the reader. Re-reading alone refetched
+   * an arrangement the editor then declined to show — `placements` prefers the
+   * draft — while the failed mutation kept `isConflict` true, so the alert
+   * stayed up saying to reload beneath a button that had just been pressed. The
+   * action has to do everything its own copy promises.
+   */
+  reload: () => void;
   /** Move by IDENTITY: the placement `fromId` takes the position of `toId`. */
   move: (fromId: string, toId: string) => void;
   toggleHidden: (placementId: string) => void;
@@ -137,6 +149,19 @@ export function useLayoutEditor(
 
   const reset = useCallback(() => {
     layout.reset.mutate(undefined, { onSuccess: () => setDraft(null) });
+  }, [layout]);
+
+  const reload = useCallback(() => {
+    // The draft goes first: it is the thing the reader was warned they would
+    // lose, and it is what stands between the refetched arrangement and being
+    // drawn.
+    setDraft(null);
+    // BOTH mutations, because `isConflict` reads both errors — a reset can lose
+    // the same race a save can, and clearing only the save left a conflict
+    // raised by the other one permanently on screen.
+    layout.save.reset();
+    layout.reset.reset();
+    void layout.reload();
   }, [layout]);
 
   // BOTH paths move by identity, through one function. The drag handler gets
@@ -233,6 +258,7 @@ export function useLayoutEditor(
     cancel,
     save,
     reset,
+    reload,
     move,
     toggleHidden,
     remove,

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -28,7 +28,7 @@ import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
 import {
   addPlacement,
   hasChanges,
-  movePlacement,
+  movePlacementTo,
   removePlacement,
   renumber,
   togglePlacementHidden,
@@ -59,43 +59,75 @@ export interface LayoutEditor {
   cancel: () => void;
   save: () => void;
   reset: () => void;
-  move: (from: number, to: number) => void;
-  moveBy: (index: number, delta: number) => void;
+  /** Move by IDENTITY: the placement `fromId` takes the position of `toId`. */
+  move: (fromId: string, toId: string) => void;
   toggleHidden: (placementId: string) => void;
   remove: (placementId: string) => void;
   add: (widgetId: string) => void;
+}
+
+/**
+ * An arrangement being edited, and the guards it is a modification of.
+ *
+ * One object, so a placement list can never be sent against a version and a
+ * scope it was not derived from.
+ */
+interface LayoutDraft {
+  placements: WidgetPlacement[];
+  version: number;
+  scope: string;
 }
 
 export function useLayoutEditor(
   layout: UseDashboardLayoutResult,
   geometryFor: WidgetGeometrySource
 ): LayoutEditor {
-  // `null` means "not editing" and an array means "editing", so the two facts
-  // cannot disagree the way a separate boolean and a draft array would — there
-  // is no state in which the reader is editing and there is nothing to edit.
-  const [draft, setDraft] = useState<WidgetPlacement[] | null>(null);
+  // `null` means "not editing" and a draft means "editing", so the two facts
+  // cannot disagree the way a separate boolean and an array would — there is no
+  // state in which the reader is editing and there is nothing to edit.
+  //
+  // 🔴 The GUARDS are captured with the placements, not read at save time. They
+  // are what the reader's arrangement is a modification OF, so they belong to
+  // the snapshot the way the placements do. Read fresh at save, the query's own
+  // `refetchOnWindowFocus` defeated them: another tab saves, this tab regains
+  // focus and refetches, `version` advances underneath an untouched draft, and
+  // the save then succeeds against the NEW version — silently overwriting the
+  // other tab with an arrangement built from a version that no longer exists.
+  // The guard was configured out of existence by the refresh policy beside it.
+  const [draft, setDraft] = useState<LayoutDraft | null>(null);
 
   const server = useMemo(
     () => layout.layout?.placements ?? [],
     [layout.layout]
   );
 
-  const begin = useCallback(() => setDraft([...server]), [server]);
+  const begin = useCallback(() => {
+    const current = layout.layout;
+    // Nothing to edit against. Editing is offered only once a read has landed,
+    // so this is a guard rather than a state the UI can reach.
+    if (!current) return;
+    setDraft({
+      placements: [...current.placements],
+      version: current.version,
+      scope: current.scope,
+    });
+  }, [layout.layout]);
   const cancel = useCallback(() => setDraft(null), []);
 
   const save = useCallback(() => {
-    const current = draft;
-    const version = layout.layout?.version;
-    const scope = layout.layout?.scope;
-    // Nothing to send, or nothing to send it against. A missing guard is a read
-    // that never landed, and inventing one would be inventing the very
-    // assertion the server checks.
-    if (!current || version === undefined || scope === undefined) return;
+    if (!draft) return;
     layout.save.mutate(
       // Renumbered on the way out: the editor reorders an ARRAY, so a moved
       // card still carries the `order` it had before. Sent as-is, the server
       // sorts by a number that no longer matches what the reader sees.
-      { placements: renumber(current), version, scope },
+      //
+      // The guards come from the DRAFT, so they are the ones this arrangement
+      // was derived from rather than whatever the last refetch produced.
+      {
+        placements: renumber(draft.placements),
+        version: draft.version,
+        scope: draft.scope,
+      },
       // Only on success. A conflict must LEAVE the draft in place, because
       // dropping it here would discard the reader's work at the exact moment
       // they are being told to try again.
@@ -107,21 +139,21 @@ export function useLayoutEditor(
     layout.reset.mutate(undefined, { onSuccess: () => setDraft(null) });
   }, [layout]);
 
+  // BOTH paths move by identity, through one function. The drag handler gets
+  // ids from dnd-kit and the buttons read them off the row they render for, so
+  // neither has to translate a position in the FILTERED view into a position in
+  // the stored array — which is exactly the translation that was wrong: with an
+  // unresolvable placement between two visible ones, a view index moved the
+  // wrong card and persisted it.
   const move = useCallback(
-    (from: number, to: number) =>
+    (fromId: string, toId: string) =>
       setDraft(current =>
-        current ? movePlacement(current, from, to) : current
-      ),
-    []
-  );
-
-  // The keyboard and button path. Expressed as a DELTA rather than as a target
-  // index so a caller cannot compute the destination differently from the way
-  // the drag path computes it.
-  const moveBy = useCallback(
-    (index: number, delta: number) =>
-      setDraft(current =>
-        current ? movePlacement(current, index, index + delta) : current
+        current
+          ? {
+              ...current,
+              placements: movePlacementTo(current.placements, fromId, toId),
+            }
+          : current
       ),
     []
   );
@@ -129,7 +161,15 @@ export function useLayoutEditor(
   const toggleHidden = useCallback(
     (placementId: string) =>
       setDraft(current =>
-        current ? togglePlacementHidden(current, placementId) : current
+        current
+          ? {
+              ...current,
+              placements: togglePlacementHidden(
+                current.placements,
+                placementId
+              ),
+            }
+          : current
       ),
     []
   );
@@ -137,7 +177,12 @@ export function useLayoutEditor(
   const remove = useCallback(
     (placementId: string) =>
       setDraft(current =>
-        current ? removePlacement(current, placementId) : current
+        current
+          ? {
+              ...current,
+              placements: removePlacement(current.placements, placementId),
+            }
+          : current
       ),
     []
   );
@@ -146,13 +191,20 @@ export function useLayoutEditor(
     (widgetId: string) =>
       setDraft(current =>
         current
-          ? addPlacement(current, widgetId, geometryFor(widgetId))
+          ? {
+              ...current,
+              placements: addPlacement(
+                current.placements,
+                widgetId,
+                geometryFor(widgetId)
+              ),
+            }
           : current
       ),
     [geometryFor]
   );
 
-  const placements = draft ?? server;
+  const placements = draft?.placements ?? server;
 
   // What the picker offers, recomputed against the DRAFT rather than taken from
   // the server's answer. `available` was true when the read landed; a card the
@@ -174,7 +226,7 @@ export function useLayoutEditor(
     isEditing: draft !== null,
     placements,
     available,
-    hasUnsavedChanges: draft !== null && hasChanges(server, draft),
+    hasUnsavedChanges: draft !== null && hasChanges(server, draft.placements),
     isSaving: layout.save.isPending || layout.reset.isPending,
     isConflict: layout.isConflict,
     begin,
@@ -182,7 +234,6 @@ export function useLayoutEditor(
     save,
     reset,
     move,
-    moveBy,
     toggleHidden,
     remove,
     add,

--- a/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
+++ b/packages/admin/src/components/features/widgets/edit/useLayoutEditor.ts
@@ -1,0 +1,190 @@
+"use client";
+
+/**
+ * The arrangement a reader is editing, and the one write that commits it.
+ *
+ * ## Why edit mode batches instead of saving each gesture
+ *
+ * Every write is guarded twice — by `version`, which catches another tab, and
+ * by `scope`, which catches the visible widget set moving underneath the
+ * snapshot in hand. Both refuse with a 409 whose only remedy is to re-read, and
+ * re-reading DISCARDS whatever is in progress. Saving on every drag would
+ * therefore turn each gesture into its own chance to lose the arrangement, and
+ * a reader dragging four cards would run that risk four times instead of once.
+ *
+ * So the editor holds a local copy, every gesture edits that, and Save commits
+ * it in one PUT. Cancel throws it away. This is also what Backstage, Grafana,
+ * Metabase and Azure Portal do; WordPress is the one that autosaves, and it has
+ * no per-placement configuration to lose when a conflict forces a reload.
+ *
+ * @module components/features/widgets/edit/useLayoutEditor
+ */
+
+import { useCallback, useMemo, useState } from "react";
+
+import type { UseDashboardLayoutResult } from "@admin/hooks/queries/useDashboardLayout";
+import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
+
+import {
+  addPlacement,
+  hasChanges,
+  movePlacement,
+  removePlacement,
+  renumber,
+  togglePlacementHidden,
+} from "../layout-editor";
+
+/** Where a card's declared geometry comes from when it is added. */
+export interface WidgetGeometrySource {
+  (widgetId: string): { size?: string; height?: string } | undefined;
+}
+
+export interface LayoutEditor {
+  /** Whether the reader is editing. Cards are only manipulable while true. */
+  isEditing: boolean;
+  /** The arrangement to DRAW — the local copy while editing, else the server's. */
+  placements: WidgetPlacement[];
+  /** Widget ids offered by the "add" picker. */
+  available: string[];
+  hasUnsavedChanges: boolean;
+  isSaving: boolean;
+  /**
+   * Whether the last commit lost a race, on either guard.
+   *
+   * The recovery is one action for both causes, so this is one flag: re-read,
+   * which necessarily discards the local copy.
+   */
+  isConflict: boolean;
+  begin: () => void;
+  cancel: () => void;
+  save: () => void;
+  reset: () => void;
+  move: (from: number, to: number) => void;
+  moveBy: (index: number, delta: number) => void;
+  toggleHidden: (placementId: string) => void;
+  remove: (placementId: string) => void;
+  add: (widgetId: string) => void;
+}
+
+export function useLayoutEditor(
+  layout: UseDashboardLayoutResult,
+  geometryFor: WidgetGeometrySource
+): LayoutEditor {
+  // `null` means "not editing" and an array means "editing", so the two facts
+  // cannot disagree the way a separate boolean and a draft array would — there
+  // is no state in which the reader is editing and there is nothing to edit.
+  const [draft, setDraft] = useState<WidgetPlacement[] | null>(null);
+
+  const server = useMemo(
+    () => layout.layout?.placements ?? [],
+    [layout.layout]
+  );
+
+  const begin = useCallback(() => setDraft([...server]), [server]);
+  const cancel = useCallback(() => setDraft(null), []);
+
+  const save = useCallback(() => {
+    const current = draft;
+    const version = layout.layout?.version;
+    const scope = layout.layout?.scope;
+    // Nothing to send, or nothing to send it against. A missing guard is a read
+    // that never landed, and inventing one would be inventing the very
+    // assertion the server checks.
+    if (!current || version === undefined || scope === undefined) return;
+    layout.save.mutate(
+      // Renumbered on the way out: the editor reorders an ARRAY, so a moved
+      // card still carries the `order` it had before. Sent as-is, the server
+      // sorts by a number that no longer matches what the reader sees.
+      { placements: renumber(current), version, scope },
+      // Only on success. A conflict must LEAVE the draft in place, because
+      // dropping it here would discard the reader's work at the exact moment
+      // they are being told to try again.
+      { onSuccess: () => setDraft(null) }
+    );
+  }, [draft, layout]);
+
+  const reset = useCallback(() => {
+    layout.reset.mutate(undefined, { onSuccess: () => setDraft(null) });
+  }, [layout]);
+
+  const move = useCallback(
+    (from: number, to: number) =>
+      setDraft(current =>
+        current ? movePlacement(current, from, to) : current
+      ),
+    []
+  );
+
+  // The keyboard and button path. Expressed as a DELTA rather than as a target
+  // index so a caller cannot compute the destination differently from the way
+  // the drag path computes it.
+  const moveBy = useCallback(
+    (index: number, delta: number) =>
+      setDraft(current =>
+        current ? movePlacement(current, index, index + delta) : current
+      ),
+    []
+  );
+
+  const toggleHidden = useCallback(
+    (placementId: string) =>
+      setDraft(current =>
+        current ? togglePlacementHidden(current, placementId) : current
+      ),
+    []
+  );
+
+  const remove = useCallback(
+    (placementId: string) =>
+      setDraft(current =>
+        current ? removePlacement(current, placementId) : current
+      ),
+    []
+  );
+
+  const add = useCallback(
+    (widgetId: string) =>
+      setDraft(current =>
+        current
+          ? addPlacement(current, widgetId, geometryFor(widgetId))
+          : current
+      ),
+    [geometryFor]
+  );
+
+  const placements = draft ?? server;
+
+  // What the picker offers, recomputed against the DRAFT rather than taken from
+  // the server's answer. `available` was true when the read landed; a card the
+  // reader has just added is placed now, and one they have just removed is
+  // offerable again. Reading the server's list would keep offering a card that
+  // is already on the grid.
+  const available = useMemo(() => {
+    const placed = new Set(placements.map(placement => placement.widgetId));
+    const offered = layout.layout?.available ?? [];
+    const removed = server
+      .map(placement => placement.widgetId)
+      .filter(widgetId => !placed.has(widgetId));
+    return [...new Set([...offered, ...removed])].filter(
+      widgetId => !placed.has(widgetId)
+    );
+  }, [placements, layout.layout, server]);
+
+  return {
+    isEditing: draft !== null,
+    placements,
+    available,
+    hasUnsavedChanges: draft !== null && hasChanges(server, draft),
+    isSaving: layout.save.isPending || layout.reset.isPending,
+    isConflict: layout.isConflict,
+    begin,
+    cancel,
+    save,
+    reset,
+    move,
+    moveBy,
+    toggleHidden,
+    remove,
+    add,
+  };
+}

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -1,0 +1,183 @@
+/**
+ * The arrangement a reader is editing, as pure data.
+ *
+ * Separated from the grid that draws it because every rule here is decidable
+ * without a DOM — where a card lands after a move, whether it can move at all,
+ * what a newly added one inherits — and a rule that needs a rendered tree to
+ * test is a rule nobody tests at the edges.
+ *
+ * ## The order field is not the array index
+ *
+ * Placements arrive sorted by `order`, and `order` is a sparse number so a card
+ * can be inserted between two neighbours without renumbering them. The editor
+ * works on the ARRAY, because that is what a reader manipulates, and
+ * renumbers on the way out — so nothing in the UI has to reason about gaps, and
+ * nothing stored ever depends on an index that a filter could shift.
+ *
+ * @module components/features/widgets/layout-editor
+ */
+
+import type { WidgetPlacement } from "@admin/types/dashboard/widgets";
+
+/** The gap left between saved positions, so one can be inserted between two. */
+const ORDER_STEP = 10;
+
+/** Where a card can move, given where it already is. */
+export interface MoveAffordance {
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+}
+
+/**
+ * Moves the placement at `from` to `to`, and returns a NEW array.
+ *
+ * Out-of-range indices return the input unchanged rather than throwing. A drag
+ * that ends outside the list and a keyboard move at the last position are both
+ * ordinary gestures, not errors, and a throw here would take the grid down over
+ * one of them.
+ */
+export function movePlacement(
+  placements: readonly WidgetPlacement[],
+  from: number,
+  to: number
+): WidgetPlacement[] {
+  if (
+    from === to ||
+    from < 0 ||
+    to < 0 ||
+    from >= placements.length ||
+    to >= placements.length
+  ) {
+    return [...placements];
+  }
+  const next = [...placements];
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
+/** Whether the card at `index` has anywhere to go. */
+export function moveAffordance(index: number, count: number): MoveAffordance {
+  return { canMoveUp: index > 0, canMoveDown: index >= 0 && index < count - 1 };
+}
+
+/**
+ * Puts a card away, or brings it back.
+ *
+ * `hidden` rather than removal, and the two are genuinely different: a hidden
+ * placement KEEPS its position and its config, so bringing it back restores the
+ * arrangement rather than appending it to the end. Removal is what the reader
+ * does when they want it gone; hiding is what they do when they want it later.
+ */
+export function togglePlacementHidden(
+  placements: readonly WidgetPlacement[],
+  placementId: string
+): WidgetPlacement[] {
+  return placements.map(placement =>
+    placement.id === placementId
+      ? { ...placement, hidden: !placement.hidden }
+      : placement
+  );
+}
+
+/** Drops a card from the arrangement entirely. */
+export function removePlacement(
+  placements: readonly WidgetPlacement[],
+  placementId: string
+): WidgetPlacement[] {
+  return placements.filter(placement => placement.id !== placementId);
+}
+
+/**
+ * A fresh placement id.
+ *
+ * `crypto.randomUUID` where it exists, and a counter-plus-random fallback where
+ * it does not — jsdom without a secure context, and older browsers, both leave
+ * it undefined. The fallback does not need to be unguessable: this id is opaque
+ * within one arrangement and is never a secret, so uniqueness is the whole
+ * requirement.
+ */
+let fallbackCounter = 0;
+export function newPlacementId(): string {
+  const generator = globalThis.crypto;
+  if (typeof generator?.randomUUID === "function") {
+    return generator.randomUUID();
+  }
+  fallbackCounter += 1;
+  return `placement-${Date.now()}-${fallbackCounter}-${Math.random()
+    .toString(36)
+    .slice(2, 10)}`;
+}
+
+/**
+ * Adds a widget to the end of the arrangement.
+ *
+ * At the END, deliberately, rather than at its declared position. A reader who
+ * adds a card has just chosen it, and putting it where the plugin thinks it
+ * belongs hides it somewhere in the middle of a dashboard they have already
+ * arranged — so the one place they will certainly look is where it goes.
+ *
+ * The geometry comes from the widget's own declaration, so an added card is the
+ * size its author intended rather than an arbitrary default.
+ */
+export function addPlacement(
+  placements: readonly WidgetPlacement[],
+  widgetId: string,
+  geometry?: { size?: string; height?: string }
+): WidgetPlacement[] {
+  const last = placements[placements.length - 1];
+  return [
+    ...placements,
+    {
+      id: newPlacementId(),
+      widgetId,
+      order: last ? last.order + ORDER_STEP : 0,
+      hidden: false,
+      ...(geometry?.size === undefined ? {} : { size: geometry.size }),
+      ...(geometry?.height === undefined ? {} : { height: geometry.height }),
+    },
+  ];
+}
+
+/**
+ * The array as it will be STORED: positions renumbered from the current order.
+ *
+ * 🔴 Renumbered rather than sent as-is. The editor reorders an array, so a
+ * moved card carries whatever `order` it had before — send that and the server
+ * sorts by a number that no longer matches what the reader sees, and their
+ * arrangement comes back rearranged. Sparse steps rather than 0..n so a later
+ * insertion between two cards needs no renumbering at all.
+ */
+export function renumber(
+  placements: readonly WidgetPlacement[]
+): WidgetPlacement[] {
+  return placements.map((placement, index) => ({
+    ...placement,
+    order: index * ORDER_STEP,
+  }));
+}
+
+/**
+ * Whether the reader has changed anything worth saving.
+ *
+ * Compared on the fields that are STORED, in order — not by reference, because
+ * every editor operation returns new objects and a reference check would report
+ * a change for a move that put a card back where it started.
+ */
+export function hasChanges(
+  original: readonly WidgetPlacement[],
+  edited: readonly WidgetPlacement[]
+): boolean {
+  if (original.length !== edited.length) return true;
+  return renumber(original).some((placement, index) => {
+    const other = renumber(edited)[index];
+    return (
+      placement.id !== other.id ||
+      placement.widgetId !== other.widgetId ||
+      placement.order !== other.order ||
+      placement.hidden !== other.hidden ||
+      placement.size !== other.size ||
+      placement.height !== other.height
+    );
+  });
+}

--- a/packages/admin/src/components/features/widgets/layout-editor.ts
+++ b/packages/admin/src/components/features/widgets/layout-editor.ts
@@ -29,6 +29,34 @@ export interface MoveAffordance {
 }
 
 /**
+ * Moves the placement identified by `fromId` to the position currently held by
+ * `toId`, and returns a NEW array.
+ *
+ * 🔴 By IDENTITY, not by index, and the difference is a real defect rather than
+ * a preference. The grid draws a FILTERED view — a placement whose declaration
+ * this admin cannot resolve is skipped — so a position in what the reader sees
+ * is not a position in what is stored. With `[A, unresolvable, B]` the reader
+ * sees `[A, B]`, and moving `B` up by view-index 1 moved the UNRESOLVABLE
+ * placement while `B` stayed put, then persisted that order.
+ *
+ * Ids survive filtering; indices do not. Both callers already hold ids — the
+ * drag handler gets them from dnd-kit, and the buttons read them off the row
+ * they are rendered for — so nothing has to translate.
+ */
+export function movePlacementTo(
+  placements: readonly WidgetPlacement[],
+  fromId: string,
+  toId: string
+): WidgetPlacement[] {
+  const from = placements.findIndex(placement => placement.id === fromId);
+  const to = placements.findIndex(placement => placement.id === toId);
+  // An id neither list knows is an ordinary outcome — a drag released over
+  // nothing, a stale row — rather than an error worth throwing over.
+  if (from === -1 || to === -1) return [...placements];
+  return movePlacement(placements, from, to);
+}
+
+/**
  * Moves the placement at `from` to `to`, and returns a NEW array.
  *
  * Out-of-range indices return the input unchanged rather than throwing. A drag

--- a/packages/admin/src/components/features/widgets/sizes.ts
+++ b/packages/admin/src/components/features/widgets/sizes.ts
@@ -50,8 +50,17 @@ export const WIDGET_SPAN_CLASSES: Readonly<Record<WidgetSize, string>> =
  * declaration over the wire, so a value outside the enum is a shape the admin
  * has to survive. Full width is the safe answer — a widget too wide is legible,
  * a widget with no span class at all collapses to the grid's implicit one.
+ *
+ * 🔴 The parameter is `string`, not `WidgetSize`, and widening it was a
+ * CORRECTION rather than a loosening. The narrow type asserted a guarantee the
+ * function never had and the codebase does not hold: the body exists precisely
+ * to survive a value outside the enum, and the callers now include a stored
+ * arrangement whose size may have been written by a plugin built against a
+ * newer core. A signature that refuses what the body handles pushes the cast to
+ * every call site, which is where the `Object.hasOwn` guard below stops being
+ * reachable.
  */
-export function widgetSpanClass(size: WidgetSize | undefined): string {
+export function widgetSpanClass(size: string | undefined): string {
   if (!size) return WIDGET_SPAN_CLASSES.full;
   // `Object.hasOwn`, not a plain lookup with `??`. The value arrives over the
   // wire from a plugin declaration, so it can be any string -- and `constructor`
@@ -63,8 +72,12 @@ export function widgetSpanClass(size: WidgetSize | undefined): string {
   // The fallback below is what makes an unknown size survivable at all, so a
   // lookup that can silently skip it defeats the boundary rather than guarding
   // it.
+  // `Object.hasOwn` narrows nothing for the compiler — it is a runtime guard,
+  // not a type predicate — so the indexed read is asserted rather than left to
+  // fail the build. The assertion is sound BECAUSE of the line above it: the
+  // key is known to be an own property of this exact table by the time it runs.
   return Object.hasOwn(WIDGET_SPAN_CLASSES, size)
-    ? WIDGET_SPAN_CLASSES[size]
+    ? WIDGET_SPAN_CLASSES[size as WidgetSize]
     : WIDGET_SPAN_CLASSES.full;
 }
 

--- a/packages/admin/src/components/features/widgets/useGridAnnouncer.ts
+++ b/packages/admin/src/components/features/widgets/useGridAnnouncer.ts
@@ -1,0 +1,87 @@
+"use client";
+
+/**
+ * What the grid says out loud, and the one region it says it through.
+ *
+ * Its own hook because announcing is a subject rather than a step: it decides
+ * when silence is right, it dedupes a repeated sentence, and it is shared by
+ * two very different events — a batch settling, and a reader moving a card.
+ * Left inline it was four more pieces of state and branching in a component the
+ * complexity gate was already objecting to.
+ *
+ * ONE region, and one announcer feeding it. Several announcers on one surface
+ * interrupt each other and a reader cannot tell which announcement belonged to
+ * what they just did — the reason the grid has a single live region at all, and
+ * an argument that does not weaken because the second announcer would be the
+ * grid itself rather than a card.
+ *
+ * @module components/features/widgets/useGridAnnouncer
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface GridAnnouncer {
+  /** The live region's current text. */
+  announcement: string;
+  /** Say where a card landed. */
+  announceMove: (title: string, position: number, count: number) => void;
+}
+
+/**
+ * What the grid says once a batch settles, or `null` for a state not worth
+ * interrupting a reader for.
+ *
+ * Mid-flight says nothing, for the same reason `DocumentStatusLive` stays quiet
+ * during a save: this grid refetches on every window focus, and announcing the
+ * start of each refresh would speak over the reader every time they came back
+ * to the tab. What matters is where it came to rest.
+ */
+function settledAnnouncement(
+  isLoading: boolean,
+  total: number,
+  failed: number
+): string | null {
+  if (total === 0) return null;
+  if (isLoading) return null;
+  const loaded = total - failed;
+  const noun = total === 1 ? "widget" : "widgets";
+  return failed > 0
+    ? `${loaded} of ${total} ${noun} updated, ${failed} failed.`
+    : `${loaded} of ${total} ${noun} updated.`;
+}
+
+export function useGridAnnouncer(
+  settling: boolean,
+  counted: number,
+  failed: number
+): GridAnnouncer {
+  const [announcement, setAnnouncement] = useState("");
+  // What was last spoken, so an unchanged outcome does not re-fire. A ref
+  // rather than state because it must not itself cause a render.
+  const spoken = useRef("");
+  const next = settledAnnouncement(settling, counted, failed);
+
+  useEffect(() => {
+    if (!next || next === spoken.current) return;
+    spoken.current = next;
+    setAnnouncement(next);
+  }, [next]);
+
+  const announceMove = useCallback(
+    (title: string, position: number, count: number) => {
+      // The zero-width space alternates the string, because a live region does
+      // not re-announce text that did not change -- and moving a card up twice
+      // produces the same sentence both times. Same device as the builder's
+      // `keyboard-actions`, which is where this grid's convention comes from.
+      setAnnouncement(
+        current =>
+          `${title} moved to position ${position} of ${count}.${
+            current.endsWith("​") ? "" : "​"
+          }`
+      );
+    },
+    []
+  );
+
+  return { announcement, announceMove };
+}

--- a/packages/admin/src/components/features/widgets/useWidgetBatch.ts
+++ b/packages/admin/src/components/features/widgets/useWidgetBatch.ts
@@ -57,11 +57,20 @@ function worthAsking(widget: DashboardWidget): boolean {
 }
 
 export function useWidgetBatch(widgets: DashboardWidget[]): WidgetBatch {
+  // 🔴 Sorted by ID, not left in display order. `useWidgetQueries` puts the
+  // request partitions into its TanStack query keys, so a key built from the
+  // visual arrangement CHANGES every time a card moves — and every drag or
+  // button press re-issued the whole batch, spending access-checked database
+  // reads and blanking cards mid-edit, though not one data question had
+  // changed. A stable identity order makes the key describe what is being
+  // asked rather than where it happens to sit; results are keyed back by widget
+  // id, which never depended on order.
   const requests = useMemo<WidgetQueryRequest[]>(
     () =>
       widgets
         .filter(worthAsking)
-        .map(widget => ({ widgetId: widget.id, query: widget.query! })),
+        .map(widget => ({ widgetId: widget.id, query: widget.query! }))
+        .sort((a, b) => a.widgetId.localeCompare(b.widgetId)),
     [widgets]
   );
 

--- a/packages/admin/src/components/features/widgets/useWidgetBatch.ts
+++ b/packages/admin/src/components/features/widgets/useWidgetBatch.ts
@@ -1,0 +1,110 @@
+"use client";
+
+/**
+ * What the visible cards need fetched, and what the grid says once it lands.
+ *
+ * Extracted from the grid, which had grown three subjects — what the cards ARE,
+ * how they are ARRANGED, and what they need FETCHED — and the complexity gate
+ * objected before a reader would have. This is the third; `useDashboardArrangement`
+ * is the second.
+ *
+ * @module components/features/widgets/useWidgetBatch
+ */
+
+import { useMemo } from "react";
+
+import {
+  useWidgetQueries,
+  type WidgetQueryRequest,
+} from "@admin/hooks/queries/useWidgetQueries";
+import type {
+  DashboardWidget,
+  WidgetSlot,
+} from "@admin/types/dashboard/widgets";
+
+import { coreDraws, resolveWidgetOutcome } from "./outcome";
+
+export interface WidgetBatch {
+  slots: Record<string, WidgetSlot>;
+  isFetching: boolean;
+  updatedAt: Date | null;
+  /** Whether this widget took part in the batch at all. */
+  requested: ReadonlySet<string>;
+  /** How many cards the announcement should describe, and how many failed. */
+  counted: number;
+  failed: number;
+  settling: boolean;
+}
+
+/**
+ * Whether asking for this widget's data can produce anything drawable.
+ *
+ * A query is only worth running if SOMETHING can draw its result. A widget
+ * naming an archetype core cannot draw yet, and shipping no component to draw
+ * it instead, resolves to a card reading "not rendered yet" — so asking spends
+ * an access-checked read, and one of the batch's limited slots, on a result
+ * thrown away on arrival. `custom` always draws, because the plugin's component
+ * decides what to do with the slot.
+ *
+ * Asked of `coreDraws` rather than listed here, so the read starts happening on
+ * its own the day core learns to draw one — and asked of the whole DECLARATION,
+ * not just the archetype, because a renderer that will refuse this particular
+ * widget makes the read just as wasted as no renderer at all.
+ */
+function worthAsking(widget: DashboardWidget): boolean {
+  if (!widget.query) return false;
+  return widget.archetype === "custom" || coreDraws(widget);
+}
+
+export function useWidgetBatch(widgets: DashboardWidget[]): WidgetBatch {
+  const requests = useMemo<WidgetQueryRequest[]>(
+    () =>
+      widgets
+        .filter(worthAsking)
+        .map(widget => ({ widgetId: widget.id, query: widget.query! })),
+    [widgets]
+  );
+
+  const { slots, isFetching, updatedAt } = useWidgetQueries(requests);
+
+  // Which widgets are actually IN the batch, taken from the requests that were
+  // sent rather than re-derived from `widget.query`.
+  //
+  // Those two disagree, and the disagreement is the point: a widget declaring a
+  // query whose archetype nothing can draw is deliberately left out of the
+  // batch above, but it still HAS a `widget.query`. Testing that field again
+  // gave such a card a freshness line for a request that never ran, and marked
+  // it `aria-busy` during someone else's refetch.
+  const requested = useMemo(
+    () => new Set(requests.map(request => request.widgetId)),
+    [requests]
+  );
+
+  // The same answer the cards are drawn from, so the announcement cannot
+  // describe a dashboard other than the one on screen. Counting slots instead
+  // said "3 of 3 widgets updated" while a card read "the list archetype is not
+  // rendered yet": the response was fine and the card was not.
+  //
+  // Only widgets that ASKED are counted, and self-drawn ones are dropped even
+  // when they did. A plugin component decides what it shows from the slot it
+  // was handed, so core cannot say whether it worked, and guessing either way
+  // would put a number in the reader's ear that nothing on screen supports.
+  const outcomes = useMemo(
+    () =>
+      widgets
+        .filter(widget => widget.query)
+        .map(widget => resolveWidgetOutcome(widget, slots[widget.id]))
+        .filter(outcome => outcome.state !== "self-drawn"),
+    [widgets, slots]
+  );
+
+  return {
+    slots,
+    isFetching,
+    updatedAt,
+    requested,
+    counted: outcomes.length,
+    failed: outcomes.filter(outcome => outcome.state === "failed").length,
+    settling: outcomes.some(outcome => outcome.state === "loading"),
+  };
+}

--- a/packages/admin/src/hooks/queries/useDashboardLayout.ts
+++ b/packages/admin/src/hooks/queries/useDashboardLayout.ts
@@ -73,6 +73,16 @@ export interface UseDashboardLayoutResult {
    * authors both messages and both end "Reload and try again."
    */
   isConflict: boolean;
+  /**
+   * A write that failed for any OTHER reason, as something to show the reader.
+   *
+   * Separate from `isConflict` because the remedies differ: a conflict is
+   * recovered by reloading, a network error or a 500 by trying again. Reported
+   * at all because it previously was not — only conflicts were rendered, so a
+   * failed save left the reader in edit mode with the spinner stopped and
+   * nothing said, believing their arrangement had been stored.
+   */
+  writeError: Error | null;
   reload: () => Promise<unknown>;
 }
 
@@ -85,6 +95,11 @@ function isConflictError(error: Error | null): boolean {
   const status = (error as { status?: number }).status;
   const code = (error as { code?: string }).code;
   return status === 409 || code === "CONFLICT";
+}
+
+/** The first failure that is NOT a lost race, or `null`. */
+function nonConflictError(...errors: Array<Error | null>): Error | null {
+  return errors.find(error => error && !isConflictError(error)) ?? null;
 }
 
 export function useDashboardLayout(): UseDashboardLayoutResult {
@@ -108,11 +123,22 @@ export function useDashboardLayout(): UseDashboardLayoutResult {
   const save = useMutation({
     mutationFn: (input: SaveLayoutInput) =>
       protectedApi.put<unknown>(LAYOUT_PATH, input),
+    // 🔴 No retries, against the provider's default of two. A version-guarded
+    // write is not idempotent under an AMBIGUOUS failure: if the server commits
+    // and the response is lost, the retry sends the same now-stale version, the
+    // server refuses it, and the reader is told another editor changed their
+    // dashboard — when in fact their own save had already succeeded. The retry
+    // manufactures the exact conflict the guard exists to report truthfully.
+    retry: false,
     onSuccess: invalidate,
   });
 
   const reset = useMutation({
     mutationFn: () => protectedApi.delete<unknown>(LAYOUT_PATH),
+    // Idempotent by design — deleting a row that is already gone is the same
+    // answer — but retried silently it would still hide a server that is
+    // failing, and the reader would watch a spinner rather than a message.
+    retry: false,
     onSuccess: invalidate,
   });
 
@@ -127,6 +153,7 @@ export function useDashboardLayout(): UseDashboardLayoutResult {
     isConflict:
       isConflictError(save.error ?? null) ||
       isConflictError(reset.error ?? null),
+    writeError: nonConflictError(save.error ?? null, reset.error ?? null),
     reload: invalidate,
   };
 }

--- a/packages/admin/src/hooks/queries/useDashboardLayout.ts
+++ b/packages/admin/src/hooks/queries/useDashboardLayout.ts
@@ -1,0 +1,132 @@
+/**
+ * One reader's dashboard arrangement, and the two guards a write must echo.
+ *
+ * `GET /api/dashboard/layout` answers the arrangement RESOLVED against the live
+ * registry — placements whose widget no longer exists, or whose permission this
+ * caller lacks, are already gone — plus `available`, the widgets they may see
+ * and have not placed.
+ *
+ * ## Why a write echoes two things and not one
+ *
+ * `version` guards the ROW: another tab saved first. `scope` guards the FILTER
+ * that shaped what this client was shown: a permission grant, a role change or
+ * a plugin registering elsewhere moves the visible set without touching the
+ * row, so `version` still matches while the snapshot in hand is stale. A
+ * mismatch on either is a 409, and the remedy for both is identical — re-read.
+ * That is why this hook exposes one `conflict` flag rather than two: a caller
+ * that had to tell them apart would be a caller with two recovery paths, and
+ * there is only one.
+ *
+ * ## Why saving invalidates rather than writing through
+ *
+ * The response echoes what was submitted, not what was stored — the server
+ * merges back placements this caller was never shown, and deliberately does not
+ * disclose them. Seeding the cache from the response would therefore be seeding
+ * it with a deliberately partial answer. Invalidating costs one round trip and
+ * keeps the client's copy the server's copy.
+ *
+ * @module hooks/queries/useDashboardLayout
+ */
+
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+  type UseMutationResult,
+} from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { protectedApi } from "@admin/lib/api/protectedApi";
+import type {
+  DashboardLayoutResponse,
+  WidgetPlacement,
+} from "@admin/types/dashboard/widgets";
+
+/** The one query key this feature owns, so a save can invalidate exactly it. */
+export const DASHBOARD_LAYOUT_KEY = ["dashboard", "layout"] as const;
+
+const LAYOUT_PATH = "/dashboard/layout";
+
+/** What a save sends. Both guards, always — neither is optional server-side. */
+export interface SaveLayoutInput {
+  placements: WidgetPlacement[];
+  version: number;
+  scope: string;
+}
+
+export interface UseDashboardLayoutResult {
+  layout: DashboardLayoutResponse | undefined;
+  isPending: boolean;
+  /**
+   * Whether the arrangement could not be read at all.
+   *
+   * Distinct from an empty one: a reader with no widgets and a reader whose
+   * request failed both hold zero placements, and only the second is a fault.
+   */
+  isUnavailable: boolean;
+  save: UseMutationResult<unknown, Error, SaveLayoutInput>;
+  reset: UseMutationResult<unknown, Error, void>;
+  /**
+   * Whether the last write lost a race — on EITHER guard.
+   *
+   * One flag for two causes because the recovery is one action. The server
+   * authors both messages and both end "Reload and try again."
+   */
+  isConflict: boolean;
+  reload: () => Promise<unknown>;
+}
+
+/** Whether a failed write was a lost race rather than a broken request. */
+function isConflictError(error: Error | null): boolean {
+  if (!error) return false;
+  // The status is what the server actually distinguishes on; the message is
+  // human copy that may be translated or reworded. Read the code where one is
+  // available and fall back to the status only.
+  const status = (error as { status?: number }).status;
+  const code = (error as { code?: string }).code;
+  return status === 409 || code === "CONFLICT";
+}
+
+export function useDashboardLayout(): UseDashboardLayoutResult {
+  const queryClient = useQueryClient();
+
+  const query = useQuery({
+    queryKey: DASHBOARD_LAYOUT_KEY,
+    queryFn: () => protectedApi.get<DashboardLayoutResponse>(LAYOUT_PATH),
+    // Matching `useDashboardStats` and `useWidgetQueries`: fresh on mount and
+    // on focus, and NO polling. An arrangement that rearranges itself while
+    // somebody is reading it is worse than a stale one.
+    staleTime: 0,
+    refetchOnWindowFocus: true,
+  });
+
+  const invalidate = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: DASHBOARD_LAYOUT_KEY }),
+    [queryClient]
+  );
+
+  const save = useMutation({
+    mutationFn: (input: SaveLayoutInput) =>
+      protectedApi.put<unknown>(LAYOUT_PATH, input),
+    onSuccess: invalidate,
+  });
+
+  const reset = useMutation({
+    mutationFn: () => protectedApi.delete<unknown>(LAYOUT_PATH),
+    onSuccess: invalidate,
+  });
+
+  return {
+    layout: query.data,
+    isPending: query.isPending,
+    // A cached answer that a BACKGROUND refetch failed over is still a usable
+    // answer, so only an error with nothing to show counts as unavailable.
+    isUnavailable: query.isError && query.data === undefined,
+    save,
+    reset,
+    isConflict:
+      isConflictError(save.error ?? null) ||
+      isConflictError(reset.error ?? null),
+    reload: invalidate,
+  };
+}

--- a/packages/admin/src/types/dashboard/widgets.ts
+++ b/packages/admin/src/types/dashboard/widgets.ts
@@ -114,3 +114,47 @@ export interface DashboardWidget {
    */
   chrome?: WidgetChrome;
 }
+
+/**
+ * One card's place in a reader's arrangement.
+ *
+ * 🔴 `size` and `height` are `string`, not the size/height unions, and that is
+ * load-bearing rather than sloppy. A placement's geometry is seeded from a
+ * widget's declaration, and that widget may come from a plugin built against a
+ * NEWER core — so a stored arrangement can legitimately name a size this admin
+ * has never heard of. `widgetSpanClass` already survives one by falling back;
+ * a narrower type here would be a promise this client cannot keep, and would
+ * push the lie into every consumer.
+ */
+export interface WidgetPlacement {
+  /** Opaque, and unique within a layout. Not a widget id, except by default. */
+  id: string;
+  widgetId: string;
+  order: number;
+  hidden: boolean;
+  size?: string;
+  height?: string;
+  config?: Record<string, unknown>;
+}
+
+/** What `GET /api/dashboard/layout` answers. */
+export interface DashboardLayoutResponse {
+  placements: WidgetPlacement[];
+  /**
+   * Widget ids this reader may see and has not placed.
+   *
+   * The server's answer, not something to re-derive here: it is the only party
+   * that filters by permission authoritatively. A newly installed widget is
+   * never inserted into an arrangement behind the reader's back, so this is
+   * what makes it reachable at all.
+   */
+  available: string[];
+  version: number;
+  /** Which layer the arrangement came from: their own row, or the registry. */
+  source: "own" | "default";
+  /**
+   * An opaque token for the set of widgets this reader could see when the
+   * arrangement was read. Echoed back on write; a mismatch is a 409.
+   */
+  scope: string;
+}

--- a/packages/nextly/src/api/widget-layout.test.ts
+++ b/packages/nextly/src/api/widget-layout.test.ts
@@ -51,8 +51,13 @@ import {
   listWidgets,
   registerWidget,
 } from "../domains/widgets/registry";
+import { setContributedWidgets } from "../domains/widgets/canonical";
 
-import { getWidgetLayout, putWidgetLayout } from "./widget-layout";
+import {
+  deleteWidgetLayout,
+  getWidgetLayout,
+  putWidgetLayout,
+} from "./widget-layout";
 
 const reqAuth = vi.mocked(requireAuthentication);
 
@@ -60,6 +65,7 @@ const reqAuth = vi.mocked(requireAuthentication);
 let stored: { layout: string; version: number } | undefined;
 let saved: { placements: WidgetPlacement[]; expected: number } | undefined;
 let saveThrows: Error | undefined;
+let deleted: { kind: string; scope: string } | undefined;
 const logged: object[] = [];
 
 const fakeService = {
@@ -78,6 +84,10 @@ const fakeService = {
       logged.push({ unreadable: true });
       return { layout: undefined, version: stored.version, unreadable: true };
     }
+  },
+  deleteLayout: async (kind: string, scope: string) => {
+    deleted = { kind, scope };
+    stored = undefined;
   },
   saveLayout: async (
     _kind: string,
@@ -159,8 +169,10 @@ beforeEach(() => {
   stored = undefined;
   saved = undefined;
   saveThrows = undefined;
+  deleted = undefined;
   logged.length = 0;
   clearWidgets();
+  setContributedWidgets([]);
   reqAuth.mockResolvedValue({
     userId: "user-1",
     permissions: [],
@@ -269,6 +281,83 @@ describe("GET /api/dashboard/layout", () => {
     // that is still there -- turning a recoverable bad row into a dashboard
     // that can never be saved.
     expect(body.version).toBe(7);
+  });
+});
+
+describe("a widget that only CONTRIBUTED", () => {
+  it("appears in the default arrangement", async () => {
+    // 🔴 The defect. Layout resolution read the imperative registry alone, so a
+    // plugin using the documented `contributes.admin.widgets` surface rendered
+    // a card on the grid that was absent from every arrangement.
+    registerWidget(widget({ id: "core/a" }));
+    setContributedWidgets([{ id: "forms/latest", defaultOrder: 5 }]);
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements?.map(p => p.widgetId)).toEqual([
+      "forms/latest",
+      "core/a",
+    ]);
+  });
+
+  it("can be saved into an arrangement", async () => {
+    // Every PUT naming a contributed widget was refused as unavailable, so the
+    // card could not be arranged, hidden or added even by a client that knew
+    // about it.
+    setContributedWidgets([{ id: "forms/latest" }]);
+
+    const res = await putWidgetLayout(
+      putReq({
+        placements: [
+          { id: "p1", widgetId: "forms/latest", order: 0, hidden: false },
+        ],
+        version: 0,
+        scope: scopeFor(["forms/latest"]),
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(saved?.placements.map(p => p.widgetId)).toEqual(["forms/latest"]);
+  });
+
+  it("is offered in `available` when it is not placed", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    setContributedWidgets([{ id: "forms/latest" }]);
+    stored = {
+      version: 2,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: false },
+      ]),
+    };
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.available).toEqual(["forms/latest"]);
+  });
+
+  it("is gated by its declared permission like any other", async () => {
+    setContributedWidgets([
+      { id: "forms/latest", requiredPermission: "read-forms" },
+    ]);
+    callerHoldsPermission.mockResolvedValue(false);
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements).toEqual([]);
+    expect(callerHoldsPermission).toHaveBeenCalledWith(
+      "read-forms",
+      expect.anything()
+    );
+  });
+
+  it("takes the geometry it declared, unknown values included", async () => {
+    // A contribution may come from a plugin built against a newer core, so an
+    // unrecognised size must reach the placement rather than being refused.
+    setContributedWidgets([{ id: "forms/latest", defaultSize: "xxl" }]);
+
+    const body = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(body.placements?.[0]).toMatchObject({ size: "xxl" });
   });
 });
 
@@ -855,5 +944,70 @@ describe("PUT /api/dashboard/layout", () => {
     );
 
     expect(res.status).toBe(409);
+  });
+});
+
+describe("DELETE /api/dashboard/layout", () => {
+  it("removes the row and reports the reset", async () => {
+    registerWidget(widget({ id: "core/a" }));
+    stored = {
+      version: 4,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: true },
+      ]),
+    };
+
+    const res = await deleteWidgetLayout(
+      new Request("http://localhost/api/dashboard/layout", { method: "DELETE" })
+    );
+
+    expect(res.status).toBe(200);
+    expect(deleted).toEqual({ kind: "user", scope: "user-1" });
+  });
+
+  it("leaves the reader tracking the live registry, not a frozen copy", async () => {
+    // 🔴 The reason this is a DELETE and not a PUT of the current defaults.
+    // Writing a snapshot would freeze today's defaults into the row, so a
+    // widget registered later — or a `defaultOrder` a plugin changes later —
+    // would never reach this reader again. They would be "reset" onto a layout
+    // that no longer tracks the thing they reset to.
+    registerWidget(widget({ id: "core/a" }));
+    stored = {
+      version: 4,
+      layout: serializeLayout([
+        { id: "p1", widgetId: "core/a", order: 0, hidden: true },
+      ]),
+    };
+
+    await deleteWidgetLayout(
+      new Request("http://localhost/api/dashboard/layout", { method: "DELETE" })
+    );
+
+    // A widget that did not exist when the row was written.
+    registerWidget(widget({ id: "core/added-later" }));
+    const after = await bodyOf(await getWidgetLayout(getReq()));
+
+    expect(after.source).toBe("default");
+    expect(after.version).toBe(0);
+    expect(after.placements?.map(p => p.widgetId)).toEqual([
+      "core/a",
+      "core/added-later",
+    ]);
+  });
+
+  it("refuses an API key", async () => {
+    reqAuth.mockResolvedValue({
+      userId: "user-1",
+      permissions: [],
+      roles: [],
+      authMethod: "api-key",
+    });
+
+    const res = await deleteWidgetLayout(
+      new Request("http://localhost/api/dashboard/layout", { method: "DELETE" })
+    );
+
+    expect(res.status).toBe(403);
+    expect(deleted).toBeUndefined();
   });
 });

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -36,6 +36,7 @@ import {
   callerHoldsPermission,
   type ReadAccessCaller,
 } from "../auth/entity-read-access";
+import type { AuthContext } from "../auth/middleware";
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
@@ -345,31 +346,50 @@ function readScope(body: Record<string, unknown>): string {
   return scope;
 }
 
-export const putWidgetLayout = withErrorHandler(async (req: Request) => {
+/**
+ * Authenticate a WRITE to the layout, and refuse the callers who may never make
+ * one.
+ *
+ * Shared by both mutating verbs because they share the reason, not merely the
+ * code. Two copies of a precondition agree until one is edited, and the edit
+ * that matters here is the one that relaxes it — an api-key refusal present on
+ * the save and absent from the reset would let a key discard its minter's
+ * arrangement while being unable to change it.
+ *
+ * 🔴 Refuses BEFORE the body is read, and before anything is parsed, resolved
+ * or constructed. This is a precondition, not a defensive check: a caller that
+ * can never perform the operation must be refused on that ground, and refused
+ * first. Placed after the body, a malformed payload came back as a validation
+ * error — telling a caller which FIELD it got wrong on a request it was never
+ * allowed to make, and paying for the parse in order to say so.
+ *
+ * A dashboard arrangement is one person's personalization of their own admin
+ * screen, and an API key has no screen. Refused rather than gated behind a
+ * permission slug, because no grant would make it meaningful: the key would be
+ * acting on the layout of whoever minted it. Reading stays open — it tells a
+ * key nothing it could not already ask the registry.
+ *
+ * Read off the AUTH CONTEXT rather than the resolved caller, because that is
+ * available here and the resolved caller is not: resolving one is a database
+ * read, which is exactly the work this refusal exists to avoid doing.
+ */
+async function authenticateLayoutWrite(
+  req: Request,
+  intent: string
+): Promise<AuthContext> {
   const auth = await requireAuthentication(req);
   if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
 
-  // 🔴 BEFORE the body is read, and before anything is parsed, resolved or
-  // constructed. This is a precondition, not a defensive check: a caller that
-  // can never perform this operation must be refused on that ground, and
-  // refused first. Placed after the body it answered a malformed payload with a
-  // validation error — telling a caller which FIELD it got wrong on a request
-  // it was never allowed to make, and paying for the parse to say so.
-  //
-  // A dashboard arrangement is one person's personalization of their own admin
-  // screen, and an API key has no screen. Refused rather than gated behind a
-  // permission slug, because no grant would make it meaningful: the key would
-  // be rewriting the layout of whoever minted it. Reading stays open — it tells
-  // a key nothing it could not already ask the registry.
-  //
-  // Read off the auth context rather than the resolved caller, because that is
-  // available here and the resolved caller is not: resolving it is a database
-  // read, which is work this refusal exists to avoid doing.
   if (auth.authMethod === "api-key") {
     throw NextlyError.forbidden({
-      logContext: { reason: "an api key may not write a dashboard layout" },
+      logContext: { reason: `an api key may not ${intent} a dashboard layout` },
     });
   }
+  return auth;
+}
+
+export const putWidgetLayout = withErrorHandler(async (req: Request) => {
+  const auth = await authenticateLayoutWrite(req, "write");
 
   // Bounded BEFORE it is buffered. `req.json()` reads the whole body first, so
   // a quota checked on the parsed result has already paid for the memory and
@@ -532,14 +552,7 @@ function firstDuplicateId(
  * its minter's.
  */
 export const deleteWidgetLayout = withErrorHandler(async (req: Request) => {
-  const auth = await requireAuthentication(req);
-  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
-
-  if (auth.authMethod === "api-key") {
-    throw NextlyError.forbidden({
-      logContext: { reason: "an api key may not reset a dashboard layout" },
-    });
-  }
+  const auth = await authenticateLayoutWrite(req, "reset");
 
   const service = await getLayoutService();
   const caller = readAccessCaller(await readCaller(auth));

--- a/packages/nextly/src/api/widget-layout.ts
+++ b/packages/nextly/src/api/widget-layout.ts
@@ -39,7 +39,7 @@ import {
 import { isErrorResponse, requireAuthentication } from "../auth/middleware";
 import { toNextlyAuthError } from "../auth/middleware/to-nextly-error";
 import { container } from "../di";
-import type { WidgetDefinition } from "../domains/widgets/definition";
+import { allWidgets, type CanonicalWidget } from "../domains/widgets/canonical";
 import {
   MAX_LAYOUT_BYTES,
   defaultPlacements,
@@ -50,7 +50,6 @@ import {
   visibilityToken,
   type WidgetPlacement,
 } from "../domains/widgets/layout";
-import { listWidgets } from "../domains/widgets/registry";
 import { NextlyError } from "../errors/nextly-error";
 import { getCachedNextly } from "../init";
 import {
@@ -65,6 +64,7 @@ import {
 } from "./authenticated-read";
 import { readBoundedJsonBody } from "./read-json-body";
 import {
+  respondAction,
   respondData,
   respondMutation,
   SKIP_DATE_FORMATTING_HEADER,
@@ -122,7 +122,7 @@ function carriedPlacements(
   if (storedPlacements) {
     return partitionPlacements(storedPlacements, visibleIds).invisible;
   }
-  return partitionPlacements(defaultPlacements(listWidgets()), visibleIds)
+  return partitionPlacements(defaultPlacements(allWidgets()), visibleIds)
     .invisible;
 }
 
@@ -143,10 +143,10 @@ function carriedPlacements(
  * materializations that agree only while nothing is hidden.
  */
 function visibleDefaults(
-  widgets: readonly WidgetDefinition[]
+  widgets: readonly CanonicalWidget[]
 ): WidgetPlacement[] {
   const visibleIds = new Set(widgets.map(widget => widget.id));
-  return partitionPlacements(defaultPlacements(listWidgets()), visibleIds)
+  return partitionPlacements(defaultPlacements(allWidgets()), visibleIds)
     .visible;
 }
 
@@ -181,8 +181,8 @@ async function getLayoutService(): Promise<WidgetLayoutService> {
  */
 async function visibleWidgets(
   caller: ReadAccessCaller
-): Promise<WidgetDefinition[]> {
-  const all = listWidgets();
+): Promise<CanonicalWidget[]> {
+  const all = allWidgets();
 
   const slugs = [
     ...new Set(
@@ -226,7 +226,7 @@ async function visibleWidgets(
  * `typeof` on a value already in hand costs nothing.
  */
 function isVisibleTo(
-  widget: WidgetDefinition,
+  widget: CanonicalWidget,
   verdicts: ReadonlyMap<string, boolean>
 ): boolean {
   const slug: unknown = widget.requiredPermission;
@@ -479,10 +479,18 @@ export const putWidgetLayout = withErrorHandler(async (req: Request) => {
   // `respondMutation`, not `respondData`: this is a write, and every write in
   // this package answers `{ message, item }`. A bespoke top-level shape would
   // be one the shared client parser cannot read at all.
+  // Sorted the way a GET sorts, not echoed in submission order. A valid PUT may
+  // list placements in any array order — only each `order` field is validated —
+  // and the stored row is normalized by `partitionPlacements` on the next read.
+  // Echoing the raw array made this response a SECOND representation of the
+  // same arrangement: a client trusting it to chain another edit without
+  // re-reading would render `[10, 0]` where a reload gives `[0, 10]`.
+  const echoed = [...submitted].sort((a, b) => a.order - b.order);
+
   return respondMutation(
     "Dashboard layout saved.",
     {
-      placements: submitted,
+      placements: echoed,
       version,
       source: "own" satisfies LayoutSource,
       // Echoed so a client can make a second edit without a round trip. It is
@@ -506,3 +514,46 @@ function firstDuplicateId(
   }
   return undefined;
 }
+
+/**
+ * DELETE `/api/dashboard/layout` — put the dashboard back to the registry's
+ * own order.
+ *
+ * Removes the row rather than writing the current defaults into it, and the
+ * difference is the whole point. A written snapshot freezes today's defaults
+ * into the reader's arrangement, so a widget added later, or a `defaultOrder`
+ * a plugin changes later, never reaches them again — the reader would be
+ * "reset" onto a layout that stops tracking the thing it was reset to. With no
+ * row, resolution falls through to the live registry on every read, which is
+ * what a default IS.
+ *
+ * Refused for an API key on the same ground as the write: a dashboard
+ * arrangement belongs to a person, and a key resetting one would be discarding
+ * its minter's.
+ */
+export const deleteWidgetLayout = withErrorHandler(async (req: Request) => {
+  const auth = await requireAuthentication(req);
+  if (isErrorResponse(auth)) throw toNextlyAuthError(auth);
+
+  if (auth.authMethod === "api-key") {
+    throw NextlyError.forbidden({
+      logContext: { reason: "an api key may not reset a dashboard layout" },
+    });
+  }
+
+  const service = await getLayoutService();
+  const caller = readAccessCaller(await readCaller(auth));
+  await service.deleteLayout(SCOPE_KIND, caller.userId);
+
+  // No version echoed, because there is no row to hold one: the next read
+  // answers 0 and `source: "default"`, which is the state the caller asked to
+  // be in. Returning a version here would hand a client a number to send back
+  // in a guard that now has nothing to guard.
+  return respondAction(
+    "Dashboard layout reset.",
+    {},
+    {
+      headers: OPAQUE_CONFIG_HEADERS,
+    }
+  );
+});

--- a/packages/nextly/src/di/register.ts
+++ b/packages/nextly/src/di/register.ts
@@ -718,7 +718,7 @@ export async function registerServices(
   // needed. Building them from `transformedConfig.collections` here was the
   // defect: a Builder-authored collection has no config entry at all, so one
   // of the framework's two schema modes had no queryable source.
-  resetWidgetRegistries();
+  resetWidgetRegistries(transformedConfig.plugins ?? []);
 
   // Then layer in the registry-stored opt-outs. Builder-authored collections and
   // singles have no code-first config to publish from, so without this read their

--- a/packages/nextly/src/di/registrations/register-widgets.ts
+++ b/packages/nextly/src/di/registrations/register-widgets.ts
@@ -37,13 +37,26 @@
  * @module di/registrations/register-widgets
  */
 
+import { setContributedWidgets } from "../../domains/widgets/canonical";
 import { CORE_WIDGETS } from "../../domains/widgets/core-widgets";
 import { clearWidgets, registerWidget } from "../../domains/widgets/registry";
 import { clearSources } from "../../domains/widgets/sources";
+import type { PluginDefinition } from "../../plugins/plugin-context";
+import { contributedWidgetSummaries } from "../../plugins/validate-admin-widgets";
 
-export function resetWidgetRegistries(): void {
+export function resetWidgetRegistries(
+  plugins: readonly PluginDefinition[] = []
+): void {
   clearWidgets();
   clearSources();
+
+  // The OTHER channel a widget arrives by. A contribution never passes through
+  // `registerWidget`, so without this the server's canonical set holds core's
+  // cards alone -- and every server-side question about which widgets exist
+  // answers differently from the grid, which has always resolved both.
+  // Replaced rather than merged, for the same reason the registry is cleared
+  // above: a hot reload must not accumulate the previous boot's plugins.
+  setContributedWidgets(contributedWidgetSummaries(plugins));
 
   for (const definition of CORE_WIDGETS) {
     registerWidget(definition);

--- a/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
@@ -53,6 +53,40 @@ describe("the canonical widget set", () => {
     expect(merged[0].defaultOrder).toBe(5);
   });
 
+  it("keeps a CONTRIBUTED order the registration did not state", () => {
+    // 🔴 A collision was resolved by wholesale replacement, which the admin
+    // does not do: `resolve-widgets.ts` reads
+    // `registration.defaultOrder ?? contribution.defaultOrder`. So a
+    // registration that stated no order dropped the contributed one here and
+    // kept it there -- the server building the default arrangement from one
+    // declaration while the grid drew it from another, with a card sorted into
+    // a position the reader never sees.
+    registerWidget(registered({ id: "dup/one" }));
+    const merged = canonicalWidgets([{ id: "dup/one", defaultOrder: 99 }]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].defaultOrder).toBe(99);
+  });
+
+  it("keeps a CONTRIBUTED height the registration did not state", () => {
+    registerWidget(registered({ id: "dup/one" }));
+    expect(
+      canonicalWidgets([{ id: "dup/one", defaultHeight: "tall" }])[0]
+    ).toHaveProperty("defaultHeight", "tall");
+  });
+
+  it("does NOT inherit a contributed permission, matching the admin", () => {
+    // The asymmetry is deliberate. The registry is the override channel, so a
+    // registration that states no permission has stated that, and
+    // `mergeCollision` reads it exactly that way. Falling back here would gate
+    // a card the admin renders ungated -- the reader sees it and every write
+    // naming it is refused, which is the same disagreement inverted.
+    registerWidget(registered({ id: "dup/one" }));
+    const merged = canonicalWidgets([
+      { id: "dup/one", requiredPermission: "read-forms" },
+    ]);
+    expect(merged[0]).not.toHaveProperty("requiredPermission");
+  });
+
   it("carries the fields placement reads, from a registration", () => {
     registerWidget(
       registered({

--- a/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
+++ b/packages/nextly/src/domains/widgets/__tests__/canonical.test.ts
@@ -1,0 +1,99 @@
+/**
+ * One answer to "which widgets exist", across two channels that do not share a
+ * shape.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { canonicalWidgets, type CanonicalWidget } from "../canonical";
+import type { WidgetDefinition } from "../definition";
+import { clearWidgets, registerWidget } from "../registry";
+
+function registered(patch: Partial<WidgetDefinition>): WidgetDefinition {
+  return {
+    id: "core/a",
+    title: "A",
+    archetype: "custom",
+    defaultSize: "full",
+    component: "core#A",
+    ...patch,
+  } as WidgetDefinition;
+}
+
+beforeEach(() => clearWidgets());
+
+describe("the canonical widget set", () => {
+  it("includes a widget that only CONTRIBUTED", () => {
+    // 🔴 The defect. `listWidgets()` answers the imperative registry alone, so
+    // a plugin using the documented `contributes.admin.widgets` surface was
+    // absent from the default arrangement and from `available`, and every write
+    // naming it was refused as unavailable — a card that renders and can never
+    // be arranged.
+    const contributed: CanonicalWidget[] = [{ id: "forms/latest" }];
+    expect(canonicalWidgets(contributed).map(w => w.id)).toEqual([
+      "forms/latest",
+    ]);
+  });
+
+  it("includes widgets from both channels", () => {
+    registerWidget(registered({ id: "core/team" }));
+    expect(
+      canonicalWidgets([{ id: "forms/latest" }])
+        .map(w => w.id)
+        .sort()
+    ).toEqual(["core/team", "forms/latest"]);
+  });
+
+  it("lets a REGISTRATION win a collision, matching the admin's resolver", () => {
+    // The two must agree. If the server ordered a card by the contribution
+    // while the admin drew it from the registration, the arrangement would
+    // order one declaration and render another, and nothing would look wrong.
+    registerWidget(registered({ id: "dup/one", defaultOrder: 5 }));
+    const merged = canonicalWidgets([{ id: "dup/one", defaultOrder: 99 }]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].defaultOrder).toBe(5);
+  });
+
+  it("carries the fields placement reads, from a registration", () => {
+    registerWidget(
+      registered({
+        id: "core/team",
+        requiredPermission: "read-users",
+        defaultSize: "md",
+        defaultHeight: "tall",
+        defaultOrder: 20,
+      })
+    );
+    expect(canonicalWidgets([])[0]).toEqual({
+      id: "core/team",
+      requiredPermission: "read-users",
+      defaultSize: "md",
+      defaultHeight: "tall",
+      defaultOrder: 20,
+    });
+  });
+
+  it("omits what a declaration did not state", () => {
+    registerWidget(registered({ id: "core/team" }));
+    const [widget] = canonicalWidgets([]);
+    expect(widget).not.toHaveProperty("requiredPermission");
+    expect(widget).not.toHaveProperty("defaultOrder");
+  });
+
+  it("keeps a contributed size this core has never heard of", () => {
+    // A contribution crosses a version boundary. Refusing an unknown size here
+    // would drop the whole card from the arrangement over a value the admin
+    // already survives by falling back.
+    expect(canonicalWidgets([{ id: "p/w", defaultSize: "xxl" }])[0]).toEqual({
+      id: "p/w",
+      defaultSize: "xxl",
+    });
+  });
+
+  it("drops a contribution with no usable id", () => {
+    expect(canonicalWidgets([{ id: "" }])).toEqual([]);
+  });
+
+  it("is empty when neither channel has anything", () => {
+    expect(canonicalWidgets([])).toEqual([]);
+  });
+});

--- a/packages/nextly/src/domains/widgets/canonical.ts
+++ b/packages/nextly/src/domains/widgets/canonical.ts
@@ -71,14 +71,56 @@ function fromRegistration(definition: WidgetDefinition): CanonicalWidget {
 }
 
 /**
+ * One id declared through BOTH channels, as the single summary it describes.
+ *
+ * 🔴 MERGED FIELD BY FIELD, not substituted, because that is what the admin
+ * does and the two must agree. `resolve-widgets.ts` reads
+ * `registration.defaultOrder ?? contribution.defaultOrder`; a wholesale replace
+ * here dropped a contributed order that the admin kept, so the server built the
+ * default arrangement from one declaration while the grid drew it from another
+ * — a card sorted into a position the reader never sees, with nothing visibly
+ * wrong to say so.
+ *
+ * `requiredPermission` deliberately does NOT fall back, and the asymmetry is
+ * the point rather than an omission. The registry is the override channel —
+ * `overrideWidget` and `extendWidget` exist so a later plugin can correct an
+ * earlier widget — so a registration that states no permission has STATED that,
+ * and the admin reads it exactly that way. A `??` here would gate a card the
+ * admin renders ungated: the reader would see it and the server would refuse
+ * every write naming it, which is the same disagreement in the other direction.
+ *
+ * `defaultSize` needs no fallback either, for a duller reason: `WidgetDefinition`
+ * requires it and `validateWidgetDefinition` enforces it, so a registration
+ * always states one.
+ *
+ * What is left is the two fields a registration may legally omit and a
+ * contribution may legally state, and for those the contribution is read.
+ */
+function mergeCanonical(
+  contribution: CanonicalWidget,
+  registration: CanonicalWidget
+): CanonicalWidget {
+  const defaultOrder = registration.defaultOrder ?? contribution.defaultOrder;
+  const defaultHeight =
+    registration.defaultHeight ?? contribution.defaultHeight;
+  return {
+    // The registration wholesale first: id, `requiredPermission` and
+    // `defaultSize` are its to state, including by stating nothing.
+    ...registration,
+    ...(defaultOrder === undefined ? {} : { defaultOrder }),
+    ...(defaultHeight === undefined ? {} : { defaultHeight }),
+  };
+}
+
+/**
  * Every widget this install has, from both channels, deduplicated by id.
  *
  * 🔴 A REGISTRATION WINS a collision, which is the same precedence the admin's
- * own resolver applies (`resolve-widgets.ts` reads
- * `registration.defaultOrder ?? contribution.defaultOrder`). The two must agree:
- * if the server resolved a colliding id to the contribution while the admin
- * rendered the registration, the arrangement would order a card by one
- * declaration and draw it from another, and nothing would look wrong.
+ * own resolver applies — field by field, through {@link mergeCanonical}, rather
+ * than by replacing the contribution outright. The two must agree: if the
+ * server resolved a colliding id differently from the admin, the arrangement
+ * would order a card by one declaration and draw it from another, and nothing
+ * would look wrong.
  *
  * Contributions are taken as already-validated summaries rather than raw
  * declarations, so this module never has to know how a plugin is shaped — and
@@ -88,13 +130,18 @@ export function canonicalWidgets(
   contributed: readonly CanonicalWidget[]
 ): CanonicalWidget[] {
   const byId = new Map<string, CanonicalWidget>();
-  // Contributions first, so a registration with the same id overwrites one
+  // Contributions first, so a registration with the same id merges over one
   // rather than being dropped by it.
   for (const widget of contributed) {
     if (widget.id) byId.set(widget.id, widget);
   }
   for (const definition of listWidgets()) {
-    byId.set(definition.id, fromRegistration(definition));
+    const registration = fromRegistration(definition);
+    const contribution = byId.get(definition.id);
+    byId.set(
+      definition.id,
+      contribution ? mergeCanonical(contribution, registration) : registration
+    );
   }
   return [...byId.values()];
 }

--- a/packages/nextly/src/domains/widgets/canonical.ts
+++ b/packages/nextly/src/domains/widgets/canonical.ts
@@ -1,0 +1,139 @@
+/**
+ * ONE answer to "which widgets exist", for every server-side question that
+ * needs one.
+ *
+ * 🔴 A widget reaches the dashboard by TWO channels — `registerWidget`, which
+ * writes the imperative registry, and `contributes.admin.widgets`, which a
+ * plugin declares and which never touches that registry at all. The admin grid
+ * has always resolved both. The layout store, written later, read only the
+ * first, and the two consequences were invisible while nothing consumed it:
+ * a contributed widget was absent from the default arrangement and from
+ * `available`, and every write naming one was refused as unavailable. So a
+ * plugin using the documented contribution surface could render a card that
+ * could never be arranged, hidden, or added.
+ *
+ * The fix is not for the layout endpoint to learn about contributions — that
+ * would be a third place answering the same question. It is for the question to
+ * have one implementation that both channels feed.
+ *
+ * ## Why this is a SUMMARY and not a `WidgetDefinition`
+ *
+ * The two channels do not carry the same shape and cannot be made to. A
+ * registration is a resolved widget and requires `title` and `defaultSize`; a
+ * contribution may omit both, and resolution fills them in downstream. Forcing
+ * a contribution into `WidgetDefinition` here would mean inventing the missing
+ * fields server-side and then disagreeing with whatever the admin invented.
+ *
+ * Layout resolution needs four things and none of them are the missing ones:
+ * which ids exist, which permission gates each, where it sits by default, and
+ * what geometry it starts with. That is what this carries. Rendering still
+ * reads the full declaration through the channel it came from.
+ *
+ * @module domains/widgets/canonical
+ */
+
+import type { WidgetDefinition } from "./definition";
+import { listWidgets } from "./registry";
+
+/**
+ * The part of a widget that layout resolution needs, from either channel.
+ *
+ * `defaultSize` and `defaultHeight` are `string`, not the enums, for the reason
+ * every other layout type is: a contribution may come from a plugin built
+ * against a newer core, and a value outside this core's vocabulary is a shape
+ * to survive rather than one to refuse.
+ */
+export interface CanonicalWidget {
+  id: string;
+  requiredPermission?: string;
+  defaultSize?: string;
+  defaultHeight?: string;
+  defaultOrder?: number;
+}
+
+/** The summary of one registered widget. */
+function fromRegistration(definition: WidgetDefinition): CanonicalWidget {
+  return {
+    id: definition.id,
+    ...(definition.requiredPermission === undefined
+      ? {}
+      : { requiredPermission: definition.requiredPermission }),
+    ...(definition.defaultSize === undefined
+      ? {}
+      : { defaultSize: definition.defaultSize }),
+    ...(definition.defaultHeight === undefined
+      ? {}
+      : { defaultHeight: definition.defaultHeight }),
+    ...(definition.defaultOrder === undefined
+      ? {}
+      : { defaultOrder: definition.defaultOrder }),
+  };
+}
+
+/**
+ * Every widget this install has, from both channels, deduplicated by id.
+ *
+ * 🔴 A REGISTRATION WINS a collision, which is the same precedence the admin's
+ * own resolver applies (`resolve-widgets.ts` reads
+ * `registration.defaultOrder ?? contribution.defaultOrder`). The two must agree:
+ * if the server resolved a colliding id to the contribution while the admin
+ * rendered the registration, the arrangement would order a card by one
+ * declaration and draw it from another, and nothing would look wrong.
+ *
+ * Contributions are taken as already-validated summaries rather than raw
+ * declarations, so this module never has to know how a plugin is shaped — and
+ * the validation stays where the version boundary is understood.
+ */
+export function canonicalWidgets(
+  contributed: readonly CanonicalWidget[]
+): CanonicalWidget[] {
+  const byId = new Map<string, CanonicalWidget>();
+  // Contributions first, so a registration with the same id overwrites one
+  // rather than being dropped by it.
+  for (const widget of contributed) {
+    if (widget.id) byId.set(widget.id, widget);
+  }
+  for (const definition of listWidgets()) {
+    byId.set(definition.id, fromRegistration(definition));
+  }
+  return [...byId.values()];
+}
+
+/**
+ * The contributed half, pinned where the registry itself is pinned.
+ *
+ * On `globalThis`, like every other boot-time widget store, so it survives the
+ * module re-evaluation Next.js and Turbopack perform — and so a hot reload that
+ * re-registers the same plugins replaces the set rather than accumulating it.
+ *
+ * Written at boot rather than read from the route handler's config on demand,
+ * which is what an earlier version did. Reaching from `api/` into
+ * `route-handler/` for boot state inverts the layering — the request path
+ * should not have to know how boot stores anything — and it made this question
+ * unanswerable in any test that had not mocked the boot module. Populated
+ * where every other widget store is populated, it is a plain domain question
+ * again.
+ */
+const globalForContributed = globalThis as unknown as {
+  __nextly_contributedWidgets?: CanonicalWidget[];
+};
+
+/** Replace the contributed set. Called once per boot, beside the registry. */
+export function setContributedWidgets(
+  widgets: readonly CanonicalWidget[]
+): void {
+  globalForContributed.__nextly_contributedWidgets = [...widgets];
+}
+
+/**
+ * Every widget this install has, from both channels.
+ *
+ * The question every server-side consumer should ask. `listWidgets()` answers
+ * only the imperative registry and is the reason a contributed widget could
+ * render and never be arranged.
+ */
+export function allWidgets(): CanonicalWidget[] {
+  return canonicalWidgets(
+    globalForContributed.__nextly_contributedWidgets ?? []
+  );
+}

--- a/packages/nextly/src/domains/widgets/layout.ts
+++ b/packages/nextly/src/domains/widgets/layout.ts
@@ -50,8 +50,6 @@ import { createHash } from "node:crypto";
 
 import { NextlyError } from "../../errors/nextly-error";
 
-import type { WidgetDefinition } from "./definition";
-
 /**
  * The shape this core writes and understands.
  *
@@ -88,6 +86,23 @@ export interface WidgetPlacement {
 export interface StoredLayout {
   schemaVersion: number;
   placements: WidgetPlacement[];
+}
+
+/**
+ * What placing a widget actually reads from its declaration.
+ *
+ * Four fields, and deliberately not `WidgetDefinition`. A widget reaches the
+ * dashboard by two channels whose shapes differ — a registration is a resolved
+ * widget and carries `title` and `archetype`, a contribution may carry neither
+ * — and placement needs none of the fields they disagree about. Typing this on
+ * what it reads lets both satisfy it without either being cast into the other's
+ * shape, which is where an invented `title` would have come from.
+ */
+export interface PlaceableWidget {
+  id: string;
+  defaultOrder?: number;
+  defaultSize?: string;
+  defaultHeight?: string;
 }
 
 /** How far apart default placements sit, so one can be inserted between two. */
@@ -306,7 +321,7 @@ export function serializeLayout(
  * Two unstated widgets compare as `NaN`, which `Array.prototype.sort` treats as
  * "leave them alone", so they keep registration order.
  */
-function byDeclaredOrder(a: WidgetDefinition, b: WidgetDefinition): number {
+function byDeclaredOrder(a: PlaceableWidget, b: PlaceableWidget): number {
   return (
     (a.defaultOrder ?? Number.POSITIVE_INFINITY) -
     (b.defaultOrder ?? Number.POSITIVE_INFINITY)
@@ -327,7 +342,7 @@ function byDeclaredOrder(a: WidgetDefinition, b: WidgetDefinition): number {
  * has to re-key on every fetch.
  */
 export function defaultPlacements(
-  widgets: readonly WidgetDefinition[]
+  widgets: readonly PlaceableWidget[]
 ): WidgetPlacement[] {
   return [...widgets].sort(byDeclaredOrder).map((widget, index) => ({
     id: widget.id,
@@ -406,7 +421,16 @@ export function mergePreservingHidden(
   invisible: readonly WidgetPlacement[]
 ): WidgetPlacement[] {
   const taken = new Set(submitted.map(placement => placement.id));
-  const carried = invisible.map(placement => {
+  // What is left for carried placements after the caller's own snapshot. Never
+  // negative: a submission at the cap leaves nothing, and `slice(0, 0)` is the
+  // empty carry rather than a `slice` that means "everything".
+  const room = Math.max(0, MAX_STORED_PLACEMENTS - submitted.length);
+  // Oldest-positioned first, so the cap keeps a stable, order-derived subset
+  // rather than whichever ones happened to arrive last.
+  const bounded = [...invisible]
+    .sort((a, b) => a.order - b.order)
+    .slice(0, room);
+  const carried = bounded.map(placement => {
     if (!taken.has(placement.id)) {
       taken.add(placement.id);
       return placement;
@@ -435,6 +459,28 @@ export function mergePreservingHidden(
  * without any caller ever meeting the dialect's own edge.
  */
 export const MAX_PLACEMENTS = 200;
+
+/**
+ * The ceiling on the row as STORED, carried placements included.
+ *
+ * 🔴 `MAX_PLACEMENTS` bounds one submission and therefore bounds nothing about
+ * the row: `mergePreservingHidden` retains placements from every earlier
+ * visibility set, so a reader who repeatedly saves a full arrangement and then
+ * loses access to those widgets appends another hidden group each time. The
+ * accumulation is unbounded, and at the dialect's own ceiling an otherwise
+ * valid write starts failing — which puts the acceptance boundary back where a
+ * caller can measure hidden data against it.
+ *
+ * Bounded by DROPPING the surplus rather than by refusing the write, and that
+ * choice is the whole point. A refusal would depend on how much hidden data
+ * there is, which is the oracle; a silent cap depends only on a constant, so
+ * every submission under the caller's own budget is accepted whatever is behind
+ * it. The cost is real and worth stating: past this many placements, the
+ * least-recently-positioned hidden cards are forgotten. Twice a full
+ * arrangement, so no reader reaches it by arranging their dashboard — only by
+ * accumulating hidden groups, which is the case being bounded.
+ */
+export const MAX_STORED_PLACEMENTS = MAX_PLACEMENTS * 2;
 export const MAX_LAYOUT_BYTES = 32 * 1024;
 
 /**

--- a/packages/nextly/src/plugins/__tests__/contributed-widget-summaries.test.ts
+++ b/packages/nextly/src/plugins/__tests__/contributed-widget-summaries.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Which contributed widgets the server's canonical set admits.
+ */
+import { describe, expect, it } from "vitest";
+
+import type { PluginDefinition } from "../plugin-context";
+import { contributedWidgetSummaries } from "../validate-admin-widgets";
+
+function plugin(patch: Record<string, unknown>): PluginDefinition {
+  return {
+    name: "@acme/plugin",
+    contributes: {
+      admin: {
+        widgets: [
+          {
+            id: "acme/latest",
+            title: "Latest",
+            archetype: "metric",
+            query: { source: "collection:posts", op: "count" },
+          },
+        ],
+      },
+    },
+    ...patch,
+  } as unknown as PluginDefinition;
+}
+
+describe("contributed widget summaries", () => {
+  it("includes a plugin with no `enabled` field", () => {
+    // Absence means enabled — the reading admin-meta, reload-config and the
+    // field-type registry each apply.
+    expect(contributedWidgetSummaries([plugin({})]).map(w => w.id)).toEqual([
+      "acme/latest",
+    ]);
+  });
+
+  it("includes an explicitly enabled plugin", () => {
+    expect(
+      contributedWidgetSummaries([plugin({ enabled: true })]).map(w => w.id)
+    ).toEqual(["acme/latest"]);
+  });
+
+  it("excludes a DISABLED plugin", () => {
+    // 🔴 `buildPluginAdminMeta` withholds every behavioural admin surface from
+    // a disabled plugin, so the admin has no declaration to draw one of its
+    // widgets with. Admitting them here put ghost ids into default placements,
+    // into `available` and into the scope token — cards the reader could
+    // arrange and never see.
+    expect(contributedWidgetSummaries([plugin({ enabled: false })])).toEqual(
+      []
+    );
+  });
+
+  it("keeps the enabled plugins when one of several is disabled", () => {
+    const summaries = contributedWidgetSummaries([
+      plugin({ enabled: false }),
+      plugin({
+        name: "@acme/other",
+        enabled: true,
+        contributes: {
+          admin: {
+            widgets: [
+              {
+                id: "acme/other",
+                title: "Other",
+                archetype: "metric",
+                query: { source: "collection:pages", op: "count" },
+              },
+            ],
+          },
+        },
+      }),
+    ]);
+    expect(summaries.map(w => w.id)).toEqual(["acme/other"]);
+  });
+});

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -17,6 +17,7 @@
  * @module plugins/validate-admin-widgets
  */
 
+import type { CanonicalWidget } from "../domains/widgets/canonical";
 import {
   actionProblem,
   chromeProblem,
@@ -412,4 +413,50 @@ export function assertAdminWidgets(plugins: PluginDefinition[]): void {
       warnUnknownArchetype(plugin.name, widget);
     }
   }
+}
+
+/**
+ * Every contributed widget across every plugin, reduced to the summary layout
+ * resolution reads.
+ *
+ * Built from `validatedAdminWidgets`, which is the same reduction admin-meta
+ * publishes — so the server's canonical set and the payload the admin renders
+ * from cannot disagree about which contributed widgets exist. A plugin whose
+ * declaration this validator refuses contributes nothing here, exactly as it
+ * contributes nothing to the admin.
+ *
+ * Reads the fields WITHOUT narrowing them: a contribution may come from a
+ * plugin built against a newer core, so `defaultSize` is copied as whatever
+ * string it is rather than checked against this core's vocabulary. Refusing an
+ * unknown one here would drop the whole card from the arrangement over a value
+ * the admin already survives.
+ */
+export function contributedWidgetSummaries(
+  plugins: readonly PluginDefinition[]
+): CanonicalWidget[] {
+  const summaries: CanonicalWidget[] = [];
+  for (const plugin of plugins) {
+    for (const widget of validatedAdminWidgets(plugin) ?? []) {
+      const declaration = widget as unknown as Record<string, unknown>;
+      const id = declaration.id;
+      if (typeof id !== "string" || id === "") continue;
+      summaries.push({
+        id,
+        ...(typeof declaration.requiredPermission === "string"
+          ? { requiredPermission: declaration.requiredPermission }
+          : {}),
+        ...(typeof declaration.defaultSize === "string"
+          ? { defaultSize: declaration.defaultSize }
+          : {}),
+        ...(typeof declaration.defaultHeight === "string"
+          ? { defaultHeight: declaration.defaultHeight }
+          : {}),
+        ...(typeof declaration.defaultOrder === "number" &&
+        Number.isFinite(declaration.defaultOrder)
+          ? { defaultOrder: declaration.defaultOrder }
+          : {}),
+      });
+    }
+  }
+  return summaries;
 }

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -487,8 +487,23 @@ export function contributedWidgetSummaries(
   plugins: readonly PluginDefinition[]
 ): CanonicalWidget[] {
   return plugins.flatMap(plugin =>
-    (validatedAdminWidgets(plugin) ?? [])
-      .map(toSummary)
-      .filter((summary): summary is CanonicalWidget => summary !== undefined)
+    // 🔴 Disabled plugins contribute NOTHING, matching `buildPluginAdminMeta`,
+    // which withholds every behavioural admin surface — menu, pages, settings,
+    // widgets — from a plugin the config has switched off. Without this the two
+    // answers drifted: the layout endpoint put a disabled plugin's widget ids
+    // into default placements, into `available` and into the scope token, while
+    // the admin had no declaration to draw any of them with. Ghost cards the
+    // reader could arrange and never see.
+    //
+    // `enabled !== false` rather than `enabled === true`, because the field is
+    // optional and its absence means enabled — the same reading admin-meta,
+    // `reload-config` and the field-type registry each apply.
+    plugin.enabled === false
+      ? []
+      : (validatedAdminWidgets(plugin) ?? [])
+          .map(toSummary)
+          .filter(
+            (summary): summary is CanonicalWidget => summary !== undefined
+          )
   );
 }

--- a/packages/nextly/src/plugins/validate-admin-widgets.ts
+++ b/packages/nextly/src/plugins/validate-admin-widgets.ts
@@ -431,32 +431,64 @@ export function assertAdminWidgets(plugins: PluginDefinition[]): void {
  * unknown one here would drop the whole card from the arrangement over a value
  * the admin already survives.
  */
+/** A contributed field, when it is a usable string. */
+function contributedText(
+  declaration: Record<string, unknown>,
+  field: string
+): string | undefined {
+  const value = declaration[field];
+  return typeof value === "string" && value !== "" ? value : undefined;
+}
+
+/**
+ * One contributed declaration, reduced to the summary layout resolution reads,
+ * or `undefined` when it carries no usable id.
+ *
+ * Reads the fields WITHOUT narrowing them: a contribution may come from a
+ * plugin built against a newer core, so `defaultSize` is copied as whatever
+ * string it is rather than checked against this core's vocabulary. Refusing an
+ * unknown one here would drop the whole card from the arrangement over a value
+ * the admin already survives.
+ */
+function toSummary(widget: PluginAdminWidget): CanonicalWidget | undefined {
+  const declaration = widget as unknown as Record<string, unknown>;
+  const id = contributedText(declaration, "id");
+  if (id === undefined) return undefined;
+
+  const requiredPermission = contributedText(declaration, "requiredPermission");
+  const defaultSize = contributedText(declaration, "defaultSize");
+  const defaultHeight = contributedText(declaration, "defaultHeight");
+  const defaultOrder = declaration.defaultOrder;
+
+  return {
+    id,
+    ...(requiredPermission === undefined ? {} : { requiredPermission }),
+    ...(defaultSize === undefined ? {} : { defaultSize }),
+    ...(defaultHeight === undefined ? {} : { defaultHeight }),
+    // `Number.isFinite`, so a `NaN` or an infinity a plugin computed cannot
+    // become a sort key that puts the card nowhere in particular.
+    ...(typeof defaultOrder === "number" && Number.isFinite(defaultOrder)
+      ? { defaultOrder }
+      : {}),
+  };
+}
+
+/**
+ * Every contributed widget across every plugin, reduced to the summary layout
+ * resolution reads.
+ *
+ * Built from `validatedAdminWidgets`, which is the same reduction admin-meta
+ * publishes — so the server's canonical set and the payload the admin renders
+ * from cannot disagree about which contributed widgets exist. A plugin whose
+ * declaration that validator refuses contributes nothing here, exactly as it
+ * contributes nothing to the admin.
+ */
 export function contributedWidgetSummaries(
   plugins: readonly PluginDefinition[]
 ): CanonicalWidget[] {
-  const summaries: CanonicalWidget[] = [];
-  for (const plugin of plugins) {
-    for (const widget of validatedAdminWidgets(plugin) ?? []) {
-      const declaration = widget as unknown as Record<string, unknown>;
-      const id = declaration.id;
-      if (typeof id !== "string" || id === "") continue;
-      summaries.push({
-        id,
-        ...(typeof declaration.requiredPermission === "string"
-          ? { requiredPermission: declaration.requiredPermission }
-          : {}),
-        ...(typeof declaration.defaultSize === "string"
-          ? { defaultSize: declaration.defaultSize }
-          : {}),
-        ...(typeof declaration.defaultHeight === "string"
-          ? { defaultHeight: declaration.defaultHeight }
-          : {}),
-        ...(typeof declaration.defaultOrder === "number" &&
-        Number.isFinite(declaration.defaultOrder)
-          ? { defaultOrder: declaration.defaultOrder }
-          : {}),
-      });
-    }
-  }
-  return summaries;
+  return plugins.flatMap(plugin =>
+    (validatedAdminWidgets(plugin) ?? [])
+      .map(toSummary)
+      .filter((summary): summary is CanonicalWidget => summary !== undefined)
+  );
 }

--- a/packages/nextly/src/route-handler/__tests__/route-parser.dashboard.test.ts
+++ b/packages/nextly/src/route-handler/__tests__/route-parser.dashboard.test.ts
@@ -1,8 +1,8 @@
 /**
  * `/api/dashboard` routes.
  *
- * Six routes, none deeper than the top-level id segment (`stats`,
- * `recent-entries`, `activity`, `query`, and `layout` under two verbs). The
+ * Seven routes, none deeper than the top-level id segment (`stats`,
+ * `recent-entries`, `activity`, `query`, and `layout` under three verbs). The
  * risk this file pins: a longer path must 404 rather than match one of them
  * and silently drop the tail, which would let `/api/dashboard/query/extra`
  * reach the widget-query executor as if it were the bare route.
@@ -58,12 +58,15 @@ describe("dashboard routes", () => {
     expect(parseRestRoute(["dashboard", "unknown"], "GET")).toEqual({});
   });
 
-  it("resolves the layout route under both of its verbs", () => {
+  it("resolves the layout route under each of its verbs", () => {
     expect(parseRestRoute(["dashboard", "layout"], "GET")).toMatchObject({
       method: "getWidgetLayout",
     });
     expect(parseRestRoute(["dashboard", "layout"], "PUT")).toMatchObject({
       method: "putWidgetLayout",
+    });
+    expect(parseRestRoute(["dashboard", "layout"], "DELETE")).toMatchObject({
+      method: "deleteWidgetLayout",
     });
   });
 
@@ -74,6 +77,11 @@ describe("dashboard routes", () => {
     expect(
       parseRestRoute(["dashboard", "layout", "extra"], "GET").method
     ).not.toBe("getWidgetLayout");
+  });
+
+  it("rejects a DELETE to an id other than layout", () => {
+    expect(parseRestRoute(["dashboard", "stats"], "DELETE")).toEqual({});
+    expect(parseRestRoute(["dashboard", "query"], "DELETE")).toEqual({});
   });
 
   it("rejects a PUT to an id other than layout", () => {
@@ -116,7 +124,6 @@ describe("dashboard routes", () => {
   it("rejects a verb none of the routes declare", () => {
     expect(parseRestRoute(["dashboard", "stats"], "DELETE")).toEqual({});
     expect(parseRestRoute(["dashboard", "query"], "PATCH")).toEqual({});
-    expect(parseRestRoute(["dashboard", "layout"], "DELETE")).toEqual({});
     expect(parseRestRoute(["dashboard", "layout"], "POST")).toEqual({});
   });
 });

--- a/packages/nextly/src/route-handler/route-parser.ts
+++ b/packages/nextly/src/route-handler/route-parser.ts
@@ -2522,6 +2522,9 @@ const DASHBOARD_ROUTES: Readonly<
   PUT: {
     layout: { operation: "update", method: "putWidgetLayout" },
   },
+  DELETE: {
+    layout: { operation: "delete", method: "deleteWidgetLayout" },
+  },
 };
 
 /**
@@ -2532,6 +2535,7 @@ const DASHBOARD_ROUTES: Readonly<
  *   GET  /api/dashboard/activity       → getDashboardActivity
  *   GET  /api/dashboard/layout         → getWidgetLayout
  *   PUT  /api/dashboard/layout         → putWidgetLayout
+ *   DELETE /api/dashboard/layout       → deleteWidgetLayout
  *   POST /api/dashboard/query          → postWidgetQuery
  *
  * All require authentication (no specific permission). Handlers manage their

--- a/packages/nextly/src/routeHandler.ts
+++ b/packages/nextly/src/routeHandler.ts
@@ -84,7 +84,11 @@ import {
   redeliverWebhookDelivery,
   drainWebhooks,
 } from "./api/webhooks";
-import { getWidgetLayout, putWidgetLayout } from "./api/widget-layout";
+import {
+  deleteWidgetLayout,
+  getWidgetLayout,
+  putWidgetLayout,
+} from "./api/widget-layout";
 import { postWidgetQuery } from "./api/widget-query";
 import { readAccessTokenCookie } from "./auth/cookies/access-token-cookie";
 import type { SanitizedNextlyConfig } from "./collections/config/define-config";
@@ -491,6 +495,8 @@ async function handleDashboardRequest(
       return getWidgetLayout(req);
     case "putWidgetLayout":
       return putWidgetLayout(req);
+    case "deleteWidgetLayout":
+      return deleteWidgetLayout(req);
     default:
       return new Response(
         JSON.stringify({ error: "Unknown dashboard operation" }),

--- a/packages/nextly/src/services/widgets/widget-layout-service.ts
+++ b/packages/nextly/src/services/widgets/widget-layout-service.ts
@@ -219,6 +219,28 @@ export class WidgetLayoutService extends BaseService {
     }
     return nextVersion;
   }
+
+  /**
+   * Removes one scope's arrangement, so reads fall back to the registry's own
+   * order again.
+   *
+   * Idempotent, and that is the contract rather than an accident: resetting a
+   * dashboard that is already at its default is a request that has already been
+   * satisfied, so it answers the same way as one that removed a row. Reporting
+   * "nothing to delete" would make a client handle a state that is
+   * indistinguishable from success from the reader's side.
+   *
+   * No version guard. Every other write on this table is a read-modify-write
+   * that a concurrent editor could silently overwrite, which is what `version`
+   * exists to catch — but this one carries no content to lose. A reset racing a
+   * save means one of them happened last, and both outcomes are states the
+   * reader asked for.
+   */
+  async deleteLayout(kind: LayoutScopeKind, scopeId: string): Promise<void> {
+    await this.db
+      .delete(this.table)
+      .where(eq(this.table.id, layoutRowId(kind, scopeId)));
+  }
 }
 
 /**


### PR DESCRIPTION
Phase 2 PR B: the dashboard becomes arrangeable. Builds on the layout store merged in #1454.

An **Edit dashboard** button turns the grid into edit mode. Drag a card, or move it with buttons; hide one without losing where it sat; remove one entirely; add back anything missing. Save commits; Cancel discards; Reset returns you to the default *and keeps you tracking it*.

## The decisions worth reviewing

**Edit mode batches; it does not autosave.** Every write echoes two guards — a `version` that catches another tab and a `scope` token that catches the visible widget set moving underneath the snapshot in hand. Both refuse with a 409 whose only remedy is a re-read, and re-reading **discards work in progress**. Autosaving each drag would run that risk once per gesture instead of once per session. Backstage, Grafana, Metabase and Azure Portal all batch; WordPress is the lone autosaver and has no per-placement config to lose.

**Move up / Move down are not a convenience.** WCAG 2.2 SC 2.5.7 requires a single-pointer alternative to any dragging movement, and a *keyboard* alternative does not satisfy it — that is 2.1.1, a different criterion. dnd-kit's `KeyboardSensor` therefore closes one gap and leaves this one open, which is how every other drag surface in this admin is currently non-conforming. Buttons are clickable *and* focusable, so one pair answers both.

**🔴 An absent arrangement falls back to the declared order.** Deriving the grid from the layout alone blanked the entire dashboard while the request was in flight — every page load — and for the whole of any outage. That is the same three-states-folded-into-one shape this file already fixed once for branding. "Not read yet" and "arranged down to nothing" are separate states now, and editing is offered only once there is a version and a scope to guard a write with.

**Hide and remove are both offered, and each label names its consequence.** Hiding keeps the placement, so unhiding restores position and settings; removing drops it and re-adding appends fresh. Two similar actions are exactly the pair a reader confuses.

## Also here, closing four findings from #1454

- **One canonical widget set.** A widget reaches the dashboard by two channels — `registerWidget` and `contributes.admin.widgets` — and the grid resolved both while the layout store read only the first. A contributed card was absent from defaults and from `available`, and **every write naming one was refused as unavailable**. `domains/widgets/canonical` is now the single answer both channels feed, with a registration winning a collision because that is the precedence the admin's own resolver applies.
- **`DELETE /api/dashboard/layout`**, which Reset needs. It removes the row rather than writing today's defaults — a written snapshot freezes them, so a widget added later never reaches a reader who has "reset".
- The PUT response is sorted the way GET sorts, rather than echoing the submitted array.
- Hidden placements are bounded, **dropped rather than refused**, because a refusal would depend on how much hidden data there is — the oracle this endpoint keeps closing.

## Verification

- **nextly**: 862 files / 10,782 tests. **admin**: 380 files / 3,671 tests. Both tsc programs, lint clean on both packages.
- `fallow audit --base <merge-base>` → **`verdict: pass`, zero introduced findings** in dead code, complexity, duplication and styling. Getting there meant splitting the grid's three subjects and bounding `contributedWidgetSummaries` — both real, both fixed rather than suppressed.
- **Every new guard break-verified.** Removing the fallback fails the two blank-dashboard tests; un-renumbering the save fails the ordering test; discarding the draft on conflict fails the conflict test; sourcing `available` from the server rather than the draft fails two picker tests; making Reset a PUT fails the reset test.
- The grid's "exactly ONE live region" invariant was **widened, not loosened**: dnd-kit contributes one required region for drag announcements, so it is excluded *by its own id*. Break-verified that the invariant still catches both a per-card announcer and a second grid-level region.

## Known and deliberate

No per-widget config UI — designed into the storage, built later. No role-scoped layouts — `scope_kind` is in the key so they need no migration.