### PR TITLE
fix(builder): one corrupt class can no longer take down the class manager

### DIFF
--- a/.changeset/a-corrupt-class-cannot-take-the-panel-down.md
+++ b/.changeset/a-corrupt-class-cannot-take-the-panel-down.md
@@ -1,0 +1,48 @@
+---
+"nextly": patch
+"create-nextly-app": patch
+"@nextlyhq/admin": patch
+"@nextlyhq/admin-css": patch
+"@nextlyhq/blocks-engine": patch
+"@nextlyhq/blocks-react": patch
+"@nextlyhq/ui": patch
+"@nextlyhq/adapter-drizzle": patch
+"@nextlyhq/adapter-postgres": patch
+"@nextlyhq/adapter-mysql": patch
+"@nextlyhq/adapter-sqlite": patch
+"@nextlyhq/storage-s3": patch
+"@nextlyhq/storage-uploadthing": patch
+"@nextlyhq/storage-vercel-blob": patch
+"@nextlyhq/plugin-form-builder": patch
+"@nextlyhq/plugin-page-builder": patch
+"@nextlyhq/plugin-seo": patch
+"@nextlyhq/plugin-sdk": patch
+"@nextlyhq/eslint-config": patch
+"@nextlyhq/eslint-plugin": patch
+"@nextlyhq/prettier-config": patch
+"@nextlyhq/telemetry": patch
+"@nextlyhq/tsconfig": patch
+"@nextlyhq/builder": patch
+"@nextlyhq/module-specifiers": patch
+---
+
+The class manager could be taken down by one corrupt class.
+
+`NodeStyles` says states map to breakpoints map to values. A stored document only
+promises to be JSON, and the usability gate admits a class whose `styles` is a plain
+record without walking into it — so a persisted `{ base: { base: null } }` reached
+`Object.keys(null)` and threw. Not one broken row: the whole panel, including the
+rows an author would have used to delete the class that broke it.
+
+Three shapes reached it, in two different functions — a null state map, a null
+values map under any state, and a null base that got as far as the engine's
+compiler and threw inside it. All three are now guarded with `isPlainRecord`, the
+predicate the page compiler already uses for exactly this, at exactly these two
+levels. The class is still listed, because repairing a corrupt entry is not this
+panel's job and hiding it would take away the only row an author could act on.
+
+A context that writes no rule is also no longer counted as behaviour. The row said
+"1 more elsewhere" whenever a state or breakpoint held any key at all, including
+keys naming a property the catalog does not define or a value whose grammar it
+refuses — both of which the compiler drops. The count now comes from the compiled
+declarations, so the caveat describes the stylesheet the visitor actually gets.

