### PR TITLE
fix(blocks-react): give an embed a shape before an author sets one

### DIFF
--- a/.changeset/an-embed-has-a-shape.md
+++ b/.changeset/an-embed-has-a-shape.md
@@ -1,0 +1,37 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+An embed block dropped on a page rendered at 300 by 150 pixels — the size a
+browser gives an iframe when nobody says otherwise — so a video sat
+postage-stamp sized in the corner of a full-width column. The block declared no
+default size at all.
+
+An embed now fills the width it is given and takes its height from a sixteen by
+nine ratio, which is what the players this block exists for actually serve. It
+is a default rather than a rule: an author setting their own height or ratio
+still wins, which is what a square player or an audio embed needs.

--- a/packages/blocks-react/src/blocks/base-styles.test.tsx
+++ b/packages/blocks-react/src/blocks/base-styles.test.tsx
@@ -251,6 +251,7 @@ describe("every default the core library declares", () => {
       "core/column",
       "core/columns",
       "core/divider",
+      "core/embed",
       "core/form",
       "core/gallery",
       "core/image",

--- a/packages/blocks-react/src/blocks/embed.tsx
+++ b/packages/blocks-react/src/blocks/embed.tsx
@@ -90,6 +90,33 @@ export function renderEmbed({
   );
 }
 
+/**
+ * The shape an embed takes before an author gives it one.
+ *
+ * A user agent sizes an `<iframe>` at 300x150 and nothing here overrode it, so
+ * a video dropped on a page rendered at postage-stamp size in the corner of a
+ * full-width column — measured on a published page, and the block declared no
+ * defaults at all.
+ *
+ * `16 / 9` because that is what the sources an embed block is for actually
+ * serve: YouTube, Vimeo and every player that follows them. It is a DEFAULT
+ * rather than a rule — `dimensions` is in this block's `supports`, so an
+ * author setting a height or a ratio of their own outranks it, which is what
+ * an audio embed or a square player needs.
+ *
+ * `width: 100%` alongside it, because a ratio alone still resolves against the
+ * 300px the user agent starts from: the pair is what makes the frame fill its
+ * column and take its height from that width.
+ */
+const EMBED_BASE_STYLES = {
+  base: {
+    base: {
+      width: "100%",
+      aspectRatio: "16 / 9",
+    },
+  },
+} as const;
+
 // Defined against the ENGINE's `defineBlock`, not the plugin SDK's: the engine
 // declares the contract and the SDK re-exports it for third parties. The
 // context is named rather than augmented, so a block compiled against the
@@ -117,6 +144,7 @@ export const embed = defineBlock<EmbedProps, PageContext>({
   example: {
     props: { src: "https://example.com/player", title: "A product demo" },
   },
+  baseStyles: EMBED_BASE_STYLES,
   supports: {
     spacing: true,
     dimensions: true,

--- a/packages/blocks-react/src/blocks/primitives.test.tsx
+++ b/packages/blocks-react/src/blocks/primitives.test.tsx
@@ -413,6 +413,40 @@ describe("core/image", () => {
 });
 
 describe("core/embed", () => {
+  it("has a SHAPE before an author gives it one", () => {
+    /*
+     * A user agent sizes an `<iframe>` at 300x150, and this block declared no
+     * defaults at all — so a video dropped on a page rendered postage-stamp
+     * sized in the corner of a full-width column. Measured on a published page
+     * before this: 300 by 150 with `aspect-ratio: auto`.
+     *
+     * The pair is the point. A ratio alone still resolves against the 300px
+     * the user agent starts from, so the width is what makes the frame fill
+     * its column and the ratio is what takes its height from that width.
+     *
+     * These assert the VALUES. That they reach a compiled stylesheet at all is
+     * `base-styles.test.tsx`'s job, and it covers this block automatically now
+     * that it declares defaults — the two checks are complementary rather than
+     * one restated.
+     */
+    const base = embed.baseStyles?.base?.base as
+      | Record<string, unknown>
+      | undefined;
+    expect(base).toBeDefined();
+    expect(base?.width).toBe("100%");
+    expect(base?.aspectRatio).toBe("16 / 9");
+  });
+
+  it("still lets an author override the shape", () => {
+    /*
+     * `16 / 9` is what the sources this block exists for actually serve, and it
+     * is a DEFAULT rather than a rule — an audio player or a square embed needs
+     * to say otherwise. `dimensions` in `supports` is what makes that
+     * reachable, so the default is only safe while that stays declared.
+     */
+    expect(embed.supports?.dimensions).toBe(true);
+  });
+
   it("sandboxes without granting same-origin alongside scripts", () => {
     // Both together let the frame remove its own sandbox.
     const out = html(


### PR DESCRIPTION
Last of four fixes from the U-5 visual sweep.

## What was wrong

A browser sizes an `<iframe>` at **300×150** when nothing says otherwise, and `core/embed` declared **no defaults at all**. So a video dropped on a page rendered postage-stamp sized in the corner of a full-width column.

Measured on a published page (`/blocks/block-sweep`, playground):

```
iframe → 300 × 150 · aspect-ratio: auto
```

## What this changes

The embed fills the width it is given and takes its height from a **16 / 9** ratio.

The **pair** is the point rather than either half: a ratio alone still resolves against the 300px the user agent starts from, so the width is what makes the frame fill its column and the ratio is what gives it a height from that width.

Measured after: **1280 × 720**, computed ratio 1.78.

## Why 16 / 9, and why it is safe

It is what the players this block exists for actually serve — YouTube, Vimeo, and everything that follows them.

It is a **default and not a rule.** `dimensions` is in this block's `supports`, so an author setting their own height or ratio outranks it, which is what a square player or an audio embed needs. **A test asserts that support stays declared**, because the default is only safe while the override is reachable — withdrawing `dimensions` would turn a helpful default into a cage, and nothing else would have said so.

If you would rather an embed had no default and every author set their own, this is the PR to say it on — the change is two properties.

## The guard caught the addition

The population control in `base-styles.test.tsx` failed the moment `core/embed` started declaring defaults, because it was not in the list of blocks that suite inspects. That is exactly what that control is for, and it means the new defaults are now covered by both the catalog-membership case and the compiled-output case automatically.

## Evidence

| gate | result |
| --- | --- |
| build | exit 0 |
| blocks-react suite | 43 files / **1029 tests** |
| `check-types` / `lint` | 0 / 0 |
| `lint:design` | passed, 1172 files |
| `fallow audit --base origin/main` | ✓ no issues, 4 changed files |
| `changeset status` | parses |

Break-verified by failing test NAME:

| break | test that failed |
| --- | --- |
| drop the ratio | `has a SHAPE before an author gives it one` |
| drop the width | `has a SHAPE before an author gives it one` |
| withdraw `dimensions` support | `still lets an author override the shape` |

`aspectRatio` was checked against the catalog **before** writing it — the lesson from #1464, where I wrote `justify-self`, had it silently dropped, and passed the whole suite.

## Risk

Appearance only. No stored shape changes, no new props. Any author who already sized an embed still wins.

Independent of #1464 and #1465; all three can merge in any order.
