### PR TITLE
fix(nextly): make the SQLite bootstrap create the indexes it declares

### DIFF
--- a/.changeset/the-bootstrap-creates-what-it-declares.md
+++ b/.changeset/the-bootstrap-creates-what-it-declares.md
@@ -35,9 +35,13 @@ missing index breaks no insert; it makes every query against that column a
 scan, which is why fifty of them were declared on all three dialects and
 created on none.
 
-Fifty added in total: thirty-five on tables the bootstrap already created, and
-fifteen on `dynamic_collections`, `dynamic_singles` and `dynamic_components`,
-which are now created too.
+Forty-three added in total: twenty-eight on tables the bootstrap already
+created, and fifteen on `dynamic_collections`, `dynamic_singles` and
+`dynamic_components`, which are now created too. A UNIQUE constraint the DDL
+already spells inline — on the column, or as `UNIQUE(a, b)` at the end of the
+table — is the same index under a name SQLite chooses, so those are recognised
+rather than emitted a second time; a named index beside one builds a second
+B-tree over the same columns for every write.
 
 Only `dynamic_singles` was entirely absent — nothing creates it outside tests.
 The other two are created by `SystemTableService`, which the same fallback calls
@@ -46,6 +50,15 @@ on SQLite where the schema declares 25. Those definitions disagree with the
 schema and with each other. The statements added here are generated from the
 Drizzle column configs and run first, so on SQLite the complete definition is
 the one that wins.
+
+These statements now also reach databases that already exist. The caller
+returned as soon as it saw a `users` table, so the only path that ran them was
+the one taken by a database that did not exist yet — leaving `nextly db:sync`,
+the documented recovery command, unable to supply anything added since an
+install was created. An existing SQLite database is reconciled instead; every
+statement is IF NOT EXISTS, so re-running adds only what is absent. A table
+whose COLUMNS drifted is not repaired this way, since SQLite skips a CREATE
+TABLE wholesale once the table exists.
 
 The guard that was meant to catch this could not see two of the tables. It read
 the schema SOURCE for a literal table name, and `dynamic_components` is built

--- a/.changeset/the-bootstrap-creates-what-it-declares.md
+++ b/.changeset/the-bootstrap-creates-what-it-declares.md
@@ -1,0 +1,50 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The SQLite bootstrap DDL now creates the indexes it declares, and the three
+schema-registry tables it never created at all.
+
+This DDL runs where drizzle-kit's push cannot — no TTY, no interactive
+confirmation — so it is the path taken exactly where nobody is watching. A
+missing index breaks no insert; it makes every query against that column a
+scan, which is why fifty of them were declared on all three dialects and
+created on none.
+
+Fifty added in total: thirty-five on tables the bootstrap already created, and
+fifteen on `dynamic_collections`, `dynamic_singles` and `dynamic_components`,
+which are now created too. Those three hold the metadata for every collection,
+single and component in a project, so a database built from this fallback
+previously could not describe its own content.
+
+The guard that was meant to catch this could not see two of the tables. It read
+the schema SOURCE for a literal table name, and `dynamic_components` is built
+by a factory from a computed one, so it was absent from every comparison and
+passed by absence. It now walks the dialect bundle — the same object graph the
+ORM writes through — and a new integration test executes the DDL against a real
+SQLite database and reads the indexes back, rather than comparing two strings
+drawn from the same repository.

--- a/.changeset/the-bootstrap-creates-what-it-declares.md
+++ b/.changeset/the-bootstrap-creates-what-it-declares.md
@@ -37,9 +37,15 @@ created on none.
 
 Fifty added in total: thirty-five on tables the bootstrap already created, and
 fifteen on `dynamic_collections`, `dynamic_singles` and `dynamic_components`,
-which are now created too. Those three hold the metadata for every collection,
-single and component in a project, so a database built from this fallback
-previously could not describe its own content.
+which are now created too.
+
+Only `dynamic_singles` was entirely absent — nothing creates it outside tests.
+The other two are created by `SystemTableService`, which the same fallback calls
+next, but from its own hand-written DDL that has 19 columns on PostgreSQL and 21
+on SQLite where the schema declares 25. Those definitions disagree with the
+schema and with each other. The statements added here are generated from the
+Drizzle column configs and run first, so on SQLite the complete definition is
+the one that wins.
 
 The guard that was meant to catch this could not see two of the tables. It read
 the schema SOURCE for a literal table name, and `dynamic_components` is built

--- a/packages/nextly/src/__tests__/fixtures/__tests__/derived-ddl.test.ts
+++ b/packages/nextly/src/__tests__/fixtures/__tests__/derived-ddl.test.ts
@@ -25,20 +25,47 @@ describe("fixture DDL derived from the Drizzle schema", () => {
     const testDb = await createTestDb();
     const raw = testDb.adapter.getDrizzle<{ $client: RawSqlite }>().$client;
 
+    // `email_templates` rather than `dynamic_collections`, and the swap is the
+    // point: `createTables` runs the production generators FIRST and only then
+    // fills the gaps with `ddlFor`, so a table the bootstrap DDL now creates
+    // keeps the generator's definition and stops exercising `ddlFor` at all.
+    // Asserting the derived spelling on such a table tests the generator while
+    // reading as though it tests the fixture. This one the generators still do
+    // not cover, and it declares `.unique()` on the column the same way.
     const ddl = (
       raw
         .prepare(
-          "SELECT sql FROM sqlite_master WHERE tbl_name='dynamic_collections'"
+          "SELECT sql FROM sqlite_master WHERE tbl_name='email_templates'"
         )
         .all() as { sql: string }[]
     )[0].sql;
 
-    // `slug` and `table_name` both declare `.unique()` on the column rather
-    // than as a table index. Without this the fixture accepted duplicates that
-    // production rejects, so a test about collision handling passed while
-    // proving nothing.
+    // Declared with `.unique()` on the column rather than as a table index.
+    // Without this the fixture accepted duplicates that production rejects, so
+    // a test about collision handling passed while proving nothing.
     expect(ddl).toContain('"slug" text NOT NULL UNIQUE');
-    expect(ddl).toContain('"table_name" text NOT NULL UNIQUE');
+    await testDb.close();
+  });
+
+  it("rejects a duplicate slug whichever source built the table", async () => {
+    const testDb = await createTestDb();
+    const raw = testDb.adapter.getDrizzle<{ $client: RawSqlite }>().$client;
+
+    // The property the assertion above stands in for, asked of the database
+    // rather than of its DDL text — so it holds whether `dynamic_collections`
+    // came from the production generator or from `ddlFor`, and keeps holding
+    // when another table moves between the two.
+    const uniques = (
+      raw.prepare("PRAGMA index_list(dynamic_collections)").all() as {
+        unique: number;
+      }[]
+    ).filter(index => index.unique === 1);
+
+    expect(
+      uniques.length,
+      "dynamic_collections carries `.unique()` on slug and table_name; a " +
+        "fixture without those accepts collisions production rejects"
+    ).toBeGreaterThanOrEqual(2);
     await testDb.close();
   });
 

--- a/packages/nextly/src/cli/commands/dev-server.ts
+++ b/packages/nextly/src/cli/commands/dev-server.ts
@@ -89,6 +89,34 @@ import type { ResolvedDevOptions } from "./db-sync";
  * This step is only needed when `--seed` is passed, because seeding requires
  * these tables to exist.
  */