--- a/packages/builder/src/class-library.test.ts
+++ b/packages/builder/src/class-library.test.ts
@@ -711,12 +711,13 @@ describe("what a class writes", () => {
      * describe a different stylesheet the first time the catalog changed.
      */
     const values = { color: "#112233", paddingBlockStart: "1rem" };
-    const summary = classDeclarations(
-      { base: { [BASE_BREAKPOINT]: values } },
-      "hero"
-    );
+    const summary = classDeclarations({ base: { [BASE_BREAKPOINT]: values } });
     expect(summary.shown.map(d => d.property)).toEqual(
-      compileStyleValues(values, "class:hero").declarations.map(d => d.property)
+      // The same path the summary compiles under. It is incidental to WHICH
+      // declarations a valid map produces, and not incidental in general: the
+      // path is charged against the style-issue budget, which is why the summary
+      // uses one short constant rather than the class's own identity.
+      compileStyleValues(values, "class").declarations.map(d => d.property)
     );
     // The must-be-found control: the compiler really did produce something, so
     // the equality above is not two empty lists agreeing.
@@ -737,7 +738,7 @@ describe("what a class writes", () => {
       },
       hover: { [BASE_BREAKPOINT]: { color: "#778899" } },
     };
-    const summary = classDeclarations(styles, "hero", WITH_MD);
+    const summary = classDeclarations(styles, WITH_MD);
     expect(summary.shown.map(d => d.property)).toEqual(["color"]);
     // Two places this class also behaves differently: one other breakpoint the
     // site DEFINES, and one other state.
@@ -748,7 +749,7 @@ describe("what a class writes", () => {
      * does NOT define `md`, the compiler emits no rule for it, so the class
      * behaves no differently there and the count must not claim it does.
      */
-    const withoutMd = classDeclarations(styles, "hero", undefined);
+    const withoutMd = classDeclarations(styles, undefined);
     expect(withoutMd.elsewhere).toBe(1);
   });
 
@@ -757,14 +758,13 @@ describe("what a class writes", () => {
     // class behaves differently, so counting it would inflate the caveat.
     const summary = classDeclarations(
       { base: { [BASE_BREAKPOINT]: { color: "#112233" }, md: {} } },
-      "hero",
       WITH_MD
     );
     expect(summary.elsewhere).toBe(0);
   });
 
   it("says nothing at all for a class that writes nothing", () => {
-    const summary = classDeclarations({}, "hero");
+    const summary = classDeclarations({});
     expect(summary.shown).toEqual([]);
     expect(summary.elsewhere).toBe(0);
   });
@@ -787,7 +787,6 @@ describe("what a class writes", () => {
           md: { notARealProperty: "1rem" },
         },
       } as never,
-      "hero",
       WITH_MD
     );
 
@@ -819,7 +818,7 @@ describe("persisted class styles that are not the shape the type promises", () =
   ];
 
   it.each(cases)("survives %s", (_label, styles) => {
-    expect(() => classDeclarations(styles as never, "hero")).not.toThrow();
+    expect(() => classDeclarations(styles as never)).not.toThrow();
   });
 
   it("treats a malformed context as styling NOTHING, not as behaviour", () => {
@@ -834,13 +833,50 @@ describe("persisted class styles that are not the shape the type promises", () =
         base: { [BASE_BREAKPOINT]: { color: "#112233" }, md: null },
         hover: null,
       } as never,
-      "hero",
       WITH_MD
     );
 
     expect(summary.elsewhere).toBe(0);
     // Must-be-found: the well-formed base still came through, so this is a
     // judgement about the malformed contexts beside it.
+    expect(summary.shown.map(d => d.property)).toEqual(["color"]);
+  });
+
+  it("does not let the DIAGNOSTIC path decide what it reports", () => {
+    /*
+     * `basePath` is repeated into every diagnostic and charged against the
+     * style-issue budget, and an exhausted budget refuses the WHOLE map rather
+     * than the property that exhausted it. So a longer path compiles to fewer
+     * declarations from identical values — measured:
+     *
+     *     compileStyleValues(values, `class:${128-char slug}/hover/md`) -> 0
+     *     compileStyleValues(values, "class")                           -> 1
+     *
+     * `compilePageCss` compiles the same class under `/classes/<position>/...`.
+     * A summary keyed on the class's own identity could therefore report "no
+     * behaviour elsewhere" for a context the page does emit — a disagreement
+     * produced by a diagnostic string rather than by the styles.
+     *
+     * The map below is malformed enough to exhaust a budget under a long path
+     * and carries one perfectly good declaration.
+     */
+    const values: Record<string, string> = { color: "#112233" };
+    for (let index = 0; index < 150; index += 1) {
+      values[`k${"x".repeat(200)}${index}`] = "1px";
+    }
+
+    const summary = classDeclarations(
+      {
+        base: { [BASE_BREAKPOINT]: { color: "#445566" } },
+        hover: { [BASE_BREAKPOINT]: values },
+      } as never,
+      WITH_MD
+    );
+
+    // The valid declaration inside the noisy map is still behaviour elsewhere.
+    expect(summary.elsewhere).toBe(1);
+    // Must-be-found: the base compiled too, so the count above is a judgement
+    // about the hover map rather than a walk that found nothing.
     expect(summary.shown.map(d => d.property)).toEqual(["color"]);
   });
 

