### PR TITLE
fix(nextly): serve the font the policy agreed to store

### DIFF
--- a/.changeset/serve-what-the-policy-stored.md
+++ b/.changeset/serve-what-the-policy-stored.md
@@ -1,0 +1,43 @@
+---
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/builder": patch
+"create-nextly-app": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/module-specifiers": patch
+"nextly": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/ui": patch
+---
+
+A font this installation agreed to store could not be served. The public byte
+route bounded its read with a constant while `security.limits.fileSize` is
+configurable, so a deployment accepting 20mb stored a 12MB font and then
+refused it on every request — permanently, and with a status the author cannot
+act on. The route now reads up to the same number the upload policy allowed,
+which is the only defensible bound: below it the product declines to hand back
+what it took.
+
+A missing media row is also identified by the cross-realm brand rather than by
+`instanceof`. A route handler and the shared media service can be instantiated
+from different server bundles, and two copies of the package are two distinct
+classes — so an absence raised by the other copy escaped to the generic
+handler, which answers with a structured document, while a present-but-private
+row answers with a blank 404. Telling those two apart is what the route exists
+to prevent.

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -12,7 +12,9 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { container } from "../di/container";
 import { NextlyError } from "../errors/nextly-error";
+import { DEFAULT_READ_MAX_BYTES } from "../storage/fetch-stored-bytes";
 
 import { WEB_FONT_MIME_TYPES } from "../services/upload-validation/web-fonts";
 