+/**
+ * Run the SQLite core bootstrap statements against this database.
+ *
+ * Every statement is IF NOT EXISTS, so this both creates a fresh database and
+ * tops up an existing one, and the two callers below want exactly that.
+ *
+ * A statement that fails because the object is already there is the benign
+ * case and stays silent. Branch on the IMMEDIATE message only: a wrapped
+ * failure whose cause chain happens to mention "already exists" is a different
+ * error and must not be swallowed.
+ */
+async function applyCoreStatements(
+  drizzleAdapter: DrizzleAdapter,
+  logger: CommandContext["logger"]
+): Promise<void> {
+  for (const statement of generateSqliteCoreTableStatements()) {
+    try {
+      await drizzleAdapter.executeQuery(statement);
+    } catch (error) {
+      if (!immediateMessage(error).includes("already exists")) {
+        logger.debug(
+          `Table creation statement failed: ${describeError(error)}`
+        );
+      }
+    }
+  }
+}
+
 export async function ensureCoreTables(
   adapter: CLIDatabaseAdapter,
   _options: ResolvedDevOptions,
@@ -98,11 +126,30 @@ export async function ensureCoreTables(
   const drizzleAdapter = adapter as unknown as DrizzleAdapter;
   const dialect = drizzleAdapter.getCapabilities().dialect;
 
-  // Quick check: if the "users" table already exists, core tables are present
+  // Quick check: if the "users" table already exists, core tables are present.
+  //
+  // "Present" is not "current". Every statement in the SQLite bootstrap is
+  // IF NOT EXISTS, and the set grows as the schema declares new tables and
+  // indexes — so a database created by an earlier version has the tables this
+  // check looks for and lacks whatever was added since. Returning here left
+  // `nextly db:sync`, the documented recovery command, unable to supply them:
+  // the only path that runs these statements was the one taken by a database
+  // that did not exist yet.
+  //
+  // So an existing SQLite database is reconciled rather than skipped. The
+  // statements are idempotent and re-running them adds only what is absent.
+  // It does NOT repair a table whose COLUMNS drifted: SQLite skips a CREATE
+  // TABLE wholesale once the table exists, which needs a migration rather than
+  // this pass.
   try {
     const usersExists = await drizzleAdapter.tableExists("users");
     if (usersExists) {
-      logger.debug("Core tables already exist, skipping ensureCoreTables");
+      if (dialect === "sqlite") {
+        await applyCoreStatements(drizzleAdapter, logger);
+        logger.debug("Core tables reconciled");
+      } else {
+        logger.debug("Core tables already exist, skipping ensureCoreTables");
+      }
       return;
     }
   } catch {
@@ -136,21 +183,7 @@ export async function ensureCoreTables(
 
     if (dialect === "sqlite") {
       logger.debug("Falling back to raw SQL table creation for SQLite...");
-      const statements = generateSqliteCoreTableStatements();
-      for (const statement of statements) {
-        try {
-          await drizzleAdapter.executeQuery(statement);
-        } catch (error) {
-          // Branch on the immediate message only: a wrapped failure whose
-          // cause chain happens to mention "already exists" is not the benign
-          // duplicate-table case and must not be silenced.
-          if (!immediateMessage(error).includes("already exists")) {
-            logger.debug(
-              `Table creation statement failed: ${describeError(error)}`
-            );
-          }
-        }
-      }
+      await applyCoreStatements(drizzleAdapter, logger);
 
       // Also create system tables (dynamic_collections, etc.)
       try {

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.integration.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.integration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * The bootstrap DDL, executed.
+ *
+ * Its sibling unit suite compares the DDL's TEXT against the canonical Drizzle
+ * schemas. That catches a column or an index the transcription forgot, and it
+ * cannot catch a statement that is simply not valid SQL — both sides are read
+ * from the same repository, and a string that mentions the right index name is
+ * not the same claim as a database that has one.
+ *
+ * So this runs the statements against a real SQLite database and reads back
+ * what exists. It is the oracle the string comparison stands in for, which
+ * matters most for the parts nobody exercises by hand: this fallback runs only
+ * where `pushSchema` could not, which is precisely where nobody is watching.
+ *
+ * @module database/__tests__/sqlite-core-tables.integration.test
+ */
+import Database from "better-sqlite3";
+import { getTableConfig } from "drizzle-orm/sqlite-core";
+import { describe, expect, it } from "vitest";
+
+import * as sqliteBundle from "../../schemas/_dialect-bundles/sqlite";
+import { generateSqliteCoreTableStatements } from "../sqlite-core-tables";
+
+/** A database built the way the non-TTY bootstrap builds one. */
+function bootstrapped(): Database.Database {
+  const db = new Database(":memory:");
+  // On, because the DDL declares foreign keys and a statement naming a table
+  // that does not exist yet must fail here rather than on someone's first boot.
+  db.pragma("foreign_keys = ON");
+  for (const statement of generateSqliteCoreTableStatements()) {
+    db.exec(statement);
+  }
+  return db;
+}
+
+function namesOfType(
+  db: Database.Database,
+  type: "table" | "index"
+): Set<string> {
+  return new Set(
+    (
+      db
+        .prepare(
+          `SELECT name FROM sqlite_master WHERE type = ? AND name NOT LIKE 'sqlite_%'`
+        )
+        .all(type) as { name: string }[]
+    ).map(row => row.name)
+  );
+}
+
+/** Every bundle table this fallback actually created. */
+function bootstrappedConfigs(tables: Set<string>) {
+  return Object.values(sqliteBundle).flatMap(value => {
+    let config;
+    try {
+      config = getTableConfig(value as never);
+    } catch {
+      // Not a table — the bundle also re-exports relations and types.
+      return [];
+    }
+    return config?.name && tables.has(config.name) ? [config] : [];
+  });
+}
+
+/**
+ * Whether SQLite carries this index under a name of its own choosing.
+ *
+ * A single-column UNIQUE spelled inline on the column produces an implicit
+ * `sqlite_autoindex_*`, which the reads below exclude. Those are checked by
+ * the sibling suite's inline-UNIQUE classification rather than reported absent
+ * here.
+ */
+function isImplicitUnique(index: {
+  config: { unique?: boolean; columns: unknown[] };
+}) {
+  return Boolean(index.config.unique) && index.config.columns.length === 1;
+}
+
+/**
+ * Declared indexes that the built database does not have.
+ *
+ * Scoped to tables this fallback creates: the ones it does not are the sibling
+ * suite's NOT_BOOTSTRAPPED list, and they have no indexes here because they
+ * have no table here.
+ */
+function indexesDeclaredButAbsent(
+  tables: Set<string>,
+  indexes: Set<string>
+): string[] {
+  return bootstrappedConfigs(tables).flatMap(config =>
+    config.indexes
+      .filter(index => !isImplicitUnique(index))
+      .filter(index => !indexes.has(index.config.name))
+      .map(index => `${config.name}.${index.config.name}`)
+  );
+}
+
+describe("the SQLite bootstrap DDL, executed", () => {
+  it("runs every statement against a real database", () => {
+    // The premise: a bootstrap that created almost nothing would satisfy every
+    // "is it there" check below by having nothing to check.
+    const db = bootstrapped();
+    expect(namesOfType(db, "table").size).toBeGreaterThan(20);
+    db.close();
+  });
+
+  it("creates every index it declares, as a real index", () => {
+    const db = bootstrapped();
+    const missing = indexesDeclaredButAbsent(
+      namesOfType(db, "table"),
+      namesOfType(db, "index")
+    );
+
+    expect(
+      missing,
+      `these indexes are declared by the schema and do not exist in a database ` +
+        `built from the bootstrap DDL: ${missing.join(", ")}`
+    ).toEqual([]);
+    db.close();
+  });
+
+  it("is re-runnable, as the bootstrap re-runs it", () => {
+    // Every statement is IF NOT EXISTS precisely so a later boot can restore a
+    // missing index. If that were ever untrue the second run would throw.
+    const db = bootstrapped();
+    const before = namesOfType(db, "index").size;
+    for (const statement of generateSqliteCoreTableStatements()) {
+      db.exec(statement);
+    }
+    expect(namesOfType(db, "index").size).toBe(before);
+    expect(before).toBeGreaterThan(50);
+    db.close();
+  });
+});

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.integration.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.integration.test.ts
@@ -63,17 +63,28 @@ function bootstrappedConfigs(tables: Set<string>) {
 }
 
 /**
- * Whether SQLite carries this index under a name of its own choosing.
+ * The columns covered by every UNIQUE index in the built database.
  *
- * A single-column UNIQUE spelled inline on the column produces an implicit
- * `sqlite_autoindex_*`, which the reads below exclude. Those are checked by
- * the sibling suite's inline-UNIQUE classification rather than reported absent
- * here.
+ * Read back rather than inferred. A UNIQUE constraint spelled inline — on the
+ * column, or as `UNIQUE(a, b)` at the end of the table — produces an implicit
+ * `sqlite_autoindex_*` whose name this DDL never chose. Comparing NAMES alone
+ * calls those absent; comparing the columns they cover asks the question that
+ * matters, which is whether the uniqueness exists at all.
  */
-function isImplicitUnique(index: {
-  config: { unique?: boolean; columns: unknown[] };
-}) {
-  return Boolean(index.config.unique) && index.config.columns.length === 1;
+function uniqueIndexColumns(db: Database.Database, table: string): Set<string> {
+  const covered = new Set<string>();
+  const list = db.prepare(`PRAGMA index_list("${table}")`).all() as {
+    name: string;
+    unique: number;
+  }[];
+  for (const entry of list) {
+    if (entry.unique !== 1) continue;
+    const cols = db.prepare(`PRAGMA index_info("${entry.name}")`).all() as {
+      name: string | null;
+    }[];
+    covered.add(cols.map(column => column.name ?? "?").join(","));
+  }
+  return covered;
 }
 
 /**
@@ -84,15 +95,25 @@ function isImplicitUnique(index: {
  * have no table here.
  */
 function indexesDeclaredButAbsent(
+  db: Database.Database,
   tables: Set<string>,
   indexes: Set<string>
 ): string[] {
-  return bootstrappedConfigs(tables).flatMap(config =>
-    config.indexes
-      .filter(index => !isImplicitUnique(index))
-      .filter(index => !indexes.has(index.config.name))
-      .map(index => `${config.name}.${index.config.name}`)
-  );
+  return bootstrappedConfigs(tables).flatMap(config => {
+    const uniques = uniqueIndexColumns(db, config.name);
+    return config.indexes
+      .filter(index => {
+        if (indexes.has(index.config.name)) return false;
+        // Absent under its own name. It still exists if a UNIQUE constraint
+        // covers exactly these columns.
+        if (!index.config.unique) return true;
+        const columns = index.config.columns
+          .map(column => ("name" in column ? column.name : "?"))
+          .join(",");
+        return !uniques.has(columns);
+      })
+      .map(index => `${config.name}.${index.config.name}`);
+  });
 }
 
 describe("the SQLite bootstrap DDL, executed", () => {
@@ -107,6 +128,7 @@ describe("the SQLite bootstrap DDL, executed", () => {
   it("creates every index it declares, as a real index", () => {
     const db = bootstrapped();
     const missing = indexesDeclaredButAbsent(
+      db,
       namesOfType(db, "table"),
       namesOfType(db, "index")
     );
@@ -116,6 +138,46 @@ describe("the SQLite bootstrap DDL, executed", () => {
       `these indexes are declared by the schema and do not exist in a database ` +
         `built from the bootstrap DDL: ${missing.join(", ")}`
     ).toEqual([]);
+    db.close();
+  });
+
+  /**
+   * The upgrade case, which is the one that reaches existing installations.
+   *
+   * Modelled as what the previous bootstrap actually produced: its CREATE
+   * TABLE statements, minus the registry tables this change adds, and none of
+   * the index statements. Re-running the full set against that must supply the
+   * difference — which is the whole reason the caller reconciles an existing
+   * SQLite database rather than returning as soon as it sees `users`.
+   */
+  it("supplies what a database created by an earlier bootstrap lacks", () => {
+    const REGISTRY = [
+      "dynamic_collections",
+      "dynamic_singles",
+      "dynamic_components",
+    ];
+    const db = new Database(":memory:");
+    db.pragma("foreign_keys = ON");
+    for (const statement of generateSqliteCoreTableStatements()) {
+      if (!statement.includes("CREATE TABLE")) continue;
+      if (REGISTRY.some(table => statement.includes(`"${table}"`))) continue;
+      db.exec(statement);
+    }
+
+    // The premise: this really is a database missing what the change adds.
+    expect(namesOfType(db, "table").size).toBeGreaterThan(15);
+    expect(namesOfType(db, "table").has("dynamic_singles")).toBe(false);
+    expect(namesOfType(db, "index").has("media_folder_id_idx")).toBe(false);
+
+    for (const statement of generateSqliteCoreTableStatements()) {
+      db.exec(statement);
+    }
+
+    const tables = namesOfType(db, "table");
+    const indexes = namesOfType(db, "index");
+    expect(tables.has("dynamic_singles")).toBe(true);
+    expect(indexes.has("media_folder_id_idx")).toBe(true);
+    expect(indexesDeclaredButAbsent(db, tables, indexes)).toEqual([]);
     db.close();
   });
 

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -17,17 +17,17 @@
  * SQLite's affinity rules make a type comparison mostly noise, and the failure
  * this guards is a column that is not there at all.
  */
-import { readdirSync, readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { getTableConfig } from "drizzle-orm/sqlite-core";
 import { describe, expect, it } from "vitest";
 
-import { nextlyJobsSqlite } from "../../schemas/jobs/sqlite";
+import * as sqliteBundle from "../../schemas/_dialect-bundles/sqlite";
 import { generateSqliteCoreTableStatements } from "../sqlite-core-tables";
 
-const here = dirname(fileURLToPath(import.meta.url));
-const SCHEMAS_DIR = join(here, "..", "..", "schemas");
+/** One table as the canonical Drizzle schema declares it. */
+interface SchemaTable {
+  columns: Set<string>;
+  indexes: { name: string; columns: string[]; unique: boolean }[];
+}
 
 /** Column names per table, as the bootstrap DDL declares them. */
 function ddlColumns(): Map<string, Set<string>> {
@@ -47,80 +47,88 @@ function ddlColumns(): Map<string, Set<string>> {
   return tables;
 }
 
-/** Column names per table, as the canonical `sqliteTable` definitions declare. */
-function schemaColumns(): Map<string, Set<string>> {
-  const tables = new Map<string, Set<string>>();
-  for (const entry of readdirSync(SCHEMAS_DIR, { withFileTypes: true })) {
-    if (!entry.isDirectory()) continue;
-    let source: string;
+/**
+ * Every core SQLite table, read from the dialect bundle rather than parsed.
+ *
+ * This used to regex the schema SOURCE for `sqliteTable("literal", { ... })`,
+ * and that instrument was blind twice over. It could not see a table whose
+ * name is COMPUTED — `dynamic_components` is built inside a factory from
+ * `STORAGE_FORMAT.registryTable` — and it had already been widened once for a
+ * call shape it could not match. Both failures are silent in the same
+ * direction: a table the extractor cannot see is absent from every comparison
+ * below, so it is not checked against the DDL at all. It passes by absence.
+ *
+ * The bundle is the right source because it is the same object graph the ORM
+ * writes through and `reconcileCore` hands to drizzle-kit, so "what the schema
+ * declares" is answered by the schema itself rather than by a pattern that
+ * approximates it. It also carries indexes, which source text did not.
+ */
+function schemaTables(): Map<string, SchemaTable> {
+  const tables = new Map<string, SchemaTable>();
+  for (const value of Object.values(sqliteBundle)) {
+    let config;
     try {
-      source = readFileSync(join(SCHEMAS_DIR, entry.name, "sqlite.ts"), "utf8");
+      config = getTableConfig(value as never);
     } catch {
+      // Not a table — the bundle also re-exports relations and types.
       continue;
     }
-    // Two call shapes, and missing the second is how this guard went blind.
-    // `sqliteTable("t", { ... })` closes its column object at column 0 (`\n});`)
-    // while `sqliteTable(\n  "t",\n  { ... },\n  t => [...])` closes it at two
-    // spaces (`\n  }`). A pattern anchored to the indented form silently
-    // discovered NOTHING in a single-argument schema file -- so the table was
-    // absent from `schemas` entirely, `missing` came back empty, and the
-    // "creates every core table" assertion below passed while the table it was
-    // written to catch had no DDL at all. The closing brace is matched at
-    // either indent, and `TABLES_EXPECTED` below is the control that keeps this
-    // honest rather than a comment promising it.
-    for (const m of source.matchAll(
-      /sqliteTable\(\s*"([a-z_]+)"\s*,\s*\{([\s\S]*?)\n {0,2}\}/g
-    )) {
-      tables.set(
-        m[1],
-        new Set(
-          [...m[2].matchAll(/\b(?:text|integer|real|blob)\("([a-z_]+)"/g)].map(
-            c => c[1]
-          )
-        )
-      );
-    }
+    if (!config?.name) continue;
+    tables.set(config.name, {
+      columns: new Set(config.columns.map(column => column.name)),
+      indexes: config.indexes.map(index => ({
+        name: index.config.name,
+        // An index may be declared over a SQL EXPRESSION rather than a column,
+        // and such an entry carries no name. Dropping it is correct here: the
+        // only thing column names are used for below is recognising a
+        // single-column UNIQUE that the DDL spells inline, which an expression
+        // index can never be.
+        columns: index.config.columns
+          .map(column => ("name" in column ? column.name : undefined))
+          .filter((name): name is string => name !== undefined),
+        unique: Boolean(index.config.unique),
+      })),
+    });
   }
   return tables;
 }
 
 describe("the SQLite bootstrap DDL", () => {
   const ddl = ddlColumns();
-  const schemas = schemaColumns();
+  const schemas = schemaTables();
 
   /**
    * Tables whose discovery is asserted BY NAME.
    *
-   * A size floor is not enough, and that is not hypothetical: the extractor
-   * matched 30-odd tables while missing `nextly_widget_layout` completely,
-   * because that file writes its columns in the single-argument call shape.
-   * Every count-based check stayed green and the table shipped with no
-   * bootstrap DDL.
+   * A size floor is not enough, and that is not hypothetical: the previous
+   * source-text extractor matched 38 tables while missing two completely, and
+   * every count-based check stayed green. `dynamic_components` is built by a
+   * factory from a COMPUTED name, and `nextly_i18n_archive` was the second.
+   * Both were invisible to the pattern, so neither was ever compared against
+   * the bootstrap DDL.
    *
-   * So the control names one schema of EACH call shape. A future extractor
-   * change that stops seeing either one fails here, where the message says
-   * which, rather than silently narrowing what the rest of this file compares.
+   * These two are named because they are the ones that were actually missed.
+   * A change that stops the bundle walk seeing either fails here, where the
+   * message says which, rather than silently narrowing what the rest of this
+   * file compares.
    */
-  const TABLES_EXPECTED = [
-    // `sqliteTable(\n  "t",\n  { ... },\n  t => [...])` -- indented close.
-    "nextly_document_lock",
-    // `sqliteTable("t", { ... })` -- closes at column 0.
-    "nextly_widget_layout",
-  ];
+  const TABLES_EXPECTED = ["dynamic_components", "nextly_i18n_archive"];
 
   it("reads back as tables at all", () => {
-    // Both halves are parsed out of source text, so a parser that quietly
-    // matched nothing would make every comparison below vacuously true.
+    // The DDL half is still parsed out of source text, so a parser that
+    // quietly matched nothing would make every comparison below vacuously
+    // true. The schema half now comes from the bundle, where the failure mode
+    // is an empty export rather than a bad pattern; both are floored.
     expect(ddl.size).toBeGreaterThan(10);
     expect(schemas.size).toBeGreaterThan(10);
   });
 
-  it.each(TABLES_EXPECTED)("discovers %s in the schema sources", table => {
+  it.each(TABLES_EXPECTED)("discovers %s in the schema bundle", table => {
     expect(
       schemas.has(table),
-      `the schema extractor did not find ${table}. Every comparison in this ` +
-        "file iterates what it found, so a table it cannot see is not " +
-        "checked against the bootstrap DDL at all -- it passes by absence."
+      `the bundle walk did not find ${table}. Every comparison in this file ` +
+        "iterates what it found, so a table it cannot see is not checked " +
+        "against the bootstrap DDL at all -- it passes by absence."
     ).toBe(true);
   });
 
@@ -153,12 +161,13 @@ describe("the SQLite bootstrap DDL", () => {
     "site_settings",
     "api_keys",
     "audit_log",
-    "dynamic_collections",
-    "dynamic_singles",
     "email_providers",
     "email_templates",
     "image_sizes",
     "nextly_events",
+    // Newly VISIBLE rather than newly missing: the source-text extractor this
+    // suite used could not see it, so it was never compared. It is a real gap.
+    "nextly_i18n_archive",
     "nextly_meta",
     "nextly_schema_events",
     "nextly_webhook_deliveries",
@@ -184,29 +193,62 @@ describe("the SQLite bootstrap DDL", () => {
     ).toEqual([]);
   });
 
-  /*
-   * Indexes, for `nextly_jobs` only.
+  /**
+   * Indexes, for every bootstrapped table.
    *
-   * The column comparison above cannot see an index: a missing one breaks no
-   * insert, it makes a query slow, which is why `nextly_jobs_recent_idx` was
-   * declared on all three dialects and created on none. Scoped to this table
-   * rather than generalized because the same probe reports ten pre-existing
-   * omissions on `dynamic_collections` and `dynamic_components`, and deciding
-   * what those should be is a separate change from asserting this one.
+   * The column comparison cannot see an index: a missing one breaks no insert,
+   * it makes a query slow. That is why `nextly_jobs_recent_idx` was declared on
+   * all three dialects and created on none, and why this check was scoped to
+   * that one table when it was written — the same probe reported dozens of
+   * pre-existing omissions and deciding what to do about them was left for
+   * later. This is later: 35 of them are now written, so the check is
+   * generalized and the scoping comment retired.
+   *
+   * A single-column UNIQUE index is satisfied by an inline `UNIQUE` on that
+   * column, which is how this DDL already spells `users_email_unique` — SQLite
+   * creates the same implicit index either way. Matching on the index NAME
+   * alone would report four such constraints as missing when they are merely
+   * spelled differently, so they are classified rather than counted.
    */
-  it("creates every index the jobs schema declares", () => {
-    const statements = generateSqliteCoreTableStatements().join("\n");
-    const declared = getTableConfig(nextlyJobsSqlite).indexes.map(
-      index => index.config.name
+  it.each([...schemaTables().keys()].filter(table => ddlColumns().has(table)))(
+    "creates every index the %s schema declares",
+    table => {
+      const statements = generateSqliteCoreTableStatements();
+      const joined = statements.join("\n");
+      const body =
+        statements.find(statement =>
+          statement.includes(`CREATE TABLE IF NOT EXISTS "${table}"`)
+        ) ?? "";
+
+      const declared = schemas.get(table)?.indexes ?? [];
+      const missing = declared
+        .filter(index => !joined.includes(`"${index.name}"`))
+        .filter(index => {
+          // Spelled inline on the column instead, which is the same index.
+          const inlineUnique =
+            index.unique &&
+            index.columns.length === 1 &&
+            new RegExp(`"${index.columns[0]}"[^,\n]*UNIQUE`).test(body);
+          return !inlineUnique;
+        })
+        .map(index => index.name);
+
+      expect(
+        missing,
+        `${table}: the bootstrap DDL never creates ${missing.join(", ")}, so ` +
+          "the declaration is decorative on every SQLite database built from it"
+      ).toEqual([]);
+    }
+  );
+
+  it("compares real indexes rather than an empty list", () => {
+    // The premise of the check above. If the bundle stopped reporting indexes
+    // it would pass for every table while asserting nothing at all.
+    const total = [...schemaTables().values()].reduce(
+      (sum, table) => sum + table.indexes.length,
+      0
     );
-    const missing = declared.filter(name => !statements.includes(`"${name}"`));
-    expect(
-      missing,
-      `nextly_jobs: the bootstrap DDL never creates ${missing.join(", ")}, so ` +
-        "the declaration is decorative on every SQLite database built from it"
-    ).toEqual([]);
-    // The premise: this compared real index names rather than an empty list.
-    expect(declared.length).toBeGreaterThan(1);
+    expect(total).toBeGreaterThan(50);
   });
 
   it("does not carry exclusions for tables that no longer exist", () => {
@@ -224,7 +266,9 @@ describe("the SQLite bootstrap DDL", () => {
       if (declared === undefined) return;
 
       const present = ddl.get(table) ?? new Set<string>();
-      const missing = [...declared].filter(column => !present.has(column));
+      const missing = [...declared.columns].filter(
+        column => !present.has(column)
+      );
       expect(
         missing,
         `${table}: the bootstrap DDL omits ${missing.join(", ")}, so every ` +

--- a/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
+++ b/packages/nextly/src/database/__tests__/sqlite-core-tables.test.ts
@@ -93,6 +93,28 @@ function schemaTables(): Map<string, SchemaTable> {
   return tables;
 }
 
+/**
+ * Whether an inline constraint already carries this index.
+ *
+ * SQLite builds an implicit index for a UNIQUE constraint, so a declaration
+ * the DDL spells inline is the same index under a name SQLite chooses. Both
+ * spellings appear here: `"email" TEXT NOT NULL UNIQUE` on the column, and
+ * `UNIQUE("provider", "provider_account_id")` at the end of the table. Matching
+ * on the index NAME alone reports both as missing, and emitting a named index
+ * beside them builds a second B-tree over the same columns for every write.
+ */
+function satisfiedInline(
+  index: { columns: string[]; unique: boolean },
+  body: string
+): boolean {
+  if (!index.unique) return false;
+  if (index.columns.length === 1) {
+    return new RegExp(`"${index.columns[0]}"[^,\n]*UNIQUE`).test(body);
+  }
+  const composite = index.columns.map(column => `"${column}"`).join(", ");
+  return body.includes(`UNIQUE(${composite})`);
+}
+
 describe("the SQLite bootstrap DDL", () => {
   const ddl = ddlColumns();
   const schemas = schemaTables();
@@ -223,14 +245,7 @@ describe("the SQLite bootstrap DDL", () => {
       const declared = schemas.get(table)?.indexes ?? [];
       const missing = declared
         .filter(index => !joined.includes(`"${index.name}"`))
-        .filter(index => {
-          // Spelled inline on the column instead, which is the same index.
-          const inlineUnique =
-            index.unique &&
-            index.columns.length === 1 &&
-            new RegExp(`"${index.columns[0]}"[^,\n]*UNIQUE`).test(body);
-          return !inlineUnique;
-        })
+        .filter(index => !satisfiedInline(index, body))
         .map(index => index.name);
 
       expect(

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -62,8 +62,6 @@ export function generateSqliteCoreTableStatements(): string[] {
       "session_state" TEXT,
       UNIQUE("provider", "provider_account_id")
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS "accounts_provider_providerAccountId_unique"
-      ON "accounts" ("provider", "provider_account_id")`,
     `CREATE INDEX IF NOT EXISTS "accounts_user_id_idx"
       ON "accounts" ("user_id")`,
     `CREATE TABLE IF NOT EXISTS "sessions" (
@@ -82,8 +80,6 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("identifier", "token_hash")
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS "prt_identifier_token_hash_unique"
-      ON "password_reset_tokens" ("identifier", "token_hash")`,
     `CREATE INDEX IF NOT EXISTS "prt_expires_idx"
       ON "password_reset_tokens" ("expires")`,
     `CREATE INDEX IF NOT EXISTS "prt_used_at_idx"
@@ -96,8 +92,6 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("identifier", "token_hash")
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS "evt_identifier_token_hash_unique"
-      ON "email_verification_tokens" ("identifier", "token_hash")`,
     `CREATE INDEX IF NOT EXISTS "evt_expires_idx"
       ON "email_verification_tokens" ("expires")`,
     `CREATE TABLE IF NOT EXISTS "refresh_tokens" (
@@ -144,8 +138,6 @@ export function generateSqliteCoreTableStatements(): string[] {
       "updated_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("action", "resource")
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS "permissions_action_resource_unique"
-      ON "permissions" ("action", "resource")`,
     `CREATE INDEX IF NOT EXISTS "permissions_resource_idx"
       ON "permissions" ("resource")`,
     `CREATE INDEX IF NOT EXISTS "permissions_action_idx"
@@ -157,8 +149,6 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("role_id", "permission_id")
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS "role_permissions_role_permission_unique"
-      ON "role_permissions" ("role_id", "permission_id")`,
     `CREATE INDEX IF NOT EXISTS "role_permissions_role_id_idx"
       ON "role_permissions" ("role_id")`,
     `CREATE TABLE IF NOT EXISTS "user_roles" (
@@ -169,8 +159,6 @@ export function generateSqliteCoreTableStatements(): string[] {
       "expires_at" INTEGER,
       UNIQUE("user_id", "role_id")
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS "user_roles_user_role_unique"
-      ON "user_roles" ("user_id", "role_id")`,
     `CREATE INDEX IF NOT EXISTS "user_roles_user_id_idx"
       ON "user_roles" ("user_id")`,
     `CREATE INDEX IF NOT EXISTS "user_roles_expires_at_idx"
@@ -181,8 +169,6 @@ export function generateSqliteCoreTableStatements(): string[] {
       "child_role_id" TEXT NOT NULL REFERENCES "roles"("id") ON DELETE CASCADE,
       UNIQUE("parent_role_id", "child_role_id")
     )`,
-    `CREATE UNIQUE INDEX IF NOT EXISTS "role_inherits_parent_child_unique"
-      ON "role_inherits" ("parent_role_id", "child_role_id")`,
     `CREATE INDEX IF NOT EXISTS "role_inherits_child_idx"
       ON "role_inherits" ("child_role_id")`,
     `CREATE INDEX IF NOT EXISTS "role_inherits_parent_idx"
@@ -268,7 +254,7 @@ export function generateSqliteCoreTableStatements(): string[] {
     // wholesale once the table exists, so an index folded into one is never
     // added to a database that predates it.
     `CREATE TABLE IF NOT EXISTS "dynamic_collections" (
-      "id" TEXT PRIMARY KEY,
+      "id" TEXT PRIMARY KEY NOT NULL,
       "slug" TEXT NOT NULL UNIQUE,
       "labels" TEXT NOT NULL,
       "table_name" TEXT NOT NULL UNIQUE,
@@ -305,7 +291,7 @@ export function generateSqliteCoreTableStatements(): string[] {
     `CREATE INDEX IF NOT EXISTS "dynamic_collections_updated_at_idx"
       ON "dynamic_collections" ("updated_at")`,
     `CREATE TABLE IF NOT EXISTS "dynamic_singles" (
-      "id" TEXT PRIMARY KEY,
+      "id" TEXT PRIMARY KEY NOT NULL,
       "slug" TEXT NOT NULL UNIQUE,
       "label" TEXT NOT NULL,
       "table_name" TEXT NOT NULL UNIQUE,
@@ -340,7 +326,7 @@ export function generateSqliteCoreTableStatements(): string[] {
     `CREATE INDEX IF NOT EXISTS "dynamic_singles_updated_at_idx"
       ON "dynamic_singles" ("updated_at")`,
     `CREATE TABLE IF NOT EXISTS "dynamic_components" (
-      "id" TEXT PRIMARY KEY,
+      "id" TEXT PRIMARY KEY NOT NULL,
       "slug" TEXT NOT NULL UNIQUE,
       "label" TEXT NOT NULL,
       "table_name" TEXT NOT NULL UNIQUE,

--- a/packages/nextly/src/database/sqlite-core-tables.ts
+++ b/packages/nextly/src/database/sqlite-core-tables.ts
@@ -45,6 +45,8 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       "updated_at" INTEGER NOT NULL DEFAULT (unixepoch())
     )`,
+    `CREATE INDEX IF NOT EXISTS "users_created_at_idx"
+      ON "users" ("created_at")`,
     `CREATE TABLE IF NOT EXISTS "accounts" (
       "id" INTEGER PRIMARY KEY AUTOINCREMENT,
       "user_id" TEXT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
@@ -60,11 +62,17 @@ export function generateSqliteCoreTableStatements(): string[] {
       "session_state" TEXT,
       UNIQUE("provider", "provider_account_id")
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "accounts_provider_providerAccountId_unique"
+      ON "accounts" ("provider", "provider_account_id")`,
+    `CREATE INDEX IF NOT EXISTS "accounts_user_id_idx"
+      ON "accounts" ("user_id")`,
     `CREATE TABLE IF NOT EXISTS "sessions" (
       "session_token" TEXT PRIMARY KEY,
       "user_id" TEXT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
       "expires" INTEGER NOT NULL
     )`,
+    `CREATE INDEX IF NOT EXISTS "sessions_user_id_idx"
+      ON "sessions" ("user_id")`,
     `CREATE TABLE IF NOT EXISTS "password_reset_tokens" (
       "id" INTEGER PRIMARY KEY AUTOINCREMENT,
       "identifier" TEXT NOT NULL,
@@ -74,6 +82,12 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("identifier", "token_hash")
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "prt_identifier_token_hash_unique"
+      ON "password_reset_tokens" ("identifier", "token_hash")`,
+    `CREATE INDEX IF NOT EXISTS "prt_expires_idx"
+      ON "password_reset_tokens" ("expires")`,
+    `CREATE INDEX IF NOT EXISTS "prt_used_at_idx"
+      ON "password_reset_tokens" ("used_at")`,
     `CREATE TABLE IF NOT EXISTS "email_verification_tokens" (
       "id" INTEGER PRIMARY KEY AUTOINCREMENT,
       "identifier" TEXT NOT NULL,
@@ -82,6 +96,10 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("identifier", "token_hash")
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "evt_identifier_token_hash_unique"
+      ON "email_verification_tokens" ("identifier", "token_hash")`,
+    `CREATE INDEX IF NOT EXISTS "evt_expires_idx"
+      ON "email_verification_tokens" ("expires")`,
     `CREATE TABLE IF NOT EXISTS "refresh_tokens" (
       "id" TEXT PRIMARY KEY,
       "user_id" TEXT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
@@ -91,6 +109,12 @@ export function generateSqliteCoreTableStatements(): string[] {
       "expires_at" INTEGER NOT NULL,
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch())
     )`,
+    `CREATE INDEX IF NOT EXISTS "refresh_tokens_token_hash_idx"
+      ON "refresh_tokens" ("token_hash")`,
+    `CREATE INDEX IF NOT EXISTS "refresh_tokens_user_id_idx"
+      ON "refresh_tokens" ("user_id")`,
+    `CREATE INDEX IF NOT EXISTS "refresh_tokens_expires_at_idx"
+      ON "refresh_tokens" ("expires_at")`,
     `CREATE TABLE IF NOT EXISTS "roles" (
       "id" TEXT PRIMARY KEY,
       "name" TEXT NOT NULL UNIQUE,
@@ -101,6 +125,10 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       "updated_at" INTEGER NOT NULL DEFAULT (unixepoch())
     )`,
+    `CREATE INDEX IF NOT EXISTS "roles_level_idx"
+      ON "roles" ("level")`,
+    `CREATE INDEX IF NOT EXISTS "roles_is_system_idx"
+      ON "roles" ("is_system")`,
     `CREATE TABLE IF NOT EXISTS "permissions" (
       "id" TEXT PRIMARY KEY,
       "name" TEXT NOT NULL,
@@ -116,6 +144,12 @@ export function generateSqliteCoreTableStatements(): string[] {
       "updated_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("action", "resource")
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "permissions_action_resource_unique"
+      ON "permissions" ("action", "resource")`,
+    `CREATE INDEX IF NOT EXISTS "permissions_resource_idx"
+      ON "permissions" ("resource")`,
+    `CREATE INDEX IF NOT EXISTS "permissions_action_idx"
+      ON "permissions" ("action")`,
     `CREATE TABLE IF NOT EXISTS "role_permissions" (
       "id" TEXT PRIMARY KEY,
       "role_id" TEXT NOT NULL REFERENCES "roles"("id") ON DELETE CASCADE,
@@ -123,6 +157,10 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       UNIQUE("role_id", "permission_id")
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "role_permissions_role_permission_unique"
+      ON "role_permissions" ("role_id", "permission_id")`,
+    `CREATE INDEX IF NOT EXISTS "role_permissions_role_id_idx"
+      ON "role_permissions" ("role_id")`,
     `CREATE TABLE IF NOT EXISTS "user_roles" (
       "id" TEXT PRIMARY KEY,
       "user_id" TEXT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
@@ -131,12 +169,24 @@ export function generateSqliteCoreTableStatements(): string[] {
       "expires_at" INTEGER,
       UNIQUE("user_id", "role_id")
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "user_roles_user_role_unique"
+      ON "user_roles" ("user_id", "role_id")`,
+    `CREATE INDEX IF NOT EXISTS "user_roles_user_id_idx"
+      ON "user_roles" ("user_id")`,
+    `CREATE INDEX IF NOT EXISTS "user_roles_expires_at_idx"
+      ON "user_roles" ("expires_at")`,
     `CREATE TABLE IF NOT EXISTS "role_inherits" (
       "id" TEXT PRIMARY KEY,
       "parent_role_id" TEXT NOT NULL REFERENCES "roles"("id") ON DELETE CASCADE,
       "child_role_id" TEXT NOT NULL REFERENCES "roles"("id") ON DELETE CASCADE,
       UNIQUE("parent_role_id", "child_role_id")
     )`,
+    `CREATE UNIQUE INDEX IF NOT EXISTS "role_inherits_parent_child_unique"
+      ON "role_inherits" ("parent_role_id", "child_role_id")`,
+    `CREATE INDEX IF NOT EXISTS "role_inherits_child_idx"
+      ON "role_inherits" ("child_role_id")`,
+    `CREATE INDEX IF NOT EXISTS "role_inherits_parent_idx"
+      ON "role_inherits" ("parent_role_id")`,
     // row_level_security_policies table was removed in the RLS cleanup
     // (refactor(nextly): remove RLS, commits 8c61348f + 433927f9).
     `CREATE TABLE IF NOT EXISTS "media_folders" (
@@ -148,6 +198,12 @@ export function generateSqliteCoreTableStatements(): string[] {
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       "updated_at" INTEGER NOT NULL DEFAULT (unixepoch())
     )`,
+    `CREATE INDEX IF NOT EXISTS "media_folders_parent_id_idx"
+      ON "media_folders" ("parent_id")`,
+    `CREATE INDEX IF NOT EXISTS "media_folders_created_by_idx"
+      ON "media_folders" ("created_by")`,
+    `CREATE INDEX IF NOT EXISTS "media_folders_created_at_idx"
+      ON "media_folders" ("created_at")`,
     `CREATE TABLE IF NOT EXISTS "media" (
       "id" TEXT PRIMARY KEY,
       "filename" TEXT NOT NULL,
@@ -170,6 +226,14 @@ export function generateSqliteCoreTableStatements(): string[] {
       "uploaded_at" INTEGER NOT NULL DEFAULT (unixepoch()),
       "updated_at" INTEGER NOT NULL DEFAULT (unixepoch())
     )`,
+    `CREATE INDEX IF NOT EXISTS "media_uploaded_by_idx"
+      ON "media" ("uploaded_by")`,
+    `CREATE INDEX IF NOT EXISTS "media_mime_type_idx"
+      ON "media" ("mime_type")`,
+    `CREATE INDEX IF NOT EXISTS "media_uploaded_at_idx"
+      ON "media" ("uploaded_at")`,
+    `CREATE INDEX IF NOT EXISTS "media_folder_id_idx"
+      ON "media" ("folder_id")`,
     `CREATE TABLE IF NOT EXISTS "user_permission_cache" (
       "id" TEXT PRIMARY KEY,
       "user_id" TEXT NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
@@ -180,6 +244,12 @@ export function generateSqliteCoreTableStatements(): string[] {
       "expires_at" INTEGER NOT NULL,
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch())
     )`,
+    `CREATE INDEX IF NOT EXISTS "upc_user_id_idx"
+      ON "user_permission_cache" ("user_id")`,
+    `CREATE INDEX IF NOT EXISTS "upc_expires_at_idx"
+      ON "user_permission_cache" ("expires_at")`,
+    `CREATE INDEX IF NOT EXISTS "upc_user_action_resource_idx"
+      ON "user_permission_cache" ("user_id", "action", "resource")`,
     `CREATE TABLE IF NOT EXISTS "content_schema_events" (
       "id" INTEGER PRIMARY KEY AUTOINCREMENT,
       "op" TEXT NOT NULL,
@@ -188,6 +258,117 @@ export function generateSqliteCoreTableStatements(): string[] {
       "meta" TEXT,
       "created_at" INTEGER NOT NULL DEFAULT (unixepoch())
     )`,
+    // The three schema-registry tables. Every collection, single and component
+    // Nextly knows about is a row in one of these, so a database built from
+    // this fallback without them cannot describe its own content: boot reads
+    // the registry before it can load a dynamic table. They were listed as
+    // known gaps rather than written, and their fifteen indexes were declared
+    // on all three dialects and created on none. Their own statements, for the
+    // reason the versions indexes above give: SQLite skips a CREATE TABLE
+    // wholesale once the table exists, so an index folded into one is never
+    // added to a database that predates it.
+    `CREATE TABLE IF NOT EXISTS "dynamic_collections" (
+      "id" TEXT PRIMARY KEY,
+      "slug" TEXT NOT NULL UNIQUE,
+      "labels" TEXT NOT NULL,
+      "table_name" TEXT NOT NULL UNIQUE,
+      "description" TEXT,
+      "fields" TEXT NOT NULL,
+      "timestamps" INTEGER NOT NULL DEFAULT 1,
+      "status" INTEGER NOT NULL DEFAULT 0,
+      "localized" INTEGER NOT NULL DEFAULT 0,
+      "versions" TEXT,
+      "revalidate" TEXT,
+      "webhooks" TEXT,
+      "admin" TEXT,
+      "hooks" TEXT,
+      "source" TEXT NOT NULL DEFAULT 'ui',
+      "locked" INTEGER NOT NULL DEFAULT 0,
+      "config_path" TEXT,
+      "schema_hash" TEXT NOT NULL,
+      "schema_version" INTEGER NOT NULL DEFAULT 1,
+      "migration_status" TEXT NOT NULL DEFAULT 'pending',
+      "last_migration_id" TEXT,
+      "access_rules" TEXT,
+      "created_by" TEXT REFERENCES "users"("id"),
+      "created_at" INTEGER NOT NULL,
+      "updated_at" INTEGER NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_collections_source_idx"
+      ON "dynamic_collections" ("source")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_collections_migration_status_idx"
+      ON "dynamic_collections" ("migration_status")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_collections_created_by_idx"
+      ON "dynamic_collections" ("created_by")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_collections_created_at_idx"
+      ON "dynamic_collections" ("created_at")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_collections_updated_at_idx"
+      ON "dynamic_collections" ("updated_at")`,
+    `CREATE TABLE IF NOT EXISTS "dynamic_singles" (
+      "id" TEXT PRIMARY KEY,
+      "slug" TEXT NOT NULL UNIQUE,
+      "label" TEXT NOT NULL,
+      "table_name" TEXT NOT NULL UNIQUE,
+      "description" TEXT,
+      "fields" TEXT NOT NULL,
+      "admin" TEXT,
+      "access_rules" TEXT,
+      "source" TEXT NOT NULL DEFAULT 'ui',
+      "locked" INTEGER NOT NULL DEFAULT 0,
+      "status" INTEGER NOT NULL DEFAULT 0,
+      "localized" INTEGER NOT NULL DEFAULT 0,
+      "versions" TEXT,
+      "revalidate" TEXT,
+      "webhooks" TEXT,
+      "config_path" TEXT,
+      "schema_hash" TEXT NOT NULL,
+      "schema_version" INTEGER NOT NULL DEFAULT 1,
+      "migration_status" TEXT NOT NULL DEFAULT 'pending',
+      "last_migration_id" TEXT,
+      "created_by" TEXT,
+      "created_at" INTEGER NOT NULL,
+      "updated_at" INTEGER NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_singles_source_idx"
+      ON "dynamic_singles" ("source")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_singles_migration_status_idx"
+      ON "dynamic_singles" ("migration_status")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_singles_created_by_idx"
+      ON "dynamic_singles" ("created_by")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_singles_created_at_idx"
+      ON "dynamic_singles" ("created_at")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_singles_updated_at_idx"
+      ON "dynamic_singles" ("updated_at")`,
+    `CREATE TABLE IF NOT EXISTS "dynamic_components" (
+      "id" TEXT PRIMARY KEY,
+      "slug" TEXT NOT NULL UNIQUE,
+      "label" TEXT NOT NULL,
+      "table_name" TEXT NOT NULL UNIQUE,
+      "description" TEXT,
+      "fields" TEXT NOT NULL,
+      "admin" TEXT,
+      "source" TEXT NOT NULL DEFAULT 'ui',
+      "locked" INTEGER NOT NULL DEFAULT 0,
+      "localized" INTEGER NOT NULL DEFAULT 0,
+      "config_path" TEXT,
+      "schema_hash" TEXT NOT NULL,
+      "schema_version" INTEGER NOT NULL DEFAULT 1,
+      "migration_status" TEXT NOT NULL DEFAULT 'pending',
+      "last_migration_id" TEXT,
+      "created_by" TEXT,
+      "created_at" INTEGER NOT NULL,
+      "updated_at" INTEGER NOT NULL
+    )`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_components_source_idx"
+      ON "dynamic_components" ("source")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_components_migration_status_idx"
+      ON "dynamic_components" ("migration_status")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_components_created_by_idx"
+      ON "dynamic_components" ("created_by")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_components_created_at_idx"
+      ON "dynamic_components" ("created_at")`,
+    `CREATE INDEX IF NOT EXISTS "dynamic_components_updated_at_idx"
+      ON "dynamic_components" ("updated_at")`,
     // Content-version store. Columns match schemas/versions/sqlite.ts. The
     // durable-sequence unique index is created here too, not just the table:
     // once a fallback-created DB exists, later boots skip ensureCoreTables and


### PR DESCRIPTION
## What was wrong

`generateSqliteCoreTableStatements` is the bootstrap that runs where drizzle-kit's `pushSchema` cannot — no TTY, no interactive confirmation. It is the path taken precisely where nobody is watching, and it was creating 17 of the 67 indexes the schema declares.

A missing index breaks no insert. It makes every query against that column a scan, which is why these were declared on all three dialects and created on none — the same failure `nextly_jobs_recent_idx` had, fixed in #1438 with a check deliberately scoped to that one table.

## What the audit found

The ledger recorded this as *"10 missing indexes, five each on `dynamic_collections` and `dynamic_components`."* Measured by walking `getTableConfig(...).indexes` over the dialect bundle against the generated statements:

| | |
|---|---|
| real index gaps on tables that **are** bootstrapped | **35 across 14 tables** |
| core tables with **no bootstrap DDL at all** | **19** |
| declared indexes on the three registry tables | **15** |

**50 gaps, not 10.** `dynamic_singles` was missed by the original count entirely, and all three registry tables had `tableInDDL=false` — so the task as filed was not implementable: a `CREATE INDEX` for a table the DDL never creates simply fails.

Four further apparent gaps were **classified out rather than counted**: a single-column `uniqueIndex` that the DDL spells as an inline column `UNIQUE` is the same index, which is how `users_email_unique` is already written.

## Why the guard never caught it

The suite that exists to catch exactly this regex-matched the schema **source** for `sqliteTable("literal_name"`. `dynamic_components` is built by a factory from `STORAGE_FORMAT.registryTable`, and `nextly_i18n_archive` was the second casualty. Neither reached the comparison, so neither was checked — they passed by absence. The file's own comments record this blindness biting once before, on `nextly_widget_layout`.

It now walks `schemas/_dialect-bundles/sqlite.ts` — the same object graph the ORM writes through and `reconcileCore` hands to drizzle-kit — so a computed name and a call shape are both non-issues.

## The change

- **50 index statements added**: 35 on already-bootstrapped tables, 15 on the three registry tables.
- **`dynamic_collections`, `dynamic_singles`, `dynamic_components` are now created.** They hold the metadata for every collection, single and component in a project, so a database built from this fallback previously could not describe its own content — boot reads the registry before it can load a dynamic table. Their DDL is **generated from the Drizzle column configs**, not transcribed by hand, which is how the last transcription of `dynamic_collections` ended up with 10 of its 25 columns.
- **The index check is generalised** from `nextly_jobs` to every bootstrapped table, with the inline-UNIQUE classification.
- **A new integration test executes the DDL against a real SQLite database** and reads the indexes back from `sqlite_master`. The existing suite compares two strings drawn from the same repository; this one asks the database. It also asserts the statements are re-runnable, which is what `IF NOT EXISTS` is for.

Result, verified against a real database: **26 tables, 67 indexes**, foreign keys on.

## One coupling worth reviewing

`fixtures/db.ts` creates tables from the production generators first and fills gaps with `ddlFor`, commenting that *"the generators are the better source where they exist."* Bootstrapping `dynamic_collections` therefore moves it from `ddlFor` to the generator — and a fixture test asserting `ddlFor`'s exact lowercase spelling on that table began testing the generator while reading as though it tested the fixture.

It now asserts on `email_templates`, which the generators still do not cover, plus a source-independent `PRAGMA index_list` check on `dynamic_collections` for the property the docblock actually cares about: that duplicates are rejected.

## Not fixed here

**16 core tables still have no bootstrap DDL** and remain in `NOT_BOOTSTRAPPED`, now with that stated. `nextly_i18n_archive` is newly listed — newly *visible* rather than newly missing.

Separately: drizzle-kit's programmatic `generateDrizzleJson` / `generateMigration` are already wired in `database/drizzle-kit-lazy.ts` and need no TTY, so this DDL could in principle be **derived** rather than hand-maintained, deleting the whole drift class. That is a boot-path change that breaks first run for every SQLite install if wrong, so it is raised, not attempted.

## Evidence

Every test was seen to fail for its intended reason:

- removing a newly added index fails the generalised check — verified on a **new** table (`dynamic_collections`) and a **pre-existing** one (`media`), so the generalisation is what is tested, not just the additions
- hiding `dynamic_components` from the bundle walk fails the discovery control, reproducing the exact blindness this replaces
- removing an index fails the executed-DDL test against the real database
- dropping `UNIQUE` from the new `dynamic_collections` DDL fails the fixture's collision check

## Verification

- `pnpm --filter nextly check-types` — clean (it caught a real error vitest could not see: `IndexColumn` may be a `SQL` expression with no `.name`)
- nextly unit — 864 files, 10 867 tests passing
- nextly integration, SQLite — 245 files, 1485 tests passing
- `fallow audit --base origin/main --gate new-only` — exit 0, all introduced counts 0, scope 5 files