--- a/packages/builder/src/class-library.test.ts
+++ b/packages/builder/src/class-library.test.ts
@@ -56,6 +56,7 @@ import {
   withClassApplied,
   withClassRemoved,
   classDeclarations,
+  usableSiteClasses,
 } from "./class-library";
 
 /** A library entry, with the styles envelope left empty where it is not read. */
@@ -766,5 +767,91 @@ describe("what a class writes", () => {
     const summary = classDeclarations({}, "hero");
     expect(summary.shown).toEqual([]);
     expect(summary.elsewhere).toBe(0);
+  });
+
+  it("counts a context whose values COMPILE to nothing as nothing", () => {
+    /*
+     * A stored key is not a declaration. A property the catalog does not define
+     * is dropped by the compiler rather than passed through, so counting keys
+     * claimed "1 more elsewhere" for styling no visitor can see — the same class
+     * of lie as counting a breakpoint the site has since deleted, which the case
+     * above already refuses.
+     *
+     * `md` here holds a key of the right SHAPE and no meaning, so a count of
+     * stored keys says 1 and the compiled answer says 0.
+     */
+    const summary = classDeclarations(
+      {
+        base: {
+          [BASE_BREAKPOINT]: { color: "#112233" },
+          md: { notARealProperty: "1rem" },
+        },
+      } as never,
+      "hero",
+      WITH_MD
+    );
+
+    expect(summary.elsewhere).toBe(0);
+    // Must-be-found control: the base still compiled, so the zero above is a
+    // judgement about `md` and not a walk that found nothing anywhere.
+    expect(summary.shown.map(d => d.property)).toEqual(["color"]);
+  });
+});
+
+describe("persisted class styles that are not the shape the type promises", () => {
+  /*
+   * The type says states map to breakpoints map to values. The stored document
+   * only promises to be JSON, and `usableSiteClasses` admits a class whose
+   * `styles` is a plain record without walking into it — so a malformed nested
+   * value reached the projection and threw, taking down the WHOLE class manager
+   * rather than hiding one row.
+   *
+   * Each shape below is a separate throw site, which is why they are separate
+   * cases rather than one loop: two threw inside this module's own walk and one
+   * got as far as `compileStyleValues` and threw inside the engine.
+   */
+  const cases: [string, unknown][] = [
+    ["a null base, which reached the compiler", { base: { base: null } }],
+    ["a null state map", { base: null }],
+    ["a null values map under a non-base state", { hover: { base: null } }],
+    ["a state map that is an array", { base: [] }],
+    ["values that are a string", { base: { base: "red" } }],
+  ];
+
+  it.each(cases)("survives %s", (_label, styles) => {
+    expect(() => classDeclarations(styles as never, "hero")).not.toThrow();
+  });
+
+  it("treats a malformed context as styling NOTHING, not as behaviour", () => {
+    /*
+     * Not throwing is half the answer. The other half is what it then says: a
+     * context the compiler writes no rule for is not a place the class behaves
+     * differently, so it must not be counted — otherwise the row trades a crash
+     * for a caveat that misdescribes the page.
+     */
+    const summary = classDeclarations(
+      {
+        base: { [BASE_BREAKPOINT]: { color: "#112233" }, md: null },
+        hover: null,
+      } as never,
+      "hero",
+      WITH_MD
+    );
+
+    expect(summary.elsewhere).toBe(0);
+    // Must-be-found: the well-formed base still came through, so this is a
+    // judgement about the malformed contexts beside it.
+    expect(summary.shown.map(d => d.property)).toEqual(["color"]);
+  });
+
+  it("still admits the class, because repair is not this module's job", () => {
+    // The guard makes the projection survive the shape; it does not make the
+    // class disappear. Hiding it would lose the author the only row from which
+    // they could delete or rename it.
+    expect(
+      usableSiteClasses([
+        { id: "c1", slug: "hero", styles: { base: { base: null } } },
+      ] as never)
+    ).toHaveLength(1);
   });
 });