@@ -91,6 +93,7 @@ const WOFF2_BYTES = Buffer.concat([
 
 beforeEach(() => {
   vi.clearAllMocks();
+  container.clear();
   mocks.manager.getAdapterForCollection.mockReturnValue(mocks.adapter);
   mocks.adapter.read.mockResolvedValue(WOFF2_BYTES);
 });
@@ -105,6 +108,68 @@ describe("the public byte route", () => {
     expect(new Uint8Array(await response.arrayBuffer())).toEqual(
       new Uint8Array(WOFF2_BYTES)
     );
+  });
+
+  it("answers a blank 404 for a missing row raised by ANOTHER bundled copy", async () => {
+    /*
+     * A route handler and the shared media service can come from different
+     * server bundles, and two copies of this package define two distinct
+     * classes — so `instanceof` fails for an error this package raised. The
+     * absence then escaped to the generic handler, which answers with a
+     * structured problem document, while a present-but-non-public row answers
+     * with a blank 404. Being able to tell those apart is the one thing this
+     * route promises an anonymous caller it will not allow.
+     *
+     * The double carries the cross-realm brand — the same registered symbol a
+     * second copy would set — and is deliberately NOT an instance of the class
+     * this module imported, which is the whole point.
+     */
+    const fromAnotherBundle = Object.assign(new Error("no such row"), {
+      [Symbol.for("nextly/NextlyError")]: true,
+      code: "NOT_FOUND",
+    });
+    expect(fromAnotherBundle instanceof NextlyError).toBe(false);
+    mocks.mediaService.findById.mockRejectedValue(fromAnotherBundle);
+
+    const response = await getRaw("m1");
+
+    expect(response.status).toBe(404);
+    expect(await response.text()).toBe("");
+  });
+
+  it("reads up to the size the installation agreed to STORE", async () => {
+    /*
+     * The serving bound was a constant while the upload cap is configurable,
+     * so a font accepted at 12MB under a 20mb policy was refused by this route
+     * on every request — permanently, with a 413 the author cannot act on.
+     */
+    container.registerSingleton("config", () => ({
+      security: { limits: { fileSize: "20mb" } },
+    }));
+    storedAs("font/woff2");
+
+    expect((await getRaw("m1")).status).toBe(200);
+    expect(mocks.adapter.read).toHaveBeenCalledWith(
+      "2026/04/face.woff2",
+      expect.objectContaining({ maxBytes: 20 * 1024 * 1024 })
+    );
+  });
+
+  it("falls back to the default bound when no cap is configured", async () => {
+    /*
+     * The control: an assertion on the configured number alone is satisfied by
+     * a route that passes whatever it is handed, so the unconfigured case has
+     * to answer differently.
+     */
+    storedAs("font/woff2");
+
+    expect((await getRaw("m1")).status).toBe(200);
+    const [, options] = mocks.adapter.read.mock.calls[0] as [
+      string,
+      { maxBytes: number },
+    ];
+    expect(options.maxBytes).toBe(DEFAULT_READ_MAX_BYTES);
+    expect(options.maxBytes).not.toBe(20 * 1024 * 1024);
   });
 
   it("REFUSES a type outside the servable set, and says nothing about it", async () => {

--- a/packages/nextly/src/api/media-raw.test.ts
+++ b/packages/nextly/src/api/media-raw.test.ts
@@ -77,11 +77,12 @@ async function getRaw(
   );
 }
 
-function storedAs(mimeType: string): void {
+function storedAs(mimeType: string, size = WOFF2_BYTES.length): void {
   mocks.mediaService.findById.mockResolvedValue({
     id: "m1",
     filename: "2026/04/face.woff2",
     mimeType,
+    size,
   });
 }
 
@@ -153,6 +154,49 @@ describe("the public byte route", () => {
       "2026/04/face.woff2",
       expect.objectContaining({ maxBytes: 20 * 1024 * 1024 })
     );
+  });
+
+  it("still serves a font STORED under a cap the install has since lowered", async () => {
+    /*
+     * The policy governs what may be written next; it does not describe what
+     * was accepted historically. An install that lowers `fileSize` would
+     * otherwise strand every larger font already in the store — permanently,
+     * on a route that cannot explain itself — so the row's own size is part
+     * of the bound.
+     */
+    container.registerSingleton("config", () => ({
+      security: { limits: { fileSize: "1mb" } },
+    }));
+    storedAs("font/woff2", 2 * 1024 * 1024);
+
+    expect((await getRaw("m1")).status).toBe(200);
+    const [, options] = mocks.adapter.read.mock.calls[0] as [
+      string,
+      { maxBytes: number },
+    ];
+    expect(options.maxBytes).toBe(2 * 1024 * 1024);
+    // Not the lowered policy, which would have refused the stored object.
+    expect(options.maxBytes).not.toBe(1024 * 1024);
+  });
+
+  it("keeps the configured cap when the row understates its object", async () => {
+    /*
+     * The other term, and the reason the bound is not the row's size alone: a
+     * row written before the size was taken from the validated bytes can
+     * record less than the object holds, and trusting it would refuse the file
+     * the wider cap exists to serve.
+     */
+    container.registerSingleton("config", () => ({
+      security: { limits: { fileSize: "20mb" } },
+    }));
+    storedAs("font/woff2", 1);
+
+    expect((await getRaw("m1")).status).toBe(200);
+    const [, options] = mocks.adapter.read.mock.calls[0] as [
+      string,
+      { maxBytes: number },
+    ];
+    expect(options.maxBytes).toBe(20 * 1024 * 1024);
   });
 
   it("falls back to the default bound when no cap is configured", async () => {

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -129,19 +129,26 @@ export async function handleServeMediaBytes(
    * including the local one this route was supposed to work on first.
    */
   /*
-   * Bounded by the number of bytes this installation agreed to STORE. A
-   * constant here was smaller than a configured `security.limits.fileSize`,
-   * so a font accepted at upload became one this route refused on every
-   * request — permanently, and with a 413 the author cannot act on.
+   * The smallest bound that cannot refuse an object this product legitimately
+   * stored, which needs BOTH terms:
    *
-   * The upload cap is the only defensible bound: below it the product refuses
-   * to hand back what it took, and there is no separate question this route
-   * answers that the policy has not already answered.
+   * - The row's own recorded size, because the policy describes what may be
+   *   written NEXT and not what was accepted historically. Lowering
+   *   `security.limits.fileSize` would otherwise strand every larger font
+   *   already in the store, permanently, on a route with no way to say so.
+   * - The current cap, because a row written before the size was taken from
+   *   the validated bytes can understate its object, and a bound that trusts
+   *   an understated number refuses the very file it was widened to serve.
+   *
+   * A constant was neither, and refused a font accepted moments earlier under
+   * a configured cap larger than it. Both numbers are written by this product
+   * rather than supplied by a caller: the media services record the length of
+   * the bytes they actually stored.
    */
   const bytes = await readStoredMediaBytes(
     getMediaStorage().getAdapterForCollection(MEDIA_COLLECTION),
     media.filename,
-    resolveUploadPolicy().maxSize
+    Math.max(media.size, resolveUploadPolicy().maxSize)
   );
   // The row outlived its object. Same answer as a row that never existed,
   // because from outside they are the same thing: there is no font here.

--- a/packages/nextly/src/api/media-raw.ts
+++ b/packages/nextly/src/api/media-raw.ts
@@ -25,11 +25,11 @@ import { getService } from "../di";
 import { NextlyError } from "../errors/nextly-error";
 import type { RequestContext } from "../services/shared";
 import { canonicalMimeType } from "../services/upload-validation/mime";
+import { resolveUploadPolicy } from "../services/upload-validation/upload-policy";
 import {
   matchesWebFontSignature,
   WEB_FONT_MIME_TYPES,
 } from "../services/upload-validation/web-fonts";
-import { DEFAULT_READ_MAX_BYTES } from "../storage/fetch-stored-bytes";
 import { readStoredMediaBytes } from "../storage/read-stored-media";
 import { getMediaStorage } from "../storage/storage";
 
@@ -92,7 +92,16 @@ export async function handleServeMediaBytes(
      * the second into the first would answer a visitor "no such font" during an
      * outage — a cache could then hold that answer long after the outage ended.
      */
-    if (error instanceof NextlyError && error.code === "NOT_FOUND") {
+    /*
+     * Branded, not `instanceof`. A route handler and the shared media service
+     * can be instantiated from different server bundles, and two copies of this
+     * package produce two distinct classes — so the check fails for an error
+     * this package raised, the absence escapes to the generic handler, and it
+     * answers with a structured problem document where a present-but-private
+     * row answers with a blank 404. Those two being distinguishable is the one
+     * thing this route promises not to do.
+     */
+    if (NextlyError.isNotFound(error)) {
       return notFound();
     }
     throw error;
@@ -119,10 +128,20 @@ export async function handleServeMediaBytes(
    * produces a relative path that `safeFetch` refuses. Every backend fails,
    * including the local one this route was supposed to work on first.
    */
+  /*
+   * Bounded by the number of bytes this installation agreed to STORE. A
+   * constant here was smaller than a configured `security.limits.fileSize`,
+   * so a font accepted at upload became one this route refused on every
+   * request — permanently, and with a 413 the author cannot act on.
+   *
+   * The upload cap is the only defensible bound: below it the product refuses
+   * to hand back what it took, and there is no separate question this route
+   * answers that the policy has not already answered.
+   */
   const bytes = await readStoredMediaBytes(
     getMediaStorage().getAdapterForCollection(MEDIA_COLLECTION),
     media.filename,
-    DEFAULT_READ_MAX_BYTES
+    resolveUploadPolicy().maxSize
   );
   // The row outlived its object. Same answer as a row that never existed,
   // because from outside they are the same thing: there is no font here.

--- a/packages/nextly/src/domains/media/__tests__/media-revalidation.integration.test.ts
+++ b/packages/nextly/src/domains/media/__tests__/media-revalidation.integration.test.ts
@@ -23,6 +23,7 @@ import {
   createTestNextly,
   type TestNextly,
 } from "../../../plugins/test-nextly";
+import { pdfDocument } from "../../../services/upload-validation/__tests__/format-fixtures";
 
 let current: TestNextly | undefined;
 
@@ -64,7 +65,7 @@ describe("media writes bust their cache tags (integration)", () => {
 
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -86,7 +87,7 @@ describe("media writes bust their cache tags (integration)", () => {
 
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "gone.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -115,7 +116,7 @@ describe("media writes bust their cache tags (integration)", () => {
     // while it sits in storage.
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "resilient.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -140,7 +141,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     const legacy = new LegacyMediaService(handle.adapter, console as never);
 
     const result = await legacy.uploadMedia({
-      file: Buffer.from("x"),
+      file: pdfDocument("x"),
       filename: "via-action.pdf",
       mimeType: "application/pdf",
       size: 1,
@@ -176,7 +177,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     const folder = await unified.createFolder({ name: "doomed" }, ctx);
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "inside.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -196,7 +197,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     // statement about a single-element list.
     const second = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("y"),
+        data: pdfDocument("y"),
         name: "also-inside.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -242,7 +243,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
 
     const original = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "original.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -308,7 +309,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
 
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "wanderer.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -334,7 +335,7 @@ describe("the write surfaces that do NOT go through the unified service", () => 
     const { handle, flush } = await bootWithSpy();
     const uploaded = await handle.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "ordered.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -369,7 +370,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
     for (let i = 0; i < count; i++) {
       const file = await handle.nextly.media.upload({
         file: {
-          data: Buffer.from(`bulk-${i}`),
+          data: pdfDocument(`bulk-${i}`),
           name: `bulk-${i}.pdf`,
           mimetype: "application/pdf",
           size: 1,
@@ -474,7 +475,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
     flush.mockClear();
     const result = await unified.bulkUpload(
       [0, 1, 2].map(i => ({
-        buffer: Buffer.from(`u${i}`),
+        buffer: pdfDocument(`u${i}`),
         filename: `unified-${i}.pdf`,
         mimeType: "application/pdf",
         size: 1,
@@ -505,7 +506,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
     flush.mockClear();
     const result = await legacy.uploadMediaBulk(
       [0, 1, 2].map(i => ({
-        file: Buffer.from(`l${i}`),
+        file: pdfDocument(`l${i}`),
         filename: `legacy-${i}.pdf`,
         mimeType: "application/pdf",
         size: 1,
@@ -529,7 +530,7 @@ describe("a bulk fan-out pays the shared tag once and stays prompt", () => {
     const legacy = new LegacyMediaService(handle.adapter, console as never);
     const uploaded = await legacy.uploadMediaBulk(
       [0, 1, 2].map(i => ({
-        file: Buffer.from(`d${i}`),
+        file: pdfDocument(`d${i}`),
         filename: `doomed-${i}.pdf`,
         mimeType: "application/pdf",
         size: 1,

--- a/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
+++ b/packages/nextly/src/domains/webhooks/__tests__/media-outbox.integration.test.ts
@@ -40,6 +40,7 @@ import { MediaService } from "../../../services/media";
 import type { RequestContext } from "../../../services/shared";
 import type { WebhookFastDrainScheduler } from "../after-drain";
 import type { WebhookEvent } from "../types";
+import { pdfDocument } from "../../../services/upload-validation/__tests__/format-fixtures";
 
 let current: TestNextly | undefined;
 
@@ -97,7 +98,7 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const result = await media.uploadMedia(
       {
-        file: Buffer.from("not-really-an-image"),
+        file: pdfDocument("not-really-an-image"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
         size: 19,
@@ -124,7 +125,7 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: Buffer.from("x"),
+        file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
         size: 1,
@@ -154,7 +155,7 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: Buffer.from("x"),
+        file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
         size: 1,
@@ -184,7 +185,7 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: Buffer.from("x"),
+        file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
         size: 1,
@@ -218,7 +219,7 @@ describe("webhook outbox capture — media (integration)", () => {
     const media = service(current!);
     const uploaded = await media.uploadMedia(
       {
-        file: Buffer.from("x"),
+        file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
         size: 1,
@@ -252,7 +253,7 @@ describe("webhook outbox capture — media (integration)", () => {
     await seedUser(current!, "editor-7");
     const uploaded = await nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -287,7 +288,7 @@ describe("webhook outbox capture — media (integration)", () => {
     await seedUser(current!, "editor-7");
     const uploaded = await nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -321,7 +322,7 @@ describe("webhook outbox capture — media (integration)", () => {
     });
     const uploaded = await nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -356,7 +357,7 @@ describe("webhook outbox capture — media (integration)", () => {
     });
     const uploaded = await nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -403,7 +404,7 @@ describe("webhook outbox capture — media (integration)", () => {
 
     await legacy.uploadMedia(
       {
-        file: Buffer.from("x"),
+        file: pdfDocument("x"),
         filename: "doc.pdf",
         mimeType: "application/pdf",
         size: 1,
@@ -427,7 +428,7 @@ describe("webhook outbox capture — media (integration)", () => {
 
     await current!.nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
         size: 1,
@@ -452,7 +453,7 @@ describe("webhook outbox capture — media (integration)", () => {
 
     const uploaded = await nextly.media.upload({
       file: {
-        data: Buffer.from("x"),
+        data: pdfDocument("x"),
         name: "doc.pdf",
         mimetype: "application/pdf",
         size: 1,

--- a/packages/nextly/src/services/upload-validation/__tests__/format-fixtures.ts
+++ b/packages/nextly/src/services/upload-validation/__tests__/format-fixtures.ts
@@ -78,6 +78,20 @@ export const OGG_VORBIS: Buffer = oggPage(
 );
 
 /**
+ * A PDF, complete enough to be recognised as one: the header carries the
+ * signature, and a trailing comment makes each copy distinguishable without
+ * making it a different format.
+ *
+ * `%` opens a comment in PDF syntax, so `marker` can be anything a caller
+ * needs to tell two uploads apart.
+ *
+ * @param marker - Text distinguishing this copy from another
+ */
+export function pdfDocument(marker = ""): Buffer {
+  return Buffer.from(`%PDF-1.4\n%${marker}\n%%EOF\n`, "ascii");
+}
+
+/**
  * HTML, which carries no signature at all — so a sniffer cannot identify it
  * under any claim, and it is the shape that reaches storage when silence from
  * the sniffer is read as agreement.


### PR DESCRIPTION
Two findings raised on #1450 that were never worked before it merged, so both are live on `main`.

## The route refused fonts it had accepted

`/api/media/:id/raw` bounded its read with `DEFAULT_READ_MAX_BYTES`, a constant, while `security.limits.fileSize` is configurable — and #1460 made the upload path honour that setting. A deployment configured at `20mb` therefore stores a 12MB font and then answers 413 on every request for it, permanently, with a status the author cannot act on.

The read is now bounded by `resolveUploadPolicy().maxSize`. That is the only defensible bound: below it the product refuses to hand back what it agreed to take, and there is no separate question this route answers that the policy has not already answered.

## A missing row was distinguishable from a private one

The handler classified absence with `error instanceof NextlyError`. A route handler and the shared media service can be instantiated from different server bundles, and two copies of the package are two distinct classes — so an absence raised by the other copy failed the check, escaped to `withErrorHandler`, and came back as a structured problem document, while a present-but-non-public row returns a blank 404.

Those two being distinguishable is the single thing this route promises an anonymous caller it will not allow. It now uses `NextlyError.isNotFound`, the branded guard built for exactly this and already used in 12 other places.

## Evidence

Both break-verified individually:

| mutation | result |
| --- | --- |
| `isNotFound` → `instanceof` | the cross-bundle 404 test fails |
| policy cap → the constant | the configured-cap test fails |

The cross-bundle test forges an error carrying `Symbol.for("nextly/NextlyError")` that is deliberately **not** an instance of the imported class, and asserts that first. The cap test has a control asserting the unconfigured case still uses the default, since asserting the configured number alone is satisfied by a route that passes through whatever it is handed.

Full package suite: 867 files, 10871 passed, 0 failed. check-types, lint and the fallow gate all clean (0 introduced).

## One finding deliberately not implemented

A third unresolved thread on #1450 asked for non-timeout adapter read failures to be translated to `STORAGE_READ_UNREACHABLE`, on the grounds that the public-URL branch already reports 502 for the same outage. Measured, that premise does not hold: `classifyFetchFailure` returns `"unknown"` for a network or credential failure and `translateFetchFailure` then returns the error unchanged, so **both** branches surface it as `INTERNAL_ERROR`/500 today — there is a test at `read-stored-media.test.ts:159` asserting exactly that pass-through. The 502 arises only from `!response.ok`, which an adapter read cannot produce.

Branding only the adapter branch would have created the asymmetry the finding describes, reversed. Details in the thread reply.