--- a/packages/builder/src/class-library.ts
+++ b/packages/builder/src/class-library.ts
@@ -57,6 +57,7 @@ import {
   NAMED_CLASS_SLUG_RE,
   STYLE_STATES,
   compileStyleValues,
+  isPlainRecord,
   namedClassName,
   usableNamedClasses,
   type Declaration,
@@ -191,18 +192,34 @@ function indexedUsage(usage: ClassUsageCounts, classId: string): number {
  */
 function storedContexts(
   styles: NodeStyles
-): { state: string; breakpoint: string; count: number }[] {
-  const pairs: { state: string; breakpoint: string; count: number }[] = [];
+): { state: string; breakpoint: string; values: Record<string, unknown> }[] {
+  const pairs: {
+    state: string;
+    breakpoint: string;
+    values: Record<string, unknown>;
+  }[] = [];
   for (const state of STYLE_STATES) {
-    const byBreakpoint = styles[state];
-    if (byBreakpoint === undefined) continue;
+    const byBreakpoint: unknown = styles[state];
+    // GUARDED at both levels, the way `compilePageCss` guards the same two.
+    //
+    // The type says these are records; the stored document only promises to be
+    // JSON. A persisted `{ base: { base: null } }` passes `usableSiteClasses`,
+    // and `Object.keys(null)` throws — which took the whole class manager down
+    // rather than hiding one row. Three shapes reached it: a null state map, a
+    // null values map under any state, and a null base that went on to
+    // `compileStyleValues` and threw inside the engine instead.
+    //
+    // `isPlainRecord` rather than a null check, because it is the predicate the
+    // compiler already uses for exactly this and it also excludes the shapes
+    // that do not throw and still style nothing — a number, a string, an array.
+    // Skipping silently is right HERE and not in the compiler: this is a
+    // summary of what a class does, and a context that writes no rule does
+    // nothing. `compilePageCss` is where the author is told why.
+    if (!isPlainRecord(byBreakpoint)) continue;
     for (const breakpoint of Object.keys(byBreakpoint)) {
-      const values = byBreakpoint[breakpoint];
-      pairs.push({
-        state,
-        breakpoint,
-        count: values === undefined ? 0 : Object.keys(values).length,
-      });
+      const values: unknown = byBreakpoint[breakpoint];
+      if (!isPlainRecord(values)) continue;
+      pairs.push({ state, breakpoint, values });
     }
   }
   return pairs;
@@ -217,13 +234,28 @@ function storedContexts(
  */
 function contextsElsewhere(
   styles: NodeStyles,
-  emitted: ReadonlySet<string>
+  emitted: ReadonlySet<string>,
+  slug: string,
+  context?: StyleCompileContext
 ): number {
   return storedContexts(styles).filter(
     pair =>
       !(pair.state === "base" && pair.breakpoint === BASE_BREAKPOINT) &&
       emitted.has(pair.breakpoint) &&
-      pair.count > 0
+      // COMPILED, not counted. A stored key is not a declaration: a property
+      // the catalog does not define, or a value whose grammar it refuses,
+      // writes nothing — so counting keys claimed "1 more elsewhere" for
+      // styling the page does not have, which is the same class of lie as
+      // counting a breakpoint the site has since deleted. The one implementation
+      // of "stored values become declarations" is asked instead.
+      compileStyleValues(
+        pair.values,
+        `class:${slug}/${pair.state}/${pair.breakpoint}`,
+        undefined,
+        undefined,
+        undefined,
+        { mayFetchUrl: context?.mayFetchUrl }
+      ).declarations.length > 0
   ).length;
 }
 
@@ -267,9 +299,11 @@ export function classDeclarations(
    */
   context?: StyleCompileContext
 ): { shown: readonly Declaration[]; elsewhere: number } {
-  const base = styles.base?.[BASE_BREAKPOINT];
+  const base: unknown = styles.base?.[BASE_BREAKPOINT];
   const shown =
-    base === undefined
+    // The same guard the walk below uses, for the same reason: a stored `null`
+    // here reached `Object.hasOwn` inside `compileStyleValues` and threw.
+    !isPlainRecord(base)
       ? []
       : compileStyleValues(
           base,
@@ -282,7 +316,7 @@ export function classDeclarations(
   const emitted = new Set(
     breakpointContexts(context?.breakpoints).map(entry => entry.id)
   );
-  const elsewhere = contextsElsewhere(styles, emitted);
+  const elsewhere = contextsElsewhere(styles, emitted, slug, context);
   return { shown, elsewhere };
 }
 

--- a/packages/builder/src/class-library.ts
+++ b/packages/builder/src/class-library.ts
@@ -183,6 +183,28 @@ function indexedUsage(usage: ClassUsageCounts, classId: string): number {
 }
 
 /**
+ * The path handed to the compiler for a SUMMARY compile.
+ *
+ * Short, constant, and deliberately not the class's own identity. `basePath` is
+ * only ever repeated into diagnostics, and this module discards them — but it is
+ * also charged against the style-issue budget, and an exhausted budget refuses
+ * the WHOLE map rather than the property that exhausted it.
+ *
+ * So path length decides what compiles. Measured on one map of 150 long unknown
+ * keys beside one valid `color`, with a 128-character slug:
+ *
+ *     compileStyleValues(values, `class:${slug}/hover/md`) -> 0 declarations
+ *     compileStyleValues(values, "class")                  -> 1 declaration
+ *
+ * `compilePageCss` compiles the same class under `/classes/<position>/styles/...`,
+ * so a longer path here would let the panel report "nothing" for styling the page
+ * does emit — a disagreement produced by the diagnostic string rather than by the
+ * styles. Kept shorter than the page's own path, so this can only ever be at
+ * least as permissive as what the visitor gets.
+ */
+const SUMMARY_PATH = "class";
+
+/**
  * Every (state, breakpoint) pair this class stores values under.
  *
  * The WALK, separated from the judgement below, because a nested loop carrying
@@ -235,7 +257,6 @@ function storedContexts(
 function contextsElsewhere(
   styles: NodeStyles,
   emitted: ReadonlySet<string>,
-  slug: string,
   context?: StyleCompileContext
 ): number {
   return storedContexts(styles).filter(
@@ -250,7 +271,7 @@ function contextsElsewhere(
       // of "stored values become declarations" is asked instead.
       compileStyleValues(
         pair.values,
-        `class:${slug}/${pair.state}/${pair.breakpoint}`,
+        SUMMARY_PATH,
         undefined,
         undefined,
         undefined,
@@ -281,7 +302,6 @@ function contextsElsewhere(
  */
 export function classDeclarations(
   styles: NodeStyles,
-  slug: string,
   /**
    * The context the PAGE is compiled with, so the summary describes the same
    * stylesheet the visitor gets.
@@ -307,7 +327,7 @@ export function classDeclarations(
       ? []
       : compileStyleValues(
           base,
-          `class:${slug}`,
+          SUMMARY_PATH,
           undefined,
           undefined,
           undefined,
@@ -316,7 +336,7 @@ export function classDeclarations(
   const emitted = new Set(
     breakpointContexts(context?.breakpoints).map(entry => entry.id)
   );
-  const elsewhere = contextsElsewhere(styles, emitted, slug, context);
+  const elsewhere = contextsElsewhere(styles, emitted, context);
   return { shown, elsewhere };
 }
 

--- a/packages/builder/src/class-manager-panel.tsx
+++ b/packages/builder/src/class-manager-panel.tsx
@@ -849,11 +849,7 @@ function ClassRowView({
           pendingSlug={pendingSlug}
           row={row}
         />
-        <DeclarationSummary
-          styles={styles}
-          slug={row.slug}
-          styleContext={styleContext}
-        />
+        <DeclarationSummary styles={styles} styleContext={styleContext} />
         <UsageNote row={row} usageKnown={usageKnown} />
         {isSupplied ? (
           // Named rather than shown disabled. A greyed button invites an
@@ -1176,19 +1172,17 @@ function DeleteConfirm({
  */
 function DeclarationSummary({
   styles,
-  slug,
   styleContext,
 }: {
   styles: NodeStyles | undefined;
-  slug: string;
   styleContext: StyleCompileContext | undefined;
 }): React.ReactElement | null {
   const summary = React.useMemo(
     () =>
       styles === undefined
         ? undefined
-        : classDeclarations(styles, slug, styleContext),
-    [styles, slug, styleContext]
+        : classDeclarations(styles, styleContext),
+    [styles, styleContext]
   );
   if (summary === undefined) return null;
   if (summary.shown.length === 0 && summary.elsewhere === 0) return null;


### PR DESCRIPTION
Follow-up to #1458, closing two of the three findings left open on it.

## The crash

`NodeStyles` says states map to breakpoints map to values. A stored document only promises to be JSON, and `usableSiteClasses` admits a class whose `styles` is a plain record without walking into it — so a persisted `{ base: { base: null } }` reached `Object.keys(null)` and threw.

Not one broken row. The whole class manager went, including the rows an author would have used to delete the class that broke it.

**Three shapes reached it, in two functions — not the one line the report named.** Mapped by running each:

| stored shape | threw in |
| --- | --- |
| `{ base: { base: null } }` | `compileStyleValues` (blocks-engine `declarations.ts`, `Object.hasOwn`) |
| `{ base: null }` | `storedContexts` (builder) |
| `{ hover: { base: null } }` | `storedContexts` (builder) |

The first never reaches this module’s walk at all: the base is compiled first and throws inside the engine. `{ base: { base: 42 } }` and `{ hover: { md: "str" } }` do **not** throw — a number and a string box fine — so they were always safe, and the tests say so rather than implying a wider fix.

## The guard

`isPlainRecord`, from the engine — the predicate `compilePageCss` already uses for exactly this, at exactly these two levels — rather than a null check written here. It also excludes the shapes that do not throw and still style nothing: a number, a string, an array.

Skipping silently is right in a SUMMARY and wrong in the compiler, which is where the author is told why. This module’s own docblock already says repairing a dropped entry is not its job, and the class stays listed for the same reason — hiding it would take away the only row an author could act on.

## The count

A context that writes no rule is no longer counted as behaviour. The row claimed "1 more elsewhere" whenever a state or breakpoint held any key at all, including one naming a property the catalog does not define or a value whose grammar it refuses — both dropped by the compiler. The count now comes from the compiled declarations.

That is the rule the surrounding code already applied to a breakpoint the site has since deleted; this makes it one rule instead of two.

## Evidence

Each guard break-verified separately, by failing test name:

```
restore the undefined-only guards → × survives a null base, which reached the compiler
                                    × survives a null state map
                                    × survives a null values map under a non-base state
                                    × treats a malformed context as styling NOTHING
count stored keys again           → × counts a context whose values COMPILE to nothing as nothing
```

2761 tests across 99 files in `builder`; `check-types`, `lint`, `lint:design`, `build` and `fallow audit --base origin/main` (no issues in 3 changed files) all pass.

## Not in this PR

The third #1458 finding — a CSS-escaped `var()` bypassing the tokens panel’s preview guard — is real and needs a **new public export from `blocks-engine`**, since the engine owns CSS semantics and a second answer in the builder is the defect, not the fix. It gets its own PR rather than a slot in this one.